### PR TITLE
fix(bcs/e2e): align bot IDs/names with 5bots_profile and rename to role code names

### DIFF
--- a/src/bcs/scripts/e2e-test/common.sh
+++ b/src/bcs/scripts/e2e-test/common.sh
@@ -14,12 +14,12 @@ BCS_MOCK_USER_ID="${BCS_MOCK_USER_ID:-001}"
 BCS_MOCK_USER_NICK_NAME="${BCS_MOCK_USER_NICK_NAME:-admin}"
 
 # Bot IDs (must match the default 5bots_profile started by ./scripts/singlebox.sh --local start bcs_bots).
-# Role mapping: PMO=CEO, 测试Bot-A/B/C/D = 产品/研发/验证/客服.
-BOT_PMO_ID="${BOT_PMO_ID:-CEO-马斯克}"
-BOT_TANGHUA_ID="${BOT_TANGHUA_ID:-产品-乔布斯}"
-BOT_MENGCHANG_ID="${BOT_MENGCHANG_ID:-研发-Linus}"
-BOT_XIONGBING_ID="${BOT_XIONGBING_ID:-验证-图灵}"
-BOT_XIAHONG_ID="${BOT_XIAHONG_ID:-客服-张勇}"
+# Code names map to the 5bots_profile roles: CEO / 产品经理(PM) / 研发(ENG) / 验证(QA) / 客服(CS).
+BOT_CEO_ID="${BOT_CEO_ID:-CEO}"
+BOT_PM_ID="${BOT_PM_ID:-产品经理}"
+BOT_ENG_ID="${BOT_ENG_ID:-研发}"
+BOT_QA_ID="${BOT_QA_ID:-验证}"
+BOT_CS_ID="${BOT_CS_ID:-客服}"
 
 # ============================================================================
 # Colors
@@ -212,7 +212,7 @@ api_patch() {
 # ============================================================================
 
 # Resolve a bot name to its UUID by querying GET /bots.
-# Usage: uuid=$(resolve_bot_uuid "PMO")
+# Usage: uuid=$(resolve_bot_uuid "CEO")
 resolve_bot_uuid() {
     local name="$1"
     local url="${BCS_API_BASE_URL}/bots?limit=100"
@@ -235,17 +235,17 @@ except:
 }
 
 # Resolve all bot UUIDs. Call after BCS is healthy and bots are onboarded.
-# Sets BOT_PMO_UUID, BOT_TANGHUA_UUID, etc.
+# Sets BOT_CEO_UUID, BOT_PM_UUID, etc.
 resolve_all_bot_uuids() {
     info "Resolving bot UUIDs..."
-    BOT_PMO_UUID=$(resolve_bot_uuid "$BOT_PMO_ID")
-    BOT_TANGHUA_UUID=$(resolve_bot_uuid "$BOT_TANGHUA_ID")
-    BOT_MENGCHANG_UUID=$(resolve_bot_uuid "$BOT_MENGCHANG_ID")
-    BOT_XIONGBING_UUID=$(resolve_bot_uuid "$BOT_XIONGBING_ID")
-    BOT_XIAHONG_UUID=$(resolve_bot_uuid "$BOT_XIAHONG_ID")
+    BOT_CEO_UUID=$(resolve_bot_uuid "$BOT_CEO_ID")
+    BOT_PM_UUID=$(resolve_bot_uuid "$BOT_PM_ID")
+    BOT_ENG_UUID=$(resolve_bot_uuid "$BOT_ENG_ID")
+    BOT_QA_UUID=$(resolve_bot_uuid "$BOT_QA_ID")
+    BOT_CS_UUID=$(resolve_bot_uuid "$BOT_CS_ID")
 
     local failed=0
-    for var in BOT_PMO_UUID BOT_TANGHUA_UUID BOT_MENGCHANG_UUID BOT_XIONGBING_UUID BOT_XIAHONG_UUID; do
+    for var in BOT_CEO_UUID BOT_PM_UUID BOT_ENG_UUID BOT_QA_UUID BOT_CS_UUID; do
         if [ -z "${!var}" ]; then
             fail "Could not resolve UUID for $var"
             failed=$((failed + 1))
@@ -255,7 +255,7 @@ resolve_all_bot_uuids() {
         fail "Some bot UUIDs not resolved. Are bots onboarded?"
         return 1
     fi
-    pass "Bot UUIDs resolved (PMO=$BOT_PMO_UUID, 产品=$BOT_TANGHUA_UUID, ...)"
+    pass "Bot UUIDs resolved (CEO=$BOT_CEO_UUID, PM=$BOT_PM_UUID, ...)"
 }
 
 # ============================================================================

--- a/src/bcs/scripts/e2e-test/e2e.sh
+++ b/src/bcs/scripts/e2e-test/e2e.sh
@@ -7,8 +7,8 @@
 #
 #     ./scripts/singlebox.sh --local start bcs_bots
 #
-#   This onboards 5 bots (CEO-马斯克 / 产品-乔布斯 / 研发-Linus / 验证-图灵 /
-#   客服-张勇), which e2e resolves by name (see BOT_*_ID defaults in common.sh).
+#   This onboards 5 bots (CEO / 产品经理 / 研发 / 验证 / 客服), which e2e
+#   resolves by name (see BOT_*_ID defaults in common.sh).
 #   Override the BCS endpoint with BCS_API_BASE_URL if it is not on
 #   http://127.0.0.1:21000.
 #
@@ -157,7 +157,7 @@ fi
 # Always clean up leftover groups driven by the PMO bot before running tests.
 # The BCS enforces a per-driver active-group cap; without this, repeated e2e
 # runs accumulate groups and `POST /groups` starts returning 400.
-cleanup_driver_groups "$BOT_PMO_UUID"
+cleanup_driver_groups "$BOT_CEO_UUID"
 
 # ============================================================================
 # Run Tests

--- a/src/bcs/scripts/e2e-test/friends.sh
+++ b/src/bcs/scripts/e2e-test/friends.sh
@@ -16,8 +16,8 @@ E2E_TESTS_FRIENDS=(
 # Public bot: friend request is auto-accepted — just verify they become friends.
 test_friend_auto_accept_public() {
     info "Friends: add public bot as friend (auto-accept)"
-    # 研发-Linus should be public (default visibility from singlebox 5bots_profile)
-    api_post "/friends/request" "{\"from_bot\":\"$BOT_PMO_UUID\",\"to_bot\":\"$BOT_MENGCHANG_UUID\"}"
+    # 研发 should be public (default visibility from singlebox 5bots_profile)
+    api_post "/friends/request" "{\"from_bot\":\"$BOT_CEO_UUID\",\"to_bot\":\"$BOT_ENG_UUID\"}"
     if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "201" ]; then
         pass "send friend request to public bot returns $HTTP_STATUS"
         TESTS_PASSED=$((TESTS_PASSED + 1))
@@ -27,19 +27,19 @@ test_friend_auto_accept_public() {
     fi
     TESTS_TOTAL=$((TESTS_TOTAL + 1))
     # Verify they are friends
-    api_get "/bots/$BOT_PMO_UUID/friends"
-    assert_eq "list CEO-马斯克 friends returns 200" "$HTTP_STATUS" "200"
-    assert_contains "CEO-马斯克 is friends with 研发-Linus" "$RESPONSE" "$BOT_MENGCHANG_UUID"
+    api_get "/bots/$BOT_CEO_UUID/friends"
+    assert_eq "list CEO friends returns 200" "$HTTP_STATUS" "200"
+    assert_contains "CEO is friends with 研发" "$RESPONSE" "$BOT_ENG_UUID"
 }
 
 # Protected bot: friend request stays pending, must be manually accepted.
 test_friend_request_accept_protected() {
     info "Friends: add protected bot as friend (manual accept)"
-    # Set 产品-乔布斯 to protected
-    api_put "/bots/$BOT_TANGHUA_UUID/visibility" "{\"visibility\":\"protected\"}"
-    assert_eq "set 产品-乔布斯 to protected returns 200" "$HTTP_STATUS" "200"
-    # Send friend request from 验证-图灵 to 产品-乔布斯
-    api_post "/friends/request" "{\"from_bot\":\"$BOT_XIONGBING_UUID\",\"to_bot\":\"$BOT_TANGHUA_UUID\"}"
+    # Set 产品经理 to protected
+    api_put "/bots/$BOT_PM_UUID/visibility" "{\"visibility\":\"protected\"}"
+    assert_eq "set 产品经理 to protected returns 200" "$HTTP_STATUS" "200"
+    # Send friend request from 验证 to 产品经理
+    api_post "/friends/request" "{\"from_bot\":\"$BOT_QA_UUID\",\"to_bot\":\"$BOT_PM_UUID\"}"
     if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "201" ]; then
         pass "send friend request to protected bot returns $HTTP_STATUS"
         TESTS_PASSED=$((TESTS_PASSED + 1))
@@ -56,13 +56,13 @@ d = json.load(sys.stdin)
 print('yes' if d.get('message','') == 'Already friends' or 'already' in d.get('message','').lower() else 'no')
 " 2>/dev/null || echo "no")
     if [ "$already_friends" = "yes" ]; then
-        warn "验证-图灵 and 产品-乔布斯 are already friends (idempotent)"
+        warn "验证 and 产品经理 are already friends (idempotent)"
         pass "accept friend request (already friends)"
         TESTS_PASSED=$((TESTS_PASSED + 1))
         TESTS_TOTAL=$((TESTS_TOTAL + 1))
     else
         # Find the pending request
-        api_get "/friends/requests?bot_uuid=$BOT_TANGHUA_UUID&direction=received&status=pending"
+        api_get "/friends/requests?bot_uuid=$BOT_PM_UUID&direction=received&status=pending"
         assert_eq "list pending requests returns 200" "$HTTP_STATUS" "200"
         local request_id
         request_id=$(echo "$RESPONSE" | python3 -c "
@@ -71,11 +71,11 @@ d = json.load(sys.stdin)
 data = d.get('data', d.get('items', []))
 if isinstance(data, dict): data = data.get('items', [])
 for r in data:
-    if r.get('from_bot') == '$BOT_XIONGBING_UUID':
+    if r.get('from_bot') == '$BOT_QA_UUID':
         print(r.get('id', ''))
         break
 ")
-        assert_not_empty "pending request exists for 验证-图灵→产品-乔布斯" "$request_id"
+        assert_not_empty "pending request exists for 验证→产品经理" "$request_id"
         # Accept it
         if [ -n "$request_id" ]; then
             api_post "/friends/requests/$request_id/accept" '{}'
@@ -83,21 +83,21 @@ for r in data:
         fi
     fi
     # Verify they are friends
-    api_get "/bots/$BOT_XIONGBING_UUID/friends"
-    assert_eq "list 验证-图灵 friends returns 200" "$HTTP_STATUS" "200"
-    assert_contains "验证-图灵 is friends with 产品-乔布斯" "$RESPONSE" "$BOT_TANGHUA_UUID"
-    # Restore 产品-乔布斯 to public
-    api_put "/bots/$BOT_TANGHUA_UUID/visibility" "{\"visibility\":\"public\"}"
+    api_get "/bots/$BOT_QA_UUID/friends"
+    assert_eq "list 验证 friends returns 200" "$HTTP_STATUS" "200"
+    assert_contains "验证 is friends with 产品经理" "$RESPONSE" "$BOT_PM_UUID"
+    # Restore 产品经理 to public
+    api_put "/bots/$BOT_PM_UUID/visibility" "{\"visibility\":\"public\"}"
 }
 
 # Protected bot: friend request rejected — should NOT become friends.
 test_friend_request_reject_protected() {
     info "Friends: reject friend request to protected bot"
-    # Set 客服-张勇 to protected
-    api_put "/bots/$BOT_XIAHONG_UUID/visibility" "{\"visibility\":\"protected\"}"
-    assert_eq "set 客服-张勇 to protected returns 200" "$HTTP_STATUS" "200"
-    # Send friend request from 研发-Linus to 客服-张勇
-    api_post "/friends/request" "{\"from_bot\":\"$BOT_MENGCHANG_UUID\",\"to_bot\":\"$BOT_XIAHONG_UUID\"}"
+    # Set 客服 to protected
+    api_put "/bots/$BOT_CS_UUID/visibility" "{\"visibility\":\"protected\"}"
+    assert_eq "set 客服 to protected returns 200" "$HTTP_STATUS" "200"
+    # Send friend request from 研发 to 客服
+    api_post "/friends/request" "{\"from_bot\":\"$BOT_ENG_UUID\",\"to_bot\":\"$BOT_CS_UUID\"}"
     if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "201" ]; then
         pass "send friend request returns $HTTP_STATUS"
         TESTS_PASSED=$((TESTS_PASSED + 1))
@@ -107,7 +107,7 @@ test_friend_request_reject_protected() {
     fi
     TESTS_TOTAL=$((TESTS_TOTAL + 1))
     # Find the pending request
-    api_get "/friends/requests?bot_uuid=$BOT_XIAHONG_UUID&direction=received&status=pending"
+    api_get "/friends/requests?bot_uuid=$BOT_CS_UUID&direction=received&status=pending"
     local request_id
     request_id=$(echo "$RESPONSE" | python3 -c "
 import json, sys
@@ -115,37 +115,37 @@ d = json.load(sys.stdin)
 data = d.get('data', d.get('items', []))
 if isinstance(data, dict): data = data.get('items', [])
 for r in data:
-    if r.get('from_bot') == '$BOT_MENGCHANG_UUID':
+    if r.get('from_bot') == '$BOT_ENG_UUID':
         print(r.get('id', ''))
         break
 ")
-    assert_not_empty "pending request exists for 研发-Linus→客服-张勇" "$request_id"
+    assert_not_empty "pending request exists for 研发→客服" "$request_id"
     # Reject it
     if [ -n "$request_id" ]; then
         api_post "/friends/requests/$request_id/reject" '{}'
         assert_eq "reject friend request returns 200" "$HTTP_STATUS" "200"
     fi
     # Verify they are NOT friends
-    api_get "/bots/$BOT_MENGCHANG_UUID/friends"
-    assert_eq "list 研发-Linus friends returns 200" "$HTTP_STATUS" "200"
-    # 客服-张勇 should NOT appear in 研发-Linus's friend list
-    if [[ "$RESPONSE" == *"$BOT_XIAHONG_UUID"* ]]; then
-        fail "研发-Linus should NOT be friends with 客服-张勇 after reject"
+    api_get "/bots/$BOT_ENG_UUID/friends"
+    assert_eq "list 研发 friends returns 200" "$HTTP_STATUS" "200"
+    # 客服 should NOT appear in 研发's friend list
+    if [[ "$RESPONSE" == *"$BOT_CS_UUID"* ]]; then
+        fail "研发 should NOT be friends with 客服 after reject"
         TESTS_FAILED=$((TESTS_FAILED + 1))
     else
-        pass "研发-Linus is NOT friends with 客服-张勇 (correctly rejected)"
+        pass "研发 is NOT friends with 客服 (correctly rejected)"
         TESTS_PASSED=$((TESTS_PASSED + 1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL + 1))
-    # Restore 客服-张勇 to public
-    api_put "/bots/$BOT_XIAHONG_UUID/visibility" "{\"visibility\":\"public\"}"
+    # Restore 客服 to public
+    api_put "/bots/$BOT_CS_UUID/visibility" "{\"visibility\":\"public\"}"
 }
 
 # List friends: verify known friendship exists.
 test_list_friends() {
     info "Friends: list friends"
-    # CEO-马斯克 and 研发-Linus should be friends (from test_friend_auto_accept_public)
-    api_get "/bots/$BOT_PMO_UUID/friends"
+    # CEO and 研发 should be friends (from test_friend_auto_accept_public)
+    api_get "/bots/$BOT_CEO_UUID/friends"
     assert_eq "list friends returns 200" "$HTTP_STATUS" "200"
-    assert_contains "CEO-马斯克's friend list contains 研发-Linus" "$RESPONSE" "$BOT_MENGCHANG_UUID"
+    assert_contains "CEO's friend list contains 研发" "$RESPONSE" "$BOT_ENG_UUID"
 }

--- a/src/bcs/scripts/e2e-test/group.sh
+++ b/src/bcs/scripts/e2e-test/group.sh
@@ -19,7 +19,7 @@ E2E_TESTS_GROUP=(
 
 test_create_group() {
     info "Group: create group"
-    api_post "/groups" "{\"driver_bot\":\"$BOT_PMO_UUID\"}"
+    api_post "/groups" "{\"driver_bot\":\"$BOT_CEO_UUID\"}"
     assert_eq "create group returns 200" "$HTTP_STATUS" "200"
     local group_id
     group_id=$(json_field "$RESPONSE" "id")
@@ -28,7 +28,7 @@ test_create_group() {
 
 test_create_group_with_members() {
     info "Group: create group with members"
-    local body="{\"driver_bot\":\"$BOT_PMO_UUID\",\"participants\":[{\"bot_uuid\":\"$BOT_TANGHUA_UUID\"},{\"bot_uuid\":\"$BOT_MENGCHANG_UUID\"}]}"
+    local body="{\"driver_bot\":\"$BOT_CEO_UUID\",\"participants\":[{\"bot_uuid\":\"$BOT_PM_UUID\"},{\"bot_uuid\":\"$BOT_ENG_UUID\"}]}"
     api_post "/groups" "$body"
     assert_eq "create group with members returns 200" "$HTTP_STATUS" "200"
     local group_id
@@ -44,7 +44,7 @@ test_create_group_with_members() {
 
 test_get_group_detail() {
     info "Group: get group detail"
-    api_post "/groups" "{\"driver_bot\":\"$BOT_PMO_UUID\"}"
+    api_post "/groups" "{\"driver_bot\":\"$BOT_CEO_UUID\"}"
     local group_id
     group_id=$(json_field "$RESPONSE" "id")
     # Get detail
@@ -59,7 +59,7 @@ test_get_group_detail() {
 test_list_groups() {
     info "Group: list groups"
     # Create a group to ensure at least one exists
-    api_post "/groups" "{\"driver_bot\":\"$BOT_PMO_UUID\"}"
+    api_post "/groups" "{\"driver_bot\":\"$BOT_CEO_UUID\"}"
     # List groups
     api_get "/groups?limit=50&group_kind=all"
     assert_eq "list groups returns 200" "$HTTP_STATUS" "200"
@@ -78,11 +78,11 @@ test_list_groups() {
 
 test_add_member() {
     info "Group: add member"
-    api_post "/groups" "{\"driver_bot\":\"$BOT_PMO_UUID\"}"
+    api_post "/groups" "{\"driver_bot\":\"$BOT_CEO_UUID\"}"
     local group_id
     group_id=$(json_field "$RESPONSE" "id")
     # Add a member
-    api_post "/groups/$group_id/members" "{\"bot_uuid\":\"$BOT_TANGHUA_UUID\"}"
+    api_post "/groups/$group_id/members" "{\"bot_uuid\":\"$BOT_PM_UUID\"}"
     assert_eq "add member returns 200" "$HTTP_STATUS" "200"
     # Verify member was added
     api_get "/groups/$group_id"
@@ -93,12 +93,12 @@ test_add_member() {
 
 test_remove_member() {
     info "Group: remove member"
-    local body="{\"driver_bot\":\"$BOT_PMO_UUID\",\"participants\":[{\"bot_uuid\":\"$BOT_TANGHUA_UUID\"}]}"
+    local body="{\"driver_bot\":\"$BOT_CEO_UUID\",\"participants\":[{\"bot_uuid\":\"$BOT_PM_UUID\"}]}"
     api_post "/groups" "$body"
     local group_id
     group_id=$(json_field "$RESPONSE" "id")
     # Remove the member
-    api_delete "/groups/$group_id/members/$BOT_TANGHUA_UUID"
+    api_delete "/groups/$group_id/members/$BOT_PM_UUID"
     assert_eq "remove member returns 200" "$HTTP_STATUS" "200"
     # Verify member was removed
     api_get "/groups/$group_id"
@@ -109,7 +109,7 @@ test_remove_member() {
 
 test_update_group_label() {
     info "Group: update group label"
-    api_post "/groups" "{\"driver_bot\":\"$BOT_PMO_UUID\"}"
+    api_post "/groups" "{\"driver_bot\":\"$BOT_CEO_UUID\"}"
     local group_id
     group_id=$(json_field "$RESPONSE" "id")
     # Update label (requires bot auth — may return 401 in human-only mock mode)
@@ -130,7 +130,7 @@ test_update_group_label() {
 
 test_update_group_visibility() {
     info "Group: update group visibility"
-    api_post "/groups" "{\"driver_bot\":\"$BOT_PMO_UUID\"}"
+    api_post "/groups" "{\"driver_bot\":\"$BOT_CEO_UUID\"}"
     local group_id
     group_id=$(json_field "$RESPONSE" "id")
     # Update visibility


### PR DESCRIPTION
The e2e bot ID defaults (CEO-马斯克 / 产品-乔布斯 / 研发-Linus / 验证-图灵 / 客服-张勇) didn't match any onboarded bot name, so resolve_bot_uuid matched nothing and setup aborted with "Some bot UUIDs not resolved". Align the defaults with the actual 5bots_profile names (CEO / 产品经理 / 研发 / 验证 / 客服), and rename the variable code names (BOT_PMO/TANGHUA/MENGCHANG/ XIONGBING/XIAHONG) to role-based codes (BOT_CEO/PM/ENG/QA/CS) across common.sh, group.sh, friends.sh, and e2e.sh. Stale display labels in friends.sh updated accordingly.