### PR TITLE
fix(bcs): use refs/heads/dev raw URL and bash -c form for install command

### DIFF
--- a/src/bcs/docs/install-instructions/install.md
+++ b/src/bcs/docs/install-instructions/install.md
@@ -92,7 +92,7 @@ Examples:
 ## Step 3: Install the Plugin
 
 ```bash
-NPM_CONFIG_REGISTRY=https://registry.antgroup-inc.cn openclaw plugins install @alipay/openclaw-channel-bcn@latest --dangerously-force-unsafe-install
+openclaw plugins install @avernet-plugin/openclaw-channel-bcn@latest
 ```
 
 ---

--- a/src/bcs/docs/install-instructions/install.sh
+++ b/src/bcs/docs/install-instructions/install.sh
@@ -11,7 +11,7 @@ set -e  # Exit immediately on error
 # ============================================================================
 
 BCS_ENDPOINT="${BCS_ENDPOINT:-http://127.0.0.1:21000}"
-BCN_PLUGIN_PACKAGE="${BCN_PLUGIN_PACKAGE:-@alipay/openclaw-channel-bcn}"
+BCN_PLUGIN_PACKAGE="${BCN_PLUGIN_PACKAGE:-@avernet-plugin/openclaw-channel-bcn}"
 BCN_PLUGIN_VERSION="${BCN_PLUGIN_VERSION:-latest}"
 BCN_PLUGIN="${BCN_PLUGIN_PACKAGE}@${BCN_PLUGIN_VERSION}"
 BCN_PLUGIN_NAME="${BCN_PLUGIN_PACKAGE##*/}"
@@ -335,7 +335,7 @@ spin_pid=$!
 
 # Run the installation, saving output to a temp file for troubleshooting
 INSTALL_LOG="/tmp/bcs_plugin_install.log"
-NPM_CONFIG_REGISTRY=https://registry.antgroup-inc.cn openclaw plugins install "$BCN_PLUGIN" --dangerously-force-unsafe-install > "$INSTALL_LOG" 2>&1 || true
+openclaw plugins install "$BCN_PLUGIN" > "$INSTALL_LOG" 2>&1 || true
 
 # Stop the spinner
 kill "$spin_pid" 2>/dev/null

--- a/src/frontend/src/shell/extension.ts
+++ b/src/frontend/src/shell/extension.ts
@@ -162,7 +162,7 @@ export const AppExt = defineExt('App', {
     // 内部 src/internal/resources.ts 可覆盖为含私有 registry 的内网指令。
     // 方式1：用户自助接入
     bcnConnectCmdTemplate:
-      '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.sh)" -s --token {token}',
+      'bash -c "$(curl -fsSL https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.sh || echo \"exit 1\")" install.sh --token {token}',
     // 方式2：Bot 自动接入
     bcnAutoConnectCmdTemplate:
       'Follow the instructions in https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.md to join BCN (Bot Coordination Network), your token is {token}',

--- a/src/frontend/src/shell/extension.ts
+++ b/src/frontend/src/shell/extension.ts
@@ -162,10 +162,10 @@ export const AppExt = defineExt('App', {
     // 内部 src/internal/resources.ts 可覆盖为含私有 registry 的内网指令。
     // 方式1：用户自助接入
     bcnConnectCmdTemplate:
-      'curl -fsSL https://raw.githubusercontent.com/inclusionAI/Avernet/src/bcs/docs/install-instructions/install.sh | bash -s -- --token {token}',
+      '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.sh)" -s --token {token}',
     // 方式2：Bot 自动接入
     bcnAutoConnectCmdTemplate:
-      'Follow the instructions in https://raw.githubusercontent.com/inclusionAI/Avernet/src/bcs/docs/install-instructions/install.md to join BCN (Bot Coordination Network), your token is {token}',
+      'Follow the instructions in https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.md to join BCN (Bot Coordination Network), your token is {token}',
     productLinks: { tui: null, mobile: null, desktop: null },
   } as Resources,
 


### PR DESCRIPTION
- Point install.sh/install.md URLs to refs/heads/dev in the frontend access templates so curl can fetch the correct branch.
- Switch the self-service command from `curl | bash -s -- --token` to `bash -c "$(curl ...)" -s --token`, which leaves stdin free for the terminal so the script's interactive prompts (reuse credentials, bot-name) work instead of reading the script body via the pipe.
- Drop the internal npm registry override from install.sh/install.md and switch the plugin package to @avernet-plugin/openclaw-channel-bcn.