### PR TITLE
feat(bcs): add pluggable security gateway registry

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -191,12 +191,10 @@ default_page_limit = 100000000
 max_page_limit = 100000000
 
 [security_gateway]
-# provider 选择安全网关实现："noop"（开源默认，永远放行）| "agentpass"（AgentPass HTTP 网关）
-provider = "agentpass"
+# provider 选择安全网关实现。开源默认只内置 "noop"（永远放行）。
+# 其他 provider 由链接进二进制的插件注册，并通过 [security_gateway.providers.<provider>] 传递私有配置。
+provider = "noop"
 dry_run = true
-timeout_ms = 300
-domain = "security-gateway.example.com"
-endpoint = "/api/security/check"
 
 [security.outbound_url]
 block_private_networks = true

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -146,7 +146,7 @@ max_page_limit = 100000000
 
 [security_gateway]
 # 开源默认：noop provider，不出网、永远放行。
-# noop 只需 provider 字段；dry_run / domain / endpoint / timeout_ms 仅 agentpass provider 使用。
+# 非 noop provider 由链接进二进制的插件注册，并通过 [security_gateway.providers.<provider>] 传递私有配置。
 provider = "noop"
 
 [security.outbound_url]

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -1,5 +1,6 @@
 //! Configuration for the Bot Coordination Service.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use secrecy::Secret;
@@ -620,15 +621,17 @@ impl Default for BcsConfig {
     }
 }
 
+pub type SecurityGatewayProviderConfig = BTreeMap<String, serde_json::Value>;
+
 /// AI安全网关配置。
 ///
-/// `provider` 选择安全网关实现并在启动阶段注入对应 `SecurityGatewayPort`：
-/// - `"noop"`（默认）：开源版默认，永远放行；
-/// - `"agentpass"`：注入 AgentPass HTTP 安全网关 client（使用 `domain`/`endpoint`/`timeout_ms`）。
+/// `provider` 选择安全网关实现并在启动阶段注入对应 `SecurityGatewayPort`。
+/// 开源版内置 `"noop"`（永远放行）；其他 provider 由链接进二进制的插件注册。
 ///
 /// `dry_run` 是投递策略：true 仅观测（拦截只打日志），false 真正阻断。
-/// `domain`/`endpoint`/`timeout_ms` 仅被 `agentpass` provider 使用。
+/// provider 私有配置放在 `providers.<provider>` map 中，由具体插件解析。
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityGatewayConfig {
     #[serde(default = "default_security_provider")]
     pub provider: String,
@@ -637,13 +640,7 @@ pub struct SecurityGatewayConfig {
     pub dry_run: bool,
 
     #[serde(default)]
-    pub domain: String,
-
-    #[serde(default = "default_security_endpoint")]
-    pub endpoint: String,
-
-    #[serde(default = "default_security_timeout_ms")]
-    pub timeout_ms: u64,
+    pub providers: BTreeMap<String, SecurityGatewayProviderConfig>,
 }
 
 impl Default for SecurityGatewayConfig {
@@ -651,9 +648,7 @@ impl Default for SecurityGatewayConfig {
         Self {
             provider: default_security_provider(),
             dry_run: default_security_dry_run(),
-            domain: String::new(),
-            endpoint: default_security_endpoint(),
-            timeout_ms: default_security_timeout_ms(),
+            providers: BTreeMap::new(),
         }
     }
 }
@@ -664,14 +659,6 @@ fn default_security_provider() -> String {
 
 fn default_security_dry_run() -> bool {
     true
-}
-
-fn default_security_endpoint() -> String {
-    "/api/security/check".to_string()
-}
-
-fn default_security_timeout_ms() -> u64 {
-    300
 }
 
 fn standalone_env_config_path(config_dir: &Path) -> Option<PathBuf> {
@@ -1868,6 +1855,60 @@ skip_auth = true
         let err =
             toml::from_str::<BcsConfig>(toml).expect_err("top-level redis should be rejected");
         assert!(err.to_string().contains("redis"));
+    }
+
+    #[test]
+    fn test_security_gateway_provider_options_parse_as_map() {
+        let toml = r#"
+bind = "0.0.0.0"
+port = 21000
+bots_base_dir = "/bots"
+
+[security_gateway]
+provider = "agentpass"
+dry_run = false
+
+[security_gateway.providers.agentpass]
+domain = "security-gateway.example.com"
+endpoint = "/api/agentpass/zero_check.json"
+timeout_ms = 300
+"#;
+
+        let config: BcsConfig = toml::from_str(toml).unwrap();
+        let provider = config
+            .security_gateway
+            .providers
+            .get("agentpass")
+            .expect("agentpass provider config");
+
+        assert_eq!(config.security_gateway.provider, "agentpass");
+        assert!(!config.security_gateway.dry_run);
+        assert_eq!(
+            provider.get("endpoint").and_then(|value| value.as_str()),
+            Some("/api/agentpass/zero_check.json")
+        );
+        assert_eq!(
+            provider.get("timeout_ms").and_then(|value| value.as_u64()),
+            Some(300)
+        );
+    }
+
+    #[test]
+    fn test_security_gateway_rejects_legacy_top_level_provider_options() {
+        let toml = r#"
+bind = "0.0.0.0"
+port = 21000
+bots_base_dir = "/bots"
+
+[security_gateway]
+provider = "agentpass"
+dry_run = false
+endpoint = "/api/agentpass/zero_check.json"
+"#;
+
+        let err = toml::from_str::<BcsConfig>(toml)
+            .expect_err("legacy top-level provider options should be rejected");
+        assert!(err.to_string().contains("endpoint"));
     }
 
 }

--- a/src/bcs/crates/bootstrap/bcs/src/lib.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/lib.rs
@@ -155,7 +155,8 @@ pub mod logging;
 pub use config::{
     AuthSdkConfig, BcsConfig, CacheConfig, DatabaseConfig, DatabaseType, DingTalkAccountConfig,
     InviteConfig, LlmConfig, LlmProviderType, LoggingConfig, MessageHistoryConfig, MetricsConfig,
-    MetricsMode, MistConfig, RedisCacheConfig, StructuredOutputMode,
+    MetricsMode, MistConfig, RedisCacheConfig, SecurityGatewayProviderConfig,
+    StructuredOutputMode,
 };
 pub use error::{BcsError, Result};
 pub use plugins::{CachePluginKind, DbPluginKind, InfrastructurePlugins};

--- a/src/bcs/crates/bootstrap/bcs/src/plugins.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/plugins.rs
@@ -13,11 +13,12 @@ use bcs_db_api::DbPlugin;
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_db_mysql::{MysqlDbManager, MysqlDbPlugin};
 use bcs_llm_api::LlmChatCompletionPort;
+use bcs_security_gateway_api::SecurityGatewayPort;
 use bcs_service_api::LeaderElectionPort;
 use bcs_service_api::lifecycle::ServiceLifecycle;
 use futures::future::BoxFuture;
 
-use crate::config::{BcsConfig, DatabaseType};
+use crate::config::{BcsConfig, DatabaseType, SecurityGatewayProviderConfig};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CachePluginKind {
@@ -111,6 +112,23 @@ pub struct LeaderElectionFactory {
 
 inventory::collect!(LeaderElectionFactory);
 
+#[derive(Clone)]
+pub struct SecurityGatewayRegistration {
+    pub gateway: Arc<dyn SecurityGatewayPort>,
+}
+
+pub type SecurityGatewayBuild = fn(
+    BcsConfig,
+    SecurityGatewayProviderConfig,
+) -> crate::Result<SecurityGatewayRegistration>;
+
+pub struct SecurityGatewayFactory {
+    pub name: &'static str,
+    pub build: SecurityGatewayBuild,
+}
+
+inventory::collect!(SecurityGatewayFactory);
+
 async fn build_registered_cache_plugin(
     config: &BcsConfig,
     provider: &str,
@@ -155,6 +173,19 @@ pub async fn build_registered_leader_election(
     for factory in inventory::iter::<LeaderElectionFactory> {
         if factory.name == provider {
             return Ok(Some((factory.build)(config.clone(), provider_config).await?));
+        }
+    }
+    Ok(None)
+}
+
+pub fn build_registered_security_gateway(
+    config: &BcsConfig,
+    provider: &str,
+    provider_config: SecurityGatewayProviderConfig,
+) -> crate::Result<Option<SecurityGatewayRegistration>> {
+    for factory in inventory::iter::<SecurityGatewayFactory> {
+        if factory.name == provider {
+            return Ok(Some((factory.build)(config.clone(), provider_config)?));
         }
     }
     Ok(None)
@@ -438,6 +469,28 @@ mod tests {
         }
     }
 
+    fn test_security_gateway_factory(
+        _config: BcsConfig,
+        provider_config: SecurityGatewayProviderConfig,
+    ) -> crate::Result<SecurityGatewayRegistration> {
+        if provider_config.get("mode").and_then(|value| value.as_str()) != Some("allow") {
+            return Err(crate::BcsError::InvalidConfig(
+                "expected security gateway provider option mode = allow".to_string(),
+            ));
+        }
+
+        Ok(SecurityGatewayRegistration {
+            gateway: Arc::new(bcs_security_gateway_local::NoopSecurityGateway),
+        })
+    }
+
+    inventory::submit! {
+        SecurityGatewayFactory {
+            name: "test-security-options",
+            build: test_security_gateway_factory,
+        }
+    }
+
     #[test]
     fn default_config_selects_memory_cache_and_local_db_plugins() {
         let config = BcsConfig::default();
@@ -512,6 +565,37 @@ mod tests {
         .expect("leader factory should be registered");
 
         assert!(registration.leader.is_leader().await.expect("is leader"));
+    }
+
+    #[tokio::test]
+    async fn registered_security_gateway_factory_receives_provider_options() {
+        let mut provider_config = SecurityGatewayProviderConfig::new();
+        provider_config.insert(
+            "mode".to_string(),
+            serde_json::Value::String("allow".to_string()),
+        );
+
+        let registration = build_registered_security_gateway(
+            &BcsConfig::default(),
+            "test-security-options",
+            provider_config,
+        )
+        .expect("security gateway factory should build")
+        .expect("security gateway factory should be registered");
+
+        let request = bcs_security_gateway_api::SecurityCheckRequest {
+            sender_bot_id: "sender".to_string(),
+            receiver_bot_id: "receiver".to_string(),
+            sender_agent_code: None,
+            receiver_agent_code: None,
+            agent_token: None,
+            message_content: "hello".to_string(),
+            message_id: "msg-1".to_string(),
+        };
+        assert!(matches!(
+            registration.gateway.check(request).await,
+            bcs_security_gateway_api::SecurityVerdict::Allow { task_id: None }
+        ));
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -28,6 +28,7 @@ use crate::lifecycle::LifecycleOrchestrator;
 use crate::plugins::{
     DbPluginKind, InfrastructurePlugins, LeaderElectionRegistration,
     build_registered_leader_election, build_registered_llm_provider,
+    build_registered_security_gateway,
 };
 use bcs_bot::{Bot, BotCore, ProviderBotEvents, ProviderCore, ProviderManagement};
 use bcs_bot_store::{DbProviderStore, PersistentBotRepo, MemoryBotRepo, MemoryProviderStore};
@@ -523,7 +524,8 @@ impl Default for BcsServerState {
                 frontend_run_channels.clone(),
             ));
         let frontend_delivery = maybe_wrap_frontend_delivery(&config, raw_frontend_delivery);
-        let interceptors = create_interceptor_chain(&config);
+        let interceptors =
+            create_interceptor_chain(&config).expect("default security gateway config is valid");
         let cutoff_timestamp = config.message_history.cutoff_timestamp;
         let manager_worker_cutoff_timestamp =
             config.message_history.manager_worker_cutoff_timestamp;
@@ -1103,7 +1105,7 @@ fn create_message_flow_services(
     message_flow
 }
 
-fn create_interceptor_chain(config: &BcsConfig) -> Arc<InterceptorChain> {
+fn create_interceptor_chain(config: &BcsConfig) -> crate::Result<Arc<InterceptorChain>> {
     let mut chain = InterceptorChain::new();
 
     #[cfg(feature = "prometheus-metrics")]
@@ -1116,29 +1118,24 @@ fn create_interceptor_chain(config: &BcsConfig) -> Arc<InterceptorChain> {
     }
 
     let sg = &config.security_gateway;
-    // The open-source base only ships the noop/local backend. Real gateway
-    // backends (e.g. AgentPass) live in the Ant overlay and are injected at the
-    // overlay composition root, never selected here.
-    let gateway: Option<Arc<dyn SecurityGatewayPort>> = match sg.provider.as_str() {
-        "noop" => {
-            info!(provider = "noop", dry_run = sg.dry_run, "Initializing noop security gateway interceptor");
-            Some(Arc::new(NoopSecurityGateway))
-        }
-        other => {
-            warn!(
-                provider = %other,
-                "security_gateway provider not available in the open-source base \
-                 (real backends are injected by the Ant overlay); falling back to noop"
-            );
-            Some(Arc::new(NoopSecurityGateway))
-        }
+    let provider = sg.provider.trim();
+    let gateway: Arc<dyn SecurityGatewayPort> = if provider.is_empty() || provider == "noop" {
+        info!(provider = "noop", dry_run = sg.dry_run, "Initializing noop security gateway interceptor");
+        Arc::new(NoopSecurityGateway)
+    } else {
+        let provider_config = sg.providers.get(provider).cloned().unwrap_or_default();
+        build_registered_security_gateway(config, provider, provider_config)?
+            .ok_or_else(|| {
+                crate::BcsError::InvalidConfig(format!(
+                    "security_gateway provider '{provider}' is not available in this binary"
+                ))
+            })?
+            .gateway
     };
 
-    if let Some(gateway) = gateway {
-        chain.push(SecurityInterceptor::new(gateway, sg.dry_run));
-    }
+    chain.push(SecurityInterceptor::new(gateway, sg.dry_run));
 
-    Arc::new(chain)
+    Ok(Arc::new(chain))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1629,7 +1626,8 @@ impl BcsServer {
                 frontend_run_channels.clone(),
             ));
         let frontend_delivery = maybe_wrap_frontend_delivery(&config, raw_frontend_delivery);
-        let interceptors = create_interceptor_chain(&config);
+        let interceptors = create_interceptor_chain(&config)
+            .expect("security gateway config is valid for in-memory server");
         let cutoff_timestamp = config.message_history.cutoff_timestamp;
         let manager_worker_cutoff_timestamp =
             config.message_history.manager_worker_cutoff_timestamp;
@@ -2070,7 +2068,7 @@ impl BcsServer {
                 frontend_run_channels.clone(),
             ));
         let frontend_delivery = maybe_wrap_frontend_delivery(&config, raw_frontend_delivery);
-        let interceptors = create_interceptor_chain(&config);
+        let interceptors = create_interceptor_chain(&config)?;
         let cutoff_timestamp = config.message_history.cutoff_timestamp;
         let manager_worker_cutoff_timestamp =
             config.message_history.manager_worker_cutoff_timestamp;


### PR DESCRIPTION
Introduce a security gateway provider registry in the public BCS bootstrap so non-noop providers can be supplied by linked plugins instead of being hardcoded in the public binary.

Replace the provider-specific top-level security_gateway fields with a generic providers.<name> configuration map. This keeps public configuration provider-neutral, lets private plugins parse their own options, and rejects legacy top-level provider options instead of silently ignoring them.

Keep the open-source default on the noop security gateway and make missing non-noop providers fail startup with a clear InvalidConfig error rather than falling back to noop. This prevents deployments from believing a real security gateway is active when the provider plugin is not linked.

Tests: cargo test --manifest-path ocb-public/src/bcs/Cargo.toml --package bcs security_gateway --lib