### PR TITLE
feat(bcs): e2e line-coverage orchestration with parallel pre-push gate

### DIFF
--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -39,12 +39,6 @@ matches_any() {
   printf '%s\n' "$changed_files" | grep -Eq "$pattern"
 }
 
-run_required() {
-  echo ""
-  echo "== required: $* =="
-  "$@"
-}
-
 echo "base: $base"
 echo "head: $head"
 
@@ -55,7 +49,9 @@ fi
 
 if matches_any '^src/bcs/'; then
   if [[ "${OCB_PRE_PUSH_ENABLE_BCS:-1}" == "1" ]]; then
-    run_required "$repo_root/src/bcs/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail
+    echo ""
+    echo "== required: src/bcs/scripts/pre_push.sh --base $base --head $head =="
+    "$repo_root/src/bcs/scripts/pre_push.sh" --base "$base" --head "$head"
   else
     echo "bcs changes detected; BCS/BCN CI gate skipped (OCB_PRE_PUSH_ENABLE_BCS=0)"
   fi

--- a/scripts/modules/bcs.sh
+++ b/scripts/modules/bcs.sh
@@ -713,7 +713,7 @@ onboard_default_openclaw_if_connected() {
         return 0
     fi
 
-    local bcs_cli="${BCS_DIR}/target/debug/bcs-cli"
+    local bcs_cli; bcs_cli="$(bcs_cli_path)"
     if [ ! -x "$bcs_cli" ]; then
         log_warn "bcs-cli not found or not executable: ${bcs_cli}; skipping default OpenClaw onboard"
         return 0
@@ -780,7 +780,8 @@ start_bcs_binary() {
     mkdir -p "${BCS_DATA_DIR}"
 
     # Start BCS service
-    SERVER_ENV="${BCS_SERVER_ENV}" nohup ./target/debug/bcs >> "${BCS_LOG}" 2>&1 &
+    local bcs_bin="${BCS_BIN:-./target/debug/bcs}"
+    SERVER_ENV="${BCS_SERVER_ENV}" nohup "$bcs_bin" >> "${BCS_LOG}" 2>&1 &
     local bcs_pid=$!
 
     # Verify process started successfully

--- a/scripts/modules/bots.sh
+++ b/scripts/modules/bots.sh
@@ -585,7 +585,7 @@ bots_dynamic_start_openclaw() {
 
     profile_dir="$(bcs_bot_profile_dir "$profile")"
     workspace_dir="$(bots_dynamic_workspace_dir "$name" "$profile" "$source")"
-    bcs_cli_dir="${BCS_DIR}/target/debug"
+    bcs_cli_dir="$(dirname "$(bcs_cli_path)")"
     existing_pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
     if [ -n "$existing_pids" ]; then
         log_error "${name} port ${port} is already in use by PID(s): $(echo "$existing_pids" | tr '\n' ' ' | xargs)"
@@ -666,7 +666,7 @@ bots_dynamic_wait_ready() {
 }
 
 bots_dynamic_onboard() {
-    local bcs_cli="${BCS_DIR}/target/debug/bcs-cli"
+    local bcs_cli; bcs_cli="$(bcs_cli_path)"
     local name profile port source summary domains skills scopes profile_dir session_file token
 
     while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
@@ -936,7 +936,7 @@ bots_dynamic_prereqs() {
     fi
 
     if check_bcs_cli_binary; then
-        prereq_ok "bcs-cli: ${BCS_DIR}/target/debug/bcs-cli"
+        prereq_ok "bcs-cli: $(bcs_cli_path)"
     else
         prereq_error "bcs-cli not found. Run: $(singlebox_cmd setup bcs)"
         has_error=true
@@ -1352,7 +1352,7 @@ bots_prereqs() {
     fi
 
     if check_bcs_cli_binary; then
-        prereq_ok "bcs-cli: ${BCS_DIR}/target/debug/bcs-cli"
+        prereq_ok "bcs-cli: $(bcs_cli_path)"
     else
         prereq_error "bcs-cli not found. Run: $(singlebox_cmd setup bcs)"
         has_error=true

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -119,6 +119,7 @@ ENGINE_STATE_FILE="${LOG_DIR}/.engine_type"
 
 # ============ 运行模式 ============
 LOCAL_MODE=true
+with_bcs_coverage=0
 STANDALONE_MODE=false
 
 # Local Mode directories
@@ -397,6 +398,7 @@ show_help() {
     echo "  --profile-dir DIR            Bot persona source dir for 'bots' target; requires DIR/bots.json"
     echo "  --bcs-auto-onboard            Legacy compatibility flag; use bcs_bots for BCS + bots"
     echo "  --no-bcs-auto-onboard         Legacy compatibility flag; use bcs for BCS-only"
+    echo "  --with-bcs-coverage           Build instrumented bcs (target/cov-e2e) for e2e line coverage"
     echo "  -h, --help                    Show this help message"
     echo ""
     echo "Services:"
@@ -432,10 +434,80 @@ show_help() {
     echo ""
 }
 
+# 编译插编 bcs 到 target/cov-e2e/llvm-cov-target/ 并 export BCS_BIN/LLVM_PROFILE_FILE。
+# 由 --with-bcs-coverage 触发;缓存:已存在则 skip 编译。
+#
+# 路径布局:cargo llvm-cov report 从 <CARGO_TARGET_DIR>/llvm-cov-target/ 读 profraw
+# 和对象文件。故 build 时 CARGO_TARGET_DIR 必须 = target/cov-e2e/llvm-cov-target,
+# 使 bcs 落 .../llvm-cov-target/debug/bcs,profraw 也落 .../llvm-cov-target/*.profraw,
+# 与对象同层,report 一搜就对。
+prepare_bcs_coverage_bin() {
+    local cov_root="$BCS_DIR/target/cov-e2e"
+    local cov_dir="$cov_root/llvm-cov-target"
+    local cov_bin="$cov_dir/debug/bcs"
+
+    # 环境校验:cargo-llvm-cov + llvm-tools(rustup component list --installed
+    # 输出带 target 后缀,如 llvm-tools-x86_64-apple-darwin,用 ^llvm-tools 匹配)
+    if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+        log_error "cargo-llvm-cov not installed. Run: cargo install cargo-llvm-cov --locked"
+        exit 1
+    fi
+    if ! rustup component list --installed 2>/dev/null | grep -q '^llvm-tools'; then
+        log_error "llvm-tools component not installed. Run: rustup component add llvm-tools"
+        exit 1
+    fi
+
+    # Keep the profraw dir present even on a cache hit (it may have been pruned).
+    mkdir -p "$cov_dir"
+
+    if [[ ! -x "$cov_bin" ]] || [[ "${BCS_COVERAGE_FORCE_REBUILD:-0}" == "1" ]]; then
+        if [[ "${BCS_COVERAGE_FORCE_REBUILD:-0}" == "1" ]]; then
+            log_info "Force-rebuilding instrumented bcs (BCS_COVERAGE_FORCE_REBUILD=1)..."
+        else
+            log_info "Building instrumented bcs for coverage (target/cov-e2e/llvm-cov-target)..."
+        fi
+        (
+            cd "$BCS_DIR"
+            # Manually set RUSTFLAGS to instrument the cargo build. Don't use
+            # `source <(cargo llvm-cov show-env)` + a bare `cargo build` —
+            # cargo-llvm-cov 0.8.x's wrapper only injects instrumentation flags
+            # for `cargo llvm-cov <subcommand>`, so a bare build yields a binary
+            # with zeroed __llvm_profile symbols that writes no profraw.
+            # -Clink-dead-code keeps LLVM's uncalled functions so line coverage
+            # attribution has the full function table.
+            # LLVM_PROFILE_FILE here redirects profraw emitted during the build
+            # itself (build scripts / proc-macros run instrumented but without a
+            # profile path, defaulting to default-*.profraw in each crate's
+            # cwd). Pointing it at target/tmp keeps the source tree clean; those
+            # build-time profiles are excluded from the report anyway (--package
+            # bcs). Runtime profraw (the bcs binary) is controlled by the
+            # LLVM_PROFILE_FILE set later for actual runs.
+            export RUSTFLAGS="-Cinstrument-coverage -Clink-dead-code"
+            export CARGO_INCREMENTAL=0
+            export CARGO_PROFILE_DEV_DEBUG=line-tables-only
+            export CARGO_TARGET_DIR="$cov_dir"
+            local build_tmp="$BCS_DIR/target/tmp"
+            mkdir -p "$build_tmp"
+            export LLVM_PROFILE_FILE="$build_tmp/build-%m-%p.profraw"
+            cargo build --package bcs --package bcs-cli
+        ) || { log_error "coverage build failed"; exit 1; }
+    else
+        log_info "Reusing cached instrumented bcs: $cov_bin"
+    fi
+
+    export BCS_BIN="$cov_bin"
+    export BCS_CLI_BIN="$cov_dir/debug/bcs-cli"
+    export LLVM_PROFILE_FILE="$cov_dir/bcs-%m-%p.profraw"
+}
+
 # ============ 当前默认安装流程 (无参数调用) ============
 setup_all_and_start() {
     # 加载之前保存的引擎类型
     load_engine_type
+
+    if [[ "$with_bcs_coverage" -eq 1 ]]; then
+        prepare_bcs_coverage_bin
+    fi
 
     # 显示模式信息
     if [ "$STANDALONE_MODE" = true ]; then
@@ -571,6 +643,10 @@ main() {
                 BCS_AUTO_ONBOARD=0
                 shift
                 ;;
+            --with-bcs-coverage)
+                with_bcs_coverage=1
+                shift
+                ;;
             -h|--help)
                 show_help
                 exit 0
@@ -669,6 +745,9 @@ main() {
             ;;
         start)
             load_engine_type
+            if [[ "$with_bcs_coverage" -eq 1 ]]; then
+                prepare_bcs_coverage_bin
+            fi
             for svc in "${services[@]}"; do
                 start_service "$svc"
             done

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1000,9 +1000,16 @@ check_relay_installed() {
 
 # ============ BCS 检查 ============
 
+# Resolve the bcs server binary path. Honors BCS_BIN override (set by
+# --with-bcs-coverage, which builds bcs into target/cov-e2e/.../debug);
+# falls back to target/debug/bcs (matches start_bcs_binary's BCS_BIN usage).
+bcs_bin_path() {
+    echo "${BCS_BIN:-${BCS_DIR}/target/debug/bcs}"
+}
+
 # 检查 BCS binary 是否存在
 check_bcs_binary() {
-    local bcs_bin="${BCS_DIR}/target/debug/bcs"
+    local bcs_bin; bcs_bin="$(bcs_bin_path)"
     if [ -f "$bcs_bin" ] && [ -x "$bcs_bin" ]; then
         return 0
     else
@@ -1010,9 +1017,16 @@ check_bcs_binary() {
     fi
 }
 
+# Resolve the bcs-cli binary path. Honors BCS_CLI_BIN override (set by
+# --with-bcs-coverage, which builds bcs-cli into target/cov-e2e/.../debug
+# rather than the default target/debug); falls back to target/debug/bcs-cli.
+bcs_cli_path() {
+    echo "${BCS_CLI_BIN:-${BCS_DIR}/target/debug/bcs-cli}"
+}
+
 # 检查 bcs-cli binary 是否存在
 check_bcs_cli_binary() {
-    local bcs_cli="${BCS_DIR}/target/debug/bcs-cli"
+    local bcs_cli; bcs_cli="$(bcs_cli_path)"
     if [ -f "$bcs_cli" ] && [ -x "$bcs_cli" ]; then
         return 0
     else

--- a/src/bcs/.gitignore
+++ b/src/bcs/.gitignore
@@ -1,6 +1,15 @@
 # Build output
 /target/
 
+# Stray profraw from instrumented build scripts / proc-macros during
+# `cargo build` with RUSTFLAGS=-Cinstrument-coverage. These processes run
+# without LLVM_PROFILE_FILE and write default-*.profraw to cwd. Harmless
+# (cargo llvm-cov report only reads profraw under llvm-cov-target/), but
+# noisy and easy to accidentally commit. *.profraw catches the merged
+# output and any future naming too.
+default_*.profraw
+*.profraw
+
 # IDE
 /.idea/
 *.iml

--- a/src/bcs/scripts/e2e_coverage.sh
+++ b/src/bcs/scripts/e2e_coverage.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# BCS e2e line-coverage orchestration script (bcs-only, ported and trimmed
+# from ocb).
+# Flow: singlebox --with-bcs-coverage start bcs_bots -> e2e.sh -> SIGTERM bcs
+#       (flush profraw) -> singlebox stop bcs_bots -> cargo llvm-cov report
+#       --cobertura.
+#
+# Gate semantics:
+#   - e2e is always a 100% gate (no switch): any e2e failure makes the script
+#     exit with the non-zero e2e exit code.
+#   - --bcs-min defaults to 0: do not gate coverage, just collect; pass a value
+#     to additionally gate on line coverage.
+#   - The two are independent: e2e failure does not block aggregation
+#     (cobertura.xml is still produced), and low coverage does not block the
+#     exit code (default 0).
+#
+# Usage:
+#   bash src/bcs/scripts/e2e_coverage.sh              # full flow
+#   bash src/bcs/scripts/e2e_coverage.sh --skip-start # instrumented bcs already running; run e2e + stop + aggregate only
+#   bash src/bcs/scripts/e2e_coverage.sh --no-stop    # do not stop bcs after running (debug; no aggregation)
+#   bash src/bcs/scripts/e2e_coverage.sh --bcs-min 30 # additionally gate coverage >= 30%
+#   bash src/bcs/scripts/e2e_coverage.sh --force-rebuild # force-rebuild instrumented bcs (ignore cache)
+#
+# Coverage scope: bcs server (crate bcs) only; excludes the 5 bots / Python.
+
+repo_root="$(git rev-parse --show-toplevel)"
+bcs_dir="$repo_root/src/bcs"
+cov_dir="$bcs_dir/target/cov-e2e"
+out_xml="$cov_dir/cobertura.xml"
+report_file="$cov_dir/coverage.txt"
+bcs_port="${BCS_PORT:-21000}"
+bcs_min="${BCS_E2E_COVERAGE_MIN:-0}"
+
+skip_start=0
+no_stop=0
+force_rebuild=0
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --skip-start)   skip_start=1; shift ;;
+    --no-stop)      no_stop=1;    shift ;;
+    --bcs-min)
+      if [[ "$#" -lt 2 ]]; then
+        echo "Error: --bcs-min requires a value" >&2
+        exit 2
+      fi
+      bcs_min="$2"; shift 2 ;;
+    --force-rebuild) force_rebuild=1; shift ;;
+    -h|--help)      sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# With --force-rebuild, rebuild the instrumented bcs even when a cached binary
+# exists. The pre-push gate uses this so an up-to-date binary reflecting the
+# pushed source is exercised; cargo build is incremental so a no-op rebuild
+# only re-links.
+if [[ "$force_rebuild" -eq 1 ]]; then
+  export BCS_COVERAGE_FORCE_REBUILD=1
+fi
+
+# Trap fallback: SIGTERM bcs on early exit (set -e, etc.) so profraw flushes as
+# best it can. Install only when --no-stop is not set (avoid the contradiction
+# of --no-stop still killing bcs).
+cleanup_bcs() {
+  local pids
+  pids=$(lsof -tiTCP:"$bcs_port" -sTCP:LISTEN 2>/dev/null || true)
+  [[ -n "$pids" ]] && echo "$pids" | xargs kill -TERM 2>/dev/null || true
+}
+if [[ "$no_stop" -eq 0 ]]; then
+  trap cleanup_bcs EXIT
+fi
+
+# The 5 bot ports, matching the BOT1..BOT5_PORT defaults in scripts/modules/bcs.sh.
+bot_ports=(30001 30011 30021 30031 30041)
+
+# Preflight reclamation: the coverage bcs must be the instrumented build, and
+# bots_start hard-errors if any of 30001-30041 are occupied. So before launch,
+# if 21000 (bcs) or any bot port is already in use (leftover from a prior run /
+# a bcs_bots started elsewhere / full stack / non-singlebox processes), kill
+# the occupying bcs/openclaw processes with a warning, then start the
+# instrumented stack. Do NOT call `singlebox stop` here (it would also tear down
+# the frontend, which e2e does not need).
+# Skipped under --skip-start (caller takes responsibility for the instrumented bcs).
+preflight_reclaim_ports() {
+  local busy=() p
+  lsof -tiTCP:"$bcs_port" -sTCP:LISTEN >/dev/null 2>&1 && busy+=("$bcs_port")
+  for p in "${bot_ports[@]}"; do
+    lsof -tiTCP:"$p" -sTCP:LISTEN >/dev/null 2>&1 && busy+=("$p")
+  done
+  [ ${#busy[@]} -eq 0 ] && return 0
+
+  echo "WARN: ports busy (${busy[*]}); killing existing bcs/openclaw processes" >&2
+  local port pids
+  # SIGTERM first (openclaw exits cleanly, avoiding profile residue); SIGKILL
+  # anything still holding a port after 2s.
+  for port in "${busy[@]}"; do
+    pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    [ -n "$pids" ] && echo "$pids" | xargs kill 2>/dev/null || true
+  done
+  sleep 2
+  for port in "${busy[@]}"; do
+    pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null || true
+  done
+  sleep 1
+}
+
+# 1. Start the instrumented service + 5 bots (unless --skip-start).
+#    Uses --standalone so bot profiles live under <checkout>/.standalone-openclaw
+#    (per-checkout isolation) instead of the shared ~/.openclaw-* that --local
+#    writes. Without this, running in a second checkout/worktree collides with
+#    the first's ~/.openclaw-* stamps ("profile exists but does not match this
+#    singlebox local stack"). e2e.sh needs the 5 demo bots onboarded first
+#    (UUIDs resolved by name), so start bcs_bots not just bcs; otherwise
+#    GET /bots is empty and every resolution fails. bcs_bots = bcs + bots,
+#    no frontend (e2e needs none).
+if [[ "$skip_start" -eq 0 ]]; then
+  preflight_reclaim_ports
+  "$repo_root/scripts/singlebox.sh" --standalone --with-bcs-coverage start bcs_bots
+fi
+
+# 2. Run e2e (curl hits :21000, exercising the instrumented bcs; profraw is
+#    appended continuously). Do not let e2e failure abort aggregation: the
+#    coverage report is produced even on failure (a failing run is still useful
+#    to see what was covered).
+e2e_status=0
+bash "$bcs_dir/scripts/e2e-test/e2e.sh" || e2e_status=$?
+if [[ "$e2e_status" -ne 0 ]]; then
+  echo "WARN: e2e exited with $e2e_status; continuing to flush profraw and aggregate coverage." >&2
+fi
+
+# 3 & 4 & 5: stop bcs (SIGTERM flush) -> stop bots -> aggregate.
+if [[ "$no_stop" -eq 0 ]]; then
+  # 3. SIGTERM bcs, wait for graceful shutdown (max 30s), fall back to SIGKILL
+  #    on timeout (WARN, not fail). lsof may return multiple PIDs (e.g. socket
+  #    sharing or child processes), so signal via xargs and check liveness per
+  #    PID rather than quoting the multi-line string to a single kill.
+  bcs_pids=$(lsof -tiTCP:"$bcs_port" -sTCP:LISTEN 2>/dev/null || true)
+  if [[ -n "$bcs_pids" ]]; then
+    echo "--- SIGTERM bcs (pids=$(echo "$bcs_pids" | tr '\n' ' ')) to flush profraw ---"
+    echo "$bcs_pids" | xargs kill -TERM 2>/dev/null || true
+    still=""
+    for i in $(seq 1 30); do
+      still=""
+      while IFS= read -r p; do
+        [ -n "$p" ] && kill -0 "$p" 2>/dev/null && still="$still $p"
+      done <<< "$bcs_pids"
+      [ -z "$still" ] && break
+      sleep 1
+    done
+    still=""
+    while IFS= read -r p; do
+      [ -n "$p" ] && kill -0 "$p" 2>/dev/null && still="$still $p"
+    done <<< "$bcs_pids"
+    if [[ -n "$still" ]]; then
+      echo "WARN: bcs did not exit in 30s (pids:$still), SIGKILL (profraw may be incomplete)" >&2
+      echo "$still" | xargs kill -9 2>/dev/null || true
+    else
+      echo "--- bcs exited gracefully ---"
+    fi
+  else
+    echo "WARN: no bcs listening on :$bcs_port; skip SIGTERM" >&2
+  fi
+
+  # 4. Stop bots (bcs already stopped via SIGTERM; bots are non-Rust, so
+  #    SIGKILL is harmless). Stop bcs_bots only, not the frontend (e2e needs no
+  #    frontend; do not kill the user's dev server). Pass --standalone so singlebox
+  #    resolves the per-checkout standalone pid/profile paths started in step 1.
+  "$repo_root/scripts/singlebox.sh" --standalone stop bcs_bots
+
+  # 5. Aggregate cobertura + text table.
+  # Two report runs: one with --cobertura --output-path to produce the XML
+  # (--fail-under-lines enforces the threshold; --output-path consumes stdout);
+  # one plain-text pass into coverage.txt (per-file table for the record and for
+  # grepping TOTAL).
+  # --package bcs: coverage scope is the bcs server only. Onboarding invokes the
+  # instrumented bcs-cli (BCS_CLI_BIN points at the instrumented build), whose
+  # profraw lands in the same dir; -p bcs excludes bcs-cli lines from the report,
+  # upholding the "bcs server only" intent.
+  echo "--- aggregating coverage ---"
+  set +e
+  (
+    cd "$bcs_dir"
+    export CARGO_TARGET_DIR="$cov_dir"
+    cargo llvm-cov report --package bcs --cobertura \
+      --output-path "$out_xml" \
+      --fail-under-lines="$bcs_min" > /dev/null 2>&1
+    cobertura_status=$?
+    cargo llvm-cov report --package bcs > "$report_file" 2>&1
+    exit "$cobertura_status"
+  )
+  cov_status=$?
+  set -e
+
+  echo ""
+  echo "✓ Coverage report: $out_xml"
+  echo "--- summary ---"
+  grep '^TOTAL' "$report_file" || tail -20 "$report_file"
+
+  if [[ "$cov_status" -ne 0 ]]; then
+    echo "bcs coverage failed (threshold --bcs-min=$bcs_min not met); full report: $report_file" >&2
+    tail -40 "$report_file" >&2
+    # Coverage threshold failed: if e2e fully passed, exit with the coverage
+    # failure code.
+    [[ "$e2e_status" -eq 0 ]] && exit "$cov_status"
+  fi
+fi
+
+# Post-aggregation cleanup of profraw. The instrumented cargo build redirects
+# build-time profraw (build scripts / proc-macros, worthless to the report) to
+# src/bcs/target/tmp via LLVM_PROFILE_FILE (set in prepare_bcs_coverage_bin),
+# so they never touch the source tree. As a belt-and-suspenders guard, also
+# remove any default-*.profraw that an older code path may still write into the
+# source tree. Runtime profraw under cov_dir is already merged into
+# cobertura.xml/coverage.txt; clear it too. Skipped under --no-stop (debugging
+# may still want them).
+if [[ "$no_stop" -eq 0 ]]; then
+  removed=0
+  while IFS= read -r -d '' f; do rm -f "$f"; removed=$((removed + 1)); done \
+    < <(find "$bcs_dir" -name 'default_*.profraw' -not -path '*/target/*' -print0 2>/dev/null)
+  if [[ "$removed" -gt 0 ]]; then
+    echo "Cleaned up $removed stray profraw file(s) from bcs source tree"
+  fi
+  # cov_dir contains the llvm-cov-target/ subdirectory where runtime profraw
+  # (e.g. bcs-*.profraw) lands; recursively delete all profraw under cov_dir
+  # (already merged into cobertura.xml/coverage.txt). Also clear build-time
+  # profraw redirected to src/bcs/target/tmp so it doesn't accumulate across runs.
+  find "$cov_dir" -name '*.profraw' -delete 2>/dev/null || true
+  find "$bcs_dir/target/tmp" -name '*.profraw' -delete 2>/dev/null || true
+fi
+
+# The e2e exit code is the script's final exit code (e2e is always a 100% gate).
+exit "$e2e_status"

--- a/src/bcs/scripts/pre_push.sh
+++ b/src/bcs/scripts/pre_push.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# BCS pre-push gates: unit tests (nextest, fast-fail) + e2e line coverage
+# (instrumented bcs + 5 bots, --bcs-min 30) — run in parallel with fail-fast.
+#
+# Invoked by scripts/ci/pre_push.sh when the push range touches src/bcs/.
+# Mirrors ci_test.sh's --base/--head contract and OCB_PRE_PUSH_ENABLE_BCS*
+# opt-out flags.
+#
+# Usage:
+#   bash src/bcs/scripts/pre_push.sh --base <base> --head <head>
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+bcs_dir="$repo_root/src/bcs"
+
+base=""
+head="HEAD"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --base)
+      if [[ "$#" -lt 2 ]]; then
+        echo "Error: --base requires a value" >&2
+        exit 2
+      fi
+      base="$2"; shift 2 ;;
+    --head)
+      if [[ "$#" -lt 2 ]]; then
+        echo "Error: --head requires a value" >&2
+        exit 2
+      fi
+      head="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,11p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+run_required() {
+  echo ""
+  echo "== required: $* =="
+  "$@"
+}
+
+# ----------------------------------------------------------------------------
+# Parallel-gate helpers (Bash 3.2 compatible: no associative arrays, no wait -n)
+# ----------------------------------------------------------------------------
+_PREPUSH_LOG_DIR="$repo_root/scripts/.dependencies/logs/prepush"
+
+# _kill_tree <pid> [signal] — recursively terminate a process and all its
+# descendants. Portable (no `setsid`); macOS ships pgrep/pkill in /usr/bin.
+# Descendants first so a parent's exit traps/cleanup don't re-spawn them.
+_kill_tree() {
+  local pid="$1" sig="${2:-TERM}"
+  local child
+  while IFS= read -r child; do
+    [ -n "$child" ] && _kill_tree "$child" "$sig"
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+  kill -"$sig" "$pid" 2>/dev/null || true
+}
+
+# _exit_rc <exitfile> -> the exit code recorded in <exitfile>, sanitized:
+# strip whitespace and default to 124 (timeout/abnormal) when missing/empty.
+# An empty or non-numeric value would otherwise break `[[ "$rc" -ne 0 ]]`.
+_exit_rc() {
+  local rc
+  rc=$(cat "$1" 2>/dev/null || true)
+  rc="${rc//[[:space:]]/}"
+  echo "${rc:-124}"
+}
+
+# _launch_tagged <tag> <exitfile> <cmd...>
+# Runs cmd in a background subshell; combined stdout+stderr is teed through a
+# FIFO to a line-prefixer that tags every line "[<tag>] ..." for interleaved-
+# but-tidy live output, and a copy is written to <tag>.log. The command's exit
+# code is written to <exitfile> so the scheduler can detect completion. Sets
+# globals _TASK_READER (prefixer pid) and _TASK_PID (producer pid); use
+# _kill_tree on the latter to tear the whole tree down on fail-fast.
+_launch_tagged() {
+  local tag="$1" exitfile="$2"; shift 2
+  local fifo="$_PREPUSH_LOG_DIR/pipe.$tag"
+  local logfile="$_PREPUSH_LOG_DIR/$tag.log"
+  rm -f "$fifo" "$exitfile"
+  mkfifo "$fifo"
+  # `[[ -n "$line" ]]` lets the loop capture a final line lacking a trailing
+  # newline (read returns non-zero on EOF even when it read a partial line),
+  # so the last tagged line is never dropped.
+  ( while IFS= read -r line || [[ -n "$line" ]]; do
+      printf '%s\n' "[$tag] $line"
+    done < "$fifo" ) &
+  _TASK_READER=$!
+  # Pass fifo/logfile/exitfile as positional args instead of interpolating them
+  # into the bash -c string; the nested-quoting form is fragile for paths with
+  # special characters.
+  bash -c '
+    set +em
+    fifo="$1"; logfile="$2"; exitfile="$3"; shift 3
+    "$@" 2>&1 | tee "$fifo" >"$logfile"
+    printf "%s\n" "${PIPESTATUS[0]}" > "$exitfile"
+  ' _ "$fifo" "$logfile" "$exitfile" "$@" < /dev/null &
+  _TASK_PID=$!
+  disown "$_TASK_PID" 2>/dev/null || true
+}
+
+# Run the unit and e2e-coverage gates in parallel with fail-fast. Both gates
+# share no resources (isolated CARGO_TARGET_DIR, ephemeral unit-test ports vs
+# fixed 21000/3000x in e2e, temp vs shared data dirs), so concurrent execution
+# is safe. Output is line-tagged via FIFO so streams interleave cleanly; a
+# per-gate PASSED/FAIL/KILLED summary block is printed at the end. The first
+# gate to exit non-zero terminates the other's whole process tree and blocks
+# the push. Returns non-zero on any failure.
+bcs_parallel_gates() {
+  local base="$1" head="$2"
+  mkdir -p "$_PREPUSH_LOG_DIR"
+  local unit_log="$_PREPUSH_LOG_DIR/unit.log"
+  local e2e_log="$_PREPUSH_LOG_DIR/e2e.log"
+  local unit_exit="$_PREPUSH_LOG_DIR/unit.exit"
+  local e2e_exit="$_PREPUSH_LOG_DIR/e2e.exit"
+  rm -f "$unit_log" "$e2e_log"
+
+  echo ""
+  echo "== launching bcs gates in parallel =="
+  printf '  unit: src/bcs/scripts/ci_test.sh --fast-fail   (log: %s)\n' "$unit_log"
+  printf '  e2e:  src/bcs/scripts/e2e_coverage.sh --bcs-min 30 --force-rebuild   (log: %s)\n' "$e2e_log"
+  echo ""
+
+  _launch_tagged unit "$unit_exit" \
+    "$bcs_dir/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail
+  local u_reader=$_TASK_READER u_pid=$_TASK_PID
+  _launch_tagged e2e "$e2e_exit" \
+    "$bcs_dir/scripts/e2e_coverage.sh" --bcs-min 30 --force-rebuild
+  local e_reader=$_TASK_READER e_pid=$_TASK_PID
+
+  # Wait for the first gate to finish (exitfile written) or die abnormally.
+  local first_tag="" first_rc="124"
+  while true; do
+    if [[ -f "$unit_exit" ]]; then first_tag=unit; first_rc=$(_exit_rc "$unit_exit"); break; fi
+    if [[ -f "$e2e_exit" ]]; then first_tag=e2e; first_rc=$(_exit_rc "$e2e_exit"); break; fi
+    # Abnormal: process gone without writing exit (e.g. SIGKILL).
+    if ! kill -0 "$u_pid" 2>/dev/null; then first_tag=unit; first_rc=124; break; fi
+    if ! kill -0 "$e_pid" 2>/dev/null; then first_tag=e2e; first_rc=124; break; fi
+    sleep 1
+  done
+
+  local unit_state e2e_state unit_rc e2e_rc
+  if [[ "$first_rc" -ne 0 ]]; then
+    # Fail-fast: terminate the other gate's whole process tree.
+    if [[ "$first_tag" == unit ]]; then
+      unit_rc="$first_rc"; unit_state="FAIL"
+      _kill_tree "$e_pid" TERM
+      e2e_rc=124; e2e_state="KILLED"
+    else
+      e2e_rc="$first_rc"; e2e_state="FAIL"
+      _kill_tree "$u_pid" TERM
+      unit_rc=124; unit_state="KILLED"
+    fi
+    # Give whoever is being torn down a moment to flush log lines, then reap.
+    sleep 1
+    wait "$u_reader" 2>/dev/null || true
+    wait "$e_reader" 2>/dev/null || true
+  else
+    # First gate passed; wait for the second.
+    if [[ "$first_tag" == unit ]]; then
+      unit_rc="$first_rc"; unit_state="PASS"
+      while ! [[ -f "$e2e_exit" ]] && kill -0 "$e_pid" 2>/dev/null; do sleep 1; done
+      e2e_rc=$(_exit_rc "$e2e_exit")
+    else
+      e2e_rc="$first_rc"; e2e_state="PASS"
+      while ! [[ -f "$unit_exit" ]] && kill -0 "$u_pid" 2>/dev/null; do sleep 1; done
+      unit_rc=$(_exit_rc "$unit_exit")
+    fi
+    [[ "$unit_rc" -eq 0 ]] && unit_state="PASS" || unit_state="FAIL"
+    [[ "$e2e_rc" -eq 0 ]] && e2e_state="PASS" || e2e_state="FAIL"
+    wait "$u_reader" 2>/dev/null || true
+    wait "$e_reader" 2>/dev/null || true
+  fi
+
+  echo ""
+  echo "================== BCS pre-push gates: summary =================="
+  printf '  unit (ci_test.sh)        %s  (rc=%s)\n' "$unit_state" "$unit_rc"
+  printf '  e2e  (e2e_coverage.sh)   %s  (rc=%s)\n' "$e2e_state" "$e2e_rc"
+  printf 'logs:\n  unit: %s\n  e2e:  %s\n' "$unit_log" "$e2e_log"
+
+  if [[ "$unit_rc" -ne 0 || "$e2e_rc" -ne 0 ]]; then
+    local fail_tag fail_log fail_rc
+    if [[ "$e2e_rc" -ne 0 ]]; then fail_tag=e2e; fail_log="$e2e_log"; fail_rc="$e2e_rc"
+    else fail_tag=unit; fail_log="$unit_log"; fail_rc="$unit_rc"; fi
+    echo ""
+    echo "Result: push BLOCKED — failing gate: $fail_tag (rc=$fail_rc)."
+    echo "--- last 40 lines of $fail_tag log ($fail_log) ---"
+    tail -n 40 "$fail_log" 2>/dev/null || true
+    echo "--- end ---"
+    return 1
+  fi
+  echo "Result: PASSED — both gates green."
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Dispatch
+# ----------------------------------------------------------------------------
+unit_on=1; e2e_on=1
+[[ "${OCB_PRE_PUSH_ENABLE_BCS:-1}" == "1" ]] || unit_on=0
+[[ "${OCB_PRE_PUSH_ENABLE_BCS_E2E:-1}" == "1" ]] || e2e_on=0
+
+if [[ $unit_on -eq 0 && $e2e_on -eq 0 ]]; then
+  echo "bcs changes detected; BCS gates skipped (OCB_PRE_PUSH_ENABLE_BCS=0 OCB_PRE_PUSH_ENABLE_BCS_E2E=0)"
+elif [[ $unit_on -eq 1 && $e2e_on -eq 1 ]]; then
+  bcs_parallel_gates "$base" "$head"
+elif [[ $unit_on -eq 1 ]]; then
+  run_required "$bcs_dir/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail
+else
+  run_required "$bcs_dir/scripts/e2e_coverage.sh" --bcs-min 30 --force-rebuild
+fi

--- a/src/bcs/scripts/start_bcs_bots.sh
+++ b/src/bcs/scripts/start_bcs_bots.sh
@@ -40,9 +40,9 @@ fi
 export BCS_API_BASE_URL
 export BCS_CONFIG_DIR
 export MOLTIS_BCS_CONFIG
-BCS_CLI="$PROJECT_ROOT/target/debug/bcs-cli"
+BCS_CLI="${BCS_CLI_BIN:-$PROJECT_ROOT/target/debug/bcs-cli}"
 BCS_ADMIN="$PROJECT_ROOT/target/debug/bcs-admin"
-BCS_BIN="$PROJECT_ROOT/target/debug/bcs"
+BCS_BIN="${BCS_BIN:-$PROJECT_ROOT/target/debug/bcs}"
 # use monorepo plugin source
 BCN_PLUGIN_SRC_DIR="$PROJECT_ROOT/../../src/plugin/packages/openclaw-channel-bcn"
 BCN_PLUGIN_PACKAGE_DIR="$BCN_PLUGIN_SRC_DIR/package"
@@ -989,8 +989,8 @@ start_bcs() {
     # ------------------------------------------------------------------------
     if [ "${BCS_AUTH_MOCK:-0}" = "1" ]; then
         export BCS_AUTH_MOCK=1
-        export BCS_MOCK_USER_ID="${BCS_MOCK_USER_ID:-11111111}"
-        export BCS_MOCK_USER_NICK_NAME="${BCS_MOCK_USER_NICK_NAME:-Local Developer}"
+        export BCS_MOCK_USER_ID="${BCS_MOCK_USER_ID:-001}"
+        export BCS_MOCK_USER_NICK_NAME="${BCS_MOCK_USER_NICK_NAME:-admin}"
         export BCS_MOCK_USER_CHANNEL="${BCS_MOCK_USER_CHANNEL:-mock}"
         warn "BCS_AUTH_MOCK enabled: user_id=$BCS_MOCK_USER_ID nick_name=$BCS_MOCK_USER_NICK_NAME channel=$BCS_MOCK_USER_CHANNEL" >&2
     fi


### PR DESCRIPTION
Add an end-to-end coverage pipeline for the BCS server, exercised by the e2e-test suite and gated on the pre-push hook. e2e_coverage.sh starts the instrumented bcs plus 5 demo bots via singlebox --standalone, runs e2e-test/e2e.sh, SIGTERMs bcs to flush profraw, stops bcs_bots, then aggregates Cobertura plus a text table via cargo llvm-cov report --package bcs. e2e is a 100% gate; --bcs-min additionally gates line coverage.

prepare_bcs_coverage_bin builds instrumented bcs/bcs-cli into an isolated target/cov-e2e dir with -Cinstrument-coverage/-Clink-dead-code and exports BCS_BIN/BCS_CLI_BIN plus the runtime LLVM_PROFILE_FILE. --force-rebuild bypasses the cache so the pre-push gate exercises the pushed source. Build-time profraw from build scripts and proc-macros is redirected to src/bcs/target/tmp, keeping the source tree clean; all profraw is cleared after aggregation, and *.profraw is gitignored. bcs_bin_path/bcs_cli_path honor the coverage overrides so check_bcs_*_binary, bots/bcs onboarding, and start_bcs_bots.sh work after rm -r target. A preflight step reclaims busy bcs/bot ports by SIGTERM/SIGKILL so re-runs don't fail, without touching the frontend (e2e needs none).

The bot stack starts in --standalone mode so profiles live under <checkout>/.standalone-openclaw per-checkout instead of the shared ~/.openclaw-* that --local stamps with the first checkout's workspace; without this the e2e-coverage gate fails in a second checkout/worktree ("profile exists but does not match this singlebox local stack").

The BCS pre-push gate (src/bcs/scripts/pre_push.sh, mirroring ci_test.sh's --base/--head contract) runs the unit (nextest, fast-fail) and e2e-coverage gates concurrently with fail-fast: the first gate to exit non-zero terminates the other's whole process tree (_kill_tree via pgrep, portable without setsid) and blocks the push. Output is line-tagged via FIFO ([unit]/[e2e]) so the interleaved streams stay atomic; a per-gate PASSED/FAIL/KILLED summary block is printed at the end, with full logs under scripts/.dependencies/logs/prepush/. The generic scripts/ci/pre_push.sh just computes the push range, gates on OCB_PRE_PUSH_ENABLE_BCS, and delegates. OCB_PRE_PUSH_ENABLE_BCS=0 / OCB_PRE_PUSH_ENABLE_BCS_E2E=0 opt out (the latter selects serial unit-only).

Tests: rm -r src/bcs/target then bash src/bcs/scripts/e2e_coverage.sh --bcs-min 30 --force-rebuild (e2e 38/38, ~37.8% > 30%, 0 stray profraw); scripts/ci/pre_push.sh --base HEAD~2 --head HEAD over a src/bcs/ range delegates to src/bcs/scripts/pre_push.sh -> unit 2066/2066 + e2e 38/38 @37.76% > 30%, exit 0; reproduced the ~/.openclaw-* collision in .worktrees/bugfix and confirmed it passes with --standalone (40/40). Synthetic both-pass and fail-fast stubs verify tagging and process-tree teardown.