### PR TITLE
feat(bcs): add pluggable user directory support

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -138,6 +138,12 @@ max_keep_days = 7
 hyper = "warn"
 tower_http = "warn"
 
+[user_directory]
+# Optional external user directory. Enable this only when the selected provider
+# plugin is linked into the binary, then put provider-specific options under
+# [user_directory.providers.<provider>].
+enabled = false
+
 [auth]
 chain = ["oauth_session"]
 require_authentication = true

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -113,6 +113,12 @@ app_name = "bcs"
 remote_server_domain = ""
 use_remote_login_check = false
 
+[user_directory]
+# Optional external user directory. Public local builds keep this disabled;
+# linked plugins can enable a provider and pass options under
+# [user_directory.providers.<provider>].
+enabled = false
+
 [auth]
 chain = ["local", "session"]
 require_authentication = false

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -19,6 +19,7 @@ pub use bcs_config_api::{
     AuthChainConfig, AuthSdkConfig, DingTalkAccountConfig, FusionProviderConfig, LlmConfig,
     LlmProviderType, LogOutputConfig, LogOutputFormat, LoggingConfig, ManifestConfig,
     LeaderElectionConfig, StructuredOutputMode, SecurityConfig,
+    UserDirectoryConfig, UserDirectoryProviderConfig,
     deserialize_optional_secret, serialize_optional_secret,
 };
 #[allow(unused_imports)]
@@ -263,6 +264,11 @@ pub struct BcsConfig {
     /// and bot ownership verification.
     #[serde(default)]
     pub auth_sdk: AuthSdkConfig,
+
+    /// External user directory used to resolve stable user ids to display
+    /// metadata. Disabled by default; providers are supplied by linked plugins.
+    #[serde(default)]
+    pub user_directory: UserDirectoryConfig,
 
     /// Auth plugin chain configuration (`[auth]` section). Selects which auth
     /// plugins are enabled and in what order. Empty/omitted → build-profile
@@ -601,6 +607,7 @@ impl Default for BcsConfig {
             logging: LoggingConfig::default(),
             bcsfuse: BcsFuseConfig::default(),
             auth_sdk: AuthSdkConfig::default(),
+            user_directory: UserDirectoryConfig::default(),
             auth: AuthChainConfig::default(),
             cors: CorsConfig::default(),
             group_logger: None,
@@ -1909,6 +1916,59 @@ endpoint = "/api/agentpass/zero_check.json"
         let err = toml::from_str::<BcsConfig>(toml)
             .expect_err("legacy top-level provider options should be rejected");
         assert!(err.to_string().contains("endpoint"));
+    }
+
+    #[test]
+    fn test_user_directory_provider_options_parse_as_map() {
+        let toml = r#"
+bind = "0.0.0.0"
+port = 21000
+bots_base_dir = "/bots"
+
+[user_directory]
+enabled = true
+provider = "ldap"
+
+[user_directory.providers.ldap]
+base_url = "https://directory.example.com"
+timeout_ms = 300
+"#;
+
+        let config: BcsConfig = toml::from_str(toml).unwrap();
+        let provider = config
+            .user_directory
+            .providers
+            .get("ldap")
+            .expect("ldap provider config");
+
+        assert!(config.user_directory.enabled);
+        assert_eq!(config.user_directory.provider.as_deref(), Some("ldap"));
+        assert_eq!(
+            provider.get("base_url").and_then(|value| value.as_str()),
+            Some("https://directory.example.com")
+        );
+        assert_eq!(
+            provider.get("timeout_ms").and_then(|value| value.as_u64()),
+            Some(300)
+        );
+    }
+
+    #[test]
+    fn test_user_directory_rejects_legacy_top_level_provider_options() {
+        let toml = r#"
+bind = "0.0.0.0"
+port = 21000
+bots_base_dir = "/bots"
+
+[user_directory]
+enabled = true
+provider = "ldap"
+base_url = "https://directory.example.com"
+"#;
+
+        let err = toml::from_str::<BcsConfig>(toml)
+            .expect_err("legacy top-level provider options should be rejected");
+        assert!(err.to_string().contains("base_url"));
     }
 
 }

--- a/src/bcs/crates/bootstrap/bcs/src/lib.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/lib.rs
@@ -156,7 +156,7 @@ pub use config::{
     AuthSdkConfig, BcsConfig, CacheConfig, DatabaseConfig, DatabaseType, DingTalkAccountConfig,
     InviteConfig, LlmConfig, LlmProviderType, LoggingConfig, MessageHistoryConfig, MetricsConfig,
     MetricsMode, MistConfig, RedisCacheConfig, SecurityGatewayProviderConfig,
-    StructuredOutputMode,
+    StructuredOutputMode, UserDirectoryConfig, UserDirectoryProviderConfig,
 };
 pub use error::{BcsError, Result};
 pub use plugins::{CachePluginKind, DbPluginKind, InfrastructurePlugins};

--- a/src/bcs/crates/bootstrap/bcs/src/plugins.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/plugins.rs
@@ -16,9 +16,12 @@ use bcs_llm_api::LlmChatCompletionPort;
 use bcs_security_gateway_api::SecurityGatewayPort;
 use bcs_service_api::LeaderElectionPort;
 use bcs_service_api::lifecycle::ServiceLifecycle;
+use bcs_user_directory_api::UserDirectoryPlugin;
 use futures::future::BoxFuture;
 
-use crate::config::{BcsConfig, DatabaseType, SecurityGatewayProviderConfig};
+use crate::config::{
+    BcsConfig, DatabaseType, SecurityGatewayProviderConfig, UserDirectoryProviderConfig,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CachePluginKind {
@@ -129,6 +132,21 @@ pub struct SecurityGatewayFactory {
 
 inventory::collect!(SecurityGatewayFactory);
 
+#[derive(Clone)]
+pub struct UserDirectoryRegistration {
+    pub plugin: Arc<dyn UserDirectoryPlugin>,
+}
+
+pub type UserDirectoryBuild =
+    fn(BcsConfig, UserDirectoryProviderConfig) -> crate::Result<UserDirectoryRegistration>;
+
+pub struct UserDirectoryFactory {
+    pub name: &'static str,
+    pub build: UserDirectoryBuild,
+}
+
+inventory::collect!(UserDirectoryFactory);
+
 async fn build_registered_cache_plugin(
     config: &BcsConfig,
     provider: &str,
@@ -184,6 +202,19 @@ pub fn build_registered_security_gateway(
     provider_config: SecurityGatewayProviderConfig,
 ) -> crate::Result<Option<SecurityGatewayRegistration>> {
     for factory in inventory::iter::<SecurityGatewayFactory> {
+        if factory.name == provider {
+            return Ok(Some((factory.build)(config.clone(), provider_config)?));
+        }
+    }
+    Ok(None)
+}
+
+pub fn build_registered_user_directory(
+    config: &BcsConfig,
+    provider: &str,
+    provider_config: UserDirectoryProviderConfig,
+) -> crate::Result<Option<UserDirectoryRegistration>> {
+    for factory in inventory::iter::<UserDirectoryFactory> {
         if factory.name == provider {
             return Ok(Some((factory.build)(config.clone(), provider_config)?));
         }
@@ -491,6 +522,46 @@ mod tests {
         }
     }
 
+    struct TestUserDirectoryPlugin;
+
+    #[async_trait::async_trait]
+    impl UserDirectoryPlugin for TestUserDirectoryPlugin {
+        async fn lookup_by_staff_no(
+            &self,
+            staff_no: &str,
+        ) -> Result<
+            Option<bcs_user_directory_api::UserDirectoryProfile>,
+            bcs_user_directory_api::UserDirectoryError,
+        > {
+            Ok(Some(bcs_user_directory_api::UserDirectoryProfile {
+                staff_no: staff_no.to_string(),
+                nick_name: Some("test-user".to_string()),
+            }))
+        }
+    }
+
+    fn test_user_directory_factory(
+        _config: BcsConfig,
+        provider_config: UserDirectoryProviderConfig,
+    ) -> crate::Result<UserDirectoryRegistration> {
+        if provider_config.get("source").and_then(|value| value.as_str()) != Some("unit") {
+            return Err(crate::BcsError::InvalidConfig(
+                "expected user directory provider option source = unit".to_string(),
+            ));
+        }
+
+        Ok(UserDirectoryRegistration {
+            plugin: Arc::new(TestUserDirectoryPlugin),
+        })
+    }
+
+    inventory::submit! {
+        UserDirectoryFactory {
+            name: "test-user-directory-options",
+            build: test_user_directory_factory,
+        }
+    }
+
     #[test]
     fn default_config_selects_memory_cache_and_local_db_plugins() {
         let config = BcsConfig::default();
@@ -596,6 +667,32 @@ mod tests {
             registration.gateway.check(request).await,
             bcs_security_gateway_api::SecurityVerdict::Allow { task_id: None }
         ));
+    }
+
+    #[tokio::test]
+    async fn registered_user_directory_factory_receives_provider_options() {
+        let mut provider_config = UserDirectoryProviderConfig::new();
+        provider_config.insert(
+            "source".to_string(),
+            serde_json::Value::String("unit".to_string()),
+        );
+
+        let registration = build_registered_user_directory(
+            &BcsConfig::default(),
+            "test-user-directory-options",
+            provider_config,
+        )
+        .expect("user directory factory should build")
+        .expect("user directory factory should be registered");
+
+        let profile = registration
+            .plugin
+            .lookup_by_staff_no("197262")
+            .await
+            .expect("lookup should succeed")
+            .expect("profile should be found");
+        assert_eq!(profile.staff_no, "197262");
+        assert_eq!(profile.nick_name.as_deref(), Some("test-user"));
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -28,7 +28,7 @@ use crate::lifecycle::LifecycleOrchestrator;
 use crate::plugins::{
     DbPluginKind, InfrastructurePlugins, LeaderElectionRegistration,
     build_registered_leader_election, build_registered_llm_provider,
-    build_registered_security_gateway,
+    build_registered_security_gateway, build_registered_user_directory,
 };
 use bcs_bot::{Bot, BotCore, ProviderBotEvents, ProviderCore, ProviderManagement};
 use bcs_bot_store::{DbProviderStore, PersistentBotRepo, MemoryBotRepo, MemoryProviderStore};
@@ -429,8 +429,34 @@ fn build_provider_services_with_webhook_url_guard(
     (provider_core, provider_bot_core, provider_management)
 }
 
-fn create_user_directory_plugin(_config: &BcsConfig) -> Option<Arc<dyn UserDirectoryPlugin>> {
-    None
+fn create_user_directory_plugin(
+    config: &BcsConfig,
+) -> crate::Result<Option<Arc<dyn UserDirectoryPlugin>>> {
+    let directory = &config.user_directory;
+    if !directory.enabled {
+        return Ok(None);
+    }
+
+    let provider = directory
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+        .ok_or_else(|| {
+            crate::BcsError::InvalidConfig(
+                "user_directory.provider is required when user_directory.enabled = true"
+                    .to_string(),
+            )
+        })?;
+
+    let provider_config = directory.providers.get(provider).cloned().unwrap_or_default();
+    build_registered_user_directory(config, provider, provider_config)?
+        .ok_or_else(|| {
+            crate::BcsError::InvalidConfig(format!(
+                "user_directory provider '{provider}' is not available in this binary"
+            ))
+        })
+        .map(|registration| Some(registration.plugin))
 }
 
 fn create_provider_stream_gray_list(config: &BcsConfig) -> Arc<ProviderStreamGrayList> {
@@ -464,7 +490,8 @@ impl Default for BcsServerState {
         // F.1/F.2 dual-write wiring: relation store must be created BEFORE
         // friend_store and provider_management so it can be injected into both.
         let relation_store: Arc<RelationCore> = Arc::new(RelationCore::memory());
-        let user_directory = create_user_directory_plugin(&config);
+        let user_directory = create_user_directory_plugin(&config)
+            .expect("default user directory config is valid");
         let (provider_core, provider_bot_core, provider_management) =
             build_provider_services_with_webhook_url_guard(
                 &provider_repos,
@@ -1558,7 +1585,8 @@ impl BcsServer {
         // F.1/F.2 dual-write wiring: relation store must be created BEFORE
         // friend_store and provider_management so it can be injected into both.
         let relation_store: Arc<RelationCore> = Arc::new(RelationCore::memory());
-        let user_directory = create_user_directory_plugin(&config);
+        let user_directory = create_user_directory_plugin(&config)
+            .expect("user directory config is valid for in-memory server");
         let (provider_core, provider_bot_core, provider_management) =
             build_provider_services_with_webhook_url_guard(
                 &provider_repos,
@@ -1870,10 +1898,10 @@ impl BcsServer {
         use bcs_service_api::BotRegistryCoreService;
 
         let outbound_url_guard = outbound_url_guard_from_config(&config);
-        let user_directory = extensions
-            .user_directory_plugin
-            .clone()
-            .or_else(|| create_user_directory_plugin(&config));
+        let user_directory = match extensions.user_directory_plugin.clone() {
+            Some(plugin) => Some(plugin),
+            None => create_user_directory_plugin(&config)?,
+        };
         info!(
             cache_plugin = %infrastructure_plugins.cache_kind(),
             db_plugin = %infrastructure_plugins.db_kind(),

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1619,17 +1619,18 @@ impl BcsServer {
 
         let (fusion, fuse_client) = create_fusion_service(&config);
         let bot_connections = Arc::new(BotConnectionRegistry::new());
-        let bot_use_cases = Arc::new(
-            Bot::new_with_friend(bot_registry.clone(), friend_store.clone())
-                .with_bot_core(bot_core_arc.clone())
-                .with_relation(
-                    relation_store.clone() as Arc<dyn bcs_service_api::RelationCoreService>
-                )
-                .with_connection_control(
-                    bot_connections.clone()
-                        as Arc<dyn bcs_service_api::BotConnectionControlPort>,
-                ),
-        );
+        let mut bot_use_cases = Bot::new_with_friend(bot_registry.clone(), friend_store.clone())
+            .with_bot_core(bot_core_arc.clone())
+            .with_relation(
+                relation_store.clone() as Arc<dyn bcs_service_api::RelationCoreService>
+            )
+            .with_connection_control(
+                bot_connections.clone() as Arc<dyn bcs_service_api::BotConnectionControlPort>
+            );
+        if let Some(user_directory) = user_directory.clone() {
+            bot_use_cases = bot_use_cases.with_user_directory(user_directory);
+        }
+        let bot_use_cases = Arc::new(bot_use_cases);
         let frontend_bot_query: Arc<dyn bcs_service_api::BotQueryService> = bot_use_cases.clone();
         let frontend_connections = Arc::new(WorkbenchConnectionRegistry::with_bot_query(
             frontend_bot_query,
@@ -2064,15 +2065,19 @@ impl BcsServer {
             (friend_store, friend_request_store)
         };
         let bot_connections = Arc::new(BotConnectionRegistry::new());
+        let mut bot_runtime_for_session =
+            Bot::new_with_friend(bot_registry.clone(), friend_svc.clone())
+                .with_bot_core(bot_core_arc.clone())
+                .with_connection_control(
+                    bot_connections.clone()
+                        as Arc<dyn bcs_service_api::BotConnectionControlPort>,
+                );
+        if let Some(user_directory) = user_directory.clone() {
+            bot_runtime_for_session =
+                bot_runtime_for_session.with_user_directory(user_directory);
+        }
         let bot_runtime_for_session: Arc<dyn bcs_service_api::BotRuntimeConnectionService> =
-            Arc::new(
-                Bot::new_with_friend(bot_registry.clone(), friend_svc.clone())
-                    .with_bot_core(bot_core_arc.clone())
-                    .with_connection_control(
-                        bot_connections.clone()
-                            as Arc<dyn bcs_service_api::BotConnectionControlPort>,
-                    ),
-            );
+            Arc::new(bot_runtime_for_session);
         let frontend_connections = Arc::new(WorkbenchConnectionRegistry::new());
         let run_channels = Arc::new(RunChannelManager::new());
         let frontend_run_channels = run_channels.clone();

--- a/src/bcs/crates/bootstrap/bcs/tests/e2e_ws_messaging.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/e2e_ws_messaging.rs
@@ -70,6 +70,7 @@ fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
         logging: bcs::LoggingConfig::default(),
         bcsfuse: bcs_fuse_client::BcsFuseConfig::default(),
         auth_sdk: Default::default(),
+        user_directory: Default::default(),
         auth: Default::default(),
         cors: Default::default(),
         group_logger: None,

--- a/src/bcs/crates/bootstrap/bcs/tests/helpers/mod.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/helpers/mod.rs
@@ -60,6 +60,7 @@ pub fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
         logging: LoggingConfig::default(),
         bcsfuse: bcs_fuse_client::BcsFuseConfig::default(),
         auth_sdk: Default::default(),
+        user_directory: Default::default(),
         auth: Default::default(),
         cors: Default::default(),
         group_logger: None,

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_bcsfuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_bcsfuse.rs
@@ -55,6 +55,7 @@ fn create_test_config_bcsfuse_enabled(bots_dir: &PathBuf) -> BcsConfig {
             ..Default::default()
         },
         auth_sdk: Default::default(),
+        user_directory: Default::default(),
         auth: Default::default(),
         cors: Default::default(),
         group_logger: None,

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
@@ -63,6 +63,7 @@ fn create_config_bcsfuse_enabled(bots_dir: &PathBuf) -> BcsConfig {
             ..Default::default()
         },
         auth_sdk: Default::default(),
+        user_directory: Default::default(),
         auth: Default::default(),
         cors: Default::default(),
         group_logger: None,

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_onboarding.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_onboarding.rs
@@ -75,6 +75,7 @@ fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
         logging: LoggingConfig::default(),
         bcsfuse: bcs_fuse_client::BcsFuseConfig::default(),
         auth_sdk: Default::default(),
+        user_directory: Default::default(),
         auth: Default::default(),
         cors: Default::default(),
         group_logger: None,

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_ownership.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_ownership.rs
@@ -73,6 +73,7 @@ fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
         logging: LoggingConfig::default(),
         bcsfuse: bcs_fuse_client::BcsFuseConfig::default(),
         auth_sdk: Default::default(), // SDK NOT initialized
+        user_directory: Default::default(),
         auth: Default::default(),
         cors: Default::default(),
         group_logger: None,

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -322,6 +322,31 @@ pub trait AuthSdkEnvView {
 }
 
 // ---------------------------------------------------------------------------
+// User directory
+// ---------------------------------------------------------------------------
+
+/// Provider-specific user-directory options.
+pub type UserDirectoryProviderConfig = BTreeMap<String, serde_json::Value>;
+
+/// Optional external user directory used to resolve stable user ids to display
+/// metadata. This does not authenticate requests or store users.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserDirectoryConfig {
+    /// Enable user-directory lookups. Default is off for public/local builds.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// User-directory provider to load when enabled.
+    #[serde(default)]
+    pub provider: Option<String>,
+
+    /// Provider-specific options keyed by provider name.
+    #[serde(default)]
+    pub providers: BTreeMap<String, UserDirectoryProviderConfig>,
+}
+
+// ---------------------------------------------------------------------------
 // Auth plugin chain
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Introduce a public user_directory configuration contract with provider-specific option maps so deployments can select linked directory plugins without hard-coding provider settings in bootstrap.

Add a UserDirectoryFactory registry alongside the existing cache, database, leader election, LLM, and security gateway registries. Wire server startup to load the configured provider, pass its option map through to the factory, and fail fast when an enabled provider is missing from the binary.

Document the disabled-by-default public configuration shape and update tests that construct BcsConfig directly so they remain explicit about the new field.