### PR TITLE
ci(unit-tests): add backend and engine test jobs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,5 @@
 /docs/arch/ @carolynli @xianmuyq
 /src/bcs/ @carolynli @vzvince @questchaos @RaymondHX
 /src/plugin/ @RaymondHX @vzvince @carolynli @questchaos
+/src/backend/ @totalfrank @xianmuyq
+/src/engine/ @totalfrank @xianmuyq

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -145,3 +145,127 @@ jobs:
 
       - name: Run unit tests
         run: npm test -- --runInBand --passWithNoTests
+
+  backend:
+    name: Backend unit tests
+    runs-on: ubuntu-latest
+    env:
+      # PR: compare against the PR's base branch. push/dispatch: compare against dev
+      # (the repo default branch) so coverage-gated diff detection still has a base.
+      BACKEND_BASE_REF: origin/${{ github.base_ref || 'dev' }}
+    defaults:
+      run:
+        working-directory: src/backend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect backend changes vs base
+        id: changes
+        # Run from the repo root so the "-- src/backend" pathspec resolves; the job
+        # default working-directory is src/backend, so override to the workspace root.
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          # Make sure the base ref is present locally (shallow clones may not have it).
+          git fetch --no-tags --depth=1 origin "${BACKEND_BASE_REF#origin/}" 2>/dev/null || true
+          # Diff the base ref against the working tree. PR runs check out a merge commit,
+          # for which "<base>...HEAD" collapses to nothing; diffing base against the tree
+          # sees all PR-introduced changes regardless of the merge-commit checkout.
+          mapfile -t files < <(git diff --name-only "${BACKEND_BASE_REF}" -- src/backend || true)
+          n=${#files[@]}
+          if [ "$n" -eq 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No changes under src/backend vs ${BACKEND_BASE_REF}; skipping backend tests."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Detected ${n} changed file(s) under src/backend vs ${BACKEND_BASE_REF}."
+            printf '%s\n' "${files[@]}" | sed 's/^/  - /'
+          fi
+
+      - name: Set up Python
+        if: steps.changes.outputs.skip != 'true'
+        uses: actions/setup-python@v5
+        with:
+          # Backend targets Python >=3.12,<3.13 (see src/backend/pyproject.toml).
+          python-version: '3.12'
+
+      - name: Install uv
+        if: steps.changes.outputs.skip != 'true'
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: src/backend/uv.lock
+
+      - name: Run unit tests with coverage
+        if: steps.changes.outputs.skip != 'true'
+        # ci_test.sh runs pytest with coverage and enforces the case-pass-rate /
+        # line-coverage / changed-line-coverage gates via scripts/ci/report_check.py.
+        run: bash scripts/ci_test.sh --base "$BACKEND_BASE_REF"
+
+      - name: Upload backend test results
+        if: always() && steps.changes.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-testresult
+          path: src/backend/pytest_report/
+          if-no-files-found: ignore
+
+  engine:
+    name: Engine unit tests
+    runs-on: ubuntu-latest
+    env:
+      ENGINE_BASE_REF: origin/${{ github.base_ref || 'dev' }}
+    defaults:
+      run:
+        working-directory: src/engine
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect engine changes vs base
+        id: changes
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          git fetch --no-tags --depth=1 origin "${ENGINE_BASE_REF#origin/}" 2>/dev/null || true
+          mapfile -t files < <(git diff --name-only "${ENGINE_BASE_REF}" -- src/engine || true)
+          n=${#files[@]}
+          if [ "$n" -eq 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No changes under src/engine vs ${ENGINE_BASE_REF}; skipping engine tests."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Detected ${n} changed file(s) under src/engine vs ${ENGINE_BASE_REF}."
+            printf '%s\n' "${files[@]}" | sed 's/^/  - /'
+          fi
+
+      - name: Set up Python
+        if: steps.changes.outputs.skip != 'true'
+        uses: actions/setup-python@v5
+        with:
+          # Engine targets Python >=3.12 (see src/engine/pyproject.toml).
+          python-version: '3.12'
+
+      - name: Install uv
+        if: steps.changes.outputs.skip != 'true'
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: src/engine/uv.lock
+
+      - name: Run unit tests with coverage
+        if: steps.changes.outputs.skip != 'true'
+        run: bash scripts/ci_test.sh --base "$ENGINE_BASE_REF"
+
+      - name: Upload engine test results
+        if: always() && steps.changes.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-testresult
+          path: src/engine/pytest_report/
+          if-no-files-found: ignore


### PR DESCRIPTION
## What
Adds `Backend unit tests` and `Engine unit tests` jobs to the Unit Tests workflow, so the newly imported `src/backend` and `src/engine` subtrees get CI coverage.

## How
Mirrors the existing BCS job pattern:
- **Change detection** — diff the subtree against the PR base; skip the job when nothing under `src/backend` / `src/engine` changed, otherwise run the full suite.
- **Runner** — invokes the vendored `scripts/ci_test.sh`, which runs pytest with coverage and enforces the gates via `scripts/ci/report_check.py`:
  - backend: 100% case pass · ≥75% line · ≥80% changed-line
  - engine: 100% case pass · ≥70% line · ≥90% changed-line
- **Python** pinned to 3.12 (backend targets `>=3.12,<3.13`; engine `>=3.12`).
- **uv** with lockfile-scoped caching.

## Scale note
A change touching one file under a subtree runs that subtree's entire suite (~6,700 backend / ~1,700 engine test functions). This is the first time these suites run in CI, so the initial run may surface env-dependent failures or coverage-gate misses to tune.

## Follow-up
Once the check names appear, add `Backend unit tests` and `Engine unit tests` to the `protect-dev` ruleset's required status checks so they gate merges (currently only the BCS checks are required).