### PR TITLE
Migrate pre-push gates to Avernet

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,14 +18,19 @@ run_for_ref() {
   local remote_sha="$2"
   local base=""
 
+  # local_sha 全 0 表示删除远端分支,没有代码需要检查。
   if [[ "$local_sha" == "0000000000000000000000000000000000000000" ]]; then
     return 0
   fi
 
-  if [[ "$remote_sha" != "0000000000000000000000000000000000000000" ]]; then
-    base="$remote_sha"
-  elif git rev-parse --verify origin/dev >/dev/null 2>&1; then
+  # base 是“本地模拟 PR CI 的检查起点”:
+  # - 优先和 origin/dev 取 merge-base,即检查“当前分支整体相对 dev 引入的变化”
+  # - 这比 remote_sha -> local_sha 更接近线上 PR CI 的 pullRequest.changes 口径
+  # - 如果本地没有 origin/dev,已有远端分支则退回 remote_sha,新分支退回仓库初始提交
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
     base="$(git merge-base "$local_sha" origin/dev)"
+  elif [[ "$remote_sha" != "0000000000000000000000000000000000000000" ]]; then
+    base="$remote_sha"
   else
     base="$(git rev-list --max-parents=0 "$local_sha" | tail -1)"
   fi
@@ -34,12 +39,18 @@ run_for_ref() {
 }
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  # stdin 每行格式:
+  #   <local ref> <local sha> <remote ref> <remote sha>
+  # 例如:
+  #   refs/heads/dev_xxx abc123 refs/heads/dev_xxx def456
   [[ -n "${local_ref:-}" ]] || continue
   seen_ref=1
   run_for_ref "$local_sha" "$remote_sha" || status=$?
 done
 
 if [[ "$seen_ref" -eq 0 ]]; then
+  # 有些手动调用场景没有 stdin,这里用 HEAD 做一次兜底检查,
+  # 方便本地直接执行 .githooks/pre-push 来验证 hook 行为。
   if git rev-parse --verify origin/dev >/dev/null 2>&1; then
     run_for_ref HEAD "$(git merge-base HEAD origin/dev)" || status=$?
   else

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Use this path if you want the fastest native local development stack and accept 
 #### Start
 
 ```bash
-# Check and install or upgrade the toolchain. This may change your host environment.
+# Check and install or upgrade the toolchain, and install the pre-push hook.
+# This may change your host environment.
 ./scripts/singlebox.sh install-tools
 
 # Build and start the local stack: Avernet process + 5 local test bots + frontend
@@ -51,7 +52,8 @@ Use this path if you want the fastest native local development stack and accept 
 
 > **Note**:
 > 1. `install-tools` is an interactive install wizard and may install OpenClaw and related tools. If you only want to preflight dependencies, run `./scripts/singlebox.sh check`.
-> 2. If you see duplicate demo bots in the frontend, it means the demo bot tokens are incorrect and the corresponding data no longer exists in the local SQLite database.
+> 2. Running `singlebox.sh` also installs the repo-local pre-push hook by setting `core.hooksPath=.githooks`. To skip this, set `OCB_SKIP_GIT_HOOKS=1`.
+> 3. If you see duplicate demo bots in the frontend, it means the demo bot tokens are incorrect and the corresponding data no longer exists in the local SQLite database.
 
 ##### Optional: edit local configuration
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -40,6 +40,10 @@ Rust/Cargo, and protobuf/protoc. When Node.js 22+ is missing or too old, it
 installs Node.js through nvm; when uv is missing, it tries `pip` or the official
 installer. Run it only after confirming those local writes are acceptable.
 
+Running `singlebox.sh` also installs the repo-local pre-push hook by setting
+`core.hooksPath=.githooks`. Set `OCB_SKIP_GIT_HOOKS=1` if you need to skip hook
+installation for a one-off command.
+
 ## Safety rules
 
 - Stop for confirmation before running `sudo`, global installs,

--- a/docs/dependencies.zh-CN.md
+++ b/docs/dependencies.zh-CN.md
@@ -22,6 +22,8 @@
 
 `install-tools` 可能安装 Node.js、uv、OpenClaw、Rust/Cargo、protobuf/protoc，并写入用户目录或调用本机包管理器。当前脚本会在安装 OpenClaw、Rust/Cargo、protobuf/protoc 前询问确认；Node.js 缺失或版本过低时会通过 nvm 安装 Node.js 22，uv 缺失时会尝试通过 `pip` 或官方安装脚本安装。执行前请确认这些本机写入可以接受。
 
+运行 `singlebox.sh` 时也会安装仓库级 pre-push hook，即设置 `core.hooksPath=.githooks`。如果某次命令需要跳过 hook 安装，可以设置 `OCB_SKIP_GIT_HOOKS=1`。
+
 ## 安全规则
 
 - 执行 `sudo`、全局安装、`brew link --force`、`curl | sh` 或等价的系统级写入前，必须停下确认。

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -110,6 +110,10 @@ installing OpenClaw, Rust/Cargo, and protobuf/protoc.
 ./scripts/singlebox.sh install-tools
 ```
 
+Running `singlebox.sh` also installs the repo-local pre-push hook by setting
+`core.hooksPath=.githooks`. Set `OCB_SKIP_GIT_HOOKS=1` if you need to skip hook
+installation for a one-off command.
+
 `check` is the preflight command. It only checks dependencies, directories, and
 ports; except for initializing a few local runtime directories, it does not
 install, build, start, or stop processes:

--- a/docs/quick-start.zh-CN.md
+++ b/docs/quick-start.zh-CN.md
@@ -80,6 +80,8 @@ USE_CN_MIRROR=1
 
 `install-tools` 可能安装 Node.js、uv、OpenClaw、Rust/Cargo、protobuf/protoc，并写入用户目录或调用本机包管理器。当前脚本会在安装 OpenClaw、Rust/Cargo、protobuf/protoc 前询问确认；Node.js 缺失或版本过低时会通过 nvm 安装 Node.js 22，uv 缺失时会尝试通过 `pip` 或官方安装脚本安装。
 
+运行 `singlebox.sh` 时也会安装仓库级 pre-push hook，即设置 `core.hooksPath=.githooks`。如果某次命令需要跳过 hook 安装，可以设置 `OCB_SKIP_GIT_HOOKS=1`。
+
 预检通过后，启动本机默认路径：
 
 ```bash

--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -6,7 +6,12 @@ cd "$repo_root"
 
 base=""
 head="HEAD"
+dry_run="${OCB_PRE_PUSH_DRY_RUN:-0}"
+skip_singlebox_coverage="${OCB_PRE_PUSH_SKIP_SINGLEBOX_COVERAGE:-0}"
 
+# 这个脚本既可以被 .githooks/pre-push 调用,也可以手动运行:
+#   scripts/ci/pre_push.sh --base origin/dev --head HEAD
+# base/head 用来计算“本次变更文件”,从而只跑受影响模块的 CI gate。
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --base)
@@ -17,6 +22,14 @@ while [[ "$#" -gt 0 ]]; do
       head="$2"
       shift 2
       ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --skip-singlebox-coverage)
+      skip_singlebox_coverage=1
+      shift
+      ;;
     *)
       echo "unknown argument: $1" >&2
       exit 2
@@ -25,6 +38,8 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 if [[ -z "$base" ]]; then
+  # 手动运行时如果没传 base,默认和 origin/dev 比较。
+  # 这和 PR 场景的目标分支思路一致,避免把整个历史都算作本次变更。
   if git rev-parse --verify origin/dev >/dev/null 2>&1; then
     base="$(git merge-base "$head" origin/dev)"
   else
@@ -33,28 +48,100 @@ if [[ -z "$base" ]]; then
 fi
 
 changed_files="$(git diff --name-only "$base" "$head")"
+singlebox_coverage_ran=0
 
 matches_any() {
+  # 判断本次变更文件里是否命中某个路径正则。
+  # 后面的模块分发都基于这个函数,例如 '^src/backend/'。
   local pattern="$1"
   printf '%s\n' "$changed_files" | grep -Eq "$pattern"
+}
+
+run_required() {
+  # required gate: 命令失败就让 pre-push 失败,阻止 push。
+  echo ""
+  echo "== required: $* =="
+  if [[ "$dry_run" == "1" ]]; then
+    echo "dry-run: command skipped"
+    return 0
+  fi
+  "$@"
+}
+
+run_singlebox_coverage_once() {
+  if [[ "$skip_singlebox_coverage" == "1" ]]; then
+    echo "singlebox coverage skipped (OCB_PRE_PUSH_SKIP_SINGLEBOX_COVERAGE=1)"
+    return 0
+  fi
+  if [[ "$singlebox_coverage_ran" == "1" ]]; then
+    echo "singlebox coverage already ran; skipping duplicate"
+    return 0
+  fi
+  run_required "$repo_root/scripts/ci/singlebox_coverage.sh"
+  singlebox_coverage_ran=1
 }
 
 echo "base: $base"
 echo "head: $head"
 
 if [[ -z "$changed_files" ]]; then
+  # pre-push 只检查已提交的 push range。
+  # 工作区未提交改动不在这里检查,这是 git hook 的自然边界。
   echo "no committed changes in push range; CI gates skipped"
   exit 0
 fi
 
-if matches_any '^src/bcs/'; then
-  if [[ "${OCB_PRE_PUSH_ENABLE_BCS:-1}" == "1" ]]; then
-    echo ""
-    echo "== required: src/bcs/scripts/pre_push.sh --base $base --head $head =="
-    "$repo_root/src/bcs/scripts/pre_push.sh" --base "$base" --head "$head"
+if matches_any '^src/backend/'; then
+  # Backend 默认强卡点:
+  # 1) python_sast_local.sh 近似线上 python-sast block 规则,且只扫本次变更 Python 文件
+  # 2) backend ci_test.sh 跑 pytest + coverage + report_check
+  # 3) singlebox coverage 默认并入 pre-push,保证 Backend 变更会跑 singlebox E2E 覆盖率入口。
+  run_required "$repo_root/scripts/ci/python_sast_local.sh" src/backend 1 --base "$base" --head "$head"
+  run_required "$repo_root/src/backend/scripts/ci_test.sh" --base "$base" --head "$head"
+  run_singlebox_coverage_once
+fi
+
+if matches_any '^src/baas/'; then
+  # BaaS 默认强卡点:
+  # 1) 跑 BaaS 自己的 ci_test.sh
+  # 2) 默认同样跑 singlebox coverage,用于保证 Backend + BaaS live E2E 入口被触发。
+  # 如需临时跳过 BaaS CI,显式设置 OCB_PRE_PUSH_ENABLE_BAAS=0。
+  if [[ "${OCB_PRE_PUSH_ENABLE_BAAS:-1}" == "1" ]]; then
+    run_required "$repo_root/scripts/ci/python_sast_local.sh" src/baas 1 --base "$base" --head "$head"
+    run_required "$repo_root/src/baas/scripts/ci_test.sh" --base "$base" --head "$head"
+    run_singlebox_coverage_once
   else
-    echo "bcs changes detected; BCS/BCN CI gate skipped (OCB_PRE_PUSH_ENABLE_BCS=0)"
+    echo "BaaS changes detected; BaaS CI gate skipped (OCB_PRE_PUSH_ENABLE_BAAS=0)"
   fi
+fi
+
+if matches_any '^src/engine/'; then
+  # Engine 默认强卡点:
+  # SAST 先兜底语法/高危 lint,再跑 engine 自己的 pytest/coverage gate。
+  run_required "$repo_root/scripts/ci/python_sast_local.sh" src/engine 1 --base "$base" --head "$head"
+  run_required "$repo_root/src/engine/scripts/ci_test.sh" --base "$base" --head "$head"
+fi
+
+if matches_any '^src/bcs/'; then
+  # BCS/BCN 默认强卡点。
+  # pre-push 走 --fast-fail: 第一个失败就退出,节省本地等待时间。
+  # 如需临时跳过,显式设置 OCB_PRE_PUSH_ENABLE_BCS=0。
+  if [[ "${OCB_PRE_PUSH_ENABLE_BCS:-1}" == "1" ]]; then
+    run_required "$repo_root/src/bcs/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail
+  else
+    echo "BCS/BCN changes detected; BCS/BCN CI gate skipped (OCB_PRE_PUSH_ENABLE_BCS=0)"
+  fi
+fi
+
+if matches_any '^src/frontend/'; then
+  # Frontend 也通过模块自己的 ci_test.sh 作为统一入口。
+  run_required "$repo_root/src/frontend/scripts/ci_test.sh" --base "$base" --head "$head"
+fi
+
+if matches_any '^(scripts/singlebox\.sh|scripts/modules/|scripts/ci/singlebox_coverage\.sh|src/backend/tests/community/acceptance/|src/baas/packages/community/tests/e2e/)'; then
+  # singlebox 自身脚本或 live E2E 用例变更时,即便没有 Backend/BaaS 源码变更,
+  # 也要触发 singlebox coverage gate。
+  run_singlebox_coverage_once
 fi
 
 echo ""

--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -15,10 +15,18 @@ skip_singlebox_coverage="${OCB_PRE_PUSH_SKIP_SINGLEBOX_COVERAGE:-0}"
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --base)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --base requires an argument" >&2
+        exit 2
+      fi
       base="$2"
       shift 2
       ;;
     --head)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --head requires an argument" >&2
+        exit 2
+      fi
       head="$2"
       shift 2
       ;;

--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+coverage_root="${SINGLEBOX_COVERAGE_ROOT:-$repo_root/scripts/.dependencies/coverage/singlebox}"
+report_dir="$coverage_root/reports"
+mode="${SINGLEBOX_COVERAGE_MODE:-mock}"
+
+usage() {
+  cat <<USAGE
+Usage: scripts/ci/singlebox_coverage.sh [OPTIONS]
+
+Singlebox coverage gate entrypoint used by pre-push and PR CI.
+
+Current GitHub bootstrap behavior:
+  - default mode is mock, so pre-push can enforce the architecture before the
+    real open-source singlebox startup path is fully stable;
+  - set SINGLEBOX_COVERAGE_MODE=real to attempt the live singlebox path.
+
+Options:
+  --coverage-root DIR     Coverage output root, default: $coverage_root
+  --mode mock|real        Override SINGLEBOX_COVERAGE_MODE
+  -h, --help              Show this help
+USAGE
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --coverage-root)
+      coverage_root="$2"
+      report_dir="$coverage_root/reports"
+      shift 2
+      ;;
+    --mode)
+      mode="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+write_mock_reports() {
+  mkdir -p "$report_dir"
+  cat > "$report_dir/summary.json" <<JSON
+{
+  "mode": "mock",
+  "status": "passed",
+  "systems": {
+    "backend": {"core": null, "router_api": null, "plugin_api": null},
+    "baas": {"core": null, "router_api": null, "plugin_api": null},
+    "bcs": {"core": null, "router_api": null, "plugin_api": null},
+    "engine": {"core": null, "router_api": null, "plugin_api": null}
+  },
+  "note": "Mock singlebox coverage gate. The pre-push architecture is active; real coverage is enabled by SINGLEBOX_COVERAGE_MODE=real after open-source singlebox startup is stabilized."
+}
+JSON
+  cat > "$report_dir/summary.md" <<MD
+# Singlebox Coverage Gate
+
+- mode: mock
+- status: passed
+- note: pre-push invoked the singlebox coverage gate; real startup is deferred to SINGLEBOX_COVERAGE_MODE=real.
+MD
+  cat > "$report_dir/dashboard.html" <<HTML
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Singlebox Coverage Gate</title>
+<body>
+  <h1>Singlebox Coverage Gate</h1>
+  <p>Mode: mock</p>
+  <p>Status: passed</p>
+  <p>The pre-push architecture invoked this gate. Switch to <code>SINGLEBOX_COVERAGE_MODE=real</code> when open-source singlebox startup is stable.</p>
+</body>
+</html>
+HTML
+}
+
+run_real_singlebox() {
+  mkdir -p "$coverage_root/raw" "$report_dir"
+  echo "singlebox coverage real mode"
+  echo "coverage_root: $coverage_root"
+  echo "This mode currently verifies startup only; full coverage combine/reporting will be restored with the real singlebox worktree."
+  env SINGLEBOX_COVERAGE=1 SINGLEBOX_COVERAGE_DIR="$coverage_root/raw" OCB_SKIP_GIT_HOOKS=1 \
+    bash "$repo_root/scripts/singlebox.sh" --local start baas backend bcs
+  env OCB_SKIP_GIT_HOOKS=1 bash "$repo_root/scripts/singlebox.sh" --local stop bcs backend baas
+}
+
+case "$mode" in
+  mock)
+    echo "singlebox coverage gate: mock mode"
+    echo "coverage reports: $report_dir"
+    write_mock_reports
+    ;;
+  real)
+    run_real_singlebox
+    ;;
+  *)
+    echo "unknown singlebox coverage mode: $mode" >&2
+    exit 2
+    ;;
+esac
+
+echo "singlebox coverage gate passed"

--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -29,11 +29,19 @@ USAGE
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --coverage-root)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --coverage-root requires an argument" >&2
+        exit 2
+      fi
       coverage_root="$2"
       report_dir="$coverage_root/reports"
       shift 2
       ;;
     --mode)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --mode requires an argument" >&2
+        exit 2
+      fi
       mode="$2"
       shift 2
       ;;
@@ -91,9 +99,14 @@ run_real_singlebox() {
   echo "singlebox coverage real mode"
   echo "coverage_root: $coverage_root"
   echo "This mode currently verifies startup only; full coverage combine/reporting will be restored with the real singlebox worktree."
+  cleanup_real_singlebox() {
+    env OCB_SKIP_GIT_HOOKS=1 bash "$repo_root/scripts/singlebox.sh" --local stop bcs backend baas || true
+  }
+  trap cleanup_real_singlebox EXIT
   env SINGLEBOX_COVERAGE=1 SINGLEBOX_COVERAGE_DIR="$coverage_root/raw" OCB_SKIP_GIT_HOOKS=1 \
     bash "$repo_root/scripts/singlebox.sh" --local start baas backend bcs
-  env OCB_SKIP_GIT_HOOKS=1 bash "$repo_root/scripts/singlebox.sh" --local stop bcs backend baas
+  cleanup_real_singlebox
+  trap - EXIT
 }
 
 case "$mode" in

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -33,8 +33,13 @@ hooks_before="$(git config --worktree --get core.hooksPath 2>/dev/null || git co
 chmod +x .githooks/pre-push
 chmod +x scripts/ci/pre_push.sh
 chmod +x scripts/ci/python_sast_local.sh
+chmod +x scripts/ci/singlebox_coverage.sh
 chmod +x scripts/ci/report_check.py
+chmod +x src/backend/scripts/ci_test.sh
+chmod +x src/baas/scripts/ci_test.sh
 chmod +x src/bcs/scripts/ci_test.sh
+chmod +x src/engine/scripts/ci_test.sh
+chmod +x src/frontend/scripts/ci_test.sh
 
 config_scope="this worktree"
 if ! git config --worktree core.hooksPath .githooks 2>/dev/null; then

--- a/src/frontend/scripts/ci_test.sh
+++ b/src/frontend/scripts/ci_test.sh
@@ -10,10 +10,18 @@ head="HEAD"
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --base)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --base requires an argument" >&2
+        exit 2
+      fi
       base="$2"
       shift 2
       ;;
     --head)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --head requires an argument" >&2
+        exit 2
+      fi
       head="$2"
       shift 2
       ;;

--- a/src/frontend/scripts/ci_test.sh
+++ b/src/frontend/scripts/ci_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+frontend_dir="$(cd "$script_dir/.." && pwd)"
+
+base=""
+head="HEAD"
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --base)
+      base="$2"
+      shift 2
+      ;;
+    --head)
+      head="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$frontend_dir"
+
+if [[ ! -f package.json ]]; then
+  echo "frontend CI failed: package.json not found" >&2
+  exit 1
+fi
+
+package_runner="${FRONTEND_CI_PACKAGE_MANAGER:-}"
+if [[ -z "$package_runner" ]]; then
+  if [[ -f package-lock.json ]] && command -v npm >/dev/null 2>&1; then
+    package_runner=npm
+  elif command -v tnpm >/dev/null 2>&1; then
+    package_runner=tnpm
+  elif command -v npm >/dev/null 2>&1; then
+    package_runner=npm
+  else
+    package_runner=""
+  fi
+fi
+
+if [[ -z "$package_runner" ]]; then
+  echo "frontend CI failed: neither npm nor tnpm found" >&2
+  exit 127
+fi
+
+if ! command -v "$package_runner" >/dev/null 2>&1; then
+  echo "frontend CI failed: package runner not found: $package_runner" >&2
+  exit 127
+fi
+
+if [[ ! -x node_modules/.bin/max ]]; then
+  if [[ "${FRONTEND_CI_SKIP_INSTALL:-0}" == "1" ]]; then
+    echo "frontend CI failed: node_modules/.bin/max missing and FRONTEND_CI_SKIP_INSTALL=1" >&2
+    exit 127
+  fi
+  if [[ "$package_runner" == "npm" && -f package-lock.json ]]; then
+    HUSKY=0 "$package_runner" ci
+  else
+    HUSKY=0 "$package_runner" install
+  fi
+fi
+
+echo "frontend CI gate"
+echo "frontend_dir: $frontend_dir"
+echo "base: ${base:-<none>}"
+echo "head: $head"
+
+"$package_runner" run ci
+echo "frontend CI gate passed"

--- a/src/frontend/src/shell/extension.ts
+++ b/src/frontend/src/shell/extension.ts
@@ -162,7 +162,7 @@ export const AppExt = defineExt('App', {
     // 内部 src/internal/resources.ts 可覆盖为含私有 registry 的内网指令。
     // 方式1：用户自助接入
     bcnConnectCmdTemplate:
-      'bash -c "$(curl -fsSL https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.sh || echo \"exit 1\")" install.sh --token {token}',
+      'bash -c "$(curl -fsSL https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.sh || echo "exit 1")" install.sh --token {token}',
     // 方式2：Bot 自动接入
     bcnAutoConnectCmdTemplate:
       'Follow the instructions in https://raw.githubusercontent.com/inclusionAI/Avernet/refs/heads/dev/src/bcs/docs/install-instructions/install.md to join BCN (Bot Coordination Network), your token is {token}',


### PR DESCRIPTION
## Summary

- Add repo-local pre-push routing for Backend, BaaS, BCS, Engine, Frontend, and singlebox coverage.
- Add mock-capable singlebox coverage reporting so the gate can run by default while real singlebox startup is handled separately.
- Add frontend CI entrypoint and install hook setup wiring.
- Document that running `singlebox.sh install-tools` also installs the repo-local pre-push hook.

## Validation

- `git diff --check`
- Real `git push` triggered `.githooks/pre-push` and passed:
  - `src/frontend/scripts/ci_test.sh`
  - `scripts/ci/singlebox_coverage.sh` in mock mode
