### PR TITLE
test(bcs): add actor/register/session e2e suites for endpoint coverage

### DIFF
--- a/src/bcs/scripts/e2e-test/actor.sh
+++ b/src/bcs/scripts/e2e-test/actor.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# actor.sh — Actor directory + bot query/chat e2e tests.
+#
+# Covers previously-uncovered HTTP endpoints:
+#   GET  /actors/list              routes::actors::list_actors
+#   GET  /actors/search            routes::actors::search_actors
+#   PUT  /actors/{aid}/status      routes::actors::put_actor_status
+#   GET  /bots/my                  routes::bots::list_my_bots
+#   GET  /bots/paged               routes::bots::list_bots_paged
+#   POST /bots/query               routes::bots::query_bots
+#   POST /bots/{id}/chat           routes::bot_chat::bot_chat   (sync 1:1)
+# (GET /bots/{id}/groups is exercised in group.sh's test_bot_groups_of_bot.)
+
+# Test registration (consumed by e2e.sh)
+E2E_TESTS_ACTOR=(
+    "test_actor_list"
+    "test_actor_search"
+    "test_actor_put_status"
+    "test_bots_my"
+    "test_bots_paged"
+    "test_bots_query"
+    "test_bot_chat_sync"
+)
+
+# A bot-token-authenticated request. The /actors/{aid}/status PUT and the sync
+# /bots/{id}/chat resolve the caller bot from its session token (X-BCS-Bot-Token
+# or Authorization: Bearer) — api_put/api_post only send the mock-human headers,
+# so use the shared bot_request (see common.sh) which sends the bot token.
+# Usage: _bot_request <METHOD> <PATH> <BODY> <BOT_NAME>
+_bot_request() {
+    bot_request "$1" "$2" "$4" "${3:-}"
+}
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+# GET /actors/list — list the actor directory from CEO's perspective.
+# NOTE: the directory applies a visibility filter (public bots + the current
+# bot's friends), so the result may legitimately be empty when CEO has no
+# friends yet (e.g. running this suite standalone, before friends.sh runs).
+# We assert the response shape, not a non-empty result.
+test_actor_list() {
+    info "Actors: GET /actors/list (from CEO)"
+    api_get "/actors/list?current_bot_uuid=${BOT_CEO_UUID}&cooperatable_only=false&limit=20"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "GET /actors/list returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "GET /actors/list returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    # Response is { bots: [...], total: N }.
+    local ok total
+    read -r ok total <<EOF
+$(printf '%s' "$RESPONSE" | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin)
+    print('1' if isinstance(d.get('bots'),list) and isinstance(d.get('total'),int) else '0', d.get('total',0))
+except Exception:
+    print('0','0')
+" 2>/dev/null)
+EOF
+    if [ "$ok" = "1" ]; then
+        pass "actor list well-formed (total=$total)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "actor list response shape unexpected: $(printf '%s' "$RESPONSE" | head -c 120)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}
+
+# GET /actors/search — keyword search over the actor directory.
+test_actor_search() {
+    info "Actors: GET /actors/search (q=产品, from CEO)"
+    api_get "/actors/search?q=%E4%BA%A7%E5%93%81&current_bot_uuid=${BOT_CEO_UUID}&cooperatable_only=false"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "GET /actors/search returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "GET /actors/search returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    # Response is { bots: [...], context: {...} }. Search may fall back to the
+    # registry when the recommend worker is unwired, so only assert the shape.
+    local ok
+    ok=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print('1' if 'bots' in d and 'context' in d else '0')" 2>/dev/null || echo 0)
+    if [ "$ok" = "1" ]; then
+        pass "actor search response has bots + context"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "actor search response shape unexpected: $(printf '%s' "$RESPONSE" | head -c 120)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}
+
+# PUT /actors/{aid}/status — a bot updates its own status (hidden, then back).
+# Self-update (caller_actor_id == actor_id) is permitted without further checks.
+test_actor_put_status() {
+    info "Actors: PUT /actors/{CEO}/status hidden -> online (self, bot token)"
+    if ! ensure_cli_token CEO; then
+        skip_case "no CEO token; skipping actor PUT" || { TESTS_TOTAL=$((TESTS_TOTAL + 1)); return; }
+    fi
+    _bot_request PUT "/actors/${BOT_CEO_UUID}/status" '{"status":"hidden"}' CEO
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "PUT status=hidden returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 160)"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "PUT status=hidden returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    local status_val
+    status_val=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('status',''))" 2>/dev/null || echo "")
+    assert_eq "status reflected as hidden" "$status_val" "hidden" || true
+
+    # Restore online so the bot stays collaboratable for the rest of the suite.
+    _bot_request PUT "/actors/${BOT_CEO_UUID}/status" '{"status":"online"}' CEO
+    if [ "$HTTP_STATUS" = "200" ]; then
+        pass "PUT status=online restored (200)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "PUT status=online returned $HTTP_STATUS"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}
+
+# GET /bots/my — the mock human's owned bots (staff_no from mock identity).
+test_bots_my() {
+    info "Bots: GET /bots/my (mock human 001)"
+    api_get "/bots/my?limit=20"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "GET /bots/my returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "GET /bots/my returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    local total
+    total=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('total',0))" 2>/dev/null || echo 0)
+    if [ "$total" -ge 1 ]; then
+        pass "/bots/my returned total=$total"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "/bots/my returned no owned bots (mock human may own none)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}
+
+# GET /bots/paged — paginated bot list.
+test_bots_paged() {
+    info "Bots: GET /bots/paged?limit=5"
+    api_get "/bots/paged?limit=5&offset=0"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "GET /bots/paged returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "GET /bots/paged returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    local n
+    n=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('items',[])))" 2>/dev/null || echo 0)
+    if [ "$n" -ge 1 ]; then
+        pass "/bots/paged returned $n item(s)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "/bots/paged returned no items"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}
+
+# POST /bots/query — bulk-fetch bots by uuid.
+test_bots_query() {
+    info "Bots: POST /bots/query (CEO + PM)"
+    api_post "/bots/query" "{\"bot_uuids\":[\"${BOT_CEO_UUID}\",\"${BOT_PM_UUID}\"]}"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "POST /bots/query returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "POST /bots/query returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    local n
+    n=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else 0)" 2>/dev/null || echo 0)
+    if [ "$n" -ge 2 ]; then
+        pass "/bots/query resolved $n bot(s)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "/bots/query resolved $n bot(s) (expected >=2)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}
+
+# POST /bots/{id}/chat — synchronous 1:1 bot chat (CEO -> PM). Blocks up to
+# timeout_ms; accept 200 (delivered) or a timeout-family code (the demo bot may
+# not reply within the small window, in which case BCS returns 500
+# "Timeout waiting for bot response" — the endpoint is still exercised). Fail
+# on auth/not-found/connection errors only.
+test_bot_chat_sync() {
+    info "Bots: POST /bots/{PM}/chat sync (from CEO, 6s timeout)"
+    if ! ensure_cli_token CEO; then
+        skip_case "no CEO token; skipping sync chat" || { TESTS_TOTAL=$((TESTS_TOTAL + 1)); return; }
+    fi
+    _bot_request POST "/bots/${BOT_PM_UUID}/chat" \
+        '{"message":"ping","timeout_ms":6000}' CEO
+    case "$HTTP_STATUS" in
+        200)
+            pass "sync bot chat returned 200 (delivered)"
+            TESTS_PASSED=$((TESTS_PASSED + 1)) ;;
+        # The chat route maps the blocking-chat timeout to HTTP 500 with body
+        # "Timeout waiting for bot response" — accept that (and 408/502/504) as
+        # the endpoint being exercised. But do NOT blanket-accept any 500: the
+        # route also maps generic ServiceError::InternalError to 500, and treating
+        # those as pass would mask a real regression. Only accept 500 when the
+        # body carries the known timeout message.
+        408|502|504)
+            warn "sync bot chat returned $HTTP_STATUS (timeout family — endpoint exercised)"
+            pass "sync bot chat endpoint reachable (status $HTTP_STATUS)"
+            TESTS_PASSED=$((TESTS_PASSED + 1)) ;;
+        500)
+            if [[ "$RESPONSE" == *"Timeout waiting for bot response"* ]]; then
+                warn "sync bot chat returned 500 (timeout waiting for bot response — endpoint exercised)"
+                pass "sync bot chat endpoint reachable (timeout)"
+                TESTS_PASSED=$((TESTS_PASSED + 1))
+            else
+                fail "sync bot chat returned 500 (non-timeout server error): $(printf '%s' "$RESPONSE" | head -c 200)"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            fi
+            ;;
+        *)
+            fail "sync bot chat returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 160)"
+            TESTS_FAILED=$((TESTS_FAILED + 1)) ;;
+    esac
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}

--- a/src/bcs/scripts/e2e-test/common.sh
+++ b/src/bcs/scripts/e2e-test/common.sh
@@ -207,6 +207,29 @@ api_patch() {
     _api_request PATCH "$1" "${2:-}"
 }
 
+# Bot-token-authenticated request. Some endpoints (actor self-status PUT, sync
+# bot chat, session create/member/chat) resolve the caller from its bot session
+# token (X-BCS-Bot-Token / Bearer) rather than the mock-human headers _api_request
+# sends. Sets HTTP_STATUS / RESPONSE like _api_request.
+# Usage: bot_request <METHOD> <PATH> <BOT_NAME> [BODY]
+bot_request() {
+    local method="$1" path="$2" bot="$3" body="${4:-}"
+    ensure_cli_token "$bot" >/dev/null || { HTTP_STATUS="000"; RESPONSE=""; return 1; }
+    local url="${BCS_API_BASE_URL}${path}"
+    local curl_args=(-s -o "$_RESPONSE_FILE" -w '%{http_code}' -X "$method"
+        -H "X-BCS-Bot-Token: $BCS_CLI_TOKEN"
+        -H "Content-Type: application/json")
+    [ -n "$body" ] && curl_args+=(-d "$body")
+    HTTP_STATUS=$(curl "${curl_args[@]}" "$url" 2>/dev/null) || HTTP_STATUS="000"
+    RESPONSE=$(cat "$_RESPONSE_FILE")
+}
+
+bot_get()    { bot_request GET    "$1" "$2"; }
+bot_post()   { bot_request POST   "$1" "$2" "${3:-}"; }
+bot_put()    { bot_request PUT    "$1" "$2" "${3:-}"; }
+bot_patch()  { bot_request PATCH  "$1" "$2" "${3:-}"; }
+bot_delete() { bot_request DELETE "$1" "$2"; }
+
 # ============================================================================
 # Bot UUID Resolution
 # ============================================================================

--- a/src/bcs/scripts/e2e-test/e2e.sh
+++ b/src/bcs/scripts/e2e-test/e2e.sh
@@ -82,12 +82,14 @@ done
 source "$SCRIPT_DIR/group.sh"
 source "$SCRIPT_DIR/friends.sh"
 source "$SCRIPT_DIR/cli.sh"
+source "$SCRIPT_DIR/actor.sh"
+source "$SCRIPT_DIR/register.sh"
 
 # ============================================================================
 # Collect All Tests (Bash 3.2 compatible — no associative arrays)
 # ============================================================================
 
-ALL_SUITES=(group friends cli)
+ALL_SUITES=(group friends cli actor register)
 ALL_TESTS=()
 
 for test_name in "${E2E_TESTS_GROUP[@]}"; do
@@ -98,6 +100,12 @@ for test_name in "${E2E_TESTS_FRIENDS[@]}"; do
 done
 for test_name in "${E2E_TESTS_CLI[@]}"; do
     ALL_TESTS+=("cli:$test_name")
+done
+for test_name in "${E2E_TESTS_ACTOR[@]}"; do
+    ALL_TESTS+=("actor:$test_name")
+done
+for test_name in "${E2E_TESTS_REGISTER[@]}"; do
+    ALL_TESTS+=("register:$test_name")
 done
 
 # ============================================================================
@@ -116,6 +124,14 @@ if [ "$LIST_ONLY" = true ]; then
     done
     echo "  cli:"
     for test_name in "${E2E_TESTS_CLI[@]}"; do
+        echo "    - $test_name"
+    done
+    echo "  actor:"
+    for test_name in "${E2E_TESTS_ACTOR[@]}"; do
+        echo "    - $test_name"
+    done
+    echo "  register:"
+    for test_name in "${E2E_TESTS_REGISTER[@]}"; do
         echo "    - $test_name"
     done
     exit 0

--- a/src/bcs/scripts/e2e-test/group.sh
+++ b/src/bcs/scripts/e2e-test/group.sh
@@ -22,6 +22,11 @@ E2E_TESTS_GROUP=(
     # --- share cases (group invite-link via API; session invite-link via CLI) ---
     "test_group_invite_link"
     "test_session_invite_link"
+    # --- bot-side group listing ---
+    "test_bot_groups_of_bot"
+    # --- session lifecycle (session = a group's instantiated run) ---
+    "test_session_invite_join"
+    "test_session_lifecycle"
 )
 
 # ============================================================================
@@ -374,6 +379,232 @@ test_session_invite_link() {
     else
         fail "session invite-link did not return an invite_token"
         TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+    _cli_delete_group "$gid"
+}
+
+# GET /bots/{id}/groups — a bot lists the groups it belongs to. Create a
+# PM-driven group, then verify it shows up in PM's bot-group listing.
+test_bot_groups_of_bot() {
+    info "Group: GET /bots/{PM}/groups lists a group PM belongs to"
+    ensure_cli_token PM || { skip_case "no PM token"; TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+    local gid; gid="$(_cli_create_group)"
+    [[ -z "$gid" ]] && { fail "setup create-group failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+
+    api_get "/bots/${BOT_PM_UUID}/groups?limit=50&group_kind=all"
+    if [[ "$HTTP_STATUS" != "200" ]]; then
+        fail "GET /bots/{id}/groups returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+        _cli_delete_group "$gid"; return
+    fi
+    pass "GET /bots/{id}/groups returned 200"
+    TESTS_PASSED=$((TESTS_PASSED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # The fresh group must appear in PM's listing (items[*].group_id or .id).
+    local found
+    found=$(printf '%s' "$RESPONSE" | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin)
+    ids=[i.get('group_id') or i.get('id') for i in d.get('items',[])]
+    print('1' if sys.argv[1] in ids else '0')
+except Exception:
+    print('0')
+" "$gid" 2>/dev/null || echo 0)
+    if [[ "$found" = "1" ]]; then
+        pass "created group $gid listed under /bots/{PM}/groups"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "created group $gid NOT found in /bots/{PM}/groups: $(printf '%s' "$RESPONSE" | head -c 160)"
+        TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+    _cli_delete_group "$gid"
+}
+
+# Create a chat session in <group> as PM (bot token). Echoes the session id
+# (session_id or id). Empty on failure. PM is the group driver/creator, so it
+# has access to create sessions in its group. Requires PM token resolved.
+_api_create_session() {
+    local gid="$1" title="${2:-e2e-sess}"
+    bot_post "/groups/${gid}/sessions" PM "{\"session_title\":\"${title}\"}" >/dev/null 2>&1 || true
+    if [ "$HTTP_STATUS" != "200" ] && [ "$HTTP_STATUS" != "201" ]; then
+        warn "_api_create_session: HTTP $HTTP_STATUS body=$(printf '%s' "$RESPONSE" | head -c 120)"
+        return 1
+    fi
+    local sid
+    sid=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('session_id') or d.get('id') or '')" 2>/dev/null)
+    if [ -z "$sid" ]; then
+        warn "_api_create_session: empty sid from body=$(printf '%s' "$RESPONSE" | head -c 120)"
+        return 1
+    fi
+    printf '%s' "$sid"
+}
+
+# DELETE /sessions/{sid}?bot_id=<creator>. The creator (caller) must match the
+# session's created_by; PM created the session so pass PM's uuid. Best-effort.
+_api_delete_session() {
+    [[ -z "$1" ]] && return
+    api_delete "/sessions/$1?bot_id=${BOT_PM_UUID}"
+}
+
+# POST /sessions/join/{token} — the standard "human joins a session" flow.
+# Builds on the bcs-cli session invite-link test: create a session, mint an
+# invite token, then have the mock human join it, verifying the closed
+# invite loop (create invite-link -> human join).
+test_session_invite_join() {
+    info "Session(share): invite-link -> human joins via POST /sessions/join/{token}"
+    ensure_cli_token PM || { skip_case "no PM token"; TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+    local gid; gid="$(_cli_create_group)"
+    [[ -z "$gid" ]] && { fail "setup create-group failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+    local sid; sid="$(_api_create_session "$gid" share-sess)"
+    if [[ -z "$sid" ]]; then
+        fail "session create failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+        _cli_delete_group "$gid"; return
+    fi
+
+    # Mint a session invite token as PM (bot token) — returns {invite_token, expires_at, join_url}.
+    bot_post "/sessions/${sid}/invite-link" PM '{"ttl_seconds":300}'
+    if [[ "$HTTP_STATUS" != "200" ]]; then
+        fail "session invite-link returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+        _cli_delete_group "$gid"; return
+    fi
+    local invite_token
+    invite_token=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('invite_token',''))" 2>/dev/null || echo "")
+    if [[ -z "$invite_token" ]]; then
+        fail "no invite_token in session invite-link"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+        _cli_delete_group "$gid"; return
+    fi
+
+    # Human (mock identity) joins the session via the invite token.
+    api_post "/sessions/join/${invite_token}" '{}'
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "human joined session via POST /sessions/join/{token}"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "sessions/join returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 160)"
+        TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+    _cli_delete_group "$gid"
+}
+
+# Full session lifecycle as a self-contained flow: session is a group's
+# instantiated run. Create group -> create session -> PATCH title ->
+# add member (ENG) -> set member mode -> session chat -> get messages ->
+# remove member -> delete session -> verify gone.
+test_session_lifecycle() {
+    info "Session: create -> patch -> add member -> mode -> chat -> messages -> remove -> delete"
+    ensure_cli_token PM || { skip_case "no PM token"; TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+    local gid; gid="$(_cli_create_group)"
+    [[ -z "$gid" ]] && { fail "setup create-group failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+
+    local sid; sid="$(_api_create_session "$gid" lifecycle-sess)"
+    if [[ -z "$sid" ]]; then
+        fail "session create failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+        _cli_delete_group "$gid"; return
+    fi
+    pass "session created ($sid)"; TESTS_PASSED=$((TESTS_PASSED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # PATCH /sessions/{sid} — rename the session title.
+    bot_patch "/sessions/${sid}" PM '{"session_title":"renamed-sess"}'
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "PATCH /sessions/{sid} title updated"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "PATCH /sessions/{sid} returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # POST /sessions/{sid}/members — add ENG to the session (default consultant role).
+    bot_post "/sessions/${sid}/members" PM "{\"bot_uuid\":\"${BOT_ENG_UUID}\"}"
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "POST /sessions/{sid}/members added ENG"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "add member returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 120)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # PATCH /sessions/{sid}/members/{bot_uuid} — set ENG's mode to muted.
+    bot_patch "/sessions/${sid}/members/${BOT_ENG_UUID}" PM '{"mode":"muted"}'
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "PATCH member mode set to muted"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "set member mode returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # POST /sessions/{sid}/chat — PM (a participant) sends a message to the session.
+    bot_post "/sessions/${sid}/chat" PM '{"message":"hello-session"}'
+    # session_chat may deliver 0 (bots not connected) — treat 200 as success, a
+    # forbidden/conflict as exercisable-but-blocked; fail only on auth/not-found/5xx.
+    case "$HTTP_STATUS" in
+        200) pass "POST /sessions/{sid}/chat returned 200"; TESTS_PASSED=$((TESTS_PASSED+1)) ;;
+        403|409) warn "session chat returned $HTTP_STATUS (endpoint exercised)"; pass "session chat reachable"; TESTS_PASSED=$((TESTS_PASSED+1)) ;;
+        *) fail "session chat returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 120)"; TESTS_FAILED=$((TESTS_FAILED+1)) ;;
+    esac
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # GET /sessions/{sid}/messages — fetch session message history (public caller ok).
+    api_get "/sessions/${sid}/messages?limit=50"
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "GET /sessions/{sid}/messages returned 200"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "GET /sessions/{sid}/messages returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # DELETE /sessions/{sid}/members/{bot_uuid} — remove ENG.
+    if ! bot_delete "/sessions/${sid}/members/${BOT_ENG_UUID}" PM; then
+        : # bot_delete returns the curl rc; HTTP_STATUS carries the real code
+    fi
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "DELETE member removed ENG"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "DELETE member returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 120)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # DELETE /sessions/{sid}?bot_id=<PM UUID> — PM (creator) deletes the session.
+    api_delete "/sessions/${sid}?bot_id=${BOT_PM_UUID}"
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "DELETE /sessions/{sid} returned 200 (creator delete)"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "DELETE /sessions/{sid} returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # Closed loop: session must be gone after delete. Require the listing request
+    # itself to be healthy (HTTP 200) and the body to parse; a failed/malformed
+    # verification response must NOT default to "gone" — that would mask auth or
+    # route regressions in the verification request. gone: 1 = not listed, 0 =
+    # still present OR verification request failed/unparseable.
+    api_get "/groups/${gid}/sessions"
+    local gone
+    if [[ "$HTTP_STATUS" != "200" ]]; then
+        gone=0
+    else
+        gone=$(printf '%s' "$RESPONSE" | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin)
+    items=d.get('items') or d.get('sessions') or (d if isinstance(d,list) else [])
+    ids=[i.get('session_id') or i.get('id') for i in items]
+    print('1' if sys.argv[1] not in ids else '0')
+except Exception:
+    print('0')
+" "$sid" 2>/dev/null || echo 0)
+    fi
+    if [[ "$gone" = "1" ]]; then
+        pass "session $sid gone after delete (deletion verified)"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "session $sid deletion NOT verified (HTTP=$HTTP_STATUS body=$(printf '%s' "$RESPONSE" | head -c 100))"; TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
     _cli_delete_group "$gid"

--- a/src/bcs/scripts/e2e-test/register.sh
+++ b/src/bcs/scripts/e2e-test/register.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# register.sh — Human-initiated bot registration + owner delete e2e tests.
+#
+# Closed loop: GET /register/token  ->  POST /register  ->  DELETE /bots/{id}.
+#
+#   GET  /register/token   routes::register::get_register_token
+#   POST /register         routes::register::register_bot
+#   DELETE /bots/{id}      routes::bots::leave_bot
+#
+# All three run under the mock human identity (X-Mock-User-Id: 001, set by the
+# api_* helpers). GET /register/token mints a human-bound register token
+# (human_001), POST /register consumes it to create a bot owned by that human,
+# and DELETE /bots/{id} (owner delete) removes it — then GET /bots/{id} must
+# 404, proving the deletion stuck and closing the loop.
+
+# Test registration (consumed by e2e.sh)
+E2E_TESTS_REGISTER=(
+    "test_register_token"
+    "test_register_full_flow"
+)
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+# GET /register/token — the mock human fetches a registration token.
+test_register_token() {
+    info "Register: GET /register/token (mock human)"
+    api_get "/register/token"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "GET /register/token returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 160)"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "GET /register/token returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    local token exp
+    token=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo "")
+    exp=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('expires_at',''))" 2>/dev/null || echo "")
+    assert_not_empty "register token returned" "$token" || true
+    assert_not_empty "register token expires_at returned" "$exp" || true
+}
+
+# GET /register/token -> POST /register -> DELETE /bots/{id} -> GET /bots/{id}
+# (404). Verifies the bot_token is returned on register and that owner delete
+# then removes the bot.
+test_register_full_flow() {
+    info "Register: GET token -> POST /register -> DELETE /bots/{id} -> verify gone"
+
+    # 1. Mint a register token for the mock human.
+    api_get "/register/token"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "setup GET /register/token returned $HTTP_STATUS"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    local reg_token
+    reg_token=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo "")
+    if [ -z "$reg_token" ]; then
+        fail "register token empty"; TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+
+    # 2. POST /register?token=<enc>&bot-name=<unique>. Token may contain
+    #    URL-special chars (+/=), so URL-encode both params. Use a unique name
+    #    so repeated e2e runs don't collide on any name uniqueness.
+    local bot_name enc_token enc_name
+    bot_name="reg-e2e-$$-$(date +%s 2>/dev/null || echo $$)"
+    # Truncate to a safe length and keep it within the 2-64 char rule.
+    bot_name="${bot_name:0:40}"
+    enc_token=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$reg_token")
+    enc_name=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$bot_name")
+    api_post "/register?token=${enc_token}&bot-name=${enc_name}"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        fail "POST /register returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 200)"
+        TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1)); return
+    fi
+    pass "POST /register returned 200"
+    TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    # 3. Credentials: bot_uuid + bot_token must both be present.
+    local bot_uuid bot_token
+    bot_uuid=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('bot_uuid',''))" 2>/dev/null || echo "")
+    bot_token=$(printf '%s' "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('bot_token',''))" 2>/dev/null || echo "")
+    if [ -n "$bot_uuid" ] && [ -n "$bot_token" ]; then
+        pass "register returned bot_uuid + bot_token"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "register missing credentials (uuid='$bot_uuid' token_len=${#bot_token})"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    # Sanity: the just-registered bot is visible before deletion.
+    api_get "/bots/${bot_uuid}"
+    if [ "$HTTP_STATUS" = "200" ]; then
+        pass "registered bot visible via GET /bots/{id} before delete"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "registered bot not found before delete (GET $HTTP_STATUS)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    # 4. Owner delete — same mock human identity owns the bot (created_by is
+    #    human_001 from the register token). api_delete sends the mock headers.
+    api_delete "/bots/${bot_uuid}"
+    if [ "$HTTP_STATUS" = "200" ]; then
+        pass "DELETE /bots/{id} returned 200 (owner delete ok)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "DELETE /bots/{id} returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 200)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    # 5. Closed loop: bot must be gone after delete (soft-deleted -> 404).
+    api_get "/bots/${bot_uuid}"
+    if [ "$HTTP_STATUS" = "404" ]; then
+        pass "GET /bots/{id} returns 404 after delete (deletion verified)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "GET /bots/{id} returned $HTTP_STATUS after delete (expected 404)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}


### PR DESCRIPTION
## Summary

Adds three new e2e test suites that cover previously-uncovered HTTP endpoints, raising the adapters **endpoint coverage from 33.7% → 51.9%** (35 → 54 of 104 endpoints). End-point coverage is the per-route report introduced in #18.

## New suites

**`actor.sh`** — actor directory + bot query/chat
- `GET /actors/list`, `GET /actors/search`
- `PUT /actors/{aid}/status` (self-update, bot token)
- `GET /bots/my`, `GET /bots/paged`, `POST /bots/query`
- `POST /bots/{id}/chat` (sync 1:1)

**`register.sh`** — human-initiated registration, closed loop
- `GET /register/token` → `POST /register` (verifies `bot_token` returned) → `DELETE /bots/{id}` → `GET /bots/{id}` asserts 404

**`group.sh` additions** — session lifecycle (a session is a group's instantiated run)
- `GET /bots/{id}/groups`
- `test_session_invite_join`: invite-link → `POST /sessions/join/{token}` (human joins)
- `test_session_lifecycle`: create → `PATCH` title → add member → `PATCH` member mode → `POST` chat → `GET` messages → remove member → `DELETE` session → verify gone

Covers: `/sessions/join/{token}`, `DELETE/PATCH /sessions/{sid}`, `POST /sessions/{sid}/chat`, `POST /sessions/{sid}/members`, `DELETE/PATCH /sessions/{sid}/members/{bot_uuid}`, `GET /sessions/{sid}/messages`.

## Supporting change

- `common.sh`: add `bot_request()`/`bot_get..delete()` helpers for bot-token authenticated requests (caller resolved from `X-BCS-Bot-Token`); `actor.sh`'s `_bot_request` now wraps them.

## Verification

Full e2e suite: **94/94 passing**.