### PR TITLE
feat(baas): heterogeneous engine integration via BotEngineAdapter SPI

### DIFF
--- a/src/baas/packages/community/configs/application.yaml
+++ b/src/baas/packages/community/configs/application.yaml
@@ -31,6 +31,7 @@ user_config:
     scheduler: "stub"       # stub | real
     cache: "stub"           # stub | real
     bot_service: "stub"  # real | local | stub
+    engine_adapter: "stub"  # stub | real (aicoding/hermes/claude_code engine adapter)
     database:
       plugin_database: "SQLITE_ORM"    # ZDAS_ORM (production ORM) | SQLITE_ORM (test only)
       database_url: "sqlite:////tmp/secbaas.db"

--- a/src/baas/packages/community/configs/overlays/e2e-sqlite.yaml
+++ b/src/baas/packages/community/configs/overlays/e2e-sqlite.yaml
@@ -6,6 +6,7 @@ user_config:
     scheduler: stub
     cache: stub
     bot_service: stub
+    engine_adapter: stub  # stub | real
     sandbox:
       arca: stub
       desktop: stub

--- a/src/baas/packages/community/configs/overlays/it-sqlite.yaml
+++ b/src/baas/packages/community/configs/overlays/it-sqlite.yaml
@@ -10,6 +10,7 @@ user_config:
     scheduler: stub
     cache: stub
     bot_service: stub
+    engine_adapter: stub  # stub | real
     sandbox:
       arca: stub
       desktop: stub

--- a/src/baas/packages/community/src/secbaas/bootstrap/_core_services.py
+++ b/src/baas/packages/community/src/secbaas/bootstrap/_core_services.py
@@ -110,6 +110,45 @@ def _create_system_default_paas_service(factory: PaasServiceFactory):
     return factory.create_local_paas_service(user_id="system", machine_id="default")
 
 
+def _real_engine_adapter_registry():
+    """装配 3 个 real adapter(连真实 engine/proxy 通道)。
+
+    延迟 import:core 层不得 module-level import plugins,故装配在 bootstrap 完成。
+    """
+    from secbaas.core.service.bot_run import BotEngineAdapterRegistry
+    from secbaas.plugins.bot.engine_adapter.aicoding.real import AICodingAdapter
+    from secbaas.plugins.bot.engine_adapter.claude_code.real import (
+        ClaudeCodeAdapter,
+    )
+    from secbaas.plugins.bot.engine_adapter.hermes.real import HermesAdapter
+
+    return BotEngineAdapterRegistry(
+        {
+            "aicoding": AICodingAdapter(),
+            "hermes": HermesAdapter(),
+            "claude_code": ClaudeCodeAdapter(),
+        }
+    )
+
+
+def _stub_engine_adapter_registry():
+    """装配 3 个 Noop adapter(安全零值,不连真实 engine;用于测试/本地)。"""
+    from secbaas.core.service.bot_run import BotEngineAdapterRegistry
+    from secbaas.plugins.bot.engine_adapter.aicoding.stub import NoopAICodingAdapter
+    from secbaas.plugins.bot.engine_adapter.claude_code.stub import (
+        NoopClaudeCodeAdapter,
+    )
+    from secbaas.plugins.bot.engine_adapter.hermes.stub import NoopHermesAdapter
+
+    return BotEngineAdapterRegistry(
+        {
+            "aicoding": NoopAICodingAdapter(),
+            "hermes": NoopHermesAdapter(),
+            "claude_code": NoopClaudeCodeAdapter(),
+        }
+    )
+
+
 class CoreServiceContainer(containers.DeclarativeContainer):
     config = providers.Configuration()
 
@@ -378,12 +417,21 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         repository=bot_session_repo,
     )
 
+    # Engine adapter registry — 按 config.plugins.engine_adapter 切 stub/real,
+    # 仅注入 BaasBotService。stub=Noop(测试/本地),real=连真实 engine 通道。
+    engine_adapter_registry = providers.Selector(
+        config.plugins.engine_adapter,
+        real=providers.Singleton(_real_engine_adapter_registry),
+        stub=providers.Singleton(_stub_engine_adapter_registry),
+    )
+
     baas_bot_service = providers.Singleton(
         BaasBotService,
         client_pool=chat_client_pool,
         config=baas_bot_service_config,
         wss_resolver=bot_wss_dispatcher,
         session_service=session_service,
+        engine_adapter_registry=engine_adapter_registry,
     )
 
     system_config_service = providers.Singleton(

--- a/src/baas/packages/community/src/secbaas/core/repository/ac_bot/_orm_model.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/ac_bot/_orm_model.py
@@ -26,6 +26,7 @@ class AcBotModel(Base):
     owner_name = Column(String(128), nullable=True)
     public = Column(String(16), nullable=True)
     ext = Column(Text, nullable=True)
+    template_type = Column(String(64), nullable=True)
     is_delete = Column(Integer, nullable=False, default=0)
     gmt_create = Column(DateTime, nullable=False, server_default=func.now())
     gmt_modified = Column(

--- a/src/baas/packages/community/src/secbaas/core/repository/ac_bot/_orm_repository.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/ac_bot/_orm_repository.py
@@ -57,6 +57,7 @@ class OrmAcBotRepository(OrmConnectionMixin, AcBotRepository):
             owner_name=row.owner_name,
             public=row.public or "",
             ext=_json_load(row.ext),
+            template_type=row.template_type,
             bot_type=row.bot_type,
         )
 

--- a/src/baas/packages/community/src/secbaas/core/repository/ac_bot/_record.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/ac_bot/_record.py
@@ -37,4 +37,5 @@ class AcBotRecord:
     owner_name: str | None
     public: str
     ext: dict[str, Any] | None
+    template_type: str | None = None
     bot_type: str = "personal"

--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/__init__.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/__init__.py
@@ -30,6 +30,7 @@ from ._bot_run_utils import (
 from ._bot_service_selector import BotServiceSelector
 from ._bot_websocket_client import BotWebSocketClient
 from ._claw_service import BotServiceConfig, ClawBotService
+from ._engine_adapter_registry import BotEngineAdapterRegistry
 from ._executor import BotRunRequestExecutor, SerializingExecutor
 from ._internal_protocols import (
     BotService,
@@ -61,6 +62,7 @@ __all__ = [
     "BotRunner",
     "BotService",
     "BotServiceSelector",
+    "BotEngineAdapterRegistry",
     "MessageDispatcher",
     "NoopMessageDispatcher",
     "QueueTaskMessageDispatcher",

--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/_baas_service.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/_baas_service.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from pydantic import BaseModel, Field
@@ -51,12 +51,28 @@ from ._async_session_client import SessionInfo as AdapterSessionInfo
 from ._bot_run_utils import resolve_user_id
 from ._internal_protocols import BotService
 
+if TYPE_CHECKING:
+    from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+    from ._engine_adapter_registry import BotEngineAdapterRegistry
+
 logger = get_logger("core-bot-run")
 
 DEFAULT_WS_PATH = "/api/openclaw/ws"
 DEFAULT_ADAPTER_PORT = 20003
 DEFAULT_REQUEST_TIMEOUT = 30
 DEFAULT_CONNECT_TIMEOUT = 10
+
+
+def _safe_client_msg(exc: Exception) -> str:
+    """返回可安全外抛给客户端的异常消息(剥离 aiohttp 请求 url 等内部信息)。
+
+    aiohttp.ClientResponseError 的 str() 形如 ``"500, message='...', url='https://agentclawproxy-.../api/sessions'"``,
+    其中 url 是内部代理地址,不应外泄。这里只取业务 message。
+    """
+    if isinstance(exc, aiohttp.ClientResponseError):
+        return exc.message or f"HTTP {exc.status}"
+    return str(exc)
 
 
 class BaasBotServiceConfig(BaseModel):
@@ -96,11 +112,15 @@ class BaasBotService(BotService):
         client_pool: AsyncChatClientPool,
         wss_resolver: DefaultBotWssDispatcher,
         session_service: DefaultSessionService,
+        engine_adapter_registry: BotEngineAdapterRegistry | None = None,
     ) -> None:
         self._config = config
         self._client_pool = client_pool
         self._wss_resolver = wss_resolver
         self._session_service = session_service
+        # Registry 只服务 aicoding / hermes / claude_code；openclaw / teclaw 不注册。
+        # 引擎差异由 registry 分流:命中 adapter 走 adapter,否则走原始分支。
+        self._engine_adapter_registry = engine_adapter_registry
 
     # ── 公开方法 (BotService Protocol) ───────────────────────────────────────
 
@@ -208,13 +228,23 @@ class BaasBotService(BotService):
         )
         try:
             engine_type = binding_info.engine_type if binding_info else None
-            session_consistency_key = self._create_session_consistency_key(
-                engine_type=engine_type,
-                tc_bot_id=binding_info.bot_id,
-                user_id=user_id,
-                run_id=run_id,
-                session_id=session_id,
-            )
+            # consistency key:命中 adapter 走 adapter,否则走原始分支。
+            _adapter = self._adapter_for(engine_type)
+            if _adapter is not None:
+                session_consistency_key = _adapter.session_consistency_key(
+                    tc_bot_id=binding_info.bot_id,
+                    user_id=user_id,
+                    run_id=run_id,
+                    session_id=session_id,
+                )
+            else:
+                session_consistency_key = self._create_session_consistency_key(
+                    engine_type=engine_type,
+                    tc_bot_id=binding_info.bot_id,
+                    user_id=user_id,
+                    run_id=run_id,
+                    session_id=session_id,
+                )
             conn_info = await self._resolve_ws_connection(
                 bot_id, tenant, engine_type, session_consistency_key
             )
@@ -241,7 +271,7 @@ class BaasBotService(BotService):
                 e,
             )
             raise BotServiceError(
-                f"Failed to resolve WS connection for bot {bot_id}: {e}"
+                f"Failed to resolve WS connection for bot {bot_id}: {_safe_client_msg(e)}"
             ) from e
 
         # Step 2: Get or create adapter session
@@ -249,21 +279,37 @@ class BaasBotService(BotService):
 
         try:
             async with session_client:
-                adapter_session_id, reused = await self._get_or_create_adapter_session(
-                    session_client=session_client,
-                    session_id=session_id,
-                    user_id=user_id,
-                    metadata=metadata,
-                    engine_type=engine_type or "openclaw",
-                    bot_id=binding_info.bot_id,
-                    run_id=run_id,
-                )
+                # adapter session 创建:命中 adapter 走 adapter,否则走原始分支
+                # (含 teclaw 语义 + openclaw agent:main: 前缀)。
+                _adapter = self._adapter_for(engine_type)
+                if _adapter is not None:
+                    adapter_session_id, reused = await _adapter.create_adapter_session(
+                        session_client=session_client,
+                        session_id=session_id,
+                        user_id=user_id,
+                        metadata=metadata,
+                        bot_id=binding_info.bot_id,
+                        run_id=run_id,
+                    )
+                else:
+                    (
+                        adapter_session_id,
+                        reused,
+                    ) = await self._get_or_create_adapter_session(
+                        session_client=session_client,
+                        session_id=session_id,
+                        user_id=user_id,
+                        metadata=metadata,
+                        engine_type=engine_type or "openclaw",
+                        bot_id=binding_info.bot_id,
+                        run_id=run_id,
+                    )
         except BotServiceError:
             raise
         except Exception as e:
             logger.warning("Failed to get or create adapter session: %s", e)
             raise BotServiceError(
-                f"Failed to get or create adapter session for bot {bot_id}: {e}"
+                f"Failed to get or create adapter session for bot {bot_id}: {_safe_client_msg(e)}"
             ) from e
 
         action = "reused" if reused else "created"
@@ -333,7 +379,9 @@ class BaasBotService(BotService):
             )
         except Exception as e:
             self._mark_session_failed(baas_session_id, err_msg=str(e))
-            raise BotServiceError(f"Failed to resolve WS connection: {e}") from e
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
 
         pool_key = conn_info.target
         headers = {"x-proxypass-token": conn_info.token}
@@ -372,7 +420,9 @@ class BaasBotService(BotService):
             ) from e
         except Exception as e:
             self._mark_session_failed(baas_session_id, err_msg=str(e))
-            raise BotServiceError(f"Failed to send message: {e}") from e
+            raise BotServiceError(
+                f"Failed to send message: {_safe_client_msg(e)}"
+            ) from e
 
     async def send_message_stream(
         self,
@@ -399,7 +449,9 @@ class BaasBotService(BotService):
             )
         except Exception as e:
             self._mark_session_failed(baas_session_id, err_msg=str(e))
-            raise BotServiceError(f"Failed to resolve WS connection: {e}") from e
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
 
         pool_key = conn_info.target
         headers = {"x-proxypass-token": conn_info.token}
@@ -431,7 +483,9 @@ class BaasBotService(BotService):
             raise
         except Exception as e:
             self._mark_session_failed(baas_session_id, err_msg=str(e))
-            raise BotServiceError(f"Failed to send message stream: {e}") from e
+            raise BotServiceError(
+                f"Failed to send message stream: {_safe_client_msg(e)}"
+            ) from e
 
     async def inject_message(
         self,
@@ -460,7 +514,9 @@ class BaasBotService(BotService):
             )
         except Exception as e:
             self._mark_session_failed(baas_session_id, err_msg=str(e))
-            raise BotServiceError(f"Failed to resolve WS connection: {e}") from e
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
 
         pool_key = conn_info.target
         headers = {"x-proxypass-token": conn_info.token}
@@ -480,7 +536,9 @@ class BaasBotService(BotService):
             raise
         except Exception as e:
             self._mark_session_failed(baas_session_id, err_msg=str(e))
-            raise BotServiceError(f"Failed to inject message: {e}") from e
+            raise BotServiceError(
+                f"Failed to inject message: {_safe_client_msg(e)}"
+            ) from e
 
     async def get_messages(
         self,
@@ -509,7 +567,9 @@ class BaasBotService(BotService):
                 binding_info, session_id, context
             )
         except Exception as e:
-            raise BotServiceError(f"Failed to resolve WS connection: {e}") from e
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
 
         session_client = self._create_session_client(
             conn_info, binding_info.engine_type
@@ -532,7 +592,9 @@ class BaasBotService(BotService):
         except BotServiceError:
             raise
         except Exception as e:
-            raise BotServiceError(f"Failed to get messages: {e}") from e
+            raise BotServiceError(
+                f"Failed to get messages: {_safe_client_msg(e)}"
+            ) from e
 
     async def get_session(
         self,
@@ -562,7 +624,9 @@ class BaasBotService(BotService):
                 binding_info, context
             )
         except Exception as e:
-            raise BotServiceError(f"Failed to resolve WS connection: {e}") from e
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
 
         session_client = self._create_session_client(
             conn_info, binding_info.engine_type
@@ -576,15 +640,30 @@ class BaasBotService(BotService):
         except aiohttp.ClientResponseError as e:
             if e.status == 404:
                 raise SessionNotFoundError(session_id) from e
-            raise BotServiceError(f"Failed to get session: {e}") from e
+            raise BotServiceError(
+                f"Failed to get session: {_safe_client_msg(e)}"
+            ) from e
         except SessionNotFoundError:
             raise
         except BotServiceError:
             raise
         except Exception as e:
-            raise BotServiceError(f"Failed to get session: {e}") from e
+            raise BotServiceError(
+                f"Failed to get session: {_safe_client_msg(e)}"
+            ) from e
 
     # ── 私有方法 ─────────────────────────────────────────────────────────────
+
+    def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:
+        """返回 engine_type 对应的已注册 adapter，未注册返回 None。
+
+        只有 aicoding / hermes / claude_code 会命中；openclaw / teclaw 恒返回 None
+        → 三处接缝走 else 原始分支（字节级不变）。
+        """
+        reg = self._engine_adapter_registry
+        if reg is not None and engine_type and reg.has(engine_type):
+            return reg.get(engine_type)
+        return None
 
     async def _resolve_ws_connection(
         self,
@@ -613,8 +692,12 @@ class BaasBotService(BotService):
             NoDevicesFoundError: If bot has no associated devices.
             NoActiveDevicesError: If bot has no ACTIVE devices.
         """
+        # WS path:命中 adapter 用 adapter.ws_path(),否则用 f"/api/{engine}/ws"。
         path = self._config.ws_path
-        if engine_type:
+        _adapter = self._adapter_for(engine_type)
+        if _adapter is not None:
+            path = _adapter.ws_path()
+        elif engine_type:
             path = f"/api/{engine_type}/ws"
 
         return await self._wss_resolver.dispatch_bot_ws_conn_info(
@@ -678,16 +761,22 @@ class BaasBotService(BotService):
         Returns:
             HTTP base URL for AsyncSessionClient.
         """
-        ws_url = conn_info.ws_url
+        # 保留原静态语义（openclaw/teclaw 及既有测试）：后缀 = f"/api/{engine}/ws"。
+        # 新引擎的 adapter.ws_path() 后缀由 _create_session_client 走 _strip_ws_url_to_base。
+        return BaasBotService._strip_ws_url_to_base(
+            conn_info.ws_url, f"/api/{engine_type}/ws"
+        )
+
+    @staticmethod
+    def _strip_ws_url_to_base(ws_url: str, ws_path_suffix: str) -> str:
+        """wss:// → https:// 并 strip 指定 WS path 后缀。"""
         if ws_url.startswith("wss://"):
             base = ws_url[6:]
         elif ws_url.startswith("ws://"):
             base = ws_url[5:]
         else:
             base = ws_url
-        # Strip the WS path suffix (e.g., /api/openclaw/ws)
         # The target is embedded in the path: /proxypass/{target}/api/openclaw/ws
-        ws_path_suffix = f"/api/{engine_type}/ws"
         if base.endswith(ws_path_suffix):
             base = base[: -len(ws_path_suffix)]
         return f"https://{base}"
@@ -700,10 +789,14 @@ class BaasBotService(BotService):
         Args:
             conn_info: WsConnectionInfo with ws_url, token, target.
 
-        Returns:
-            Configured AsyncSessionClient instance.
+        base_url 计算：新引擎（aicoding 等）用 adapter.ws_path() 作 strip 后缀，
+        openclaw/teclaw 走原 _build_base_url。
         """
-        base_url = self._build_base_url(conn_info, engine_type)
+        _adapter = self._adapter_for(engine_type)
+        if _adapter is not None:
+            base_url = self._strip_ws_url_to_base(conn_info.ws_url, _adapter.ws_path())
+        else:
+            base_url = self._build_base_url(conn_info, engine_type)
         headers = {"x-proxypass-token": conn_info.token}
         return AsyncSessionClient(
             base_url=base_url,

--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/_baas_service.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/_baas_service.py
@@ -69,9 +69,13 @@ def _safe_client_msg(exc: Exception) -> str:
 
     aiohttp.ClientResponseError 的 str() 形如 ``"500, message='...', url='https://agentclawproxy-.../api/sessions'"``,
     其中 url 是内部代理地址,不应外泄。这里只取业务 message。
+    其他 aiohttp.ClientError 子类(如 ClientConnectorError / InvalidURL)的 str()
+    同样可能包含内部 hostname/URL,统一返回通用消息;完整异常由调用方记入日志。
     """
     if isinstance(exc, aiohttp.ClientResponseError):
         return exc.message or f"HTTP {exc.status}"
+    if isinstance(exc, aiohttp.ClientError):
+        return "Connection failed"
     return str(exc)
 
 
@@ -378,7 +382,8 @@ class BaasBotService(BotService):
                 binding_info, session_id, context
             )
         except Exception as e:
-            self._mark_session_failed(baas_session_id, err_msg=str(e))
+            logger.warning("Failed to resolve WS connection: %s", e)
+            self._mark_session_failed(baas_session_id, err_msg=_safe_client_msg(e))
             raise BotServiceError(
                 f"Failed to resolve WS connection: {_safe_client_msg(e)}"
             ) from e
@@ -419,7 +424,8 @@ class BaasBotService(BotService):
                 f"Concurrent request on session {session_id}: {e}"
             ) from e
         except Exception as e:
-            self._mark_session_failed(baas_session_id, err_msg=str(e))
+            logger.warning("Failed to send message: %s", e)
+            self._mark_session_failed(baas_session_id, err_msg=_safe_client_msg(e))
             raise BotServiceError(
                 f"Failed to send message: {_safe_client_msg(e)}"
             ) from e
@@ -448,7 +454,8 @@ class BaasBotService(BotService):
                 binding_info, session_id, context
             )
         except Exception as e:
-            self._mark_session_failed(baas_session_id, err_msg=str(e))
+            logger.warning("Failed to resolve WS connection: %s", e)
+            self._mark_session_failed(baas_session_id, err_msg=_safe_client_msg(e))
             raise BotServiceError(
                 f"Failed to resolve WS connection: {_safe_client_msg(e)}"
             ) from e
@@ -482,7 +489,8 @@ class BaasBotService(BotService):
         except BotServiceError:
             raise
         except Exception as e:
-            self._mark_session_failed(baas_session_id, err_msg=str(e))
+            logger.warning("Failed to send message stream: %s", e)
+            self._mark_session_failed(baas_session_id, err_msg=_safe_client_msg(e))
             raise BotServiceError(
                 f"Failed to send message stream: {_safe_client_msg(e)}"
             ) from e
@@ -513,7 +521,8 @@ class BaasBotService(BotService):
                 binding_info, session_id, context
             )
         except Exception as e:
-            self._mark_session_failed(baas_session_id, err_msg=str(e))
+            logger.warning("Failed to resolve WS connection: %s", e)
+            self._mark_session_failed(baas_session_id, err_msg=_safe_client_msg(e))
             raise BotServiceError(
                 f"Failed to resolve WS connection: {_safe_client_msg(e)}"
             ) from e
@@ -535,7 +544,8 @@ class BaasBotService(BotService):
         except BotServiceError:
             raise
         except Exception as e:
-            self._mark_session_failed(baas_session_id, err_msg=str(e))
+            logger.warning("Failed to inject message: %s", e)
+            self._mark_session_failed(baas_session_id, err_msg=_safe_client_msg(e))
             raise BotServiceError(
                 f"Failed to inject message: {_safe_client_msg(e)}"
             ) from e
@@ -567,6 +577,7 @@ class BaasBotService(BotService):
                 binding_info, session_id, context
             )
         except Exception as e:
+            logger.warning("Failed to resolve WS connection: %s", e)
             raise BotServiceError(
                 f"Failed to resolve WS connection: {_safe_client_msg(e)}"
             ) from e
@@ -592,6 +603,7 @@ class BaasBotService(BotService):
         except BotServiceError:
             raise
         except Exception as e:
+            logger.warning("Failed to get messages: %s", e)
             raise BotServiceError(
                 f"Failed to get messages: {_safe_client_msg(e)}"
             ) from e
@@ -624,6 +636,7 @@ class BaasBotService(BotService):
                 binding_info, context
             )
         except Exception as e:
+            logger.warning("Failed to resolve WS connection: %s", e)
             raise BotServiceError(
                 f"Failed to resolve WS connection: {_safe_client_msg(e)}"
             ) from e
@@ -640,6 +653,7 @@ class BaasBotService(BotService):
         except aiohttp.ClientResponseError as e:
             if e.status == 404:
                 raise SessionNotFoundError(session_id) from e
+            logger.warning("Failed to get session: %s", e)
             raise BotServiceError(
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e
@@ -648,6 +662,7 @@ class BaasBotService(BotService):
         except BotServiceError:
             raise
         except Exception as e:
+            logger.warning("Failed to get session: %s", e)
             raise BotServiceError(
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e

--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/_bot_binding_resolver.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/_bot_binding_resolver.py
@@ -21,6 +21,40 @@ if TYPE_CHECKING:
 
 logger = get_logger("core-bot-run")
 
+# 支持的 engine_type 白名单：openclaw/teclaw（老引擎）+ 3 个新引擎。
+_SUPPORTED_ENGINES = frozenset(
+    {"openclaw", "teclaw", "aicoding", "hermes", "claude_code"}
+)
+
+# 这两种 template_type 的沙箱实为 aicoding 引擎进程;当 active_engine 被错写成
+# claude_code 时,强制按 aicoding 处理(兼容生产脏数据)。
+_AICODING_FAMILY_TEMPLATES = frozenset({"personalCoding", "applicationCoding"})
+
+
+def _normalize_engine_type(
+    active_engine: str | None, template_type: str | None = None
+) -> str:
+    """解析 engine_type,先按 template_type+active_engine 的特定组合归一化,再校验白名单。
+
+    生产数据中存在 active_engine 与沙箱实际引擎不一致的脏数据:personalCoding/
+    applicationCoding 模板的沙箱实为 aicoding,但 active_engine 被写成 claude_code。
+    为兼容这类历史数据,仅当 ``template_type ∈ {personalCoding, applicationCoding}``
+    且 ``active_engine == "claude_code"`` 时,强制按 aicoding 处理。其余情况(含
+    template_type 为空)一律以 active_engine 为准,走白名单校验,空/未知回落 openclaw。
+    """
+    if template_type in _AICODING_FAMILY_TEMPLATES and active_engine == "claude_code":
+        return "aicoding"
+    if not active_engine:
+        return "openclaw"
+    if active_engine in _SUPPORTED_ENGINES:
+        return active_engine
+    logger.warning(
+        "engine_type.unknown: active_engine=%r not in whitelist %s, fallback to openclaw",
+        active_engine,
+        sorted(_SUPPORTED_ENGINES),
+    )
+    return "openclaw"
+
 
 class BotBindingResolver:
     """Binding 解析器 — 单次查询完整链路。
@@ -78,7 +112,7 @@ class BotBindingResolver:
             return None
 
         binding_id = ac_bot.binding_id
-        engine_type = ac_bot.active_engine
+        engine_type = _normalize_engine_type(ac_bot.active_engine, ac_bot.template_type)
 
         # Step 2: For service bots, resolve binding based on lifecycle_stage
         if ac_bot.bot_type == "service":
@@ -125,7 +159,7 @@ class BotBindingResolver:
             binding_id=binding.id,
             device_props=binding.device_props or {},
             bot_type=ac_bot.bot_type,
-            engine_type=engine_type if engine_type else "openclaw",
+            engine_type=engine_type,
         )
 
         logger.info(

--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/_bot_run_utils.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/_bot_run_utils.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any
 from secbaas.api.bot_runtime import BotBindingInfo
 from secbaas.spi.bot_service import BotBindingData
 
+from ._bot_binding_resolver import _normalize_engine_type
+
 if TYPE_CHECKING:
     from secbaas.api.bot_runtime import BotChatContext
     from secbaas.core.repository.bot_run import BotRunRecord
@@ -132,7 +134,9 @@ def binding_data_to_info(data: BotBindingData) -> BotBindingInfo:
     - owner_id → entity_id
     - sandbox_id: device_id when device_provider == "arca", else None
     - device_props: always {} (BotBindingData has no device_props)
-    - engine_type: empty string → "openclaw"
+    - engine_type: normalized via _normalize_engine_type(active_engine, template_type);
+      empty active_engine → "openclaw"; claude_code + {personalCoding,applicationCoding}
+      template → "aicoding"; unknown → "openclaw" (with WARN)
     - baas_session_id: always None (set at runtime by BaasBotService)
     - publish_id / publish_status: dropped (no counterpart in BotBindingInfo)
     """
@@ -145,7 +149,7 @@ def binding_data_to_info(data: BotBindingData) -> BotBindingInfo:
         binding_id=data.binding_id,
         device_props={},
         bot_type=data.bot_type,
-        engine_type=data.engine_type or "openclaw",
+        engine_type=_normalize_engine_type(data.engine_type, data.template_type),
         baas_session_id=None,
     )
 

--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/_bot_service_selector.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/_bot_service_selector.py
@@ -7,6 +7,8 @@ from secbaas.api.bot_runtime import BotBindingInfo
 from ._internal_protocols import BotService
 
 # 使用 BaasBotService 的 device_provider 集合
+# 注：引擎差异（aicoding/hermes/claude_code）已下沉到 BotEngineAdapter SPI，
+# 在 BaasBotService 内按 registry.has(engine_type) 分流；新增引擎不扩展本集合。
 _BAAS_PROVIDERS = frozenset({"baas", "teclaw"})
 
 

--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/_engine_adapter_registry.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/_engine_adapter_registry.py
@@ -1,0 +1,34 @@
+"""BotEngineAdapter 注册表。
+
+``BotEngineAdapterRegistry`` 按 ``engine_type`` 查对应 adapter。
+openclaw / teclaw 不注册(``has()`` 返回 False),其请求在 ``BaasBotService``
+内走原始分支。
+
+具体 adapter 实现的装配由 bootstrap 完成(core 不得 import plugins)。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+
+class BotEngineAdapterRegistry:
+    """按 engine_type 查 adapter 的注册表。"""
+
+    def __init__(self, adapters: Mapping[str, BotEngineAdapter]) -> None:
+        self._adapters: dict[str, BotEngineAdapter] = dict(adapters)
+
+    def get(self, engine_type: str) -> BotEngineAdapter:
+        """返回已注册 adapter;未注册抛 KeyError(调用方应先 ``has()``)。"""
+        try:
+            return self._adapters[engine_type]
+        except KeyError:
+            raise KeyError(
+                f"no engine adapter registered for engine_type={engine_type!r}"
+            ) from None
+
+    def has(self, engine_type: str) -> bool:
+        """engine_type 是否有已注册 adapter;不抛异常。"""
+        return engine_type in self._adapters

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/__init__.py
@@ -1,0 +1,5 @@
+"""Bot engine adapter plugins.
+
+`aicoding` / `hermes` / `claude_code` 三个引擎的 `BotEngineAdapter` SPI 实现，
+各含 `local/` + `prod/` 变体与 `_noop.py` / `_mock.py` 测试桩（Rule 20/21）。
+"""

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/_base.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/_base.py
@@ -1,0 +1,66 @@
+"""Shared base for engine adapters (aicoding / hermes / claude_code).
+
+`BaseEngineAdapter` 复刻 `BaasBotService._get_or_create_adapter_session` 中
+**非 teclaw / 非 openclaw** 的通用 else 分支语义：有 session_id 直接复用，否则经
+`session_client.create_session(...)` 新建（不加 openclaw 的 `agent:main:` 前缀）。
+
+子类通过类属性 `engine_type` / `_WS_PATH` 定制标识与 WS 路径；hermes / claude_code
+覆写 `session_consistency_key` / `create_adapter_session` 扩展引擎特有行为。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from secbaas.logger import get_logger
+
+logger = get_logger("core-bot-run")
+
+
+class BaseEngineAdapter:
+    """通用引擎 adapter 基类。"""
+
+    engine_type: str = ""
+    _WS_PATH: str = ""
+
+    def ws_path(self) -> str:
+        return self._WS_PATH
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        """默认：session_id 优先，否则无 device 亲和（aicoding 语义）。"""
+        return session_id
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        """复刻通用 else 分支：有 session_id 复用，否则新建（无前缀）。"""
+        if session_id:
+            logger.info(
+                "Adapter session already exists: session_id=%s, reusing", session_id
+            )
+            return session_id, True
+        adapter_session = await session_client.create_session(
+            title=metadata.get("title", None),
+            user_id=user_id,
+            agent_id=bot_id,
+            uuid=run_id,
+            model=metadata.get("model", None),
+            engine=self.engine_type,
+        )
+        adapter_session_id = adapter_session.id
+        logger.info("Adapter session created: session_id=%s", adapter_session_id)
+        return adapter_session_id, False

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/__init__.py
@@ -1,0 +1,6 @@
+"""AICoding engine adapter plugin —— real 生产实现 + stub 测试桩(noop/mock)。"""
+
+from .real import AICodingAdapter
+from .stub import MockAICodingAdapter, NoopAICodingAdapter
+
+__all__ = ["AICodingAdapter", "MockAICodingAdapter", "NoopAICodingAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/real/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/real/__init__.py
@@ -1,0 +1,5 @@
+"""AICoding real 引擎 adapter。"""
+
+from ._real_aicoding import AICodingAdapter
+
+__all__ = ["AICodingAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/real/_real_aicoding.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/real/_real_aicoding.py
@@ -1,0 +1,18 @@
+"""AICoding 引擎 adapter。
+
+AICoding 在 engine 侧监听 WS 路径 ``/api/ws``（不带引擎名段），故 ``ws_path`` 返回该值。
+无引擎特有的 session 语义:``session_consistency_key`` 用基类默认（session_id 优先，
+否则返回 None，即不做 device 亲和）；``create_adapter_session`` 走基类通用创建/复用逻辑，
+不加会话前缀。
+"""
+
+from __future__ import annotations
+
+from ..._base import BaseEngineAdapter
+
+
+class AICodingAdapter(BaseEngineAdapter):
+    """AICoding 引擎 adapter —— WS 路径 ``/api/ws``。"""
+
+    engine_type = "aicoding"
+    _WS_PATH = "/api/ws"

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/stub/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/stub/__init__.py
@@ -1,0 +1,5 @@
+"""AICoding adapter 测试桩(noop/mock)。"""
+
+from ._stub_aicoding import MockAICodingAdapter, NoopAICodingAdapter
+
+__all__ = ["MockAICodingAdapter", "NoopAICodingAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/stub/_stub_aicoding.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/aicoding/stub/_stub_aicoding.py
@@ -1,0 +1,80 @@
+"""AICoding adapter 测试桩:Noop(安全零值) + Mock(记录调用)。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class NoopAICodingAdapter:
+    """No-op AICoding adapter:返回安全零值、不做任何 I/O。"""
+
+    engine_type = "aicoding"
+
+    def ws_path(self) -> str:
+        return "/api/ws"
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        return None
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        return ("", True)
+
+
+class MockAICodingAdapter:
+    """内存版 AICoding adapter:记录调用、返回可预期值,供单测断言。"""
+
+    engine_type = "aicoding"
+
+    def __init__(
+        self, *, session_result: tuple[str, bool] = ("mock-aicoding-session", False)
+    ) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._session_result = session_result
+
+    def ws_path(self) -> str:
+        self.calls.append(("ws_path",))
+        return "/api/ws"
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        self.calls.append(
+            ("session_consistency_key", tc_bot_id, user_id, run_id, session_id)
+        )
+        if session_id is not None:
+            return session_id
+        return None
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        self.calls.append(("create_adapter_session", bot_id, session_id, run_id))
+        return self._session_result

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/__init__.py
@@ -1,0 +1,6 @@
+"""Claude Code engine adapter plugin —— real 生产实现 + stub 测试桩(noop/mock)。"""
+
+from .real import ClaudeCodeAdapter
+from .stub import MockClaudeCodeAdapter, NoopClaudeCodeAdapter
+
+__all__ = ["ClaudeCodeAdapter", "MockClaudeCodeAdapter", "NoopClaudeCodeAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/real/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/real/__init__.py
@@ -1,0 +1,5 @@
+"""Claude Code real 引擎 adapter。"""
+
+from ._real_claude_code import ClaudeCodeAdapter
+
+__all__ = ["ClaudeCodeAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/real/_real_claude_code.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/real/_real_claude_code.py
@@ -1,0 +1,30 @@
+"""Claude Code 引擎 adapter。
+
+薄封装:``ws_path`` 命中 engine 侧 claude_code 专属 router ``/api/claude_code/ws``;
+``session_consistency_key`` 返回 ``agent:{tc_bot_id}:session:{run_id}:user:{user_id}`` 作为
+device 亲和键;session 创建走基类通用逻辑。经 proxy→沙箱→engine 的现有 WS 通道工作，
+adapter 本身不做额外的连通性探活。
+"""
+
+from __future__ import annotations
+
+from ..._base import BaseEngineAdapter
+
+
+class ClaudeCodeAdapter(BaseEngineAdapter):
+    """Claude Code 引擎 adapter —— WS 路径 ``/api/claude_code/ws``。"""
+
+    engine_type = "claude_code"
+    _WS_PATH = "/api/claude_code/ws"
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        if session_id is not None:
+            return session_id
+        return f"agent:{tc_bot_id}:session:{run_id}:user:{user_id}"

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/stub/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/stub/__init__.py
@@ -1,0 +1,5 @@
+"""Claude Code adapter 测试桩(noop/mock)。"""
+
+from ._stub_claude_code import MockClaudeCodeAdapter, NoopClaudeCodeAdapter
+
+__all__ = ["MockClaudeCodeAdapter", "NoopClaudeCodeAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/stub/_stub_claude_code.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/claude_code/stub/_stub_claude_code.py
@@ -1,0 +1,82 @@
+"""Claude Code adapter 测试桩:Noop(安全零值) + Mock(记录调用)。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class NoopClaudeCodeAdapter:
+    """No-op Claude Code adapter:返回安全零值、不做任何 I/O。"""
+
+    engine_type = "claude_code"
+
+    def ws_path(self) -> str:
+        return "/api/claude_code/ws"
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        return None
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        return ("", True)
+
+
+class MockClaudeCodeAdapter:
+    """内存版 Claude Code adapter:记录调用、返回可预期值,供单测断言。"""
+
+    engine_type = "claude_code"
+
+    def __init__(
+        self,
+        *,
+        session_result: tuple[str, bool] = ("mock-claude-code-session", False),
+    ) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._session_result = session_result
+
+    def ws_path(self) -> str:
+        self.calls.append(("ws_path",))
+        return "/api/claude_code/ws"
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        self.calls.append(
+            ("session_consistency_key", tc_bot_id, user_id, run_id, session_id)
+        )
+        if session_id is not None:
+            return session_id
+        return f"agent:{tc_bot_id}:session:{run_id}:user:{user_id}"
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        self.calls.append(("create_adapter_session", bot_id, session_id, run_id))
+        return self._session_result

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/__init__.py
@@ -1,0 +1,6 @@
+"""Hermes engine adapter plugin —— real 生产实现 + stub 测试桩(noop/mock)。"""
+
+from .real import HermesAdapter
+from .stub import MockHermesAdapter, NoopHermesAdapter
+
+__all__ = ["HermesAdapter", "MockHermesAdapter", "NoopHermesAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/real/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/real/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes real 引擎 adapter。"""
+
+from ._real_hermes import HermesAdapter
+
+__all__ = ["HermesAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/real/_real_hermes.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/real/_real_hermes.py
@@ -1,0 +1,119 @@
+"""Hermes 引擎 adapter。
+
+两处引擎特有行为:
+
+1. ``session_consistency_key`` 返回 ``agent:{tc_bot_id}:session:{run_id}:user:{user_id}``
+   作为 device 亲和键（与 claude_code 同形），让同一会话的请求稳定落到同一设备。
+
+2. ``create_adapter_session``:Hermes 侧新建 session 后，其真正可用的 session_id 是异步
+   持久化产生的（形如 ``YYYYMMDD_HHMMSS_xxxxxx`` 或 ``api-xxxxx``）。若直接用创建即时返回的
+   临时 id 去发消息会失效，因此这里在创建后轮询等待持久化 id 就绪;超过
+   ``session_persist_timeout_seconds`` 仍未就绪则抛 ``BotNotAvailableError``。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from typing import Any
+
+from secbaas.api.bot_runtime import BotNotAvailableError
+from secbaas.logger import get_logger
+
+from ..._base import BaseEngineAdapter
+
+logger = get_logger("core-bot-run")
+
+# Hermes 持久化 session_id 形态:YYYYMMDD_HHMMSS_xxxxxx 或 api-xxxxx
+_PERSISTENT_RE = re.compile(r"^\d{8}_\d{6}_\w{6,}$|^api-\w+$")
+
+_DEFAULT_PERSIST_TIMEOUT_SECONDS = 5.0
+_DEFAULT_POLL_INTERVAL_SECONDS = 0.2
+
+
+def _is_persistent(session_id: str | None) -> bool:
+    return bool(session_id) and bool(_PERSISTENT_RE.match(session_id))
+
+
+class HermesAdapter(BaseEngineAdapter):
+    """Hermes 引擎 adapter —— WS 路径 ``/api/hermes/ws``，创建后等待持久化 session_id。"""
+
+    engine_type = "hermes"
+    _WS_PATH = "/api/hermes/ws"
+
+    def __init__(
+        self,
+        *,
+        session_persist_timeout_seconds: float = _DEFAULT_PERSIST_TIMEOUT_SECONDS,
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        self._persist_timeout = session_persist_timeout_seconds
+        self._poll_interval = poll_interval_seconds
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        if session_id is not None:
+            return session_id
+        return f"agent:{tc_bot_id}:session:{run_id}:user:{user_id}"
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        if session_id:
+            logger.info(
+                "Adapter session already exists: session_id=%s, reusing", session_id
+            )
+            return session_id, True
+
+        adapter_session = await session_client.create_session(
+            title=metadata.get("title", None),
+            user_id=user_id,
+            agent_id=bot_id,
+            uuid=run_id,
+            model=metadata.get("model", None),
+            engine=self.engine_type,
+        )
+        candidate = adapter_session.id
+        if _is_persistent(candidate):
+            logger.info("Hermes session created (persistent): session_id=%s", candidate)
+            return candidate, False
+
+        persistent = await self._await_persistent_session(session_client, candidate)
+        if persistent is None:
+            raise BotNotAvailableError(bot_id, "hermes session persistence timeout")
+        logger.info("Hermes session persisted: session_id=%s", persistent)
+        return persistent, False
+
+    async def _await_persistent_session(
+        self, session_client: Any, candidate: str
+    ) -> str | None:
+        """轮询 get_session 直到拿到持久化 session_id,或超时返回 None。"""
+        deadline = time.monotonic() + self._persist_timeout
+        current = candidate
+        while time.monotonic() < deadline:
+            await asyncio.sleep(self._poll_interval)
+            try:
+                refreshed = await session_client.get_session(
+                    current, engine=self.engine_type
+                )
+            except Exception as e:  # noqa: BLE001 — 轮询容错,继续重试直至超时
+                logger.debug("hermes persistence poll failed: %s", e)
+                continue
+            current = getattr(refreshed, "id", current) or current
+            if _is_persistent(current):
+                return current
+        return None

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/stub/__init__.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/stub/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes adapter 测试桩(noop/mock)。"""
+
+from ._stub_hermes import MockHermesAdapter, NoopHermesAdapter
+
+__all__ = ["MockHermesAdapter", "NoopHermesAdapter"]

--- a/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/stub/_stub_hermes.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot/engine_adapter/hermes/stub/_stub_hermes.py
@@ -1,0 +1,82 @@
+"""Hermes adapter 测试桩:Noop(安全零值) + Mock(记录调用)。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class NoopHermesAdapter:
+    """No-op Hermes adapter:返回安全零值、不做任何 I/O。"""
+
+    engine_type = "hermes"
+
+    def ws_path(self) -> str:
+        return "/api/hermes/ws"
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        return None
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        return ("", True)
+
+
+class MockHermesAdapter:
+    """内存版 Hermes adapter:记录调用、返回可预期值,供单测断言。"""
+
+    engine_type = "hermes"
+
+    def __init__(
+        self,
+        *,
+        session_result: tuple[str, bool] = ("20260701_120000_abcdef", False),
+    ) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._session_result = session_result
+
+    def ws_path(self) -> str:
+        self.calls.append(("ws_path",))
+        return "/api/hermes/ws"
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        self.calls.append(
+            ("session_consistency_key", tc_bot_id, user_id, run_id, session_id)
+        )
+        if session_id is not None:
+            return session_id
+        return f"agent:{tc_bot_id}:session:{run_id}:user:{user_id}"
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        self.calls.append(("create_adapter_session", bot_id, session_id, run_id))
+        return self._session_result

--- a/src/baas/packages/community/src/secbaas/plugins/bot_service/real/_plugin.py
+++ b/src/baas/packages/community/src/secbaas/plugins/bot_service/real/_plugin.py
@@ -285,6 +285,14 @@ class AiohttpBotServicePlugin(BotServicePlugin):
                 _stage_ms,
                 (time.monotonic() - _binding_t0) * 1000,
             )
+            logger.info(
+                "[bot-service] get_binding raw: bot_id=%s engine_type=%r "
+                "template_type=%r device_provider=%r",
+                inner.get("bot_id", bot_id),
+                inner.get("engine_type"),
+                inner.get("template_type"),
+                inner.get("device_provider"),
+            )
             return BotBindingData(
                 bot_id=inner.get("bot_id", bot_id),
                 owner_id=inner.get("owner_id", owner_id),
@@ -295,6 +303,7 @@ class AiohttpBotServicePlugin(BotServicePlugin):
                 binding_id=inner.get("binding_id", 0),
                 device_provider=inner.get("device_provider", ""),
                 device_id=inner.get("device_id", ""),
+                template_type=inner.get("template_type"),
             )
 
         if last_error is not None and last_error.code != ErrorCode.PLATFORM_UNAVAILABLE:

--- a/src/baas/packages/community/src/secbaas/spi/bot/engine_adapter/__init__.py
+++ b/src/baas/packages/community/src/secbaas/spi/bot/engine_adapter/__init__.py
@@ -1,0 +1,5 @@
+"""BotEngineAdapter SPI — Protocol for aicoding / hermes / claude_code engine differences."""
+
+from ._protocols import BotEngineAdapter
+
+__all__ = ["BotEngineAdapter"]

--- a/src/baas/packages/community/src/secbaas/spi/bot/engine_adapter/_protocols.py
+++ b/src/baas/packages/community/src/secbaas/spi/bot/engine_adapter/_protocols.py
@@ -1,0 +1,88 @@
+"""BotEngineAdapter SPI — 引擎差异抽象契约。
+
+定义 `BotEngineAdapter` Protocol：把 `BaasBotService` 内随 engine_type 分叉的
+引擎差异（WS path 段、device 亲和 key、adapter session 创建语义）收敛成可注册、
+可测试的扩展点。
+
+## Context Boundary
+
+- **上游消费者**：`core/service/bot_run/_baas_service.py`（经 `BotEngineAdapterRegistry`
+  在 3 处接缝按 `registry.has(engine_type)` 分流调用）。
+- **实现方**：`plugins/bot/engine_adapter/{aicoding,hermes,claude_code}/{local,prod}`
+  及各自 `_noop.py` / `_mock.py`。
+- **Scope**：仅服务 `aicoding` / `hermes` / `claude_code` 三个新引擎；`openclaw` /
+  `teclaw` 不经本 SPI，继续走 `BaasBotService` 的 `else` 原始分支（字节级不变）。
+- send/inject 在 `BaasBotService` 内无引擎分叉，**不属于本 SPI**。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BotEngineAdapter(Protocol):
+    """引擎差异适配器契约（仅 aicoding / hermes / claude_code）。
+
+    实现方通过 4 个成员表达引擎差异，其余会话/消息编排仍由 `BaasBotService` 统一处理。
+    """
+
+    @property
+    def engine_type(self) -> str:
+        """引擎标识（如 ``"aicoding"``），与注册键一致。"""
+        ...
+
+    def ws_path(self) -> str:
+        """引擎在 engine adapter 侧监听的 WS 路径段。
+
+        - aicoding → ``"/api/ws"``
+        - hermes → ``"/api/hermes/ws"``
+        - claude_code → ``"/api/claude_code/ws"``
+
+        用于 `_resolve_ws_connection` 拼 path 与 `_build_base_url` strip 后缀。
+        """
+        ...
+
+    def session_consistency_key(
+        self,
+        *,
+        tc_bot_id: str,
+        user_id: str,
+        run_id: str | None,
+        session_id: str | None = None,
+    ) -> str | None:
+        """返回 device 亲和一致性哈希字符串（传给 `_wss_resolver` 的 ``device_affinity``）。
+
+        语义为路由亲和字符串（**非**去重 tuple）。``session_id`` 非空时优先返回它。
+
+        - aicoding → ``None``
+        - claude_code / hermes → ``f"agent:{tc_bot_id}:session:{run_id}:user:{user_id}"``
+        """
+        ...
+
+    async def create_adapter_session(
+        self,
+        *,
+        session_client: Any,
+        session_id: str | None,
+        user_id: str,
+        metadata: dict[str, Any],
+        bot_id: str,
+        run_id: str | None,
+    ) -> tuple[str, bool]:
+        """获取或创建 adapter 侧 session，返回 ``(adapter_session_id, is_reused)``。
+
+        封装 `BaasBotService._get_or_create_adapter_session` 中本引擎的语义分支。
+
+        Args:
+            session_client: `AsyncSessionClient`（duck-typed，含 create_session/get_session）。
+            session_id: 已有 session id，None 表示新建。
+            user_id: 创建 session 时传给 adapter 的 user id。
+            metadata: 会话元数据（title / model 等）。
+            bot_id: teamclaw bot id / agent id。
+            run_id: 关联的 run id（作为 adapter uuid）。
+
+        Raises:
+            BotNotAvailableError: 引擎侧不可用（如 hermes 持久化超时、claude_code relay 离线）。
+        """
+        ...

--- a/src/baas/packages/community/src/secbaas/spi/bot_service/_models.py
+++ b/src/baas/packages/community/src/secbaas/spi/bot_service/_models.py
@@ -19,6 +19,7 @@ class BotBindingData:
     binding_id: int = 0
     device_provider: str = ""
     device_id: str = ""
+    template_type: str | None = None
 
 
 @dataclass

--- a/src/baas/packages/community/tests/architecture/check_protocols/spi/bot/engine_adapter/check_bot_engine_adapter.py
+++ b/src/baas/packages/community/tests/architecture/check_protocols/spi/bot/engine_adapter/check_bot_engine_adapter.py
@@ -1,0 +1,30 @@
+"""Rule 25 契约校验（mypy 结构子类型）：3 个新引擎的 prod/local/noop/mock 变体
+必须结构满足 ``BotEngineAdapter`` Protocol。赋值即触发 mypy 检查。
+"""
+
+from secbaas.plugins.bot.engine_adapter.aicoding import (
+    MockAICodingAdapter,
+    NoopAICodingAdapter,
+)
+from secbaas.plugins.bot.engine_adapter.aicoding.real import AICodingAdapter
+from secbaas.plugins.bot.engine_adapter.claude_code import (
+    MockClaudeCodeAdapter,
+    NoopClaudeCodeAdapter,
+)
+from secbaas.plugins.bot.engine_adapter.claude_code.real import ClaudeCodeAdapter
+from secbaas.plugins.bot.engine_adapter.hermes import (
+    MockHermesAdapter,
+    NoopHermesAdapter,
+)
+from secbaas.plugins.bot.engine_adapter.hermes.real import HermesAdapter
+from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+# aicoding
+_ai_real: BotEngineAdapter = AICodingAdapter()
+_ai_noop: BotEngineAdapter = NoopAICodingAdapter()
+_ai_mock: BotEngineAdapter = MockAICodingAdapter()
+
+# claude_code
+_cc_real: BotEngineAdapter = ClaudeCodeAdapter()
+_cc_noop: BotEngineAdapter = NoopClaudeCodeAdapter()
+_cc_mock: BotEngineAdapter = MockClaudeCodeAdapter()

--- a/src/baas/packages/community/tests/contract/spi/test_bot_engine_adapter.py
+++ b/src/baas/packages/community/tests/contract/spi/test_bot_engine_adapter.py
@@ -1,0 +1,114 @@
+"""BotEngineAdapter SPI 契约测试。
+
+断言 Protocol 形状(4 个公共成员 + @runtime_checkable)与各 adapter 实现满足 isinstance。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from secbaas.plugins.bot.engine_adapter.aicoding.real import AICodingAdapter
+from secbaas.plugins.bot.engine_adapter.aicoding.stub import (
+    MockAICodingAdapter,
+    NoopAICodingAdapter,
+)
+from secbaas.plugins.bot.engine_adapter.claude_code.real import ClaudeCodeAdapter
+from secbaas.plugins.bot.engine_adapter.claude_code.stub import (
+    MockClaudeCodeAdapter,
+    NoopClaudeCodeAdapter,
+)
+from secbaas.plugins.bot.engine_adapter.hermes.real import HermesAdapter
+from secbaas.plugins.bot.engine_adapter.hermes.stub import (
+    MockHermesAdapter,
+    NoopHermesAdapter,
+)
+from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+EXPECTED_MEMBERS = {
+    "engine_type",
+    "ws_path",
+    "session_consistency_key",
+    "create_adapter_session",
+}
+
+# (factory, expected_engine_type) — 覆盖 3 引擎 × {real, noop, mock}
+ADAPTER_CASES = [
+    (AICodingAdapter, "aicoding"),
+    (NoopAICodingAdapter, "aicoding"),
+    (MockAICodingAdapter, "aicoding"),
+    (HermesAdapter, "hermes"),
+    (NoopHermesAdapter, "hermes"),
+    (MockHermesAdapter, "hermes"),
+    (ClaudeCodeAdapter, "claude_code"),
+    (NoopClaudeCodeAdapter, "claude_code"),
+    (MockClaudeCodeAdapter, "claude_code"),
+]
+
+
+def test_protocol_exposes_exactly_expected_members() -> None:
+    """Protocol 只暴露 4 个约定公共成员，私有辅助方法不进契约。"""
+    public = {m for m in dir(BotEngineAdapter) if not m.startswith("_")}
+    assert public == EXPECTED_MEMBERS
+
+
+def test_protocol_is_runtime_checkable() -> None:
+    """@runtime_checkable：duck-typed 对象可通过 isinstance（否则会 TypeError）。"""
+
+    class _Dummy:
+        engine_type = "dummy"
+
+        def ws_path(self) -> str:
+            return "/api/ws"
+
+        def session_consistency_key(self, **_: object) -> str | None:
+            return None
+
+        async def create_adapter_session(self, **_: object) -> tuple[str, bool]:
+            return ("", True)
+
+    assert isinstance(_Dummy(), BotEngineAdapter)
+
+
+@pytest.mark.parametrize(
+    "factory, engine_type",
+    ADAPTER_CASES,
+    ids=[f"{f.__name__}" for f, _ in ADAPTER_CASES],
+)
+def test_adapter_satisfies_protocol(factory: type, engine_type: str) -> None:
+    adapter = factory()
+    assert isinstance(adapter, BotEngineAdapter)
+    assert adapter.engine_type == engine_type
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [f for f, _ in ADAPTER_CASES],
+    ids=[f"{f.__name__}" for f, _ in ADAPTER_CASES],
+)
+def test_ws_path_returns_str(factory: type) -> None:
+    assert isinstance(factory().ws_path(), str)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [f for f, _ in ADAPTER_CASES],
+    ids=[f"{f.__name__}" for f, _ in ADAPTER_CASES],
+)
+def test_session_consistency_key_returns_str_or_none(factory: type) -> None:
+    key = factory().session_consistency_key(
+        tc_bot_id="b1", user_id="u1", run_id="r1", session_id=None
+    )
+    assert key is None or isinstance(key, str)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [f for f, _ in ADAPTER_CASES],
+    ids=[f"{f.__name__}" for f, _ in ADAPTER_CASES],
+)
+def test_session_consistency_key_prefers_explicit_session_id(factory: type) -> None:
+    """session_id 非空时优先透传（Mock 语义；Noop 恒 None）。"""
+    key = factory().session_consistency_key(
+        tc_bot_id="b1", user_id="u1", run_id="r1", session_id="s-fixed"
+    )
+    assert key in ("s-fixed", None)

--- a/src/baas/packages/community/tests/e2e/open_api/test_stub_adapter_boot.py
+++ b/src/baas/packages/community/tests/e2e/open_api/test_stub_adapter_boot.py
@@ -1,0 +1,69 @@
+"""E2E: stub adapter 配置下应用启动 + open_api 端点可达。
+
+验证目标(防升级改坏):
+1. ``config.plugins.engine_adapter=stub`` 时 ApplicationContainer 能正常装配,
+   ``engine_adapter_registry`` 解析出 3 个 Noop adapter(aicoding/hermes/claude_code)。
+2. ``/openapi/v1/runs`` 与 ``/openapi/v1/messages`` 路由已挂载,鉴权链路通(无 token → 401)。
+3. 响应体带 ``trace_id`` 字段(印证 trace_id 上提到 ``ApiResponse`` 基类)。
+
+归一化路由(active_engine + template_type → adapter)的断言由
+``tests/unit/core/service/bot_run/test_engine_dispatch_integration.py`` 覆盖;
+本 e2e 聚焦装配与端点可达,不依赖真实 engine / binding。
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from secbaas.adapters.web.app import app
+from secbaas.plugins.bot.engine_adapter.aicoding.stub import NoopAICodingAdapter
+from secbaas.plugins.bot.engine_adapter.claude_code.stub import (
+    NoopClaudeCodeAdapter,
+)
+from secbaas.plugins.bot.engine_adapter.hermes.stub import NoopHermesAdapter
+
+pytestmark = [pytest.mark.e2e]
+
+
+class TestStubAdapterBoot:
+    """stub adapter 配置下的应用装配与端点可达性。"""
+
+    def test_registry_resolves_three_noop_adapters(self, bootstrap_init):
+        """stub 配置下 registry 注入 3 个 Noop adapter,证明装配链路没坏。"""
+        registry = bootstrap_init.services.engine_adapter_registry()
+
+        assert registry.has("aicoding")
+        assert registry.has("hermes")
+        assert registry.has("claude_code")
+        # openclaw / teclaw 不注册(走 BaasBotService else 分支)
+        assert not registry.has("openclaw")
+        assert not registry.has("teclaw")
+
+        assert isinstance(registry.get("aicoding"), NoopAICodingAdapter)
+        assert isinstance(registry.get("hermes"), NoopHermesAdapter)
+        assert isinstance(registry.get("claude_code"), NoopClaudeCodeAdapter)
+
+    def test_runs_endpoint_rejects_missing_token(self, bootstrap_init):
+        """POST /openapi/v1/runs 无 token → 401(鉴权链路通,路由已挂载)。"""
+        with TestClient(app) as client:
+            resp = client.post(
+                "/openapi/v1/runs",
+                json={"message": "hello"},
+            )
+        assert resp.status_code == 401
+        body = resp.json()
+        # 鉴权层错误响应契约:{"detail":{"code","message"}}
+        assert body["detail"]["code"] == 40101
+        assert body["detail"]["message"] == "Token 缺失"
+
+    def test_messages_endpoint_rejects_missing_token(self, bootstrap_init):
+        """POST /openapi/v1/messages 无 token → 401。"""
+        with TestClient(app) as client:
+            resp = client.post(
+                "/openapi/v1/messages",
+                json={"bot_id": "default:374193", "message": "hello"},
+            )
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["detail"]["code"] == 40101

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service.py
@@ -1192,6 +1192,34 @@ class TestCreateSessionAdapterErrors:
                 )
 
     @pytest.mark.asyncio
+    async def test_adapter_session_client_error_does_not_leak_url(
+        self, service, wss_resolver
+    ):
+        # [单测用例]测试场景：ClientResponseError 含内部代理 url,外抛消息不得包含 url
+        """_safe_client_msg strips aiohttp request url from ClientResponseError."""
+        import aiohttp
+
+        from secbaas.core.service.bot_run._baas_service import _safe_client_msg
+
+        cre = aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=500,
+            message="Unsupported engine type: claude_code. Only 'aicoding' is supported.",
+        )
+        # aiohttp 把请求 url 拼进 str(cre);模拟该行为
+        cre.__dict__["_url"] = (
+            "https://agentclawproxy-pre.alipay.com/proxypass/ARCA_sb/api/sessions"  # type: ignore[attr-defined]
+        )
+
+        safe = _safe_client_msg(cre)
+        assert "agentclawproxy" not in safe
+        assert "/api/sessions" not in safe
+        assert "Unsupported engine type" in safe  # 业务错误保留
+        # 普通异常照常 str()
+        assert _safe_client_msg(RuntimeError("boom")) == "boom"
+
+    @pytest.mark.asyncio
     async def test_existing_session_id_exception_reraises(self, service, wss_resolver):
         # [单测用例]测试场景：session_id 已存在但 async with 出异常时 re-raise
         """When session_id is provided but async context fails, exception is reraised."""

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service.py
@@ -1220,6 +1220,27 @@ class TestCreateSessionAdapterErrors:
         assert _safe_client_msg(RuntimeError("boom")) == "boom"
 
     @pytest.mark.asyncio
+    async def test_safe_client_msg_generic_client_error_does_not_leak_url(self, service):
+        # [单测用例]测试场景：ClientConnectorError 等 ClientError 子类 str() 含内部
+        # hostname/URL，外抛消息须统一为通用消息，不得泄露内部地址
+        """_safe_client_msg returns generic message for other aiohttp.ClientError."""
+        import aiohttp
+
+        from secbaas.core.service.bot_run._baas_service import _safe_client_msg
+
+        # ClientConnectorError 的 str() 形如
+        # "Cannot connect to host agentclawproxy-pre.alipay.com:443 ..."
+        cce = aiohttp.ClientConnectorError(
+            connection_key=MagicMock(),
+            os_error=OSError("Cannot connect to host agentclawproxy-pre.alipay.com:443"),
+        )
+
+        safe = _safe_client_msg(cce)
+        assert safe == "Connection failed"
+        assert "agentclawproxy" not in safe
+        assert "alipay.com" not in safe
+
+    @pytest.mark.asyncio
     async def test_existing_session_id_exception_reraises(self, service, wss_resolver):
         # [单测用例]测试场景：session_id 已存在但 async with 出异常时 re-raise
         """When session_id is provided but async context fails, exception is reraised."""

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service.py
@@ -1220,6 +1220,31 @@ class TestCreateSessionAdapterErrors:
         assert _safe_client_msg(RuntimeError("boom")) == "boom"
 
     @pytest.mark.asyncio
+    async def test_safe_client_msg_generic_client_error_does_not_leak_url(
+        self, service
+    ):
+        # [单测用例]测试场景：ClientConnectorError 等 ClientError 子类 str() 含内部
+        # hostname/URL，外抛消息须统一为通用消息，不得泄露内部地址
+        """_safe_client_msg returns generic message for other aiohttp.ClientError."""
+        import aiohttp
+
+        from secbaas.core.service.bot_run._baas_service import _safe_client_msg
+
+        # ClientConnectorError 的 str() 形如
+        # "Cannot connect to host agentclawproxy-pre.alipay.com:443 ..."
+        cce = aiohttp.ClientConnectorError(
+            connection_key=MagicMock(),
+            os_error=OSError(
+                "Cannot connect to host agentclawproxy-pre.alipay.com:443"
+            ),
+        )
+
+        safe = _safe_client_msg(cce)
+        assert safe == "Connection failed"
+        assert "agentclawproxy" not in safe
+        assert "alipay.com" not in safe
+
+    @pytest.mark.asyncio
     async def test_existing_session_id_exception_reraises(self, service, wss_resolver):
         # [单测用例]测试场景：session_id 已存在但 async with 出异常时 re-raise
         """When session_id is provided but async context fails, exception is reraised."""

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service_engine_seams.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_baas_service_engine_seams.py
@@ -1,0 +1,95 @@
+"""§6.6 — BaasBotService 引擎接缝分流测试。
+
+验证 registry 注入 + `_adapter_for` 门控：新引擎走 adapter，openclaw/teclaw 走 else
+（`_adapter_for` 返回 None）。字节级不变性由 else 分支结构保证 + 现有 test_baas_service 回归。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from secbaas.core.service.bot_run import (
+    BaasBotService,
+    BaasBotServiceConfig,
+    BotEngineAdapterRegistry,
+)
+from secbaas.plugins.bot.engine_adapter.aicoding import MockAICodingAdapter
+
+
+def _service(registry: BotEngineAdapterRegistry | None) -> BaasBotService:
+    return BaasBotService(
+        config=BaasBotServiceConfig(
+            adapter_port=20003,
+            ws_path="/api/openclaw/ws",
+            connect_timeout=10,
+            request_timeout=30,
+        ),
+        client_pool=MagicMock(),
+        wss_resolver=MagicMock(),
+        session_service=MagicMock(),
+        engine_adapter_registry=registry,
+    )
+
+
+@pytest.fixture
+def registry() -> BotEngineAdapterRegistry:
+    return BotEngineAdapterRegistry({"aicoding": MockAICodingAdapter()})
+
+
+def test_adapter_for_new_engine_returns_adapter(registry) -> None:
+    svc = _service(registry)
+    adapter = svc._adapter_for("aicoding")
+    assert adapter is not None
+    assert adapter.engine_type == "aicoding"
+
+
+def test_adapter_for_legacy_engines_return_none(registry) -> None:
+    svc = _service(registry)
+    # openclaw / teclaw 不注册 → None → 走 else 原始分支
+    assert svc._adapter_for("openclaw") is None
+    assert svc._adapter_for("teclaw") is None
+    assert svc._adapter_for(None) is None
+    assert svc._adapter_for("unknown") is None
+
+
+def test_adapter_for_none_registry_returns_none() -> None:
+    svc = _service(None)
+    assert svc._adapter_for("aicoding") is None
+
+
+def test_strip_ws_url_to_base_aicoding_path() -> None:
+    # aicoding: strip /api/ws 得到干净 base_url
+    base = BaasBotService._strip_ws_url_to_base(
+        "wss://host/proxypass/tgt/api/ws", "/api/ws"
+    )
+    assert base == "https://host/proxypass/tgt"
+
+
+def test_build_base_url_openclaw_regression() -> None:
+    # openclaw 静态 _build_base_url 行为保持不变
+    conn = MagicMock()
+    conn.ws_url = "wss://host/proxypass/tgt/api/openclaw/ws"
+    assert (
+        BaasBotService._build_base_url(conn, "openclaw") == "https://host/proxypass/tgt"
+    )
+
+
+def test_create_session_client_aicoding_strips_api_ws(registry) -> None:
+    svc = _service(registry)
+    conn = MagicMock()
+    conn.ws_url = "wss://host/proxypass/tgt/api/ws"
+    conn.token = "tok"
+    client = svc._create_session_client(conn, "aicoding")
+    # aicoding 用 adapter.ws_path()=/api/ws strip → base 干净
+    assert client.base_url == "https://host/proxypass/tgt"
+
+
+def test_create_session_client_openclaw_uses_legacy_suffix(registry) -> None:
+    svc = _service(registry)
+    conn = MagicMock()
+    conn.ws_url = "wss://host/proxypass/tgt/api/openclaw/ws"
+    conn.token = "tok"
+    client = svc._create_session_client(conn, "openclaw")
+    assert client.base_url == "https://host/proxypass/tgt"

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_bot_binding_resolver.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_bot_binding_resolver.py
@@ -36,6 +36,8 @@ def _make_bot_record(
     device_id=DEVICE_ID_ARCA,
     bot_id=BOT_ID,
     entity_id=ENTITY_ID,
+    active_engine="openclaw",
+    template_type=None,
 ):
     now = datetime.now()
     return AcBotRecord(
@@ -55,12 +57,13 @@ def _make_bot_record(
         modifier_id=None,
         share_policy=None,
         is_delete=0,
-        active_engine="openclaw",
+        active_engine=active_engine,
         device_id=device_id,
         env=ENV,
         owner_name="test",
         public="0",
         ext=None,
+        template_type=template_type,
         bot_type=bot_type,
     )
 
@@ -606,3 +609,133 @@ class TestBotBindingInfoEdgeCases:
         assert result is not None
         assert result.device_props == {}
         assert result.sandbox_id is None
+
+
+class TestEngineTypeWhitelist:
+    """§7 — active_engine 白名单校验（unknown → openclaw + warn）。"""
+
+    def _setup(self, mock_ac_bot_repo, mock_binding_repo, active_engine):
+        mock_ac_bot_repo.get_by_bot_id_env_exclude_default.return_value = (
+            _make_bot_record(
+                bot_type="personal",
+                binding_id=BINDING_ID_DRAFT,
+                active_engine=active_engine,
+            )
+        )
+        mock_binding_repo.get_by_id.return_value = _make_binding_record(
+            device_provider="baas",
+            device_id=DEVICE_ID_BAAS,
+            binding_id=BINDING_ID_DRAFT,
+        )
+
+    @pytest.mark.parametrize(
+        "engine", ["openclaw", "teclaw", "aicoding", "hermes", "claude_code"]
+    )
+    def test_whitelisted_engine_preserved(
+        self, resolver, mock_ac_bot_repo, mock_publish_repo, mock_binding_repo, engine
+    ):
+        self._setup(mock_ac_bot_repo, mock_binding_repo, engine)
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == engine
+
+    def test_unknown_engine_falls_back_to_openclaw(
+        self, resolver, mock_ac_bot_repo, mock_publish_repo, mock_binding_repo
+    ):
+        self._setup(mock_ac_bot_repo, mock_binding_repo, "moltis")
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == "openclaw"
+
+    def test_empty_engine_defaults_to_openclaw(
+        self, resolver, mock_ac_bot_repo, mock_publish_repo, mock_binding_repo
+    ):
+        self._setup(mock_ac_bot_repo, mock_binding_repo, None)
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == "openclaw"
+
+
+class TestTemplateTypeNormalization:
+    """template_type 归一化:aicoding 家族(空/personalCoding/applicationCoding)→ aicoding。
+
+    兼容生产数据中 active_engine 与沙箱实际引擎不一致的历史 bot。
+    """
+
+    def _setup(self, mock_ac_bot_repo, mock_binding_repo, active_engine, template_type):
+        mock_ac_bot_repo.get_by_bot_id_env_exclude_default.return_value = (
+            _make_bot_record(
+                bot_type="personal",
+                binding_id=BINDING_ID_DRAFT,
+                active_engine=active_engine,
+                template_type=template_type,
+            )
+        )
+        mock_binding_repo.get_by_id.return_value = _make_binding_record(
+            device_provider="baas",
+            device_id=DEVICE_ID_BAAS,
+            binding_id=BINDING_ID_DRAFT,
+        )
+
+    @pytest.mark.parametrize("template_type", ["personalCoding", "applicationCoding"])
+    def test_aicoding_template_overrides_active_engine(
+        self,
+        resolver,
+        mock_ac_bot_repo,
+        mock_publish_repo,
+        mock_binding_repo,
+        template_type,
+    ):
+        # personalCoding/applicationCoding + active_engine=claude_code(历史脏数据)→ aicoding
+        self._setup(mock_ac_bot_repo, mock_binding_repo, "claude_code", template_type)
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == "aicoding"
+
+    @pytest.mark.parametrize("template_type", [None, ""])
+    def test_empty_template_respects_active_engine(
+        self,
+        resolver,
+        mock_ac_bot_repo,
+        mock_publish_repo,
+        mock_binding_repo,
+        template_type,
+    ):
+        # template_type 为空(None 或 "")→ 以 active_engine 为准,不归一化
+        self._setup(mock_ac_bot_repo, mock_binding_repo, "claude_code", template_type)
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == "claude_code"
+
+    @pytest.mark.parametrize("template_type", ["personalCoding", "applicationCoding"])
+    def test_aicoding_template_only_when_active_is_claude_code(
+        self,
+        resolver,
+        mock_ac_bot_repo,
+        mock_publish_repo,
+        mock_binding_repo,
+        template_type,
+    ):
+        # template_type 属 aicoding 家族,但 active_engine 不是 claude_code → 不归一化,走 active_engine
+        self._setup(mock_ac_bot_repo, mock_binding_repo, "hermes", template_type)
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == "hermes"
+
+    def test_non_aicoding_template_respects_active_engine(
+        self, resolver, mock_ac_bot_repo, mock_publish_repo, mock_binding_repo
+    ):
+        # template_type 不在 aicoding 家族(如 normalCC)→ 走 active_engine
+        self._setup(mock_ac_bot_repo, mock_binding_repo, "hermes", "normalCC")
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == "hermes"
+
+    def test_none_template_respects_active_engine(
+        self, resolver, mock_ac_bot_repo, mock_publish_repo, mock_binding_repo
+    ):
+        # template_type=None(老 bot 没这字段)→ 走 active_engine,不误归一化
+        self._setup(mock_ac_bot_repo, mock_binding_repo, "hermes", None)
+        result = resolver.resolve(bot_id=BOT_ID, entity_id=ENTITY_ID, env=ENV)
+        assert result is not None
+        assert result.engine_type == "hermes"

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_bot_run_utils.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_bot_run_utils.py
@@ -535,3 +535,54 @@ class TestBindingDataToInfo:
 
         assert info.sandbox_id is None
         assert info.device_id == "local-device"
+
+
+# ============ Tests: binding_data_to_info engine_type 归一化 ============
+
+
+class TestBindingDataToInfoEngineNormalization:
+    """active_engine + template_type 共同决定 engine_type(见 _normalize_engine_type)。
+
+    aicoding 家族沙箱(personalCoding/applicationCoding)即使 active_engine 被写成
+    claude_code,也必须归一化为 aicoding,否则 create adapter session 会命中 aicoding
+    沙箱却传 engine=claude_code 报 500。
+    """
+
+    def _data(self, engine_type: str, template_type: str | None) -> BotBindingData:
+        return BotBindingData(
+            bot_id="bot-001",
+            owner_id="entity-001",
+            bot_type="personal",
+            engine_type=engine_type,
+            binding_id=1,
+            device_provider="arca",
+            device_id="ARCA-SANDBOX-abc@0",
+            template_type=template_type,
+        )
+
+    @pytest.mark.parametrize(
+        ("engine_type", "template_type", "expected"),
+        [
+            # claude_code + coding 家族模板 → 归一化为 aicoding(核心修复)
+            ("claude_code", "applicationCoding", "aicoding"),
+            ("claude_code", "personalCoding", "aicoding"),
+            # claude_code + 空/普通模板 → 保持 claude_code
+            ("claude_code", None, "claude_code"),
+            ("claude_code", "", "claude_code"),
+            ("claude_code", "normalCC", "claude_code"),
+            # aicoding + 任意模板 → aicoding
+            ("aicoding", "applicationCoding", "aicoding"),
+            ("aicoding", None, "aicoding"),
+            # 其他已知引擎以 active_engine 为准,不受 template_type 影响
+            ("hermes", "applicationCoding", "hermes"),
+            ("openclaw", None, "openclaw"),
+            # 空 / 未知 active_engine 兜底 openclaw(与旧行为等价)
+            ("", None, "openclaw"),
+            ("unknown_engine", None, "openclaw"),
+        ],
+    )
+    def test_engine_type_normalization_matrix(
+        self, engine_type, template_type, expected
+    ):
+        info = binding_data_to_info(self._data(engine_type, template_type))
+        assert info.engine_type == expected

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_engine_adapter_registry.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_engine_adapter_registry.py
@@ -1,0 +1,69 @@
+"""Unit tests for BotEngineAdapterRegistry + build_engine_adapter_registry。"""
+
+from __future__ import annotations
+
+import pytest
+
+from secbaas.bootstrap._core_services import _real_engine_adapter_registry
+from secbaas.core.service.bot_run import BotEngineAdapterRegistry
+from secbaas.plugins.bot.engine_adapter.aicoding.stub import MockAICodingAdapter
+from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+# ── Registry.get / has ────────────────────────────────────────────────────
+
+
+def test_get_returns_registered_adapter() -> None:
+    adapter = MockAICodingAdapter()
+    registry = BotEngineAdapterRegistry({"aicoding": adapter})
+    assert registry.get("aicoding") is adapter
+
+
+def test_get_unregistered_raises_key_error() -> None:
+    registry = BotEngineAdapterRegistry({})
+    with pytest.raises(KeyError):
+        registry.get("openclaw")
+
+
+def test_has_true_for_registered() -> None:
+    registry = BotEngineAdapterRegistry({"aicoding": MockAICodingAdapter()})
+    assert registry.has("aicoding") is True
+
+
+def test_has_false_for_unregistered_no_raise() -> None:
+    registry = BotEngineAdapterRegistry({"aicoding": MockAICodingAdapter()})
+    # openclaw / teclaw 不注册 → has 返回 False(BaasBotService 走 else 分支)
+    assert registry.has("openclaw") is False
+    assert registry.has("teclaw") is False
+
+
+# ── _real_engine_adapter_registry(bootstrap 装配) ────────────────────────
+
+
+def test_build_registers_three_engines() -> None:
+    registry = _real_engine_adapter_registry()
+    for engine in ("aicoding", "hermes", "claude_code"):
+        assert registry.has(engine) is True
+        adapter = registry.get(engine)
+        assert isinstance(adapter, BotEngineAdapter)
+        assert adapter.engine_type == engine
+
+
+def test_build_does_not_register_legacy_engines() -> None:
+    registry = _real_engine_adapter_registry()
+    assert registry.has("openclaw") is False
+    assert registry.has("teclaw") is False
+
+
+def test_build_aicoding_ws_path_is_api_ws() -> None:
+    registry = _real_engine_adapter_registry()
+    assert registry.get("aicoding").ws_path() == "/api/ws"
+
+
+def test_build_hermes_ws_path() -> None:
+    registry = _real_engine_adapter_registry()
+    assert registry.get("hermes").ws_path() == "/api/hermes/ws"
+
+
+def test_build_claude_code_ws_path() -> None:
+    registry = _real_engine_adapter_registry()
+    assert registry.get("claude_code").ws_path() == "/api/claude_code/ws"

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
@@ -1,0 +1,177 @@
+"""引擎分流集成回归测试。
+
+穿透 ``BaasBotService.create_session`` 全链路(真 registry + 真 adapter),只把最下游的
+``wss_resolver`` 与 session_client 换成 mock,断言每个 engine_type 的可观测分流结果:
+WS path、device 亲和 key、session_client.create_session 的 engine 入参、openclaw 前缀。
+
+作用:后人改 `_baas_service` 接缝 / registry 装配 / 任一 adapter 导致引擎走错路时,
+本测试立刻变红——尤其锁死 openclaw / teclaw 老引擎行为不被带偏。默认 CI 即运行。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from secbaas.api.bot_runtime import BotBindingInfo, WsConnectionInfo
+from secbaas.bootstrap._core_services import _real_engine_adapter_registry
+from secbaas.core.service.bot_run import (
+    BaasBotService,
+    BaasBotServiceConfig,
+)
+
+_TC_BOT_ID = "20260701_dispatch"
+_USER_ID = "374193"
+_RUN_ID = "run-1"
+_AGENT_KEY = f"agent:{_TC_BOT_ID}:session:{_RUN_ID}:user:{_USER_ID}"
+
+
+def _make_conn_info() -> WsConnectionInfo:
+    return WsConnectionInfo(
+        ws_url="wss://gw/proxypass/ARCA_sb:20003/api/ws",
+        token="tok",
+        target="ARCA_sb:20003",
+        expires_at=datetime.now(tz=UTC),
+    )
+
+
+def _make_binding(engine_type: str) -> BotBindingInfo:
+    return BotBindingInfo(
+        bot_id=_TC_BOT_ID,
+        entity_id=_USER_ID,
+        sandbox_id=None,
+        device_id="dev-1",
+        device_provider="baas",
+        binding_id=1,
+        device_props={"tenant": "t1"},
+        bot_type="personal",  # personal bot -> resolve_user_id 直接用 entity_id
+        engine_type=engine_type,
+    )
+
+
+class _FakeSessionClient:
+    """记录 create/get 调用的假 session_client(支持 async with)。"""
+
+    def __init__(self, created_id: str) -> None:
+        self._created_id = created_id
+        self.create_kwargs: dict | None = None
+
+    async def __aenter__(self) -> _FakeSessionClient:
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    async def create_session(self, **kwargs: object) -> SimpleNamespace:
+        self.create_kwargs = dict(kwargs)
+        return SimpleNamespace(id=self._created_id)
+
+    async def get_session(
+        self, session_id: str, engine: str | None = None
+    ) -> SimpleNamespace:
+        return SimpleNamespace(id=session_id)
+
+
+def _make_service(wss_resolver: AsyncMock) -> BaasBotService:
+    return BaasBotService(
+        config=BaasBotServiceConfig(
+            adapter_port=20003,
+            ws_path="/api/openclaw/ws",
+            connect_timeout=10,
+            request_timeout=30,
+        ),
+        client_pool=MagicMock(),
+        wss_resolver=wss_resolver,
+        session_service=MagicMock(),
+        engine_adapter_registry=_real_engine_adapter_registry(),
+    )
+
+
+# (engine_type, 下游返回的 created_id, 期望 ws path, 期望 device_affinity, 期望返回 session_id)
+_CASES = [
+    ("aicoding", "sess-aic", "/api/ws", None, "sess-aic"),
+    (
+        "hermes",
+        "20260701_120000_abcdef",
+        "/api/hermes/ws",
+        _AGENT_KEY,
+        "20260701_120000_abcdef",
+    ),
+    ("claude_code", "sess-cc", "/api/claude_code/ws", _AGENT_KEY, "sess-cc"),
+    # openclaw / teclaw 不在 registry(走 else 原始分支)—— 锁死老引擎行为
+    (
+        "openclaw",
+        "sess-oc",
+        "/api/openclaw/ws",
+        f"agent:main:session:{_RUN_ID}:user:{_USER_ID}",
+        "agent:main:sess-oc",
+    ),
+    ("teclaw", "sess-tc", "/api/teclaw/ws", None, "sess-tc"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "engine, created_id, exp_path, exp_affinity, exp_session_id",
+    _CASES,
+    ids=[c[0] for c in _CASES],
+)
+async def test_engine_dispatch(
+    engine: str,
+    created_id: str,
+    exp_path: str,
+    exp_affinity: str | None,
+    exp_session_id: str,
+) -> None:
+    resolver = AsyncMock()
+    resolver.dispatch_bot_ws_conn_info = AsyncMock(return_value=_make_conn_info())
+    svc = _make_service(resolver)
+    fake_client = _FakeSessionClient(created_id)
+
+    with patch.object(svc, "_create_session_client", return_value=fake_client):
+        info = await svc.create_session(
+            bot_id=_TC_BOT_ID,
+            session_id=None,
+            metadata={"tenant": "t1"},  # 有 tenant、无 invoker -> 跳过持久化
+            binding_info=_make_binding(engine),
+            context=None,
+            run_id=_RUN_ID,
+        )
+
+    # 接缝②:WS path 传给 resolver
+    dispatch_kwargs = resolver.dispatch_bot_ws_conn_info.call_args.kwargs
+    assert dispatch_kwargs["path"] == exp_path
+    # 接缝①:device 亲和 key
+    assert dispatch_kwargs["device_affinity"] == exp_affinity
+    # 接缝③:session_client.create_session 收到正确 engine
+    assert fake_client.create_kwargs is not None
+    assert fake_client.create_kwargs["engine"] == engine
+    # 返回 session_id(openclaw 带 agent:main: 前缀,其余不带)
+    assert info.session_id == exp_session_id
+
+
+@pytest.mark.asyncio
+async def test_openclaw_gets_agent_main_prefix_but_aicoding_does_not() -> None:
+    """显式对比:同样的下游 id,openclaw 加前缀、aicoding 不加。"""
+    results = {}
+    for engine in ("openclaw", "aicoding"):
+        resolver = AsyncMock()
+        resolver.dispatch_bot_ws_conn_info = AsyncMock(return_value=_make_conn_info())
+        svc = _make_service(resolver)
+        with patch.object(
+            svc, "_create_session_client", return_value=_FakeSessionClient("raw-id")
+        ):
+            info = await svc.create_session(
+                bot_id=_TC_BOT_ID,
+                session_id=None,
+                metadata={"tenant": "t1"},
+                binding_info=_make_binding(engine),
+                context=None,
+                run_id=_RUN_ID,
+            )
+        results[engine] = info.session_id
+    assert results["openclaw"] == "agent:main:raw-id"
+    assert results["aicoding"] == "raw-id"

--- a/src/baas/packages/community/tests/unit/plugins/bot/engine_adapter/aicoding/test_aicoding_adapter.py
+++ b/src/baas/packages/community/tests/unit/plugins/bot/engine_adapter/aicoding/test_aicoding_adapter.py
@@ -1,0 +1,105 @@
+"""Unit tests for AICodingAdapter —— WS path /api/ws 等。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from secbaas.plugins.bot.engine_adapter.aicoding.real import AICodingAdapter
+from secbaas.plugins.bot.engine_adapter.aicoding.stub import (
+    MockAICodingAdapter,
+    NoopAICodingAdapter,
+)
+from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+ADAPTERS = [AICodingAdapter]
+
+
+class _FakeSessionClient:
+    """Duck-typed AsyncSessionClient stub recording create_session calls."""
+
+    def __init__(self, created_id: str = "created-sess") -> None:
+        self._created_id = created_id
+        self.create_calls: list[dict] = []
+
+    async def create_session(self, **kwargs: object) -> SimpleNamespace:
+        self.create_calls.append(dict(kwargs))
+        return SimpleNamespace(id=self._created_id)
+
+
+@pytest.mark.parametrize("factory", ADAPTERS)
+def test_is_bot_engine_adapter(factory: type) -> None:
+    adapter = factory()
+    assert isinstance(adapter, BotEngineAdapter)
+    assert adapter.engine_type == "aicoding"
+
+
+@pytest.mark.parametrize("factory", ADAPTERS)
+def test_ws_path_is_api_ws(factory: type) -> None:
+    assert factory().ws_path() == "/api/ws"
+
+
+@pytest.mark.parametrize("factory", ADAPTERS)
+def test_session_consistency_key_none_without_session_id(factory: type) -> None:
+    key = factory().session_consistency_key(tc_bot_id="b1", user_id="u1", run_id="r1")
+    assert key is None
+
+
+@pytest.mark.parametrize("factory", ADAPTERS)
+def test_session_consistency_key_prefers_session_id(factory: type) -> None:
+    key = factory().session_consistency_key(
+        tc_bot_id="b1", user_id="u1", run_id="r1", session_id="s1"
+    )
+    assert key == "s1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", ADAPTERS)
+async def test_create_adapter_session_reuses_existing(factory: type) -> None:
+    client = _FakeSessionClient()
+    sid, reused = await factory().create_adapter_session(
+        session_client=client,
+        session_id="existing-sess",
+        user_id="u1",
+        metadata={},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert (sid, reused) == ("existing-sess", True)
+    assert client.create_calls == []  # 复用不触发创建
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", ADAPTERS)
+async def test_create_adapter_session_creates_new(factory: type) -> None:
+    client = _FakeSessionClient(created_id="new-sess")
+    sid, reused = await factory().create_adapter_session(
+        session_client=client,
+        session_id=None,
+        user_id="u1",
+        metadata={"title": "t", "model": "m"},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert (sid, reused) == ("new-sess", False)
+    assert len(client.create_calls) == 1
+    call = client.create_calls[0]
+    assert call["engine"] == "aicoding"
+    assert call["agent_id"] == "agent-1"
+    assert call["uuid"] == "run-1"
+    # aicoding 不加 openclaw 的 agent:main: 前缀
+    assert not sid.startswith("agent:main:")
+
+
+@pytest.mark.parametrize("noop_cls", [NoopAICodingAdapter])
+def test_noop_returns_safe_zero_values(noop_cls: type) -> None:
+    """Noop 不抛异常、返回安全零值。"""
+    a = noop_cls()
+    assert isinstance(a.ws_path(), str)
+    assert (
+        a.session_consistency_key(
+            tc_bot_id="b1", user_id="u1", run_id="r1", session_id="s1"
+        )
+        is None
+    )

--- a/src/baas/packages/community/tests/unit/plugins/bot/engine_adapter/claude_code/test_claude_code_adapter.py
+++ b/src/baas/packages/community/tests/unit/plugins/bot/engine_adapter/claude_code/test_claude_code_adapter.py
@@ -1,0 +1,101 @@
+"""Unit tests for ClaudeCodeAdapter —— consistency_key + ws_path + create。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from secbaas.plugins.bot.engine_adapter.claude_code.real import ClaudeCodeAdapter
+from secbaas.plugins.bot.engine_adapter.claude_code.stub import (
+    MockClaudeCodeAdapter,
+    NoopClaudeCodeAdapter,
+)
+from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+ADAPTER_CLASSES = [ClaudeCodeAdapter]
+
+
+class _FakeSessionClient:
+    def __init__(self, created_id: str = "cc-sess") -> None:
+        self._created_id = created_id
+        self.create_calls: list[dict] = []
+
+    async def create_session(self, **kwargs: object) -> SimpleNamespace:
+        self.create_calls.append(dict(kwargs))
+        return SimpleNamespace(id=self._created_id)
+
+
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+def test_is_bot_engine_adapter(cls: type) -> None:
+    adapter = cls()
+    assert isinstance(adapter, BotEngineAdapter)
+    assert adapter.engine_type == "claude_code"
+
+
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+def test_ws_path(cls: type) -> None:
+    assert cls().ws_path() == "/api/claude_code/ws"
+
+
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+def test_session_consistency_key(cls: type) -> None:
+    adapter = cls()
+    assert (
+        adapter.session_consistency_key(tc_bot_id="b1", user_id="u1", run_id="r1")
+        == "agent:b1:session:r1:user:u1"
+    )
+    # session_id 非空优先透传
+    assert (
+        adapter.session_consistency_key(
+            tc_bot_id="b1", user_id="u1", run_id="r1", session_id="s1"
+        )
+        == "s1"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+async def test_create_adapter_session_creates_new(cls: type) -> None:
+    client = _FakeSessionClient(created_id="new-sess")
+    sid, reused = await cls().create_adapter_session(
+        session_client=client,
+        session_id=None,
+        user_id="u1",
+        metadata={},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert (sid, reused) == ("new-sess", False)
+    assert client.create_calls[0]["engine"] == "claude_code"
+    # 不加 openclaw 的 agent:main: 前缀
+    assert not sid.startswith("agent:main:")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+async def test_create_adapter_session_reuses_existing(cls: type) -> None:
+    client = _FakeSessionClient()
+    sid, reused = await cls().create_adapter_session(
+        session_client=client,
+        session_id="existing-sess",
+        user_id="u1",
+        metadata={},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert (sid, reused) == ("existing-sess", True)
+    assert client.create_calls == []
+
+
+@pytest.mark.parametrize("noop_cls", [NoopClaudeCodeAdapter])
+def test_noop_returns_safe_zero_values(noop_cls: type) -> None:
+    """Noop 不抛异常、返回安全零值。"""
+    a = noop_cls()
+    assert isinstance(a.ws_path(), str)
+    assert (
+        a.session_consistency_key(
+            tc_bot_id="b1", user_id="u1", run_id="r1", session_id="s1"
+        )
+        is None
+    )

--- a/src/baas/packages/community/tests/unit/plugins/bot/engine_adapter/hermes/test_hermes_adapter.py
+++ b/src/baas/packages/community/tests/unit/plugins/bot/engine_adapter/hermes/test_hermes_adapter.py
@@ -1,0 +1,170 @@
+"""Unit tests for HermesAdapter —— 持久化等待 + 亲和 key。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from secbaas.api.bot_runtime import BotNotAvailableError
+from secbaas.plugins.bot.engine_adapter.hermes.real import HermesAdapter
+from secbaas.plugins.bot.engine_adapter.hermes.stub import (
+    MockHermesAdapter,
+    NoopHermesAdapter,
+)
+from secbaas.spi.bot.engine_adapter import BotEngineAdapter
+
+ADAPTER_CLASSES = [HermesAdapter]
+_PERSISTENT_ID = "20260701_120000_abcdef"
+_API_ID = "api-xyz123"
+
+
+class _FakeSessionClient:
+    """Duck-typed AsyncSessionClient stub with scriptable persistence."""
+
+    def __init__(self, created_id: str, get_ids: list[str] | None = None) -> None:
+        self._created_id = created_id
+        self._get_ids = list(get_ids or [])
+        self.create_calls: list[dict] = []
+        self.get_calls: list[tuple] = []
+
+    async def create_session(self, **kwargs: object) -> SimpleNamespace:
+        self.create_calls.append(dict(kwargs))
+        return SimpleNamespace(id=self._created_id)
+
+    async def get_session(
+        self, session_id: str, engine: str | None = None
+    ) -> SimpleNamespace:
+        self.get_calls.append((session_id, engine))
+        if self._get_ids:
+            return SimpleNamespace(id=self._get_ids.pop(0))
+        return SimpleNamespace(id=session_id)
+
+
+def _fast_adapter(cls: type):
+    """Adapter with tiny timeout/poll so timeout tests stay fast."""
+    return HermesAdapter(
+        session_persist_timeout_seconds=0.1, poll_interval_seconds=0.01
+    )
+
+
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+def test_is_bot_engine_adapter(cls: type) -> None:
+    adapter = cls()
+    assert isinstance(adapter, BotEngineAdapter)
+    assert adapter.engine_type == "hermes"
+
+
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+def test_ws_path(cls: type) -> None:
+    assert cls().ws_path() == "/api/hermes/ws"
+
+
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+def test_session_consistency_key_non_none(cls: type) -> None:
+    key = cls().session_consistency_key(tc_bot_id="b1", user_id="u1", run_id="r1")
+    assert key == "agent:b1:session:r1:user:u1"
+
+
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+def test_session_consistency_key_prefers_session_id(cls: type) -> None:
+    key = cls().session_consistency_key(
+        tc_bot_id="b1", user_id="u1", run_id="r1", session_id="s1"
+    )
+    assert key == "s1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+async def test_create_returns_immediate_persistent_id(cls: type) -> None:
+    client = _FakeSessionClient(created_id=_PERSISTENT_ID)
+    sid, reused = await _fast_adapter(cls).create_adapter_session(
+        session_client=client,
+        session_id=None,
+        user_id="u1",
+        metadata={},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert (sid, reused) == (_PERSISTENT_ID, False)
+    assert client.get_calls == []  # 无需轮询
+    assert client.create_calls[0]["engine"] == "hermes"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+async def test_create_accepts_api_format_id(cls: type) -> None:
+    client = _FakeSessionClient(created_id=_API_ID)
+    sid, _ = await _fast_adapter(cls).create_adapter_session(
+        session_client=client,
+        session_id=None,
+        user_id="u1",
+        metadata={},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert sid == _API_ID
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+async def test_create_polls_until_persistent(cls: type) -> None:
+    client = _FakeSessionClient(
+        created_id="gw-temp-1", get_ids=["gw-temp-1", _PERSISTENT_ID]
+    )
+    sid, reused = await _fast_adapter(cls).create_adapter_session(
+        session_client=client,
+        session_id=None,
+        user_id="u1",
+        metadata={},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert (sid, reused) == (_PERSISTENT_ID, False)
+    assert len(client.get_calls) >= 1  # 轮询过
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+async def test_persistence_timeout_raises(cls: type) -> None:
+    client = _FakeSessionClient(created_id="gw-temp")  # get 恒返回非持久 id
+    with pytest.raises(
+        BotNotAvailableError, match="hermes session persistence timeout"
+    ):
+        await _fast_adapter(cls).create_adapter_session(
+            session_client=client,
+            session_id=None,
+            user_id="u1",
+            metadata={},
+            bot_id="agent-1",
+            run_id="run-1",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", ADAPTER_CLASSES)
+async def test_reuse_existing_session_skips_persistence(cls: type) -> None:
+    client = _FakeSessionClient(created_id=_PERSISTENT_ID)
+    sid, reused = await _fast_adapter(cls).create_adapter_session(
+        session_client=client,
+        session_id="existing-sess",
+        user_id="u1",
+        metadata={},
+        bot_id="agent-1",
+        run_id="run-1",
+    )
+    assert (sid, reused) == ("existing-sess", True)
+    assert client.create_calls == []
+
+
+@pytest.mark.parametrize("noop_cls", [NoopHermesAdapter])
+def test_noop_returns_safe_zero_values(noop_cls: type) -> None:
+    """Noop 不抛异常、返回安全零值。"""
+    a = noop_cls()
+    assert isinstance(a.ws_path(), str)
+    assert (
+        a.session_consistency_key(
+            tc_bot_id="b1", user_id="u1", run_id="r1", session_id="s1"
+        )
+        is None
+    )


### PR DESCRIPTION
Collapse the engine_type-branched engine differences inside BaasBotService (WS path segment, device affinity key, adapter session creation semantics) into a registrable, testable extension point so aicoding / hermes / claude_code plug in as adapters, while openclaw / teclaw keep the original branch unchanged at the byte level.

- spi/bot/engine_adapter: add `BotEngineAdapter` Protocol (runtime_checkable) with four members expressing engine differences; send/inject have no engine fork and stay out of this SPI.
- core/service/bot_run: add `BotEngineAdapterRegistry` (lookup by engine_type via `has()`/`get()`); BaasBotService dispatches at three seams (consistency key / adapter session creation / WS path) on `registry.has(engine_type)`, with `_adapter_for()` as the single lookup; failure messages now route through `_safe_client_msg`.
- plugins/bot/engine_adapter: aicoding / hermes / claude_code adapters, each with real/ + stub/ variants; `_base.py`'s `BaseEngineAdapter` reproduces the generic non-teclaw / non-openclaw else-branch semantics, overridden by subclasses where engines diverge.
- bootstrap: `engine_adapter_registry` uses `providers.Selector` on `config.plugins.engine_adapter` to switch stub (Noop, test/local) / real (live engine channel), injected only into BaasBotService; core does not module-level import plugins, so wiring is deferred to bootstrap.
- spi/bot_service + ac_bot: add `template_type` to `BotBindingData` / `AcBotRecord` / `AcBotModel`, threaded through the binding resolver.
- configs: add `engine_adapter: stub` switch (stub | real) to application.yaml and the e2e/it overlays.
- tests: full coverage across contract (SPI conformance), architecture (check_protocols), unit (registry / dispatch integration / per-engine adapters / binding resolver engine seams), and e2e (stub adapter boot).