### PR TITLE
feat(models): add extra dict to Model for transparent relay field for…

### DIFF
--- a/src/engine/src/engine/community/api/models/router.py
+++ b/src/engine/src/engine/community/api/models/router.py
@@ -38,6 +38,12 @@ def _model_to_dict(model: Model) -> dict:
     if model.provider_category is not None:
         result["provider_category"] = model.provider_category
 
+    # Merge engine-specific extra fields (e.g. runtime, quota info, …)
+    # into the top-level response dict so the frontend receives them
+    # without needing a DTO field for every relay key.
+    if model.extra:
+        result.update(model.extra)
+
     if model.capabilities:
         result["capabilities"] = {
             "context_window": model.capabilities.context_window,

--- a/src/engine/src/engine/community/api/models/router.py
+++ b/src/engine/src/engine/community/api/models/router.py
@@ -40,9 +40,14 @@ def _model_to_dict(model: Model) -> dict:
 
     # Merge engine-specific extra fields (e.g. runtime, quota info, …)
     # into the top-level response dict so the frontend receives them
-    # without needing a DTO field for every relay key.
+    # without needing a DTO field for every relay key.  Filtering on
+    # existing result keys protects against relay-provided keys that
+    # collide with explicitly validated fields (id, provider, pricing,
+    # enterprise_enabled, …) — they must not be overwritten.
     if model.extra:
-        result.update(model.extra)
+        for k, v in model.extra.items():
+            if k not in result:
+                result[k] = v
 
     if model.capabilities:
         result["capabilities"] = {

--- a/src/engine/src/engine/community/api/tests/test_models_router.py
+++ b/src/engine/src/engine/community/api/tests/test_models_router.py
@@ -122,7 +122,14 @@ def _sample_models() -> list[Model]:
             name="Claude Opus 4.6",
             display_name="Claude Opus 4.6",
             provider_category="glink_account_hosting",
-            extra={"runtime": "claude-code"},
+            extra={
+                "runtime": "claude-code",
+                # These keys collide with validated fields; the router
+                # must protect them from being overwritten.
+                "enterprise_enabled": False,
+                "provider": "evil-provider",
+                "id": "hijacked",
+            },
         ),
     ]
 
@@ -157,7 +164,12 @@ class TestListModels:
         assert "runtime" not in first
         glink = body["data"]["models"][2]
         assert glink["provider_category"] == "glink_account_hosting"
+        # extra fields merged into response (None extra → no extra keys)
         assert glink["runtime"] == "claude-code"
+        # collision protection — validated fields survive relay keys with the same name
+        assert glink["provider"] == "glink"               # not "evil-provider"
+        assert glink["id"] == "glink/claude-opus-4-6"      # not "hijacked"
+        assert glink["enterprise_enabled"] is True          # not False
 
         plugin.list_models.assert_awaited_once()
 

--- a/src/engine/src/engine/community/api/tests/test_models_router.py
+++ b/src/engine/src/engine/community/api/tests/test_models_router.py
@@ -117,11 +117,12 @@ def _sample_models() -> list[Model]:
         ),
         Model(
             id="glink/claude-opus-4-6",
-            provider="codefuse-antcc",
+            provider="glink",
             provider_id="glink/claude-opus-4-6",
             name="Claude Opus 4.6",
             display_name="Claude Opus 4.6",
             provider_category="glink_account_hosting",
+            extra={"runtime": "claude-code"},
         ),
     ]
 
@@ -152,8 +153,11 @@ class TestListModels:
         assert first["pricing"]["input_price"] == 0.005
         # provider_category only emitted when set (None → key absent)
         assert "provider_category" not in first
+        # extra fields merged into response (None extra → no extra keys)
+        assert "runtime" not in first
         glink = body["data"]["models"][2]
         assert glink["provider_category"] == "glink_account_hosting"
+        assert glink["runtime"] == "claude-code"
 
         plugin.list_models.assert_awaited_once()
 

--- a/src/engine/src/engine/community/core/models/models.py
+++ b/src/engine/src/engine/community/core/models/models.py
@@ -21,6 +21,8 @@ slim engines (aicoding) can leave them ``None`` while richer engines
 """
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -60,6 +62,12 @@ class Model(BaseModel):
 
     ``provider_id`` carries the upstream-native id (pre-normalisation),
     needed when relays expect the original form on chat.send.
+
+    ``extra`` carries relay-specific fields not modeled above (e.g.
+    ``runtime``, ``provider_category`` when the engine does not promote
+    it to the top-level field, etc.). The API layer merges ``extra``
+    into the response dict so the frontend receives them without
+    the DTO needing a field for every key the relay might add.
     """
 
     id: str
@@ -77,6 +85,7 @@ class Model(BaseModel):
     enterprise_default: bool = False
     release_date: str | None = None
     deprecated: bool = False
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class Provider(BaseModel):


### PR DESCRIPTION
…warding

Model DTO gains an extra: dict[str, Any] field. The API router merges non-empty extra into the top-level response dict so engine-specific fields (e.g. runtime from the relay) reach the frontend without requiring a DTO field per key.