### PR TITLE
fix(bcs): accumulate thinking deltas per segment

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -52,6 +52,10 @@ pub async fn handle_bot_event(
     // We accumulate BEFORE publishing to the frontend so we can synthesize the
     // segment-cumulative `message.content` the frontend SDK renders from — the
     // raw SSE delta frame only carries `delta_text` and no `message`.
+    if cmd.state == ChatEventState::Delta && cmd.event_type == "agent" {
+        normalize_thinking_delta(flow, &mut cmd).await;
+    }
+
     if cmd.state == ChatEventState::Delta
         && matches!(cmd.event_type.as_str(), "chat" | "chat.event")
     {
@@ -105,6 +109,12 @@ pub async fn handle_bot_event(
     // thinking frames are cheap no-ops once the buffer is drained.
     if is_chat_segment_boundary_stream(&cmd.event_payload) {
         flush_chat_segment(flow, &cmd, None).await;
+    }
+    if cmd.state == ChatEventState::Delta
+        && cmd.event_type == "agent"
+        && is_thinking_segment_boundary_stream(&cmd.event_payload)
+    {
+        flow.message_tracker.clear_thinking_buf(&cmd.run_id).await;
     }
 
     if is_terminal_state(&cmd.state) {
@@ -1016,6 +1026,33 @@ fn extract_delta_text(event: &Value) -> Option<&str> {
     event.get("delta_text").and_then(|value| value.as_str())
 }
 
+async fn normalize_thinking_delta(flow: &BcsMessageFlow, cmd: &mut BotEventCommand) {
+    if cmd.event_payload.get("stream").and_then(|value| value.as_str()) != Some("thinking") {
+        return;
+    }
+    let Some(delta) = extract_thinking_delta(&cmd.event_payload) else {
+        return;
+    };
+    let accumulated = flow
+        .message_tracker
+        .append_thinking_delta(&cmd.run_id, delta)
+        .await;
+    inject_thinking_text(&mut cmd.event_payload, &accumulated);
+}
+
+fn extract_thinking_delta(event: &Value) -> Option<&str> {
+    event
+        .get("data")
+        .and_then(|data| data.get("delta"))
+        .and_then(|value| value.as_str())
+}
+
+fn inject_thinking_text(event: &mut Value, accumulated_text: &str) {
+    if let Some(data) = event.get_mut("data").and_then(|value| value.as_object_mut()) {
+        data.insert("text".to_string(), Value::String(accumulated_text.to_string()));
+    }
+}
+
 /// Overwrite the frame's `message` with a synthesized assistant message whose
 /// `content` is the segment-accumulated text. The SSE (raw engine) delta frame
 /// carries only `delta_text`; the frontend SDK renders `message.content[].text`
@@ -1055,6 +1092,13 @@ fn is_chat_segment_boundary_stream(payload: &Value) -> bool {
     )
 }
 
+fn is_thinking_segment_boundary_stream(payload: &Value) -> bool {
+    payload
+        .get("stream")
+        .and_then(|value| value.as_str())
+        .map(|stream| stream != "thinking")
+        .unwrap_or(false)
+}
 
 async fn cache_tool_start(flow: &BcsMessageFlow, cmd: &BotEventCommand, data: &Value) {
     if cmd.group_id.is_empty() {

--- a/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
@@ -38,6 +38,12 @@ pub struct MessageTracker {
     /// the accumulated buffer (delta mode) or override with the final frame's
     /// full text (legacy plugin mode). Cleared on run cleanup.
     chat_delta_mode: Mutex<HashSet<String>>,
+    /// run_id → text buffered for the CURRENT open thinking segment.
+    ///
+    /// Raw BCN SSE thinking frames may carry run-cumulative `data.text` across
+    /// tool blocks. BCS rebuilds segment-local thinking text from `data.delta`
+    /// and clears this buffer whenever a non-thinking stream event is observed.
+    streaming_thinking_buf: Mutex<HashMap<String, String>>,
 }
 
 impl MessageTracker {
@@ -47,6 +53,7 @@ impl MessageTracker {
             coordination_echoes: Mutex::new(HashMap::new()),
             streaming_chat_buf: Mutex::new(HashMap::new()),
             chat_delta_mode: Mutex::new(HashSet::new()),
+            streaming_thinking_buf: Mutex::new(HashMap::new()),
         }
     }
 
@@ -95,6 +102,25 @@ impl MessageTracker {
         map.entry(run_id.to_string()).or_default().push_str(delta);
     }
 
+    /// Append an incremental thinking `delta` to the run's current thinking
+    /// segment and return the segment-accumulated text. Memory only.
+    pub async fn append_thinking_delta(&self, run_id: &str, delta: &str) -> String {
+        let mut map = self.streaming_thinking_buf.lock().await;
+        if let Some(buf) = map.get_mut(run_id) {
+            buf.push_str(delta);
+            return buf.clone();
+        }
+        let mut buf = String::new();
+        buf.push_str(delta);
+        map.insert(run_id.to_string(), buf.clone());
+        buf
+    }
+
+    /// Clear the current thinking segment buffer for the run.
+    pub async fn clear_thinking_buf(&self, run_id: &str) {
+        self.streaming_thinking_buf.lock().await.remove(run_id);
+    }
+
     /// Whether the run has received any `delta_text` frame (SSE self-accumulate
     /// mode). At `final`, delta-mode runs flush their accumulated buffer instead
     /// of overriding with the final frame's cumulative full text.
@@ -130,6 +156,7 @@ impl MessageTracker {
     /// Returns any pending chat buffer that was not yet flushed.
     pub async fn cleanup_run(&self, run_id: &str) -> Option<String> {
         self.chat_delta_mode.lock().await.remove(run_id);
+        self.streaming_thinking_buf.lock().await.remove(run_id);
         self.streaming_chat_buf.lock().await.remove(run_id)
     }
 }

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -259,6 +259,372 @@ async fn bot_event_with_bcs_session_id_publishes_to_session_target() {
     assert_eq!(fallback.session_id, "group-1:abcdef12");
 }
 
+
+#[tokio::test]
+async fn agent_thinking_delta_self_accumulates_and_resets_after_tool_block() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    for (delta, upstream_text) in [("AA", "upstream-run-text-AA"), ("A", "upstream-run-text-AAA")] {
+        flow.handle_bot_event(BotEventCommand {
+            bot_id: "bot-observer".to_string(),
+            run_id: "run-thinking-delta".to_string(),
+            group_id: "group-1".to_string(),
+            event_type: "agent".to_string(),
+            event_payload: json!({
+                "stream": "thinking",
+                "data": {
+                    "stream": "thinking",
+                    "delta": delta,
+                    "text": upstream_text,
+                },
+            }),
+            state: ChatEventState::Delta,
+            bcs_session_id: None,
+        })
+        .await
+        .unwrap();
+    }
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-delta".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "tool",
+            "data": {
+                "phase": "start",
+                "toolCallId": "tool-1",
+                "name": "Bash",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-delta".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "BB",
+                "text": "AAABB",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 4);
+
+    let second: Value = serde_json::from_str(&events[1]).unwrap();
+    assert_eq!(second["payload"]["data"]["delta"], "A");
+    assert_eq!(second["payload"]["data"]["text"], "AAA");
+
+    let after_tool: Value = serde_json::from_str(&events[3]).unwrap();
+    assert_eq!(after_tool["payload"]["data"]["delta"], "BB");
+    assert_eq!(
+        after_tool["payload"]["data"]["text"],
+        "BB",
+        "thinking text should be rebuilt from the current segment's delta, not upstream run-cumulative text"
+    );
+}
+
+#[tokio::test]
+async fn agent_thinking_delta_resets_after_non_tool_block() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-approval-boundary".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "before",
+                "text": "before",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-approval-boundary".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "approval",
+            "data": {
+                "state": "pending",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-approval-boundary".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "after",
+                "text": "beforeafter",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 3);
+
+    let after_boundary: Value = serde_json::from_str(&events[2]).unwrap();
+    assert_eq!(after_boundary["payload"]["data"]["delta"], "after");
+    assert_eq!(
+        after_boundary["payload"]["data"]["text"],
+        "after",
+        "any non-thinking agent block should close the previous thinking segment"
+    );
+}
+
+#[tokio::test]
+async fn agent_thinking_delta_buffers_are_isolated_by_run_id() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    for (run_id, delta, upstream_text) in [
+        ("run-thinking-a", "A", "A"),
+        ("run-thinking-b", "B", "B"),
+        ("run-thinking-a", "A2", "AA2"),
+        ("run-thinking-b", "B2", "BB2"),
+    ] {
+        flow.handle_bot_event(BotEventCommand {
+            bot_id: "bot-observer".to_string(),
+            run_id: run_id.to_string(),
+            group_id: "group-1".to_string(),
+            event_type: "agent".to_string(),
+            event_payload: json!({
+                "stream": "thinking",
+                "data": {
+                    "stream": "thinking",
+                    "delta": delta,
+                    "text": upstream_text,
+                },
+            }),
+            state: ChatEventState::Delta,
+            bcs_session_id: None,
+        })
+        .await
+        .unwrap();
+    }
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 4);
+
+    let run_a_second: Value = serde_json::from_str(&events[2]).unwrap();
+    assert_eq!(run_a_second["payload"]["data"]["text"], "AA2");
+
+    let run_b_second: Value = serde_json::from_str(&events[3]).unwrap();
+    assert_eq!(run_b_second["payload"]["data"]["text"], "BB2");
+}
+
+#[tokio::test]
+async fn non_agent_stream_event_does_not_reset_thinking_delta_buffer() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-non-agent-boundary".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "AA",
+                "text": "upstream-AA",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-non-agent-boundary".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "diagnostic".to_string(),
+        event_payload: json!({
+            "stream": "tool",
+            "data": {
+                "note": "stream-shaped but not an agent stream event",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-non-agent-boundary".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "BB",
+                "text": "upstream-AABB",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 3);
+
+    let after_non_agent: Value = serde_json::from_str(&events[2]).unwrap();
+    assert_eq!(after_non_agent["payload"]["data"]["delta"], "BB");
+    assert_eq!(
+        after_non_agent["payload"]["data"]["text"],
+        "AABB",
+        "only non-thinking agent stream events should close a thinking segment"
+    );
+}
+
+#[tokio::test]
+async fn terminal_cleanup_clears_thinking_delta_buffer_for_reused_run_id() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-cleanup".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "old",
+                "text": "upstream-old",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-cleanup".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "chat.event".to_string(),
+        event_payload: json!({
+            "state": "error",
+            "display_message": "run failed",
+        }),
+        state: ChatEventState::Error,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-cleanup".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "new",
+                "text": "upstream-oldnew",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 3);
+
+    let after_cleanup: Value = serde_json::from_str(&events[2]).unwrap();
+    assert_eq!(after_cleanup["payload"]["data"]["delta"], "new");
+    assert_eq!(
+        after_cleanup["payload"]["data"]["text"],
+        "new",
+        "terminal cleanup should clear any open thinking segment buffer"
+    );
+}
+
 #[tokio::test]
 async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;


### PR DESCRIPTION
 ## Summary

  Fixes BCS forwarding of agent thinking stream events when upstream BCN sends run-cumulative data.text across block boundaries.

  BCS now treats data.delta as the authoritative incremental thinking content and rebuilds data.text per thinking segment, similar to how chat delta self-accumulation is handled. The
  thinking accumulator is reset when a non-thinking agent block is observed, such as tool or approval, so a new thinking block after a tool call no longer starts with the previous thinking
  block’s full content.

  ## Changes

  - Added per-run thinking segment buffering in MessageTracker.
  - Normalized agent + thinking delta events before publishing to the frontend:
      - preserve the original data.delta
      - overwrite data.text with BCS-accumulated segment-local text

  - Reset thinking buffers on non-thinking agent stream boundaries.
  - Clean up thinking buffers when a run is cleaned up.
  - Added regression tests covering:
      - thinking delta accumulation within the same thinking block
      - reset after a tool block
      - reset after a non-tool block such as approval
      - per-run thinking buffer isolation

  ## Why

  Production logs showed that upstream thinking frames can carry cumulative data.text for the whole run, even after tool blocks. For example, after a previous thinking block ended with AAA,
  a later thinking block could arrive with:

  {
    "delta": "BB",
    "text": "AAABB"
  }

  Downstream consumers expect text to represent the current thinking block/segment, not all previous thinking content. This caused multiple thinking blocks to appear cumulatively appended.

  With this change, BCS rewrites that frame as:

  {
    "delta": "BB",
    "text": "BB"
  }

  when it is the first thinking delta after a boundary.

  ## Validation

  Ran:

  cd src/bcs
  cargo test --package bcs-message-flow --test contract_bot_event agent_thinking_delta
  cargo test --package bcs-message-flow --test contract_bot_event
  cargo test --package bcs-message-flow

  Results:

  - agent_thinking_delta*: 3 passed
  - contract_bot_event: 71 passed
  - full bcs-message-flow package tests passed:
      - 25 unit tests
      - 4 conformance tests
      - 29 contract_a2a_chat tests
      - 71 contract_bot_event tests
      - 2 contract_group_fusion tests
      - 49 contract_message_flow tests
      - doc tests passed

  No global formatting was run.