### PR TITLE
fix(baas): fire log-relation report in background and normalize openc…

### DIFF
--- a/src/baas/packages/community/src/secbaas/core/service/bot_run/_runner.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_run/_runner.py
@@ -22,6 +22,7 @@ DB-First 流程：
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -182,8 +183,8 @@ class BotRunner:
         )
 
         chat_metadata = build_chat_metadata(metadata, run_id=message_id)
-        # 5. 上报日志关联
-        await self._report_log_relation(
+        # 5. 上报日志关联(后台执行,不阻塞主链路)
+        self._fire_and_forget_report(
             run_id=message_id,
             session_id=actual_session_id,
             binding_info=route.binding_info,
@@ -280,8 +281,8 @@ class BotRunner:
             chat_metadata=chat_metadata,
         )
 
-        # 5. 上报日志关联
-        await self._report_log_relation(
+        # 5. 上报日志关联(后台执行,不阻塞主链路)
+        self._fire_and_forget_report(
             run_id=message_id,
             session_id=actual_session_id,
             binding_info=route.binding_info,
@@ -486,6 +487,58 @@ class BotRunner:
                 run_id,
                 biz_task_id,
                 exc_info=True,
+            )
+
+    def _fire_and_forget_report(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        binding_info: BotBindingInfo,
+        chat_metadata: dict[str, str] | None,
+    ) -> None:
+        """Fire the log-relation report in the background without blocking the main path.
+
+        log-relation is fire-and-forget side logic: its success/speed has no
+        impact on the business flow (the return value is unused, failure only
+        logs a WARNING). Running it via create_task keeps a worst-case ~10s HTTP
+        request off the response path.
+
+        Normalize session_id: the openclaw engine requires the session_key to be
+        prefixed with ``agent:main:`` (mirroring the normalization done when
+        ``_claw_service`` creates a session). The prefix is added before
+        reporting so downstream log-relation lookups can resolve the session.
+        """
+        if (
+            binding_info.engine_type == "openclaw"
+            and session_id
+            and not session_id.startswith("agent:main:")
+        ):
+            session_id = f"agent:main:{session_id}"
+
+        task = asyncio.create_task(
+            self._report_log_relation(
+                run_id=run_id,
+                session_id=session_id,
+                binding_info=binding_info,
+                chat_metadata=chat_metadata,
+            )
+        )
+        task.add_done_callback(self._on_report_done)
+
+    @staticmethod
+    def _on_report_done(task: asyncio.Task[None]) -> None:
+        """后台上报任务收尾:吞掉异常,避免 "Task exception was never retrieved"。
+
+        _report_log_relation 内部已捕获并记 WARNING,这里仅作兜底防御。
+        """
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "[runner.report] background report task error",
+                exc_info=exc,
             )
 
     def _select_dispatcher(self, bot_id: str) -> MessageDispatcher:

--- a/src/baas/packages/community/tests/unit/core/service/bot_run/test_bot_runner_log_relation.py
+++ b/src/baas/packages/community/tests/unit/core/service/bot_run/test_bot_runner_log_relation.py
@@ -7,6 +7,7 @@ Covers:
 - Empty string biz_task_id is not replaced by run_id (is not None check)
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -109,6 +110,15 @@ def _make_runner(
     )
 
 
+async def _flush_background_report() -> None:
+    """让出事件循环,等待 _fire_and_forget_report create_task 执行完毕。
+
+    log-relation 上报现在在后台 create_task 中运行,deliver_message 返回时
+    尚未发生。测试需要 yield 一次让后台任务跑完后再断言 report 调用。
+    """
+    await asyncio.sleep(0)
+
+
 # ==================== Tests: BotRunner._report_log_relation integration ======
 
 
@@ -131,6 +141,7 @@ class TestBotRunnerLogRelationIntegration:
             message_id="test-msg-id",
         )
 
+        await _flush_background_report()
         mock_bot_service_plugin.report.assert_called_once()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         assert isinstance(payload, LogRelationPayload)
@@ -162,6 +173,9 @@ class TestBotRunnerLogRelationIntegration:
             message_id="test-msg-id",
         )
 
+        # 后台任务自主失败并被吞掉,主链路无感知
+        await _flush_background_report()
+
 
 # ==================== Tests: metadata biz fields ====================
 
@@ -188,6 +202,7 @@ class TestMetadataBizFields:
             message_id="test-msg-id",
         )
 
+        await _flush_background_report()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         assert payload.biz_task_id == "custom-task-456"
         assert payload.biz_scene == "custom_scene"
@@ -210,6 +225,7 @@ class TestMetadataBizFields:
             message_id="run-abc-123",
         )
 
+        await _flush_background_report()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         assert payload.biz_task_id == "run-abc-123"
 
@@ -231,6 +247,7 @@ class TestMetadataBizFields:
             message_id="test-msg-id",
         )
 
+        await _flush_background_report()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         assert payload.biz_scene == "default"
 
@@ -256,6 +273,7 @@ class TestMetadataBizFields:
             message_id="run-abc-123",
         )
 
+        await _flush_background_report()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         assert payload.biz_task_id == ""
         # It should NOT be "run-abc-123"
@@ -278,6 +296,7 @@ class TestMetadataBizFields:
             message_id="run-xyz-789",
         )
 
+        await _flush_background_report()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         assert payload.biz_task_id == "run-xyz-789"
 
@@ -304,6 +323,9 @@ class TestMetadataBizFields:
             message_id="test-msg-id",
         )
 
+        # 后台任务自主失败并被吞掉,主链路无感知
+        await _flush_background_report()
+
     @pytest.mark.asyncio
     async def test_report_log_relation_uses_entity_id_for_user_id(
         self,
@@ -322,6 +344,7 @@ class TestMetadataBizFields:
             message_id="test-msg-id",
         )
 
+        await _flush_background_report()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         # user_id should come from binding_info.entity_id
         assert payload.user_id == ENTITY_ID
@@ -344,6 +367,7 @@ class TestMetadataBizFields:
             message_id="test-msg-id",
         )
 
+        await _flush_background_report()
         payload = mock_bot_service_plugin.report.call_args[0][0]
         assert payload.refs == [
             {"ref_type": "session_key", "ref_value": "agent:main:sess-001"}


### PR DESCRIPTION
…law session_key

Log-relation reporting is now fire-and-forget via asyncio.create_task so a worst-case ~10s HTTP call no longer blocks the response path. For the openclaw engine, prefix the session_id with `agent:main:` before reporting (mirroring _claw_service's session-creation normalization) when absent, keeping downstream lookups consistent.