### PR TITLE
ci: add singlebox coverage workflow

### DIFF
--- a/.github/workflows/singlebox-coverage.yml
+++ b/.github/workflows/singlebox-coverage.yml
@@ -122,6 +122,11 @@ jobs:
           echo "SINGLEBOX_COVERAGE_MODE=${SINGLEBOX_COVERAGE_MODE}"
           bash scripts/ci/singlebox_coverage.sh
 
+      - name: Verify singlebox coverage artifacts
+        run: |
+          python3 scripts/ci/verify_singlebox_coverage_artifacts.py \
+            --reports-dir scripts/.dependencies/coverage/singlebox/reports
+
       - name: Show singlebox diagnostics on failure
         if: failure()
         run: |

--- a/.github/workflows/singlebox-coverage.yml
+++ b/.github/workflows/singlebox-coverage.yml
@@ -1,0 +1,149 @@
+name: Singlebox Coverage
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths:
+      - "scripts/**"
+      - "src/backend/**"
+      - "src/baas/**"
+      - "src/bcs/**"
+      - "src/engine/**"
+      - "src/frontend/**"
+      - "src/plugin/**"
+      - ".github/workflows/singlebox-coverage.yml"
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - "scripts/**"
+      - "src/backend/**"
+      - "src/baas/**"
+      - "src/bcs/**"
+      - "src/engine/**"
+      - "src/frontend/**"
+      - "src/plugin/**"
+      - ".github/workflows/singlebox-coverage.yml"
+  workflow_dispatch:
+    inputs:
+      use_cn_mirror:
+        description: "Use public China mirrors for dependency downloads"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: singlebox-coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  singlebox-coverage:
+    name: Singlebox coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CI: "true"
+      OCB_SKIP_GIT_HOOKS: "1"
+      SINGLEBOX_MODEL_CONFIG_MODE: mock
+      SINGLEBOX_COVERAGE_MODE: real
+      USE_CN_MIRROR: ${{ inputs.use_cn_mirror && '1' || '' }}
+      BCN_PLUGIN_SOURCE: source
+      CARGO_TERM_COLOR: always
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ github.workspace }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add llvm-tools
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+          rustc --version
+          cargo --version
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            git \
+            jq \
+            libsqlite3-dev \
+            libssl-dev \
+            lsof \
+            pkg-config \
+            procps \
+            protobuf-compiler
+
+      - name: Install Python tooling
+        run: |
+          python -m pip install --upgrade pip uv
+          uv --version
+
+      - name: Install OpenClaw CLI
+        run: |
+          npm install -g openclaw@2026.6.1
+          openclaw --version || true
+
+      - name: Validate shell scripts
+        run: |
+          bash -n scripts/singlebox.sh
+          bash -n scripts/ci/singlebox_coverage.sh
+          find scripts/modules -name "*.sh" -print0 | xargs -0 -n1 bash -n
+
+      - name: Run singlebox coverage
+        run: |
+          echo "SINGLEBOX_COVERAGE_MODE=${SINGLEBOX_COVERAGE_MODE}"
+          bash scripts/ci/singlebox_coverage.sh
+
+      - name: Show singlebox diagnostics on failure
+        if: failure()
+        run: |
+          bash scripts/singlebox.sh --standalone status all || true
+          bash scripts/singlebox.sh --local status all || true
+          find scripts/.dependencies/logs -maxdepth 2 -type f -print -exec tail -n 160 {} \; || true
+          find .standalone-openclaw -type f -name "*.log" -print -exec tail -n 160 {} \; || true
+
+      - name: Stop singlebox
+        if: always()
+        run: |
+          bash scripts/singlebox.sh --standalone stop all || true
+          bash scripts/singlebox.sh --local stop all || true
+
+      - name: Upload singlebox artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: singlebox-coverage-artifacts
+          path: |
+            scripts/.dependencies/logs/**
+            scripts/.dependencies/coverage/singlebox/**
+            scripts/.dependencies/standalone/**
+            .standalone-openclaw/logs/**
+          if-no-files-found: ignore

--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -10,6 +10,8 @@ coverage_root="${SINGLEBOX_COVERAGE_ROOT:-$repo_root/scripts/.dependencies/cover
 report_dir="$coverage_root/reports"
 mode="${SINGLEBOX_COVERAGE_MODE:-real}"
 acceptance_target="${SINGLEBOX_COVERAGE_ACCEPTANCE_TARGET:-tests/community/acceptance/cron/test_cron_query_lifecycle.py}"
+coverage_standalone_root=""
+coverage_standalone_runtime=""
 
 usage() {
   cat <<USAGE
@@ -60,8 +62,8 @@ done
 run_real_singlebox() {
   rm -rf "$coverage_root/raw" "$report_dir"
   mkdir -p "$coverage_root/raw" "$report_dir"
-  local coverage_standalone_root="$coverage_root/standalone-openclaw"
-  local coverage_standalone_runtime="$coverage_root/standalone-runtime"
+  coverage_standalone_root="$coverage_root/standalone-openclaw"
+  coverage_standalone_runtime="$coverage_root/standalone-runtime"
   echo "singlebox coverage real mode"
   echo "coverage_root: $coverage_root"
   echo "standalone_openclaw_root: $coverage_standalone_root"
@@ -75,7 +77,12 @@ run_real_singlebox() {
       bash "$repo_root/scripts/singlebox.sh" --standalone stop all || true
   }
   trap cleanup_real_singlebox EXIT
+  env OCB_SKIP_GIT_HOOKS=1 SINGLEBOX_MODEL_CONFIG_MODE=mock \
+    STANDALONE_OPENCLAW_ROOT="$coverage_standalone_root" \
+    STANDALONE_RUNTIME_DIR="$coverage_standalone_runtime" \
+    bash "$repo_root/scripts/singlebox.sh" --standalone setup all
   env SINGLEBOX_COVERAGE=1 SINGLEBOX_COVERAGE_DIR="$coverage_root/raw" OCB_SKIP_GIT_HOOKS=1 SINGLEBOX_MODEL_CONFIG_MODE=mock \
+    BACKEND_READY_ATTEMPTS="${BACKEND_READY_ATTEMPTS:-120}" \
     STANDALONE_OPENCLAW_ROOT="$coverage_standalone_root" \
     STANDALONE_RUNTIME_DIR="$coverage_standalone_runtime" \
     bash "$repo_root/scripts/singlebox.sh" --standalone start all

--- a/scripts/ci/verify_singlebox_coverage_artifacts.py
+++ b/scripts/ci/verify_singlebox_coverage_artifacts.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate Singlebox coverage artifacts produced by singlebox_coverage.sh.
+
+This script is intentionally a first-version anti-regression gate. It verifies
+that the real Singlebox stack ran, the live acceptance smoke produced a passing
+JUnit report, runtime hit counters are non-trivial, and backend/BaaS coverage
+stays above low-water marks based on the current baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_FILES = (
+    "summary.json",
+    "summary.md",
+    "dashboard.html",
+    "acceptance.log",
+    "acceptance-junit.xml",
+    "backend-coverage.json",
+    "backend-coverage.txt",
+    "html/backend/index.html",
+    "baas-coverage.json",
+    "baas-coverage.txt",
+    "html/baas/index.html",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify Singlebox coverage reports and low-water thresholds.",
+    )
+    parser.add_argument(
+        "--reports-dir",
+        default="scripts/.dependencies/coverage/singlebox/reports",
+        help="Directory containing summary.json and coverage artifacts.",
+    )
+    parser.add_argument("--backend-min", type=float, default=38.0)
+    parser.add_argument("--baas-min", type=float, default=45.0)
+    parser.add_argument("--backend-router-min", type=int, default=10)
+    parser.add_argument("--backend-plugin-min", type=int, default=300)
+    parser.add_argument("--baas-router-min", type=int, default=10)
+    return parser.parse_args()
+
+
+def load_json(path: Path, errors: list[str]) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as file_obj:
+            data = json.load(file_obj)
+    except FileNotFoundError:
+        errors.append(f"missing required JSON file: {path}")
+        return {}
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON file {path}: {exc}")
+        return {}
+
+    if not isinstance(data, dict):
+        errors.append(f"JSON file must contain an object: {path}")
+        return {}
+    return data
+
+
+def get_nested(data: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = data
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def as_number(value: Any, label: str, errors: list[str]) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    errors.append(f"{label} is missing or not numeric")
+    return 0.0
+
+
+def validate_required_files(reports_dir: Path, errors: list[str]) -> None:
+    for relative in REQUIRED_FILES:
+        path = reports_dir / relative
+        if not path.is_file():
+            errors.append(f"missing required artifact: {path}")
+
+
+def validate_summary(summary: dict[str, Any], args: argparse.Namespace, errors: list[str]) -> None:
+    expected_fields = {
+        ("status",): "passed",
+        ("mode",): "real",
+        ("stack",): "standalone start all",
+    }
+    for path, expected in expected_fields.items():
+        actual = get_nested(summary, path)
+        if actual != expected:
+            errors.append(f"summary.{'.'.join(path)} expected {expected!r}, got {actual!r}")
+
+    backend_router_hits = as_number(
+        get_nested(summary, ("coverage", "backend", "router_hits")),
+        "summary.coverage.backend.router_hits",
+        errors,
+    )
+    backend_plugin_hits = as_number(
+        get_nested(summary, ("coverage", "backend", "plugin_hits")),
+        "summary.coverage.backend.plugin_hits",
+        errors,
+    )
+    baas_router_hits = as_number(
+        get_nested(summary, ("coverage", "baas", "router_hits")),
+        "summary.coverage.baas.router_hits",
+        errors,
+    )
+
+    if backend_router_hits < args.backend_router_min:
+        errors.append(
+            f"backend router hits {backend_router_hits:.0f} < {args.backend_router_min}",
+        )
+    if backend_plugin_hits < args.backend_plugin_min:
+        errors.append(
+            f"backend plugin hits {backend_plugin_hits:.0f} < {args.backend_plugin_min}",
+        )
+    if baas_router_hits < args.baas_router_min:
+        errors.append(f"BaaS router hits {baas_router_hits:.0f} < {args.baas_router_min}")
+
+
+def validate_acceptance_junit(junit_path: Path, errors: list[str]) -> None:
+    try:
+        root = ET.parse(junit_path).getroot()
+    except FileNotFoundError:
+        errors.append(f"missing acceptance JUnit: {junit_path}")
+        return
+    except ET.ParseError as exc:
+        errors.append(f"invalid acceptance JUnit {junit_path}: {exc}")
+        return
+
+    suites = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
+    if not suites:
+        errors.append(f"acceptance JUnit contains no testsuite: {junit_path}")
+        return
+
+    tests = sum(int(suite.attrib.get("tests", "0")) for suite in suites)
+    failures = sum(int(suite.attrib.get("failures", "0")) for suite in suites)
+    errors_count = sum(int(suite.attrib.get("errors", "0")) for suite in suites)
+    skipped = sum(int(suite.attrib.get("skipped", "0")) for suite in suites)
+
+    if tests <= 0:
+        errors.append("acceptance JUnit contains zero tests")
+    if tests - skipped <= 0:
+        errors.append("acceptance JUnit contains no executed tests")
+    if failures or errors_count:
+        errors.append(
+            f"acceptance JUnit has failures/errors: failures={failures}, errors={errors_count}",
+        )
+
+
+def coverage_percent(coverage_path: Path, label: str, errors: list[str]) -> float:
+    coverage = load_json(coverage_path, errors)
+    percent = get_nested(coverage, ("totals", "percent_covered"))
+    return as_number(percent, f"{label} totals.percent_covered", errors)
+
+
+def main() -> int:
+    args = parse_args()
+    reports_dir = Path(args.reports_dir)
+    errors: list[str] = []
+
+    validate_required_files(reports_dir, errors)
+    summary = load_json(reports_dir / "summary.json", errors)
+    if summary:
+        validate_summary(summary, args, errors)
+    validate_acceptance_junit(reports_dir / "acceptance-junit.xml", errors)
+
+    backend_percent = coverage_percent(reports_dir / "backend-coverage.json", "backend", errors)
+    baas_percent = coverage_percent(reports_dir / "baas-coverage.json", "BaaS", errors)
+
+    if backend_percent < args.backend_min:
+        errors.append(f"backend coverage {backend_percent:.2f}% < {args.backend_min:.2f}%")
+    if baas_percent < args.baas_min:
+        errors.append(f"BaaS coverage {baas_percent:.2f}% < {args.baas_min:.2f}%")
+
+    if errors:
+        print("singlebox coverage artifact verification failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    backend_router_hits = int(get_nested(summary, ("coverage", "backend", "router_hits")) or 0)
+    backend_plugin_hits = int(get_nested(summary, ("coverage", "backend", "plugin_hits")) or 0)
+    baas_router_hits = int(get_nested(summary, ("coverage", "baas", "router_hits")) or 0)
+
+    print("singlebox coverage artifacts verified")
+    print(f"backend coverage: {backend_percent:.2f}%")
+    print(f"BaaS coverage: {baas_percent:.2f}%")
+    print(f"backend router/plugin hits: {backend_router_hits}/{backend_plugin_hits}")
+    print(f"BaaS router hits: {baas_router_hits}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/verify_singlebox_coverage_artifacts.py
+++ b/scripts/ci/verify_singlebox_coverage_artifacts.py
@@ -44,7 +44,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--backend-min", type=float, default=38.0)
     parser.add_argument("--baas-min", type=float, default=45.0)
     parser.add_argument("--backend-router-min", type=int, default=10)
-    parser.add_argument("--backend-plugin-min", type=int, default=300)
+    parser.add_argument("--backend-plugin-min", type=int, default=30)
     parser.add_argument("--baas-router-min", type=int, default=10)
     return parser.parse_args()
 

--- a/scripts/run_bcs_mixed_provider.sh
+++ b/scripts/run_bcs_mixed_provider.sh
@@ -654,7 +654,7 @@ start_frontend() {
     echo $! > "${FRONTEND_PID_FILE}"
   )
   wait_port "${FRONTEND_PORT}" "frontend" 80
-  log "frontend URL: http://agentclaw-local.stable.alipay.net:${FRONTEND_PORT}/"
+  log "frontend URL: http://agentclaw-local.localhost:${FRONTEND_PORT}/"
 }
 
 start_all() {
@@ -699,7 +699,7 @@ Claude Code Provider bot:
   bridge mode=${MOCK_MODE}
 
 Frontend:
-  http://agentclaw-local.stable.alipay.net:${FRONTEND_PORT}/
+  http://agentclaw-local.localhost:${FRONTEND_PORT}/
 
 Logs:
   ${OPENCLAW_LOG}

--- a/src/bcs/scripts/mock_provider_bridge.py
+++ b/src/bcs/scripts/mock_provider_bridge.py
@@ -322,7 +322,7 @@ async def drive_turn(
     try:
         async with websockets.connect(
             url, max_size=16 * 1024 * 1024,
-            additional_headers={"Origin": "https://teamclaw.alipay.com"},
+            additional_headers={"Origin": cfg.engine_origin},
         ) as ws:
             # v3 handshake
             connect_id = uuid.uuid4().hex
@@ -434,7 +434,7 @@ async def drive_turn_callback(run_id: str, session_key: str, message: str, cfg: 
     try:
         async with websockets.connect(
             url, max_size=16 * 1024 * 1024,
-            additional_headers={"Origin": "https://teamclaw.alipay.com"},
+            additional_headers={"Origin": cfg.engine_origin},
         ) as ws:
             await ws.send(json.dumps(build_connect_frame(uuid.uuid4().hex)))
             chat_id = uuid.uuid4().hex
@@ -535,7 +535,7 @@ async def drive_request(run_id: str, frame: dict, engine: str, cfg: "BridgeConfi
     try:
         async with websockets.connect(
             url, max_size=16 * 1024 * 1024,
-            additional_headers={"Origin": "https://teamclaw.alipay.com"},
+            additional_headers={"Origin": cfg.engine_origin},
         ) as ws:
             await ws.send(json.dumps(build_connect_frame(uuid.uuid4().hex)))
             await ws.send(json.dumps(frame))
@@ -665,12 +665,14 @@ class BridgeConfig:
         provider_bot_ref: str = "",
         provider_admin_token: str = "",
         permission_mode: str = "",
+        engine_origin: str = "https://teamclaw.localhost",
     ):
         self.engine = engine
         self.engine_host = engine_host
         self.engine_port = engine_port
         self.idle_timeout_s = idle_timeout_s
         self.permission_mode = permission_mode
+        self.engine_origin = engine_origin
         # send response shape:
         #   "sse"          -> 2.0 SSE: respond with text/event-stream, stream frames.
         #   "callback-2.0" -> 2.0 callback streaming: JSON-ack the POST, then
@@ -704,6 +706,7 @@ def main() -> None:
     parser.add_argument("--provider-bot-ref", default="", help="provider_bot_ref for callback auth headers")
     parser.add_argument("--provider-admin-token", default="", help="provider_admin_token (Bearer) for callback auth")
     parser.add_argument("--permission-mode", default="", help="optional engine chat.send permissionMode")
+    parser.add_argument("--engine-origin", default="https://teamclaw.localhost", help="Origin header for engine websocket calls")
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
@@ -723,6 +726,7 @@ def main() -> None:
         provider_bot_ref=args.provider_bot_ref,
         provider_admin_token=args.provider_admin_token,
         permission_mode=args.permission_mode,
+        engine_origin=args.engine_origin,
     )
     app = web.Application()
     app.router.add_post("/webhook", make_webhook_handler(cfg))

--- a/src/frontend/config/config.local.ts
+++ b/src/frontend/config/config.local.ts
@@ -64,11 +64,11 @@ const hasHttpServer = Object.entries(preset.servers).some(
 
 const frontendPort = process.env.PORT || '8000';
 const frontendUrl = !hasHttpServer
-  ? `https://dev.alipay.com:${frontendPort}`
-  : `http://dev.alipay.net:${frontendPort}`;
+  ? `https://dev.localhost:${frontendPort}`
+  : `http://dev.localhost:${frontendPort}`;
 const hostConfig = !hasHttpServer
-  ? '127.0.0.1 dev.alipay.com'
-  : '127.0.0.1 dev.alipay.net';
+  ? '127.0.0.1 dev.localhost'
+  : '127.0.0.1 dev.localhost';
 const localDevEnv =
   presetName === 'local'
     ? 'LOCAL'
@@ -169,13 +169,13 @@ if (process.env.BCS_PORT || process.env.BCSFUSE_PORT) {
 
 // ==================== 副屏 UMD 组件 CDN 同源代理（dev-only）====================
 // 副屏 UMD 组件由 UmdLoader 在浏览器里 fetch(cdn) 拉取（cdn 是后端下发的绝对地址）。
-// fetch 受 CORS 约束：受限 CDN 只放行白名单内的 origin（如 *.alipay.net），导致
+// fetch 受 CORS 约束：受限 CDN 只放行白名单内的 origin，导致
 // 用 localhost 打开时副屏「组件加载失败」。
 //
 // 解法：dev 下让前端把 fetch 改写成同源路径 /__umd_cdn?target=<绝对CDN地址>，
 // 由 dev server 转发到真实 CDN。浏览器只与 dev server 同源通信（不触发 CORS），
 // dev server 用 Node 拉 CDN 是服务端请求（不受 CORS 白名单限制）。于是无论 CDN
-// 换成哪个域名、前端用 localhost 还是 dev.alipay.net，都能加载——前端域名与 CDN
+// 换成哪个域名、前端用 localhost 还是 dev.localhost，都能加载——前端域名与 CDN
 // 域名彻底解耦。配套改写见 src/components/UmdLoader/loadUmd.ts（同名 UMD_CDN_PROXY
 // define 守卫；生产不注入，直连原始 CDN）。
 //


### PR DESCRIPTION
## Summary

Add a dedicated GitHub Actions workflow for the singlebox coverage gate.

The workflow intentionally keeps the product logic in `scripts/ci/singlebox_coverage.sh`; GitHub Actions only prepares the runner, invokes the script in real mode, prints diagnostics on failure, stops the stack, and uploads singlebox artifacts.

## Notes

- Based on `dev` after PR #23 was merged.
- `SINGLEBOX_COVERAGE_MODE=real` is set explicitly so CI cannot silently pass through a mock fallback.
- `SINGLEBOX_MODEL_CONFIG_MODE=mock` is used so CI can validate the local stack without real model credentials.
- `workflow_dispatch` is enabled for manual validation before making this check required in branch protection.

## Validation

- Parsed `.github/workflows/singlebox-coverage.yml` locally with Ruby YAML parser.
- This PR should run the workflow against the full singlebox stack from PR #23.