### PR TITLE
fix(baas): close api-key policy/env authorization gaps

### DIFF
--- a/src/baas/packages/community/src/secbaas/adapters/web/routers/admin/api_gateway_router.py
+++ b/src/baas/packages/community/src/secbaas/adapters/web/routers/admin/api_gateway_router.py
@@ -349,8 +349,7 @@ async def get_allowed_bots_admin(
         )
 
     policy = parse_policy(api_key.policy)
-    # 过滤 NONE 哨兵值，对外返回语义为空列表
-    bots = [b for b in policy.allowed_bots if b != "NONE"]
+    bots = policy.allowed_bots
     logger.info(
         f"Audit: get_allowed_bots_admin operator={_op_ctx.operator} "
         f"prefix={api_key_prefix} count={len(bots)}"
@@ -398,9 +397,6 @@ async def grant_allowed_bot_admin(
 
     policy = parse_policy(api_key.policy)
 
-    # 如果当前是 NONE 哨兵，清空后替换为实际 bot_id
-    if policy.allowed_bots == ["NONE"]:
-        policy.allowed_bots = []
     if data.bot_id not in set(policy.allowed_bots):
         policy.allowed_bots.append(data.bot_id)
 

--- a/src/baas/packages/community/src/secbaas/adapters/web/routers/config_management/api_gateway_router.py
+++ b/src/baas/packages/community/src/secbaas/adapters/web/routers/config_management/api_gateway_router.py
@@ -160,7 +160,7 @@ async def create_bot_key(
 @router.post(
     "/app",
     summary="创建 App API Key",
-    description='创建一个 app_type 为 app 的 API Key，自动设置 app_type=app。任何已认证用户均可创建，owner 自动填充为当前用户，policy 默认不允许访问任何 bot (allowed_bots=["NONE"])，后续通过 grant/revoke 接口管理',
+    description="创建一个 app_type 为 app 的 API Key，自动设置 app_type=app。任何已认证用户均可创建，owner 自动填充为当前用户，policy 默认不允许访问任何 bot (allowed_bots=[])，后续通过 grant/revoke 接口管理",
     response_model=ApiResponse,
     responses={
         200: {"description": "API Key 创建成功"},
@@ -183,7 +183,7 @@ async def create_app_key(
         **data.model_dump(),
         app_type="app",
         owner=operator,
-        policy='{"allowed_bots":["NONE"]}',
+        policy='{"allowed_bots":[]}',
     )
     try:
         key = await service.create_key(create_data, op_ctx)
@@ -383,8 +383,7 @@ async def get_allowed_bots(
         )
 
     policy = parse_policy(_checked.policy)
-    # 过滤 NONE 哨兵值，对外返回语义为空列表
-    bots = [b for b in policy.allowed_bots if b != "NONE"]
+    bots = policy.allowed_bots
     logger.info(f"Get allowed_bots: prefix={api_key_prefix}, count={len(bots)}")
     return ApiResponse(data={"allowed_bots": bots})
 
@@ -416,9 +415,6 @@ async def grant_allowed_bot(
 
     policy = parse_policy(_key.policy)
 
-    # 如果当前是 NONE 哨兵，清空后替换为实际 bot_id
-    if policy.allowed_bots == ["NONE"]:
-        policy.allowed_bots = []
     if data.bot_id not in set(policy.allowed_bots):
         policy.allowed_bots.append(data.bot_id)
 

--- a/src/baas/packages/community/src/secbaas/adapters/web/routers/open_api/dependencies.py
+++ b/src/baas/packages/community/src/secbaas/adapters/web/routers/open_api/dependencies.py
@@ -3,7 +3,12 @@
 from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, Header, HTTPException, Request, status
 
-from secbaas.api.api_gateway import APIKeyRecord, APIKeyValidator, parse_policy
+from secbaas.api.api_gateway import (
+    APIKeyPolicy,
+    APIKeyRecord,
+    APIKeyValidator,
+    parse_policy,
+)
 from secbaas.api.bot_runtime import BotChatContext
 from secbaas.api.open_api import OpenAPICode
 from secbaas.bootstrap import ApplicationContainer
@@ -179,25 +184,32 @@ def validate_policy(
 ) -> str:
     """根据 API Key 的 policy 校验对目标 bot 的访问权限
 
+    policy 语义（parse_policy 归一化后）：
+    - allowed_bots 含 "*"：允许访问所有 bot（含历史未配置的存量 key）。
+    - allowed_bots 为空（含历史 ["NONE"] 哨兵）：拒绝所有 bot（fail-closed）。
+    - 否则：白名单匹配，仅命中的 bot 放行。
+
     Args:
         api_key_record: API Key 记录
         target_bot_id: 目标 bot ID，格式为 <real_bot_id>:<entity_id>
 
     Returns:
         str: 校验通过后应使用的 bot_id。
-             当 allowed_bots 非空时返回匹配到的 allowed_bots 中的权威格式；
-             当 allowed_bots 为空（允许所有 bot）时返回原始 target_bot_id。
+             当为显式 allow-all 时返回原始 target_bot_id；
+             当为白名单匹配时返回匹配到的 allowed_bots 中的权威格式。
 
     Raises:
         HTTPException: 403 如果无权限
     """
     policy = parse_policy(api_key_record.policy)
-    if not policy.allowed_bots:
-        # allowed_bots 为空时表示允许访问所有 bot（向前兼容）
+
+    if APIKeyPolicy.ALL in policy.allowed_bots:
+        # 显式 allow-all（含历史未配置存量 key 的归一结果）
         return target_bot_id
 
     matched = match_allowed_bots(target_bot_id, policy.allowed_bots)
     if matched is None:
+        # 白名单未命中 / 空（含 NONE）即拒绝所有 bot（fail-closed）
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={

--- a/src/baas/packages/community/src/secbaas/api/api_gateway/_models.py
+++ b/src/baas/packages/community/src/secbaas/api/api_gateway/_models.py
@@ -79,7 +79,7 @@ class AppAPIKeyCreate(BaseModel):
     """创建 App API Key 请求（app_type 固定为 app）
 
     owner 由服务端从 OperationContext 自动填充，无需客户端指定。
-    policy 默认不允许访问任何 bot (allowed_bots=["NONE"])，后续通过 allowed-bots API 授权。
+    policy 默认不允许访问任何 bot (allowed_bots=[])，后续通过 allowed-bots API 授权。
     """
 
     app_id: str = Field(..., min_length=1, max_length=128, description="应用ID")

--- a/src/baas/packages/community/src/secbaas/api/api_gateway/_policy.py
+++ b/src/baas/packages/community/src/secbaas/api/api_gateway/_policy.py
@@ -1,4 +1,19 @@
-"""Policy parsing utilities for API Gateway."""
+"""Policy parsing utilities for API Gateway.
+
+Policy semantics (read after :func:`parse_policy` normalization):
+
+- ``allowed_bots`` contains ``"*"`` → allow all bots (explicit).
+- ``allowed_bots`` is empty → deny all bots (fail-closed; also covers the
+  legacy ``"NONE"`` sentinel, which is filtered out — a lone ``["NONE"]``
+  therefore normalizes to empty = deny all).
+- otherwise → whitelist: only bots listed in ``allowed_bots`` are allowed.
+
+Historical compatibility: a key whose ``policy`` is ``NULL``/empty or whose
+JSON object lacks the ``allowed_bots`` key historically meant "allow all".
+This is preserved by normalizing those forms to ``["*"]`` on read, so legacy
+unchanged keys keep working. New code writes explicit, structured policies
+(empty list = deny all).
+"""
 
 from __future__ import annotations
 
@@ -15,6 +30,7 @@ class APIKeyPolicy:
     """
 
     NONE: str = "NONE"
+    ALL: str = "*"
 
     allowed_bots: list[str] = field(default_factory=list)
 
@@ -28,23 +44,39 @@ class APIKeyPolicy:
 
 
 def parse_policy(policy: str | None) -> APIKeyPolicy:
-    """Parse a policy JSON string into an APIKeyPolicy.
+    """Parse a policy JSON string into an :class:`APIKeyPolicy`.
+
+    Normalization rules:
+
+    - ``None`` / empty string → ``allowed_bots=["*"]`` (legacy allow-all).
+    - dict without ``allowed_bots`` key → ``["*"]`` (legacy allow-all).
+    - dict with ``allowed_bots`` containing the ``"NONE"`` sentinel → the
+      sentinel is filtered out (a lone ``["NONE"]`` becomes empty = deny all;
+      ``["NONE", "bot-1"]`` keeps ``["bot-1"]``).
+    - any parse failure (invalid JSON / non-dict / types) → ``[]`` (deny all,
+      fail-closed).
 
     Args:
         policy: JSON-format policy string, may be None.
 
     Returns:
-        Parsed APIKeyPolicy; empty default policy on parse failure or
-        None input.
+        Normalized :class:`APIKeyPolicy`.
     """
-    if not policy:
-        return APIKeyPolicy()
+    if not policy or not policy.strip():
+        return APIKeyPolicy(allowed_bots=[APIKeyPolicy.ALL])
     try:
         result = json.loads(policy)
-        if not isinstance(result, dict):
-            return APIKeyPolicy()
-        return APIKeyPolicy(
-            allowed_bots=result.get("allowed_bots", []) or [],
-        )
     except (json.JSONDecodeError, TypeError):
-        return APIKeyPolicy()
+        return APIKeyPolicy()  # fail-closed: deny all
+    if not isinstance(result, dict):
+        return APIKeyPolicy()  # fail-closed: deny all
+    if "allowed_bots" not in result:
+        return APIKeyPolicy(allowed_bots=[APIKeyPolicy.ALL])  # legacy allow-all
+    raw = result.get("allowed_bots")
+    if not isinstance(raw, list):
+        return APIKeyPolicy()  # fail-closed: deny all
+    # Filter out legacy "NONE" sentinel; a lone ["NONE"] becomes empty (deny all)
+    bots = [b for b in raw if b != APIKeyPolicy.NONE]
+    if APIKeyPolicy.ALL in bots:
+        return APIKeyPolicy(allowed_bots=[APIKeyPolicy.ALL])  # explicit allow-all wins
+    return APIKeyPolicy(allowed_bots=bots)

--- a/src/baas/packages/community/src/secbaas/core/repository/api_gateway/_orm_repository.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/api_gateway/_orm_repository.py
@@ -96,16 +96,23 @@ class OrmAPIKeyRepository(OrmConnectionMixin, APIKeyRepository):
         return record
 
     @with_orm_session
-    def get_by_prefix_and_status(self, prefix: str, status: str) -> APIKeyRecord | None:
-        log.info("get_by_prefix_and_status: prefix=%s, status=%s", prefix, status)
-        row = (
-            self._session.query(APIKeyModel)
-            .filter(
-                APIKeyModel.api_key_prefix == prefix,
-                APIKeyModel.status == status,
-            )
-            .first()
+    def get_by_prefix_and_status(
+        self, prefix: str, status: str, env: str | None = None
+    ) -> APIKeyRecord | None:
+        log.info(
+            "get_by_prefix_and_status: prefix=%s, status=%s, env=%s",
+            prefix,
+            status,
+            env,
         )
+        query = self._session.query(APIKeyModel).filter(
+            APIKeyModel.api_key_prefix == prefix,
+            APIKeyModel.status == status,
+        )
+        # env 过滤：共享 DB 下钉死当前环境，避免跨环境 API Key 互认。
+        if env is not None:
+            query = query.filter(APIKeyModel.env == env)
+        row = query.first()
         record = row.to_record() if row else None
         log.info(
             "[api-gateway:get_by_prefix_and_status] result: %s",

--- a/src/baas/packages/community/src/secbaas/core/repository/api_gateway/_protocol.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/api_gateway/_protocol.py
@@ -38,8 +38,14 @@ class APIKeyRepository(Protocol):
         """根据前缀查询"""
         ...
 
-    def get_by_prefix_and_status(self, prefix: str, status: str) -> APIKeyRecord | None:
-        """根据前缀和状态查询"""
+    def get_by_prefix_and_status(
+        self, prefix: str, status: str, env: str | None = None
+    ) -> APIKeyRecord | None:
+        """根据前缀和状态查询
+
+        Args:
+            env: 可选环境过滤；传入时仅返回该环境的记录，避免共享 DB 跨环境互认。
+        """
         ...
 
     def list_keys(

--- a/src/baas/packages/community/src/secbaas/core/service/api_gateway/_key_validator.py
+++ b/src/baas/packages/community/src/secbaas/core/service/api_gateway/_key_validator.py
@@ -5,6 +5,7 @@
 
 from secbaas.api.api_gateway import APIKeyRecord
 from secbaas.core.repository.api_gateway import APIKeyRepository
+from secbaas.core.utils import env_utils
 from secbaas.logger import get_logger
 
 from ._key_gen import APIKeyGenerator
@@ -34,7 +35,11 @@ class DefaultAPIKeyValidator(APIKeyValidator):
 
         prefix = api_key[:8]
 
-        record = self._repository.get_by_prefix_and_status(prefix, "ACTIVE")
+        # 鉴权钉死当前环境：共享 DB 下避免跨环境 API Key 互认。
+        # env 口径与创建侧一致（均经 env_utils.get_current_env 归一）。
+        record = self._repository.get_by_prefix_and_status(
+            prefix, "ACTIVE", env=env_utils.get_current_env()
+        )
 
         if record is None:
             logger.debug(f"[verify] No active key found for prefix: {prefix}")
@@ -64,7 +69,9 @@ class DefaultAPIKeyValidator(APIKeyValidator):
 
         prefix = api_key[:8]
 
-        record = self._repository.get_by_prefix_and_status(prefix, "ACTIVE")
+        record = self._repository.get_by_prefix_and_status(
+            prefix, "ACTIVE", env=env_utils.get_current_env()
+        )
 
         if record is None:
             logger.debug(f"[verify_sync] No active key found for prefix: {prefix}")

--- a/src/baas/packages/community/tests/unit/adapters/web/open_api/test_dependencies.py
+++ b/src/baas/packages/community/tests/unit/adapters/web/open_api/test_dependencies.py
@@ -383,14 +383,28 @@ class TestValidatePolicy:
         result = validate_policy(record, "bot-1:entity-1")
         assert result == "bot-1:entity-1"
 
-    def test_empty_allowed_bots_list_allows_all(self):
-        """Empty allowed_bots → all bots allowed (forward compat)，返回原始 target_bot_id。"""
+    def test_empty_allowed_bots_list_denies_all(self):
+        """Empty allowed_bots → deny all (fail-closed)，返回 403。"""
         record = _make_api_key_record(policy='{"allowed_bots": []}')
+        with pytest.raises(HTTPException) as exc:
+            validate_policy(record, "any-bot")
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_none_sentinel_denies_all(self):
+        """Lone ['NONE'] sentinel → deny all (normalized to empty)。返回 403。"""
+        record = _make_api_key_record(policy='{"allowed_bots": ["NONE"]}')
+        with pytest.raises(HTTPException) as exc:
+            validate_policy(record, "any-bot")
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_explicit_allow_all(self):
+        """allowed_bots 含 '*' → 允许所有 bot，返回原始 target_bot_id。"""
+        record = _make_api_key_record(policy='{"allowed_bots": ["*"]}')
         result = validate_policy(record, "any-bot")
         assert result == "any-bot"
 
     def test_no_allowed_bots_key_allows_all(self):
-        """Policy without allowed_bots key → allows all，返回原始 target_bot_id。"""
+        """Policy without allowed_bots key → legacy allow-all，返回原始 target_bot_id。"""
         record = _make_api_key_record(policy='{"other_key": "value"}')
         result = validate_policy(record, "any-bot")
         assert result == "any-bot"
@@ -425,21 +439,23 @@ class TestValidatePolicy:
             validate_policy(record, "default:entity-2")
         assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_invalid_json_policy_returns_early(self):
-        """Invalid JSON is treated as empty dict → no restriction，返回原始 target_bot_id。"""
+    def test_invalid_json_policy_denies_all(self):
+        """Invalid JSON → fail-closed deny all，返回 403。"""
         record = _make_api_key_record(policy="{invalid json}")
-        result = validate_policy(record, "any-bot")
-        assert result == "any-bot"
+        with pytest.raises(HTTPException) as exc:
+            validate_policy(record, "any-bot")
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_policy_with_non_dict_parsed_value(self):
-        """parse_policy returns non-dict → returns early，返回原始 target_bot_id。"""
+    def test_policy_with_non_dict_parsed_value_denies_all(self):
+        """parse_policy returns empty (non-dict) → fail-closed deny all，返回 403。"""
         with patch(
             "secbaas.adapters.web.routers.open_api.dependencies.parse_policy",
             return_value=MagicMock(allowed_bots=[]),
         ):
             record = _make_api_key_record(policy='["list"]')
-            result = validate_policy(record, "any-bot")
-            assert result == "any-bot"
+            with pytest.raises(HTTPException) as exc:
+                validate_policy(record, "any-bot")
+            assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
     def test_multiple_bots_in_policy(self):
         """Ensure any matching bot_id passes and returns the matched entry."""

--- a/src/baas/packages/community/tests/unit/adapters/web/test_api_gateway_router.py
+++ b/src/baas/packages/community/tests/unit/adapters/web/test_api_gateway_router.py
@@ -492,12 +492,12 @@ class TestCreateAppKey:
         assert create_dto.app_type == "app"
 
     @pytest.mark.asyncio
-    async def test_create_app_key_default_policy_is_none_sentinel(
+    async def test_create_app_key_default_policy_is_deny_all(
         self,
         op_ctx: OperationContext,
         mock_service: AsyncMock,
     ) -> None:
-        """create_app_key sets default policy to '{\"allowed_bot\":[\"NONE\"]}'."""
+        """create_app_key sets default policy to '{\"allowed_bots\":[]}' (deny all)."""
         from secbaas.api.api_gateway import AppAPIKeyCreate
 
         data = AppAPIKeyCreate(app_id="my-app")
@@ -517,7 +517,7 @@ class TestCreateAppKey:
             env="test",
             creator="user-001",
             modifier=None,
-            policy='{"allowed_bots":["NONE"]}',
+            policy='{"allowed_bots":[]}',
             gmt_create=datetime(2024, 1, 1),
             gmt_modified=datetime(2024, 1, 1),
         )
@@ -525,7 +525,7 @@ class TestCreateAppKey:
         await create_app_key(data, op_ctx=op_ctx, service=mock_service)
         call_args = mock_service.create_key.call_args
         create_dto = call_args[0][0]
-        assert create_dto.policy == '{"allowed_bots":["NONE"]}'
+        assert create_dto.policy == '{"allowed_bots":[]}'
 
     @pytest.mark.asyncio
     async def test_api_key_error(
@@ -842,11 +842,11 @@ class TestGetAllowedBots:
         self,
         sample_app_key_response: APIKeyResponse,
     ) -> None:
-        """Key with None policy → return empty list."""
+        """Key with None policy → legacy allow-all, normalized to ['*']."""
         key = sample_app_key_response.model_copy(update={"policy": None})
         result = await get_allowed_bots("sk-app", key)
         assert isinstance(result, ApiResponse)
-        assert result.data == {"allowed_bots": []}
+        assert result.data == {"allowed_bots": ["*"]}
 
     @pytest.mark.asyncio
     async def test_none_sentinel_filtered_out(
@@ -942,7 +942,7 @@ class TestGrantAllowedBot:
         self,
         mock_service: AsyncMock,
     ) -> None:
-        """When policy is ['NONE'], grant clears NONE and appends the real bot_id."""
+        """When policy is ['NONE'], grant normalizes it to empty and appends the bot_id."""
         none_policy_key = APIKeyResponse(
             id=60,
             app_id="my-app",

--- a/src/baas/packages/community/tests/unit/core/repository/api_gateway/test_orm_api_gateway_repository.py
+++ b/src/baas/packages/community/tests/unit/core/repository/api_gateway/test_orm_api_gateway_repository.py
@@ -284,6 +284,39 @@ class TestGetByPrefixAndStatus:
 
         assert result is None
 
+    def test_filters_by_env_when_provided(self, repository, mock_session):
+        """传入 env 时，查询应追加 env 过滤条件。"""
+        record = _mock_record(id_val=11, api_key_prefix="sk-env", status="ACTIVE")
+        mock_model = MagicMock()
+        mock_model.to_record.return_value = record
+        filtered = mock_session.query.return_value.filter.return_value
+        filtered.filter.return_value.first.return_value = mock_model
+
+        from secbaas.core.repository.api_gateway._orm_model import APIKeyModel
+
+        result = repository.get_by_prefix_and_status("sk-env", "ACTIVE", env="prod")
+
+        assert result is not None
+        # 应有两次 filter 调用：第一次 prefix+status，第二次 env
+        first_filter = mock_session.query.return_value.filter
+        first_filter.assert_called_once()
+        second_filter = first_filter.return_value.filter
+        second_filter.assert_called_once()
+        # 第二次 filter 的参数应为 env 过滤条件
+        env_arg = second_filter.call_args[0][0]
+        assert str(env_arg) == str(APIKeyModel.env == "prod")
+
+    def test_no_env_filter_when_env_none(self, repository, mock_session):
+        """不传 env 时，不追加额外过滤（向后兼容）。"""
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        repository.get_by_prefix_and_status("sk-env", "ACTIVE")
+
+        first_filter = mock_session.query.return_value.filter
+        # 不传 env → 只有一次 filter（prefix+status），不追加 env 过滤
+        first_filter.assert_called_once()
+        first_filter.return_value.filter.assert_not_called()
+
 
 # ==================== list_keys ====================
 

--- a/src/baas/packages/community/tests/unit/core/service/api_gateway/test_key_validator.py
+++ b/src/baas/packages/community/tests/unit/core/service/api_gateway/test_key_validator.py
@@ -98,6 +98,39 @@ class TestVerify:
 
         assert result is None
 
+    async def test_verify_passes_current_env_to_repository(self, validator, repo):
+        """verify 必须把当前环境透传给 repository，钉死当前 env 过滤。"""
+        repo.get_by_prefix_and_status.return_value = _make_record()
+
+        with (
+            patch(
+                "secbaas.core.service.api_gateway._key_gen.APIKeyGenerator.verify_key",
+                return_value=True,
+            ),
+            patch(
+                "secbaas.core.service.api_gateway._key_validator.env_utils.get_current_env",
+                return_value="prod",
+            ),
+        ):
+            await validator.verify("xK9mP2nQ1234567890123456789012345")
+
+        args, kwargs = repo.get_by_prefix_and_status.call_args
+        # env 通过关键字传入
+        assert kwargs.get("env") == "prod"
+
+    async def test_verify_cross_env_returns_none(self, validator, repo):
+        """跨环境的 key（repository 按 env 过滤后查不到）→ None，统一 401 不泄露。"""
+        # repository 在当前 env 下查不到（跨环境记录被过滤）→ 返回 None
+        repo.get_by_prefix_and_status.return_value = None
+
+        with patch(
+            "secbaas.core.service.api_gateway._key_validator.env_utils.get_current_env",
+            return_value="prod",
+        ):
+            result = await validator.verify("xK9mP2nQ1234567890123456789012345")
+
+        assert result is None
+
 
 # ==================== verify_sync ====================
 
@@ -136,3 +169,22 @@ class TestVerifySync:
             result = validator.verify_sync("xK9mP2nQ1234567890123456789012345")
 
         assert result is None
+
+    def test_verify_sync_passes_current_env_to_repository(self, validator, repo):
+        """verify_sync 必须把当前环境透传给 repository。"""
+        repo.get_by_prefix_and_status.return_value = _make_record()
+
+        with (
+            patch(
+                "secbaas.core.service.api_gateway._key_gen.APIKeyGenerator.verify_key",
+                return_value=True,
+            ),
+            patch(
+                "secbaas.core.service.api_gateway._key_validator.env_utils.get_current_env",
+                return_value="prod",
+            ),
+        ):
+            validator.verify_sync("xK9mP2nQ1234567890123456789012345")
+
+        args, kwargs = repo.get_by_prefix_and_status.call_args
+        assert kwargs.get("env") == "prod"

--- a/src/baas/packages/community/tests/unit/core/service/api_gateway/test_policy.py
+++ b/src/baas/packages/community/tests/unit/core/service/api_gateway/test_policy.py
@@ -1,9 +1,10 @@
 """Unit tests for policy parsing module.
 
 Covers:
-- parse_policy: valid JSON, None input, empty string, invalid JSON, non-dict JSON
-- APIKeyPolicy: to_json round-trip, NONE sentinel
-- parse_policy: NONE sentinel policy
+- parse_policy normalization: legacy allow-all (None/empty/missing key),
+  explicit allow-all ("*"), deny-all (empty / NONE sentinel / mixed),
+  whitelist parsing, fail-closed on bad input.
+- APIKeyPolicy: to_json round-trip, NONE/ALL sentinel constants
 """
 
 from secbaas.api.api_gateway import APIKeyPolicy, parse_policy
@@ -38,15 +39,10 @@ class TestAPIKeyPolicy:
         parsed = json.loads(result)
         assert "allowed_bots" in parsed
 
-    def test_none_sentinel_constant(self):
-        """NONE sentinel constant should be 'NONE'."""
+    def test_sentinel_constants(self):
+        """NONE / ALL sentinel constants."""
         assert APIKeyPolicy.NONE == "NONE"
-
-    def test_to_json_with_none_sentinel(self):
-        """Policy with NONE sentinel serializes correctly."""
-        policy = APIKeyPolicy(allowed_bots=["NONE"])
-        result = policy.to_json()
-        assert result == '{"allowed_bots":["NONE"]}'
+        assert APIKeyPolicy.ALL == "*"
 
 
 class TestParsePolicy:
@@ -55,42 +51,57 @@ class TestParsePolicy:
         assert isinstance(result, APIKeyPolicy)
         assert result.allowed_bots == ["bot1:e1", "bot2:e2"]
 
-    def test_valid_json_without_allowed_bots(self):
-        result = parse_policy('{"other_key": "value"}')
-        assert isinstance(result, APIKeyPolicy)
-        assert result.allowed_bots == []
-
-    def test_none_input(self):
+    # --- legacy allow-all compatibility (NULL / empty / missing key) ---
+    def test_none_input_legacy_allow_all(self):
         result = parse_policy(None)
-        assert isinstance(result, APIKeyPolicy)
-        assert result.allowed_bots == []
+        assert result.allowed_bots == ["*"]
 
-    def test_empty_string(self):
+    def test_empty_string_legacy_allow_all(self):
         result = parse_policy("")
-        assert isinstance(result, APIKeyPolicy)
-        assert result.allowed_bots == []
+        assert result.allowed_bots == ["*"]
 
-    def test_whitespace_string(self):
+    def test_whitespace_string_legacy_allow_all(self):
         result = parse_policy("   ")
-        assert isinstance(result, APIKeyPolicy)
+        assert result.allowed_bots == ["*"]
+
+    def test_missing_allowed_bots_key_legacy_allow_all(self):
+        """dict without allowed_bots key → legacy allow-all."""
+        result = parse_policy('{"other_key": "value"}')
+        assert result.allowed_bots == ["*"]
+
+    # --- explicit allow-all ---
+    def test_explicit_allow_all(self):
+        result = parse_policy('{"allowed_bots": ["*"]}')
+        assert result.allowed_bots == ["*"]
+
+    # --- deny-all: empty / NONE sentinel / fail-closed ---
+    def test_empty_allowed_bots_denies_all(self):
+        result = parse_policy('{"allowed_bots": []}')
         assert result.allowed_bots == []
 
-    def test_invalid_json(self):
-        result = parse_policy("not-json")
-        assert isinstance(result, APIKeyPolicy)
-        assert result.allowed_bots == []
-
-    def test_non_dict_json(self):
-        result = parse_policy('["list", "not", "dict"]')
-        assert isinstance(result, APIKeyPolicy)
-        assert result.allowed_bots == []
-
-    def test_allowed_bots_null(self):
+    def test_allowed_bots_null_denies_all(self):
         result = parse_policy('{"allowed_bots": null}')
-        assert isinstance(result, APIKeyPolicy)
         assert result.allowed_bots == []
 
-    def test_parse_none_sentinel_policy(self):
-        """Parse a policy that contains the NONE sentinel."""
+    def test_none_sentinel_denies_all(self):
+        """Lone ['NONE'] sentinel → normalized to empty = deny all."""
         result = parse_policy('{"allowed_bots": ["NONE"]}')
-        assert result.allowed_bots == ["NONE"]
+        assert result.allowed_bots == []
+
+    def test_none_sentinel_filtered_from_mixed(self):
+        """['NONE', 'bot-1'] keeps ['bot-1'] (NONE filtered, not a full deny)."""
+        result = parse_policy('{"allowed_bots": ["NONE", "bot-1:e1"]}')
+        assert result.allowed_bots == ["bot-1:e1"]
+
+    # --- fail-closed: bad input denies all ---
+    def test_invalid_json_denies_all(self):
+        result = parse_policy("not-json")
+        assert result.allowed_bots == []
+
+    def test_non_dict_json_denies_all(self):
+        result = parse_policy('["list", "not", "dict"]')
+        assert result.allowed_bots == []
+
+    def test_non_list_allowed_bots_denies_all(self):
+        result = parse_policy('{"allowed_bots": "bot-1"}')
+        assert result.allowed_bots == []


### PR DESCRIPTION
Policy semantics (parse_policy normalization, validate_policy):
- empty allowed_bots / lone ["NONE"] = deny all (fail-closed), fixing the revoke-to-empty privilege escalation to allow-all.
- NULL / missing allowed_bots key = legacy allow-all (back-compat preserved).
- explicit ["*"] = allow all; bad JSON / non-dict / non-list = deny all.
- create_app_key default policy now [] (deny all) instead of ["NONE"]; grant no longer needs to clear the NONE sentinel; get_allowed_bots returns the normalized list as-is.

Env isolation (shared DB cross-env key reuse):
- get_by_prefix_and_status gains optional env filter; validator forwards env_utils.get_current_env() so keys are pinned to the current env, with the same env normalization as key creation.

Tests updated to the new semantics; env passthrough cross-env denial covered. Full unit + integration suite green.