### PR TITLE
fix: fan out service bot cron by runtime devices

### DIFF
--- a/src/backend/src/agentclaw/community/core/cron/protocols.py
+++ b/src/backend/src/agentclaw/community/core/cron/protocols.py
@@ -113,6 +113,23 @@ class DeviceConnectionProvider(Protocol):
         """
         ...
 
+    def list_devices_by_runtime_binding(
+        self,
+        *,
+        binding_id: int,
+    ) -> list[str]:
+        """按运行态 binding 获取设备列表。
+
+        返回用于运行态路由的 device_uuid 列表。
+
+        Args:
+            binding_id: 设备绑定ID
+
+        Returns:
+            ["device_uuid"]
+        """
+        ...
+
 
 class DeviceBindingStatus:
     """设备绑定状态枚举"""

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -309,13 +309,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
                     self._failed_target(target, "cron_api_failed", str(result))
                 )
                 continue
-            data = result.get("data", {})
-            if isinstance(data, dict):
-                running_list = data.get("running", [])
-                for item in running_list:
-                    self._decorate_runtime_item(item, target)
-                all_running.extend(running_list)
-            elif result.get("success") is False:
+            if result.get("success") is False:
                 failed_targets.append(
                     self._failed_target(
                         target,
@@ -323,6 +317,13 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
                         result.get("error") or result.get("message") or "cron api failed",
                     )
                 )
+                continue
+            data = result.get("data", {})
+            if isinstance(data, dict):
+                running_list = data.get("running", [])
+                for item in running_list:
+                    self._decorate_runtime_item(item, target)
+                all_running.extend(running_list)
 
         return {"success": True, "data": all_running, "failed_targets": failed_targets}
 
@@ -510,8 +511,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             logger.warning(f"[_fetch_bot_crons] Failed to get device status for bot {bot_id}: {e}")
             return {"success": False, "error": f"Device not available: {e}"}
 
-        # 通过 DeviceContextResolver 拿 DeviceContext(全仓唯一 provider 解析点),
-        # 替代旧的 ``device_service.get_device_connection_v2(binding_id, user_id, nick_name)``。
+        # 构造该 bot 当前 binding 的 adapter 连接上下文。
         try:
             ctx = self._resolver.resolve_for_bot(bot_id, user_id)
         except Exception as e:
@@ -769,10 +769,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
                 raise
             raise ValueError(f"Device not available: {e}")
 
-        # 2. 通过 DeviceContextResolver 拿 DeviceContext(全仓唯一 provider 解析点),
-        # 替代旧的 ``get_device_connection_v2`` — 后者对 baas service bot 落 direct
-        # 分支丢 binding_id,transport fallback 裸 httpx 直发 ARCA-SANDBOX 内网 → 500。
-        # 走 resolver → 永填 binding_id → transport 走 baas proxypass。
+        # 2. 构造目标运行态的 adapter 连接上下文。
         if runtime_stage == RUNTIME_STAGE_DRAFT:
             ctx = self._resolver.resolve_for_bot(bot_id, user_id)
         else:

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_operations.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_operations.py
@@ -20,7 +20,10 @@ logger = get_logger()
 
 
 class CronRuntimeOperationsMixin:
+    """定时任务运行态接口的显式用例入口。"""
+
     def _validate_runtime_stage(self, runtime_stage: str) -> None:
+        """校验 runtime_stage 查询参数。"""
         if runtime_stage not in VALID_RUNTIME_STAGES:
             raise CronRelayError(
                 f"Invalid runtime_stage: {runtime_stage}",
@@ -34,6 +37,7 @@ class CronRuntimeOperationsMixin:
         user_id: str,
         runtime_stage: str,
     ) -> tuple[dict, CronRuntimeTarget]:
+        """解析一次请求要访问的运行态目标。"""
         self._validate_runtime_stage(runtime_stage)
         bot = self._bot_provider.get_bot(bot_id, user_id)
         if runtime_stage != RUNTIME_STAGE_DRAFT:
@@ -62,6 +66,7 @@ class CronRuntimeOperationsMixin:
         bot_id: str,
         target: CronRuntimeTarget,
     ) -> Any:
+        """读取运行态 binding 对应的设备记录。"""
         try:
             return self._device_provider.get_device(binding_id=target.binding_id)
         except Exception as e:
@@ -82,6 +87,7 @@ class CronRuntimeOperationsMixin:
         runtime_stage: str,
         device: Any,
     ) -> None:
+        """确保运行态设备处于可转发状态。"""
         device_status = self._read_field(device, "status")
         if device_status == DeviceBindingStatus.ACTIVE:
             return
@@ -106,6 +112,7 @@ class CronRuntimeOperationsMixin:
         runtime_stage: str,
         target: CronRuntimeTarget,
     ) -> Any:
+        """读取并校验运行态设备。"""
         device = self._read_runtime_device(bot_id=bot_id, target=target)
         self._ensure_runtime_device_active(
             bot_id=bot_id,
@@ -131,6 +138,7 @@ class CronRuntimeOperationsMixin:
         self,
         failed_targets: list[dict[str, Any]],
     ) -> dict:
+        """生成发布态实例不可用的统一响应。"""
         return {
             "success": False,
             "message": "runtime instances unavailable",
@@ -150,6 +158,7 @@ class CronRuntimeOperationsMixin:
         bot: dict,
         include_runtime: bool,
     ) -> None:
+        """为单目标 adapter 响应补充 bot 与运行态元数据。"""
         if not (
             result.get("success")
             and result.get("data")
@@ -178,6 +187,7 @@ class CronRuntimeOperationsMixin:
         body: Optional[dict] = None,
         params: Optional[dict] = None,
     ) -> dict:
+        """转发到单个运行态目标。"""
         bot, target = self._resolve_request_target(
             bot_id=bot_id,
             user_id=user_id,
@@ -214,6 +224,7 @@ class CronRuntimeOperationsMixin:
         body: Optional[dict],
         params: Optional[dict],
     ) -> dict:
+        """发布态多实例 fan-out；单实例 provider 保持单次转发。"""
         expanded_targets, failed_targets = self._expand_runtime_target(
             target,
             device=device,
@@ -253,6 +264,7 @@ class CronRuntimeOperationsMixin:
         user_id: str,
         nick_name: str,
     ) -> dict:
+        """获取草稿态 cron 能力状态。"""
         return await self._forward_single_stage_request(
             bot_id=bot_id,
             user_id=user_id,
@@ -270,6 +282,7 @@ class CronRuntimeOperationsMixin:
         task_id: str,
         runtime_stage: str = RUNTIME_STAGE_DRAFT,
     ) -> dict:
+        """获取指定运行态的任务详情。"""
         return await self._forward_single_stage_request(
             bot_id=bot_id,
             user_id=user_id,
@@ -286,6 +299,7 @@ class CronRuntimeOperationsMixin:
         nick_name: str,
         body: dict,
     ) -> dict:
+        """在草稿态创建定时任务。"""
         return await self._forward_single_stage_request(
             bot_id=bot_id,
             user_id=user_id,
@@ -305,6 +319,7 @@ class CronRuntimeOperationsMixin:
         body: Optional[dict],
         runtime_stage: str = RUNTIME_STAGE_DRAFT,
     ) -> dict:
+        """更新定时任务；发布态仅支持启停同步。"""
         if runtime_stage == RUNTIME_STAGE_DRAFT:
             return await self._forward_single_stage_request(
                 bot_id=bot_id,
@@ -353,6 +368,7 @@ class CronRuntimeOperationsMixin:
         task_id: str,
         runtime_stage: str = RUNTIME_STAGE_DRAFT,
     ) -> dict:
+        """删除草稿态定时任务。"""
         self._validate_runtime_stage(runtime_stage)
         if runtime_stage != RUNTIME_STAGE_DRAFT:
             raise CronRelayError("发布态定时任务不支持删除", error_code=403)
@@ -374,6 +390,7 @@ class CronRuntimeOperationsMixin:
         force: bool = False,
         runtime_stage: str = RUNTIME_STAGE_DRAFT,
     ) -> dict:
+        """触发定时任务；发布态会按运行实例 fan-out。"""
         if runtime_stage == RUNTIME_STAGE_DRAFT:
             return await self._forward_single_stage_request(
                 bot_id=bot_id,
@@ -415,6 +432,7 @@ class CronRuntimeOperationsMixin:
         runtime_stage: str = RUNTIME_STAGE_DRAFT,
         device_uuid: str | None = None,
     ) -> dict:
+        """获取任务运行记录；发布态可按实例筛选。"""
         if device_uuid and runtime_stage == RUNTIME_STAGE_DRAFT:
             raise CronRelayError(
                 "device_uuid requires published runtime_stage",

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
@@ -1,4 +1,4 @@
-"""Runtime target helpers for cron relay service."""
+"""Cron 运行态目标构造、实例展开与结果装饰。"""
 from __future__ import annotations
 
 import asyncio
@@ -20,10 +20,16 @@ VALID_RUNTIME_STAGES = {
     RUNTIME_STAGE_ONLINE,
 }
 MULTI_INSTANCE_DEVICE_PROVIDERS = {"baas", "teclaw"}
+SINGLE_INSTANCE_DEVICE_PROVIDERS = {"arca", "local"}
 
 
 @dataclass(frozen=True)
 class CronRuntimeTarget:
+    """一次 cron 请求的运行态路由目标。
+
+    ``device_uuid`` 为空表示按 binding 路由；有值表示按发布态实例路由。
+    """
+
     bot_id: str
     bot_name: str
     owner_id: str
@@ -33,11 +39,6 @@ class CronRuntimeTarget:
     publish_id: int | None = None
     publish_status: str | None = None
     device_uuid: str | None = None
-    provider_device_id: str | None = None
-    bot_uuid: str | None = None
-    instance_status: str | None = None
-    instance_health: str | None = None
-    instance_health_status: str | None = None
 
 
 class CronRuntimeTargetMixin:
@@ -47,10 +48,17 @@ class CronRuntimeTargetMixin:
             return value.get(field)
         return getattr(value, field, None)
 
+    def _get_runtime_devices(self, target: CronRuntimeTarget) -> list[str]:
+        """获取发布态 fan-out 所需的运行设备 UUID 列表。"""
+        return self._device_provider.list_devices_by_runtime_binding(
+            binding_id=target.binding_id,
+        )
+
     def _expand_runtime_targets(
         self,
         targets: list[CronRuntimeTarget],
     ) -> tuple[list[CronRuntimeTarget], list[dict[str, Any]]]:
+        """将一组运行态目标展开成实际请求目标。"""
         expanded: list[CronRuntimeTarget] = []
         failed_targets: list[dict[str, Any]] = []
         for target in targets:
@@ -65,6 +73,7 @@ class CronRuntimeTargetMixin:
         *,
         device: Any | None = None,
     ) -> tuple[list[CronRuntimeTarget], list[dict[str, Any]]]:
+        """将服务 bot 多实例发布态目标展开到 device_uuid 维度。"""
         if target.bot_type != "service" or target.device_uuid:
             return [target], []
 
@@ -90,16 +99,26 @@ class CronRuntimeTargetMixin:
             ]
 
         device_provider = self._read_field(device, "device_provider")
-        if not isinstance(device_provider, str):
+        if isinstance(device_provider, str):
+            device_provider = device_provider.lower()
+        # arca/local 只有一个运行设备，按 binding 转发一次即可。
+        if device_provider in SINGLE_INSTANCE_DEVICE_PROVIDERS:
             return [target], []
         if device_provider not in MULTI_INSTANCE_DEVICE_PROVIDERS:
-            return [target], []
+            return [], [
+                self._failed_target(
+                    target,
+                    "unsupported_device_provider",
+                    (
+                        f"Bot {target.bot_id} stage={target.runtime_stage} "
+                        f"has unsupported device_provider={device_provider}"
+                    ),
+                )
+            ]
 
+        # baas/teclaw 发布态可能存在多个运行设备，需要逐实例转发。
         try:
-            instance_result = self._device_provider.get_instances(
-                binding_id=target.binding_id,
-                health_check=False,
-            )
+            device_uuids = self._get_runtime_devices(target)
         except Exception as e:
             logger.error(
                 "[_expand_runtime_target] Failed to query instances for "
@@ -111,9 +130,7 @@ class CronRuntimeTargetMixin:
             )
             return [], [self._failed_target(target, "instances_query_failed", str(e))]
 
-        bot_uuid = instance_result.get("bot_uuid")
-        devices = instance_result.get("devices", []) or []
-        if not devices:
+        if not device_uuids:
             return [], [
                 self._failed_target(
                     target,
@@ -126,61 +143,28 @@ class CronRuntimeTargetMixin:
             ]
 
         expanded: list[CronRuntimeTarget] = []
-        failed_targets: list[dict[str, Any]] = []
-        for instance in devices:
-            device_uuid = self._read_field(instance, "device_uuid")
-            if not device_uuid:
-                failed_targets.append(
-                    self._failed_target_from_values(
-                        bot_id=target.bot_id,
-                        bot_name=target.bot_name,
-                        owner_id=target.owner_id,
-                        runtime_stage=target.runtime_stage,
-                        publish_id=target.publish_id,
-                        reason="instance_device_uuid_missing",
-                        message=(
-                            f"Bot {target.bot_id} stage={target.runtime_stage} "
-                            "instance has no device_uuid"
-                        ),
-                        provider_device_id=self._read_field(
-                            instance, "provider_device_id"
-                        ),
-                        bot_uuid=self._read_field(instance, "bot_uuid") or bot_uuid,
-                        instance_status=self._read_field(instance, "status"),
-                        instance_health=self._read_field(instance, "health"),
-                        instance_health_status=self._read_field(
-                            instance, "health_status"
-                        ),
-                    )
-                )
-                continue
-
+        for device_uuid in device_uuids:
             expanded.append(
                 replace(
                     target,
                     device_uuid=str(device_uuid),
-                    provider_device_id=self._read_field(
-                        instance, "provider_device_id"
-                    ),
-                    bot_uuid=self._read_field(instance, "bot_uuid") or bot_uuid,
-                    instance_status=self._read_field(instance, "status"),
-                    instance_health=self._read_field(instance, "health"),
-                    instance_health_status=self._read_field(
-                        instance, "health_status"
-                    ),
                 )
             )
 
-        return expanded, failed_targets
+        return expanded, []
 
     def _decorate_runtime_item(
         self,
         item: dict[str, Any],
         target: CronRuntimeTarget,
     ) -> None:
+        """为 adapter 返回项补充 cron relay 的运行态元数据。"""
         item["bot_id"] = target.bot_id
         item["bot_name"] = target.bot_name
         item["owner_id"] = target.owner_id
+        if target.bot_type != "service":
+            return
+
         item["runtime_stage"] = target.runtime_stage
         if target.publish_id is not None:
             item["publish_id"] = target.publish_id
@@ -188,18 +172,9 @@ class CronRuntimeTargetMixin:
             item["publish_status"] = target.publish_status
         if target.device_uuid:
             item["device_uuid"] = target.device_uuid
-        if target.provider_device_id:
-            item["provider_device_id"] = target.provider_device_id
-        if target.bot_uuid:
-            item["bot_uuid"] = target.bot_uuid
-        if target.instance_status is not None:
-            item["instance_status"] = target.instance_status
-        if target.instance_health is not None:
-            item["instance_health"] = target.instance_health
-        if target.instance_health_status is not None:
-            item["instance_health_status"] = target.instance_health_status
 
     def _resolve_runtime_context(self, target: CronRuntimeTarget):
+        """根据 target 构造 adapter 连接上下文。"""
         kwargs: dict[str, Any] = {}
         if target.device_uuid:
             kwargs["device_uuid"] = target.device_uuid
@@ -222,6 +197,7 @@ class CronRuntimeTargetMixin:
         user_id: str,
         path: str = "/api/cron",
     ) -> dict:
+        """读取单个运行态目标的 cron 列表或运行中任务。"""
         try:
             device = self._device_provider.get_device(binding_id=target.binding_id)
             device_status = self._read_field(device, "status")
@@ -269,6 +245,7 @@ class CronRuntimeTargetMixin:
         reason: str,
         message: str,
     ) -> dict[str, Any]:
+        """按运行态目标生成失败项。"""
         return self._failed_target_from_values(
             bot_id=target.bot_id,
             bot_name=target.bot_name,
@@ -278,11 +255,6 @@ class CronRuntimeTargetMixin:
             reason=reason,
             message=message,
             device_uuid=target.device_uuid,
-            provider_device_id=target.provider_device_id,
-            bot_uuid=target.bot_uuid,
-            instance_status=target.instance_status,
-            instance_health=target.instance_health,
-            instance_health_status=target.instance_health_status,
         )
 
     def _failed_target_from_values(
@@ -296,11 +268,6 @@ class CronRuntimeTargetMixin:
         reason: str,
         message: str,
         device_uuid: str | None = None,
-        provider_device_id: str | None = None,
-        bot_uuid: str | None = None,
-        instance_status: str | None = None,
-        instance_health: str | None = None,
-        instance_health_status: str | None = None,
     ) -> dict[str, Any]:
         failed_target: dict[str, Any] = {
             "bot_id": bot_id,
@@ -314,16 +281,6 @@ class CronRuntimeTargetMixin:
             failed_target["publish_id"] = publish_id
         if device_uuid:
             failed_target["device_uuid"] = device_uuid
-        if provider_device_id:
-            failed_target["provider_device_id"] = provider_device_id
-        if bot_uuid:
-            failed_target["bot_uuid"] = bot_uuid
-        if instance_status is not None:
-            failed_target["instance_status"] = instance_status
-        if instance_health is not None:
-            failed_target["instance_health"] = instance_health
-        if instance_health_status is not None:
-            failed_target["instance_health_status"] = instance_health_status
         return failed_target
 
     async def _forward_runtime_target_request(
@@ -347,8 +304,19 @@ class CronRuntimeTargetMixin:
         reason: str | None = None,
         message: str | None = None,
     ) -> dict[str, Any]:
-        item: dict[str, Any] = {}
-        self._decorate_runtime_item(item, target)
+        item: dict[str, Any] = {
+            "bot_id": target.bot_id,
+            "bot_name": target.bot_name,
+            "owner_id": target.owner_id,
+        }
+        if target.bot_type == "service":
+            item["runtime_stage"] = target.runtime_stage
+            if target.publish_id is not None:
+                item["publish_id"] = target.publish_id
+            if target.publish_status is not None:
+                item["publish_status"] = target.publish_status
+        if target.device_uuid:
+            item["device_uuid"] = target.device_uuid
         item["success"] = success
         if data is not None:
             item["data"] = data
@@ -368,6 +336,7 @@ class CronRuntimeTargetMixin:
         params: Optional[dict],
         failed_targets: list[dict[str, Any]] | None = None,
     ) -> dict:
+        """并发转发到多个运行实例并聚合每个实例的结果。"""
         failed = list(failed_targets or [])
         tasks = [
             self._forward_runtime_target_request(
@@ -400,8 +369,6 @@ class CronRuntimeTargetMixin:
             if result.get("success", True):
                 succeeded += 1
                 data = result.get("data")
-                if isinstance(data, dict):
-                    self._decorate_runtime_item(data, target)
                 response_items.append(
                     self._runtime_target_result_item(
                         target,
@@ -423,13 +390,25 @@ class CronRuntimeTargetMixin:
                 )
             )
 
+        failed_count = len(failed)
+        # 多实例写操作需要所有实例成功；部分成功也返回失败供前端展示明细。
+        if succeeded > 0 and failed_count == 0:
+            success = True
+            message = "OK"
+        elif succeeded > 0:
+            success = False
+            message = "partial runtime instances failed"
+        else:
+            success = False
+            message = "all runtime instances failed"
+
         return {
-            "success": succeeded > 0,
-            "message": "OK" if succeeded > 0 else "all runtime instances failed",
+            "success": success,
+            "message": message,
             "data": {
                 "results": response_items,
                 "succeeded": succeeded,
-                "failed": len(failed),
+                "failed": failed_count,
             },
             "failed_targets": failed,
         }

--- a/src/backend/src/agentclaw/community/core/devices/services/device_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_instance_service.py
@@ -4,7 +4,7 @@
 解析到同一 ``bot_uuid``，调 BaaS 查设备列表，逐条合成健康四态。
 
 - 健康四态由 BaaS ``status`` + ``health`` 合成（§0.5），不落 BaaS 侧。
-- bot_id 入口经 ``ext.binding.online`` 解析运行态 binding_id（不用草稿 binding）。
+- bot_id 入口经 ``ext.binding.online`` 解析运行态 binding_id。
 - engine_type 走运行态 binding 的 ``device_props.bolt_id`` → ``active_engine``。
 """
 from __future__ import annotations
@@ -45,7 +45,7 @@ class BotPublishNotFoundError(RuntimeError):
 
 
 class BindingNotFoundError(RuntimeError):
-    """binding_id 查不到 / 非 baas / 跨环境 / 已释放。"""
+    """binding_id 无效或不支持实例查询。"""
 
 
 class InstanceHealthStatus:
@@ -101,7 +101,6 @@ class DeviceInstanceService:
 
         查该 bot 最新一条 status=success 的发布单，取
         ``json.loads(ext)["binding"]["online"]``（int）= 运行态 binding_id。
-        **不用** ``get_active_by_bot_and_owner`` —— 那会命中草稿 binding。
 
         Raises:
             BotPublishNotFoundError: 无 success 发布单 / ext 缺失 / binding.online 缺失
@@ -265,6 +264,31 @@ class DeviceInstanceService:
             )
 
         return {"bot_uuid": bot_uuid, "devices": devices}
+
+    def list_devices_by_runtime_binding(
+        self,
+        *,
+        binding_id: int,
+    ) -> list[str]:
+        """运行态设备列表（binding_id 入口）。
+
+        返回运行态路由所需的 device_uuid 列表。
+        """
+        _, bot_uuid = self._validate_binding_for_instances(binding_id)
+
+        baas_service = self._get_baas_service()
+        if baas_service is None:
+            raise DeviceServiceError(
+                "BaasService not available for runtime device query"
+            )
+
+        devices: list[str] = []
+        for d in baas_service.list_devices_by_bot_uuid(bot_uuid) or []:
+            device_uuid = d.get("device_uuid")
+            if device_uuid:
+                devices.append(str(device_uuid))
+
+        return devices
 
     def get_instances_by_bot(
         self,

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -1295,6 +1295,16 @@ class DeviceService:
             f"{type(self).__name__} does not support multi-instance listing"
         )
 
+    def list_devices_by_runtime_binding(
+        self,
+        *,
+        binding_id: int,
+    ) -> list[str]:
+        """获取运行态路由设备列表。"""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support runtime device listing"
+        )
+
     def restart_device(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
@@ -924,6 +924,17 @@ class DeviceServiceRouter(DeviceService):
         )
 
     @override
+    def list_devices_by_runtime_binding(
+        self,
+        *,
+        binding_id: int,
+    ) -> list[str]:
+        """按运行态 binding 获取设备列表。委托 DeviceInstanceService。"""
+        return self._instance_service().list_devices_by_runtime_binding(
+            binding_id=binding_id
+        )
+
+    @override
     def restart_device(
         self,
         *,

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
@@ -96,27 +96,6 @@ def _make_device(
     return SimpleNamespace(status=status, device_provider=device_provider)
 
 
-def _make_instance(
-    device_uuid: str,
-    *,
-    provider_device_id: str | None = None,
-    bot_uuid: str | None = None,
-    status: str = "ACTIVE",
-    health: str = "true",
-    health_status: str = "ACTIVE",
-):
-    instance = {
-        "device_uuid": device_uuid,
-        "status": status,
-        "health": health,
-        "provider_device_id": provider_device_id or f"provider-{device_uuid}",
-        "health_status": health_status,
-    }
-    if bot_uuid:
-        instance["bot_uuid"] = bot_uuid
-    return instance
-
-
 class TestFetchBotCronsUsesResolver:
     @pytest.mark.asyncio
     async def test_fetch_bot_crons_calls_resolver_not_v2(self):
@@ -205,6 +184,53 @@ class TestListAllCronsOwnerId:
 
         assert result["data"][0]["bot_id"] == "default"
         assert result["data"][0]["owner_id"] == "owner-1"
+
+    @pytest.mark.asyncio
+    async def test_list_all_crons_does_not_expose_runtime_stage_for_personal_bot(self):
+        """Personal bots do not have draft/verify/online runtime stages."""
+        bot_provider = MagicMock()
+        bot_provider.get_bot.return_value = {
+            "bot_id": "personal-bot",
+            "owner_id": "owner-1",
+            "binding_id": 42,
+            "bot_name": "Personal Bot",
+            "bot_type": "personal",
+        }
+
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = MagicMock(
+            status=DeviceBindingStatus.ACTIVE
+        )
+
+        resolver = MagicMock()
+        resolver.resolve_for_bot.return_value = _make_ctx(
+            binding_id=42,
+            bot_id="personal-bot",
+            user_id="owner-1",
+        )
+
+        transport = MagicMock()
+        transport.invoke = AsyncMock(return_value={
+            "success": True,
+            "data": [{"id": "task-1", "name": "daily"}],
+        })
+
+        svc = _make_service(
+            bot_provider=bot_provider,
+            device_provider=device_provider,
+            resolver=resolver,
+            transport=transport,
+        )
+
+        result = await svc.list_all_crons(
+            user_id="owner-1",
+            nick_name="Owner",
+            bot_id="personal-bot",
+        )
+
+        assert result["success"] is True
+        assert result["data"][0]["bot_id"] == "personal-bot"
+        assert "runtime_stage" not in result["data"][0]
 
     @pytest.mark.asyncio
     async def test_list_all_crons_all_scope_includes_collaborator_bots(self):
@@ -321,7 +347,7 @@ class TestListServiceBotRuntimeStages:
         )
 
         device_provider = MagicMock()
-        device_provider.get_device.return_value = MagicMock(status=DeviceBindingStatus.ACTIVE)
+        device_provider.get_device.return_value = _make_device(device_provider="arca")
 
         resolver = MagicMock()
         resolver.resolve_for_bot.return_value = _make_ctx(
@@ -402,13 +428,10 @@ class TestListServiceBotRuntimeStages:
                 30: _make_device(device_provider="baas"),
             }[binding_id]
         )
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_bot.return_value = _make_ctx(
@@ -461,6 +484,7 @@ class TestListServiceBotRuntimeStages:
         assert {item["id"] for item in online_rows} == {"shared-task"}
         assert result["failed_targets"] == []
         device_provider.get_instances.assert_not_called()
+        device_provider.list_devices_by_runtime_binding.assert_not_called()
         resolver.resolve_for_binding.assert_called_once_with(
             30, "owner-1", bot_id="service-bot"
         )
@@ -495,7 +519,7 @@ class TestListServiceBotRuntimeStages:
                 30: _make_device(device_provider="baas"),
             }[binding_id]
         )
-        device_provider.get_instances.side_effect = RuntimeError("baas timeout")
+        device_provider.list_devices_by_runtime_binding.side_effect = RuntimeError("baas timeout")
 
         resolver = MagicMock()
         resolver.resolve_for_bot.return_value = _make_ctx(
@@ -542,6 +566,7 @@ class TestListServiceBotRuntimeStages:
         ]
         assert result["failed_targets"] == []
         device_provider.get_instances.assert_not_called()
+        device_provider.list_devices_by_runtime_binding.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_service_bot_list_records_failed_runtime_without_failing_result(self):
@@ -579,7 +604,7 @@ class TestListServiceBotRuntimeStages:
         )
 
         device_provider = MagicMock()
-        device_provider.get_device.return_value = MagicMock(status=DeviceBindingStatus.ACTIVE)
+        device_provider.get_device.return_value = _make_device(device_provider="arca")
 
         resolver = MagicMock()
         resolver.resolve_for_bot.return_value = _make_ctx(
@@ -926,13 +951,10 @@ class TestListRunningCronsOwnerId:
                 30: _make_device(device_provider="baas"),
             }[binding_id]
         )
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_bot.return_value = _make_ctx(
@@ -975,14 +997,12 @@ class TestListRunningCronsOwnerId:
             "DEVICE-001",
             "DEVICE-002",
         }
-        assert {item["provider_device_id"] for item in result["data"]} == {
-            "PDS-001",
-            "PDS-002",
-        }
-        assert {item["bot_uuid"] for item in result["data"]} == {"bot-uuid-online"}
-        assert {item["instance_health_status"] for item in result["data"]} == {
-            "ACTIVE"
-        }
+        for item in result["data"]:
+            assert "provider_device_id" not in item
+            assert "bot_uuid" not in item
+            assert "instance_status" not in item
+            assert "instance_health" not in item
+            assert "instance_health_status" not in item
         assert result["failed_targets"] == []
 
     @pytest.mark.asyncio
@@ -1020,13 +1040,10 @@ class TestListRunningCronsOwnerId:
                 30: _make_device(device_provider="baas"),
             }[binding_id]
         )
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_binding.side_effect = (
@@ -1109,13 +1126,10 @@ class TestListRunningCronsOwnerId:
 
         device_provider = MagicMock()
         device_provider.get_device.return_value = _make_device(device_provider="baas")
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_binding.side_effect = (
@@ -1170,14 +1184,67 @@ class TestListRunningCronsOwnerId:
 
         assert exc_info.value.error_code == 400
 
+    @pytest.mark.asyncio
+    async def test_list_running_crons_records_adapter_failure_with_dict_data(self):
+        bot_provider = MagicMock()
+        bot_provider.get_bot.return_value = {
+            "bot_id": "service-bot",
+            "owner_id": "owner-1",
+            "binding_id": 10,
+            "bot_name": "Service Bot",
+            "bot_type": "service",
+        }
+
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = _make_device(device_provider="arca")
+
+        resolver = MagicMock()
+        resolver.resolve_for_bot.return_value = _make_ctx(
+            binding_id=10,
+            bot_id="service-bot",
+            user_id="owner-1",
+        )
+
+        transport = MagicMock()
+        transport.invoke = AsyncMock(return_value={
+            "success": False,
+            "message": "adapter rejected",
+            "data": {},
+        })
+        publish_repo = MagicMock()
+        publish_repo.get_latest_by_source_bot_id_and_owner_and_status.return_value = None
+
+        svc = _make_service(
+            bot_provider=bot_provider,
+            device_provider=device_provider,
+            resolver=resolver,
+            transport=transport,
+            publish_repo=publish_repo,
+        )
+
+        result = await svc.list_running_crons(
+            user_id="owner-1",
+            nick_name="Owner",
+            bot_id="service-bot",
+        )
+
+        assert result["data"] == []
+        assert result["failed_targets"] == [
+            {
+                "bot_id": "service-bot",
+                "bot_name": "Service Bot",
+                "owner_id": "owner-1",
+                "runtime_stage": "draft",
+                "reason": "cron_api_failed",
+                "message": "adapter rejected",
+            }
+        ]
+
 
 class TestForwardRequestUsesResolver:
     @pytest.mark.asyncio
     async def test_forward_request_calls_resolver_not_v2(self):
-        """forward_request(create/update/delete cron)走 resolver,不再调 v2 —
-        否则 baas service bot 落 v2 direct 分支丢 binding_id → fallback 裸 httpx 直发
-        ARCA-SANDBOX 内网 target → 500。走 resolver 才永填 binding_id → proxypass。
-        """
+        """forward_request uses the resolver-built adapter connection context."""
         bot_provider = MagicMock()
         bot_provider.get_bot.return_value = {
             "bot_id": "bot-1", "owner_id": "user-1", "binding_id": 42,
@@ -1280,7 +1347,7 @@ class TestForwardRequestUsesResolver:
         )
 
         device_provider = MagicMock()
-        device_provider.get_device.return_value = MagicMock(status=DeviceBindingStatus.ACTIVE)
+        device_provider.get_device.return_value = _make_device(device_provider="arca")
 
         resolver = MagicMock()
         resolver.resolve_for_binding.return_value = _make_ctx(
@@ -1336,7 +1403,7 @@ class TestForwardRequestUsesResolver:
         )
 
         device_provider = MagicMock()
-        device_provider.get_device.return_value = MagicMock(status=DeviceBindingStatus.ACTIVE)
+        device_provider.get_device.return_value = _make_device(device_provider="arca")
 
         resolver = MagicMock()
         resolver.resolve_for_binding.return_value = _make_ctx(
@@ -1398,13 +1465,10 @@ class TestForwardRequestUsesResolver:
 
         device_provider = MagicMock()
         device_provider.get_device.return_value = _make_device(device_provider="baas")
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_binding.side_effect = (
@@ -1441,10 +1505,24 @@ class TestForwardRequestUsesResolver:
             runtime_stage="online",
         )
 
-        assert result["success"] is True
+        assert result["success"] is False
+        assert result["message"] == "partial runtime instances failed"
+        assert "target" not in result["data"]
         assert result["data"]["succeeded"] == 1
         assert result["data"]["failed"] == 1
-        assert result["data"]["results"][0]["device_uuid"] == "DEVICE-001"
+        success_item = result["data"]["results"][0]
+        assert success_item["bot_id"] == "service-bot"
+        assert success_item["bot_name"] == "Service Bot"
+        assert success_item["owner_id"] == "owner-1"
+        assert success_item["runtime_stage"] == "online"
+        assert success_item["publish_id"] == 202
+        assert success_item["publish_status"] == PublishStatus.SUCCESS.value
+        assert success_item["device_uuid"] == "DEVICE-001"
+        assert "provider_device_id" not in success_item
+        assert "bot_uuid" not in success_item
+        assert "instance_status" not in success_item
+        assert "instance_health" not in success_item
+        assert "instance_health_status" not in success_item
         assert result["failed_targets"] == [
             {
                 "bot_id": "service-bot",
@@ -1455,11 +1533,6 @@ class TestForwardRequestUsesResolver:
                 "reason": "cron_api_failed",
                 "message": "DEVICE-002 timeout",
                 "device_uuid": "DEVICE-002",
-                "provider_device_id": "PDS-002",
-                "bot_uuid": "bot-uuid-online",
-                "instance_status": "ACTIVE",
-                "instance_health": "true",
-                "instance_health_status": "ACTIVE",
             }
         ]
         resolver.resolve_for_binding.assert_any_call(
@@ -1493,13 +1566,10 @@ class TestForwardRequestUsesResolver:
 
         device_provider = MagicMock()
         device_provider.get_device.return_value = _make_device(device_provider="baas")
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_binding.side_effect = (
@@ -1535,13 +1605,69 @@ class TestForwardRequestUsesResolver:
         )
 
         assert result["success"] is False
+        assert "target" not in result["data"]
         assert result["data"]["succeeded"] == 0
         assert result["data"]["failed"] == 2
+        assert {item["bot_id"] for item in result["data"]["results"]} == {
+            "service-bot",
+        }
+        assert {item["runtime_stage"] for item in result["data"]["results"]} == {
+            "online",
+        }
         assert [item["reason"] for item in result["failed_targets"]] == [
             "cron_api_failed",
             "cron_api_failed",
         ]
         assert transport.invoke.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_cron_rejects_service_runtime_without_device_provider(self):
+        bot_provider = MagicMock()
+        bot_provider.get_bot.return_value = {
+            "bot_id": "service-bot",
+            "owner_id": "owner-1",
+            "binding_id": 10,
+            "bot_name": "Service Bot",
+            "bot_type": "service",
+        }
+
+        publish_repo = MagicMock()
+        publish_repo.get_latest_by_source_bot_id_and_owner_and_status.return_value = (
+            _make_publish_record(
+                publish_id=202,
+                status=PublishStatus.SUCCESS.value,
+                binding_key="online",
+                binding_id=30,
+            )
+        )
+
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = MagicMock(
+            status=DeviceBindingStatus.ACTIVE
+        )
+
+        transport = MagicMock()
+        transport.invoke = AsyncMock(return_value={"success": True, "data": {}})
+
+        svc = _make_service(
+            bot_provider=bot_provider,
+            device_provider=device_provider,
+            transport=transport,
+            publish_repo=publish_repo,
+        )
+
+        result = await svc.run_cron(
+            bot_id="service-bot",
+            user_id="owner-1",
+            nick_name="Owner",
+            task_id="task-o",
+            force=True,
+            runtime_stage="online",
+        )
+
+        assert result["success"] is False
+        assert result["failed_targets"][0]["reason"] == "unsupported_device_provider"
+        transport.invoke.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_cron_runs_fans_out_to_runtime_instances(self):
@@ -1566,13 +1692,10 @@ class TestForwardRequestUsesResolver:
 
         device_provider = MagicMock()
         device_provider.get_device.return_value = _make_device(device_provider="baas")
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_binding.side_effect = (
@@ -1588,7 +1711,10 @@ class TestForwardRequestUsesResolver:
             device_uuid = conn_info["device_uuid"]
             return {
                 "success": True,
-                "data": {"runs": [{"run_id": f"run-{device_uuid}"}]},
+                "data": {
+                    "input": "hello",
+                    "runs": [{"run_id": f"run-{device_uuid}"}],
+                },
             }
 
         transport = MagicMock()
@@ -1612,6 +1738,7 @@ class TestForwardRequestUsesResolver:
         )
 
         assert result["success"] is True
+        assert "target" not in result["data"]
         assert result["data"]["succeeded"] == 2
         assert {item["device_uuid"] for item in result["data"]["results"]} == {
             "DEVICE-001",
@@ -1621,6 +1748,20 @@ class TestForwardRequestUsesResolver:
             item["data"]["runs"][0]["run_id"]
             for item in result["data"]["results"]
         } == {"run-DEVICE-001", "run-DEVICE-002"}
+        for item in result["data"]["results"]:
+            assert item["bot_id"] == "service-bot"
+            assert item["bot_name"] == "Service Bot"
+            assert item["owner_id"] == "owner-1"
+            assert item["runtime_stage"] == "online"
+            assert item["publish_id"] == 202
+            assert item["publish_status"] == PublishStatus.SUCCESS.value
+            assert "provider_device_id" not in item
+            assert "bot_uuid" not in item
+            assert "instance_status" not in item
+            assert "instance_health" not in item
+            assert "instance_health_status" not in item
+            assert "bot_id" not in item["data"]
+            assert "runtime_stage" not in item["data"]
         resolver.resolve_for_binding.assert_any_call(
             30, "owner-1", bot_id="service-bot", device_uuid="DEVICE-001"
         )
@@ -1628,6 +1769,90 @@ class TestForwardRequestUsesResolver:
             30, "owner-1", bot_id="service-bot", device_uuid="DEVICE-002"
         )
         assert transport.invoke.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_cron_runs_uses_runtime_device_list_not_get_instances(self):
+        bot_provider = MagicMock()
+        bot_provider.get_bot.return_value = {
+            "bot_id": "service-bot",
+            "owner_id": "owner-1",
+            "binding_id": 10,
+            "bot_name": "Service Bot",
+            "bot_type": "service",
+        }
+
+        publish_repo = MagicMock()
+        publish_repo.get_latest_by_source_bot_id_and_owner_and_status.return_value = (
+            _make_publish_record(
+                publish_id=202,
+                status=PublishStatus.SUCCESS.value,
+                binding_key="online",
+                binding_id=30,
+            )
+        )
+
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = _make_device(device_provider="teclaw")
+        device_provider.get_instances.side_effect = AssertionError(
+            "cron runtime expansion must not use get_instances"
+        )
+        device_provider.list_devices_by_runtime_binding.return_value = ["DEVICE-001"]
+
+        resolver = MagicMock()
+        resolver.resolve_for_binding.side_effect = (
+            lambda binding_id, operator_id, *, bot_id, device_uuid=None: _make_ctx(
+                binding_id=binding_id,
+                bot_id=bot_id,
+                user_id=operator_id,
+                device_uuid=device_uuid,
+            )
+        )
+
+        transport = MagicMock()
+        transport.invoke = AsyncMock(return_value={
+            "success": True,
+            "data": {"runs": [{"run_id": "run-DEVICE-001"}]},
+        })
+
+        svc = _make_service(
+            bot_provider=bot_provider,
+            device_provider=device_provider,
+            resolver=resolver,
+            transport=transport,
+            publish_repo=publish_repo,
+        )
+
+        result = await svc.get_cron_runs(
+            bot_id="service-bot",
+            user_id="owner-1",
+            nick_name="Owner",
+            task_id="task-o",
+            limit=20,
+            runtime_stage="online",
+        )
+
+        assert result["success"] is True
+        assert "target" not in result["data"]
+        assert result["data"]["succeeded"] == 1
+        result_item = result["data"]["results"][0]
+        assert result_item["bot_id"] == "service-bot"
+        assert result_item["bot_name"] == "Service Bot"
+        assert result_item["owner_id"] == "owner-1"
+        assert result_item["runtime_stage"] == "online"
+        assert result_item["publish_id"] == 202
+        assert result_item["publish_status"] == PublishStatus.SUCCESS.value
+        assert result_item["device_uuid"] == "DEVICE-001"
+        assert result["failed_targets"] == []
+        device_provider.get_instances.assert_not_called()
+        device_provider.list_devices_by_runtime_binding.assert_called_once_with(
+            binding_id=30,
+        )
+        resolver.resolve_for_binding.assert_called_once_with(
+            30,
+            "owner-1",
+            bot_id="service-bot",
+            device_uuid="DEVICE-001",
+        )
 
     @pytest.mark.asyncio
     async def test_get_cron_runs_routes_specific_device_uuid(self):
@@ -1652,13 +1877,10 @@ class TestForwardRequestUsesResolver:
 
         device_provider = MagicMock()
         device_provider.get_device.return_value = _make_device(device_provider="baas")
-        device_provider.get_instances.return_value = {
-            "bot_uuid": "bot-uuid-online",
-            "devices": [
-                _make_instance("DEVICE-001", provider_device_id="PDS-001"),
-                _make_instance("DEVICE-002", provider_device_id="PDS-002"),
-            ],
-        }
+        device_provider.list_devices_by_runtime_binding.return_value = [
+            "DEVICE-001",
+            "DEVICE-002",
+        ]
 
         resolver = MagicMock()
         resolver.resolve_for_binding.side_effect = (
@@ -1755,7 +1977,8 @@ class TestForwardRequestUsesResolver:
         )
 
         device_provider = MagicMock()
-        device_provider.get_device.return_value = MagicMock(status=DeviceBindingStatus.ACTIVE)
+        device_provider.get_device.return_value = _make_device(device_provider="teclaw")
+        device_provider.list_devices_by_runtime_binding.return_value = ["DEVICE-T1"]
 
         binding_repo = MagicMock()
         binding_repo.get_by_id.return_value = _make_binding(
@@ -1800,6 +2023,7 @@ class TestForwardRequestUsesResolver:
 
         binding_repo.get_by_id.assert_called_once_with(30)
         teclaw_builder.build.assert_called_once()
+        assert teclaw_builder.build.call_args.kwargs["device_uuid"] == "DEVICE-T1"
         sent_conn_info = transport.invoke.await_args.args[0]
         assert sent_conn_info["engine_type"] == "teclaw"
         assert sent_conn_info["bind_id"] == 30

--- a/src/backend/tests/community/core/devices/services/test_multi_instance.py
+++ b/src/backend/tests/community/core/devices/services/test_multi_instance.py
@@ -240,6 +240,37 @@ def test_get_instances_accepts_teclaw_binding_and_queries_baas_devices():
     assert result["devices"][0]["engine_type"] == "openclaw"
 
 
+def test_list_devices_by_runtime_binding_queries_devices_by_bot_uuid():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_record(
+        id=1001,
+        device_id="bot-uuid-teclaw",
+        device_provider=TECLAW_DEVICE_PROVIDER,
+        device_props={},
+    )
+
+    baas = MagicMock()
+    baas.get_bot.side_effect = AssertionError(
+        "runtime device list must not query get_bot"
+    )
+    baas.list_devices_by_bot_uuid.return_value = [
+        {
+            "device_uuid": "DEVICE-T1",
+            "status": "ACTIVE",
+            "health": "true",
+            "provider_type": "TECLAW",
+            "provider_device_id": "teclaw-pds-1",
+        }
+    ]
+
+    router = _make_router(repo=repo, baas_service=baas, bot_repo=None)
+    result = router.list_devices_by_runtime_binding(binding_id=1001)
+
+    baas.get_bot.assert_not_called()
+    baas.list_devices_by_bot_uuid.assert_called_once_with("bot-uuid-teclaw")
+    assert result == ["DEVICE-T1"]
+
+
 def test_get_instances_engine_type_defaults_openclaw_without_bot_repo():
     repo = MagicMock()
     repo.get_by_id.return_value = _make_record(id=1001)


### PR DESCRIPTION
Resolve service bot cron runtime targets from the runtime device list instead of the public instance list, so BaaS/Teclaw multi-instance published stages can route by device_uuid without health checks.

Keep personal bots on the legacy draft path, reject published-stage params for personal bots, and keep Arca/local published stages as single-target routing.

Restore multi-instance update/run/runs responses to the documented results[] shape, with per-result runtime metadata and no instance health fields.