### PR TITLE
fix(bot): personalCoding 模板同 applicationCoding 下发 model/runtime/token

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -2088,12 +2088,12 @@ class BotService:
                     )
                 logger.info(f"[bot_service.update_bot] Template updated for bot {bot_id}")
 
-                # applicationCoding bot：token 变化时把新 token 下发到运行中容器
-                # 的 codefuse.json（与 save_codefuse_token / apply_device 启动写入、
-                # reconciler 重启写入同路径），使 PUT /api/bots/{bot_id} 改 token 后
-                # 无需前端再单独调 codefuse/auth。仅当本次入参携带 token 字段且与
-                # 旧值解密后不同才触发；异步执行，失败只告警不阻断主流程。
-                if bot.get("template_type") == "applicationCoding" and isinstance(
+                # coding 类 bot（applicationCoding / personalCoding）：token 变化时把新
+                # token 下发到运行中容器的 codefuse.json（与 save_codefuse_token /
+                # apply_device 启动写入、reconciler 重启写入同路径），使 PUT /api/bots/{bot_id}
+                # 改 token 后无需前端再单独调 codefuse/auth。仅当本次入参携带 token 字段且
+                # 与旧值解密后不同才触发；异步执行，失败只告警不阻断主流程。
+                if bot.get("template_type") in ("applicationCoding", "personalCoding") and isinstance(
                     template_config, dict
                 ) and "token" in template_config:
                     self._maybe_refresh_codefuse_token_async(

--- a/src/backend/src/agentclaw/community/core/bot_management/services/template_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/template_service.py
@@ -94,13 +94,13 @@ class TemplateService:
     def _encrypt_token_field(
         self, template_config: Dict[str, Any], template_type: Optional[str]
     ) -> Dict[str, Any]:
-        """仅 applicationCoding 且 token 为明文时加密 token 字段。幂等。
+        """仅 coding 类模板（applicationCoding / personalCoding）且 token 为明文时加密 token 字段。幂等。
 
         门控由显式 template_type 参数决定（不依赖 template_config 字典内键），
-        与 DeviceService.apply_device 读取门控对称。master_key 空（singlebox）
-        时 vault.encrypt 退化为原样返回，无需在此特判。
+        与 DeviceService.apply_device / BaasDeviceService 读取门控对称。master_key 空
+        （singlebox）时 vault.encrypt 退化为原样返回，无需在此特判。
         """
-        if template_type != "applicationCoding":
+        if template_type not in ("applicationCoding", "personalCoding"):
             return template_config
         token = template_config.get("token")
         if not isinstance(token, str) or not token or token.startswith(CIPHER_PREFIX):
@@ -122,8 +122,9 @@ class TemplateService:
         Args:
             bot_id: Bot ID
             template_config: Template configuration dictionary (stored in ext field)
-            template_type: Optional template type gate; when ``applicationCoding``,
-                the ``token`` field of template_config is encrypted before persist.
+            template_type: Optional template type gate; when ``applicationCoding``
+                or ``personalCoding``, the ``token`` field of template_config is
+                encrypted before persist.
 
         Returns:
             Created template record
@@ -220,7 +221,7 @@ class TemplateService:
         return None
 
     def get_decrypted_codefuse_token(self, bot_id: str) -> Optional[str]:
-        """读取 applicationCoding bot 已落库的 codefuse token 并解密为明文 auth_code。
+        """读取 coding 类（applicationCoding / personalCoding）bot 已落库的 codefuse token 并解密为明文 auth_code。
 
         ``ac_templates.ext.token`` 落库前已由 ``_encrypt_token_field`` 加密
         （``enc:v1:`` 前缀）；这里用 vault 解密回明文，供运行中容器刷新
@@ -231,9 +232,9 @@ class TemplateService:
         master_key 空（singlebox）时 ``decrypt_or_passthrough`` 退化为原样返回，
         与本地无密钥场景兼容。
 
-        门控与 ``_encrypt_token_field`` 对称：仅 applicationCoding bot 的 token
-        才落库加密；调用方（``BotService.update_bot``）应先校验
-        ``bot.template_type == "applicationCoding"`` 再调用本方法。此处只负责
+        门控与 ``_encrypt_token_field`` 对称：仅 coding 类模板（applicationCoding
+        / personalCoding）bot 的 token 才落库加密；调用方（``BotService.update_bot``）
+        应先校验 ``bot.template_type`` 属于 coding 类再调用本方法。此处只负责
         取值与解密，前缀缺失时 ``decrypt_or_passthrough`` 原样透传（兼容历史明文）。
 
         Args:
@@ -274,8 +275,9 @@ class TemplateService:
         Args:
             bot_id: Bot ID
             template_config: New template configuration dictionary
-            template_type: Optional template type gate; when ``applicationCoding``,
-                the ``token`` field of template_config is encrypted before persist.
+            template_type: Optional template type gate; when ``applicationCoding``
+                or ``personalCoding``, the ``token`` field of template_config is
+                encrypted before persist.
 
         Returns:
             Updated template record or None if not found
@@ -440,8 +442,9 @@ class TemplateService:
         Args:
             bot_id: Bot ID
             template_config: Template configuration dictionary
-            template_type: Optional template type gate; when ``applicationCoding``,
-                the ``token`` field of template_config is encrypted before persist.
+            template_type: Optional template type gate; when ``applicationCoding``
+                or ``personalCoding``, the ``token`` field of template_config is
+                encrypted before persist.
 
         Returns:
             Created or updated template record

--- a/src/backend/src/agentclaw/community/core/bot_management/utils.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/utils.py
@@ -161,6 +161,8 @@ def build_aix_extra_envs(
         典型场景:
         - applicationCoding: {"BOT_TYPE": "application", "AIX_DEVFLOW_INFO": ..., "GIT_ADDRESSES": ...}
         - personalCoding: {"BOT_TYPE": "personal"}（通常没有 devflow / repos）
+        - 两者均可携带 model / runtime 入参，有值即写入 RELAY_DEFAULT_MODEL /
+          RELAY_DEFAULT_RUNTIME（覆盖容器写死默认）。
     """
     envs: Dict[str, str] = {}
 
@@ -191,11 +193,11 @@ def build_aix_extra_envs(
         if repo_list:
             envs["GIT_ADDRESSES"] = json.dumps(repo_list, ensure_ascii=False)
 
-        # RELAY_DEFAULT_MODEL / RELAY_DEFAULT_RUNTIME：仅 applicationCoding 下发 model / runtime，
-        # 作为容器内 relay 的默认配置（覆盖容器写死默认）。显式判 template_type，避免
-        # personalCoding 等被误注入；有值才写。create / restart 都经本函数，env 经 extra_envs
-        # 透传到 arca/baas 两条分支。
-        if (template_type or "") == "applicationCoding":
+        # RELAY_DEFAULT_MODEL / RELAY_DEFAULT_RUNTIME：applicationCoding 与 personalCoding
+        # 均下发 model / runtime，作为容器内 relay 的默认配置（覆盖容器写死默认）。显式判
+        # template_type，避免非 coding 模板被误注入；有值才写。create / restart 都经本函数，
+        # env 经 extra_envs 透传到 arca/baas 两条分支。
+        if (template_type or "") in ("applicationCoding", "personalCoding"):
             model = template_config.get("model")
             if isinstance(model, str) and model.strip():
                 envs["RELAY_DEFAULT_MODEL"] = model.strip()

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
@@ -521,7 +521,7 @@ class BaasDeviceService(DeviceService):
 
         raw_codefuse_token = (
             template_config.get("token")
-            if template_type == "applicationCoding"
+            if template_type in ("applicationCoding", "personalCoding")
             else None
         )
         codefuse_token = (

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -508,7 +508,7 @@ class BaasRestartPublishPollHandler:
     def _read_codefuse_token(self, *, bot_id: str, bot: Any) -> str | None:
         if not isinstance(bot, dict):
             return None
-        if bot.get("template_type") != "applicationCoding":
+        if bot.get("template_type") not in ("applicationCoding", "personalCoding"):
             return None
         if self._template_service is None:
             return None

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -296,9 +296,9 @@ class DeviceService:
             bot_id: Bot ID
             owner_id: Owner ID
             admins: List of admin user IDs
-            codefuse_token: CodeFuse SSO auth_code（base64）。仅 applicationCoding bot
-                由 apply_device 透传非空值；provider 在容器就绪初始化里解码后写
-                codefuse.json。base 默认实现不处理（Noop）。
+            codefuse_token: CodeFuse SSO auth_code（base64）。仅 coding 类 bot
+                （applicationCoding / personalCoding）由 apply_device 透传非空值；provider
+                在容器就绪初始化里解码后写 codefuse.json。base 默认实现不处理（Noop）。
 
         Returns:
             Tuple of (success, message)
@@ -688,14 +688,14 @@ class DeviceService:
             return record
 
         # 5. Start service asynchronously
-        # 仅 applicationCoding bot 透传 CodeFuse token（从 ext 读回密文，启动时解密为明文）。
-        # 解密在异步闭包内：密文损坏/密钥错配时由 start_service 的 except 承接为 FAILED，
-        # 与 token 写入失败同语义（failure-closed），避免同步段抛错导致 binding 已落库但
-        # apply_device 返回 500 的状态机不一致。token 全程 in-memory 不进 device_props；
-        # get_template_config 不解密 → API 返回密文脱敏。
+        # 仅 coding 类 bot（applicationCoding / personalCoding）透传 CodeFuse token（从 ext
+        # 读回密文，启动时解密为明文）。解密在异步闭包内：密文损坏/密钥错配时由 start_service
+        # 的 except 承接为 FAILED，与 token 写入失败同语义（failure-closed），避免同步段抛错
+        # 导致 binding 已落库但 apply_device 返回 500 的状态机不一致。token 全程 in-memory
+        # 不进 device_props；get_template_config 不解密 → API 返回密文脱敏。
         _raw_codefuse_token = (
             (template_config or {}).get("token")
-            if (template_type or "") == "applicationCoding"
+            if (template_type or "") in ("applicationCoding", "personalCoding")
             else None
         )
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -225,11 +225,11 @@ class TestRestartBaasEnvInjection:
         # template_config 透传到 BaaS device 层（供 SandboxOverrides 覆写镜像/规格）
         assert kwargs["template_config"] is not None
 
-    def test_personal_coding_injects_bot_type_personal_no_relay_defaults(self):
-        """personalCoding + claude_code → BOT_TYPE=personal，不写 RELAY_DEFAULT_*。"""
+    def test_personal_coding_injects_bot_type_personal_and_relay_defaults(self):
+        """personalCoding + claude_code → BOT_TYPE=personal，且 model/runtime 写入 RELAY_DEFAULT_*。"""
         svc, baas, _ = _make_service(
             active_engine="claude_code",
-            template_config={"model": "m1", "runtime": "py"},  # 应被门控忽略
+            template_config={"model": "m1", "runtime": "py"},
         )
         bot = _make_bot(active_engine="claude_code", template_type="personalCoding")
 
@@ -239,8 +239,8 @@ class TestRestartBaasEnvInjection:
         envs = kwargs["extra_envs"]
         assert envs is not None
         assert envs["BOT_TYPE"] == "personal"
-        assert "RELAY_DEFAULT_MODEL" not in envs
-        assert "RELAY_DEFAULT_RUNTIME" not in envs
+        assert envs["RELAY_DEFAULT_MODEL"] == "m1"
+        assert envs["RELAY_DEFAULT_RUNTIME"] == "py"
 
     def test_claude_code_engine_injects_envs(self):
         """claude_code 引擎同样命中门控（与 aicoding 等价）。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_update_codefuse_token.py
@@ -197,9 +197,9 @@ class TestUpdateBotCodefuseTokenDispatch:
 
     # ── 条件过滤 ─────────────────────────────────────────────────
 
-    def test_no_dispatch_when_not_application_coding(self, repo, template_svc):
-        repo.get_by_id_and_owner.return_value = _bot_record(template_type="personalCoding")
-        repo.update_by_owner.return_value = _bot_record(template_type="personalCoding")
+    def test_no_dispatch_when_non_coding_template_type(self, repo, template_svc):
+        repo.get_by_id_and_owner.return_value = _bot_record(template_type="sometype")
+        repo.update_by_owner.return_value = _bot_record(template_type="sometype")
         service = _make_bot_service(repository=repo, template_service=template_svc)
 
         with patch(
@@ -216,6 +216,37 @@ class TestUpdateBotCodefuseTokenDispatch:
                     cookie="c",
                 )
                 mock_refresh.assert_not_called()
+
+    def test_dispatches_when_personal_coding(self, repo, template_svc):
+        """personalCoding 同 applicationCoding：token 变化时也异步下发到容器。"""
+        repo.get_by_id_and_owner.return_value = _bot_record(template_type="personalCoding")
+        repo.update_by_owner.return_value = _bot_record(template_type="personalCoding")
+        self._wire_get_template_config(
+            template_svc,
+            old_db_token="enc:v1:OLD_CIPHERTEXT",
+            new_db_token="enc:v1:NEW_CIPHERTEXT",
+        )
+        service = _make_bot_service(repository=repo, template_service=template_svc)
+        new_config = {"token": "new-plaintext-auth-code"}
+
+        with patch(
+            "agentclaw.community.core.bot_management.services.bot_service.threading.Thread",
+            _FakeThread,
+        ):
+            with patch.object(
+                service, "_refresh_codefuse_token_on_device"
+            ) as mock_refresh:
+                service.update_bot(
+                    bot_id="bot-1",
+                    user_id="user1",
+                    template_config=new_config,
+                    cookie="c",
+                )
+                mock_refresh.assert_called_once_with(
+                    bot_id="bot-1",
+                    user_id="user1",
+                    plaintext_token="new-plaintext-auth-code",
+                )
 
     def test_no_dispatch_when_no_template_config(self, repo, template_svc):
         service = _make_bot_service(repository=repo, template_service=template_svc)

--- a/src/backend/tests/community/core/bot_management/services/test_template_service_codefuse_encrypt.py
+++ b/src/backend/tests/community/core/bot_management/services/test_template_service_codefuse_encrypt.py
@@ -31,10 +31,18 @@ class TestCreateTemplateEncryptsToken:
         assert svc._vault.decrypt_or_passthrough(stored["token"]) == "abcdef0123456789"
         assert stored["other"] == "x"
 
-    def test_non_applicationCoding_not_encrypted(self):
+    def test_personalCoding_token_encrypted(self):
         svc, repo = _make_service()
         cfg = {"token": "abcdef0123456789"}
         svc.create_template(bot_id="B1", template_config=cfg, template_type="personalCoding")
+        stored = repo.insert.call_args.args[0]["ext"]
+        assert stored["token"].startswith(CIPHER_PREFIX)
+        assert svc._vault.decrypt_or_passthrough(stored["token"]) == "abcdef0123456789"
+
+    def test_non_coding_template_type_not_encrypted(self):
+        svc, repo = _make_service()
+        cfg = {"token": "abcdef0123456789"}
+        svc.create_template(bot_id="B1", template_config=cfg, template_type="sometype")
         stored = repo.insert.call_args.args[0]["ext"]
         assert stored["token"] == "abcdef0123456789"
 

--- a/src/backend/tests/community/core/bot_management/test_build_aix_extra_envs.py
+++ b/src/backend/tests/community/core/bot_management/test_build_aix_extra_envs.py
@@ -3,7 +3,7 @@
 覆盖：
 - applicationCoding + 非空 model → 写 ``RELAY_DEFAULT_MODEL``（strip 后）。
 - applicationCoding + 非空 runtime → 写 ``RELAY_DEFAULT_RUNTIME``（strip 后）。
-- personalCoding + model / runtime → **不写**（门控仅 applicationCoding）。
+- personalCoding + model / runtime → 照样写（门控覆盖两类 coding 模板）。
 - applicationCoding + 缺失 / 空 / 非字符串 model / runtime → 不写。
 - model / runtime 与 BOT_TYPE / AIX_DEVFLOW_INFO / GIT_ADDRESSES 共存。
 - template_config=None 时不写（只可能有 BOT_TYPE）。
@@ -25,11 +25,11 @@ class TestRelayDefaultModel:
         envs = build_aix_extra_envs({"model": "  m1  "}, template_type="applicationCoding")
         assert envs["RELAY_DEFAULT_MODEL"] == "m1"
 
-    def test_personal_coding_does_not_inject_model(self):
-        """门控仅 applicationCoding：personalCoding 即使带 model 也不写 RELAY_DEFAULT_MODEL。"""
+    def test_personal_coding_injects_model(self):
+        """门控覆盖两类 coding 模板：personalCoding 带 model 同样写 RELAY_DEFAULT_MODEL。"""
         envs = build_aix_extra_envs({"model": "antchat/x"}, template_type="personalCoding")
-        assert "RELAY_DEFAULT_MODEL" not in envs
-        assert envs == {"BOT_TYPE": "personal"}
+        assert envs["RELAY_DEFAULT_MODEL"] == "antchat/x"
+        assert envs["BOT_TYPE"] == "personal"
 
     def test_application_coding_without_model(self):
         envs = build_aix_extra_envs({"devflow_workflow": "d.yaml"}, template_type="applicationCoding")
@@ -71,11 +71,11 @@ class TestRelayDefaultRuntime:
         envs = build_aix_extra_envs({"runtime": "  py  "}, template_type="applicationCoding")
         assert envs["RELAY_DEFAULT_RUNTIME"] == "py"
 
-    def test_personal_coding_does_not_inject_runtime(self):
-        """门控仅 applicationCoding：personalCoding 即使带 runtime 也不写 RELAY_DEFAULT_RUNTIME。"""
+    def test_personal_coding_injects_runtime(self):
+        """门控覆盖两类 coding 模板：personalCoding 带 runtime 同样写 RELAY_DEFAULT_RUNTIME。"""
         envs = build_aix_extra_envs({"runtime": "py"}, template_type="personalCoding")
-        assert "RELAY_DEFAULT_RUNTIME" not in envs
-        assert envs == {"BOT_TYPE": "personal"}
+        assert envs["RELAY_DEFAULT_RUNTIME"] == "py"
+        assert envs["BOT_TYPE"] == "personal"
 
     def test_application_coding_without_runtime(self):
         envs = build_aix_extra_envs({"devflow_workflow": "d.yaml"}, template_type="applicationCoding")


### PR DESCRIPTION
之前 build_aix_extra_envs / _encrypt_token_field / apply_device / baas_device_service / baas_publish_task_handlers 多处门控仅对 applicationCoding 生效，导致 personalCoding bot 在 template_config 里携带的 model / runtime / token 被静默丢弃，个人 coding bot 无法 覆盖容器默认模型与 codefuse token。

将上述下发与加解密门控从 applicationCoding 放宽到 coding 类模板
（applicationCoding + personalCoding），让个人 coding bot 的 model / runtime / token 与应用 coding bot 同口径生效。DIMA 工作空间、 memory 初始化、cron autoInitiate 等 application 专属能力保持不变。

同步更新相关单测：personalCoding 现在也会写入 RELAY_DEFAULT_MODEL / RELAY_DEFAULT_RUNTIME、落库加密 token、update_bot 时异步下发 token 刷新。