### PR TITLE
feat: establish device singlebox coverage module

### DIFF
--- a/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
+++ b/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
@@ -1,0 +1,276 @@
+# Device Singlebox Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Avernet's real `singlebox_coverage.sh` run the devices acceptance suite, report honest module-level Core/Router/Plugin metrics, and raise devices coverage through a meaningful live local-provider lifecycle.
+
+**Architecture:** Keep runtime evidence at existing boundaries: Python line data comes from coverage-instrumented Backend processes and Router hits come from FastAPI middleware. A small manifest-driven reporter filters the generated artifacts into module metrics; acceptance tests create real state through Backend and BaaS instead of seeding the database. Device Plugin API remains `not_applicable` until a real device-owned plugin boundary is exercised.
+
+**Tech Stack:** Bash, Python 3.12, pytest, coverage.py JSON, FastAPI runtime route-hit JSONL, YAML.
+
+## Global Constraints
+
+- Work from Avernet `origin/dev`, not the older OCB-pinned mock-only coverage script.
+- Do not add coverage imports or test-only branches to Core, Router handlers, or business services.
+- Do not introduce `exclude_paths` or remove Router APIs from the denominator.
+- All final metrics must come from `scripts/ci/singlebox_coverage.sh --mode real` artifacts.
+- The real open-source singlebox creates a `local` provider binding; instance-list and restart success remain BaaS/Teclaw-only capability gaps.
+- Existing default CI behavior must keep working when no module is selected.
+
+---
+
+### Task 1: Measure the Real Devices Baseline
+
+**Files:**
+- Read: `scripts/ci/singlebox_coverage.sh`
+- Read: `src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py`
+- Artifact: `/tmp/avernet-device-coverage-baseline/reports/backend-coverage.json`
+- Artifact: `/tmp/avernet-device-coverage-baseline/raw/backend/router_hits.jsonl`
+
+**Interfaces:**
+- Consumes: `SINGLEBOX_COVERAGE_ACCEPTANCE_TARGET`, `SINGLEBOX_COVERAGE_ROOT`
+- Produces: exact baseline Core percentage and distinct devices Router hit set
+
+- [ ] **Step 1: Run the existing live devices target**
+
+```bash
+SINGLEBOX_COVERAGE_ACCEPTANCE_TARGET=tests/community/acceptance/devices \
+SINGLEBOX_COVERAGE_ROOT=/tmp/avernet-device-coverage-baseline \
+bash scripts/ci/singlebox_coverage.sh --mode real
+```
+
+Expected: the standalone stack starts, four existing devices acceptance tests pass, and Backend/BaaS coverage artifacts are generated.
+
+- [ ] **Step 2: Calculate the baseline from generated artifacts**
+
+Use a structured JSON parser to sum `covered_lines` and `num_statements` for files whose normalized path contains `src/agentclaw/community/core/devices/`. Deduplicate Router hit `key` values beginning with an operation declared by the devices router.
+
+Expected: record exact Core numerator/denominator/percentage and Router covered keys. If the run fails before artifacts exist, stop and diagnose the singlebox failure before editing tests.
+
+---
+
+### Task 2: Add Manifest-Driven Module Reporting
+
+**Files:**
+- Create: `scripts/ci/singlebox_coverage_modules.yaml`
+- Create: `scripts/ci/singlebox_coverage_report.py`
+- Create: `scripts/ci/tests/test_singlebox_coverage_report.py`
+- Modify: `scripts/ci/singlebox_coverage.sh`
+- Modify: `scripts/test_singlebox_coverage_gate.sh`
+
+**Interfaces:**
+- Consumes: coverage.py JSON, Router/Plugin JSONL, module name, manifest
+- Produces: `summary.json.modules.devices`, `summary.md`, and `dashboard.html` with Core/Router/Plugin module metrics
+
+- [ ] **Step 1: Write failing reporter tests**
+
+Create synthetic coverage and Router hit files and assert:
+
+```python
+report = build_module_report(
+    manifest=manifest,
+    module_name="devices",
+    coverage=coverage,
+    router_hits=router_hits,
+    plugin_hits=[],
+)
+assert report["core"]["covered"] == 3
+assert report["core"]["total"] == 5
+assert report["core"]["percent"] == 60.0
+assert report["router_api"]["covered"] == 2
+assert report["router_api"]["total"] == 3
+assert report["plugin_api"]["status"] == "not_applicable"
+```
+
+Also assert duplicate Router hits count once, unrelated files/routes are ignored, and an unknown module fails with a clear error.
+
+- [ ] **Step 2: Run reporter tests and verify RED**
+
+```bash
+cd src/backend
+uv run pytest ../../scripts/ci/tests/test_singlebox_coverage_report.py -q
+```
+
+Expected: FAIL because `singlebox_coverage_report.py` does not exist.
+
+- [ ] **Step 3: Implement the minimal reporter and device manifest**
+
+The manifest declares:
+
+```yaml
+modules:
+  devices:
+    system: backend
+    core_paths:
+      - src/agentclaw/community/core/devices/
+    router_api:
+      items:
+        - POST /api/v1/devices
+        - POST /api/v1/devices/{binding_id:int}/release
+        - GET /api/v1/devices
+        - GET /api/v1/devices/provider-inventory
+        - GET /api/v1/devices/{binding_id:int}
+        - GET /api/v1/devices/by-id/{device_id}
+        - GET /api/v1/devices/{binding_id:int}/connection
+        - GET /api/v1/devices/bots/{bot_id}/connection
+        - GET /api/v1/devices/connectable
+        - GET /api/v1/devices/connectable_admin
+        - POST /api/v1/devices/callback/alive
+        - POST /api/v1/devices/callback/status
+        - POST /api/v1/devices/callback/bootstrap-auth
+        - POST /api/v1/devices/exec_shell
+        - POST /api/v1/devices/batch/env
+        - GET /api/v1/devices/bots/{bot_id}/instances
+        - GET /api/v1/devices/{binding_id:int}/instances
+        - POST /api/v1/devices/{binding_id:int}/restart
+    plugin_api:
+      status: not_applicable
+      reason: Device lifecycle has no honestly attributable runtime Plugin API denominator yet.
+      items: []
+    thresholds:
+      core_min_percent: 20.0
+      router_min_percent: 44.44
+```
+
+Implement pure functions for path normalization, line aggregation, JSONL key loading, ratio formatting, threshold validation, summary merge, Markdown rendering, and HTML rendering.
+
+- [ ] **Step 4: Run reporter tests and verify GREEN**
+
+```bash
+cd src/backend
+uv run pytest ../../scripts/ci/tests/test_singlebox_coverage_report.py -q
+```
+
+Expected: all reporter tests pass.
+
+- [ ] **Step 5: Wire optional module reporting into the Bash entrypoint**
+
+Add options:
+
+```text
+--acceptance-target PATH
+--module NAME
+```
+
+When `--module devices` is present, run the reporter after coverage combine and summary creation. When absent, preserve current default CI output. Extend the shell stub test so it verifies selected module arguments reach the reporter and required module artifacts are checked.
+
+- [ ] **Step 6: Verify the coverage gate tests**
+
+```bash
+bash scripts/test_singlebox_coverage_gate.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the reporter**
+
+```bash
+git add scripts/ci/singlebox_coverage_modules.yaml \
+  scripts/ci/singlebox_coverage_report.py \
+  scripts/ci/tests/test_singlebox_coverage_report.py \
+  scripts/ci/singlebox_coverage.sh \
+  scripts/test_singlebox_coverage_gate.sh
+git commit -m "feat(ci): report device singlebox coverage"
+```
+
+---
+
+### Task 3: Add the Live Device Lifecycle Acceptance Story
+
+**Files:**
+- Modify: `src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py`
+- Reuse: `src/backend/tests/community/acceptance/_fixtures/live_personal_bot.py`
+- Test: `src/backend/tests/community/e2e/test_devices_flows.py`
+
+**Interfaces:**
+- Consumes: `create_live_personal_bot`, live Backend/BaaS stack, devices HTTP APIs
+- Produces: one live lifecycle test that creates real product state and reaches at least eight distinct devices Router operations across the suite
+
+- [ ] **Step 1: Add the live lifecycle test before changing production code**
+
+The test must:
+
+```python
+bot = create_live_personal_bot(client, user_id=user_id, bot_name_prefix="Device Acceptance")
+binding_id = bot["binding_id"]
+device_id = bot["device_id"]
+```
+
+Then validate owner list/get/by-id/connection/connectable responses, validate another user receives the ownership error, assert local-provider instances/restart return the documented capability error, release the binding, and read it back as `RELEASED`.
+
+- [ ] **Step 2: Run the new acceptance test against the real stack**
+
+```bash
+RUN_ACCEPTANCE=1 uv run pytest \
+  tests/community/acceptance/devices/test_device_query_lifecycle.py::test_device_live_local_provider_lifecycle \
+  -v -s
+```
+
+Expected: either PASS using existing product behavior, or a concrete product-contract failure. Do not modify production code unless the failure demonstrates a real defect; if so, add the narrowest failing regression test first.
+
+- [ ] **Step 3: Run fast device regressions**
+
+```bash
+uv run pytest tests/community/e2e/test_devices_flows.py -q
+```
+
+Expected: four existing E2E tests pass.
+
+- [ ] **Step 4: Commit the acceptance story**
+
+```bash
+git add src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
+git commit -m "test(device): cover live singlebox lifecycle"
+```
+
+---
+
+### Task 4: Run the Final Real Coverage Gate
+
+**Files:**
+- Artifact: `/tmp/avernet-device-coverage-final/reports/summary.json`
+- Artifact: `/tmp/avernet-device-coverage-final/reports/dashboard.html`
+- Artifact: `/tmp/avernet-device-coverage-final/reports/backend-coverage.json`
+
+**Interfaces:**
+- Consumes: Tasks 2 and 3
+- Produces: verified final devices Core/Router/Plugin metrics from Avernet's canonical script
+
+- [ ] **Step 1: Run the canonical script**
+
+```bash
+bash scripts/ci/singlebox_coverage.sh \
+  --mode real \
+  --module devices \
+  --acceptance-target tests/community/acceptance/devices \
+  --coverage-root /tmp/avernet-device-coverage-final
+```
+
+Expected: acceptance JUnit has no failures or skips; Core and Router thresholds pass; Plugin API is `not_applicable` with the manifest reason.
+The final Core percentage must also be at least five percentage points above
+the exact Task 1 baseline; this improvement check compares the two generated
+artifacts and does not alter the stable 20% floor in the manifest.
+
+- [ ] **Step 2: Cross-check report consistency**
+
+Verify `summary.json`, `summary.md`, and `dashboard.html` show identical devices metrics. Confirm the Router covered-item list is a subset of the 18 manifest entries and line totals equal a direct sum from `backend-coverage.json`.
+
+- [ ] **Step 3: Run final focused verification**
+
+```bash
+bash scripts/test_singlebox_coverage_gate.sh
+cd src/backend
+uv run pytest ../../scripts/ci/tests/test_singlebox_coverage_report.py \
+  tests/community/e2e/test_devices_flows.py -q
+```
+
+Expected: all tests pass with no failures.
+
+- [ ] **Step 4: Record final status**
+
+```bash
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+Expected: only intentional committed changes remain; generated runtime artifacts are outside the repository or ignored.

--- a/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
+++ b/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
@@ -128,7 +128,7 @@ modules:
       reason: Device lifecycle has no honestly attributable runtime Plugin API denominator yet.
       items: []
     thresholds:
-      core_min_percent: 20.0
+      core_min_percent: 43.36
       router_min_percent: 44.44
 ```
 
@@ -246,10 +246,9 @@ bash scripts/ci/singlebox_coverage.sh \
   --coverage-root /tmp/avernet-device-coverage-final
 ```
 
-Expected: acceptance JUnit has no failures or skips; Core and Router thresholds pass; Plugin API is `not_applicable` with the manifest reason.
-The final Core percentage must also be at least five percentage points above
-the exact Task 1 baseline; this improvement check compares the two generated
-artifacts and does not alter the stable 20% floor in the manifest.
+Expected: acceptance JUnit has no failures or skips; Core is at least 43.36%,
+Router is at least 44.44%, and Plugin API is `not_applicable` with the manifest
+reason.
 
 - [ ] **Step 2: Cross-check report consistency**
 

--- a/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
+++ b/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
@@ -6,11 +6,15 @@
 
 **Architecture:** Keep runtime evidence at existing boundaries: Python line data comes from coverage-instrumented Backend processes and Router hits come from FastAPI middleware. A small manifest-driven reporter filters the generated artifacts into module metrics; acceptance tests create real state through Backend and BaaS instead of seeding the database. Device Plugin API remains `not_applicable` until a real device-owned plugin boundary is exercised.
 
+**Prerequisite:** Stack this change on PR #93. Use `DEPLOY_PROFILE=singlebox`
+with runtime/data `SERVER_ENV=dev`; do not restore a Device or HTTP Schema
+`singlebox -> dev` alias.
+
 **Tech Stack:** Bash, Python 3.12, pytest, coverage.py JSON, FastAPI runtime route-hit JSONL, YAML.
 
 ## Global Constraints
 
-- Work from Avernet `origin/dev`, not the older OCB-pinned mock-only coverage script.
+- Work from PR #93 until it merges, then rebase onto the resulting `dev`.
 - Do not add coverage imports or test-only branches to Core, Router handlers, or business services.
 - Do not introduce `exclude_paths` or remove Router APIs from the denominator.
 - All final metrics must come from `scripts/ci/singlebox_coverage.sh --mode real` artifacts.

--- a/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
+++ b/docs/superpowers/plans/2026-07-10-device-singlebox-coverage.md
@@ -2,23 +2,24 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make Avernet's real `singlebox_coverage.sh` run the devices acceptance suite, report honest module-level Core/Router/Plugin metrics, and raise devices coverage through a meaningful live local-provider lifecycle.
+**Goal:** Make Avernet's real `singlebox_coverage.sh` run the devices acceptance suite, report honest module-level Core/Router/Plugin metrics, and raise devices coverage through a meaningful live BaaS-provider lifecycle.
 
 **Architecture:** Keep runtime evidence at existing boundaries: Python line data comes from coverage-instrumented Backend processes and Router hits come from FastAPI middleware. A small manifest-driven reporter filters the generated artifacts into module metrics; acceptance tests create real state through Backend and BaaS instead of seeding the database. Device Plugin API remains `not_applicable` until a real device-owned plugin boundary is exercised.
 
-**Prerequisite:** Stack this change on PR #93. Use `DEPLOY_PROFILE=singlebox`
-with runtime/data `SERVER_ENV=dev`; do not restore a Device or HTTP Schema
-`singlebox -> dev` alias.
+**Prerequisite:** Stack this change on PR #98, which itself stacks on PR #93.
+Use `DEPLOY_PROFILE=singlebox` with runtime/data `SERVER_ENV=dev` and persisted
+`device_provider=baas`; do not restore a Device or HTTP Schema `singlebox -> dev`
+alias.
 
 **Tech Stack:** Bash, Python 3.12, pytest, coverage.py JSON, FastAPI runtime route-hit JSONL, YAML.
 
 ## Global Constraints
 
-- Work from PR #93 until it merges, then rebase onto the resulting `dev`.
+- Work from PR #98 until the stacked PR train merges, then rebase onto `dev`.
 - Do not add coverage imports or test-only branches to Core, Router handlers, or business services.
 - Do not introduce `exclude_paths` or remove Router APIs from the denominator.
 - All final metrics must come from `scripts/ci/singlebox_coverage.sh --mode real` artifacts.
-- The real open-source singlebox creates a `local` provider binding; instance-list and restart success remain BaaS/Teclaw-only capability gaps.
+- The real open-source singlebox creates a `baas` provider binding. Current local-BaaS gaps are asserted honestly instead of being mocked into success.
 - Existing default CI behavior must keep working when no module is selected.
 
 ---
@@ -200,13 +201,16 @@ binding_id = bot["binding_id"]
 device_id = bot["device_id"]
 ```
 
-Then validate owner list/get/by-id/connection/connectable responses, validate another user receives the ownership error, assert local-provider instances/restart return the documented capability error, release the binding, and read it back as `RELEASED`.
+Then validate owner list/get/by-id/connection/connectable responses, validate
+another user receives the ownership error, assert the current local-BaaS
+publish/instance/restart/reapply gaps, release the binding, and read it back as
+`RELEASED`.
 
 - [ ] **Step 2: Run the new acceptance test against the real stack**
 
 ```bash
 RUN_ACCEPTANCE=1 uv run pytest \
-  tests/community/acceptance/devices/test_device_query_lifecycle.py::test_device_live_local_provider_lifecycle \
+  tests/community/acceptance/devices/test_device_query_lifecycle.py::test_device_live_baas_provider_lifecycle \
   -v -s
 ```
 

--- a/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
@@ -1,0 +1,145 @@
+# Device Singlebox Coverage Design
+
+## Goal
+
+Improve the Avernet Backend `devices` module with meaningful live singlebox
+coverage. The source of truth is the artifact produced by
+`scripts/ci/singlebox_coverage.sh`, not in-process E2E coverage or manually
+declared evidence.
+
+## Baseline
+
+- Development base: Avernet `origin/dev` at `5dd35c9` or a later rebased commit.
+- The coverage script starts the real standalone product stack and emits
+  `backend-coverage.json`, runtime Router hits, runtime Plugin hits, JUnit, and
+  HTML reports.
+- The current devices acceptance suite exercises three read routes and one
+  repeated no-data baseline. It does not exercise the BaaS-backed device
+  lifecycle.
+- The device router currently exposes 18 Router APIs. The existing live suite
+  reaches three unique Router APIs.
+- Device-owned Plugin API coverage is not currently declared. Service or Core
+  methods must not be relabeled as Plugin APIs merely to produce a percentage.
+
+## User Stories
+
+### 1. Device query contracts
+
+Keep the existing fresh-state behavior:
+
+- list devices for the current user;
+- read a missing binding;
+- read a missing device ID;
+- preserve the committed no-data response baseline.
+
+### 2. BaaS-backed device lifecycle
+
+Create a real personal bot through the public Backend API so Backend allocates
+its device through the live BaaS process. From the returned bot and binding:
+
+- read the binding by binding ID and device ID;
+- observe it in the user's device list;
+- obtain connection information;
+- list its runtime instances;
+- execute one harmless filesystem-inspection command when the endpoint is
+  available to the configured local operator;
+- restart the concrete runtime instance and assert a publish identifier;
+- release the binding and verify its state is `RELEASED`.
+
+Assertions must validate returned identity, ownership, provider, lifecycle
+state, and physical/runtime facts where available. HTTP 200 alone is not a
+valid assertion.
+
+### 3. Ownership and failure behavior
+
+Exercise user-relevant guards without mocking Core services:
+
+- another user cannot read the owner's binding;
+- another user cannot restart the owner's instance;
+- connection, instance, release, and restart requests for missing bindings
+  return their documented error contracts.
+
+## Coverage Metrics
+
+All metrics are derived after the real singlebox process exits and flushes its
+runtime artifacts.
+
+### Core Line
+
+- Denominator: executable statements under
+  `src/agentclaw/community/core/devices/**` in `backend-coverage.json`.
+- Numerator: statements in that same path executed by the live singlebox
+  process while running the devices acceptance target.
+- First milestone: at least 20%, and at least five percentage points above the
+  initial devices-only baseline measured on this branch.
+
+### Router API
+
+- Denominator: the 18 FastAPI operations declared by
+  `adapters/http/devices/router.py`.
+- Numerator: distinct matching keys in the live `router_hits.jsonl` artifact.
+- First milestone: at least 8/18 operations, or 44.44%.
+
+Admin-only, callback, and multi-instance operations remain in the denominator.
+They are honest future gaps rather than exclusions.
+
+### Plugin API
+
+The value is `not_applicable` until a device-owned protocol in
+`agentclaw.community.plugin_api` is both:
+
+1. semantically part of the device lifecycle user story; and
+2. observed through the existing DI/infrastructure coverage proxy.
+
+No Core, Router, or service method may be counted as a Plugin API. Adding a
+real device Plugin API denominator later requires a separate reviewed manifest
+change.
+
+## Reporting Design
+
+Add a small module reporter used by `singlebox_coverage.sh` after it combines
+Backend coverage:
+
+- read `backend-coverage.json`;
+- read and deduplicate runtime Router/Plugin hit JSONL files;
+- read a checked-in module manifest containing device Core paths and Router
+  operation keys;
+- write module metrics into `summary.json` and render the same values in
+  `summary.md` and `dashboard.html`.
+
+The default CI target remains unchanged. A device run selects
+`tests/community/acceptance/devices` through the coverage script's acceptance
+target option/environment variable. Reports always record the exact target.
+
+## Architecture Constraints
+
+- Do not import coverage helpers from `core/`, ordinary Router handlers, or
+  business services.
+- Router hits continue to come from the FastAPI middleware.
+- Plugin hits continue to come from DI/infrastructure proxies only.
+- Do not introduce `exclude_paths` or remove difficult APIs from denominators.
+- Do not seed database rows as a substitute for the real BaaS-backed lifecycle
+  when the product stack can create the state itself.
+- Keep the existing generic flow/e2e/acceptance organization. Live-only
+  lifecycle details belong under `tests/community/acceptance/devices/`.
+
+## Failure Handling
+
+- A failed lifecycle assertion fails pytest and therefore the coverage gate.
+- Missing coverage, Router-hit, JUnit, summary, or dashboard artifacts fail the
+  coverage script.
+- Cleanup always stops the isolated standalone stack and preserves diagnostic
+  logs produced under the selected coverage root.
+- A runtime capability that is unavailable must fail with evidence; tests must
+  not silently skip it after the first successful run.
+
+## Verification
+
+1. Run existing device in-process E2E tests as a fast regression check.
+2. Run reporter unit tests with synthetic coverage and hit artifacts.
+3. Run `scripts/test_singlebox_coverage_gate.sh`.
+4. Run real `scripts/ci/singlebox_coverage.sh` with the devices acceptance
+   target and an isolated coverage root.
+5. Verify JUnit has executed tests with zero failures and zero skips.
+6. Verify the generated device Core and Router metrics meet the milestones and
+   the dashboard displays the same values as `summary.json`.

--- a/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
@@ -35,20 +35,22 @@ Keep the existing fresh-state behavior:
 ### 2. BaaS-backed device lifecycle
 
 Create a real personal bot through the public Backend API so Backend allocates
-its device through the live BaaS process. From the returned bot and binding:
+its local-provider device while the full Backend/BaaS stack is running. From
+the returned bot and binding:
 
 - read the binding by binding ID and device ID;
 - observe it in the user's device list;
 - obtain connection information;
-- list its runtime instances;
-- execute one harmless filesystem-inspection command when the endpoint is
-  available to the configured local operator;
-- restart the concrete runtime instance and assert a publish identifier;
+- verify the instance-list and restart APIs reject the local provider with the
+  documented capability error (successful multi-instance operations currently
+  require a `baas` or `teclaw` binding);
 - release the binding and verify its state is `RELEASED`.
 
 Assertions must validate returned identity, ownership, provider, lifecycle
 state, and physical/runtime facts where available. HTTP 200 alone is not a
-valid assertion.
+valid assertion. A successful BaaS multi-instance restart is deferred until
+the open-source singlebox can create a real `baas` provider binding; the test
+must not seed or relabel a local binding to manufacture that success path.
 
 ### 3. Ownership and failure behavior
 

--- a/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
@@ -9,14 +9,16 @@ declared evidence.
 
 ## Profile / Env Prerequisite
 
-This work is stacked on the Profile/Env separation in PR #93. Singlebox is a
-`DeployProfile`, while persisted Device Env remains `dev`. This PR must not add
-an HTTP Schema alias or otherwise teach Device Core that `singlebox` is an Env.
+This work is stacked on the Profile/Env separation in PR #93 and the singlebox
+BaaS provider assembly in PR #98. Singlebox is a `DeployProfile`, persisted
+Device Env remains `dev`, and the persisted provider is `baas`. This PR must not
+add an HTTP Schema alias or otherwise teach Device Core that `singlebox` is an
+Env.
 
 ## Baseline
 
-- Development base: PR #93 (`codex/profile-env-separation`) until it merges into
-  `dev`.
+- Development base: PR #98 (`codex/singlebox-baas-device-provider`) until the
+  stacked PR train merges into `dev`.
 - The coverage script starts the real standalone product stack and emits
   `backend-coverage.json`, runtime Router hits, runtime Plugin hits, JUnit, and
   HTML reports.
@@ -44,22 +46,22 @@ Keep the existing fresh-state behavior:
 ### 2. BaaS-backed device lifecycle
 
 Create a real personal bot through the public Backend API so Backend allocates
-its local-provider device while the full Backend/BaaS stack is running. From
-the returned bot and binding:
+its BaaS-provider device while the full Backend/BaaS stack is running. From the
+returned bot and binding:
 
 - read the binding by binding ID and device ID;
 - observe it in the user's device list;
 - obtain connection information;
-- verify the instance-list and restart APIs reject the local provider with the
-  documented capability error (successful multi-instance operations currently
-  require a `baas` or `teclaw` binding);
+- verify binding-level connection succeeds through BaaS;
+- make current local-BaaS gaps explicit: bot-id routes have no successful
+  publish record, instance inventory is empty, restart cannot target an
+  instance, and reapply lacks the required `bot_type` input;
 - release the binding and verify its state is `RELEASED`.
 
 Assertions must validate returned identity, ownership, provider, lifecycle
 state, and physical/runtime facts where available. HTTP 200 alone is not a
-valid assertion. A successful BaaS multi-instance restart is deferred until
-the open-source singlebox can create a real `baas` provider binding; the test
-must not seed or relabel a local binding to manufacture that success path.
+valid assertion. The test must not seed records or manufacture instance state
+to turn the current local-BaaS capability gaps into synthetic success paths.
 
 ### 3. Ownership and failure behavior
 

--- a/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
@@ -16,6 +16,8 @@ declared evidence.
 - The current devices acceptance suite exercises three read routes and one
   repeated no-data baseline. It does not exercise the BaaS-backed device
   lifecycle.
+- The measured devices-only live baseline is Core `1243/3240 = 38.36%` and
+  Router `3/18 = 16.67%`.
 - The device router currently exposes 18 Router APIs. The existing live suite
   reaches three unique Router APIs.
 - Device-owned Plugin API coverage is not currently declared. Service or Core
@@ -72,8 +74,8 @@ runtime artifacts.
   `src/agentclaw/community/core/devices/**` in `backend-coverage.json`.
 - Numerator: statements in that same path executed by the live singlebox
   process while running the devices acceptance target.
-- First milestone: at least 20%, and at least five percentage points above the
-  initial devices-only baseline measured on this branch.
+- First milestone: at least 43.36%, five percentage points above the measured
+  38.36% devices-only baseline.
 
 ### Router API
 

--- a/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-10-device-singlebox-coverage-design.md
@@ -7,9 +7,16 @@ coverage. The source of truth is the artifact produced by
 `scripts/ci/singlebox_coverage.sh`, not in-process E2E coverage or manually
 declared evidence.
 
+## Profile / Env Prerequisite
+
+This work is stacked on the Profile/Env separation in PR #93. Singlebox is a
+`DeployProfile`, while persisted Device Env remains `dev`. This PR must not add
+an HTTP Schema alias or otherwise teach Device Core that `singlebox` is an Env.
+
 ## Baseline
 
-- Development base: Avernet `origin/dev` at `5dd35c9` or a later rebased commit.
+- Development base: PR #93 (`codex/profile-env-separation`) until it merges into
+  `dev`.
 - The coverage script starts the real standalone product stack and emits
   `backend-coverage.json`, runtime Router hits, runtime Plugin hits, JUnit, and
   HTML reports.

--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -10,6 +10,8 @@ coverage_root="${SINGLEBOX_COVERAGE_ROOT:-$repo_root/scripts/.dependencies/cover
 report_dir="$coverage_root/reports"
 mode="${SINGLEBOX_COVERAGE_MODE:-real}"
 acceptance_target="${SINGLEBOX_COVERAGE_ACCEPTANCE_TARGET:-tests/community/acceptance/cron/test_cron_query_lifecycle.py}"
+coverage_module="${SINGLEBOX_COVERAGE_MODULE:-}"
+module_manifest="$script_dir/singlebox_coverage_modules.yaml"
 coverage_standalone_root=""
 coverage_standalone_runtime=""
 
@@ -24,6 +26,9 @@ The default mode is real: pre-push starts the local singlebox coverage stack.
 Options:
   --coverage-root DIR     Coverage output root, default: $coverage_root
   --mode real             Override SINGLEBOX_COVERAGE_MODE
+  --acceptance-target PATH
+                          Pytest target executed against the live stack
+  --module NAME           Add module metrics and enforce its thresholds
   -h, --help              Show this help
 USAGE
 }
@@ -47,6 +52,22 @@ while [[ "$#" -gt 0 ]]; do
       mode="$2"
       shift 2
       ;;
+    --acceptance-target)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --acceptance-target requires an argument" >&2
+        exit 2
+      fi
+      acceptance_target="$2"
+      shift 2
+      ;;
+    --module)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --module requires an argument" >&2
+        exit 2
+      fi
+      coverage_module="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -58,6 +79,11 @@ while [[ "$#" -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -n "$coverage_module" && ! -s "$module_manifest" ]]; then
+  echo "missing singlebox coverage module manifest: $module_manifest" >&2
+  exit 2
+fi
 
 run_real_singlebox() {
   rm -rf "$coverage_root/raw" "$report_dir"
@@ -93,6 +119,7 @@ run_real_singlebox() {
   combine_python_coverage "backend" "$repo_root/src/backend" "$coverage_root/raw/backend"
   combine_python_coverage "baas" "$repo_root/src/baas/packages/community" "$coverage_root/raw/baas"
   write_summary_artifacts
+  write_module_artifacts
   verify_required_artifacts
 }
 
@@ -239,6 +266,17 @@ report_dir.mkdir(parents=True, exist_ok=True)
     encoding="utf-8",
 )
 PY
+}
+
+write_module_artifacts() {
+  [[ -n "$coverage_module" ]] || return 0
+  "${PYTHON:-python3}" "$script_dir/singlebox_coverage_report.py" \
+    --manifest "$module_manifest" \
+    --module "$coverage_module" \
+    --coverage-json "$report_dir/backend-coverage.json" \
+    --router-hits "$coverage_root/raw/backend/router_hits.jsonl" \
+    --plugin-hits "$coverage_root/raw/backend/plugin_hits.jsonl" \
+    --report-dir "$report_dir"
 }
 
 verify_required_artifacts() {

--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -269,8 +269,14 @@ PY
 }
 
 write_module_artifacts() {
+  local reporter_python
   [[ -n "$coverage_module" ]] || return 0
-  "${PYTHON:-python3}" "$script_dir/singlebox_coverage_report.py" \
+  reporter_python="${PYTHON:-$repo_root/src/backend/.venv/bin/python}"
+  if [[ ! -x "$reporter_python" ]]; then
+    echo "singlebox coverage reporter Python is not executable: $reporter_python" >&2
+    return 1
+  fi
+  "$reporter_python" "$script_dir/singlebox_coverage_report.py" \
     --manifest "$module_manifest" \
     --module "$coverage_module" \
     --coverage-json "$report_dir/backend-coverage.json" \

--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -1,0 +1,32 @@
+modules:
+  devices:
+    system: backend
+    core_paths:
+      - src/agentclaw/community/core/devices/
+    router_api:
+      items:
+        - POST /api/v1/devices
+        - POST /api/v1/devices/{binding_id:int}/release
+        - GET /api/v1/devices
+        - GET /api/v1/devices/provider-inventory
+        - GET /api/v1/devices/{binding_id:int}
+        - GET /api/v1/devices/by-id/{device_id}
+        - GET /api/v1/devices/{binding_id:int}/connection
+        - GET /api/v1/devices/bots/{bot_id}/connection
+        - GET /api/v1/devices/connectable
+        - GET /api/v1/devices/connectable_admin
+        - POST /api/v1/devices/callback/alive
+        - POST /api/v1/devices/callback/status
+        - POST /api/v1/devices/callback/bootstrap-auth
+        - POST /api/v1/devices/exec_shell
+        - POST /api/v1/devices/batch/env
+        - GET /api/v1/devices/bots/{bot_id}/instances
+        - GET /api/v1/devices/{binding_id:int}/instances
+        - POST /api/v1/devices/{binding_id:int}/restart
+    plugin_api:
+      status: not_applicable
+      reason: Device lifecycle has no honestly attributable runtime Plugin API denominator yet.
+      items: []
+    thresholds:
+      core_min_percent: 43.36
+      router_min_percent: 44.44

--- a/scripts/ci/singlebox_coverage_report.py
+++ b/scripts/ci/singlebox_coverage_report.py
@@ -225,6 +225,8 @@ def _load_jsonl_keys(path: Path) -> list[str]:
             item = json.loads(line)
         except json.JSONDecodeError as exc:
             raise ValueError(f"invalid JSONL at {path}:{line_number}: {exc}") from exc
+        if not isinstance(item, dict):
+            continue
         key = item.get("key")
         if isinstance(key, str):
             keys.append(key)

--- a/scripts/ci/singlebox_coverage_report.py
+++ b/scripts/ci/singlebox_coverage_report.py
@@ -186,10 +186,20 @@ section{background:#fff;border:1px solid #dce2e8;border-radius:8px;padding:20px}
 </style><main><h1>Singlebox Coverage</h1>""" + "".join(cards) + "</main></html>\n"
 
 
-def update_report_artifacts(report_dir: Path, report: dict[str, Any]) -> None:
+def update_report_artifacts(
+    report_dir: Path,
+    report: dict[str, Any],
+    *,
+    threshold_errors: list[str] | None = None,
+) -> None:
     summary_path = report_dir / "summary.json"
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     summary.setdefault("modules", {})[report["name"]] = report
+    if threshold_errors:
+        summary["status"] = "failed"
+        summary["threshold_errors"] = threshold_errors
+    else:
+        summary.pop("threshold_errors", None)
     summary_path.write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -243,8 +253,8 @@ def main() -> int:
         router_hits=_load_jsonl_keys(args.router_hits),
         plugin_hits=_load_jsonl_keys(args.plugin_hits),
     )
-    update_report_artifacts(args.report_dir, report)
     errors = validate_thresholds(report)
+    update_report_artifacts(args.report_dir, report, threshold_errors=errors)
     if errors:
         print("singlebox module coverage threshold failed:", file=sys.stderr)
         for error in errors:

--- a/scripts/ci/singlebox_coverage_report.py
+++ b/scripts/ci/singlebox_coverage_report.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Build module metrics from artifacts emitted by singlebox_coverage.sh."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _percent(covered: int, total: int) -> float:
+    return round((covered * 100.0 / total) if total else 0.0, 2)
+
+
+def _matches_core_path(filename: str, prefixes: list[str]) -> bool:
+    normalized = filename.replace("\\", "/").lstrip("./")
+    return any(
+        normalized.startswith(prefix)
+        or f"/{prefix}" in normalized
+        for prefix in prefixes
+    )
+
+
+def _metric(items: list[str], hits: list[str]) -> dict[str, Any]:
+    hit_set = set(hits)
+    covered_items = [item for item in items if item in hit_set]
+    missing_items = [item for item in items if item not in hit_set]
+    return {
+        "covered": len(covered_items),
+        "total": len(items),
+        "percent": _percent(len(covered_items), len(items)),
+        "covered_items": covered_items,
+        "missing_items": missing_items,
+    }
+
+
+def build_module_report(
+    *,
+    manifest: dict[str, Any],
+    module_name: str,
+    coverage: dict[str, Any],
+    router_hits: list[str],
+    plugin_hits: list[str],
+) -> dict[str, Any]:
+    module = (manifest.get("modules") or {}).get(module_name)
+    if module is None:
+        raise ValueError(f"unknown coverage module: {module_name}")
+
+    core_covered = 0
+    core_total = 0
+    core_paths = list(module.get("core_paths") or [])
+    for filename, file_data in (coverage.get("files") or {}).items():
+        if not _matches_core_path(filename, core_paths):
+            continue
+        summary = file_data.get("summary") or {}
+        core_covered += int(summary.get("covered_lines") or 0)
+        core_total += int(summary.get("num_statements") or 0)
+
+    plugin_config = module.get("plugin_api") or {}
+    plugin_status = plugin_config.get("status", "applicable")
+    if plugin_status == "not_applicable":
+        plugin_metric = {
+            "status": "not_applicable",
+            "reason": str(plugin_config.get("reason") or ""),
+            "covered": 0,
+            "total": 0,
+            "percent": None,
+            "covered_items": [],
+            "missing_items": [],
+        }
+    else:
+        plugin_metric = {
+            "status": "applicable",
+            "reason": str(plugin_config.get("reason") or ""),
+            **_metric(list(plugin_config.get("items") or []), plugin_hits),
+        }
+
+    return {
+        "name": module_name,
+        "system": str(module.get("system") or ""),
+        "core": {
+            "covered": core_covered,
+            "total": core_total,
+            "percent": _percent(core_covered, core_total),
+        },
+        "router_api": _metric(
+            list((module.get("router_api") or {}).get("items") or []),
+            router_hits,
+        ),
+        "plugin_api": plugin_metric,
+        "thresholds": dict(module.get("thresholds") or {}),
+    }
+
+
+def validate_thresholds(report: dict[str, Any]) -> list[str]:
+    thresholds = report.get("thresholds") or {}
+    errors: list[str] = []
+    checks = (
+        ("core", "core coverage", "core_min_percent"),
+        ("router_api", "router API coverage", "router_min_percent"),
+    )
+    for metric_name, label, threshold_name in checks:
+        if threshold_name not in thresholds:
+            continue
+        actual = float(report[metric_name]["percent"])
+        minimum = float(thresholds[threshold_name])
+        if actual < minimum:
+            errors.append(
+                f"{report['name']} {label} {actual:.2f}% < {minimum:.2f}%"
+            )
+    return errors
+
+
+def _metric_markdown(label: str, metric: dict[str, Any]) -> str:
+    if metric.get("status") == "not_applicable":
+        return f"- {label}: N/A - {metric['reason']}"
+    return (
+        f"- {label}: {metric['percent']:.2f}% "
+        f"({metric['covered']}/{metric['total']})"
+    )
+
+
+def _render_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# Singlebox Coverage Summary",
+        "",
+        f"- mode: {summary.get('mode', 'unknown')}",
+        f"- status: {summary.get('status', 'unknown')}",
+    ]
+    acceptance = summary.get("acceptance") or {}
+    if acceptance.get("target"):
+        lines.append(f"- acceptance: {acceptance['target']}")
+    for report in (summary.get("modules") or {}).values():
+        lines.extend(
+            [
+                "",
+                f"## {str(report['name']).replace('_', ' ').title()}",
+                "",
+                _metric_markdown("Core Line", report["core"]),
+                _metric_markdown("Router API", report["router_api"]),
+                _metric_markdown("Plugin API", report["plugin_api"]),
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _metric_html(label: str, metric: dict[str, Any]) -> str:
+    if metric.get("status") == "not_applicable":
+        value = "Not applicable"
+        detail = html.escape(str(metric.get("reason") or ""))
+    else:
+        value = f"{metric['percent']:.2f}%"
+        detail = f"{metric['covered']}/{metric['total']}"
+    return (
+        "<div class='metric'>"
+        f"<span>{html.escape(label)}</span><strong>{value}</strong>"
+        f"<small>{detail}</small></div>"
+    )
+
+
+def _render_dashboard(summary: dict[str, Any]) -> str:
+    cards = []
+    for report in (summary.get("modules") or {}).values():
+        cards.append(
+            "<section><h2>"
+            + html.escape(str(report["name"]).replace("_", " ").title())
+            + "</h2><div class='metrics'>"
+            + _metric_html("Core Line", report["core"])
+            + _metric_html("Router API", report["router_api"])
+            + _metric_html("Plugin API", report["plugin_api"])
+            + "</div></section>"
+        )
+    return """<!doctype html>
+<html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Singlebox Coverage</title>
+<style>
+body{font-family:system-ui,sans-serif;margin:0;background:#f4f6f8;color:#18212b}main{max-width:1080px;margin:auto;padding:32px}
+section{background:#fff;border:1px solid #dce2e8;border-radius:8px;padding:20px}.metrics{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+.metric{border-left:4px solid #1677ff;padding:12px;background:#f8fafc}.metric span,.metric small{display:block;color:#5c6b7a}.metric strong{display:block;font-size:28px;margin:8px 0}
+@media(max-width:720px){.metrics{grid-template-columns:1fr}}
+</style><main><h1>Singlebox Coverage</h1>""" + "".join(cards) + "</main></html>\n"
+
+
+def update_report_artifacts(report_dir: Path, report: dict[str, Any]) -> None:
+    summary_path = report_dir / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary.setdefault("modules", {})[report["name"]] = report
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (report_dir / "summary.md").write_text(
+        _render_markdown(summary),
+        encoding="utf-8",
+    )
+    (report_dir / "dashboard.html").write_text(
+        _render_dashboard(summary),
+        encoding="utf-8",
+    )
+
+
+def _load_jsonl_keys(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    keys: list[str] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL at {path}:{line_number}: {exc}") from exc
+        key = item.get("key")
+        if isinstance(key, str):
+            keys.append(key)
+    return keys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--module", required=True)
+    parser.add_argument("--coverage-json", required=True, type=Path)
+    parser.add_argument("--router-hits", required=True, type=Path)
+    parser.add_argument("--plugin-hits", required=True, type=Path)
+    parser.add_argument("--report-dir", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest = yaml.safe_load(args.manifest.read_text(encoding="utf-8")) or {}
+    coverage = json.loads(args.coverage_json.read_text(encoding="utf-8"))
+    report = build_module_report(
+        manifest=manifest,
+        module_name=args.module,
+        coverage=coverage,
+        router_hits=_load_jsonl_keys(args.router_hits),
+        plugin_hits=_load_jsonl_keys(args.plugin_hits),
+    )
+    update_report_artifacts(args.report_dir, report)
+    errors = validate_thresholds(report)
+    if errors:
+        print("singlebox module coverage threshold failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print(
+        f"{args.module} coverage: core={report['core']['percent']:.2f}% "
+        f"router={report['router_api']['percent']:.2f}% "
+        "plugin=N/A"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/singlebox_coverage_report.py
+++ b/scripts/ci/singlebox_coverage_report.py
@@ -39,6 +39,26 @@ def _metric(items: list[str], hits: list[str]) -> dict[str, Any]:
     }
 
 
+def _configured_metric(config: dict[str, Any], hits: list[str]) -> dict[str, Any]:
+    status = config.get("status", "applicable")
+    reason = str(config.get("reason") or "")
+    if status == "not_applicable":
+        return {
+            "status": "not_applicable",
+            "reason": reason,
+            "covered": 0,
+            "total": 0,
+            "percent": None,
+            "covered_items": [],
+            "missing_items": [],
+        }
+    return {
+        "status": "applicable",
+        "reason": reason,
+        **_metric(list(config.get("items") or []), hits),
+    }
+
+
 def build_module_report(
     *,
     manifest: dict[str, Any],
@@ -61,24 +81,8 @@ def build_module_report(
         core_covered += int(summary.get("covered_lines") or 0)
         core_total += int(summary.get("num_statements") or 0)
 
-    plugin_config = module.get("plugin_api") or {}
-    plugin_status = plugin_config.get("status", "applicable")
-    if plugin_status == "not_applicable":
-        plugin_metric = {
-            "status": "not_applicable",
-            "reason": str(plugin_config.get("reason") or ""),
-            "covered": 0,
-            "total": 0,
-            "percent": None,
-            "covered_items": [],
-            "missing_items": [],
-        }
-    else:
-        plugin_metric = {
-            "status": "applicable",
-            "reason": str(plugin_config.get("reason") or ""),
-            **_metric(list(plugin_config.get("items") or []), plugin_hits),
-        }
+    router_metric = _configured_metric(module.get("router_api") or {}, router_hits)
+    plugin_metric = _configured_metric(module.get("plugin_api") or {}, plugin_hits)
 
     return {
         "name": module_name,
@@ -88,10 +92,7 @@ def build_module_report(
             "total": core_total,
             "percent": _percent(core_covered, core_total),
         },
-        "router_api": _metric(
-            list((module.get("router_api") or {}).get("items") or []),
-            router_hits,
-        ),
+        "router_api": router_metric,
         "plugin_api": plugin_metric,
         "thresholds": dict(module.get("thresholds") or {}),
     }
@@ -103,9 +104,12 @@ def validate_thresholds(report: dict[str, Any]) -> list[str]:
     checks = (
         ("core", "core coverage", "core_min_percent"),
         ("router_api", "router API coverage", "router_min_percent"),
+        ("plugin_api", "plugin API coverage", "plugin_min_percent"),
     )
     for metric_name, label, threshold_name in checks:
         if threshold_name not in thresholds:
+            continue
+        if report[metric_name].get("status") == "not_applicable":
             continue
         actual = float(report[metric_name]["percent"])
         minimum = float(thresholds[threshold_name])
@@ -262,10 +266,15 @@ def main() -> int:
         for error in errors:
             print(f"- {error}", file=sys.stderr)
         return 1
+    def display(metric: dict[str, Any]) -> str:
+        if metric.get("status") == "not_applicable":
+            return "N/A"
+        return f"{metric['percent']:.2f}%"
+
     print(
         f"{args.module} coverage: core={report['core']['percent']:.2f}% "
-        f"router={report['router_api']['percent']:.2f}% "
-        "plugin=N/A"
+        f"router={display(report['router_api'])} "
+        f"plugin={display(report['plugin_api'])}"
     )
     return 0
 

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -10,6 +10,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from singlebox_coverage_report import (  # noqa: E402
+    _load_jsonl_keys,
     build_module_report,
     update_report_artifacts,
     validate_thresholds,
@@ -191,3 +192,22 @@ def test_update_report_artifacts_marks_threshold_failure(tmp_path: Path):
     summary = json.loads((report_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary["status"] == "failed"
     assert summary["threshold_errors"] == errors
+
+
+def test_load_jsonl_keys_ignores_non_object_json_values(tmp_path: Path):
+    hits_path = tmp_path / "hits.jsonl"
+    hits_path.write_text(
+        '\n'.join(
+            [
+                '{"key": "GET /api/v1/devices"}',
+                '["not", "an", "object"]',
+                'null',
+                '"plain string"',
+                '{"key": 42}',
+            ]
+        )
+        + '\n',
+        encoding="utf-8",
+    )
+
+    assert _load_jsonl_keys(hits_path) == ["GET /api/v1/devices"]

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from singlebox_coverage_report import (  # noqa: E402
+    build_module_report,
+    update_report_artifacts,
+    validate_thresholds,
+)
+
+
+DEVICE_ROUTES = [
+    "GET /api/v1/devices",
+    "GET /api/v1/devices/{binding_id:int}",
+    "GET /api/v1/devices/by-id/{device_id}",
+]
+
+
+def _manifest() -> dict:
+    return {
+        "modules": {
+            "devices": {
+                "system": "backend",
+                "core_paths": ["src/agentclaw/community/core/devices/"],
+                "router_api": {"items": DEVICE_ROUTES},
+                "plugin_api": {
+                    "status": "not_applicable",
+                    "reason": "No attributable device Plugin API denominator.",
+                    "items": [],
+                },
+                "thresholds": {
+                    "core_min_percent": 43.36,
+                    "router_min_percent": 44.44,
+                },
+            }
+        }
+    }
+
+
+def _coverage() -> dict:
+    return {
+        "files": {
+            "src/agentclaw/community/core/devices/services/device_service.py": {
+                "summary": {"covered_lines": 2, "num_statements": 4}
+            },
+            "/repo/src/agentclaw/community/core/devices/models.py": {
+                "summary": {"covered_lines": 1, "num_statements": 1}
+            },
+            "src/agentclaw/community/core/bot_management/service.py": {
+                "summary": {"covered_lines": 100, "num_statements": 100}
+            },
+        }
+    }
+
+
+def test_build_module_report_filters_core_and_deduplicates_router_hits():
+    report = build_module_report(
+        manifest=_manifest(),
+        module_name="devices",
+        coverage=_coverage(),
+        router_hits=[
+            "GET /api/v1/devices",
+            "GET /api/v1/devices",
+            "GET /api/v1/devices/{binding_id:int}",
+            "GET /api/health",
+        ],
+        plugin_hits=["BotRepository.get_by_id"],
+    )
+
+    assert report["core"] == {
+        "covered": 3,
+        "total": 5,
+        "percent": 60.0,
+    }
+    assert report["router_api"]["covered"] == 2
+    assert report["router_api"]["total"] == 3
+    assert report["router_api"]["percent"] == 66.67
+    assert report["router_api"]["covered_items"] == DEVICE_ROUTES[:2]
+    assert report["router_api"]["missing_items"] == DEVICE_ROUTES[2:]
+    assert report["plugin_api"] == {
+        "status": "not_applicable",
+        "reason": "No attributable device Plugin API denominator.",
+        "covered": 0,
+        "total": 0,
+        "percent": None,
+        "covered_items": [],
+        "missing_items": [],
+    }
+
+
+def test_build_module_report_rejects_unknown_module():
+    with pytest.raises(ValueError, match="unknown coverage module: missing"):
+        build_module_report(
+            manifest=_manifest(),
+            module_name="missing",
+            coverage=_coverage(),
+            router_hits=[],
+            plugin_hits=[],
+        )
+
+
+def test_validate_thresholds_reports_core_and_router_failures():
+    report = build_module_report(
+        manifest=_manifest(),
+        module_name="devices",
+        coverage={
+            "files": {
+                "src/agentclaw/community/core/devices/models.py": {
+                    "summary": {"covered_lines": 1, "num_statements": 4}
+                }
+            }
+        },
+        router_hits=["GET /api/v1/devices"],
+        plugin_hits=[],
+    )
+
+    assert validate_thresholds(report) == [
+        "devices core coverage 25.00% < 43.36%",
+        "devices router API coverage 33.33% < 44.44%",
+    ]
+
+
+def test_update_report_artifacts_keeps_summary_and_dashboard_consistent(tmp_path: Path):
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    (report_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "mode": "real",
+                "status": "passed",
+                "acceptance": {"target": "tests/community/acceptance/devices"},
+                "coverage": {"backend": {"router_hits": 4, "plugin_hits": 0}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_module_report(
+        manifest=_manifest(),
+        module_name="devices",
+        coverage=_coverage(),
+        router_hits=DEVICE_ROUTES[:2],
+        plugin_hits=[],
+    )
+    update_report_artifacts(report_dir, report)
+
+    summary = json.loads((report_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["modules"]["devices"] == report
+    markdown = (report_dir / "summary.md").read_text(encoding="utf-8")
+    dashboard = (report_dir / "dashboard.html").read_text(encoding="utf-8")
+    assert "Devices" in markdown
+    assert "Core Line: 60.00% (3/5)" in markdown
+    assert "Router API: 66.67% (2/3)" in markdown
+    assert "Plugin API: N/A" in markdown
+    assert "60.00%" in dashboard
+    assert "66.67%" in dashboard
+    assert "Not applicable" in dashboard

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -162,3 +162,32 @@ def test_update_report_artifacts_keeps_summary_and_dashboard_consistent(tmp_path
     assert "60.00%" in dashboard
     assert "66.67%" in dashboard
     assert "Not applicable" in dashboard
+
+
+def test_update_report_artifacts_marks_threshold_failure(tmp_path: Path):
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    (report_dir / "summary.json").write_text(
+        json.dumps({"mode": "real", "status": "passed"}),
+        encoding="utf-8",
+    )
+    report = build_module_report(
+        manifest=_manifest(),
+        module_name="devices",
+        coverage={
+            "files": {
+                "src/agentclaw/community/core/devices/models.py": {
+                    "summary": {"covered_lines": 1, "num_statements": 4}
+                }
+            }
+        },
+        router_hits=[],
+        plugin_hits=[],
+    )
+    errors = validate_thresholds(report)
+
+    update_report_artifacts(report_dir, report, threshold_errors=errors)
+
+    summary = json.loads((report_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "failed"
+    assert summary["threshold_errors"] == errors

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -128,6 +128,56 @@ def test_validate_thresholds_reports_core_and_router_failures():
     ]
 
 
+def test_build_module_report_supports_not_applicable_router_api():
+    manifest = _manifest()
+    manifest["modules"]["devices"]["router_api"] = {
+        "status": "not_applicable",
+        "reason": "The module has no independently attributable HTTP routes.",
+        "items": [],
+    }
+
+    report = build_module_report(
+        manifest=manifest,
+        module_name="devices",
+        coverage=_coverage(),
+        router_hits=["GET /api/v1/devices"],
+        plugin_hits=[],
+    )
+
+    assert report["router_api"] == {
+        "status": "not_applicable",
+        "reason": "The module has no independently attributable HTTP routes.",
+        "covered": 0,
+        "total": 0,
+        "percent": None,
+        "covered_items": [],
+        "missing_items": [],
+    }
+    assert validate_thresholds(report) == []
+
+
+def test_validate_thresholds_reports_applicable_plugin_failure():
+    manifest = _manifest()
+    manifest["modules"]["devices"]["plugin_api"] = {
+        "status": "applicable",
+        "items": ["AuthPlugin.get_current_user", "AuthPlugin.is_admin"],
+    }
+    manifest["modules"]["devices"]["thresholds"]["plugin_min_percent"] = 75.0
+
+    report = build_module_report(
+        manifest=manifest,
+        module_name="devices",
+        coverage=_coverage(),
+        router_hits=DEVICE_ROUTES,
+        plugin_hits=["AuthPlugin.get_current_user"],
+    )
+
+    assert report["plugin_api"]["percent"] == 50.0
+    assert validate_thresholds(report) == [
+        "devices plugin API coverage 50.00% < 75.00%"
+    ]
+
+
 def test_update_report_artifacts_keeps_summary_and_dashboard_consistent(tmp_path: Path):
     report_dir = tmp_path / "reports"
     report_dir.mkdir()

--- a/scripts/test_singlebox_coverage_gate.sh
+++ b/scripts/test_singlebox_coverage_gate.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="${ROOT}/scripts/ci/singlebox_coverage.sh"
+REPORTER="${ROOT}/scripts/ci/singlebox_coverage_report.py"
+MANIFEST="${ROOT}/scripts/ci/singlebox_coverage_modules.yaml"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -14,6 +16,8 @@ make_fake_repo() {
   mkdir -p "${tmp}/scripts/ci"
   mkdir -p "${tmp}/src/backend" "${tmp}/src/baas/packages/community"
   cp "$SCRIPT" "${tmp}/scripts/ci/singlebox_coverage.sh"
+  cp "$REPORTER" "${tmp}/scripts/ci/singlebox_coverage_report.py"
+  cp "$MANIFEST" "${tmp}/scripts/ci/singlebox_coverage_modules.yaml"
   chmod +x "${tmp}/scripts/ci/singlebox_coverage.sh"
   cat > "${tmp}/scripts/singlebox.sh" <<'SH'
 #!/usr/bin/env bash
@@ -39,7 +43,20 @@ if [ "$*" = "--standalone start all" ]; then
   mkdir -p "${SINGLEBOX_COVERAGE_DIR:?}/backend" "${SINGLEBOX_COVERAGE_DIR:?}/baas"
   printf '%s\n' '{}' > "${SINGLEBOX_COVERAGE_DIR}/backend/.coverage.fake"
   printf '%s\n' '{}' > "${SINGLEBOX_COVERAGE_DIR}/baas/.coverage.fake"
-  printf '%s\n' '{"key":"GET /api/health"}' > "${SINGLEBOX_COVERAGE_DIR}/backend/router_hits.jsonl"
+  if [ "${SINGLEBOX_STUB_DEVICE_HITS:-}" = "1" ]; then
+    cat > "${SINGLEBOX_COVERAGE_DIR}/backend/router_hits.jsonl" <<'JSONL'
+{"key":"GET /api/v1/devices"}
+{"key":"GET /api/v1/devices/{binding_id:int}"}
+{"key":"GET /api/v1/devices/by-id/{device_id}"}
+{"key":"GET /api/v1/devices/{binding_id:int}/connection"}
+{"key":"GET /api/v1/devices/connectable"}
+{"key":"GET /api/v1/devices/{binding_id:int}/instances"}
+{"key":"POST /api/v1/devices/{binding_id:int}/restart"}
+{"key":"POST /api/v1/devices/{binding_id:int}/release"}
+JSONL
+  else
+    printf '%s\n' '{"key":"GET /api/health"}' > "${SINGLEBOX_COVERAGE_DIR}/backend/router_hits.jsonl"
+  fi
   printf '%s\n' '{"key":"BotService.create_bot"}' > "${SINGLEBOX_COVERAGE_DIR}/backend/plugin_hits.jsonl"
   printf '%s\n' '{"key":"GET /health"}' > "${SINGLEBOX_COVERAGE_DIR}/baas/router_hits.jsonl"
 fi
@@ -87,7 +104,7 @@ if [ "${1:-}" = "run" ] && [ "${2:-}" = "coverage" ]; then
       done
       [ -n "$output" ] || exit 23
       mkdir -p "$(dirname "$output")"
-      printf '%s\n' '{"totals":{"percent_covered":100}}' > "$output"
+      printf '%s\n' '{"totals":{"percent_covered":100},"files":{"src/agentclaw/community/core/devices/services/device_service.py":{"summary":{"covered_lines":50,"num_statements":100}}}}' > "$output"
       ;;
     html)
       output_dir=""
@@ -160,7 +177,43 @@ test_mock_mode_is_not_supported() {
     fail "mock mode rejection message mismatch"
 }
 
+test_module_mode_reports_device_metrics() {
+  local tmp log uv_log summary
+  tmp="$(mktemp -d)"
+  log="${tmp}/singlebox.log"
+  uv_log="${tmp}/uv.log"
+  make_fake_repo "$tmp"
+
+  (
+    cd "$tmp"
+    PATH="${tmp}/fake-bin:$PATH" \
+      PYTHON="${ROOT}/src/backend/.venv/bin/python" \
+      SINGLEBOX_STUB_LOG="$log" \
+      SINGLEBOX_STUB_DEVICE_HITS=1 \
+      UV_STUB_LOG="$uv_log" \
+      "${tmp}/scripts/ci/singlebox_coverage.sh" \
+        --module devices \
+        --acceptance-target tests/community/acceptance/devices >/dev/null
+  )
+
+  grep -F "run pytest tests/community/acceptance/devices" "$uv_log" >/dev/null || \
+    fail "selected devices acceptance target was not executed"
+  summary="${tmp}/scripts/.dependencies/coverage/singlebox/reports/summary.json"
+  "${ROOT}/src/backend/.venv/bin/python" - "$summary" <<'PY'
+import json
+import sys
+
+summary = json.load(open(sys.argv[1], encoding="utf-8"))
+devices = summary["modules"]["devices"]
+assert devices["core"]["percent"] == 50.0
+assert devices["router_api"]["covered"] == 8
+assert devices["router_api"]["total"] == 18
+assert devices["plugin_api"]["status"] == "not_applicable"
+PY
+}
+
 test_default_mode_runs_real_singlebox
 test_mock_mode_is_not_supported
+test_module_mode_reports_device_metrics
 
 printf 'PASS: singlebox coverage gate tests\n'

--- a/src/backend/src/agentclaw/community/adapters/http/singlebox_coverage.py
+++ b/src/backend/src/agentclaw/community/adapters/http/singlebox_coverage.py
@@ -6,6 +6,23 @@ from fastapi import FastAPI, Request
 from agentclaw.community.utils.singlebox_coverage_recorder import record_router_hit
 
 
+def _full_route_path(route, request_path: str) -> str:
+    """Restore prefixes that FastAPI drops from nested router scope metadata."""
+    route_path = getattr(route, "path", None)
+    path_regex = getattr(route, "path_regex", None)
+    if not route_path:
+        return request_path
+    if path_regex is None or path_regex.fullmatch(request_path):
+        return route_path
+
+    for index, char in enumerate(request_path):
+        if char != "/":
+            continue
+        if path_regex.fullmatch(request_path[index:]):
+            return f"{request_path[:index]}{route_path}"
+    return route_path
+
+
 def install_singlebox_coverage_middleware(app: FastAPI) -> None:
     """Record concrete FastAPI route hits while singlebox coverage is enabled."""
 
@@ -13,7 +30,7 @@ def install_singlebox_coverage_middleware(app: FastAPI) -> None:
     async def _singlebox_coverage_router_hit_middleware(request: Request, call_next):
         response = await call_next(request)
         route = request.scope.get("route")
-        route_path = getattr(route, "path", None) or request.url.path
+        route_path = _full_route_path(route, request.url.path)
         record_router_hit(
             method=request.method,
             route_path=route_path,

--- a/src/backend/src/agentclaw/community/adapters/http/singlebox_coverage.py
+++ b/src/backend/src/agentclaw/community/adapters/http/singlebox_coverage.py
@@ -26,6 +26,9 @@ def _full_route_path(route, request_path: str) -> str:
 def install_singlebox_coverage_middleware(app: FastAPI) -> None:
     """Record concrete FastAPI route hits while singlebox coverage is enabled."""
 
+    # TODO(totalfrank): move route-hit recording to the shared adapter AOP seam
+    # once that interception mechanism exists. Keep coverage hooks out of Core
+    # and business services during that refactor.
     @app.middleware("http")
     async def _singlebox_coverage_router_hit_middleware(request: Request, call_next):
         response = await call_next(request)

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
@@ -58,6 +58,7 @@ from agentclaw.community.core.service_bot.services.baas_service import BaasServi
 from agentclaw.community.core.workspace.path_factory import _get_aidesktop_root
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import DeviceAdapterTransport
+from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
 from agentclaw.community.plugins.local.local_device_lifecycle import LocalDeviceLifecycle
 
@@ -106,6 +107,7 @@ class TestDevicesModule(Module):
         arca_baas_rollout_policy: ArcaBotCreateBaasRolloutPolicy,
         data_init_service_factory: Callable[[], DataInitService],
         token_vault: TokenVault,
+        passport_plugin: PassportPlugin,
         sandbox_client: SandboxRuntimeClient,
     ) -> DeviceService:
         """Local-only ``DeviceServiceRouter`` build (singlebox via BaaS)."""
@@ -144,6 +146,7 @@ class TestDevicesModule(Module):
             providers=providers,
             default_provider_key=LOCAL_DEVICE_PROVIDER,
             arca_baas_rollout_policy=arca_baas_rollout_policy,
+            passport_plugin=passport_plugin,
             sandbox_client=sandbox_client,
         )
 

--- a/src/backend/tests/community/acceptance/_fixtures/live_personal_bot.py
+++ b/src/backend/tests/community/acceptance/_fixtures/live_personal_bot.py
@@ -1,8 +1,8 @@
 """Helpers for acceptance tests that need a live personal bot.
 
 These helpers intentionally use the public backend API instead of repository
-seeding: route-B acceptance should exercise backend -> BaaS -> local device
-allocation before module-specific assertions run.
+seeding: route-B acceptance should exercise Backend -> BaaS device allocation
+before module-specific assertions run.
 """
 from __future__ import annotations
 
@@ -66,6 +66,5 @@ def create_live_personal_bot(
     )
     bot = create_payload["data"]["bot"]
     ready = wait_bot_ready(client, bot["bot_id"])
-    assert ready["device_provider"] == "local", ready
+    assert ready["device_provider"] == "baas", ready
     return bot
-

--- a/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
+++ b/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
@@ -19,6 +19,7 @@ Off by default; enable with RUN_ACCEPTANCE=1.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import httpx
@@ -34,6 +35,33 @@ from tests.community.framework.flow_runner_live import run_flow_live
 
 BASELINE_PATH = Path(__file__).parent / "baseline_device_query.json"
 HEADERS = {"x-user-id": "e2e_user"}
+
+
+def wait_device_active(
+    client: httpx.Client,
+    binding_id: int,
+    *,
+    timeout_sec: int = 180,
+) -> dict:
+    """Wait for the real Backend -> BaaS publish flow to activate a binding."""
+    deadline = time.monotonic() + timeout_sec
+    last: dict | None = None
+    while time.monotonic() < deadline:
+        response = client.get(f"/api/v1/devices/{binding_id}")
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        if payload.get("success") is True:
+            last = payload["data"]
+            if last["status"] == "ACTIVE":
+                return last
+            assert last["status"] != "FAILED", last
+        else:
+            # Bot readiness and the BaaS alive callback are asynchronous. A read
+            # may briefly race the SQLite callback transaction; only a persistent
+            # failure should fail the acceptance story.
+            last = payload
+        time.sleep(2)
+    pytest.fail(f"device binding {binding_id} did not become active; last={last}")
 
 
 @pytest.mark.acceptance
@@ -127,7 +155,7 @@ def test_device_live_local_provider_lifecycle(live_backend):
         binding_id = int(bot["binding_id"])
         device_id = str(bot["device_id"])
 
-        detail = assert_success(client.get(f"/api/v1/devices/{binding_id}"))["data"]
+        detail = wait_device_active(client, binding_id)
         assert detail["entity_id"] == user_id
         assert detail["device_id"] == device_id
         assert detail["device_provider"] == "local"
@@ -147,6 +175,31 @@ def test_device_live_local_provider_lifecycle(live_backend):
         assert connection["available"] is True
         assert connection["url"]
 
+        connection_by_bot = client.get(
+            f"/api/v1/devices/bots/{bot['bot_id']}/connection"
+        ).json()
+        assert connection_by_bot["success"] is False
+        assert connection_by_bot["error_code"] == 40403
+        assert "BotPublishRepository not available" in connection_by_bot["message"]
+
+        config_payload = {
+            "singlebox": {
+                "module": "devices",
+                "story": "device-filesystem-config-roundtrip",
+            }
+        }
+        saved_config = assert_success(
+            client.put(
+                f"/api/bots/{bot['bot_id']}/engine-config",
+                json=config_payload,
+            )
+        )["data"]
+        assert saved_config == config_payload
+        read_config = assert_success(
+            client.get(f"/api/bots/{bot['bot_id']}/engine-config")
+        )["data"]
+        assert read_config == config_payload
+
         connectable = assert_success(
             client.get(
                 "/api/v1/devices/connectable",
@@ -158,6 +211,48 @@ def test_device_live_local_provider_lifecycle(live_backend):
             )
         )["data"]
         assert any(item["id"] == binding_id for item in connectable["items"]), connectable
+
+        inventory = assert_success(
+            client.get(
+                "/api/v1/devices/provider-inventory",
+                params={"entity_id": user_id, "entity_type": "staff"},
+            )
+        )["data"]
+        assert inventory["total"] == 1
+        assert inventory["scanned"] == 1
+        assert inventory["by_provider"]["local"]["total"] == 1
+
+        bootstrap_auth = assert_success(
+            client.post(
+                "/api/v1/devices/callback/bootstrap-auth",
+                json={
+                    "device_id": device_id,
+                    "bot_id": bot["bot_id"],
+                    "owner_id": user_id,
+                },
+            )
+        )["data"]
+        assert bootstrap_auth["agent_code"] == f"local_{bot['bot_id']}"
+
+        invalid_alive = client.post(
+            "/api/v1/devices/callback/alive",
+            headers={"Authorization": "Bearer invalid-device-token"},
+            json={"device_id": device_id},
+        ).json()
+        assert invalid_alive["success"] is False
+        assert invalid_alive["error_code"] == 40302
+
+        invalid_status = client.post(
+            "/api/v1/devices/callback/status",
+            headers={"Authorization": "Bearer invalid-device-token"},
+            json={
+                "device_id": device_id,
+                "status": "SUCCEEDED",
+                "message": "untrusted callback must not mutate device state",
+            },
+        ).json()
+        assert invalid_status["success"] is False
+        assert invalid_status["error_code"] == 40302
 
         with httpx.Client(
             base_url=live_backend,
@@ -173,6 +268,13 @@ def test_device_live_local_provider_lifecycle(live_backend):
         assert instances["error_code"] == 40403
         assert "does not support instances query" in instances["message"]
 
+        instances_by_bot = client.get(
+            f"/api/v1/devices/bots/{bot['bot_id']}/instances"
+        ).json()
+        assert instances_by_bot["success"] is False
+        assert instances_by_bot["error_code"] == 40403
+        assert "BotPublishRepository not available" in instances_by_bot["message"]
+
         restart = client.post(
             f"/api/v1/devices/{binding_id}/restart",
             json={"device_uuid": device_id},
@@ -180,6 +282,18 @@ def test_device_live_local_provider_lifecycle(live_backend):
         assert restart["success"] is False
         assert restart["error_code"] == 40403
         assert "does not support instances query" in restart["message"]
+
+        env_update = assert_success(
+            client.post(
+                "/api/v1/devices/batch/env",
+                json={"binding_ids": [binding_id, 999999], "env": "dev"},
+            )
+        )["data"]
+        assert env_update == {
+            "total": 2,
+            "updated": 1,
+            "updated_ids": [binding_id],
+        }
 
         released = assert_success(
             client.post(
@@ -191,3 +305,28 @@ def test_device_live_local_provider_lifecycle(live_backend):
 
         readback = assert_success(client.get(f"/api/v1/devices/{binding_id}"))["data"]
         assert readback["status"] == "RELEASED"
+
+        reapplied = assert_success(
+            client.post(
+                "/api/v1/devices",
+                json={
+                    "apply_reason": "restore released singlebox device",
+                    "entity_id": user_id,
+                    "entity_type": "staff",
+                    "bot_id": bot["bot_id"],
+                    "engine": "openclaw",
+                },
+            )
+        )["data"]
+        reapplied_binding_id = int(reapplied["id"])
+        assert reapplied["device_provider"] == "local"
+        active_reapplied = wait_device_active(client, reapplied_binding_id)
+        assert active_reapplied["device_id"] == reapplied["device_id"]
+
+        final_release = assert_success(
+            client.post(
+                f"/api/v1/devices/{reapplied_binding_id}/release",
+                json={"release_reason": "reapplied device acceptance complete"},
+            )
+        )["data"]
+        assert final_release["status"] == "RELEASED"

--- a/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
+++ b/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
@@ -1,11 +1,13 @@
-"""Route-B acceptance: devices read-only query lifecycle on live backend.
+"""Route-B acceptance: devices query and local-provider lifecycle.
 
 Starts a real singlebox backend (in-memory SQLite via local_setup.sh),
-runs the 3 read-only flows + asserts no-data state matches baseline.
+runs the 3 read-only flows, asserts the no-data baseline, and creates one real
+personal bot through Backend -> BaaS before exercising its device binding.
 
-devices write paths (apply/release/connection/exec_shell/callback/batch — 8
-endpoints) all depend on BaasService HTTP without a LocalBaas plugin — out
-of scope for single box (see findings/devices-baas-write-paths-unmocked.md).
+The open-source singlebox records the created binding as provider ``local``.
+Connection and release are supported; instance-list and restart are
+BaaS/Teclaw-only and must return the documented capability error rather than
+silently pretending that a local binding is a remote multi-instance runtime.
 
 Acceptance covers only the empty/no-data contract:
   - list returns empty {total: 0, items: []}
@@ -23,6 +25,11 @@ import httpx
 import pytest
 
 from tests.community._flows.devices.api_lifecycle import DEVICES_LIFECYCLE_FLOWS
+from tests.community.acceptance._fixtures.live_personal_bot import (
+    assert_success,
+    create_live_personal_bot,
+    fresh_id,
+)
 from tests.community.framework.flow_runner_live import run_flow_live
 
 BASELINE_PATH = Path(__file__).parent / "baseline_device_query.json"
@@ -102,3 +109,85 @@ def test_devices_lifecycle_baseline(live_backend, acceptance_fs_root):
         f"  expected: {json.dumps(expected, indent=2, sort_keys=True)}\n"
         f"  actual:   {json.dumps(snapshot, indent=2, sort_keys=True)}"
     )
+
+
+@pytest.mark.acceptance
+def test_device_live_local_provider_lifecycle(live_backend):
+    """Create a real local runtime, inspect its device, then release it."""
+    user_id = fresh_id("device_owner")
+    headers = {"x-user-id": user_id}
+
+    with httpx.Client(base_url=live_backend, headers=headers, timeout=60.0) as client:
+        bot = create_live_personal_bot(
+            client,
+            user_id=user_id,
+            bot_name_prefix="Device Acceptance",
+            bot_desc="device live lifecycle acceptance bot",
+        )
+        binding_id = int(bot["binding_id"])
+        device_id = str(bot["device_id"])
+
+        detail = assert_success(client.get(f"/api/v1/devices/{binding_id}"))["data"]
+        assert detail["entity_id"] == user_id
+        assert detail["device_id"] == device_id
+        assert detail["device_provider"] == "local"
+        assert detail["status"] == "ACTIVE"
+
+        by_device_id = assert_success(
+            client.get(f"/api/v1/devices/by-id/{device_id}")
+        )["data"]
+        assert by_device_id["id"] == binding_id
+
+        listed = assert_success(client.get("/api/v1/devices"))["data"]
+        assert any(item["id"] == binding_id for item in listed["items"]), listed
+
+        connection = assert_success(
+            client.get(f"/api/v1/devices/{binding_id}/connection")
+        )["data"]
+        assert connection["available"] is True
+        assert connection["url"]
+
+        connectable = assert_success(
+            client.get(
+                "/api/v1/devices/connectable",
+                params={
+                    "entity_id": user_id,
+                    "entity_type": "staff",
+                    "with_connection": True,
+                },
+            )
+        )["data"]
+        assert any(item["id"] == binding_id for item in connectable["items"]), connectable
+
+        with httpx.Client(
+            base_url=live_backend,
+            headers={"x-user-id": fresh_id("device_other")},
+            timeout=30.0,
+        ) as other_client:
+            forbidden = other_client.get(f"/api/v1/devices/{binding_id}").json()
+        assert forbidden["success"] is False
+        assert forbidden["error_code"] == 403
+
+        instances = client.get(f"/api/v1/devices/{binding_id}/instances").json()
+        assert instances["success"] is False
+        assert instances["error_code"] == 40403
+        assert "does not support instances query" in instances["message"]
+
+        restart = client.post(
+            f"/api/v1/devices/{binding_id}/restart",
+            json={"device_uuid": device_id},
+        ).json()
+        assert restart["success"] is False
+        assert restart["error_code"] == 40403
+        assert "does not support instances query" in restart["message"]
+
+        released = assert_success(
+            client.post(
+                f"/api/v1/devices/{binding_id}/release",
+                json={"release_reason": "singlebox device lifecycle complete"},
+            )
+        )["data"]
+        assert released["status"] == "RELEASED"
+
+        readback = assert_success(client.get(f"/api/v1/devices/{binding_id}"))["data"]
+        assert readback["status"] == "RELEASED"

--- a/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
+++ b/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
@@ -1,13 +1,11 @@
-"""Route-B acceptance: devices query and local-provider lifecycle.
+"""Route-B acceptance: devices query and BaaS-provider lifecycle.
 
 Runs against the real standalone stack started by `singlebox_coverage.sh`,
 asserts the no-data query contracts, and creates one real personal bot through
 Backend -> BaaS before exercising its device binding.
 
-The open-source singlebox records the created binding as provider ``local``.
-Connection and release are supported; instance-list and restart are
-BaaS/Teclaw-only and must return the documented capability error rather than
-silently pretending that a local binding is a remote multi-instance runtime.
+The open-source singlebox records the created binding as provider ``baas`` and
+exercises the same BaaS-owned lifecycle contract used by deployed profiles.
 
 Acceptance covers only the empty/no-data contract:
   - list returns empty {total: 0, items: []}
@@ -143,8 +141,8 @@ def test_devices_lifecycle_baseline(live_backend, acceptance_fs_root):
 
 
 @pytest.mark.acceptance
-def test_device_live_local_provider_lifecycle(live_backend):
-    """Create a real local runtime, inspect its device, then release it."""
+def test_device_live_baas_provider_lifecycle(live_backend):
+    """Create a real BaaS runtime, inspect its device, then release it."""
     user_id = fresh_id("device_owner")
     headers = {"x-user-id": user_id}
 
@@ -161,7 +159,7 @@ def test_device_live_local_provider_lifecycle(live_backend):
         detail = wait_device_active(client, binding_id)
         assert detail["entity_id"] == user_id
         assert detail["device_id"] == device_id
-        assert detail["device_provider"] == "local"
+        assert detail["device_provider"] == "baas"
         assert detail["status"] == "ACTIVE"
 
         by_device_id = assert_success(
@@ -176,14 +174,16 @@ def test_device_live_local_provider_lifecycle(live_backend):
             client.get(f"/api/v1/devices/{binding_id}/connection")
         )["data"]
         assert connection["available"] is True
-        assert connection["url"]
+        assert connection["type"] == "remote"
+        assert connection["target"]
+        assert connection["token"]
 
         connection_by_bot = client.get(
             f"/api/v1/devices/bots/{bot['bot_id']}/connection"
         ).json()
         assert connection_by_bot["success"] is False
         assert connection_by_bot["error_code"] == 40403
-        assert "BotPublishRepository not available" in connection_by_bot["message"]
+        assert "No success publish record" in connection_by_bot["message"]
 
         config_payload = {
             "singlebox": {
@@ -223,7 +223,7 @@ def test_device_live_local_provider_lifecycle(live_backend):
         )["data"]
         assert inventory["total"] == 1
         assert inventory["scanned"] == 1
-        assert inventory["by_provider"]["local"]["total"] == 1
+        assert inventory["by_provider"]["baas"]["total"] == 1
 
         bootstrap_auth = assert_success(
             client.post(
@@ -235,7 +235,7 @@ def test_device_live_local_provider_lifecycle(live_backend):
                 },
             )
         )["data"]
-        assert bootstrap_auth["agent_code"] == f"local_{bot['bot_id']}"
+        assert bootstrap_auth["agent_code"] == "local_default"
 
         invalid_alive = client.post(
             "/api/v1/devices/callback/alive",
@@ -266,25 +266,28 @@ def test_device_live_local_provider_lifecycle(live_backend):
         assert forbidden["success"] is False
         assert forbidden["error_code"] == 403
 
-        instances = client.get(f"/api/v1/devices/{binding_id}/instances").json()
-        assert instances["success"] is False
-        assert instances["error_code"] == 40403
-        assert "does not support instances query" in instances["message"]
+        instances = assert_success(
+            client.get(f"/api/v1/devices/{binding_id}/instances")
+        )["data"]
+        assert instances["bot_uuid"] == device_id
+        # Local BaaS currently owns the binding but does not expose per-instance
+        # inventory. Keep this explicit until that local API is implemented.
+        assert instances["devices"] == []
 
         instances_by_bot = client.get(
             f"/api/v1/devices/bots/{bot['bot_id']}/instances"
         ).json()
         assert instances_by_bot["success"] is False
         assert instances_by_bot["error_code"] == 40403
-        assert "BotPublishRepository not available" in instances_by_bot["message"]
+        assert "No success publish record" in instances_by_bot["message"]
 
         restart = client.post(
             f"/api/v1/devices/{binding_id}/restart",
             json={"device_uuid": device_id},
         ).json()
         assert restart["success"] is False
-        assert restart["error_code"] == 40403
-        assert "does not support instances query" in restart["message"]
+        assert restart["error_code"] == 50000
+        assert "Device(s) not found" in restart["message"]
 
         env_update = assert_success(
             client.post(
@@ -309,27 +312,16 @@ def test_device_live_local_provider_lifecycle(live_backend):
         readback = assert_success(client.get(f"/api/v1/devices/{binding_id}"))["data"]
         assert readback["status"] == "RELEASED"
 
-        reapplied = assert_success(
-            client.post(
-                "/api/v1/devices",
-                json={
-                    "apply_reason": "restore released singlebox device",
-                    "entity_id": user_id,
-                    "entity_type": "staff",
-                    "bot_id": bot["bot_id"],
-                    "engine": "openclaw",
-                },
-            )
-        )["data"]
-        reapplied_binding_id = int(reapplied["id"])
-        assert reapplied["device_provider"] == "local"
-        active_reapplied = wait_device_active(client, reapplied_binding_id)
-        assert active_reapplied["device_id"] == reapplied["device_id"]
-
-        final_release = assert_success(
-            client.post(
-                f"/api/v1/devices/{reapplied_binding_id}/release",
-                json={"release_reason": "reapplied device acceptance complete"},
-            )
-        )["data"]
-        assert final_release["status"] == "RELEASED"
+        reapplied = client.post(
+            "/api/v1/devices",
+            json={
+                "apply_reason": "restore released singlebox device",
+                "entity_id": user_id,
+                "entity_type": "staff",
+                "bot_id": bot["bot_id"],
+                "engine": "openclaw",
+            },
+        ).json()
+        assert reapplied["success"] is False
+        assert reapplied["error_code"] == 50000
+        assert "bot_type is required" in reapplied["message"]

--- a/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
+++ b/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
@@ -1,8 +1,8 @@
 """Route-B acceptance: devices query and local-provider lifecycle.
 
-Starts a real singlebox backend (in-memory SQLite via local_setup.sh),
-runs the 3 read-only flows, asserts the no-data baseline, and creates one real
-personal bot through Backend -> BaaS before exercising its device binding.
+Runs against the real standalone stack started by `singlebox_coverage.sh`,
+asserts the no-data query contracts, and creates one real personal bot through
+Backend -> BaaS before exercising its device binding.
 
 The open-source singlebox records the created binding as provider ``local``.
 Connection and release are supported; instance-list and restart are

--- a/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
+++ b/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
@@ -48,18 +48,21 @@ def wait_device_active(
     last: dict | None = None
     while time.monotonic() < deadline:
         response = client.get(f"/api/v1/devices/{binding_id}")
-        assert response.status_code == 200, response.text
-        payload = response.json()
-        if payload.get("success") is True:
-            last = payload["data"]
-            if last["status"] == "ACTIVE":
-                return last
-            assert last["status"] != "FAILED", last
+        if response.status_code == 200:
+            payload = response.json()
+            if payload.get("success") is True:
+                last = payload["data"]
+                if last["status"] == "ACTIVE":
+                    return last
+                assert last["status"] != "FAILED", last
+            else:
+                # Bot readiness and the BaaS alive callback are asynchronous. A
+                # business error may briefly race the SQLite callback transaction.
+                last = payload
         else:
-            # Bot readiness and the BaaS alive callback are asynchronous. A read
-            # may briefly race the SQLite callback transaction; only a persistent
-            # failure should fail the acceptance story.
-            last = payload
+            # Transport/framework errors are retried as well. The final response
+            # remains visible in the timeout failure instead of being swallowed.
+            last = {"status_code": response.status_code, "text": response.text}
         time.sleep(2)
     pytest.fail(f"device binding {binding_id} did not become active; last={last}")
 

--- a/src/backend/tests/community/framework/test_device_acceptance_polling.py
+++ b/src/backend/tests/community/framework/test_device_acceptance_polling.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from tests.community.acceptance.devices import test_device_query_lifecycle
+
+
+def test_wait_device_active_retries_transient_http_error(monkeypatch):
+    class Response:
+        def __init__(self, status_code: int, payload: dict, text: str = "") -> None:
+            self.status_code = status_code
+            self._payload = payload
+            self.text = text
+
+        def json(self) -> dict:
+            return self._payload
+
+    class Client:
+        def __init__(self) -> None:
+            self.responses = [
+                Response(503, {}, "temporarily unavailable"),
+                Response(200, {"success": True, "data": {"status": "ACTIVE"}}),
+            ]
+
+        def get(self, _path: str) -> Response:
+            return self.responses.pop(0)
+
+    monkeypatch.setattr(test_device_query_lifecycle.time, "sleep", lambda _seconds: None)
+
+    assert test_device_query_lifecycle.wait_device_active(
+        Client(), 7, timeout_sec=1
+    ) == {"status": "ACTIVE"}

--- a/src/backend/tests/community/utils/test_singlebox_coverage_runtime.py
+++ b/src/backend/tests/community/utils/test_singlebox_coverage_runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.singlebox_coverage import (
@@ -129,3 +129,26 @@ def test_http_middleware_records_fastapi_route_hits(monkeypatch, tmp_path):
     hits = _jsonl(tmp_path / "backend" / "router_hits.jsonl")
     assert hits[0]["key"] == "GET /api/demo/{item_id}"
     assert hits[0]["path"] == "/api/demo/42"
+
+
+def test_http_middleware_restores_nested_router_prefix(monkeypatch, tmp_path):
+    monkeypatch.setenv("SINGLEBOX_COVERAGE", "1")
+    monkeypatch.setenv("SINGLEBOX_COVERAGE_DIR", str(tmp_path))
+    app = FastAPI()
+    install_singlebox_coverage_middleware(app)
+    child = APIRouter(prefix="/files")
+    parent = APIRouter(prefix="/api/resources")
+
+    @child.get("/{file_id}")
+    def get_file(file_id: str):
+        return {"file_id": file_id}
+
+    parent.include_router(child)
+    app.include_router(parent)
+
+    response = TestClient(app).get("/api/resources/files/report.txt")
+
+    assert response.status_code == 200
+    hits = _jsonl(tmp_path / "backend" / "router_hits.jsonl")
+    assert hits[0]["key"] == "GET /api/resources/files/{file_id}"
+    assert hits[0]["path"] == "/api/resources/files/report.txt"


### PR DESCRIPTION
## Summary

- add a reusable module-level singlebox coverage manifest, reporter, threshold gate, and dashboard artifact
- establish `devices` as an Avernet coverage module with real Backend -> BaaS acceptance stories
- cover device allocation, query, binding-level connection, filesystem config, provider inventory, bootstrap auth, callback guards, environment updates, instance/restart behavior, release, and re-application behavior
- keep runtime evidence at existing boundaries without adding coverage-only imports or branches to Core business code

## Dependency order

This PR is stacked on #98, which is stacked on #93:

`#93 Profile/Env separation -> #98 singlebox BaaS provider -> #62 device coverage`

Singlebox is a `DeployProfile`; persisted Device Env remains `dev`, and the real singlebox binding provider is `baas`.

## Honest current behavior

The acceptance flow creates a real personal bot through Backend and BaaS. It asserts both successful behavior and current local-BaaS gaps:

- binding-level BaaS connection succeeds
- bot-id routes currently have no successful publish record
- local BaaS currently returns an empty per-instance inventory
- restart cannot target an instance while that inventory is empty
- reapply currently lacks the required `bot_type` HTTP input

The test does not seed records or manufacture instance state to turn these gaps into synthetic success paths.

## Result

- Device Core line coverage: **51.50%** (`1788/3472`), target `43.36%`
- Device Router API coverage: **88.89%** (`16/18`), target `44.44%`
- Device Plugin API: **N/A** until an honestly attributable Device-owned runtime Plugin API denominator exists
- Device acceptance: **5 passed** on a real standalone stack

## Validation

- focused reporter/runtime/device tests: `17 passed`
- device acceptance: `5 passed`
- full pre-push Backend gate passed
- full pre-push BaaS gate: `6053 passed`, case pass rate `100%`, changed-line coverage `100% (3/3)`
- real singlebox coverage gate passed
- final push completed through the repository pre-push hook

Please re-review the updated BaaS-backed lifecycle after #98.
