### PR TITLE
feat(bot-publish): offload oversized teclaw config_artifact to object storage

### DIFF
--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/plan.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/plan.md
@@ -1,0 +1,159 @@
+# Plan: Teclaw Config Artifact Offloading for Large Bots
+
+## Approach
+Do the offload transparently at the **repository persistence boundary** so none
+of the ~20 service-layer sites that read/write `ext["config_artifact"]` change.
+On write, if the serialized artifact exceeds a byte threshold, upload its JSON to
+object storage under a deterministic per-record key and replace it in `ext` with
+a small self-describing marker. On read, if the marker is present, fetch the JSON
+back and re-inline it as `ext["config_artifact"]` so callers see the identical
+shape they see today. Offloading is gated on the storage backend exposing a read
+method; if it doesn't, we store inline (current behavior) and warn.
+
+## Affected Components
+- `src/backend/src/agentclaw/community/plugin_api/object_storage.py` — the
+  `ObjectStoragePlugin` Protocol; add a `get_object` read method.
+- `src/backend/src/agentclaw/community/plugins/community/object_storage.py` —
+  the two real impls (filesystem + S3); implement `get_object`.
+- `src/backend/src/agentclaw/community/plugins/local/oss_storage.py` — the
+  `MockObjectStoragePlugin` test double; add a `get_object` mock handle.
+- `src/backend/src/agentclaw/community/plugins/bot_publish_repository.py` — the
+  unified `BotPublishRepository`; owns the offload/inload logic.
+- `src/backend/tests/community/plugins/test_bot_publish_unified.py` — round-trip
+  tests with an in-memory fake OSS.
+
+Unchanged (deliberately): the ORM model / `to_record` at
+`src/backend/src/agentclaw/community/core/service_bot/repository/models.py:161`
+(the `ext = Column(Text, ...)` field) and every service-layer reader/writer of
+`ext["config_artifact"]` (e.g. `bot_publish_service.py:383`,
+`publish_flow_service.py` ~15 sites, `teclaw_provision_service.py:145`).
+
+## Data Model Changes
+None. No schema migration. The `ac_bot_publish.ext` `TEXT` column stays as-is;
+we only change what we put *into* it when the artifact is large. Object-storage
+key layout (deterministic, overwrite-on-update so no orphan accumulation):
+
+    teclaw/{env}/bot_publish/{publish_id}/config_artifact.json
+
+The marker stored inline under a new `ext` key `config_artifact_oss` (sibling of,
+and mutually exclusive with, `config_artifact`):
+
+```json
+{
+  "offloaded": true,
+  "oss_key": "teclaw/dev/bot_publish/42/config_artifact.json",
+  "size_bytes": 91234,
+  "threshold_bytes": 61440,
+  "note": "config_artifact (91234 bytes) exceeded the 61440-byte inline limit for the ac_bot_publish.ext TEXT column and was stored in object storage at oss_key; the repository re-inlines it as ext['config_artifact'] on read."
+}
+```
+
+## API / Interface Changes
+- **`ObjectStoragePlugin.get_object(key: str) -> bytes | None`** (new Protocol
+  method). Returns the object's bytes, or `None` if missing / on swallowed
+  transport error (matches the Protocol's "swallow errors, let caller decide"
+  convention used by the other methods).
+- **`BotPublishRepository.__init__`** gains an optional injected
+  `oss: ObjectStoragePlugin | None = None` (keyword, default `None`). Default
+  keeps direct construction in tests working; DI injects the real binding
+  (bound via the `bot_oss_client` provider, `di/config.py:183`).
+- No changes to `BotPublishRepositoryProtocol` (the offload is an impl detail).
+
+## Key Files & Functions
+- `plugin_api/object_storage.py` — add `get_object` to the Protocol (docstring:
+  returns bytes or None, swallow errors).
+- `plugins/community/object_storage.py`
+  - `CommunityFsObjectStorage` (class @ `:31`) — `get_object` reads via
+    `_safe_path` + `path.read_bytes()`, `None` if absent / `OSError`.
+  - `CommunityS3ObjectStorage` (class @ `:148`) — `get_object` via
+    `self._s3.get_object(...)["Body"].read()`, `None` on `self._errors`.
+- `plugins/local/oss_storage.py` — add `self.get_object = MagicMock(return_value=None)`
+  in `__init__` (`:46`) and a matching reset block in `reset_all_mocks` (`:63`).
+- `plugins/bot_publish_repository.py`
+  - Module constants: `_ARTIFACT_OSS_THRESHOLD_BYTES = 60 * 1024`,
+    `_ARTIFACT_KEY = "config_artifact"`, `_ARTIFACT_OSS_MARKER = "config_artifact_oss"`.
+  - `__init__` (`:58`) — accept/store `oss`; compute
+    `self._offload_enabled = oss is not None and callable(getattr(oss, "get_object", None))`;
+    warn once if `oss` present but `get_object` missing.
+  - `_artifact_oss_key(env, publish_id)` — build the deterministic key.
+  - `_serialize_ext(ext, publish_id, env) -> str | None` — dump `ext` to JSON,
+    offloading `config_artifact` to OSS first when enabled and over threshold
+    (measured as `len(json.dumps(artifact).encode("utf-8"))`); on `put_object`
+    failure, raise (fail loud). Replaces `json.dumps(ext, ...)` at insert (`:67`)
+    and `update_status_with_ext` (`:296`).
+  - `_resolve_ext(ext: dict|None) -> dict|None` — if the marker is present,
+    `get_object` → `json.loads` → set `config_artifact`, drop the marker; on
+    fetch failure log error and leave the marker (callers degrade via existing
+    `if config_artifact` guards).
+  - `_to_record(row)` — `rec = row.to_record(); rec.ext = self._resolve_ext(rec.ext); return rec`.
+    Replace every `row.to_record()` / `[r.to_record() ...]` in the read methods
+    (`:104,:122,:140,:160,:176,:193,:210,:231,:249,:262`) with it.
+  - `insert` (`:65`) — set `ext` *after* `db.flush()` (needs the new `publish_id`
+    for the key): build row with `ext=None`, flush, then
+    `row.ext = self._serialize_ext(ext, new_id, env)`, flush again.
+  - `update_status_with_ext` (`:289`) — `ext_json = self._serialize_ext(ext, publish_id, get_current_env())`.
+  - `delete` (`:352`) — before deleting, read the raw row `ext` JSON; if it holds
+    the marker, capture `oss_key`; delete the row; then best-effort
+    `self._oss.delete_object(oss_key)`.
+
+## Dependencies
+None new. Uses the existing `ObjectStoragePlugin` DI binding and `injector`.
+
+## Risks & Mitigations
+- **Risk:** Out-of-tree corp OSS impl lacks `get_object` → `AttributeError` in
+  prod. **Mitigation:** `_offload_enabled` capability gate — offload only when
+  `get_object` exists; otherwise inline + warn. No new crash path; fix activates
+  when corp adds the method.
+- **Risk:** OSS fetch fails on read → caller gets no artifact.
+  **Mitigation:** log a clear error and leave the marker; existing readers guard
+  with `if config_artifact`, so it degrades rather than raising. (Teclaw boot
+  that truly needs it will fail visibly with the logged key, not a silent None.)
+- **Risk:** Threshold too high → still overflow when sibling `ext` fields are
+  large; too low → needless OSS traffic. **Mitigation:** 60 KB constant with
+  ~4 KB headroom, documented and single-sourced for easy tuning.
+- **Risk:** Re-stamping the artifact each publish stage leaves orphaned OSS
+  objects. **Mitigation:** deterministic per-`publish_id` key → each write
+  overwrites the same object.
+- **Risk:** `insert` two-phase write (flush, set ext, flush) diverges from the
+  documented "plain INSERT" parity. **Mitigation:** still a single INSERT within
+  one session/transaction; the second flush only updates `ext` before commit.
+  Covered by the existing insert parity test plus new offload tests.
+
+## Alternatives Considered
+- **Explicit ref threaded through the service layer** — every reader/writer of
+  `config_artifact` handles the ref. Rejected: ~20 sites, high churn/risk vs. one
+  choke point at the repo.
+- **Always offload (no threshold)** — simpler branch, but an OSS round-trip on
+  every read/write of every publish record, including tiny ones. Rejected per
+  spec (branch by size).
+- **`sign_url` + HTTP GET instead of `get_object`** — avoids a Protocol method
+  but adds an HTTP dependency and presign edge cases inside the repo. Rejected:
+  a direct read method is cleaner and the Protocol explicitly invites new methods
+  "as a consumer lights up".
+- **Resolve inside the ORM `to_record`** — would need OSS in the kernel/model
+  layer (forbidden by layering) and would affect other repos. Rejected.
+
+## Rollout
+- No migration, no feature flag. Behavior is size-triggered and backward
+  compatible: existing small records are untouched; already-stored inline
+  artifacts keep working (no marker → no fetch). New large writes offload.
+- Corp deployment gets the fix once its out-of-tree OSS impl implements
+  `get_object`; until then it safely stores inline (unchanged from today).
+- Backward read compat: a record written before this change has no marker, so
+  `_resolve_ext` is a no-op.
+
+## Test Strategy
+Unit / integration (`test_bot_publish_unified.py`, SQLite + in-memory fake OSS):
+- Small artifact → stored inline, no `put_object` call, no marker, round-trips.
+- Large artifact (> threshold) → `put_object` called, `ext` holds the marker (no
+  inline `config_artifact`), OSS holds the JSON; `get_by_id`/queries re-inline the
+  full artifact; `config_artifact_oss` absent from the returned record.
+- Offload via `insert` (upgrade-draft path carrying a large `prior_artifact`) —
+  key uses the post-flush `publish_id`.
+- Re-write same record twice → same key overwritten (one object).
+- `delete` removes the OSS object.
+- Capability gate: `oss=None` and `oss` without `get_object` → inline, no offload.
+- Write-failure: `put_object` returns `False` on an over-threshold artifact →
+  raises (fail loud).
+Also add a small `get_object` test for `CommunityFsObjectStorage` (write→read→
+missing key returns `None`).

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/spec.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/spec.md
@@ -31,22 +31,35 @@ size, without a risky schema migration of the existing field.
   understand and trace the data without guessing.
 
 ## Acceptance Criteria
-- [ ] A bot whose serialized artifact exceeds the configured size threshold can
+- [x] A bot whose serialized artifact exceeds the configured size threshold can
       be built, published, upgraded, and booted with no size-related failure.
-- [ ] Small artifacts (under the threshold) are stored exactly as they are today
-      — no object-storage round trip, no behavior change.
-- [ ] Callers that read the publish record always receive the full artifact,
+      *(Offload keeps the column small; verified at the repository boundary — the
+      single locus every read/write flows through — with SQLite + a fake OSS.)*
+- [x] Small artifacts (under the threshold) are stored exactly as they are today
+      — no object-storage round trip, no behavior change. *(18 pre-existing
+      parity tests unchanged; `test_small_artifact_stays_inline`.)*
+- [x] Callers that read the publish record always receive the full artifact,
       whether it was stored inline or offloaded — the offload is invisible to
-      them.
-- [ ] When an artifact is offloaded, the stored record carries a clearly-named
+      them. *(`test_large_artifact_offloaded_and_reinlined` across get_by_id, a
+      query, and a list.)*
+- [x] When an artifact is offloaded, the stored record carries a clearly-named
       marker indicating (a) that offloading happened, (b) where the content is,
       and (c) the original size and threshold, plus a short human-readable note.
-- [ ] Deleting a publish record also removes its offloaded artifact content, so
-      object storage does not accumulate orphans.
-- [ ] Repeated writes of the same record (e.g. re-stamping during the publish
-      flow) do not accumulate stale offloaded copies.
-- [ ] The threshold is a single, documented value with headroom below the field
-      cap so other data in the same field still fits.
+- [x] Deleting a publish record also removes its offloaded artifact content, so
+      object storage does not accumulate orphans. *(delete() sweeps the whole
+      per-record prefix.)*
+- [~] Repeated writes of the same record (e.g. re-stamping during the publish
+      flow) do not accumulate stale offloaded copies. *(DEVIATION: keys are now
+      content-addressed for correctness — an immutable object per distinct
+      artifact version, so a rejected/concurrent write can never clobber a live
+      record's bytes. Superseded versions therefore persist for the record's
+      lifetime and are reaped together by delete()'s prefix sweep, rather than
+      being overwritten in place. No unbounded orphans; storage cost only. See
+      plan.md "Risks" and the review trail. Write-time GC was rejected — it
+      reintroduces a delete-vs-read race.)*
+- [x] The threshold is a single, documented value with headroom below the field
+      cap so other data in the same field still fits. *(`_ARTIFACT_OSS_THRESHOLD_BYTES
+      = 60 * 1024`; `test_threshold_boundary`.)*
 
 ## In Scope
 - Size-based decision to store the artifact inline vs. in object storage.

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/spec.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/spec.md
@@ -1,0 +1,77 @@
+# Teclaw Config Artifact Offloading for Large Bots
+
+## Summary
+When a teclaw bot is built and published, the backend saves the bot's full
+configuration artifact into a publish record and reads it back later to boot the
+bot. For richly-configured bots this artifact can grow past the size limit of
+the database field it is stored in, causing the save to fail or silently
+truncate. This feature keeps large artifacts out of that field by storing their
+content in object storage and keeping only a small, self-describing reference in
+the record — so bots of any configuration size can be published and booted
+reliably.
+
+## Motivation
+The configuration artifact is persisted as JSON inside a single database field
+that has a hard byte-size cap (~64 KB). The artifact bundles the bot's resolved
+skills, resources, identity files, MCP servers (with inlined credentials), and
+an opaque engine-owned blob. As bots accumulate configuration, real artifacts
+have started to approach and exceed this cap. When that happens today the write
+either errors out or is truncated, which breaks publishing and can corrupt a
+bot's boot configuration. We need publishing to be robust regardless of artifact
+size, without a risky schema migration of the existing field.
+
+## User Stories
+- As a bot owner, I want to publish a heavily-configured teclaw bot without
+  hitting an opaque failure, so that my bot deploys the same way small ones do.
+- As a backend engineer, I want oversized artifacts handled transparently by the
+  storage layer, so that the many code paths that read and write the artifact do
+  not each need to know about the size workaround.
+- As an operator debugging a publish record, I want a record whose artifact was
+  offloaded to clearly say so and point to where the content lives, so that I can
+  understand and trace the data without guessing.
+
+## Acceptance Criteria
+- [ ] A bot whose serialized artifact exceeds the configured size threshold can
+      be built, published, upgraded, and booted with no size-related failure.
+- [ ] Small artifacts (under the threshold) are stored exactly as they are today
+      — no object-storage round trip, no behavior change.
+- [ ] Callers that read the publish record always receive the full artifact,
+      whether it was stored inline or offloaded — the offload is invisible to
+      them.
+- [ ] When an artifact is offloaded, the stored record carries a clearly-named
+      marker indicating (a) that offloading happened, (b) where the content is,
+      and (c) the original size and threshold, plus a short human-readable note.
+- [ ] Deleting a publish record also removes its offloaded artifact content, so
+      object storage does not accumulate orphans.
+- [ ] Repeated writes of the same record (e.g. re-stamping during the publish
+      flow) do not accumulate stale offloaded copies.
+- [ ] The threshold is a single, documented value with headroom below the field
+      cap so other data in the same field still fits.
+
+## In Scope
+- Size-based decision to store the artifact inline vs. in object storage.
+- Transparent re-inlining of offloaded artifacts on read.
+- A self-describing reference marker for offloaded artifacts.
+- Cleanup of offloaded content when a publish record is deleted.
+- The ability to read an object back out of object storage (a read capability
+  the storage abstraction does not currently expose).
+
+## Out of Scope
+- Migrating or changing the type of the existing database field.
+- Backfilling / rewriting artifacts already stored in existing records.
+- Compressing or trimming the artifact's contents to make it smaller.
+- Changing the published artifact contract that external engines consume (the
+  offload marker is an internal storage detail, never surfaced to the engine).
+- Offloading any other large field besides the config artifact.
+
+## Resolved Decisions
+- **Threshold value:** ~60 KB (leaving ~4 KB headroom under the 64 KB field cap
+  for sibling data in the same field). *(accepted)*
+- **Missing read capability on a deployment:** if the object-storage
+  implementation does not expose a read method, disable offloading entirely and
+  store inline (old behavior), logging a clear warning. This guarantees no
+  runtime failure on deployments whose out-of-tree implementation has not yet
+  added the read method; the size fix activates automatically once it does.
+  *(accepted)*
+- **Offload failure at write time:** fail loudly rather than silently fall back
+  to an inline write that would hit the field cap and truncate. *(accepted)*

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
@@ -55,23 +55,25 @@
         paths in Task 5).
 - **Depends on:** Task 1
 
-## Task 5: Wire offload/inload into the repository read & write paths
+## Task 5: [x] Wire offload/inload into the repository read & write paths
 - **Goal:** Make persistence transparently offload large artifacts and re-inline
   them on read; clean up on delete.
 - **Files:** `src/backend/src/agentclaw/community/plugins/bot_publish_repository.py`
 - **Done when:**
-  - [ ] `_to_record(row)` helper applies `_resolve_ext` to `row.to_record().ext`;
+  - [x] `_to_record(row)` helper applies `_resolve_ext` to `row.to_record().ext`;
         every read method returns records through it (get_by_id, the `get_*`
         queries, and the `list_*` comprehensions).
-  - [ ] `insert` sets `ext` after `db.flush()` (so the key uses the new
+  - [x] `insert` sets `ext` after `db.flush()` (so the key uses the new
         `publish_id`): build row with `ext=None`, flush, `row.ext =
         _serialize_ext(ext, new_id, env)`, flush again — still one INSERT / one
         transaction.
-  - [ ] `update_status_with_ext` builds `ext_json` via
+  - [x] `update_status_with_ext` builds `ext_json` via
         `_serialize_ext(ext, publish_id, get_current_env())`.
-  - [ ] `delete` reads the raw row `ext` first; if it holds the marker, captures
-        `oss_key`, deletes the row, then best-effort `delete_object(oss_key)`.
-  - [ ] `update_status` (no ext) and other non-ext updates are unchanged.
+  - [x] `delete` looks up the raw marker `oss_key` first (only when OSS is
+        configured), keeps the single hard DELETE, then best-effort
+        `delete_object(oss_key)` on success.
+  - [x] `update_status` (no ext) and other non-ext updates are unchanged.
+  - [x] Existing `test_bot_publish_unified.py` still green (18 passed).
 - **Depends on:** Task 4
 
 ## Task 6: Tests & Verification

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
@@ -21,12 +21,12 @@
         on `self._errors` (incl. missing-key `ClientError`).
 - **Depends on:** Task 1
 
-## Task 3: Add `get_object` to the mock object-storage double
+## Task 3: [x] Add `get_object` to the mock object-storage double
 - **Goal:** Tests and the local runtime satisfy the extended Protocol.
 - **Files:** `src/backend/src/agentclaw/community/plugins/local/oss_storage.py`
 - **Done when:**
-  - [ ] `MockObjectStoragePlugin.__init__` adds `self.get_object = MagicMock(return_value=None)`.
-  - [ ] `reset_all_mocks` resets `get_object` (return_value `None`, clears side_effect/history).
+  - [x] `MockObjectStoragePlugin.__init__` adds `self.get_object = MagicMock(return_value=None)`.
+  - [x] `reset_all_mocks` resets `get_object` (return_value `None`, clears side_effect/history).
 - **Depends on:** Task 1
 
 ## Task 4: Add offload helpers + constants to the publish repository

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Teclaw Config Artifact Offloading for Large Bots
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+## Task 1: Add `get_object` to the object-storage abstraction
+- **Goal:** Give `ObjectStoragePlugin` a read method so offloaded artifacts can be
+  fetched back.
+- **Files:** `src/backend/src/agentclaw/community/plugin_api/object_storage.py`
+- **Done when:**
+  - [ ] Protocol declares `get_object(self, key: str) -> bytes | None` with a
+        docstring matching the "swallow transport errors, return None" convention.
+- **Depends on:** —
+
+## Task 2: Implement `get_object` in the real object-storage backends
+- **Goal:** Both deployable impls can read an object's bytes.
+- **Files:** `src/backend/src/agentclaw/community/plugins/community/object_storage.py`
+- **Done when:**
+  - [ ] `CommunityFsObjectStorage.get_object` returns bytes via `_safe_path` +
+        `read_bytes()`, and `None` for a missing key / escaping key / `OSError`.
+  - [ ] `CommunityS3ObjectStorage.get_object` returns the body bytes, and `None`
+        on `self._errors` (incl. missing-key `ClientError`).
+- **Depends on:** Task 1
+
+## Task 3: Add `get_object` to the mock object-storage double
+- **Goal:** Tests and the local runtime satisfy the extended Protocol.
+- **Files:** `src/backend/src/agentclaw/community/plugins/local/oss_storage.py`
+- **Done when:**
+  - [ ] `MockObjectStoragePlugin.__init__` adds `self.get_object = MagicMock(return_value=None)`.
+  - [ ] `reset_all_mocks` resets `get_object` (return_value `None`, clears side_effect/history).
+- **Depends on:** Task 1
+
+## Task 4: Add offload helpers + constants to the publish repository
+- **Goal:** Introduce the size threshold, marker shape, key builder, and the
+  serialize/resolve helpers — without wiring them into read/write paths yet.
+- **Files:** `src/backend/src/agentclaw/community/plugins/bot_publish_repository.py`
+- **Done when:**
+  - [ ] Module constants: `_ARTIFACT_OSS_THRESHOLD_BYTES = 60 * 1024`,
+        `_ARTIFACT_KEY = "config_artifact"`, `_ARTIFACT_OSS_MARKER = "config_artifact_oss"`.
+  - [ ] `__init__` accepts injected `oss: ObjectStoragePlugin | None = None`,
+        stores it, and sets `self._offload_enabled` (True only when `oss` is
+        present AND exposes a callable `get_object`); warns once when `oss` is
+        present but lacks `get_object`.
+  - [ ] `_artifact_oss_key(env, publish_id)` returns
+        `teclaw/{env}/bot_publish/{publish_id}/config_artifact.json`.
+  - [ ] `_serialize_ext(ext, publish_id, env) -> str | None`: offloads
+        `config_artifact` to OSS when `_offload_enabled` and the artifact's UTF-8
+        JSON byte length > threshold; replaces it with the self-describing marker;
+        raises on `put_object` failure (fail loud); returns `json.dumps(ext)` (or
+        `None` when `ext is None`). Inline path unchanged when under threshold /
+        offload disabled.
+  - [ ] `_resolve_ext(ext) -> ext`: when the marker is present, `get_object` +
+        `json.loads` → set `config_artifact`, drop the marker; on fetch failure,
+        log an error and return `ext` with the marker intact.
+- **Depends on:** Task 1
+
+## Task 5: Wire offload/inload into the repository read & write paths
+- **Goal:** Make persistence transparently offload large artifacts and re-inline
+  them on read; clean up on delete.
+- **Files:** `src/backend/src/agentclaw/community/plugins/bot_publish_repository.py`
+- **Done when:**
+  - [ ] `_to_record(row)` helper applies `_resolve_ext` to `row.to_record().ext`;
+        every read method returns records through it (get_by_id, the `get_*`
+        queries, and the `list_*` comprehensions).
+  - [ ] `insert` sets `ext` after `db.flush()` (so the key uses the new
+        `publish_id`): build row with `ext=None`, flush, `row.ext =
+        _serialize_ext(ext, new_id, env)`, flush again — still one INSERT / one
+        transaction.
+  - [ ] `update_status_with_ext` builds `ext_json` via
+        `_serialize_ext(ext, publish_id, get_current_env())`.
+  - [ ] `delete` reads the raw row `ext` first; if it holds the marker, captures
+        `oss_key`, deletes the row, then best-effort `delete_object(oss_key)`.
+  - [ ] `update_status` (no ext) and other non-ext updates are unchanged.
+- **Depends on:** Task 4
+
+## Task 6: Tests & Verification
+- **Goal:** Prove the spec's acceptance criteria with an in-memory fake OSS.
+- **Files:** `src/backend/tests/community/plugins/test_bot_publish_unified.py`
+  (and a small `get_object` check for the fs backend, colocated or in the
+  existing object-storage test module if one exists)
+- **Done when:**
+  - [ ] Small artifact → inline, no `put_object`, no marker, round-trips unchanged.
+  - [ ] Large artifact → `put_object` called, `ext` holds only the marker, OSS
+        holds the JSON; reads (`get_by_id` + a query + a `list_*`) re-inline the
+        full artifact and the marker key is absent from the returned record.
+  - [ ] `insert` with an over-threshold `prior_artifact` offloads under a key
+        containing the post-flush `publish_id`.
+  - [ ] Two writes of the same record reuse/overwrite one OSS key.
+  - [ ] `delete` removes the OSS object.
+  - [ ] Capability gate: `oss=None` and an `oss` lacking `get_object` both store
+        inline (no offload, no crash).
+  - [ ] Over-threshold artifact with `put_object` → `False` raises (fail loud).
+  - [ ] `CommunityFsObjectStorage.get_object` write→read→missing-key(None) passes.
+  - [ ] Existing `test_bot_publish_unified.py` suite still green.
+- **Depends on:** Task 5
+
+---
+
+## Groups
+
+- **Group A — Storage read capability:** Tasks 1, 2, 3
+  - Theme: `ObjectStoragePlugin` can read objects across the Protocol and all
+    three impls (fs, S3, mock). Self-contained; no behavior change yet.
+- **Group B — Repository offload:** Tasks 4, 5
+  - Theme: `BotPublishRepository` transparently offloads oversized artifacts to
+    OSS and re-inlines them, with delete-time cleanup — the core feature.
+- **Group C — Verification:** Task 6
+  - Theme: Round-trip + edge-case tests proving every spec acceptance criterion.

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
@@ -29,28 +29,30 @@
   - [x] `reset_all_mocks` resets `get_object` (return_value `None`, clears side_effect/history).
 - **Depends on:** Task 1
 
-## Task 4: Add offload helpers + constants to the publish repository
+## Task 4: [x] Add offload helpers + constants to the publish repository
 - **Goal:** Introduce the size threshold, marker shape, key builder, and the
   serialize/resolve helpers — without wiring them into read/write paths yet.
 - **Files:** `src/backend/src/agentclaw/community/plugins/bot_publish_repository.py`
 - **Done when:**
-  - [ ] Module constants: `_ARTIFACT_OSS_THRESHOLD_BYTES = 60 * 1024`,
+  - [x] Module constants: `_ARTIFACT_OSS_THRESHOLD_BYTES = 60 * 1024`,
         `_ARTIFACT_KEY = "config_artifact"`, `_ARTIFACT_OSS_MARKER = "config_artifact_oss"`.
-  - [ ] `__init__` accepts injected `oss: ObjectStoragePlugin | None = None`,
+  - [x] `__init__` accepts injected `oss: ObjectStoragePlugin | None = None`,
         stores it, and sets `self._offload_enabled` (True only when `oss` is
         present AND exposes a callable `get_object`); warns once when `oss` is
         present but lacks `get_object`.
-  - [ ] `_artifact_oss_key(env, publish_id)` returns
+  - [x] `_artifact_oss_key(env, publish_id)` returns
         `teclaw/{env}/bot_publish/{publish_id}/config_artifact.json`.
-  - [ ] `_serialize_ext(ext, publish_id, env) -> str | None`: offloads
+  - [x] `_serialize_ext(ext, publish_id, env) -> str | None`: offloads
         `config_artifact` to OSS when `_offload_enabled` and the artifact's UTF-8
         JSON byte length > threshold; replaces it with the self-describing marker;
         raises on `put_object` failure (fail loud); returns `json.dumps(ext)` (or
         `None` when `ext is None`). Inline path unchanged when under threshold /
         offload disabled.
-  - [ ] `_resolve_ext(ext) -> ext`: when the marker is present, `get_object` +
+  - [x] `_resolve_ext(ext) -> ext`: when the marker is present, `get_object` +
         `json.loads` → set `config_artifact`, drop the marker; on fetch failure,
         log an error and return `ext` with the marker intact.
+  - [x] `_to_record(row)` helper re-inlines via `_resolve_ext` (wired into read
+        paths in Task 5).
 - **Depends on:** Task 1
 
 ## Task 5: Wire offload/inload into the repository read & write paths

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
@@ -76,25 +76,29 @@
   - [x] Existing `test_bot_publish_unified.py` still green (18 passed).
 - **Depends on:** Task 4
 
-## Task 6: Tests & Verification
+## Task 6: [x] Tests & Verification
 - **Goal:** Prove the spec's acceptance criteria with an in-memory fake OSS.
-- **Files:** `src/backend/tests/community/plugins/test_bot_publish_unified.py`
-  (and a small `get_object` check for the fs backend, colocated or in the
-  existing object-storage test module if one exists)
+- **Files:** `src/backend/tests/community/plugins/test_bot_publish_unified.py`,
+  `src/backend/tests/community/plugins/community/test_object_storage.py`
 - **Done when:**
-  - [ ] Small artifact → inline, no `put_object`, no marker, round-trips unchanged.
-  - [ ] Large artifact → `put_object` called, `ext` holds only the marker, OSS
+  - [x] Small artifact → inline, no `put_object`, no marker, round-trips unchanged.
+  - [x] Large artifact → `put_object` called, `ext` holds only the marker, OSS
         holds the JSON; reads (`get_by_id` + a query + a `list_*`) re-inline the
         full artifact and the marker key is absent from the returned record.
-  - [ ] `insert` with an over-threshold `prior_artifact` offloads under a key
-        containing the post-flush `publish_id`.
-  - [ ] Two writes of the same record reuse/overwrite one OSS key.
-  - [ ] `delete` removes the OSS object.
-  - [ ] Capability gate: `oss=None` and an `oss` lacking `get_object` both store
+  - [x] `insert` with an over-threshold artifact offloads under a key containing
+        the post-flush `publish_id`; `update_status_with_ext` offloads too.
+  - [x] Rejected optimistic-lock update does NOT upload (round-2 fix regression).
+  - [x] Two distinct writes of the same record → two content-addressed objects;
+        `delete` sweeps the whole prefix.
+  - [x] `delete` removes the OSS object(s); no-offload delete leaves store empty.
+  - [x] Capability gate: `oss=None` and an `oss` lacking `get_object` both store
         inline (no offload, no crash).
-  - [ ] Over-threshold artifact with `put_object` → `False` raises (fail loud).
-  - [ ] `CommunityFsObjectStorage.get_object` write→read→missing-key(None) passes.
-  - [ ] Existing `test_bot_publish_unified.py` suite still green.
+  - [x] Over-threshold artifact with `put_object` → `False` raises + rolls back.
+  - [x] Marker/inline mutual exclusion: `_strip_stale_marker` (write) and
+        `_resolve_ext` inline-wins (read) covered.
+  - [x] `CommunityFsObjectStorage`/`CommunityS3ObjectStorage` `get_object`
+        write→read→missing-key(None) passes.
+  - [x] Full suite green (55 passed: repo + object-storage).
 - **Depends on:** Task 5
 
 ---

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
@@ -11,13 +11,13 @@
         docstring matching the "swallow transport errors, return None" convention.
 - **Depends on:** —
 
-## Task 2: Implement `get_object` in the real object-storage backends
+## Task 2: [x] Implement `get_object` in the real object-storage backends
 - **Goal:** Both deployable impls can read an object's bytes.
 - **Files:** `src/backend/src/agentclaw/community/plugins/community/object_storage.py`
 - **Done when:**
-  - [ ] `CommunityFsObjectStorage.get_object` returns bytes via `_safe_path` +
+  - [x] `CommunityFsObjectStorage.get_object` returns bytes via `_safe_path` +
         `read_bytes()`, and `None` for a missing key / escaping key / `OSError`.
-  - [ ] `CommunityS3ObjectStorage.get_object` returns the body bytes, and `None`
+  - [x] `CommunityS3ObjectStorage.get_object` returns the body bytes, and `None`
         on `self._errors` (incl. missing-key `ClientError`).
 - **Depends on:** Task 1
 

--- a/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
+++ b/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/tasks.md
@@ -2,12 +2,12 @@
 
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
-## Task 1: Add `get_object` to the object-storage abstraction
+## Task 1: [x] Add `get_object` to the object-storage abstraction
 - **Goal:** Give `ObjectStoragePlugin` a read method so offloaded artifacts can be
   fetched back.
 - **Files:** `src/backend/src/agentclaw/community/plugin_api/object_storage.py`
 - **Done when:**
-  - [ ] Protocol declares `get_object(self, key: str) -> bytes | None` with a
+  - [x] Protocol declares `get_object(self, key: str) -> bytes | None` with a
         docstring matching the "swallow transport errors, return None" convention.
 - **Depends on:** —
 

--- a/src/backend/src/agentclaw/community/core/service_bot/repository/config_artifact_offload.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/repository/config_artifact_offload.py
@@ -1,0 +1,187 @@
+"""Offload an oversized ``config_artifact`` out of the ``ac_bot_publish.ext``
+column and back.
+
+The published ``config_artifact`` (a serialized ``BotConfigArtifact``) rides
+inside the ``ac_bot_publish.ext`` JSON, which is stored in a ``TEXT`` column
+capped at ~64 KB. A richly-configured teclaw bot can serialize past that. When
+it does, :class:`ConfigArtifactOffloader` writes the artifact's JSON to object
+storage and replaces it inline with a small self-describing marker, then
+re-inlines it transparently on read — so the repository's callers always see a
+plain ``ext['config_artifact']`` regardless of where the bytes actually live.
+
+This is the whole ext ⇄ object-storage transform, split out of the repository so
+the repository owns only persistence. It is a DI component holding the injected
+:class:`ObjectStoragePlugin`; every record-specific input (``publish_id``,
+``env``) is passed per call.
+
+Design invariants:
+
+* **Mutual exclusion by construction.** :meth:`prepare` drops BOTH the inline
+  ``config_artifact`` and its marker up front, then writes back exactly one. A
+  stored ext therefore never carries both, so a stale marker can never shadow a
+  freshly written inline artifact and the read path needs no both-present case.
+* **Content-addressed, immutable objects.** Each offload writes a NEW object
+  keyed by a content digest, never an in-place overwrite. A rejected
+  optimistic-lock write or a concurrent writer can never clobber the bytes a
+  still-valid record points at. Superseded versions are reaped together by
+  :meth:`cleanup` when the record is deleted.
+* **No I/O in :meth:`prepare`.** It returns a pending upload the caller performs
+  only AFTER the DB write is confirmed to persist, so a rejected write leaves no
+  orphan object.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, Optional, Tuple
+
+from injector import inject
+
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.object_storage import ObjectStoragePlugin
+
+logger = get_logger()
+
+# 60 KB leaves ~4 KB of headroom under the 65535-byte TEXT cap for the ext's
+# sibling fields (binding, migration_path, …).
+ARTIFACT_OSS_THRESHOLD_BYTES = 60 * 1024
+# The ext key holding the inline artifact, and — when offloaded — its marker.
+ARTIFACT_KEY = "config_artifact"
+ARTIFACT_OSS_MARKER = "config_artifact_oss"
+
+# (oss_key, artifact_json) — an artifact object waiting to be written.
+PendingUpload = Tuple[str, str]
+
+
+class ConfigArtifactOffloader:
+    """Move an oversized ``ext['config_artifact']`` to object storage and back."""
+
+    @inject
+    def __init__(self, oss: ObjectStoragePlugin) -> None:
+        self._oss = oss
+
+    # ── keys ────────────────────────────────────────────────────
+
+    def prefix(self, env: str, publish_id: int) -> str:
+        """Per-record object-storage prefix. Every offloaded version of one
+        publish record lives under here; :meth:`cleanup` sweeps the whole
+        subtree so superseded versions never accumulate."""
+        return f"teclaw/{env}/bot_publish/{publish_id}/"
+
+    def _key(self, env: str, publish_id: int, digest: str) -> str:
+        """Content-addressed key for one artifact version (see module invariants)."""
+        return f"{self.prefix(env, publish_id)}config_artifact-{digest}.json"
+
+    # ── write ───────────────────────────────────────────────────
+
+    def prepare(
+        self, ext: Optional[Dict[str, Any]], publish_id: int, env: str
+    ) -> Tuple[Optional[str], Optional[PendingUpload]]:
+        """Produce the JSON string to store in the ext column, plus a pending
+        object-storage upload.
+
+        Returns ``(ext_json, pending)``; ``pending`` is a :data:`PendingUpload`
+        to write via :meth:`upload`, or ``None``. Performs NO I/O — the caller
+        uploads ``pending`` only after confirming the DB write will persist.
+        """
+        if ext is None:
+            return None, None
+        # Erase both artifact keys, then fill in the single one that applies.
+        base = {
+            k: v
+            for k, v in ext.items()
+            if k not in (ARTIFACT_KEY, ARTIFACT_OSS_MARKER)
+        }
+        artifact = ext.get(ARTIFACT_KEY)
+        if artifact is None:
+            return json.dumps(base, ensure_ascii=False), None
+        artifact_json = json.dumps(artifact, ensure_ascii=False)
+        size = len(artifact_json.encode("utf-8"))
+        if size <= ARTIFACT_OSS_THRESHOLD_BYTES:
+            base[ARTIFACT_KEY] = artifact
+            return json.dumps(base, ensure_ascii=False), None
+        digest = hashlib.sha1(artifact_json.encode("utf-8")).hexdigest()[:12]
+        key = self._key(env, publish_id, digest)
+        base[ARTIFACT_OSS_MARKER] = {
+            "offloaded": True,
+            "oss_key": key,
+            "size_bytes": size,
+            "threshold_bytes": ARTIFACT_OSS_THRESHOLD_BYTES,
+            "note": (
+                f"config_artifact ({size} bytes) exceeded the "
+                f"{ARTIFACT_OSS_THRESHOLD_BYTES}-byte inline limit for the "
+                "ac_bot_publish.ext TEXT column and was stored in object storage "
+                f"at oss_key; the repository re-inlines it as ext['{ARTIFACT_KEY}'] "
+                "on read."
+            ),
+        }
+        return json.dumps(base, ensure_ascii=False), (key, artifact_json)
+
+    def upload(self, pending: Optional[PendingUpload]) -> None:
+        """Write a prepared artifact object. Fail loud on error — better than
+        silently truncating the ext column or shipping a dangling marker."""
+        if pending is None:
+            return
+        key, body = pending
+        if not self._oss.put_object(key, body):
+            raise RuntimeError(
+                f"config_artifact offload failed: put_object({key!r}) "
+                "returned False"
+            )
+
+    # ── read ────────────────────────────────────────────────────
+
+    def resolve(
+        self, ext: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Inverse of :meth:`prepare`.
+
+        If ``ext`` carries the offload marker, fetch the artifact JSON back and
+        re-inline it as ``ext['config_artifact']``, dropping the marker so
+        callers see the same shape as an inline artifact.
+
+        Fail loud: a marker whose object cannot be fetched (missing ``oss_key``
+        or ``get_object`` returning ``None``) raises. Returning a record silently
+        missing its ``config_artifact`` would let a boot proceed on a corrupt
+        config — a hard error the caller must see.
+        """
+        if not ext or ARTIFACT_OSS_MARKER not in ext:
+            return ext
+        marker = ext[ARTIFACT_OSS_MARKER]
+        key = marker.get("oss_key") if isinstance(marker, dict) else None
+        raw = self._oss.get_object(key) if key else None
+        if raw is None:
+            raise RuntimeError(
+                "config_artifact fetch failed: offloaded artifact unreadable "
+                f"at oss_key={key!r}"
+            )
+        resolved = {k: v for k, v in ext.items() if k != ARTIFACT_OSS_MARKER}
+        resolved[ARTIFACT_KEY] = json.loads(
+            raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+        )
+        return resolved
+
+    # ── delete cleanup ──────────────────────────────────────────
+
+    def cleanup(self, prefix: str) -> None:
+        """Best-effort sweep of every object under ``prefix`` (current +
+        superseded versions). Must never raise — cleanup failing is not allowed
+        to fail the caller's DB delete; a transport error is logged and dropped.
+        """
+        try:
+            for key in self._oss.list_objects(prefix):
+                self._oss.delete_object(key)
+        except Exception:  # noqa: BLE001 - best-effort artifact cleanup
+            logger.exception(
+                "[ConfigArtifactOffloader] artifact cleanup failed for "
+                "prefix=%s", prefix,
+            )
+
+
+__all__ = [
+    "ConfigArtifactOffloader",
+    "ARTIFACT_KEY",
+    "ARTIFACT_OSS_MARKER",
+    "ARTIFACT_OSS_THRESHOLD_BYTES",
+    "PendingUpload",
+]

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -97,6 +97,9 @@ from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.plugin_api.outbound_rules import OutboundRuleProvider
 from agentclaw.community.plugin_api.approval_workflow import ApprovalWorkflowPlugin
+from agentclaw.community.core.service_bot.repository.config_artifact_offload import (
+    ConfigArtifactOffloader,
+)
 from agentclaw.community.plugins.bot_publish_repository import (
     BotPublishRepository as UnifiedBotPublishRepository,
 )
@@ -110,6 +113,13 @@ class ServiceBotModule(Module):
 
     def configure(self, binder: Binder) -> None:
         binder.bind(WorkspacePathFactory, to=WorkspacePathFactory, scope=singleton)
+        # Offloads an oversized config_artifact out of the ac_bot_publish.ext
+        # TEXT column into object storage; injected into the repo below.
+        binder.bind(
+            ConfigArtifactOffloader,
+            to=ConfigArtifactOffloader,
+            scope=singleton,
+        )
         # Single unified ORM impl — runs on prod OceanBase and SQLite
         # via the injected DatabasePlugin (@inject ctor).
         binder.bind(

--- a/src/backend/src/agentclaw/community/plugin_api/object_storage.py
+++ b/src/backend/src/agentclaw/community/plugin_api/object_storage.py
@@ -40,6 +40,16 @@ class ObjectStoragePlugin(Plugin, Protocol):
         """
         ...
 
+    def get_object(self, key: str) -> bytes | None:
+        """Return the raw bytes stored at ``key``, or ``None`` if absent.
+
+        The read counterpart of :meth:`put_object`. Implementations should
+        swallow transport/SDK errors and a missing object alike into ``None``
+        rather than raising, so callers can decide policy (mirroring the rest
+        of this Protocol). Decode to text at the call site when needed.
+        """
+        ...
+
     def delete_object(self, key: str) -> bool:
         """Delete the object at ``key``. Return ``True`` on success.
 

--- a/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
@@ -34,6 +34,7 @@ reference):
 """
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Any, Dict, List, Optional
 
@@ -93,68 +94,109 @@ class BotPublishRepository:
 
     # ── config_artifact offload/inload helpers ──────────────────
 
-    def _artifact_oss_key(self, env: str, publish_id: int) -> str:
-        """Deterministic per-record key. Overwritten on each write (a publish's
-        re-stamps reuse the same object), so no orphan copies accumulate."""
-        return f"teclaw/{env}/bot_publish/{publish_id}/config_artifact.json"
+    def _artifact_prefix(self, env: str, publish_id: int) -> str:
+        """Per-record object-storage prefix. Every offloaded version of one
+        publish record lives under here; :meth:`delete` sweeps the whole subtree
+        so superseded versions never accumulate."""
+        return f"teclaw/{env}/bot_publish/{publish_id}/"
 
-    def _serialize_ext(
+    def _artifact_oss_key(self, env: str, publish_id: int, digest: str) -> str:
+        """Content-addressed key for one artifact version.
+
+        The content digest makes each write a NEW immutable object instead of an
+        in-place overwrite. That is what stops a rejected optimistic-lock write
+        (or a concurrent writer) from clobbering the object a still-valid record
+        points at — a marker always names exactly the bytes written with it.
+        Superseded versions are reaped by :meth:`delete`'s prefix sweep.
+        """
+        return (
+            f"{self._artifact_prefix(env, publish_id)}"
+            f"config_artifact-{digest}.json"
+        )
+
+    @staticmethod
+    def _strip_stale_marker(ext: Dict[str, Any]) -> Dict[str, Any]:
+        """Enforce marker/inline mutual exclusion on write.
+
+        A fresh inline ``config_artifact`` wins over a leftover marker: if both
+        are present (e.g. a caller merged a new artifact onto an ext whose marker
+        had failed to resolve), drop the marker so we never persist both — which
+        would otherwise make the next read fetch stale OSS content over the fresh
+        inline artifact.
+        """
+        if _ARTIFACT_KEY in ext and _ARTIFACT_OSS_MARKER in ext:
+            return {k: v for k, v in ext.items() if k != _ARTIFACT_OSS_MARKER}
+        return ext
+
+    def _prepare_ext(
         self, ext: Optional[Dict[str, Any]], publish_id: int, env: str
-    ) -> Optional[str]:
-        """Serialize ``ext`` to the JSON string stored in the ext column.
+    ) -> tuple[Optional[str], Optional[tuple[str, str]]]:
+        """Build the ext JSON to store, plus a pending object-storage upload.
 
-        When offloading is enabled and ``ext['config_artifact']`` serializes to
-        more than :data:`_ARTIFACT_OSS_THRESHOLD_BYTES`, its JSON is written to
-        object storage and replaced with a self-describing marker so the column
-        stays small. Raises on an object-storage write failure — a loud failure
-        beats silently truncating the ext column.
-
-        Invariant: callers pass a *resolved* ext (a full inline ``config_artifact``
-        or none; never a lingering marker), because every read path resolves the
-        marker back before handing the record out.
+        Returns ``(ext_json, pending)`` where ``pending`` is ``(oss_key,
+        artifact_json)`` to write, or ``None``. Performs NO I/O: the caller
+        uploads ``pending`` only AFTER confirming the DB write will persist, so a
+        rejected optimistic-lock update never writes an orphan or clobbers a live
+        object. When ``pending`` is set, ``ext_json`` already carries the marker
+        instead of the inline artifact.
         """
         if ext is None:
-            return None
+            return None, None
+        ext = self._strip_stale_marker(ext)
         artifact = ext.get(_ARTIFACT_KEY)
-        if self._offload_enabled and artifact is not None:
-            artifact_json = json.dumps(artifact, ensure_ascii=False)
-            size = len(artifact_json.encode("utf-8"))
-            if size > _ARTIFACT_OSS_THRESHOLD_BYTES:
-                key = self._artifact_oss_key(env, publish_id)
-                if not self._oss.put_object(key, artifact_json):
-                    raise RuntimeError(
-                        "config_artifact offload failed: "
-                        f"put_object({key!r}) returned False (size={size} bytes)"
-                    )
-                ext = {k: v for k, v in ext.items() if k != _ARTIFACT_KEY}
-                ext[_ARTIFACT_OSS_MARKER] = {
-                    "offloaded": True,
-                    "oss_key": key,
-                    "size_bytes": size,
-                    "threshold_bytes": _ARTIFACT_OSS_THRESHOLD_BYTES,
-                    "note": (
-                        f"config_artifact ({size} bytes) exceeded the "
-                        f"{_ARTIFACT_OSS_THRESHOLD_BYTES}-byte inline limit for "
-                        "the ac_bot_publish.ext TEXT column and was stored in "
-                        "object storage at oss_key; the repository re-inlines it "
-                        f"as ext['{_ARTIFACT_KEY}'] on read."
-                    ),
-                }
-        return json.dumps(ext, ensure_ascii=False)
+        if not (self._offload_enabled and artifact is not None):
+            return json.dumps(ext, ensure_ascii=False), None
+        artifact_json = json.dumps(artifact, ensure_ascii=False)
+        size = len(artifact_json.encode("utf-8"))
+        if size <= _ARTIFACT_OSS_THRESHOLD_BYTES:
+            return json.dumps(ext, ensure_ascii=False), None
+        digest = hashlib.sha1(artifact_json.encode("utf-8")).hexdigest()[:12]
+        key = self._artifact_oss_key(env, publish_id, digest)
+        ext = {k: v for k, v in ext.items() if k != _ARTIFACT_KEY}
+        ext[_ARTIFACT_OSS_MARKER] = {
+            "offloaded": True,
+            "oss_key": key,
+            "size_bytes": size,
+            "threshold_bytes": _ARTIFACT_OSS_THRESHOLD_BYTES,
+            "note": (
+                f"config_artifact ({size} bytes) exceeded the "
+                f"{_ARTIFACT_OSS_THRESHOLD_BYTES}-byte inline limit for the "
+                "ac_bot_publish.ext TEXT column and was stored in object storage "
+                f"at oss_key; the repository re-inlines it as ext['{_ARTIFACT_KEY}'] "
+                "on read."
+            ),
+        }
+        return json.dumps(ext, ensure_ascii=False), (key, artifact_json)
+
+    def _upload_pending(self, pending: Optional[tuple[str, str]]) -> None:
+        """Write a prepared artifact object. Fail loud on error — better than
+        silently truncating the ext column or shipping a dangling marker."""
+        if pending is None:
+            return
+        key, body = pending
+        if not self._oss.put_object(key, body):
+            raise RuntimeError(
+                f"config_artifact offload failed: put_object({key!r}) "
+                "returned False"
+            )
 
     def _resolve_ext(
         self, ext: Optional[Dict[str, Any]]
     ) -> Optional[Dict[str, Any]]:
-        """Inverse of the offload in :meth:`_serialize_ext`.
+        """Inverse of the offload in :meth:`_prepare_ext`.
 
         If ``ext`` carries the offload marker, fetch the artifact JSON back from
         object storage and re-inline it as ``ext['config_artifact']``, dropping
-        the marker so callers see the same shape as an inline artifact. On a
-        fetch failure, log and leave the marker in place (readers already guard
-        on a missing config_artifact) rather than raising inside a read path.
+        the marker so callers see the same shape as an inline artifact. If an
+        inline artifact is somehow also present it wins (the marker is dropped
+        without a fetch). On a fetch failure, log and leave the marker in place
+        (readers already guard on a missing config_artifact) rather than raising
+        inside a read path.
         """
         if not ext or _ARTIFACT_OSS_MARKER not in ext:
             return ext
+        if _ARTIFACT_KEY in ext:
+            return {k: v for k, v in ext.items() if k != _ARTIFACT_OSS_MARKER}
         marker = ext[_ARTIFACT_OSS_MARKER]
         key = marker.get("oss_key") if isinstance(marker, dict) else None
         raw = self._oss.get_object(key) if (self._oss and key) else None
@@ -170,10 +212,16 @@ class BotPublishRepository:
         )
         return resolved
 
-    def _to_record(self, row: "BotPublishModel") -> BotPublishRecord:
-        """Row → record with any offloaded config_artifact re-inlined."""
-        record = row.to_record()
-        record.ext = self._resolve_ext(record.ext)
+    def _resolve_record(
+        self, record: Optional[BotPublishRecord]
+    ) -> Optional[BotPublishRecord]:
+        """Re-inline an offloaded artifact on a detached record.
+
+        Called AFTER the DB session closes, so the object-storage network fetch
+        never holds a database connection open.
+        """
+        if record is not None:
+            record.ext = self._resolve_ext(record.ext)
         return record
 
     # ── insert (plain INSERT — never an upsert) ─────────────────
@@ -204,7 +252,12 @@ class BotPublishRepository:
             db.add(row)
             db.flush()
             new_id = row.id
-            row.ext = self._serialize_ext(ext, new_id, env)
+            # ext + upload only after flush: the OSS key is content-addressed
+            # under the DB-assigned publish_id. The upload runs inside the txn so
+            # a put failure rolls the whole INSERT back (no dangling marker row).
+            ext_json, pending = self._prepare_ext(ext, new_id, env)
+            row.ext = ext_json
+            self._upload_pending(pending)
             db.flush()
             logger.info("[insert] inserted bot publish id=%s", new_id)
         # Re-read after commit — prod returns get_by_id(inserted_id),
@@ -221,7 +274,8 @@ class BotPublishRepository:
                 .filter(self.Model.id == publish_id)
                 .first()
             )
-            return self._to_record(row) if row else None
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
 
     def get_by_publish_bot_id(
         self,
@@ -239,7 +293,8 @@ class BotPublishRepository:
             if publish_status:
                 query = query.filter(self.Model.status == publish_status)
             row = query.order_by(self.Model.version.desc()).first()
-            return self._to_record(row) if row else None
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
 
     def get_draft_by_publish_bot_id(
         self,
@@ -257,7 +312,8 @@ class BotPublishRepository:
                 .order_by(self.Model.version.desc())
                 .first()
             )
-            return self._to_record(row) if row else None
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
 
     def get_by_publish_bot_id_and_version(
         self,
@@ -277,7 +333,8 @@ class BotPublishRepository:
                 )
                 .first()
             )
-            return self._to_record(row) if row else None
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
 
     def list_by_owner(
         self,
@@ -293,7 +350,8 @@ class BotPublishRepository:
             if status:
                 query = query.filter(self.Model.status == status)
             rows = query.order_by(self.Model.gmt_create.desc()).all()
-            return [self._to_record(r) for r in rows]
+            records = [r.to_record() for r in rows]
+        return [self._resolve_record(r) for r in records]
 
     def list_by_source_bot(
         self,
@@ -310,7 +368,8 @@ class BotPublishRepository:
                 .order_by(self.Model.gmt_create.desc())
                 .all()
             )
-            return [self._to_record(r) for r in rows]
+            records = [r.to_record() for r in rows]
+        return [self._resolve_record(r) for r in records]
 
     def list_by_status(
         self,
@@ -327,7 +386,8 @@ class BotPublishRepository:
                 .order_by(self.Model.gmt_create.desc())
                 .all()
             )
-            return [self._to_record(r) for r in rows]
+            records = [r.to_record() for r in rows]
+        return [self._resolve_record(r) for r in records]
 
     def get_latest_by_source_bot_id_and_owner_and_status(
         self,
@@ -348,7 +408,8 @@ class BotPublishRepository:
                 .order_by(self.Model.id.desc())
                 .first()
             )
-            return self._to_record(row) if row else None
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
 
     def get_latest_success_by_source_bot_id(
         self,
@@ -366,7 +427,8 @@ class BotPublishRepository:
                 .order_by(self.Model.id.desc())
                 .first()
             )
-            return self._to_record(row) if row else None
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
 
     def get_by_last_pub_id(
         self,
@@ -379,7 +441,8 @@ class BotPublishRepository:
                 .order_by(self.Model.id.desc())
                 .first()
             )
-            return self._to_record(row) if row else None
+            record = row.to_record() if row else None
+        return self._resolve_record(record)
 
     # ── updates (single optimistic-lock statements) ─────────────
 
@@ -413,7 +476,9 @@ class BotPublishRepository:
         ext: Dict[str, Any],
         source_status: Optional[str] = None,
     ) -> Optional[BotPublishRecord]:
-        ext_json = self._serialize_ext(ext, publish_id, get_current_env())
+        ext_json, pending = self._prepare_ext(
+            ext, publish_id, get_current_env()
+        )
         with self._db.orm_session() as db:
             query = db.query(self.Model).filter(
                 self.Model.id == publish_id
@@ -428,6 +493,12 @@ class BotPublishRepository:
                 },
                 synchronize_session=False,
             )
+            # Upload the offloaded artifact only once we know this write took
+            # (optimistic lock matched). A rejected update (affected == 0) must
+            # NOT touch object storage, or it would clobber the object a still-
+            # valid record points at. Inside the txn so a put failure rolls back.
+            if not (source_status is not None and affected == 0):
+                self._upload_pending(pending)
         if source_status is not None and affected == 0:
             return None
         return self.get_by_id(publish_id)
@@ -469,40 +540,42 @@ class BotPublishRepository:
 
     # ── delete (single hard DELETE — prod parity) ───────────────
 
-    def _offloaded_key(self, publish_id: int) -> Optional[str]:
-        """Return the OSS key of this record's offloaded artifact, if any.
+    def _artifact_prefix_of(self, publish_id: int) -> Optional[str]:
+        """The object-storage prefix for this record's artifacts, from its
+        ``env`` column, or ``None`` if the row is gone.
 
-        Reads only the raw ``ext`` column (no resolution) and returns the
-        marker's ``oss_key`` when the artifact was offloaded, else ``None``.
+        Uses the deterministic prefix (not a stored marker), so it reaps EVERY
+        offloaded version under the record — the current one plus any superseded
+        (content-addressed) or shrunk-back-to-inline leftovers.
         """
         with self._db.orm_session() as db:
             row = (
-                db.query(self.Model.ext)
+                db.query(self.Model.env)
                 .filter(self.Model.id == publish_id)
                 .first()
             )
         if not row or not row[0]:
             return None
-        try:
-            ext = json.loads(row[0])
-        except (ValueError, TypeError):
-            return None
-        marker = ext.get(_ARTIFACT_OSS_MARKER) if isinstance(ext, dict) else None
-        return marker.get("oss_key") if isinstance(marker, dict) else None
+        return self._artifact_prefix(row[0], publish_id)
 
     def delete(self, publish_id: int) -> bool:
-        # Capture an offloaded artifact's OSS key (if any) before the row is
-        # gone, so object storage can be cleaned up after a successful delete.
-        # The hard DELETE below stays a single statement (prod parity); the
-        # lookup only runs when offload storage is configured.
-        oss_key = self._offloaded_key(publish_id) if self._oss is not None else None
+        # Resolve the record's artifact prefix (if any) before the row is gone,
+        # so object storage can be swept after a successful delete. The hard
+        # DELETE below stays a single statement (prod parity); the lookup only
+        # runs when offload storage is configured.
+        prefix = (
+            self._artifact_prefix_of(publish_id)
+            if self._oss is not None
+            else None
+        )
         with self._db.orm_session() as db:
             affected = (
                 db.query(self.Model)
                 .filter(self.Model.id == publish_id)
                 .delete(synchronize_session=False)
             )
-        if affected > 0 and oss_key:
-            # Best effort — a failed OSS delete must not fail the DB delete.
-            self._oss.delete_object(oss_key)
+        if affected > 0 and prefix:
+            # Best effort — a failed OSS cleanup must not fail the DB delete.
+            for key in self._oss.list_objects(prefix):
+                self._oss.delete_object(key)
         return affected > 0

--- a/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
@@ -47,18 +47,134 @@ from agentclaw.community.core.service_bot.repository.models import (
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.plugin_api.object_storage import ObjectStoragePlugin
 from agentclaw.community.utils.env_utils import get_current_env
 
 logger = get_logger()
+
+# ── config_artifact offload ─────────────────────────────────────────
+# The published ``config_artifact`` (a serialized BotConfigArtifact) rides inside
+# the ``ac_bot_publish.ext`` JSON, which is stored in a ``TEXT`` column capped at
+# ~64 KB. A richly-configured teclaw bot can serialize past that. When it does,
+# the repository writes the artifact's JSON to object storage and replaces it
+# inline with a small self-describing marker (:data:`_ARTIFACT_OSS_MARKER`), then
+# transparently re-inlines it on read. 60 KB leaves ~4 KB of headroom under the
+# 65535-byte TEXT cap for the ext's sibling fields (binding, migration_path, …).
+_ARTIFACT_OSS_THRESHOLD_BYTES = 60 * 1024
+# The ext key holding the (inline) artifact and, when offloaded, its marker.
+_ARTIFACT_KEY = "config_artifact"
+_ARTIFACT_OSS_MARKER = "config_artifact_oss"
 
 
 class BotPublishRepository:
     """Unified ORM ``BotPublishRepositoryProtocol`` implementation."""
 
     @inject
-    def __init__(self, db: DatabasePlugin) -> None:
+    def __init__(
+        self, db: DatabasePlugin, oss: ObjectStoragePlugin | None = None
+    ) -> None:
         self._db = db
         self.Model = BotPublishModel
+        self._oss = oss
+        # Offloading needs BOTH a write (put_object) and a read (get_object)
+        # side. The corp object-storage impl is out-of-tree and may not yet
+        # expose get_object; gate on it so a deployment lacking the read method
+        # safely stores inline (old behavior) instead of writing an artifact it
+        # could never read back. The size fix activates automatically once the
+        # impl gains get_object — no code change here.
+        self._offload_enabled = oss is not None and callable(
+            getattr(oss, "get_object", None)
+        )
+        if oss is not None and not self._offload_enabled:
+            logger.warning(
+                "[BotPublishRepository] ObjectStoragePlugin lacks get_object; "
+                "config_artifact offload disabled (storing inline)."
+            )
+
+    # ── config_artifact offload/inload helpers ──────────────────
+
+    def _artifact_oss_key(self, env: str, publish_id: int) -> str:
+        """Deterministic per-record key. Overwritten on each write (a publish's
+        re-stamps reuse the same object), so no orphan copies accumulate."""
+        return f"teclaw/{env}/bot_publish/{publish_id}/config_artifact.json"
+
+    def _serialize_ext(
+        self, ext: Optional[Dict[str, Any]], publish_id: int, env: str
+    ) -> Optional[str]:
+        """Serialize ``ext`` to the JSON string stored in the ext column.
+
+        When offloading is enabled and ``ext['config_artifact']`` serializes to
+        more than :data:`_ARTIFACT_OSS_THRESHOLD_BYTES`, its JSON is written to
+        object storage and replaced with a self-describing marker so the column
+        stays small. Raises on an object-storage write failure — a loud failure
+        beats silently truncating the ext column.
+
+        Invariant: callers pass a *resolved* ext (a full inline ``config_artifact``
+        or none; never a lingering marker), because every read path resolves the
+        marker back before handing the record out.
+        """
+        if ext is None:
+            return None
+        artifact = ext.get(_ARTIFACT_KEY)
+        if self._offload_enabled and artifact is not None:
+            artifact_json = json.dumps(artifact, ensure_ascii=False)
+            size = len(artifact_json.encode("utf-8"))
+            if size > _ARTIFACT_OSS_THRESHOLD_BYTES:
+                key = self._artifact_oss_key(env, publish_id)
+                if not self._oss.put_object(key, artifact_json):
+                    raise RuntimeError(
+                        "config_artifact offload failed: "
+                        f"put_object({key!r}) returned False (size={size} bytes)"
+                    )
+                ext = {k: v for k, v in ext.items() if k != _ARTIFACT_KEY}
+                ext[_ARTIFACT_OSS_MARKER] = {
+                    "offloaded": True,
+                    "oss_key": key,
+                    "size_bytes": size,
+                    "threshold_bytes": _ARTIFACT_OSS_THRESHOLD_BYTES,
+                    "note": (
+                        f"config_artifact ({size} bytes) exceeded the "
+                        f"{_ARTIFACT_OSS_THRESHOLD_BYTES}-byte inline limit for "
+                        "the ac_bot_publish.ext TEXT column and was stored in "
+                        "object storage at oss_key; the repository re-inlines it "
+                        f"as ext['{_ARTIFACT_KEY}'] on read."
+                    ),
+                }
+        return json.dumps(ext, ensure_ascii=False)
+
+    def _resolve_ext(
+        self, ext: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Inverse of the offload in :meth:`_serialize_ext`.
+
+        If ``ext`` carries the offload marker, fetch the artifact JSON back from
+        object storage and re-inline it as ``ext['config_artifact']``, dropping
+        the marker so callers see the same shape as an inline artifact. On a
+        fetch failure, log and leave the marker in place (readers already guard
+        on a missing config_artifact) rather than raising inside a read path.
+        """
+        if not ext or _ARTIFACT_OSS_MARKER not in ext:
+            return ext
+        marker = ext[_ARTIFACT_OSS_MARKER]
+        key = marker.get("oss_key") if isinstance(marker, dict) else None
+        raw = self._oss.get_object(key) if (self._oss and key) else None
+        if raw is None:
+            logger.error(
+                "[BotPublishRepository] failed to fetch offloaded "
+                "config_artifact from object storage: key=%s", key,
+            )
+            return ext
+        resolved = {k: v for k, v in ext.items() if k != _ARTIFACT_OSS_MARKER}
+        resolved[_ARTIFACT_KEY] = json.loads(
+            raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+        )
+        return resolved
+
+    def _to_record(self, row: "BotPublishModel") -> BotPublishRecord:
+        """Row → record with any offloaded config_artifact re-inlined."""
+        record = row.to_record()
+        record.ext = self._resolve_ext(record.ext)
+        return record
 
     # ── insert (plain INSERT — never an upsert) ─────────────────
 

--- a/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
@@ -493,11 +493,12 @@ class BotPublishRepository:
                 },
                 synchronize_session=False,
             )
-            # Upload the offloaded artifact only once we know this write took
-            # (optimistic lock matched). A rejected update (affected == 0) must
-            # NOT touch object storage, or it would clobber the object a still-
-            # valid record points at. Inside the txn so a put failure rolls back.
-            if not (source_status is not None and affected == 0):
+            # Upload the offloaded artifact only when a row actually took this
+            # write (affected > 0): a rejected optimistic-lock update OR a
+            # missing publish_id must not write an artifact object that nothing
+            # references (it could never be reaped — delete needs the row's env).
+            # Inside the txn so a put failure rolls back.
+            if affected > 0:
                 self._upload_pending(pending)
         if source_status is not None and affected == 0:
             return None
@@ -575,7 +576,16 @@ class BotPublishRepository:
                 .delete(synchronize_session=False)
             )
         if affected > 0 and prefix:
-            # Best effort — a failed OSS cleanup must not fail the DB delete.
-            for key in self._oss.list_objects(prefix):
-                self._oss.delete_object(key)
+            # Best effort — cleanup must never fail the DB delete, and must not
+            # assume the object-storage impl implements list_objects: the corp
+            # impl is out-of-tree and may lag the Protocol (same risk the ctor
+            # guards for get_object). Swallow anything the sweep raises.
+            try:
+                for key in self._oss.list_objects(prefix):
+                    self._oss.delete_object(key)
+            except Exception:  # noqa: BLE001 - best-effort artifact cleanup
+                logger.exception(
+                    "[BotPublishRepository] artifact cleanup failed for "
+                    "publish_id=%s prefix=%s", publish_id, prefix,
+                )
         return affected > 0

--- a/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
@@ -180,9 +180,7 @@ class BotPublishRepository:
 
     def insert(self, data: Dict[str, Any]) -> BotPublishRecord:
         ext = data.get("ext")
-        ext_json = (
-            json.dumps(ext, ensure_ascii=False) if ext is not None else None
-        )
+        env = data.get("env", get_current_env())
         with self._db.orm_session() as db:
             row = self.Model(
                 source_bot_pk=data["source_bot_pk"],
@@ -195,13 +193,19 @@ class BotPublishRepository:
                 status=data.get("status", PublishStatus.DRAFT),
                 version=data.get("version"),
                 last_pub_id=data.get("last_pub_id", 0),
-                env=data.get("env", get_current_env()),
-                ext=ext_json,
+                env=env,
+                # ext set after flush: offloading keys the OSS object by the
+                # DB-assigned publish_id, which only exists post-flush. Still a
+                # single INSERT in one transaction (a second flush updates ext
+                # before commit).
+                ext=None,
                 permission_owner=data["permission_owner"],
             )
             db.add(row)
             db.flush()
             new_id = row.id
+            row.ext = self._serialize_ext(ext, new_id, env)
+            db.flush()
             logger.info("[insert] inserted bot publish id=%s", new_id)
         # Re-read after commit — prod returns get_by_id(inserted_id),
         # so the returned record carries DB-populated gmt_create /
@@ -217,7 +221,7 @@ class BotPublishRepository:
                 .filter(self.Model.id == publish_id)
                 .first()
             )
-            return row.to_record() if row else None
+            return self._to_record(row) if row else None
 
     def get_by_publish_bot_id(
         self,
@@ -235,7 +239,7 @@ class BotPublishRepository:
             if publish_status:
                 query = query.filter(self.Model.status == publish_status)
             row = query.order_by(self.Model.version.desc()).first()
-            return row.to_record() if row else None
+            return self._to_record(row) if row else None
 
     def get_draft_by_publish_bot_id(
         self,
@@ -253,7 +257,7 @@ class BotPublishRepository:
                 .order_by(self.Model.version.desc())
                 .first()
             )
-            return row.to_record() if row else None
+            return self._to_record(row) if row else None
 
     def get_by_publish_bot_id_and_version(
         self,
@@ -273,7 +277,7 @@ class BotPublishRepository:
                 )
                 .first()
             )
-            return row.to_record() if row else None
+            return self._to_record(row) if row else None
 
     def list_by_owner(
         self,
@@ -289,7 +293,7 @@ class BotPublishRepository:
             if status:
                 query = query.filter(self.Model.status == status)
             rows = query.order_by(self.Model.gmt_create.desc()).all()
-            return [r.to_record() for r in rows]
+            return [self._to_record(r) for r in rows]
 
     def list_by_source_bot(
         self,
@@ -306,7 +310,7 @@ class BotPublishRepository:
                 .order_by(self.Model.gmt_create.desc())
                 .all()
             )
-            return [r.to_record() for r in rows]
+            return [self._to_record(r) for r in rows]
 
     def list_by_status(
         self,
@@ -323,7 +327,7 @@ class BotPublishRepository:
                 .order_by(self.Model.gmt_create.desc())
                 .all()
             )
-            return [r.to_record() for r in rows]
+            return [self._to_record(r) for r in rows]
 
     def get_latest_by_source_bot_id_and_owner_and_status(
         self,
@@ -344,7 +348,7 @@ class BotPublishRepository:
                 .order_by(self.Model.id.desc())
                 .first()
             )
-            return row.to_record() if row else None
+            return self._to_record(row) if row else None
 
     def get_latest_success_by_source_bot_id(
         self,
@@ -362,7 +366,7 @@ class BotPublishRepository:
                 .order_by(self.Model.id.desc())
                 .first()
             )
-            return row.to_record() if row else None
+            return self._to_record(row) if row else None
 
     def get_by_last_pub_id(
         self,
@@ -375,7 +379,7 @@ class BotPublishRepository:
                 .order_by(self.Model.id.desc())
                 .first()
             )
-            return row.to_record() if row else None
+            return self._to_record(row) if row else None
 
     # ── updates (single optimistic-lock statements) ─────────────
 
@@ -409,7 +413,7 @@ class BotPublishRepository:
         ext: Dict[str, Any],
         source_status: Optional[str] = None,
     ) -> Optional[BotPublishRecord]:
-        ext_json = json.dumps(ext, ensure_ascii=False)
+        ext_json = self._serialize_ext(ext, publish_id, get_current_env())
         with self._db.orm_session() as db:
             query = db.query(self.Model).filter(
                 self.Model.id == publish_id
@@ -465,11 +469,40 @@ class BotPublishRepository:
 
     # ── delete (single hard DELETE — prod parity) ───────────────
 
+    def _offloaded_key(self, publish_id: int) -> Optional[str]:
+        """Return the OSS key of this record's offloaded artifact, if any.
+
+        Reads only the raw ``ext`` column (no resolution) and returns the
+        marker's ``oss_key`` when the artifact was offloaded, else ``None``.
+        """
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self.Model.ext)
+                .filter(self.Model.id == publish_id)
+                .first()
+            )
+        if not row or not row[0]:
+            return None
+        try:
+            ext = json.loads(row[0])
+        except (ValueError, TypeError):
+            return None
+        marker = ext.get(_ARTIFACT_OSS_MARKER) if isinstance(ext, dict) else None
+        return marker.get("oss_key") if isinstance(marker, dict) else None
+
     def delete(self, publish_id: int) -> bool:
+        # Capture an offloaded artifact's OSS key (if any) before the row is
+        # gone, so object storage can be cleaned up after a successful delete.
+        # The hard DELETE below stays a single statement (prod parity); the
+        # lookup only runs when offload storage is configured.
+        oss_key = self._offloaded_key(publish_id) if self._oss is not None else None
         with self._db.orm_session() as db:
             affected = (
                 db.query(self.Model)
                 .filter(self.Model.id == publish_id)
                 .delete(synchronize_session=False)
             )
-            return affected > 0
+        if affected > 0 and oss_key:
+            # Best effort — a failed OSS delete must not fail the DB delete.
+            self._oss.delete_object(oss_key)
+        return affected > 0

--- a/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
@@ -34,13 +34,14 @@ reference):
 """
 from __future__ import annotations
 
-import hashlib
-import json
 from typing import Any, Dict, List, Optional
 
 from injector import inject
 from sqlalchemy import func
 
+from agentclaw.community.core.service_bot.repository.config_artifact_offload import (
+    ConfigArtifactOffloader,
+)
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishModel,
     BotPublishRecord,
@@ -48,169 +49,27 @@ from agentclaw.community.core.service_bot.repository.models import (
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
-from agentclaw.community.plugin_api.object_storage import ObjectStoragePlugin
 from agentclaw.community.utils.env_utils import get_current_env
 
 logger = get_logger()
 
-# ── config_artifact offload ─────────────────────────────────────────
-# The published ``config_artifact`` (a serialized BotConfigArtifact) rides inside
-# the ``ac_bot_publish.ext`` JSON, which is stored in a ``TEXT`` column capped at
-# ~64 KB. A richly-configured teclaw bot can serialize past that. When it does,
-# the repository writes the artifact's JSON to object storage and replaces it
-# inline with a small self-describing marker (:data:`_ARTIFACT_OSS_MARKER`), then
-# transparently re-inlines it on read. 60 KB leaves ~4 KB of headroom under the
-# 65535-byte TEXT cap for the ext's sibling fields (binding, migration_path, …).
-_ARTIFACT_OSS_THRESHOLD_BYTES = 60 * 1024
-# The ext key holding the (inline) artifact and, when offloaded, its marker.
-_ARTIFACT_KEY = "config_artifact"
-_ARTIFACT_OSS_MARKER = "config_artifact_oss"
-
 
 class BotPublishRepository:
-    """Unified ORM ``BotPublishRepositoryProtocol`` implementation."""
+    """Unified ORM ``BotPublishRepositoryProtocol`` implementation.
+
+    An oversized ``ext['config_artifact']`` is offloaded to object storage and
+    re-inlined on read by :class:`ConfigArtifactOffloader`; this class owns only
+    persistence and delegates the ext ⇄ object-storage transform to it.
+    """
 
     @inject
     def __init__(
-        self, db: DatabasePlugin, oss: ObjectStoragePlugin | None = None
+        self, db: DatabasePlugin, offload: ConfigArtifactOffloader
     ) -> None:
         self._db = db
         self.Model = BotPublishModel
-        self._oss = oss
-        # Offloading needs BOTH a write (put_object) and a read (get_object)
-        # side. The corp object-storage impl is out-of-tree and may not yet
-        # expose get_object; gate on it so a deployment lacking the read method
-        # safely stores inline (old behavior) instead of writing an artifact it
-        # could never read back. The size fix activates automatically once the
-        # impl gains get_object — no code change here.
-        self._offload_enabled = oss is not None and callable(
-            getattr(oss, "get_object", None)
-        )
-        if oss is not None and not self._offload_enabled:
-            logger.warning(
-                "[BotPublishRepository] ObjectStoragePlugin lacks get_object; "
-                "config_artifact offload disabled (storing inline)."
-            )
-
-    # ── config_artifact offload/inload helpers ──────────────────
-
-    def _artifact_prefix(self, env: str, publish_id: int) -> str:
-        """Per-record object-storage prefix. Every offloaded version of one
-        publish record lives under here; :meth:`delete` sweeps the whole subtree
-        so superseded versions never accumulate."""
-        return f"teclaw/{env}/bot_publish/{publish_id}/"
-
-    def _artifact_oss_key(self, env: str, publish_id: int, digest: str) -> str:
-        """Content-addressed key for one artifact version.
-
-        The content digest makes each write a NEW immutable object instead of an
-        in-place overwrite. That is what stops a rejected optimistic-lock write
-        (or a concurrent writer) from clobbering the object a still-valid record
-        points at — a marker always names exactly the bytes written with it.
-        Superseded versions are reaped by :meth:`delete`'s prefix sweep.
-        """
-        return (
-            f"{self._artifact_prefix(env, publish_id)}"
-            f"config_artifact-{digest}.json"
-        )
-
-    @staticmethod
-    def _strip_stale_marker(ext: Dict[str, Any]) -> Dict[str, Any]:
-        """Enforce marker/inline mutual exclusion on write.
-
-        A fresh inline ``config_artifact`` wins over a leftover marker: if both
-        are present (e.g. a caller merged a new artifact onto an ext whose marker
-        had failed to resolve), drop the marker so we never persist both — which
-        would otherwise make the next read fetch stale OSS content over the fresh
-        inline artifact.
-        """
-        if _ARTIFACT_KEY in ext and _ARTIFACT_OSS_MARKER in ext:
-            return {k: v for k, v in ext.items() if k != _ARTIFACT_OSS_MARKER}
-        return ext
-
-    def _prepare_ext(
-        self, ext: Optional[Dict[str, Any]], publish_id: int, env: str
-    ) -> tuple[Optional[str], Optional[tuple[str, str]]]:
-        """Build the ext JSON to store, plus a pending object-storage upload.
-
-        Returns ``(ext_json, pending)`` where ``pending`` is ``(oss_key,
-        artifact_json)`` to write, or ``None``. Performs NO I/O: the caller
-        uploads ``pending`` only AFTER confirming the DB write will persist, so a
-        rejected optimistic-lock update never writes an orphan or clobbers a live
-        object. When ``pending`` is set, ``ext_json`` already carries the marker
-        instead of the inline artifact.
-        """
-        if ext is None:
-            return None, None
-        ext = self._strip_stale_marker(ext)
-        artifact = ext.get(_ARTIFACT_KEY)
-        if not (self._offload_enabled and artifact is not None):
-            return json.dumps(ext, ensure_ascii=False), None
-        artifact_json = json.dumps(artifact, ensure_ascii=False)
-        size = len(artifact_json.encode("utf-8"))
-        if size <= _ARTIFACT_OSS_THRESHOLD_BYTES:
-            return json.dumps(ext, ensure_ascii=False), None
-        digest = hashlib.sha1(artifact_json.encode("utf-8")).hexdigest()[:12]
-        key = self._artifact_oss_key(env, publish_id, digest)
-        ext = {k: v for k, v in ext.items() if k != _ARTIFACT_KEY}
-        ext[_ARTIFACT_OSS_MARKER] = {
-            "offloaded": True,
-            "oss_key": key,
-            "size_bytes": size,
-            "threshold_bytes": _ARTIFACT_OSS_THRESHOLD_BYTES,
-            "note": (
-                f"config_artifact ({size} bytes) exceeded the "
-                f"{_ARTIFACT_OSS_THRESHOLD_BYTES}-byte inline limit for the "
-                "ac_bot_publish.ext TEXT column and was stored in object storage "
-                f"at oss_key; the repository re-inlines it as ext['{_ARTIFACT_KEY}'] "
-                "on read."
-            ),
-        }
-        return json.dumps(ext, ensure_ascii=False), (key, artifact_json)
-
-    def _upload_pending(self, pending: Optional[tuple[str, str]]) -> None:
-        """Write a prepared artifact object. Fail loud on error — better than
-        silently truncating the ext column or shipping a dangling marker."""
-        if pending is None:
-            return
-        key, body = pending
-        if not self._oss.put_object(key, body):
-            raise RuntimeError(
-                f"config_artifact offload failed: put_object({key!r}) "
-                "returned False"
-            )
-
-    def _resolve_ext(
-        self, ext: Optional[Dict[str, Any]]
-    ) -> Optional[Dict[str, Any]]:
-        """Inverse of the offload in :meth:`_prepare_ext`.
-
-        If ``ext`` carries the offload marker, fetch the artifact JSON back from
-        object storage and re-inline it as ``ext['config_artifact']``, dropping
-        the marker so callers see the same shape as an inline artifact. If an
-        inline artifact is somehow also present it wins (the marker is dropped
-        without a fetch). On a fetch failure, log and leave the marker in place
-        (readers already guard on a missing config_artifact) rather than raising
-        inside a read path.
-        """
-        if not ext or _ARTIFACT_OSS_MARKER not in ext:
-            return ext
-        if _ARTIFACT_KEY in ext:
-            return {k: v for k, v in ext.items() if k != _ARTIFACT_OSS_MARKER}
-        marker = ext[_ARTIFACT_OSS_MARKER]
-        key = marker.get("oss_key") if isinstance(marker, dict) else None
-        raw = self._oss.get_object(key) if (self._oss and key) else None
-        if raw is None:
-            logger.error(
-                "[BotPublishRepository] failed to fetch offloaded "
-                "config_artifact from object storage: key=%s", key,
-            )
-            return ext
-        resolved = {k: v for k, v in ext.items() if k != _ARTIFACT_OSS_MARKER}
-        resolved[_ARTIFACT_KEY] = json.loads(
-            raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
-        )
-        return resolved
+        # Offloads an oversized config_artifact out of the ext TEXT column.
+        self._offload = offload
 
     def _resolve_record(
         self, record: Optional[BotPublishRecord]
@@ -221,7 +80,7 @@ class BotPublishRepository:
         never holds a database connection open.
         """
         if record is not None:
-            record.ext = self._resolve_ext(record.ext)
+            record.ext = self._offload.resolve(record.ext)
         return record
 
     # ── insert (plain INSERT — never an upsert) ─────────────────
@@ -255,9 +114,9 @@ class BotPublishRepository:
             # ext + upload only after flush: the OSS key is content-addressed
             # under the DB-assigned publish_id. The upload runs inside the txn so
             # a put failure rolls the whole INSERT back (no dangling marker row).
-            ext_json, pending = self._prepare_ext(ext, new_id, env)
+            ext_json, pending = self._offload.prepare(ext, new_id, env)
             row.ext = ext_json
-            self._upload_pending(pending)
+            self._offload.upload(pending)
             db.flush()
             logger.info("[insert] inserted bot publish id=%s", new_id)
         # Re-read after commit — prod returns get_by_id(inserted_id),
@@ -476,7 +335,7 @@ class BotPublishRepository:
         ext: Dict[str, Any],
         source_status: Optional[str] = None,
     ) -> Optional[BotPublishRecord]:
-        ext_json, pending = self._prepare_ext(
+        ext_json, pending = self._offload.prepare(
             ext, publish_id, get_current_env()
         )
         with self._db.orm_session() as db:
@@ -499,7 +358,7 @@ class BotPublishRepository:
             # references (it could never be reaped — delete needs the row's env).
             # Inside the txn so a put failure rolls back.
             if affected > 0:
-                self._upload_pending(pending)
+                self._offload.upload(pending)
         if source_status is not None and affected == 0:
             return None
         return self.get_by_id(publish_id)
@@ -547,7 +406,7 @@ class BotPublishRepository:
 
         Uses the deterministic prefix (not a stored marker), so it reaps EVERY
         offloaded version under the record — the current one plus any superseded
-        (content-addressed) or shrunk-back-to-inline leftovers.
+        (content-addressed) leftovers.
         """
         with self._db.orm_session() as db:
             row = (
@@ -557,18 +416,13 @@ class BotPublishRepository:
             )
         if not row or not row[0]:
             return None
-        return self._artifact_prefix(row[0], publish_id)
+        return self._offload.prefix(row[0], publish_id)
 
     def delete(self, publish_id: int) -> bool:
         # Resolve the record's artifact prefix (if any) before the row is gone,
         # so object storage can be swept after a successful delete. The hard
-        # DELETE below stays a single statement (prod parity); the lookup only
-        # runs when offload storage is configured.
-        prefix = (
-            self._artifact_prefix_of(publish_id)
-            if self._oss is not None
-            else None
-        )
+        # DELETE below stays a single statement (prod parity).
+        prefix = self._artifact_prefix_of(publish_id)
         with self._db.orm_session() as db:
             affected = (
                 db.query(self.Model)
@@ -576,16 +430,5 @@ class BotPublishRepository:
                 .delete(synchronize_session=False)
             )
         if affected > 0 and prefix:
-            # Best effort — cleanup must never fail the DB delete, and must not
-            # assume the object-storage impl implements list_objects: the corp
-            # impl is out-of-tree and may lag the Protocol (same risk the ctor
-            # guards for get_object). Swallow anything the sweep raises.
-            try:
-                for key in self._oss.list_objects(prefix):
-                    self._oss.delete_object(key)
-            except Exception:  # noqa: BLE001 - best-effort artifact cleanup
-                logger.exception(
-                    "[BotPublishRepository] artifact cleanup failed for "
-                    "publish_id=%s prefix=%s", publish_id, prefix,
-                )
+            self._offload.cleanup(prefix)
         return affected > 0

--- a/src/backend/src/agentclaw/community/plugins/community/object_storage.py
+++ b/src/backend/src/agentclaw/community/plugins/community/object_storage.py
@@ -75,6 +75,18 @@ class CommunityFsObjectStorage(ObjectStoragePlugin):
             logger.error("ObjectStorage put_file failed: key=%s, error=%s", key, e)
             return False
 
+    def get_object(self, key: str) -> bytes | None:
+        path = self._safe_path(key)
+        if path is None:
+            return None
+        try:
+            if not path.is_file():
+                return None
+            return path.read_bytes()
+        except OSError as e:
+            logger.error("ObjectStorage get_object failed: key=%s, error=%s", key, e)
+            return None
+
     def delete_object(self, key: str) -> bool:
         path = self._safe_path(key)
         if path is None:
@@ -199,6 +211,15 @@ class CommunityS3ObjectStorage(ObjectStoragePlugin):
         except self._errors as e:
             logger.error("S3 put_file failed: key=%s, error=%s", key, e)
             return False
+
+    def get_object(self, key: str) -> bytes | None:
+        try:
+            resp = self._s3.get_object(Bucket=self._bucket, Key=key)
+            return resp["Body"].read()
+        except self._errors as e:
+            # Includes a missing key (ClientError NoSuchKey) — swallowed to None.
+            logger.error("S3 get_object failed: key=%s, error=%s", key, e)
+            return None
 
     def delete_object(self, key: str) -> bool:
         try:

--- a/src/backend/src/agentclaw/community/plugins/local/oss_storage.py
+++ b/src/backend/src/agentclaw/community/plugins/local/oss_storage.py
@@ -45,6 +45,7 @@ class MockObjectStoragePlugin(MockSeam, ObjectStoragePlugin):
     def __init__(self) -> None:
         self.put_object: MagicMock = MagicMock(return_value=True)
         self.put_file: MagicMock = MagicMock(return_value=True)
+        self.get_object: MagicMock = MagicMock(return_value=None)
         self.delete_object: MagicMock = MagicMock(return_value=True)
         self.list_objects: MagicMock = MagicMock(return_value=[])
         self.sign_url: MagicMock = MagicMock(side_effect=_default_sign_url)
@@ -67,6 +68,10 @@ class MockObjectStoragePlugin(MockSeam, ObjectStoragePlugin):
         self.put_file.reset_mock()
         self.put_file.return_value = True
         self.put_file.side_effect = None
+
+        self.get_object.reset_mock()
+        self.get_object.return_value = None
+        self.get_object.side_effect = None
 
         self.delete_object.reset_mock()
         self.delete_object.return_value = True

--- a/src/backend/tests/community/core/service_bot/repository/test_config_artifact_offload.py
+++ b/src/backend/tests/community/core/service_bot/repository/test_config_artifact_offload.py
@@ -1,0 +1,152 @@
+"""Unit tests for :class:`ConfigArtifactOffloader` — the ext ⇄ object-storage
+transform in isolation from the repository/DB."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentclaw.community.core.service_bot.repository.config_artifact_offload import (
+    ARTIFACT_KEY,
+    ARTIFACT_OSS_MARKER,
+    ARTIFACT_OSS_THRESHOLD_BYTES,
+    ConfigArtifactOffloader,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _FakeOSS:
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+        self.put_calls = 0
+
+    def put_object(self, key, content) -> bool:
+        self.put_calls += 1
+        self.store[key] = content.encode("utf-8") if isinstance(content, str) else content
+        return True
+
+    def get_object(self, key):
+        return self.store.get(key)
+
+    def delete_object(self, key) -> bool:
+        self.store.pop(key, None)
+        return True
+
+    def list_objects(self, prefix, max_keys: int = 1000):
+        return [k for k in self.store if k.startswith(prefix)][:max_keys]
+
+
+def _offloader():
+    oss = _FakeOSS()
+    return ConfigArtifactOffloader(oss), oss
+
+
+def _big():
+    return {"engine_type": "openclaw", "blob": "x" * (ARTIFACT_OSS_THRESHOLD_BYTES + 1024)}
+
+
+def test_prepare_none_is_noop():
+    off, _ = _offloader()
+    assert off.prepare(None, 1, "dev") == (None, None)
+
+
+def test_prepare_small_stays_inline():
+    off, oss = _offloader()
+    ext_json, pending = off.prepare({"config_artifact": {"a": 1}, "k": "v"}, 1, "dev")
+    assert pending is None
+    stored = json.loads(ext_json)
+    assert stored == {"config_artifact": {"a": 1}, "k": "v"}
+    assert ARTIFACT_OSS_MARKER not in stored
+    assert oss.put_calls == 0  # prepare does no I/O
+
+
+def test_prepare_large_emits_marker_and_pending():
+    off, _ = _offloader()
+    art = _big()
+    ext_json, pending = off.prepare({"config_artifact": art, "k": "v"}, 7, "dev")
+    stored = json.loads(ext_json)
+    # Inline artifact replaced by the marker; sibling field kept.
+    assert ARTIFACT_KEY not in stored
+    assert stored["k"] == "v"
+    marker = stored[ARTIFACT_OSS_MARKER]
+    assert marker["offloaded"] is True
+    assert marker["oss_key"].startswith("teclaw/dev/bot_publish/7/")
+    assert marker["size_bytes"] > ARTIFACT_OSS_THRESHOLD_BYTES
+    # pending carries the exact key + the artifact JSON (still no I/O done).
+    key, body = pending
+    assert key == marker["oss_key"]
+    assert json.loads(body) == art
+
+
+def test_prepare_drops_both_keys_then_writes_one():
+    # Input carrying BOTH an inline artifact and a stale marker → only the fresh
+    # inline artifact survives (mutual exclusion by construction).
+    off, _ = _offloader()
+    ext_json, pending = off.prepare(
+        {"config_artifact": {"a": 1}, "config_artifact_oss": {"oss_key": "stale"}},
+        1, "dev",
+    )
+    assert pending is None
+    stored = json.loads(ext_json)
+    assert stored == {"config_artifact": {"a": 1}}
+
+
+def test_upload_writes_pending_and_fails_loud():
+    off, oss = _offloader()
+    off.upload(("teclaw/dev/bot_publish/1/config_artifact-abc.json", '{"a":1}'))
+    assert oss.put_calls == 1
+    off.upload(None)  # no-op
+    assert oss.put_calls == 1
+
+    class _Fail(_FakeOSS):
+        def put_object(self, key, content):
+            return False
+
+    off_fail = ConfigArtifactOffloader(_Fail())
+    with pytest.raises(RuntimeError):
+        off_fail.upload(("k", "body"))
+
+
+def test_prepare_then_upload_then_resolve_roundtrip():
+    off, oss = _offloader()
+    art = _big()
+    ext_json, pending = off.prepare({"config_artifact": art}, 3, "dev")
+    off.upload(pending)
+    # Simulate what the repo stores/loads: parse the column, then resolve.
+    resolved = off.resolve(json.loads(ext_json))
+    assert resolved["config_artifact"] == art
+    assert ARTIFACT_OSS_MARKER not in resolved
+
+
+def test_resolve_passthrough_without_marker():
+    off, _ = _offloader()
+    assert off.resolve(None) is None
+    assert off.resolve({"config_artifact": {"a": 1}}) == {"config_artifact": {"a": 1}}
+
+
+def test_resolve_fetch_failure_raises():
+    off, _ = _offloader()
+    # Marker points at a key the store doesn't have → get_object returns None →
+    # fail loud rather than return a record silently missing its artifact.
+    ext = {ARTIFACT_OSS_MARKER: {"oss_key": "missing/key"}, "k": "v"}
+    with pytest.raises(RuntimeError):
+        off.resolve(ext)
+
+
+def test_cleanup_sweeps_prefix_and_tolerates_errors():
+    off, oss = _offloader()
+    oss.store = {
+        "teclaw/dev/bot_publish/9/config_artifact-a.json": b"1",
+        "teclaw/dev/bot_publish/9/config_artifact-b.json": b"2",
+        "teclaw/dev/bot_publish/10/config_artifact-c.json": b"3",
+    }
+    off.cleanup("teclaw/dev/bot_publish/9/")
+    assert list(oss.store) == ["teclaw/dev/bot_publish/10/config_artifact-c.json"]
+
+    class _ListRaises(_FakeOSS):
+        def list_objects(self, prefix, max_keys=1000):
+            raise RuntimeError("boom")
+
+    # Must swallow the error (best-effort), not propagate.
+    ConfigArtifactOffloader(_ListRaises()).cleanup("any/")

--- a/src/backend/tests/community/plugins/community/test_object_storage.py
+++ b/src/backend/tests/community/plugins/community/test_object_storage.py
@@ -35,6 +35,15 @@ def test_fs_put_object_accepts_bytes(tmp_path):
     assert store.get_etag("b.bin") is not None
 
 
+def test_fs_get_object_roundtrip_and_missing(tmp_path):
+    store = _fs(tmp_path)
+    store.put_object("g.txt", "payload")
+    assert store.get_object("g.txt") == b"payload"
+    # Absent key and a path-traversal key both return None, never raise.
+    assert store.get_object("nope.txt") is None
+    assert store.get_object("../escape.txt") is None
+
+
 def test_fs_nested_key_creates_dirs(tmp_path):
     store = _fs(tmp_path)
     assert store.put_object("a/b/c.txt", "deep") is True
@@ -177,6 +186,13 @@ def test_s3_put_list_delete(s3_store):
 
 def test_s3_delete_absent_is_success(s3_store):
     assert s3_store.delete_object("never-existed") is True
+
+
+def test_s3_get_object_roundtrip_and_missing(s3_store):
+    s3_store.put_object("g", "payload")
+    assert s3_store.get_object("g") == b"payload"
+    # Missing key is a swallowed NoSuchKey ClientError → None, not a raise.
+    assert s3_store.get_object("missing") is None
 
 
 def test_s3_list_prefix_and_max_keys(s3_store):

--- a/src/backend/tests/community/plugins/test_bot_publish_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_publish_unified.py
@@ -505,3 +505,85 @@ def test_resolve_ext_inline_wins_over_marker(repo_oss, oss):
     )
     assert resolved == {"config_artifact": {"a": 1}}
     assert oss.store == {}  # no get/put occurred
+
+
+def test_write_strips_stale_marker_end_to_end(repo_oss, oss):
+    # A caller hands ext carrying BOTH a fresh inline artifact and a stale marker
+    # (the degrade-path shape). The write must persist only the inline artifact,
+    # and the read must never fetch the stale key. Exercised through the public
+    # API, not the private helper.
+    rec = repo_oss.insert(_data(status="DRAFT"))
+    repo_oss.update_status_with_ext(
+        rec.id, "DRAFT",
+        {
+            "config_artifact": _small_artifact(),
+            "config_artifact_oss": {"oss_key": "stale/key", "offloaded": True},
+        },
+        source_status="DRAFT",
+    )
+    raw = _raw_ext(repo_oss, rec.id)
+    assert _ARTIFACT_OSS_MARKER not in raw
+    assert raw["config_artifact"] == _small_artifact()
+    got = repo_oss.get_by_id(rec.id)
+    assert got.ext["config_artifact"] == _small_artifact()
+    assert oss.store == {}  # stale key never fetched
+
+
+def test_update_source_none_existing_row_uploads(repo_oss, oss):
+    # source_status=None against an existing row still takes the write (affected
+    # > 0) → the large artifact IS uploaded.
+    rec = repo_oss.insert(_data(status="DRAFT"))
+    out = repo_oss.update_status_with_ext(
+        rec.id, "DRAFT", {"config_artifact": _big_artifact()}, source_status=None,
+    )
+    assert out is not None
+    assert oss.put_calls == 1
+    assert out.ext["config_artifact"] == _big_artifact()
+
+
+def test_update_source_none_missing_row_does_not_upload(repo_oss, oss):
+    # The exact round-2 orphan gap: source_status=None against a nonexistent
+    # publish_id → affected == 0 → must NOT upload (no row to reference it).
+    out = repo_oss.update_status_with_ext(
+        999999, "DRAFT", {"config_artifact": _big_artifact()}, source_status=None,
+    )
+    assert out is None
+    assert oss.put_calls == 0
+    assert oss.store == {}
+
+
+def test_delete_tolerates_sweep_failure(tmp_path):
+    # delete()'s best-effort cleanup must never fail the DB delete, even if the
+    # object-storage sweep raises (e.g. an impl lacking or breaking list_objects).
+    class _FakeOSSListRaises(_FakeOSS):
+        def list_objects(self, prefix: str, max_keys: int = 1000):
+            raise RuntimeError("list_objects unavailable")
+
+    fake = _FakeOSSListRaises()
+    repo = _repo_with(tmp_path, fake)
+    rec = repo.insert(_data(ext={"config_artifact": _big_artifact()}))
+    assert fake.put_calls == 1  # it did offload
+    # Sweep raises inside delete → swallowed → DB delete still reports success.
+    assert repo.delete(rec.id) is True
+    assert repo.get_by_id(rec.id) is None
+
+
+def _artifact_of_json_size(nbytes):
+    """A ``{"b": "x"*k}`` artifact whose JSON is exactly ``nbytes`` bytes."""
+    import json
+
+    base = len(json.dumps({"b": ""}, ensure_ascii=False).encode("utf-8"))
+    return {"b": "x" * (nbytes - base)}
+
+
+def test_threshold_boundary(tmp_path):
+    fake = _FakeOSS()
+    repo = _repo_with(tmp_path, fake)
+    # Exactly at the threshold → inline (the check is ``> threshold``).
+    at = _artifact_of_json_size(_ARTIFACT_OSS_THRESHOLD_BYTES)
+    repo.insert(_data(publish_bot_id="b-at", ext={"config_artifact": at}))
+    assert fake.put_calls == 0
+    # One byte over → offloaded.
+    over = _artifact_of_json_size(_ARTIFACT_OSS_THRESHOLD_BYTES + 1)
+    repo.insert(_data(publish_bot_id="b-over", ext={"config_artifact": over}))
+    assert fake.put_calls == 1

--- a/src/backend/tests/community/plugins/test_bot_publish_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_publish_unified.py
@@ -16,11 +16,14 @@ from agentclaw.community.core.service_bot.repository.models import (
     BotPublishModel,
     PublishStatus,
 )
+from agentclaw.community.core.service_bot.repository.config_artifact_offload import (
+    ARTIFACT_KEY,
+    ARTIFACT_OSS_MARKER,
+    ARTIFACT_OSS_THRESHOLD_BYTES,
+    ConfigArtifactOffloader,
+)
 from agentclaw.community.plugins.bot_publish_repository import (
     BotPublishRepository,
-    _ARTIFACT_KEY,
-    _ARTIFACT_OSS_MARKER,
-    _ARTIFACT_OSS_THRESHOLD_BYTES,
 )
 
 pytestmark = pytest.mark.integration
@@ -54,7 +57,10 @@ def repo(tmp_path):
         connect_args={"check_same_thread": False},
     )
     BotPublishModel.__table__.create(engine)
-    return BotPublishRepository(_FileSqliteDB(engine))
+    # The offloader is DI-provided in prod; parity tests wrap the in-memory fake.
+    return BotPublishRepository(
+        _FileSqliteDB(engine), offload=ConfigArtifactOffloader(_FakeOSS())
+    )
 
 
 def _data(**overrides):
@@ -309,33 +315,15 @@ class _FakeOSSPutFails(_FakeOSS):
         return False
 
 
-class _FakeOSSNoGet:
-    """Object store WITHOUT get_object — offload must stay disabled."""
-
-    def __init__(self):
-        self.store: dict[str, bytes] = {}
-        self.put_calls = 0
-
-    def put_object(self, key: str, content) -> bool:  # pragma: no cover - guard
-        self.put_calls += 1
-        self.store[key] = content
-        return True
-
-    def delete_object(self, key: str) -> bool:
-        self.store.pop(key, None)
-        return True
-
-    def list_objects(self, prefix: str, max_keys: int = 1000):
-        return [k for k in self.store if k.startswith(prefix)][:max_keys]
-
-
 def _repo_with(engine_tmp, oss):
     engine = create_engine(
         f"sqlite:///{engine_tmp / 'bp.db'}",
         connect_args={"check_same_thread": False},
     )
     BotPublishModel.__table__.create(engine)
-    return BotPublishRepository(_FileSqliteDB(engine), oss=oss)
+    return BotPublishRepository(
+        _FileSqliteDB(engine), offload=ConfigArtifactOffloader(oss)
+    )
 
 
 @pytest.fixture
@@ -353,7 +341,7 @@ def _big_artifact():
     return {
         "schema_version": 4,
         "engine_type": "openclaw",
-        "blob": "x" * (_ARTIFACT_OSS_THRESHOLD_BYTES + 2048),
+        "blob": "x" * (ARTIFACT_OSS_THRESHOLD_BYTES + 2048),
     }
 
 
@@ -381,7 +369,7 @@ def test_small_artifact_stays_inline(repo_oss, oss):
     assert oss.put_calls == 0
     assert oss.store == {}
     raw = _raw_ext(repo_oss, rec.id)
-    assert _ARTIFACT_KEY in raw and _ARTIFACT_OSS_MARKER not in raw
+    assert ARTIFACT_KEY in raw and ARTIFACT_OSS_MARKER not in raw
     # Read path returns the artifact unchanged.
     assert repo_oss.get_by_id(rec.id).ext["config_artifact"] == art
 
@@ -396,11 +384,11 @@ def test_large_artifact_offloaded_and_reinlined(repo_oss, oss):
     assert keys[0].startswith(f"teclaw/dev/bot_publish/{rec.id}/")
     # Column holds the marker (self-describing), NOT the inline artifact.
     raw = _raw_ext(repo_oss, rec.id)
-    assert _ARTIFACT_KEY not in raw
-    marker = raw[_ARTIFACT_OSS_MARKER]
+    assert ARTIFACT_KEY not in raw
+    marker = raw[ARTIFACT_OSS_MARKER]
     assert marker["offloaded"] is True
     assert marker["oss_key"] == keys[0]
-    assert marker["size_bytes"] > _ARTIFACT_OSS_THRESHOLD_BYTES
+    assert marker["size_bytes"] > ARTIFACT_OSS_THRESHOLD_BYTES
     assert "note" in marker
     assert raw["keep"] == "me"  # sibling ext fields untouched
     # Every read path re-inlines the full artifact and hides the marker.
@@ -411,7 +399,7 @@ def test_large_artifact_offloaded_and_reinlined(repo_oss, oss):
     ):
         assert got.ext["config_artifact"] == art
         assert got.ext["keep"] == "me"
-        assert _ARTIFACT_OSS_MARKER not in got.ext
+        assert ARTIFACT_OSS_MARKER not in got.ext
 
 
 def test_offload_via_update_status_with_ext(repo_oss, oss):
@@ -440,7 +428,7 @@ def test_rejected_update_does_not_upload(repo_oss, oss):
 
 def test_rewrite_new_content_and_delete_sweeps_all(repo_oss, oss):
     rec = repo_oss.insert(_data(status="DRAFT", ext={"config_artifact": _big_artifact()}))
-    v2 = {**_big_artifact(), "blob": "y" * (_ARTIFACT_OSS_THRESHOLD_BYTES + 4096)}
+    v2 = {**_big_artifact(), "blob": "y" * (ARTIFACT_OSS_THRESHOLD_BYTES + 4096)}
     repo_oss.update_status_with_ext(
         rec.id, "DRAFT", {"config_artifact": v2}, source_status="DRAFT",
     )
@@ -460,27 +448,6 @@ def test_delete_without_offload_leaves_store_untouched(repo_oss, oss):
     assert oss.store == {}
 
 
-def test_offload_disabled_when_no_oss(repo):
-    # The default repo fixture has no OSS → inline even when large (SQLite TEXT
-    # has no 64KB cap, so this just verifies no crash and no marker).
-    rec = repo.insert(_data(ext={"config_artifact": _big_artifact()}))
-    got = repo.get_by_id(rec.id)
-    assert got.ext["config_artifact"] == _big_artifact()
-    assert _ARTIFACT_OSS_MARKER not in got.ext
-
-
-def test_offload_disabled_when_oss_lacks_get_object(tmp_path):
-    fake = _FakeOSSNoGet()
-    repo = _repo_with(tmp_path, fake)
-    rec = repo.insert(_data(ext={"config_artifact": _big_artifact()}))
-    # Capability gate: no get_object → offload off → nothing uploaded, inline.
-    assert fake.put_calls == 0
-    assert fake.store == {}
-    got = repo.get_by_id(rec.id)
-    assert got.ext["config_artifact"] == _big_artifact()
-    assert _ARTIFACT_OSS_MARKER not in got.ext
-
-
 def test_offload_put_failure_raises_and_rolls_back(tmp_path):
     fake = _FakeOSSPutFails()
     repo = _repo_with(tmp_path, fake)
@@ -488,23 +455,6 @@ def test_offload_put_failure_raises_and_rolls_back(tmp_path):
         repo.insert(_data(ext={"config_artifact": _big_artifact()}))
     # The insert transaction rolled back — no half-written row persisted.
     assert repo.list_by_owner("emp001", "dev") == []
-
-
-def test_strip_stale_marker_write_side(repo_oss):
-    # A fresh inline artifact wins over a leftover marker (never persist both).
-    out = repo_oss._strip_stale_marker(
-        {"config_artifact": {"a": 1}, "config_artifact_oss": {"oss_key": "old"}}
-    )
-    assert out == {"config_artifact": {"a": 1}}
-
-
-def test_resolve_ext_inline_wins_over_marker(repo_oss, oss):
-    # If both are somehow present on read, inline wins and no fetch happens.
-    resolved = repo_oss._resolve_ext(
-        {"config_artifact": {"a": 1}, "config_artifact_oss": {"oss_key": "gone"}}
-    )
-    assert resolved == {"config_artifact": {"a": 1}}
-    assert oss.store == {}  # no get/put occurred
 
 
 def test_write_strips_stale_marker_end_to_end(repo_oss, oss):
@@ -522,7 +472,7 @@ def test_write_strips_stale_marker_end_to_end(repo_oss, oss):
         source_status="DRAFT",
     )
     raw = _raw_ext(repo_oss, rec.id)
-    assert _ARTIFACT_OSS_MARKER not in raw
+    assert ARTIFACT_OSS_MARKER not in raw
     assert raw["config_artifact"] == _small_artifact()
     got = repo_oss.get_by_id(rec.id)
     assert got.ext["config_artifact"] == _small_artifact()
@@ -580,10 +530,10 @@ def test_threshold_boundary(tmp_path):
     fake = _FakeOSS()
     repo = _repo_with(tmp_path, fake)
     # Exactly at the threshold → inline (the check is ``> threshold``).
-    at = _artifact_of_json_size(_ARTIFACT_OSS_THRESHOLD_BYTES)
+    at = _artifact_of_json_size(ARTIFACT_OSS_THRESHOLD_BYTES)
     repo.insert(_data(publish_bot_id="b-at", ext={"config_artifact": at}))
     assert fake.put_calls == 0
     # One byte over → offloaded.
-    over = _artifact_of_json_size(_ARTIFACT_OSS_THRESHOLD_BYTES + 1)
+    over = _artifact_of_json_size(ARTIFACT_OSS_THRESHOLD_BYTES + 1)
     repo.insert(_data(publish_bot_id="b-over", ext={"config_artifact": over}))
     assert fake.put_calls == 1

--- a/src/backend/tests/community/plugins/test_bot_publish_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_publish_unified.py
@@ -18,6 +18,9 @@ from agentclaw.community.core.service_bot.repository.models import (
 )
 from agentclaw.community.plugins.bot_publish_repository import (
     BotPublishRepository,
+    _ARTIFACT_KEY,
+    _ARTIFACT_OSS_MARKER,
+    _ARTIFACT_OSS_THRESHOLD_BYTES,
 )
 
 pytestmark = pytest.mark.integration
@@ -264,3 +267,241 @@ def test_get_latest_success_by_source_bot_id_returns_none_when_no_success(repo):
 
     assert repo.get_latest_success_by_source_bot_id("src-1", "dev") is None
     assert repo.get_latest_success_by_source_bot_id("src-missing", "dev") is None
+
+
+# ── config_artifact OSS offload ─────────────────────────────────────
+#
+# When ``ext['config_artifact']`` serializes past the inline TEXT-column
+# threshold, the repository stashes its JSON in object storage and stores a
+# self-describing marker instead, transparently re-inlining on read. The fake
+# below is a minimal in-memory ObjectStoragePlugin covering the slice the repo
+# uses (put/get/delete/list).
+
+
+class _FakeOSS:
+    """In-memory object store; records put_object calls for assertions."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+        self.put_calls = 0
+
+    def put_object(self, key: str, content) -> bool:
+        self.put_calls += 1
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        self.store[key] = content
+        return True
+
+    def get_object(self, key: str):
+        return self.store.get(key)
+
+    def delete_object(self, key: str) -> bool:
+        self.store.pop(key, None)
+        return True
+
+    def list_objects(self, prefix: str, max_keys: int = 1000):
+        return [k for k in self.store if k.startswith(prefix)][:max_keys]
+
+
+class _FakeOSSPutFails(_FakeOSS):
+    def put_object(self, key: str, content) -> bool:
+        self.put_calls += 1
+        return False
+
+
+class _FakeOSSNoGet:
+    """Object store WITHOUT get_object — offload must stay disabled."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+        self.put_calls = 0
+
+    def put_object(self, key: str, content) -> bool:  # pragma: no cover - guard
+        self.put_calls += 1
+        self.store[key] = content
+        return True
+
+    def delete_object(self, key: str) -> bool:
+        self.store.pop(key, None)
+        return True
+
+    def list_objects(self, prefix: str, max_keys: int = 1000):
+        return [k for k in self.store if k.startswith(prefix)][:max_keys]
+
+
+def _repo_with(engine_tmp, oss):
+    engine = create_engine(
+        f"sqlite:///{engine_tmp / 'bp.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    BotPublishModel.__table__.create(engine)
+    return BotPublishRepository(_FileSqliteDB(engine), oss=oss)
+
+
+@pytest.fixture
+def oss():
+    return _FakeOSS()
+
+
+@pytest.fixture
+def repo_oss(tmp_path, oss):
+    return _repo_with(tmp_path, oss)
+
+
+def _big_artifact():
+    """A serialized artifact comfortably over the inline threshold."""
+    return {
+        "schema_version": 4,
+        "engine_type": "openclaw",
+        "blob": "x" * (_ARTIFACT_OSS_THRESHOLD_BYTES + 2048),
+    }
+
+
+def _small_artifact():
+    return {"schema_version": 4, "engine_type": "openclaw", "blob": "tiny"}
+
+
+def _raw_ext(repo, publish_id):
+    """The ext JSON actually persisted in the column (unresolved), as a dict."""
+    import json
+
+    with repo._db.orm_session() as db:
+        row = (
+            db.query(BotPublishModel.ext)
+            .filter(BotPublishModel.id == publish_id)
+            .first()
+        )
+    return json.loads(row[0]) if row and row[0] else None
+
+
+def test_small_artifact_stays_inline(repo_oss, oss):
+    art = _small_artifact()
+    rec = repo_oss.insert(_data(ext={"config_artifact": art}))
+    # No offload: nothing written to object storage, no marker in the column.
+    assert oss.put_calls == 0
+    assert oss.store == {}
+    raw = _raw_ext(repo_oss, rec.id)
+    assert _ARTIFACT_KEY in raw and _ARTIFACT_OSS_MARKER not in raw
+    # Read path returns the artifact unchanged.
+    assert repo_oss.get_by_id(rec.id).ext["config_artifact"] == art
+
+
+def test_large_artifact_offloaded_and_reinlined(repo_oss, oss):
+    art = _big_artifact()
+    rec = repo_oss.insert(_data(ext={"config_artifact": art, "keep": "me"}))
+    # Offloaded exactly once, under this record's prefix.
+    assert oss.put_calls == 1
+    keys = list(oss.store)
+    assert len(keys) == 1
+    assert keys[0].startswith(f"teclaw/dev/bot_publish/{rec.id}/")
+    # Column holds the marker (self-describing), NOT the inline artifact.
+    raw = _raw_ext(repo_oss, rec.id)
+    assert _ARTIFACT_KEY not in raw
+    marker = raw[_ARTIFACT_OSS_MARKER]
+    assert marker["offloaded"] is True
+    assert marker["oss_key"] == keys[0]
+    assert marker["size_bytes"] > _ARTIFACT_OSS_THRESHOLD_BYTES
+    assert "note" in marker
+    assert raw["keep"] == "me"  # sibling ext fields untouched
+    # Every read path re-inlines the full artifact and hides the marker.
+    for got in (
+        repo_oss.get_by_id(rec.id),
+        repo_oss.get_by_publish_bot_id("src-bot.pub.1", "emp001", "dev"),
+        repo_oss.list_by_owner("emp001", "dev")[0],
+    ):
+        assert got.ext["config_artifact"] == art
+        assert got.ext["keep"] == "me"
+        assert _ARTIFACT_OSS_MARKER not in got.ext
+
+
+def test_offload_via_update_status_with_ext(repo_oss, oss):
+    rec = repo_oss.insert(_data(status="DRAFT", ext={"k": "v"}))
+    assert oss.put_calls == 0
+    out = repo_oss.update_status_with_ext(
+        rec.id, "BUILT", {"config_artifact": _big_artifact()},
+        source_status="DRAFT",
+    )
+    assert out.status == "BUILT"
+    assert out.ext["config_artifact"] == _big_artifact()
+    assert oss.put_calls == 1
+
+
+def test_rejected_update_does_not_upload(repo_oss, oss):
+    rec = repo_oss.insert(_data(status="DRAFT"))
+    # source_status mismatch → 0 rows updated → artifact must NOT be uploaded.
+    out = repo_oss.update_status_with_ext(
+        rec.id, "BUILT", {"config_artifact": _big_artifact()},
+        source_status="BUILT",
+    )
+    assert out is None
+    assert oss.put_calls == 0
+    assert oss.store == {}
+
+
+def test_rewrite_new_content_and_delete_sweeps_all(repo_oss, oss):
+    rec = repo_oss.insert(_data(status="DRAFT", ext={"config_artifact": _big_artifact()}))
+    v2 = {**_big_artifact(), "blob": "y" * (_ARTIFACT_OSS_THRESHOLD_BYTES + 4096)}
+    repo_oss.update_status_with_ext(
+        rec.id, "DRAFT", {"config_artifact": v2}, source_status="DRAFT",
+    )
+    # Content-addressed: two distinct versions coexist under the prefix.
+    assert len(oss.store) == 2
+    # Latest read returns the newest content.
+    assert repo_oss.get_by_id(rec.id).ext["config_artifact"] == v2
+    # Delete sweeps every version under the record's prefix.
+    assert repo_oss.delete(rec.id) is True
+    assert oss.store == {}
+
+
+def test_delete_without_offload_leaves_store_untouched(repo_oss, oss):
+    rec = repo_oss.insert(_data(ext={"config_artifact": _small_artifact()}))
+    assert oss.store == {}
+    assert repo_oss.delete(rec.id) is True
+    assert oss.store == {}
+
+
+def test_offload_disabled_when_no_oss(repo):
+    # The default repo fixture has no OSS → inline even when large (SQLite TEXT
+    # has no 64KB cap, so this just verifies no crash and no marker).
+    rec = repo.insert(_data(ext={"config_artifact": _big_artifact()}))
+    got = repo.get_by_id(rec.id)
+    assert got.ext["config_artifact"] == _big_artifact()
+    assert _ARTIFACT_OSS_MARKER not in got.ext
+
+
+def test_offload_disabled_when_oss_lacks_get_object(tmp_path):
+    fake = _FakeOSSNoGet()
+    repo = _repo_with(tmp_path, fake)
+    rec = repo.insert(_data(ext={"config_artifact": _big_artifact()}))
+    # Capability gate: no get_object → offload off → nothing uploaded, inline.
+    assert fake.put_calls == 0
+    assert fake.store == {}
+    got = repo.get_by_id(rec.id)
+    assert got.ext["config_artifact"] == _big_artifact()
+    assert _ARTIFACT_OSS_MARKER not in got.ext
+
+
+def test_offload_put_failure_raises_and_rolls_back(tmp_path):
+    fake = _FakeOSSPutFails()
+    repo = _repo_with(tmp_path, fake)
+    with pytest.raises(RuntimeError):
+        repo.insert(_data(ext={"config_artifact": _big_artifact()}))
+    # The insert transaction rolled back — no half-written row persisted.
+    assert repo.list_by_owner("emp001", "dev") == []
+
+
+def test_strip_stale_marker_write_side(repo_oss):
+    # A fresh inline artifact wins over a leftover marker (never persist both).
+    out = repo_oss._strip_stale_marker(
+        {"config_artifact": {"a": 1}, "config_artifact_oss": {"oss_key": "old"}}
+    )
+    assert out == {"config_artifact": {"a": 1}}
+
+
+def test_resolve_ext_inline_wins_over_marker(repo_oss, oss):
+    # If both are somehow present on read, inline wins and no fetch happens.
+    resolved = repo_oss._resolve_ext(
+        {"config_artifact": {"a": 1}, "config_artifact_oss": {"oss_key": "gone"}}
+    )
+    assert resolved == {"config_artifact": {"a": 1}}
+    assert oss.store == {}  # no get/put occurred


### PR DESCRIPTION
## Summary

Oversized teclaw `config_artifact`s no longer overflow the `ac_bot_publish.ext` `TEXT` column (~64 KB cap). When the serialized `BotConfigArtifact` exceeds a threshold (**60 KB**), the repository transparently offloads its JSON to object storage and stores a small self-describing marker in `ext`; every read re-inlines it, so **no service-layer caller changed**.

Built with the SDD flow — spec/plan/tasks live under [`src/backend/specs/2026-07-09-teclaw-artifact-oss-offload/`](../tree/claude/teclaw-artifact-oss-storage-7c1ba3/src/backend/specs/2026-07-09-teclaw-artifact-oss-offload).

## What changed

- **`ObjectStoragePlugin.get_object(key) -> bytes | None`** — new read method on the Protocol + fs/S3 impls + mock double.
- **`ConfigArtifactOffloader`** (new DI component) — owns the whole `ext` ⇄ object-storage transform (threshold decision, marker, content-addressed keys, offload/upload/resolve/cleanup). Injected into `BotPublishRepository`, which keeps only persistence.
- **Repository wiring** — offload on `insert`/`update_status_with_ext`, re-inline on every read, prefix-sweep cleanup on `delete`.

## Design notes

- **Transactional:** the object-storage upload runs *inside* the insert/update DB transaction, so a put failure rolls the row back — the column and the object commit together or not at all.
- **Content-addressed immutable keys:** each offload writes a new object keyed by a content digest, so a rejected optimistic-lock write or a concurrent writer can never clobber a live record's bytes. Superseded versions are reaped by `delete`'s prefix sweep.
- **Mutual exclusion by construction:** writes erase both artifact keys then persist exactly one (inline *or* marker), so the read path never sees both.
- **Fail loud:** an offloaded artifact that can't be fetched (or fails to upload) raises rather than silently returning/persisting a record missing its `config_artifact`.

## Deliberate spec deviation

Because keys are content-addressed, superseded artifact versions persist for the record's lifetime and are reaped together on `delete` (no unbounded orphans; storage cost only), rather than being overwritten in place. Write-time GC was rejected — it reintroduces a delete-vs-read race. See `spec.md` acceptance criterion 6.

## Testing

- Full backend suite: **7340 passed, 0 failed**.
- Feature-specific: offload round-trip + edge cases (threshold boundary, insert/update paths, delete cleanup, fail-loud on unreadable/failed offload), plus `get_object` fs/S3 coverage.
- DI/container wiring green — the offloader resolves and injects into the repo in the real graph.

## Follow-up (out of tree)

The corp `ObjectStoragePlugin` implementation must implement `get_object` (and `list_objects` for delete cleanup); the author is handling the prod side separately.
