### PR TITLE
feat(dormant): add passport-only unfreeze endpoint

### DIFF
--- a/src/backend/specs/2026-07-10-dormant-unfreeze-passport-one/plan.md
+++ b/src/backend/specs/2026-07-10-dormant-unfreeze-passport-one/plan.md
@@ -1,0 +1,407 @@
+# Dormant Passport Unfreeze One Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an authenticated internal endpoint that synchronously brings one Bot passport online without reading or changing Bot state or starting a container.
+
+**Architecture:** The FastAPI adapter validates and authenticates the request, then delegates to `DormantOpsService`. The core service depends only on the existing `PassportPlugin` contract and calls `unfreeze_agent_passport`; no contract or plugin implementation changes are required.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic v2, Injector, pytest, Ruff, uv.
+
+## Global Constraints
+
+- Endpoint: `POST /api/internal/dormant/unfreeze-passport-one`.
+- Authentication: existing `verify_dormant_internal_token` Bearer dependency.
+- Required non-blank request fields: `bot_id`, `owner_id`, `reason`.
+- Only side effect: `PassportPlugin.unfreeze_agent_passport`.
+- Do not query `BotModel`, change Bot status, start a container, or call `ActivateBotService`.
+- Do not change `PassportPlugin` or any concrete Passport implementation.
+- Do not log Bearer tokens or Passport credentials.
+
+---
+
+### Task 1: Core passport-only operation
+
+**Files:**
+- Modify: `src/agentclaw/community/core/bot_dormant/ops_service.py:7-24`
+- Modify: `tests/community/core/bot_dormant/test_decide.py:208-337`
+- Create: `tests/community/core/bot_dormant/test_ops_service.py`
+
+**Interfaces:**
+- Consumes: `PassportPlugin.unfreeze_agent_passport(bot_id: str, owner_workno: str, reason: str) -> None`.
+- Produces: `DormantOpsService.unfreeze_passport_one(*, bot_id: str, owner_id: str, reason: str) -> dict`.
+
+- [ ] **Step 1: Write the failing core tests**
+
+Create `test_ops_service.py` with:
+
+```python
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.bot_dormant.ops_service import DormantOpsService
+from agentclaw.community.core.bot_dormant.service import DormantBotService
+from agentclaw.community.plugin_api.passport import PassportPlugin
+
+
+def test_unfreeze_passport_one_only_calls_passport() -> None:
+    dormant_service = MagicMock(spec=DormantBotService)
+    passport = MagicMock(spec=PassportPlugin)
+    service = DormantOpsService(dormant_service, passport)
+
+    result = service.unfreeze_passport_one(
+        bot_id="default",
+        owner_id="37565",
+        reason="recover license",
+    )
+
+    assert result == {
+        "bot_id": "default",
+        "owner_id": "37565",
+        "status": "passport_online",
+    }
+    passport.unfreeze_agent_passport.assert_called_once_with(
+        bot_id="default",
+        owner_workno="37565",
+        reason="recover license",
+    )
+    assert dormant_service.mock_calls == []
+
+
+def test_unfreeze_passport_one_propagates_passport_error() -> None:
+    passport = MagicMock(spec=PassportPlugin)
+    passport.unfreeze_agent_passport.side_effect = RuntimeError("passport unavailable")
+    service = DormantOpsService(MagicMock(spec=DormantBotService), passport)
+
+    with pytest.raises(RuntimeError, match="passport unavailable"):
+        service.unfreeze_passport_one(
+            bot_id="default",
+            owner_id="37565",
+            reason="recover license",
+        )
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+DEPLOY_PROFILE=test uv run pytest \
+  tests/community/core/bot_dormant/test_ops_service.py -q -p no:cacheprovider
+```
+
+Expected: FAIL because `DormantOpsService.__init__` does not accept `PassportPlugin` and `unfreeze_passport_one` does not exist.
+
+- [ ] **Step 3: Add the required plugin dependency and minimal method**
+
+Update `ops_service.py` to import `PassportPlugin`, require it in the injected constructor, and add:
+
+```python
+def unfreeze_passport_one(
+    self,
+    *,
+    bot_id: str,
+    owner_id: str,
+    reason: str,
+) -> dict:
+    logger.info(
+        "[dormant.ops.unfreeze_passport_one] event=start "
+        "bot_id=%s owner_id=%s reason=%s",
+        bot_id,
+        owner_id,
+        reason,
+    )
+    try:
+        self._passport.unfreeze_agent_passport(
+            bot_id=bot_id,
+            owner_workno=owner_id,
+            reason=reason,
+        )
+    except Exception:
+        logger.exception(
+            "[dormant.ops.unfreeze_passport_one] event=failed "
+            "bot_id=%s owner_id=%s reason=%s",
+            bot_id,
+            owner_id,
+            reason,
+        )
+        raise
+    logger.info(
+        "[dormant.ops.unfreeze_passport_one] event=done "
+        "bot_id=%s owner_id=%s reason=%s",
+        bot_id,
+        owner_id,
+        reason,
+    )
+    return {
+        "bot_id": bot_id,
+        "owner_id": owner_id,
+        "status": "passport_online",
+    }
+```
+
+Update existing `DormantOpsService(...)` constructions in `test_decide.py` to pass a `MagicMock(spec=PassportPlugin)` as the second constructor argument. Do not change recycle assertions.
+
+- [ ] **Step 4: Run core tests and verify GREEN**
+
+Run:
+
+```bash
+DEPLOY_PROFILE=test uv run pytest \
+  tests/community/core/bot_dormant/test_ops_service.py \
+  tests/community/core/bot_dormant/test_decide.py -q -p no:cacheprovider
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 5: Commit the core operation**
+
+```bash
+git add \
+  src/agentclaw/community/core/bot_dormant/ops_service.py \
+  tests/community/core/bot_dormant/test_ops_service.py \
+  tests/community/core/bot_dormant/test_decide.py
+git commit -m "feat: add passport-only dormant operation"
+```
+
+### Task 2: Authenticated HTTP endpoint
+
+**Files:**
+- Modify: `src/agentclaw/community/adapters/http/bot_dormant/schemas.py:1-72`
+- Modify: `src/agentclaw/community/adapters/http/bot_dormant/router.py:84-218`
+- Modify: `tests/community/core/bot_dormant/test_internal_endpoints.py:1-340`
+
+**Interfaces:**
+- Consumes: `DormantOpsService.unfreeze_passport_one(*, bot_id: str, owner_id: str, reason: str) -> dict` from Task 1.
+- Produces: `POST /api/internal/dormant/unfreeze-passport-one` with the success and error semantics in `spec.md`.
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+Add these tests:
+
+```python
+def test_unfreeze_passport_one_forwards_audit_reason() -> None:
+    ops_svc = MagicMock(spec=DormantOpsService)
+    ops_svc.unfreeze_passport_one.return_value = {
+        "bot_id": "default",
+        "owner_id": "37565",
+        "status": "passport_online",
+    }
+    activate_svc = MagicMock(spec=ActivateBotService)
+    client = _build_app(ops_svc=ops_svc, activate_svc=activate_svc)
+
+    response = client.post(
+        "/api/internal/dormant/unfreeze-passport-one",
+        json={
+            "bot_id": "default",
+            "owner_id": "37565",
+            "reason": "recover license",
+        },
+        headers={"Authorization": "Bearer test-tok"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "data": {
+            "bot_id": "default",
+            "owner_id": "37565",
+            "status": "passport_online",
+        },
+    }
+    ops_svc.unfreeze_passport_one.assert_called_once_with(
+        bot_id="default",
+        owner_id="37565",
+        reason="recover license",
+    )
+    activate_svc.activate.assert_not_called()
+
+
+def test_unfreeze_passport_one_returns_500_for_passport_error() -> None:
+    ops_svc = MagicMock(spec=DormantOpsService)
+    ops_svc.unfreeze_passport_one.side_effect = RuntimeError("passport unavailable")
+    client = _build_app(ops_svc=ops_svc)
+
+    response = client.post(
+        "/api/internal/dormant/unfreeze-passport-one",
+        json={"bot_id": "default", "owner_id": "37565", "reason": "recover"},
+        headers={"Authorization": "Bearer test-tok"},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "passport unavailable"
+
+
+@pytest.mark.parametrize("field", ["bot_id", "owner_id", "reason"])
+def test_unfreeze_passport_one_rejects_blank_fields(field: str) -> None:
+    payload = {"bot_id": "default", "owner_id": "37565", "reason": "recover"}
+    payload[field] = "   "
+    client = _build_app()
+
+    response = client.post(
+        "/api/internal/dormant/unfreeze-passport-one",
+        json=payload,
+        headers={"Authorization": "Bearer test-tok"},
+    )
+
+    assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run endpoint tests and verify RED**
+
+Run:
+
+```bash
+DEPLOY_PROFILE=test uv run pytest \
+  tests/community/core/bot_dormant/test_internal_endpoints.py \
+  -q -p no:cacheprovider
+```
+
+Expected: FAIL with HTTP 404 for the new route.
+
+- [ ] **Step 3: Add schema and route implementation**
+
+Use Pydantic v2 constrained strings:
+
+```python
+from typing import Annotated
+
+from pydantic import BaseModel, StringConstraints
+
+NonBlankString = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]
+
+
+class OpsUnfreezePassportOneRequest(BaseModel):
+    bot_id: NonBlankString
+    owner_id: NonBlankString
+    reason: NonBlankString
+```
+
+Import the schema in `router.py`, then add:
+
+```python
+@internal_router.post("/unfreeze-passport-one")
+async def unfreeze_passport_one(
+    body: OpsUnfreezePassportOneRequest,
+    _: None = Depends(verify_dormant_internal_token),
+    service: DormantOpsService = Injected(DormantOpsService),
+) -> dict:
+    """Ops-only helper: bring one Bot passport online without activation."""
+    logger.info(
+        "[dormant.ops.unfreeze_passport_one] request "
+        "bot_id=%s owner_id=%s reason=%s",
+        body.bot_id,
+        body.owner_id,
+        body.reason,
+    )
+    try:
+        data = service.unfreeze_passport_one(
+            bot_id=body.bot_id,
+            owner_id=body.owner_id,
+            reason=body.reason,
+        )
+        return {"ok": True, "data": data}
+    except Exception as e:
+        logger.exception(
+            "[dormant.ops.unfreeze_passport_one] failed "
+            "bot_id=%s owner_id=%s reason=%s",
+            body.bot_id,
+            body.owner_id,
+            body.reason,
+        )
+        raise HTTPException(status_code=500, detail=str(e)) from e
+```
+
+- [ ] **Step 4: Run endpoint and dormant regression tests**
+
+Run:
+
+```bash
+DEPLOY_PROFILE=test uv run pytest \
+  tests/community/core/bot_dormant/test_internal_endpoints.py \
+  tests/community/core/bot_dormant/test_ops_service.py \
+  tests/community/core/bot_dormant/test_decide.py \
+  tests/community/core/bot_dormant/test_activate.py \
+  -q -p no:cacheprovider
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 5: Commit the HTTP endpoint**
+
+```bash
+git add \
+  src/agentclaw/community/adapters/http/bot_dormant/schemas.py \
+  src/agentclaw/community/adapters/http/bot_dormant/router.py \
+  tests/community/core/bot_dormant/test_internal_endpoints.py
+git commit -m "feat: add dormant passport unfreeze endpoint"
+```
+
+### Task 3: Verification and publication
+
+**Files:**
+- Verify only; no planned production-file changes.
+
+**Interfaces:**
+- Consumes: completed Tasks 1 and 2.
+- Produces: verified branch and a draft PR targeting `inclusionAI/Avernet:dev`.
+
+- [ ] **Step 1: Run formatting and lint checks**
+
+```bash
+uv run ruff check \
+  src/agentclaw/community/core/bot_dormant/ops_service.py \
+  src/agentclaw/community/adapters/http/bot_dormant/schemas.py \
+  src/agentclaw/community/adapters/http/bot_dormant/router.py \
+  tests/community/core/bot_dormant/test_ops_service.py \
+  tests/community/core/bot_dormant/test_decide.py \
+  tests/community/core/bot_dormant/test_internal_endpoints.py
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run the complete dormant test package**
+
+```bash
+DEPLOY_PROFILE=test uv run pytest \
+  tests/community/core/bot_dormant -q -p no:cacheprovider
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Run the backend CI gate**
+
+```bash
+BACKEND_CI_BASE=origin/dev bash scripts/ci_test.sh
+```
+
+Expected: pytest, coverage, and changed-line coverage gates exit 0.
+
+- [ ] **Step 4: Audit the final diff**
+
+```bash
+git diff --check origin/dev...HEAD
+git status -sb
+git log --oneline origin/dev..HEAD
+```
+
+Expected: clean worktree and only the design, plan, service, schema, router, and related tests in scope.
+
+- [ ] **Step 5: Push and create the PR**
+
+```bash
+git push -u origin agent/dormant-unfreeze-passport-one
+gh pr create \
+  --repo inclusionAI/Avernet \
+  --base dev \
+  --head agent/dormant-unfreeze-passport-one \
+  --draft \
+  --title "feat(dormant): add passport-only unfreeze endpoint" \
+  --body-file /tmp/avernet-dormant-unfreeze-passport-pr.md
+```
+
+Expected: a draft PR URL targeting `inclusionAI/Avernet:dev`.

--- a/src/backend/specs/2026-07-10-dormant-unfreeze-passport-one/spec.md
+++ b/src/backend/specs/2026-07-10-dormant-unfreeze-passport-one/spec.md
@@ -1,0 +1,133 @@
+# 指定 Bot 许可证上线运维接口
+
+## Summary
+
+新增 Bearer Token 保护的内部运维接口：
+
+```http
+POST /api/internal/dormant/unfreeze-passport-one
+Authorization: Bearer <DORMANT_INTERNAL_TOKEN>
+Content-Type: application/json
+
+{
+  "bot_id": "default",
+  "owner_id": "37565",
+  "reason": "recover license after service bot restart_publish_for_others"
+}
+```
+
+该接口只调用 `PassportPlugin.unfreeze_agent_passport` 将指定 Bot 的身份凭据上线。
+它不读取或修改 Bot 状态，不启动容器，也不复用完整的 `ActivateBotService` 流程。
+
+## Motivation
+
+Bot 可能已经处于 `ACTIVE`，但许可证因异常回收仍被冻结。完整 activate 流程会修改
+状态并启动容器，不适合这种仅订正许可证状态的场景。运维需要一个影响面受限、可审计、
+同步返回 Passport 调用结果的内部入口。
+
+## Scope
+
+### In Scope
+
+- 在现有 `/api/internal/dormant` Router 下新增接口。
+- 复用现有 `verify_dormant_internal_token` Bearer Token 鉴权。
+- 请求体包含非空的 `bot_id`、`owner_id`、`reason`。
+- Core 运维服务调用 `PassportPlugin.unfreeze_agent_passport`。
+- 记录请求、成功和失败日志；日志包含 Bot、Owner 和审计 reason。
+- 对请求转发、成功响应、Passport 异常和输入校验增加测试。
+
+### Out of Scope
+
+- 查询或校验 `BotModel` 是否存在、是否为 `ACTIVE`。
+- 修改 `BotModel.status`。
+- 启动或重启 Bot 容器。
+- 调用 `ActivateBotService.activate` 或完整 activate 状态机。
+- 新增数据库审计表；`reason` 通过结构化日志和 Passport SDK 请求进入审计链路。
+- 修改 `PassportPlugin` 合同或具体插件实现。
+
+## Architecture
+
+HTTP Adapter 只负责鉴权、请求解析和异常到 HTTP 状态码的映射。业务动作位于
+`DormantOpsService`：它依赖既有的 `PassportPlugin` 合同，不依赖具体 Passport 实现。
+这保持 `core -> plugin_api` 的依赖方向，并避免在 Router 中直接选择插件实现。
+
+调用链：
+
+```text
+HTTP request
+  -> verify_dormant_internal_token
+  -> unfreeze_passport_one router handler
+  -> DormantOpsService.unfreeze_passport_one
+  -> PassportPlugin.unfreeze_agent_passport
+  -> configured Passport implementation
+```
+
+`DormantOpsService` 继续作为小型运维编排入口。其构造函数新增 `PassportPlugin` 依赖，
+现有 dormant recycle 行为保持不变。
+
+## API Contract
+
+### Request
+
+`OpsUnfreezePassportOneRequest`：
+
+| 字段 | 类型 | 约束 | 说明 |
+|---|---|---|---|
+| `bot_id` | string | 去除首尾空白后长度至少 1 | Bot ID |
+| `owner_id` | string | 去除首尾空白后长度至少 1 | Owner 工号 |
+| `reason` | string | 去除首尾空白后长度至少 1 | Passport 审计原因 |
+
+### Success
+
+HTTP 200：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "bot_id": "default",
+    "owner_id": "37565",
+    "status": "passport_online"
+  }
+}
+```
+
+`PassportPlugin.unfreeze_agent_passport` 是同步调用。只有它未抛异常时才返回成功。
+
+### Errors
+
+- Bearer Token 缺失或错误：复用现有鉴权行为。
+- 请求字段为空或仅包含空白：HTTP 422，由 Pydantic 请求模型拒绝。
+- Passport 调用抛出异常：记录异常日志并返回 HTTP 500。
+
+## Observability and Audit
+
+Router 在收到请求时记录 `bot_id`、`owner_id`、`reason`。Core Service 在 Passport 调用
+开始、成功和失败时记录相同审计维度。不得记录 Bearer Token 或 Passport 凭据。
+
+## Testing
+
+采用测试驱动开发：
+
+1. Router 测试先证明新路径不存在或未转发，然后实现路由。
+2. Service 测试证明参数被原样传给 `PassportPlugin.unfreeze_agent_passport`。
+3. Service 测试证明 Passport 异常向上传播，Router 映射为 HTTP 500。
+4. 请求模型测试覆盖空白字段返回 HTTP 422。
+5. 测试不绑定 `ActivateBotService`，并断言该接口只调用 Passport 运维服务。
+6. 运行 dormant 模块测试、Ruff 和仓库后端 CI 门禁。
+
+## Acceptance Criteria
+
+- [ ] 使用正确 Bearer Token 和有效请求时，只调用一次 Passport 解冻能力。
+- [ ] `reason` 不被替换或丢弃。
+- [ ] 成功响应明确标识 `passport_online`。
+- [ ] Passport 异常不会被误报为成功。
+- [ ] 空白 `bot_id`、`owner_id` 或 `reason` 被拒绝。
+- [ ] 不读写 Bot 状态，不启动容器，不调用完整 activate 流程。
+- [ ] 现有 dormant 接口与测试保持通过。
+
+## Rollout
+
+代码首先合入 `inclusionAI/Avernet:dev`。合并提交同步到内部
+`code.alipay.com/mirrors/Avernet` 后，OCB 再将 `ocb-public` gitlink 更新到该提交。
+外层 OCB 不应提前固定到仅存在于未合并 PR 分支的提交。

--- a/src/backend/src/agentclaw/community/adapters/http/bot_dormant/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_dormant/router.py
@@ -89,6 +89,7 @@ from agentclaw.community.adapters.http.bot_dormant.schemas import (  # noqa: E40
     MarkSentResponse,
     OpsActivateOneRequest,
     OpsRecycleOneRequest,
+    OpsUnfreezePassportOneRequest,
     PendingNotification,
     PendingNotificationsResponse,
 )
@@ -181,6 +182,38 @@ async def recycle_one(
         logger.exception(
             "[dormant.ops.recycle_one] failed bot_id=%s owner_id=%s",
             body.bot_id, body.owner_id,
+        )
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@internal_router.post("/unfreeze-passport-one")
+async def unfreeze_passport_one(
+    body: OpsUnfreezePassportOneRequest,
+    _: None = Depends(verify_dormant_internal_token),
+    service: DormantOpsService = Injected(DormantOpsService),
+) -> dict:
+    """Ops-only helper: bring one Bot passport online without activation."""
+    logger.info(
+        "[dormant.ops.unfreeze_passport_one] request "
+        "bot_id=%s owner_id=%s reason=%s",
+        body.bot_id,
+        body.owner_id,
+        body.reason,
+    )
+    try:
+        data = service.unfreeze_passport_one(
+            bot_id=body.bot_id,
+            owner_id=body.owner_id,
+            reason=body.reason,
+        )
+        return {"ok": True, "data": data}
+    except Exception as e:
+        logger.exception(
+            "[dormant.ops.unfreeze_passport_one] failed "
+            "bot_id=%s owner_id=%s reason=%s",
+            body.bot_id,
+            body.owner_id,
+            body.reason,
         )
         raise HTTPException(status_code=500, detail=str(e)) from e
 

--- a/src/backend/src/agentclaw/community/adapters/http/bot_dormant/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_dormant/schemas.py
@@ -1,6 +1,14 @@
 """Pydantic schemas for bot dormant / reactivation endpoints."""
 
-from pydantic import BaseModel
+from typing import Annotated
+
+from pydantic import BaseModel, StringConstraints
+
+
+NonBlankString = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]
 
 
 class ActivateBotResponse(BaseModel):
@@ -64,6 +72,12 @@ class OpsRecycleOneRequest(BaseModel):
     owner_id: str
     dry_run: bool = True
     reason: str | None = None
+
+
+class OpsUnfreezePassportOneRequest(BaseModel):
+    bot_id: NonBlankString
+    owner_id: NonBlankString
+    reason: NonBlankString
 
 
 class OpsActivateOneRequest(BaseModel):

--- a/src/backend/src/agentclaw/community/core/bot_dormant/ops_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/ops_service.py
@@ -9,6 +9,7 @@ from injector import inject
 from agentclaw.community.core.bot_dormant.service import Candidate, DormantBotService
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.models import BotModel
+from agentclaw.community.plugin_api.passport import PassportPlugin
 
 
 logger = get_logger()
@@ -18,8 +19,56 @@ class DormantOpsService:
     """Small operations facade that reuses the production dormant recycle path."""
 
     @inject
-    def __init__(self, dormant_service: DormantBotService) -> None:
+    def __init__(
+        self,
+        dormant_service: DormantBotService,
+        passport_plugin: PassportPlugin,
+    ) -> None:
         self._dormant_service = dormant_service
+        self._passport = passport_plugin
+
+    def unfreeze_passport_one(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        reason: str,
+    ) -> dict:
+        """Bring one Bot passport online without changing Bot lifecycle state."""
+        logger.info(
+            "[dormant.ops.unfreeze_passport_one] event=start "
+            "bot_id=%s owner_id=%s reason=%s",
+            bot_id,
+            owner_id,
+            reason,
+        )
+        try:
+            self._passport.unfreeze_agent_passport(
+                bot_id=bot_id,
+                owner_workno=owner_id,
+                reason=reason,
+            )
+        except Exception:
+            logger.exception(
+                "[dormant.ops.unfreeze_passport_one] event=failed "
+                "bot_id=%s owner_id=%s reason=%s",
+                bot_id,
+                owner_id,
+                reason,
+            )
+            raise
+        logger.info(
+            "[dormant.ops.unfreeze_passport_one] event=done "
+            "bot_id=%s owner_id=%s reason=%s",
+            bot_id,
+            owner_id,
+            reason,
+        )
+        return {
+            "bot_id": bot_id,
+            "owner_id": owner_id,
+            "status": "passport_online",
+        }
 
     def recycle_one(
         self,

--- a/src/backend/tests/community/core/bot_dormant/test_decide.py
+++ b/src/backend/tests/community/core/bot_dormant/test_decide.py
@@ -218,7 +218,7 @@ def test_manual_recycle_one_reuses_recycle_side_effects_and_writes_audit():
         bot_service=bot_service,
         passport_plugin=passport,
     )
-    ops_service = DormantOpsService(service)
+    ops_service = DormantOpsService(service, passport)
 
     result = ops_service.recycle_one(
         bot_id="ops_bot",
@@ -266,7 +266,7 @@ def test_manual_recycle_one_dry_run_skips_side_effects_but_records_intent():
         bot_service=bot_service,
         passport_plugin=passport,
     )
-    ops_service = DormantOpsService(service)
+    ops_service = DormantOpsService(service, passport)
 
     result = ops_service.recycle_one(
         bot_id="ops_bot",
@@ -288,7 +288,7 @@ def test_manual_recycle_one_dry_run_skips_side_effects_but_records_intent():
 def test_manual_recycle_one_rejects_missing_bot():
     """Manual ops recycle should fail clearly when bot_id + owner_id misses."""
     session = _make_session()
-    ops_service = DormantOpsService(_make_service(session))
+    ops_service = DormantOpsService(_make_service(session), MagicMock())
 
     with pytest.raises(ValueError, match="bot not found"):
         ops_service.recycle_one(
@@ -308,7 +308,7 @@ def test_manual_recycle_one_rejects_non_active_bot():
         owner_id="owner1",
         status="RECYCLED",
     )
-    ops_service = DormantOpsService(_make_service(session))
+    ops_service = DormantOpsService(_make_service(session), MagicMock())
 
     with pytest.raises(ValueError, match="only ACTIVE bot"):
         ops_service.recycle_one(
@@ -328,7 +328,7 @@ def test_manual_recycle_one_rejects_non_personal_bot():
         owner_id="owner1",
         bot_type="team",
     )
-    ops_service = DormantOpsService(_make_service(session))
+    ops_service = DormantOpsService(_make_service(session), MagicMock())
 
     with pytest.raises(ValueError, match="only personal bot"):
         ops_service.recycle_one(

--- a/src/backend/tests/community/core/bot_dormant/test_internal_endpoints.py
+++ b/src/backend/tests/community/core/bot_dormant/test_internal_endpoints.py
@@ -305,6 +305,87 @@ def test_recycle_one_returns_500_for_unexpected_error():
 
 
 @pytest.mark.unit
+def test_unfreeze_passport_one_forwards_audit_reason():
+    """Passport-only ops must not enter the full bot activation flow."""
+    ops_svc = MagicMock(spec=DormantOpsService)
+    ops_svc.unfreeze_passport_one.return_value = {
+        "bot_id": "default",
+        "owner_id": "37565",
+        "status": "passport_online",
+    }
+    activate_svc = MagicMock(spec=ActivateBotService)
+    client = _build_app(ops_svc=ops_svc, activate_svc=activate_svc)
+
+    response = client.post(
+        "/api/internal/dormant/unfreeze-passport-one",
+        json={
+            "bot_id": "default",
+            "owner_id": "37565",
+            "reason": "recover license",
+        },
+        headers={"Authorization": "Bearer test-tok"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "data": {
+            "bot_id": "default",
+            "owner_id": "37565",
+            "status": "passport_online",
+        },
+    }
+    ops_svc.unfreeze_passport_one.assert_called_once_with(
+        bot_id="default",
+        owner_id="37565",
+        reason="recover license",
+    )
+    activate_svc.activate.assert_not_called()
+
+
+@pytest.mark.unit
+def test_unfreeze_passport_one_returns_500_for_passport_error():
+    ops_svc = MagicMock(spec=DormantOpsService)
+    ops_svc.unfreeze_passport_one.side_effect = RuntimeError(
+        "passport unavailable"
+    )
+    client = _build_app(ops_svc=ops_svc)
+
+    response = client.post(
+        "/api/internal/dormant/unfreeze-passport-one",
+        json={
+            "bot_id": "default",
+            "owner_id": "37565",
+            "reason": "recover",
+        },
+        headers={"Authorization": "Bearer test-tok"},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "passport unavailable"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["bot_id", "owner_id", "reason"])
+def test_unfreeze_passport_one_rejects_blank_fields(field: str):
+    payload = {
+        "bot_id": "default",
+        "owner_id": "37565",
+        "reason": "recover",
+    }
+    payload[field] = "   "
+    client = _build_app()
+
+    response = client.post(
+        "/api/internal/dormant/unfreeze-passport-one",
+        json=payload,
+        headers={"Authorization": "Bearer test-tok"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
 def test_activate_one_forwards_to_activate_service():
     """ops activate-one should reuse the normal RECYCLED bot activation path."""
     activate_svc = MagicMock(spec=ActivateBotService)

--- a/src/backend/tests/community/core/bot_dormant/test_ops_service.py
+++ b/src/backend/tests/community/core/bot_dormant/test_ops_service.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.bot_dormant.ops_service import DormantOpsService
+from agentclaw.community.core.bot_dormant.service import DormantBotService
+from agentclaw.community.plugin_api.passport import PassportPlugin
+
+
+def test_unfreeze_passport_one_only_calls_passport() -> None:
+    dormant_service = MagicMock(spec=DormantBotService)
+    passport = MagicMock(spec=PassportPlugin)
+    service = DormantOpsService(dormant_service, passport)
+
+    result = service.unfreeze_passport_one(
+        bot_id="default",
+        owner_id="37565",
+        reason="recover license",
+    )
+
+    assert result == {
+        "bot_id": "default",
+        "owner_id": "37565",
+        "status": "passport_online",
+    }
+    passport.unfreeze_agent_passport.assert_called_once_with(
+        bot_id="default",
+        owner_workno="37565",
+        reason="recover license",
+    )
+    assert dormant_service.mock_calls == []
+
+
+def test_unfreeze_passport_one_propagates_passport_error() -> None:
+    passport = MagicMock(spec=PassportPlugin)
+    passport.unfreeze_agent_passport.side_effect = RuntimeError(
+        "passport unavailable"
+    )
+    service = DormantOpsService(MagicMock(spec=DormantBotService), passport)
+
+    with pytest.raises(RuntimeError, match="passport unavailable"):
+        service.unfreeze_passport_one(
+            bot_id="default",
+            owner_id="37565",
+            reason="recover license",
+        )

--- a/src/backend/tests/community/endpoints/test_bot_dormant_ops_router.py
+++ b/src/backend/tests/community/endpoints/test_bot_dormant_ops_router.py
@@ -29,6 +29,22 @@ def _seed_recycle_error(world) -> None:
     world.injector.binder.bind(DormantOpsService, to=svc, scope=None)
 
 
+def _seed_unfreeze_passport_ok(world) -> None:
+    svc = MagicMock(spec=DormantOpsService)
+    svc.unfreeze_passport_one.return_value = {
+        "bot_id": "default",
+        "owner_id": "37565",
+        "status": "passport_online",
+    }
+    world.injector.binder.bind(DormantOpsService, to=svc, scope=None)
+
+
+def _seed_unfreeze_passport_error(world) -> None:
+    svc = MagicMock(spec=DormantOpsService)
+    svc.unfreeze_passport_one.side_effect = RuntimeError("passport unavailable")
+    world.injector.binder.bind(DormantOpsService, to=svc, scope=None)
+
+
 def _seed_activate_ok(world) -> None:
     svc = MagicMock(spec=ActivateBotService)
     svc.activate.return_value = {"status": "REACTIVATING", "message": "激活中"}
@@ -78,6 +94,52 @@ def recycle_one_ok():
 )
 def recycle_one_err():
     """Error path: domain validation is surfaced as HTTP 400."""
+    pass
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/internal/dormant/unfreeze-passport-one",
+    scenario="ok",
+    input=CaseInput(
+        headers=_AUTH_HEADERS,
+        json_body={
+            "bot_id": "default",
+            "owner_id": "37565",
+            "reason": "recover license",
+        },
+    ),
+    seed=_seed_unfreeze_passport_ok,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"ok": True, "data": {"status": "passport_online"}},
+    ),
+)
+def unfreeze_passport_one_ok():
+    """Happy path: passport-only ops returns the online status."""
+    pass
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/internal/dormant/unfreeze-passport-one",
+    scenario="err",
+    input=CaseInput(
+        headers=_AUTH_HEADERS,
+        json_body={
+            "bot_id": "default",
+            "owner_id": "37565",
+            "reason": "recover license",
+        },
+    ),
+    seed=_seed_unfreeze_passport_error,
+    expect=ExpectError(
+        status=500,
+        json_contains={"detail": "passport unavailable"},
+    ),
+)
+def unfreeze_passport_one_err():
+    """Error path: Passport failures are surfaced as HTTP 500."""
     pass
 
 


### PR DESCRIPTION
## What changed

- add `POST /api/internal/dormant/unfreeze-passport-one`
- reuse the existing dormant Bearer-token authentication
- validate non-blank `bot_id`, `owner_id`, and audit `reason`
- add a passport-only `DormantOpsService` operation that calls
  `PassportPlugin.unfreeze_agent_passport`
- cover the core operation, HTTP success/error/validation behavior, and the
  repository endpoint coverage gate

## Why

An already-`ACTIVE` Bot can have an incorrectly frozen passport after an
abnormal license recycle. Running the complete activate flow would modify Bot
state and may start a container. This endpoint provides a narrowly scoped
operations correction that only brings the passport online.

## Behavior boundary

This endpoint does **not**:

- query or update Bot status
- start or restart a Bot container
- call `ActivateBotService`
- run the complete activate state machine

The supplied `reason` is forwarded unchanged to the Passport plugin and is
included in structured operation logs.

## Structural analysis

- Contract change: additive internal HTTP API; no Service API or Plugin API
  contract change
- Plugin consumers affected: `DormantOpsService` now consumes the existing
  `PassportPlugin.unfreeze_agent_passport` capability
- Plugin implementations affected: none
- Compatibility: backward compatible and additive
- Migration/deprecation: none
- Architecture waiver: none

## Verification

- TDD red/green cycles for core and HTTP behavior
- Ruff on all touched Python files
- dormant module: `140 passed`
- endpoint framework: `460 passed`
- complete backend gate: `7326 passed`
- case pass rate: `100.00%`
- line coverage: `81.73%`
- `backend CI gate passed`
