### PR TITLE
fix(message-flow): 区分群聊投递失败与 bot 离线，修复 dynamic_status=active 仍报 "已离线"

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -625,10 +625,15 @@ pub async fn handle_web_send(
 
     let frontend_deliveries = publish_web_user_message(flow, &cmd).await;
 
-    // Notify when @-mentioned (Send) bots failed delivery (offline/unreachable).
-    // Excludes bots blocked by interceptors (already have their own error surface).
+    // Notify when @-mentioned (Send) bots failed delivery. A failed delivery
+    // is reported as "已离线" when the bot is genuinely unreachable
+    // (is_available=false / no resolvable delivery target); when the bot is
+    // still online (is_available=true) but the delivery itself failed (e.g. a
+    // transient HTTP provider webhook error), it is reported as a retryable
+    // delivery failure instead, so a still-active bot is not wrongly shown as
+    // offline.
     {
-        let offline_bot_names: Vec<String> = decision
+        let failed_targets: Vec<&RoutingTarget> = decision
             .targets
             .iter()
             .filter(|t| t.delivery_type == DeliveryType::Send)
@@ -637,25 +642,51 @@ pub async fn handle_web_send(
                     .iter()
                     .any(|r| r.target_bot_id == t.bot_uuid && !r.delivered)
             })
-            .filter_map(|t| {
-                group
-                    .get_participant(&t.bot_uuid)
-                    .and_then(|p| p.bot_name.clone())
-                    .or_else(|| Some(t.bot_uuid.clone()))
-            })
             .collect();
 
-        if !offline_bot_names.is_empty() {
-            if let Some(ref system_message) = flow.system_message {
-                let session_id = cmd.session_id.as_deref().unwrap_or(&cmd.group_id);
+        let mut offline_bot_names: Vec<String> = Vec::new();
+        let mut failed_bot_names: Vec<String> = Vec::new();
+        for t in &failed_targets {
+            let name = group
+                .get_participant(&t.bot_uuid)
+                .and_then(|p| p.bot_name.clone())
+                .unwrap_or_else(|| t.bot_uuid.clone());
+            let is_online = match flow.registry.resolve_delivery_target(&t.bot_uuid).await {
+                Ok(target) => flow.bot_delivery.is_available(&target).await,
+                Err(_) => false,
+            };
+            if is_online {
+                failed_bot_names.push(name);
+            } else {
+                offline_bot_names.push(name);
+            }
+        }
+
+        if let Some(ref system_message) = flow.system_message {
+            let session_id = cmd.session_id.as_deref().unwrap_or(&cmd.group_id);
+            let receivers: Vec<Participant> = group
+                .participants
+                .iter()
+                .filter(|p| p.is_bot() && p.bot_uuid != cmd.from_actor_id)
+                .cloned()
+                .collect();
+
+            if !offline_bot_names.is_empty() {
                 let names = offline_bot_names.join("、");
                 let message = format!("Bot {} 已离线", names);
-                let receivers: Vec<Participant> = group
-                    .participants
-                    .iter()
-                    .filter(|p| p.is_bot() && p.bot_uuid != cmd.from_actor_id)
-                    .cloned()
-                    .collect();
+                let event = SystemMessageEvent::GenericNotification {
+                    group_id: cmd.group_id.clone(),
+                    message,
+                    receivers: receivers.clone(),
+                };
+                let _ = system_message
+                    .notify(&cmd.group_id, event, session_id, &group.participants)
+                    .await;
+            }
+
+            if !failed_bot_names.is_empty() {
+                let names = failed_bot_names.join("、");
+                let message = format!("消息投递给 Bot {} 失败，请稍后重试", names);
                 let event = SystemMessageEvent::GenericNotification {
                     group_id: cmd.group_id.clone(),
                     message,


### PR DESCRIPTION
## Background

群聊中会出现误报「Bot xxx 已离线」：被 @ 提及的 bot 实际 \`dynamic_status\` 仍为 \`active\`，却触发了离线系统消息。issue #60 有详细排查与日志证据。

根因：群聊 \`deliver_group_message\` 对 @ 提及（\`DeliveryType::Send\`）的投递失败，**只看投递结果 \`delivered\`，不回查 bot 在线状态**。当一个仍在线的 bot 因瞬时原因投递失败（如 HTTP provider bot 的 webhook 瞬时 transport error），也会被当成离线。

线上日志佐证（agentclawscs / logstore \`ls-cfg-bcs-log-1776160864-23ec\`，2026-07-10 09:59）：
- \`内容安全值班Bot\`（HTTP provider bot）仍是 \`dynamic_status=active\`（同秒其 chat.inject 还成功 ack）；
- 但一次 \`chat.send\` 调 webhook \`secbaas-prod.alipay.com/bcn/downlink\` 遇到 \`error sending request for url (...)`（65s 连接超时）→ \`delivered=false\`；
- group_flow 随即发出「Bot 内容安全值班Bot 已离线」。

## Change

修改 \`src/bcs/crates/services/bcs-message-flow/src/group_flow.rs\` 中投递失败的通知判定：

投递失败的 \`Send\` 目标不再一律报离线，而是逐个回查 bot 可用性 \`flow.bot_delivery.is_available(resolve_delivery_target(bot_id))\`：

- **仍在线**(\`is_available=true\`) → 报「消息投递给 Bot xxx 失败，请稍后重试」(瞬时投递失败，非真离线)；
- **真不可达**(\`is_available=false\` / resolve 不到 delivery target) → 仍报「Bot xxx 已离线」(行为不变)；

两条系统消息独立发送（同一 session_id / receivers）。

\`is_available\` 语义与 \`dynamic_status=active\` 一致：生产装配的 \`flow.bot_delivery\` 是 \`BotTransportMux\`(\`server.rs:790\`)，对 HTTP provider target 返回 \`target.is_http_provider()\`=true，对 WebSocket target 看 WS 连接是否存在。

## Verification

- \`cargo build --package bcs-message-flow\` 通过
- \`cargo test --package bcs-message-flow\`：49 个测试全过（含 \`web_send_partial_delivery_failure_is_represented_in_outcome\`、\`web_send_blocking_interceptor_prevents_bot_delivery\` 等相关用例）

## Refs

- Fixes #60