### PR TITLE
fix(publish): restore target version's DingTalk channels on rollback

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -2033,6 +2033,20 @@ class PublishFlowService:
         if not bot:
             raise PublishFlowServiceError(f"Bot不存在: {current_record.source_bot_id}")
 
+        # 4.5 复原目标版本的线上投递产物：把 engine_ext.stage 盖回 release 并叠加目标
+        # 版本**存储的** online 渠道 engine_overrides（回滚发生时那个版本的 DingTalk
+        # 配置，含 card_template_id），而**不是**从 DB 实时重取——实时渠道行可能已在本次
+        # 回滚之前被改动（如修改了卡片模版 id）。若不叠加，回滚只投递构建期产物，运行中
+        # 的 bot 会保留当前（改动后）的渠道配置，导致 card_template_id 无法恢复到回滚目标
+        # 版本的值。与 _restart_bot_async 的按阶段重放逻辑一致。无存储 overrides（旧记录）
+        # 或无 config_artifact（ARCA 挂载路径）时均 no-op。
+        stored_overrides = (target_ext.get("engine_overrides_by_stage") or {}).get(
+            PublishStage.ONLINE.value
+        )
+        config_artifact = self._artifact_for_stage(
+            config_artifact, PublishStage.ONLINE, stored_overrides
+        )
+
         # 5. 调用 BaaS upgrade 接口重新部署
         version = f"{target_record.version}"
         upgrade_result = await self._build_service.upgrade_async(

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -1551,13 +1551,15 @@ async def test_execute_rollback_with_config_artifact():
         source_bot_id="bot-456",
     )
 
-    # 目标版本只有 config_artifact（没有 migration_path）
+    # 目标版本只有 config_artifact（没有 migration_path）。旧记录无按阶段存储的
+    # engine_overrides —— overlay no-op，投递 restamp 后的原产物。
+    base_artifact = _enriched_artifact("release")
     target_record = _make_publish_record(
         id=2,
         status=PublishStatus.SUCCESS.value,
         version=2,
         ext={
-            "config_artifact": "s3://bucket/artifact/v2.json",
+            "config_artifact": base_artifact,
             "binding": {"online": 200},
         },
     )
@@ -1582,13 +1584,80 @@ async def test_execute_rollback_with_config_artifact():
         operator="user1",
     )
 
-    # 验证 upgrade_async 使用了 config_artifact
+    # 验证 upgrade_async 使用了 config_artifact（restamp 到 release，无 overlay）
     upgrade_call = build_service.upgrade_async.call_args
-    assert upgrade_call.kwargs["config_artifact"] == "s3://bucket/artifact/v2.json"
+    assert upgrade_call.kwargs["config_artifact"] == base_artifact
+    assert upgrade_call.kwargs["config_artifact"]["engine_ext"]["stage"] == "release"
     assert upgrade_call.kwargs["migration_path"] is None
 
     assert result.publish_id == 2
     assert result.status == PublishStatus.ONLINE_PUB
+
+
+@pytest.mark.asyncio
+async def test_execute_rollback_overlays_stored_online_channel_overrides():
+    """回滚应叠加目标版本**存储的** online 渠道 engine_overrides（含 card_template_id），
+    还原到回滚目标版本发布时的 DingTalk 配置——而非实时重取（实时行可能已被改动）。
+
+    回归 bug：修改钉钉卡片模版 id 并发布后再回滚，卡片 id 未恢复。
+    """
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    bot_service = Mock()
+
+    build_service.upgrade_async = AsyncMock(return_value={"publish_id": 12345})
+    build_service.generate_request_id = Mock(return_value="req-rollback-3")
+    baas_service.approve_publish = Mock()
+
+    svc = _pf(publish_service, build_service, baas_service, bot_service, _arca_router(build_service))
+
+    current_record = _make_publish_record(
+        id=3, status=PublishStatus.DRAFT.value, version=3, source_bot_id="bot-789",
+    )
+
+    # 目标版本发布时快照的 online 渠道（旧卡片模版 id）。构建期产物的 engine_overrides
+    # 是另一个值（draft 渠道），回滚必须投递存储的 online 快照而非构建期值。
+    stored_online = {
+        "channels": {
+            "dingding": {
+                "enabled": True,
+                "accounts": [{"client_id": "cid-1", "card_template_id": "OLD-TEMPLATE"}],
+            }
+        }
+    }
+    build_time = {"channels": {"dingding": {"accounts": [{"client_id": "cid-draft"}]}}}
+    target_record = _make_publish_record(
+        id=2,
+        status=PublishStatus.SUCCESS.value,
+        version=2,
+        ext={
+            "config_artifact": _enriched_artifact("release", build_time),
+            "engine_overrides_by_stage": {"online": stored_online},
+            "binding": {"online": 200},
+        },
+    )
+
+    mock_binding = Mock()
+    mock_binding.device_id = "device-uuid-003"
+
+    def get_publish_side_effect(pk):
+        if pk == 2:
+            return target_record
+        elif pk == 3:
+            return current_record
+        return None
+
+    publish_service.get_publish_by_id = Mock(side_effect=get_publish_side_effect)
+    publish_service.get_device_binding_by_id.return_value = mock_binding
+    bot_service.get_bot.return_value = {"bot_id": "bot-789", "entity_id": "e3", "entity_type": "staff"}
+
+    await svc.execute_rollback(current_publish_id=3, target_publish_id=2, operator="user1")
+
+    delivered = build_service.upgrade_async.call_args.kwargs["config_artifact"]
+    # 投递的产物携带目标版本存储的 online 渠道（旧卡片模版 id），而非构建期 draft 渠道
+    assert delivered["engine_overrides"] == stored_online
+    assert delivered["engine_ext"]["stage"] == "release"
 
 
 # ── teclaw build-time file promotion (Task 10) ───────────────────────


### PR DESCRIPTION
## Problem

Reported for teclaw bot `20260629_tl7vfiw7`: editing the DingTalk card `templateId`, publishing the bot, then rolling back does **not** restore the previous card templateId.

## Root cause

For a teclaw bot, DingTalk channel config (client_id, `card_template_id`, …) is **not baked into the frozen build artifact**. At each promotion stage the publish flow instead:

1. Live-reads the bot's active channel rows for that stage from the DB, overlays them onto the artifact via `_artifact_for_stage(...)`, and delivers that.
2. Snapshots those overrides into `ext["engine_overrides_by_stage"][stage]` on the publish record.

The restart path (`_restart_bot_async`) already re-delivers using that **stored** snapshot — deliberately *reproducing what was promoted, not a live re-fetch*.

`execute_rollback` did not follow this: it passed the target version's `config_artifact` to `upgrade_async` **raw**, never overlaying `engine_overrides_by_stage.online`. Since the stored artifact carries only the build-time channels, rollback shipped an artifact without the target version's real online channel config, and the DB's live online row still held the newly-edited card templateId — so nothing restored the old one.

## Fix

In `execute_rollback`, before redeploying, overlay the target version's stored online `engine_overrides` and re-stamp `engine_ext.stage=release`, mirroring the per-stage replay `_restart_bot_async` performs:

```python
stored_overrides = (target_ext.get("engine_overrides_by_stage") or {}).get(
    PublishStage.ONLINE.value
)
config_artifact = self._artifact_for_stage(
    config_artifact, PublishStage.ONLINE, stored_overrides
)
```

Safe for existing paths:
- **ARCA** (no `config_artifact`, migration_path only) → `_artifact_for_stage` returns `None`, no-op.
- **Pre-feature records** (no `engine_overrides_by_stage`) → overlay no-ops, raw artifact delivered as before.
- **Teclaw with snapshot** → the target's stored online channels (old card templateId) are restored.

## Tests

- Updated `test_execute_rollback_with_config_artifact` to use a realistic dict artifact and assert the restamped artifact is delivered.
- Added `test_execute_rollback_overlays_stored_online_channel_overrides` as the regression guard: with `engine_overrides_by_stage.online` present, the delivered artifact carries the stored online channels (old `card_template_id`), not the build-time draft channels.
- Full `service_bot`, `channel`, and `endpoints` suites pass (1097 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Le8yEghGao6nhTR5jLL1n8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Le8yEghGao6nhTR5jLL1n8)_