### PR TITLE
fix(group): 群成员含已删 bot 时仍显示 bot_name

### DIFF
--- a/src/bcs/crates/service-api/bcs-service-api/src/core/registry.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/registry.rs
@@ -67,6 +67,16 @@ pub trait BotRegistryCoreService: Send + Sync {
     /// Note: This method excludes sensitive fields (agent_code, agent_token) from the returned capabilities.
     async fn get(&self, bot_id: &str) -> Option<RegisteredBot>;
 
+    /// Like [`get`](Self::get) but also returns soft-deleted bots.
+    ///
+    /// Used for display-only enrichment (e.g. filling in a removed bot's name
+    /// in group participant listings). Default implementation delegates to
+    /// `get`, so deleted bots resolve to `None` unless the implementation
+    /// overrides this to read the retained row.
+    async fn get_including_deleted(&self, bot_id: &str) -> Option<RegisteredBot> {
+        self.get(bot_id).await
+    }
+
     /// Get sensitive agent credentials (agent_code and agent_token) for a bot.
     /// This is a separate method to avoid leaking sensitive data in regular get() calls.
     /// Used by AI Security Gateway for message validation.
@@ -521,7 +531,11 @@ pub async fn backfill_bot_names(registry: &dyn BotRegistryCoreService, group: &m
             continue;
         }
 
-        if let Some(bot) = registry.get(&participant.bot_uuid).await {
+        // Use get_including_deleted so removed (soft-deleted) bots still resolve
+        // their name snapshot for display; the group participant row is retained
+        // after a bot is deleted, and without this the frontend would only see
+        // the bot_uuid with no bot_name.
+        if let Some(bot) = registry.get_including_deleted(&participant.bot_uuid).await {
             if let Some(name) = bot
                 .capabilities
                 .name
@@ -546,7 +560,8 @@ pub async fn backfill_participant_names(
             continue;
         }
 
-        if let Some(bot) = registry.get(&participant.bot_uuid).await {
+        // See backfill_bot_names: include soft-deleted bots for display.
+        if let Some(bot) = registry.get_including_deleted(&participant.bot_uuid).await {
             if let Some(name) = bot
                 .capabilities
                 .name

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot.rs
@@ -33,6 +33,16 @@ pub trait BotRepoPort: Send + Sync {
 
     async fn update_status(&self, bot_id: &str, status: BotDynamicStatus) -> bool;
     async fn get(&self, bot_id: &str) -> Option<RegisteredBot>;
+
+    /// Like [`get`](Self::get) but also returns soft-deleted bots.
+    ///
+    /// Default implementation delegates to `get` (which excludes deleted bots),
+    /// returning `None` for deleted bots; persistent stores override this to
+    /// read the retained (soft-deleted) row so display-only callers can still
+    /// resolve a removed bot's name snapshot.
+    async fn get_including_deleted(&self, bot_id: &str) -> Option<RegisteredBot> {
+        self.get(bot_id).await
+    }
     async fn get_agent_credentials(&self, bot_id: &str) -> Option<AgentCredentials>;
 
     /// Set an in-memory extension field on a bot record by key.

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -449,6 +449,7 @@ impl PersistentBotRepo {
     async fn load_from_db(
         &self,
         bot_uuid: &str,
+        include_deleted: bool,
     ) -> Option<(
         BotCapabilities,
         Option<String>,
@@ -460,10 +461,18 @@ impl PersistentBotRepo {
         let env = resolve_env();
         // Code-Review fix #1: include `actor_kind` so the registry read path can
         // propagate it back to callers (O.5 / P.3 / F.3 all gate on actor_kind).
-        let sql = "SELECT name, bot_info, visibility, status, actor_kind, env, created_by, agent_code FROM bcs_bots WHERE bot_uuid = ? AND env = ? AND COALESCE(is_deleted, 0) = 0";
+        //
+        // `include_deleted` skips the soft-delete filter so callers that only
+        // need display metadata (e.g. group participant names of removed bots)
+        // can still read the `name` snapshot from the retained row.
+        let sql = if include_deleted {
+            "SELECT name, bot_info, visibility, status, actor_kind, env, created_by, agent_code FROM bcs_bots WHERE bot_uuid = ? AND env = ?".to_string()
+        } else {
+            "SELECT name, bot_info, visibility, status, actor_kind, env, created_by, agent_code FROM bcs_bots WHERE bot_uuid = ? AND env = ? AND COALESCE(is_deleted, 0) = 0".to_string()
+        };
 
         let rows = self
-            .db_query(sql, vec![Value::from(bot_uuid), Value::from(env.as_str())])
+            .db_query(&sql, vec![Value::from(bot_uuid), Value::from(env.as_str())])
             .await
             .ok()?;
 
@@ -1420,7 +1429,46 @@ impl BotRepoPort for PersistentBotRepo {
         // returning defaults; otherwise O.5/P.3/F.3 will misclassify any actor
         // whose row is no longer cached in process memory.
         let (mut capabilities, env, _hidden, created_by, actor_kind, status) =
-            self.load_from_db(bot_id).await?;
+            self.load_from_db(bot_id, false).await?;
+        let dynamic_status = self.load_status_from_cache(bot_id).await;
+
+        // 清除敏感字段，防止通过常规接口泄露
+        capabilities.agent_code = None;
+        capabilities.agent_token = None;
+
+        Some(RegisteredBot {
+            bot_uuid: bot_id.to_string(),
+            capabilities,
+            dynamic_status,
+            env,
+            created_by,
+            actor_kind,
+            status,
+        })
+    }
+
+    /// Like [`get`](Self::get) but also returns soft-deleted bots (rows with
+    /// `is_deleted = 1`). Used for display-only enrichment where the bot's
+    /// `name` snapshot is still needed after removal (e.g. group participant
+    /// names in `/bots/{id}/groups`). Sensitive fields are stripped the same
+    /// way as `get`.
+    ///
+    /// Checks the in-memory cache first (the common case during backfill, where
+    /// most participants are active, cached bots) and only falls back to a
+    /// database read — with the soft-delete filter dropped — on a cache miss,
+    /// so removed bots can still be resolved from the retained row without
+    /// hitting the database for every participant.
+    async fn get_including_deleted(&self, bot_id: &str) -> Option<RegisteredBot> {
+        let bots = self.bots.read().await;
+        if let Some(bot) = bots.get(bot_id) {
+            if !bot.is_expired() {
+                return Some(bot.to_registered_bot());
+            }
+        }
+        drop(bots);
+
+        let (mut capabilities, env, _hidden, created_by, actor_kind, status) =
+            self.load_from_db(bot_id, true).await?;
         let dynamic_status = self.load_status_from_cache(bot_id).await;
 
         // 清除敏感字段，防止通过常规接口泄露
@@ -1456,7 +1504,7 @@ impl BotRepoPort for PersistentBotRepo {
 
         // Fallback: load from database
         let (capabilities, _env, _hidden, _created_by, _actor_kind, _status) =
-            self.load_from_db(bot_id).await?;
+            self.load_from_db(bot_id, false).await?;
 
         Some(bcs_service_api::AgentCredentials {
             agent_code: capabilities.agent_code,
@@ -1644,7 +1692,7 @@ impl BotRepoPort for PersistentBotRepo {
     // ===== Persistence =====
 
     async fn load_from_storage(&self, bot_id: &str) -> Option<BotCapabilities> {
-        self.load_from_db(bot_id).await.map(
+        self.load_from_db(bot_id, false).await.map(
             |(mut caps, _env, _hidden, _created_by, _actor_kind, _status)| {
                 // agent_token 是运行时敏感字段，只存内存，不从 DB 恢复
                 caps.agent_token = None;
@@ -2306,7 +2354,7 @@ impl BotRepoPort for PersistentBotRepo {
             // reconnected entry reflects the true actor type and lifecycle
             // status (Human reconnects must not silently downgrade to Bot/Online).
             let (capabilities, env, _hidden, created_by, actor_kind, actor_status) =
-                self.load_from_db(&bot_id).await.unwrap_or((
+                self.load_from_db(&bot_id, false).await.unwrap_or((
                     BotCapabilities::default(),
                     Some(resolve_env()),
                     false,

--- a/src/bcs/crates/services/bcs-bot/src/core/bot_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/bot_core.rs
@@ -173,6 +173,10 @@ impl BotRegistryCoreService for BotCore {
         self.repo.get(bot_id).await
     }
 
+    async fn get_including_deleted(&self, bot_id: &str) -> Option<RegisteredBot> {
+        self.repo.get_including_deleted(bot_id).await
+    }
+
     async fn get_agent_credentials(&self, bot_id: &str) -> Option<AgentCredentials> {
         self.repo.get_agent_credentials(bot_id).await
     }


### PR DESCRIPTION
## 问题

\`GET /bots/{bot_uuid}/groups\` 返回的群成员里,如果某个 participant bot 已被删除(软删 \`is_deleted=1\`),则只剩 \`bot_uuid\`、没有 \`bot_name\`,前端展示不友好。

## 根因

MySQL 的群参与者表(\`bcs_group_participants\`)不持久化 \`bot_name\`,读路径完全依赖 \`backfill_bot_names → registry.get\` 实时回填。而 \`registry.get\` 走的 \`bcs_bots\` 查询带 \`COALESCE(is_deleted,0)=0\` 过滤,已删 bot 返回 \`None\` → \`bot_name\` 填不上,DTO 序列化时被 \`skip_serializing_if\` 省略。

注意:软删(\`soft_delete\`)只把 \`bcs_bots\` 行标记为 \`is_deleted=1\`,行仍保留、\`name\` 仍可读。

## 改动

新增一个"含已删"的读取路径,从保留的 \`bcs_bots\` 行读 name 快照,供仅展示场景使用:

- \`BotRepoPort\` / \`BotRegistryCoreService\`:新增 \`get_including_deleted\`(默认退化为 \`get\`)。
- \`BotCore\` + \`PersistentBotRepo\`:覆盖该方法;\`load_from_db\` 增加 \`include_deleted\` 参数以切换 \`is_deleted\` 过滤(原有 4 个调用点传 \`false\`,行为不变)。
- \`backfill_bot_names\` / \`backfill_participant_names\`:改用 \`get_including_deleted\`。

## SQLite / 内存

- **SQLite 无需单独改**:MySQL 与 SQLite 走同一个 \`PersistentBotRepo → load_from_db\`(经 db-api plugin 跑通用 SQL),改一处覆盖两种后端。
- **内存模式天然不受影响**:\`MemoryBotRepo::get\` 本不过滤软删(\`soft_delete\` 只往 \`deleted_bot_ids\` 集合加 id、不从 \`bots\` map 移除),默认实现即可。

## 验证

- \`cargo build\` 通过(bcs-service-api / bcs-bot / bcs-bot-store / bcs-group / bcs-message-flow)。
- \`cargo test\` 通过:bcs-bot-store / bcs-bot / bcs-service-api / bcs-group / bcs-message-flow,0 失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)