### PR TITLE
feat(bcs): stream manager-worker task downlink

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -114,7 +114,13 @@ impl BotDeliveryPort for HttpProviderTransport {
 
     async fn deliver(&self, cmd: BotDeliveryCommand) -> ServiceResult<BotDeliveryResult> {
         let target_bot_id = cmd.target_bot_id().to_string();
-        if matches!(cmd.delivery_kind, BotDeliveryKind::Send) {
+        if matches!(
+            cmd.delivery_kind,
+            BotDeliveryKind::Send
+                | BotDeliveryKind::TaskDispatch
+                | BotDeliveryKind::TaskMessage
+                | BotDeliveryKind::TaskResult
+        ) {
             let BcsFrame::Request(request) = &cmd.frame else {
                 return Err(ServiceError::InvalidOperation {
                     message: "chat.send provider delivery requires request frame".to_string(),
@@ -158,7 +164,7 @@ impl BotDeliveryPort for HttpProviderTransport {
             let wants_sse = matches!(
                 cmd.provider_transport,
                 ProviderTransportPreference::CallbackSse
-            ) && matches!(cmd.delivery_kind, BotDeliveryKind::Send);
+            ) && method == "chat.send";
             let client = if wants_sse { &self.sse_client } else { &self.client };
             let resp =
                 send_provider_request(client, &self.url_guard, &cmd.target, &body, wants_sse)

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -311,7 +311,7 @@ async fn provider_delivery_protocol2_sse_ingests_events() {
     assert!(result.delivered);
     tokio::time::timeout(Duration::from_secs(1), async {
         loop {
-            if message_flow.events.lock().await.len() >= 2 {
+            if message_flow.events.lock().await.len() >= 3 {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
@@ -320,15 +320,95 @@ async fn provider_delivery_protocol2_sse_ingests_events() {
     .await
     .expect("SSE reader should ingest stream events");
     let events = message_flow.events.lock().await;
-    assert_eq!(events.len(), 2);
+    assert_eq!(events.len(), 3);
     assert_eq!(events[0].run_id, "run-sse");
     assert_eq!(events[0].event_type, "agent");
     assert_eq!(events[0].event_payload["stream"], "tool");
     assert_eq!(events[1].event_type, "chat.event");
-    assert_eq!(events[1].state, ChatEventState::Final);
-    assert_eq!(events[1].event_payload["state"], "final");
+    assert_eq!(events[1].state, ChatEventState::Delta);
+    assert_eq!(events[1].event_payload["delta_text"], "streaming ");
+    assert_eq!(events[2].event_type, "chat.event");
+    assert_eq!(events[2].state, ChatEventState::Final);
+    assert_eq!(events[2].event_payload["state"], "final");
     drop(events);
     assert!(run_context.get_context("run-sse").await.unwrap().terminal);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn provider_delivery_protocol2_task_kinds_sse_ingest_events() {
+    let app = Router::new().route("/webhook", post(capture_sse));
+    let (webhook_url, server) = spawn_server(app).await;
+
+    let message_flow = Arc::new(RecordingMessageFlow::default());
+    let run_context = Arc::new(RecordingRunContext::default());
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    transport.set_ingest(message_flow.clone(), run_context.clone());
+
+    for (suffix, delivery_kind) in [
+        ("dispatch", BotDeliveryKind::TaskDispatch),
+        ("message", BotDeliveryKind::TaskMessage),
+        ("result", BotDeliveryKind::TaskResult),
+    ] {
+        let run_id = format!("task-{suffix}-sse");
+        run_context
+            .put_context(BotRunContext {
+                run_id: run_id.clone(),
+                bot_id: "bot-provider".to_string(),
+                group_id: "group-sse".to_string(),
+                bcs_session_id: Some("group-sse:abc12345".to_string()),
+                deadline_ms: bcs_protocol::now_ms() + 60_000,
+                terminal: false,
+            })
+            .await;
+        let event_offset = message_flow.events.lock().await.len();
+
+        let result = transport
+            .deliver(BotDeliveryCommand {
+                target: provider_target_with_protocol(webhook_url.clone(), "2.0"),
+                run_id: run_id.clone(),
+                frame: BcsFrame::Request(RequestFrame::new(
+                    run_id.clone(),
+                    "chat.send",
+                    Some(json!({
+                        "session_key": "group:sse",
+                        "bcs_session_id": "group-sse:abc12345",
+                        "bcs_group_id": "group-sse",
+                        "message": {
+                            "text": "hello"
+                        }
+                    })),
+                )),
+                delivery_kind,
+                provider_transport: ProviderTransportPreference::CallbackSse,
+            })
+            .await
+            .unwrap();
+
+        assert!(result.delivered);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if message_flow.events.lock().await.len() >= event_offset + 3 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("SSE reader should ingest task events");
+        let events = message_flow.events.lock().await;
+        let task_events = &events[event_offset..event_offset + 3];
+        assert_eq!(task_events[0].run_id, run_id);
+        assert_eq!(task_events[0].event_type, "agent");
+        assert_eq!(task_events[1].event_type, "chat.event");
+        assert_eq!(task_events[1].state, ChatEventState::Delta);
+        assert_eq!(task_events[1].event_payload["delta_text"], "streaming ");
+        assert_eq!(task_events[2].event_type, "chat.event");
+        assert_eq!(task_events[2].state, ChatEventState::Final);
+        drop(events);
+        assert!(run_context.get_context(&run_id).await.unwrap().terminal);
+    }
 
     server.abort();
 }
@@ -611,7 +691,10 @@ async fn capture_sse() -> Response {
         "data: {\"runId\":\"engine-run-sse\",\"seq\":1,\"stream\":\"tool\",\"phase\":\"result\",\"toolCallId\":\"tc-1\",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
         "\n",
         "event: chat\n",
-        "data: {\"runId\":\"engine-run-sse\",\"seq\":2,\"state\":\"final\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"done\"}]}}\n",
+        "data: {\"runId\":\"engine-run-sse\",\"seq\":2,\"state\":\"delta\",\"deltaText\":\"streaming \"}\n",
+        "\n",
+        "event: chat\n",
+        "data: {\"runId\":\"engine-run-sse\",\"seq\":3,\"state\":\"final\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"streaming done\"}]}}\n",
         "\n",
     );
     Response::builder()
@@ -880,6 +963,53 @@ async fn provider_delivery_2_0_chat_send_with_sse_preference_advertises_sse() {
     );
     assert_eq!(request.transport.as_deref(), Some("sse"));
     assert_eq!(request.body["method"], "chat.send");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn provider_delivery_2_0_task_kinds_accept_json_callback_fallback() {
+    let captured: CapturedState = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/webhook", post(capture_ack))
+        .with_state(captured.clone());
+    let (webhook_url, server) = spawn_server(app).await;
+
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    for (suffix, delivery_kind) in [
+        ("dispatch", BotDeliveryKind::TaskDispatch),
+        ("message", BotDeliveryKind::TaskMessage),
+        ("result", BotDeliveryKind::TaskResult),
+    ] {
+        let run_id = format!("task-{suffix}-json-fallback");
+        let result = transport
+            .deliver(BotDeliveryCommand {
+                target: provider_target_v2(webhook_url.clone()),
+                run_id: run_id.clone(),
+                frame: BcsFrame::Request(RequestFrame::new(
+                    run_id,
+                    "chat.send",
+                    Some(json!({
+                        "bcs_session_id": "group-1:feedbeef",
+                        "bcs_group_id": "group-1",
+                        "message": { "text": "hello" }
+                    })),
+                )),
+                delivery_kind,
+                provider_transport: ProviderTransportPreference::CallbackSse,
+            })
+            .await
+            .expect("2.0 task JSON ack should fall back to callbacks");
+
+        assert!(result.delivered);
+        let request = captured.lock().await.clone().unwrap();
+        assert_eq!(
+            request.accept.as_deref(),
+            Some("text/event-stream, application/json")
+        );
+        assert_eq!(request.transport.as_deref(), Some("sse"));
+        assert_eq!(request.body["method"], "chat.send");
+    }
 
     server.abort();
 }

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -731,14 +731,22 @@ async fn handle_task_bot_event(
         &entry.task_id,
         &manager_result_run_id,
     );
+    let delivery_target = flow
+        .registry
+        .resolve_delivery_target(&entry.driver_bot)
+        .await?;
+    let delivery_kind = BotDeliveryKind::TaskResult;
+    let provider_transport = flow
+        .provider_transport_preference(&entry.driver_bot, &delivery_kind, &delivery_target)
+        .await;
     let result = flow
         .bot_delivery
         .deliver(BotDeliveryCommand {
-            target: flow.registry.resolve_delivery_target(&entry.driver_bot).await?,
+            target: delivery_target,
             run_id: manager_result_run_id.clone(),
             frame,
-            delivery_kind: BotDeliveryKind::TaskResult,
-            provider_transport: Default::default(),
+            delivery_kind,
+            provider_transport,
         })
         .await?;
     if !result.delivered {

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -136,7 +136,13 @@ impl BcsMessageFlow {
         delivery_kind: &BotDeliveryKind,
         delivery_target: &BotDeliveryTarget,
     ) -> ProviderTransportPreference {
-        if !matches!(delivery_kind, BotDeliveryKind::Send) {
+        if !matches!(
+            delivery_kind,
+            BotDeliveryKind::Send
+                | BotDeliveryKind::TaskDispatch
+                | BotDeliveryKind::TaskMessage
+                | BotDeliveryKind::TaskResult
+        ) {
             return ProviderTransportPreference::Callback;
         }
         if !matches!(

--- a/src/bcs/crates/services/bcs-message-flow/src/task_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/task_flow.rs
@@ -196,14 +196,18 @@ pub async fn handle_task_dispatch(
             return Err(error);
         }
     };
+    let delivery_kind = BotDeliveryKind::TaskDispatch;
+    let provider_transport = flow
+        .provider_transport_preference(&target_bot_id, &delivery_kind, &delivery_target)
+        .await;
     let result = match flow
         .bot_delivery
         .deliver(BotDeliveryCommand {
             target: delivery_target,
             run_id: effective_task_id.clone(),
             frame,
-            delivery_kind: BotDeliveryKind::TaskDispatch,
-            provider_transport: Default::default(),
+            delivery_kind,
+            provider_transport,
         })
         .await
     {
@@ -539,14 +543,18 @@ pub async fn handle_task_message(
             return Err(error);
         }
     };
+    let delivery_kind = BotDeliveryKind::TaskMessage;
+    let provider_transport = flow
+        .provider_transport_preference(&manager.bot_uuid, &delivery_kind, &delivery_target)
+        .await;
     let result = flow
         .bot_delivery
         .deliver(BotDeliveryCommand {
             target: delivery_target,
             run_id: run_id.clone(),
             frame,
-            delivery_kind: BotDeliveryKind::TaskMessage,
-            provider_transport: Default::default(),
+            delivery_kind,
+            provider_transport,
         })
         .await?;
 

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -4,12 +4,15 @@ use bcs_message_flow::{BcsMessageFlow, MemoryBotRunContextStore};
 use bcs_message_flow::task_store::{new_task_entry, TaskLedgerStatus, TASK_TTL_MS};
 use bcs_protocol::BcsFrame;
 use bcs_service_api::{
-    ActorKind, BotDeliveryKind, BotEventCommand, ChatEventState, ChatResponseMode, DefaultDelivery, FrontendDeliveryTarget,
-    GroupCoreService, GroupKind, MessageFlowService, GroupStatus, BotRunContextPort, Participant, ParticipantMode,
-    ParticipantRole, RoutingMode, RoutingPolicy, ServiceError, GroupStrategy, ServiceSpec,
-    Session, SessionKind, SessionManagementService, SessionStatus, SessionUseCaseError,
-    SystemMessageEvent, SystemMessageService, TaskCompleteCommand, TaskDispatchCommand,
-    TaskMessageCommand, TaskRunAliasRegistration, ChannelService, ChannelUseCaseError,
+    ActorKind, BotDeliveryKind, BotDeliveryTarget, BotEventCommand, BotRegistryCoreService,
+    BotRunContextPort, ChatEventState, ChatResponseMode, DefaultDelivery,
+    FrontendDeliveryTarget, GroupCoreService, GroupKind, GroupStatus, GroupStrategy,
+    MessageFlowService, Participant, ParticipantMode, ParticipantRole,
+    ProviderStreamGrayList, ProviderTransportPreference,
+    RoutingMode, RoutingPolicy, ServiceError, ServiceSpec, Session, SessionKind,
+    SessionManagementService, SessionStatus, SessionUseCaseError, SystemMessageEvent,
+    SystemMessageService, TaskCompleteCommand, TaskDispatchCommand, TaskMessageCommand,
+    TaskRunAliasRegistration, ChannelService, ChannelUseCaseError,
     interceptor::{BlockReason, InterceptorDecision, MessageInterceptor, OutboundMessage},
 };
 use serde_json::{Value, json};
@@ -3976,6 +3979,46 @@ async fn manager_worker_flow_with_repo() -> (
     (support, repo, flow)
 }
 
+async fn configure_provider_v2_target(
+    support: &support::FlowTestSupport,
+    bot_id: &str,
+    created_by: &str,
+) {
+    support
+        .registry
+        .save_created_by(bot_id, created_by, true)
+        .await
+        .unwrap();
+    let mut provider_target = support::FakeRegistryService::provider_target(bot_id);
+    if let BotDeliveryTarget::HttpProvider {
+        protocol_version, ..
+    } = &mut provider_target
+    {
+        *protocol_version = "2.0".to_string();
+    }
+    support
+        .registry
+        .set_delivery_target(bot_id, provider_target)
+        .await;
+}
+
+fn manager_worker_flow_with_provider_stream(
+    support: &support::FlowTestSupport,
+    repo: Arc<RecordingMessageRepo>,
+) -> BcsMessageFlow {
+    BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_message_repo(repo)
+    .with_provider_stream_gray_list(Arc::new(ProviderStreamGrayList::new(vec![
+        "gray-user".to_string(),
+    ])))
+}
+
 async fn manager_worker_flow_with_blocking_repo() -> (
     support::FlowTestSupport,
     Arc<BlockingMessageRepo>,
@@ -4024,6 +4067,101 @@ async fn register_manager_worker_task(
             response_mode,
         ))
         .await;
+}
+
+#[tokio::test]
+async fn manager_worker_task_dispatch_uses_sse_for_eligible_provider_worker() {
+    let (support, repo, _) = manager_worker_flow_with_repo().await;
+    configure_provider_v2_target(&support, "bot-worker", "gray-user").await;
+    let flow = manager_worker_flow_with_provider_stream(&support, repo);
+
+    flow.handle_task_dispatch(TaskDispatchCommand {
+        driver_bot_id: "bot-manager".to_string(),
+        group_id: "group-1".to_string(),
+        target_bot_id: "bot-worker".to_string(),
+        target_bot_name: None,
+        payload: json!({
+            "message": "do work",
+            "bcs_session_id": "group-1:abcdef12",
+        }),
+    })
+    .await
+    .expect("task.dispatch should deliver to provider worker");
+
+    assert_eq!(
+        support.bot_delivery.provider_transports().await,
+        vec![ProviderTransportPreference::CallbackSse]
+    );
+}
+
+#[tokio::test]
+async fn manager_worker_task_message_uses_sse_for_eligible_provider_manager() {
+    let (support, repo, _) = manager_worker_flow_with_repo().await;
+    configure_provider_v2_target(&support, "bot-manager", "gray-user").await;
+    let flow = manager_worker_flow_with_provider_stream(&support, repo);
+
+    flow.handle_task_message(TaskMessageCommand {
+        worker_bot_id: "bot-worker".to_string(),
+        group_id: "group-1".to_string(),
+        payload: json!({
+            "message": "progress update",
+            "bcs_session_id": "group-1:abcdef12",
+        }),
+    })
+    .await
+    .expect("task.message should deliver to provider manager");
+
+    assert_eq!(
+        support.bot_delivery.provider_transports().await,
+        vec![ProviderTransportPreference::CallbackSse]
+    );
+}
+
+#[tokio::test]
+async fn manager_worker_task_result_uses_sse_for_eligible_provider_manager() {
+    let (support, repo, _) = manager_worker_flow_with_repo().await;
+    configure_provider_v2_target(&support, "bot-manager", "gray-user").await;
+    let flow = manager_worker_flow_with_provider_stream(&support, repo);
+
+    let dispatch = flow
+        .handle_task_dispatch(TaskDispatchCommand {
+            driver_bot_id: "bot-manager".to_string(),
+            group_id: "group-1".to_string(),
+            target_bot_id: "bot-worker".to_string(),
+            target_bot_name: None,
+            payload: json!({
+                "message": "do work",
+                "bcs_session_id": "group-1:abcdef12",
+            }),
+        })
+        .await
+        .expect("task.dispatch should deliver to worker");
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-worker".to_string(),
+        run_id: dispatch.task_id,
+        group_id: "group-1".to_string(),
+        event_type: "chat.event".to_string(),
+        event_payload: json!({
+            "state": "final",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "task done"}],
+            },
+        }),
+        state: ChatEventState::Final,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .expect("worker final should deliver task result to provider manager");
+
+    assert_eq!(
+        support.bot_delivery.provider_transports().await,
+        vec![
+            ProviderTransportPreference::Callback,
+            ProviderTransportPreference::CallbackSse,
+        ]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- enable Provider 2.0 SSE delivery for `task.dispatch`, `task.message`, and `task.result` when the target provider matches the existing stream gray list
- validate task downlink request IDs against the delivery run ID and ingest streamed agent, chat delta, and final events
- preserve JSON callback fallback and existing behavior for Provider 1.0, WebSocket, and gray-list misses

## Why

Manager-worker task downlink previously defaulted to the callback transport. When a worker used the provider downlink path, the manager could only receive the asynchronous final callback, so the frontend could not observe the worker response incrementally.

## Impact

This is a backend-only change. Frontend contracts, task terminal state, and task-ledger semantics remain unchanged.

## Validation

- `cargo test -p bcs-message-flow -p bcs-provider-http`
- `git diff --check`

Strict Clippy with `-D warnings` remains blocked by pre-existing repository warnings unrelated to this change.