### PR TITLE
feat(bcs-cli): list current bot groups

### DIFF
--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/group.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/group.md
@@ -10,7 +10,7 @@
 | `confirm-group-help` | `--url`                 | 确认群聊提案                 |
 | `create-group`       | `--topic`               | 直接创建群组                 |
 | `get-group`          | `--group`               | 获取群组信息                 |
-| `list-groups`        | -                       | 列出所有群组                 |
+| `list-groups`        | `[--mine]`              | 列出所有群组，或当前 Bot 所在群组 |
 | `add-member`         | `--group`, `--bot-uuid` | 添加成员到已有群组           |
 | `group-status`       | `--group`, `--status`   | 更新群组状态（仅协调者）     |
 | `terminate-group`    | `--group`               | 终止群组会话（仅 driver）    |
@@ -166,12 +166,19 @@ bcs get-group --group "grp-001"
 
 ---
 
-## list-groups - 列出所有群组
+## list-groups - 列出群组
 
-列出当前 Bot 参与的所有群组：
+默认列出所有群组：
 
 ```bash
 bcs list-groups
+```
+
+使用 `--mine` 仅列出当前 Bot 参与的群组。当前 Bot 从
+`$BOT_DATA_DIR/.bcs/session.json` 的 `bot_uuid` 读取：
+
+```bash
+bcs list-groups --mine
 ```
 
 **返回示例：**

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -1606,8 +1606,7 @@ impl BcsClient {
         );
 
         let response = self
-            .http_client
-            .get(&url)
+            .add_auth(self.http_client.get(&url))
             .send()
             .await
             .context("Failed to list bot groups")?;

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -1597,6 +1597,32 @@ impl BcsClient {
         Ok(items)
     }
 
+    /// List groups that include a specific bot.
+    pub async fn list_bot_groups(&self, bot_uuid: &str) -> Result<Vec<serde_json::Value>> {
+        let url = format!(
+            "{}/bots/{}/groups",
+            self.base_url,
+            urlencoding::encode(bot_uuid)
+        );
+
+        let response = self
+            .http_client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to list bot groups")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!("List bot groups failed ({}): {}", status, body));
+        }
+
+        let result: serde_json::Value = response.json().await.context("Invalid bot groups response")?;
+
+        Ok(result["items"].as_array().cloned().unwrap_or_default())
+    }
+
     /// Add a member to a group.
     pub async fn add_group_member(
         &self,

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -971,11 +971,15 @@ enum Commands {
         focus: Option<String>,
     },
 
-    /// List all groups
+    /// List groups, optionally limited to groups the current bot participates in
     ListGroups {
         /// Authentication token (auto-discovered if not provided)
         #[arg(short, long)]
         token: Option<String>,
+
+        /// List only groups that include the current bot from the session file
+        #[arg(long)]
+        mine: bool,
     },
 
     /// Add a member to an existing group
@@ -2626,7 +2630,7 @@ async fn main() -> Result<()> {
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
 
-        Commands::ListGroups { token } => {
+        Commands::ListGroups { token, mine } => {
             let token = get_token(token.as_deref())?;
             let client = create_client(
                 &bcs_url,
@@ -2635,9 +2639,20 @@ async fn main() -> Result<()> {
                 oauth_headers.as_ref(),
             );
 
-            debug_request!(debug, "GET", "/groups", json!({}));
-
-            let groups = client.list_groups().await?;
+            let (groups, current_bot_uuid) = if mine {
+                let bot_uuid = resolve_my_bot_uuid()?;
+                debug_request!(
+                    debug,
+                    "GET",
+                    &format!("/bots/{}/groups", &bot_uuid),
+                    json!({})
+                );
+                let groups = client.list_bot_groups(&bot_uuid).await?;
+                (groups, Some(bot_uuid))
+            } else {
+                debug_request!(debug, "GET", "/groups", json!({}));
+                (client.list_groups().await?, None)
+            };
 
             debug_response!(
                 debug,
@@ -2647,7 +2662,11 @@ async fn main() -> Result<()> {
                 })
             );
 
-            println!("Groups ({}):", groups.len());
+            if let Some(bot_uuid) = current_bot_uuid {
+                println!("Groups for current bot {} ({}):", bot_uuid, groups.len());
+            } else {
+                println!("Groups ({}):", groups.len());
+            }
             for group in groups {
                 let id = group
                     .get("id")

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
@@ -2,7 +2,7 @@
 
 use crate::common::{assert_output_contains, assert_success, TestContext};
 use wiremock::{
-    matchers::{method, path},
+    matchers::{bearer_token, method, path},
     Mock, ResponseTemplate,
 };
 
@@ -13,6 +13,7 @@ async fn list_groups_mine_uses_current_bot_from_session() {
 
     Mock::given(method("GET"))
         .and(path(bot_groups_path))
+        .and(bearer_token(&ctx.session.token))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "bot_uuid": ctx.session.bot_uuid,
             "items": [{

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
@@ -1,0 +1,40 @@
+//! E2E tests for `bcs-cli list-groups`.
+
+use crate::common::{assert_output_contains, assert_success, TestContext};
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
+
+#[tokio::test]
+async fn list_groups_mine_uses_current_bot_from_session() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
+
+    Mock::given(method("GET"))
+        .and(path(bot_groups_path))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bot_uuid": ctx.session.bot_uuid,
+            "items": [{
+                "id": "group-for-current-bot",
+                "mode": "agent",
+                "driver_bot": "current-bot"
+            }],
+            "total": 1,
+            "offset": 0,
+            "limit": 10
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("list-groups")
+        .arg("--mine")
+        .output()
+        .expect("Failed to execute command");
+
+    assert_success(&output);
+    assert_output_contains(&output, "Groups for current bot");
+    assert_output_contains(&output, "group-for-current-bot");
+}

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/main.rs
@@ -3,3 +3,4 @@
 mod common;
 mod smoke_test;
 mod list_test;
+mod groups_test;


### PR DESCRIPTION
## What changed

- Added `bcs-cli list-groups --mine` to list only groups containing the current bot.
- Resolves the bot UUID from `$BOT_DATA_DIR/.bcs/session.json` and calls the existing `GET /bots/{bot_uuid}/groups` endpoint.
- Preserved the existing full-list behavior for `bcs-cli list-groups`.
- Added CLI documentation and an end-to-end test.

## Why

The CLI previously always called `GET /groups`, so a bot could not discover only the groups it belongs to.

## Validation

- `cargo test --package bcs-cli --test e2e list_groups_mine_uses_current_bot_from_session`
- CLI unit tests and E2E suite
- `cargo check --package bcs-cli --all-targets`

Note: the full `cargo test --package bcs-cli` run still has an unrelated existing failure in `health_tests::test_health_unreachable_json`, whose expected error text differs from the current health-command output.