### PR TITLE
chore(observability): trace provider SSE handoff

### DIFF
--- a/src/baas/packages/community/src/secbaas/adapters/web/routers/bcn_downlink/bcn_router.py
+++ b/src/baas/packages/community/src/secbaas/adapters/web/routers/bcn_downlink/bcn_router.py
@@ -19,6 +19,7 @@
 参考: BCN Bot 下行连接接入方案 (内部文档)
 """
 
+import asyncio
 import json
 import uuid
 from collections.abc import AsyncIterator, Callable
@@ -278,16 +279,51 @@ async def _dispatch_chat_send_stream(
     converter = converter_factory.create("bcn")
 
     async def _stream() -> AsyncIterator[str]:
+        frame_count = 0
+        close_reason = "eof"
+        last_chunk_type: str | None = None
+        logger.info(
+            "[chat.send.stream] response body started: "
+            "run_id=%s media_type=text/event-stream",
+            req.id,
+        )
         try:
             async for chunk in chunk_iter:
+                last_chunk_type = chunk.type
                 event = converter.convert(chunk, run_id=req.id)
                 if event is None:
                     continue
+                frame_count += 1
+                if frame_count == 1:
+                    logger.info(
+                        "[chat.send.stream] first SSE frame: "
+                        "run_id=%s event=%s chunk_type=%s",
+                        req.id,
+                        event.event,
+                        chunk.type,
+                    )
                 sse = event.to_sse()
                 yield sse
+        except asyncio.CancelledError:
+            close_reason = "cancelled"
+            raise
+        except GeneratorExit:
+            close_reason = "generator_exit"
+            raise
         except Exception as e:
+            close_reason = "error"
             logger.exception("[chat.send.stream] Unexpected error: run_id=%s", req.id)
+            frame_count += 1
             yield _build_sse_error(req.id, "INTERNAL_ERROR", str(e), False)
+        finally:
+            logger.info(
+                "[chat.send.stream] response body closed: "
+                "run_id=%s reason=%s frame_count=%d last_chunk_type=%s",
+                req.id,
+                close_reason,
+                frame_count,
+                last_chunk_type,
+            )
 
     return StreamingResponse(
         _stream(),

--- a/src/baas/packages/community/tests/unit/adapters/web/open_api/test_bcn_router.py
+++ b/src/baas/packages/community/tests/unit/adapters/web/open_api/test_bcn_router.py
@@ -53,7 +53,8 @@ def _chat_send_request() -> ChatSendRequest:
 
 
 @pytest.mark.asyncio
-async def test_stream_dispatch_skips_dropped_converter_events():
+async def test_stream_dispatch_skips_dropped_converter_events(caplog):
+    caplog.set_level("INFO")
     response = await _dispatch_chat_send_stream(
         _chat_send_request(),
         _StreamService(),
@@ -77,3 +78,41 @@ async def test_stream_dispatch_skips_dropped_converter_events():
         "state": "delta",
         "deltaText": "hello",
     }
+    assert response.media_type == "text/event-stream"
+    assert response.headers["x-accel-buffering"] == "no"
+    assert any(
+        "[chat.send.stream] response body started: "
+        "run_id=run-1 media_type=text/event-stream" in message
+        for message in caplog.messages
+    )
+    assert any(
+        "[chat.send.stream] first SSE frame: "
+        "run_id=run-1 event=chat chunk_type=delta" in message
+        for message in caplog.messages
+    )
+    assert any(
+        "[chat.send.stream] response body closed: "
+        "run_id=run-1 reason=eof frame_count=1 last_chunk_type=delta" in message
+        for message in caplog.messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_dispatch_logs_generator_exit_when_consumer_closes(caplog):
+    caplog.set_level("INFO")
+    response = await _dispatch_chat_send_stream(
+        _chat_send_request(),
+        _StreamService(),
+        _ConverterFactory(),
+    )
+
+    first = await anext(response.body_iterator)
+    assert first.startswith("id: 1\nevent: chat\n")
+    await response.body_iterator.aclose()
+
+    assert any(
+        "[chat.send.stream] response body closed: "
+        "run_id=run-1 reason=generator_exit frame_count=1 last_chunk_type=delta"
+        in message
+        for message in caplog.messages
+    )

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -160,15 +160,36 @@ impl BotDeliveryPort for HttpProviderTransport {
                 ProviderTransportPreference::CallbackSse
             ) && matches!(cmd.delivery_kind, BotDeliveryKind::Send);
             let client = if wants_sse { &self.sse_client } else { &self.client };
+            let request_started = Instant::now();
             let resp =
                 send_provider_request(client, &self.url_guard, &cmd.target, &body, wants_sse)
                     .await?;
+            let response_elapsed_ms = request_started.elapsed().as_millis();
+            let response_status = resp.status();
             let ctype = resp
                 .headers()
                 .get(reqwest::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .unwrap_or("")
                 .to_string();
+            let transfer_encoding = resp
+                .headers()
+                .get(reqwest::header::TRANSFER_ENCODING)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("");
+            info!(
+                target_bot_id = %target_bot_id,
+                provider_id = %provider_id,
+                method = %method,
+                run_id = %run_id,
+                wants_sse,
+                status = %response_status.as_u16(),
+                content_type = %ctype,
+                content_length = ?resp.content_length(),
+                transfer_encoding = %transfer_encoding,
+                elapsed_ms = %response_elapsed_ms,
+                "provider downlink: HTTP response headers received"
+            );
             if wants_sse && ctype.starts_with("text/event-stream") {
                 let (Some(flow), Some(ctx)) =
                     (self.message_flow.read().expect("message_flow lock poisoned").clone(), self.bot_run_context.read().expect("bot_run_context lock poisoned").clone())


### PR DESCRIPTION
## Summary

- log provider HTTP response status, content type, framing headers, and latency before BCS selects the SSE or JSON path
- log SecBaaS SSE response-body start, first frame, and close reason with frame counts
- cover normal EOF and consumer-initiated stream closure in the SecBaaS router tests

## Why

A provider run can complete inside SecBaaS while BCS never reports that it accepted the SSE response. These logs make the HTTP response-header and stream-lifecycle boundary observable so the next deployment can distinguish response classification, proxy interruption, and client cancellation.

## Impact

Observability only. The provider protocol and delivery behavior are unchanged. Logs intentionally exclude credentials, message content, and unrestricted response headers.

## Validation

- `cargo test --package bcs-provider-http --test provider_transport_contract` (12 passed)
- `uv run pytest tests/unit/adapters/web/open_api/test_bcn_router.py -q` (2 passed)
- targeted Ruff checks passed
- `git diff --check` passed