### PR TITLE
fix: prevent bot list from blocking ceiling requests

### DIFF
--- a/docs/superpowers/plans/2026-07-10-bot-list-event-loop-p0.md
+++ b/docs/superpowers/plans/2026-07-10-bot-list-event-loop-p0.md
@@ -42,7 +42,7 @@ def test_desktop_status_uses_persisted_value_without_baas_query(self):
 
 - [ ] **Step 2: Run the test and confirm RED**
 
-Run: `uv run pytest tests/community/core/bot_management/services/test_list_desktop_live_status.py::TestDesktopLiveStatusMerge::test_desktop_status_uses_persisted_value_without_baas_query -q`
+Run: `uv run pytest tests/community/core/bot_management/services/test_list_desktop_live_status.py::TestBotListUsesPersistedStatus::test_desktop_status_uses_persisted_value_without_baas_query -q`
 
 Expected: FAIL because the current bulk merge changes `OFFLINE` to `ACTIVE` and invokes BaaS.
 

--- a/docs/superpowers/plans/2026-07-10-bot-list-event-loop-p0.md
+++ b/docs/superpowers/plans/2026-07-10-bot-list-event-loop-p0.md
@@ -1,0 +1,195 @@
+# Bot List Event-Loop P0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent the owner-or-collaborator Bot list from blocking unrelated requests and remove BaaS fan-out from its first-paint path.
+
+**Architecture:** The HTTP adapter will offload complete synchronous response-data construction with `asyncio.to_thread`. The core list service will return persisted desktop status without invoking BaaS; the existing single-bot live-status resolver remains unchanged for explicit freshness checks.
+
+**Tech Stack:** Python 3.12, FastAPI, asyncio, pytest, pytest-asyncio
+
+## Global Constraints
+
+- Do not change HTTP request or response schemas.
+- Do not change `resolve_desktop_live_status` semantics.
+- Do not include P1 permission batching, path caching, frontend, or polling changes.
+- Follow test-first red-green-refactor for each behavior.
+
+---
+
+### Task 1: Make the list use persisted desktop status
+
+**Files:**
+- Modify: `src/backend/tests/community/core/bot_management/services/test_list_desktop_live_status.py`
+- Modify: `src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py:1837-1992`
+
+**Interfaces:**
+- Consumes: `BotService.list_bots_by_owner_or_collaborator(owner_id, page=1, page_size=100) -> dict`
+- Preserves: `BotService.resolve_desktop_live_status(bot: dict) -> str | None`
+- Produces: list results whose desktop `status` is the repository value and which perform no BaaS query
+
+- [ ] **Step 1: Change the desktop-list test to require persisted status**
+
+```python
+def test_desktop_status_uses_persisted_value_without_baas_query(self):
+    items = [_desktop("d1", status="OFFLINE")]
+    client = _client_returning(bot_status="ACTIVE", device_status="ALL_ONLINE")
+    svc = _make_bot_service(_repo_returning(items), client)
+    result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
+    assert result["items"][0]["status"] == "OFFLINE"
+    client.query_device_status.assert_not_called()
+```
+
+- [ ] **Step 2: Run the test and confirm RED**
+
+Run: `uv run pytest tests/community/core/bot_management/services/test_list_desktop_live_status.py::TestDesktopLiveStatusMerge::test_desktop_status_uses_persisted_value_without_baas_query -q`
+
+Expected: FAIL because the current bulk merge changes `OFFLINE` to `ACTIVE` and invokes BaaS.
+
+- [ ] **Step 3: Remove bulk merge from list reads**
+
+Delete the `self._merge_desktop_live_status(items)` call, `_merge_desktop_live_status`, and its list-only timeout/worker constants. Keep `resolve_desktop_live_status` and `_MERGE_SKIP_LOCAL_STATUSES` because the skill upload gate uses them.
+
+- [ ] **Step 4: Run the service tests and confirm GREEN**
+
+Run: `uv run pytest tests/community/core/bot_management/services/test_list_desktop_live_status.py -q`
+
+Expected: all persisted-list and single-bot resolver tests pass.
+
+### Task 2: Offload complete synchronous list assembly
+
+**Files:**
+- Modify: `src/backend/tests/community/endpoints/test_bot_management_router.py`
+- Modify: `src/backend/src/agentclaw/community/adapters/http/bot_management/router.py:1-60,1344-1412`
+
+**Interfaces:**
+- Produces: `_build_bots_by_owner_or_collaborator_data(owner_id: str, bot_service: BotServiceProtocol) -> dict[str, Any]`
+- Preserves: `list_bots_by_owner_or_collaborator(ctx, bot_service) -> ApiResponse`
+
+- [ ] **Step 1: Add an async responsiveness regression test**
+
+```python
+@pytest.mark.asyncio
+async def test_owner_or_collaborator_list_does_not_block_event_loop():
+    class SlowBotService:
+        def list_bots_by_owner_or_collaborator(self, **kwargs):
+            time.sleep(0.1)
+            return {
+                "total": 1,
+                "items": [{
+                    "bot_id": "bot-1",
+                    "entity_id": "entity-1",
+                    "entity_type": "staff",
+                    "engine_types": ["openclaw"],
+                    "active_engine": "openclaw",
+                }],
+            }
+
+        def get_engine_paths(self, *args):
+            time.sleep(0.1)
+            return {"openclaw": "/tmp/bot-1/openclaw"}
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    task = asyncio.create_task(
+        list_bots_by_owner_or_collaborator(
+            ctx=SimpleNamespace(user_id="u"),
+            bot_service=SlowBotService(),
+        )
+    )
+    await asyncio.sleep(0.01)
+    assert loop.time() - started < 0.1
+    response = await task
+    assert response.success is True
+```
+
+- [ ] **Step 2: Run the test and confirm RED**
+
+Run: `uv run pytest tests/community/endpoints/test_bot_management_router.py -k event_loop -q`
+
+Expected: FAIL because the heartbeat is delayed by approximately `0.2` seconds.
+
+- [ ] **Step 3: Extract and offload synchronous response assembly**
+
+```python
+def _build_bots_by_owner_or_collaborator_data(
+    owner_id: str,
+    bot_service: BotServiceProtocol,
+) -> dict[str, Any]:
+    engine_types = _get_engine_types()
+    result = bot_service.list_bots_by_owner_or_collaborator(
+        owner_id=owner_id,
+        page=1,
+        page_size=100,
+    )
+    items = result["items"]
+    for bot in items:
+        entity_id = bot.get("entity_id")
+        entity_type = bot.get("entity_type", "staff")
+        bot_id = str(bot.get("bot_id"))
+        bot_engine_types = bot.get("engine_types", engine_types)
+        bot["engine_paths"] = bot_service.get_engine_paths(
+            entity_id, bot_id, bot_engine_types, entity_type
+        )
+        active = bot.get("active_engine", DEFAULT_ENGINE_TYPE)
+        engine_paths = bot["engine_paths"]
+        fallback = list(engine_paths.values())[0] if engine_paths else ""
+        bot["bot_work_dir"] = engine_paths.get(active, fallback)
+
+    default_bot = None
+    if items:
+        first_bot = items[0]
+        first_engine = first_bot.get("active_engine", DEFAULT_ENGINE_TYPE)
+        default_bot = {
+            "entity_id": first_bot.get("entity_id"),
+            "bot_id": first_bot.get("bot_id"),
+            "entity_type": first_bot.get("entity_type", "staff"),
+            "bot_work_dir": first_bot.get("engine_paths", {}).get(
+                first_engine, first_bot.get("bot_work_dir", "")
+            ),
+        }
+    return {"total": result["total"], "items": items, "default_bot": default_bot}
+
+
+data = await asyncio.to_thread(
+    _build_bots_by_owner_or_collaborator_data,
+    owner_id,
+    bot_service,
+)
+```
+
+- [ ] **Step 4: Run endpoint and service tests and confirm GREEN**
+
+Run: `uv run pytest tests/community/endpoints/test_bot_management_router.py tests/community/core/bot_management/services/test_list_desktop_live_status.py -q`
+
+Expected: all tests pass.
+
+### Task 3: Validate and publish
+
+**Files:**
+- Verify all modified source, test, design, and plan files
+
+- [ ] **Step 1: Run formatting, lint, and architecture checks**
+
+Run:
+
+```bash
+uv run ruff check \
+  src/agentclaw/community/adapters/http/bot_management/router.py \
+  src/agentclaw/community/core/bot_management/services/bot_service.py \
+  tests/community/endpoints/test_bot_management_router.py \
+  tests/community/core/bot_management/services/test_list_desktop_live_status.py
+uv run pytest tests/community/architecture tests/community/endpoints/test_bot_management_router.py tests/community/core/bot_management/services/test_list_desktop_live_status.py -q
+```
+
+Expected: exit code 0 for both commands.
+
+- [ ] **Step 2: Inspect the final diff**
+
+Run: `git diff --check && git status -sb && git diff github/REL20260710...HEAD`
+
+Expected: only the approved P0 source, regression tests, design, and plan are present.
+
+- [ ] **Step 3: Commit and publish**
+
+Commit the implementation and tests, push `agent/ceiling-event-loop-p0-rel20260710` to GitHub, then create a draft PR with base `REL20260710`.

--- a/docs/superpowers/specs/2026-07-10-bot-list-event-loop-p0-design.md
+++ b/docs/superpowers/specs/2026-07-10-bot-list-event-loop-p0-design.md
@@ -49,4 +49,3 @@ or fail this list endpoint; persisted status is returned instead.
   released.
 - Existing bot-management endpoint and desktop-status resolution tests remain
   green.
-

--- a/docs/superpowers/specs/2026-07-10-bot-list-event-loop-p0-design.md
+++ b/docs/superpowers/specs/2026-07-10-bot-list-event-loop-p0-design.md
@@ -1,0 +1,52 @@
+# Bot List Event-Loop P0 Fix
+
+## Problem
+
+`GET /api/bots/by-owner-or-collaborator` is an async route that performs a
+synchronous bot-list build on the event-loop thread. The list build also fans
+out live BaaS status queries for desktop bots and waits up to five seconds.
+When BaaS is slow, the worker cannot serve unrelated requests such as
+`GET /api/bots/ceiling`.
+
+## Scope
+
+This P0 change has two parts:
+
+1. Run the complete synchronous list build, including path enrichment, outside
+   the event-loop thread.
+2. Stop querying BaaS from the owner-or-collaborator list. The list returns the
+   persisted desktop-bot status maintained by the existing reconciliation
+   path. Single-bot operations that explicitly need live status continue to use
+   `resolve_desktop_live_status`.
+
+The change does not alter API schemas, authentication, policy lookup, bot
+switch behavior, permission queries, or frontend polling.
+
+## Design
+
+The HTTP adapter delegates synchronous response-data construction to a small
+helper through `asyncio.to_thread`. The helper owns the repository/service call,
+engine path enrichment, and default-bot calculation, so no synchronous portion
+of the list build remains on the event loop.
+
+`BotService.list_bots_by_owner_or_collaborator` no longer calls the bulk live
+status merge. The unused bulk thread-pool implementation and its five-second
+budget are removed. `resolve_desktop_live_status` remains available because
+single-bot safety checks have different freshness requirements.
+
+## Failure Behavior
+
+Repository, permission, and path failures keep their current HTTP error
+mapping. Removing best-effort BaaS enrichment means a BaaS outage cannot delay
+or fail this list endpoint; persisted status is returned instead.
+
+## Verification
+
+- A service test proves list reads preserve persisted desktop status and never
+  invoke the BaaS status client.
+- An async router test blocks synchronous list construction in a worker thread
+  and proves an event-loop heartbeat still executes before the list is
+  released.
+- Existing bot-management endpoint and desktop-status resolution tests remain
+  green.
+

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -10,6 +10,7 @@ Provides CRUD operations for bots:
 
 Each bot is associated with an entity (staff, proj, team) and has its own device.
 """
+import asyncio
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
 
@@ -1341,6 +1342,57 @@ async def refresh_bot_passport_token(
         )
 
 
+def _build_bots_by_owner_or_collaborator_data(
+    owner_id: str,
+    bot_service: BotServiceProtocol,
+) -> dict[str, Any]:
+    """Build list response data synchronously outside the event loop."""
+    engine_types = _get_engine_types()
+    result = bot_service.list_bots_by_owner_or_collaborator(
+        owner_id=owner_id,
+        page=1,
+        page_size=100,
+    )
+    items = result["items"]
+
+    for bot in items:
+        entity_id = bot.get("entity_id")
+        entity_type = bot.get("entity_type", "staff")
+        bot_id = str(bot.get("bot_id"))
+        bot_engine_types = bot.get("engine_types", engine_types)
+        bot["engine_paths"] = bot_service.get_engine_paths(
+            entity_id,
+            bot_id,
+            bot_engine_types,
+            entity_type,
+        )
+
+        active = bot.get("active_engine", DEFAULT_ENGINE_TYPE)
+        engine_paths = bot["engine_paths"]
+        fallback = list(engine_paths.values())[0] if engine_paths else ""
+        bot["bot_work_dir"] = engine_paths.get(active, fallback)
+
+    default_bot = None
+    if items:
+        first_bot = items[0]
+        first_engine = first_bot.get("active_engine", DEFAULT_ENGINE_TYPE)
+        default_bot = {
+            "entity_id": first_bot.get("entity_id"),
+            "bot_id": first_bot.get("bot_id"),
+            "entity_type": first_bot.get("entity_type", "staff"),
+            "bot_work_dir": first_bot.get("engine_paths", {}).get(
+                first_engine,
+                first_bot.get("bot_work_dir", ""),
+            ),
+        }
+
+    return {
+        "total": result["total"],
+        "items": items,
+        "default_bot": default_bot,
+    }
+
+
 @router.get("/by-owner-or-collaborator", response_model=ApiResponse)
 async def list_bots_by_owner_or_collaborator(
     ctx: RequestContext = Depends(get_request_context),
@@ -1356,49 +1408,14 @@ async def list_bots_by_owner_or_collaborator(
     - bots where current authenticated user is a collaborator
     """
     try:
-        owner_id = ctx.user_id
-
-        engine_types = _get_engine_types()
-
-        result = bot_service.list_bots_by_owner_or_collaborator(
-            owner_id=owner_id,
-            page=1,
-            page_size=100,
+        data = await asyncio.to_thread(
+            _build_bots_by_owner_or_collaborator_data,
+            ctx.user_id,
+            bot_service,
         )
-
-        items = result["items"]
-
-        for bot in items:
-            entity_id = bot.get("entity_id")
-            entity_type = bot.get("entity_type", "staff")
-            bot_id = str(bot.get("bot_id"))
-            bot_engine_types = bot.get("engine_types", engine_types)
-
-            bot["engine_paths"] = bot_service.get_engine_paths(entity_id, bot_id, bot_engine_types, entity_type)
-
-            active = bot.get("active_engine", DEFAULT_ENGINE_TYPE)
-            engine_paths = bot["engine_paths"]
-            fallback = list(engine_paths.values())[0] if engine_paths else ""
-            bot["bot_work_dir"] = engine_paths.get(active, fallback)
-
-        default_bot = None
-        if items:
-            first_bot = items[0]
-            first_engine = first_bot.get("active_engine", DEFAULT_ENGINE_TYPE)
-            default_bot = {
-                "entity_id": first_bot.get("entity_id"),
-                "bot_id": first_bot.get("bot_id"),
-                "entity_type": first_bot.get("entity_type", "staff"),
-                "bot_work_dir": first_bot.get("engine_paths", {}).get(first_engine, first_bot.get("bot_work_dir", "")),
-            }
-
         return ApiResponse(
             success=True,
-            data={
-                "total": result["total"],
-                "items": items,
-                "default_bot": default_bot,
-            },
+            data=data,
             message="获取 Bot 列表成功",
         )
     except Exception as e:

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -1359,7 +1359,9 @@ def _build_bots_by_owner_or_collaborator_data(
         entity_id = bot.get("entity_id")
         entity_type = bot.get("entity_type", "staff")
         bot_id = str(bot.get("bot_id"))
-        bot_engine_types = bot.get("engine_types", engine_types)
+        bot_engine_types = bot.get("engine_types")
+        if bot_engine_types is None:
+            bot_engine_types = engine_types
         bot["engine_paths"] = bot_service.get_engine_paths(
             entity_id,
             bot_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -4,7 +4,6 @@ Bot service for managing bot lifecycle.
 This service handles bot creation, retrieval, updates, and deletion.
 It integrates with the device service to allocate devices for bots.
 """
-import concurrent.futures
 import json
 import random
 import re
@@ -1866,21 +1865,13 @@ class BotService:
         except Exception as e:
             logger.warning(f"[bot_service.list_bots_by_owner_or_collaborator] Failed to add can_edit_bot: {e}")
 
-        items = self._merge_desktop_live_status(items)
-        # Teclaw rows are NOT merged here: their stored status is kept fresh by
-        # the TeclawStatusReconciler (persisted post-provision), so the DB column
-        # is authoritative — list, detail, and search all read it directly.
+        # List reads use the persisted status. Live desktop status is reconciled
+        # outside this request path so a slow BaaS cannot delay first paint.
 
         return {
             "total": total,
             "items": items,
         }
-
-    # Concurrency for the per-bot BaaS reads. Small: the list is a user-facing
-    # real-time request, not a bulk scan — it must not saturate BaaS.
-    _MERGE_WORKERS = 8
-    # Total wall-clock budget so a slow/hung BaaS never stalls the first paint.
-    _MERGE_BUDGET_SECONDS = 5.0
 
     # Transient/process states where BaaS is NOT yet an authoritative source of
     # truth: while a desktop bot is creating (PENDING) or releasing (RELEASING),
@@ -1923,73 +1914,6 @@ class BotService:
                 bot.get("bot_id"), e,
             )
             return None
-
-    def _merge_desktop_live_status(self, items: list[dict]) -> list[dict]:
-        """Overwrite steady-state desktop bots' status with BaaS live status.
-
-        Delegates the per-bot判定 + BaaS read to
-        :meth:`resolve_desktop_live_status` so the list and the single-bot
-        upload gate share one definition of "desktop steady-state live status".
-
-        Best-effort and non-blocking by design:
-        - per-bot failure / unmapped status → keep the DB status
-        - total failure → return items unchanged
-        - a ``_MERGE_BUDGET_SECONDS`` wall-clock cap so a hung BaaS can't stall
-          the list (in-flight queries are abandoned, those bots keep DB status)
-
-        Read-only: never writes the DB. Persisting live status is the periodic
-        scan's job, so opening a list never causes writes or gmt_modified churn.
-        """
-        targets = [
-            b for b in items
-            if b.get("bot_type") == "desktop"
-            and b.get("device_id")
-            and b.get("status") not in self._MERGE_SKIP_LOCAL_STATUSES
-        ]
-        if not targets:
-            return items
-
-        try:
-            pool = concurrent.futures.ThreadPoolExecutor(
-                max_workers=min(len(targets), self._MERGE_WORKERS)
-            )
-            try:
-                future_to_bot = {
-                    pool.submit(
-                        self.resolve_desktop_live_status,
-                        bot,
-                    ): bot
-                    for bot in targets
-                }
-                done, not_done = concurrent.futures.wait(
-                    future_to_bot, timeout=self._MERGE_BUDGET_SECONDS
-                )
-                for fut in done:
-                    bot = future_to_bot[fut]
-                    try:
-                        display = fut.result()
-                        if display:
-                            bot["status"] = display
-                    except Exception as e:  # single-bot failure: keep DB status
-                        logger.warning(
-                            "[list-desktop-merge] bot=%s status merge failed: %s",
-                            bot.get("bot_id"), e,
-                        )
-                if not_done:
-                    logger.warning(
-                        "[list-desktop-merge] %d/%d desktop bots timed out "
-                        "(budget=%.1fs), kept DB status",
-                        len(not_done), len(targets), self._MERGE_BUDGET_SECONDS,
-                    )
-            finally:
-                # NOT a `with` block: __exit__ calls shutdown(wait=True), which
-                # would block until every in-flight query finished — defeating
-                # the budget and letting a hung BaaS stall the request. wait=False
-                # returns immediately; cancel_futures drops not-yet-started tasks.
-                pool.shutdown(wait=False, cancel_futures=True)
-        except Exception as e:  # total failure: degrade, items unchanged
-            logger.warning("[list-desktop-merge] merge aborted: %s", e)
-        return items
 
     def update_bot(
         self,

--- a/src/backend/tests/community/core/bot_management/services/test_list_desktop_live_status.py
+++ b/src/backend/tests/community/core/bot_management/services/test_list_desktop_live_status.py
@@ -1,10 +1,4 @@
-"""Tests for desktop live-status merge in list_bots_by_owner_or_collaborator.
-
-The frontend bot list calls /by-owner-or-collaborator. Desktop bots' DB status
-lags, so the list directly consumes BaaS live status (read-only, no DB write).
-Only desktop bots with a device_id are touched; non-desktop bots pass through;
-per-bot failure degrades to the DB status; total failure leaves items unchanged.
-"""
+"""Tests for persisted list status and explicit desktop live-status reads."""
 from unittest.mock import MagicMock, Mock
 
 from agentclaw.community.core.bot_management.services.bot_service import BotService
@@ -63,79 +57,17 @@ def _teclaw(bot_id, status="PENDING", binding_id=5):
             "binding_id": binding_id, "owner_id": "u", "status": status, "entity_id": "e"}
 
 
-class TestDesktopLiveStatusMerge:
-    def test_desktop_status_overwritten_with_baas_live(self):
+class TestBotListUsesPersistedStatus:
+    def test_desktop_status_uses_persisted_value_without_baas_query(self):
         items = [_desktop("d1", status="OFFLINE")]
-        client = _client_returning(bot_status="ACTIVE", device_status="ALL_ONLINE")
-        svc = _make_bot_service(_repo_returning(items), client)
-        result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
-        assert result["items"][0]["status"] == "ACTIVE"
-
-    def test_pending_trusts_backend_not_queried(self):
-        # Process state: a PENDING bot (creating/restarting) is NOT yet reliably
-        # reflected by BaaS — the container may be up while the process hasn't
-        # reconnected (BaaS would say ALL_OFFLINE). Trust the backend status and
-        # don't even query BaaS.
-        items = [_desktop("d1", status="PENDING")]
-        client = _client_returning(bot_status="ACTIVE", device_status="ALL_OFFLINE")
-        svc = _make_bot_service(_repo_returning(items), client)
-        result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
-        assert result["items"][0]["status"] == "PENDING"
-        client.query_device_status.assert_not_called()
-
-    def test_releasing_trusts_backend_not_queried(self):
-        items = [_desktop("d1", status="RELEASING")]
-        client = _client_returning(bot_status="ACTIVE", device_status="ALL_ONLINE")
-        svc = _make_bot_service(_repo_returning(items), client)
-        result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
-        assert result["items"][0]["status"] == "RELEASING"
-        client.query_device_status.assert_not_called()
-
-    def test_offline_steady_state_consumes_baas(self):
-        # Steady state OFFLINE → consume BaaS live value (may flip to ACTIVE).
-        items = [_desktop("d1", status="OFFLINE")]
-        client = _client_returning(bot_status="ACTIVE", device_status="ALL_ONLINE")
-        svc = _make_bot_service(_repo_returning(items), client)
-        result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
-        assert result["items"][0]["status"] == "ACTIVE"
-
-    def test_non_desktop_not_touched(self):
-        items = [_personal("p1", status="ACTIVE")]
-        client = _client_returning(bot_status="ACTIVE", device_status="ALL_OFFLINE")
-        svc = _make_bot_service(_repo_returning(items), client)
-        result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
-        assert result["items"][0]["status"] == "ACTIVE"
-        client.query_device_status.assert_not_called()
-
-    def test_desktop_without_device_id_skipped(self):
-        items = [_desktop("d1", status="OFFLINE", device_id="")]
         client = _client_returning(bot_status="ACTIVE", device_status="ALL_ONLINE")
         svc = _make_bot_service(_repo_returning(items), client)
         result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
         assert result["items"][0]["status"] == "OFFLINE"
         client.query_device_status.assert_not_called()
-
-    def test_none_mapping_keeps_db_status(self):
-        # BaaS PENDING → map_baas_to_display returns None → keep DB status.
-        items = [_desktop("d1", status="ACTIVE")]
-        client = _client_returning(bot_status="PENDING", device_status="ALL_OFFLINE")
-        svc = _make_bot_service(_repo_returning(items), client)
-        result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
-        assert result["items"][0]["status"] == "ACTIVE"
-
-    def test_per_bot_failure_keeps_db_status(self):
-        items = [_desktop("d1", status="OFFLINE")]
-        client = MagicMock()
-        client.query_device_status.side_effect = RuntimeError("boom")
-        svc = _make_bot_service(_repo_returning(items), client)
-        result = svc.list_bots_by_owner_or_collaborator(owner_id="u")
-        assert result["items"][0]["status"] == "OFFLINE"
-
 
 class TestResolveDesktopLiveStatus:
-    """Unit tests for the shared single-bot resolver the list-merge and the
-    upload gate both call. Covers every branch: who is queried, who is skipped,
-    and how failures degrade."""
+    """Unit tests for the single-bot resolver used by the upload gate."""
 
     def test_non_desktop_returns_none_without_query(self):
         # Cloud bot (personal/service) never consults BaaS — gate trusts DB.
@@ -194,4 +126,3 @@ class TestTeclawStatusNotMerged:
         assert result["items"][0]["status"] == "PENDING"
         # No read-through: the list never probes baas for a teclaw bot.
         teclaw.get_live_status_by_binding_id.assert_not_called()
-

--- a/src/backend/tests/community/endpoints/test_bot_management_router.py
+++ b/src/backend/tests/community/endpoints/test_bot_management_router.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from agentclaw.community.adapters.http.bot_management.router import (
+    _build_bots_by_owner_or_collaborator_data,
     list_bots_by_owner_or_collaborator as list_bots_route,
 )
 from tests.community.factories.access import make_staff_user
@@ -161,6 +162,48 @@ def _assert_response_has_total_and_items(response, world):
 # ============================================================================
 
 
+def test_owner_or_collaborator_list_defaults_null_engine_types():
+    class BotServiceWithNullEngineTypes:
+        def list_bots_by_owner_or_collaborator(self, **kwargs):
+            return {
+                "total": 1,
+                "items": [
+                    {
+                        "bot_id": "bot-1",
+                        "entity_id": "entity-1",
+                        "entity_type": "staff",
+                        "engine_types": None,
+                        "active_engine": "openclaw",
+                    }
+                ],
+            }
+
+        def get_engine_paths(
+            self,
+            entity_id,
+            bot_id,
+            engine_types,
+            entity_type,
+        ):
+            return {
+                engine: f"/tmp/{bot_id}/{engine}"
+                for engine in engine_types
+            }
+
+    with patch(
+        "agentclaw.community.adapters.http.bot_management.router._get_engine_types",
+        return_value=["openclaw"],
+    ):
+        data = _build_bots_by_owner_or_collaborator_data(
+            owner_id="u",
+            bot_service=BotServiceWithNullEngineTypes(),
+        )
+
+    assert data["items"][0]["engine_paths"] == {
+        "openclaw": "/tmp/bot-1/openclaw"
+    }
+
+
 @pytest.mark.asyncio
 async def test_owner_or_collaborator_list_does_not_block_event_loop():
     release_path_build = threading.Event()
@@ -187,7 +230,6 @@ async def test_owner_or_collaborator_list_does_not_block_event_loop():
 
     loop = asyncio.get_running_loop()
     started = loop.time()
-    fallback_release.start()
     task = asyncio.create_task(
         list_bots_route(
             ctx=SimpleNamespace(user_id="u"),
@@ -195,13 +237,16 @@ async def test_owner_or_collaborator_list_does_not_block_event_loop():
         )
     )
 
-    await asyncio.sleep(0)
-    heartbeat_delay = loop.time() - started
-    release_path_build.set()
-    fallback_release.cancel()
-    response = await task
+    try:
+        fallback_release.start()
+        await asyncio.sleep(0)
+        heartbeat_delay = loop.time() - started
+        assert heartbeat_delay < 0.25
+    finally:
+        release_path_build.set()
+        fallback_release.cancel()
+        response = await task
 
-    assert heartbeat_delay < 0.25
     assert response.success is True
 
 

--- a/src/backend/tests/community/endpoints/test_bot_management_router.py
+++ b/src/backend/tests/community/endpoints/test_bot_management_router.py
@@ -5,8 +5,16 @@ Tests the following endpoints from ``adapters/http/bot_management/router.py``:
 """
 from __future__ import annotations
 
+import asyncio
+import threading
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
+from agentclaw.community.adapters.http.bot_management.router import (
+    list_bots_by_owner_or_collaborator as list_bots_route,
+)
 from tests.community.factories.access import make_staff_user
 from tests.community.factories.bot_collaborator import make_bot, make_collaborator
 from tests.community.framework import (
@@ -151,6 +159,50 @@ def _assert_response_has_total_and_items(response, world):
 # ============================================================================
 # GET /api/bots/by-owner-or-collaborator
 # ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_owner_or_collaborator_list_does_not_block_event_loop():
+    release_path_build = threading.Event()
+    fallback_release = threading.Timer(0.5, release_path_build.set)
+
+    class SlowBotService:
+        def list_bots_by_owner_or_collaborator(self, **kwargs):
+            return {
+                "total": 1,
+                "items": [
+                    {
+                        "bot_id": "bot-1",
+                        "entity_id": "entity-1",
+                        "entity_type": "staff",
+                        "engine_types": ["openclaw"],
+                        "active_engine": "openclaw",
+                    }
+                ],
+            }
+
+        def get_engine_paths(self, *args):
+            release_path_build.wait(timeout=1)
+            return {"openclaw": "/tmp/bot-1/openclaw"}
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    fallback_release.start()
+    task = asyncio.create_task(
+        list_bots_route(
+            ctx=SimpleNamespace(user_id="u"),
+            bot_service=SlowBotService(),
+        )
+    )
+
+    await asyncio.sleep(0)
+    heartbeat_delay = loop.time() - started
+    release_path_build.set()
+    fallback_release.cancel()
+    response = await task
+
+    assert heartbeat_delay < 0.25
+    assert response.success is True
 
 
 @endpoint_test(


### PR DESCRIPTION
## Summary

- offload the complete `/api/bots/by-owner-or-collaborator` response build with `asyncio.to_thread`, including repository access, permission enrichment, and engine path construction
- remove bulk live BaaS status fan-out and its 5-second wait from the owner/collaborator list path
- keep `resolve_desktop_live_status` unchanged for single-bot operations that explicitly require live status
- add regressions proving list reads use persisted status without BaaS and synchronous enrichment no longer blocks the event loop

## Root cause

The async list route called synchronous list assembly directly on the event-loop thread. Desktop rows then triggered parallel BaaS reads followed by `concurrent.futures.wait(timeout=5.0)`. Slow BaaS calls blocked the worker, and per-bot engine-path enrichment continued synchronously afterward. Unrelated requests such as `/api/bots/ceiling` queued behind that work and appeared to take about seven seconds.

## Behavior impact

The owner/collaborator list now returns the persisted desktop status maintained by the existing periodic reconciliation path. A slow or unavailable BaaS can no longer delay first paint for this list. HTTP schemas, authentication, policy lookup, and single-bot live-status checks are unchanged.

## Validation

- TDD RED: event-loop heartbeat was delayed by about 0.510s before the fix
- TDD GREEN: heartbeat executes while synchronous list assembly runs in a worker thread
- `ruff check`: passed
- Bot Management core suite: 582 passed
- architecture + relevant endpoint runner selection: 153 passed
- GitHub pre-push gate: passed

## Structural impact

- Contract change: no
- Service API / Plugin API change: no
- New dependency: no
- Waiver required: no

Related work item: https://project.alipay.com/workItem?workItemId=2026071000117337289
