### PR TITLE
perf(mcp): dedupe whole-artifact device delivery + skip CLI aggregation for MCP-only reads (#81)

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -301,12 +301,25 @@ async def list_skill_set_resources(
     entity_type: Optional[str] = Query(None, description="Entity type (staff/proj/team, default: staff)"),
     bot_id: Optional[str] = Query(None, description="Bot ID (default: default)"),
     engine_type: Optional[str] = Query(None, description="Engine type (default: moltis)"),
+    include_clis: bool = Query(
+        True,
+        description=(
+            "是否聚合默认能力集的 CLI 许可证范围。默认 True 保持兼容；"
+            "MCP-only 屏幕（MCP 市场/新增弹窗）传 False 可跳过同步的 AgentPass "
+            "查询，避免为不消费的 CLI 数据付延迟。"
+        ),
+    ),
     ctx: RequestContext = Depends(get_request_context),
     bot_repo: BotRepository = Injected(BotRepository),
     skill_set_service_factory: SkillSetServiceFactoryProtocol = Injected(SkillSetServiceFactoryProtocol),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
 ) -> SkillSetResourcesResponse:
-    """获取能力集资源聚合视图（MCP + 默认能力集 CLI）。"""
+    """获取能力集资源聚合视图（MCP + 默认能力集 CLI）。
+
+    ``include_clis=False`` 时跳过 AgentPass CLI 查询，仅返回 MCP/Skill 能力集，
+    供只关心 MCP 的屏幕（MCP 市场/新增弹窗）使用，避免同步查询 CLI 的延迟。
+    默认 ``True`` 与旧行为一致。
+    """
     effective_entity_id_param = user_id or entity_id
     effective_entity_id, effective_bot_id, effective_engine, effective_entity_type, is_desktop = _get_path_params(ctx, effective_entity_id_param, entity_type, bot_id, engine_type, bot_repo=bot_repo)
 
@@ -321,15 +334,19 @@ async def list_skill_set_resources(
     skill_sets = sorted(skill_sets, key=lambda s: (not s.get('is_default'), s.get('gmt_created')))
 
     # CLI 展示依赖 AgentPass 查询，失败时只降级隐藏 CLI，不影响 MCP/Skill 能力集返回。
-    try:
-        default_clis = passport_plugin.query_passport_clis(effective_bot_id, effective_entity_id)
-    except Exception as e:
-        logger.warning(
-            "[list_skill_set_resources] query CLI resources failed: bot_id=%s, owner=%s, error=%s",
-            effective_bot_id,
-            effective_entity_id,
-            e,
-        )
+    # include_clis=False 的 MCP-only 调用方不消费 CLI，直接跳过同步查询省去这段延迟。
+    if include_clis:
+        try:
+            default_clis = passport_plugin.query_passport_clis(effective_bot_id, effective_entity_id)
+        except Exception as e:
+            logger.warning(
+                "[list_skill_set_resources] query CLI resources failed: bot_id=%s, owner=%s, error=%s",
+                effective_bot_id,
+                effective_entity_id,
+                e,
+            )
+            default_clis = []
+    else:
         default_clis = []
 
     data = []

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -297,6 +297,7 @@ class MCPSyncService:
         bot_id: str,
         entity_type: str = "staff",
         engine_type: Optional[str] = None,
+        skip_device_declare_when_whole_artifact: bool = False,
     ) -> dict[str, Any]:
         """刷新 bot 的 MCP 授权范围。
 
@@ -309,6 +310,13 @@ class MCPSyncService:
             bot_id: 目标 bot ID。
             entity_type: 实体类型，默认 ``staff``。
             engine_type: 引擎类型，默认 ``openclaw``。
+            skip_device_declare_when_whole_artifact: 调用方**已经**通过前置的
+                详情投递（``sync_mcp_detail``）向设备下发了一次完整配置时置 True。
+                对整产物 provider（teclaw）而言，那次投递已含最新白名单，本方法
+                的 ``_declare_mcp_scope`` 会重组并再投递同一份 artifact——纯属重复
+                设备工作。置 True 时对整产物 provider 跳过该重复投递，仅保留必需
+                的 passport 更新；增量 provider（arca/baas）不受影响，filter-servers
+                声明照常执行。默认 False 保持既有行为。
 
         Returns:
             ``{"success": bool, "error": str|None}`` 格式的结果字典。
@@ -345,15 +353,28 @@ class MCPSyncService:
             )
 
         # 先向设备声明白名单：即使 active_mcps 为空也会调用，防止设备残留旧白名单。
-        scope_result = await self._declare_mcp_scope(
-            bot_id=bot_id,
-            user_id=user_id,
-            entity_id=entity_id,
-            entity_type=entity_type,
-            engine_type=effective_engine,
+        # 整产物 provider（teclaw）+ 调用方已前置投递整产物时，跳过这次重复投递
+        # （见 skip_device_declare_when_whole_artifact 说明），只保留下方 passport 更新。
+        skip_declare = (
+            skip_device_declare_when_whole_artifact
+            and self._provider_delivers_whole_artifact(bot_id=bot_id, entity_id=entity_id)
         )
-        if not scope_result.get("success"):
-            return scope_result
+        if skip_declare:
+            logger.info(
+                "[MCPSyncService] 整产物 provider 的白名单已由前置整产物投递覆盖，"
+                "跳过重复的设备白名单声明，仅更新 passport: bot_id=%s",
+                bot_id,
+            )
+        else:
+            scope_result = await self._declare_mcp_scope(
+                bot_id=bot_id,
+                user_id=user_id,
+                entity_id=entity_id,
+                entity_type=entity_type,
+                engine_type=effective_engine,
+            )
+            if not scope_result.get("success"):
+                return scope_result
 
         # 白名单声明成功后，再更新 passport 供前端权限校验使用。
         passport_result = await self._update_passport(
@@ -487,6 +508,32 @@ class MCPSyncService:
             }
 
         return {"success": True, "sync_results": sync_results, "error": None}
+
+    def _provider_delivers_whole_artifact(self, *, bot_id: str, entity_id: str) -> bool:
+        """探测 bot 的 per-bot 投递插件是否为整产物投递（teclaw）。
+
+        用 ``entity_id`` 解析（与 ``_declare_mcp_scope`` / ``collect_bot_active_mcps``
+        的 entity 口径一致）。设备未绑定/未知 provider 时返回 False——让上层照常走
+        ``_declare_mcp_scope``，由其统一上报"缺少设备连接信息"，不改变既有行为。
+        用 ``getattr`` 读取 capability：未实现该方法的插件按增量语义（False）处理，
+        保证仅在插件显式声明整产物时才跳过重复投递。
+        """
+        try:
+            ctx = self._resolver_provider().resolve_for_bot(bot_id, entity_id)
+        except (DeviceNotBoundError, UnknownProviderError):
+            return False
+        plugin = self._device_sync_dispatcher_provider().dispatch(ctx)
+        check = getattr(plugin, "delivers_whole_artifact", None)
+        if not callable(check):
+            return False
+        try:
+            return bool(check())
+        except Exception as e:  # 探测失败不阻断主流程，退化为增量语义。
+            logger.warning(
+                "[MCPSyncService] 探测整产物 capability 失败，按增量处理: bot_id=%s, error=%s",
+                bot_id, e,
+            )
+            return False
 
     async def _declare_mcp_scope(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1312,8 +1312,15 @@ class SkillSetService:
                 "sync_error": error,
             }
 
-        # 触发 scope 同步（更新 allowServers 列表 + passport）
-        scope_result = await self.refresh_mcp_scope(user_id=user_id)
+        # 触发 scope 同步（更新 allowServers 列表 + passport）。
+        # 上面的 sync_mcp_detail 已把 MCP 配置投递到设备：对整产物 provider（teclaw）
+        # 那次投递已是含最新白名单的整份 artifact（关联已先落库），此处的白名单声明
+        # 会重组并再投递同一份 artifact——重复设备工作。传 skip 标志让整产物 provider
+        # 跳过该重复投递，仅保留必需的 passport 更新；增量 provider（arca/baas）照旧。
+        scope_result = await self.refresh_mcp_scope(
+            user_id=user_id,
+            skip_device_declare_when_whole_artifact=True,
+        )
         if not scope_result.get("success"):
             error = scope_result.get("error", "Unknown error")
             logger.error("[add_mcp_to_skill_set] 刷新 MCP 授权范围失败: %s", error)
@@ -1731,6 +1738,7 @@ class SkillSetService:
         self,
         user_id: str,
         engine_type: Optional[str] = None,
+        skip_device_declare_when_whole_artifact: bool = False,
     ) -> dict[str, Any]:
         """刷新MCP授权范围（异步方法）。
 
@@ -1740,6 +1748,10 @@ class SkillSetService:
         Args:
             user_id: User ID for database queries (required, cannot be empty)
             engine_type: Engine type for scoping. If None, falls back to Bot.active_engine.
+            skip_device_declare_when_whole_artifact: 调用方已通过前置详情投递向设备
+                下发过一次完整配置时置 True，对整产物 provider（teclaw）跳过重复的
+                白名单设备投递，仅保留 passport 更新。默认 False。详见
+                ``MCPSyncService.refresh_mcp_scope``。
 
         Returns:
             ``{"success": bool, "error": str|None}`` 格式的结果字典。
@@ -1764,6 +1776,7 @@ class SkillSetService:
             bot_id=self.bot_id,
             entity_type=self.entity_type,
             engine_type=effective_engine,
+            skip_device_declare_when_whole_artifact=skip_device_declare_when_whole_artifact,
         )
 
 

--- a/src/backend/src/agentclaw/community/plugin_api/device_sync.py
+++ b/src/backend/src/agentclaw/community/plugin_api/device_sync.py
@@ -117,3 +117,26 @@ class DeviceSyncPlugin(Plugin, Protocol):
         ``True`` (always deliver + count in the batch — Option B).
         """
         ...
+
+    def delivers_whole_artifact(self) -> bool:
+        """Whether one MCP delivery pushes the **entire** composed device
+        artifact rather than an incremental delta.
+
+        Whole-artifact providers (teclaw) recompose and re-POST the complete
+        ``BotConfigArtifact`` on *every* MCP method — ``sync_single_mcp``,
+        ``sync_all_mcp_servers`` and ``sync_remove_mcp`` all delegate to the
+        same compose-and-deliver path. So once the DB relation is persisted, a
+        single detail push already reflects the full allow-list, and a
+        subsequent ``sync_all_mcp_servers`` (filter-servers) delivery is
+        duplicate device work. Callers use this to collapse the config push and
+        the allow-list declaration into one delivery for such providers.
+
+        Incremental providers (arca/baas) push a per-MCP ``/api/mcp`` delta and
+        a separate filter-servers update, so they return ``False`` — the two
+        deliveries are genuinely different work and must both run.
+
+        The default is ``False`` (incremental / safe): a plugin that does not
+        implement this method is treated as incremental, so no delivery is
+        skipped. Whole-artifact impls override it to return ``True``.
+        """
+        return False

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -40,6 +40,10 @@ def _make_plugin(**overrides):
     plugin.sync_single_mcp = MagicMock(return_value=True)
     plugin.sync_remove_mcp = MagicMock(return_value=True)
     plugin.has_mcp = MagicMock(return_value=True)
+    # Default to the incremental (arca/baas) capability; whole-artifact tests
+    # override this to True. Explicit so getattr() doesn't see an auto-created
+    # truthy MagicMock.
+    plugin.delivers_whole_artifact = MagicMock(return_value=False)
     for k, v in overrides.items():
         setattr(plugin, k, v)
     return plugin
@@ -611,3 +615,153 @@ class TestSyncMcpDetailToAllBots:
 
         assert result["success"] is True
         assert result["sync_results"][0]["reason"] == "缺少设备连接信息"
+
+
+class TestRefreshMcpScopeWholeArtifactDedup:
+    """refresh_mcp_scope(skip_device_declare_when_whole_artifact=True) collapses
+    the redundant whitelist redeliver for whole-artifact providers (teclaw).
+
+    Context: add_mcp_to_skill_set first pushes the MCP config
+    (``sync_mcp_detail``); for a whole-artifact provider that push already
+    delivered the complete artifact reflecting the new allow-list. The
+    subsequent scope refresh's device declare (``sync_all_mcp_servers``) would
+    recompose and re-POST the *same* artifact — duplicate device work. The skip
+    flag drops that second delivery for whole-artifact providers only, while
+    keeping the (still required) passport update. Incremental providers
+    (arca/baas) are unaffected: their filter-servers declaration is genuinely
+    separate work and must still run.
+    """
+
+    @pytest.mark.asyncio
+    async def test_skip_flag_skips_declare_for_whole_artifact_provider(self):
+        """Whole-artifact provider + skip flag → no second device delivery,
+        passport still updated."""
+        passport_update = MagicMock()
+        passport_update.query_passport_clis.return_value = []
+        plugin = _make_plugin(
+            delivers_whole_artifact=MagicMock(return_value=True),
+        )
+        resolver, dispatcher, _ = _make_resolver_and_dispatcher(plugin=plugin)
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[{"server_code": "mcp.test.1"}]),
+            passport_update=passport_update,
+            resolver=resolver,
+            dispatcher=dispatcher,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="user1", entity_id="100", bot_id="bot1",
+            entity_type="staff", engine_type="openclaw",
+            skip_device_declare_when_whole_artifact=True,
+        )
+
+        assert result["success"] is True
+        plugin.sync_all_mcp_servers.assert_not_called()
+        passport_update.update_passport.assert_called_once()
+        resource_scope = passport_update.update_passport.call_args.kwargs["resource_scope"]
+        assert resource_scope["mcp_codes"] == ["mcp.test.1"]
+
+    @pytest.mark.asyncio
+    async def test_skip_flag_still_declares_for_incremental_provider(self):
+        """Incremental provider (delivers_whole_artifact=False) ignores the skip
+        flag: the filter-servers declaration still runs."""
+        passport_update = MagicMock()
+        passport_update.query_passport_clis.return_value = []
+        plugin = _make_plugin(
+            delivers_whole_artifact=MagicMock(return_value=False),
+        )
+        resolver, dispatcher, _ = _make_resolver_and_dispatcher(plugin=plugin)
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[{"server_code": "mcp.test.1"}]),
+            passport_update=passport_update,
+            resolver=resolver,
+            dispatcher=dispatcher,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="user1", entity_id="100", bot_id="bot1",
+            entity_type="staff", engine_type="openclaw",
+            skip_device_declare_when_whole_artifact=True,
+        )
+
+        assert result["success"] is True
+        plugin.sync_all_mcp_servers.assert_called_once_with([{"server_code": "mcp.test.1"}])
+        passport_update.update_passport.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_default_still_declares_for_whole_artifact_provider(self):
+        """Without the skip flag (default), a whole-artifact provider still gets
+        the device declare — scope-only flows (activate/switch) rely on it as
+        their sole delivery."""
+        passport_update = MagicMock()
+        passport_update.query_passport_clis.return_value = []
+        plugin = _make_plugin(
+            delivers_whole_artifact=MagicMock(return_value=True),
+        )
+        resolver, dispatcher, _ = _make_resolver_and_dispatcher(plugin=plugin)
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[{"server_code": "mcp.test.1"}]),
+            passport_update=passport_update,
+            resolver=resolver,
+            dispatcher=dispatcher,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="user1", entity_id="100", bot_id="bot1",
+            entity_type="staff", engine_type="openclaw",
+        )
+
+        assert result["success"] is True
+        plugin.sync_all_mcp_servers.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skip_reports_passport_failure_without_second_delivery(self):
+        """Partial failure: skip declare, then passport update fails → surfaces
+        the passport error and never performs a second artifact delivery."""
+        passport_update = MagicMock()
+        passport_update.query_passport_clis.side_effect = RuntimeError("tcauth down")
+        plugin = _make_plugin(
+            delivers_whole_artifact=MagicMock(return_value=True),
+        )
+        resolver, dispatcher, _ = _make_resolver_and_dispatcher(plugin=plugin)
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[{"server_code": "mcp.test.1"}]),
+            passport_update=passport_update,
+            resolver=resolver,
+            dispatcher=dispatcher,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="user1", entity_id="100", bot_id="bot1",
+            entity_type="staff", engine_type="openclaw",
+            skip_device_declare_when_whole_artifact=True,
+        )
+
+        assert result["success"] is False
+        assert "查询 CLI 范围失败" in result["error"]
+        plugin.sync_all_mcp_servers.assert_not_called()
+        passport_update.update_passport.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skip_falls_back_to_declare_when_device_unavailable(self):
+        """Skip flag set but no syncable device: capability probe returns False,
+        so the declare path runs and surfaces the missing-device error (no
+        behavior change vs. today)."""
+        passport_update = MagicMock()
+        resolver, dispatcher, _ = _make_resolver_and_dispatcher(unavailable=True)
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[{"server_code": "mcp.test.1"}]),
+            passport_update=passport_update,
+            resolver=resolver,
+            dispatcher=dispatcher,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="user1", entity_id="100", bot_id="bot1",
+            entity_type="staff", engine_type="openclaw",
+            skip_device_declare_when_whole_artifact=True,
+        )
+
+        assert result["success"] is False
+        assert "缺少设备连接信息" in result["error"]
+        passport_update.update_passport.assert_not_called()

--- a/src/backend/tests/community/core/skill_center/services/test_mcp_sync_params.py
+++ b/src/backend/tests/community/core/skill_center/services/test_mcp_sync_params.py
@@ -45,4 +45,5 @@ class TestRefreshMcpScope:
             bot_id="test-bot",
             entity_type="staff",
             engine_type="openclaw",
+            skip_device_declare_when_whole_artifact=False,
         )

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -818,11 +818,15 @@ class TestAddMcpToSkillSetTeclawEndToEnd:
         from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
 
         # Per-bot DeviceSyncPlugin double: MCP methods are SYNC (run via to_thread).
-        # For a teclaw bot the real plugin delivers the whole artifact; here we assert
-        # the service routes the add + scope legs through it (provider-blind).
+        # A teclaw plugin delivers the whole artifact on every MCP method, so it
+        # declares delivers_whole_artifact() == True. The add leg's sync_single_mcp
+        # already ships the complete artifact (with the new MCP in the allow-list,
+        # since the DB relation is persisted first); the scope leg must therefore
+        # NOT re-deliver — exactly one device delivery per add (acceptance #1).
         plugin = MagicMock()
         plugin.sync_single_mcp = MagicMock(return_value=True)
         plugin.sync_all_mcp_servers = MagicMock(return_value=True)
+        plugin.delivers_whole_artifact = MagicMock(return_value=True)
         ctx = DeviceContext(
             provider="teclaw",
             conn_info={"engine_type": "teclaw"},
@@ -866,15 +870,16 @@ class TestAddMcpToSkillSetTeclawEndToEnd:
 
         # The reported bug: this used to be False with "缺少设备连接信息".
         assert result["success"] is True, result
-        # Delivered via the per-bot plugin (resolved through resolver+dispatcher): the
-        # add leg pushes the MCP and the scope leg declares the allow-list.
+        # Delivered via the per-bot plugin (resolved through resolver+dispatcher).
         resolver.resolve_for_bot.assert_called()
         dispatcher.dispatch.assert_called()
+        # Exactly ONE whole-artifact delivery: the add leg ships it; the scope leg's
+        # redundant re-delivery is deduped for whole-artifact providers (Finding 1).
         plugin.sync_single_mcp.assert_called_once()
-        plugin.sync_all_mcp_servers.assert_called_once()
+        plugin.sync_all_mcp_servers.assert_not_called()
         # DB association persisted — no rollback.
         skill_set_repo.remove_mcp_from_set.assert_not_called()
-        # Scope refresh still updates the passport for teclaw.
+        # Scope refresh still updates the passport for teclaw (auth layer preserved).
         passport_update.update_passport.assert_called_once()
 
 

--- a/src/backend/tests/community/endpoints/test_skillset_cli_resources.py
+++ b/src/backend/tests/community/endpoints/test_skillset_cli_resources.py
@@ -154,6 +154,67 @@ def list_skillset_resources_degrades_when_cli_query_fails():
     """CLI query failures should not block Skill/MCP resource listing."""
 
 
+def _assert_cli_query_skipped(response, world) -> None:
+    """MCP-only reads must not pay for the synchronous AgentPass CLI lookup."""
+    passport = world.get(PassportPlugin)
+    passport.query_passport_clis.assert_not_called()
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/skillsets/resources",
+    scenario="include_clis_false_skips_cli_query",
+    input=CaseInput(
+        query_params={**_QUERY, "include_clis": "false"},
+        headers=_HEADERS,
+    ),
+    seed=_seed_resources_happy,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": [
+                {
+                    "id": _SKILL_SET_ID,
+                    "mcps": [{"server_code": "web-search"}],
+                    "clis": [],
+                }
+            ],
+        },
+    ),
+    extra_assertions=(_assert_cli_query_skipped,),
+)
+def list_skillset_resources_include_clis_false_skips_agentpass():
+    """include_clis=false omits CLI aggregation and never calls AgentPass."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/skillsets/resources",
+    scenario="include_clis_true_default_returns_cli",
+    input=CaseInput(
+        query_params={**_QUERY, "include_clis": "true"},
+        headers=_HEADERS,
+    ),
+    seed=_seed_resources_happy,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": [
+                {
+                    "id": _SKILL_SET_ID,
+                    "mcps": [{"server_code": "web-search"}],
+                    "clis": [{"cli_code": "cli.keep"}],
+                }
+            ],
+        },
+    ),
+)
+def list_skillset_resources_include_clis_true_returns_cli():
+    """include_clis=true (the default) keeps full CLI aggregation for capability views."""
+
+
 @endpoint_test(
     method="GET",
     path="/api/skillsets/resources",


### PR DESCRIPTION
## Summary

Backend performance fixes for the "add MCP to capability set" flow investigated in #81. Addresses the two findings whose code lives in this community repo — **Finding 1** (duplicate Teclaw device delivery) and **Finding 2** (MCP-only reads paying for a synchronous CLI lookup).

### Scope note (please read)
This is the **community** distribution. Two parts of #81 are **out of scope for this repo**:
- **Finding 3 (frontend triple-refresh)** — the named files (`SkillModal.tsx`, `SkillTab.tsx`, `useChatCommand.tsx`, `useMcpMarket.ts`) do not exist in this tree or git history; `src/frontend` here is the group-chat/Beacon app and nothing calls `GET /api/skillsets/resources`. This needs the (separate/closed) Assistant frontend.
- **The Teclaw compose plugin** (`plugins/prod/teclaw_device_sync.py`, `_compose_and_deliver`) is in closed corp modules. This PR fixes the provider-agnostic **orchestration** here and adds the capability seam the Teclaw plugin plugs into by declaring `delivers_whole_artifact() -> True` (a documented follow-up in that repo).
- **Acceptance "one real Teclaw pre-production add trace"** cannot be produced in this environment (no Teclaw plugin, no pre-prod access). Verified via unit tests only.

## Finding 1 — one whole-artifact delivery per Teclaw MCP add

`add_mcp_to_skill_set` did: persist relation → `sync_mcp_detail` (device delivery) → `refresh_mcp_scope` → `_declare_mcp_scope` → `sync_all_mcp_servers` (a **second** device delivery) → Passport update. For whole-artifact providers (Teclaw) both deliveries recompose and re-POST the same complete `BotConfigArtifact`, and the relation is persisted before the first compose, so the second delivery is pure duplicate device work (~3.7 s in the trace).

- New `delivers_whole_artifact()` capability on the `DeviceSyncPlugin` protocol (default `False` = incremental/safe).
- `add_mcp_to_skill_set` passes `skip_device_declare_when_whole_artifact=True`; `MCPSyncService.refresh_mcp_scope` then skips the redundant declare **only** for whole-artifact providers, while still running the required Passport update.
- Capability is read via `getattr` — plugins that don't implement it default to incremental, so there is **no runtime behavior change until a provider opts in**.
- Preserved: rollback on device-delivery failure; Passport-partial-failure reporting with **no** second delivery; incremental providers (arca/baas); scope-only flows (activate/switch) which still rely on the declare as their sole delivery.
- No provider `if`-branch in the service/adapter layer (respects the module's Dispatcher-only routing rule).

## Finding 2 — MCP-only reads skip the synchronous CLI lookup

`GET /api/skillsets/resources` always called `query_passport_clis` (AgentPass) even for screens that discard CLI data (~2.24 s server-side in the sample). Added a backward-compatible `include_clis` query flag (default `True`); `include_clis=false` returns MCP/Skill sets without touching AgentPass.

## Tests

- `test_sync_service.py`: whole-artifact dedupe (no second delivery), incremental-unchanged, default-still-declares, Passport partial failure (no second delivery), device-unavailable fallback.
- `test_skillset_cli_resources.py`: `include_clis=false` returns empty CLIs **and asserts AgentPass is never called**; `include_clis=true` still returns CLI.
- Updated the Teclaw end-to-end add test to assert exactly **one** device delivery (acceptance criterion #1) + Passport still updated.
- Full affected sweep green: `1921 passed, 3 skipped`; architecture + gateway contract guards: `92 passed`.

## Out-of-repo follow-ups
1. Teclaw plugin: override `delivers_whole_artifact()` to return `True`.
2. Assistant frontend: centralized `invalidateSkillSetResources` + in-flight dedupe; call `include_clis=false` from MCP-only dialogs (Finding 3).
3. One real Teclaw pre-prod add-flow trace + before/after latency comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bTBC9cRY1Q6NEKRKhQCWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013bTBC9cRY1Q6NEKRKhQCWJ)_