### PR TITLE
fix(bcs): harden provider SSE transport

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -3609,6 +3609,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -128,7 +128,7 @@ bytes       = "1"
 futures     = "0.3"
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots"], default-features = false }
+reqwest = { version = "0.12", features = ["http2", "json", "stream", "rustls-tls-native-roots"], default-features = false }
 
 # UUID
 uuid = { version = "1", features = ["v4"] }

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -19,7 +19,7 @@ use bcs_service_api::{
 };
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 mod sse;
 
@@ -40,6 +40,31 @@ const SSE_CTX_RETRY_MAX: u32 = 20;
 /// twice (enter + recover), not once per frame.
 const SSE_LAG_ALERT_MS: u64 = 5_000;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ProviderClientPolicy {
+    total_timeout: Option<Duration>,
+    read_timeout: Option<Duration>,
+    http2_only: bool,
+}
+
+impl ProviderClientPolicy {
+    fn for_request(accept_sse: bool) -> Self {
+        if accept_sse {
+            Self {
+                total_timeout: None,
+                read_timeout: Some(Duration::from_secs(125)),
+                http2_only: true,
+            }
+        } else {
+            Self {
+                total_timeout: Some(Duration::from_secs(65)),
+                read_timeout: None,
+                http2_only: false,
+            }
+        }
+    }
+}
+
 /// Edge-triggered tracker for a run's consumption lag, so a sustained backlog
 /// produces exactly one "falling behind" WARN and one "recovered" WARN rather
 /// than a per-frame flood.
@@ -52,8 +77,8 @@ struct LagTracker {
 pub struct HttpProviderTransport {
     /// Callback / history client with a 65s total timeout.
     client: reqwest::Client,
-    /// SSE client with NO total timeout (#3): a total `.timeout()` would cut a
-    /// long-lived stream. Idle detection is handled inside the read loop.
+    /// HTTP/2-only SSE client with NO total timeout (#3): a total `.timeout()`
+    /// would cut a long-lived stream. Idle detection is handled in the read loop.
     sse_client: reqwest::Client,
     url_guard: OutboundUrlGuard,
     message_flow: std::sync::RwLock<Option<Arc<dyn MessageFlowService>>>,
@@ -66,18 +91,33 @@ impl HttpProviderTransport {
     }
 
     pub fn allowing_private_networks_for_tests() -> Self {
-        Self::with_url_guard(OutboundUrlGuard::allowing_private_networks_for_tests())
+        // Local contract servers are HTTP/1. Production constructors and every
+        // DNS-pinned SSE client keep the strict HTTP/2-only policy.
+        Self::with_url_guard_and_sse_policy(
+            OutboundUrlGuard::allowing_private_networks_for_tests(),
+            ProviderClientPolicy {
+                http2_only: false,
+                ..ProviderClientPolicy::for_request(true)
+            },
+        )
     }
 
     pub fn with_url_guard(url_guard: OutboundUrlGuard) -> Self {
+        Self::with_url_guard_and_sse_policy(
+            url_guard,
+            ProviderClientPolicy::for_request(true),
+        )
+    }
+
+    fn with_url_guard_and_sse_policy(
+        url_guard: OutboundUrlGuard,
+        sse_policy: ProviderClientPolicy,
+    ) -> Self {
         Self {
-            client: provider_client_builder()
+            client: provider_client_builder(ProviderClientPolicy::for_request(false))
                 .build()
                 .expect("build provider http client"),
-            sse_client: reqwest::Client::builder()
-                // No total `.timeout()` — only a per-read timeout so a healthy
-                // long stream is never cut while a dead socket still unblocks.
-                .read_timeout(Duration::from_secs(125))
+            sse_client: provider_client_builder(sse_policy)
                 .build()
                 .expect("build provider sse client"),
             url_guard,
@@ -610,9 +650,11 @@ async fn send_provider_request(
             message: format!("provider webhook_url is not allowed: {error}"),
             request_id: Some(body.id.clone()),
         })?;
-    let pinned_client = provider_client_for_url(&guarded_url).map_err(|error| {
+    let client_policy = ProviderClientPolicy::for_request(accept_sse);
+    let pinned_client = provider_client_for_url(&guarded_url, client_policy).map_err(|error| {
         ServiceError::InternalError(format!("provider HTTP client build failed: {error}"))
     })?;
+    let dns_pinned = pinned_client.is_some();
     let request_client = pinned_client.as_ref().unwrap_or(client);
 
     let message_id = uuid::Uuid::new_v4().to_string();
@@ -643,7 +685,9 @@ async fn send_provider_request(
         request_body = %request_body,
         "provider downlink: request body"
     );
-    debug!(
+    let request_started_ms = bcs_protocol::now_ms();
+    let request_started = Instant::now();
+    info!(
         provider_id = %body.to_bot.provider_id,
         method = %body.method,
         frame_id = %body.id,
@@ -652,6 +696,11 @@ async fn send_provider_request(
         protocol_version = %protocol_version,
         accept = %accept,
         transport = %transport,
+        dns_pinned,
+        http2_only = client_policy.http2_only,
+        total_timeout_ms = ?client_policy.total_timeout.map(|timeout| timeout.as_millis()),
+        read_timeout_ms = ?client_policy.read_timeout.map(|timeout| timeout.as_millis()),
+        request_started_ms,
         "provider downlink: posting webhook"
     );
     let mut request = request_client
@@ -670,12 +719,16 @@ async fn send_provider_request(
         .send()
         .await
         .map_err(|error| {
+            let elapsed_ms = request_started.elapsed().as_millis();
             warn!(
                 provider_id = %body.to_bot.provider_id,
                 method = %body.method,
                 frame_id = %body.id,
                 message_id = %message_id,
                 webhook_url = %webhook_url,
+                dns_pinned,
+                http2_only = client_policy.http2_only,
+                elapsed_ms,
                 error = %error,
                 "provider downlink: webhook transport error"
             );
@@ -683,6 +736,35 @@ async fn send_provider_request(
         })?;
 
     let status = response.status();
+    let response_version = response.version();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    let transfer_encoding = response
+        .headers()
+        .get(reqwest::header::TRANSFER_ENCODING)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    info!(
+        target_bot_id = %target.bot_id(),
+        provider_id = %body.to_bot.provider_id,
+        method = %body.method,
+        frame_id = %body.id,
+        message_id = %message_id,
+        webhook_url = %webhook_url,
+        dns_pinned,
+        http2_only = client_policy.http2_only,
+        accept_sse,
+        status = %status.as_u16(),
+        http_version = ?response_version,
+        content_type,
+        content_length = ?response.content_length(),
+        transfer_encoding,
+        headers_elapsed_ms = request_started.elapsed().as_millis(),
+        "provider downlink: response headers received"
+    );
     if !status.is_success() {
         warn!(
             provider_id = %body.to_bot.provider_id,
@@ -701,19 +783,28 @@ async fn send_provider_request(
     Ok(response)
 }
 
-fn provider_client_builder() -> reqwest::ClientBuilder {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(65))
-        .redirect(reqwest::redirect::Policy::none())
+fn provider_client_builder(policy: ProviderClientPolicy) -> reqwest::ClientBuilder {
+    let mut builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::none());
+    if let Some(timeout) = policy.total_timeout {
+        builder = builder.timeout(timeout);
+    }
+    if let Some(read_timeout) = policy.read_timeout {
+        builder = builder.read_timeout(read_timeout);
+    }
+    if policy.http2_only {
+        builder = builder.http2_prior_knowledge();
+    }
+    builder
 }
 
 fn provider_client_for_url(
     guarded_url: &bcs_route_security::ValidatedRequestUrl,
+    policy: ProviderClientPolicy,
 ) -> Result<Option<reqwest::Client>, reqwest::Error> {
     let Some((host, addrs)) = guarded_url.dns_override() else {
         return Ok(None);
     };
-    provider_client_builder()
+    provider_client_builder(policy)
         .resolve_to_addrs(host, addrs)
         .build()
         .map(Some)
@@ -1340,6 +1431,70 @@ async fn ingest(
     };
     if let Err(error) = flow.handle_bot_event(cmd).await {
         warn!(run_id = %bcn_run_id, %error, "ingest handle_bot_event failed");
+    }
+}
+
+#[cfg(test)]
+mod client_policy_tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn spawn_http1_server() -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .await
+                .unwrap();
+        });
+        addr
+    }
+
+    #[test]
+    fn sse_policy_is_http2_only_without_total_timeout() {
+        let policy = ProviderClientPolicy::for_request(true);
+
+        assert_eq!(policy.total_timeout, None);
+        assert_eq!(policy.read_timeout, Some(Duration::from_secs(125)));
+        assert!(policy.http2_only);
+    }
+
+    #[test]
+    fn callback_policy_keeps_total_timeout_and_protocol_negotiation() {
+        let policy = ProviderClientPolicy::for_request(false);
+
+        assert_eq!(policy.total_timeout, Some(Duration::from_secs(65)));
+        assert_eq!(policy.read_timeout, None);
+        assert!(!policy.http2_only);
+    }
+
+    #[tokio::test]
+    async fn sse_builder_rejects_http1_while_callback_builder_accepts_it() {
+        let callback_addr = spawn_http1_server().await;
+        let callback_client = provider_client_builder(ProviderClientPolicy::for_request(false))
+            .build()
+            .unwrap();
+        let callback_response = callback_client
+            .get(format!("http://{callback_addr}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(callback_response.version(), reqwest::Version::HTTP_11);
+
+        let sse_addr = spawn_http1_server().await;
+        let sse_client = provider_client_builder(ProviderClientPolicy::for_request(true))
+            .build()
+            .unwrap();
+        let error = sse_client
+            .get(format!("http://{sse_addr}"))
+            .send()
+            .await
+            .unwrap_err();
+        assert!(error.is_request());
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -67,13 +67,14 @@ where
     fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
         let mut visitor = FieldVisitor::default();
         event.record(&mut visitor);
-        if visitor
-            .fields
-            .get("message")
-            .is_some_and(|message| {
-                message.trim_matches('"') == "provider downlink: history response"
-            })
-        {
+        if visitor.fields.get("message").is_some_and(|message| {
+            matches!(
+                message.trim_matches('"'),
+                "provider downlink: posting webhook"
+                    | "provider downlink: response headers received"
+                    | "provider downlink: history response"
+            )
+        }) {
             self.events
                 .lock()
                 .unwrap()
@@ -540,7 +541,50 @@ async fn provider_history_logs_provider_bot_group_and_history_response() {
         .await
         .unwrap();
 
+    let frame_id = captured.lock().await.clone().unwrap().body["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
     let events = logs.lock().unwrap();
+    let request_event = events
+        .iter()
+        .find(|event| {
+            event.field("message").as_deref() == Some("provider downlink: posting webhook")
+                && event.field("frame_id").as_deref() == Some(frame_id.as_str())
+        })
+        .expect("provider request start log");
+    assert_eq!(request_event.field("dns_pinned").as_deref(), Some("false"));
+    assert_eq!(request_event.field("http2_only").as_deref(), Some("false"));
+    assert_eq!(
+        request_event.field("total_timeout_ms").as_deref(),
+        Some("Some(65000)")
+    );
+    assert!(request_event.field("request_started_ms").is_some());
+
+    let response_event = events
+        .iter()
+        .find(|event| {
+            event.field("message").as_deref()
+                == Some("provider downlink: response headers received")
+                && event.field("frame_id").as_deref() == Some(frame_id.as_str())
+        })
+        .expect("provider response headers log");
+    assert_eq!(response_event.field("dns_pinned").as_deref(), Some("false"));
+    assert_eq!(response_event.field("http2_only").as_deref(), Some("false"));
+    assert_eq!(response_event.field("accept_sse").as_deref(), Some("false"));
+    assert_eq!(
+        response_event.field("target_bot_id").as_deref(),
+        Some("bot-provider")
+    );
+    assert_eq!(response_event.field("http_version").as_deref(), Some("HTTP/1.1"));
+    assert_eq!(
+        response_event.field("content_type").as_deref(),
+        Some("application/json")
+    );
+    assert!(response_event.field("content_length").is_some());
+    assert_eq!(response_event.field("transfer_encoding").as_deref(), Some(""));
+    assert!(response_event.field("headers_elapsed_ms").is_some());
+
     let event = events
         .iter()
         .find(|event| event.field("session_id").as_deref() == Some("group-log:cafebabe"))

--- a/src/bcs/docs/plans/2026-07-10-sse-pinned-http2.md
+++ b/src/bcs/docs/plans/2026-07-10-sse-pinned-http2.md
@@ -1,0 +1,61 @@
+# SSE Pinned HTTP/2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure BCS provider SSE requests remain unbounded by the normal 65-second timeout after DNS pinning, use HTTP/2 only, and expose request-to-response-header timing.
+
+**Architecture:** Model normal and SSE client behavior as explicit policies and use the selected policy for both shared and DNS-pinned clients. Keep the existing per-frame SSE diagnostics and add request-stage fields around the outbound POST so response-header stalls can be distinguished from stream-read stalls.
+
+**Tech Stack:** Rust, reqwest, tokio, existing `bcs-provider-http` unit tests.
+
+---
+
+### Task 1: Lock Down Client Policy
+
+**Files:**
+- Modify: `crates/adapters/http/bcs-provider-http/src/lib.rs`
+
+1. Add failing unit tests asserting that SSE policy has no total timeout and is HTTP/2-only, while callback policy retains the 65-second timeout.
+2. Run the focused tests and confirm they fail because the policy API does not exist.
+3. Add the minimal policy type and policy-aware client builder.
+4. Run the focused tests and confirm they pass.
+
+### Task 2: Preserve Policy Through DNS Pinning
+
+**Files:**
+- Modify: `crates/adapters/http/bcs-provider-http/src/lib.rs`
+
+1. Add a failing test for selecting SSE policy when constructing a DNS-pinned client.
+2. Pass the selected policy into `provider_client_for_url` so DNS resolution changes only addresses, not timeout or protocol behavior.
+3. Configure SSE builders with `http2_prior_knowledge`, no total timeout, the existing 125-second read timeout, and redirect rejection.
+4. Run the focused tests and confirm they pass.
+
+### Task 3: Add Request-Stage Diagnostics
+
+**Files:**
+- Modify: `crates/adapters/http/bcs-provider-http/src/lib.rs`
+
+1. Log the selected client policy, whether DNS pinning is active, and request start metadata before sending.
+2. Log response-header elapsed time, response status, and negotiated HTTP version after `send()` returns.
+3. Keep `bcs_sse_detail` as the source of per-frame `frame_ts`, `recv_ms`, and `lag_ms`.
+
+### Task 4: Verify
+
+**Files:**
+- Test: `crates/adapters/http/bcs-provider-http/src/lib.rs`
+
+1. Run `cargo test -p bcs-provider-http`.
+2. Run `cargo check -p bcs-provider-http`.
+3. Inspect the diff to ensure no BAAS files or unrelated formatting changed.
+4. Query the successful production run's `bcs-sse-detail` records and calculate delay statistics from `lag_ms`.
+
+### Task 5: Merge PR 82 Response Header Diagnostics
+
+**Files:**
+- Modify: `crates/adapters/http/bcs-provider-http/src/lib.rs`
+- Test: `crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs`
+
+1. Extend the existing tracing contract test to require `accept_sse`, `target_bot_id`, `content_type`, `content_length`, and `transfer_encoding` on the response-header event.
+2. Run the focused contract test and confirm it fails because those fields are absent.
+3. Add the fields to the existing `provider downlink: response headers received` event without adding a duplicate log event.
+4. Run the focused test, the full `bcs-provider-http` test suite, and `cargo check -p bcs-provider-http`.


### PR DESCRIPTION
## Summary

- Preserve the selected provider transport policy when DNS pinning rebuilds the reqwest client.
- Make provider SSE requests HTTP/2-only, with no total request timeout and a 125-second read timeout.
- Add request, response-header, transport-error, and per-frame timing fields for diagnosing buffering and stalled delivery.
- Keep callback/history requests on the existing 65-second total timeout and normal HTTP protocol negotiation.
- Limit the change to BCS; BAAS behavior is unchanged.

## Root cause

Protocol 2.0 correctly selected the SSE client without a total timeout, but domain-based provider URLs were then handled by the DNS-pinning path. That path rebuilt the client using the normal provider builder, silently restoring the 65-second total timeout and losing the SSE-specific transport policy.

When an intermediary delayed response headers or SSE frames, BCS could therefore fail delivery at roughly 65 seconds before the stream reader observed any event.

## Changes

- Introduce an explicit provider client policy shared by normal and DNS-pinned client construction.
- Use strict HTTP/2 for SSE requests, including DNS-pinned requests.
- Retain the existing SSE idle timeout while removing the unintended total timeout.
- Record transport policy, DNS-pinning state, response HTTP version/header timing, and error elapsed time.
- Extend detailed SSE logs with correlated frame timing so end-to-end receive delay can be calculated.
- Add transport-policy and protocol-negotiation contract tests.

## Validation

- `cargo test -p bcs-provider-http --no-fail-fast`
  - 18 unit tests passed
  - 14 contract tests passed
- `cargo check -p bcs-provider-http`
- `git diff --check`
