### PR TITLE
fix(cron): preserve verify targets after online release

### DIFF
--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -575,19 +575,16 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         if bot_type != "service":
             return targets, failed_targets
 
-        # 服务 Bot 的 verify/online 分别由验证中和发布成功记录提供 binding。
-        for runtime_stage, publish_status, binding_key in (
-            (RUNTIME_STAGE_VERIFY, PublishStatus.VALIDATING.value, "verify"),
-            (RUNTIME_STAGE_ONLINE, PublishStatus.SUCCESS.value, "online"),
+        # 服务 Bot 的 verify/online 从对应发布记录中读取 binding。
+        for runtime_stage, binding_key in (
+            (RUNTIME_STAGE_VERIFY, "verify"),
+            (RUNTIME_STAGE_ONLINE, "online"),
         ):
             try:
-                publish_record = (
-                    self._publish_repo.get_latest_by_source_bot_id_and_owner_and_status(
-                        source_bot_id=bot_id,
-                        owner_id=owner_id,
-                        status=publish_status,
-                        env=get_current_env(),
-                    )
+                publish_record = self._get_runtime_publish_record(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    runtime_stage=runtime_stage,
                 )
             except Exception as e:
                 failed_targets.append(
@@ -632,11 +629,41 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
                     runtime_stage=runtime_stage,
                     binding_id=stage_binding_id,
                     publish_id=publish_id,
-                    publish_status=getattr(publish_record, "status", publish_status),
+                    publish_status=getattr(publish_record, "status", None),
                 )
             )
 
         return targets, failed_targets
+
+    def _get_runtime_publish_record(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        runtime_stage: str,
+    ) -> Any | None:
+        """获取运行态发布记录；verify 优先使用验证中版本，否则使用已发布版本。"""
+        publish_statuses = {
+            RUNTIME_STAGE_VERIFY: (
+                PublishStatus.VALIDATING.value,
+                PublishStatus.SUCCESS.value,
+            ),
+            RUNTIME_STAGE_ONLINE: (PublishStatus.SUCCESS.value,),
+        }[runtime_stage]
+
+        for publish_status in publish_statuses:
+            publish_record = (
+                self._publish_repo.get_latest_by_source_bot_id_and_owner_and_status(
+                    source_bot_id=bot_id,
+                    owner_id=owner_id,
+                    status=publish_status,
+                    env=get_current_env(),
+                )
+            )
+            if publish_record is not None:
+                return publish_record
+
+        return None
 
     def _resolve_published_runtime_target(
         self,
@@ -654,15 +681,14 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
                 error_code=400,
             )
 
-        publish_status, binding_key = {
-            RUNTIME_STAGE_VERIFY: (PublishStatus.VALIDATING.value, "verify"),
-            RUNTIME_STAGE_ONLINE: (PublishStatus.SUCCESS.value, "online"),
+        binding_key = {
+            RUNTIME_STAGE_VERIFY: "verify",
+            RUNTIME_STAGE_ONLINE: "online",
         }[runtime_stage]
-        publish_record = self._publish_repo.get_latest_by_source_bot_id_and_owner_and_status(
-            source_bot_id=bot_id,
+        publish_record = self._get_runtime_publish_record(
+            bot_id=bot_id,
             owner_id=owner_id,
-            status=publish_status,
-            env=get_current_env(),
+            runtime_stage=runtime_stage,
         )
         if publish_record is None:
             raise CronRelayError(
@@ -686,7 +712,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             runtime_stage=runtime_stage,
             binding_id=binding_id,
             publish_id=getattr(publish_record, "id", None),
-            publish_status=getattr(publish_record, "status", publish_status),
+            publish_status=getattr(publish_record, "status", None),
         )
 
     def _validate_runtime_operation(

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
@@ -412,6 +412,38 @@ class TestListAllCronsOwnerId:
 
 
 class TestListServiceBotRuntimeStages:
+    def test_success_publish_record_supplies_verify_and_online_targets(self):
+        bot = {
+            "bot_id": "service-bot",
+            "owner_id": "owner-1",
+            "binding_id": 10,
+            "bot_name": "Service Bot",
+            "bot_type": "service",
+        }
+        success_record = SimpleNamespace(
+            id=202,
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"verify": 20, "online": 30}},
+        )
+        publish_repo = MagicMock()
+        publish_repo.get_latest_by_source_bot_id_and_owner_and_status.side_effect = (
+            lambda source_bot_id, owner_id, status, env: (
+                success_record if status == PublishStatus.SUCCESS.value else None
+            )
+        )
+        svc = _make_service(publish_repo=publish_repo)
+
+        targets, failed_targets = svc._build_runtime_targets(bot, "owner-1")
+
+        assert failed_targets == []
+        by_stage = {target.runtime_stage: target for target in targets}
+        assert by_stage["draft"].binding_id == 10
+        assert by_stage["verify"].binding_id == 20
+        assert by_stage["verify"].publish_id == 202
+        assert by_stage["verify"].publish_status == PublishStatus.SUCCESS.value
+        assert by_stage["online"].binding_id == 30
+        assert by_stage["online"].publish_id == 202
+
     @pytest.mark.asyncio
     async def test_service_bot_list_expands_draft_verify_online_targets(self):
         bot_provider = MagicMock()
@@ -513,11 +545,10 @@ class TestListServiceBotRuntimeStages:
         publish_repo = MagicMock()
         publish_repo.get_latest_by_source_bot_id_and_owner_and_status.side_effect = (
             lambda source_bot_id, owner_id, status, env: {
-                PublishStatus.SUCCESS.value: _make_publish_record(
-                    publish_id=202,
+                PublishStatus.SUCCESS.value: SimpleNamespace(
+                    id=202,
                     status=PublishStatus.SUCCESS.value,
-                    binding_key="online",
-                    binding_id=30,
+                    ext={"binding": {"verify": 20, "online": 30}},
                 ),
             }.get(status)
         )
@@ -526,6 +557,7 @@ class TestListServiceBotRuntimeStages:
         device_provider.get_device.side_effect = (
             lambda *, binding_id: {
                 10: _make_device(device_provider="arca"),
+                20: _make_device(device_provider="arca"),
                 30: _make_device(device_provider="baas"),
             }[binding_id]
         )
@@ -586,7 +618,7 @@ class TestListServiceBotRuntimeStages:
         assert result["failed_targets"] == []
         device_provider.get_instances.assert_not_called()
         device_provider.list_devices_by_runtime_binding.assert_not_called()
-        resolver.resolve_for_binding.assert_called_once_with(
+        resolver.resolve_for_binding.assert_any_call(
             30, "owner-1", bot_id="service-bot"
         )
 
@@ -604,11 +636,10 @@ class TestListServiceBotRuntimeStages:
         publish_repo = MagicMock()
         publish_repo.get_latest_by_source_bot_id_and_owner_and_status.side_effect = (
             lambda source_bot_id, owner_id, status, env: {
-                PublishStatus.SUCCESS.value: _make_publish_record(
-                    publish_id=202,
+                PublishStatus.SUCCESS.value: SimpleNamespace(
+                    id=202,
                     status=PublishStatus.SUCCESS.value,
-                    binding_key="online",
-                    binding_id=30,
+                    ext={"binding": {"verify": 20, "online": 30}},
                 ),
             }.get(status)
         )
@@ -617,6 +648,7 @@ class TestListServiceBotRuntimeStages:
         device_provider.get_device.side_effect = (
             lambda *, binding_id: {
                 10: _make_device(device_provider="arca"),
+                20: _make_device(device_provider="arca"),
                 30: _make_device(device_provider="baas"),
             }[binding_id]
         )
@@ -639,6 +671,11 @@ class TestListServiceBotRuntimeStages:
                 return {
                     "success": True,
                     "data": [{"id": "online-task"}],
+                }
+            if conn_info["binding_id"] == 20:
+                return {
+                    "success": True,
+                    "data": [{"id": "verify-task"}],
                 }
             return {
                 "success": True,
@@ -663,6 +700,7 @@ class TestListServiceBotRuntimeStages:
         assert result["success"] is True
         assert [item["id"] for item in result["data"]] == [
             "draft-task",
+            "verify-task",
             "online-task",
         ]
         assert result["failed_targets"] == []
@@ -1426,6 +1464,45 @@ class TestListRunningCronsOwnerId:
 
 
 class TestForwardRequestUsesResolver:
+    def test_verify_stage_falls_back_to_success_publish_record(self):
+        bot = {
+            "bot_id": "service-bot",
+            "owner_id": "owner-1",
+            "binding_id": 10,
+            "bot_name": "Service Bot",
+            "bot_type": "service",
+        }
+        success_record = SimpleNamespace(
+            id=202,
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"verify": 20, "online": 30}},
+        )
+        publish_repo = MagicMock()
+        publish_repo.get_latest_by_source_bot_id_and_owner_and_status.side_effect = (
+            lambda source_bot_id, owner_id, status, env: (
+                success_record if status == PublishStatus.SUCCESS.value else None
+            )
+        )
+        svc = _make_service(publish_repo=publish_repo)
+
+        target = svc._resolve_published_runtime_target(
+            bot,
+            "owner-1",
+            "verify",
+        )
+
+        assert target.binding_id == 20
+        assert target.publish_id == 202
+        assert target.publish_status == PublishStatus.SUCCESS.value
+        queried_statuses = [
+            call.kwargs["status"]
+            for call in publish_repo.get_latest_by_source_bot_id_and_owner_and_status.mock_calls
+        ]
+        assert queried_statuses == [
+            PublishStatus.VALIDATING.value,
+            PublishStatus.SUCCESS.value,
+        ]
+
     @pytest.mark.asyncio
     async def test_forward_request_calls_resolver_not_v2(self):
         """forward_request uses the resolver-built adapter connection context."""


### PR DESCRIPTION
Resolve verify targets from validating publish records first, then fall back to the latest successful publish record.\n\nKeep cron list and stage-specific operations aligned after a service bot reaches online.