### PR TITLE
fix(cron): parallelize runtime query preparation

### DIFF
--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -42,6 +42,7 @@ from agentclaw.community.core.cron.services.cron_runtime_targets import (
     RUNTIME_STAGE_DRAFT,
     RUNTIME_STAGE_ONLINE,
     RUNTIME_STAGE_VERIFY,
+    RUNTIME_QUERY_PREPARE_CONCURRENCY,
     VALID_RUNTIME_STAGES,
 )
 from agentclaw.community.core.cron.services.cron_runtime_operations import (
@@ -90,6 +91,10 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         self._resolver = resolver
         self._template_repo = template_repo
         self._publish_repo = publish_repo
+        # Cron 批量查询共用限流器，控制同步设备连接准备占用的线程数。
+        self._runtime_query_prepare_semaphore = asyncio.Semaphore(
+            RUNTIME_QUERY_PREPARE_CONCURRENCY
+        )
 
     async def list_all_crons(
         self,

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
@@ -28,10 +28,11 @@ VALID_RUNTIME_STAGES = {
 MULTI_INSTANCE_DEVICE_PROVIDERS = {"baas", "teclaw"}
 SINGLE_INSTANCE_DEVICE_PROVIDERS = {"arca", "local"}
 
-# Cron 查询只等待有限时间；设备枚举并发数用于限制同步 BaaS 请求占用的线程数。
-CRON_READ_TIMEOUT_SECONDS = 8.0
-RUNTIME_DEVICE_QUERY_TIMEOUT_SECONDS = 8.0
+# Cron 查询只等待有限时间；并发数用于限制同步设备请求占用的线程数。
+CRON_READ_TIMEOUT_SECONDS = 10.0
+RUNTIME_DEVICE_QUERY_TIMEOUT_SECONDS = 10.0
 RUNTIME_DEVICE_QUERY_CONCURRENCY = 8
+RUNTIME_QUERY_PREPARE_CONCURRENCY = 8
 
 
 @dataclass(frozen=True)
@@ -244,19 +245,16 @@ class CronRuntimeTargetMixin:
             **kwargs,
         )
 
-    async def _fetch_runtime_target_crons(
+    def _prepare_runtime_query(
         self,
         target: CronRuntimeTarget,
-        user_id: str,
-        path: str = "/api/cron",
-    ) -> dict:
-        """读取单个运行态目标的 cron 列表或运行中任务。"""
-        # 设备不可用时直接生成该目标的失败结果，不再解析连接。
+    ) -> tuple[Any | None, dict[str, Any] | None]:
+        """校验目标设备并构造 cron 查询所需的连接上下文。"""
         try:
             device = self._device_provider.get_device(binding_id=target.binding_id)
             device_status = self._read_field(device, "status")
             if device_status != DeviceBindingStatus.ACTIVE:
-                return {
+                return None, {
                     "success": False,
                     "reason": "binding_not_active",
                     "error": (
@@ -265,13 +263,40 @@ class CronRuntimeTargetMixin:
                     ),
                 }
         except Exception as e:
-            return {"success": False, "reason": "device_unavailable", "error": str(e)}
+            return None, {
+                "success": False,
+                "reason": "device_unavailable",
+                "error": str(e),
+            }
 
-        # 将运行态目标解析成 adapter 能使用的连接信息。
         try:
-            ctx = self._resolve_runtime_context(target)
+            return self._resolve_runtime_context(target), None
         except Exception as e:
-            return {"success": False, "reason": "resolver_failed", "error": str(e)}
+            return None, {
+                "success": False,
+                "reason": "resolver_failed",
+                "error": str(e),
+            }
+
+    async def _prepare_runtime_query_async(
+        self,
+        target: CronRuntimeTarget,
+    ) -> tuple[Any | None, dict[str, Any] | None]:
+        """在线程中准备查询上下文，并限制设备控制面并发量。"""
+        async with self._runtime_query_prepare_semaphore:
+            return await asyncio.to_thread(self._prepare_runtime_query, target)
+
+    async def _fetch_runtime_target_crons(
+        self,
+        target: CronRuntimeTarget,
+        user_id: str,
+        path: str = "/api/cron",
+    ) -> dict:
+        """读取单个运行态目标的 cron 列表或运行中任务。"""
+        ctx, failure = await self._prepare_runtime_query_async(target)
+        if failure is not None:
+            return failure
+        assert ctx is not None
 
         # 下游异常统一转换成可聚合的失败原因。
         try:
@@ -366,7 +391,7 @@ class CronRuntimeTargetMixin:
         body: Optional[dict],
         params: Optional[dict],
     ) -> dict:
-        """调用 adapter，并为 cron 读请求设置端到端超时。"""
+        """调用 adapter，并为 cron 读请求设置下游请求超时。"""
         # 列表、详情和 runs 等 GET 使用 cron 读超时；写请求使用 transport 默认值。
         if method.upper() != "GET":
             return await self._transport.invoke(

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
@@ -754,7 +754,7 @@ class TestListServiceBotRuntimeStages:
                 "runtime_stage": "verify",
                 "publish_id": 101,
                 "reason": "cron_api_timeout",
-                "message": "cron_api_timeout: no response within 8s for /api/cron",
+                "message": "cron_api_timeout: no response within 10s for /api/cron",
             }
         ]
 
@@ -918,6 +918,123 @@ class TestRuntimeTargetExpansion:
         assert failed == []
         assert len(expanded) == 12
         assert 1 < max_active <= 3
+
+
+class TestRuntimeQueryConcurrency:
+    @pytest.mark.asyncio
+    async def test_runtime_query_preparation_is_bounded(self):
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = _make_device()
+
+        def resolve(bot_id, user_id):
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            time.sleep(0.02)
+            with lock:
+                active -= 1
+            binding_id = int(bot_id.rsplit("-", 1)[1])
+            return _make_ctx(
+                binding_id=binding_id,
+                bot_id=bot_id,
+                user_id=user_id,
+            )
+
+        resolver = MagicMock()
+        resolver.resolve_for_bot.side_effect = resolve
+        transport = MagicMock()
+        transport.invoke = AsyncMock(return_value={"success": True, "data": []})
+        svc = _make_service(
+            device_provider=device_provider,
+            resolver=resolver,
+            transport=transport,
+        )
+        targets = [
+            CronRuntimeTarget(
+                bot_id=f"personal-bot-{binding_id}",
+                bot_name="Personal Bot",
+                owner_id="owner-1",
+                bot_type="personal",
+                runtime_stage="draft",
+                binding_id=binding_id,
+            )
+            for binding_id in range(12)
+        ]
+
+        results = await asyncio.gather(
+            *(svc._fetch_runtime_target_crons(target, "owner-1") for target in targets)
+        )
+
+        assert all(result["success"] for result in results)
+        assert 1 < max_active <= cron_runtime_targets.RUNTIME_QUERY_PREPARE_CONCURRENCY
+
+    @pytest.mark.asyncio
+    async def test_slow_preparation_does_not_cause_false_transport_timeouts(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            cron_runtime_targets,
+            "CRON_READ_TIMEOUT_SECONDS",
+            0.05,
+        )
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = _make_device()
+
+        def resolve(bot_id, user_id):
+            time.sleep(0.02)
+            binding_id = int(bot_id.rsplit("-", 1)[1])
+            return _make_ctx(
+                binding_id=binding_id,
+                bot_id=bot_id,
+                user_id=user_id,
+            )
+
+        resolver = MagicMock()
+        resolver.resolve_for_bot.side_effect = resolve
+
+        async def invoke(
+            conn_info,
+            method,
+            path,
+            body=None,
+            params=None,
+            *,
+            timeout=None,
+        ):
+            await asyncio.sleep(0.005)
+            return {"success": True, "data": []}
+
+        transport = MagicMock()
+        transport.invoke = AsyncMock(side_effect=invoke)
+        svc = _make_service(
+            device_provider=device_provider,
+            resolver=resolver,
+            transport=transport,
+        )
+        targets = [
+            CronRuntimeTarget(
+                bot_id=f"personal-bot-{binding_id}",
+                bot_name="Personal Bot",
+                owner_id="owner-1",
+                bot_type="personal",
+                runtime_stage="draft",
+                binding_id=binding_id,
+            )
+            for binding_id in range(6)
+        ]
+
+        results = await asyncio.gather(
+            *(svc._fetch_runtime_target_crons(target, "owner-1") for target in targets)
+        )
+
+        assert all(result["success"] for result in results)
+        assert transport.invoke.await_count == len(targets)
 
 
 class TestListRunningCronsOwnerId:
@@ -2013,7 +2130,7 @@ class TestForwardRequestUsesResolver:
         assert transport.invoke.await_count == 2
         assert {
             call.kwargs["timeout"] for call in transport.invoke.await_args_list
-        } == {8.0}
+        } == {10.0}
 
     @pytest.mark.asyncio
     async def test_get_cron_runs_keeps_partial_results_on_timeout(self, monkeypatch):


### PR DESCRIPTION
Run blocking device and connection-context preparation with a shared concurrency limit for cron list and running queries.

Raise cron read and runtime-device query timeouts to 10 seconds, and cover bounded concurrency plus false-timeout regression cases.