### PR TITLE
test(bcs): strengthen user-story E2E coverage and quality gates

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -157,16 +157,18 @@ jobs:
         #   singlebox --standalone --with-bcs-coverage start bcs_bots
         #     -> builds the instrumented bcs in target/cov-e2e/llvm-cov-target,
         #        starts BCS + 5 OpenClaw bots (BCN plugin built by setup_bcn_plugin)
-        #   e2e.sh                      -> 60 cases (group/friends/cli)
+        #   e2e.sh                      -> 12 user-story cases
         #   SIGTERM bcs                 -> flush profraw
         #   singlebox stop bcs_bots     -> tear down
-        #   cargo llvm-cov report --cobertura --fail-under-lines=20
-        #     -> aggregate + enforce e2e line-coverage gate
+        #   cargo llvm-cov report + endpoint coverage report
+        #     -> aggregate + enforce line >=40%, method >=36%, HTTP endpoints=100%,
+        #        and bcs-cli leaf commands=100%
         # --force-rebuild (mirroring pre_push): always rebuild the instrumented
         # binary from the pushed source instead of reusing a cached one, so the
         # measured coverage is correct. Exits non-zero on ANY e2e failure OR
-        # e2e line-coverage < 20%.
-        run: bash src/bcs/scripts/e2e_coverage.sh --bcs-min 20 --force-rebuild
+        # e2e line-coverage <40%, method coverage <36%, HTTP endpoint coverage
+        # below 100%, or CLI command coverage below 100%.
+        run: bash src/bcs/scripts/e2e_coverage.sh --bcs-line-min 40 --bcs-method-min 36 --force-rebuild
 
       - name: Stop stack (best-effort cleanup)
         if: always() && steps.changes.outputs.skip-bcs != 'true'
@@ -189,4 +191,5 @@ jobs:
             src/bcs/target/cov-e2e/summary.json
             src/bcs/target/cov-e2e/endpoint_coverage.txt
             src/bcs/target/cov-e2e/endpoint_coverage.xml
+            src/bcs/target/cov-e2e/cli_command_coverage.txt
           if-no-files-found: ignore

--- a/scripts/modules/demo_bot.sh
+++ b/scripts/modules/demo_bot.sh
@@ -132,18 +132,6 @@ demo_bot_wait_ready() {
     done
 }
 
-demo_bot_bcs_cli() {
-    if command -v bcs-cli >/dev/null 2>&1; then
-        command -v bcs-cli
-        return 0
-    fi
-    if [ -x "${BCS_DIR}/target/debug/bcs-cli" ]; then
-        printf '%s\n' "${BCS_DIR}/target/debug/bcs-cli"
-        return 0
-    fi
-    return 1
-}
-
 demo_bot_connect_bcs() {
     local backend_bot_id="$1"
     local bcs_bot_id base_url payload response
@@ -195,24 +183,31 @@ demo_bot_admin_onboard_bcs() {
 
 demo_bot_verify_bcn() {
     local backend_bot_id="$1"
-    local bcs_bot_id cli
+    local bcs_bot_id base_url response
     bcs_bot_id="$(demo_bot_bcs_bot_id "$backend_bot_id")"
-    cli="$(demo_bot_bcs_cli)" || {
-        log_error "bcs-cli not found; run: ./scripts/singlebox.sh setup bcs"
-        return 1
-    }
-
-    "$cli" --url "http://127.0.0.1:${BCS_PORT}" get "$bcs_bot_id" >> "${DEMO_BOT_LOG}" 2>&1
+    base_url="$(demo_bot_bcs_base_url)"
+    response="$(
+        curl --noproxy '*' --connect-timeout 2 --max-time 10 -fsS \
+            -H "X-Mock-User-Id: ${BCS_MOCK_USER_ID:-001}" \
+            -H "X-Mock-Nick-Name: ${BCS_MOCK_USER_NICK_NAME:-admin}" \
+            "${base_url}/bots/${bcs_bot_id}" \
+            2>>"${DEMO_BOT_LOG}" || true
+    )"
+    printf '%s\n' "$response" >> "${DEMO_BOT_LOG}"
+    printf '%s\n' "$response" | jq -e --arg bot_id "$bcs_bot_id" '.bot_uuid == $bot_id' >/dev/null 2>&1
 }
 
 demo_bot_has_expected_bcn_metadata() {
     local bcs_bot_id="$1"
-    local log_tail
-    log_tail="$(tail -n 20 "${DEMO_BOT_LOG}" 2>/dev/null || true)"
+    local response
+    response="$(tail -n 1 "${DEMO_BOT_LOG}" 2>/dev/null || true)"
 
-    printf '%s\n' "$log_tail" | grep -F "Bot: ${bcs_bot_id}" >/dev/null 2>&1 || return 1
-    printf '%s\n' "$log_tail" | grep -F "Name: ${DEMO_BOT_NAME}" >/dev/null 2>&1 || return 1
-    printf '%s\n' "$log_tail" | grep -F "Summary: ${DEMO_BOT_DESC}" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$response" | jq -e \
+        --arg bot_id "$bcs_bot_id" \
+        --arg name "$DEMO_BOT_NAME" \
+        --arg summary "$DEMO_BOT_DESC" \
+        '.bot_uuid == $bot_id and .capabilities.name == $name and .capabilities.summary == $summary' \
+        >/dev/null 2>&1
 }
 
 demo_bot_ensure_bcn() {
@@ -291,12 +286,6 @@ demo_bot_prereqs() {
         prereq_ok "curl: $(command -v curl)"
     else
         prereq_error "curl not found."
-        has_error=true
-    fi
-    if demo_bot_bcs_cli >/dev/null 2>&1; then
-        prereq_ok "bcs-cli: $(demo_bot_bcs_cli)"
-    else
-        prereq_error "bcs-cli not found. Run: ./scripts/singlebox.sh setup bcs"
         has_error=true
     fi
     [ "$has_error" = false ]

--- a/scripts/modules/demo_bot.sh
+++ b/scripts/modules/demo_bot.sh
@@ -181,49 +181,93 @@ demo_bot_admin_onboard_bcs() {
     printf '%s\n' "$response" | jq -e '.onboarded == true' >/dev/null 2>&1
 }
 
+# Return 0 when the BCS entry is exact, 1 when it is missing or repairable by
+# admin onboard, and 2 for fatal transport, authentication, or contract errors.
 demo_bot_verify_bcn() {
     local backend_bot_id="$1"
-    local bcs_bot_id base_url response
+    local bcs_bot_id base_url response_file response http_status curl_rc actual_bot_id actual_name actual_summary
     bcs_bot_id="$(demo_bot_bcs_bot_id "$backend_bot_id")"
     base_url="$(demo_bot_bcs_base_url)"
-    response="$(
-        curl --noproxy '*' --connect-timeout 2 --max-time 10 -fsS \
+    response_file="$(mktemp)" || {
+        log_error "Failed to allocate a temporary file for demo bot verification"
+        return 2
+    }
+
+    curl_rc=0
+    http_status="$(
+        curl --noproxy '*' --connect-timeout 2 --max-time 10 -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
             -H "X-Mock-User-Id: ${BCS_MOCK_USER_ID:-001}" \
             -H "X-Mock-Nick-Name: ${BCS_MOCK_USER_NICK_NAME:-admin}" \
             "${base_url}/bots/${bcs_bot_id}" \
-            2>>"${DEMO_BOT_LOG}" || true
-    )"
+            2>>"${DEMO_BOT_LOG}"
+    )" || curl_rc=$?
+    response="$(<"$response_file")"
+    rm -f "$response_file"
     printf '%s\n' "$response" >> "${DEMO_BOT_LOG}"
-    printf '%s\n' "$response" | jq -e --arg bot_id "$bcs_bot_id" '.bot_uuid == $bot_id' >/dev/null 2>&1
-}
 
-demo_bot_has_expected_bcn_metadata() {
-    local bcs_bot_id="$1"
-    local response
-    response="$(tail -n 1 "${DEMO_BOT_LOG}" 2>/dev/null || true)"
+    if [ "$curl_rc" -ne 0 ]; then
+        log_error "Failed to query demo bot from local BCS: curl exit ${curl_rc}. Check ${DEMO_BOT_LOG}"
+        return 2
+    fi
 
-    printf '%s\n' "$response" | jq -e \
-        --arg bot_id "$bcs_bot_id" \
+    case "$http_status" in
+        200) ;;
+        404)
+            return 1
+            ;;
+        401|403)
+            log_error "BCS rejected demo bot verification with HTTP ${http_status}; singlebox local mock human authentication must be enabled"
+            return 2
+            ;;
+        *)
+            log_error "Unexpected HTTP ${http_status:-unknown} while verifying demo bot in local BCS"
+            return 2
+            ;;
+    esac
+
+    if ! printf '%s\n' "$response" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        log_error "BCS returned invalid JSON while verifying demo bot: ${bcs_bot_id}"
+        return 2
+    fi
+
+    actual_bot_id="$(printf '%s\n' "$response" | jq -r '.bot_uuid // empty')"
+    if [ "$actual_bot_id" != "$bcs_bot_id" ]; then
+        log_error "BCS demo bot identity mismatch: expected=${bcs_bot_id}, actual=${actual_bot_id:-missing}"
+        return 2
+    fi
+
+    if printf '%s\n' "$response" | jq -e \
         --arg name "$DEMO_BOT_NAME" \
         --arg summary "$DEMO_BOT_DESC" \
-        '.bot_uuid == $bot_id and .capabilities.name == $name and .capabilities.summary == $summary' \
-        >/dev/null 2>&1
+        '.capabilities.name == $name and .capabilities.summary == $summary' \
+        >/dev/null 2>&1; then
+        return 0
+    fi
+
+    actual_name="$(printf '%s\n' "$response" | jq -r '.capabilities.name // empty')"
+    actual_summary="$(printf '%s\n' "$response" | jq -r '.capabilities.summary // empty')"
+    log_warn "BCS demo bot metadata needs repair: name=${actual_name:-missing}, summary=${actual_summary:-missing}"
+    return 1
 }
 
 demo_bot_ensure_bcn() {
     local backend_bot_id="$1"
-    local bcs_bot_id
+    local bcs_bot_id verify_rc=0
     bcs_bot_id="$(demo_bot_bcs_bot_id "$backend_bot_id")"
 
-    if demo_bot_verify_bcn "$backend_bot_id"; then
-        if demo_bot_has_expected_bcn_metadata "$bcs_bot_id"; then
-            return 0
-        fi
+    demo_bot_verify_bcn "$backend_bot_id" || verify_rc=$?
+    if [ "$verify_rc" -eq 0 ]; then
+        return 0
+    fi
+    if [ "$verify_rc" -ne 1 ]; then
+        return "$verify_rc"
     fi
 
     log_info "Registering demo bot in local BCS: ${bcs_bot_id}"
     demo_bot_admin_onboard_bcs "$backend_bot_id" || return 1
-    demo_bot_verify_bcn "$backend_bot_id" && demo_bot_has_expected_bcn_metadata "$bcs_bot_id"
+    demo_bot_verify_bcn "$backend_bot_id"
 }
 
 demo_bot_start() {

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -457,11 +457,17 @@ prepare_bcs_coverage_bin() {
         exit 1
     fi
 
-    # Fresh checkouts do not contain the gitignored panel dist. Build it before
-    # the coverage stack copies runtime assets; reuse existing output locally.
+    # The panel dist is gitignored and may be missing or stale. Always rebuild
+    # it before the coverage stack copies runtime assets, then fail here rather
+    # than later as a manifest download 404.
+    log_info "Building BCS panel asset for coverage..."
+    if ! ( build_bcs_panel_asset ); then
+        log_error "Failed to build BCS panel asset for coverage"
+        return 1
+    fi
     if [[ ! -f "${BCS_PANEL_ASSET_DIR}/dist/index.umd.js" ]]; then
-        log_info "BCS panel asset missing; building it for coverage..."
-        ( build_bcs_panel_asset ) || exit 1
+        log_error "BCS panel build completed without expected artifact: ${BCS_PANEL_ASSET_DIR}/dist/index.umd.js"
+        return 1
     fi
 
     # Keep the profraw dir present even on a cache hit (it may have been pruned).

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -457,6 +457,13 @@ prepare_bcs_coverage_bin() {
         exit 1
     fi
 
+    # Fresh checkouts do not contain the gitignored panel dist. Build it before
+    # the coverage stack copies runtime assets; reuse existing output locally.
+    if [[ ! -f "${BCS_PANEL_ASSET_DIR}/dist/index.umd.js" ]]; then
+        log_info "BCS panel asset missing; building it for coverage..."
+        ( build_bcs_panel_asset ) || exit 1
+    fi
+
     # Keep the profraw dir present even on a cache hit (it may have been pruned).
     mkdir -p "$cov_dir"
 

--- a/scripts/test_singlebox_demo_bot.sh
+++ b/scripts/test_singlebox_demo_bot.sh
@@ -26,6 +26,12 @@ setup_env() {
   unset SINGLEBOX_DEMO_TEMPLATE_TYPE
   unset SINGLEBOX_DEMO_BOT_READY_TIMEOUT_SECONDS
   unset SINGLEBOX_DEMO_BOT_READY_POLL_INTERVAL_SECONDS
+  unset BCS_MOCK_USER_ID
+  unset BCS_MOCK_USER_NICK_NAME
+  unset CURL_ARGS_FILE
+  unset CURL_RESPONSE_BODY
+  unset CURL_RESPONSE_STATUS
+  unset CURL_EXIT_CODE
 
   export PROJECT_ROOT="$ROOT"
   export SCRIPT_DIR="${ROOT}/scripts"
@@ -41,6 +47,30 @@ setup_env() {
   check_command() { command -v "$1" >/dev/null 2>&1; }
   backend_ready() { return 0; }
   bcs_ready() { return 0; }
+}
+
+install_verify_curl_stub() {
+  local tmpbin="$1"
+  cat > "${tmpbin}/curl" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ -n "${CURL_ARGS_FILE:-}" ]; then
+  printf '%s\n' "$*" > "$CURL_ARGS_FILE"
+fi
+output_file=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    output_file="$1"
+  fi
+  shift
+done
+[ -n "$output_file" ] || exit 90
+printf '%s' "${CURL_RESPONSE_BODY:-}" > "$output_file"
+printf '%s' "${CURL_RESPONSE_STATUS:-200}"
+exit "${CURL_EXIT_CODE:-0}"
+SH
+  chmod +x "${tmpbin}/curl"
 }
 
 test_defaults_are_community_safe() {
@@ -212,14 +242,10 @@ SH
 test_verify_uses_bcs_http_get() {
   setup_env
   tmpbin="$(mktemp -d)"
-  cat > "${tmpbin}/curl" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' "$*" > "${CURL_ARGS_FILE}"
-printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
-SH
-  chmod +x "${tmpbin}/curl"
+  install_verify_curl_stub "$tmpbin"
   PATH="${tmpbin}:$PATH"
   export CURL_ARGS_FILE="${tmpbin}/args.txt"
+  export CURL_RESPONSE_BODY='{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
 
   # shellcheck source=/dev/null
   source "$MODULE"
@@ -227,6 +253,138 @@ SH
   demo_bot_verify_bcn "default"
   grep -F 'X-Mock-User-Id: 001' "$CURL_ARGS_FILE" >/dev/null || fail "mock user header missing"
   grep -F 'http://127.0.0.1:21000/bots/default:mock-user' "$CURL_ARGS_FILE" >/dev/null || fail "BCS bot URL missing"
+}
+
+test_verify_honors_custom_mock_identity() {
+  setup_env
+  tmpbin="$(mktemp -d)"
+  install_verify_curl_stub "$tmpbin"
+  PATH="${tmpbin}:$PATH"
+  export CURL_ARGS_FILE="${tmpbin}/args.txt"
+  export CURL_RESPONSE_BODY='{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
+  export BCS_MOCK_USER_ID="custom-user"
+  export BCS_MOCK_USER_NICK_NAME="Custom User"
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+  demo_bot_verify_bcn "default"
+  grep -F 'X-Mock-User-Id: custom-user' "$CURL_ARGS_FILE" >/dev/null || fail "custom mock user header missing"
+  grep -F 'X-Mock-Nick-Name: Custom User' "$CURL_ARGS_FILE" >/dev/null || fail "custom mock nickname header missing"
+}
+
+test_verify_fails_fast_when_mock_auth_is_rejected() {
+  setup_env
+  tmpbin="$(mktemp -d)"
+  install_verify_curl_stub "$tmpbin"
+  PATH="${tmpbin}:$PATH"
+  export CURL_RESPONSE_STATUS="401"
+  export CURL_RESPONSE_BODY='{"error":"Unauthorized"}'
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+  err_file="$(mktemp)"
+  if demo_bot_verify_bcn "default" 2>"$err_file"; then
+    fail "verification should fail when mock auth is rejected"
+  else
+    rc=$?
+  fi
+  assert_eq "2" "$rc" "auth rejection return code"
+  grep -F 'mock human authentication must be enabled' "$err_file" >/dev/null || fail "auth rejection should explain the singlebox requirement"
+}
+
+test_verify_fails_fast_on_transport_error() {
+  setup_env
+  tmpbin="$(mktemp -d)"
+  install_verify_curl_stub "$tmpbin"
+  PATH="${tmpbin}:$PATH"
+  export CURL_RESPONSE_STATUS="000"
+  export CURL_EXIT_CODE="7"
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+  if demo_bot_verify_bcn "default" 2>/dev/null; then
+    fail "verification should fail on a transport error"
+  else
+    rc=$?
+  fi
+  assert_eq "2" "$rc" "transport error return code"
+}
+
+test_verify_fails_fast_on_server_error() {
+  setup_env
+  tmpbin="$(mktemp -d)"
+  install_verify_curl_stub "$tmpbin"
+  PATH="${tmpbin}:$PATH"
+  export CURL_RESPONSE_STATUS="500"
+  export CURL_RESPONSE_BODY='{"error":"internal"}'
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+  if demo_bot_verify_bcn "default" 2>/dev/null; then
+    fail "verification should fail on a BCS server error"
+  else
+    rc=$?
+  fi
+  assert_eq "2" "$rc" "server error return code"
+}
+
+test_verify_rejects_invalid_json() {
+  setup_env
+  tmpbin="$(mktemp -d)"
+  install_verify_curl_stub "$tmpbin"
+  PATH="${tmpbin}:$PATH"
+  export CURL_RESPONSE_BODY='<html>bad gateway</html>'
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+  if demo_bot_verify_bcn "default" 2>/dev/null; then
+    fail "verification should reject invalid JSON"
+  else
+    rc=$?
+  fi
+  assert_eq "2" "$rc" "invalid JSON return code"
+}
+
+test_verify_rejects_wrong_bot_identity() {
+  setup_env
+  tmpbin="$(mktemp -d)"
+  install_verify_curl_stub "$tmpbin"
+  PATH="${tmpbin}:$PATH"
+  export CURL_RESPONSE_BODY='{"bot_uuid":"other:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+  if demo_bot_verify_bcn "default" 2>/dev/null; then
+    fail "verification should reject a different bot UUID"
+  else
+    rc=$?
+  fi
+  assert_eq "2" "$rc" "wrong bot UUID return code"
+}
+
+test_verify_reports_missing_bot_as_repairable() {
+  setup_env
+  tmpbin="$(mktemp -d)"
+  install_verify_curl_stub "$tmpbin"
+  PATH="${tmpbin}:$PATH"
+  export CURL_RESPONSE_STATUS="404"
+  export CURL_RESPONSE_BODY='{"error":"Not Found"}'
+
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+  if demo_bot_verify_bcn "default"; then
+    fail "verification should report a missing bot"
+  else
+    rc=$?
+  fi
+  assert_eq "1" "$rc" "missing bot return code"
 }
 
 test_connect_posts_fixed_bcs_bot_id() {
@@ -287,12 +445,9 @@ SH
 test_ensure_skips_connect_when_already_visible() {
   setup_env
   tmpbin="$(mktemp -d)"
-  cat > "${tmpbin}/curl" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
-SH
-  chmod +x "${tmpbin}/curl"
+  install_verify_curl_stub "$tmpbin"
   PATH="${tmpbin}:$PATH"
+  export CURL_RESPONSE_BODY='{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
 
   # shellcheck source=/dev/null
   source "$MODULE"
@@ -312,10 +467,8 @@ test_ensure_onboards_minimal_runtime_entry() {
   demo_bot_verify_bcn() {
     verify_count=$((verify_count + 1))
     printf '%s\n' "verify" >> "$sequence_file"
-    if [ "$verify_count" -gt 1 ]; then
-      printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}' >> "${DEMO_BOT_LOG}"
-    else
-      printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{}}' >> "${DEMO_BOT_LOG}"
+    if [ "$verify_count" -eq 1 ]; then
+      return 1
     fi
     return 0
   }
@@ -345,7 +498,6 @@ test_ensure_onboards_without_connect_when_bcs_entry_missing() {
     if [ "$verify_count" -eq 1 ]; then
       return 1
     fi
-    printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}' >> "${DEMO_BOT_LOG}"
     return 0
   }
   demo_bot_connect_bcs() {
@@ -358,6 +510,54 @@ test_ensure_onboards_without_connect_when_bcs_entry_missing() {
 
   demo_bot_ensure_bcn "default"
   assert_eq $'verify\nonboard:default\nverify' "$(cat "$sequence_file")" "missing BCS entry should onboard without pre-connect"
+}
+
+test_ensure_does_not_onboard_after_fatal_verification_error() {
+  setup_env
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+
+  sequence_file="$(mktemp)"
+  demo_bot_verify_bcn() {
+    printf '%s\n' "verify" >> "$sequence_file"
+    return 2
+  }
+  demo_bot_admin_onboard_bcs() {
+    printf '%s\n' "onboard:$1" >> "$sequence_file"
+  }
+
+  if demo_bot_ensure_bcn "default"; then
+    fail "fatal verification error should fail without onboarding"
+  else
+    rc=$?
+  fi
+  assert_eq "2" "$rc" "fatal verification return code"
+  assert_eq "verify" "$(cat "$sequence_file")" "fatal verification should not mutate BCS"
+}
+
+test_ensure_fails_when_metadata_is_still_wrong_after_onboard() {
+  setup_env
+  # shellcheck source=/dev/null
+  source "$MODULE"
+  demo_bot_defaults
+
+  sequence_file="$(mktemp)"
+  demo_bot_verify_bcn() {
+    printf '%s\n' "verify" >> "$sequence_file"
+    return 1
+  }
+  demo_bot_admin_onboard_bcs() {
+    printf '%s\n' "onboard:$1" >> "$sequence_file"
+  }
+
+  if demo_bot_ensure_bcn "default"; then
+    fail "ensure should fail when post-onboard metadata still mismatches"
+  else
+    rc=$?
+  fi
+  assert_eq "1" "$rc" "persistent metadata mismatch return code"
+  assert_eq $'verify\nonboard:default\nverify' "$(cat "$sequence_file")" "post-onboard verification sequence"
 }
 
 test_start_waits_for_backend_ready_before_bcn_onboard() {
@@ -408,11 +608,20 @@ test_create_handles_curl_failure_without_exiting
 test_wait_ready_polls_backend_status_success
 test_wait_ready_fails_on_backend_failed_status
 test_verify_uses_bcs_http_get
+test_verify_honors_custom_mock_identity
+test_verify_fails_fast_when_mock_auth_is_rejected
+test_verify_fails_fast_on_transport_error
+test_verify_fails_fast_on_server_error
+test_verify_rejects_invalid_json
+test_verify_rejects_wrong_bot_identity
+test_verify_reports_missing_bot_as_repairable
 test_connect_posts_fixed_bcs_bot_id
 test_admin_onboard_posts_demo_metadata
 test_ensure_skips_connect_when_already_visible
 test_ensure_onboards_minimal_runtime_entry
 test_ensure_onboards_without_connect_when_bcs_entry_missing
+test_ensure_does_not_onboard_after_fatal_verification_error
+test_ensure_fails_when_metadata_is_still_wrong_after_onboard
 test_start_waits_for_backend_ready_before_bcn_onboard
 test_all_order_includes_bots_and_demo_before_frontend
 test_backend_ready_function_exists

--- a/scripts/test_singlebox_demo_bot.sh
+++ b/scripts/test_singlebox_demo_bot.sh
@@ -209,23 +209,24 @@ SH
   fi
 }
 
-test_verify_uses_bcs_cli_get() {
+test_verify_uses_bcs_http_get() {
   setup_env
   tmpbin="$(mktemp -d)"
-  cat > "${tmpbin}/bcs-cli" <<'SH'
+  cat > "${tmpbin}/curl" <<'SH'
 #!/usr/bin/env bash
-[ "$1" = "--url" ] || exit 2
-[ "$3" = "get" ] || exit 3
-[ "$4" = "default:mock-user" ] || exit 4
-printf '%s\n' '{"bot_id":"default:mock-user"}'
+printf '%s\n' "$*" > "${CURL_ARGS_FILE}"
+printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
 SH
-  chmod +x "${tmpbin}/bcs-cli"
+  chmod +x "${tmpbin}/curl"
   PATH="${tmpbin}:$PATH"
+  export CURL_ARGS_FILE="${tmpbin}/args.txt"
 
   # shellcheck source=/dev/null
   source "$MODULE"
   demo_bot_defaults
   demo_bot_verify_bcn "default"
+  grep -F 'X-Mock-User-Id: 001' "$CURL_ARGS_FILE" >/dev/null || fail "mock user header missing"
+  grep -F 'http://127.0.0.1:21000/bots/default:mock-user' "$CURL_ARGS_FILE" >/dev/null || fail "BCS bot URL missing"
 }
 
 test_connect_posts_fixed_bcs_bot_id() {
@@ -286,18 +287,11 @@ SH
 test_ensure_skips_connect_when_already_visible() {
   setup_env
   tmpbin="$(mktemp -d)"
-  cat > "${tmpbin}/bcs-cli" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' 'Bot: default:mock-user'
-printf '%s\n' '  Name: developer'
-printf '%s\n' '  Summary: Local demo bot for OpenOCB Singlebox'
-printf '%s\n' '  Visibility: protected'
-SH
   cat > "${tmpbin}/curl" <<'SH'
 #!/usr/bin/env bash
-exit 9
+printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}'
 SH
-  chmod +x "${tmpbin}/bcs-cli" "${tmpbin}/curl"
+  chmod +x "${tmpbin}/curl"
   PATH="${tmpbin}:$PATH"
 
   # shellcheck source=/dev/null
@@ -318,12 +312,11 @@ test_ensure_onboards_minimal_runtime_entry() {
   demo_bot_verify_bcn() {
     verify_count=$((verify_count + 1))
     printf '%s\n' "verify" >> "$sequence_file"
-    printf '%s\n' "Bot: default:mock-user" >> "${DEMO_BOT_LOG}"
     if [ "$verify_count" -gt 1 ]; then
-      printf '%s\n' "  Name: developer" >> "${DEMO_BOT_LOG}"
-      printf '%s\n' "  Summary: Local demo bot for OpenOCB Singlebox" >> "${DEMO_BOT_LOG}"
+      printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}' >> "${DEMO_BOT_LOG}"
+    else
+      printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{}}' >> "${DEMO_BOT_LOG}"
     fi
-    printf '%s\n' "  Visibility: protected" >> "${DEMO_BOT_LOG}"
     return 0
   }
   demo_bot_connect_bcs() {
@@ -352,10 +345,7 @@ test_ensure_onboards_without_connect_when_bcs_entry_missing() {
     if [ "$verify_count" -eq 1 ]; then
       return 1
     fi
-    printf '%s\n' "Bot: default:mock-user" >> "${DEMO_BOT_LOG}"
-    printf '%s\n' "  Name: developer" >> "${DEMO_BOT_LOG}"
-    printf '%s\n' "  Summary: Local demo bot for OpenOCB Singlebox" >> "${DEMO_BOT_LOG}"
-    printf '%s\n' "  Visibility: protected" >> "${DEMO_BOT_LOG}"
+    printf '%s\n' '{"bot_uuid":"default:mock-user","capabilities":{"name":"developer","summary":"Local demo bot for OpenOCB Singlebox"}}' >> "${DEMO_BOT_LOG}"
     return 0
   }
   demo_bot_connect_bcs() {
@@ -417,7 +407,7 @@ test_create_ignores_malformed_response
 test_create_handles_curl_failure_without_exiting
 test_wait_ready_polls_backend_status_success
 test_wait_ready_fails_on_backend_failed_status
-test_verify_uses_bcs_cli_get
+test_verify_uses_bcs_http_get
 test_connect_posts_fixed_bcs_bot_id
 test_admin_onboard_posts_demo_metadata
 test_ensure_skips_connect_when_already_visible

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -447,10 +447,9 @@ async fn debug_middleware(req: Request<Body>, next: Next) -> Response {
         let uri = req.uri();
         let path = uri.path();
 
-        // Skip health check spam
-        if path != "/health" {
-            eprintln!("\x1b[2m[→BCS] {} {}\x1b[0m", method, path);
-        }
+        // BCS_DEBUG is also the E2E endpoint-coverage signal, so health must
+        // be logged together with every other registered HTTP route.
+        eprintln!("\x1b[2m[→BCS] {} {}\x1b[0m", method, path);
     }
 
     next.run(req).await

--- a/src/bcs/crates/services/bcs-group-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/lib.rs
@@ -1077,13 +1077,15 @@ impl GroupRepoPort for MySqlGroupStore {
     }
 
     /// Update workspace - NOT PERSISTED (memory only, lost on restart).
-    async fn update_workspace(&self, id: &str, _workspace: Workspace) -> ServiceResult<()> {
-        // Verify group exists
-        if self.get(id).await.is_none() {
-            return Err(ServiceError::GroupNotFound(id.to_string()));
-        }
+    async fn update_workspace(&self, id: &str, workspace: Workspace) -> ServiceResult<()> {
+        let mut group = self
+            .get(id)
+            .await
+            .ok_or_else(|| ServiceError::GroupNotFound(id.to_string()))?;
+        group.workspace = workspace;
+        self.cache.write().await.insert(id.to_string(), group);
 
-        debug!(group_id = %id, "Group workspace update ignored (not persisted)");
+        debug!(group_id = %id, "Group workspace updated in memory (not persisted)");
         Ok(())
     }
 
@@ -2773,6 +2775,30 @@ mod tests {
                 && statement.contains("group_id = ?")
                 && statement.contains("dm_pair_key = ?")
         }));
+    }
+
+    #[tokio::test]
+    async fn workspace_update_is_visible_until_restart() {
+        let db = Arc::new(RecordingDbPlugin::default());
+        let repo = MySqlGroupStore::new(db, "local".to_string());
+        let group = Group::new("group-1", "driver", Vec::new());
+        repo.cache
+            .write()
+            .await
+            .insert(group.id.clone(), group);
+        let workspace = Workspace {
+            decisions: vec!["ship the hotfix".to_string()],
+            notes: vec!["customer impact contained".to_string()],
+            ..Workspace::default()
+        };
+
+        repo.update_workspace("group-1", workspace.clone())
+            .await
+            .expect("update workspace");
+
+        let stored = repo.get("group-1").await.expect("group exists");
+        assert_eq!(stored.workspace.decisions, workspace.decisions);
+        assert_eq!(stored.workspace.notes, workspace.notes);
     }
 
     #[test]

--- a/src/bcs/scripts/adapters_endpoint_coverage.py
+++ b/src/bcs/scripts/adapters_endpoint_coverage.py
@@ -9,7 +9,7 @@ Two inputs:
      inspection (build_api_routes is the single, unconditional, no-nest
      registration site; there is no OpenAPI/utoipa spec to read instead).
   2. The set of endpoints actually hit — the instrumented bcs logs every
-     non-/health request as `[→BCS] METHOD PATH` (see debug_middleware in
+     request as `[→BCS] METHOD PATH` (see debug_middleware in
      crates/bootstrap/bcs/src/server.rs, gated on BCS_DEBUG=true; e2e_coverage.sh
      exports it). Path params in hits are concrete (a real bot uuid), registered
      templates have `{param}` placeholders, so hits are matched to templates.
@@ -125,7 +125,7 @@ def parse_router(router_path: str) -> list:
             hstart = mm.end()
             hend = _matching_paren(block, hstart - 1)
             inside = block[hstart:hend].strip()
-            handler = re.split(r"[,\s]", inside, 1)[0]
+            handler = re.split(r"[,\s]", inside, maxsplit=1)[0]
             endpoints.append(Endpoint(method, path, handler, line))
     return endpoints
 
@@ -296,6 +296,12 @@ def gh_notice(msg):
         sys.stdout.write("::notice::" + msg + "\n")
 
 
+def gh_error(msg):
+    """Emit a GitHub Actions error annotation in CI."""
+    if in_ci():
+        sys.stdout.write("::error::" + msg + "\n")
+
+
 def build_summary(endpoints, cov, hits, seen_hits, args):
     """Return (summary_lines, per_method_totals, covered_eps, uncov_eps, pct).
     summary_lines is the short human summary (no per-endpoint detail)."""
@@ -448,7 +454,12 @@ def main():
                     help="live-probe each parsed route against --probe-base to drop over-counts")
     ap.add_argument("--probe-base", default="http://127.0.0.1:21000",
                     help="base URL for --probe")
+    ap.add_argument("--min", type=float, default=0.0,
+                    help="minimum endpoint coverage %% (0 = report only)")
     args = ap.parse_args()
+
+    if args.min < 0 or args.min > 100:
+        ap.error("--min must be between 0 and 100")
 
     endpoints = parse_router(args.router)
     if not endpoints:
@@ -509,6 +520,18 @@ def main():
             sys.stdout.write(ln + "\n")
     else:
         sys.stdout.write(summary)
+
+    if args.min > 0:
+        if pct + 1e-9 < args.min:
+            message = ("Adapter endpoint coverage %.1f%% (%d / %d) is below "
+                       "the required %.1f%%" %
+                       (pct, covered_n, total_eps, args.min))
+            gh_error(message)
+            if not in_ci():
+                sys.stderr.write("FAIL: " + message + "\n")
+            sys.exit(1)
+        gh_notice("Adapter endpoint coverage gate passed: %.1f%% (%d / %d)"
+                  % (pct, covered_n, total_eps))
 
 
 if __name__ == "__main__":

--- a/src/bcs/scripts/cli_command_coverage.py
+++ b/src/bcs/scripts/cli_command_coverage.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Report and gate bcs-cli leaf-command coverage from E2E invocations.
+
+The command inventory is discovered from the built CLI's recursive `--help`
+output, so adding a new Clap command automatically creates a coverage gap.
+`help` pseudo-commands and visible aliases are intentionally excluded.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def in_ci():
+    return os.environ.get("CI") == "true" and os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def annotate(kind, message):
+    if in_ci():
+        print("::%s::%s" % (kind, message))
+
+
+def child_commands(cli, prefix):
+    result = subprocess.run(
+        [cli, *prefix, "--help"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "failed to inspect `%s --help`: %s"
+            % (" ".join([cli, *prefix]), result.stderr.strip())
+        )
+
+    commands = []
+    in_commands = False
+    for line in result.stdout.splitlines():
+        if line == "Commands:":
+            in_commands = True
+            continue
+        if not in_commands:
+            continue
+        if not line.strip():
+            break
+        match = re.match(r"^  ([a-z][a-z0-9-]*)(?:\s|$)", line)
+        if match and match.group(1) != "help":
+            commands.append(match.group(1))
+    return commands
+
+
+def leaf_commands(cli):
+    leaves = []
+
+    def visit(prefix):
+        children = child_commands(cli, prefix)
+        if not children:
+            leaves.append(" ".join(prefix))
+            return
+        for child in children:
+            visit([*prefix, child])
+
+    for command in child_commands(cli, []):
+        visit([command])
+    return sorted(leaves)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="BCS CLI E2E command coverage")
+    parser.add_argument("--cli", required=True, help="path to the built bcs-cli binary")
+    parser.add_argument("--log", required=True, help="newline-delimited invoked command paths")
+    parser.add_argument("--out-txt", help="write the full coverage report to this path")
+    parser.add_argument("--min", type=float, default=0.0, help="minimum coverage %%")
+    args = parser.parse_args()
+
+    if args.min < 0 or args.min > 100:
+        parser.error("--min must be between 0 and 100")
+
+    try:
+        expected = leaf_commands(args.cli)
+    except (OSError, RuntimeError) as error:
+        print("ERROR: %s" % error, file=sys.stderr)
+        sys.exit(1)
+    if not expected:
+        print("ERROR: discovered 0 bcs-cli leaf commands", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(args.log, encoding="utf-8", errors="replace") as handle:
+            invocations = [line.strip() for line in handle if line.strip()]
+    except OSError as error:
+        print("ERROR: cannot read CLI coverage log %s: %s" % (args.log, error), file=sys.stderr)
+        sys.exit(1)
+
+    expected_set = set(expected)
+    hit_set = set(invocations) & expected_set
+    covered = sorted(hit_set)
+    uncovered = sorted(expected_set - hit_set)
+    unknown = sorted(set(invocations) - expected_set)
+    percentage = len(covered) / len(expected) * 100.0
+
+    summary = [
+        "bcs-cli leaf command coverage: %d / %d (%.1f%%)"
+        % (len(covered), len(expected), percentage),
+        "raw invocations: %d" % len(invocations),
+    ]
+    report = [*summary, "", "Covered commands (%d):" % len(covered)]
+    report.extend("  ✓ %s" % command for command in covered)
+    report.append("")
+    report.append("Uncovered commands (%d):" % len(uncovered))
+    report.extend("  ✗ %s" % command for command in uncovered)
+    if unknown:
+        report.append("")
+        report.append("Unknown logged command paths (%d):" % len(unknown))
+        report.extend("  ? %s" % command for command in unknown)
+    report_text = "\n".join(report) + "\n"
+
+    if args.out_txt:
+        os.makedirs(os.path.dirname(os.path.abspath(args.out_txt)), exist_ok=True)
+        with open(args.out_txt, "w", encoding="utf-8") as handle:
+            handle.write(report_text)
+    print("\n".join(summary))
+
+    if percentage + 1e-9 < args.min:
+        message = (
+            "bcs-cli command coverage %.1f%% (%d / %d) is below the required %.1f%%"
+            % (percentage, len(covered), len(expected), args.min)
+        )
+        annotate("error", message)
+        if not in_ci():
+            print("FAIL: " + message, file=sys.stderr)
+        sys.exit(1)
+
+    annotate(
+        "notice",
+        "bcs-cli command coverage gate passed: %.1f%% (%d / %d)"
+        % (percentage, len(covered), len(expected)),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bcs/scripts/e2e-test/cli-stories.sh
+++ b/src/bcs/scripts/e2e-test/cli-stories.sh
@@ -1,0 +1,362 @@
+#!/bin/bash
+# cli-stories.sh — Complete bcs-cli coverage organized as user journeys.
+
+_cli_story_run() {
+    local desc="$1" bot="$2"; shift 2
+    info "CLI story: bcs-cli $*"
+    if bcs_cli_json "$bot" "$@"; then
+        pass "$desc"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        return 0
+    fi
+    fail "$desc (exit=$BCS_CLI_EXIT): $(printf '%s' "${BCS_CLI_STDERR:-$BCS_CLI_STDOUT}" | head -c 240)"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    return 1
+}
+
+_cli_json_array_has_object() {
+    local json="$1" path="$2" key="$3" expected="$4" key2="${5:-}" expected2="${6:-}"
+    printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    value = json.load(sys.stdin)
+    if sys.argv[1]:
+        for part in sys.argv[1].split("."):
+            value = value[int(part)] if isinstance(value, list) else value[part]
+    found = any(
+        isinstance(item, dict)
+        and str(item.get(sys.argv[2], "")) == sys.argv[3]
+        and (not sys.argv[4] or str(item.get(sys.argv[4], "")) == sys.argv[5])
+        for item in value
+    )
+    print("1" if found else "0")
+except Exception:
+    print("0")
+' "$path" "$key" "$expected" "$key2" "$expected2"
+}
+
+_cli_json_has_path() {
+    local json="$1" path="$2"
+    printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    value = json.load(sys.stdin)
+    for part in sys.argv[1].split("."):
+        value = value[int(part)] if isinstance(value, list) else value[part]
+    print("1")
+except Exception:
+    print("0")
+' "$path"
+}
+
+_cli_json_is_array() {
+    printf '%s' "$1" | python3 -c 'import json,sys; print("1" if isinstance(json.load(sys.stdin), list) else "0")' 2>/dev/null || echo 0
+}
+
+_cli_story_create_pm_group() {
+    local topic="$1"
+    CLI_STORY_GROUP_ID=""
+    _cli_story_run "operator creates a CLI-managed group" PM create-group \
+        --driver "$BOT_PM_UUID" \
+        --participants "$BOT_PM_UUID,$BOT_ENG_UUID" \
+        --context "Release coordination through bcs-cli" \
+        --topic "$topic" || return
+    CLI_STORY_GROUP_ID=$(printf '%s' "$BCS_CLI_STDOUT" | grep -oE 'ID: [A-Za-z0-9_-]+' | head -1 | sed 's/ID: //')
+    assert_not_empty "CLI-created group returns an id" "$CLI_STORY_GROUP_ID"
+    [[ -n "$CLI_STORY_GROUP_ID" ]]
+}
+
+_story_cli_direct_onboard() {
+    api_get "/register/token"
+    require_status "CLI onboarding fixture obtains a register token" "200" || return
+    local register_token bot_name register_path bot_uuid bot_token
+    register_token=$(json_path "$RESPONSE" "token")
+    bot_name="cli-direct-agent-$$-$(date +%s)"
+    assert_not_empty "CLI onboarding fixture has a register token" "$register_token"
+    [[ -n "$register_token" ]] || return
+
+    register_path="/register?token=$(urlencode "$register_token")&bot-name=$(urlencode "$bot_name")"
+    api_post "$register_path"
+    require_status "CLI onboarding fixture registers a temporary agent" "200" || return
+    bot_uuid=$(json_path "$RESPONSE" "bot_uuid")
+    bot_token=$(json_path "$RESPONSE" "bot_token")
+    assert_not_empty "CLI onboarding fixture returns bot id" "$bot_uuid"
+    assert_not_empty "CLI onboarding fixture returns bot token" "$bot_token"
+    [[ -n "$bot_uuid" && -n "$bot_token" ]] || return
+
+    _cli_story_run "operator directly onboards a temporary agent" "token:${bot_token}" onboard \
+        --name "$bot_name" --summary "Direct CLI onboarding story" \
+        --skills "triage,review" --domains "release" --scopes "local" || return
+    assert_json_eq "direct CLI onboarding keeps the registered bot id" "$BCS_CLI_STDOUT" "bot_uuid" "$bot_uuid"
+    assert_json_eq "direct CLI onboarding is persisted" "$BCS_CLI_STDOUT" "onboarded" "true"
+    assert_json_eq "direct CLI onboarding keeps the selected name" "$BCS_CLI_STDOUT" "name" "$bot_name"
+
+    api_get "/bots/${bot_uuid}"
+    require_status "directly onboarded CLI agent is queryable" "200" || return
+    assert_json_eq "CLI-onboarded capabilities are visible" "$RESPONSE" "capabilities.name" "$bot_name"
+    api_delete "/bots/${bot_uuid}"
+    require_status "temporary CLI-onboarded agent is removed" "200" || return
+    api_get "/bots/${bot_uuid}"
+    require_status "removed CLI-onboarded agent returns 404" "404" || return
+}
+
+# User story: An operator establishes trust and coordinates a release team entirely through bcs-cli.
+#
+# Flow:
+#   Protect an agent -> request and reject friendship -> create and inspect a group
+#   -> add a specialist -> list owned groups -> fuse context -> complete one group
+#   -> terminate another group -> clean up all fixtures.
+#
+# Critical assertions:
+#   - Rejected friendship never appears in the requester's friend list.
+#   - Group identity, driver, and membership survive independent CLI reads.
+#   - Context fusion returns a recommendation payload.
+#   - Group status and termination are observable as completed states.
+story_cli_operator_builds_collaboration_team() {
+    info "Story: an operator establishes trust and coordinates a release team through bcs-cli"
+
+    _cli_story_run "customer-service agent protects incoming friendship requests" CS visibility set --value protected || return
+    assert_json_eq "protected visibility update succeeds" "$BCS_CLI_STDOUT" "success" "true"
+    assert_json_eq "protected visibility is returned" "$BCS_CLI_STDOUT" "data.visibility" "protected"
+
+    _cli_story_run "engineering requests a protected friendship" ENG friend request --bot-uuid "$BOT_CS_UUID" || return
+    assert_json_eq "CLI friend request succeeds" "$BCS_CLI_STDOUT" "success" "true"
+
+    _cli_story_run "customer-service lists pending requests" CS friend requests --direction received --status pending || return
+    local request_id
+    request_id=$(printf '%s' "$BCS_CLI_STDOUT" | python3 -c '
+import json,sys
+items=json.load(sys.stdin)
+for item in items:
+    if item.get("from_bot") == sys.argv[1] and item.get("to_bot") == sys.argv[2] and item.get("status") == "pending":
+        print(item.get("id", "")); break
+' "$BOT_ENG_UUID" "$BOT_CS_UUID" 2>/dev/null)
+    assert_not_empty "pending CLI friend request is identifiable" "$request_id"
+    [[ -n "$request_id" ]] || return
+
+    _cli_story_run "customer-service rejects the friendship request" CS friend reject --request-id "$request_id" || return
+    assert_json_eq "CLI friend rejection succeeds" "$BCS_CLI_STDOUT" "success" "true"
+
+    _cli_story_run "engineering verifies the rejected relationship" ENG friend list || return
+    local rejected_absent
+    rejected_absent=$(_cli_json_array_has_object "$BCS_CLI_STDOUT" "" "bot_uuid" "$BOT_CS_UUID")
+    assert_eq "rejected agent is absent from CLI friend list" "$rejected_absent" "0"
+
+    _cli_story_run "customer-service restores public visibility" CS visibility set --value public || return
+    assert_json_eq "public visibility restore succeeds" "$BCS_CLI_STDOUT" "data.visibility" "public"
+
+    _cli_story_create_pm_group "CLI release coordination" || return
+    local group_id="$CLI_STORY_GROUP_ID"
+
+    _cli_story_run "operator reads the CLI-managed group" PM get-group --id "$group_id" || return
+    assert_json_eq "CLI group read keeps its id" "$BCS_CLI_STDOUT" "id" "$group_id"
+    assert_json_eq "CLI group read keeps its driver" "$BCS_CLI_STDOUT" "driver_bot" "$BOT_PM_UUID"
+
+    _cli_story_run "operator adds verification to the group" PM add-member \
+        --group "$group_id" --bot-uuid "$BOT_QA_UUID" --role consultant || return
+    _cli_story_run "operator reads the expanded group" PM get-group --id "$group_id" || return
+    assert_contains "CLI group read contains the added specialist" "$BCS_CLI_STDOUT" "$BOT_QA_UUID"
+
+    _cli_story_run "operator lists groups containing itself" PM list-groups --mine || return
+    assert_contains "CLI --mine list identifies the current bot" "$BCS_CLI_STDOUT" "Groups for current bot ${BOT_PM_UUID}"
+    local cli_mine_output="$BCS_CLI_STDOUT" cli_mine_count api_mine_count
+    cli_mine_count=$(printf '%s\n' "$cli_mine_output" | sed -nE 's/^Groups for current bot .+ \(([0-9]+)\):$/\1/p' | head -1)
+    assert_not_empty "CLI --mine list exposes its result count" "$cli_mine_count"
+    api_get "/bots/${BOT_PM_UUID}/groups"
+    require_status "CLI --mine result can be checked against the bot-group API" "200" || return
+    assert_contains "bot-group read-back contains the CLI-managed group" "$RESPONSE" "$group_id"
+    api_mine_count=$(printf '%s' "$RESPONSE" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d.get("items", [])))' 2>/dev/null)
+    assert_eq "CLI --mine count matches the bot-group API" "$cli_mine_count" "$api_mine_count"
+
+    _cli_story_run "operator fuses team perspectives" PM fuse --group "$group_id" \
+        --question "Is the release ready?" \
+        --participants "$BOT_PM_UUID,$BOT_ENG_UUID,$BOT_QA_UUID" \
+        --focus "release risk" || return
+    assert_contains "CLI fusion returns a recommendation" "$BCS_CLI_STDOUT" "recommendation"
+
+    _cli_story_run "operator marks the coordinated group completed" PM group-status \
+        --group "$group_id" --status completed --reason "release reviewed" || return
+    _cli_story_run "operator verifies the completed group" PM get-group --id "$group_id" || return
+    assert_json_eq "CLI group status persists completed" "$BCS_CLI_STDOUT" "status" "completed"
+
+    api_delete "/groups/${group_id}?bot_id=${BOT_PM_UUID}"
+    require_status "completed CLI group is cleaned up" "200" || return
+
+    _cli_story_create_pm_group "CLI termination drill" || return
+    local terminated_group_id="$CLI_STORY_GROUP_ID"
+    _cli_story_run "operator terminates a CLI-managed group" PM terminate-group --group "$terminated_group_id" || return
+    _cli_story_run "operator reads the terminated group" PM get-group --id "$terminated_group_id" || return
+    assert_json_eq "terminated CLI group is completed" "$BCS_CLI_STDOUT" "status" "completed"
+    api_delete "/groups/${terminated_group_id}?bot_id=${BOT_PM_UUID}"
+    require_status "terminated CLI group is cleaned up" "200" || return
+}
+
+# User story: A release operator drives a full session and service lifecycle through bcs-cli.
+#
+# Flow:
+#   Create and query a session -> patch it -> add and mute a participant -> chat
+#   -> inspect messages -> create an invite -> remove the participant -> complete
+#   the session -> invoke, inspect, and wait on a service session -> clean up.
+#
+# Critical assertions:
+#   - Every session mutation is visible through a later CLI read.
+#   - Chat history contains the submitted message and invite credentials are usable values.
+#   - Completion preserves the exact output payload.
+#   - Service status preserves identity and caller isolation; wait has a precise terminal or timeout result.
+story_cli_operator_runs_sessions_and_services() {
+    info "Story: a release operator runs sessions and services through bcs-cli"
+    _cli_story_create_pm_group "CLI session and service lifecycle" || return
+    local group_id="$CLI_STORY_GROUP_ID"
+
+    _cli_story_run "operator creates a release session" PM session create \
+        --group "$group_id" --title "CLI full session" \
+        --input '{"release":"2026.07"}' --meta '{"source":"cli-story"}' || return
+    local session_id
+    session_id=$(json_path "$BCS_CLI_STDOUT" "session_id")
+    assert_not_empty "CLI session creation returns an id" "$session_id"
+    assert_json_eq "CLI session belongs to the managed group" "$BCS_CLI_STDOUT" "group_id" "$group_id"
+    [[ -n "$session_id" ]] || return
+
+    _cli_story_run "operator lists the created release session" PM session list \
+        --group "$group_id" --status running --q "CLI full" \
+        --participant "$BOT_PM_UUID" --offset 0 --limit 20 || return
+    local listed
+    listed=$(_cli_json_array_has_object "$BCS_CLI_STDOUT" "items" "session_id" "$session_id")
+    assert_eq "CLI session list contains the created session" "$listed" "1"
+
+    _cli_story_run "operator reads the release session" PM session get "$session_id" || return
+    assert_json_eq "CLI session get keeps its id" "$BCS_CLI_STDOUT" "session_id" "$session_id"
+    assert_json_eq "CLI session get keeps its title" "$BCS_CLI_STDOUT" "session_title" "CLI full session"
+
+    _cli_story_run "operator renames the release session" PM session patch "$session_id" --title "CLI release sign-off" || return
+    assert_json_eq "CLI session patch returns the new title" "$BCS_CLI_STDOUT" "session_title" "CLI release sign-off"
+
+    _cli_story_run "operator adds verification to the session" PM session add-member "$session_id" \
+        --bot-uuid "$BOT_QA_UUID" --role consultant || return
+    local added
+    added=$(_cli_json_array_has_object "$BCS_CLI_STDOUT" "participants" "bot_uuid" "$BOT_QA_UUID")
+    assert_eq "CLI session add-member returns verification" "$added" "1"
+
+    _cli_story_run "operator mutes verification in the session" PM session set-member-mode \
+        "$session_id" "$BOT_QA_UUID" --mode muted || return
+    _cli_story_run "operator reads the updated session membership" PM session get "$session_id" || return
+    local muted
+    muted=$(_cli_json_array_has_object "$BCS_CLI_STDOUT" "participants" "bot_uuid" "$BOT_QA_UUID" "mode" "muted")
+    assert_eq "CLI session read shows verification muted" "$muted" "1"
+
+    local chat_message="CLI release readiness check $$"
+    _cli_story_run "operator chats in the release session" PM session chat \
+        --session "$session_id" --message "$chat_message" || return
+    assert_json_eq "CLI session chat keeps the session id" "$BCS_CLI_STDOUT" "session_id" "$session_id"
+    assert_json_eq "CLI session chat keeps the group id" "$BCS_CLI_STDOUT" "group_id" "$group_id"
+    assert_eq "CLI session chat exposes delivery results" "$(_cli_json_has_path "$BCS_CLI_STDOUT" "delivery_results")" "1"
+
+    _cli_story_run "operator reads release-session messages" PM session messages "$session_id" \
+        --view-bot "$BOT_PM_UUID" --limit 50 || return
+    assert_eq "CLI session messages returns a JSON array" "$(_cli_json_is_array "$BCS_CLI_STDOUT")" "1"
+    assert_contains "CLI session history contains the submitted message" "$BCS_CLI_STDOUT" "$chat_message"
+
+    _cli_story_run "operator creates a session invite" PM session invite-link "$session_id" --ttl-seconds 300 || return
+    assert_json_not_empty "CLI session invite returns a token" "$BCS_CLI_STDOUT" "invite_token"
+    assert_json_not_empty "CLI session invite returns a join URL" "$BCS_CLI_STDOUT" "join_url"
+
+    _cli_story_run "operator removes verification from the session" PM session remove-member \
+        "$session_id" "$BOT_QA_UUID" || return
+    _cli_story_run "operator verifies session membership removal" PM session get "$session_id" || return
+    local removed
+    removed=$(_cli_json_array_has_object "$BCS_CLI_STDOUT" "participants" "bot_uuid" "$BOT_QA_UUID")
+    assert_eq "removed participant is absent from CLI session read" "$removed" "0"
+
+    _cli_story_run "operator completes the release session" PM session complete "$session_id" \
+        --output '{"summary":"approved by CLI"}' || return
+    assert_json_eq "CLI session completion returns completed" "$BCS_CLI_STDOUT" "status" "completed"
+    assert_json_eq "CLI session completion keeps its output" "$BCS_CLI_STDOUT" "output.summary" "approved by CLI"
+
+    api_patch "/groups/${group_id}/settings" '{"service_spec":{"max_concurrency":2}}'
+    require_status "CLI service fixture enables group invocation" "200" || return
+
+    _cli_story_run "release pipeline invokes the group service" PM service invoke \
+        --group "$group_id" --input '{"commit":"cli123"}' \
+        --meta '{"source":"cli-story"}' --caller-id "cli-release-pipeline" \
+        --title "CLI automated release audit" --detach || return
+    local service_session_id
+    service_session_id=$(json_path "$BCS_CLI_STDOUT" "session_id")
+    assert_not_empty "CLI service invoke returns a session id" "$service_session_id"
+    assert_json_eq "CLI service invoke returns service kind" "$BCS_CLI_STDOUT" "session_kind" "service_invocation"
+    [[ -n "$service_session_id" ]] || return
+
+    _cli_story_run "release pipeline checks service status" PM service status "$service_session_id" || return
+    assert_json_eq "CLI service status keeps its session id" "$BCS_CLI_STDOUT" "session_id" "$service_session_id"
+    assert_json_eq "CLI service status keeps its group" "$BCS_CLI_STDOUT" "group_id" "$group_id"
+
+    info "CLI story: bcs-cli service wait"
+    if bcs_cli_json PM service wait "$service_session_id" --timeout-ms 1; then
+        pass "CLI service wait returns a completed session"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        assert_json_eq "completed CLI service wait keeps its session id" "$BCS_CLI_STDOUT" "session_id" "$service_session_id"
+        assert_json_eq "completed CLI service wait is terminal" "$BCS_CLI_STDOUT" "status" "completed"
+    else
+        if [[ "$BCS_CLI_STDERR" == *"Timed out after"* && "$BCS_CLI_STDERR" == *"$service_session_id"* ]]; then
+            pass "CLI service wait returns the precise bounded-timeout contract"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+        else
+            fail "CLI service wait failed unexpectedly: $(printf '%s' "$BCS_CLI_STDERR" | head -c 240)"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+        fi
+        TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    fi
+
+    api_delete "/sessions/${session_id}?bot_id=${BOT_PM_UUID}"
+    require_status "completed CLI chat session is cleaned up" "200" || return
+    api_delete "/sessions/${service_session_id}?bot_id=$(urlencode "bot:${BOT_PM_UUID}")"
+    require_status "CLI service session is cleaned up" "200" || return
+    api_delete "/groups/${group_id}?bot_id=${BOT_PM_UUID}"
+    require_status "CLI session/service group is cleaned up" "200" || return
+}
+
+# User story: An operator validates channel-management behavior before a provider is installed.
+#
+# Flow:
+#   Attempt to bind a channel -> list bindings -> unbind a missing binding -> list again.
+#
+# Critical assertions:
+#   - Bind fails with the explicit disabled-bridge contract and never leaks the supplied secret.
+#   - List returns a well-formed items array.
+#   - Disabled-bridge unbind follows the documented no-op acknowledgement.
+#   - No phantom binding appears after the rejected and no-op operations.
+story_cli_operator_validates_channel_management() {
+    info "Story: an operator validates channel management through bcs-cli"
+    local account="cli-channel-$$" missing_id="cli-missing-binding-$$"
+
+    info "CLI story: bcs-cli channel bind"
+    if bcs_cli_json CEO channel bind \
+        --account "$account" --target-kind bot --target-id "$BOT_CEO_UUID" \
+        --visibility full_transcript --env local --robot-code "e2e-robot" \
+        --client-id "e2e-client" --client-secret "not-a-real-secret" \
+        --send-mode normal --message-type markdown; then
+        fail "CLI channel bind unexpectedly succeeded without a channel provider"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        return
+    fi
+    if [[ "$BCS_CLI_STDERR" == *"channel bridge is disabled"* && "$BCS_CLI_STDERR" != *"not-a-real-secret"* ]]; then
+        pass "CLI channel bind returns the redacted disabled-bridge contract"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "CLI channel bind error is unexpected or leaked its secret: $(printf '%s' "$BCS_CLI_STDERR" | head -c 240)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    _cli_story_run "operator lists channel bindings" CEO channel list || return
+    assert_eq "CLI channel list exposes items" "$(_cli_json_has_path "$BCS_CLI_STDOUT" "items")" "1"
+
+    _cli_story_run "operator unbinds a missing disabled-bridge binding" CEO channel unbind --id "$missing_id" || return
+    assert_json_eq "CLI channel unbind acknowledges the no-op" "$BCS_CLI_STDOUT" "ok" "true"
+
+    _cli_story_run "operator confirms no phantom channel binding exists" CEO channel list || return
+    assert_json_eq "CLI channel list remains empty" "$BCS_CLI_STDOUT" "items" "[]"
+}

--- a/src/bcs/scripts/e2e-test/cli.sh
+++ b/src/bcs/scripts/e2e-test/cli.sh
@@ -41,16 +41,17 @@ test_cli_list() {
     info "CLI: bcs-cli list"
     ensure_cli_token CEO || { skip_case "no token"; TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
     bcs_cli CEO list || { fail "bcs-cli list exited $BCS_CLI_EXIT"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
-    # Expect at least the 5 demo bots' UUIDs echoed somewhere.
+    # The seeded five-bot environment is the fixture for this story; require the
+    # complete fixture rather than accepting an arbitrary non-empty list.
     local hit=0
     for u in "$BOT_CEO_UUID" "$BOT_PM_UUID" "$BOT_ENG_UUID" "$BOT_QA_UUID" "$BOT_CS_UUID"; do
         _cli_contains "$BCS_CLI_STDOUT" "$u" && hit=$((hit+1))
     done
-    if [[ "$hit" -ge 2 ]]; then
-        pass "bcs-cli list returned >=2 known bot UUIDs"
+    if [[ "$hit" -eq 5 ]]; then
+        pass "bcs-cli list returned all 5 known bot UUIDs"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        fail "bcs-cli list matched only $hit known UUIDs"
+        fail "bcs-cli list matched $hit/5 known UUIDs"
         TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
@@ -79,14 +80,8 @@ test_cli_discover() {
         pass "bcs-cli discover matched 客服 (CS) bot"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        # discover match semantics vary; treat non-empty result as acceptable.
-        if [[ -n "$BCS_CLI_STDOUT" && "$BCS_CLI_STDOUT" != "[]" ]]; then
-            pass "bcs-cli discover returned non-empty results"
-            TESTS_PASSED=$((TESTS_PASSED+1))
-        else
-            fail "bcs-cli discover returned empty"
-            TESTS_FAILED=$((TESTS_FAILED+1))
-        fi
+        fail "bcs-cli discover did not return the expected 客服 bot"
+        TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
 }
@@ -98,8 +93,9 @@ test_cli_visibility_get_set() {
     bcs_cli CEO visibility get || { fail "visibility get exited $BCS_CLI_EXIT"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
     local before
     before="$(_cli_json_field "$BCS_CLI_STDOUT" visibility 2>/dev/null)"
-    # Some bcs-cli shapes put visibility at top-level; fall back to raw scan.
-    [[ -z "$before" ]] && before="$(printf '%s' "$BCS_CLI_STDOUT" | grep -oE '"visibility":"[^"]*"' | head -1 | sed 's/"visibility":"//;s/"//')"
+    # Default CLI output is the stable human-readable contract
+    # `Visibility: <value>`; --json uses the field parsed above.
+    [[ -z "$before" ]] && before="$(printf '%s\n' "$BCS_CLI_STDOUT" | sed -nE 's/^Visibility: (public|protected|private)$/\1/p' | head -1)"
     # Set to public, verify, restore.
     if ! bcs_cli CEO visibility set --value public; then
         fail "visibility set public exited $BCS_CLI_EXIT"
@@ -114,8 +110,23 @@ test_cli_visibility_get_set() {
         TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
-    # Restore original (best-effort, not asserted).
-    [[ -n "$before" ]] && bcs_cli CEO visibility set --value "$before" >/dev/null 2>&1 || true
+    if [[ -z "$before" ]]; then
+        fail "visibility get did not expose the original value"
+        TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return
+    fi
+    if ! bcs_cli CEO visibility set --value "$before"; then
+        fail "visibility restore to $before exited $BCS_CLI_EXIT"
+        TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return
+    fi
+    bcs_cli CEO visibility get || true
+    if _cli_contains "$BCS_CLI_STDOUT" "$before"; then
+        pass "bcs-cli visibility restored to $before"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "visibility get after restore did not show $before"
+        TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
 }
 
 # connect: re-connect with CEO's existing token; expect a session/token back.
@@ -256,19 +267,22 @@ test_cli_list_groups() {
         fail "bcs-cli list-groups exited $BCS_CLI_EXIT"
         TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return
     fi
-    # Expect JSON array or pagination structure with total/groups/items.
-    if _cli_contains "$BCS_CLI_STDOUT" "total" || _cli_contains "$BCS_CLI_STDOUT" "groups" || _cli_contains "$BCS_CLI_STDOUT" "items" || _cli_contains "$BCS_CLI_STDOUT" "id"; then
-        pass "bcs-cli list-groups returned a group list"
+    local valid_shape
+    valid_shape=$(printf '%s\n' "$BCS_CLI_STDOUT" | python3 -c '
+import re, sys
+lines = [line for line in sys.stdin.read().splitlines() if line.strip()]
+header = re.fullmatch(r"Groups \((\d+)\):", lines[0]) if lines else None
+expected = int(header.group(1)) if header else -1
+entry = re.compile(r"\s+- bcs_grp_[0-9a-f-]+ \[[^]]+\] driver=\S+")
+ok = header is not None and len(lines[1:]) == expected and all(entry.fullmatch(line) for line in lines[1:])
+print("1" if ok else "0")
+' 2>/dev/null)
+    if [[ "$valid_shape" = "1" ]]; then
+        pass "bcs-cli list-groups returned a valid group-list shape"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        # Empty list acceptable; ensure it is valid JSON array.
-        if _cli_contains "$BCS_CLI_STDOUT" "[" || _cli_contains "$BCS_CLI_STDOUT" "{"; then
-            pass "bcs-cli list-groups returned a JSON payload (empty ok)"
-            TESTS_PASSED=$((TESTS_PASSED+1))
-        else
-            fail "bcs-cli list-groups unexpected output: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
-            TESTS_FAILED=$((TESTS_FAILED+1))
-        fi
+        fail "bcs-cli list-groups unexpected output: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
+        TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
 }
@@ -287,14 +301,8 @@ test_cli_friend() {
         pass "bcs-cli friend list contains 研发"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        # Allow empty list if no friends; require valid JSON array/object.
-        if _cli_contains "$BCS_CLI_STDOUT" "[" || _cli_contains "$BCS_CLI_STDOUT" "{"; then
-            pass "bcs-cli friend list returned valid JSON (no 研发 is acceptable)"
-            TESTS_PASSED=$((TESTS_PASSED+1))
-        else
-            fail "bcs-cli friend list unexpected output: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
-            TESTS_FAILED=$((TESTS_FAILED+1))
-        fi
+        fail "bcs-cli friend list did not contain the expected 研发 bot"
+        TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
 }

--- a/src/bcs/scripts/e2e-test/cli.sh
+++ b/src/bcs/scripts/e2e-test/cli.sh
@@ -31,7 +31,7 @@ test_cli_health() {
         pass "bcs-cli health returned a health payload"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        fail "bcs-cli health payload unexpected: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
+        fail "bcs-cli health payload unexpected: $(printf '%s\n' "$BCS_CLI_STDOUT" | head -c 120)"
         TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
@@ -167,7 +167,7 @@ test_cli_onboard() {
         pass "bcs-cli onboard --web produced a registration URL"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        fail "bcs-cli onboard --web output unexpected: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
+        fail "bcs-cli onboard --web output unexpected: $(printf '%s\n' "$BCS_CLI_STDOUT" | head -c 120)"
         TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
@@ -186,7 +186,7 @@ test_cli_update_status() {
         pass "bcs-cli update-status idle accepted (CLI path ok)"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        fail "bcs-cli update-status output unexpected: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
+        fail "bcs-cli update-status output unexpected: $(printf '%s\n' "$BCS_CLI_STDOUT" | head -c 120)"
         TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
@@ -253,7 +253,7 @@ test_cli_chat() {
         pass "bcs-cli chat returned a run/session handle"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        fail "bcs-cli chat output had no run/session handle: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
+        fail "bcs-cli chat output had no run/session handle: $(printf '%s\n' "$BCS_CLI_STDOUT" | head -c 120)"
         TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
@@ -281,7 +281,7 @@ print("1" if ok else "0")
         pass "bcs-cli list-groups returned a valid group-list shape"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else
-        fail "bcs-cli list-groups unexpected output: $(echo "$BCS_CLI_STDOUT" | head -c 120)"
+        fail "bcs-cli list-groups unexpected output: $(printf '%s\n' "$BCS_CLI_STDOUT" | head -c 120)"
         TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))

--- a/src/bcs/scripts/e2e-test/common.sh
+++ b/src/bcs/scripts/e2e-test/common.sh
@@ -44,6 +44,10 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 TESTS_TOTAL=0
 RESPONSE=""
+RESPONSE_HEADERS=""
+BCS_CLI_STDOUT=""
+BCS_CLI_STDERR=""
+BCS_CLI_EXIT=0
 
 # ============================================================================
 # Assertion Helpers
@@ -95,6 +99,71 @@ assert_contains() {
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL + 1))
+}
+
+assert_status() {
+    local desc="$1" expected="$2"
+    assert_eq "$desc" "$HTTP_STATUS" "$expected"
+}
+
+assert_json_eq() {
+    local desc="$1" json="$2" path="$3" expected="$4"
+    local actual
+    actual=$(printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    value = json.load(sys.stdin)
+    for part in sys.argv[1].split("."):
+        value = value[int(part)] if isinstance(value, list) else value[part]
+    if isinstance(value, bool):
+        print("true" if value else "false")
+    elif value is None:
+        print("null")
+    elif isinstance(value, (dict, list)):
+        print(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+    else:
+        print(value)
+except Exception:
+    print("__JSON_PATH_ERROR__")
+' "$path")
+    assert_eq "$desc" "$actual" "$expected"
+}
+
+assert_json_not_empty() {
+    local desc="$1" json="$2" path="$3"
+    local actual
+    actual=$(printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    value = json.load(sys.stdin)
+    for part in sys.argv[1].split("."):
+        value = value[int(part)] if isinstance(value, list) else value[part]
+    if value is None or value == "" or value == [] or value == {}:
+        print("")
+    elif isinstance(value, (dict, list)):
+        print(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+    else:
+        print(value)
+except Exception:
+    print("")
+' "$path")
+    assert_not_empty "$desc" "$actual"
+}
+
+assert_json_array_contains() {
+    local desc="$1" json="$2" path="$3" expected="$4"
+    local found
+    found=$(printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    value = json.load(sys.stdin)
+    for part in sys.argv[1].split("."):
+        value = value[int(part)] if isinstance(value, list) else value[part]
+    print("1" if sys.argv[2] in value else "0")
+except Exception:
+    print("0")
+' "$path" "$expected")
+    assert_eq "$desc" "$found" "1"
 }
 
 # ============================================================================
@@ -167,7 +236,8 @@ summary() {
 
 # Temp file for response body (persists across subshell boundaries).
 _RESPONSE_FILE=$(mktemp)
-trap 'rm -f "$_RESPONSE_FILE"' EXIT
+_RESPONSE_HEADERS_FILE=$(mktemp)
+trap 'rm -f "$_RESPONSE_FILE" "$_RESPONSE_HEADERS_FILE"' EXIT
 
 # Generic request helper. Sets globals:
 #   HTTP_STATUS — the HTTP status code (e.g. "200")
@@ -176,7 +246,7 @@ trap 'rm -f "$_RESPONSE_FILE"' EXIT
 _api_request() {
     local method="$1" path="$2" body="${3:-}"
     local url="${BCS_API_BASE_URL}${path}"
-    local curl_args=(-s -o "$_RESPONSE_FILE" -w '%{http_code}' -X "$method"
+    local curl_args=(-s -o "$_RESPONSE_FILE" -D "$_RESPONSE_HEADERS_FILE" -w '%{http_code}' -X "$method"
         -H "X-Mock-User-Id: $BCS_MOCK_USER_ID"
         -H "X-Mock-Nick-Name: $BCS_MOCK_USER_NICK_NAME"
         -H "Content-Type: application/json")
@@ -185,6 +255,28 @@ _api_request() {
     fi
     HTTP_STATUS=$(curl "${curl_args[@]}" "$url" 2>/dev/null) || HTTP_STATUS="000"
     RESPONSE=$(cat "$_RESPONSE_FILE")
+    RESPONSE_HEADERS=$(cat "$_RESPONSE_HEADERS_FILE")
+}
+
+# Request with caller-supplied headers. The usual mock-human headers are still
+# present, so stories can add provider admin/runtime credentials without
+# losing the local human identity used by owner checks.
+# Usage: api_request_headers METHOD PATH BODY "Header: value" ...
+api_request_headers() {
+    local method="$1" path="$2" body="$3"; shift 3
+    local url="${BCS_API_BASE_URL}${path}"
+    local curl_args=(-s -o "$_RESPONSE_FILE" -D "$_RESPONSE_HEADERS_FILE" -w '%{http_code}' -X "$method"
+        -H "X-Mock-User-Id: $BCS_MOCK_USER_ID"
+        -H "X-Mock-Nick-Name: $BCS_MOCK_USER_NICK_NAME"
+        -H "Content-Type: application/json")
+    while [[ "$#" -gt 0 ]]; do
+        curl_args+=(-H "$1")
+        shift
+    done
+    [[ -n "$body" ]] && curl_args+=(-d "$body")
+    HTTP_STATUS=$(curl "${curl_args[@]}" "$url" 2>/dev/null) || HTTP_STATUS="000"
+    RESPONSE=$(cat "$_RESPONSE_FILE")
+    RESPONSE_HEADERS=$(cat "$_RESPONSE_HEADERS_FILE")
 }
 
 api_get() {
@@ -216,12 +308,13 @@ bot_request() {
     local method="$1" path="$2" bot="$3" body="${4:-}"
     ensure_cli_token "$bot" >/dev/null || { HTTP_STATUS="000"; RESPONSE=""; return 1; }
     local url="${BCS_API_BASE_URL}${path}"
-    local curl_args=(-s -o "$_RESPONSE_FILE" -w '%{http_code}' -X "$method"
+    local curl_args=(-s -o "$_RESPONSE_FILE" -D "$_RESPONSE_HEADERS_FILE" -w '%{http_code}' -X "$method"
         -H "X-BCS-Bot-Token: $BCS_CLI_TOKEN"
         -H "Content-Type: application/json")
     [ -n "$body" ] && curl_args+=(-d "$body")
     HTTP_STATUS=$(curl "${curl_args[@]}" "$url" 2>/dev/null) || HTTP_STATUS="000"
     RESPONSE=$(cat "$_RESPONSE_FILE")
+    RESPONSE_HEADERS=$(cat "$_RESPONSE_HEADERS_FILE")
 }
 
 bot_get()    { bot_request GET    "$1" "$2"; }
@@ -489,8 +582,9 @@ bcs_cli() {
     local bin
     get_bcs_cli_bin >/dev/null
     bin="$BCS_CLI_BIN_PATH"
-    local sub="$1"
-    local args=()
+    local sub="$1" nested="${2:-}" command_path
+    local args=() global_args=()
+    [[ "${BCS_CLI_FORCE_JSON:-0}" = "1" ]] && global_args+=(--json)
     # bcs-cli's top-level URL flag is -u/--url (NOT --base-url), and
     # confirm-group-help reuses --url/<URL> for the confirm URL. To avoid any
     # flag-namespace collision, inject the base URL via the MOLTIS_BCS_URL env
@@ -498,13 +592,18 @@ bcs_cli() {
     export MOLTIS_BCS_URL="$BCS_API_BASE_URL"
     if [[ -z "$sub" ]]; then
         BCS_CLI_STDOUT=""
+        BCS_CLI_STDERR=""
         BCS_CLI_EXIT=2
         warn "bcs_cli: no subcommand given"
         return 2
     fi
     args+=("$sub")
     if [[ -n "$bot" ]]; then
-        ensure_cli_token "$bot" >/dev/null || { BCS_CLI_STDOUT=""; BCS_CLI_EXIT=126; return 126; }
+        if [[ "$bot" == token:* ]]; then
+            BCS_CLI_TOKEN="${bot#token:}"
+        else
+            ensure_cli_token "$bot" >/dev/null || { BCS_CLI_STDOUT=""; BCS_CLI_STDERR=""; BCS_CLI_EXIT=126; return 126; }
+        fi
         args+=(--token "$BCS_CLI_TOKEN")
     fi
     shift
@@ -519,19 +618,35 @@ bcs_cli() {
     # inline for THIS call only (no leak to the parent shell). For tokenless
     # calls (bot=""), leave the env untouched.
     local bot_dir=""
-    if [[ -n "$bot" ]]; then
+    if [[ -n "$bot" && "$bot" != token:* ]]; then
         bot_dir="$(_get_bot_data_dir "$bot")"
     fi
+    command_path="$sub"
+    case "$sub" in
+        friend|channel|visibility|session|service)
+            [[ -n "$nested" && "$nested" != -* ]] && command_path="$sub $nested"
+            ;;
+    esac
+    if [[ -n "${BCS_CLI_COVERAGE_LOG:-}" ]]; then
+        printf '%s\n' "$command_path" >> "$BCS_CLI_COVERAGE_LOG"
+    fi
     if [[ -n "$bot_dir" ]]; then
-        out="$( BOT_DATA_DIR="$bot_dir" $bin "${args[@]}" 2>"$err_file" )" && rc=$? || rc=$?
+        out="$( BOT_DATA_DIR="$bot_dir" $bin ${global_args[@]+"${global_args[@]}"} "${args[@]}" 2>"$err_file" )" && rc=$? || rc=$?
     else
-        out="$( $bin "${args[@]}" 2>"$err_file" )" && rc=$? || rc=$?
+        out="$( $bin ${global_args[@]+"${global_args[@]}"} "${args[@]}" 2>"$err_file" )" && rc=$? || rc=$?
     fi
     BCS_CLI_STDOUT="$out"
+    BCS_CLI_STDERR="$(cat "$err_file")"
     BCS_CLI_EXIT="$rc"
     if [[ "$rc" -ne 0 ]] && [[ -s "$err_file" ]]; then
-        warn "bcs-cli $sub exited $rc: $(head -c 200 "$err_file")"
+        warn "bcs-cli $command_path exited $rc: $(printf '%s' "$BCS_CLI_STDERR" | head -c 200)"
     fi
     rm -f "$err_file"
     return "$rc"
+}
+
+# Run bcs-cli with structured JSON output while preserving the regular
+# human-readable behavior used by existing CLI assertions.
+bcs_cli_json() {
+    BCS_CLI_FORCE_JSON=1 bcs_cli "$@"
 }

--- a/src/bcs/scripts/e2e-test/e2e.sh
+++ b/src/bcs/scripts/e2e-test/e2e.sh
@@ -14,9 +14,7 @@
 #
 # Usage:
 #   ./e2e.sh                  # Run all tests
-#   ./e2e.sh -t group         # Run group tests only
-#   ./e2e.sh -t friends       # Run friends tests only
-#   ./e2e.sh -t group friends # Run multiple test suites
+#   ./e2e.sh -t stories       # Run user-story E2E tests
 #   ./e2e.sh -l               # List available tests
 #   ./e2e.sh --skip-setup     # Skip BCS health check and ensure-human
 #   ./e2e.sh --help           # Show usage
@@ -57,15 +55,14 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: $0 [options]"
             echo ""
             echo "Options:"
-            echo "  -t <suite...>    Run specific test suites (group, friends)"
+            echo "  -t <suite...>    Run specific test suites (stories)"
             echo "  -l, --list       List available tests"
             echo "  --skip-setup     Skip BCS health check and ensure-human"
             echo "  --help           Show this help"
             echo ""
             echo "Examples:"
             echo "  $0                # Run all tests"
-            echo "  $0 -t group       # Run group tests only"
-            echo "  $0 -t group friends"
+            echo "  $0 -t stories     # Run user-story tests"
             exit 0
             ;;
         *)
@@ -84,28 +81,18 @@ source "$SCRIPT_DIR/friends.sh"
 source "$SCRIPT_DIR/cli.sh"
 source "$SCRIPT_DIR/actor.sh"
 source "$SCRIPT_DIR/register.sh"
+source "$SCRIPT_DIR/stories.sh"
+source "$SCRIPT_DIR/cli-stories.sh"
 
 # ============================================================================
 # Collect All Tests (Bash 3.2 compatible — no associative arrays)
 # ============================================================================
 
-ALL_SUITES=(group friends cli actor register)
+ALL_SUITES=(stories)
 ALL_TESTS=()
 
-for test_name in "${E2E_TESTS_GROUP[@]}"; do
-    ALL_TESTS+=("group:$test_name")
-done
-for test_name in "${E2E_TESTS_FRIENDS[@]}"; do
-    ALL_TESTS+=("friends:$test_name")
-done
-for test_name in "${E2E_TESTS_CLI[@]}"; do
-    ALL_TESTS+=("cli:$test_name")
-done
-for test_name in "${E2E_TESTS_ACTOR[@]}"; do
-    ALL_TESTS+=("actor:$test_name")
-done
-for test_name in "${E2E_TESTS_REGISTER[@]}"; do
-    ALL_TESTS+=("register:$test_name")
+for test_name in "${E2E_TESTS_STORIES[@]}"; do
+    ALL_TESTS+=("stories:$test_name")
 done
 
 # ============================================================================
@@ -114,24 +101,8 @@ done
 
 if [ "$LIST_ONLY" = true ]; then
     echo "Available test suites:"
-    echo "  group:"
-    for test_name in "${E2E_TESTS_GROUP[@]}"; do
-        echo "    - $test_name"
-    done
-    echo "  friends:"
-    for test_name in "${E2E_TESTS_FRIENDS[@]}"; do
-        echo "    - $test_name"
-    done
-    echo "  cli:"
-    for test_name in "${E2E_TESTS_CLI[@]}"; do
-        echo "    - $test_name"
-    done
-    echo "  actor:"
-    for test_name in "${E2E_TESTS_ACTOR[@]}"; do
-        echo "    - $test_name"
-    done
-    echo "  register:"
-    for test_name in "${E2E_TESTS_REGISTER[@]}"; do
+    echo "  stories:"
+    for test_name in "${E2E_TESTS_STORIES[@]}"; do
         echo "    - $test_name"
     done
     exit 0
@@ -199,12 +170,17 @@ for entry in "${RUN_TESTS[@]}"; do
     test_name="${entry#*:}"
     echo ""
     info "[$suite] $test_name"
+    failures_before=$TESTS_FAILED
     if $test_name; then
         : # test function handles its own assertions
     else
-        fail "$test_name exited with error"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        if [[ "$TESTS_FAILED" -eq "$failures_before" ]]; then
+            fail "$test_name exited without recording an assertion failure"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+            TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        else
+            warn "$test_name stopped after a failed assertion"
+        fi
     fi
 done
 

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -1,0 +1,806 @@
+#!/bin/bash
+# stories.sh — User-story-oriented BCS Adapter API E2E suite.
+#
+# The public test list intentionally exposes stories, not one case per route.
+# Each story follows a real user/operator journey and validates both response
+# contracts and observable state transitions. The step functions from the
+# older domain files remain reusable implementation details; they are not
+# registered as standalone default cases.
+
+E2E_TESTS_STORIES=(
+    "story_user_prepares_agent_network"
+    "story_user_builds_trusted_team"
+    "story_user_operates_group_workspace"
+    "story_user_runs_and_shares_sessions"
+    "story_user_has_direct_agent_conversation"
+    "story_user_runs_structured_collaboration"
+    "story_provider_operator_publishes_agent"
+    "story_user_validates_external_channel_setup"
+    "story_operator_coordinates_with_cli"
+    "story_cli_operator_builds_collaboration_team"
+    "story_cli_operator_runs_sessions_and_services"
+    "story_cli_operator_validates_channel_management"
+)
+
+require_status() {
+    local desc="$1" expected="$2"
+    assert_status "$desc" "$expected"
+    if [[ "$HTTP_STATUS" != "$expected" ]]; then
+        warn "response: $(printf '%s' "$RESPONSE" | head -c 300)"
+    fi
+    [[ "$HTTP_STATUS" = "$expected" ]]
+}
+
+json_path() {
+    local json="$1" path="$2"
+    printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    value = json.load(sys.stdin)
+    for part in sys.argv[1].split("."):
+        value = value[int(part)] if isinstance(value, list) else value[part]
+    if value is None:
+        print("")
+    elif isinstance(value, (dict, list)):
+        print(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
+    else:
+        print(value)
+except Exception:
+    print("")
+' "$path"
+}
+
+urlencode() {
+    python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$1"
+}
+
+# User story: A signed-in user opens Avernet and prepares an owned agent for use.
+#
+# Flow:
+#   Open the platform -> load advertised assets -> inspect the current identity
+#   -> browse the agent directory -> register an agent -> onboard and review it
+#   -> read it back -> remove the temporary agent.
+#
+# Critical assertions:
+#   - Platform, manifest, asset, and identity contracts are complete and consistent.
+#   - Registration returns usable credentials and onboarding persists capabilities.
+#   - Administrative review is observable through an independent read-back.
+#   - Removing the agent makes subsequent lookup return 404.
+story_user_prepares_agent_network() {
+    info "Story: user opens Avernet, inspects identity, and registers an owned agent"
+    _story_platform_entrypoints || return
+    test_actor_list
+    test_actor_search
+    test_actor_put_status
+    test_bots_my
+    test_bots_paged
+    test_bots_query
+    _story_register_and_onboard_owned_agent || return
+}
+
+_story_platform_entrypoints() {
+    api_get "/health"
+    require_status "platform health returns 200" "200" || return
+    assert_json_eq "health status is ok" "$RESPONSE" "status" "ok"
+    assert_json_eq "health service is bcs" "$RESPONSE" "service" "bcs"
+
+    api_get "/manifest"
+    require_status "manifest returns 200" "200" || return
+    assert_json_eq "manifest schema version is 1" "$RESPONSE" "schema_version" "1"
+    assert_json_not_empty "manifest environment is present" "$RESPONSE" "env"
+    assert_json_not_empty "manifest exposes at least one bundle" "$RESPONSE" "bundles.0.name"
+    local asset_url
+    asset_url=$(json_path "$RESPONSE" "bundles.0.url")
+    assert_not_empty "manifest bundle has an asset URL" "$asset_url"
+    [[ -n "$asset_url" ]] || return
+
+    api_get "$asset_url"
+    require_status "advertised manifest asset is downloadable" "200" || return
+    assert_contains "manifest asset uses JavaScript content type" "$RESPONSE_HEADERS" "application/javascript"
+    local asset_bytes
+    asset_bytes=$(printf '%s' "$RESPONSE" | wc -c | tr -d ' ')
+    if [[ "$asset_bytes" -gt 1000 ]]; then
+        pass "manifest asset is non-trivial (${asset_bytes} bytes)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "manifest asset is unexpectedly small (${asset_bytes} bytes)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    api_get "/me"
+    require_status "current identity returns 200" "200" || return
+    assert_json_eq "current user_id matches mock identity" "$RESPONSE" "user_id" "$BCS_MOCK_USER_ID"
+    assert_json_eq "current actor UUID is derived from staff id" "$RESPONSE" "actor_uuid" "human_${BCS_MOCK_USER_ID}"
+    assert_json_eq "current nickname matches mock identity" "$RESPONSE" "nick_name" "$BCS_MOCK_USER_NICK_NAME"
+
+    api_get "/me/repair-info"
+    require_status "identity repair inspection returns 200" "200" || return
+    assert_json_eq "repair inspection succeeds" "$RESPONSE" "ok" "true"
+    assert_json_eq "repair inspection targets current actor" "$RESPONSE" "actor_uuid" "human_${BCS_MOCK_USER_ID}"
+
+    api_get "/admin/secret/e2e-missing-secret"
+    require_status "disabled local secret backend returns 503 without leaking a value" "503" || return
+    assert_json_eq "disabled secret backend has stable error code" "$RESPONSE" "error" "unavailable"
+}
+
+_story_register_and_onboard_owned_agent() {
+    api_get "/register/token"
+    require_status "human obtains a register token" "200" || return
+    local register_token expires_at
+    register_token=$(json_path "$RESPONSE" "token")
+    expires_at=$(json_path "$RESPONSE" "expires_at")
+    assert_not_empty "register token is present" "$register_token"
+    assert_not_empty "register token expiry is present" "$expires_at"
+    [[ -n "$register_token" ]] || return
+
+    local bot_name="story-agent-$$-$(date +%s)"
+    local register_path="/register?token=$(urlencode "$register_token")&bot-name=$(urlencode "$bot_name")"
+    api_post "$register_path"
+    require_status "human registers a new agent" "200" || return
+    local bot_uuid bot_token
+    bot_uuid=$(json_path "$RESPONSE" "bot_uuid")
+    bot_token=$(json_path "$RESPONSE" "bot_token")
+    assert_not_empty "registration returns bot UUID" "$bot_uuid"
+    assert_not_empty "registration returns bot token" "$bot_token"
+    [[ -n "$bot_uuid" && -n "$bot_token" ]] || return
+
+    api_request_headers POST "/bots/onboard" \
+        "{\"name\":\"${bot_name}\",\"summary\":\"Story-owned support agent\",\"domains\":[\"support\"],\"skills\":[\"triage\"],\"scopes\":[\"local\"]}" \
+        "X-BCS-Bot-Token: ${bot_token}"
+    require_status "new agent onboards its capabilities" "200" || return
+    assert_json_eq "onboard response identifies the new agent" "$RESPONSE" "bot_uuid" "$bot_uuid"
+    assert_json_eq "onboard response confirms persistence" "$RESPONSE" "onboarded" "true"
+    assert_json_eq "onboard response keeps the chosen name" "$RESPONSE" "name" "$bot_name"
+
+    api_get "/onboard/url?token=$(urlencode "$bot_token")&name=$(urlencode "$bot_name")&summary=$(urlencode "Story-owned support agent")"
+    require_status "user can obtain the browser onboarding URL" "200" || return
+    assert_json_not_empty "browser onboarding URL is present" "$RESPONSE" "onboard_url"
+    assert_contains "browser onboarding URL contains the registration path" "$RESPONSE" "/bcn/register"
+
+    local admin_name="${bot_name}-admin"
+    api_post "/admin/bots/onboard" \
+        "{\"bot_id\":\"${bot_uuid}\",\"name\":\"${admin_name}\",\"summary\":\"Admin-reviewed agent\",\"domains\":[\"support\"],\"skills\":[\"triage\"],\"scopes\":[\"local\"]}"
+    require_status "administrator can re-onboard the owned agent" "200" || return
+    assert_json_eq "admin onboard targets the same bot" "$RESPONSE" "bot_uuid" "$bot_uuid"
+    assert_json_eq "admin onboard persists the reviewed name" "$RESPONSE" "name" "$admin_name"
+
+    api_get "/bots/${bot_uuid}"
+    require_status "onboarded agent is queryable" "200" || return
+    assert_json_eq "stored capability name matches admin review" "$RESPONSE" "capabilities.name" "$admin_name"
+
+    api_delete "/bots/${bot_uuid}"
+    require_status "owner can remove the temporary agent" "200" || return
+    api_get "/bots/${bot_uuid}"
+    require_status "removed agent is no longer visible" "404" || return
+}
+
+# User story: Agents establish and manage trusted collaboration relationships.
+#
+# Flow:
+#   Befriend a public agent -> request access to a protected agent -> accept it
+#   -> submit another protected request -> reject it -> inspect friends via API
+#   and CLI.
+#
+# Critical assertions:
+#   - Public friendship becomes visible without a pending approval step.
+#   - Protected requests expose a concrete pending request that can be accepted.
+#   - A rejected request never creates a friendship.
+#   - API and CLI friend lists contain the expected agents after each decision.
+story_user_builds_trusted_team() {
+    info "Story: agents establish, accept, reject, and inspect trust relationships"
+    test_friend_auto_accept_public
+    test_friend_request_accept_protected
+    test_friend_request_reject_protected
+    test_list_friends
+    test_friend_flow_via_cli
+}
+
+# User story: A user forms and operates an incident-response collaboration group.
+#
+# Flow:
+#   Create a group -> manage members and visibility -> configure participant mode,
+#   workspace, routing, and service settings -> exchange persistent and live messages
+#   -> process an agent callback -> close the group -> confirm a proposed group.
+#
+# Critical assertions:
+#   - Membership, labels, visibility, and participant identity changes are exact.
+#   - Workspace and routing updates survive an independent read-back.
+#   - Messages and callbacks produce routing or delivery results for the same group.
+#   - Deleted groups return 404, while confirmed proposals create the requested group.
+story_user_operates_group_workspace() {
+    info "Story: a user forms a team, configures its workspace, and collaborates"
+    # Reuse stable CRUD/CLI steps as implementation details of this story.
+    test_create_group
+    test_create_group_with_members
+    test_get_group_detail
+    test_list_groups
+    test_add_member
+    test_remove_member
+    test_update_group_label
+    test_update_group_visibility
+    test_group_create_via_cli
+    test_group_add_member_via_cli
+    test_group_get_via_cli
+    test_group_fuse_via_cli
+    test_group_status_via_cli
+    test_group_terminate_via_cli
+    _story_group_workspace_round_trip || return
+    _story_group_proposal_confirmation || return
+}
+
+_story_group_workspace_round_trip() {
+    local body
+    body="{\"driver_bot\":\"${BOT_CEO_UUID}\",\"label\":\"Incident response room\",\"participants\":[{\"bot_uuid\":\"${BOT_CEO_UUID}\",\"role\":\"driver\"},{\"bot_uuid\":\"${BOT_PM_UUID}\",\"role\":\"consultant\"},{\"bot_uuid\":\"${BOT_ENG_UUID}\",\"role\":\"consultant\"}]}"
+    bot_post "/groups" CEO "$body"
+    require_status "driver creates the incident response group" "200" || return
+    local group_id
+    group_id=$(json_path "$RESPONSE" "id")
+    assert_not_empty "incident response group has an id" "$group_id"
+    [[ -n "$group_id" ]] || return
+
+    api_get "/groups/${group_id}"
+    require_status "user reads the incident response group" "200" || return
+    assert_json_eq "incident response group keeps its label" "$RESPONSE" "label" "Incident response room"
+
+    bot_put "/groups/${group_id}/participants/${BOT_ENG_UUID}/mode" ENG '{"mode":"muted"}'
+    require_status "participant mutes itself" "200" || return
+    assert_json_eq "participant mode is muted" "$RESPONSE" "data.mode" "muted"
+    assert_json_eq "participant mode response identifies the actor" "$RESPONSE" "data.actor_id" "$BOT_ENG_UUID"
+
+    api_put "/groups/${group_id}/workspace" \
+        '{"decisions":["ship the hotfix"],"notes":["customer impact contained"],"tasks":[],"audit_log":[]}'
+    require_status "team updates its shared workspace" "200" || return
+    assert_json_array_contains "workspace update stores the decision" "$RESPONSE" "workspace.decisions" "ship the hotfix"
+    assert_json_array_contains "workspace update stores the note" "$RESPONSE" "workspace.notes" "customer impact contained"
+
+    api_get "/groups/${group_id}/workspace"
+    require_status "team reads the shared workspace" "200" || return
+    assert_json_array_contains "workspace read returns the decision" "$RESPONSE" "decisions" "ship the hotfix"
+    assert_json_array_contains "workspace read returns the note" "$RESPONSE" "notes" "customer impact contained"
+
+    bot_put "/groups/${group_id}/routing-policy" CEO \
+        "{\"mode\":\"structured\",\"default_bot_final_delivery\":\"inject_observers\",\"sender_routes\":{\"${BOT_CEO_UUID}\":[\"${BOT_PM_UUID}\"]}}"
+    require_status "driver configures structured routing" "200" || return
+    assert_json_eq "routing mode is persisted" "$RESPONSE" "routing_policy.mode" "structured"
+    assert_json_eq "default delivery is persisted" "$RESPONSE" "routing_policy.default_bot_final_delivery" "inject_observers"
+
+    api_patch "/groups/${group_id}/settings" '{"service_spec":{"max_concurrency":2}}'
+    require_status "group is exposed as a bounded service" "200" || return
+    assert_json_eq "service group max concurrency is persisted" "$RESPONSE" "service_spec.max_concurrency" "2"
+    assert_json_eq "group settings update returns stable status" "$RESPONSE" "status" "ok"
+
+    api_post "/groups/${group_id}/messages" \
+        "{\"sender\":\"${BOT_CEO_UUID}\",\"content\":\"Please validate the hotfix\",\"message_type\":\"bot\",\"role\":\"user\"}"
+    require_status "human posts a persistent group message" "200" || return
+    assert_json_not_empty "persistent message receives an id" "$RESPONSE" "message_id"
+    assert_json_not_empty "persistent message records routing targets" "$RESPONSE" "routed_to"
+
+    api_get "/groups/${group_id}/messages?limit=20"
+    require_status "human reads group message history" "200" || return
+    local history_is_array
+    history_is_array=$(printf '%s' "$RESPONSE" | python3 -c 'import json,sys; print("1" if isinstance(json.load(sys.stdin), list) else "0")' 2>/dev/null || echo 0)
+    assert_eq "group history response is a JSON array" "$history_is_array" "1"
+
+    bot_post "/groups/${group_id}/chat" CEO \
+        "{\"message\":\"@产品经理 please coordinate the release\",\"from\":\"${BOT_CEO_UUID}\"}"
+    require_status "driver sends a live group chat message" "200" || return
+    assert_json_eq "group chat response identifies the group" "$RESPONSE" "group_id" "$group_id"
+    assert_json_not_empty "group chat reports delivery results" "$RESPONSE" "delivery_results"
+
+    api_post "/groups/${group_id}/callback" \
+        "{\"message\":\"Engineering validation finished\",\"mentions\":[\"${BOT_CEO_UUID}\"],\"metadata\":{\"source\":\"e2e\"}}"
+    require_status "agent callback is delivered into the group" "200" || return
+    assert_json_eq "callback response identifies the group" "$RESPONSE" "group_id" "$group_id"
+    assert_json_not_empty "callback reports delivery results" "$RESPONSE" "delivery_results"
+
+    api_delete "/groups/${group_id}?bot_id=${BOT_CEO_UUID}"
+    require_status "driver closes the temporary incident group" "200" || return
+    assert_json_eq "group deletion confirms the id" "$RESPONSE" "id" "$group_id"
+    api_get "/groups/${group_id}"
+    require_status "closed incident group is gone" "404" || return
+}
+
+_story_group_proposal_confirmation() {
+    bot_post "/groups/request" CEO \
+        "{\"topic\":\"Review release readiness\",\"suggested_participants\":[\"${BOT_PM_UUID}\",\"${BOT_QA_UUID}\"],\"suggested_driver\":\"${BOT_CEO_UUID}\"}"
+    require_status "driver requests a release-readiness group" "200" || return
+    assert_json_eq "group proposal is created" "$RESPONSE" "proposal_created" "true"
+    local confirm_url confirm_path
+    confirm_url=$(json_path "$RESPONSE" "confirm_url")
+    assert_not_empty "group proposal returns a confirmation URL" "$confirm_url"
+    [[ -n "$confirm_url" ]] || return
+    confirm_path=$(python3 -c 'import sys,urllib.parse; u=urllib.parse.urlparse(sys.argv[1]); print(u.path)' "$confirm_url")
+
+    api_get "$confirm_path"
+    require_status "user previews the group confirmation page" "200" || return
+    assert_contains "confirmation page shows the proposal topic" "$RESPONSE" "Review release readiness"
+    assert_contains "confirmation page posts back to the same token" "$RESPONSE" "$confirm_path"
+
+    api_post "$confirm_path"
+    require_status "user confirms the proposed group" "200" || return
+    assert_json_eq "confirmed proposal creates a group" "$RESPONSE" "created" "true"
+    local group_id
+    group_id=$(json_path "$RESPONSE" "group_id")
+    assert_not_empty "confirmed proposal returns group id" "$group_id"
+    [[ -n "$group_id" ]] || return
+
+    api_get "/groups/${group_id}"
+    require_status "confirmed group is queryable" "200" || return
+    assert_json_eq "confirmed group uses the proposed driver" "$RESPONSE" "driver_bot" "$BOT_CEO_UUID"
+    api_delete "/groups/${group_id}?bot_id=${BOT_CEO_UUID}"
+    require_status "confirmed group is cleaned up" "200" || return
+}
+
+# User story: A team creates, shares, completes, and invokes collaboration sessions.
+#
+# Flow:
+#   Create a group session -> list and inspect it -> share group/session invitations
+#   -> join them -> manage session members and messages -> complete a chat session
+#   -> expose the group as a service -> invoke and inspect a service session -> clean up.
+#
+# Critical assertions:
+#   - Invite tokens lead to the intended group or session and created sessions are queryable.
+#   - Completion status and output survive an independent read-back.
+#   - Service sessions preserve kind, group, title, and caller isolation.
+#   - Cross-caller reads and use of the wrong completion API are rejected with 403.
+story_user_runs_and_shares_sessions() {
+    info "Story: a team creates, shares, completes, and invokes collaboration sessions"
+    test_group_session_via_cli
+    test_group_invite_link
+    test_session_invite_link
+    test_bot_groups_of_bot
+    test_session_invite_join
+    test_session_lifecycle
+    _story_complete_and_invoke_sessions || return
+}
+
+_story_complete_and_invoke_sessions() {
+    local group_body
+    group_body="{\"driver_bot\":\"${BOT_PM_UUID}\",\"label\":\"Release service\",\"participants\":[{\"bot_uuid\":\"${BOT_PM_UUID}\",\"role\":\"driver\"},{\"bot_uuid\":\"${BOT_ENG_UUID}\",\"role\":\"worker\"}]}"
+    bot_post "/groups" PM "$group_body"
+    require_status "product manager creates a release service group" "200" || return
+    local group_id
+    group_id=$(json_path "$RESPONSE" "id")
+    assert_not_empty "release service group has an id" "$group_id"
+    [[ -n "$group_id" ]] || return
+
+    local session_id
+    session_id=$(_api_create_session "$group_id" "Release sign-off")
+    assert_not_empty "release sign-off session is created" "$session_id"
+    [[ -n "$session_id" ]] || return
+
+    bot_post "/sessions/${session_id}/complete" PM \
+        '{"output":{"summary":"release approved"}}'
+    require_status "group driver completes the sign-off session" "200" || return
+    assert_json_eq "completed session status is completed" "$RESPONSE" "status" "completed"
+    assert_json_eq "completed session stores its output" "$RESPONSE" "output.summary" "release approved"
+
+    api_get "/sessions/${session_id}"
+    require_status "completed session can be read back" "200" || return
+    assert_json_eq "read-back keeps completed status" "$RESPONSE" "status" "completed"
+    assert_json_eq "read-back keeps completion output" "$RESPONSE" "output.summary" "release approved"
+
+    api_patch "/groups/${group_id}/settings" '{"service_spec":{"max_concurrency":2}}'
+    require_status "release group is configured for service invocations" "200" || return
+    assert_json_eq "service invocation concurrency is two" "$RESPONSE" "service_spec.max_concurrency" "2"
+
+    bot_post "/services/${group_id}/sessions" PM \
+        '{"caller_id":"release-pipeline-1","session_title":"Automated release audit","input":{"commit":"abc123"},"meta":{"source":"e2e"}}'
+    require_status "release pipeline starts a service session" "202" || return
+    local service_session_id
+    service_session_id=$(json_path "$RESPONSE" "session_id")
+    assert_not_empty "service invocation returns a session id" "$service_session_id"
+    assert_json_eq "service invocation uses the service session kind" "$RESPONSE" "session_kind" "service_invocation"
+    [[ -n "$service_session_id" ]] || return
+
+    bot_get "/services/${group_id}/sessions/${service_session_id}" PM
+    require_status "service caller reads its own session" "200" || return
+    assert_json_eq "service session belongs to the release group" "$RESPONSE" "group_id" "$group_id"
+    assert_json_eq "service session preserves the title" "$RESPONSE" "session_title" "Automated release audit"
+
+    bot_get "/services/${group_id}/sessions/${service_session_id}" CEO
+    require_status "different bot cannot read another caller's service session" "403" || return
+    assert_json_eq "service session caller isolation returns forbidden" "$RESPONSE" "error" "forbidden"
+
+    bot_post "/sessions/${service_session_id}/complete" PM '{"output":{"summary":"wrong endpoint"}}'
+    require_status "service session rejects the chat-session completion API" "403" || return
+    assert_json_eq "service completion guardrail returns forbidden" "$RESPONSE" "error" "forbidden"
+    assert_contains "service completion guardrail identifies the wrong endpoint" "$RESPONSE" "service sessions cannot be completed via this endpoint"
+
+    api_delete "/sessions/${session_id}?bot_id=${BOT_PM_UUID}"
+    require_status "completed chat session is cleaned up" "200" || return
+    api_delete "/sessions/${service_session_id}?bot_id=$(urlencode "bot:${BOT_PM_UUID}")"
+    require_status "service session is cleaned up by its creator" "200" || return
+
+    api_delete "/groups/${group_id}?bot_id=${BOT_PM_UUID}"
+    require_status "release service group is cleaned up" "200" || return
+}
+
+# User story: One agent starts, observes, and cancels a direct conversation with another.
+#
+# Flow:
+#   Attempt synchronous chat -> start an asynchronous chat -> inspect its run
+#   -> cancel the run -> inspect the terminal state.
+#
+# Critical assertions:
+#   - Synchronous chat accepts only delivery or the documented timeout contract.
+#   - Async start returns stable run/session identifiers for the requested target agent.
+#   - Run lookup preserves identity and exposes lifecycle state.
+#   - Cancellation is acknowledged and remains terminal on a later read.
+story_user_has_direct_agent_conversation() {
+    info "Story: an agent starts a direct async conversation, inspects it, and cancels it"
+    test_bot_chat_sync
+
+    bot_post "/bots/${BOT_PM_UUID}/chat-async" CEO \
+        '{"message":"Prepare a release checklist","timeout_ms":60000,"tags":["e2e","release"]}'
+    require_status "agent starts an asynchronous direct conversation" "202" || return
+    local run_id session_id
+    run_id=$(json_path "$RESPONSE" "run_id")
+    session_id=$(json_path "$RESPONSE" "session_id")
+    assert_not_empty "async conversation returns a run id" "$run_id"
+    assert_not_empty "async conversation returns a session id" "$session_id"
+    assert_json_eq "async conversation targets product manager" "$RESPONSE" "bot_uuid" "$BOT_PM_UUID"
+    [[ -n "$run_id" ]] || return
+
+    bot_get "/chat/runs/${run_id}" CEO
+    require_status "caller reads its direct chat run" "200" || return
+    assert_json_eq "chat run read-back keeps run id" "$RESPONSE" "run_id" "$run_id"
+    assert_json_not_empty "chat run exposes current state" "$RESPONSE" "state"
+
+    bot_post "/chat/runs/${run_id}/cancel" CEO
+    require_status "caller cancels the direct chat run" "200" || return
+    assert_json_eq "chat run cancellation is acknowledged" "$RESPONSE" "cancelled" "true"
+    assert_json_eq "cancelled chat run has cancelled state" "$RESPONSE" "state" "cancelled"
+
+    bot_get "/chat/runs/${run_id}" CEO
+    require_status "caller reads the cancelled chat run" "200" || return
+    assert_json_eq "cancelled run stays cancelled" "$RESPONSE" "state" "cancelled"
+    assert_json_eq "cancelled run is terminal" "$RESPONSE" "is_terminal" "true"
+}
+
+# User story: A user evolves and executes a template-based structured collaboration.
+#
+# Flow:
+#   Browse templates -> open one -> create a state-machine group -> inspect and patch
+#   its bound definition -> reject an unavailable upgrade -> start a run -> inspect
+#   run, graph, and node state -> cancel the run -> remove the group.
+#
+# Critical assertions:
+#   - Template identity, language, and authoring YAML match the request.
+#   - Definition patches increment the version and preserve the revised instruction.
+#   - Missing upgrades fail with 404 and identify the definition and target version.
+#   - Run, graph, and node views refer to the same run, which remains aborted after cancel.
+story_user_runs_structured_collaboration() {
+    info "Story: user chooses a template, evolves a workflow, starts it, and cancels it"
+
+    api_get "/collaboration/templates?lang=zh-CN"
+    require_status "user lists collaboration templates" "200" || return
+    assert_contains "template catalog includes guided answer" "$RESPONSE" "single-bot-guided-answer"
+
+    api_get "/collaboration/templates/single-bot-guided-answer?lang=zh-CN&format=json"
+    require_status "user opens a collaboration template" "200" || return
+    assert_json_eq "template detail keeps requested id" "$RESPONSE" "id" "single-bot-guided-answer"
+    assert_json_eq "template detail keeps requested language" "$RESPONSE" "lang" "zh-CN"
+    assert_json_not_empty "template detail includes authoring YAML" "$RESPONSE" "yaml"
+
+    local definition_yaml
+    definition_yaml="name: E2E Guided Answer
+participants:
+  driver:
+    bot_id: \"${BOT_CEO_UUID}\"
+    required: true
+runtime:
+  kind: state_machine
+  state_machine:
+    graph_mode: acyclic
+    nodes:
+      answer:
+        kind: bot_task
+        display_name: Draft answer
+        assignee:
+          type: bot_binding
+          binding: driver
+        instruction: Draft a concise release recommendation.
+        final_output: true"
+    local create_body
+    create_body=$(python3 -c '
+import json,sys
+print(json.dumps({
+  "driver_bot": sys.argv[1],
+  "label": "Structured release review",
+  "participants": [
+    {"bot_uuid": sys.argv[1]},
+    {"bot_uuid": sys.argv[2]}
+  ],
+  "group_strategy": "state_machine",
+  "collaboration_definition_yaml": sys.argv[3]
+}, ensure_ascii=False))
+' "$BOT_CEO_UUID" "$BOT_PM_UUID" "$definition_yaml")
+    bot_post "/groups" CEO "$create_body"
+    require_status "user creates a structured collaboration group" "200" || return
+    local group_id
+    group_id=$(json_path "$RESPONSE" "id")
+    assert_not_empty "structured group has an id" "$group_id"
+    [[ -n "$group_id" ]] || return
+
+    api_get "/groups/${group_id}"
+    require_status "user reads the structured collaboration group" "200" || return
+    assert_json_eq "structured group records state-machine strategy" "$RESPONSE" "group_strategy" "state_machine"
+
+    api_get "/groups/${group_id}/collaboration-definition"
+    require_status "user reads the bound collaboration definition" "200" || return
+    local definition_id base_version
+    definition_id=$(json_path "$RESPONSE" "default_definition.id")
+    base_version=$(json_path "$RESPONSE" "default_definition.version")
+    assert_not_empty "bound definition has an id" "$definition_id"
+    assert_not_empty "bound definition has a version" "$base_version"
+    assert_json_eq "bound definition preserves original YAML" "$RESPONSE" "yaml_source" "original"
+    [[ -n "$definition_id" && -n "$base_version" ]] || return
+
+    local patched_yaml patch_body
+    patched_yaml="${definition_yaml/Draft a concise release recommendation./Draft and verify a concise release recommendation.}"
+    patch_body=$(python3 -c '
+import json,sys
+print(json.dumps({
+  "base_definition": {"id": sys.argv[1], "version": int(sys.argv[2])},
+  "definition_yaml": sys.argv[3]
+}, ensure_ascii=False))
+' "$definition_id" "$base_version" "$patched_yaml")
+    api_patch "/groups/${group_id}/collaboration-definition" "$patch_body"
+    require_status "user patches the collaboration definition" "200" || return
+    local patched_version
+    patched_version=$(json_path "$RESPONSE" "default_definition.version")
+    assert_eq "definition patch increments version" "$patched_version" "$((base_version + 1))"
+    assert_contains "definition patch persists revised instruction" "$RESPONSE" "Draft and verify"
+
+    local missing_version upgrade_body
+    missing_version=$((patched_version + 100))
+    upgrade_body=$(python3 -c '
+import json,sys
+print(json.dumps({
+  "base_definition": {"id": sys.argv[1], "version": int(sys.argv[2])},
+  "target_definition": {"id": sys.argv[1], "version": int(sys.argv[3])}
+}))
+' "$definition_id" "$patched_version" "$missing_version")
+    api_post "/groups/${group_id}/collaboration-definition/upgrade" "$upgrade_body"
+    require_status "upgrade to an unpublished definition is rejected" "404" || return
+    assert_contains "missing upgrade target identifies the definition" "$RESPONSE" "$definition_id"
+    assert_contains "missing upgrade target identifies the version" "$RESPONSE" "@${missing_version}"
+
+    api_post "/groups/${group_id}/state-machine-runs" \
+        '{"input":{"question":"Is the release ready?"}}'
+    require_status "user starts the bound state-machine workflow" "202" || return
+    local run_id
+    run_id=$(json_path "$RESPONSE" "run.run_id")
+    assert_not_empty "state-machine start returns run id" "$run_id"
+    assert_json_eq "state-machine run belongs to structured group" "$RESPONSE" "run.group_id" "$group_id"
+    assert_json_not_empty "state-machine start returns node state" "$RESPONSE" "nodes.0.node_id"
+    [[ -n "$run_id" ]] || return
+
+    api_get "/state-machine-runs/${run_id}"
+    require_status "user reads state-machine run status" "200" || return
+    assert_json_eq "run status read-back keeps run id" "$RESPONSE" "run.run_id" "$run_id"
+    assert_json_not_empty "run status exposes lifecycle state" "$RESPONSE" "run.status"
+
+    api_get "/state-machine-runs/${run_id}/graph"
+    require_status "user inspects state-machine graph" "200" || return
+    assert_json_eq "graph identifies the active run" "$RESPONSE" "run.run_id" "$run_id"
+    assert_json_eq "graph exposes the answer node" "$RESPONSE" "nodes.0.node_id" "answer"
+
+    api_get "/state-machine-runs/${run_id}/nodes/answer"
+    require_status "user inspects the active state-machine node" "200" || return
+    assert_json_eq "node detail identifies answer node" "$RESPONSE" "node.node_id" "answer"
+    assert_json_eq "node detail belongs to active run" "$RESPONSE" "node.run_id" "$run_id"
+
+    api_post "/state-machine-runs/${run_id}/cancel" '{"reason":"E2E fixture completed"}'
+    require_status "user cancels the state-machine run" "200" || return
+    assert_json_eq "cancelled state-machine run is aborted" "$RESPONSE" "run.status" "aborted"
+
+    api_get "/state-machine-runs/${run_id}"
+    require_status "user reads cancelled state-machine run" "200" || return
+    assert_json_eq "cancelled state-machine run remains aborted" "$RESPONSE" "run.status" "aborted"
+
+    api_delete "/groups/${group_id}?bot_id=${BOT_CEO_UUID}"
+    require_status "structured collaboration fixture is cleaned up" "200" || return
+}
+
+# User story: A provider operator publishes, governs, and retires a provider-backed agent.
+#
+# Flow:
+#   Register a provider -> configure stream rollout -> inspect and update metadata
+#   -> publish and list an agent -> exercise runtime callbacks and guardrails
+#   -> disable and re-enable the provider -> retire the agent -> restore rollout state.
+#
+# Critical assertions:
+#   - Provider registration returns admin, callback, and runtime credentials as applicable.
+#   - Provider and agent identities remain stable across update and list operations.
+#   - Unknown callbacks and unauthorized delivery takeover fail with precise errors.
+#   - Disable/enable and retirement are observable, and temporary rollout state is restored.
+story_provider_operator_publishes_agent() {
+    info "Story: provider operator registers a provider, publishes an agent, and retires it"
+
+    api_post "/providers" \
+        '{"name":"E2E Provider","webhook_url":"https://provider.example.com/bcs/webhook","auth":{"mode":"static_bearer"},"protocol_version":"2.0","coordination":{"mode":"native_tool"}}'
+    require_status "operator registers a Provider 2.0 integration" "200" || return
+    local provider_id admin_token bcs_token
+    provider_id=$(json_path "$RESPONSE" "provider_id")
+    admin_token=$(json_path "$RESPONSE" "provider_admin_token")
+    bcs_token=$(json_path "$RESPONSE" "bcs_to_provider_token")
+    assert_not_empty "provider registration returns provider id" "$provider_id"
+    assert_not_empty "provider registration returns admin token" "$admin_token"
+    assert_not_empty "provider registration returns BCS callback token" "$bcs_token"
+    [[ -n "$provider_id" && -n "$admin_token" ]] || return
+
+    api_get "/providers/stream-gray"
+    require_status "operator reads provider streaming rollout" "200" || return
+    assert_json_not_empty "stream rollout exposes enabled flag" "$RESPONSE" "enabled"
+
+    api_put "/providers/stream-gray" \
+        "{\"enabled\":true,\"created_by\":[\"${BCS_MOCK_USER_ID}\"]}"
+    require_status "operator enables streaming for the current owner" "200" || return
+    assert_json_eq "stream rollout is enabled" "$RESPONSE" "enabled" "true"
+    assert_json_array_contains "stream rollout contains current owner" "$RESPONSE" "created_by" "$BCS_MOCK_USER_ID"
+
+    api_request_headers GET "/providers/${provider_id}" "" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator reads provider metadata" "200" || return
+    assert_json_eq "provider metadata keeps id" "$RESPONSE" "provider_id" "$provider_id"
+    assert_json_eq "provider metadata keeps protocol auth mode" "$RESPONSE" "auth_mode" "static_bearer"
+    assert_json_eq "provider starts enabled" "$RESPONSE" "disabled" "false"
+
+    api_request_headers PATCH "/providers/${provider_id}" \
+        '{"name":"E2E Provider Updated","protocol_version":"2.0"}' \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator updates provider metadata" "200" || return
+    assert_json_eq "provider name update is persisted" "$RESPONSE" "name" "E2E Provider Updated"
+    assert_json_eq "provider id is stable across update" "$RESPONSE" "provider_id" "$provider_id"
+
+    local provider_bot_ref="reviewer-$$-$(date +%s)"
+    api_request_headers POST "/providers/${provider_id}/bots" \
+        "{\"name\":\"Provider Review Agent\",\"summary\":\"Reviews release plans\",\"owners\":[\"${BCS_MOCK_USER_ID}\"],\"provider_bot_ref\":\"${provider_bot_ref}\",\"domains\":[\"release\"],\"skills\":[\"review\"],\"scopes\":[\"local\"]}" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator publishes a provider-backed agent" "200" || return
+    local provider_bot_uuid runtime_token
+    provider_bot_uuid=$(json_path "$RESPONSE" "bot_uuid")
+    runtime_token=$(json_path "$RESPONSE" "bot_runtime_token")
+    assert_not_empty "provider agent receives BCS bot id" "$provider_bot_uuid"
+    assert_not_empty "static-bearer agent receives runtime token" "$runtime_token"
+    assert_json_eq "provider agent keeps provider ref" "$RESPONSE" "provider_bot_ref" "$provider_bot_ref"
+    [[ -n "$provider_bot_uuid" && -n "$runtime_token" ]] || return
+
+    api_request_headers GET "/providers/${provider_id}/bots" "" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator lists provider-backed agents" "200" || return
+    local listed_bot
+    listed_bot=$(printf '%s' "$RESPONSE" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+target=sys.argv[1]
+print("1" if any(i.get("bot_uuid") == target for i in d.get("items", [])) else "0")
+' "$provider_bot_uuid" 2>/dev/null || echo 0)
+    assert_eq "published provider agent appears in provider list" "$listed_bot" "1"
+
+    api_request_headers POST "/providers/agentpass/resolve" '{}' \
+        "X-BCN-Provider-Id: ${provider_id}" \
+        "Authorization: Bearer ${runtime_token}"
+    require_status "agentpass lookup handles a non-agentpass credential safely" "200" || return
+    assert_json_eq "non-agentpass credential resolves no agent code" "$RESPONSE" "agent_code" "null"
+    assert_json_eq "non-agentpass credential resolves no provider binding" "$RESPONSE" "provider_bot_binding" "null"
+
+    local missing_run="missing-provider-run-$$"
+    api_request_headers POST "/bot/events" \
+        "{\"run_id\":\"${missing_run}\",\"state\":\"final\",\"message\":{\"text\":\"late provider result\"}}" \
+        "X-BCN-Provider-Id: ${provider_id}" \
+        "Authorization: Bearer ${runtime_token}"
+    require_status "late provider callback is rejected for an unknown run" "404" || return
+    assert_json_eq "late provider callback reports run_not_found" "$RESPONSE" "error" "run_not_found"
+
+    api_request_headers POST "/bot/events/coordination" \
+        "{\"run_id\":\"${missing_run}\",\"tool_call_id\":\"tool-1\",\"kind\":\"coordination_intent\",\"intent\":{\"v\":1,\"tool\":\"bcs_send_task_message\",\"arguments\":{\"message\":\"done\"}}}" \
+        "X-BCN-Provider-Id: ${provider_id}" \
+        "Authorization: Bearer ${runtime_token}"
+    require_status "late coordination callback is rejected for an unknown run" "404" || return
+    assert_json_eq "late coordination callback reports run_not_found" "$RESPONSE" "error" "run_not_found"
+
+    api_request_headers POST "/providers/${provider_id}/delivery/switch-bot" \
+        "{\"bot_id\":\"${BOT_QA_UUID}\",\"provider_bot_ref\":\"${provider_bot_ref}\"}" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "unapproved provider cannot take over an existing bot" "403" || return
+    assert_contains "delivery switch guardrail names provider allow-list" "$RESPONSE" "not allowed to switch bot delivery"
+
+    api_request_headers POST "/providers/${provider_id}/disable" "" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator disables the provider" "200" || return
+    assert_json_eq "provider disable is persisted" "$RESPONSE" "disabled" "true"
+
+    api_request_headers POST "/providers/${provider_id}/enable" "" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator re-enables the provider" "200" || return
+    assert_json_eq "provider enable is persisted" "$RESPONSE" "disabled" "false"
+
+    api_request_headers DELETE "/providers/${provider_id}/bots/${provider_bot_ref}" "" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator retires the provider-backed agent" "200" || return
+    assert_json_eq "provider agent deletion is acknowledged" "$RESPONSE" "deleted" "true"
+    assert_json_eq "provider agent deletion keeps provider ref" "$RESPONSE" "provider_bot_ref" "$provider_bot_ref"
+
+    api_request_headers GET "/providers/${provider_id}/bots" "" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator verifies provider agent retirement" "200" || return
+    assert_json_eq "provider agent list is empty after retirement" "$RESPONSE" "items" "[]"
+
+    api_put "/providers/stream-gray" '{"enabled":false,"created_by":[]}'
+    require_status "operator restores provider streaming rollout" "200" || return
+    assert_json_eq "stream rollout is restored to disabled" "$RESPONSE" "enabled" "false"
+    assert_json_eq "stream rollout owner list is cleared" "$RESPONSE" "created_by" "[]"
+}
+
+# User story: A user validates channel behavior before an external provider is installed.
+#
+# Flow:
+#   Attempt to create a binding -> inspect configured bindings -> pause and delete
+#   a missing binding through the disabled bridge -> inspect bindings again.
+#
+# Critical assertions:
+#   - Binding creation fails with the explicit disabled-bridge bad-request contract.
+#   - Binding reads always expose a well-formed items array.
+#   - Disabled-bridge pause and delete follow their documented no-op acknowledgements.
+#   - No phantom binding appears after the rejected and no-op operations.
+story_user_validates_external_channel_setup() {
+    info "Story: user validates channel setup before a provider is installed"
+
+    api_post "/channels/bindings" \
+        "{\"channel_type\":\"e2e-uninstalled-channel\",\"account_ref\":\"account-$$\",\"target\":{\"bot\":{\"bot_id\":\"${BOT_CEO_UUID}\"}},\"outbound_visibility\":\"full_transcript\",\"env\":\"local\",\"config\":{\"mode\":\"story\"}}"
+    require_status "binding an uninstalled channel provider is rejected" "400" || return
+    assert_json_eq "disabled channel setup returns bad_request" "$RESPONSE" "code" "bad_request"
+    assert_contains "channel setup error identifies disabled bridge" "$RESPONSE" "channel bridge is disabled"
+
+    api_get "/channels/bindings"
+    require_status "user can still inspect configured channel bindings" "200" || return
+    local items_is_array
+    items_is_array=$(printf '%s' "$RESPONSE" | python3 -c 'import json,sys; print("1" if isinstance(json.load(sys.stdin).get("items"), list) else "0")' 2>/dev/null || echo 0)
+    assert_eq "channel binding list exposes an items array" "$items_is_array" "1"
+
+    local missing_binding="missing-binding-$$"
+    api_patch "/channels/bindings/${missing_binding}" '{"active":false}'
+    require_status "disabled bridge accepts a no-op pause" "200" || return
+    assert_json_eq "disabled bridge pause is acknowledged" "$RESPONSE" "ok" "true"
+
+    api_delete "/channels/bindings/${missing_binding}"
+    require_status "disabled bridge accepts a no-op delete" "200" || return
+    assert_json_eq "disabled bridge delete is acknowledged" "$RESPONSE" "ok" "true"
+
+    api_get "/channels/bindings"
+    require_status "disabled bridge remains free of phantom bindings" "200" || return
+    assert_json_eq "disabled bridge binding list remains empty" "$RESPONSE" "items" "[]"
+}
+
+# User story: An operator inspects and coordinates the agent network through bcs-cli.
+#
+# Flow:
+#   Check health -> list, get, and discover agents -> change and restore visibility
+#   -> reconnect and generate onboarding information -> update status -> propose a group
+#   -> start a direct chat -> inspect groups and trusted relationships.
+#
+# Critical assertions:
+#   - Directory commands return the exact seeded agents and requested identities.
+#   - Visibility changes are read back and restored to the original value.
+#   - Onboarding, group proposal, and chat commands return actionable URLs or handles.
+#   - Group-list output has a consistent count/entry shape and friends include the expected agent.
+story_operator_coordinates_with_cli() {
+    info "Story: an operator uses bcs-cli to inspect and coordinate the agent network"
+    test_cli_health
+    test_cli_list
+    test_cli_get
+    test_cli_discover
+    test_cli_visibility_get_set
+    test_cli_connect
+    test_cli_onboard
+    _story_cli_direct_onboard || return
+    test_cli_update_status
+    test_cli_request_group_help
+    test_cli_chat
+    test_cli_list_groups
+    test_cli_friend
+}

--- a/src/bcs/scripts/e2e_coverage.sh
+++ b/src/bcs/scripts/e2e_coverage.sh
@@ -10,19 +10,22 @@ set -euo pipefail
 # Gate semantics:
 #   - e2e is always a 100% gate (no switch): any e2e failure makes the script
 #     exit with the non-zero e2e exit code.
-#   - --bcs-min defaults to 0 (collect + report only, no threshold). Pass a
-#     value N to additionally gate: e2e_cov_gate.py enforces line AND method
-#     (function) coverage >= N%; region coverage is reported but NOT gated.
-#     Emits GitHub ::notice::/::error:: annotations (local: OK/FAIL) for each.
-#   - The two gates are independent and BOTH can fail the run: e2e failure
-#     takes precedence, but a passing e2e with coverage below threshold still
-#     fails (the gate runs and surfaces annotations regardless of e2e_status).
+#   - Line and method coverage thresholds default to 0 (collect + report only).
+#     Pass --bcs-line-min / --bcs-method-min to gate them independently.
+#     --bcs-min remains as a compatibility shortcut that sets both thresholds.
+#     Region coverage is reported but NOT gated. Emits GitHub
+#     ::notice::/::error:: annotations (local: OK/FAIL) for each metric.
+#   - Adapter HTTP endpoint coverage is always gated at 100%.
+#   - bcs-cli leaf-command coverage is always gated at 100%.
+#   - The gates are independent and can fail the run: e2e failure takes
+#     precedence, followed by endpoint/CLI coverage, then line/method coverage.
 #
 # Usage:
 #   bash src/bcs/scripts/e2e_coverage.sh              # full flow
 #   bash src/bcs/scripts/e2e_coverage.sh --skip-start # instrumented bcs already running; run e2e + stop + aggregate only
 #   bash src/bcs/scripts/e2e_coverage.sh --no-stop    # do not stop bcs after running (debug; no aggregation)
-#   bash src/bcs/scripts/e2e_coverage.sh --bcs-min 20 # gate line+method coverage >= 20% (region report-only)
+#   bash src/bcs/scripts/e2e_coverage.sh --bcs-line-min 40 --bcs-method-min 36
+#                                                    # gate line >=40%, method >=36%
 #   bash src/bcs/scripts/e2e_coverage.sh --force-rebuild # force-rebuild instrumented bcs (ignore cache)
 #
 # Coverage scope: bcs server (crate bcs) only; excludes the 5 bots / Python.
@@ -33,7 +36,9 @@ cov_dir="$bcs_dir/target/cov-e2e"
 out_xml="$cov_dir/cobertura.xml"
 report_file="$cov_dir/coverage.txt"
 bcs_port="${BCS_PORT:-21000}"
-bcs_min="${BCS_E2E_COVERAGE_MIN:-0}"
+compat_min="${BCS_E2E_COVERAGE_MIN:-0}"
+line_min="${BCS_E2E_LINE_MIN:-$compat_min}"
+method_min="${BCS_E2E_METHOD_MIN:-$compat_min}"
 
 skip_start=0
 no_stop=0
@@ -47,9 +52,21 @@ while [[ "$#" -gt 0 ]]; do
         echo "Error: --bcs-min requires a value" >&2
         exit 2
       fi
-      bcs_min="$2"; shift 2 ;;
+      line_min="$2"; method_min="$2"; shift 2 ;;
+    --bcs-line-min)
+      if [[ "$#" -lt 2 ]]; then
+        echo "Error: --bcs-line-min requires a value" >&2
+        exit 2
+      fi
+      line_min="$2"; shift 2 ;;
+    --bcs-method-min)
+      if [[ "$#" -lt 2 ]]; then
+        echo "Error: --bcs-method-min requires a value" >&2
+        exit 2
+      fi
+      method_min="$2"; shift 2 ;;
     --force-rebuild) force_rebuild=1; shift ;;
-    -h|--help)      sed -n '2,18p' "$0"; exit 0 ;;
+    -h|--help)      sed -n '2,30p' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -130,7 +147,7 @@ if [[ "$skip_start" -eq 0 ]]; then
   # keeps runtime profraw next to the objects cargo llvm-cov report merges.
   cov_runtime_dir="$bcs_dir/target/cov-e2e/llvm-cov-target"
   export LLVM_PROFILE_FILE="$cov_runtime_dir/bcs-%m-%p.profraw"
-  # Enable BCS_DEBUG so bcs's debug_middleware logs every non-/health request as
+  # Enable BCS_DEBUG so bcs's debug_middleware logs every request as
   # `[→BCS] METHOD PATH` to bcs.log (singlebox redirects bcs stderr there). The
   # endpoint-coverage report below diffs those hits against router.rs's full
   # registered endpoint set. Exported here so the bcs server singlebox launches
@@ -173,6 +190,8 @@ fi
 #    to see what was covered).
 e2e_status=0
 cov_gate_status=0
+endpoint_gate_status=0
+cli_gate_status=0
 # Baseline the BCS_DEBUG hit log so the endpoint-coverage report (run at
 # aggregation time) counts only this e2e suite's requests, not singlebox's
 # bot-onboarding setup nor a prior run's stale log. bcs appends to bcs_log, so
@@ -181,6 +200,10 @@ cov_gate_status=0
 # caller also set BCS_LOG to point elsewhere — otherwise reuse the default.
 bcs_log="${bcs_log:-$repo_root/scripts/.dependencies/logs/bcs.log}"
 : > "$bcs_log" 2>/dev/null || true
+cli_coverage_log="$cov_dir/cli_commands.log"
+mkdir -p "$cov_dir"
+: > "$cli_coverage_log"
+export BCS_CLI_COVERAGE_LOG="$cli_coverage_log"
 bash "$bcs_dir/scripts/e2e-test/e2e.sh" || e2e_status=$?
 if [[ "$e2e_status" -ne 0 ]]; then
   echo "WARN: e2e exited with $e2e_status; continuing to flush profraw and aggregate coverage." >&2
@@ -252,29 +275,31 @@ if [[ "$no_stop" -eq 0 ]]; then
   grep '^TOTAL' "$report_file" || tail -20 "$report_file"
 
   # Coverage gate (e2e_cov_gate.py). Replaces the old --fail-under-lines gate:
-  #   - Enforces line AND method (function) coverage >= --bcs-min; region is
+  #   - Enforces line and method (function) coverage independently; region is
   #     reported but NOT gated (e2e runtime region coverage is low/noisy).
   #   - Emits GitHub ::notice::/::error:: annotations (local: OK/FAIL lines)
   #     for each metric, mirroring cov_gate.py's style.
   #   - Runs regardless of e2e_status so its annotations always surface, and
   #     its exit code is combined with e2e's below — no more swallowed gate
   #     (the old `[[ e2e eq 0 ]] && exit` skipped coverage failure when e2e
-  #     itself failed, so --bcs-min appeared not to take effect).
-  # bcs_min=0 (default / no --bcs-min) -> line & method thresholds = 0 =>
-  # report-only (does not block). Pre-push/CI pass --bcs-min 20 to gate.
+  #     itself failed, so coverage thresholds appeared not to take effect).
+  # A threshold of 0 is report-only. Pre-push/CI gate line >=40% and method
+  # >=36%; --bcs-min remains available to set both to one value.
   if [[ -f "$summary_json" ]]; then
     ( cd "$bcs_dir" && python3 scripts/e2e_cov_gate.py \
         --summary "$summary_json" \
-        --line-min "$bcs_min" \
-        --method-min "$bcs_min" ) || cov_gate_status=$?
+        --line-min "$line_min" \
+        --method-min "$method_min" ) || cov_gate_status=$?
   else
     echo "WARN: coverage summary.json not found ($summary_json); skipping coverage gate." >&2
     # Missing summary is itself a gate failure when a threshold was requested:
     # silently passing would let coverage regressions go unnoticed.
-    [[ "$bcs_min" -gt 0 ]] && cov_gate_status=1
+    if [[ "$line_min" != "0" || "$method_min" != "0" ]]; then
+      cov_gate_status=1
+    fi
   fi
 
-  # Adapters endpoint coverage (report-only, never gates): of all HTTP routes
+  # Adapters endpoint coverage (hard 100% gate): of all HTTP routes
   # registered in bcs-http's router.rs, which does this e2e run exercise? Diff
   # the BCS_DEBUG hit log (collected above) against the parsed endpoint set.
   # See scripts/adapters_endpoint_coverage.py for the over/under-count self-checks.
@@ -286,8 +311,24 @@ if [[ "$no_stop" -eq 0 ]]; then
       --router crates/adapters/http/bcs-http/src/router.rs \
       --log "$bcs_log" \
       --out-txt "$endpoint_txt" \
-      --out-xml "$endpoint_xml" ) \
-      || echo "WARN: endpoint coverage report failed (see stderr above)" >&2
+      --out-xml "$endpoint_xml" \
+      --min 100 ) || endpoint_gate_status=$?
+
+  # bcs-cli command coverage (hard 100% gate): discover the complete leaf
+  # command tree recursively from Clap --help and compare it with command paths
+  # recorded by the shared E2E bcs_cli wrapper. Help pseudo-commands and aliases
+  # are intentionally excluded by the reporter.
+  cli_coverage_txt="$cov_dir/cli_command_coverage.txt"
+  if [[ -x "$cov_cli_bin" ]]; then
+    ( cd "$bcs_dir" && python3 scripts/cli_command_coverage.py \
+        --cli "$cov_cli_bin" \
+        --log "$cli_coverage_log" \
+        --out-txt "$cli_coverage_txt" \
+        --min 100 ) || cli_gate_status=$?
+  else
+    echo "FAIL: bcs-cli command coverage binary not found at $cov_cli_bin" >&2
+    cli_gate_status=1
+  fi
 fi
 
 # Post-aggregation cleanup of profraw. The instrumented cargo build redirects
@@ -321,11 +362,17 @@ if [[ "$no_stop" -eq 0 ]]; then
 fi
 
 # Final exit code: e2e is always a 100% gate; the coverage gate (when a
-# --bcs-min threshold was requested) is an independent gate. e2e failure takes
+# a line/method threshold was requested) is an independent gate. e2e failure takes
 # precedence (the suite is broken), but a passing e2e with a breached coverage
 # threshold must still fail the run — which the old swallowed `[[ e2e eq 0 ]]
 # && exit` logic did not guarantee.
 if [[ "$e2e_status" -ne 0 ]]; then
   exit "$e2e_status"
+fi
+if [[ "$endpoint_gate_status" -ne 0 ]]; then
+  exit "$endpoint_gate_status"
+fi
+if [[ "$cli_gate_status" -ne 0 ]]; then
+  exit "$cli_gate_status"
 fi
 exit "$cov_gate_status"

--- a/src/bcs/scripts/pre_push.sh
+++ b/src/bcs/scripts/pre_push.sh
@@ -126,14 +126,14 @@ bcs_parallel_gates() {
   echo ""
   echo "== launching bcs gates in parallel =="
   printf '  unit: src/bcs/scripts/ci_test.sh --fast-fail %s  (log: %s)\n' "${unit_cov_args[*]:-}" "$unit_log"
-  printf '  e2e:  src/bcs/scripts/e2e_coverage.sh --bcs-min 20 --force-rebuild   (log: %s)\n' "$e2e_log"
+  printf '  e2e:  src/bcs/scripts/e2e_coverage.sh --bcs-line-min 40 --bcs-method-min 36 --force-rebuild   (log: %s)\n' "$e2e_log"
   echo ""
 
   _launch_tagged unit "$unit_exit" \
     "$bcs_dir/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail "${unit_cov_args[@]+"${unit_cov_args[@]}"}"
   local u_reader=$_TASK_READER u_pid=$_TASK_PID
   _launch_tagged e2e "$e2e_exit" \
-    "$bcs_dir/scripts/e2e_coverage.sh" --bcs-min 20 --force-rebuild
+    "$bcs_dir/scripts/e2e_coverage.sh" --bcs-line-min 40 --bcs-method-min 36 --force-rebuild
   local e_reader=$_TASK_READER e_pid=$_TASK_PID
 
   # Wait for the first gate to finish (exitfile written) or die abnormally.
@@ -265,5 +265,5 @@ elif [[ $unit_on -eq 1 ]]; then
   run_required "$bcs_dir/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail "${unit_cov_args[@]+"${unit_cov_args[@]}"}"
   bcs_coverage_gate "$base" || exit 1
 else
-  run_required "$bcs_dir/scripts/e2e_coverage.sh" --bcs-min 20 --force-rebuild
+  run_required "$bcs_dir/scripts/e2e_coverage.sh" --bcs-line-min 40 --bcs-method-min 36 --force-rebuild
 fi


### PR DESCRIPTION
## Summary

- Reorganize the default BCS E2E suite into 12 user-story journeys with strict response and state-transition assertions.
- Cover and gate all 104 registered HTTP Adapter endpoints and all 41 `bcs-cli` leaf commands.
- Raise E2E coverage gates to Line >= 40% and Method >= 36%; keep Region report-only.
- Fix `MySqlGroupStore::update_workspace` so successful updates are visible in the in-memory cache, with a regression test.

## Why

The previous E2E suite was largely organized by individual APIs, had permissive assertions in several CLI paths, and did not block regressions in Adapter endpoint or CLI command coverage. The new workspace read-back story also exposed a false-success bug where `update_workspace` returned `Ok(())` while discarding the new workspace.

## Impact

- CI now fails if any user-story assertion fails, HTTP endpoint coverage drops below 100%, CLI leaf-command coverage drops below 100%, Line falls below 40%, or Method falls below 36%.
- Local BCS pre-push uses the same E2E Line/Method thresholds.
- Workspace updates remain memory-only and are still lost on restart, but are now observable during the process lifetime.
- No public HTTP contract is changed.

## Validation

- 12/12 user stories passed
- 405/405 assertions passed
- HTTP Adapter endpoints: 104/104
- `bcs-cli` leaf commands: 41/41
- E2E Line: 42.16%
- E2E Method: 37.50%
- E2E Region: 38.34% (report-only)
- Workspace pre-push: 2177/2177 tests passed (43 skipped)
- `cargo test -p bcs-group-store workspace_update_is_visible_until_restart`
- Shell/Python syntax checks and `git diff --check`