### PR TITLE
fix(bcs): reset thinking accumulation at agent stream boundaries

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -324,6 +324,7 @@ async fn provider_delivery_protocol2_sse_ingests_events() {
     assert_eq!(events.len(), 3);
     assert_eq!(events[0].run_id, "run-sse");
     assert_eq!(events[0].event_type, "agent");
+    assert_eq!(events[0].state, ChatEventState::ToolCallEnd);
     assert_eq!(events[0].event_payload["stream"], "tool");
     assert_eq!(events[1].event_type, "chat.event");
     assert_eq!(events[1].state, ChatEventState::Delta);

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -52,8 +52,14 @@ pub async fn handle_bot_event(
     // We accumulate BEFORE publishing to the frontend so we can synthesize the
     // segment-cumulative `message.content` the frontend SDK renders from — the
     // raw SSE delta frame only carries `delta_text` and no `message`.
-    if cmd.state == ChatEventState::Delta && cmd.event_type == "agent" {
-        normalize_thinking_delta(flow, &mut cmd).await;
+    if cmd.event_type == "agent" {
+        match cmd.event_payload.get("stream").and_then(|value| value.as_str()) {
+            Some("thinking") if cmd.state == ChatEventState::Delta => {
+                normalize_thinking_delta(flow, &mut cmd).await;
+            }
+            Some("thinking") | None => {}
+            Some(_) => flow.message_tracker.clear_thinking_buf(&cmd.run_id).await,
+        }
     }
 
     if cmd.state == ChatEventState::Delta
@@ -110,13 +116,6 @@ pub async fn handle_bot_event(
     if is_chat_segment_boundary_stream(&cmd.event_payload) {
         flush_chat_segment(flow, &cmd, None).await;
     }
-    if cmd.state == ChatEventState::Delta
-        && cmd.event_type == "agent"
-        && is_thinking_segment_boundary_stream(&cmd.event_payload)
-    {
-        flow.message_tracker.clear_thinking_buf(&cmd.run_id).await;
-    }
-
     if is_terminal_state(&cmd.state) {
         flow.frontend_delivery.unregister_run(&cmd.run_id).await?;
     }
@@ -1098,14 +1097,6 @@ fn is_chat_segment_boundary_stream(payload: &Value) -> bool {
         payload.get("stream").and_then(|value| value.as_str()),
         Some("thinking") | Some("approval")
     )
-}
-
-fn is_thinking_segment_boundary_stream(payload: &Value) -> bool {
-    payload
-        .get("stream")
-        .and_then(|value| value.as_str())
-        .map(|stream| stream != "thinking")
-        .unwrap_or(false)
 }
 
 async fn cache_tool_start(flow: &BcsMessageFlow, cmd: &BotEventCommand, data: &Value) {

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -264,7 +264,7 @@ async fn bot_event_with_bcs_session_id_publishes_to_session_target() {
 
 
 #[tokio::test]
-async fn agent_thinking_delta_self_accumulates_and_resets_after_tool_block() {
+async fn agent_thinking_delta_self_accumulates_and_resets_after_tool_start() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let flow = BcsMessageFlow::new(
         support.group.clone(),
@@ -308,7 +308,7 @@ async fn agent_thinking_delta_self_accumulates_and_resets_after_tool_block() {
                 "name": "Bash",
             },
         }),
-        state: ChatEventState::Delta,
+        state: ChatEventState::ToolCallStart,
         bcs_session_id: None,
     })
     .await
@@ -346,6 +346,87 @@ async fn agent_thinking_delta_self_accumulates_and_resets_after_tool_block() {
         after_tool["payload"]["data"]["text"],
         "BB",
         "thinking text should be rebuilt from the current segment's delta, not upstream run-cumulative text"
+    );
+}
+
+#[tokio::test]
+async fn agent_thinking_delta_resets_after_tool_end() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-tool-end".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "before",
+                "text": "upstream-before",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-tool-end".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "tool",
+            "data": {
+                "phase": "result",
+                "toolCallId": "tool-1",
+                "name": "Bash",
+                "result": "ok",
+            },
+        }),
+        state: ChatEventState::ToolCallEnd,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-thinking-tool-end".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": {
+                "stream": "thinking",
+                "delta": "after",
+                "text": "upstream-beforeafter",
+            },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: None,
+    })
+    .await
+    .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 3);
+
+    let after_tool: Value = serde_json::from_str(&events[2]).unwrap();
+    assert_eq!(after_tool["payload"]["data"]["delta"], "after");
+    assert_eq!(
+        after_tool["payload"]["data"]["text"],
+        "after",
+        "tool-call end should close the previous thinking segment"
     );
 }
 


### PR DESCRIPTION
## Summary

- Reset the per-run thinking accumulator when any non-thinking agent stream event arrives.
- Handle real `ToolCallStart` and `ToolCallEnd` boundaries instead of requiring `ChatEventState::Delta`.
- Add regression coverage for tool start/end segmentation and provider result-state mapping.

## Root Cause

Thinking segmentation was gated on `ChatEventState::Delta`. Provider SSE maps tool `start` and `result` phases to `ToolCallStart` and `ToolCallEnd`, so those events never cleared the thinking buffer and later thinking segments included earlier content.

## Impact

Frontend thinking snapshots now remain cumulative only within the current thinking segment and reset correctly across tool calls.

## Validation

- `cargo test --manifest-path src/bcs/Cargo.toml -p bcs-message-flow -p bcs-provider-http`
- Verified the consuming `bcs-internal` binary still compiles in the integration workspace.