### PR TITLE
fix(baas): stabilize local bot activation

### DIFF
--- a/scripts/modules/baas.sh
+++ b/scripts/modules/baas.sh
@@ -7,6 +7,87 @@ _BAAS_SH_LOADED=1
 BAAS_LOG="${LOG_DIR}/baas.log"
 BAAS_APP_DIR="${BAAS_APP_DIR:-${BAAS_DIR}/packages/community}"
 
+baas_backup_bcs_sessions() {
+    local backup_dir="$1"
+    local session_file relative_path destination manifest
+
+    if [[ -e "$backup_dir" ]]; then
+        log_error "Refusing to overwrite existing BCS session backup: ${backup_dir}"
+        return 1
+    fi
+    [[ -d "${LOCAL_BOTS_DIR}" ]] || return 0
+
+    manifest="$(mktemp "${TMPDIR:-/tmp}/avernet-bcs-sessions.XXXXXX")" || return 1
+    if ! find "${LOCAL_BOTS_DIR}" -type f -path '*/.bcs/session.json' -print0 > "$manifest"; then
+        rm -f "$manifest"
+        return 1
+    fi
+
+    while IFS= read -r -d '' session_file; do
+        relative_path="${session_file#"${LOCAL_BOTS_DIR}/"}"
+        destination="${backup_dir}/${relative_path}"
+        (umask 077 && mkdir -p "$(dirname "$destination")") || {
+            rm -f "$manifest"
+            return 1
+        }
+        cp -p "$session_file" "$destination" || {
+            rm -f "$manifest"
+            return 1
+        }
+        chmod 600 "$destination" || {
+            rm -f "$manifest"
+            return 1
+        }
+    done < "$manifest"
+    rm -f "$manifest"
+}
+
+baas_restore_bcs_sessions() {
+    local backup_dir="$1"
+    local session_file relative_path destination manifest
+
+    [[ -d "$backup_dir" ]] || return 0
+
+    manifest="$(mktemp "${TMPDIR:-/tmp}/avernet-bcs-sessions.XXXXXX")" || return 1
+    if ! find "$backup_dir" -type f -path '*/.bcs/session.json' -print0 > "$manifest"; then
+        rm -f "$manifest"
+        return 1
+    fi
+
+    while IFS= read -r -d '' session_file; do
+        relative_path="${session_file#"${backup_dir}/"}"
+        destination="${LOCAL_BOTS_DIR}/${relative_path}"
+        if [[ -e "$destination" ]]; then
+            continue
+        fi
+        (umask 077 && mkdir -p "$(dirname "$destination")") || {
+            rm -f "$manifest"
+            return 1
+        }
+        cp -p "$session_file" "$destination" || {
+            rm -f "$manifest"
+            return 1
+        }
+        chmod 600 "$destination" || {
+            rm -f "$manifest"
+            return 1
+        }
+    done < "$manifest"
+
+    rm -f "$manifest"
+    rm -rf "$backup_dir"
+}
+
+baas_prepare_bcs_session_backup() {
+    local backup_dir="$1"
+
+    if [[ -d "$backup_dir" ]]; then
+        log_warn "Recovering stale BCS session backup before cleanup: ${backup_dir}"
+        baas_restore_bcs_sessions "$backup_dir" || return 1
+    fi
+    baas_backup_bcs_sessions "$backup_dir"
+}
+
 baas_setup() {
     # Setup the underlying engine that baas spawns on demand
     local engine_svc=$(_resolve_engine_svc)
@@ -58,6 +139,8 @@ baas_start() {
     log_info "Starting BAAS with singlebox mode..."
 
     if [ "$LOCAL_MODE" = true ]; then
+      local bcs_session_backup="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+
       # Remove existing SQLite database to start fresh
       if [ -f "${RUNTIME_DATA_DIR}/baas.db" ]; then
           log_info "Removing existing SQLite database for fresh start..."
@@ -67,7 +150,15 @@ baas_start() {
       # Clean bots dir
       if [[ -d "${LOCAL_BOTS_DIR}" ]]; then
           log_info "Cleaning bots dir: ${LOCAL_BOTS_DIR} ..."
+          baas_prepare_bcs_session_backup "$bcs_session_backup" || {
+              log_error "Failed to back up BCS sessions before cleaning bots dir"
+              return 1
+          }
           rm -rf "${LOCAL_BOTS_DIR:?}/"*
+          baas_restore_bcs_sessions "$bcs_session_backup" || {
+              log_error "Failed to restore BCS sessions after cleaning bots dir"
+              return 1
+          }
       fi
     fi
 

--- a/scripts/modules/baas.sh
+++ b/scripts/modules/baas.sh
@@ -7,25 +7,37 @@ _BAAS_SH_LOADED=1
 BAAS_LOG="${LOG_DIR}/baas.log"
 BAAS_APP_DIR="${BAAS_APP_DIR:-${BAAS_DIR}/packages/community}"
 
+baas_normalize_dir_path() {
+    local path="$1"
+
+    while [[ "$path" != "/" && "$path" == */ ]]; do
+        path="${path%/}"
+    done
+    printf '%s\n' "$path"
+}
+
 baas_backup_bcs_sessions() {
     local backup_dir="$1"
     local session_file relative_path destination manifest
+    local bots_dir backup_dir_norm
+    bots_dir="$(baas_normalize_dir_path "${LOCAL_BOTS_DIR}")"
+    backup_dir_norm="$(baas_normalize_dir_path "$backup_dir")"
 
-    if [[ -e "$backup_dir" ]]; then
-        log_error "Refusing to overwrite existing BCS session backup: ${backup_dir}"
+    if [[ -e "$backup_dir_norm" ]]; then
+        log_error "Refusing to overwrite existing BCS session backup: ${backup_dir_norm}"
         return 1
     fi
-    [[ -d "${LOCAL_BOTS_DIR}" ]] || return 0
+    [[ -d "$bots_dir" ]] || return 0
 
     manifest="$(mktemp "${TMPDIR:-/tmp}/avernet-bcs-sessions.XXXXXX")" || return 1
-    if ! find "${LOCAL_BOTS_DIR}" -type f -path '*/.bcs/session.json' -print0 > "$manifest"; then
+    if ! find "$bots_dir" -type f -path '*/.bcs/session.json' -print0 > "$manifest"; then
         rm -f "$manifest"
         return 1
     fi
 
     while IFS= read -r -d '' session_file; do
-        relative_path="${session_file#"${LOCAL_BOTS_DIR}/"}"
-        destination="${backup_dir}/${relative_path}"
+        relative_path="${session_file#"${bots_dir}/"}"
+        destination="${backup_dir_norm}/${relative_path}"
         (umask 077 && mkdir -p "$(dirname "$destination")") || {
             rm -f "$manifest"
             return 1
@@ -45,18 +57,21 @@ baas_backup_bcs_sessions() {
 baas_restore_bcs_sessions() {
     local backup_dir="$1"
     local session_file relative_path destination manifest
+    local bots_dir backup_dir_norm
+    bots_dir="$(baas_normalize_dir_path "${LOCAL_BOTS_DIR}")"
+    backup_dir_norm="$(baas_normalize_dir_path "$backup_dir")"
 
-    [[ -d "$backup_dir" ]] || return 0
+    [[ -d "$backup_dir_norm" ]] || return 0
 
     manifest="$(mktemp "${TMPDIR:-/tmp}/avernet-bcs-sessions.XXXXXX")" || return 1
-    if ! find "$backup_dir" -type f -path '*/.bcs/session.json' -print0 > "$manifest"; then
+    if ! find "$backup_dir_norm" -type f -path '*/.bcs/session.json' -print0 > "$manifest"; then
         rm -f "$manifest"
         return 1
     fi
 
     while IFS= read -r -d '' session_file; do
-        relative_path="${session_file#"${backup_dir}/"}"
-        destination="${LOCAL_BOTS_DIR}/${relative_path}"
+        relative_path="${session_file#"${backup_dir_norm}/"}"
+        destination="${bots_dir}/${relative_path}"
         if [[ -e "$destination" ]]; then
             continue
         fi
@@ -75,7 +90,7 @@ baas_restore_bcs_sessions() {
     done < "$manifest"
 
     rm -f "$manifest"
-    rm -rf "$backup_dir"
+    rm -rf "$backup_dir_norm"
 }
 
 baas_prepare_bcs_session_backup() {
@@ -140,6 +155,13 @@ baas_start() {
 
     if [ "$LOCAL_MODE" = true ]; then
       local bcs_session_backup="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+      local bots_dir
+      bots_dir="$(baas_normalize_dir_path "${LOCAL_BOTS_DIR}")"
+
+      if [[ -z "$bots_dir" || "$bots_dir" == "/" ]]; then
+          log_error "Refusing to clean empty or root LOCAL_BOTS_DIR"
+          return 1
+      fi
 
       # Remove existing SQLite database to start fresh
       if [ -f "${RUNTIME_DATA_DIR}/baas.db" ]; then
@@ -148,13 +170,13 @@ baas_start() {
       fi
 
       # Clean bots dir
-      if [[ -d "${LOCAL_BOTS_DIR}" ]]; then
-          log_info "Cleaning bots dir: ${LOCAL_BOTS_DIR} ..."
+      if [[ -d "$bots_dir" ]]; then
+          log_info "Cleaning bots dir: ${bots_dir} ..."
           baas_prepare_bcs_session_backup "$bcs_session_backup" || {
               log_error "Failed to back up BCS sessions before cleaning bots dir"
               return 1
           }
-          rm -rf "${LOCAL_BOTS_DIR:?}/"*
+          rm -rf "${bots_dir:?}/"*
           baas_restore_bcs_sessions "$bcs_session_backup" || {
               log_error "Failed to restore BCS sessions after cleaning bots dir"
               return 1

--- a/scripts/test_singlebox_service_guards.sh
+++ b/scripts/test_singlebox_service_guards.sh
@@ -137,6 +137,128 @@ test_baas_stop_does_not_delegate_to_app_stop() {
     fail "baas_stop should clean the BAAS port with ownership verification"
 }
 
+test_baas_bot_cleanup_preserves_bcs_sessions() {
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  export LOCAL_BOTS_DIR="$(mktemp -d)"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  local session_file unrelated_file backup_dir mode
+  session_file="${LOCAL_BOTS_DIR}/staff_mock-user/default/openclaw/.bcs/session.json"
+  unrelated_file="${LOCAL_BOTS_DIR}/staff_mock-user/default/openclaw/runtime.tmp"
+  backup_dir="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+  mkdir -p "$(dirname "$session_file")"
+  printf '%s\n' '{"bot_uuid":"test-bot","token":"test-token"}' > "$session_file"
+  printf '%s\n' 'remove me' > "$unrelated_file"
+  chmod 600 "$session_file"
+
+  baas_backup_bcs_sessions "$backup_dir"
+  rm -rf "${LOCAL_BOTS_DIR:?}/"*
+  baas_restore_bcs_sessions "$backup_dir"
+
+  [ -f "$session_file" ] || fail "BAAS cleanup should restore BCS session files"
+  assert_eq '{"bot_uuid":"test-bot","token":"test-token"}' "$(cat "$session_file")" \
+    "restored BCS session content"
+  [ ! -e "$unrelated_file" ] || fail "BAAS cleanup should not restore unrelated bot files"
+  [ ! -e "$backup_dir" ] || fail "BAAS cleanup should remove the temporary session backup"
+
+  if stat -f '%Lp' "$session_file" >/dev/null 2>&1; then
+    mode="$(stat -f '%Lp' "$session_file")"
+  else
+    mode="$(stat -c '%a' "$session_file")"
+  fi
+  assert_eq "600" "$mode" "restored BCS session permissions"
+}
+
+test_baas_session_backup_refuses_to_overwrite_stale_backup() {
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  export LOCAL_BOTS_DIR="$(mktemp -d)"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  local backup_dir stale_session current_session result
+  backup_dir="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+  stale_session="${backup_dir}/staff_mock-user/stale/openclaw/.bcs/session.json"
+  current_session="${LOCAL_BOTS_DIR}/staff_mock-user/current/openclaw/.bcs/session.json"
+  mkdir -p "$(dirname "$stale_session")" "$(dirname "$current_session")"
+  printf '%s\n' '{"bot_uuid":"stale-bot"}' > "$stale_session"
+  printf '%s\n' '{"bot_uuid":"current-bot"}' > "$current_session"
+
+  if baas_backup_bcs_sessions "$backup_dir"; then
+    result=0
+  else
+    result=$?
+  fi
+
+  [ "$result" -ne 0 ] || fail "BAAS backup should refuse to overwrite stale recovery data"
+  assert_eq '{"bot_uuid":"stale-bot"}' "$(cat "$stale_session")" \
+    "stale BCS backup content"
+}
+
+test_baas_session_backup_recovers_stale_backup_before_snapshot() {
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  export LOCAL_BOTS_DIR="$(mktemp -d)"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  local backup_dir stale_session current_session
+  backup_dir="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+  stale_session="${backup_dir}/staff_mock-user/stale/openclaw/.bcs/session.json"
+  current_session="${LOCAL_BOTS_DIR}/staff_mock-user/current/openclaw/.bcs/session.json"
+  mkdir -p "$(dirname "$stale_session")" "$(dirname "$current_session")"
+  printf '%s\n' '{"bot_uuid":"stale-bot"}' > "$stale_session"
+  printf '%s\n' '{"bot_uuid":"current-bot"}' > "$current_session"
+
+  baas_prepare_bcs_session_backup "$backup_dir"
+
+  [ -f "${backup_dir}/staff_mock-user/stale/openclaw/.bcs/session.json" ] || \
+    fail "recovered stale session should be included in the fresh backup"
+  [ -f "${backup_dir}/staff_mock-user/current/openclaw/.bcs/session.json" ] || \
+    fail "current session should be included in the fresh backup"
+}
+
+test_baas_session_scan_failure_keeps_source_and_backup() {
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  export LOCAL_BOTS_DIR="$(mktemp -d)"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  local backup_dir source_session backup_session backup_result restore_result
+  backup_dir="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+  source_session="${LOCAL_BOTS_DIR}/staff_mock-user/default/openclaw/.bcs/session.json"
+  backup_session="${backup_dir}/staff_mock-user/default/openclaw/.bcs/session.json"
+  mkdir -p "$(dirname "$source_session")"
+  printf '%s\n' '{"bot_uuid":"source-bot"}' > "$source_session"
+
+  find() { return 23; }
+  if baas_backup_bcs_sessions "$backup_dir"; then
+    backup_result=0
+  else
+    backup_result=$?
+  fi
+  unset -f find
+
+  [ "$backup_result" -ne 0 ] || fail "BAAS backup should fail when session scan fails"
+  [ -f "$source_session" ] || fail "failed backup must keep source sessions"
+
+  mkdir -p "$(dirname "$backup_session")"
+  printf '%s\n' '{"bot_uuid":"backup-bot"}' > "$backup_session"
+  find() { return 23; }
+  if baas_restore_bcs_sessions "$backup_dir"; then
+    restore_result=0
+  else
+    restore_result=$?
+  fi
+  unset -f find
+
+  [ "$restore_result" -ne 0 ] || fail "BAAS restore should fail when session scan fails"
+  [ -f "$backup_session" ] || fail "failed restore must keep recovery data"
+}
+
 test_5bot_openclaw_config_is_written_private() {
   grep -F 'umask 077' "${ROOT}/src/bcs/scripts/start_bcs_bots.sh" >/dev/null || \
     fail "5bot openclaw config should be written under umask 077"
@@ -159,6 +281,10 @@ test_backend_wait_fails_when_started_process_exits
 test_service_modules_use_ownership_aware_stop_helpers
 test_service_starts_fail_when_ports_remain_occupied
 test_baas_stop_does_not_delegate_to_app_stop
+test_baas_bot_cleanup_preserves_bcs_sessions
+test_baas_session_backup_refuses_to_overwrite_stale_backup
+test_baas_session_backup_recovers_stale_backup_before_snapshot
+test_baas_session_scan_failure_keeps_source_and_backup
 test_5bot_openclaw_config_is_written_private
 test_ready_banner_describes_full_stack
 

--- a/scripts/test_singlebox_service_guards.sh
+++ b/scripts/test_singlebox_service_guards.sh
@@ -171,6 +171,48 @@ test_baas_bot_cleanup_preserves_bcs_sessions() {
   assert_eq "600" "$mode" "restored BCS session permissions"
 }
 
+test_baas_session_backup_normalizes_trailing_slashes() {
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  local bots_dir backup_dir session_file expected_backup
+  bots_dir="$(mktemp -d)"
+  backup_dir="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+  export LOCAL_BOTS_DIR="${bots_dir}///"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  session_file="${bots_dir}/staff_mock-user/default/openclaw/.bcs/session.json"
+  expected_backup="${backup_dir}/staff_mock-user/default/openclaw/.bcs/session.json"
+  mkdir -p "$(dirname "$session_file")"
+  printf '%s\n' '{"bot_uuid":"test-bot"}' > "$session_file"
+
+  baas_backup_bcs_sessions "${backup_dir}///"
+
+  [ -f "$expected_backup" ] || \
+    fail "BAAS backup should normalize trailing slashes in bots and backup paths"
+}
+
+test_baas_session_restore_normalizes_trailing_slashes() {
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  local bots_dir backup_dir backup_session expected_session
+  bots_dir="$(mktemp -d)"
+  backup_dir="${RUNTIME_DATA_DIR}/.baas-bcs-sessions"
+  export LOCAL_BOTS_DIR="${bots_dir}///"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  backup_session="${backup_dir}/staff_mock-user/default/openclaw/.bcs/session.json"
+  expected_session="${bots_dir}/staff_mock-user/default/openclaw/.bcs/session.json"
+  mkdir -p "$(dirname "$backup_session")"
+  printf '%s\n' '{"bot_uuid":"test-bot"}' > "$backup_session"
+
+  baas_restore_bcs_sessions "${backup_dir}///"
+
+  [ -f "$expected_session" ] || \
+    fail "BAAS restore should normalize trailing slashes in bots and backup paths"
+}
+
 test_baas_session_backup_refuses_to_overwrite_stale_backup() {
   setup_env
   export RUNTIME_DATA_DIR="$(mktemp -d)"
@@ -259,6 +301,38 @@ test_baas_session_scan_failure_keeps_source_and_backup() {
   [ -f "$backup_session" ] || fail "failed restore must keep recovery data"
 }
 
+test_baas_start_refuses_root_bots_dir() (
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  export LOCAL_AIDESKTOP_DIR="$(mktemp -d)"
+  export LOCAL_BOTS_DIR="////"
+  export LOCAL_MODE=true
+  export CHAT_ENGINE="openclaw"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  local events_file result
+  events_file="$(mktemp)"
+  stop_port_processes_if_owned() { return 0; }
+  stop_matching_processes_if_owned() { return 0; }
+  require_port_available_after_owned_stop() { return 0; }
+  check_directory_exists() { return 0; }
+  baas_prepare_bcs_session_backup() { return 0; }
+  baas_restore_bcs_sessions() { return 0; }
+  rm() { printf 'rm %s\n' "$*" >> "$events_file"; }
+  env() { return 0; }
+  set -f
+
+  if baas_start; then
+    result=0
+  else
+    result=$?
+  fi
+
+  [ "$result" -ne 0 ] || fail "baas_start should reject a root LOCAL_BOTS_DIR"
+  [ ! -s "$events_file" ] || fail "baas_start must reject root before calling rm"
+)
+
 test_5bot_openclaw_config_is_written_private() {
   grep -F 'umask 077' "${ROOT}/src/bcs/scripts/start_bcs_bots.sh" >/dev/null || \
     fail "5bot openclaw config should be written under umask 077"
@@ -282,9 +356,12 @@ test_service_modules_use_ownership_aware_stop_helpers
 test_service_starts_fail_when_ports_remain_occupied
 test_baas_stop_does_not_delegate_to_app_stop
 test_baas_bot_cleanup_preserves_bcs_sessions
+test_baas_session_backup_normalizes_trailing_slashes
+test_baas_session_restore_normalizes_trailing_slashes
 test_baas_session_backup_refuses_to_overwrite_stale_backup
 test_baas_session_backup_recovers_stale_backup_before_snapshot
 test_baas_session_scan_failure_keeps_source_and_backup
+test_baas_start_refuses_root_bots_dir
 test_5bot_openclaw_config_is_written_private
 test_ready_banner_describes_full_stack
 

--- a/src/baas/packages/community/src/secbaas/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/packages/community/src/secbaas/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -808,7 +808,7 @@ class LocalProcessManager:
         env["ZERO_CHECK_ENABLED"] = "false"
         no_proxy_hosts = []
         for key in ("NO_PROXY", "no_proxy"):
-            for host in env.get(key, "").split(","):
+            for host in (env.get(key) or "").split(","):
                 host = host.strip()
                 if host and host not in no_proxy_hosts:
                     no_proxy_hosts.append(host)

--- a/src/baas/packages/community/src/secbaas/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/packages/community/src/secbaas/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -764,16 +764,21 @@ class LocalProcessManager:
     def _wait_for_hermes_health(self, port: int, timeout: float = 30.0) -> bool:
         """Wait for Hermes Dashboard to become healthy via HTTP GET."""
         deadline = time.monotonic() + timeout
-        url = f"http://localhost:{port}/"
+        url = f"http://127.0.0.1:{port}/"
+        session = requests.Session()
+        session.trust_env = False
 
-        while time.monotonic() < deadline:
-            try:
-                resp = requests.get(url, timeout=2)
-                if resp.status_code == 200:
-                    return True
-            except requests.RequestException:
-                pass
-            time.sleep(HEALTH_CHECK_INTERVAL)
+        try:
+            while time.monotonic() < deadline:
+                try:
+                    resp = session.get(url, timeout=2)
+                    if resp.status_code == 200:
+                        return True
+                except requests.RequestException:
+                    pass
+                time.sleep(HEALTH_CHECK_INTERVAL)
+        finally:
+            session.close()
 
         return False
 
@@ -801,18 +806,27 @@ class LocalProcessManager:
         env["CREDENTIALS_PATH"] = str(config_dir / ".credentials")
         # Disable zero-check
         env["ZERO_CHECK_ENABLED"] = "false"
+        no_proxy_hosts = []
+        for key in ("NO_PROXY", "no_proxy"):
+            for host in env.get(key, "").split(","):
+                host = host.strip()
+                if host and host not in no_proxy_hosts:
+                    no_proxy_hosts.append(host)
+        for host in ("localhost", "127.0.0.1", "::1"):
+            if host not in no_proxy_hosts:
+                no_proxy_hosts.append(host)
+        no_proxy = ",".join(no_proxy_hosts)
+        env["NO_PROXY"] = no_proxy
+        env["no_proxy"] = no_proxy
         # Singlebox per-bot workspace 根目录;adapter 进程的 _convert_path
         # 和 skill 模块都读这个 env 决定路径根。详见
         # docs/superpowers/specs/2026-06-10-engine-per-bot-workspace-design.md §4.3.A3
         env["OPENCLAW_WORKSPACE_DIR"] = str(workspace_dir)
 
         if engine == "openclaw":
-            # Use `localhost`, not `127.0.0.1`: macOS ExcludeSimpleHostnames
-            # bypasses dotless hosts from the system HTTP/HTTPS proxy. The
-            # `websockets` lib passes `host:port` to urllib.proxy_bypass, which
-            # defeats wildcard rules like `*.stable.example.net` — `localhost`
-            # is the one form that survives the port suffix.
-            env["OPENCLAW_GATEWAY_URL"] = f"ws://localhost:{engine_port}"
+            # Numeric loopback avoids macOS system proxies intercepting local
+            # WebSocket handshakes when localhost is not in the bypass list.
+            env["OPENCLAW_GATEWAY_URL"] = f"ws://127.0.0.1:{engine_port}"
             env["OPENCLAW_GATEWAY_TOKEN"] = ""
 
             # Disable adapter's built-in engine process management.
@@ -825,18 +839,18 @@ class LocalProcessManager:
         elif engine == "hermes":
             # Set Hermes Dashboard URL for the adapter.
             # Engine adapter will connect to Hermes Dashboard via HTTP/WebSocket.
-            env["HERMES_URL"] = f"http://localhost:{engine_port}"
+            env["HERMES_URL"] = f"http://127.0.0.1:{engine_port}"
         elif engine == "aicoding":
             # teamclaw-aicoding-relay is managed externally (start_service.sh).
             # Respect an operator-provided AICODING_RELAY_URL; otherwise fall
             # back to the relay's default port 18900 (matches
             # engine.aicoding.config._DEFAULT_RELAY_URL).
-            env.setdefault("AICODING_RELAY_URL", "ws://localhost:18900")
+            env.setdefault("AICODING_RELAY_URL", "ws://127.0.0.1:18900")
         elif engine == "claude_code":
             # Claude Code engine uses the same relay pattern as aicoding.
             # Respect an operator-provided CLAUDE_CODE_RELAY_URL; otherwise
             # fall back to the relay's default port 18900.
-            env.setdefault("CLAUDE_CODE_RELAY_URL", "ws://localhost:18900")
+            env.setdefault("CLAUDE_CODE_RELAY_URL", "ws://127.0.0.1:18900")
             logger.info(
                 "Claude Code engine env: CLAUDE_CODE_RELAY_URL=%s",
                 env["CLAUDE_CODE_RELAY_URL"],
@@ -850,7 +864,7 @@ class LocalProcessManager:
 
         if engine == "openclaw":
             logger.info(
-                "Spawning engine adapter: engine=%s port=%s, openclaw_url=ws://localhost:%s, log=%s",
+                "Spawning engine adapter: engine=%s port=%s, openclaw_url=ws://127.0.0.1:%s, log=%s",
                 engine,
                 adapter_port,
                 engine_port,
@@ -858,7 +872,7 @@ class LocalProcessManager:
             )
         elif engine == "hermes":
             logger.info(
-                "Spawning engine adapter: engine=%s port=%s, hermes_url=http://localhost:%s, log=%s",
+                "Spawning engine adapter: engine=%s port=%s, hermes_url=http://127.0.0.1:%s, log=%s",
                 engine,
                 adapter_port,
                 engine_port,

--- a/src/baas/packages/community/src/secbaas/plugins/sandbox/arca/local_proc/_sandbox_plugin.py
+++ b/src/baas/packages/community/src/secbaas/plugins/sandbox/arca/local_proc/_sandbox_plugin.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import urllib.parse
+import urllib.request
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -33,6 +35,34 @@ ENGINE_MAP = {
     "hermes-default": "hermes",
     "claude_code": "claude_code",
 }
+
+
+def _resolve_engine(
+    *,
+    envs: dict[str, str] | None,
+    metadata: dict[str, str] | None,
+) -> str:
+    """Resolve the per-sandbox engine before falling back to process defaults."""
+    requested = (
+        (envs or {}).get("AGENTCLAW_ENGINE")
+        or (metadata or {}).get("engine")
+        or os.environ.get("CHAT_ENGINE")
+        or "openclaw"
+    )
+    return ENGINE_MAP.get(requested, requested)
+
+
+def _open_callback_request(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+) -> Any:
+    """Open local callbacks directly so macOS system proxies cannot intercept them."""
+    hostname = urllib.parse.urlsplit(request.full_url).hostname
+    if hostname in {"localhost", "127.0.0.1", "::1"}:
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        return opener.open(request, timeout=timeout)
+    return urllib.request.urlopen(request, timeout=timeout)
 
 
 class LocalProcessArcaSandboxPlugin(ArcaSandboxPlugin):
@@ -107,7 +137,7 @@ class LocalProcessArcaSandboxPlugin(ArcaSandboxPlugin):
         )
 
         # 确定引擎类型
-        engine = os.environ.get("CHAT_ENGINE", "openclaw")
+        engine = _resolve_engine(envs=envs, metadata=metadata)
 
         # 从 metadata 提取必要信息
         # Check required fields
@@ -265,7 +295,6 @@ class LocalProcessArcaSandboxPlugin(ArcaSandboxPlugin):
         """
         import json
         import urllib.error
-        import urllib.request
 
         callback_url = os.environ.get(
             "LOCAL_CALLBACK_URL", "http://localhost:8890"
@@ -317,7 +346,7 @@ class LocalProcessArcaSandboxPlugin(ArcaSandboxPlugin):
                 headers={"Content-Type": "application/json"},
                 method="POST",
             )
-            with urllib.request.urlopen(req, timeout=5) as resp:
+            with _open_callback_request(req, timeout=5) as resp:
                 body = resp.read().decode("utf-8", errors="replace")
                 logger.info(
                     "Device callback response: url=%s, status=%s, body=%s",

--- a/src/baas/packages/community/tests/unit/plugins/sandbox/arca/test_process_manager_env.py
+++ b/src/baas/packages/community/tests/unit/plugins/sandbox/arca/test_process_manager_env.py
@@ -130,6 +130,36 @@ def test_spawn_adapter_uses_numeric_loopback_for_local_engines(
     assert set(captured["env"]["no_proxy"].split(",")) == expected_no_proxy
 
 
+def test_spawn_adapter_tolerates_empty_proxy_values(monkeypatch, tmp_path):
+    manager = pm.LocalProcessManager()
+    captured = {}
+
+    class FakeProcess:
+        pid = 12345
+
+    def fake_popen(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return FakeProcess()
+
+    monkeypatch.setattr(pm.os, "environ", {"NO_PROXY": None, "no_proxy": None})
+    monkeypatch.setattr(manager, "_resolve_engine_src_dir", lambda: tmp_path)
+    monkeypatch.setattr(manager, "_resolve_engine_python", lambda _: "/usr/bin/python3")
+    monkeypatch.setattr(manager, "_wait_for_health", lambda *args, **kwargs: True)
+    monkeypatch.setattr(pm.subprocess, "Popen", fake_popen)
+
+    manager._spawn_adapter(
+        adapter_port=20010,
+        engine_port=18888,
+        config_dir=tmp_path,
+        workspace_dir=tmp_path / "workspace",
+        engine="openclaw",
+    )
+
+    expected_no_proxy = {"localhost", "127.0.0.1", "::1"}
+    assert set(captured["env"]["NO_PROXY"].split(",")) == expected_no_proxy
+    assert set(captured["env"]["no_proxy"].split(",")) == expected_no_proxy
+
+
 def test_wait_for_hermes_health_disables_environment_proxies(monkeypatch):
     manager = pm.LocalProcessManager()
 

--- a/src/baas/packages/community/tests/unit/plugins/sandbox/arca/test_process_manager_env.py
+++ b/src/baas/packages/community/tests/unit/plugins/sandbox/arca/test_process_manager_env.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 import inspect
 import json
 import stat
+import urllib.request
 from pathlib import Path
 
 import pytest
 
 from secbaas.plugins.sandbox.arca.local_proc import _process_manager as pm
+from secbaas.plugins.sandbox.arca.local_proc import _sandbox_plugin as sandbox_plugin
 
 
 def _repo_bcn_plugin_path() -> Path:
@@ -21,6 +23,43 @@ def _repo_bcn_plugin_path() -> Path:
         if candidate.is_dir():
             return candidate
     raise AssertionError("repo BCN plugin path not found")
+
+
+def test_resolve_engine_prefers_request_env_over_global_default(monkeypatch):
+    monkeypatch.setenv("CHAT_ENGINE", "openclaw")
+
+    assert (
+        sandbox_plugin._resolve_engine(
+            envs={"AGENTCLAW_ENGINE": "claude_code"},
+            metadata=None,
+        )
+        == "claude_code"
+    )
+
+
+def test_open_callback_request_bypasses_proxy_for_loopback(monkeypatch):
+    marker = object()
+    captured_handlers = []
+
+    class FakeOpener:
+        def open(self, request, *, timeout):
+            assert request.full_url == "http://localhost:8890/callback"
+            assert timeout == 5
+            return marker
+
+    def fake_build_opener(*handlers):
+        captured_handlers.extend(handlers)
+        return FakeOpener()
+
+    monkeypatch.setattr(urllib.request, "build_opener", fake_build_opener)
+    request = urllib.request.Request("http://localhost:8890/callback")
+
+    result = sandbox_plugin._open_callback_request(request, timeout=5)
+
+    assert result is marker
+    assert len(captured_handlers) == 1
+    assert isinstance(captured_handlers[0], urllib.request.ProxyHandler)
+    assert captured_handlers[0].proxies == {}
 
 
 @pytest.mark.skip(
@@ -39,6 +78,120 @@ def test_spawn_adapter_source_injects_workspace_dir_env():
         "_spawn_adapter 应该注入 OPENCLAW_WORKSPACE_DIR 给 adapter 进程"
     )
     assert "workspace_dir" in src, "注入值应该是 workspace_dir 参数"
+
+
+@pytest.mark.parametrize(
+    ("engine", "env_key", "expected_url"),
+    [
+        ("openclaw", "OPENCLAW_GATEWAY_URL", "ws://127.0.0.1:18888"),
+        ("hermes", "HERMES_URL", "http://127.0.0.1:18888"),
+        ("aicoding", "AICODING_RELAY_URL", "ws://127.0.0.1:18900"),
+        ("claude_code", "CLAUDE_CODE_RELAY_URL", "ws://127.0.0.1:18900"),
+    ],
+)
+def test_spawn_adapter_uses_numeric_loopback_for_local_engines(
+    monkeypatch, tmp_path, engine, env_key, expected_url
+):
+    manager = pm.LocalProcessManager()
+    captured = {}
+
+    class FakeProcess:
+        pid = 12345
+
+    def fake_popen(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return FakeProcess()
+
+    monkeypatch.delenv(env_key, raising=False)
+    monkeypatch.setenv("NO_PROXY", "upper.example")
+    monkeypatch.setenv("no_proxy", "lower.example")
+    monkeypatch.setattr(manager, "_resolve_engine_src_dir", lambda: tmp_path)
+    monkeypatch.setattr(manager, "_resolve_engine_python", lambda _: "/usr/bin/python3")
+    monkeypatch.setattr(manager, "_wait_for_health", lambda *args, **kwargs: True)
+    monkeypatch.setattr(pm.subprocess, "Popen", fake_popen)
+
+    manager._spawn_adapter(
+        adapter_port=20010,
+        engine_port=18888,
+        config_dir=tmp_path,
+        workspace_dir=tmp_path / "workspace",
+        engine=engine,
+    )
+
+    assert captured["env"][env_key] == expected_url
+    expected_no_proxy = {
+        "upper.example",
+        "lower.example",
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }
+    assert set(captured["env"]["NO_PROXY"].split(",")) == expected_no_proxy
+    assert set(captured["env"]["no_proxy"].split(",")) == expected_no_proxy
+
+
+def test_wait_for_hermes_health_disables_environment_proxies(monkeypatch):
+    manager = pm.LocalProcessManager()
+
+    class Response:
+        status_code = 200
+
+    class FakeSession:
+        trust_env = True
+        closed = False
+
+        def get(self, url, *, timeout):
+            assert self.trust_env is False
+            assert url == "http://127.0.0.1:18765/"
+            assert timeout == 2
+            return Response()
+
+        def close(self):
+            self.closed = True
+
+    session = FakeSession()
+    monkeypatch.setattr(pm.requests, "Session", lambda: session)
+    monkeypatch.setattr(
+        pm.requests,
+        "get",
+        lambda *args, **kwargs: pytest.fail(
+            "health check must use a proxy-free session"
+        ),
+    )
+
+    assert manager._wait_for_hermes_health(18765, timeout=0.1) is True
+    assert session.closed is True
+
+
+def test_wait_for_hermes_health_retries_after_request_failure(monkeypatch):
+    manager = pm.LocalProcessManager()
+    sleeps = []
+
+    class Response:
+        status_code = 200
+
+    class FakeSession:
+        trust_env = True
+        calls = 0
+        closed = False
+
+        def get(self, url, *, timeout):
+            self.calls += 1
+            if self.calls == 1:
+                raise pm.requests.RequestException("not ready")
+            return Response()
+
+        def close(self):
+            self.closed = True
+
+    session = FakeSession()
+    monkeypatch.setattr(pm.requests, "Session", lambda: session)
+    monkeypatch.setattr(pm.time, "sleep", sleeps.append)
+
+    assert manager._wait_for_hermes_health(18765, timeout=1) is True
+    assert session.calls == 2
+    assert sleeps == [pm.HEALTH_CHECK_INTERVAL]
+    assert session.closed is True
 
 
 def test_resolve_engine_src_dir_prefers_configured_path(monkeypatch, tmp_path):


### PR DESCRIPTION
## Why

Native singlebox bot requests could silently fall back to the global `CHAT_ENGINE`, system proxy settings could intercept loopback callbacks, and BaaS restarts removed the persisted BCS session identity. Together these made configured local agents appear online but fail to activate reliably.

Fixes #96

## What changed

- Resolve the engine per request with precedence: `AGENTCLAW_ENGINE` environment override, bot metadata, then global `CHAT_ENGINE`.
- Use numeric loopback endpoints and explicitly bypass environment proxies for local health checks and callbacks.
- Preserve only `.bcs/session.json` during bot directory cleanup, with fail-safe snapshot, stale-backup recovery, and mode restoration.
- Add regression coverage for engine precedence, proxy bypass, Hermes retries, and BCS session preservation failures.

## Verification

- Targeted Python suite: 18 passed, 1 skipped.
- Singlebox service guard suite: passed.
- Full BaaS CI gate: 6060 passed, 23 skipped; changed-line coverage 91.67% (33/36).
- Ruff formatting/checks, shell syntax checks, and `git diff --check`: passed.
- Manual Claude adapter path returned accepted/final responses with all seven configured bots online.

The standalone Singlebox coverage rerun is currently blocked by the existing hostname-resolution failure tracked in #83 (`socket.gethostbyname(socket.gethostname())`), outside this change set.