### PR TITLE
fix(singlebox): route device lifecycle through BaaS

### DIFF
--- a/docs/superpowers/specs/2026-07-11-singlebox-baas-device-provider.md
+++ b/docs/superpowers/specs/2026-07-11-singlebox-baas-device-provider.md
@@ -1,0 +1,38 @@
+# Singlebox BaaS Device Provider
+
+## Problem
+
+`DeployProfile.SINGLEBOX` currently shares `TestDevicesModule` with unit tests.
+That module builds a BaaS-backed `LocalDeviceService`, registers it under the
+`local` provider key, and persists `device_provider=local`.
+
+The persisted provider is a domain fact, not a deployment-location flag.
+Singlebox device, bot, and process lifecycles are owned by the local BaaS
+service (`LocalPaasService` performs the host process spawn), so the binding
+must persist `device_provider=baas` while the independent runtime axes remain:
+
+- `DEPLOY_PROFILE=singlebox`
+- `SERVER_ENV=dev`
+- `device_provider=baas`
+
+## Contract
+
+1. `test` keeps `TestDevicesModule` and its local/in-memory doubles.
+2. `singlebox` installs a dedicated `SingleboxDevicesModule`.
+3. The singlebox `DeviceServiceRouter` registers only
+   `baas -> BaasDeviceService`, with `baas` as its default provider.
+4. Singlebox create-time routing always selects `baas`.
+5. `DeviceAccessor` resolves to `BaasDeviceAccessor` so filesystem, sync, and
+   connection consumers agree with the persisted provider.
+6. Local BaaS configuration still decides where processes run; no caller
+   derives provider identity from `DeployProfile` or `SERVER_ENV`.
+7. Unit-test-only local bindings must not leak into the singlebox runtime.
+
+## Compatibility
+
+Existing singlebox databases are recreated by the startup script, so no
+`local -> baas` data migration is required. Production profiles and their
+ARCA/BaaS routing are unchanged.
+
+PR #62 will stack on this change and verify the live BaaS lifecycle instead of
+asserting that a singlebox binding is rejected as a non-BaaS provider.

--- a/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
@@ -34,6 +34,14 @@ user_config:
     description: "Single Box mode — no external network."
     local_debug: true
 
+  # BaaS publish/create completion is delivered through the durable task queue.
+  # Singlebox runs one Backend process, so a short, jitter-free poll keeps local
+  # bot creation deterministic without changing the neutral default (disabled).
+  task_queue_worker:
+    enabled: true
+    poll_interval_seconds: 0.2
+    poll_jitter_seconds: 0.0
+
   # token_exchange — 外网替换为本地 mock
   token_exchange:
     buc_url: "http://127.0.0.1:9999"

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/__init__.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/__init__.py
@@ -1,0 +1,1 @@
+"""Singlebox infrastructure bindings."""

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
@@ -1,0 +1,168 @@
+"""Singlebox BaaS-only device runtime bindings."""
+
+from __future__ import annotations
+
+from typing import cast  # noqa: UP035 - injector binding key matches provider side
+
+from injector import Binder, Module, inject, provider, singleton
+
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.services.teclaw_status_reconciler import (
+    TeclawStatusReconciler,
+)
+from agentclaw.community.core.devices.protocols import BotQueryProtocol
+from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.core.devices.services.arca_bot_create_baas_rollout_policy import (
+    ArcaBotCreateBaasRolloutDecision,
+    ArcaBotCreateBaasRolloutPolicy,
+)
+from agentclaw.community.core.devices.services.baas_device_accessor import (
+    BaasDeviceAccessor,
+)
+from agentclaw.community.core.devices.services.baas_device_service import (
+    BaasDeviceService,
+)
+from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.device_service import (
+    BAAS_DEVICE_PROVIDER,
+    DeviceService,
+)
+from agentclaw.community.core.devices.services.device_service_router import (
+    DeviceServiceRouter,
+)
+from agentclaw.community.core.notify.protocol import NotifyBotLister
+from agentclaw.community.core.system_config import SystemConfigService
+from agentclaw.community.di import config as cfg
+from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
+    BotPublishRepositoryProtocol,
+)
+from agentclaw.community.core.service_bot.services.baas_service import BaasService
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterTransport,
+)
+from agentclaw.community.plugin_api.device_connection_manager import (
+    DeviceConnectionManagerPlugin,
+)
+from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
+from agentclaw.community.di.modules.infrastructure.singlebox.template_config import (
+    SingleboxBaasTemplateConfigLifecycle,
+)
+
+
+class _SingleboxAllBaasRolloutPolicy(ArcaBotCreateBaasRolloutPolicy):
+    """Singlebox has no ARCA provider, so every allocation is BaaS-owned."""
+
+    def __init__(self) -> None:
+        pass
+
+    def decide(
+        self,
+        *,
+        user_id: str,
+        bot_type: str | None,
+        engine_type: str | None = None,
+        template_type: str | None = None,
+    ) -> ArcaBotCreateBaasRolloutDecision:
+        return ArcaBotCreateBaasRolloutDecision(
+            target_provider=BAAS_DEVICE_PROVIDER,
+            reason="singlebox_baas_only",
+            engine_bucket=self.normalize_engine_bucket(
+                engine_type=engine_type,
+                template_type=template_type,
+            ),
+        )
+
+
+class SingleboxDevicesModule(Module):
+    """Bind singlebox to the real BaaS domain provider over local HTTP."""
+
+    def configure(self, binder: Binder) -> None:
+        from agentclaw.community.plugins.local.device_connection_manager import (
+            NoopDeviceConnectionManagerPlugin,
+        )
+
+        binder.bind(
+            DeviceConnectionManagerPlugin,
+            to=NoopDeviceConnectionManagerPlugin,
+            scope=singleton,
+        )
+        binder.bind(DeviceAccessor, to=BaasDeviceAccessor, scope=singleton)
+
+    @singleton
+    @provider
+    @inject
+    def singlebox_baas_template_config_lifecycle(
+        self,
+        config_service: SystemConfigService,
+        baas: cfg.BaasConfig,
+    ) -> SingleboxBaasTemplateConfigLifecycle:
+        return SingleboxBaasTemplateConfigLifecycle(
+            config_service=config_service,
+            template_uuid=baas.template_uuid,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def device_service(
+        self,
+        baas_device_service: BaasDeviceService,
+        repository: DeviceBindingRepository,
+        bot_repository: BotRepository,
+        bot_publish_repo: BotPublishRepositoryProtocol,
+        passport_plugin: PassportPlugin,
+        sandbox_client: SandboxRuntimeClient,
+    ) -> DeviceService:
+        bot_query = cast(BotQueryProtocol, bot_repository)
+        providers: dict[str, DeviceService] = {
+            BAAS_DEVICE_PROVIDER: baas_device_service,
+        }
+        return DeviceServiceRouter(
+            repository=repository,
+            bot_query=bot_query,
+            providers=providers,
+            default_provider_key=BAAS_DEVICE_PROVIDER,
+            arca_baas_rollout_policy=_SingleboxAllBaasRolloutPolicy(),
+            passport_plugin=passport_plugin,
+            sandbox_client=sandbox_client,
+            publish_repo=bot_publish_repo,
+            bot_repo=bot_repository,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def teclaw_status_reconciler(
+        self,
+        baas_service: BaasService,
+        bot_repository: BotRepository,
+        device_binding_repo: DeviceBindingRepository,
+    ) -> TeclawStatusReconciler:
+        """Keep background reconciliation disabled in the local stack."""
+        return TeclawStatusReconciler(
+            baas_service=baas_service,
+            bot_repository=bot_repository,
+            device_binding_repo=device_binding_repo,
+            schedule=lambda _fn, _delay: None,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def notify_bot_lister(self, bot_repository: BotRepository) -> NotifyBotLister:
+        from agentclaw.community.core.notify.local_bot_lister import (
+            LocalNotifyBotLister,
+        )
+
+        return LocalNotifyBotLister(bot_repository=bot_repository)
+
+    @singleton
+    @provider
+    def device_adapter_transport(self) -> DeviceAdapterTransport:
+        """Preserve the current in-memory adapter seam in the OSS singlebox."""
+        from agentclaw.community.plugins.local.device_adapter_transport import (
+            InMemoryDeviceAdapterTransport,
+        )
+
+        return InMemoryDeviceAdapterTransport()

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
@@ -1,0 +1,79 @@
+"""Profile-owned bootstrap for the local BaaS template routing map."""
+
+from __future__ import annotations
+
+from agentclaw.community.core.devices.services.baas_template_resolver import (
+    BAAS_TEMPLATE_MAPPING_CATEGORY,
+    BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
+)
+from agentclaw.community.core.system_config import SystemConfigService
+from agentclaw.community.kernel.lifecycle import LifecycleBase
+from agentclaw.community.log import get_logger
+from agentclaw.community.utils import env_utils
+
+
+logger = get_logger()
+
+_LOCAL_TEMPLATE_UID = "local_default"
+_SUPPORTED_ENGINES = ("openclaw", "moltis", "hermes", "aicoding", "claude_code")
+
+
+class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):
+    """Install an idempotent BaaS template map after SQLite bootstrap."""
+
+    def __init__(
+        self,
+        *,
+        config_service: SystemConfigService,
+        template_uuid: str | None,
+    ) -> None:
+        self._config_service = config_service
+        self._template_uuid = template_uuid.strip() if template_uuid else ""
+
+    async def startup(self) -> None:
+        env = env_utils.get_current_env()
+        existing = self._config_service.get_config(
+            category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+            config_key=BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
+            env=env,
+        )
+        if isinstance(existing, dict):
+            return
+        if not self._template_uuid.startswith("TEMPLATE-"):
+            raise RuntimeError(
+                "singlebox requires baas.template_uuid in TEMPLATE-* format"
+            )
+
+        self._config_service.create_category(
+            category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+            category_name="System",
+            description="Local BaaS system configuration",
+            env=env,
+            operator="local-bootstrap",
+        )
+        config_id = self._config_service.set_config(
+            category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+            config_key=BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
+            config_value={
+                "version": "local-v1",
+                "selectors": [
+                    {"engine": engine, "template_uid": _LOCAL_TEMPLATE_UID}
+                    for engine in _SUPPORTED_ENGINES
+                ],
+                "templates": {
+                    _LOCAL_TEMPLATE_UID: {
+                        "template_uuid": self._template_uuid,
+                    }
+                },
+            },
+            env=env,
+            description="Generated from the local deployment configuration",
+            operator="local-bootstrap",
+        )
+        if not config_id:
+            raise RuntimeError("failed to seed local BaaS template mapping")
+        logger.info(
+            "Seeded local BaaS template mapping: env=%s template_uuid=%s",
+            env,
+            self._template_uuid,
+        )

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Callable, cast  # noqa: UP035 - injector binding key must match provider side
 
-from injector import Injector, Module, inject, provider, singleton
+from injector import Binder, Injector, Module, inject, provider, singleton
 
 from agentclaw.community.api.baas_service import BaasServiceProtocol
 from agentclaw.community.core.bot_management.token_vault import TokenVault
@@ -50,6 +50,8 @@ from agentclaw.community.core.devices.services.device_service import (
     DeviceService,
 )
 from agentclaw.community.core.devices.services.device_service_router import DeviceServiceRouter
+from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.local_device_accessor import LocalDeviceAccessor
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.notify.protocol import NotifyBotLister
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
@@ -57,6 +59,7 @@ from agentclaw.community.core.workspace.path_factory import _get_aidesktop_root
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import DeviceAdapterTransport
 from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
+from agentclaw.community.plugins.local.local_device_lifecycle import LocalDeviceLifecycle
 
 
 logger = get_logger()
@@ -65,7 +68,7 @@ logger = get_logger()
 class TestDevicesModule(Module):
     """Corp-free SQLite + local-mode overrides for devices (test / singlebox)."""
 
-    def configure(self, binder) -> None:
+    def configure(self, binder: Binder) -> None:
         """Rebind the prod Moltis ``DeviceConnectionManagerPlugin`` to the Noop.
 
         ``DevicesModule`` unconditionally binds the prod Moltis impl; local/SQLite
@@ -84,6 +87,9 @@ class TestDevicesModule(Module):
             to=NoopDeviceConnectionManagerPlugin,
             scope=singleton,
         )
+        binder.bind(LocalDeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
+        binder.bind(DeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
+        binder.bind(LocalDeviceLifecycle, to=LocalDeviceLifecycle, scope=singleton)
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/modules/testing_skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/testing_skill_center_module.py
@@ -9,24 +9,18 @@ Service constructors run unchanged from :class:`SkillCenterModule`; the
 OSS upload dependency they require is satisfied by a
 :class:`MockObjectStoragePlugin` bound here.
 
-NOTE: ``DeviceAccessor`` and ``SkillRepoSyncPlugin`` are arguably
-infrastructure (Local vs Arca) rather than skill_center bindings. In
-practice all current call sites have these aligned with the profile, so
-they're bundled into this ``test`` / ``singlebox`` module. They move to
-their own per-concern modules when the device/skill clusters decompose
-(B6 / B7).
+``DeviceAccessor`` and device lifecycle bindings live in the profile's device
+module. Keeping them out of this shared module lets ``test`` use the local
+device double while ``singlebox`` uses the real local BaaS runtime.
 """
 from __future__ import annotations
 
 
-from injector import Binder, Module, inject, provider, singleton
+from injector import Binder, Module, provider, singleton
 
 from agentclaw.community.log import get_logger
-from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
 from agentclaw.community.plugin_api.object_storage import ObjectStoragePlugin
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
-from agentclaw.community.core.devices.services.local_device_accessor import LocalDeviceAccessor
-from agentclaw.community.plugins.local.local_device_lifecycle import LocalDeviceLifecycle
 from agentclaw.community.plugins.local.oss_storage import MockObjectStoragePlugin
 
 logger = get_logger()
@@ -57,16 +51,6 @@ class TestingSkillCenterModule(Module):
             scope=singleton,
         )
 
-        # Bind LocalDeviceAccessor to itself as a singleton; the
-        # device_plugin() provider below resolves the same instance to bind as
-        # the DeviceAccessor Protocol.
-        binder.bind(LocalDeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
-        # The singlebox device boot/shutdown Lifecycle is a standalone
-        # ``plugins/local`` participant (B9 split — it drives other local
-        # plugins, so it can't live in ``core`` with the accessor). Bind it as a
-        # singleton so ``discover_lifecycle_participants`` finds it.
-        binder.bind(LocalDeviceLifecycle, to=LocalDeviceLifecycle, scope=singleton)
-
     # SkillRepository / SkillSetRepository are no longer overridden:
     # the unified repositories (bound in SkillCenterModule) are a
     # faithful prod port that runs on SQLite too — they only need the
@@ -79,26 +63,6 @@ class TestingSkillCenterModule(Module):
     # SkillCategoryRepository is no longer overridden: the unified
     # repository (bound in SkillCenterModule) runs on SQLite too — it only
     # needs the SQLite DatabasePlugin injected. One impl, both runtimes.
-
-    @singleton
-    @provider
-    @inject
-    def device_plugin(
-        self,
-        local_plugin: LocalDeviceAccessor,
-    ) -> DeviceAccessor:
-        """Local ``DeviceAccessor`` — binding 直绑 ``LocalDeviceAccessor``。
-
-        Local 模式下只有 ``LocalDeviceAccessor`` 一种实现,业务 caller 走
-        :class:`DeviceContextResolver` + 各 ConnInfoBuilder,不再依赖
-        provider 分流。
-
-        ``local_plugin`` 是 ``configure()`` 中绑定的同一 singleton 实例,
-        injecting it here (rather than constructing inline) ensures
-        ``discover_lifecycle_participants`` returns one instance.
-        """
-        logger.info("[NEW-ARCH] DeviceAccessor: LocalDeviceAccessor (testing override)")
-        return local_plugin
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/profile_modules.py
+++ b/src/backend/src/agentclaw/community/di/profile_modules.py
@@ -139,14 +139,6 @@ def modules_for(profile: DeployProfile) -> list[Module]:
             # App services — corp-free test module: real BotChatService, local_sql
             # router, dummy Dima config, community no-op code-platform (AntCode).
             TestAppServicesModule(),
-            # Devices — corp-free local/SQLite doubles (no ARCA factory / corp config).
-            # Installed LAST on purpose: ``CommunityDeviceSyncModule`` also binds
-            # ``DeviceAdapterTransport`` to the community no-op, but the test column
-            # needs the stateful ``InMemoryDeviceAdapterTransport`` (cron gateway
-            # contract tests). Injector is last-wins, so ``TestDevicesModule`` must
-            # come after ``CommunityDeviceSyncModule`` to reinstate the in-memory
-            # transport.
-            TestDevicesModule(),
         ]
 
         if profile is DeployProfile.TEST:
@@ -154,13 +146,16 @@ def modules_for(profile: DeployProfile) -> list[Module]:
                 TestHttpClientModule,
             )
 
-            column.append(TestHttpClientModule())
+            column.extend([TestDevicesModule(), TestHttpClientModule()])
         else:
             from agentclaw.community.di.modules.singlebox_access_module import (
                 SingleboxAccessModule,
             )
+            from agentclaw.community.di.modules.infrastructure.singlebox.devices import (
+                SingleboxDevicesModule,
+            )
 
-            column.append(SingleboxAccessModule())
+            column.extend([SingleboxDevicesModule(), SingleboxAccessModule()])
 
         return column
 

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -175,6 +175,11 @@
       ],
       "storage_dir": "./data/skills_scan"
     },
+    "task_queue_worker": {
+      "enabled": true,
+      "poll_interval_seconds": 0.2,
+      "poll_jitter_seconds": 0.0
+    },
     "token_exchange": {
       "agent_id": "singlebox_AGENT_LOCAL",
       "api_path": "/api/v1/login/token/exchange",
@@ -302,11 +307,11 @@
     },
     "task_queue_worker": {
       "batch_size": 10,
-      "enabled": false,
+      "enabled": true,
       "lease_seconds": 60,
       "max_concurrency": 10,
-      "poll_interval_seconds": 2.0,
-      "poll_jitter_seconds": 0.5,
+      "poll_interval_seconds": 0.2,
+      "poll_jitter_seconds": 0.0,
       "retry_backoff_max_seconds": 60.0,
       "retry_backoff_min_seconds": 1.0
     },

--- a/src/backend/tests/community/di/test_profile_and_modules_for.py
+++ b/src/backend/tests/community/di/test_profile_and_modules_for.py
@@ -3,6 +3,7 @@
 Asserts the additive mechanism reproduces today's per-profile module sets
 and that the mandatory switch errors out on unset / unknown values.
 """
+
 from __future__ import annotations
 
 from typing import Annotated
@@ -11,6 +12,22 @@ import pytest
 from injector import Injector
 
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.services.teclaw_status_reconciler import (
+    TeclawStatusReconciler,
+)
+from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.core.devices.services.baas_device_accessor import (
+    BaasDeviceAccessor,
+)
+from agentclaw.community.core.devices.services.baas_device_service import (
+    BaasDeviceService,
+)
+from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.device_service import DeviceService
+from agentclaw.community.core.devices.services.device_service_router import (
+    DeviceServiceRouter,
+)
 from agentclaw.community.core.access.services.policy_service import PolicyService
 from agentclaw.community.di.container import build_injector
 from agentclaw.community.di.modules.http_client_module import HttpClientModule
@@ -19,6 +36,8 @@ from agentclaw.community.di.modules.infrastructure.test.http_client import (
 )
 from agentclaw.community.di.profile import DeployProfile, validate_deploy_environment
 from agentclaw.community.di.profile_modules import modules_for
+from agentclaw.community.core.service_bot.services.baas_service import BaasService
+from agentclaw.community.kernel.lifecycle import discover_lifecycle_participants
 from agentclaw.community.plugin_api.http_client import (
     QUALIFIER_BAAS,
     QUALIFIER_BCN,
@@ -86,9 +105,7 @@ def test_detect_parses_value(monkeypatch, raw, expected):
     ["SERVER_ENV", "REAL_SERVER_ENV", "ALIPAY_APP_ENV"],
 )
 def test_legacy_singlebox_env_is_rejected(key):
-    with pytest.raises(
-        RuntimeError, match="DEPLOY_PROFILE=singlebox SERVER_ENV=dev"
-    ):
+    with pytest.raises(RuntimeError, match="DEPLOY_PROFILE=singlebox SERVER_ENV=dev"):
         validate_deploy_environment({key: "singlebox"})
 
 
@@ -158,15 +175,19 @@ def test_test_and_singlebox_have_explicit_access_and_http_bindings():
     legacy_access_module = "Testing" + "AccessModule"
 
     assert "TestHttpClientModule" in test_names
+    assert "TestDevicesModule" in test_names
+    assert "SingleboxDevicesModule" not in test_names
     assert "SingleboxAccessModule" not in test_names
     assert legacy_access_module not in test_names
 
     assert "SingleboxAccessModule" in singlebox_names
     assert "TestHttpClientModule" not in singlebox_names
+    assert "SingleboxDevicesModule" in singlebox_names
+    assert "TestDevicesModule" not in singlebox_names
     assert legacy_access_module not in singlebox_names
 
-    assert test_names - {"TestHttpClientModule"} == (
-        singlebox_names - {"SingleboxAccessModule"}
+    assert test_names - {"TestHttpClientModule", "TestDevicesModule"} == (
+        singlebox_names - {"SingleboxAccessModule", "SingleboxDevicesModule"}
     )
 
 
@@ -185,9 +206,49 @@ def test_singlebox_profile_resolves_local_policy_and_real_http_clients():
 
     assert isinstance(injector.get(PolicyServiceProtocol), LocalPolicyService)
     assert all(
-        isinstance(client, HttpxClient)
-        for client in _resolve_http_clients(injector)
+        isinstance(client, HttpxClient) for client in _resolve_http_clients(injector)
     )
+
+
+def test_singlebox_profile_resolves_baas_only_device_runtime():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+
+    service = injector.get(DeviceService)
+    assert isinstance(service, DeviceServiceRouter)
+    assert set(service._providers) == {"baas"}
+    assert isinstance(service._providers["baas"], BaasDeviceService)
+    assert isinstance(injector.get(DeviceAccessor), BaasDeviceAccessor)
+    participant_names = {
+        type(participant).__name__
+        for participant in discover_lifecycle_participants(injector)
+    }
+    assert "SingleboxBaasTemplateConfigLifecycle" in participant_names
+    assert "LocalDeviceLifecycle" not in participant_names
+
+
+def test_singlebox_rollout_policy_preserves_normalized_engine_bucket():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+    service = injector.get(DeviceService)
+
+    decision = service._arca_baas_rollout_policy.decide(
+        user_id="owner",
+        bot_type="personal",
+        engine_type="claude-code",
+        template_type="personalCoding",
+    )
+
+    assert decision.target_provider == "baas"
+    assert decision.engine_bucket == "aicoding"
+
+
+def test_singlebox_reconciler_uses_real_dependencies_with_noop_scheduler():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+
+    reconciler = injector.get(TeclawStatusReconciler)
+
+    assert reconciler._baas is injector.get(BaasService)
+    assert reconciler._bot_repository is injector.get(BotRepository)
+    assert reconciler._device_binding_repo is injector.get(DeviceBindingRepository)
 
 
 def test_test_http_override_wins_when_installed_after_base():

--- a/src/backend/tests/community/di/test_singlebox_baas_template_config.py
+++ b/src/backend/tests/community/di/test_singlebox_baas_template_config.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentclaw.community.di.modules.infrastructure.singlebox.template_config import (
+    SingleboxBaasTemplateConfigLifecycle,
+)
+
+
+@pytest.mark.asyncio
+async def test_seeds_singlebox_baas_template_mapping():
+    config_service = MagicMock()
+    config_service.get_config.return_value = None
+    config_service.set_config.return_value = 7
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid="TEMPLATE-local",
+    )
+
+    with patch(
+        "agentclaw.community.di.modules.infrastructure.singlebox.template_config."
+        "env_utils.get_current_env",
+        return_value="dev",
+    ):
+        await lifecycle.startup()
+
+    mapping = config_service.set_config.call_args.kwargs["config_value"]
+    assert mapping["templates"]["local_default"]["template_uuid"] == ("TEMPLATE-local")
+    assert {item["engine"] for item in mapping["selectors"]} == {
+        "openclaw",
+        "moltis",
+        "hermes",
+        "aicoding",
+        "claude_code",
+    }
+    assert config_service.set_config.call_args.kwargs["env"] == "dev"
+
+
+@pytest.mark.asyncio
+async def test_preserves_existing_singlebox_baas_template_mapping():
+    config_service = MagicMock()
+    config_service.get_config.return_value = {"version": "custom"}
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid="TEMPLATE-local",
+    )
+
+    await lifecycle.startup()
+
+    config_service.create_category.assert_not_called()
+    config_service.set_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_template_uuid_fails_with_clear_startup_error():
+    config_service = MagicMock()
+    config_service.get_config.return_value = None
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid=None,
+    )
+
+    with pytest.raises(RuntimeError, match="baas.template_uuid"):
+        await lifecycle.startup()


### PR DESCRIPTION
## Summary

- give `singlebox` a dedicated device DI module backed only by `BaasDeviceService`
- persist `device_provider=baas` while keeping `DEPLOY_PROFILE=singlebox` and `SERVER_ENV=dev` independent
- seed the local BaaS template routing map and enable the durable task worker
- keep `LocalDeviceAccessor` / `LocalDeviceLifecycle` scoped to the unit-test profile

This is a stacked prerequisite for #62 and currently targets #93 (`codex/profile-env-separation`).

## Design

See `docs/superpowers/specs/2026-07-11-singlebox-baas-device-provider.md`.

## Verification

- Backend CI: 7373 passed; case pass rate 100%; line coverage 81.77%
- focused device/DI/config/lifecycle regression: 862 passed
- real `scripts/singlebox.sh start all`: BAAS, Backend, BCS, 5 bots, demo bot, and Frontend ready
- direct health checks: Backend/BAAS/BCS healthy; Frontend HTTP 200
- SQLite binding: `device_provider=baas`, `env=dev`, `status=ACTIVE`
- task queue: `baas.create.publish_poll` and `baas.create.init` both `SUCCEEDED`

Please review the profile/device ownership boundary, especially the separation of Profile, Env, and persisted Provider.
