### PR TITLE
feat(channel): report IM processing failures

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -169,7 +169,7 @@ impl ChannelService for DisabledChannelService {
     async fn handle_inbound(
         &self,
         _msg: bcs_service_api::application::channel::InboundMessage,
-    ) -> std::result::Result<(), bcs_service_api::application::channel::ChannelUseCaseError> {
+    ) -> std::result::Result<(), bcs_service_api::application::channel::ChannelInboundError> {
         Ok(())
     }
 

--- a/src/bcs/crates/plugin-api/bcs-channel-api/src/lib.rs
+++ b/src/bcs/crates/plugin-api/bcs-channel-api/src/lib.rs
@@ -214,6 +214,7 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
+    use bcs_service_api::application::ChannelInboundFailureKind;
     use bcs_service_api::port::channel_delivery::{
         ChannelBindingRef, ChannelDeliveryPort, ChannelDeliveryResult, ChannelOutboundEvent,
     };
@@ -272,6 +273,18 @@ mod tests {
         async fn submit(&self, _msg: InboundMessage) -> Result<(), ChannelIngressError> {
             Ok(())
         }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn legacy_ingress_error_constructors_map_to_typed_contract() {
+        let invalid = ChannelIngressError::InvalidMessage("missing text".to_string());
+        let service = ChannelIngressError::Service("dispatch unavailable".to_string());
+
+        assert_eq!(invalid.kind, ChannelInboundFailureKind::InvalidInbound);
+        assert!(!invalid.retryable);
+        assert_eq!(service.kind, ChannelInboundFailureKind::Internal);
+        assert!(service.retryable);
     }
 
     struct TestProvider;

--- a/src/bcs/crates/plugin-api/bcs-channel-api/src/lib.rs
+++ b/src/bcs/crates/plugin-api/bcs-channel-api/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bcs_service_api::application::InboundMessage;
+use bcs_service_api::application::{ChannelInboundError, InboundMessage};
 use bcs_service_api::lifecycle::ServiceLifecycle;
 use bcs_service_api::port::channel_delivery::ChannelDeliveryPort;
 use bytes::Bytes;
@@ -16,6 +16,9 @@ use thiserror::Error;
 
 /// Provider-facing result type.
 pub type ChannelProviderResult<T> = Result<T, ChannelProviderError>;
+
+/// Compatibility alias for plugins compiled against the previous ingress error name.
+pub type ChannelIngressError = ChannelInboundError;
 
 /// Provider contract failures.
 #[derive(Debug, Error)]
@@ -109,15 +112,6 @@ pub trait ChannelHttpIngressPort: Send + Sync {
 #[async_trait]
 pub trait ChannelInboundSink: Send + Sync {
     async fn submit(&self, msg: InboundMessage) -> Result<(), ChannelIngressError>;
-}
-
-/// Ingress submission failure.
-#[derive(Debug, Error)]
-pub enum ChannelIngressError {
-    #[error("invalid channel ingress message: {0}")]
-    InvalidMessage(String),
-    #[error("channel ingress service error: {0}")]
-    Service(String),
 }
 
 /// Provider HTTP route dispatcher built by the host from enabled providers.

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -62,6 +62,20 @@ impl std::fmt::Debug for ChannelInboundError {
 }
 
 impl ChannelInboundError {
+    #[doc(hidden)]
+    #[deprecated(note = "Use ChannelInboundError::new with InvalidInbound instead")]
+    #[allow(non_snake_case)]
+    pub fn InvalidMessage(diagnostic: String) -> Self {
+        Self::new(ChannelInboundFailureKind::InvalidInbound, false, diagnostic)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note = "Use ChannelInboundError::new with a typed failure kind instead")]
+    #[allow(non_snake_case)]
+    pub fn Service(diagnostic: String) -> Self {
+        Self::new(ChannelInboundFailureKind::Internal, true, diagnostic)
+    }
+
     pub fn new(
         kind: ChannelInboundFailureKind,
         retryable: bool,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -44,12 +44,21 @@ pub enum ChannelInboundFailureKind {
 }
 
 /// Typed failure returned while processing normalized channel inbound messages.
-#[derive(Debug, thiserror::Error)]
-#[error("channel inbound {kind:?}: {diagnostic}")]
+#[derive(thiserror::Error)]
+#[error("channel inbound {kind:?} (retryable={retryable})")]
 pub struct ChannelInboundError {
     pub kind: ChannelInboundFailureKind,
     pub retryable: bool,
-    pub diagnostic: String,
+    diagnostic: String,
+}
+
+impl std::fmt::Debug for ChannelInboundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChannelInboundError")
+            .field("kind", &self.kind)
+            .field("retryable", &self.retryable)
+            .finish()
+    }
 }
 
 impl ChannelInboundError {
@@ -63,6 +72,11 @@ impl ChannelInboundError {
             retryable,
             diagnostic: diagnostic.into(),
         }
+    }
+
+    /// Returns diagnostic context intended only for structured logs and telemetry.
+    pub fn diagnostic_for_logging(&self) -> &str {
+        &self.diagnostic
     }
 }
 
@@ -146,7 +160,7 @@ mod tests {
     use super::{ChannelInboundError, ChannelInboundFailureKind};
 
     #[test]
-    fn inbound_error_preserves_failure_kind_retryability_and_diagnostic() {
+    fn inbound_error_exposes_diagnostic_only_for_logging() {
         let error = ChannelInboundError::new(
             ChannelInboundFailureKind::ActorResolutionFailed,
             true,
@@ -155,6 +169,14 @@ mod tests {
 
         assert_eq!(error.kind, ChannelInboundFailureKind::ActorResolutionFailed);
         assert!(error.retryable);
-        assert!(error.diagnostic.contains("actor write failed"));
+        assert_eq!(error.diagnostic_for_logging(), "actor write failed");
+        assert_eq!(
+            error.to_string(),
+            "channel inbound ActorResolutionFailed (retryable=true)"
+        );
+        assert_eq!(
+            format!("{error:?}"),
+            "ChannelInboundError { kind: ActorResolutionFailed, retryable: true }"
+        );
     }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -30,6 +30,42 @@ impl From<ServiceError> for ChannelUseCaseError {
     }
 }
 
+/// Failure category for normalized channel inbound processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelInboundFailureKind {
+    InvalidInbound,
+    BindingNotFound,
+    BindingLookupFailed,
+    ActorResolutionFailed,
+    ContextResolutionFailed,
+    SessionResolutionFailed,
+    DispatchFailed,
+    Internal,
+}
+
+/// Typed failure returned while processing normalized channel inbound messages.
+#[derive(Debug, thiserror::Error)]
+#[error("channel inbound {kind:?}: {diagnostic}")]
+pub struct ChannelInboundError {
+    pub kind: ChannelInboundFailureKind,
+    pub retryable: bool,
+    pub diagnostic: String,
+}
+
+impl ChannelInboundError {
+    pub fn new(
+        kind: ChannelInboundFailureKind,
+        retryable: bool,
+        diagnostic: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            retryable,
+            diagnostic: diagnostic.into(),
+        }
+    }
+}
+
 /// 一条入站 IM 消息(已由 adapter 从 IM 原生 body 解析为中性结构)。
 #[derive(Debug, Clone)]
 pub struct InboundMessage {
@@ -83,8 +119,8 @@ pub struct OutboundMessage {
 pub trait ChannelService: Send + Sync {
     /// 入站:解析 binding → 确保 Human actor → 按 group strategy 分流:
     /// Chat 型 session 调 MessageFlowService,StateMachine 触发 runtime task。
-    /// 错误内部处理,不让回调 handler 失败。
-    async fn handle_inbound(&self, msg: InboundMessage) -> Result<(), ChannelUseCaseError>;
+    /// Errors are classified for the delivery adapter to provide actionable feedback.
+    async fn handle_inbound(&self, msg: InboundMessage) -> Result<(), ChannelInboundError>;
 
     /// 出站 hook:若 session 绑定了 channel 会话且可见性允许,则投递到 IM。
     /// 无绑定 / 不可见 / 来自 IM(防回环)→ no-op。
@@ -103,4 +139,22 @@ pub trait ChannelService: Send + Sync {
         config: serde_json::Value,
     ) -> Result<(), ChannelUseCaseError>;
     async fn delete_binding(&self, id: &str) -> Result<(), ChannelUseCaseError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ChannelInboundError, ChannelInboundFailureKind};
+
+    #[test]
+    fn inbound_error_preserves_failure_kind_retryability_and_diagnostic() {
+        let error = ChannelInboundError::new(
+            ChannelInboundFailureKind::ActorResolutionFailed,
+            true,
+            "actor write failed",
+        );
+
+        assert_eq!(error.kind, ChannelInboundFailureKind::ActorResolutionFailed);
+        assert!(error.retryable);
+        assert!(error.diagnostic.contains("actor write failed"));
+    }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -32,7 +32,8 @@ pub use actors::{
 };
 pub use application::SystemMessageService;
 pub use application::channel::{
-    ChannelService, ChannelUseCaseError, CreateBindingCommand, InboundMessage, OutboundMessage,
+    ChannelInboundError, ChannelInboundFailureKind, ChannelService, ChannelUseCaseError,
+    CreateBindingCommand, InboundMessage, OutboundMessage,
 };
 pub use application::message_log::{
     MessageLogContent, MessageLogEventType, MessageLogMode, MessageLogStatus,

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -33,8 +33,8 @@ use bcs_service_api::port::repo::{
     SessionRepoPort,
 };
 use bcs_service_api::{
-    BotRegistryCoreService, CollaborationRuntimeService, GroupCoreService, MessageFlowService,
-    ServiceError,
+    BotRegistryCoreService, ChannelOutboundEventKind, CollaborationRuntimeService,
+    GroupCoreService, MessageFlowService, ServiceError,
 };
 
 pub use visibility::visibility_allows;
@@ -738,7 +738,13 @@ impl ChannelService for BcsChannelService {
             if !binding_relevant_to_group(&binding, &msg.group_id, &session) {
                 continue;
             }
-            if !visibility_allows(group.group_strategy, binding.outbound_visibility, msg.sender_role) {
+            if msg.kind != ChannelOutboundEventKind::System
+                && !visibility_allows(
+                    group.group_strategy,
+                    binding.outbound_visibility,
+                    msg.sender_role,
+                )
+            {
                 continue;
             }
             let binding_ref = ChannelBindingRef {
@@ -2857,6 +2863,60 @@ mod tests {
             ))
             .await?;
         assert_eq!(harness.delivery.events.lock().await.len(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn try_outbound_system_bypasses_visibility_for_synthetic_sender() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        harness
+            .binding_repo
+            .create(active_binding(
+                "binding_1",
+                "robot_1",
+                BindingTarget::Group {
+                    group_id: "group_1".to_string(),
+                },
+                Visibility::LeadOnly,
+            ))
+            .await?;
+        harness
+            .session_repo
+            .create(
+                "group_1",
+                NewSessionParams {
+                    id: Some("group_1:00000001".to_string()),
+                    session_kind: SessionKind::Chat,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        harness
+            .conversation_repo
+            .upsert(bcs_domain::ConversationSessionMap {
+                binding_id: "binding_1".to_string(),
+                im_conversation_id: "conv_a".to_string(),
+                im_conversation_type: "2".to_string(),
+                session_scope: SessionScope::Conversation,
+                im_user_id: None,
+                bcs_session_id: "group_1:00000001".to_string(),
+                last_active_at: 1,
+            })
+            .await?;
+
+        let mut msg = outbound(
+            "group_1:00000001",
+            ParticipantRole::Observer,
+            false,
+        );
+        msg.kind = ChannelOutboundEventKind::System;
+        harness.service.try_outbound(msg).await?;
+
+        let events = harness.delivery.events.lock().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].im_conversation_id, "conv_a");
+        assert_eq!(events[0].kind, ChannelOutboundEventKind::System);
 
         Ok(())
     }

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -428,6 +428,9 @@ impl ChannelService for BcsChannelService {
         &self,
         mut msg: InboundMessage,
     ) -> Result<(), ChannelInboundError> {
+        msg.conversation_type = normalize_required(&msg.conversation_type, "conversation_type")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
         if msg.conversation_type == "2" && !msg.is_at_bot {
             info!(
                 channel_type = %msg.channel_type,
@@ -444,10 +447,12 @@ impl ChannelService for BcsChannelService {
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %msg.account_ref,
-                reason = "empty_msg_id",
-                "channel inbound: ignored"
+                reason = "invalid_empty_msg_id",
+                "channel inbound: rejected"
             );
-            return Ok(());
+            return Err(invalid_inbound(ChannelUseCaseError::InvalidParams(
+                "msg_id must not be empty".to_string(),
+            )));
         }
         msg.channel_type = normalize_required(&msg.channel_type, "channel_type")
             .map_err(|error| invalid_inbound(error))?
@@ -456,9 +461,6 @@ impl ChannelService for BcsChannelService {
             .map_err(|error| invalid_inbound(error))?
             .to_string();
         msg.im_conversation_id = normalize_required(&msg.im_conversation_id, "im_conversation_id")
-            .map_err(|error| invalid_inbound(error))?
-            .to_string();
-        msg.conversation_type = normalize_required(&msg.conversation_type, "conversation_type")
             .map_err(|error| invalid_inbound(error))?
             .to_string();
         msg.im_user_id = normalize_required(&msg.im_user_id, "im_user_id")
@@ -544,7 +546,7 @@ impl ChannelService for BcsChannelService {
                 .map_err(|error| {
                     inbound_failure(
                         ChannelInboundFailureKind::ContextResolutionFailed,
-                        true,
+                        false,
                         error,
                     )
                 })?;
@@ -1600,7 +1602,7 @@ mod tests {
     ) {
         assert_eq!(error.kind, kind);
         assert_eq!(error.retryable, retryable);
-        assert!(error.diagnostic.contains(diagnostic));
+        assert!(error.diagnostic_for_logging().contains(diagnostic));
     }
 
     #[tokio::test]
@@ -2238,10 +2240,24 @@ mod tests {
         assert!(harness.registry.ensured.lock().await.is_empty());
         assert!(harness.message_flow.web_sends.lock().await.is_empty());
 
-        harness
+        let mut whitespace_group =
+            group_inbound("conv_group", "u1", Some("张三"), "msg_whitespace", false);
+        whitespace_group.conversation_type = " 2 ".to_string();
+        harness.service.handle_inbound(whitespace_group).await?;
+        assert!(harness.registry.ensured.lock().await.is_empty());
+        assert!(harness.message_flow.web_sends.lock().await.is_empty());
+
+        let error = harness
             .service
             .handle_inbound(group_inbound("conv_group", "u1", Some("张三"), " ", true))
-            .await?;
+            .await
+            .expect_err("empty message id must be rejected");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::InvalidInbound,
+            false,
+            "msg_id",
+        );
         assert!(harness.registry.ensured.lock().await.is_empty());
         assert!(harness.message_flow.web_sends.lock().await.is_empty());
 
@@ -2295,6 +2311,64 @@ mod tests {
             ChannelInboundFailureKind::BindingLookupFailed,
             true,
             "binding lookup failed",
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn inbound_classifies_invalid_input_and_context_resolution_failure() -> TestResult {
+        let invalid_input = inbound_service(
+            Arc::new(MemoryChannelBindingRepo::new()),
+            Arc::new(MemoryImParticipantRepo::new()),
+            Arc::new(RecordingSessionRepo::default()),
+            Arc::new(RecordingMessageFlow::default()),
+            Arc::new(RecordingRegistry::default()),
+        )
+        .await;
+        let mut invalid_message = inbound("conv_invalid", "u1", Some("张三"), "msg_invalid");
+        invalid_message.account_ref = " ".to_string();
+
+        let error = invalid_input
+            .handle_inbound(invalid_message)
+            .await
+            .expect_err("missing account reference must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::InvalidInbound,
+            false,
+            "account_ref",
+        );
+
+        let bindings = Arc::new(MemoryChannelBindingRepo::new());
+        bindings
+            .create(active_binding(
+                "binding_context",
+                "robot_1",
+                BindingTarget::Group {
+                    group_id: "missing_group".to_string(),
+                },
+                Visibility::FullTranscript,
+            ))
+            .await?;
+        let context_failure = inbound_service(
+            bindings,
+            Arc::new(MemoryImParticipantRepo::new()),
+            Arc::new(RecordingSessionRepo::default()),
+            Arc::new(RecordingMessageFlow::default()),
+            Arc::new(RecordingRegistry::default()),
+        )
+        .await;
+
+        let error = context_failure
+            .handle_inbound(inbound("conv_context", "u1", Some("张三"), "msg_context"))
+            .await
+            .expect_err("missing bound group must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::ContextResolutionFailed,
+            false,
+            "missing_group",
         );
 
         Ok(())

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -443,17 +443,9 @@ impl ChannelService for BcsChannelService {
             );
             return Ok(());
         }
-        if msg.msg_id.trim().is_empty() {
-            info!(
-                channel_type = %msg.channel_type,
-                account_ref = %msg.account_ref,
-                reason = "invalid_empty_msg_id",
-                "channel inbound: rejected"
-            );
-            return Err(invalid_inbound(ChannelUseCaseError::InvalidParams(
-                "msg_id must not be empty".to_string(),
-            )));
-        }
+        msg.msg_id = normalize_required(&msg.msg_id, "msg_id")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
         msg.channel_type = normalize_required(&msg.channel_type, "channel_type")
             .map_err(|error| invalid_inbound(error))?
             .to_string();
@@ -464,9 +456,6 @@ impl ChannelService for BcsChannelService {
             .map_err(|error| invalid_inbound(error))?
             .to_string();
         msg.im_user_id = normalize_required(&msg.im_user_id, "im_user_id")
-            .map_err(|error| invalid_inbound(error))?
-            .to_string();
-        msg.msg_id = normalize_required(&msg.msg_id, "msg_id")
             .map_err(|error| invalid_inbound(error))?
             .to_string();
         let account_ref = msg.account_ref.clone();

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use bcs_channel_api::{
-    ChannelInboundSink, ChannelIngressError, ChannelProvider, ChannelProviderRegistry,
+    ChannelInboundSink, ChannelProvider, ChannelProviderRegistry,
 };
 use bcs_domain::{
     ActorKind, BindingStatus, BindingTarget, ChannelBinding, ConversationSessionMap,
@@ -18,7 +18,8 @@ use bcs_domain::{
     ParticipantRole, Session, SessionKind, SessionScope, SessionStatus, Visibility,
 };
 use bcs_service_api::application::channel::{
-    ChannelService, ChannelUseCaseError, CreateBindingCommand, InboundMessage, OutboundMessage,
+    ChannelInboundError, ChannelInboundFailureKind, ChannelService, ChannelUseCaseError,
+    CreateBindingCommand, InboundMessage, OutboundMessage,
 };
 use bcs_service_api::application::collaboration_runtime::StartStateMachineRunCommand;
 use bcs_service_api::application::message_flow::WebSendCommand;
@@ -423,8 +424,50 @@ impl BcsChannelService {
 
 #[async_trait]
 impl ChannelService for BcsChannelService {
-    async fn handle_inbound(&self, msg: InboundMessage) -> Result<(), ChannelUseCaseError> {
-        let account_ref = msg.account_ref.trim().to_string();
+    async fn handle_inbound(
+        &self,
+        mut msg: InboundMessage,
+    ) -> Result<(), ChannelInboundError> {
+        if msg.conversation_type == "2" && !msg.is_at_bot {
+            info!(
+                channel_type = %msg.channel_type,
+                account_ref = %msg.account_ref,
+                msg_id = %msg.msg_id,
+                im_conversation_id = %msg.im_conversation_id,
+                conversation_type = %msg.conversation_type,
+                reason = "group_message_without_at_bot",
+                "channel inbound: ignored"
+            );
+            return Ok(());
+        }
+        if msg.msg_id.trim().is_empty() {
+            info!(
+                channel_type = %msg.channel_type,
+                account_ref = %msg.account_ref,
+                reason = "empty_msg_id",
+                "channel inbound: ignored"
+            );
+            return Ok(());
+        }
+        msg.channel_type = normalize_required(&msg.channel_type, "channel_type")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
+        msg.account_ref = normalize_required(&msg.account_ref, "account_ref")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
+        msg.im_conversation_id = normalize_required(&msg.im_conversation_id, "im_conversation_id")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
+        msg.conversation_type = normalize_required(&msg.conversation_type, "conversation_type")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
+        msg.im_user_id = normalize_required(&msg.im_user_id, "im_user_id")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
+        msg.msg_id = normalize_required(&msg.msg_id, "msg_id")
+            .map_err(|error| invalid_inbound(error))?
+            .to_string();
+        let account_ref = msg.account_ref.clone();
         info!(
             channel_type = %msg.channel_type,
             account_ref = %account_ref,
@@ -436,50 +479,26 @@ impl ChannelService for BcsChannelService {
             text_len = msg.text.chars().count(),
             "channel inbound: received"
         );
-        if account_ref.is_empty() {
-            info!(
-                channel_type = %msg.channel_type,
-                msg_id = %msg.msg_id,
-                reason = "empty_account_ref",
-                "channel inbound: ignored"
-            );
-            return Ok(());
-        }
-        if msg.msg_id.trim().is_empty() {
-            info!(
-                channel_type = %msg.channel_type,
-                account_ref = %account_ref,
-                reason = "empty_msg_id",
-                "channel inbound: ignored"
-            );
-            return Ok(());
-        }
-        if msg.conversation_type == "2" && !msg.is_at_bot {
-            info!(
-                channel_type = %msg.channel_type,
-                account_ref = %account_ref,
-                msg_id = %msg.msg_id,
-                im_conversation_id = %msg.im_conversation_id,
-                conversation_type = %msg.conversation_type,
-                reason = "group_message_without_at_bot",
-                "channel inbound: ignored"
-            );
-            return Ok(());
-        }
         let Some(binding) = self
             .bindings
             .find_active_by_account(msg.channel_type.clone(), &account_ref)
-            .await?
+            .await
+            .map_err(|error| {
+                inbound_failure(
+                    ChannelInboundFailureKind::BindingLookupFailed,
+                    true,
+                    error,
+                )
+            })?
         else {
-            info!(
-                channel_type = %msg.channel_type,
-                account_ref = %account_ref,
-                msg_id = %msg.msg_id,
-                im_conversation_id = %msg.im_conversation_id,
-                reason = "binding_missing",
-                "channel inbound: ignored"
-            );
-            return Ok(());
+            return Err(ChannelInboundError::new(
+                ChannelInboundFailureKind::BindingNotFound,
+                false,
+                format!(
+                    "active binding not found for channel {} account {}",
+                    msg.channel_type, account_ref
+                ),
+            ));
         };
         info!(
             channel_type = %binding.channel_type,
@@ -504,7 +523,13 @@ impl ChannelService for BcsChannelService {
         }
 
         let result = async {
-            let actor_id = self.ensure_im_human_actor(&msg).await?;
+            let actor_id = self.ensure_im_human_actor(&msg).await.map_err(|error| {
+                inbound_failure(
+                    ChannelInboundFailureKind::ActorResolutionFailed,
+                    true,
+                    error,
+                )
+            })?;
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -515,7 +540,14 @@ impl ChannelService for BcsChannelService {
             );
             let ctx = self
                 .resolve_inbound_context(&binding, &msg, &actor_id)
-                .await?;
+                .await
+                .map_err(|error| {
+                    inbound_failure(
+                        ChannelInboundFailureKind::ContextResolutionFailed,
+                        true,
+                        error,
+                    )
+                })?;
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -531,10 +563,22 @@ impl ChannelService for BcsChannelService {
             if ctx.state_machine_trigger {
                 return self
                     .start_state_machine_from_inbound(&ctx, &msg, &actor_id)
-                    .await;
+                    .await
+                    .map_err(|error| {
+                        inbound_failure(ChannelInboundFailureKind::DispatchFailed, true, error)
+                    });
             }
 
-            let (session_id, reused_session) = self.resolve_or_create_chat_session(&ctx, &msg).await?;
+            let (session_id, reused_session) = self
+                .resolve_or_create_chat_session(&ctx, &msg)
+                .await
+                .map_err(|error| {
+                    inbound_failure(
+                        ChannelInboundFailureKind::SessionResolutionFailed,
+                        true,
+                        error,
+                    )
+                })?;
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -556,7 +600,14 @@ impl ChannelService for BcsChannelService {
                     bcs_session_id: session_id.clone(),
                     last_active_at: (self.now_ms)(),
                 })
-                .await?;
+                .await
+                .map_err(|error| {
+                    inbound_failure(
+                        ChannelInboundFailureKind::SessionResolutionFailed,
+                        true,
+                        error,
+                    )
+                })?;
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -570,7 +621,16 @@ impl ChannelService for BcsChannelService {
             let mut participant = Participant::human(actor_id.clone(), ParticipantRole::Consultant);
             participant.mode = Some(ParticipantMode::Present);
             participant.bot_name = msg.im_user_nick.clone();
-            self.sessions.add_participant(&session_id, participant).await?;
+            self.sessions
+                .add_participant(&session_id, participant)
+                .await
+                .map_err(|error| {
+                    inbound_failure(
+                        ChannelInboundFailureKind::SessionResolutionFailed,
+                        true,
+                        error,
+                    )
+                })?;
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -584,7 +644,8 @@ impl ChannelService for BcsChannelService {
             let dispatch_session_id = session_id.clone();
             let dispatch_actor_id = actor_id.clone();
             let dispatch_msg_id = msg.msg_id.clone();
-            self.message_flow
+            let outcome = self
+                .message_flow
                 .handle_web_send(WebSendCommand {
                     caller: CallerContext::Human(HumanActor {
                         actor_id: actor_id.clone(),
@@ -601,7 +662,20 @@ impl ChannelService for BcsChannelService {
                     idempotency_key: Some(dispatch_msg_id.clone()),
                     sender_conn_id: None,
                 })
-                .await?;
+                .await
+                .map_err(|error| {
+                    inbound_failure(ChannelInboundFailureKind::DispatchFailed, true, error)
+                })?;
+            if outcome.active_run_ids.is_empty() && outcome.failed_count > 0 {
+                return Err(ChannelInboundError::new(
+                    ChannelInboundFailureKind::DispatchFailed,
+                    true,
+                    format!(
+                        "message flow reported {} failed deliveries without an active run",
+                        outcome.failed_count
+                    ),
+                ));
+            }
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -914,12 +988,21 @@ impl ChannelServiceInboundSink {
 
 #[async_trait]
 impl ChannelInboundSink for ChannelServiceInboundSink {
-    async fn submit(&self, msg: InboundMessage) -> Result<(), ChannelIngressError> {
-        self.service
-            .handle_inbound(msg)
-            .await
-            .map_err(|error| ChannelIngressError::Service(error.to_string()))
+    async fn submit(&self, msg: InboundMessage) -> Result<(), ChannelInboundError> {
+        self.service.handle_inbound(msg).await
     }
+}
+
+fn invalid_inbound(error: ChannelUseCaseError) -> ChannelInboundError {
+    inbound_failure(ChannelInboundFailureKind::InvalidInbound, false, error)
+}
+
+fn inbound_failure(
+    kind: ChannelInboundFailureKind,
+    retryable: bool,
+    error: impl std::fmt::Display,
+) -> ChannelInboundError {
+    ChannelInboundError::new(kind, retryable, error.to_string())
 }
 
 async fn validate_target(
@@ -1119,8 +1202,8 @@ mod tests {
     };
     use bcs_service_api::lifecycle::ServiceLifecycle;
     use bcs_service_api::application::channel::{
-        ChannelService, ChannelUseCaseError, CreateBindingCommand, InboundMessage,
-        OutboundMessage,
+        ChannelInboundError, ChannelInboundFailureKind, ChannelService, ChannelUseCaseError,
+        CreateBindingCommand, InboundMessage, OutboundMessage,
     };
     use bcs_service_api::application::collaboration_runtime::{
         CancelStateMachineRunCommand, CollaborationRuntimeError, ConfigureGroupRuntimeCommand,
@@ -1199,6 +1282,61 @@ mod tests {
 
         async fn delete(&self, id: &str) -> ServiceResult<()> {
             self.inner.delete(id).await
+        }
+    }
+
+    struct FailingBindingLookupRepo;
+
+    #[async_trait]
+    impl ChannelBindingRepoPort for FailingBindingLookupRepo {
+        async fn create(&self, _binding: ChannelBinding) -> ServiceResult<()> {
+            unreachable!("inbound binding lookup test only calls find_active_by_account")
+        }
+
+        async fn get(&self, _id: &str) -> ServiceResult<Option<ChannelBinding>> {
+            unreachable!("inbound binding lookup test only calls find_active_by_account")
+        }
+
+        async fn find_active_by_account(
+            &self,
+            _channel_type: ChannelType,
+            _account_ref: &str,
+        ) -> ServiceResult<Option<ChannelBinding>> {
+            Err(ServiceError::InternalError("binding lookup failed".to_string()))
+        }
+
+        async fn list(&self) -> ServiceResult<Vec<ChannelBinding>> {
+            unreachable!("inbound binding lookup test only calls find_active_by_account")
+        }
+
+        async fn set_status(&self, _id: &str, _active: bool) -> ServiceResult<()> {
+            unreachable!("inbound binding lookup test only calls find_active_by_account")
+        }
+
+        async fn set_config(&self, _id: &str, _config: serde_json::Value) -> ServiceResult<()> {
+            unreachable!("inbound binding lookup test only calls find_active_by_account")
+        }
+
+        async fn delete(&self, _id: &str) -> ServiceResult<()> {
+            unreachable!("inbound binding lookup test only calls find_active_by_account")
+        }
+    }
+
+    struct FailingParticipantRepo;
+
+    #[async_trait]
+    impl ImParticipantRepoPort for FailingParticipantRepo {
+        async fn get(
+            &self,
+            _channel_type: ChannelType,
+            _account_ref: &str,
+            _im_user_id: &str,
+        ) -> ServiceResult<Option<bcs_domain::ImParticipantMap>> {
+            unreachable!("inbound actor test only writes the participant mapping")
+        }
+
+        async fn upsert(&self, _map: bcs_domain::ImParticipantMap) -> ServiceResult<()> {
+            Err(ServiceError::InternalError("actor write failed".to_string()))
         }
     }
 
@@ -1408,6 +1546,61 @@ mod tests {
                 collaboration_runtime,
             })
         }
+    }
+
+    async fn inbound_service(
+        bindings: Arc<dyn ChannelBindingRepoPort>,
+        im_participants: Arc<dyn ImParticipantRepoPort>,
+        sessions: Arc<dyn SessionRepoPort>,
+        message_flow: Arc<dyn MessageFlowService>,
+        registry: Arc<dyn BotRegistryCoreService>,
+    ) -> BcsChannelService {
+        let groups = Arc::new(bcs_group::GroupCore::memory());
+        groups
+            .upsert(manager_group("group_1"))
+            .await
+            .expect("inbound test group");
+        BcsChannelService::new(
+            bindings,
+            Arc::new(MemoryConversationSessionRepo::new()),
+            im_participants,
+            sessions,
+            message_flow,
+            Arc::new(RecordingCollaborationRuntime::default()),
+            groups,
+            registry,
+            Arc::new(ChannelProviderRegistry::empty()),
+            "pre",
+            Arc::new(|| 42),
+            Arc::new(|| "generated_id".to_string()),
+        )
+    }
+
+    async fn active_inbound_binding_repo() -> Arc<MemoryChannelBindingRepo> {
+        let bindings = Arc::new(MemoryChannelBindingRepo::new());
+        bindings
+            .create(active_binding(
+                "binding_1",
+                "robot_1",
+                BindingTarget::Group {
+                    group_id: "group_1".to_string(),
+                },
+                Visibility::FullTranscript,
+            ))
+            .await
+            .expect("active inbound binding");
+        bindings
+    }
+
+    fn assert_inbound_error(
+        error: ChannelInboundError,
+        kind: ChannelInboundFailureKind,
+        retryable: bool,
+        diagnostic: &str,
+    ) {
+        assert_eq!(error.kind, kind);
+        assert_eq!(error.retryable, retryable);
+        assert!(error.diagnostic.contains(diagnostic));
     }
 
     #[tokio::test]
@@ -2063,6 +2256,143 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inbound_classifies_missing_binding_and_lookup_failure() -> TestResult {
+        let missing_binding = inbound_service(
+            Arc::new(MemoryChannelBindingRepo::new()),
+            Arc::new(MemoryImParticipantRepo::new()),
+            Arc::new(RecordingSessionRepo::default()),
+            Arc::new(RecordingMessageFlow::default()),
+            Arc::new(RecordingRegistry::default()),
+        )
+        .await;
+
+        let error = missing_binding
+            .handle_inbound(inbound("conv_missing", "u1", Some("张三"), "msg_missing"))
+            .await
+            .expect_err("missing binding must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::BindingNotFound,
+            false,
+            "active binding",
+        );
+
+        let lookup_failure = inbound_service(
+            Arc::new(FailingBindingLookupRepo),
+            Arc::new(MemoryImParticipantRepo::new()),
+            Arc::new(RecordingSessionRepo::default()),
+            Arc::new(RecordingMessageFlow::default()),
+            Arc::new(RecordingRegistry::default()),
+        )
+        .await;
+
+        let error = lookup_failure
+            .handle_inbound(inbound("conv_lookup", "u1", Some("张三"), "msg_lookup"))
+            .await
+            .expect_err("binding lookup failure must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::BindingLookupFailed,
+            true,
+            "binding lookup failed",
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn inbound_classifies_actor_participant_session_and_dispatch_failures() -> TestResult {
+        let bindings = active_inbound_binding_repo().await;
+        let registry = Arc::new(RecordingRegistry::default());
+        *registry.fail_ensure_human.lock().await = Some("actor write failed".to_string());
+        let actor_failure = inbound_service(
+            bindings,
+            Arc::new(MemoryImParticipantRepo::new()),
+            Arc::new(RecordingSessionRepo::default()),
+            Arc::new(RecordingMessageFlow::default()),
+            registry,
+        )
+        .await;
+
+        let error = actor_failure
+            .handle_inbound(inbound("conv_actor", "u1", Some("张三"), "msg_actor"))
+            .await
+            .expect_err("actor write failure must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::ActorResolutionFailed,
+            true,
+            "actor write failed",
+        );
+
+        let participant_failure = inbound_service(
+            active_inbound_binding_repo().await,
+            Arc::new(FailingParticipantRepo),
+            Arc::new(RecordingSessionRepo::default()),
+            Arc::new(RecordingMessageFlow::default()),
+            Arc::new(RecordingRegistry::default()),
+        )
+        .await;
+
+        let error = participant_failure
+            .handle_inbound(inbound("conv_participant", "u1", Some("张三"), "msg_participant"))
+            .await
+            .expect_err("participant mapping failure must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::ActorResolutionFailed,
+            true,
+            "actor write failed",
+        );
+
+        let session_repo = Arc::new(RecordingSessionRepo::default());
+        *session_repo.fail_create.lock().await = Some("session create failed".to_string());
+        let session_failure = inbound_service(
+            active_inbound_binding_repo().await,
+            Arc::new(MemoryImParticipantRepo::new()),
+            session_repo,
+            Arc::new(RecordingMessageFlow::default()),
+            Arc::new(RecordingRegistry::default()),
+        )
+        .await;
+
+        let error = session_failure
+            .handle_inbound(inbound("conv_session", "u1", Some("张三"), "msg_session"))
+            .await
+            .expect_err("session failure must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::SessionResolutionFailed,
+            true,
+            "session create failed",
+        );
+
+        let message_flow = Arc::new(RecordingMessageFlow::default());
+        *message_flow.failed_dispatch_count.lock().await = 1;
+        let dispatch_failure = inbound_service(
+            active_inbound_binding_repo().await,
+            Arc::new(MemoryImParticipantRepo::new()),
+            Arc::new(RecordingSessionRepo::default()),
+            message_flow,
+            Arc::new(RecordingRegistry::default()),
+        )
+        .await;
+
+        let error = dispatch_failure
+            .handle_inbound(inbound("conv_dispatch", "u1", Some("张三"), "msg_dispatch"))
+            .await
+            .expect_err("failed message flow dispatch must be reported");
+        assert_inbound_error(
+            error,
+            ChannelInboundFailureKind::DispatchFailed,
+            true,
+            "failed deliveries",
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn inbound_returns_error_when_session_participant_write_fails() -> TestResult {
         let harness = TestHarness::new(manager_group("group_1")).await?;
         harness
@@ -2088,7 +2418,12 @@ mod tests {
             .handle_inbound(group_inbound("conv_group", "u1", Some("张三"), "msg_fail", true))
             .await;
 
-        assert!(result.is_err());
+        assert_inbound_error(
+            result.expect_err("participant write failure must be reported"),
+            ChannelInboundFailureKind::SessionResolutionFailed,
+            true,
+            "participant write failed",
+        );
         assert!(harness.message_flow.web_sends.lock().await.is_empty());
 
         Ok(())
@@ -2889,6 +3224,7 @@ mod tests {
         next: AtomicU64,
         sessions: Mutex<HashMap<String, Session>>,
         added_participants: Mutex<Vec<(String, Participant)>>,
+        fail_create: Mutex<Option<String>>,
         fail_add_participant: Mutex<Option<String>>,
     }
 
@@ -2899,6 +3235,9 @@ mod tests {
             group_id: &str,
             params: NewSessionParams,
         ) -> ServiceResult<Session> {
+            if let Some(error) = self.fail_create.lock().await.clone() {
+                return Err(ServiceError::InternalError(error));
+            }
             let n = self.next.fetch_add(1, Ordering::SeqCst) + 1;
             let id = match params.id {
                 Some(id) => id,
@@ -3130,12 +3469,14 @@ mod tests {
     #[derive(Default)]
     struct RecordingMessageFlow {
         web_sends: Mutex<Vec<WebSendCommand>>,
+        failed_dispatch_count: Mutex<usize>,
     }
 
     #[async_trait]
     impl MessageFlowService for RecordingMessageFlow {
         async fn handle_web_send(&self, cmd: WebSendCommand) -> ServiceResult<WebSendOutcome> {
             self.web_sends.lock().await.push(cmd);
+            let failed_count = *self.failed_dispatch_count.lock().await;
             Ok(WebSendOutcome {
                 primary_run_id: "run_1".to_string(),
                 status: "accepted".to_string(),
@@ -3145,7 +3486,7 @@ mod tests {
                 mentions: Vec::new(),
                 hidden_mentions: Vec::new(),
                 delivered_count: 0,
-                failed_count: 0,
+                failed_count,
                 delivery_results: Vec::<MessageDeliveryResult>::new(),
             })
         }
@@ -3412,6 +3753,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingRegistry {
         ensured: Mutex<Vec<(String, String)>>,
+        fail_ensure_human: Mutex<Option<String>>,
     }
 
     #[async_trait]
@@ -3488,6 +3830,9 @@ mod tests {
             staff_no: &str,
             nick_name: &str,
         ) -> ServiceResult<EnsureHumanResult> {
+            if let Some(error) = self.fail_ensure_human.lock().await.clone() {
+                return Err(ServiceError::InternalError(error));
+            }
             self.ensured
                 .lock()
                 .await

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -203,7 +203,12 @@ async fn try_channel_outbound(flow: &BcsMessageFlow, cmd: &BotEventCommand) {
             .unwrap_or((bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone())),
         None => (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone()),
     };
-    let text = channel_outbound_text(kind, &cmd.event_payload);
+    let text = channel_outbound_text(kind, cmd);
+    let raw_payload = if kind == ChannelOutboundEventKind::System {
+        serde_json::json!({ "state": channel_terminal_state(&cmd.state) })
+    } else {
+        cmd.event_payload.clone()
+    };
     let render_hint = match kind {
         ChannelOutboundEventKind::Agent => ChannelRenderHint::IgnoreByDefault,
         ChannelOutboundEventKind::ChatDelta
@@ -224,7 +229,7 @@ async fn try_channel_outbound(flow: &BcsMessageFlow, cmd: &BotEventCommand) {
             sender_label,
             kind,
             text: (!text.is_empty()).then_some(text),
-            raw_payload: cmd.event_payload.clone(),
+            raw_payload,
             render_hint,
             source_is_channel: false,
         })
@@ -239,6 +244,9 @@ fn channel_event_kind(cmd: &BotEventCommand) -> Option<ChannelOutboundEventKind>
         ("agent", _) => Some(ChannelOutboundEventKind::Agent),
         ("chat" | "chat.event", ChatEventState::Delta) => Some(ChannelOutboundEventKind::ChatDelta),
         ("chat" | "chat.event", ChatEventState::Final) => Some(ChannelOutboundEventKind::ChatFinal),
+        ("chat" | "chat.event", ChatEventState::Error | ChatEventState::Aborted) => {
+            Some(ChannelOutboundEventKind::System)
+        }
         ("chat" | "chat.event", ChatEventState::ToolCallStart | ChatEventState::ToolCallEnd) => {
             Some(ChannelOutboundEventKind::Agent)
         }
@@ -246,13 +254,42 @@ fn channel_event_kind(cmd: &BotEventCommand) -> Option<ChannelOutboundEventKind>
     }
 }
 
-fn channel_outbound_text(kind: ChannelOutboundEventKind, event: &Value) -> String {
+fn channel_outbound_text(kind: ChannelOutboundEventKind, cmd: &BotEventCommand) -> String {
+    if kind == ChannelOutboundEventKind::System {
+        let message = match cmd.state {
+            ChatEventState::Error => "机器人连接或执行失败，请稍后重试。",
+            ChatEventState::Aborted => "机器人已中止本次处理，请重新发送。",
+            _ => return String::new(),
+        };
+        return format!("{message} (追踪标识: {})", short_ascii_run_id(&cmd.run_id));
+    }
     if kind == ChannelOutboundEventKind::ChatDelta {
-        if let Some(delta) = extract_delta_text(event) {
+        if let Some(delta) = extract_delta_text(&cmd.event_payload) {
             return delta.to_string();
         }
     }
-    extract_message_text(event)
+    extract_message_text(&cmd.event_payload)
+}
+
+fn channel_terminal_state(state: &ChatEventState) -> &'static str {
+    match state {
+        ChatEventState::Error => "error",
+        ChatEventState::Aborted => "aborted",
+        _ => "unknown",
+    }
+}
+
+fn short_ascii_run_id(run_id: &str) -> String {
+    let trace: String = run_id
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+        .take(12)
+        .collect();
+    if trace.is_empty() {
+        "unknown".to_string()
+    } else {
+        trace
+    }
 }
 
 struct RelayOutcome {

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -12,7 +12,7 @@ use bcs_service_api::{
     RoutingMode, RoutingPolicy, ServiceError, ServiceSpec, Session, SessionKind,
     SessionManagementService, SessionStatus, SessionUseCaseError, SystemMessageEvent,
     SystemMessageService, TaskCompleteCommand, TaskDispatchCommand, TaskMessageCommand,
-    TaskRunAliasRegistration, ChannelService, ChannelUseCaseError,
+    TaskRunAliasRegistration, ChannelInboundError, ChannelService, ChannelUseCaseError,
     interceptor::{BlockReason, InterceptorDecision, MessageInterceptor, OutboundMessage},
 };
 use serde_json::{Value, json};
@@ -50,7 +50,7 @@ impl ChannelService for RecordingChannelService {
     async fn handle_inbound(
         &self,
         _msg: bcs_service_api::application::channel::InboundMessage,
-    ) -> Result<(), ChannelUseCaseError> {
+    ) -> Result<(), ChannelInboundError> {
         Ok(())
     }
 

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -5,7 +5,8 @@ use bcs_message_flow::task_store::{new_task_entry, TaskLedgerStatus, TASK_TTL_MS
 use bcs_protocol::BcsFrame;
 use bcs_service_api::{
     ActorKind, BotDeliveryKind, BotDeliveryTarget, BotEventCommand, BotRegistryCoreService,
-    BotRunContextPort, ChatEventState, ChatResponseMode, DefaultDelivery,
+    BotRunContextPort, ChannelOutboundEventKind, ChannelRenderHint, ChatEventState,
+    ChatResponseMode, DefaultDelivery,
     FrontendDeliveryTarget, GroupCoreService, GroupKind, GroupStatus, GroupStrategy,
     MessageFlowService, Participant, ParticipantMode, ParticipantRole,
     ProviderStreamGrayList, ProviderTransportPreference,
@@ -750,6 +751,72 @@ async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
         "ChatDelta sent to channel adapters must stay incremental even when BCS synthesizes cumulative message.content for frontend rendering"
     );
     assert_eq!(outbound[1].raw_payload["message"]["content"][0]["text"], "你好");
+}
+
+#[tokio::test]
+async fn bot_terminal_failures_emit_safe_system_channel_feedback() {
+    for (state, run_id, expected_text) in [
+        (
+            ChatEventState::Error,
+            "run-error-1234567890",
+            "机器人连接或执行失败，请稍后重试。",
+        ),
+        (
+            ChatEventState::Aborted,
+            "run-aborted-1234567890",
+            "机器人已中止本次处理，请重新发送。",
+        ),
+    ] {
+        let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+        let recording_channel = Arc::new(RecordingChannelService::default());
+        let flow = BcsMessageFlow::new(
+            support.group.clone(),
+            support.routing.clone(),
+            support.registry.clone(),
+            support.bot_delivery.clone(),
+            support.frontend_delivery.clone(),
+        );
+        let channel: Arc<dyn ChannelService> = recording_channel.clone();
+        assert!(flow.channel_slot().set(channel).is_ok());
+
+        flow.handle_bot_event(BotEventCommand {
+            bot_id: "bot-observer".to_string(),
+            run_id: run_id.to_string(),
+            group_id: "group-1".to_string(),
+            event_type: "chat.event".to_string(),
+            event_payload: json!({
+                "state": state_payload_name(&state),
+                "errorMessage": "provider secret detail",
+                "errorKind": "provider_internal_error",
+            }),
+            state,
+            bcs_session_id: Some("group-1:abcdef12".to_string()),
+        })
+        .await
+        .unwrap();
+
+        let outbound = recording_channel.outbound().await;
+        assert_eq!(outbound.len(), 1);
+        let outbound = &outbound[0];
+        assert_eq!(outbound.kind, ChannelOutboundEventKind::System);
+        assert_eq!(outbound.render_hint, ChannelRenderHint::Render);
+        let text = outbound.text.as_deref().expect("system feedback text");
+        assert!(text.contains(expected_text));
+        assert!(text.contains("追踪标识"));
+        assert!(!text.contains("provider secret detail"));
+        assert!(!text.contains("provider_internal_error"));
+        assert!(!text.contains(run_id), "trace reference must be shortened");
+        let raw_payload = outbound.raw_payload.to_string();
+        assert!(!raw_payload.contains("provider secret detail"));
+        assert!(!raw_payload.contains("provider_internal_error"));
+        let trace = text
+            .split("追踪标识: ")
+            .nth(1)
+            .and_then(|suffix| suffix.strip_suffix(')'))
+            .expect("short trace reference");
+        assert!(trace.is_ascii());
+        assert!(trace.len() <= 12);
+    }
 }
 
 #[tokio::test]

--- a/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
@@ -1649,7 +1649,7 @@ impl ChannelService for NoopChannelService {
     async fn handle_inbound(
         &self,
         _msg: InboundMessage,
-    ) -> Result<(), ChannelUseCaseError> {
+    ) -> Result<(), ChannelInboundError> {
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- add a typed inbound channel failure contract with legacy plugin constructor compatibility
- classify binding, actor, context, session, and dispatch failures without exposing internal diagnostics
- relay terminal bot Error/Aborted states to external IM channels as safe system messages
- preserve binding, session, and conversation routing while allowing system errors through transcript visibility filters

## Verification

- `cargo test --manifest-path src/bcs/Cargo.toml -p bcs-service-api -p bcs-channel-api -p bcs-channel -p bcs-message-flow`
- `cargo check --manifest-path src/bcs/Cargo.toml -p bcs`
- independent task reviews completed with no remaining findings