### PR TITLE
ci: use immutable PR base SHA for changed-line coverage

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,9 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      # PR: compare against the PR's base branch. push/dispatch: compare against dev
-      # (the repo default branch) so coverage-gated diff detection still has a base.
-      BCS_BASE_REF: origin/${{ github.base_ref || 'dev' }}
+      # PR: compare against the event's immutable base SHA so delayed/rerun runs
+      # are not affected by base-branch drift after the PR was created.
+      # push/dispatch: compare against dev (repo default branch) instead.
+      BCS_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/bcs
@@ -125,9 +126,10 @@ jobs:
     name: Backend unit tests
     runs-on: ubuntu-latest
     env:
-      # PR: compare against the PR's base branch. push/dispatch: compare against dev
-      # (the repo default branch) so coverage-gated diff detection still has a base.
-      BACKEND_BASE_REF: origin/${{ github.base_ref || 'dev' }}
+      # PR: compare against the event's immutable base SHA so delayed/rerun runs
+      # are not affected by base-branch drift after the PR was created.
+      # push/dispatch: compare against dev (repo default branch) instead.
+      BACKEND_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/backend
@@ -192,7 +194,7 @@ jobs:
     name: Engine unit tests
     runs-on: ubuntu-latest
     env:
-      ENGINE_BASE_REF: origin/${{ github.base_ref || 'dev' }}
+      ENGINE_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/engine
@@ -251,7 +253,7 @@ jobs:
     env:
       # PR: compare against the PR's base branch. push/dispatch: compare against dev
       # (the repo default branch) so coverage-gated diff detection still has a base.
-      BAAS_BASE_REF: origin/${{ github.base_ref || 'dev' }}
+      BAAS_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/baas/packages/community


### PR DESCRIPTION
## Summary

Resolves #101

The bcs / backend / engine / baas unit-test jobs compared the working tree against the moving ref \`origin/\${{ github.base_ref || 'dev' }}\` for both change detection and changed-line coverage. On delayed or rerun \`pull_request\` runs where \`dev\` advanced after the PR was opened, the two-dot diff attributed the intervening base-branch changes to the PR: tests ran unnecessarily and the changed-line gate evaluated unrelated lines (often computing \`0.00%\` and failing), even for PRs that never touched the relevant \`src/*\` area.

## Fix

Swap each job's \`*_BASE_REF\` env value from the moving branch ref to the event snapshot's immutable base SHA:

\`\`\`yaml
*_BASE_REF: \${{ github.event.pull_request.base.sha || 'origin/dev' }}
\`\`\`

- **\`pull_request\` events**: anchored to the PR's recorded base SHA, so base-branch drift after the event no longer leaks into change detection or changed-line coverage.
- **\`push\` / \`workflow_dispatch\`**: \`base.sha\` is empty, falls back to \`origin/dev\` — unchanged behavior.

The \`git fetch\` / \`git diff\` commands and the Python gates (\`cov_gate.py\`, \`report_check.py\`, \`\`ci_test.sh --base\`) are unchanged; they only receive the base string verbatim, so a SHA works the same as a ref.

## Scope

All four jobs updated: \`bcs\`, \`backend\`, \`engine\`, \`baas\`. The first three have changed-line gates (bcs via \`cov_gate.py\`, backend/engine via \`report_check.py\`) and were the ones that could fail spuriously; \`baas\` has no changed-line gate but inherits the correct skip behavior.

Refs #101