### PR TITLE
fix(singlebox): land BaaS-backed device runtime on dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,18 @@ traceable.
 - Keep public-local development free of company-only services, registries,
   domains, credentials, and runtime state.
 
+### Python Type Contracts
+
+- Use `T | None` only when `None` is an intentional, valid state in the domain
+  contract or at an external input boundary.
+- Keep required configuration values, request fields, constructor arguments,
+  and service method parameters non-optional end to end.
+- Do not widen a required type to `T | None` merely for defensive programming,
+  uncertain call sites, test convenience, or a fallback that hides missing
+  input. Validate at the boundary and fail clearly instead.
+- Before introducing an optional type, verify that a real caller can omit the
+  value and that the receiving code defines meaningful behavior for `None`.
+
 ## Testing Rules
 
 Choose tests based on risk:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,5 +2,8 @@
 
 Claude Code should follow the repository-wide instructions in `AGENTS.md`.
 
+In particular, do not introduce Python `T | None` types unless `None` is an
+intentional state in the contract; required values must remain non-optional.
+
 Keep this file intentionally small so agent instructions do not drift. Update
 `AGENTS.md` when project-wide rules change.

--- a/docs/superpowers/specs/2026-07-11-singlebox-baas-device-provider.md
+++ b/docs/superpowers/specs/2026-07-11-singlebox-baas-device-provider.md
@@ -1,0 +1,38 @@
+# Singlebox BaaS Device Provider
+
+## Problem
+
+`DeployProfile.SINGLEBOX` currently shares `TestDevicesModule` with unit tests.
+That module builds a BaaS-backed `LocalDeviceService`, registers it under the
+`local` provider key, and persists `device_provider=local`.
+
+The persisted provider is a domain fact, not a deployment-location flag.
+Singlebox device, bot, and process lifecycles are owned by the local BaaS
+service (`LocalPaasService` performs the host process spawn), so the binding
+must persist `device_provider=baas` while the independent runtime axes remain:
+
+- `DEPLOY_PROFILE=singlebox`
+- `SERVER_ENV=dev`
+- `device_provider=baas`
+
+## Contract
+
+1. `test` keeps `TestDevicesModule` and its local/in-memory doubles.
+2. `singlebox` installs a dedicated `SingleboxDevicesModule`.
+3. The singlebox `DeviceServiceRouter` registers only
+   `baas -> BaasDeviceService`, with `baas` as its default provider.
+4. Singlebox create-time routing always selects `baas`.
+5. `DeviceAccessor` resolves to `BaasDeviceAccessor` so filesystem, sync, and
+   connection consumers agree with the persisted provider.
+6. Local BaaS configuration still decides where processes run; no caller
+   derives provider identity from `DeployProfile` or `SERVER_ENV`.
+7. Unit-test-only local bindings must not leak into the singlebox runtime.
+
+## Compatibility
+
+Existing singlebox databases are recreated by the startup script, so no
+`local -> baas` data migration is required. Production profiles and their
+ARCA/BaaS routing are unchanged.
+
+PR #62 will stack on this change and verify the live BaaS lifecycle instead of
+asserting that a singlebox binding is rejected as a non-BaaS provider.

--- a/src/baas/packages/community/tests/unit/core/service/paas/test_arca_paas_service.py
+++ b/src/baas/packages/community/tests/unit/core/service/paas/test_arca_paas_service.py
@@ -13,8 +13,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from secbaas.api.device_manage import ArcaCredentials
+from secbaas.api.device_manage import ArcaCredentials, PaasError
 from secbaas.core.service.paas import ArcaPaasService
+from secbaas.spi.sandbox.arca import ArcaSandboxError, ArcaSandboxNotFoundError
 
 
 @pytest.fixture
@@ -130,3 +131,71 @@ class TestDestroyDeviceWithStorage:
         mock_plugin.delete_storage.assert_called_once_with("storage-abc", "test-tenant")
         mock_sandbox.destroy.assert_called_once()
         assert "Storage deletion failed" in caplog.text
+
+    def test__destroy_device_sync__already_missing_is_idempotent(
+        self, arca_credentials, mock_plugin
+    ):
+        """A missing sandbox remains a successful idempotent destroy."""
+        mock_plugin.connect_sync_sandbox.side_effect = ArcaSandboxNotFoundError(
+            "sandbox not found"
+        )
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        result = service._destroy_device_sync("missing-device-id")
+
+        assert result is True
+        assert mock_plugin.connect_sync_sandbox.call_count == 2
+        mock_plugin.delete_storage.assert_not_called()
+
+    def test__destroy_device_sync__initial_connect_failure_then_missing_is_idempotent(
+        self, arca_credentials, mock_plugin
+    ):
+        """A transient lookup failure must not break a later not-found destroy."""
+        mock_plugin.connect_sync_sandbox.side_effect = [
+            RuntimeError("lookup unavailable"),
+            ArcaSandboxNotFoundError("sandbox not found"),
+        ]
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        result = service._destroy_device_sync("missing-device-id")
+
+        assert result is True
+        assert mock_plugin.connect_sync_sandbox.call_count == 2
+        mock_plugin.delete_storage.assert_not_called()
+
+    def test__destroy_device_sync__delete_storage_exception_is_best_effort(
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
+    ):
+        """A storage API exception must not turn a successful destroy into failure."""
+        mock_info = MagicMock()
+        mock_info.storage = {"storage_id": "storage-abc"}
+        mock_sandbox.get_info.return_value = mock_info
+        mock_sandbox.destroy.return_value = True
+        mock_plugin.delete_storage.side_effect = RuntimeError("storage unavailable")
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
+
+        assert result is True
+        mock_plugin.delete_storage.assert_called_once_with("storage-abc", "test-tenant")
+        assert "Storage deletion exception" in caplog.text
+
+    def test__destroy_device_sync__non_idempotent_arca_error_is_translated(
+        self, arca_credentials, mock_plugin, mock_sandbox
+    ):
+        """A real Arca destroy failure must still surface as a PaasError."""
+        mock_sandbox.get_info.return_value = MagicMock(storage=None)
+        mock_sandbox.destroy.side_effect = ArcaSandboxError("connection refused")
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with pytest.raises(PaasError, match="connection refused"):
+            service._destroy_device_sync("test-device-id")

--- a/src/baas/packages/community/tests/unit/plugins/sandbox/arca/test_storage_cleanup.py
+++ b/src/baas/packages/community/tests/unit/plugins/sandbox/arca/test_storage_cleanup.py
@@ -1,0 +1,24 @@
+"""Contract tests for local Arca storage cleanup implementations."""
+
+import pytest
+
+from secbaas.plugins.sandbox.arca import (
+    LocalProcessArcaSandboxPlugin,
+    StubArcaSandboxPlugin,
+)
+from secbaas.plugins.sandbox.arca.local_docker import LocalDockerArcaSandboxPlugin
+
+
+@pytest.mark.parametrize(
+    "plugin_factory",
+    [
+        StubArcaSandboxPlugin,
+        LocalDockerArcaSandboxPlugin,
+        LocalProcessArcaSandboxPlugin,
+    ],
+)
+def test_delete_storage_is_successful_noop(plugin_factory):
+    """Local plugins have no remote NAS resource, so cleanup succeeds as a no-op."""
+    plugin = plugin_factory()
+
+    assert plugin.delete_storage("storage-abc", "tenant-a") is True

--- a/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
@@ -34,6 +34,14 @@ user_config:
     description: "Single Box mode — no external network."
     local_debug: true
 
+  # BaaS publish/create completion is delivered through the durable task queue.
+  # Singlebox runs one Backend process, so a short, jitter-free poll keeps local
+  # bot creation deterministic without changing the neutral default (disabled).
+  task_queue_worker:
+    enabled: true
+    poll_interval_seconds: 0.2
+    poll_jitter_seconds: 0.0
+
   # token_exchange — 外网替换为本地 mock
   token_exchange:
     buc_url: "http://127.0.0.1:9999"

--- a/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
@@ -53,15 +53,15 @@ class ArcaBotCreateBaasRolloutPolicy:
         self,
         *,
         user_id: str,
-        bot_type: str | None,
-        engine_type: str | None = None,
-        template_type: str | None = None,
+        bot_type: str,
+        engine_type: str,
+        template_type: str,
     ) -> ArcaBotCreateBaasRolloutDecision:
         engine_bucket = self.normalize_engine_bucket(
             engine_type=engine_type,
             template_type=template_type,
         )
-        normalized_bot_type = (bot_type or "").strip().lower()
+        normalized_bot_type = bot_type.strip().lower()
 
         # 这里是存量 ARCA 创建分支的 BaaS 灰度，不是新引擎的强制路由。
         # 未分类分支先回退 ARCA，并通过 warning 暴露待归类的接入方。
@@ -195,10 +195,10 @@ class ArcaBotCreateBaasRolloutPolicy:
     def normalize_engine_bucket(
         cls,
         *,
-        engine_type: str | None,
-        template_type: str | None,
+        engine_type: str,
+        template_type: str,
     ) -> str:
-        normalized_engine = (engine_type or "openclaw").strip().lower().replace("-", "_")
+        normalized_engine = engine_type.strip().lower().replace("-", "_")
         if (
             normalized_engine == "claude_code"
             and template_type in cls.CODING_TEMPLATE_TYPES

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
@@ -79,9 +79,9 @@ class _DisabledArcaBotCreateBaasRolloutPolicy:
         self,
         *,
         user_id: str,
-        bot_type: str | None = None,
-        engine_type: str | None = None,
-        template_type: str | None = None,
+        bot_type: str,
+        engine_type: str,
+        template_type: str,
     ) -> ArcaBotCreateBaasRolloutDecision:
         # 真实创建路由由 prod/local 组合根注入；占位策略不参与业务路由。
         logger.error("[ArcaBotCreateBaasRolloutPolicy] Missing injected policy")
@@ -261,9 +261,9 @@ class DeviceServiceRouter(DeviceService):
         # 未显式指定 provider 的创建请求，交给创建期灰度策略决定走 ARCA 还是 BaaS。
         decision = self._arca_baas_rollout_policy.decide(
             user_id=staff_id,
-            bot_type=bot_type,
-            engine_type=engine_type,
-            template_type=template_type,
+            bot_type=bot_type or "",
+            engine_type=engine_type or "openclaw",
+            template_type=template_type or "",
         )
         provider_name = decision.target_provider
 

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/__init__.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/__init__.py
@@ -1,0 +1,1 @@
+"""Singlebox infrastructure bindings."""

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
@@ -1,0 +1,168 @@
+"""Singlebox BaaS-only device runtime bindings."""
+
+from __future__ import annotations
+
+from typing import cast  # noqa: UP035 - injector binding key matches provider side
+
+from injector import Binder, Module, inject, provider, singleton
+
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.services.teclaw_status_reconciler import (
+    TeclawStatusReconciler,
+)
+from agentclaw.community.core.devices.protocols import BotQueryProtocol
+from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.core.devices.services.arca_bot_create_baas_rollout_policy import (
+    ArcaBotCreateBaasRolloutDecision,
+    ArcaBotCreateBaasRolloutPolicy,
+)
+from agentclaw.community.core.devices.services.baas_device_accessor import (
+    BaasDeviceAccessor,
+)
+from agentclaw.community.core.devices.services.baas_device_service import (
+    BaasDeviceService,
+)
+from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.device_service import (
+    BAAS_DEVICE_PROVIDER,
+    DeviceService,
+)
+from agentclaw.community.core.devices.services.device_service_router import (
+    DeviceServiceRouter,
+)
+from agentclaw.community.core.notify.protocol import NotifyBotLister
+from agentclaw.community.core.system_config import SystemConfigService
+from agentclaw.community.di import config as cfg
+from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
+    BotPublishRepositoryProtocol,
+)
+from agentclaw.community.core.service_bot.services.baas_service import BaasService
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterTransport,
+)
+from agentclaw.community.plugin_api.device_connection_manager import (
+    DeviceConnectionManagerPlugin,
+)
+from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
+from agentclaw.community.di.modules.infrastructure.singlebox.template_config import (
+    SingleboxBaasTemplateConfigLifecycle,
+)
+
+
+class _SingleboxAllBaasRolloutPolicy(ArcaBotCreateBaasRolloutPolicy):
+    """Singlebox has no ARCA provider, so every allocation is BaaS-owned."""
+
+    def __init__(self) -> None:
+        pass
+
+    def decide(
+        self,
+        *,
+        user_id: str,
+        bot_type: str | None,
+        engine_type: str | None = None,
+        template_type: str | None = None,
+    ) -> ArcaBotCreateBaasRolloutDecision:
+        return ArcaBotCreateBaasRolloutDecision(
+            target_provider=BAAS_DEVICE_PROVIDER,
+            reason="singlebox_baas_only",
+            engine_bucket=self.normalize_engine_bucket(
+                engine_type=engine_type,
+                template_type=template_type,
+            ),
+        )
+
+
+class SingleboxDevicesModule(Module):
+    """Bind singlebox to the real BaaS domain provider over local HTTP."""
+
+    def configure(self, binder: Binder) -> None:
+        from agentclaw.community.plugins.local.device_connection_manager import (
+            NoopDeviceConnectionManagerPlugin,
+        )
+
+        binder.bind(
+            DeviceConnectionManagerPlugin,
+            to=NoopDeviceConnectionManagerPlugin,
+            scope=singleton,
+        )
+        binder.bind(DeviceAccessor, to=BaasDeviceAccessor, scope=singleton)
+
+    @singleton
+    @provider
+    @inject
+    def singlebox_baas_template_config_lifecycle(
+        self,
+        config_service: SystemConfigService,
+        baas: cfg.BaasConfig,
+    ) -> SingleboxBaasTemplateConfigLifecycle:
+        return SingleboxBaasTemplateConfigLifecycle(
+            config_service=config_service,
+            template_uuid=baas.template_uuid,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def device_service(
+        self,
+        baas_device_service: BaasDeviceService,
+        repository: DeviceBindingRepository,
+        bot_repository: BotRepository,
+        bot_publish_repo: BotPublishRepositoryProtocol,
+        passport_plugin: PassportPlugin,
+        sandbox_client: SandboxRuntimeClient,
+    ) -> DeviceService:
+        bot_query = cast(BotQueryProtocol, bot_repository)
+        providers: dict[str, DeviceService] = {
+            BAAS_DEVICE_PROVIDER: baas_device_service,
+        }
+        return DeviceServiceRouter(
+            repository=repository,
+            bot_query=bot_query,
+            providers=providers,
+            default_provider_key=BAAS_DEVICE_PROVIDER,
+            arca_baas_rollout_policy=_SingleboxAllBaasRolloutPolicy(),
+            passport_plugin=passport_plugin,
+            sandbox_client=sandbox_client,
+            publish_repo=bot_publish_repo,
+            bot_repo=bot_repository,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def teclaw_status_reconciler(
+        self,
+        baas_service: BaasService,
+        bot_repository: BotRepository,
+        device_binding_repo: DeviceBindingRepository,
+    ) -> TeclawStatusReconciler:
+        """Keep background reconciliation disabled in the local stack."""
+        return TeclawStatusReconciler(
+            baas_service=baas_service,
+            bot_repository=bot_repository,
+            device_binding_repo=device_binding_repo,
+            schedule=lambda _fn, _delay: None,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def notify_bot_lister(self, bot_repository: BotRepository) -> NotifyBotLister:
+        from agentclaw.community.core.notify.local_bot_lister import (
+            LocalNotifyBotLister,
+        )
+
+        return LocalNotifyBotLister(bot_repository=bot_repository)
+
+    @singleton
+    @provider
+    def device_adapter_transport(self) -> DeviceAdapterTransport:
+        """Preserve the current in-memory adapter seam in the OSS singlebox."""
+        from agentclaw.community.plugins.local.device_adapter_transport import (
+            InMemoryDeviceAdapterTransport,
+        )
+
+        return InMemoryDeviceAdapterTransport()

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
@@ -60,9 +60,9 @@ class _SingleboxAllBaasRolloutPolicy(ArcaBotCreateBaasRolloutPolicy):
         self,
         *,
         user_id: str,
-        bot_type: str | None,
-        engine_type: str | None = None,
-        template_type: str | None = None,
+        bot_type: str,
+        engine_type: str,
+        template_type: str,
     ) -> ArcaBotCreateBaasRolloutDecision:
         return ArcaBotCreateBaasRolloutDecision(
             target_provider=BAAS_DEVICE_PROVIDER,
@@ -81,6 +81,9 @@ class SingleboxDevicesModule(Module):
         from agentclaw.community.plugins.local.device_connection_manager import (
             NoopDeviceConnectionManagerPlugin,
         )
+        from agentclaw.community.plugins.local.device_adapter_transport import (
+            InMemoryDeviceAdapterTransport,
+        )
 
         binder.bind(
             DeviceConnectionManagerPlugin,
@@ -88,6 +91,11 @@ class SingleboxDevicesModule(Module):
             scope=singleton,
         )
         binder.bind(BaasDeviceAccessor, to=BaasDeviceAccessor, scope=singleton)
+        binder.bind(
+            DeviceAdapterTransport,
+            to=InMemoryDeviceAdapterTransport,
+            scope=singleton,
+        )
 
     @singleton
     @provider
@@ -163,13 +171,3 @@ class SingleboxDevicesModule(Module):
         )
 
         return LocalNotifyBotLister(bot_repository=bot_repository)
-
-    @singleton
-    @provider
-    def device_adapter_transport(self) -> DeviceAdapterTransport:
-        """Preserve the current in-memory adapter seam in the OSS singlebox."""
-        from agentclaw.community.plugins.local.device_adapter_transport import (
-            InMemoryDeviceAdapterTransport,
-        )
-
-        return InMemoryDeviceAdapterTransport()

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
@@ -87,7 +87,14 @@ class SingleboxDevicesModule(Module):
             to=NoopDeviceConnectionManagerPlugin,
             scope=singleton,
         )
-        binder.bind(DeviceAccessor, to=BaasDeviceAccessor, scope=singleton)
+        binder.bind(BaasDeviceAccessor, to=BaasDeviceAccessor, scope=singleton)
+
+    @singleton
+    @provider
+    @inject
+    def device_accessor(self, accessor: BaasDeviceAccessor) -> DeviceAccessor:
+        """Expose the concrete singleton through the device-access boundary."""
+        return accessor
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
@@ -1,0 +1,79 @@
+"""Profile-owned bootstrap for the local BaaS template routing map."""
+
+from __future__ import annotations
+
+from agentclaw.community.core.devices.services.baas_template_resolver import (
+    BAAS_TEMPLATE_MAPPING_CATEGORY,
+    BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
+)
+from agentclaw.community.core.system_config import SystemConfigService
+from agentclaw.community.kernel.lifecycle import LifecycleBase
+from agentclaw.community.log import get_logger
+from agentclaw.community.utils import env_utils
+
+
+logger = get_logger()
+
+_LOCAL_TEMPLATE_UID = "local_default"
+_SUPPORTED_ENGINES = ("openclaw", "moltis", "hermes", "aicoding", "claude_code")
+
+
+class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):
+    """Install an idempotent BaaS template map after SQLite bootstrap."""
+
+    def __init__(
+        self,
+        *,
+        config_service: SystemConfigService,
+        template_uuid: str | None,
+    ) -> None:
+        self._config_service = config_service
+        self._template_uuid = template_uuid.strip() if template_uuid else ""
+
+    async def startup(self) -> None:
+        env = env_utils.get_current_env()
+        existing = self._config_service.get_config(
+            category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+            config_key=BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
+            env=env,
+        )
+        if isinstance(existing, dict):
+            return
+        if not self._template_uuid.startswith("TEMPLATE-"):
+            raise RuntimeError(
+                "singlebox requires baas.template_uuid in TEMPLATE-* format"
+            )
+
+        self._config_service.create_category(
+            category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+            category_name="System",
+            description="Local BaaS system configuration",
+            env=env,
+            operator="local-bootstrap",
+        )
+        config_id = self._config_service.set_config(
+            category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+            config_key=BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
+            config_value={
+                "version": "local-v1",
+                "selectors": [
+                    {"engine": engine, "template_uid": _LOCAL_TEMPLATE_UID}
+                    for engine in _SUPPORTED_ENGINES
+                ],
+                "templates": {
+                    _LOCAL_TEMPLATE_UID: {
+                        "template_uuid": self._template_uuid,
+                    }
+                },
+            },
+            env=env,
+            description="Generated from the local deployment configuration",
+            operator="local-bootstrap",
+        )
+        if not config_id:
+            raise RuntimeError("failed to seed local BaaS template mapping")
+        logger.info(
+            "Seeded local BaaS template mapping: env=%s template_uuid=%s",
+            env,
+            self._template_uuid,
+        )

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
@@ -25,10 +25,12 @@ class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):
         self,
         *,
         config_service: SystemConfigService,
-        template_uuid: str | None,
+        template_uuid: str,
     ) -> None:
+        if not isinstance(template_uuid, str):
+            raise TypeError("template_uuid must be str")
         self._config_service = config_service
-        self._template_uuid = template_uuid.strip() if template_uuid else ""
+        self._template_uuid = template_uuid.strip()
 
     async def startup(self) -> None:
         env = env_utils.get_current_env()

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Callable, cast  # noqa: UP035 - injector binding key must match provider side
 
-from injector import Injector, Module, inject, provider, singleton
+from injector import Binder, Injector, Module, inject, provider, singleton
 
 from agentclaw.community.api.baas_service import BaasServiceProtocol
 from agentclaw.community.core.bot_management.token_vault import TokenVault
@@ -50,6 +50,8 @@ from agentclaw.community.core.devices.services.device_service import (
     DeviceService,
 )
 from agentclaw.community.core.devices.services.device_service_router import DeviceServiceRouter
+from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.local_device_accessor import LocalDeviceAccessor
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.notify.protocol import NotifyBotLister
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
@@ -57,6 +59,7 @@ from agentclaw.community.core.workspace.path_factory import _get_aidesktop_root
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import DeviceAdapterTransport
 from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
+from agentclaw.community.plugins.local.local_device_lifecycle import LocalDeviceLifecycle
 
 
 logger = get_logger()
@@ -65,7 +68,7 @@ logger = get_logger()
 class TestDevicesModule(Module):
     """Corp-free SQLite + local-mode overrides for devices (test / singlebox)."""
 
-    def configure(self, binder) -> None:
+    def configure(self, binder: Binder) -> None:
         """Rebind the prod Moltis ``DeviceConnectionManagerPlugin`` to the Noop.
 
         ``DevicesModule`` unconditionally binds the prod Moltis impl; local/SQLite
@@ -84,6 +87,9 @@ class TestDevicesModule(Module):
             to=NoopDeviceConnectionManagerPlugin,
             scope=singleton,
         )
+        binder.bind(LocalDeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
+        binder.bind(DeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
+        binder.bind(LocalDeviceLifecycle, to=LocalDeviceLifecycle, scope=singleton)
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/test/devices.py
@@ -160,9 +160,9 @@ class TestDevicesModule(Module):
                 self,
                 *,
                 user_id: str,
-                bot_type: str | None,
-                engine_type: str | None = None,
-                template_type: str | None = None,
+                bot_type: str,
+                engine_type: str,
+                template_type: str,
             ) -> ArcaBotCreateBaasRolloutDecision:
                 return ArcaBotCreateBaasRolloutDecision(
                     target_provider=LOCAL_DEVICE_PROVIDER,

--- a/src/backend/src/agentclaw/community/di/modules/testing_devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/testing_devices_module.py
@@ -207,9 +207,9 @@ class TestingDevicesModule(Module):
                 self,
                 *,
                 user_id: str,
-                bot_type: str | None,
-                engine_type: str | None = None,
-                template_type: str | None = None,
+                bot_type: str,
+                engine_type: str,
+                template_type: str,
             ) -> ArcaBotCreateBaasRolloutDecision:
                 return ArcaBotCreateBaasRolloutDecision(
                     target_provider=LOCAL_DEVICE_PROVIDER,

--- a/src/backend/src/agentclaw/community/di/modules/testing_skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/testing_skill_center_module.py
@@ -9,24 +9,18 @@ Service constructors run unchanged from :class:`SkillCenterModule`; the
 OSS upload dependency they require is satisfied by a
 :class:`MockObjectStoragePlugin` bound here.
 
-NOTE: ``DeviceAccessor`` and ``SkillRepoSyncPlugin`` are arguably
-infrastructure (Local vs Arca) rather than skill_center bindings. In
-practice all current call sites have these aligned with the profile, so
-they're bundled into this ``test`` / ``singlebox`` module. They move to
-their own per-concern modules when the device/skill clusters decompose
-(B6 / B7).
+``DeviceAccessor`` and device lifecycle bindings live in the profile's device
+module. Keeping them out of this shared module lets ``test`` use the local
+device double while ``singlebox`` uses the real local BaaS runtime.
 """
 from __future__ import annotations
 
 
-from injector import Binder, Module, inject, provider, singleton
+from injector import Binder, Module, provider, singleton
 
 from agentclaw.community.log import get_logger
-from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
 from agentclaw.community.plugin_api.object_storage import ObjectStoragePlugin
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
-from agentclaw.community.core.devices.services.local_device_accessor import LocalDeviceAccessor
-from agentclaw.community.plugins.local.local_device_lifecycle import LocalDeviceLifecycle
 from agentclaw.community.plugins.local.oss_storage import MockObjectStoragePlugin
 
 logger = get_logger()
@@ -57,16 +51,6 @@ class TestingSkillCenterModule(Module):
             scope=singleton,
         )
 
-        # Bind LocalDeviceAccessor to itself as a singleton; the
-        # device_plugin() provider below resolves the same instance to bind as
-        # the DeviceAccessor Protocol.
-        binder.bind(LocalDeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
-        # The singlebox device boot/shutdown Lifecycle is a standalone
-        # ``plugins/local`` participant (B9 split — it drives other local
-        # plugins, so it can't live in ``core`` with the accessor). Bind it as a
-        # singleton so ``discover_lifecycle_participants`` finds it.
-        binder.bind(LocalDeviceLifecycle, to=LocalDeviceLifecycle, scope=singleton)
-
     # SkillRepository / SkillSetRepository are no longer overridden:
     # the unified repositories (bound in SkillCenterModule) are a
     # faithful prod port that runs on SQLite too — they only need the
@@ -79,26 +63,6 @@ class TestingSkillCenterModule(Module):
     # SkillCategoryRepository is no longer overridden: the unified
     # repository (bound in SkillCenterModule) runs on SQLite too — it only
     # needs the SQLite DatabasePlugin injected. One impl, both runtimes.
-
-    @singleton
-    @provider
-    @inject
-    def device_plugin(
-        self,
-        local_plugin: LocalDeviceAccessor,
-    ) -> DeviceAccessor:
-        """Local ``DeviceAccessor`` — binding 直绑 ``LocalDeviceAccessor``。
-
-        Local 模式下只有 ``LocalDeviceAccessor`` 一种实现,业务 caller 走
-        :class:`DeviceContextResolver` + 各 ConnInfoBuilder,不再依赖
-        provider 分流。
-
-        ``local_plugin`` 是 ``configure()`` 中绑定的同一 singleton 实例,
-        injecting it here (rather than constructing inline) ensures
-        ``discover_lifecycle_participants`` returns one instance.
-        """
-        logger.info("[NEW-ARCH] DeviceAccessor: LocalDeviceAccessor (testing override)")
-        return local_plugin
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/profile_modules.py
+++ b/src/backend/src/agentclaw/community/di/profile_modules.py
@@ -139,14 +139,6 @@ def modules_for(profile: DeployProfile) -> list[Module]:
             # App services — corp-free test module: real BotChatService, local_sql
             # router, dummy Dima config, community no-op code-platform (AntCode).
             TestAppServicesModule(),
-            # Devices — corp-free local/SQLite doubles (no ARCA factory / corp config).
-            # Installed LAST on purpose: ``CommunityDeviceSyncModule`` also binds
-            # ``DeviceAdapterTransport`` to the community no-op, but the test column
-            # needs the stateful ``InMemoryDeviceAdapterTransport`` (cron gateway
-            # contract tests). Injector is last-wins, so ``TestDevicesModule`` must
-            # come after ``CommunityDeviceSyncModule`` to reinstate the in-memory
-            # transport.
-            TestDevicesModule(),
         ]
 
         if profile is DeployProfile.TEST:
@@ -154,13 +146,16 @@ def modules_for(profile: DeployProfile) -> list[Module]:
                 TestHttpClientModule,
             )
 
-            column.append(TestHttpClientModule())
+            column.extend([TestDevicesModule(), TestHttpClientModule()])
         else:
             from agentclaw.community.di.modules.singlebox_access_module import (
                 SingleboxAccessModule,
             )
+            from agentclaw.community.di.modules.infrastructure.singlebox.devices import (
+                SingleboxDevicesModule,
+            )
 
-            column.append(SingleboxAccessModule())
+            column.extend([SingleboxDevicesModule(), SingleboxAccessModule()])
 
         return column
 

--- a/src/backend/src/agentclaw/community/plugins/community/devices.py
+++ b/src/backend/src/agentclaw/community/plugins/community/devices.py
@@ -26,9 +26,9 @@ class CommunityAllBaasRolloutPolicy(ArcaBotCreateBaasRolloutPolicy):
         self,
         *,
         user_id: str,
-        bot_type: str | None,
-        engine_type: str | None = None,
-        template_type: str | None = None,
+        bot_type: str,
+        engine_type: str,
+        template_type: str,
     ) -> ArcaBotCreateBaasRolloutDecision:
         return ArcaBotCreateBaasRolloutDecision(
             target_provider=BAAS_DEVICE_PROVIDER,

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -175,6 +175,11 @@
       ],
       "storage_dir": "./data/skills_scan"
     },
+    "task_queue_worker": {
+      "enabled": true,
+      "poll_interval_seconds": 0.2,
+      "poll_jitter_seconds": 0.0
+    },
     "token_exchange": {
       "agent_id": "singlebox_AGENT_LOCAL",
       "api_path": "/api/v1/login/token/exchange",
@@ -302,11 +307,11 @@
     },
     "task_queue_worker": {
       "batch_size": 10,
-      "enabled": false,
+      "enabled": true,
       "lease_seconds": 60,
       "max_concurrency": 10,
-      "poll_interval_seconds": 2.0,
-      "poll_jitter_seconds": 0.5,
+      "poll_interval_seconds": 0.2,
+      "poll_jitter_seconds": 0.0,
       "retry_backoff_max_seconds": 60.0,
       "retry_backoff_min_seconds": 1.0
     },

--- a/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
@@ -60,6 +60,7 @@ def test_disabled_rollout_fails_closed_to_arca():
         user_id="u001",
         bot_type="personal",
         engine_type="openclaw",
+        template_type="",
     )
 
     assert decision.target_provider == ARCA_DEVICE_PROVIDER
@@ -83,6 +84,7 @@ def test_matching_user_bot_type_and_engine_routes_to_baas():
         user_id="u001",
         bot_type="personal",
         engine_type="openclaw",
+        template_type="",
     )
 
     assert decision.target_provider == BAAS_DEVICE_PROVIDER
@@ -110,6 +112,7 @@ def test_rollout_decision_is_logged_with_context():
             user_id="u001",
             bot_type="personal",
             engine_type="openclaw",
+            template_type="",
         )
 
     messages = [str(call.args[0]) for call in log_info.call_args_list if call.args]
@@ -144,6 +147,7 @@ def test_matching_user_group_routes_to_baas():
         user_id="u002",
         bot_type="personal",
         engine_type="openclaw",
+        template_type="",
     )
 
     assert decision.target_provider == BAAS_DEVICE_PROVIDER
@@ -172,6 +176,7 @@ def test_rule_user_ids_and_user_groups_are_union():
             user_id=user_id,
             bot_type="personal",
             engine_type="openclaw",
+            template_type="",
         )
 
         assert decision.target_provider == BAAS_DEVICE_PROVIDER
@@ -195,6 +200,7 @@ def test_allow_all_users_routes_matching_combination_to_baas():
         user_id="any-user",
         bot_type="service",
         engine_type="openclaw",
+        template_type="",
     )
 
     assert decision.target_provider == BAAS_DEVICE_PROVIDER
@@ -217,6 +223,7 @@ def test_same_user_wrong_bot_type_fails_closed_to_arca():
         user_id="u001",
         bot_type="service",
         engine_type="openclaw",
+        template_type="",
     )
 
     assert decision.target_provider == ARCA_DEVICE_PROVIDER
@@ -239,13 +246,14 @@ def test_matching_rule_but_user_not_allowed_fails_closed_to_arca():
         user_id="u002",
         bot_type="personal",
         engine_type="openclaw",
+        template_type="",
     )
 
     assert decision.target_provider == ARCA_DEVICE_PROVIDER
     assert decision.reason == "user_not_allowed"
 
 
-def test_missing_bot_type_falls_back_to_arca():
+def test_blank_bot_type_falls_back_to_arca():
     policy = _policy(
         ArcaBotCreateBaasRolloutConfig(
             enabled=True,
@@ -260,17 +268,17 @@ def test_missing_bot_type_falls_back_to_arca():
     )
 
     with patch("agentclaw.community.core.devices.services.arca_bot_create_baas_rollout_policy.logger.warning") as log_warning:
-        for bot_type in (None, ""):
-            decision = policy.decide(
-                user_id="u001",
-                bot_type=bot_type,
-                engine_type="openclaw",
-            )
+        decision = policy.decide(
+            user_id="u001",
+            bot_type="",
+            engine_type="openclaw",
+            template_type="",
+        )
 
-            assert decision.target_provider == ARCA_DEVICE_PROVIDER
-            assert decision.reason == "unclassified_branch_fallback"
+        assert decision.target_provider == ARCA_DEVICE_PROVIDER
+        assert decision.reason == "unclassified_branch_fallback"
 
-    assert log_warning.call_count == 2
+    log_warning.assert_called_once()
 
 
 def test_personal_hermes_is_legacy_arca_branch():
@@ -281,6 +289,7 @@ def test_personal_hermes_is_legacy_arca_branch():
             user_id="u001",
             bot_type="personal",
             engine_type="hermes",
+            template_type="",
         )
 
     assert decision.target_provider == ARCA_DEVICE_PROVIDER
@@ -305,6 +314,7 @@ def test_unclassified_branch_falls_back_to_arca_with_warning(bot_type, engine_ty
             user_id="u001",
             bot_type=bot_type,
             engine_type=engine_type,
+            template_type="",
         )
 
     assert decision.target_provider == ARCA_DEVICE_PROVIDER
@@ -329,6 +339,7 @@ def test_claude_code_requires_explicit_engine_bucket():
         user_id="u001",
         bot_type="personal",
         engine_type="claude_code",
+        template_type="",
     )
 
     assert decision.target_provider == ARCA_DEVICE_PROVIDER
@@ -602,6 +613,7 @@ def test_default_scope_can_route_matching_user_to_baas():
         user_id="u001",
         bot_type="personal",
         engine_type="openclaw",
+        template_type="",
     )
 
     assert decision.target_provider == BAAS_DEVICE_PROVIDER
@@ -627,6 +639,7 @@ def test_personal_hermes_drm_rule_can_route_matching_user_to_baas():
         user_id="u001",
         bot_type="personal",
         engine_type="hermes",
+        template_type="",
     )
 
     assert decision.target_provider == BAAS_DEVICE_PROVIDER
@@ -793,4 +806,3 @@ def test_drm_payload_parser_rejects_duplicate_combination():
     )
 
     assert config.enabled is False
-

--- a/src/backend/tests/community/core/devices/services/test_device_service_router.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service_router.py
@@ -202,6 +202,7 @@ class TestDeviceServiceRouterInit:
             user_id="u001",
             bot_type="personal",
             engine_type="openclaw",
+            template_type="",
         )
 
         assert decision.target_provider == LOCAL_DEVICE_PROVIDER
@@ -321,6 +322,13 @@ class TestGetProviderForNewDevice:
         router._arca_baas_rollout_policy = _FakeArcaBotCreateBaasRolloutPolicy(LOCAL_DEVICE_PROVIDER)
 
         provider = router._get_provider_for_new_device("u001")
+
+        router._arca_baas_rollout_policy.decide.assert_called_once_with(
+            user_id="u001",
+            bot_type="",
+            engine_type="openclaw",
+            template_type="",
+        )
         assert provider is router._providers[LOCAL_DEVICE_PROVIDER]
 
     def test_unknown_create_provider_raises(self):

--- a/src/backend/tests/community/di/test_profile_and_modules_for.py
+++ b/src/backend/tests/community/di/test_profile_and_modules_for.py
@@ -3,6 +3,7 @@
 Asserts the additive mechanism reproduces today's per-profile module sets
 and that the mandatory switch errors out on unset / unknown values.
 """
+
 from __future__ import annotations
 
 from typing import Annotated
@@ -11,6 +12,22 @@ import pytest
 from injector import Injector
 
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.services.teclaw_status_reconciler import (
+    TeclawStatusReconciler,
+)
+from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.core.devices.services.baas_device_accessor import (
+    BaasDeviceAccessor,
+)
+from agentclaw.community.core.devices.services.baas_device_service import (
+    BaasDeviceService,
+)
+from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.device_service import DeviceService
+from agentclaw.community.core.devices.services.device_service_router import (
+    DeviceServiceRouter,
+)
 from agentclaw.community.core.access.services.policy_service import PolicyService
 from agentclaw.community.di.container import build_injector
 from agentclaw.community.di.modules.http_client_module import HttpClientModule
@@ -19,6 +36,8 @@ from agentclaw.community.di.modules.infrastructure.test.http_client import (
 )
 from agentclaw.community.di.profile import DeployProfile, validate_deploy_environment
 from agentclaw.community.di.profile_modules import modules_for
+from agentclaw.community.core.service_bot.services.baas_service import BaasService
+from agentclaw.community.kernel.lifecycle import discover_lifecycle_participants
 from agentclaw.community.plugin_api.http_client import (
     QUALIFIER_BAAS,
     QUALIFIER_BCN,
@@ -86,9 +105,7 @@ def test_detect_parses_value(monkeypatch, raw, expected):
     ["SERVER_ENV", "REAL_SERVER_ENV", "ALIPAY_APP_ENV"],
 )
 def test_legacy_singlebox_env_is_rejected(key):
-    with pytest.raises(
-        RuntimeError, match="DEPLOY_PROFILE=singlebox SERVER_ENV=dev"
-    ):
+    with pytest.raises(RuntimeError, match="DEPLOY_PROFILE=singlebox SERVER_ENV=dev"):
         validate_deploy_environment({key: "singlebox"})
 
 
@@ -158,15 +175,19 @@ def test_test_and_singlebox_have_explicit_access_and_http_bindings():
     legacy_access_module = "Testing" + "AccessModule"
 
     assert "TestHttpClientModule" in test_names
+    assert "TestDevicesModule" in test_names
+    assert "SingleboxDevicesModule" not in test_names
     assert "SingleboxAccessModule" not in test_names
     assert legacy_access_module not in test_names
 
     assert "SingleboxAccessModule" in singlebox_names
     assert "TestHttpClientModule" not in singlebox_names
+    assert "SingleboxDevicesModule" in singlebox_names
+    assert "TestDevicesModule" not in singlebox_names
     assert legacy_access_module not in singlebox_names
 
-    assert test_names - {"TestHttpClientModule"} == (
-        singlebox_names - {"SingleboxAccessModule"}
+    assert test_names - {"TestHttpClientModule", "TestDevicesModule"} == (
+        singlebox_names - {"SingleboxAccessModule", "SingleboxDevicesModule"}
     )
 
 
@@ -185,9 +206,49 @@ def test_singlebox_profile_resolves_local_policy_and_real_http_clients():
 
     assert isinstance(injector.get(PolicyServiceProtocol), LocalPolicyService)
     assert all(
-        isinstance(client, HttpxClient)
-        for client in _resolve_http_clients(injector)
+        isinstance(client, HttpxClient) for client in _resolve_http_clients(injector)
     )
+
+
+def test_singlebox_profile_resolves_baas_only_device_runtime():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+
+    service = injector.get(DeviceService)
+    assert isinstance(service, DeviceServiceRouter)
+    assert set(service._providers) == {"baas"}
+    assert isinstance(service._providers["baas"], BaasDeviceService)
+    assert isinstance(injector.get(DeviceAccessor), BaasDeviceAccessor)
+    participant_names = {
+        type(participant).__name__
+        for participant in discover_lifecycle_participants(injector)
+    }
+    assert "SingleboxBaasTemplateConfigLifecycle" in participant_names
+    assert "LocalDeviceLifecycle" not in participant_names
+
+
+def test_singlebox_rollout_policy_preserves_normalized_engine_bucket():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+    service = injector.get(DeviceService)
+
+    decision = service._arca_baas_rollout_policy.decide(
+        user_id="owner",
+        bot_type="personal",
+        engine_type="claude-code",
+        template_type="personalCoding",
+    )
+
+    assert decision.target_provider == "baas"
+    assert decision.engine_bucket == "aicoding"
+
+
+def test_singlebox_reconciler_uses_real_dependencies_with_noop_scheduler():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+
+    reconciler = injector.get(TeclawStatusReconciler)
+
+    assert reconciler._baas is injector.get(BaasService)
+    assert reconciler._bot_repository is injector.get(BotRepository)
+    assert reconciler._device_binding_repo is injector.get(DeviceBindingRepository)
 
 
 def test_test_http_override_wins_when_installed_after_base():

--- a/src/backend/tests/community/di/test_profile_and_modules_for.py
+++ b/src/backend/tests/community/di/test_profile_and_modules_for.py
@@ -214,10 +214,11 @@ def test_singlebox_profile_resolves_baas_only_device_runtime():
     injector = build_injector(profile=DeployProfile.SINGLEBOX)
 
     service = injector.get(DeviceService)
+    baas_device_accessor = injector.get(BaasDeviceAccessor)
     assert isinstance(service, DeviceServiceRouter)
     assert set(service._providers) == {"baas"}
     assert isinstance(service._providers["baas"], BaasDeviceService)
-    assert isinstance(injector.get(DeviceAccessor), BaasDeviceAccessor)
+    assert injector.get(DeviceAccessor) is baas_device_accessor
     participant_names = {
         type(participant).__name__
         for participant in discover_lifecycle_participants(injector)

--- a/src/backend/tests/community/di/test_singlebox_baas_template_config.py
+++ b/src/backend/tests/community/di/test_singlebox_baas_template_config.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentclaw.community.di.modules.infrastructure.singlebox.template_config import (
+    SingleboxBaasTemplateConfigLifecycle,
+)
+
+
+@pytest.mark.asyncio
+async def test_seeds_singlebox_baas_template_mapping():
+    config_service = MagicMock()
+    config_service.get_config.return_value = None
+    config_service.set_config.return_value = 7
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid="TEMPLATE-local",
+    )
+
+    with patch(
+        "agentclaw.community.di.modules.infrastructure.singlebox.template_config."
+        "env_utils.get_current_env",
+        return_value="dev",
+    ):
+        await lifecycle.startup()
+
+    mapping = config_service.set_config.call_args.kwargs["config_value"]
+    assert mapping["templates"]["local_default"]["template_uuid"] == ("TEMPLATE-local")
+    assert {item["engine"] for item in mapping["selectors"]} == {
+        "openclaw",
+        "moltis",
+        "hermes",
+        "aicoding",
+        "claude_code",
+    }
+    assert config_service.set_config.call_args.kwargs["env"] == "dev"
+
+
+@pytest.mark.asyncio
+async def test_preserves_existing_singlebox_baas_template_mapping():
+    config_service = MagicMock()
+    config_service.get_config.return_value = {"version": "custom"}
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid="TEMPLATE-local",
+    )
+
+    await lifecycle.startup()
+
+    config_service.create_category.assert_not_called()
+    config_service.set_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_template_uuid_fails_with_clear_startup_error():
+    config_service = MagicMock()
+    config_service.get_config.return_value = None
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid=None,
+    )
+
+    with pytest.raises(RuntimeError, match="baas.template_uuid"):
+        await lifecycle.startup()

--- a/src/backend/tests/community/di/test_singlebox_baas_template_config.py
+++ b/src/backend/tests/community/di/test_singlebox_baas_template_config.py
@@ -57,8 +57,16 @@ async def test_missing_template_uuid_fails_with_clear_startup_error():
     config_service.get_config.return_value = None
     lifecycle = SingleboxBaasTemplateConfigLifecycle(
         config_service=config_service,
-        template_uuid=None,
+        template_uuid="",
     )
 
     with pytest.raises(RuntimeError, match="baas.template_uuid"):
         await lifecycle.startup()
+
+
+def test_template_uuid_rejects_none_at_construction():
+    with pytest.raises(TypeError, match="template_uuid must be str"):
+        SingleboxBaasTemplateConfigLifecycle(
+            config_service=MagicMock(),
+            template_uuid=None,  # type: ignore[arg-type]
+        )

--- a/src/backend/tests/community/plugins/community/test_community_noop_services.py
+++ b/src/backend/tests/community/plugins/community/test_community_noop_services.py
@@ -64,10 +64,13 @@ def test_all_baas_rollout_policy_always_decides_baas():
     for bot_type, engine in [
         ("personal", "openclaw"),
         ("service", "claude_code"),
-        ("desktop", None),
+        ("desktop", ""),
         ("anything", "xyz"),
     ]:
         decision = policy.decide(
-            user_id="staff-1", bot_type=bot_type, engine_type=engine
+            user_id="staff-1",
+            bot_type=bot_type,
+            engine_type=engine,
+            template_type="",
         )
         assert decision.target_provider == BAAS_DEVICE_PROVIDER


### PR DESCRIPTION
## Summary

- land the effective changes from merged PR #98 onto the latest `dev`
- route the singlebox device lifecycle through the real BaaS provider
- keep test and singlebox DI profiles separated
- seed the singlebox BaaS template mapping through an explicit lifecycle participant

## Lineage

PR #98 was merged into the intermediate `codex/profile-env-separation` branch rather than `dev`. This PR reapplies its single effective commit on top of the current `dev` so the implementation actually reaches the main development line.

## Verification

- targeted DI/config tests: 30 passed
- Backend community regression: 7419 passed
- pre-push SAST, Backend suite, and BCS build passed; real singlebox setup reached BCN plugin installation, then was stopped after the local `npm install` made no progress for several minutes
