### PR TITLE
feat(ci): run registered singlebox modules in one coverage stack

### DIFF
--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -9,11 +9,21 @@ export PATH="${HOME}/.cargo/bin:${PATH}"
 coverage_root="${SINGLEBOX_COVERAGE_ROOT:-$repo_root/scripts/.dependencies/coverage/singlebox}"
 report_dir="$coverage_root/reports"
 mode="${SINGLEBOX_COVERAGE_MODE:-real}"
-acceptance_target="${SINGLEBOX_COVERAGE_ACCEPTANCE_TARGET:-tests/community/acceptance/cron/test_cron_query_lifecycle.py}"
-coverage_module="${SINGLEBOX_COVERAGE_MODULE:-}"
 module_manifest="$script_dir/singlebox_coverage_modules.yaml"
 coverage_standalone_root=""
 coverage_standalone_runtime=""
+requested_modules=()
+acceptance_targets=()
+explicit_acceptance_targets=()
+coverage_modules=()
+reporter_command=()
+
+if [[ -n "${SINGLEBOX_COVERAGE_MODULE:-}" ]]; then
+  requested_modules+=("$SINGLEBOX_COVERAGE_MODULE")
+fi
+if [[ -n "${SINGLEBOX_COVERAGE_ACCEPTANCE_TARGET:-}" ]]; then
+  explicit_acceptance_targets+=("$SINGLEBOX_COVERAGE_ACCEPTANCE_TARGET")
+fi
 
 usage() {
   cat <<USAGE
@@ -27,8 +37,9 @@ Options:
   --coverage-root DIR     Coverage output root, default: $coverage_root
   --mode real             Override SINGLEBOX_COVERAGE_MODE
   --acceptance-target PATH
-                          Pytest target executed against the live stack
-  --module NAME           Add module metrics and enforce its thresholds
+                          Override manifest targets; may be repeated
+  --module NAME           Run and gate one manifest module; may be repeated
+                          Default: every enabled module in the manifest
   -h, --help              Show this help
 USAGE
 }
@@ -57,7 +68,7 @@ while [[ "$#" -gt 0 ]]; do
         echo "error: --acceptance-target requires an argument" >&2
         exit 2
       fi
-      acceptance_target="$2"
+      explicit_acceptance_targets+=("$2")
       shift 2
       ;;
     --module)
@@ -65,7 +76,7 @@ while [[ "$#" -gt 0 ]]; do
         echo "error: --module requires an argument" >&2
         exit 2
       fi
-      coverage_module="$2"
+      requested_modules+=("$2")
       shift 2
       ;;
     -h|--help)
@@ -80,10 +91,52 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-if [[ -n "$coverage_module" && ! -s "$module_manifest" ]]; then
+if [[ ! -s "$module_manifest" ]]; then
   echo "missing singlebox coverage module manifest: $module_manifest" >&2
   exit 2
 fi
+
+resolve_reporter_command() {
+  if [[ -n "${PYTHON:-}" ]]; then
+    reporter_command=("$PYTHON")
+  elif [[ -x "$repo_root/src/backend/.venv/bin/python" ]]; then
+    reporter_command=("$repo_root/src/backend/.venv/bin/python")
+  else
+    reporter_command=(uv run --project "$repo_root/src/backend" python)
+  fi
+}
+
+resolve_coverage_scope() {
+  local selection_args=(--manifest "$module_manifest")
+  local module_name target
+  if [[ "${#requested_modules[@]}" -gt 0 ]]; then
+    for module_name in "${requested_modules[@]}"; do
+      selection_args+=(--module "$module_name")
+    done
+  fi
+
+  while IFS= read -r module_name; do
+    [[ -n "$module_name" ]] && coverage_modules+=("$module_name")
+  done < <("${reporter_command[@]}" "$script_dir/singlebox_coverage_report.py" \
+    "${selection_args[@]}" --list-modules)
+  if [[ "${#coverage_modules[@]}" -eq 0 ]]; then
+    echo "singlebox coverage manifest selected no modules" >&2
+    return 2
+  fi
+
+  if [[ "${#explicit_acceptance_targets[@]}" -gt 0 ]]; then
+    acceptance_targets=("${explicit_acceptance_targets[@]}")
+  else
+    while IFS= read -r target; do
+      [[ -n "$target" ]] && acceptance_targets+=("$target")
+    done < <("${reporter_command[@]}" "$script_dir/singlebox_coverage_report.py" \
+      "${selection_args[@]}" --list-acceptance-targets)
+  fi
+  if [[ "${#acceptance_targets[@]}" -eq 0 ]]; then
+    echo "selected coverage modules have no acceptance targets" >&2
+    return 2
+  fi
+}
 
 run_real_singlebox() {
   rm -rf "$coverage_root/raw" "$report_dir"
@@ -94,7 +147,8 @@ run_real_singlebox() {
   echo "coverage_root: $coverage_root"
   echo "standalone_openclaw_root: $coverage_standalone_root"
   echo "standalone_runtime_dir: $coverage_standalone_runtime"
-  echo "acceptance_target: $acceptance_target"
+  echo "coverage_modules: ${coverage_modules[*]}"
+  echo "acceptance_targets: ${acceptance_targets[*]}"
   cleanup_real_singlebox() {
     flush_coverage_processes || true
     env OCB_SKIP_GIT_HOOKS=1 SINGLEBOX_MODEL_CONFIG_MODE=mock \
@@ -145,7 +199,7 @@ run_acceptance_smoke() {
     RUN_ACCEPTANCE=1 \
       SINGLEBOX_ACCEPTANCE_REUSE_LIVE=1 \
       SINGLEBOX_ACCEPTANCE_KEEP_ARTIFACTS=1 \
-      uv run pytest "$acceptance_target" -q --junitxml "$junit_report"
+      uv run pytest "${acceptance_targets[@]}" -q --junitxml "$junit_report"
   ) > "$acceptance_log" 2>&1 || rc=$?
   cat "$acceptance_log"
   [ "$rc" -eq 0 ] || return "$rc"
@@ -199,16 +253,16 @@ write_summary_artifacts() {
   backend_plugin_hits="$(jsonl_count "$coverage_root/raw/backend/plugin_hits.jsonl")"
   baas_router_hits="$(jsonl_count "$coverage_root/raw/baas/router_hits.jsonl")"
 
-  "${PYTHON:-python3}" - "$report_dir" "$acceptance_target" "$backend_router_hits" "$backend_plugin_hits" "$baas_router_hits" <<'PY'
+  "${reporter_command[@]}" - "$report_dir" "$backend_router_hits" "$backend_plugin_hits" "$baas_router_hits" "${acceptance_targets[@]}" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 report_dir = Path(sys.argv[1])
-acceptance_target = sys.argv[2]
-backend_router_hits = int(sys.argv[3])
-backend_plugin_hits = int(sys.argv[4])
-baas_router_hits = int(sys.argv[5])
+backend_router_hits = int(sys.argv[2])
+backend_plugin_hits = int(sys.argv[3])
+baas_router_hits = int(sys.argv[4])
+acceptance_targets = sys.argv[5:]
 
 summary = {
     "mode": "real",
@@ -216,7 +270,7 @@ summary = {
     "stack": "standalone start all",
     "model_config_mode": "mock",
     "acceptance": {
-        "target": acceptance_target,
+        "targets": acceptance_targets,
         "junit": "acceptance-junit.xml",
     },
     "coverage": {
@@ -236,7 +290,7 @@ summary = {
 
 report_dir.mkdir(parents=True, exist_ok=True)
 (report_dir / "summary.json").write_text(
-    json.dumps(summary, indent=2, sort_keys=True) + "\n",
+    json.dumps(summary, indent=2) + "\n",
     encoding="utf-8",
 )
 (report_dir / "summary.md").write_text(
@@ -247,7 +301,7 @@ report_dir.mkdir(parents=True, exist_ok=True)
             "- mode: real",
             "- stack: standalone start all",
             "- model config: mock",
-            f"- acceptance: {acceptance_target}",
+            f"- acceptance: {', '.join(acceptance_targets)}",
             f"- backend router hits: {backend_router_hits}",
             f"- backend plugin hits: {backend_plugin_hits}",
             f"- baas router hits: {baas_router_hits}",
@@ -259,7 +313,7 @@ report_dir.mkdir(parents=True, exist_ok=True)
 (report_dir / "dashboard.html").write_text(
     "<!doctype html><meta charset='utf-8'><title>Singlebox Coverage</title>"
     "<h1>Singlebox Coverage</h1>"
-    f"<p>Acceptance: {acceptance_target}</p>"
+    f"<p>Acceptance: {', '.join(acceptance_targets)}</p>"
     f"<p>Backend router hits: {backend_router_hits}</p>"
     f"<p>Backend plugin hits: {backend_plugin_hits}</p>"
     f"<p>BaaS router hits: {baas_router_hits}</p>",
@@ -269,16 +323,14 @@ PY
 }
 
 write_module_artifacts() {
-  local reporter_python
-  [[ -n "$coverage_module" ]] || return 0
-  reporter_python="${PYTHON:-$repo_root/src/backend/.venv/bin/python}"
-  if [[ ! -x "$reporter_python" ]]; then
-    echo "singlebox coverage reporter Python is not executable: $reporter_python" >&2
-    return 1
-  fi
-  "$reporter_python" "$script_dir/singlebox_coverage_report.py" \
+  local module_args=()
+  local module_name
+  for module_name in "${coverage_modules[@]}"; do
+    module_args+=(--module "$module_name")
+  done
+  "${reporter_command[@]}" "$script_dir/singlebox_coverage_report.py" \
     --manifest "$module_manifest" \
-    --module "$coverage_module" \
+    "${module_args[@]}" \
     --coverage-json "$report_dir/backend-coverage.json" \
     --router-hits "$coverage_root/raw/backend/router_hits.jsonl" \
     --plugin-hits "$coverage_root/raw/backend/plugin_hits.jsonl" \
@@ -310,6 +362,8 @@ verify_required_artifacts() {
 
 case "$mode" in
   real)
+    resolve_reporter_command
+    resolve_coverage_scope
     run_real_singlebox
     ;;
   *)

--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -108,17 +108,21 @@ resolve_reporter_command() {
 
 resolve_coverage_scope() {
   local selection_args=(--manifest "$module_manifest")
-  local module_name target
+  local module_name target modules_output targets_output
   if [[ "${#requested_modules[@]}" -gt 0 ]]; then
     for module_name in "${requested_modules[@]}"; do
       selection_args+=(--module "$module_name")
     done
   fi
 
+  if ! modules_output="$("${reporter_command[@]}" \
+    "$script_dir/singlebox_coverage_report.py" \
+    "${selection_args[@]}" --list-modules)"; then
+    return 2
+  fi
   while IFS= read -r module_name; do
     [[ -n "$module_name" ]] && coverage_modules+=("$module_name")
-  done < <("${reporter_command[@]}" "$script_dir/singlebox_coverage_report.py" \
-    "${selection_args[@]}" --list-modules)
+  done <<< "$modules_output"
   if [[ "${#coverage_modules[@]}" -eq 0 ]]; then
     echo "singlebox coverage manifest selected no modules" >&2
     return 2
@@ -127,10 +131,14 @@ resolve_coverage_scope() {
   if [[ "${#explicit_acceptance_targets[@]}" -gt 0 ]]; then
     acceptance_targets=("${explicit_acceptance_targets[@]}")
   else
+    if ! targets_output="$("${reporter_command[@]}" \
+      "$script_dir/singlebox_coverage_report.py" \
+      "${selection_args[@]}" --list-acceptance-targets)"; then
+      return 2
+    fi
     while IFS= read -r target; do
       [[ -n "$target" ]] && acceptance_targets+=("$target")
-    done < <("${reporter_command[@]}" "$script_dir/singlebox_coverage_report.py" \
-      "${selection_args[@]}" --list-acceptance-targets)
+    done <<< "$targets_output"
   fi
   if [[ "${#acceptance_targets[@]}" -eq 0 ]]; then
     echo "selected coverage modules have no acceptance targets" >&2

--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -81,7 +81,7 @@ modules:
     router_api: *pending_router_denominator
     plugin_api: *pending_plugin_denominator
     thresholds:
-      core_min_percent: 42.27
+      core_min_percent: 41.84
 
   expert_chat:
     system: backend

--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -1,6 +1,8 @@
 modules:
   devices:
     system: backend
+    acceptance_targets:
+      - tests/community/acceptance/devices
     core_paths:
       - src/agentclaw/community/core/devices/
     router_api:
@@ -30,3 +32,93 @@ modules:
     thresholds:
       core_min_percent: 43.36
       router_min_percent: 44.44
+
+  access:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/access
+    core_paths:
+      - src/agentclaw/community/core/access/
+    router_api: &pending_router_denominator
+      status: not_applicable
+      reason: Router denominator audit has not been migrated to the Avernet manifest yet.
+      items: []
+    plugin_api: &pending_plugin_denominator
+      status: not_applicable
+      reason: Plugin boundary denominator audit has not been migrated to the Avernet manifest yet.
+      items: []
+    thresholds:
+      core_min_percent: 42.80
+
+  bot_chat:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/bot_chat
+    core_paths:
+      - src/agentclaw/community/core/bot_chat/
+    router_api: *pending_router_denominator
+    plugin_api: *pending_plugin_denominator
+    thresholds:
+      core_min_percent: 40.66
+
+  bot_collaborator:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/bot_collaborator
+    core_paths:
+      - src/agentclaw/community/core/bot_collaborator/
+    router_api: *pending_router_denominator
+    plugin_api: *pending_plugin_denominator
+    thresholds:
+      core_min_percent: 53.88
+
+  cron:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/cron
+    core_paths:
+      - src/agentclaw/community/core/cron/
+    router_api: *pending_router_denominator
+    plugin_api: *pending_plugin_denominator
+    thresholds:
+      core_min_percent: 42.27
+
+  expert_chat:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/expert_chat
+    core_paths:
+      - src/agentclaw/community/core/expert_chat/
+    router_api: *pending_router_denominator
+    plugin_api: *pending_plugin_denominator
+    thresholds:
+      core_min_percent: 63.49
+
+  harness:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/harness
+    core_paths:
+      - src/agentclaw/community/core/harness/
+    router_api: *pending_router_denominator
+    plugin_api: *pending_plugin_denominator
+    thresholds:
+      core_min_percent: 41.59
+
+pending_modules:
+  skill_center:
+    acceptance_targets:
+      - tests/community/acceptance/skill_center
+    reason: Latest BaaS-backed runtime run has three failing acceptance stories.
+  bot_management:
+    acceptance_targets:
+      - tests/community/acceptance/bot_management
+    reason: Live owner lifecycle still expects the retired local device provider.
+  mcp:
+    acceptance_targets:
+      - tests/community/acceptance/mcp
+    reason: Permission baseline and live engine connection assumptions need migration.
+  resources:
+    acceptance_targets:
+      - tests/community/acceptance/resources
+    reason: File lifecycle creates no BaaS-backed bot binding before workspace access.

--- a/scripts/ci/singlebox_coverage_report.py
+++ b/scripts/ci/singlebox_coverage_report.py
@@ -17,6 +17,41 @@ def _percent(covered: int, total: int) -> float:
     return round((covered * 100.0 / total) if total else 0.0, 2)
 
 
+def select_module_names(
+    manifest: dict[str, Any], requested_modules: list[str]
+) -> list[str]:
+    modules = manifest.get("modules") or {}
+    if requested_modules:
+        selected: list[str] = []
+        for module_name in requested_modules:
+            if module_name not in modules:
+                raise ValueError(f"unknown coverage module: {module_name}")
+            if module_name not in selected:
+                selected.append(module_name)
+        return selected
+    return [
+        module_name
+        for module_name, config in modules.items()
+        if config.get("enabled", True)
+    ]
+
+
+def acceptance_targets_for(
+    manifest: dict[str, Any], module_names: list[str]
+) -> list[str]:
+    modules = manifest.get("modules") or {}
+    targets: list[str] = []
+    for module_name in module_names:
+        module = modules.get(module_name)
+        if module is None:
+            raise ValueError(f"unknown coverage module: {module_name}")
+        for target in module.get("acceptance_targets") or []:
+            target = str(target)
+            if target not in targets:
+                targets.append(target)
+    return targets
+
+
 def _matches_core_path(filename: str, prefixes: list[str]) -> bool:
     normalized = f"/{filename.replace('\\', '/').strip('./')}/"
     return any(
@@ -133,7 +168,10 @@ def _render_markdown(summary: dict[str, Any]) -> str:
         f"- status: {summary.get('status', 'unknown')}",
     ]
     acceptance = summary.get("acceptance") or {}
-    if acceptance.get("target"):
+    targets = acceptance.get("targets") or []
+    if targets:
+        lines.append(f"- acceptance: {', '.join(targets)}")
+    elif acceptance.get("target"):
         lines.append(f"- acceptance: {acceptance['target']}")
     for report in (summary.get("modules") or {}).values():
         lines.extend(
@@ -192,20 +230,24 @@ section{background:#fff;border:1px solid #dce2e8;border-radius:8px;padding:20px}
 
 def update_report_artifacts(
     report_dir: Path,
-    report: dict[str, Any],
+    reports: dict[str, Any] | list[dict[str, Any]],
     *,
     threshold_errors: list[str] | None = None,
 ) -> None:
+    if isinstance(reports, dict):
+        reports = [reports]
     summary_path = report_dir / "summary.json"
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
-    summary.setdefault("modules", {})[report["name"]] = report
+    modules = summary.setdefault("modules", {})
+    for report in reports:
+        modules[report["name"]] = report
     if threshold_errors:
         summary["status"] = "failed"
         summary["threshold_errors"] = threshold_errors
     else:
         summary.pop("threshold_errors", None)
     summary_path.write_text(
-        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        json.dumps(summary, indent=2) + "\n",
         encoding="utf-8",
     )
     (report_dir / "summary.md").write_text(
@@ -243,27 +285,55 @@ def _load_jsonl_keys(path: Path) -> list[str]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", required=True, type=Path)
-    parser.add_argument("--module", required=True)
-    parser.add_argument("--coverage-json", required=True, type=Path)
-    parser.add_argument("--router-hits", required=True, type=Path)
-    parser.add_argument("--plugin-hits", required=True, type=Path)
-    parser.add_argument("--report-dir", required=True, type=Path)
+    parser.add_argument("--module", action="append", default=[])
+    parser.add_argument("--list-modules", action="store_true")
+    parser.add_argument("--list-acceptance-targets", action="store_true")
+    parser.add_argument("--coverage-json", type=Path)
+    parser.add_argument("--router-hits", type=Path)
+    parser.add_argument("--plugin-hits", type=Path)
+    parser.add_argument("--report-dir", type=Path)
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     manifest = yaml.safe_load(args.manifest.read_text(encoding="utf-8")) or {}
+    try:
+        module_names = select_module_names(manifest, args.module)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    if args.list_modules:
+        print("\n".join(module_names))
+        return 0
+    if args.list_acceptance_targets:
+        print("\n".join(acceptance_targets_for(manifest, module_names)))
+        return 0
+    required = {
+        "--coverage-json": args.coverage_json,
+        "--router-hits": args.router_hits,
+        "--plugin-hits": args.plugin_hits,
+        "--report-dir": args.report_dir,
+    }
+    missing = [flag for flag, value in required.items() if value is None]
+    if missing:
+        print(f"missing required reporting arguments: {', '.join(missing)}", file=sys.stderr)
+        return 2
     coverage = json.loads(args.coverage_json.read_text(encoding="utf-8"))
-    report = build_module_report(
-        manifest=manifest,
-        module_name=args.module,
-        coverage=coverage,
-        router_hits=_load_jsonl_keys(args.router_hits),
-        plugin_hits=_load_jsonl_keys(args.plugin_hits),
-    )
-    errors = validate_thresholds(report)
-    update_report_artifacts(args.report_dir, report, threshold_errors=errors)
+    router_hits = _load_jsonl_keys(args.router_hits)
+    plugin_hits = _load_jsonl_keys(args.plugin_hits)
+    reports = [
+        build_module_report(
+            manifest=manifest,
+            module_name=module_name,
+            coverage=coverage,
+            router_hits=router_hits,
+            plugin_hits=plugin_hits,
+        )
+        for module_name in module_names
+    ]
+    errors = [error for report in reports for error in validate_thresholds(report)]
+    update_report_artifacts(args.report_dir, reports, threshold_errors=errors)
     if errors:
         print("singlebox module coverage threshold failed:", file=sys.stderr)
         for error in errors:
@@ -275,11 +345,12 @@ def main() -> int:
             return "N/A"
         return f"{metric['percent']:.2f}%"
 
-    print(
-        f"{args.module} coverage: core={report['core']['percent']:.2f}% "
-        f"router={display(report['router_api'])} "
-        f"plugin={display(report['plugin_api'])}"
-    )
+    for report in reports:
+        print(
+            f"{report['name']} coverage: core={report['core']['percent']:.2f}% "
+            f"router={display(report['router_api'])} "
+            f"plugin={display(report['plugin_api'])}"
+        )
     return 0
 
 

--- a/scripts/ci/singlebox_coverage_report.py
+++ b/scripts/ci/singlebox_coverage_report.py
@@ -17,10 +17,20 @@ def _percent(covered: int, total: int) -> float:
     return round((covered * 100.0 / total) if total else 0.0, 2)
 
 
+def _module_configs(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    modules = manifest.get("modules") or {}
+    if not isinstance(modules, dict):
+        raise ValueError("coverage manifest modules must be a mapping")
+    for module_name, config in modules.items():
+        if not isinstance(config, dict):
+            raise ValueError(f"coverage module config must be a mapping: {module_name}")
+    return modules
+
+
 def select_module_names(
     manifest: dict[str, Any], requested_modules: list[str]
 ) -> list[str]:
-    modules = manifest.get("modules") or {}
+    modules = _module_configs(manifest)
     if requested_modules:
         selected: list[str] = []
         for module_name in requested_modules:
@@ -39,7 +49,7 @@ def select_module_names(
 def acceptance_targets_for(
     manifest: dict[str, Any], module_names: list[str]
 ) -> list[str]:
-    modules = manifest.get("modules") or {}
+    modules = _module_configs(manifest)
     targets: list[str] = []
     for module_name in module_names:
         module = modules.get(module_name)
@@ -101,7 +111,7 @@ def build_module_report(
     router_hits: list[str],
     plugin_hits: list[str],
 ) -> dict[str, Any]:
-    module = (manifest.get("modules") or {}).get(module_name)
+    module = _module_configs(manifest).get(module_name)
     if module is None:
         raise ValueError(f"unknown coverage module: {module_name}")
 
@@ -317,7 +327,10 @@ def main() -> int:
     }
     missing = [flag for flag, value in required.items() if value is None]
     if missing:
-        print(f"missing required reporting arguments: {', '.join(missing)}", file=sys.stderr)
+        print(
+            f"missing required reporting arguments: {', '.join(missing)}",
+            file=sys.stderr,
+        )
         return 2
     coverage = json.loads(args.coverage_json.read_text(encoding="utf-8"))
     router_hits = _load_jsonl_keys(args.router_hits)

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -75,6 +75,13 @@ def test_select_module_names_rejects_unknown_requested_module():
         select_module_names(_manifest(), ["missing"])
 
 
+def test_select_module_names_rejects_non_mapping_module_config():
+    with pytest.raises(
+        ValueError, match="coverage module config must be a mapping: empty"
+    ):
+        select_module_names({"modules": {"empty": None}}, [])
+
+
 def test_acceptance_targets_are_deduplicated_in_module_order():
     manifest = {
         "modules": {

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -12,7 +13,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from singlebox_coverage_report import (  # noqa: E402
     _load_jsonl_keys,
     _matches_core_path,
+    acceptance_targets_for,
     build_module_report,
+    select_module_names,
     update_report_artifacts,
     validate_thresholds,
 )
@@ -44,6 +47,76 @@ def _manifest() -> dict:
             }
         }
     }
+
+
+def test_select_module_names_defaults_to_all_enabled_modules():
+    manifest = _manifest()
+    manifest["modules"]["devices"]["acceptance_targets"] = [
+        "tests/community/acceptance/devices"
+    ]
+    manifest["modules"]["cron"] = {
+        "enabled": True,
+        "acceptance_targets": ["tests/community/acceptance/cron"],
+    }
+    manifest["modules"]["future"] = {
+        "enabled": False,
+        "acceptance_targets": ["tests/community/acceptance/future"],
+    }
+
+    assert select_module_names(manifest, []) == ["devices", "cron"]
+    assert acceptance_targets_for(manifest, ["devices", "cron"]) == [
+        "tests/community/acceptance/devices",
+        "tests/community/acceptance/cron",
+    ]
+
+
+def test_select_module_names_rejects_unknown_requested_module():
+    with pytest.raises(ValueError, match="unknown coverage module: missing"):
+        select_module_names(_manifest(), ["missing"])
+
+
+def test_acceptance_targets_are_deduplicated_in_module_order():
+    manifest = {
+        "modules": {
+            "one": {"acceptance_targets": ["shared", "one"]},
+            "two": {"acceptance_targets": ["shared", "two"]},
+        }
+    }
+
+    assert acceptance_targets_for(manifest, ["one", "two"]) == [
+        "shared",
+        "one",
+        "two",
+    ]
+
+
+def test_repository_manifest_registers_existing_coverage_modules_and_paths():
+    repo_root = Path(__file__).resolve().parents[3]
+    manifest = yaml.safe_load(
+        (repo_root / "scripts/ci/singlebox_coverage_modules.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    module_names = select_module_names(manifest, [])
+
+    assert module_names == [
+        "devices",
+        "access",
+        "bot_chat",
+        "bot_collaborator",
+        "cron",
+        "expert_chat",
+        "harness",
+    ]
+    for module_name in module_names:
+        module = manifest["modules"][module_name]
+        for target in module["acceptance_targets"]:
+            assert (repo_root / "src/backend" / target).exists(), target
+        for core_path in module["core_paths"]:
+            assert (repo_root / "src/backend" / core_path).exists(), core_path
+    for module in manifest["pending_modules"].values():
+        for target in module["acceptance_targets"]:
+            assert (repo_root / "src/backend" / target).exists(), target
 
 
 def _coverage() -> dict:
@@ -253,6 +326,37 @@ def test_update_report_artifacts_marks_threshold_failure(tmp_path: Path):
     update_report_artifacts(report_dir, report, threshold_errors=errors)
 
     summary = json.loads((report_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "failed"
+    assert summary["threshold_errors"] == errors
+
+
+def test_update_report_artifacts_aggregates_multiple_modules_and_errors(
+    tmp_path: Path,
+):
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    (report_dir / "summary.json").write_text(
+        json.dumps({"mode": "real", "status": "passed"}),
+        encoding="utf-8",
+    )
+    devices = build_module_report(
+        manifest=_manifest(),
+        module_name="devices",
+        coverage=_coverage(),
+        router_hits=DEVICE_ROUTES,
+        plugin_hits=[],
+    )
+    cron = {
+        **devices,
+        "name": "cron",
+        "core": {"covered": 1, "total": 4, "percent": 25.0},
+    }
+    errors = ["cron core coverage 25.00% < 40.00%"]
+
+    update_report_artifacts(report_dir, [devices, cron], threshold_errors=errors)
+
+    summary = json.loads((report_dir / "summary.json").read_text(encoding="utf-8"))
+    assert list(summary["modules"]) == ["devices", "cron"]
     assert summary["status"] == "failed"
     assert summary["threshold_errors"] == errors
 

--- a/scripts/test_singlebox_coverage_gate.sh
+++ b/scripts/test_singlebox_coverage_gate.sh
@@ -261,8 +261,35 @@ assert devices["plugin_api"]["status"] == "not_applicable"
 PY
 }
 
+test_reporter_selection_failure_is_preserved() {
+  local tmp output rc
+  tmp="$(mktemp -d)"
+  make_fake_repo "$tmp"
+  cat > "${tmp}/scripts/ci/singlebox_coverage_modules.yaml" <<'YAML'
+modules:
+  empty:
+YAML
+
+  set +e
+  output="$(
+    cd "$tmp"
+    PYTHON="${ROOT}/src/backend/.venv/bin/python" \
+      "${tmp}/scripts/ci/singlebox_coverage.sh" 2>&1
+  )"
+  rc=$?
+  set -e
+
+  [ "$rc" -eq 2 ] || fail "invalid manifest should return reporter usage error"
+  grep -F "coverage module config must be a mapping: empty" <<<"$output" >/dev/null || \
+    fail "reporter selection error should be preserved"
+  if grep -F "singlebox coverage manifest selected no modules" <<<"$output" >/dev/null; then
+    fail "reporter failure should not be replaced by an empty-selection error"
+  fi
+}
+
 test_default_mode_runs_real_singlebox
 test_mock_mode_is_not_supported
 test_module_mode_reports_device_metrics
+test_reporter_selection_failure_is_preserved
 
 printf 'PASS: singlebox coverage gate tests\n'

--- a/scripts/test_singlebox_coverage_gate.sh
+++ b/scripts/test_singlebox_coverage_gate.sh
@@ -17,7 +17,43 @@ make_fake_repo() {
   mkdir -p "${tmp}/src/backend" "${tmp}/src/baas/packages/community"
   cp "$SCRIPT" "${tmp}/scripts/ci/singlebox_coverage.sh"
   cp "$REPORTER" "${tmp}/scripts/ci/singlebox_coverage_report.py"
-  cp "$MANIFEST" "${tmp}/scripts/ci/singlebox_coverage_modules.yaml"
+  cat > "${tmp}/scripts/ci/singlebox_coverage_modules.yaml" <<'YAML'
+modules:
+  devices:
+    acceptance_targets:
+      - tests/community/acceptance/devices
+    system: backend
+    core_paths:
+      - src/agentclaw/community/core/devices/
+    router_api:
+      items:
+        - GET /api/v1/devices
+        - GET /api/v1/devices/{binding_id:int}
+        - GET /api/v1/devices/by-id/{device_id}
+    plugin_api:
+      status: not_applicable
+      reason: No device plugin denominator.
+      items: []
+    thresholds:
+      core_min_percent: 40
+      router_min_percent: 30
+  cron:
+    acceptance_targets:
+      - tests/community/acceptance/cron
+    system: backend
+    core_paths:
+      - src/agentclaw/community/core/cron/
+    router_api:
+      items:
+        - GET /api/cron
+    plugin_api:
+      status: not_applicable
+      reason: No cron plugin denominator in this fixture.
+      items: []
+    thresholds:
+      core_min_percent: 40
+      router_min_percent: 100
+YAML
   chmod +x "${tmp}/scripts/ci/singlebox_coverage.sh"
   cat > "${tmp}/scripts/singlebox.sh" <<'SH'
 #!/usr/bin/env bash
@@ -55,7 +91,10 @@ if [ "$*" = "--standalone start all" ]; then
 {"key":"POST /api/v1/devices/{binding_id:int}/release"}
 JSONL
   else
-    printf '%s\n' '{"key":"GET /api/health"}' > "${SINGLEBOX_COVERAGE_DIR}/backend/router_hits.jsonl"
+    cat > "${SINGLEBOX_COVERAGE_DIR}/backend/router_hits.jsonl" <<'JSONL'
+{"key":"GET /api/v1/devices"}
+{"key":"GET /api/cron"}
+JSONL
   fi
   printf '%s\n' '{"key":"BotService.create_bot"}' > "${SINGLEBOX_COVERAGE_DIR}/backend/plugin_hits.jsonl"
   printf '%s\n' '{"key":"GET /health"}' > "${SINGLEBOX_COVERAGE_DIR}/baas/router_hits.jsonl"
@@ -104,7 +143,7 @@ if [ "${1:-}" = "run" ] && [ "${2:-}" = "coverage" ]; then
       done
       [ -n "$output" ] || exit 23
       mkdir -p "$(dirname "$output")"
-      printf '%s\n' '{"totals":{"percent_covered":100},"files":{"src/agentclaw/community/core/devices/services/device_service.py":{"summary":{"covered_lines":50,"num_statements":100}}}}' > "$output"
+      printf '%s\n' '{"totals":{"percent_covered":100},"files":{"src/agentclaw/community/core/devices/services/device_service.py":{"summary":{"covered_lines":50,"num_statements":100}},"src/agentclaw/community/core/cron/services/cron_service.py":{"summary":{"covered_lines":50,"num_statements":100}}}}' > "$output"
       ;;
     html)
       output_dir=""
@@ -142,7 +181,9 @@ test_default_mode_runs_real_singlebox() {
 
   (
     cd "$tmp"
-    PATH="${tmp}/fake-bin:$PATH" SINGLEBOX_STUB_LOG="$log" UV_STUB_LOG="$uv_log" \
+    PATH="${tmp}/fake-bin:$PATH" \
+      PYTHON="${ROOT}/src/backend/.venv/bin/python" \
+      SINGLEBOX_STUB_LOG="$log" UV_STUB_LOG="$uv_log" \
       "${tmp}/scripts/ci/singlebox_coverage.sh" >/dev/null
   )
 
@@ -150,8 +191,10 @@ test_default_mode_runs_real_singlebox() {
     fail "default coverage mode should start the full standalone singlebox stack"
   grep -Fx -- "--standalone stop all" "$log" >/dev/null || \
     fail "default coverage mode should stop the full standalone singlebox stack"
-  grep -F "run pytest tests/community/acceptance/cron/test_cron_query_lifecycle.py" "$uv_log" >/dev/null || \
-    fail "default coverage mode should run the live acceptance smoke"
+  grep -F "run pytest tests/community/acceptance/devices tests/community/acceptance/cron" "$uv_log" >/dev/null || \
+    fail "default coverage mode should run every manifest acceptance target"
+  [ "$(grep -Fc -- '--standalone start all' "$log")" -eq 1 ] || \
+    fail "all modules should share one singlebox startup"
   grep -F "run coverage combine" "$uv_log" >/dev/null || \
     fail "default coverage mode should combine coverage"
   [ -s "${tmp}/scripts/.dependencies/coverage/singlebox/reports/summary.json" ] || \
@@ -160,6 +203,13 @@ test_default_mode_runs_real_singlebox() {
     fail "summary.md artifact missing"
   [ -s "${tmp}/scripts/.dependencies/coverage/singlebox/reports/dashboard.html" ] || \
     fail "dashboard.html artifact missing"
+  "${ROOT}/src/backend/.venv/bin/python" - "${tmp}/scripts/.dependencies/coverage/singlebox/reports/summary.json" <<'PY'
+import json
+import sys
+
+summary = json.load(open(sys.argv[1], encoding="utf-8"))
+assert list(summary["modules"]) == ["devices", "cron"]
+PY
 }
 
 test_mock_mode_is_not_supported() {
@@ -192,8 +242,7 @@ test_module_mode_reports_device_metrics() {
       SINGLEBOX_STUB_DEVICE_HITS=1 \
       UV_STUB_LOG="$uv_log" \
       "${tmp}/scripts/ci/singlebox_coverage.sh" \
-        --module devices \
-        --acceptance-target tests/community/acceptance/devices >/dev/null
+        --module devices >/dev/null
   )
 
   grep -F "run pytest tests/community/acceptance/devices" "$uv_log" >/dev/null || \
@@ -206,8 +255,8 @@ import sys
 summary = json.load(open(sys.argv[1], encoding="utf-8"))
 devices = summary["modules"]["devices"]
 assert devices["core"]["percent"] == 50.0
-assert devices["router_api"]["covered"] == 8
-assert devices["router_api"]["total"] == 18
+assert devices["router_api"]["covered"] == 3
+assert devices["router_api"]["total"] == 3
 assert devices["plugin_api"]["status"] == "not_applicable"
 PY
 }


### PR DESCRIPTION
## Summary

- start the standalone singlebox stack once and run all registered module acceptance targets in one pytest invocation
- make `--module NAME` repeatable for focused local runs while defaulting to every manifest module
- build and gate all selected module reports in one reporter pass
- preserve manifest order in summary and dashboard artifacts
- add static manifest path checks and Bash 3.2-compatible runner contract tests

## Registered blocking modules

- devices
- access
- bot_chat
- bot_collaborator
- cron
- expert_chat
- harness

The manifest also records the currently pending modules (`skill_center`, `bot_management`, `mcp`, `resources`) and the concrete migration reason for each. They are not presented as passing gates until their live acceptance failures are fixed.

## Dependency

PR #113 has merged into `dev`. This branch has been rebased onto that merged result and the PR now targets `dev` directly.

## Verification

- reporter tests: 16 passed
- shell runner contract: passed
- real pre-push standalone singlebox run: 25 acceptance tests passed across 7 modules
- real module metrics: Devices 51.79% Core / 88.89% Router; Access 42.80% Core; Bot Chat 40.66% Core; Bot Collaborator 53.88% Core; Cron 41.84% Core; Expert Chat 63.49% Core; Harness 41.59% Core

The Cron baseline was refreshed after #80 added runtime/model handling to Cron Core: the numerator remained 372 lines while the denominator grew from 880 to 889 lines. The new runtime path remains a future Cron-owned singlebox user story rather than an excluded path.

## Follow-up findings

A broader 11-module probe ran 52 live cases and found 9 stale failures in Skill Center, Bot Management, MCP, and Resources. These modules remain explicitly pending until their BaaS-backed assumptions are migrated in module-owned PRs.
