### PR TITLE
feat(openclaw-channel-bcn): align agent reply lifecycle

### DIFF
--- a/src/bcs/crates/plugins/openclaw-channel-bcn/README.md
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/README.md
@@ -48,7 +48,7 @@ Select with the flag or env var (flag wins):
 BCN_PLUGIN_SOURCE=npm ./scripts/singlebox.sh
 
 # pin a version in npm mode (default: latest)
-BCN_PLUGIN_SOURCE=npm BCN_PLUGIN_VERSION=1.0.15 ./scripts/singlebox.sh
+BCN_PLUGIN_SOURCE=npm BCN_PLUGIN_VERSION=1.0.16 ./scripts/singlebox.sh
 ```
 
 ## Configure

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/package.json
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avernet-plugin/openclaw-channel-bcn",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Installable OpenClaw BCS WebSocket channel plugin package.",
   "dependencies": {
     "ws": "^8.18.3"

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
@@ -11,6 +11,7 @@
 
 import WebSocket from 'ws';
 import * as fs from 'node:fs';
+import type { IncomingMessage } from 'node:http';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import type {
@@ -253,8 +254,14 @@ export class BcsWsClient {
         reject(err);
       }
 
-      function handleUnexpectedResponse(_req: unknown, res: any) {
+      function handleUnexpectedResponse(_req: unknown, res: IncomingMessage) {
         let body = '';
+        res.once('error', (err: Error) => {
+          log?.error?.(`Error reading unexpected BCS response body: ${err.message}`);
+          failInitialConnection(
+            new Error(`Failed to read unexpected BCS response: ${err.message}`),
+          );
+        });
         res.on('data', (chunk: Buffer) => (body += chunk));
         res.on('end', () => {
           log?.error?.(

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
@@ -230,18 +230,70 @@ export class BcsWsClient {
   private _openWebSocket(url: string): Promise<WebSocket> {
     return new Promise((resolve, reject) => {
       const logUrl = sanitizeBcsUrlForLog(url);
+      const log = this._log;
       let ws: WebSocket | null = null;
-      const timeout = setTimeout(() => {
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+
+      function cleanupInitialListeners() {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
+        if (!ws) return;
+        ws.off('unexpected-response', handleUnexpectedResponse);
+        ws.off('open', handleOpen);
+        ws.off('error', handleInitialError);
+      }
+
+      function failInitialConnection(err: Error) {
+        if (settled) return;
+        settled = true;
+        cleanupInitialListeners();
+        reject(err);
+      }
+
+      function handleUnexpectedResponse(_req: unknown, res: any) {
+        let body = '';
+        res.on('data', (chunk: Buffer) => (body += chunk));
+        res.on('end', () => {
+          log?.error?.(
+            `BCS returned HTTP ${res.statusCode} ${res.statusMessage}\n` +
+              `Headers: ${JSON.stringify(res.headers)}\n` +
+              `Body: ${body.slice(0, 500)}`,
+          );
+          failInitialConnection(
+            new Error(
+              `Unexpected server response: ${res.statusCode} ${res.statusMessage}`,
+            ),
+          );
+        });
+      }
+
+      function handleOpen() {
+        if (!ws) return;
+        settled = true;
+        cleanupInitialListeners();
+        log?.info?.(`WebSocket TCP handshake succeeded: ${logUrl}`);
+        resolve(ws);
+      }
+
+      function handleInitialError(err: Error) {
+        log?.error?.(`WebSocket connection error: ${err.message}`);
+        failInitialConnection(new Error(`Failed to connect to BCS: ${err.message}`));
+      }
+
+      timeout = setTimeout(() => {
         if (!ws) {
-          reject(new Error(`BCS connection timeout: ${logUrl}`));
+          failInitialConnection(new Error(`BCS connection timeout: ${logUrl}`));
           return;
         }
-        ws.removeAllListeners();
+        cleanupInitialListeners();
         ws.on('error', err => {
-          this._log?.warn?.(`WebSocket error during timeout cleanup: ${err.message}`);
+          log?.warn?.(`WebSocket error during timeout cleanup: ${err.message}`);
         });
         ws.terminate();
-        reject(new Error(`BCS connection timeout: ${logUrl}`));
+        failInitialConnection(new Error(`BCS connection timeout: ${logUrl}`));
       }, this._account.connectionTimeoutMs);
 
       const wsOptions: WebSocket.ClientOptions = {
@@ -254,37 +306,11 @@ export class BcsWsClient {
 
       ws = new WebSocket(url, wsOptions);
 
-      // Handle HTTP responses other than 101 Switching Protocols
-      ws.on('unexpected-response', (_req, res) => {
-        clearTimeout(timeout);
-        let body = '';
-        res.on('data', chunk => (body += chunk));
-        res.on('end', () => {
-          this._log?.error?.(
-            `BCS returned HTTP ${res.statusCode} ${res.statusMessage}\n` +
-              `Headers: ${JSON.stringify(res.headers)}\n` +
-              `Body: ${body.slice(0, 500)}`,
-          );
-          reject(
-            new Error(
-              `Unexpected server response: ${res.statusCode} ${res.statusMessage}`,
-            ),
-          );
-        });
-      });
-
-      ws.on('open', () => {
-        clearTimeout(timeout);
-        this._log?.info?.(`WebSocket TCP handshake succeeded: ${logUrl}`);
-        resolve(ws);
-      });
-
-      ws.on('error', err => {
-        clearTimeout(timeout);
-        ws.removeAllListeners();
-        this._log?.error?.(`WebSocket connection error: ${err.message}`);
-        reject(new Error(`Failed to connect to BCS: ${err.message}`));
-      });
+      // These listeners only govern the initial handshake. Runtime error/close
+      // listeners are installed after this promise resolves and must survive.
+      ws.on('unexpected-response', handleUnexpectedResponse);
+      ws.on('open', handleOpen);
+      ws.on('error', handleInitialError);
     });
   }
 

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -36,6 +36,7 @@ import type {
 const CHANNEL_ID = 'bcs';
 const OPENCLAW_GATEWAY_MIN_PROTOCOL = 3;
 const OPENCLAW_GATEWAY_MAX_PROTOCOL = 4;
+const NO_REPLY_TEXT = 'NO_REPLY';
 
 /** Extract sender name from [from:botName] prefix. Returns stripped text and sender name. */
 function extractFromPrefix(raw: string): { senderName: string; text: string } {
@@ -51,8 +52,25 @@ function extractFromPrefix(raw: string): { senderName: string; text: string } {
 /** Active streams: run_id -> AbortController */
 const activeStreams = new Map<string, AbortController>();
 
-/** Run context for agent event routing: run_id -> { groupId, client } */
-const runContexts = new Map<string, { groupId: string; client: BcsWsClient }>();
+type RunContext = {
+  groupId: string;
+  client: BcsWsClient;
+  sessionKey?: string;
+  finalSent?: boolean;
+};
+
+/** Run context for agent event routing: run_id -> context used for BCS event emission. */
+const runContexts = new Map<string, RunContext>();
+
+interface VisibleReplyState {
+  text: string;
+  flushedOffset: number;
+  deltaCount: number;
+  sawAssistantText: boolean;
+}
+
+/** Visible assistant reply accumulated from OpenClaw agent events. */
+const visibleReplyByRunId = new Map<string, VisibleReplyState>();
 
 /** Pending routing intents: run_id -> PendingRouteIntent (populated by bcs_route tool). */
 const pendingRouteByRunId = new Map<string, PendingRouteIntent>();
@@ -197,6 +215,199 @@ function extractText(content: ContentBlock[]): string {
   return parts.join('\n');
 }
 
+function buildChatEventPayload(
+  runId: string,
+  bcsGroupId: string,
+  state: ChatEventPayload['state'],
+  text: string,
+  routeIntent?: PendingRouteIntent,
+): ChatEventPayload {
+  return {
+    run_id: runId,
+    bcs_group_id: bcsGroupId,
+    state,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text }],
+      timestamp: Date.now(),
+    },
+    ...(routeIntent ? {
+      routing: {
+        responders: routeIntent.responders,
+        mode: routeIntent.mode,
+        reason: routeIntent.reason,
+        include_self: routeIntent.includeSelf,
+        dedupe_key: routeIntent.dedupeKey,
+      } satisfies ChatEventRouting,
+    } : {}),
+  };
+}
+
+function ensureVisibleReplyState(runId: string): VisibleReplyState {
+  let state = visibleReplyByRunId.get(runId);
+  if (!state) {
+    state = {
+      text: '',
+      flushedOffset: 0,
+      deltaCount: 0,
+      sawAssistantText: false,
+    };
+    visibleReplyByRunId.set(runId, state);
+  }
+  return state;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function textFromUnknownContent(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return undefined;
+
+  const parts = value
+    .map(item => {
+      if (!item || typeof item !== 'object') return undefined;
+      const record = item as Record<string, unknown>;
+      return typeof record.text === 'string' ? record.text : undefined;
+    })
+    .filter((text): text is string => typeof text === 'string');
+
+  return parts.length > 0 ? parts.join('\n') : undefined;
+}
+
+function assistantSnapshotText(data: unknown): string | undefined {
+  if (typeof data === 'string') return data;
+  if (!data || typeof data !== 'object') return undefined;
+
+  const record = data as Record<string, unknown>;
+  const direct = stringField(record, 'text') ?? stringField(record, 'body');
+  if (direct !== undefined) return direct;
+
+  const content = textFromUnknownContent(record.content);
+  if (content !== undefined) return content;
+
+  const message = record.message;
+  if (message && typeof message === 'object') {
+    return textFromUnknownContent((message as Record<string, unknown>).content);
+  }
+
+  return undefined;
+}
+
+function assistantDeltaText(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  return stringField(data as Record<string, unknown>, 'delta');
+}
+
+function recordAssistantAgentText(runId: string, data: unknown): void {
+  const state = ensureVisibleReplyState(runId);
+  const delta = assistantDeltaText(data);
+  if (delta !== undefined) {
+    state.text += delta;
+    if (delta.trim()) {
+      state.sawAssistantText = true;
+    }
+    return;
+  }
+
+  const snapshot = assistantSnapshotText(data);
+  if (snapshot !== undefined) {
+    if (snapshot.trim()) {
+      if (snapshot.length >= state.text.length) {
+        state.text = snapshot;
+      } else if (!state.text.includes(snapshot)) {
+        state.text += snapshot;
+      }
+      state.sawAssistantText = true;
+    }
+  }
+}
+
+function sendVisibleReplyDelta(
+  runId: string,
+  log?: { info: (...args: unknown[]) => void },
+): void {
+  const state = visibleReplyByRunId.get(runId);
+  const context = runContexts.get(runId);
+  if (!state || !context) return;
+
+  const deltaText = state.text.slice(state.flushedOffset);
+  if (!deltaText.trim()) return;
+
+  context.client.sendEvent(
+    'chat.event',
+    buildChatEventPayload(runId, context.groupId, 'delta', deltaText) as unknown as Record<string, unknown>,
+    nextSeq(context.client),
+  );
+  state.flushedOffset = state.text.length;
+  state.deltaCount += 1;
+  log?.info?.(`[BCS] Sent chat.event delta from agent event (part ${state.deltaCount}) for run_id=${runId}, len=${deltaText.length}`);
+}
+
+function finishVisibleReply(runId: string, log?: { info: (...args: unknown[]) => void }): string | undefined {
+  const state = visibleReplyByRunId.get(runId);
+  if (!state?.sawAssistantText || !state.text.trim()) return undefined;
+
+  sendVisibleReplyDelta(runId, log);
+  return state.text.trim();
+}
+
+function consumeRouteIntent(runId: string, sessionKey?: string): PendingRouteIntent | undefined {
+  const routeIntent = pendingRouteByRunId.get(runId);
+  if (routeIntent) {
+    pendingRouteByRunId.delete(runId);
+    return routeIntent;
+  }
+
+  if (!sessionKey) return undefined;
+  const sessionRouteIntent = pendingRouteBySessionKey.get(sessionKey);
+  if (sessionRouteIntent) {
+    pendingRouteBySessionKey.delete(sessionKey);
+  }
+  return sessionRouteIntent;
+}
+
+function sendFinalVisibleReplyOnce(
+  runId: string,
+  log?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void },
+  options?: {
+    source?: string;
+    deliveredText?: string;
+    finalDeliveredPartsCount?: number;
+    noReplyDetail?: string;
+  },
+): boolean {
+  const context = runContexts.get(runId);
+  if (!context || context.finalSent) return false;
+
+  const visibleText = finishVisibleReply(runId, log);
+  const combinedText = visibleText ?? NO_REPLY_TEXT;
+
+  if (!visibleText) {
+    log?.warn?.(`[BCS] No assistant agent text for run_id=${runId}, sending ${NO_REPLY_TEXT} final${options?.noReplyDetail ? ` ${options.noReplyDetail}` : ''}`);
+  } else if (options?.deliveredText && options.deliveredText !== visibleText) {
+    log?.warn?.(`[BCS] Agent-event final differs from dispatcher deliver buffer for run_id=${runId}; using agent-event text`);
+  } else if ((options?.finalDeliveredPartsCount ?? 0) > 1) {
+    log?.info?.(`[BCS] Combined ${options?.finalDeliveredPartsCount} final deliver parts for diagnostics for run_id=${runId}`);
+  }
+
+  const routeIntent = consumeRouteIntent(runId, context.sessionKey);
+  const chatPayload = buildChatEventPayload(runId, context.groupId, 'final', combinedText, routeIntent);
+  context.client.sendEvent('chat.event', chatPayload as unknown as Record<string, unknown>, nextSeq(context.client));
+  context.finalSent = true;
+
+  const source = options?.source ? ` (source=${options.source})` : '';
+  if (routeIntent) {
+    log?.info?.(`[BCS] Sent chat.event final with routing intent for run_id=${runId}${source}`);
+  } else {
+    log?.info?.(`[BCS] Sent chat.event final for run_id=${runId}${source}`);
+  }
+
+  return true;
+}
+
 /** Extract GroupContext from params for logging/context. */
 function extractGroupContext(sessionContext: GroupContext): Record<string, unknown> {
   return {
@@ -251,6 +462,7 @@ export async function handleChatSend(
 
   // Track run context for agent event routing
   runContexts.set(runId, { groupId: bcsGroupId, client });
+  ensureVisibleReplyState(runId);
 
   try {
     const rt = getBcsRuntime();
@@ -268,6 +480,10 @@ export async function handleChatSend(
     });
 
     log?.info?.(`[DEBUG] Resolved agent route: agentId=${route.agentId}, sessionKey=${route.sessionKey}`);
+    const runContext = runContexts.get(runId);
+    if (runContext) {
+      runContext.sessionKey = route.sessionKey;
+    }
 
     // Record bidirectional mapping: sessionKey <-> bcsGroupId
     if (bcsGroupId) {
@@ -342,34 +558,10 @@ export async function handleChatSend(
     // DEBUG: Send test message to verify plugin is loaded
     log?.info?.('[BCN PLUGIN LOADED] test message from inbound-handler');
 
-    // Stream block replies as chat deltas, while keeping terminal/non-block
-    // deliveries buffered for one final chat.event after dispatch completes.
+    // Keep SDK deliver parts only for diagnostics; chat delta/final are built
+    // from assistant agent events so BCS sees the same visible reply stream.
     const finalDeliveredParts: string[] = [];
     const blockDeliveredParts: string[] = [];
-    let streamedDeltaCount = 0;
-    const buildChatPayload = (
-      state: ChatEventPayload['state'],
-      text: string,
-      routeIntent?: PendingRouteIntent,
-    ): ChatEventPayload => ({
-      run_id: runId,
-      bcs_group_id: bcsGroupId,
-      state,
-      message: {
-        role: 'assistant',
-        content: [{ type: 'text', text }],
-        timestamp: Date.now(),
-      },
-      ...(routeIntent ? {
-        routing: {
-          responders: routeIntent.responders,
-          mode: routeIntent.mode,
-          reason: routeIntent.reason,
-          include_self: routeIntent.includeSelf,
-          dedupe_key: routeIntent.dedupeKey,
-        } satisfies ChatEventRouting,
-      } : {}),
-    });
 
     // Dispatch via SDK's buffered block dispatcher
     await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
@@ -387,13 +579,7 @@ export async function handleChatSend(
           if (kind === 'block') {
             if (!replyText.trim()) return;
             blockDeliveredParts.push(replyText);
-            client.sendEvent(
-              'chat.event',
-              buildChatPayload('delta', replyText) as unknown as Record<string, unknown>,
-              nextSeq(client),
-            );
-            streamedDeltaCount += 1;
-            log?.info?.(`[BCS] Sent chat.event delta (part ${streamedDeltaCount}) for run_id=${runId}, len=${replyText.length}`);
+            log?.info?.(`[BCS] buffered block deliver for run_id=${runId}, len=${replyText.length}`);
             return;
           }
 
@@ -417,32 +603,15 @@ export async function handleChatSend(
     if (!abortController.signal.aborted) {
       const combinedFinalText = combineDeliveredReplyParts(finalDeliveredParts);
       const combinedBlockText = combineDeliveredReplyParts(blockDeliveredParts);
-      const combinedText = combinedFinalText ?? combinedBlockText;
-
-      if (!combinedText) {
-        log?.info?.(`[BCS] Empty final text for run_id=${runId}, sending empty final event`);
-      } else if (!combinedFinalText && combinedBlockText) {
-        log?.info?.(`[BCS] Built final chat snapshot from ${blockDeliveredParts.length} block deliver parts for run_id=${runId}`);
-      } else if (finalDeliveredParts.length > 1) {
-        log?.info?.(`[BCS] Combined ${finalDeliveredParts.length} final deliver parts into one final for run_id=${runId}`);
-      }
-
-      // Read and consume pending routing intent for this run (or session-level fallback)
-      let routeIntent = pendingRouteByRunId.get(runId);
-      if (routeIntent) {
-        pendingRouteByRunId.delete(runId);
-      } else {
-        routeIntent = pendingRouteBySessionKey.get(route.sessionKey);
-        if (routeIntent) pendingRouteBySessionKey.delete(route.sessionKey);
-      }
-
-      const chatPayload = buildChatPayload('final', combinedText ?? '', routeIntent);
-      client.sendEvent('chat.event', chatPayload as unknown as Record<string, unknown>, nextSeq(client));
-
-      if (routeIntent) {
-        log?.info?.(`[BCS] Sent chat.event final with routing intent for run_id=${runId}`);
-      } else {
-        log?.info?.(`[BCS] Sent chat.event final for run_id=${runId}`);
+      const deliveredText = combinedFinalText ?? combinedBlockText;
+      const sent = sendFinalVisibleReplyOnce(runId, log, {
+        source: 'dispatcher',
+        deliveredText,
+        finalDeliveredPartsCount: finalDeliveredParts.length,
+        noReplyDetail: `(block deliver parts=${blockDeliveredParts.length}, final deliver parts=${finalDeliveredParts.length})`,
+      });
+      if (!sent) {
+        log?.info?.(`[BCS] Skipped duplicate chat.event final for run_id=${runId} (source=dispatcher)`);
       }
     }
   } catch (err: any) {
@@ -454,21 +623,26 @@ export async function handleChatSend(
       log?.error?.(`[DEBUG] Error cause for run_id=${runId}:`, err.cause);
     }
 
-    // Send error event to BCS
-    const errorPayload: ChatEventPayload = {
-      run_id: runId,
-      bcs_group_id: bcsGroupId,
-      state: 'error',
-      message: {
-        role: 'assistant',
-        content: [{ type: 'text', text: 'An error occurred while processing your message.' }],
-        timestamp: Date.now(),
-      },
-    };
-    client.sendEvent('chat.event', errorPayload as unknown as Record<string, unknown>, nextSeq(client));
+    if (runContexts.get(runId)?.finalSent) {
+      log?.warn?.(`[BCS] Dispatcher failed after final was already sent for run_id=${runId}; suppressing duplicate error event`);
+    } else {
+      // Send error event to BCS
+      const errorPayload: ChatEventPayload = {
+        run_id: runId,
+        bcs_group_id: bcsGroupId,
+        state: 'error',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'An error occurred while processing your message.' }],
+          timestamp: Date.now(),
+        },
+      };
+      client.sendEvent('chat.event', errorPayload as unknown as Record<string, unknown>, nextSeq(client));
+    }
   } finally {
     activeStreams.delete(runId);
     runContexts.delete(runId);
+    visibleReplyByRunId.delete(runId);
     pendingRouteByRunId.delete(runId);
     // Clean up sessionKey → runId mapping (find by value)
     for (const [ sk, rid ] of activeRunIdForSession) {
@@ -1102,6 +1276,7 @@ export function abortAllStreams(): void {
   }
   activeStreams.clear();
   runContexts.clear();
+  visibleReplyByRunId.clear();
   pendingRouteByRunId.clear();
   pendingRouteBySessionKey.clear();
   activeRunIdForSession.clear();
@@ -1433,6 +1608,29 @@ type SdkAgentEventPayload = {
   sessionKey?: string;
 };
 
+const TERMINAL_LIFECYCLE_VALUES = new Set([
+  'end',
+  'done',
+  'complete',
+  'completed',
+  'final',
+  'finished',
+  'success',
+  'succeeded',
+]);
+
+function isTerminalLifecycleEvent(evt: SdkAgentEventPayload): boolean {
+  if (evt.stream !== 'lifecycle') return false;
+
+  const value =
+    stringField(evt.data, 'phase') ??
+    stringField(evt.data, 'status') ??
+    stringField(evt.data, 'state') ??
+    stringField(evt.data, 'type');
+
+  return value ? TERMINAL_LIFECYCLE_VALUES.has(value.toLowerCase()) : false;
+}
+
 /** Unsubscribe function for agent events */
 let agentEventUnsubscribe: (() => boolean) | null = null;
 
@@ -1475,6 +1673,18 @@ export function initAgentEventsSubscription(log?: {
     }
 
     const { groupId, client } = context;
+
+    if (!context.finalSent) {
+      if (evt.stream === 'assistant') {
+        recordAssistantAgentText(resolvedRunId, evt.data);
+      } else {
+        sendVisibleReplyDelta(resolvedRunId, log);
+      }
+
+      if (isTerminalLifecycleEvent(evt)) {
+        sendFinalVisibleReplyOnce(resolvedRunId, log, { source: 'agent_lifecycle' });
+      }
+    }
 
     // Build the agent event payload for BCS — always use the original runId
     // so that all events for one user message share the same run_id

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -259,8 +259,9 @@ function ensureVisibleReplyState(runId: string): VisibleReplyState {
   return state;
 }
 
-function stringField(record: Record<string, unknown>, key: string): string | undefined {
-  const value = record[key];
+function stringField(record: unknown, key: string): string | undefined {
+  if (!record || typeof record !== 'object') return undefined;
+  const value = (record as Record<string, unknown>)[key];
   return typeof value === 'string' ? value : undefined;
 }
 

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -65,6 +65,7 @@ const runContexts = new Map<string, RunContext>();
 interface VisibleReplyState {
   text: string;
   flushedOffset: number;
+  segmentOffset: number;
   deltaCount: number;
   sawAssistantText: boolean;
 }
@@ -249,6 +250,7 @@ function ensureVisibleReplyState(runId: string): VisibleReplyState {
     state = {
       text: '',
       flushedOffset: 0,
+      segmentOffset: 0,
       deltaCount: 0,
       sawAssistantText: false,
     };
@@ -301,27 +303,35 @@ function assistantDeltaText(data: unknown): string | undefined {
   return stringField(data as Record<string, unknown>, 'delta');
 }
 
+function assistantReplacesCurrentSegment(data: unknown): boolean {
+  if (!data || typeof data !== 'object') return false;
+  return (data as Record<string, unknown>).replace === true;
+}
+
 function recordAssistantAgentText(runId: string, data: unknown): void {
   const state = ensureVisibleReplyState(runId);
+  if (assistantReplacesCurrentSegment(data)) {
+    const snapshot = assistantSnapshotText(data);
+    if (snapshot === undefined) return;
+
+    state.text = state.text.slice(0, state.segmentOffset) + snapshot;
+    state.sawAssistantText = Boolean(state.text.trim());
+    return;
+  }
+
   const delta = assistantDeltaText(data);
-  if (delta !== undefined) {
+  if (delta !== undefined && delta.length > 0) {
     state.text += delta;
     if (delta.trim()) {
       state.sawAssistantText = true;
     }
-    return;
   }
+}
 
-  const snapshot = assistantSnapshotText(data);
-  if (snapshot !== undefined) {
-    if (snapshot.trim()) {
-      if (snapshot.length >= state.text.length) {
-        state.text = snapshot;
-      } else if (!state.text.includes(snapshot)) {
-        state.text += snapshot;
-      }
-      state.sawAssistantText = true;
-    }
+function markVisibleReplySegmentBoundary(runId: string): void {
+  const state = visibleReplyByRunId.get(runId);
+  if (state) {
+    state.segmentOffset = state.text.length;
   }
 }
 
@@ -1679,6 +1689,7 @@ export function initAgentEventsSubscription(log?: {
         recordAssistantAgentText(resolvedRunId, evt.data);
       } else {
         sendVisibleReplyDelta(resolvedRunId, log);
+        markVisibleReplySegmentBoundary(resolvedRunId);
       }
 
       if (isTerminalLifecycleEvent(evt)) {

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { once } from 'node:events';
 import { mkdtemp, rm, stat } from 'node:fs/promises';
-import type { AddressInfo } from 'node:net';
+import { createServer, type AddressInfo, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { WebSocketServer } from 'ws';
@@ -62,6 +62,42 @@ async function startBcsStub(responseBotUuid?: string) {
       }
     },
     async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function startBrokenHttpResponseStub() {
+  const sockets = new Set<Socket>();
+  const server = createServer(socket => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    socket.once('data', () => {
+      socket.write(
+        'HTTP/1.1 502 Bad Gateway\r\n' +
+          'Content-Type: text/plain\r\n' +
+          'Content-Length: 100\r\n' +
+          'Connection: close\r\n\r\n' +
+          'partial body',
+        () => socket.destroy(),
+      );
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address() as AddressInfo | null;
+  assert.equal(typeof address, 'object');
+  assert.ok(address);
+
+  return {
+    port: address.port,
+    async close() {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
       await new Promise<void>((resolve, reject) => {
         server.close(err => (err ? reject(err) : resolve()));
       });
@@ -319,6 +355,52 @@ describe('BcsWsClient security behavior', () => {
       () => client.connect(null),
       /Invalid BCS WebSocket URL/,
     );
+  });
+
+  it('rejects when an unexpected HTTP response stream errors', async () => {
+    const bcs = await startBrokenHttpResponseStub();
+    const dataDir = await mkdtemp(join(tmpdir(), 'bcn-broken-http-response-'));
+    const logs: string[] = [];
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: `ws://127.0.0.1:${bcs.port}/ws/bot`,
+      botId: 'bot-1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60_000,
+      reconnectIntervalMs: 5_000,
+      connectionTimeoutMs: 1_000,
+    };
+    const client = new BcsWsClient({
+      account,
+      dataDir,
+      log: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: (...args: unknown[]) => logs.push(args.join(' ')),
+      },
+    });
+
+    try {
+      await assert.rejects(
+        () => client.connect(null),
+        /Failed to read unexpected BCS response/,
+      );
+      assert.equal(
+        logs.some(line => line.includes('Error reading unexpected BCS response body')),
+        true,
+      );
+    } finally {
+      await client.disconnect();
+      await bcs.close();
+      await rm(dataDir, { recursive: true, force: true });
+    }
   });
 
   it('saves session files with owner-only permissions', async () => {

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
@@ -12,12 +12,15 @@ async function startBcsStub(responseBotUuid?: string) {
   let cookieHeader: string | undefined;
   let requestUrl: string | undefined;
   let connectParams: Record<string, unknown> | undefined;
+  const sockets = new Set<any>();
   const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
   await once(server, 'listening');
 
   server.on('connection', (socket, request) => {
+    sockets.add(socket);
     cookieHeader = request.headers.cookie;
     requestUrl = request.url;
+    socket.on('close', () => sockets.delete(socket));
 
     socket.on('message', data => {
       const frame = JSON.parse(data.toString());
@@ -52,6 +55,11 @@ async function startBcsStub(responseBotUuid?: string) {
     },
     get connectParams() {
       return connectParams;
+    },
+    sendToClients(data: string | Buffer) {
+      for (const socket of sockets) {
+        socket.send(data);
+      }
     },
     async close() {
       await new Promise<void>((resolve, reject) => {
@@ -350,6 +358,56 @@ describe('BcsWsClient security behavior', () => {
       assert.equal(sessionStat.mode.toString(8).slice(-3), '600');
     } finally {
       process.umask(originalUmask);
+      await client.disconnect();
+      await bcs.close();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the close callback active after a runtime WebSocket error', async () => {
+    const bcs = await startBcsStub();
+    const dataDir = await mkdtemp(join(tmpdir(), 'bcn-runtime-error-'));
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: `ws://127.0.0.1:${bcs.port}/ws/bot`,
+      botId: 'bot-1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60_000,
+      reconnectIntervalMs: 5_000,
+      connectionTimeoutMs: 10_000,
+    };
+    const client = new BcsWsClient({
+      account,
+      dataDir,
+      log: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    try {
+      await client.connect(null);
+      const closed = new Promise<void>(resolve => {
+        client.onClose(() => resolve());
+      });
+
+      bcs.sendToClients(Buffer.alloc((2 * 1024 * 1024) + 1));
+
+      await Promise.race([
+        closed,
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(new Error('close callback was not called')), 1000);
+        }),
+      ]);
+    } finally {
       await client.disconnect();
       await bcs.close();
       await rm(dataDir, { recursive: true, force: true });

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -470,24 +470,42 @@ describe('openclaw-channel-bcn', () => {
               runId,
               stream: 'assistant',
               ts: 3,
-              data: { text: 'snapshot: before tool after first tool', delta: '\nafter first tool' },
+              data: { text: 'snapshot: before tool after first tool draft', delta: '\nafter first tool draft' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'assistant',
+              ts: 4,
+              data: { text: '\nafter first tool', delta: '', replace: true },
             });
             agentEventHandler?.({
               runId,
               stream: 'tool',
-              ts: 4,
+              ts: 5,
               data: { phase: 'result', toolCallId: 'tool-1' },
             });
             agentEventHandler?.({
               runId,
               stream: 'assistant',
-              ts: 5,
+              ts: 6,
+              data: { text: 'ignored snapshot without delta' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'assistant',
+              ts: 7,
+              data: { text: 'ignored empty delta snapshot', delta: '' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'assistant',
+              ts: 8,
               data: { text: 'snapshot: before tool after first tool final answer', delta: '\nfinal answer' },
             });
             agentEventHandler?.({
               runId,
               stream: 'lifecycle',
-              ts: 6,
+              ts: 9,
               data: { phase: 'end' },
             });
             await dispatcherOptions.deliver({ text: 'stale dispatcher block' }, { kind: 'block' });
@@ -532,7 +550,7 @@ describe('openclaw-channel-bcn', () => {
       assert.equal(typeof runId, 'string');
       assert.equal(capturedReplyOptions?.disableBlockStreaming, false);
       assert.equal(capturedReplyOptions?.sourceReplyDeliveryMode, 'automatic');
-      assert.equal(events.filter(item => item.event === 'agent').length, 6);
+      assert.equal(events.filter(item => item.event === 'agent').length, 9);
       const chatEvents = events.filter(item => item.event === 'chat.event');
       assert.deepEqual(chatEvents.map(item => item.payload.state), [ 'delta', 'delta', 'delta', 'final' ]);
       assert.deepEqual(

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -6,9 +6,11 @@ import plugin, { bcsPlugin, registerBcsCore, setBcsRuntime } from '../src/index.
 import { getDefaultBcsUrl, listAccountIds, resolveAccount } from '../src/accounts.js';
 import {
   abortAllStreams,
+  cleanupAgentEventsSubscription,
   combineDeliveredReplyParts,
   handleChatSend,
   handleBcsRouteTool,
+  initAgentEventsSubscription,
   rememberTaskToolSession,
   resolveGroupIdFromSessionKey,
 } from '../src/inbound-handler.js';
@@ -396,9 +398,10 @@ describe('openclaw-channel-bcn', () => {
     assert.equal(combineDeliveredReplyParts([ 'first', 'second' ]), 'first\n\nsecond');
   });
 
-  it('streams block deliveries as chat deltas before the final chat event', async () => {
+  it('builds chat deltas and final from assistant agent events', async () => {
     const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
     const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
+    let agentEventHandler: ((evt: Record<string, unknown>) => boolean) | undefined;
     let capturedReplyOptions: Record<string, unknown> | undefined;
     const client = {
       sendResponse(id: string, ok: boolean, payload?: Record<string, unknown>) {
@@ -430,6 +433,14 @@ describe('openclaw-channel-bcn', () => {
           return {};
         },
       },
+      events: {
+        onAgentEvent(handler: (evt: Record<string, unknown>) => boolean) {
+          agentEventHandler = handler;
+          return () => {
+            agentEventHandler = undefined;
+          };
+        },
+      },
       channel: {
         routing: {
           resolveAgentRoute() {
@@ -442,9 +453,45 @@ describe('openclaw-channel-bcn', () => {
           },
           async dispatchReplyWithBufferedBlockDispatcher({ dispatcherOptions, replyOptions }: any) {
             capturedReplyOptions = replyOptions;
-            await dispatcherOptions.deliver({ text: 'before tool' }, { kind: 'block' });
-            await dispatcherOptions.deliver({ text: 'after first tool' }, { kind: 'block' });
-            await dispatcherOptions.deliver({ text: 'final answer' }, { kind: 'final' });
+            const runId = replyOptions.runId;
+            agentEventHandler?.({
+              runId,
+              stream: 'assistant',
+              ts: 1,
+              data: { text: 'snapshot: before tool', delta: 'before tool' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'tool',
+              ts: 2,
+              data: { phase: 'start', toolCallId: 'tool-1' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'assistant',
+              ts: 3,
+              data: { text: 'snapshot: before tool after first tool', delta: '\nafter first tool' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'tool',
+              ts: 4,
+              data: { phase: 'result', toolCallId: 'tool-1' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'assistant',
+              ts: 5,
+              data: { text: 'snapshot: before tool after first tool final answer', delta: '\nfinal answer' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'lifecycle',
+              ts: 6,
+              data: { phase: 'end' },
+            });
+            await dispatcherOptions.deliver({ text: 'stale dispatcher block' }, { kind: 'block' });
+            await dispatcherOptions.deliver({ text: 'stale dispatcher final' }, { kind: 'final' });
           },
         },
         session: {
@@ -458,6 +505,7 @@ describe('openclaw-channel-bcn', () => {
       },
     };
     setBcsRuntime(runtime as any);
+    initAgentEventsSubscription();
 
     const request: RequestFrame = {
       type: 'req',
@@ -475,26 +523,39 @@ describe('openclaw-channel-bcn', () => {
       },
     };
 
-    await handleChatSend(request, client as any, account);
+    try {
+      await handleChatSend(request, client as any, account);
 
-    assert.equal(responses.length, 1);
-    assert.equal(responses[0].ok, true);
-    const runId = responses[0].payload?.run_id;
-    assert.equal(typeof runId, 'string');
-    assert.equal(capturedReplyOptions?.disableBlockStreaming, false);
-    assert.equal(capturedReplyOptions?.sourceReplyDeliveryMode, 'automatic');
-    assert.deepEqual(events.map(item => item.event), [ 'chat.event', 'chat.event', 'chat.event' ]);
-    assert.deepEqual(events.map(item => item.payload.state), [ 'delta', 'delta', 'final' ]);
-    assert.deepEqual(
-      events.map(item => (item.payload.message as any).content[0].text),
-      [ 'before tool', 'after first tool', 'final answer' ],
-    );
-    assert.deepEqual(events.map(item => item.payload.run_id), [ runId, runId, runId ]);
+      assert.equal(responses.length, 1);
+      assert.equal(responses[0].ok, true);
+      const runId = responses[0].payload?.run_id;
+      assert.equal(typeof runId, 'string');
+      assert.equal(capturedReplyOptions?.disableBlockStreaming, false);
+      assert.equal(capturedReplyOptions?.sourceReplyDeliveryMode, 'automatic');
+      assert.equal(events.filter(item => item.event === 'agent').length, 6);
+      const chatEvents = events.filter(item => item.event === 'chat.event');
+      assert.deepEqual(chatEvents.map(item => item.payload.state), [ 'delta', 'delta', 'delta', 'final' ]);
+      assert.deepEqual(
+        chatEvents.map(item => (item.payload.message as any).content[0].text),
+        [
+          'before tool',
+          '\nafter first tool',
+          '\nfinal answer',
+          'before tool\nafter first tool\nfinal answer',
+        ],
+      );
+      assert.deepEqual(chatEvents.map(item => item.payload.run_id), [ runId, runId, runId, runId ]);
+    } finally {
+      cleanupAgentEventsSubscription();
+      abortAllStreams();
+    }
   });
 
-  it('uses block deliveries as the final chat snapshot when no final part is delivered', async () => {
+  it('sends lifecycle final before dispatcher settles without duplicating final', async () => {
     const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
     const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
+    let agentEventHandler: ((evt: Record<string, unknown>) => boolean) | undefined;
+    let releaseDispatch: (() => void) | undefined;
     const client = {
       sendResponse(id: string, ok: boolean, payload?: Record<string, unknown>) {
         responses.push({ id, ok, payload });
@@ -525,6 +586,146 @@ describe('openclaw-channel-bcn', () => {
           return {};
         },
       },
+      events: {
+        onAgentEvent(handler: (evt: Record<string, unknown>) => boolean) {
+          agentEventHandler = handler;
+          return () => {
+            agentEventHandler = undefined;
+          };
+        },
+      },
+      channel: {
+        routing: {
+          resolveAgentRoute() {
+            return { agentId: 'agent-1', sessionKey: 'bcs:group-1' };
+          },
+        },
+        reply: {
+          finalizeInboundContext(ctx: Record<string, unknown>) {
+            return ctx;
+          },
+          async dispatchReplyWithBufferedBlockDispatcher({ replyOptions }: any) {
+            const runId = replyOptions.runId;
+            agentEventHandler?.({
+              runId,
+              stream: 'assistant',
+              ts: 1,
+              data: { delta: 'reply before dispatcher completion' },
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'lifecycle',
+              ts: 2,
+              data: { phase: 'end' },
+            });
+            await new Promise<void>(resolve => {
+              releaseDispatch = resolve;
+            });
+          },
+        },
+        session: {
+          resolveStorePath() {
+            return '/tmp/openclaw-bcn-test';
+          },
+          async recordInboundSession() {
+            return undefined;
+          },
+        },
+      },
+    };
+    setBcsRuntime(runtime as any);
+    initAgentEventsSubscription();
+
+    const request: RequestFrame = {
+      type: 'req',
+      id: 'chat-lifecycle-final',
+      method: 'chat.send',
+      params: {
+        bcs_group_id: 'group-1',
+        channel: { source: 'api', user_id: 'user-1' },
+        session_context: {},
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'finish from lifecycle' }],
+          timestamp: Date.now(),
+        },
+      },
+    };
+
+    try {
+      const pending = handleChatSend(request, client as any, account);
+      await new Promise(resolve => setImmediate(resolve));
+
+      assert.equal(responses.length, 1);
+      const runId = responses[0].payload?.run_id;
+      const chatEventsBeforeDispatchSettles = events.filter(item => item.event === 'chat.event');
+      assert.deepEqual(
+        chatEventsBeforeDispatchSettles.map(item => item.payload.state),
+        [ 'delta', 'final' ],
+      );
+      assert.deepEqual(
+        chatEventsBeforeDispatchSettles.map(item => (item.payload.message as any).content[0].text),
+        [ 'reply before dispatcher completion', 'reply before dispatcher completion' ],
+      );
+      assert.deepEqual(chatEventsBeforeDispatchSettles.map(item => item.payload.run_id), [ runId, runId ]);
+
+      assert.ok(releaseDispatch, 'dispatcher should still be waiting when lifecycle final is sent');
+      releaseDispatch();
+      await pending;
+
+      const finalEvents = events
+        .filter(item => item.event === 'chat.event')
+        .filter(item => item.payload.state === 'final');
+      assert.equal(finalEvents.length, 1, 'dispatcher completion must not send a duplicate final');
+    } finally {
+      cleanupAgentEventsSubscription();
+      abortAllStreams();
+      releaseDispatch?.();
+    }
+  });
+
+  it('sends NO_REPLY final when no assistant agent text is observed', async () => {
+    const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
+    const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
+    let agentEventHandler: ((evt: Record<string, unknown>) => boolean) | undefined;
+    const client = {
+      sendResponse(id: string, ok: boolean, payload?: Record<string, unknown>) {
+        responses.push({ id, ok, payload });
+      },
+      sendEvent(event: string, payload: Record<string, unknown>, seq: number) {
+        events.push({ event, payload, seq });
+      },
+    };
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: 'ws://bcs.test/ws/bot',
+      botId: 'bot-1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60000,
+      reconnectIntervalMs: 5000,
+      connectionTimeoutMs: 10000,
+    };
+    const runtime = {
+      config: {
+        async loadConfig() {
+          return {};
+        },
+      },
+      events: {
+        onAgentEvent(handler: (evt: Record<string, unknown>) => boolean) {
+          agentEventHandler = handler;
+          return () => {
+            agentEventHandler = undefined;
+          };
+        },
+      },
       channel: {
         routing: {
           resolveAgentRoute() {
@@ -536,6 +737,12 @@ describe('openclaw-channel-bcn', () => {
             return ctx;
           },
           async dispatchReplyWithBufferedBlockDispatcher({ dispatcherOptions }: any) {
+            agentEventHandler?.({
+              runId: 'unrelated-run',
+              stream: 'assistant',
+              ts: 1,
+              data: { text: 'ignored text', delta: 'ignored text' },
+            });
             await dispatcherOptions.deliver({ text: 'visible part 1' }, { kind: 'block' });
             await dispatcherOptions.deliver({ text: 'visible part 2' }, { kind: 'block' });
           },
@@ -551,6 +758,7 @@ describe('openclaw-channel-bcn', () => {
       },
     };
     setBcsRuntime(runtime as any);
+    initAgentEventsSubscription();
 
     const request: RequestFrame = {
       type: 'req',
@@ -568,17 +776,22 @@ describe('openclaw-channel-bcn', () => {
       },
     };
 
-    await handleChatSend(request, client as any, account);
+    try {
+      await handleChatSend(request, client as any, account);
 
-    assert.equal(responses.length, 1);
-    const runId = responses[0].payload?.run_id;
-    assert.deepEqual(events.map(item => item.event), [ 'chat.event', 'chat.event', 'chat.event' ]);
-    assert.deepEqual(events.map(item => item.payload.state), [ 'delta', 'delta', 'final' ]);
-    assert.deepEqual(
-      events.map(item => (item.payload.message as any).content[0].text),
-      [ 'visible part 1', 'visible part 2', 'visible part 1\n\nvisible part 2' ],
-    );
-    assert.deepEqual(events.map(item => item.payload.run_id), [ runId, runId, runId ]);
+      assert.equal(responses.length, 1);
+      const runId = responses[0].payload?.run_id;
+      const chatEvents = events.filter(item => item.event === 'chat.event');
+      assert.deepEqual(chatEvents.map(item => item.payload.state), [ 'final' ]);
+      assert.deepEqual(
+        chatEvents.map(item => (item.payload.message as any).content[0].text),
+        [ 'NO_REPLY' ],
+      );
+      assert.deepEqual(chatEvents.map(item => item.payload.run_id), [ runId ]);
+    } finally {
+      cleanupAgentEventsSubscription();
+      abortAllStreams();
+    }
   });
 
   it('returns route.resolve candidates when bcs_route targets an unknown name', async () => {

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -634,6 +634,12 @@ describe('openclaw-channel-bcn', () => {
               runId,
               stream: 'lifecycle',
               ts: 2,
+              data: null,
+            });
+            agentEventHandler?.({
+              runId,
+              stream: 'lifecycle',
+              ts: 3,
               data: { phase: 'end' },
             });
             await new Promise<void>(resolve => {


### PR DESCRIPTION
## Summary

- build visible BCS replies from OpenClaw assistant agent events
- allow terminal lifecycle events or dispatcher completion to send the final reply, with `finalSent` deduplication
- emit `NO_REPLY` when no assistant text is observed
- remove only initial WebSocket handshake listeners so runtime close/reconnect handling remains active
- bump `@avernet-plugin/openclaw-channel-bcn` to `1.0.16`

## Why

This aligns Avernet's public BCN plugin with the reply assembly and connection lifecycle behavior already used in `ocb_2`. It prevents stale dispatcher buffers from becoming the canonical reply, avoids duplicate final/error events, and preserves reconnect handling after runtime WebSocket errors.

## Compatibility

- keeps Avernet's existing explicit bot identity and stale-session validation
- keeps existing route intent merging, deduplication, and public package boundaries
- does not add dependencies or configuration keys

## Validation

- `npm run lint`
- `npm run prepublishOnly`
- `npm run test-local` — 46 passing
- targeted reply/WebSocket tests — 29 passing
- `npm publish --dry-run --access public --registry=https://registry.npmjs.org/`
- tarball gate verified ESM/CJS entries, plugin manifest, version `1.0.16`, and bundled `ws`

## Known tooling issue

The package-pinned `@arethetypeswrong/cli@0.15.3` throws `Cannot read properties of undefined (reading 'filename')` under both Node 22 and Node 25. Lint, build, tests, coverage, and npm publish dry-run complete successfully.