### PR TITLE
more logs added when storage_id not found upon arca sandbox deleting

### DIFF
--- a/src/baas/packages/community/src/secbaas/core/service/paas/_arca_paas_service.py
+++ b/src/baas/packages/community/src/secbaas/core/service/paas/_arca_paas_service.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 
 def _safe_repr(obj: object, max_len: int = 4096) -> str:
-    """Safely repr() an object, truncating to max_len bytes.
+    """Safely repr() an object, truncating to max_len characters.
 
     Returns "<repr failed: {error}>" if repr() raises an exception.
     """
@@ -442,6 +442,13 @@ class ArcaPaasService(PaasService):
                     )
                 else:
                     storage_id = storage["storage_id"]
+                    if not isinstance(storage_id, str):
+                        self._logger.warning(
+                            f"Storage cleanup skipped: storage_id is not a string, "
+                            f"paas_device_id={paas_device_id}, "
+                            f"storage_id={_safe_repr(storage_id)}"
+                        )
+                        storage_id = None
             except Exception as e:
                 self._logger.warning(
                     f"Storage cleanup skipped: get_info failed, "
@@ -504,7 +511,7 @@ class ArcaPaasService(PaasService):
         # Step 2: Best-effort storage cleanup (always reached, even on
         # idempotent destroy paths — NAS volumes must be cleaned up
         # regardless of whether the sandbox was already gone).
-        if storage_id:
+        if storage_id is not None:
             tenant_name = self._credentials.tenant_name
             if tenant_name:
                 try:

--- a/src/baas/packages/community/src/secbaas/core/service/paas/_arca_paas_service.py
+++ b/src/baas/packages/community/src/secbaas/core/service/paas/_arca_paas_service.py
@@ -46,7 +46,7 @@ def _safe_repr(obj: object, max_len: int = 4096) -> str:
     try:
         s = repr(obj)
         if len(s) > max_len:
-            s = s[:max_len]
+            s = s[:max_len - 3] + "..."
         return s
     except Exception as e:
         return f"<repr failed: {e}>"
@@ -452,8 +452,7 @@ class ArcaPaasService(PaasService):
             except Exception as e:
                 self._logger.warning(
                     f"Storage cleanup skipped: get_info failed, "
-                    f"paas_device_id={paas_device_id}, "
-                    f"get_info unavailable due to exception: {e}",
+                    f"paas_device_id={paas_device_id}",
                     exc_info=True,
                 )
         except ArcaSandboxNotFoundError:

--- a/src/baas/packages/community/src/secbaas/core/service/paas/_arca_paas_service.py
+++ b/src/baas/packages/community/src/secbaas/core/service/paas/_arca_paas_service.py
@@ -38,6 +38,20 @@ if TYPE_CHECKING:
     from secbaas.spi.sandbox.arca import ArcaSandbox
 
 
+def _safe_repr(obj: object, max_len: int = 4096) -> str:
+    """Safely repr() an object, truncating to max_len bytes.
+
+    Returns "<repr failed: {error}>" if repr() raises an exception.
+    """
+    try:
+        s = repr(obj)
+        if len(s) > max_len:
+            s = s[:max_len]
+        return s
+    except Exception as e:
+        return f"<repr failed: {e}>"
+
+
 class ArcaPaasService(PaasService):
     """Arca platform PaaS adapter using direct SDK calls.
 
@@ -409,12 +423,30 @@ class ArcaPaasService(PaasService):
             try:
                 info = sandbox.get_info()
                 storage = getattr(info, "storage", None)
-                if storage and isinstance(storage, dict):
-                    storage_id = storage.get("storage_id")
-            except Exception:
+                if storage is None:
+                    self._logger.warning(
+                        f"Storage cleanup skipped: storage attribute missing, "
+                        f"paas_device_id={paas_device_id}"
+                    )
+                elif not isinstance(storage, dict):
+                    self._logger.warning(
+                        f"Storage cleanup skipped: storage is not a dict, "
+                        f"paas_device_id={paas_device_id}, "
+                        f"get_info={_safe_repr(info)}"
+                    )
+                elif storage.get("storage_id") is None:
+                    self._logger.warning(
+                        f"Storage cleanup skipped: storage_id key missing, "
+                        f"paas_device_id={paas_device_id}, "
+                        f"get_info={_safe_repr(info)}"
+                    )
+                else:
+                    storage_id = storage["storage_id"]
+            except Exception as e:
                 self._logger.warning(
-                    "Failed to get storage info before destroy for %s",
-                    paas_device_id,
+                    f"Storage cleanup skipped: get_info failed, "
+                    f"paas_device_id={paas_device_id}, "
+                    f"get_info unavailable due to exception: {e}",
                     exc_info=True,
                 )
         except ArcaSandboxNotFoundError:

--- a/src/baas/packages/community/tests/unit/core/service/paas/test_arca_paas_service.py
+++ b/src/baas/packages/community/tests/unit/core/service/paas/test_arca_paas_service.py
@@ -72,12 +72,12 @@ class TestDestroyDeviceWithStorage:
         mock_sandbox.destroy.assert_called_once()
 
     def test__destroy_device_sync__without_storage(
-        self, arca_credentials, mock_plugin, mock_sandbox
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
     ):
         """TST-02: When sandbox has no storage, delete_storage is NOT called."""
         # Setup: sandbox info has NO storage attribute
         mock_info = MagicMock()
-        # Do NOT set mock_info.storage — so getattr(info, "storage", None) returns None
+        del mock_info.storage  # Ensure getattr(info, "storage", None) returns None
         mock_sandbox.get_info.return_value = mock_info
         mock_sandbox.destroy.return_value = True
 
@@ -85,14 +85,17 @@ class TestDestroyDeviceWithStorage:
             credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
         )
 
-        result = service._destroy_device_sync("test-device-id")
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
 
         assert result is True
         mock_plugin.delete_storage.assert_not_called()
         mock_sandbox.destroy.assert_called_once()
+        assert "Storage cleanup skipped: storage attribute missing" in caplog.text
+        assert "paas_device_id=test-device-id" in caplog.text
 
     def test__destroy_device_sync__get_info_fails(
-        self, arca_credentials, mock_plugin, mock_sandbox
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
     ):
         """TST-03: When get_info fails, destroy still succeeds and delete_storage NOT called."""
         # Setup: get_info raises an exception
@@ -103,11 +106,14 @@ class TestDestroyDeviceWithStorage:
             credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
         )
 
-        result = service._destroy_device_sync("test-device-id")
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
 
         assert result is True
         mock_plugin.delete_storage.assert_not_called()
         mock_sandbox.destroy.assert_called_once()
+        assert "Storage cleanup skipped: get_info failed" in caplog.text
+        assert "paas_device_id=test-device-id" in caplog.text
 
     def test__destroy_device_sync__delete_storage_fails(
         self, arca_credentials, mock_plugin, mock_sandbox, caplog
@@ -131,6 +137,8 @@ class TestDestroyDeviceWithStorage:
         mock_plugin.delete_storage.assert_called_once_with("storage-abc", "test-tenant")
         mock_sandbox.destroy.assert_called_once()
         assert "Storage deletion failed" in caplog.text
+
+    # ── Idempotent destroy tests (from github/dev) ──
 
     def test__destroy_device_sync__already_missing_is_idempotent(
         self, arca_credentials, mock_plugin
@@ -199,3 +207,74 @@ class TestDestroyDeviceWithStorage:
 
         with pytest.raises(PaasError, match="connection refused"):
             service._destroy_device_sync("test-device-id")
+
+    # ── Storage edge-case tests (from phase 01.1) ──
+
+    def test__destroy_device_sync__storage_not_dict(
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
+    ):
+        """Scenario C: When sandbox storage is not a dict, WARNING is logged."""
+        mock_info = MagicMock()
+        mock_info.storage = "not-a-dict"
+        mock_sandbox.get_info.return_value = mock_info
+        mock_sandbox.destroy.return_value = True
+
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
+
+        assert result is True
+        mock_plugin.delete_storage.assert_not_called()
+        mock_sandbox.destroy.assert_called_once()
+        assert "Storage cleanup skipped: storage is not a dict" in caplog.text
+        assert "paas_device_id=test-device-id" in caplog.text
+
+    def test__destroy_device_sync__storage_id_missing(
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
+    ):
+        """Scenario D: When storage_id key is missing, WARNING is logged."""
+        mock_info = MagicMock()
+        mock_info.storage = {}  # dict but no "storage_id" key
+        mock_sandbox.get_info.return_value = mock_info
+        mock_sandbox.destroy.return_value = True
+
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
+
+        assert result is True
+        mock_plugin.delete_storage.assert_not_called()
+        mock_sandbox.destroy.assert_called_once()
+        assert "Storage cleanup skipped: storage_id key missing" in caplog.text
+        assert "paas_device_id=test-device-id" in caplog.text
+
+
+# ── _safe_repr helper tests (from phase 01.1) ──
+
+def test__safe_repr__truncates():
+    """_safe_repr truncates output to max_len."""
+    from secbaas.core.service.paas._arca_paas_service import _safe_repr
+
+    result = _safe_repr("x" * 5000, max_len=10)
+    assert len(result) == 10
+    # repr() wraps strings in quotes, so result is 'xxxxxxxxx (9 x's + quote)
+    assert result.startswith("'")
+
+
+def test__safe_repr__repr_fails():
+    """_safe_repr returns error marker when repr() raises."""
+    from secbaas.core.service.paas._arca_paas_service import _safe_repr
+
+    class BadRepr:
+        def __repr__(self):
+            raise RuntimeError("boom")
+
+    result = _safe_repr(BadRepr())
+    assert "<repr failed:" in result
+    assert "boom" in result

--- a/src/baas/packages/community/tests/unit/core/service/paas/test_arca_paas_service.py
+++ b/src/baas/packages/community/tests/unit/core/service/paas/test_arca_paas_service.py
@@ -258,12 +258,13 @@ class TestDestroyDeviceWithStorage:
 # ── _safe_repr helper tests (from phase 01.1) ──
 
 def test__safe_repr__truncates():
-    """_safe_repr truncates output to max_len."""
+    """_safe_repr truncates output to max_len with ellipsis indicator."""
     from secbaas.core.service.paas._arca_paas_service import _safe_repr
 
     result = _safe_repr("x" * 5000, max_len=10)
     assert len(result) == 10
-    # repr() wraps strings in quotes, so result is 'xxxxxxxxx (9 x's + quote)
+    # Truncated at max_len with "..." appended as truncation indicator
+    assert result.endswith("...")
     assert result.startswith("'")
 
 


### PR DESCRIPTION
    fix(arca-paas-service): apply code review fixes for storage cleanup defensive checks
    
    - Fix _safe_repr docstring: 'bytes' -> 'characters' (WR-03)
    - Add isinstance(str) check for storage_id extracted from dict (WR-01)
    - Change 'if storage_id:' to 'if storage_id is not None:' for consistency (WR-02)
    
    test(01.1-01): add WARNING log tests for storage cleanup scenarios B/C/D + _safe_repr tests
    
    - Modify test__destroy_device_sync__get_info_fails: add caplog + log assertions
    - Modify test__destroy_device_sync__without_storage: add caplog + explicit del mock_info.storage
    - Add test__destroy_device_sync__storage_not_dict (scene C): verify 'storage is not a dict' WARNING
    - Add test__destroy_device_sync__storage_id_missing (scene D): verify 'storage_id key missing' WARNING
    - Add test__safe_repr__truncates: verify max_len truncation
    - Add test__safe_repr__repr_fails: verify repr() exception protection
 
    feat(01.1-01): add _safe_repr() and rewrite _destroy_device_sync() Step 0 WARNINGs
    
    - Add module-level _safe_repr() with truncation and repr() exception protection
    - Rewrite inner try/except in _destroy_device_sync() Step 0 to 4-branch if/elif/else
    - Scene A (get_info exception): enhanced f-string WARNING with paas_device_id + exc_info=True
    - Scene B (storage is None): new WARNING with 'storage attribute missing'
    - Scene C (storage not dict): new WARNING with 'storage is not a dict' + _safe_repr(info)
    - Scene D (storage_id is None): new WARNING with 'storage_id key missing' + _safe_repr(info)
    - All WARNINGs prefixed with 'Storage cleanup skipped:' for grep-ability
    - Outer connect failure and existing WARNINGs preserved (D-09)