### PR TITLE
docs: document pre-push and singlebox coverage architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,31 @@ and `.github/workflows/singlebox-coverage.yml` pointed at this same entrypoint,
 then run `verify_singlebox_coverage_artifacts.py` against the generated report
 directory so local pushes and GitHub PRs enforce the same artifact baseline.
 
+### Singlebox Coverage Details
+
+`scripts/ci/singlebox_coverage.sh` reads
+`scripts/ci/singlebox_coverage_modules.yaml`. With no `--module` arguments it
+runs every registered module; focused diagnosis can select one or more modules
+with repeated `--module <name>` arguments. The runner starts one standalone
+product stack, shares it across Backend acceptance stories and BCS user-story
+E2E, then calculates the Core, Router API, and Plugin API denominators declared
+by each module.
+
+The per-module non-regression results and the shared-stack evidence are written
+to `scripts/.dependencies/coverage/singlebox/reports/`: `summary.json`,
+`summary.md`, `dashboard.html`, acceptance JUnit/logs, Backend and BaaS
+coverage reports, plus the copied BCS reports under `bcs/`. GitHub's
+`singlebox-coverage-artifacts` artifact uploads that same directory. The
+artifact verifier must run against this report directory after the coverage
+runner, so local pre-push and PR CI enforce the same result.
+
+When adding a module, add meaningful live acceptance stories, declare the
+complete Core/Router/Plugin denominators in
+`scripts/ci/singlebox_coverage_modules.yaml`, establish thresholds from a
+fresh focused run, then run the default all-module gate to catch shared-stack
+interference. Do not inflate a result by excluding production Core paths or by
+adding test-only calls to domain logic.
+
 ## Development Guidelines
 
 Start from the requirement and the existing contract. Keep changes small and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,8 @@ target is `origin/dev`; set `avernet.prePush.mergeTarget` for a persistent
 override or `AVERNET_PRE_PUSH_MERGE_TARGET` for one `git push`. The hook must
 fetch that target and use its merge base rather than a direct target-to-head
 diff.
+
+Before changing Git hooks, module CI entrypoints, Singlebox orchestration,
+acceptance E2E tests, coverage manifests, or coverage reporting, read the
+`Pre-push Module Selection` section in `AGENTS.md` and treat it together with
+the referenced scripts as one contract.


### PR DESCRIPTION
## Summary

- document the current target-aware pre-push comparison and module dispatch contract
- document the unified Singlebox runner: module manifest, shared stack, per-module denominators, BCS evidence, and uploaded artifacts
- keep `CLAUDE.md` concise while directing tooling changes to the authoritative `AGENTS.md` section

## Scope

Rebased onto the latest `dev`. This PR changes only `AGENTS.md` and `CLAUDE.md`; it does not change hooks, CI behavior, or production code.

## Validation

- `git diff --check`
- marker checks for the target contract, full manifest path, and artifact name
- `15 passed`: pre-push hook/dispatch, Singlebox workflow, and artifact-verifier contract tests
