### PR TITLE
fix(baas): restrict DeviceTtlTimer baas_device query to ARCA provider

### DIFF
--- a/src/baas/packages/community/src/secbaas/core/repository/device_binding/_orm_repository.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/device_binding/_orm_repository.py
@@ -1453,15 +1453,19 @@ class OrmDeviceBindingRepository(OrmConnectionMixin, DeviceBindingRepository):
         *,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """查询 baas_device 中 ACTIVE 且有 sandbox_id 的记录，
+        """查询 baas_device 中 ACTIVE 且有 sandbox_id 的 ARCA 记录，
         按 TTL 过期时间 ASC 排序，取前 limit 条。
 
         用于 DeviceTtlTimer 定时任务：优先处理即将过期的服务 bot 设备。
+        限 provider_type='ARCA'（对齐 list_baas_devices_active_paginated）——
+        teclaw 的 update_device_ttl 是 NotImplementedError，k8s/docker 等沙箱
+        生命周期不由本任务续期，混入会触发无效续期 + 探活噪声。
         """
         rows = (
             self._session.query(DeviceModel)
             .filter(
                 DeviceModel.status == "ACTIVE",
+                DeviceModel.provider_type == "ARCA",
                 DeviceModel.provider_device_props.op("->>")("$.sandbox_id").isnot(None),
             )
             .order_by(

--- a/src/baas/packages/community/tests/integration/core/repository/test_device_binding_sqlite.py
+++ b/src/baas/packages/community/tests/integration/core/repository/test_device_binding_sqlite.py
@@ -234,3 +234,50 @@ class TestDeviceBindingSqliteOrmEquivalence:
         assert record.apply_reason == "equiv test"
         assert record.applied_by == "tester"
         assert record.gmt_create is not None
+
+
+class TestListBaasDevicesByTtlAscProviderFilter:
+    """list_baas_devices_by_ttl_asc 必须只返回 provider_type='ARCA' 的设备。
+
+    DeviceTtlTimer 用此查询捞服务 bot 设备做 TTL 续期 + 探活;teclaw 的
+    update_device_ttl 是 NotImplementedError,混入会触发无效续期噪声,
+    企业版还可能因探活失败累加 refresh_fail_count 误置 STOPPED。
+    """
+
+    def _insert_device(self, *, provider_type: str, sandbox_id: str, ttl: str) -> int:
+        device_repo = get_container().repository.device_repository()
+        return device_repo.insert_device(
+            device_uuid=_generate_uuid(),
+            tenant="tenant-ttl",
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+            status="ACTIVE",
+            provider_type=provider_type,
+            provider_device_id=sandbox_id,
+            provider_device_props={
+                "sandbox_id": sandbox_id,
+                "ttl_expiration_time": ttl,
+            },
+        )
+
+    def test_excludes_non_arca_providers(self):
+        """TECLAW 设备即使 ACTIVE 且有 sandbox_id,也不得被 TTL 任务捞出。"""
+        repo = get_container().repository.device_binding_repository()
+
+        arca_id = self._insert_device(
+            provider_type="ARCA", sandbox_id="sbx-arca", ttl="2026-01-01 00:00:00"
+        )
+        teclaw_id = self._insert_device(
+            provider_type="TECLAW", sandbox_id="sbx-teclaw", ttl="2026-01-01 00:00:00"
+        )
+
+        result = repo.list_baas_devices_by_ttl_asc(limit=100)
+
+        returned_ids = {row["id"] for row in result}
+        provider_types = {row["provider_type"] for row in result}
+
+        assert arca_id in returned_ids
+        assert teclaw_id not in returned_ids
+        assert provider_types == {"ARCA"}


### PR DESCRIPTION
list_baas_devices_by_ttl_asc (the query DeviceTtlTimer uses to pick service bot devices for TTL renewal + probe) had no provider_type filter, so teclaw/k8s/docker devices were swept in alongside arca. teclaw's update_device_ttl is NotImplementedError, so every teclaw device produced a spurious renewal failure each cycle (log noise + wasted batch slots that crowd out arca devices needing renewal); in the enterprise build a failing get_device_info probe could also accumulate refresh_fail_count and get the teclaw device wrongly marked STOPPED.

Add `provider_type == "ARCA"` to the query, matching the filter list_baas_devices_active_paginated already applies for the active-sandboxes endpoint — only arca sandboxes are TTL-managed by this task.

- _orm_repository.list_baas_devices_by_ttl_asc: filter provider_type='ARCA' and document why (teclaw NotImplementedError; k8s/docker not renewed here).
- Integration test: insert ARCA + TECLAW baas_device rows, assert only the ARCA row is returned.