### PR TITLE
test(bot-chat): cover live OTLP lifecycle in singlebox

### DIFF
--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -56,10 +56,21 @@ modules:
       - tests/community/acceptance/bot_chat
     core_paths:
       - src/agentclaw/community/core/bot_chat/
-    router_api: *pending_router_denominator
-    plugin_api: *pending_plugin_denominator
+    router_api:
+      status: applicable
+      reason: The Langfuse health route is external-service dependent and is outside the local singlebox denominator.
+      items:
+        - POST /api/bot-chat/otel/traces
+        - POST /api/bot-chat/log-relations
+        - GET /api/v1/bot-chats
+        - GET /api/v1/bot-chats/{trace_id}
+    plugin_api:
+      status: not_applicable
+      reason: Bot chat currently has no independently attributable Plugin API boundary.
+      items: []
     thresholds:
-      core_min_percent: 40.66
+      core_min_percent: 67.48
+      router_min_percent: 100.0
 
   bot_collaborator:
     system: backend

--- a/src/backend/tests/community/_flows/bot_chat/api_lifecycle.py
+++ b/src/backend/tests/community/_flows/bot_chat/api_lifecycle.py
@@ -5,11 +5,11 @@ Single source of truth for both executors:
   - 路 B: tests/acceptance/bot_chat/ via flow_runner_live.run_flow_live (real backend)
 and for the E3 coverage guard (tests/architecture/test_e2e_module_coverage.py).
 
-bot_chat is READ-ONLY chat-trace querying — flows do NOT create data through
-the API. The test runner seeds aw_langfuse_traces + ac_bots rows directly into
-SQLite before the flow runs (see tests/e2e/test_bot_chat_flows.py for the seed
-helper); the flow asserts the API surfaces them. This matches how the module is
-used in prod (traces emitted by chat engines, backend only queries).
+These shared query flows are read-only. The in-process runner seeds
+aw_langfuse_traces + ac_bots rows directly into SQLite before the flow runs
+(see tests/e2e/test_bot_chat_flows.py), then asserts the API surfaces them.
+Live OTLP ingestion and relation writes are covered separately by
+tests/acceptance/bot_chat/test_otel_roundtrip_lifecycle.py.
 
 LOCAL+SQLITE, mock-free for the db source. The langfuse source (log_source=langfuse)
 and /health endpoint hit an external Langfuse HTTP API (https://example.com)

--- a/src/backend/tests/community/acceptance/bot_chat/test_chat_query_lifecycle.py
+++ b/src/backend/tests/community/acceptance/bot_chat/test_chat_query_lifecycle.py
@@ -1,14 +1,12 @@
-"""Route-B acceptance: bot_chat read-only query lifecycle on live backend.
+"""Route-B acceptance: bot_chat query lifecycle on a live backend.
 
 Starts a real singlebox backend (in-memory SQLite via local_setup.sh),
 runs the LOCAL-pure flows through httpx, asserts no-data state matches a JSON
 baseline snapshot.
 
-bot_chat is read-only — single box has no chat engine producing traces — so
-acceptance covers only the empty/no-data contract: list returns empty, detail
-returns 4004 (SessionNotFoundError). The seeded path is covered in-process
-by route A (which can write via DatabasePlugin.session()); a future
-LangfuseClient local impl or chat-engine integration would extend this.
+This file pins the empty/no-data query contract: list returns empty and detail
+returns 4004 (SessionNotFoundError). The separate OTLP round-trip acceptance
+test writes traces and business relations through the live HTTP API.
 
 Off by default; enable with RUN_ACCEPTANCE=1.
 """

--- a/src/backend/tests/community/acceptance/bot_chat/test_otel_roundtrip_lifecycle.py
+++ b/src/backend/tests/community/acceptance/bot_chat/test_otel_roundtrip_lifecycle.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+import uuid
 
 import httpx
 import pytest
@@ -77,7 +78,7 @@ def _otlp_payload(trace_id: str, start_ns: int) -> dict:
 
 @pytest.mark.acceptance
 def test_bot_chat_otel_ingest_query_and_relation_roundtrip(live_backend):
-    trace_id = f"trace_singlebox_{time.time_ns()}"
+    trace_id = uuid.uuid4().hex
     payload = _otlp_payload(trace_id, time.time_ns())
 
     with httpx.Client(base_url=live_backend, headers=HEADERS, timeout=30.0) as client:

--- a/src/backend/tests/community/acceptance/bot_chat/test_otel_roundtrip_lifecycle.py
+++ b/src/backend/tests/community/acceptance/bot_chat/test_otel_roundtrip_lifecycle.py
@@ -1,0 +1,146 @@
+"""Live bot-chat OTLP ingest, query, and business-relation lifecycle."""
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+
+HEADERS = {"x-user-id": "e2e_user"}
+
+
+def _attr(key: str, value: str | int) -> dict:
+    if isinstance(value, int):
+        encoded = {"intValue": str(value)}
+    else:
+        encoded = {"stringValue": value}
+    return {"key": key, "value": encoded}
+
+
+def _otlp_payload(trace_id: str, start_ns: int) -> dict:
+    end_ns = start_ns + 1_000_000_000
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        _attr("identity.owner_id", "e2e_user"),
+                        _attr("identity.bot_id", "default"),
+                        _attr("agentic.runtime.name", "openclaw"),
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": trace_id,
+                                "spanId": "chat-root",
+                                "name": "Singlebox chat turn",
+                                "startTimeUnixNano": str(start_ns),
+                                "endTimeUnixNano": str(end_ns),
+                                "attributes": [
+                                    _attr("gen_ai.span.kind", "CHAT"),
+                                    _attr("gen_ai.session.id", "session-live"),
+                                    _attr("gen_ai.conversation.id", "session-key-live"),
+                                    _attr(
+                                        "gen_ai.input.messages",
+                                        '[{"role":"user","content":"hello singlebox"}]',
+                                    ),
+                                    _attr(
+                                        "gen_ai.output.messages",
+                                        '{"role":"assistant","content":"hello"}',
+                                    ),
+                                ],
+                            },
+                            {
+                                "traceId": trace_id,
+                                "spanId": "llm-child",
+                                "parentSpanId": "chat-root",
+                                "name": "Singlebox model call",
+                                "startTimeUnixNano": str(start_ns),
+                                "endTimeUnixNano": str(end_ns),
+                                "attributes": [
+                                    _attr("gen_ai.span.kind", "LLM"),
+                                    _attr("gen_ai.response.model", "singlebox-model"),
+                                    _attr("gen_ai.usage.input_tokens", 8),
+                                    _attr("gen_ai.usage.output_tokens", 3),
+                                ],
+                            },
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+
+
+@pytest.mark.acceptance
+def test_bot_chat_otel_ingest_query_and_relation_roundtrip(live_backend):
+    trace_id = f"trace_singlebox_{time.time_ns()}"
+    payload = _otlp_payload(trace_id, time.time_ns())
+
+    with httpx.Client(base_url=live_backend, headers=HEADERS, timeout=30.0) as client:
+        ingest = client.post("/api/bot-chat/otel/traces", json=payload)
+        assert ingest.status_code == 200, ingest.text
+        ingest_body = ingest.json()
+        assert ingest_body["success"] is True
+        assert ingest_body["data"] == {
+            "trace_count": 1,
+            "observation_count": 2,
+        }
+
+        sessions = client.get(
+            "/api/v1/bot-chats",
+            params={"owner_id": "e2e_user", "trace_id": trace_id},
+        )
+        assert sessions.status_code == 200, sessions.text
+        sessions_body = sessions.json()
+        assert sessions_body["success"] is True
+        assert sessions_body["data"]["total"] == 1
+        assert sessions_body["data"]["sessions"][0]["id"] == trace_id
+
+        detail = client.get(f"/api/v1/bot-chats/{trace_id}")
+        assert detail.status_code == 200, detail.text
+        detail_body = detail.json()
+        assert detail_body["success"] is True
+        assert detail_body["data"]["id"] == trace_id
+        assert detail_body["data"]["session_id"] == "session-live"
+        assert detail_body["data"]["total_tokens"] == 11
+        assert detail_body["data"]["observations"]
+
+        relation_payload = {
+            "biz_scene": "singlebox-coverage",
+            "biz_task_id": trace_id,
+            "engine": "openclaw",
+            "collector": "observ-openclaw",
+            "user_id": "e2e_user",
+            "bot_id": "default",
+            "refs": [
+                {
+                    "ref_type": "trace_id",
+                    "ref_value": trace_id,
+                }
+            ],
+        }
+        first_relation = client.post(
+            "/api/bot-chat/log-relations",
+            json=relation_payload,
+        )
+        assert first_relation.status_code == 200, first_relation.text
+        assert first_relation.json()["data"] == {
+            "inserted": 1,
+            "updated": 0,
+            "total": 1,
+        }
+
+        second_relation = client.post(
+            "/api/bot-chat/log-relations",
+            json=relation_payload,
+        )
+        assert second_relation.status_code == 200, second_relation.text
+        assert second_relation.json()["data"] == {
+            "inserted": 0,
+            "updated": 1,
+            "total": 1,
+        }


### PR DESCRIPTION
## Summary
- add a real HTTP OTLP ingest/query/relation round trip
- register the four locally meaningful Router APIs in the unified manifest
- keep external Langfuse health and non-attributable plugin boundaries out of the claimed denominator
- no business or Core code changes

## Coverage
- Core: 67.48%
- Router API: 100.00%
- Plugin API: N/A

## Validation
- focused module, manifest reporter, and architecture boundary tests passed on latest dev
- acceptance target collection passed
- prior real singlebox run: 4 live cases passed; gate passed

## Foundation
#292 is merged into dev. This PR now contains only bot-chat-specific coverage configuration and tests.