### PR TITLE
test(bot-dormant): cover recycle and reactivation in singlebox

### DIFF
--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -1,4 +1,29 @@
 modules:
+  bot_dormant:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/bot_dormant
+    core_paths:
+      - src/agentclaw/community/core/bot_dormant/
+    router_api:
+      status: applicable
+      reason: Internal activate-one duplicates the public path, unfreeze-passport-one is a repair-only operation, and trigger-scan is asynchronous ops tooling; they are outside this user-story denominator.
+      items:
+        - POST /api/bots/{bot_id}/activate
+        - POST /api/bots/dormant-whitelist/batch
+        - GET /api/internal/dormant/pending-notifications
+        - POST /api/internal/dormant/mark-sent
+        - POST /api/internal/dormant/recycle-one
+    plugin_api:
+      status: applicable
+      reason: Recycle and reactivation must freeze and unfreeze the bot passport through the injected plugin boundary.
+      items:
+        - PassportPlugin.freeze_agent_passport
+        - PassportPlugin.unfreeze_agent_passport
+    thresholds:
+      core_min_percent: 54.13
+      router_min_percent: 100.0
+      plugin_min_percent: 100.0
   devices:
     system: backend
     acceptance_targets:

--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -18,8 +18,14 @@ modules:
       status: applicable
       reason: Recycle and reactivation must freeze and unfreeze the bot passport through the injected plugin boundary.
       items:
-        - PassportPlugin.freeze_agent_passport
-        - PassportPlugin.unfreeze_agent_passport
+        - key: PassportPlugin.freeze_agent_passport
+          evidence:
+            path: src/agentclaw/community/plugins/local/passport.py
+            symbol: LocalPassportPlugin.freeze_agent_passport
+        - key: PassportPlugin.unfreeze_agent_passport
+          evidence:
+            path: src/agentclaw/community/plugins/local/passport.py
+            symbol: LocalPassportPlugin.unfreeze_agent_passport
     thresholds:
       core_min_percent: 54.13
       router_min_percent: 100.0

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -108,6 +108,7 @@ def test_repository_manifest_registers_existing_coverage_modules_and_paths():
     module_names = select_module_names(manifest, [])
 
     assert module_names == [
+        "bot_dormant",
         "devices",
         "access",
         "bot_chat",

--- a/src/backend/src/agentclaw/community/di/modules/bot_dormant_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_dormant_module.py
@@ -41,6 +41,9 @@ from agentclaw.community.plugin_api.cache import CachePlugin
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
+from agentclaw.community.utils.singlebox_coverage_proxy import (
+    wrap_for_singlebox_coverage,
+)
 
 
 logger = get_logger()
@@ -58,6 +61,16 @@ logger = get_logger()
 # NOTE: this is intentionally a publicly-visible string — it only ever
 # gates singlebox/local where no real authority decision is at stake.
 _SINGLEBOX_FALLBACK_TOKEN = "singlebox-dormant-token-local"
+
+
+def _passport_for_singlebox_coverage(passport_plugin: PassportPlugin) -> PassportPlugin:
+    return wrap_for_singlebox_coverage(
+        passport_plugin,
+        {
+            "freeze_agent_passport": "PassportPlugin.freeze_agent_passport",
+            "unfreeze_agent_passport": "PassportPlugin.unfreeze_agent_passport",
+        },
+    )
 
 
 class BotDormantModule(Module):
@@ -85,7 +98,7 @@ class BotDormantModule(Module):
         """Construct ActivateBotService with the passport plugin explicitly wired."""
         return ActivateBotService(
             bot_service=bot_service,
-            passport_plugin=passport_plugin,
+            passport_plugin=_passport_for_singlebox_coverage(passport_plugin),
         )
 
     @singleton
@@ -124,7 +137,7 @@ class BotDormantModule(Module):
             db=db,
             baas_client=baas_client,
             bot_service=bot_service,
-            passport_plugin=passport_plugin,
+            passport_plugin=_passport_for_singlebox_coverage(passport_plugin),
             scan_policy=scan_policy,
             common_whitelist_service=common_whitelist_service,
             dry_run=config.dry_run,

--- a/src/backend/src/agentclaw/community/di/modules/bot_dormant_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_dormant_module.py
@@ -41,9 +41,6 @@ from agentclaw.community.plugin_api.cache import CachePlugin
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
-from agentclaw.community.utils.singlebox_coverage_proxy import (
-    wrap_for_singlebox_coverage,
-)
 
 
 logger = get_logger()
@@ -61,16 +58,6 @@ logger = get_logger()
 # NOTE: this is intentionally a publicly-visible string — it only ever
 # gates singlebox/local where no real authority decision is at stake.
 _SINGLEBOX_FALLBACK_TOKEN = "singlebox-dormant-token-local"
-
-
-def _passport_for_singlebox_coverage(passport_plugin: PassportPlugin) -> PassportPlugin:
-    return wrap_for_singlebox_coverage(
-        passport_plugin,
-        {
-            "freeze_agent_passport": "PassportPlugin.freeze_agent_passport",
-            "unfreeze_agent_passport": "PassportPlugin.unfreeze_agent_passport",
-        },
-    )
 
 
 class BotDormantModule(Module):
@@ -98,7 +85,7 @@ class BotDormantModule(Module):
         """Construct ActivateBotService with the passport plugin explicitly wired."""
         return ActivateBotService(
             bot_service=bot_service,
-            passport_plugin=_passport_for_singlebox_coverage(passport_plugin),
+            passport_plugin=passport_plugin,
         )
 
     @singleton
@@ -137,7 +124,7 @@ class BotDormantModule(Module):
             db=db,
             baas_client=baas_client,
             bot_service=bot_service,
-            passport_plugin=_passport_for_singlebox_coverage(passport_plugin),
+            passport_plugin=passport_plugin,
             scan_policy=scan_policy,
             common_whitelist_service=common_whitelist_service,
             dry_run=config.dry_run,

--- a/src/backend/tests/community/acceptance/bot_dormant/__init__.py
+++ b/src/backend/tests/community/acceptance/bot_dormant/__init__.py
@@ -1,0 +1,1 @@
+"""Live dormant bot acceptance tests."""

--- a/src/backend/tests/community/acceptance/bot_dormant/test_dormant_lifecycle.py
+++ b/src/backend/tests/community/acceptance/bot_dormant/test_dormant_lifecycle.py
@@ -80,7 +80,12 @@ def test_dormant_recycle_notification_and_reactivate_live(live_backend):
         )
         assert pending.status_code == 200, pending.text
         rows = pending.json()["data"]
-        notification = next(row for row in rows if row["bot_id"] == bot_id)
+        notifications = [row for row in rows if row["bot_id"] == bot_id]
+        assert len(notifications) == 1, (
+            f"expected one notification for bot {bot_id}, got {notifications}; "
+            f"all rows={rows}"
+        )
+        notification = notifications[0]
         assert notification["notify_type"] == "recycle"
 
         marked = client.post(

--- a/src/backend/tests/community/acceptance/bot_dormant/test_dormant_lifecycle.py
+++ b/src/backend/tests/community/acceptance/bot_dormant/test_dormant_lifecycle.py
@@ -1,0 +1,136 @@
+"""Dormant recycle, notification, activation, and whitelist lifecycle."""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.community.acceptance._fixtures.live_personal_bot import (
+    create_live_personal_bot,
+    fresh_id,
+)
+
+
+INTERNAL_HEADERS = {
+    "Authorization": "Bearer singlebox-dormant-token-local",
+}
+
+
+def _wait_reactivated_bot_ready(
+    client: httpx.Client,
+    bot_id: str,
+    *,
+    timeout_sec: int = 180,
+) -> dict[str, Any]:
+    """Wait through the release-to-reallocation window after activation."""
+    deadline = time.monotonic() + timeout_sec
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        response = client.get(f"/api/bots/{bot_id}/status")
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        if payload.get("success") is not True:
+            assert payload.get("error_code") == 404, payload
+            last = payload
+            time.sleep(2)
+            continue
+
+        status = payload.get("data") or {}
+        last = status
+        if status.get("is_ready") is True:
+            return status
+        assert status.get("bot_status") not in {"FAILED", "RECYCLED"}, status
+        time.sleep(2)
+
+    pytest.fail(f"reactivated bot {bot_id} did not become ready; last={last}")
+
+
+@pytest.mark.acceptance
+def test_dormant_recycle_notification_and_reactivate_live(live_backend):
+    owner_id = fresh_id("dormant_owner")
+    headers = {"x-user-id": owner_id}
+
+    with httpx.Client(base_url=live_backend, headers=headers, timeout=180.0) as client:
+        bot = create_live_personal_bot(
+            client,
+            user_id=owner_id,
+            bot_name_prefix="Dormant Acceptance",
+            bot_desc="dormant recycle and reactivate acceptance bot",
+        )
+        bot_id = bot["bot_id"]
+
+        recycled = client.post(
+            "/api/internal/dormant/recycle-one",
+            headers=INTERNAL_HEADERS,
+            json={
+                "bot_id": bot_id,
+                "owner_id": owner_id,
+                "dry_run": False,
+                "reason": "singlebox coverage lifecycle",
+            },
+        )
+        assert recycled.status_code == 200, recycled.text
+        assert recycled.json()["data"]["status"] == "recycled"
+
+        pending = client.get(
+            "/api/internal/dormant/pending-notifications",
+            headers=INTERNAL_HEADERS,
+        )
+        assert pending.status_code == 200, pending.text
+        rows = pending.json()["data"]
+        notification = next(row for row in rows if row["bot_id"] == bot_id)
+        assert notification["notify_type"] == "recycle"
+
+        marked = client.post(
+            "/api/internal/dormant/mark-sent",
+            headers=INTERNAL_HEADERS,
+            json={"id": notification["id"], "success": True},
+        )
+        assert marked.status_code == 200, marked.text
+        assert marked.json() == {"ok": True, "status": "sent"}
+
+        repeated_mark = client.post(
+            "/api/internal/dormant/mark-sent",
+            headers=INTERNAL_HEADERS,
+            json={"id": notification["id"], "success": True},
+        )
+        assert repeated_mark.status_code == 200, repeated_mark.text
+        assert repeated_mark.json() == {
+            "ok": True,
+            "status": "already_resolved",
+        }
+
+        activated = client.post(f"/api/bots/{bot_id}/activate")
+        assert activated.status_code == 200, activated.text
+        activated_body = activated.json()
+        assert activated_body["success"] is True, activated_body
+        assert activated_body["data"]["status"] == "REACTIVATING"
+        _wait_reactivated_bot_ready(client, bot_id)
+
+
+@pytest.mark.acceptance
+def test_dormant_whitelist_is_idempotent_live(live_backend):
+    owner_id = fresh_id("dormant_whitelist_owner")
+    bot_id = fresh_id("dormant_whitelist_bot")
+    headers = {"x-user-id": owner_id}
+    payload = {
+        "entries": [
+            {
+                "bot_id": bot_id,
+                "owner_id": owner_id,
+                "governance_source": "singlebox",
+                "reason": "coverage lifecycle",
+            }
+        ]
+    }
+
+    with httpx.Client(base_url=live_backend, headers=headers, timeout=30.0) as client:
+        first = client.post("/api/bots/dormant-whitelist/batch", json=payload)
+        assert first.status_code == 200, first.text
+        assert first.json()["data"] == {"inserted": 1, "skipped": 0}
+
+        second = client.post("/api/bots/dormant-whitelist/batch", json=payload)
+        assert second.status_code == 200, second.text
+        assert second.json()["data"] == {"inserted": 0, "skipped": 1}


### PR DESCRIPTION
## Summary
- exercise personal-bot recycle, notification, idempotent mark-sent, reactivation, and whitelist behavior
- derive freeze/unfreeze PassportPlugin evidence offline from LocalPassportPlugin executed lines
- register bot_dormant in the unified module runner
- keep coverage instrumentation out of BotDormantModule and Core code

## Coverage
- Core: 54.13% (413/763)
- Router API: 100.00% (5/5)
- Plugin API: 100.00% (2/2)

## Validation
- focused module, manifest reporter, and architecture boundary tests passed on latest dev
- acceptance target collection passed
- prior real singlebox run: 2 live cases passed; gate passed

## Foundation
#292 is merged into dev. This PR now contains only bot-dormant-specific coverage configuration and tests.