### PR TITLE
test(resources): gate live metadata lifecycle coverage

### DIFF
--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -105,6 +105,38 @@ modules:
     thresholds:
       core_min_percent: 41.59
 
+  resources:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/resources/test_resource_metadata_lifecycle.py
+    core_paths:
+      - src/agentclaw/community/core/resources/
+    router_api:
+      status: applicable
+      reason: Resource metadata lifecycle; workspace file APIs are owned by the files module.
+      items:
+        - GET /api/resources/check-name
+        - GET /api/resources
+        - POST /api/resources/url
+        - POST /api/resources/node
+        - POST /api/resources/links
+        - PUT /api/resources/links/{resource_id}
+        - GET /api/resources/{resource_id}
+        - DELETE /api/resources/{resource_id}
+    plugin_api:
+      status: applicable
+      reason: Resource metadata is persisted through the unified ResourceRepository boundary.
+      items:
+        - ResourceRepository.create
+        - ResourceRepository.list_resources
+        - ResourceRepository.get_by_id
+        - ResourceRepository.update
+        - ResourceRepository.delete
+    thresholds:
+      core_min_percent: 39.07
+      router_min_percent: 100.0
+      plugin_min_percent: 100.0
+
 pending_modules:
   skill_center:
     acceptance_targets:
@@ -118,7 +150,3 @@ pending_modules:
     acceptance_targets:
       - tests/community/acceptance/mcp
     reason: Permission baseline and live engine connection assumptions need migration.
-  resources:
-    acceptance_targets:
-      - tests/community/acceptance/resources
-    reason: File lifecycle creates no BaaS-backed bot binding before workspace access.

--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -124,18 +124,12 @@ modules:
         - GET /api/resources/{resource_id}
         - DELETE /api/resources/{resource_id}
     plugin_api:
-      status: applicable
-      reason: Resource metadata is persisted through the unified ResourceRepository boundary.
-      items:
-        - ResourceRepository.create
-        - ResourceRepository.list_resources
-        - ResourceRepository.get_by_id
-        - ResourceRepository.update
-        - ResourceRepository.delete
+      status: not_applicable
+      reason: ResourceRepository is a Core persistence seam, not a declared Plugin API protocol.
+      items: []
     thresholds:
       core_min_percent: 39.07
       router_min_percent: 100.0
-      plugin_min_percent: 100.0
 
 pending_modules:
   skill_center:

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -115,6 +115,7 @@ def test_repository_manifest_registers_existing_coverage_modules_and_paths():
         "cron",
         "expert_chat",
         "harness",
+        "resources",
     ]
     for module_name in module_names:
         module = manifest["modules"][module_name]

--- a/src/backend/src/agentclaw/community/di/modules/resources_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/resources_module.py
@@ -55,9 +55,6 @@ class ResourcesModule(Module):
             ResourceFileService,
         )
         binder.bind(ResourceFileService, to=ResourceFileService, scope=singleton)
-        # Unified ORM repo (one body, ZDAS + SQLite). @inject ctor takes
-        # the bound DatabasePlugin; prod vs test differ only by which
-        # DatabasePlugin is bound (ZdasDB / SqliteDB).
         # Teclaw workspace-file metadata (ac_file): same unified-ORM pattern.
         binder.bind(
             FileRepositoryProtocol, to=FileRepository, scope=singleton

--- a/src/backend/src/agentclaw/community/di/modules/resources_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/resources_module.py
@@ -27,13 +27,9 @@ from agentclaw.community.core.files.repository.protocol import FileRepositoryPro
 from agentclaw.community.core.resources.factory import ResourceServiceFactory
 from agentclaw.community.core.resources.repository.protocol import ResourceRepositoryProtocol
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugins.file_repository import FileRepository
 from agentclaw.community.plugins.resource_repository import (
     ResourceRepository as UnifiedResourceRepository,
-)
-from agentclaw.community.utils.singlebox_coverage_proxy import (
-    wrap_for_singlebox_coverage,
 )
 
 
@@ -55,30 +51,20 @@ class ResourcesModule(Module):
             ResourceFileService,
         )
         binder.bind(ResourceFileService, to=ResourceFileService, scope=singleton)
+        # Unified ORM repo (one body, ZDAS + SQLite). @inject ctor takes
+        # the bound DatabasePlugin; prod vs test differ only by which
+        # DatabasePlugin is bound (ZdasDB / SqliteDB).
+        binder.bind(
+            ResourceRepositoryProtocol,
+            to=UnifiedResourceRepository,
+            scope=singleton,
+        )
         # Teclaw workspace-file metadata (ac_file): same unified-ORM pattern.
         binder.bind(
             FileRepositoryProtocol, to=FileRepository, scope=singleton
         )
         binder.bind(
             BotFileServiceFactory, to=BotFileServiceFactory, scope=singleton
-        )
-
-    @singleton
-    @provider
-    @inject
-    def resource_repository(
-        self, db: DatabasePlugin
-    ) -> ResourceRepositoryProtocol:
-        """Expose resource persistence evidence at the DI boundary."""
-        return wrap_for_singlebox_coverage(
-            UnifiedResourceRepository(db),
-            {
-                "create": "ResourceRepository.create",
-                "list_resources": "ResourceRepository.list_resources",
-                "get_by_id": "ResourceRepository.get_by_id",
-                "update": "ResourceRepository.update",
-                "delete": "ResourceRepository.delete",
-            },
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/resources_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/resources_module.py
@@ -27,9 +27,13 @@ from agentclaw.community.core.files.repository.protocol import FileRepositoryPro
 from agentclaw.community.core.resources.factory import ResourceServiceFactory
 from agentclaw.community.core.resources.repository.protocol import ResourceRepositoryProtocol
 from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugins.file_repository import FileRepository
 from agentclaw.community.plugins.resource_repository import (
     ResourceRepository as UnifiedResourceRepository,
+)
+from agentclaw.community.utils.singlebox_coverage_proxy import (
+    wrap_for_singlebox_coverage,
 )
 
 
@@ -54,17 +58,30 @@ class ResourcesModule(Module):
         # Unified ORM repo (one body, ZDAS + SQLite). @inject ctor takes
         # the bound DatabasePlugin; prod vs test differ only by which
         # DatabasePlugin is bound (ZdasDB / SqliteDB).
-        binder.bind(
-            ResourceRepositoryProtocol,
-            to=UnifiedResourceRepository,
-            scope=singleton,
-        )
         # Teclaw workspace-file metadata (ac_file): same unified-ORM pattern.
         binder.bind(
             FileRepositoryProtocol, to=FileRepository, scope=singleton
         )
         binder.bind(
             BotFileServiceFactory, to=BotFileServiceFactory, scope=singleton
+        )
+
+    @singleton
+    @provider
+    @inject
+    def resource_repository(
+        self, db: DatabasePlugin
+    ) -> ResourceRepositoryProtocol:
+        """Expose resource persistence evidence at the DI boundary."""
+        return wrap_for_singlebox_coverage(
+            UnifiedResourceRepository(db),
+            {
+                "create": "ResourceRepository.create",
+                "list_resources": "ResourceRepository.list_resources",
+                "get_by_id": "ResourceRepository.get_by_id",
+                "update": "ResourceRepository.update",
+                "delete": "ResourceRepository.delete",
+            },
         )
 
     @singleton

--- a/src/backend/tests/community/acceptance/resources/test_resource_metadata_lifecycle.py
+++ b/src/backend/tests/community/acceptance/resources/test_resource_metadata_lifecycle.py
@@ -1,0 +1,121 @@
+"""Real singlebox lifecycle for URL, Node, and Link resource metadata."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tests.community.acceptance._fixtures.live_personal_bot import (
+    create_live_personal_bot,
+    fresh_id,
+)
+
+
+def _assert_success(response: httpx.Response) -> dict:
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["success"] is True, payload
+    return payload
+
+
+@pytest.mark.acceptance
+def test_resource_metadata_roundtrip(live_backend):
+    """Manage local resource metadata without calling remote knowledge systems."""
+    user_id = fresh_id("e2e_resources_user")
+    headers = {"x-user-id": user_id}
+
+    with httpx.Client(base_url=live_backend, headers=headers, timeout=60.0) as client:
+        bot = create_live_personal_bot(
+            client,
+            user_id=user_id,
+            bot_name_prefix="Resources",
+            bot_desc="resource metadata lifecycle bot",
+        )
+        bot_id = bot["bot_id"]
+
+        url_payload = _assert_success(
+            client.post(
+                f"/api/resources/url?bot_id={bot_id}",
+                json={
+                    "name": "Project handbook",
+                    "url": "https://example.com/handbook",
+                },
+            )
+        )
+        url_id = url_payload["data"]["id"]
+
+        node_payload = _assert_success(
+            client.post(
+                f"/api/resources/node?bot_id={bot_id}",
+                json={
+                    "name": "Dataset node",
+                    "node_address": "ipfs://singlebox-dataset",
+                },
+            )
+        )
+        node_id = node_payload["data"]["id"]
+
+        response = client.get(
+            f"/api/resources/check-name?bot_id={bot_id}"
+            "&resource_type=url&name=Project%20handbook"
+        )
+        assert _assert_success(response)["data"]["available"] is False
+
+        listed = _assert_success(
+            client.get(
+                f"/api/resources?bot_id={bot_id}&owner_id={user_id}&search=Project"
+            )
+        )
+        assert [item["id"] for item in listed["data"]] == [url_id]
+
+        link_payload = _assert_success(
+            client.post(
+                f"/api/resources/links?bot_id={bot_id}",
+                json={
+                    "links": {
+                        "dima": [
+                            {
+                                "name": "DIMA task",
+                                "url": "https://example.com/dima/task/42",
+                            }
+                        ]
+                    }
+                },
+            )
+        )
+        link_id = link_payload["data"][0]["id"]
+
+        updated = _assert_success(
+            client.put(
+                f"/api/resources/links/{link_id}?bot_id={bot_id}",
+                json={
+                    "link_type": "antcode",
+                    "name": "Avernet source",
+                    "url": "https://github.com/inclusionAI/Avernet",
+                },
+            )
+        )
+        assert updated["data"]["link_type"] == "antcode"
+        assert updated["data"]["name"] == "Avernet source"
+
+        detail = _assert_success(
+            client.get(f"/api/resources/{link_id}?bot_id={bot_id}")
+        )
+        assert detail["data"]["url"] == "https://github.com/inclusionAI/Avernet"
+
+        deleted = _assert_success(
+            client.delete(
+                f"/api/resources/{link_id}?bot_id={bot_id}&entity_id={user_id}"
+            )
+        )
+        assert deleted["message"] == "Resource deleted"
+
+        deleted_detail = _assert_success(
+            client.get(f"/api/resources/{link_id}?bot_id={bot_id}")
+        )
+        assert deleted_detail["data"]["status"] == "deleted"
+
+        remaining = _assert_success(
+            client.get(f"/api/resources?bot_id={bot_id}&owner_id={user_id}")
+        )
+        assert {item["id"] for item in remaining["data"]} == {url_id, node_id}


### PR DESCRIPTION
## Summary
- promote Resources from pending_modules with a real BaaS-backed metadata lifecycle
- define independent Core and Router API denominators
- keep workspace-file coverage owned by the separate Files module
- classify ResourceRepository correctly as a Core persistence seam, not a Plugin API
- preserve the original ResourcesModule binding with no coverage-specific production wiring

## Coverage
- Core: 39.07% (388/993)
- Router API: 100% (8/8)
- Plugin API: N/A

## Validation
- focused module, manifest reporter, and architecture boundary tests passed on latest dev
- acceptance target collection passed
- prior real singlebox run: 1 live acceptance test passed

## Foundation
#292 is merged into dev. This PR now contains only Resources-specific coverage configuration and tests.