### PR TITLE
test(files): gate live singlebox workspace lifecycle

### DIFF
--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -112,17 +112,12 @@ modules:
         - DELETE /api/resources/files
         - POST /api/resources/files/mkdir
     plugin_api:
-      status: applicable
-      reason: Workspace file operations cross the provider-selected DeviceFileSystem boundary.
-      items:
-        - DeviceFileSystem.list_dir
-        - DeviceFileSystem.read_file
-        - DeviceFileSystem.write_file
-        - DeviceFileSystem.delete_file
+      status: not_applicable
+      reason: DeviceFileSystem is a Core service seam, not a declared Plugin API protocol.
+      items: []
     thresholds:
       core_min_percent: 63.52
       router_min_percent: 100.0
-      plugin_min_percent: 100.0
 
   harness:
     system: backend

--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -94,6 +94,36 @@ modules:
     thresholds:
       core_min_percent: 63.49
 
+  files:
+    system: backend
+    acceptance_targets:
+      - tests/community/acceptance/files
+    core_paths:
+      - src/agentclaw/community/core/files/
+      - src/agentclaw/community/core/services/resource_file_service.py
+    router_api:
+      status: applicable
+      reason: Workspace file browsing and mutation routes owned by ResourceFileService.
+      items:
+        - GET /api/resources/files
+        - POST /api/resources/files/upload
+        - GET /api/resources/files/download
+        - GET /api/resources/files/preview
+        - DELETE /api/resources/files
+        - POST /api/resources/files/mkdir
+    plugin_api:
+      status: applicable
+      reason: Workspace file operations cross the provider-selected DeviceFileSystem boundary.
+      items:
+        - DeviceFileSystem.list_dir
+        - DeviceFileSystem.read_file
+        - DeviceFileSystem.write_file
+        - DeviceFileSystem.delete_file
+    thresholds:
+      core_min_percent: 63.52
+      router_min_percent: 100.0
+      plugin_min_percent: 100.0
+
   harness:
     system: backend
     acceptance_targets:

--- a/scripts/ci/tests/test_singlebox_coverage_report.py
+++ b/scripts/ci/tests/test_singlebox_coverage_report.py
@@ -114,6 +114,7 @@ def test_repository_manifest_registers_existing_coverage_modules_and_paths():
         "bot_collaborator",
         "cron",
         "expert_chat",
+        "files",
         "harness",
     ]
     for module_name in module_names:

--- a/src/backend/tests/community/acceptance/files/__init__.py
+++ b/src/backend/tests/community/acceptance/files/__init__.py
@@ -1,0 +1,1 @@
+"""Singlebox acceptance coverage for workspace files."""

--- a/src/backend/tests/community/acceptance/files/test_workspace_file_lifecycle.py
+++ b/src/backend/tests/community/acceptance/files/test_workspace_file_lifecycle.py
@@ -14,7 +14,16 @@ from tests.community.acceptance._fixtures.live_personal_bot import (
     fresh_id,
 )
 
-TEST_BOTS_ROOT = Path(__file__).resolve().parents[6] / "test-bots"
+
+def _resolve_repo_root() -> Path:
+    """Locate the checkout that owns the singlebox runtime directories."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts" / "singlebox.sh").is_file():
+            return parent
+    raise RuntimeError("could not locate repository root from acceptance test path")
+
+
+TEST_BOTS_ROOT = _resolve_repo_root() / "test-bots"
 
 
 @pytest.mark.acceptance

--- a/src/backend/tests/community/acceptance/files/test_workspace_file_lifecycle.py
+++ b/src/backend/tests/community/acceptance/files/test_workspace_file_lifecycle.py
@@ -1,0 +1,97 @@
+"""Real singlebox lifecycle for a bot workspace file."""
+
+from __future__ import annotations
+
+import io
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tests.community.acceptance._fixtures.live_personal_bot import (
+    create_live_personal_bot,
+    fresh_id,
+)
+
+TEST_BOTS_ROOT = Path(__file__).resolve().parents[6] / "test-bots"
+
+
+@pytest.mark.acceptance
+def test_workspace_file_roundtrip(live_backend):
+    """Create, upload, inspect, download, and delete a real workspace file."""
+    user_id = fresh_id("e2e_files_user")
+    headers = {"x-user-id": user_id}
+    parent = f"files_live_{time.time_ns()}"
+    filename = "roundtrip.txt"
+    payload = b"singlebox workspace file roundtrip\n"
+
+    with httpx.Client(base_url=live_backend, headers=headers, timeout=60.0) as client:
+        bot = create_live_personal_bot(
+            client,
+            user_id=user_id,
+            bot_name_prefix="Files Acceptance",
+            bot_desc="workspace files lifecycle bot",
+        )
+        bot_id = bot["bot_id"]
+
+        response = client.post(
+            f"/api/resources/files/mkdir?bot_id={bot_id}",
+            data={"path": parent},
+        )
+        assert response.status_code == 200, response.text
+
+        response = client.post(
+            f"/api/resources/files/upload?bot_id={bot_id}&path={parent}",
+            files={"files": (filename, io.BytesIO(payload), "text/plain")},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["uploaded"][0]["path"] == f"{parent}/{filename}"
+
+        response = client.get(f"/api/resources/files?bot_id={bot_id}&path={parent}")
+        assert response.status_code == 200, response.text
+        assert filename in {item["name"] for item in response.json()["items"]}
+
+        file_path = f"{parent}/{filename}"
+        response = client.get(
+            f"/api/resources/files/preview?bot_id={bot_id}&path={file_path}"
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["data"]["content"] == payload.decode()
+
+        response = client.get(
+            f"/api/resources/files/download?bot_id={bot_id}&path={file_path}"
+        )
+        assert response.status_code == 200, response.text
+        assert response.content == payload
+        assert response.headers["content-disposition"].startswith("attachment;")
+
+        physical_matches = [
+            path
+            for path in TEST_BOTS_ROOT.rglob(filename)
+            if bot_id in str(path)
+        ]
+        assert physical_matches, "uploaded file was not materialized in the bot workspace"
+        assert physical_matches[0].read_bytes() == payload
+
+        response = client.delete(
+            f"/api/resources/files?bot_id={bot_id}&path={file_path}"
+        )
+        assert response.status_code == 200, response.text
+
+        response = client.get(f"/api/resources/files?bot_id={bot_id}&path={parent}")
+        assert response.status_code == 200, response.text
+        assert filename not in {item["name"] for item in response.json()["items"]}
+        assert not physical_matches[0].exists()
+
+
+@pytest.mark.acceptance
+def test_workspace_file_readonly_guard(live_backend):
+    """Reject deletion of protected workspace identity files before device I/O."""
+    headers = {"x-user-id": fresh_id("e2e_files_guard")}
+    with httpx.Client(base_url=live_backend, headers=headers, timeout=30.0) as client:
+        response = client.delete(
+            "/api/resources/files?bot_id=default&path=AGENTS.md"
+        )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Cannot delete read-only file"

--- a/src/backend/tests/community/acceptance/resources/test_resource_lifecycle.py
+++ b/src/backend/tests/community/acceptance/resources/test_resource_lifecycle.py
@@ -3,10 +3,10 @@
 Starts a real singlebox backend, exercises:
   - URL CRUD via run_flow_live (resources-url-resource-crud FlowCase)
   - Node CRUD via run_flow_live (resources-node-resource-crud FlowCase)
-  - File daas round-trip via httpx (mkdir Form + multipart upload + list +
-    preview), with FS rglob assertion that the uploaded file exists at the
-    real bot_data_dir under ~/.aidesktop/aidesktop_dev/bolt_data/.../workspace/
   - JSON baseline pinning URL+Node CRUD observable state
+
+Workspace file lifecycle coverage lives in acceptance/files and creates a real
+BaaS-backed bot before touching its workspace.
 
 The 3 external-dep paths (arca / yuque / publish) intentionally not covered;
 see docs/singlebox-eval/findings/resources-external-deps-unmocked.md.
@@ -15,9 +15,7 @@ Off by default; enable with RUN_ACCEPTANCE=1.
 """
 from __future__ import annotations
 
-import io
 import json
-import time
 from pathlib import Path
 
 import httpx
@@ -52,67 +50,6 @@ def test_resources_node_crud_live(live_backend, acceptance_fs_root):
     assert "node_resource_id" in ctx
     assert "first_listed_id" in ctx
     assert ctx["first_listed_id"] == ctx["node_resource_id"]
-
-
-@pytest.mark.acceptance
-def test_resources_file_daas_lifecycle_live(live_backend, acceptance_fs_root):
-    """File round-trip via httpx + real FS artifact assertion.
-
-    LOCAL device_provider != arca → file_router falls through to daas branch
-    (real local FS via FileService). The uploaded file lives somewhere under
-    ~/.aidesktop/.../bolt_data/staff_e2e_user/bot_<ns>/<engine>/workspace/<dir>/.
-    rglob from $HOME to find it by name (the engine type segment is dynamic).
-    """
-    bot_id = f"bot_e2e_live_{time.time_ns()}"
-    parent = f"live_dir_{time.time_ns()}"
-    filename = "live_test.txt"
-    payload = b"live daas content\n"
-
-    with httpx.Client(base_url=live_backend, headers=HEADERS, timeout=30.0) as client:
-        # mkdir — Form
-        r = client.post(
-            f"/api/resources/files/mkdir?bot_id={bot_id}",
-            data={"path": parent},
-        )
-        assert r.status_code == 200, r.text
-        assert r.json()["success"] is True
-
-        # upload — multipart; ?path= query for target dir (NOT parent_path)
-        r = client.post(
-            f"/api/resources/files/upload?bot_id={bot_id}&path={parent}",
-            files={"files": (filename, io.BytesIO(payload), "text/plain")},
-        )
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["success"] is True
-        assert len(body["uploaded"]) == 1, body
-        assert body["uploaded"][0]["name"] == filename
-
-        # list — FileListResponse {items}
-        r = client.get(f"/api/resources/files?bot_id={bot_id}&path={parent}")
-        assert r.status_code == 200
-        items = r.json()["items"]
-        assert any(item.get("name") == filename for item in items), items
-
-        # preview — round-trip content
-        r = client.get(
-            f"/api/resources/files/preview?bot_id={bot_id}&path={parent}/{filename}"
-        )
-        assert r.status_code == 200, r.text
-        assert payload.decode() in r.json()["data"]["content"]
-
-    # FS artifact assertion: rglob from $HOME (acceptance_fs_root) for the
-    # unique filename. Should find exactly one match under this bot's workspace.
-    home = Path(acceptance_fs_root)
-    matches = list(home.rglob(filename))
-    # Filter to matches that include our unique bot_id in the path — defends
-    # against unrelated test artifacts elsewhere on the dev host.
-    bot_matches = [m for m in matches if bot_id in str(m)]
-    assert bot_matches, f"physical file {filename} not found under {home} for bot {bot_id}; all matches: {matches}"
-    actual_content = bot_matches[0].read_bytes()
-    assert actual_content == payload, (
-        f"physical file content mismatch: expected {payload!r}, got {actual_content!r}"
-    )
 
 
 @pytest.mark.acceptance


### PR DESCRIPTION
## Summary
- add a real BaaS-backed workspace file lifecycle: mkdir, upload, list, preview, download, delete, and read-only guard
- replace the obsolete acceptance case that fabricated an unbound bot id
- classify DeviceFileSystem correctly as a Core service seam, not a Plugin API
- preserve the original singlebox device composition with no coverage-specific production wiring

## Coverage
- Core: 63.52% (148/233)
- Router API: 100% (6/6)
- Plugin API: N/A

## Validation
- focused module, manifest reporter, and architecture boundary tests passed on latest dev
- acceptance target collection passed
- prior real singlebox run: 2 live acceptance tests passed

## Foundation
#292 is merged into dev. This PR now contains only Files-specific coverage configuration and tests.

A separate existing behavior maps preview-after-delete to HTTP 500 instead of 404; this PR verifies deletion through the list API and physical artifact removal without treating that mapping as correct.