### PR TITLE
feat(aicoding): allow frontend to pass cwd directly to session endpoints

### DIFF
--- a/src/engine/src/engine/community/api/aicoding_sessions/router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/router.py
@@ -1,12 +1,25 @@
 """HTTP routes for AICoding session workspace inspection.
 
-Four endpoints, all read-only, all served directly by the engine
-running inside the aicoding container:
+Nine read-only endpoints, all served directly by the engine running inside
+the aicoding container:
 
-* ``GET /api/aicoding/sessions/file-tree``     — recursive workspace tree
-* ``GET /api/aicoding/sessions/files/preview`` — file content (size-bounded)
-* ``GET /api/aicoding/sessions/git-diff``      — changed files (tree per project)
-* ``GET /api/aicoding/sessions/files/diff``    — unified diff for one file
+* ``GET /api/aicoding/sessions``                     — sessions list + run_status enrich
+* ``GET /api/aicoding/sessions/file-tree``           — recursive workspace tree
+* ``GET /api/aicoding/sessions/files/preview``       — file content (size-bounded)
+* ``GET /api/aicoding/sessions/git-diff``            — changed files (tree per project)
+* ``GET /api/aicoding/sessions/files/diff``          — unified diff for one file
+* ``GET /api/aicoding/sessions/runs``                — devflow runs for a session
+* ``GET /api/aicoding/sessions/phases``              — phase detail for a run
+* ``GET /api/aicoding/sessions/runs/pull-requests``  — PR outputs for a session
+* ``GET /api/aicoding/sessions/worktree-status``     — .worktree.json existence/status
+
+The workspace-inspection endpoints (file-tree / files/preview / git-diff /
+files/diff / worktree-status / runs / phases / runs/pull-requests) accept an
+optional ``cwd`` query parameter: when provided it is validated
+(``WorkspaceService.validate_cwd`` / ``_validate_cwd_prefix``) and used directly
+as the session workspace root; when omitted, the legacy ``base/{session_id}``
+derivation serves as a fallback (full backwards compatibility). ``session_id``
+stays required for response correlation and fallback.
 
 Each handler composes a fresh
 :class:`engine.community.core.aicoding.workspace_service.WorkspaceService` over
@@ -121,12 +134,17 @@ def _diff_node_to_schema(node: DiffTreeNode) -> DiffTreeNodeSchema:
 @router.get("/file-tree", response_model=FileTreeResponse)
 async def list_file_tree(
     session_id: str = Query(..., description="AICoding session ID"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> FileTreeResponse:
     """Return the full workspace tree (recursive, filtered, sorted)."""
     check_capability(Capability.FILE_LIST)
     service = _workspace_service()
     try:
-        tree = await service.list_file_tree(session_id)
+        tree = await service.list_file_tree(session_id, cwd)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except NotADirectoryError as e:
@@ -147,15 +165,24 @@ async def list_file_tree(
 async def preview_file(
     session_id: str = Query(..., description="AICoding session ID"),
     path: str = Query(..., description="File path relative to workspace root"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> FilePreviewResponse:
     """Read a single workspace file (size-bounded, traversal-safe)."""
     check_capability(Capability.FILE_READ)
     service = _workspace_service()
     try:
-        content = await service.preview_file(session_id, path)
+        content = await service.preview_file(session_id, path, cwd)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+    except NotADirectoryError as e:
+        # cwd 直传指向文件（validate_cwd 阶段）→ 400。
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except IsADirectoryError as e:
+        # preview 的 path（相对 workspace）指向目录 → 400。
         raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -174,16 +201,25 @@ async def preview_file(
 @router.get("/git-diff", response_model=GitDiffResponse)
 async def list_git_diff(
     session_id: str = Query(..., description="AICoding session ID"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> GitDiffResponse:
     """Return per-project trees of changed files (modified/added/...)."""
     check_capability(Capability.BASH_EXEC)
     service = _workspace_service()
     try:
-        result = await service.list_git_diff(session_id)
+        result = await service.list_git_diff(session_id, cwd)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+    except NotADirectoryError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
 
     return GitDiffResponse(
         success=True,
@@ -205,6 +241,11 @@ async def get_file_diff(
     old_path: str | None = Query(
         None, description="Original path for renamed/copied files"
     ),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> FileDiffResponse:
     """Return the unified diff for a single file (HEAD-based, with fallbacks)."""
     check_capability(Capability.BASH_EXEC)
@@ -215,14 +256,19 @@ async def get_file_diff(
             project=project,
             file_path=path,
             old_path=old_path,
+            cwd=cwd,
         )
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+    except NotADirectoryError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except ValueError as e:
         # Covers both "Not a git repository" and traversal/invalid-project.
         detail = str(e)
         status_code = 400
         raise HTTPException(status_code=status_code, detail=detail) from e
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
 
     return FileDiffResponse(
         success=True,
@@ -273,14 +319,23 @@ async def list_sessions_with_run_status(
 @router.get("/runs", response_model=SessionRunsResponse)
 async def list_session_runs(
     session_id: str = Query(..., description="AICoding session ID"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> SessionRunsResponse:
     """API 4.2：返回该 session 工作空间下的所有 devflow runs（透传 aix 输出）。"""
     check_capability(Capability.BASH_EXEC)
     service = _runstatus_service()
     try:
-        runs = await service.get_session_runs(session_id)
+        runs = await service.get_session_runs(session_id, cwd)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+    except NotADirectoryError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return SessionRunsResponse(success=True, session_id=session_id, runs=runs)
 
 
@@ -288,14 +343,23 @@ async def list_session_runs(
 async def get_run_phases(
     session_id: str = Query(..., description="AICoding session ID"),
     run_id: str = Query(..., description="Run ID（来自 /sessions/runs）"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> RunPhaseStatusResponse:
     """API 4.3：返回某个 run 的 phase 详情（透传 ``aix run phase status --verbose``）。"""
     check_capability(Capability.BASH_EXEC)
     service = _runstatus_service()
     try:
-        data = await service.get_run_phase_status(session_id, run_id)
+        data = await service.get_run_phase_status(session_id, run_id, cwd)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+    except NotADirectoryError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return RunPhaseStatusResponse(
         success=True,
         session_id=session_id,
@@ -306,21 +370,31 @@ async def get_run_phases(
 @router.get("/runs/pull-requests", response_model=SessionPullRequestsResponse)
 async def list_session_pull_requests(
     session_id: str = Query(..., description="AICoding session ID"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> SessionPullRequestsResponse:
     """API 4.4：返回 session 工作空间下所有 run 产出的 pull-request outputs。
 
     按 ``at`` (unix ms) 倒序排列。错误语义：
 
-    - workspace 不存在 → 404
+    - cwd 越界 / 非绝对 → 400
     - 命令执行失败 → 500（带 stderr）
     - JSON 解析失败 → 500
+
+    注：本端点用 ``resolve_workspace``（仅前缀校验，不校验存在性），故 cwd
+    指向不存在目录不会抛 ``FileNotFoundError``，而是交由 aix CLI 处理。
     """
     check_capability(Capability.BASH_EXEC)
     service = _runstatus_service()
     try:
-        items = await service.get_session_pull_requests(session_id)
+        items = await service.get_session_pull_requests(session_id, cwd)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return SessionPullRequestsResponse(
         success=True,
         session_id=session_id,
@@ -334,12 +408,28 @@ async def list_session_pull_requests(
 @router.get("/worktree-status", response_model=WorktreeStatusResponse)
 async def get_worktree_status(
     session_id: str = Query(..., description="AICoding session ID"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
 ) -> WorktreeStatusResponse:
     """Check .worktree.json existence and status in session workspace."""
     import json
     from pathlib import Path
 
-    workspace = WorkspaceService.resolve_workspace(session_id)
+    # worktree-status 走 resolve_workspace（前缀校验，不校验存在性），始终返 200。
+    # cwd 直传但越界/非绝对 → resolve_workspace 抛 ValueError → 兜成 exists:false，
+    # 不破坏既有客户端契约（缺失即 idle）。
+    try:
+        workspace = WorkspaceService.resolve_workspace(session_id, cwd)
+    except ValueError as e:
+        log.warning(
+            "invalid cwd for worktree-status session=%s: %s", session_id, e
+        )
+        return WorktreeStatusResponse(
+            session_id=session_id, exists=False, status="idle"
+        )
     worktree_path = Path(workspace) / ".worktree.json"
 
     if not worktree_path.is_file():

--- a/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
@@ -64,22 +64,22 @@ class FakeWorkspaceService:
     get_file_diff_raise: Optional[BaseException] = None
     calls: list[tuple[str, dict]] = field(default_factory=list)
 
-    async def list_file_tree(self, session_id: str):
-        self.calls.append(("list_file_tree", {"session_id": session_id}))
+    async def list_file_tree(self, session_id: str, cwd: str | None = None):
+        self.calls.append(("list_file_tree", {"session_id": session_id, "cwd": cwd}))
         if self.list_file_tree_raise:
             raise self.list_file_tree_raise
         return self.list_file_tree_return or []
 
-    async def preview_file(self, session_id: str, path: str):
+    async def preview_file(self, session_id: str, path: str, cwd: str | None = None):
         self.calls.append(
-            ("preview_file", {"session_id": session_id, "path": path})
+            ("preview_file", {"session_id": session_id, "path": path, "cwd": cwd})
         )
         if self.preview_file_raise:
             raise self.preview_file_raise
         return self.preview_file_return
 
-    async def list_git_diff(self, session_id: str):
-        self.calls.append(("list_git_diff", {"session_id": session_id}))
+    async def list_git_diff(self, session_id: str, cwd: str | None = None):
+        self.calls.append(("list_git_diff", {"session_id": session_id, "cwd": cwd}))
         if self.list_git_diff_raise:
             raise self.list_git_diff_raise
         return self.list_git_diff_return
@@ -114,23 +114,25 @@ class FakeRunStatusService:
             return self.enrich_return
         return [{**s, "run_status": "idle"} for s in sessions]
 
-    async def get_session_runs(self, session_id: str):
-        self.calls.append(("get_session_runs", {"session_id": session_id}))
+    async def get_session_runs(self, session_id: str, cwd: str | None = None):
+        self.calls.append(("get_session_runs", {"session_id": session_id, "cwd": cwd}))
         if self.runs_raise:
             raise self.runs_raise
         return self.runs_return or []
 
-    async def get_run_phase_status(self, session_id: str, run_id: str):
+    async def get_run_phase_status(
+        self, session_id: str, run_id: str, cwd: str | None = None
+    ):
         self.calls.append(
-            ("get_run_phase_status", {"session_id": session_id, "run_id": run_id})
+            ("get_run_phase_status", {"session_id": session_id, "run_id": run_id, "cwd": cwd})
         )
         if self.phase_raise:
             raise self.phase_raise
         return self.phase_return
 
-    async def get_session_pull_requests(self, session_id: str):
+    async def get_session_pull_requests(self, session_id: str, cwd: str | None = None):
         self.calls.append(
-            ("get_session_pull_requests", {"session_id": session_id})
+            ("get_session_pull_requests", {"session_id": session_id, "cwd": cwd})
         )
         if self.pr_raise:
             raise self.pr_raise
@@ -712,7 +714,7 @@ def test_worktree_status_file_not_exists(client, tmp_path, monkeypatch):
     from engine.community.core.aicoding import workspace_service as ws_mod
 
     monkeypatch.setattr(
-        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid: str(tmp_path))
+        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid, cwd=None: str(tmp_path))
     )
     resp = client.get(
         "/api/aicoding/sessions/worktree-status", params={"session_id": "s1"},
@@ -735,7 +737,7 @@ def test_worktree_status_completed(client, tmp_path, monkeypatch):
     worktree_file.write_text(json.dumps({"schemaVersion": 1, "status": "completed"}))
 
     monkeypatch.setattr(
-        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid: str(tmp_path))
+        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid, cwd=None: str(tmp_path))
     )
     resp = client.get(
         "/api/aicoding/sessions/worktree-status", params={"session_id": "s1"},
@@ -756,7 +758,7 @@ def test_worktree_status_running(client, tmp_path, monkeypatch):
     worktree_file.write_text(json.dumps({"schemaVersion": 1, "status": "running"}))
 
     monkeypatch.setattr(
-        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid: str(tmp_path))
+        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid, cwd=None: str(tmp_path))
     )
     resp = client.get(
         "/api/aicoding/sessions/worktree-status", params={"session_id": "s1"},
@@ -775,7 +777,7 @@ def test_worktree_status_invalid_json(client, tmp_path, monkeypatch):
     worktree_file.write_text("not valid json {{{")
 
     monkeypatch.setattr(
-        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid: str(tmp_path))
+        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid, cwd=None: str(tmp_path))
     )
     resp = client.get(
         "/api/aicoding/sessions/worktree-status", params={"session_id": "s1"},
@@ -796,7 +798,7 @@ def test_worktree_status_missing_status_field(client, tmp_path, monkeypatch):
     worktree_file.write_text(json.dumps({"schemaVersion": 1}))
 
     monkeypatch.setattr(
-        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid: str(tmp_path))
+        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(lambda sid, cwd=None: str(tmp_path))
     )
     resp = client.get(
         "/api/aicoding/sessions/worktree-status", params={"session_id": "s1"},
@@ -804,4 +806,208 @@ def test_worktree_status_missing_status_field(client, tmp_path, monkeypatch):
     assert resp.status_code == 200
     body = resp.json()
     assert body["exists"] is True
+    assert body["status"] == "idle"
+
+
+# ── cwd 直传（新增可选参数）─────────────────────────────────────────────────
+
+
+def test_file_tree_forwards_cwd_to_service(client, workspace_svc):
+    """cwd 直传必须透传到 ``service.list_file_tree(session_id, cwd)``。"""
+    workspace_svc.list_file_tree_return = []
+    resp = client.get(
+        "/api/aicoding/sessions/file-tree",
+        params={"session_id": "s1", "cwd": "/home/admin/.aicoding/workspace/s1"},
+    )
+    assert resp.status_code == 200
+    assert workspace_svc.calls[-1][1]["cwd"] == "/home/admin/.aicoding/workspace/s1"
+
+
+def test_file_tree_cwd_missing_falls_back_to_none_cwd(client, workspace_svc):
+    """不传 cwd → service 收到 cwd=None（旧逻辑兜底，完全向后兼容）。"""
+    workspace_svc.list_file_tree_return = []
+    resp = client.get(
+        "/api/aicoding/sessions/file-tree", params={"session_id": "s1"},
+    )
+    assert resp.status_code == 200
+    assert workspace_svc.calls[-1][1]["cwd"] is None
+
+
+@pytest.mark.parametrize(
+    "exc, status",
+    [
+        (ValueError("cwd not allowed"), 400),
+        (NotADirectoryError("cwd not a directory"), 400),
+        (FileNotFoundError("cwd not found"), 404),
+    ],
+)
+def test_file_tree_cwd_validation_errors_mapped(client, workspace_svc, exc, status):
+    """cwd 校验失败三类异常 → 400/404（file-tree 端点，覆盖 §2.2）。"""
+    workspace_svc.list_file_tree_raise = exc
+    resp = client.get(
+        "/api/aicoding/sessions/file-tree",
+        params={"session_id": "s1", "cwd": "/whatever"},
+    )
+    assert resp.status_code == status
+
+
+def test_files_preview_forwards_cwd(client, workspace_svc):
+    workspace_svc.preview_file_return = FileContent(content="hi", size=2)
+    resp = client.get(
+        "/api/aicoding/sessions/files/preview",
+        params={
+            "session_id": "s1",
+            "path": "a.txt",
+            "cwd": "/home/admin/.aicoding/workspace/s1",
+        },
+    )
+    assert resp.status_code == 200
+    assert workspace_svc.calls[-1][1]["cwd"] == "/home/admin/.aicoding/workspace/s1"
+
+
+@pytest.mark.parametrize(
+    "exc, status",
+    [
+        (NotADirectoryError("cwd not a directory"), 400),
+        (PermissionError("denied"), 403),
+    ],
+)
+def test_git_diff_cwd_new_branches(client, workspace_svc, exc, status):
+    """git-diff 新增的 except 分支（设计 §2.3.3 标「新增」）。"""
+    workspace_svc.list_git_diff_raise = exc
+    resp = client.get(
+        "/api/aicoding/sessions/git-diff",
+        params={"session_id": "s1", "cwd": "/x"},
+    )
+    assert resp.status_code == status
+
+
+def test_files_diff_cwd_new_branches(client, workspace_svc):
+    """files/diff 新增 NotADirectoryError→400 / PermissionError→403。"""
+    workspace_svc.get_file_diff_raise = NotADirectoryError("cwd not a dir")
+    resp = client.get(
+        "/api/aicoding/sessions/files/diff",
+        params={"session_id": "s1", "project": "p", "path": "x", "cwd": "/x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_runs_forwards_cwd(client, runstatus_svc):
+    runstatus_svc.runs_return = []
+    resp = client.get(
+        "/api/aicoding/sessions/runs",
+        params={"session_id": "s1", "cwd": "/home/admin/.aicoding/workspace/s1"},
+    )
+    assert resp.status_code == 200
+    assert runstatus_svc.calls[-1][1]["cwd"] == "/home/admin/.aicoding/workspace/s1"
+
+
+@pytest.mark.parametrize(
+    "exc, status",
+    [
+        (ValueError("cwd not allowed"), 400),
+        (NotADirectoryError("cwd not a directory"), 400),
+    ],
+)
+def test_runs_cwd_validation_errors(client, runstatus_svc, exc, status):
+    runstatus_svc.runs_raise = exc
+    resp = client.get(
+        "/api/aicoding/sessions/runs", params={"session_id": "s1", "cwd": "/x"},
+    )
+    assert resp.status_code == status
+
+
+def test_phases_forwards_cwd(client, runstatus_svc):
+    runstatus_svc.phase_return = {
+        "runId": "r-1",
+        "workflow": "spec-to-pr",
+        "currentPhase": "summarize",
+    }
+    resp = client.get(
+        "/api/aicoding/sessions/phases",
+        params={
+            "session_id": "s1",
+            "run_id": "r-1",
+            "cwd": "/home/admin/.aicoding/workspace/s1",
+        },
+    )
+    assert resp.status_code == 200
+    assert runstatus_svc.calls[-1][1]["cwd"] == "/home/admin/.aicoding/workspace/s1"
+
+
+def test_phases_cwd_validation_400(client, runstatus_svc):
+    runstatus_svc.phase_raise = ValueError("cwd not allowed")
+    resp = client.get(
+        "/api/aicoding/sessions/phases",
+        params={"session_id": "s1", "run_id": "r-1", "cwd": "/x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_pull_requests_forwards_cwd(client, runstatus_svc):
+    runstatus_svc.pr_return = []
+    resp = client.get(
+        "/api/aicoding/sessions/runs/pull-requests",
+        params={"session_id": "s1", "cwd": "/home/admin/.aicoding/workspace/s1"},
+    )
+    assert resp.status_code == 200
+    assert runstatus_svc.calls[-1][1]["cwd"] == "/home/admin/.aicoding/workspace/s1"
+
+
+def test_pull_requests_cwd_validation_400(client, runstatus_svc):
+    """pull-requests 走 resolve_workspace（仅前缀校验）→ ValueError→400；
+    不抛 NotADirectoryError/FileNotFoundError（§2.3.4）。"""
+    runstatus_svc.pr_raise = ValueError("cwd not allowed")
+    resp = client.get(
+        "/api/aicoding/sessions/runs/pull-requests",
+        params={"session_id": "s1", "cwd": "/x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_worktree_status_forwards_cwd_to_resolve_workspace(
+    client, tmp_path, monkeypatch
+):
+    """cwd 直传必须透传到 resolve_workspace(session_id, cwd)。"""
+    from engine.community.core.aicoding import workspace_service as ws_mod
+
+    captured: dict = {}
+
+    def _capture(sid, cwd=None):
+        captured["sid"] = sid
+        captured["cwd"] = cwd
+        return str(tmp_path)
+
+    monkeypatch.setattr(
+        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(_capture)
+    )
+    # tmp_path 下无 .worktree.json → exists:false，但仍 200
+    resp = client.get(
+        "/api/aicoding/sessions/worktree-status",
+        params={"session_id": "s1", "cwd": "/home/admin/.aicoding/workspace/s1"},
+    )
+    assert resp.status_code == 200
+    assert captured["sid"] == "s1"
+    assert captured["cwd"] == "/home/admin/.aicoding/workspace/s1"
+
+
+def test_worktree_status_invalid_cwd_returns_exists_false(
+    client, monkeypatch
+):
+    """cwd 越界 → resolve_workspace 抛 ValueError → 兜成 exists:false/200（§2.3.3）。"""
+    from engine.community.core.aicoding import workspace_service as ws_mod
+
+    def _raise(sid, cwd=None):
+        raise ValueError("cwd not allowed")
+
+    monkeypatch.setattr(
+        ws_mod.WorkspaceService, "resolve_workspace", staticmethod(_raise)
+    )
+    resp = client.get(
+        "/api/aicoding/sessions/worktree-status",
+        params={"session_id": "s1", "cwd": "/etc"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["exists"] is False
     assert body["status"] == "idle"

--- a/src/engine/src/engine/community/core/aicoding/runstatus_service.py
+++ b/src/engine/src/engine/community/core/aicoding/runstatus_service.py
@@ -199,12 +199,16 @@ class RunStatusService:
         """API 4.2：返回该 session 工作空间下的所有 runs，倒序。
 
         ``cwd`` 直传优先（经 :meth:`WorkspaceService.validate_cwd` 校验含存在性），
-        缺省回退 ``resolve_workspace(session_id)``。若 workspace 不存在，抛
-        ``FileNotFoundError`` 让 router 层转 404；这与 API 4.1（列表+enrich）
-        的"静默兜底为 idle"区分开。
+        缺省回退 ``resolve_workspace(session_id)``。复用 ``ensure_workspace_exists``
+        的返回值作为 ``workspace_root`` 透传给 :meth:`_collect_runs_for_session`,
+        避免内部再 ``resolve_workspace`` 一次的冗余解析 + 前缀校验（gemini code
+        review PR#132 medium #3）。若 workspace 不存在，抛 ``FileNotFoundError``
+        让 router 层转 404；这与 API 4.1（列表+enrich）的"静默兜底为 idle"区分开。
         """
-        WorkspaceService.ensure_workspace_exists(session_id, cwd)
-        runs = await self._collect_runs_for_session(session_id, cwd)
+        workspace = WorkspaceService.ensure_workspace_exists(session_id, cwd)
+        runs = await self._collect_runs_for_session(
+            session_id, cwd, workspace_root=workspace
+        )
         return runs or []
 
     async def get_run_phase_status(
@@ -267,17 +271,27 @@ class RunStatusService:
     # ── internal ──────────────────────────────────────────────────────────────
 
     async def _collect_runs_for_session(
-        self, session_id: str, cwd: str | None = None
+        self,
+        session_id: str,
+        cwd: str | None = None,
+        workspace_root: str | None = None,
     ) -> Optional[list[dict]]:
         """在 session workspace root 上执行 ``aix run list --filter <root> --json``，
         由 aix 自己向下递归找 ``.aix/`` 并返回所有 run（含 ``projectDir``）。
 
         ``cwd`` 直传优先（经 ``resolve_workspace`` 前缀校验），缺省回退旧拼接。
+        调用方可通过 ``workspace_root`` 传入已解析（且经 ``ensure_workspace_exists``
+        校验过存在性）的路径，跳过内部 ``resolve_workspace`` 的冗余解析 + 校验
+        （gemini code review PR#132 medium #4/#5）；不传时按 ``(session_id, cwd)``
+        重新解析，供 :meth:`get_active_run_status` 等不做存在性校验的路径使用，
+        保持旧行为。
+
         新命令一次返回所有 run，因此不再需要旧实现的 ``find -name .aix`` 预扫 +
         多 project 串行调用 + 合并步骤。排序仍按 ``updatedAtUnixMs`` 兜底，因为
         aix 返回顺序未约定。
         """
-        workspace_root = WorkspaceService.resolve_workspace(session_id, cwd)
+        if not workspace_root:
+            workspace_root = WorkspaceService.resolve_workspace(session_id, cwd)
         runs = await self._aix_run_list(workspace_root)
         if not runs:
             return None

--- a/src/engine/src/engine/community/core/aicoding/runstatus_service.py
+++ b/src/engine/src/engine/community/core/aicoding/runstatus_service.py
@@ -193,23 +193,29 @@ class RunStatusService:
         self._status_cache[session_id] = (now, active)
         return active
 
-    async def get_session_runs(self, session_id: str) -> list[dict]:
+    async def get_session_runs(
+        self, session_id: str, cwd: str | None = None
+    ) -> list[dict]:
         """API 4.2：返回该 session 工作空间下的所有 runs，倒序。
 
-        若 session workspace 不存在，抛 ``FileNotFoundError`` 让 router
-        层转 404；这与 API 4.1（列表+enrich）的"静默兜底为 idle"区分开。
+        ``cwd`` 直传优先（经 :meth:`WorkspaceService.validate_cwd` 校验含存在性），
+        缺省回退 ``resolve_workspace(session_id)``。若 workspace 不存在，抛
+        ``FileNotFoundError`` 让 router 层转 404；这与 API 4.1（列表+enrich）
+        的"静默兜底为 idle"区分开。
         """
-        WorkspaceService.ensure_workspace_exists(session_id)
-        runs = await self._collect_runs_for_session(session_id)
+        WorkspaceService.ensure_workspace_exists(session_id, cwd)
+        runs = await self._collect_runs_for_session(session_id, cwd)
         return runs or []
 
-    async def get_run_phase_status(self, session_id: str, run_id: str) -> dict:
+    async def get_run_phase_status(
+        self, session_id: str, run_id: str, cwd: str | None = None
+    ) -> dict:
         """API 4.3：在 session 工作空间的 project 子目录中查找该 run_id 的 phase 详情。"""
         if not _RUN_ID_RE.match(run_id):
             raise HTTPException(status_code=400, detail=f"Invalid run_id: {run_id!r}")
 
-        cwd = WorkspaceService.ensure_workspace_exists(session_id)
-        candidates = await self._find_aix_project_dirs(cwd)
+        workspace = WorkspaceService.ensure_workspace_exists(session_id, cwd)
+        candidates = await self._find_aix_project_dirs(workspace)
         if not candidates:
             raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
 
@@ -240,32 +246,38 @@ class RunStatusService:
             detail=f"aix run phase status failed: {last_stderr or 'no stderr'}",
         )
 
-    async def get_session_pull_requests(self, session_id: str) -> list[dict]:
+    async def get_session_pull_requests(
+        self, session_id: str, cwd: str | None = None
+    ) -> list[dict]:
         """API 4.4：返回 session 工作空间下所有 run 产出的 pull-request outputs，按 at 倒序。
 
-        执行 ``aix run output list --kind pull-request --json --filter <workspace_root>``，
-        由 aix 自己向下递归找 ``.aix/``，service 不再需要预先 find + 多目录串行调用。
+        ``cwd`` 直传优先（经 ``resolve_workspace`` 前缀校验，不含存在性），缺省回退
+        ``resolve_workspace(session_id)``。执行 ``aix run output list --kind pull-request
+        --json --filter <workspace_root>``，由 aix 自己向下递归找 ``.aix/``。
 
         错误语义：
 
-        - workspace 不存在 → ``FileNotFoundError``，router 转 404；
+        - cwd 越界 / 非绝对 → ``ValueError``，router 转 400；
         - 命令执行失败 / exit_code != 0 → 抛 500，带 stderr；
         - JSON 解析失败 → 抛 500。
         """
-        workspace_root = WorkspaceService.resolve_workspace(session_id)
+        workspace_root = WorkspaceService.resolve_workspace(session_id, cwd)
         return await self._aix_run_output_list(workspace_root)
 
     # ── internal ──────────────────────────────────────────────────────────────
 
-    async def _collect_runs_for_session(self, session_id: str) -> Optional[list[dict]]:
+    async def _collect_runs_for_session(
+        self, session_id: str, cwd: str | None = None
+    ) -> Optional[list[dict]]:
         """在 session workspace root 上执行 ``aix run list --filter <root> --json``，
         由 aix 自己向下递归找 ``.aix/`` 并返回所有 run（含 ``projectDir``）。
 
+        ``cwd`` 直传优先（经 ``resolve_workspace`` 前缀校验），缺省回退旧拼接。
         新命令一次返回所有 run，因此不再需要旧实现的 ``find -name .aix`` 预扫 +
         多 project 串行调用 + 合并步骤。排序仍按 ``updatedAtUnixMs`` 兜底，因为
         aix 返回顺序未约定。
         """
-        workspace_root = WorkspaceService.resolve_workspace(session_id)
+        workspace_root = WorkspaceService.resolve_workspace(session_id, cwd)
         runs = await self._aix_run_list(workspace_root)
         if not runs:
             return None

--- a/src/engine/src/engine/community/core/aicoding/tests/test_runstatus_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_runstatus_service.py
@@ -1339,3 +1339,84 @@ async def test_get_session_runs_cwd_outrange_raises_value_error() -> None:
     service = _make_service(plugin)
     with pytest.raises(ValueError, match="cwd not allowed"):
         await service.get_session_runs(SESSION_ID, cwd="/etc")
+
+
+# ── get_session_runs 复用 ensure_workspace_exists 返回值（gemini PR#132 #3/#4/#5）─
+
+
+async def test_get_session_runs_reuses_workspace_from_ensure(monkeypatch) -> None:
+    """``get_session_runs`` 复用 ``ensure_workspace_exists`` 的返回值作为
+    ``workspace_root`` 透传给 aix，不再让 ``_collect_runs_for_session`` 内部二次
+    ``resolve_workspace``。钉法：stub ensure 返回哨兵路径，断言 resolve 零调用、
+    aix 收到哨兵。"""
+    sentinel = "/ws/sentinel-from-ensure"
+    ensure_calls: list[tuple] = []
+
+    def _ensure_stub(session_id, cwd=None):
+        ensure_calls.append((session_id, cwd))
+        return sentinel
+
+    resolve_calls: list[tuple] = []
+
+    def _resolve_stub(session_id, cwd=None):
+        resolve_calls.append((session_id, cwd))
+        return sentinel
+
+    monkeypatch.setattr(
+        WorkspaceService, "ensure_workspace_exists", staticmethod(_ensure_stub)
+    )
+    monkeypatch.setattr(
+        WorkspaceService, "resolve_workspace", staticmethod(_resolve_stub)
+    )
+
+    aix_calls: list[str] = []
+    service = _make_service(FakeBashPlugin())
+
+    async def _aix_stub(workspace_root):
+        aix_calls.append(workspace_root)
+        return []
+
+    service._aix_run_list = _aix_stub  # type: ignore[assignment]
+
+    runs = await service.get_session_runs("sid-reuse", cwd=None)
+    assert runs == []
+    assert ensure_calls == [("sid-reuse", None)]
+    assert resolve_calls == []          # 关键：不再二次 resolve
+    assert aix_calls == [sentinel]      # 复用的 workspace 透传到 aix
+
+
+async def test_collect_runs_for_session_workspace_root_takes_precedence(
+    monkeypatch,
+) -> None:
+    """显式 ``workspace_root`` 时跳过 ``resolve_workspace``；不传时回退
+    ``resolve_workspace``（保持 :meth:`get_active_run_status` 旧行为）。"""
+    resolve_calls: list[tuple] = []
+
+    def _resolve_stub(session_id, cwd=None):
+        resolve_calls.append((session_id, cwd))
+        return f"/resolved/{session_id}"
+
+    monkeypatch.setattr(
+        WorkspaceService, "resolve_workspace", staticmethod(_resolve_stub)
+    )
+
+    aix_calls: list[str] = []
+    service = _make_service(FakeBashPlugin())
+
+    async def _aix_stub(workspace_root):
+        aix_calls.append(workspace_root)
+        return []
+
+    service._aix_run_list = _aix_stub  # type: ignore[assignment]
+
+    # 显式 workspace_root -> 直接用，不 resolve
+    await service._collect_runs_for_session(
+        "sid-a", cwd=None, workspace_root="/explicit-ws"
+    )
+    assert resolve_calls == []
+    assert aix_calls == ["/explicit-ws"]
+
+    # 不传 workspace_root -> 回退 resolve_workspace（旧行为）
+    await service._collect_runs_for_session("sid-b", cwd=None)
+    assert resolve_calls == [("sid-b", None)]
+    assert aix_calls == ["/explicit-ws", "/resolved/sid-b"]

--- a/src/engine/src/engine/community/core/aicoding/tests/test_runstatus_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_runstatus_service.py
@@ -1269,3 +1269,73 @@ async def test_safe_exec_logs_warning_on_unexpected_exception(caplog) -> None:
     assert result is None
     assert any("bash exec unexpected error" in rec.message for rec in caplog.records)
     assert any("surprise" in rec.message for rec in caplog.records)
+
+
+# ── cwd 直传（前端直传工作目录，优先于 base/{session_id}）────────────────
+
+
+# ``_bypass_workspace_exists`` autouse fixture 把 ensure_workspace_exists 替换为
+# resolve_workspace；后者对 cwd 直传走 _validate_cwd_prefix（只校验格式 + 允许根
+# 前缀，不校验存在性）。下面的 cwd 都落在 CONTAINER_WORKSPACE_BASE 下，天然放行。
+
+
+async def test_get_session_runs_forwards_cwd_to_aix_filter() -> None:
+    """cwd 直传 → ``aix run list --filter <cwd>`` 与执行 cwd 跟随 cwd。"""
+    custom_cwd = f"{CONTAINER_WORKSPACE_BASE}/custom-session"
+    plugin = FakeBashPlugin()
+    plugin.add(
+        "aix run list",
+        custom_cwd,
+        BashExecResult(stdout=_runs_payload([]), stderr="", exit_code=0),
+    )
+    service = _make_service(plugin)
+    runs = await service.get_session_runs(SESSION_ID, cwd=custom_cwd)
+    assert runs == []
+    # exec 的 cwd 必须是 custom_cwd（而非 base/{SESSION_ID}）
+    assert plugin.calls[0][1] == custom_cwd
+
+
+async def test_get_run_phase_status_forwards_cwd() -> None:
+    """cwd 直传 → _find_aix_project_dirs 的 root 与 aix 执行 cwd 跟随 cwd。"""
+    custom_cwd = f"{CONTAINER_WORKSPACE_BASE}/custom-session"
+    project_dir = f"{custom_cwd}/project-fe"
+    plugin = FakeBashPlugin()
+    plugin.add(
+        "find",
+        custom_cwd,
+        BashExecResult(stdout=f"{project_dir}/.aix\n", stderr="", exit_code=0),
+    )
+    plugin.add(
+        "aix run phase status --run-id r-xyz",
+        project_dir,
+        BashExecResult(stdout=json.dumps(PHASE_PAYLOAD), stderr="", exit_code=0),
+    )
+    service = _make_service(plugin)
+    got = await service.get_run_phase_status(SESSION_ID, "r-xyz", cwd=custom_cwd)
+    assert got["runId"] == "r-xyz"
+    # find 的 cwd 是 custom_cwd（说明 ensure_workspace_exists 返回 custom_cwd）
+    find_call = next(c for c in plugin.calls if c[0].startswith("find"))
+    assert find_call[1] == custom_cwd
+
+
+async def test_get_session_pull_requests_forwards_cwd() -> None:
+    """cwd 直传 → ``aix run output list --filter <cwd>`` 执行 cwd 跟随 cwd。"""
+    custom_cwd = f"{CONTAINER_WORKSPACE_BASE}/custom-session"
+    plugin = FakeBashPlugin()
+    plugin.add(
+        "aix run output list",
+        custom_cwd,
+        BashExecResult(stdout=_pr_outputs_payload([]), stderr="", exit_code=0),
+    )
+    service = _make_service(plugin)
+    items = await service.get_session_pull_requests(SESSION_ID, cwd=custom_cwd)
+    assert items == []
+    assert plugin.calls[0][1] == custom_cwd
+
+
+async def test_get_session_runs_cwd_outrange_raises_value_error() -> None:
+    """cwd 越界（不在允许根下）→ resolve_workspace 抛 ValueError（router 转 400）。"""
+    plugin = FakeBashPlugin()
+    service = _make_service(plugin)
+    with pytest.raises(ValueError, match="cwd not allowed"):
+        await service.get_session_runs(SESSION_ID, cwd="/etc")

--- a/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
@@ -760,3 +760,197 @@ async def test_get_file_diff_accepts_worktree_pointer_file(
         session_id=SESSION_ID, project="project-fe", file_path="README.md",
     )
     assert result.diff == "worktree-diff\n"
+
+
+# ── validate_cwd / _validate_cwd_prefix（cwd 直传校验）─────────────────────
+
+
+def test_validate_cwd_accepts_existing_dir_under_allowed_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    target = tmp_path / "session-1"
+    target.mkdir()
+    got = WorkspaceService.validate_cwd(str(target))
+    assert got == os.path.normpath(str(target))
+
+
+def test_validate_cwd_normalizes_path(tmp_path: Path, monkeypatch) -> None:
+    """返回规范化绝对路径（吃掉 trailing slash）。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    target = tmp_path / "s"
+    target.mkdir()
+    got = WorkspaceService.validate_cwd(f"{target}/")
+    assert got == str(target)
+
+
+def test_validate_cwd_rejects_file_path(tmp_path: Path, monkeypatch) -> None:
+    """cwd 指向文件 → NotADirectoryError（router 转 400）。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    with pytest.raises(NotADirectoryError):
+        WorkspaceService.validate_cwd(str(f))
+
+
+def test_validate_cwd_rejects_missing_path(tmp_path: Path, monkeypatch) -> None:
+    """cwd 不存在 → FileNotFoundError（router 转 404）。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        WorkspaceService.validate_cwd(str(tmp_path / "no-such"))
+
+
+def test_validate_cwd_rejects_outside_allowed_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    with pytest.raises(ValueError, match="cwd not allowed"):
+        WorkspaceService.validate_cwd("/etc")
+
+
+def test_validate_cwd_rejects_relative_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    with pytest.raises(ValueError, match="cwd must be absolute"):
+        WorkspaceService.validate_cwd("relative/path")
+
+
+def test_validate_cwd_rejects_blank(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    with pytest.raises(ValueError, match="cwd is required"):
+        WorkspaceService.validate_cwd("   ")
+
+
+def test_validate_cwd_rejects_traversal(tmp_path: Path, monkeypatch) -> None:
+    """``..`` 穿越出允许根 → normpath 后越界 → ValueError。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    with pytest.raises(ValueError, match="cwd not allowed"):
+        WorkspaceService.validate_cwd(f"{tmp_path}/../etc")
+
+
+def test_validate_cwd_accepts_root_itself(tmp_path: Path, monkeypatch) -> None:
+    """cwd 等于允许根本身应放行（不必是其子目录）。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    got = WorkspaceService.validate_cwd(str(tmp_path))
+    assert got == str(tmp_path)
+
+
+def test_validate_cwd_default_root_only(tmp_path: Path, monkeypatch) -> None:
+    """未设 AICODING_CWD_ALLOW_ROOTS 时只允许 CONTAINER_WORKSPACE_BASE。"""
+    monkeypatch.delenv("AICODING_CWD_ALLOW_ROOTS", raising=False)
+    with pytest.raises(ValueError, match="cwd not allowed"):
+        WorkspaceService.validate_cwd(str(tmp_path))
+
+
+def test_validate_cwd_prefix_skips_existence(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """_validate_cwd_prefix 只校验格式 + 前缀，不校验存在性（供 worktree-status）。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    got = WorkspaceService._validate_cwd_prefix(str(tmp_path / "no-such"))
+    assert got == os.path.normpath(str(tmp_path / "no-such"))
+
+
+def test_allowed_cwd_roots_reads_env(tmp_path: Path, monkeypatch) -> None:
+    """env 扩展允许根（Rule 14 配置驱动）；重复 / trailing slash 规范化。"""
+    from engine.community.core.aicoding.workspace_service import _allowed_cwd_roots
+
+    monkeypatch.setenv(
+        "AICODING_CWD_ALLOW_ROOTS", f"{tmp_path}, /workspace/extra,"
+    )
+    roots = _allowed_cwd_roots()
+    assert roots[0] == CONTAINER_WORKSPACE_BASE
+    assert str(tmp_path) in roots
+    assert "/workspace/extra" in roots
+
+
+# ── resolve_workspace / ensure_workspace_exists 的 cwd 优先 ─────────────────
+
+
+def test_resolve_workspace_cwd_direct_takes_precedence(monkeypatch) -> None:
+    """cwd 直传优先于 base/{session_id} 拼接。"""
+    monkeypatch.delenv("RELAY_DEFAULT_CWD", raising=False)
+    monkeypatch.delenv("AICODING_CWD_ALLOW_ROOTS", raising=False)
+    custom = f"{CONTAINER_WORKSPACE_BASE}/custom-session"
+    got = WorkspaceService.resolve_workspace("sid", cwd=custom)
+    assert got == custom
+
+
+def test_resolve_workspace_cwd_none_falls_back_to_base(monkeypatch) -> None:
+    monkeypatch.delenv("RELAY_DEFAULT_CWD", raising=False)
+    got = WorkspaceService.resolve_workspace("sid", cwd=None)
+    assert got == f"{CONTAINER_WORKSPACE_BASE}/sid"
+
+
+def test_resolve_workspace_cwd_invalid_raises(monkeypatch) -> None:
+    """resolve_workspace 的 cwd 直传仍走前缀校验（越界 → ValueError）。"""
+    monkeypatch.delenv("AICODING_CWD_ALLOW_ROOTS", raising=False)
+    with pytest.raises(ValueError, match="cwd not allowed"):
+        WorkspaceService.resolve_workspace("sid", cwd="/etc")
+
+
+def test_ensure_workspace_exists_cwd_direct_validates_existence(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    target = tmp_path / "s"
+    target.mkdir()
+    got = WorkspaceService.ensure_workspace_exists("ignored-sid", cwd=str(target))
+    assert got == str(target)
+
+
+def test_ensure_workspace_exists_cwd_file_raises_not_a_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    with pytest.raises(NotADirectoryError):
+        WorkspaceService.ensure_workspace_exists("sid", cwd=str(f))
+
+
+def test_ensure_workspace_exists_cwd_none_falls_back(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """cwd=None → 旧逻辑：resolve_workspace(session_id) + isdir 检查。"""
+    monkeypatch.setenv("RELAY_DEFAULT_CWD", str(tmp_path))
+    sid = "sess-1"
+    (tmp_path / sid).mkdir()
+    got = WorkspaceService.ensure_workspace_exists(sid, cwd=None)
+    assert got == str(tmp_path / sid)
+
+
+# ── 业务方法 cwd 直传透传 ─────────────────────────────────────────────────
+
+
+async def test_list_file_tree_forwards_cwd_as_workspace_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """cwd 直传时以 cwd 为 workspace 根列文件树（跳过 base/{sid} 拼接）。"""
+    custom = tmp_path / "custom-cwd"
+    custom.mkdir()
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    file_plugin = FakeFilePlugin(
+        list_result=ListDirResult(
+            dir_path=str(custom), recursive=True, files=[],
+        )
+    )
+    service = _make_service(file_plugin=file_plugin)
+    await service.list_file_tree("sid", cwd=str(custom))
+    assert file_plugin.calls[0][1]["dir_path"] == str(custom)
+
+
+async def test_preview_file_forwards_cwd_as_workspace_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """cwd 直传时 preview 的 workspace 根切换到 cwd，path 相对 cwd 解析。"""
+    custom = tmp_path / "custom-cwd"
+    custom.mkdir()
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
+    target = str(custom / "a.txt")
+    file_plugin = FakeFilePlugin(read_map={target: b"hi"})
+    service = _make_service(file_plugin=file_plugin)
+    out = await service.preview_file("sid", "a.txt", cwd=str(custom))
+    assert out.content == "hi"
+    assert file_plugin.calls[0][1]["file_path"] == target

--- a/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
@@ -954,3 +954,79 @@ async def test_preview_file_forwards_cwd_as_workspace_root(
     out = await service.preview_file("sid", "a.txt", cwd=str(custom))
     assert out.content == "hi"
     assert file_plugin.calls[0][1]["file_path"] == target
+
+
+# ── cwd 白名单收紧：根路径 / 不得被掏成空串（gemini code review PR#132 HIGH）──
+
+
+def test_strip_trailing_sep_preserves_root_and_never_empties() -> None:
+    """``rstrip("/")`` 会把根 ``/`` 与 POSIX 双斜杠 ``//``（normpath 不归一）掏成
+    空串，使前缀比较 ``"" + "/" == "/"`` 让任何绝对路径过关。helper 必须把全斜杠
+    输入归一到 ``/``，永不返回空串。"""
+    from engine.community.core.aicoding.workspace_service import _strip_trailing_sep
+
+    assert _strip_trailing_sep("/") == "/"
+    assert _strip_trailing_sep("//") == "/"
+    assert _strip_trailing_sep("///") == "/"
+    # 普通路径只去末尾斜杠
+    assert _strip_trailing_sep("/home/admin/") == "/home/admin"
+    assert _strip_trailing_sep("/home/admin") == "/home/admin"
+    assert _strip_trailing_sep("/foo//") == "/foo"
+
+
+def test_allowed_cwd_roots_drops_root_slash(monkeypatch, caplog) -> None:
+    """配 ``=/`` 时根路径被显式丢弃，extras 不含 ``/`` 也不含 ``""``，并打 warning。"""
+    import logging
+    from engine.community.core.aicoding.workspace_service import _allowed_cwd_roots
+
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", "/")
+    with caplog.at_level(logging.WARNING, logger="aicoding-workspace"):
+        roots = _allowed_cwd_roots()
+    assert roots == (CONTAINER_WORKSPACE_BASE,)
+    assert "" not in roots and "/" not in roots
+    assert any("ignoring root path" in r.message for r in caplog.records)
+
+
+def test_allowed_cwd_roots_drops_path_normalizing_to_root(monkeypatch) -> None:
+    """normpath 后等于根 ``/`` 的伪装根（``/foo/..``、``//``、``/.``、``/..``）
+    同样应被丢弃，不能以 ``""`` 形式混入 extras 导致白名单失效。"""
+    from engine.community.core.aicoding.workspace_service import _allowed_cwd_roots
+
+    for bad in ("/foo/..", "//", "/.", "/.."):
+        monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", bad)
+        roots = _allowed_cwd_roots()
+        assert roots == (CONTAINER_WORKSPACE_BASE,), bad
+        assert "" not in roots and "/" not in roots
+
+
+def test_validate_cwd_prefix_rejects_double_slash_root_configured(
+    monkeypatch,
+) -> None:
+    """配 ``=//`` 后系统路径仍被拒——对抗验证发现的链式回归核心：若
+    ``_strip_trailing_sep('//')`` 返回 ``""``，前缀比较会让任何绝对路径过关。
+    helper 归一 ``//`` 为 ``/`` 后被 ``_allowed_cwd_roots`` 丢弃，白名单未失效。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", "//")
+    for bad in ("/etc", "/root", "/"):
+        with pytest.raises(ValueError, match="cwd not allowed"):
+            WorkspaceService._validate_cwd_prefix(bad)
+
+
+def test_validate_cwd_prefix_rejects_system_paths_when_root_configured(
+    monkeypatch,
+) -> None:
+    """配 ``=/``（根路径被丢弃）后系统路径 /etc、/etc/passwd、/root、/var/log 仍被拒，
+    白名单不会因运维把允许根配成根 而失效。"""
+    monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", "/")
+    for bad in ("/etc", "/etc/passwd", "/root", "/var/log"):
+        with pytest.raises(ValueError, match="cwd not allowed"):
+            WorkspaceService._validate_cwd_prefix(bad)
+
+
+def test_validate_cwd_prefix_rejects_root_slash_as_cwd(monkeypatch) -> None:
+    """cwd 直传 ``/`` 本身被拒（``_strip_trailing_sep`` 保留 ``/``，不与任何非根
+    允许根相等或前缀匹配）；含存在性的 :meth:`validate_cwd` 也在前缀校验阶段被拒。"""
+    monkeypatch.delenv("AICODING_CWD_ALLOW_ROOTS", raising=False)
+    with pytest.raises(ValueError, match="cwd not allowed"):
+        WorkspaceService._validate_cwd_prefix("/")
+    with pytest.raises(ValueError, match="cwd not allowed"):
+        WorkspaceService.validate_cwd("/")

--- a/src/engine/src/engine/community/core/aicoding/workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/workspace_service.py
@@ -54,6 +54,18 @@ def _resolve_workspace_base() -> str:
     return raw or CONTAINER_WORKSPACE_BASE
 
 
+def _strip_trailing_sep(path: str) -> str:
+    """去末尾 ``/`` 但保留根 ``/``，全斜杠输入归一为 ``/``，永不返回空串。
+
+    直接 ``rstrip("/")`` 会把根 ``/`` 与 POSIX 双斜杠 ``//``（:func:`os.path.normpath`
+    不归一 ``//``）掏成空串 ``""``，在 :func:`WorkspaceService._validate_cwd_prefix`
+    的前缀比较里 ``"" + "/" == "/"`` 会让任何绝对路径都满足 ``startswith("/")``，
+    cwd 白名单完全失效（gemini code review PR#132 HIGH + 对抗验证发现的 ``//``
+    回归）。
+    """
+    return path.rstrip("/") or "/"
+
+
 def _allowed_cwd_roots() -> tuple[str, ...]:
     """读取 ``cwd`` 直传允许根（请求态白名单）。
 
@@ -61,18 +73,32 @@ def _allowed_cwd_roots() -> tuple[str, ...]:
     （逗号分隔）可追加额外根（Rule 14：配置驱动）。每次调用重新读 env，
     便于测试用 monkeypatch 覆盖。
 
+    normpath 后经 :func:`_strip_trailing_sep` 等于根 ``/`` 的条目（如 ``/``、
+    ``//``、``/foo/..``、``/.``、``/..``）一律丢弃——把根当允许根等于关闭白名单
+    （放行容器内所有绝对路径），与白名单语义相悖，视为无效配置，避免运维手滑 /
+    占位符导致整盘开放；丢弃时打 warning。
+
     与 :class:`engine.community.core.bash.base.BaseBashService.exec` 的 exec 态
     白名单 ``ALLOWED_CWD_PREFIXES`` 互补：请求态拦端点入参 cwd，exec 态拦最终
     下沉到 subprocess 的 cwd。默认 ``CONTAINER_WORKSPACE_BASE`` 落在
     ``/home/admin/`` 下，两闸同向。
     """
     raw = os.getenv("AICODING_CWD_ALLOW_ROOTS", "").strip()
-    extras = tuple(
-        os.path.normpath(p.strip()).rstrip("/")
-        for p in raw.split(",")
-        if p.strip()
-    )
-    return (CONTAINER_WORKSPACE_BASE,) + extras
+    extras: list[str] = []
+    for piece in raw.split(","):
+        stripped = piece.strip()
+        if not stripped:
+            continue
+        normalized = os.path.normpath(stripped)
+        if _strip_trailing_sep(normalized) == "/":
+            log.warning(
+                "ignoring root path in AICODING_CWD_ALLOW_ROOTS "
+                "(would disable cwd allow-list): %r",
+                stripped,
+            )
+            continue
+        extras.append(normalized)
+    return (CONTAINER_WORKSPACE_BASE,) + tuple(extras)
 
 
 class WorkspaceService:
@@ -139,15 +165,19 @@ class WorkspaceService:
 
         供 :meth:`resolve_workspace` 使用——worktree-status 这类"目录缺失仍要
         返 200"的端点只需前缀校验，不能因目录不存在抛错。
+
+        比较 ``cwd`` 与每个允许根时两侧都过 :func:`_strip_trailing_sep`，保证根
+        ``/`` / ``//`` 不被掏成空串（否则 ``"" + "/" == "/"`` 会让任何绝对路径过关，
+        见 gemini code review PR#132 HIGH）。
         """
         if not cwd or not cwd.strip():
             raise ValueError("cwd is required")
         normalized = os.path.normpath(cwd)
         if not os.path.isabs(normalized):
             raise ValueError(f"cwd must be absolute: {cwd!r}")
-        normalized_norm = normalized.rstrip("/")
+        normalized_norm = _strip_trailing_sep(normalized)
         for root in _allowed_cwd_roots():
-            root_norm = os.path.normpath(root).rstrip("/")
+            root_norm = _strip_trailing_sep(os.path.normpath(root))
             if normalized_norm == root_norm or normalized_norm.startswith(
                 root_norm + "/"
             ):
@@ -367,5 +397,6 @@ __all__ = [
     "CONTAINER_WORKSPACE_BASE",
     "PREVIEW_MAX_BYTES",
     "_resolve_workspace_base",
+    "_strip_trailing_sep",
     "_allowed_cwd_roots",
 ]

--- a/src/engine/src/engine/community/core/aicoding/workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/workspace_service.py
@@ -54,6 +54,27 @@ def _resolve_workspace_base() -> str:
     return raw or CONTAINER_WORKSPACE_BASE
 
 
+def _allowed_cwd_roots() -> tuple[str, ...]:
+    """读取 ``cwd`` 直传允许根（请求态白名单）。
+
+    默认只放 :data:`CONTAINER_WORKSPACE_BASE`；env ``AICODING_CWD_ALLOW_ROOTS``
+    （逗号分隔）可追加额外根（Rule 14：配置驱动）。每次调用重新读 env，
+    便于测试用 monkeypatch 覆盖。
+
+    与 :class:`engine.community.core.bash.base.BaseBashService.exec` 的 exec 态
+    白名单 ``ALLOWED_CWD_PREFIXES`` 互补：请求态拦端点入参 cwd，exec 态拦最终
+    下沉到 subprocess 的 cwd。默认 ``CONTAINER_WORKSPACE_BASE`` 落在
+    ``/home/admin/`` 下，两闸同向。
+    """
+    raw = os.getenv("AICODING_CWD_ALLOW_ROOTS", "").strip()
+    extras = tuple(
+        os.path.normpath(p.strip()).rstrip("/")
+        for p in raw.split(",")
+        if p.strip()
+    )
+    return (CONTAINER_WORKSPACE_BASE,) + extras
+
+
 class WorkspaceService:
     """File tree + git operations for an AICoding session workspace."""
 
@@ -68,23 +89,31 @@ class WorkspaceService:
     # ── path helpers ──────────────────────────────────────────────────
 
     @staticmethod
-    def resolve_workspace(session_id: str) -> str:
+    def resolve_workspace(session_id: str, cwd: str | None = None) -> str:
         """Return the container-internal workspace root for a session.
 
-        Base 由 :func:`_resolve_workspace_base` 决定：``RELAY_DEFAULT_CWD``
-        环境变量优先，未设置回落到硬编码 ``CONTAINER_WORKSPACE_BASE``。
-        ``session_id`` 本身可能含 ``:``（例如
-        ``user:u1:session:s1:agent:b1``），按原样拼接。
+        ``cwd`` 直传优先：非空时经 :meth:`_validate_cwd_prefix` 校验格式 + 允许根
+        前缀（**不**校验存在性，供 ``worktree-status`` 这类"目录缺失仍返 200"
+        的端点）后原样返回；为空则按 ``RELAY_DEFAULT_CWD`` /
+        ``CONTAINER_WORKSPACE_BASE`` + ``session_id`` 拼接。``session_id`` 本身
+        可能含 ``:``（例如 ``user:u1:session:s1:agent:b1``），按原样拼接。
         """
+        if cwd:
+            return WorkspaceService._validate_cwd_prefix(cwd)
         return f"{_resolve_workspace_base()}/{session_id}"
 
     @staticmethod
-    def ensure_workspace_exists(session_id: str) -> str:
+    def ensure_workspace_exists(session_id: str, cwd: str | None = None) -> str:
         """解析 + 校验 session 工作空间是否存在；不存在抛 ``FileNotFoundError``。
 
-        返回校验通过的 workspace 绝对路径，便于调用方复用。Router 层应将
-        :class:`FileNotFoundError` 转换为 HTTP 404 返回前端。
+        ``cwd`` 直传优先：非空时经 :meth:`validate_cwd` 做完整校验（含存在性），
+        cwd 指文件抛 ``NotADirectoryError``、不存在抛 ``FileNotFoundError``、
+        越界/非绝对抛 ``ValueError``；为空则走旧 ``resolve_workspace(session_id)``
+        + ``os.path.isdir`` 检查。返回校验通过的 workspace 绝对路径，便于调用方
+        复用。Router 层应将 :class:`FileNotFoundError` 转换为 HTTP 404 返回前端。
         """
+        if cwd:
+            return WorkspaceService.validate_cwd(cwd)
         workspace = WorkspaceService.resolve_workspace(session_id)
         if not os.path.isdir(workspace):
             raise FileNotFoundError(
@@ -102,11 +131,54 @@ class WorkspaceService:
         if normalized != workspace_norm and not normalized.startswith(prefix):
             raise ValueError(f"path traversal detected: {full_path}")
 
+    # ── cwd 直传校验（前端入参） ─────────────────────────────────────────
+
+    @staticmethod
+    def _validate_cwd_prefix(cwd: str) -> str:
+        """校验 ``cwd`` 的格式 + 允许根前缀（**不**校验存在性），返回规范化绝对路径。
+
+        供 :meth:`resolve_workspace` 使用——worktree-status 这类"目录缺失仍要
+        返 200"的端点只需前缀校验，不能因目录不存在抛错。
+        """
+        if not cwd or not cwd.strip():
+            raise ValueError("cwd is required")
+        normalized = os.path.normpath(cwd)
+        if not os.path.isabs(normalized):
+            raise ValueError(f"cwd must be absolute: {cwd!r}")
+        normalized_norm = normalized.rstrip("/")
+        for root in _allowed_cwd_roots():
+            root_norm = os.path.normpath(root).rstrip("/")
+            if normalized_norm == root_norm or normalized_norm.startswith(
+                root_norm + "/"
+            ):
+                return normalized
+        raise ValueError(f"cwd not allowed: {cwd!r}")
+
+    @staticmethod
+    def validate_cwd(cwd: str) -> str:
+        """校验前端直传的 ``cwd``（含存在性），返回规范化绝对路径。
+
+        供 :meth:`ensure_workspace_exists` 与各 router 入口使用。规则：
+
+        1. 非空且为绝对路径，否则 ``ValueError``（→400）；
+        2. normpath 后真实存在且是目录，否则 ``NotADirectoryError``（指向文件,
+           →400）/ ``FileNotFoundError``（不存在，→404）；
+        3. 必须落在允许根之一之下，否则 ``ValueError``（→400）。
+        """
+        normalized = WorkspaceService._validate_cwd_prefix(cwd)
+        if os.path.isdir(normalized):
+            return normalized
+        if os.path.exists(normalized):
+            raise NotADirectoryError(f"cwd not a directory: {cwd!r}")
+        raise FileNotFoundError(f"cwd not found: {cwd!r}")
+
     # ── file tree ─────────────────────────────────────────────────────
 
-    async def list_file_tree(self, session_id: str) -> list[FileTreeNode]:
+    async def list_file_tree(
+        self, session_id: str, cwd: str | None = None
+    ) -> list[FileTreeNode]:
         """List workspace files recursively, grouped by project."""
-        workspace = self.ensure_workspace_exists(session_id)
+        workspace = self.ensure_workspace_exists(session_id, cwd)
         result = await self._file.list_dir(
             workspace, recursive=True, exclude_dirs=_FILTERED_DIRS
         )
@@ -124,12 +196,14 @@ class WorkspaceService:
 
     # ── file preview ──────────────────────────────────────────────────
 
-    async def preview_file(self, session_id: str, path: str) -> FileContent:
+    async def preview_file(
+        self, session_id: str, path: str, cwd: str | None = None
+    ) -> FileContent:
         """Read a single workspace file (size-bounded, traversal-safe)."""
         if not path or not path.strip():
             raise ValueError("path is required")
 
-        workspace = self.ensure_workspace_exists(session_id)
+        workspace = self.ensure_workspace_exists(session_id, cwd)
         full_path = os.path.normpath(os.path.join(workspace, path.strip()))
         self._ensure_within_workspace(full_path, workspace)
 
@@ -148,9 +222,11 @@ class WorkspaceService:
 
     # ── git diff ──────────────────────────────────────────────────────
 
-    async def list_git_diff(self, session_id: str) -> GitDiffTreeResult:
+    async def list_git_diff(
+        self, session_id: str, cwd: str | None = None
+    ) -> GitDiffTreeResult:
         """List changed files across all git projects in the workspace."""
-        workspace = self.ensure_workspace_exists(session_id)
+        workspace = self.ensure_workspace_exists(session_id, cwd)
 
         # 1) Discover git projects under the workspace.
         #
@@ -237,12 +313,13 @@ class WorkspaceService:
         project: str,
         file_path: str,
         old_path: str | None = None,
+        cwd: str | None = None,
     ) -> GitDiffResult:
         """Single-file unified diff with untracked / renamed fallbacks."""
         if not project or "/" in project or project in ("", ".", ".."):
             raise ValueError(f"invalid project: {project!r}")
 
-        workspace = self.ensure_workspace_exists(session_id)
+        workspace = self.ensure_workspace_exists(session_id, cwd)
         project_path = os.path.normpath(os.path.join(workspace, project))
         self._ensure_within_workspace(project_path, workspace)
 
@@ -290,4 +367,5 @@ __all__ = [
     "CONTAINER_WORKSPACE_BASE",
     "PREVIEW_MAX_BYTES",
     "_resolve_workspace_base",
+    "_allowed_cwd_roots",
 ]


### PR DESCRIPTION
新增 WorkspaceService.validate_cwd / _validate_cwd_prefix / _allowed_cwd_roots，八个会话工作区端点新增可选 cwd query：直传时经校验
直接作为 workspace 根，缺省回退 base/{session_id} 旧逻辑（完全向后兼容）。

- resolve_workspace / ensure_workspace_exists 及业务方法加 cwd=None 形参， cwd 直传优先、缺省回退旧拼接
- RunStatusService 三方法 + _collect_runs_for_session 加 cwd=None 透传
- git-diff / files-diff 补 NotADirectoryError→400 + PermissionError→403
- runs / phases 补 ValueError→400 + NotADirectoryError→400
- pull-requests 补 ValueError→400（走 resolve_workspace，不校验存在性）
- worktree-status catch ValueError → exists:false/200（不破既有 200 契约）
- router docstring 由 Four endpoints 更正为 9 端点 + cwd 说明

允许根默认 CONTAINER_WORKSPACE_BASE，env AICODING_CWD_ALLOW_ROOTS 扩展 （Rule 14 配置驱动）；与 BaseBashService.exec 的 exec 态白名单
ALLOWED_CWD_PREFIXES 互补，默认同源防漂移。

测试：community aicoding 全目录 183 passed（含 workspace/runstatus/router 新增 cwd 透传 / 越界 400 / 非目录 400 / 不存在 404 / 缺省回退 / worktree 200 兜底等用例）。