### PR TITLE
fix(ci): align module diffs with latest PR target

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,16 +6,55 @@ cd "$repo_root"
 
 remote_name="${1:-origin}"
 remote_url="${2:-}"
+configured_merge_target="$(git config --get avernet.prePush.mergeTarget 2>/dev/null || true)"
+merge_target="${AVERNET_PRE_PUSH_MERGE_TARGET:-$configured_merge_target}"
+merge_target="${merge_target:-origin/dev}"
 
 echo "== OCB pre-push gate =="
 echo "remote: ${remote_name} ${remote_url}"
+echo "merge target: $merge_target"
 
 seen_ref=0
 status=0
+target_sha=""
+
+resolve_merge_target() {
+  local target_remote=""
+  local target_branch=""
+  local target_ref=""
+
+  if [[ -n "$target_sha" ]]; then
+    return 0
+  fi
+
+  if [[ "$merge_target" != */* ]]; then
+    echo "error: pre-push merge target must use <remote>/<branch>: $merge_target" >&2
+    return 1
+  fi
+  target_remote="${merge_target%%/*}"
+  target_branch="${merge_target#*/}"
+  if [[ -z "$target_remote" || -z "$target_branch" ]] \
+    || ! git remote get-url "$target_remote" >/dev/null 2>&1 \
+    || ! git check-ref-format "refs/heads/$target_branch" >/dev/null 2>&1; then
+    echo "error: invalid pre-push merge target: $merge_target" >&2
+    return 1
+  fi
+
+  target_ref="refs/remotes/$target_remote/$target_branch"
+  if ! git fetch --quiet --no-tags "$target_remote" \
+    "+refs/heads/$target_branch:$target_ref"; then
+    echo "error: failed to refresh pre-push merge target $merge_target" >&2
+    return 1
+  fi
+  if ! target_sha="$(git rev-parse --verify "${target_ref}^{commit}")"; then
+    echo "error: pre-push merge target $merge_target is not a commit" >&2
+    return 1
+  fi
+  echo "merge target sha: $target_sha"
+}
 
 run_for_ref() {
   local local_sha="$1"
-  local remote_sha="$2"
   local base=""
 
   # local_sha 全 0 表示删除远端分支,没有代码需要检查。
@@ -23,17 +62,15 @@ run_for_ref() {
     return 0
   fi
 
-  # base 是“本地模拟 PR CI 的检查起点”:
-  # - 优先和 origin/dev 取 merge-base,即检查“当前分支整体相对 dev 引入的变化”
-  # - 这比 remote_sha -> local_sha 更接近线上 PR CI 的 pullRequest.changes 口径
-  # - 如果本地没有 origin/dev,已有远端分支则退回 remote_sha,新分支退回仓库初始提交
-  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
-    base="$(git merge-base "$local_sha" origin/dev)"
-  elif [[ "$remote_sha" != "0000000000000000000000000000000000000000" ]]; then
-    base="$remote_sha"
-  else
-    base="$(git rev-list --max-parents=0 "$local_sha" | tail -1)"
+  if ! resolve_merge_target; then
+    return 1
   fi
+  if ! base="$(git merge-base "$local_sha" "$target_sha")"; then
+    echo "error: no merge base between $local_sha and $merge_target ($target_sha)" >&2
+    return 1
+  fi
+  echo "merge base: $base"
+  echo "head: $local_sha"
 
   "$repo_root/scripts/ci/pre_push.sh" --base "$base" --head "$local_sha"
 }
@@ -45,17 +82,13 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   #   refs/heads/dev_xxx abc123 refs/heads/dev_xxx def456
   [[ -n "${local_ref:-}" ]] || continue
   seen_ref=1
-  run_for_ref "$local_sha" "$remote_sha" || status=$?
+  run_for_ref "$local_sha" || status=$?
 done
 
 if [[ "$seen_ref" -eq 0 ]]; then
   # 有些手动调用场景没有 stdin,这里用 HEAD 做一次兜底检查,
   # 方便本地直接执行 .githooks/pre-push 来验证 hook 行为。
-  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
-    run_for_ref HEAD "$(git merge-base HEAD origin/dev)" || status=$?
-  else
-    "$repo_root/scripts/ci/pre_push.sh" --base "$(git rev-list --max-parents=0 HEAD | tail -1)" --head HEAD || status=$?
-  fi
+  run_for_ref HEAD || status=$?
 fi
 
 exit "$status"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      # PR: compare against the event's immutable base SHA so delayed/rerun runs
-      # are not affected by base-branch drift after the PR was created.
+      # PR: actions/checkout checks out the synthetic merge commit, so compare
+      # against its first parent (the exact base tree used for that merge).
       # push/dispatch: compare against dev (repo default branch) instead.
-      BCS_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
+      BCS_BASE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/bcs
@@ -37,6 +37,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate unit-test diff behavior
+        working-directory: ${{ github.workspace }}
+        run: python3 scripts/ci/tests/test_unit_test_workflow_diff.py
 
       - name: Detect BCS changes vs base
         id: changes
@@ -126,10 +130,9 @@ jobs:
     name: Backend unit tests
     runs-on: ubuntu-latest
     env:
-      # PR: compare against the event's immutable base SHA so delayed/rerun runs
-      # are not affected by base-branch drift after the PR was created.
+      # PR: compare against the checked-out merge commit's exact base tree.
       # push/dispatch: compare against dev (repo default branch) instead.
-      BACKEND_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
+      BACKEND_BASE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/backend
@@ -194,7 +197,7 @@ jobs:
     name: Engine unit tests
     runs-on: ubuntu-latest
     env:
-      ENGINE_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
+      ENGINE_BASE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/engine
@@ -251,9 +254,9 @@ jobs:
     name: BaaS unit tests
     runs-on: ubuntu-latest
     env:
-      # PR: compare against the PR's base branch. push/dispatch: compare against dev
-      # (the repo default branch) so coverage-gated diff detection still has a base.
-      BAAS_BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/dev' }}
+      # PR: compare against the checked-out merge commit's exact base tree.
+      # push/dispatch: compare against dev (repo default branch) instead.
+      BAAS_BASE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || 'origin/dev' }}
     defaults:
       run:
         working-directory: src/baas/packages/community
@@ -313,4 +316,3 @@ jobs:
           name: baas-testresult
           path: src/baas/packages/community/pytest_report/
           if-no-files-found: ignore
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,55 @@ Changes should preserve or improve the gates described in
 Do not weaken these checks to make a change pass. If a check is wrong, fix the
 check and document why.
 
+## Pre-push Module Selection
+
+Install the repository hooks separately in every Git worktree:
+
+```bash
+scripts/install_git_hooks.sh
+```
+
+The pre-push hook models the change set of a pull request. Its merge target
+defaults to the remote branch `origin/dev`. Override it persistently for the
+current worktree or repository when the eventual PR targets another branch:
+
+```bash
+git config --worktree avernet.prePush.mergeTarget upstream/release/2026-07
+```
+
+Use `AVERNET_PRE_PUSH_MERGE_TARGET` for a one-command override; it has higher
+priority than Git config:
+
+```bash
+AVERNET_PRE_PUSH_MERGE_TARGET=origin/main git push
+```
+
+Target values must use `<remote>/<branch>` form. Before selecting modules, the
+hook fetches the target branch, resolves its latest commit SHA, calculates
+`git merge-base <target-sha> <local-sha>`, and diffs that merge base against
+the local SHA. Do not replace this with a direct `git diff origin/dev HEAD`:
+when `dev` has advanced but the feature has not rebased, a direct tree diff
+incorrectly includes target-only paths.
+
+The hook fails the push if the configured remote branch cannot be fetched or
+resolved, or if it has no merge base with the pushed commit. It must not fall
+back to a stale target, the pushed branch's old remote SHA, or the root commit,
+because those ranges can run unrelated module tests.
+
+Module gates are selected from the committed files in the resulting diff:
+
+| Changed path | Pre-push gate |
+| --- | --- |
+| `src/backend/` | Backend SAST, unit tests, changed-line coverage, and singlebox coverage |
+| `src/baas/` | BaaS SAST, unit tests, changed-line coverage, and singlebox coverage |
+| `src/engine/` | Engine SAST, unit tests, and changed-line coverage |
+| `src/bcs/` | BCS/BCN unit tests in fast-fail mode |
+| `src/frontend/` | Frontend CI |
+| singlebox scripts and Backend/BaaS acceptance or E2E paths | singlebox coverage |
+
+The hook only checks committed changes in the pushed ref. Uncommitted working
+tree changes are outside the natural boundary of a pre-push hook.
+
 ## Development Guidelines
 
 Start from the requirement and the existing contract. Keep changes small and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,9 @@ intentional state in the contract; required values must remain non-optional.
 
 Keep this file intentionally small so agent instructions do not drift. Update
 `AGENTS.md` when project-wide rules change.
+
+Before pushing, follow the pre-push target contract in `AGENTS.md`. The default
+target is `origin/dev`; set `avernet.prePush.mergeTarget` for a persistent
+override or `AVERNET_PRE_PUSH_MERGE_TARGET` for one `git push`. The hook must
+fetch that target and use its merge base rather than a direct target-to-head
+diff.

--- a/docs/superpowers/plans/2026-07-13-pre-push-merge-target.md
+++ b/docs/superpowers/plans/2026-07-13-pre-push-merge-target.md
@@ -1,0 +1,211 @@
+# Pre-push Merge Target Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make pre-push module selection compare feature changes against a freshly fetched, configurable PR merge target.
+
+**Architecture:** `.githooks/pre-push` owns remote-target configuration, refresh, and immutable SHA resolution. It passes a per-ref merge base and head SHA to the existing `scripts/ci/pre_push.sh` dispatcher, which remains responsible only for path-based module selection and gate execution.
+
+**Tech Stack:** Bash, Git, Python standard-library `unittest` and temporary repositories.
+
+## Global Constraints
+
+- Default target is exactly `origin/dev`.
+- Override precedence is environment, Git config, then default.
+- Target values use `<remote>/<branch>` syntax.
+- Fetch the target before calculating the merge base; do not silently use a stale ref.
+- Calculate `git diff merge-base..feature`, never a direct target-to-feature diff.
+- Fail closed on invalid, missing, or unrelated targets.
+- Deletion-only pushes skip fetch and test dispatch.
+- Preserve the existing module path patterns and gate commands.
+
+---
+
+### Task 1: Reproduce stale-target module over-selection
+
+**Files:**
+- Create: `scripts/ci/tests/test_pre_push_hook.py`
+- Test: `scripts/ci/tests/test_pre_push_hook.py`
+
+**Interfaces:**
+- Consumes: `.githooks/pre-push <remote-name> <remote-url>` and Git's four-field stdin record.
+- Produces: a temporary dispatcher that reports the hook-selected `--base`/`--head` diff paths.
+
+- [ ] **Step 1: Build a temporary Git fixture**
+
+Create a bare remote, a publisher clone, and a developer clone. Leave the
+developer's `origin/dev` at baseline `A`, advance remote `dev` to Engine commit
+`B`, create a local rebase target at `B` without updating `origin/dev`, and add
+a BCS-only feature commit `C` on top.
+
+- [ ] **Step 2: Execute the real hook through a stub dispatcher**
+
+Copy `.githooks/pre-push` into the developer clone and create this dispatcher
+contract:
+
+```bash
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --base) base="$2"; shift 2 ;;
+    --head) head="$2"; shift 2 ;;
+  esac
+done
+git diff --name-only "$base" "$head"
+```
+
+Pipe a feature branch push record into the hook and assert the output contains
+`src/bcs/feature.txt` but not `src/engine/target.txt`.
+
+- [ ] **Step 3: Run the regression test and verify RED**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_pre_push_hook.PrePushHookTest.test_refreshes_stale_default_target_before_selecting_modules -v
+```
+
+Expected: FAIL because the current hook uses stale `origin/dev`; the captured
+diff includes `src/engine/target.txt`.
+
+---
+
+### Task 2: Resolve and refresh the configured merge target
+
+**Files:**
+- Modify: `.githooks/pre-push`
+- Test: `scripts/ci/tests/test_pre_push_hook.py`
+
+**Interfaces:**
+- Consumes: `AVERNET_PRE_PUSH_MERGE_TARGET`, `avernet.prePush.mergeTarget`, and default `origin/dev`.
+- Produces: one immutable `target_sha` per hook run and one `base_sha` per pushed branch.
+
+- [ ] **Step 1: Add target resolution**
+
+Resolve configuration with:
+
+```bash
+merge_target="${AVERNET_PRE_PUSH_MERGE_TARGET:-$(git config --get avernet.prePush.mergeTarget 2>/dev/null || true)}"
+merge_target="${merge_target:-origin/dev}"
+```
+
+Split on the first slash, validate the remote and `refs/heads/<branch>`, fetch
+the branch into `refs/remotes/<remote>/<branch>`, and resolve it with
+`git rev-parse --verify '<ref>^{commit}'`.
+
+- [ ] **Step 2: Replace stale and fallback base selection**
+
+For every non-deletion local SHA, calculate:
+
+```bash
+base="$(git merge-base "$local_sha" "$target_sha")"
+```
+
+Return non-zero with a clear error if refresh, resolution, or merge-base fails.
+Do not use `remote_sha` or the root commit as a fallback.
+
+- [ ] **Step 3: Verify GREEN for the stale-target regression**
+
+Run the single test from Task 1. Expected: PASS and the dispatcher receives a
+range containing only `src/bcs/feature.txt`.
+
+- [ ] **Step 4: Add configuration and error tests**
+
+Add tests proving:
+
+- `AVERNET_PRE_PUSH_MERGE_TARGET` overrides Git config;
+- Git config overrides `origin/dev`;
+- a missing configured branch rejects the push without dispatch;
+- a deletion-only push succeeds without fetching or dispatching.
+
+- [ ] **Step 5: Run the focused suite**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_pre_push_hook -v
+```
+
+Expected: all pre-push hook tests pass.
+
+---
+
+### Task 3: Document target selection for contributors and agents
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `CLAUDE.md`
+- Test: `scripts/ci/tests/test_pre_push_hook.py`
+
+**Interfaces:**
+- Consumes: the configuration and behavior implemented in Task 2.
+- Produces: repository-wide instructions with copyable setup and override commands.
+
+- [ ] **Step 1: Add the detailed AGENTS.md contract**
+
+Document per-worktree installation, default target, both override mechanisms,
+the `<remote>/<branch>` format, fetch-and-merge-base behavior, fail-closed
+errors, and the existing Backend/BaaS/Engine/BCS/Frontend/singlebox path map.
+
+- [ ] **Step 2: Add the concise CLAUDE.md reminder**
+
+Reference the `AGENTS.md` pre-push section and include the persistent and
+one-command override names without duplicating the full path table.
+
+- [ ] **Step 3: Assert documentation contains the public contract**
+
+Extend `test_pre_push_hook.py` to read both files and assert the default,
+environment variable, Git config key, and merge-base rule are present.
+
+- [ ] **Step 4: Run the focused suite**
+
+Run `python3 -m unittest scripts.ci.tests.test_pre_push_hook -v`. Expected: all
+tests pass.
+
+---
+
+### Task 4: Verify, commit, and publish the combined CI fix
+
+**Files:**
+- Verify: `.github/workflows/unit-tests.yml`
+- Verify: `.githooks/pre-push`
+- Verify: `scripts/ci/tests/`
+- Verify: `AGENTS.md`
+- Verify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: the earlier PR Actions diff commit and Tasks 1-3.
+- Produces: one branch and draft PR targeting `dev`.
+
+- [ ] **Step 1: Run all lightweight CI-script tests**
+
+```bash
+python3 -m unittest discover -s scripts/ci/tests -p 'test_*.py' -v
+```
+
+Expected: zero failures and zero errors.
+
+- [ ] **Step 2: Run shell and diff hygiene checks**
+
+```bash
+bash -n .githooks/pre-push scripts/ci/pre_push.sh scripts/install_git_hooks.sh
+git diff --check origin/dev...HEAD
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 3: Re-run the exact stale-target scenario**
+
+Run the focused stale-target unittest by its full test name. Expected: only
+the BCS path is dispatched after the target fetch.
+
+- [ ] **Step 4: Review scope and commit**
+
+Inspect `git diff --stat origin/dev...HEAD` and `git diff origin/dev...HEAD`,
+stage only the intended hook, tests, and docs, then commit with a focused CI
+message.
+
+- [ ] **Step 5: Push and open a draft PR**
+
+Push `codex/fix-pre-push-target-diff` to `origin` and create a draft PR against
+`dev`. The PR body must explain both root causes, both fixes, TDD red/green
+evidence, and the verification commands.

--- a/docs/superpowers/specs/2026-07-13-pre-push-merge-target-design.md
+++ b/docs/superpowers/specs/2026-07-13-pre-push-merge-target-design.md
@@ -1,0 +1,87 @@
+# Pre-push Merge Target Design
+
+## Goal
+
+Make local pre-push module selection use the latest intended pull-request target,
+so target-branch commits incorporated by a rebase or merge do not trigger
+unrelated module unit tests.
+
+## Problem
+
+The hook currently computes a merge base against the cached `origin/dev` ref.
+If a feature branch already contains a newer `dev` commit while the cached
+remote-tracking ref is older, the resulting diff includes both the feature
+change and intervening `dev` changes. Path-based dispatch can therefore run an
+unrelated module, such as Engine for a BCS-only feature.
+
+Comparing `origin/dev` directly with the feature head is not a valid fix. When
+`dev` has advanced and the feature has not rebased, a direct tree-to-tree diff
+also includes target-only paths. The target must be used to find the merge
+base, and the feature delta must be calculated from that merge base.
+
+## Configuration Contract
+
+The merge target is a remote branch in `<remote>/<branch>` form.
+
+Resolution precedence is:
+
+1. `AVERNET_PRE_PUSH_MERGE_TARGET` for a one-command override.
+2. `git config avernet.prePush.mergeTarget` for a worktree or repository
+   setting.
+3. `origin/dev` as the repository default.
+
+Examples:
+
+```bash
+git config --worktree avernet.prePush.mergeTarget upstream/release/2026-07
+AVERNET_PRE_PUSH_MERGE_TARGET=origin/main git push
+```
+
+## Data Flow
+
+For the first non-deletion ref in a push, `.githooks/pre-push` will:
+
+1. Validate and split the configured target into remote and branch names.
+2. Fetch that remote branch into its remote-tracking ref.
+3. Resolve the fetched ref to an immutable target commit SHA once per hook run.
+4. Compute `base_sha = git merge-base(target_sha, local_sha)` for every pushed
+   branch.
+5. Pass immutable `base_sha` and `local_sha` values to
+   `scripts/ci/pre_push.sh`.
+6. Let the existing dispatcher select modules from
+   `git diff --name-only base_sha local_sha`.
+
+The hook logs the configured target, resolved target SHA, merge base, and head
+SHA so unexpected module selection can be diagnosed from push output.
+
+## Failure Behavior
+
+The hook fails closed when the target format is invalid, the remote or branch
+cannot be fetched, the fetched ref is not a commit, or no merge base exists.
+It must not silently fall back to the pushed branch's old remote SHA or the
+repository root, because those ranges do not model the intended PR delta.
+
+Deletion-only pushes continue to skip code gates and do not need to fetch the
+target.
+
+## Documentation
+
+`AGENTS.md` is the source of truth for the target configuration, diff
+algorithm, module path triggers, per-worktree hook installation, and failure
+behavior. `CLAUDE.md` contains the concise default and override commands and
+links agents back to the detailed `AGENTS.md` section.
+
+## Tests
+
+An integration-style Python `unittest` suite will execute the real hook in
+temporary Git repositories with a lightweight dispatcher stub. It will cover:
+
+- a feature rebased onto a target commit while its cached target ref is stale;
+- environment override precedence;
+- Git config selection when no environment override exists;
+- invalid or missing targets failing before module dispatch;
+- deletion-only pushes skipping target fetch and dispatch.
+
+The stale-target test must fail against the current hook by exposing both BCS
+and Engine paths, then pass after the hook fetches the latest target and exposes
+only the BCS path.

--- a/scripts/ci/tests/test_pre_push_hook.py
+++ b/scripts/ci/tests/test_pre_push_hook.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HOOK_PATH = REPO_ROOT / ".githooks/pre-push"
+AGENTS_PATH = REPO_ROOT / "AGENTS.md"
+CLAUDE_PATH = REPO_ROOT / "CLAUDE.md"
+ZERO_SHA = "0" * 40
+
+
+def _run(
+    repository: Path,
+    *command: str,
+    input_text: str | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=repository,
+        check=check,
+        input=input_text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def _git(repository: Path, *args: str) -> str:
+    return _run(repository, "git", *args).stdout.strip()
+
+
+def _write(repository: Path, relative_path: str, content: str) -> None:
+    path = repository / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _create_repositories(root: Path) -> tuple[Path, Path, Path]:
+    remote = root / "remote.git"
+    publisher = root / "publisher"
+    developer = root / "developer"
+
+    remote.mkdir()
+    _git(remote, "init", "--bare")
+
+    publisher.mkdir()
+    _git(publisher, "init", "--initial-branch=dev")
+    _git(publisher, "config", "user.name", "CI Test")
+    _git(publisher, "config", "user.email", "ci-test@example.com")
+    _write(publisher, "README.md", "baseline\n")
+    _git(publisher, "add", ".")
+    _git(publisher, "commit", "-m", "baseline")
+    _git(publisher, "remote", "add", "origin", str(remote))
+    _git(publisher, "push", "-u", "origin", "dev")
+
+    _run(root, "git", "clone", "--branch", "dev", str(remote), str(developer))
+    _git(developer, "config", "user.name", "CI Test")
+    _git(developer, "config", "user.email", "ci-test@example.com")
+    return remote, publisher, developer
+
+
+def _install_test_hook(developer: Path) -> Path:
+    hook = developer / ".githooks/pre-push"
+    hook.parent.mkdir(parents=True)
+    shutil.copy2(HOOK_PATH, hook)
+    hook.chmod(0o755)
+    dispatcher = developer / "scripts/ci/pre_push.sh"
+    dispatcher.parent.mkdir(parents=True)
+    dispatcher.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+base=""
+head=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --base) base="$2"; shift 2 ;;
+    --head) head="$2"; shift 2 ;;
+    *) exit 2 ;;
+  esac
+done
+printf 'dispatch-base: %s\\n' "$base"
+printf 'dispatch-head: %s\\n' "$head"
+git diff --name-only "$base" "$head"
+""",
+        encoding="utf-8",
+    )
+    dispatcher.chmod(0o755)
+    return hook
+
+
+def _invoke_hook(
+    developer: Path,
+    remote: Path,
+    hook: Path,
+    feature_sha: str,
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    effective_env = os.environ.copy() if env is None else env.copy()
+    if env is None:
+        effective_env.pop("AVERNET_PRE_PUSH_MERGE_TARGET", None)
+    push_record = (
+        f"refs/heads/feature {feature_sha} refs/heads/feature {ZERO_SHA}\n"
+    )
+    return _run(
+        developer,
+        str(hook),
+        "origin",
+        str(remote),
+        input_text=push_record,
+        env=effective_env,
+        check=check,
+    )
+
+
+def _create_feature_on_remote_target(
+    publisher: Path,
+    developer: Path,
+    *,
+    target_branch: str,
+    target_path: str,
+) -> str:
+    _git(publisher, "switch", "-c", target_branch, "dev")
+    _write(publisher, target_path, f"target-only change on {target_branch}\n")
+    _git(publisher, "add", ".")
+    _git(publisher, "commit", "-m", f"advance {target_branch}")
+    target_sha = _git(publisher, "rev-parse", "HEAD")
+    _git(publisher, "push", "origin", target_branch)
+
+    _git(developer, "fetch", "origin", target_sha)
+    _git(developer, "switch", "-c", "feature", target_sha)
+    _write(developer, "src/bcs/feature.txt", "intended BCS change\n")
+    _git(developer, "add", ".")
+    _git(developer, "commit", "-m", "change only BCS")
+    return _git(developer, "rev-parse", "HEAD")
+
+
+class PrePushHookTest(unittest.TestCase):
+    def test_refreshes_stale_default_target_before_selecting_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, publisher, developer = _create_repositories(root)
+            stale_target_sha = _git(developer, "rev-parse", "origin/dev")
+
+            _write(publisher, "src/engine/target.txt", "target-only engine change\n")
+            _git(publisher, "add", ".")
+            _git(publisher, "commit", "-m", "advance dev with engine")
+            fresh_target_sha = _git(publisher, "rev-parse", "HEAD")
+            _git(publisher, "push", "origin", "dev")
+
+            _git(
+                developer,
+                "fetch",
+                "origin",
+                fresh_target_sha,
+            )
+            _git(developer, "branch", "rebase-target", fresh_target_sha)
+            self.assertEqual(_git(developer, "rev-parse", "origin/dev"), stale_target_sha)
+            self.assertEqual(
+                _git(developer, "rev-parse", "rebase-target"), fresh_target_sha
+            )
+
+            _git(developer, "switch", "-c", "feature", "rebase-target")
+            _write(developer, "src/bcs/feature.txt", "intended BCS change\n")
+            _git(developer, "add", ".")
+            _git(developer, "commit", "-m", "change only BCS")
+            feature_sha = _git(developer, "rev-parse", "HEAD")
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(developer, remote, hook, feature_sha)
+
+            self.assertIn("src/bcs/feature.txt", result.stdout)
+            self.assertNotIn("src/engine/target.txt", result.stdout)
+
+    def test_uses_git_config_merge_target_when_environment_is_unset(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, publisher, developer = _create_repositories(root)
+            feature_sha = _create_feature_on_remote_target(
+                publisher,
+                developer,
+                target_branch="release",
+                target_path="src/baas/target.txt",
+            )
+            _git(
+                developer,
+                "config",
+                "avernet.prePush.mergeTarget",
+                "origin/release",
+            )
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(developer, remote, hook, feature_sha)
+
+            self.assertIn("merge target: origin/release", result.stdout)
+            self.assertIn("src/bcs/feature.txt", result.stdout)
+            self.assertNotIn("src/baas/target.txt", result.stdout)
+
+    def test_environment_merge_target_overrides_git_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, publisher, developer = _create_repositories(root)
+            feature_sha = _create_feature_on_remote_target(
+                publisher,
+                developer,
+                target_branch="release",
+                target_path="src/engine/target.txt",
+            )
+            _git(
+                developer,
+                "config",
+                "avernet.prePush.mergeTarget",
+                "origin/does-not-exist",
+            )
+            env = os.environ.copy()
+            env["AVERNET_PRE_PUSH_MERGE_TARGET"] = "origin/release"
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(
+                developer,
+                remote,
+                hook,
+                feature_sha,
+                env=env,
+            )
+
+            self.assertIn("merge target: origin/release", result.stdout)
+            self.assertIn("src/bcs/feature.txt", result.stdout)
+            self.assertNotIn("src/engine/target.txt", result.stdout)
+
+    def test_missing_configured_target_rejects_push_without_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, _, developer = _create_repositories(root)
+            _git(developer, "switch", "-c", "feature")
+            _write(developer, "src/bcs/feature.txt", "intended BCS change\n")
+            _git(developer, "add", ".")
+            _git(developer, "commit", "-m", "change only BCS")
+            feature_sha = _git(developer, "rev-parse", "HEAD")
+            env = os.environ.copy()
+            env["AVERNET_PRE_PUSH_MERGE_TARGET"] = "origin/does-not-exist"
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(
+                developer,
+                remote,
+                hook,
+                feature_sha,
+                env=env,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("failed to refresh", result.stderr)
+            self.assertNotIn("dispatch-base:", result.stdout)
+
+    def test_invalid_target_format_rejects_push_without_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, _, developer = _create_repositories(root)
+            _git(developer, "switch", "-c", "feature")
+            _write(developer, "src/bcs/feature.txt", "intended BCS change\n")
+            _git(developer, "add", ".")
+            _git(developer, "commit", "-m", "change only BCS")
+            feature_sha = _git(developer, "rev-parse", "HEAD")
+            env = os.environ.copy()
+            env["AVERNET_PRE_PUSH_MERGE_TARGET"] = "dev"
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(
+                developer,
+                remote,
+                hook,
+                feature_sha,
+                env=env,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must use <remote>/<branch>", result.stderr)
+            self.assertNotIn("dispatch-base:", result.stdout)
+
+    def test_unrelated_configured_target_rejects_push_without_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, publisher, developer = _create_repositories(root)
+            _git(publisher, "switch", "--orphan", "unrelated")
+            _write(publisher, "UNRELATED.md", "unrelated history\n")
+            _git(publisher, "add", ".")
+            _git(publisher, "commit", "-m", "unrelated target")
+            _git(publisher, "push", "origin", "unrelated")
+
+            _git(developer, "switch", "-c", "feature")
+            _write(developer, "src/bcs/feature.txt", "intended BCS change\n")
+            _git(developer, "add", ".")
+            _git(developer, "commit", "-m", "change only BCS")
+            feature_sha = _git(developer, "rev-parse", "HEAD")
+            env = os.environ.copy()
+            env["AVERNET_PRE_PUSH_MERGE_TARGET"] = "origin/unrelated"
+
+            hook = _install_test_hook(developer)
+            result = _invoke_hook(
+                developer,
+                remote,
+                hook,
+                feature_sha,
+                env=env,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("no merge base", result.stderr)
+            self.assertNotIn("dispatch-base:", result.stdout)
+
+    def test_deletion_only_push_skips_target_fetch_and_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote, _, developer = _create_repositories(root)
+            hook = _install_test_hook(developer)
+            _git(developer, "remote", "remove", "origin")
+            delete_record = (
+                f"(delete) {ZERO_SHA} refs/heads/obsolete "
+                f"{_git(developer, 'rev-parse', 'HEAD')}\n"
+            )
+
+            result = _run(
+                developer,
+                str(hook),
+                "origin",
+                str(remote),
+                input_text=delete_record,
+                env={
+                    key: value
+                    for key, value in os.environ.items()
+                    if key != "AVERNET_PRE_PUSH_MERGE_TARGET"
+                },
+            )
+
+            self.assertNotIn("merge target sha:", result.stdout)
+            self.assertNotIn("dispatch-base:", result.stdout)
+
+    def test_agent_docs_define_the_pre_push_target_contract(self) -> None:
+        agents = AGENTS_PATH.read_text(encoding="utf-8")
+        claude = CLAUDE_PATH.read_text(encoding="utf-8")
+
+        for expected in (
+            "origin/dev",
+            "AVERNET_PRE_PUSH_MERGE_TARGET",
+            "avernet.prePush.mergeTarget",
+            "merge-base",
+            "src/backend/",
+            "src/baas/",
+            "src/engine/",
+            "src/bcs/",
+            "src/frontend/",
+        ):
+            self.assertIn(expected, agents)
+        for expected in (
+            "origin/dev",
+            "AVERNET_PRE_PUSH_MERGE_TARGET",
+            "avernet.prePush.mergeTarget",
+            "AGENTS.md",
+        ):
+            self.assertIn(expected, claude)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_pre_push_hook.py
+++ b/scripts/ci/tests/test_pre_push_hook.py
@@ -22,6 +22,10 @@ def _run(
     env: dict[str, str] | None = None,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
+    effective_env = (env if env is not None else os.environ).copy()
+    effective_env["HOME"] = str(repository)
+    effective_env["GIT_CONFIG_GLOBAL"] = os.devnull
+    effective_env["GIT_CONFIG_NOSYSTEM"] = "1"
     return subprocess.run(
         command,
         cwd=repository,
@@ -30,7 +34,7 @@ def _run(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        env=env,
+        env=effective_env,
     )
 
 
@@ -70,11 +74,11 @@ def _create_repositories(root: Path) -> tuple[Path, Path, Path]:
 
 def _install_test_hook(developer: Path) -> Path:
     hook = developer / ".githooks/pre-push"
-    hook.parent.mkdir(parents=True)
+    hook.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(HOOK_PATH, hook)
     hook.chmod(0o755)
     dispatcher = developer / "scripts/ci/pre_push.sh"
-    dispatcher.parent.mkdir(parents=True)
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
     dispatcher.write_text(
         """#!/usr/bin/env bash
 set -euo pipefail
@@ -146,6 +150,50 @@ def _create_feature_on_remote_target(
 
 
 class PrePushHookTest(unittest.TestCase):
+    def test_git_commands_ignore_user_global_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            repository = root / "repository"
+            global_home = root / "global-home"
+            repository.mkdir()
+            global_home.mkdir()
+            _write(
+                global_home,
+                ".gitconfig",
+                "[avernet \"prePush\"]\n"
+                "\tmergeTarget = origin/leaked-global-target\n",
+            )
+            env = os.environ.copy()
+            env["HOME"] = str(global_home)
+            env.pop("GIT_CONFIG_GLOBAL", None)
+            env.pop("GIT_CONFIG_NOSYSTEM", None)
+
+            result = _run(
+                repository,
+                "git",
+                "config",
+                "--get",
+                "avernet.prePush.mergeTarget",
+                env=env,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+    def test_install_test_hook_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            _, _, developer = _create_repositories(root)
+
+            first_hook = _install_test_hook(developer)
+            try:
+                second_hook = _install_test_hook(developer)
+            except FileExistsError as error:
+                self.fail(f"test hook installation must be idempotent: {error}")
+
+            self.assertEqual(second_hook, first_hook)
+
     def test_refreshes_stale_default_target_before_selecting_modules(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/scripts/ci/tests/test_unit_test_workflow_diff.py
+++ b/scripts/ci/tests/test_unit_test_workflow_diff.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/unit-tests.yml"
+PR_MERGE_PARENT_EXPRESSION = (
+    "${{ github.event_name == 'pull_request' && 'HEAD^1' || 'origin/dev' }}"
+)
+MODULE_JOBS = {
+    "bcs": ("BCS_BASE_REF", "src/bcs"),
+    "backend": ("BACKEND_BASE_REF", "src/backend"),
+    "engine": ("ENGINE_BASE_REF", "src/engine"),
+    "baas": ("BAAS_BASE_REF", "src/baas/packages/community"),
+}
+
+
+def _git(repository: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def _write(repository: Path, relative_path: str, content: str) -> None:
+    path = repository / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class UnitTestWorkflowDiffTest(unittest.TestCase):
+    def test_pr_module_diffs_use_the_checked_out_merge_parent(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        for env_name, module_path in MODULE_JOBS.values():
+            assignment = f"{env_name}: {PR_MERGE_PARENT_EXPRESSION}"
+            self.assertEqual(workflow.count(assignment), 1)
+            self.assertIn(
+                f'git diff --name-only "${{{env_name}}}" -- {module_path}',
+                workflow,
+            )
+        for coverage_argument in (
+            '--base-ref "$BCS_BASE_REF"',
+            '--base "$BACKEND_BASE_REF"',
+            '--base "$ENGINE_BASE_REF"',
+        ):
+            self.assertIn(coverage_argument, workflow)
+        self.assertIn(
+            "      - name: Validate unit-test diff behavior\n"
+            "        working-directory: ${{ github.workspace }}\n"
+            "        run: python3 scripts/ci/tests/test_unit_test_workflow_diff.py\n",
+            workflow,
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory) / "repository"
+            repository.mkdir()
+            _git(repository, "init", "--initial-branch=target")
+            _git(repository, "config", "user.name", "CI Test")
+            _git(repository, "config", "user.email", "ci-test@example.com")
+
+            for _, module_path in MODULE_JOBS.values():
+                _write(repository, f"{module_path}/baseline.txt", "baseline\n")
+            _git(repository, "add", ".")
+            _git(repository, "commit", "-m", "baseline")
+            _git(repository, "branch", "pull-request")
+
+            for module_path in (
+                "src/backend",
+                "src/engine",
+                "src/baas/packages/community",
+            ):
+                _write(repository, f"{module_path}/target-only.txt", "target branch\n")
+            _git(repository, "add", ".")
+            _git(repository, "commit", "-m", "advance target branch")
+
+            _git(repository, "switch", "pull-request")
+            _write(repository, "src/bcs/pull-request.txt", "pull request\n")
+            _git(repository, "add", ".")
+            _git(repository, "commit", "-m", "change only BCS")
+
+            _git(repository, "switch", "target")
+            _git(
+                repository,
+                "merge",
+                "--no-ff",
+                "pull-request",
+                "-m",
+                "merge pull request",
+            )
+
+            changed_by_module = {
+                job_name: _git(
+                    repository, "diff", "--name-only", "HEAD^1", "--", module_path
+                )
+                for job_name, (_, module_path) in MODULE_JOBS.items()
+            }
+            self.assertEqual(changed_by_module["bcs"], "src/bcs/pull-request.txt")
+            self.assertEqual(changed_by_module["backend"], "")
+            self.assertEqual(changed_by_module["engine"], "")
+            self.assertEqual(changed_by_module["baas"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make PR unit-test jobs diff BCS, Backend, Engine, and BaaS from the checked-out synthetic merge commit's first parent (`HEAD^1`)
- make pre-push refresh and resolve a configurable merge target before calculating each pushed ref's merge base
- default the local target to `origin/dev`, with `AVERNET_PRE_PUSH_MERGE_TARGET` taking precedence over `avernet.prePush.mergeTarget`
- fail closed for invalid, missing, or unrelated targets instead of falling back to a stale/incorrect range
- document target selection and module trigger paths in `AGENTS.md` and `CLAUDE.md`

## Root cause

PR #106 checked out a synthetic merge commit whose first parent was newer than `github.event.pull_request.base.sha`. Diffing the old event SHA against the merge tree included target-only Engine changes and incorrectly ran the Engine workflow.

The local hook had the analogous stale-ref risk: after a feature incorporated a newer `dev` commit, a cached older `origin/dev` made `merge-base..feature` include intervening target-branch module changes.

## TDD evidence

The new temporary-repository regression first failed against the old hook with both paths selected:

```text
src/bcs/feature.txt
src/engine/target.txt
```

After refreshing the target before `merge-base`, the same scenario selects only:

```text
src/bcs/feature.txt
```

The suite also covers environment/config precedence, missing and unrelated targets, invalid target format, deletion-only pushes, and the agent documentation contract.

## Validation

- `uv run --with pytest --with pyyaml pytest scripts/ci/tests -q` — 25 passed
- `bash -n .githooks/pre-push scripts/ci/pre_push.sh scripts/install_git_hooks.sh`
- `python3 -m py_compile scripts/ci/tests/test_pre_push_hook.py scripts/ci/tests/test_unit_test_workflow_diff.py`
- `git diff --check origin/dev...HEAD`
- parsed `.github/workflows/unit-tests.yml` with PyYAML
- directly ran `.githooks/pre-push` after rebasing onto the latest `origin/dev`; resolved target and merge base were both `c140bb23722ca0a13204e4fc3c505a164f44a51c`, and the real dispatcher passed
