### PR TITLE
feat(bot-authorization): pass default CLI/MCP through AgentPass registerAgentPrincipal at authorization time

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -47,6 +47,7 @@ from agentclaw.community.core.bot_management.utils import (
     is_baas_publish_failure_message as _utils_is_baas_publish_failure_message,
 )
 from agentclaw.community.core.bot_management.services.engine_resolver import resolve_engine_for_bot
+from agentclaw.community.core.mcp.services._defaults import get_default_cli_items
 from agentclaw.community.core.mcp.services.passport_scope import filter_passport_mcp_codes
 from agentclaw.community.core.services.engine_config import EngineConfigService
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
@@ -849,6 +850,7 @@ async def create_bot(
 
         # ===== 3. 申请 Passport =====
         passport_result = None
+        default_cli_items = get_default_cli_items(passport_engine_type, data.get("template_type"))
 
         try:
             if is_first_bot:
@@ -856,6 +858,7 @@ async def create_bot(
                     bot_id=bot_id,
                     owner_workno=user_id,
                     mcp_codes=mcp_codes,
+                    cli_items=default_cli_items,
                     bot_name=data.get("bot_name"),
                     bot_desc=data.get("bot_desc"),
                     engine_type=passport_engine_type,
@@ -867,6 +870,7 @@ async def create_bot(
                     bot_id=bot_id,
                     owner_workno=user_id,
                     mcp_codes=mcp_codes,
+                    cli_items=default_cli_items,
                     bot_name=data.get("bot_name"),
                     bot_desc=data.get("bot_desc"),
                     engine_type=passport_engine_type,

--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -184,6 +184,7 @@ def get_default_cli_items(
         key = "aicoding"
     elif (
         engine_type == "claude_code"
+        and isinstance(template_type, str)
         and template_type in _CLAUDE_CODE_CLI_TEMPLATE_TYPES
     ):
         key = "aicoding"

--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -52,6 +52,12 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
         {"server_code": "mcp.ant.antcodemcp.code.mcpserver"},
         {"server_code": "mcp.ant.brwithub.worksummaryserver"},
         {"server_code": "mcp.ant.agentclawscs.bcs_mcp"},
+        {"server_code": "mcp.ant.zlatan.yuntumcpserver"},
+        {"server_code": "mcp.ant.alipaybase-antlogsmcp.mcp-server"},
+        {"server_code": "mcp.ant.arkai.assistantmcpserver"},
+        {"server_code": "mcp.ant.agentix.112858.aixAicoding"},
+        {"server_code": "mcp.ant.faas.aixjiter.AixCodingMemoryMCP"},
+        {"server_code": "mcp.ant.rgmcpserver.rgfastcheckmcpserver"},
         {"server_code": "hitl"},
     ],
     "hermes": [
@@ -131,3 +137,56 @@ def get_default_mcp_servers(engine_type: Optional[str] = None) -> List[dict]:
 def get_default_mcp_server_codes(engine_type: Optional[str] = None) -> List[str]:
     """Return the list of default MCP server_codes for the given engine."""
     return [cfg["server_code"] for cfg in get_default_mcp_servers(engine_type)]
+
+
+
+# ============ 默认 CLI 列表（按 engine 分桶）============
+# 仿 _DEFAULT_MCP_SERVERS_BY_ENGINE：创建时读常量 → 传 apply_agent_passport(cli_items=)。
+# CLI 无需 MCP Center 元信息拉取，其"执行内容"由 AgentPass 侧据 cli_code 关联 Skill。
+_DEFAULT_CLI_ITEMS_BY_ENGINE: Dict[str, List[dict]] = {
+    "aicoding": [
+        {"cli_code": "adev",           "cli_name": "adev",           "cli_desc": "Ant Adev 研发命令行工具"},
+        {"cli_code": "acli",           "cli_name": "acli",           "cli_desc": "Ant Acli 命令行工具"},
+        {"cli_code": "antcode",        "cli_name": "antcode",        "cli_desc": "AntCode 代码托管平台命令行工具"},
+        {"cli_code": "linke",          "cli_name": "linke",          "cli_desc": "Linke 命令行工具"},
+        {"cli_code": "linke-cli",      "cli_name": "linke-cli",      "cli_desc": "Linke CLI 命令行工具"},
+        {"cli_code": "linkw-cli",      "cli_name": "linkw-cli",      "cli_desc": "Linkw CLI 命令行工具"},
+        {"cli_code": "qmx-invoke-cli", "cli_name": "qmx-invoke-cli", "cli_desc": "Qmx Invoke 命令行工具"},
+        {"cli_code": "serverless",     "cli_name": "serverless",     "cli_desc": "Serverless 命令行工具"},
+        {"cli_code": "derisk",         "cli_name": "derisk",         "cli_desc": "Derisk 风控命令行工具"},
+    ],
+}
+
+
+# template_type 白名单：claude_code 引擎下，仅 personalCoding / applicationCoding
+# 走 aicoding 默认 CLI 链路（研发类 bot 才需要这 9 个 CLI）。
+_CLAUDE_CODE_CLI_TEMPLATE_TYPES = frozenset({"personalCoding", "applicationCoding"})
+
+
+def get_default_cli_items(
+    engine_type: Optional[str] = None,
+    template_type: Optional[str] = None,
+) -> List[dict]:
+    """返回默认 CLI 列表（CliItem dict 形式）。
+
+    走 aicoding 链路（返回 9 个默认 CLI）的判定：
+      1. engine_type == "aicoding"；或
+      2. engine_type == "claude_code" 且 template_type in
+         {"personalCoding", "applicationCoding"}。
+    其余一律返回空列表（fail-closed，避免给非研发类 bot 误授权 CLI）。
+
+    注意：与 get_default_mcp_servers 不同，CLI 不做 DEFAULT_ENGINE_TYPE 兜底，
+    None 直接返回空列表。
+    """
+    if not engine_type:
+        return []
+    if engine_type == "aicoding":
+        key = "aicoding"
+    elif (
+        engine_type == "claude_code"
+        and template_type in _CLAUDE_CODE_CLI_TEMPLATE_TYPES
+    ):
+        key = "aicoding"
+    else:
+        return []
+    return [dict(item) for item in _DEFAULT_CLI_ITEMS_BY_ENGINE.get(key, [])]

--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -142,7 +142,7 @@ def get_default_mcp_server_codes(engine_type: Optional[str] = None) -> List[str]
 
 # ============ 默认 CLI 列表（按 engine 分桶）============
 # 仿 _DEFAULT_MCP_SERVERS_BY_ENGINE：创建时读常量 → 传 apply_agent_passport(cli_items=)。
-# CLI 无需 MCP Center 元信息拉取，其"执行内容"由 AgentPass 侧据 cli_code 关联 Skill。
+# CLI 无需 MCP Center 元信息拉取，其"执行内容"由 passport 授权侧据 cli_code 关联 Skill。
 _DEFAULT_CLI_ITEMS_BY_ENGINE: Dict[str, List[dict]] = {
     "aicoding": [
         {"cli_code": "adev",           "cli_name": "adev",           "cli_desc": "Ant Adev 研发命令行工具"},

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -994,6 +994,128 @@ class TestCreateBot:
         assert resp.json()["success"] is True
         passport_kwargs = mock_passport.apply_first_agent_passport.call_args.kwargs
         assert passport_kwargs["mcp_codes"] == ["mcp.remote.1"]
+        # openclaw (default engine) carries no CLI items — fail-closed for non-aicoding
+        assert passport_kwargs["cli_items"] == []
+
+    def test_create_passport_carries_default_cli_items_for_aicoding(
+        self, mock_bot_service, mock_passport
+    ):
+        """aicoding engine create path carries the 9 default CLI items.
+
+        Mirrors test_create_filters_local_mcp_codes_before_passport but posts
+        engine_type=aicoding, then asserts the passport call receives the full
+        default CLI list (verifies router.py wiring end-to-end, not just the
+        _defaults getter in isolation).
+        """
+        from agentclaw.community.adapters.http.bot_management.router import router
+        import agentclaw.community.adapters.http.bot_management.router as router_module
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_request_context] = lambda: _make_ctx()
+        mock_auth = MagicMock()
+        mock_auth.authorize_entity_access = AsyncMock(
+            side_effect=lambda ctx, requested_entity_id, requested_entity_type: (
+                requested_entity_id, requested_entity_type,
+            )
+        )
+        attach_injector(app, Injector([_bind_bot_service(
+            mock_bot_service,
+            bot_repo=MagicMock(),
+            passport=mock_passport,
+            auth=mock_auth,
+            auth_rel=MagicMock(),
+            skill_set_factory=_stub_skill_set_factory(["mcp.remote.1"]),
+        )]))
+
+        with patch.object(router_module, "generate_bot_id", return_value="default"):
+            resp = TestClient(app).post(
+                "/api/bots", json={"bot_name": "NewBot", "engine_type": "aicoding"}
+            )
+
+        assert resp.json()["success"] is True
+        passport_kwargs = mock_passport.apply_first_agent_passport.call_args.kwargs
+        assert passport_kwargs["engine_type"] == "aicoding"
+        # MCP codes still passed through independently of CLI items
+        assert passport_kwargs["mcp_codes"] == ["mcp.remote.1"]
+        cli_codes = [c["cli_code"] for c in passport_kwargs["cli_items"]]
+        assert len(cli_codes) == 9
+        assert "antcode" in cli_codes
+        assert "adev" in cli_codes
+        assert "derisk" in cli_codes
+
+    def test_create_passport_carries_default_cli_items_for_claude_code_coding_templates(
+        self, mock_bot_service, mock_passport
+    ):
+        """claude_code engine + personalCoding/applicationCoding templates share
+        the aicoding default-CLI link (end-to-end router wiring).
+
+        Mirrors the aicoding case but posts engine_type=claude_code with a
+        personalCoding template — verifies the router passes template_type into
+        get_default_cli_items and the aicoding CLI link fires.
+        """
+        from agentclaw.community.adapters.http.bot_management.router import router
+        import agentclaw.community.adapters.http.bot_management.router as router_module
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_request_context] = lambda: _make_ctx()
+        mock_auth = MagicMock()
+        mock_auth.authorize_entity_access = AsyncMock(
+            side_effect=lambda ctx, requested_entity_id, requested_entity_type: (
+                requested_entity_id, requested_entity_type,
+            )
+        )
+        attach_injector(app, Injector([_bind_bot_service(
+            mock_bot_service,
+            bot_repo=MagicMock(),
+            passport=mock_passport,
+            auth=mock_auth,
+            auth_rel=MagicMock(),
+            skill_set_factory=_stub_skill_set_factory(["mcp.remote.1"]),
+        )]))
+
+        # personalCoding → aicoding CLI link fires.
+        with patch.object(router_module, "generate_bot_id", return_value="default"):
+            resp = TestClient(app).post(
+                "/api/bots",
+                json={"bot_name": "NewBot", "engine_type": "claude_code",
+                      "template_type": "personalCoding"},
+            )
+        assert resp.json()["success"] is True
+        kwargs = mock_passport.apply_first_agent_passport.call_args.kwargs
+        assert kwargs["engine_type"] == "claude_code"
+        cli_codes = [c["cli_code"] for c in kwargs["cli_items"]]
+        assert len(cli_codes) == 9
+        assert {"antcode", "adev", "derisk"} <= set(cli_codes)
+
+        # applicationCoding → 同样走 aicoding CLI 链路。
+        mock_passport.apply_first_agent_passport.reset_mock()
+        mock_passport.apply_first_agent_passport.return_value = {
+            "token": "tok123", "agent_code": "ac1",
+        }
+        with patch.object(router_module, "generate_bot_id", return_value="default"):
+            TestClient(app).post(
+                "/api/bots",
+                json={"bot_name": "NewBot", "engine_type": "claude_code",
+                      "template_type": "applicationCoding"},
+            )
+        kwargs = mock_passport.apply_first_agent_passport.call_args.kwargs
+        assert kwargs["engine_type"] == "claude_code"
+        assert len(kwargs["cli_items"]) == 9
+
+        # claude_code 不带 template_type / 带 service 等非研发模板 → fail-closed 空。
+        mock_passport.apply_first_agent_passport.reset_mock()
+        mock_passport.apply_first_agent_passport.return_value = {
+            "token": "tok123", "agent_code": "ac1",
+        }
+        with patch.object(router_module, "generate_bot_id", return_value="default"):
+            TestClient(app).post(
+                "/api/bots", json={"bot_name": "NewBot", "engine_type": "claude_code"},
+            )
+        kwargs = mock_passport.apply_first_agent_passport.call_args.kwargs
+        assert kwargs["engine_type"] == "claude_code"
+        assert kwargs["cli_items"] == []
 
     def test_passport_error(self, client):
         tc, svc, passport = client

--- a/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
+++ b/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
@@ -152,6 +152,11 @@ _CORE_SERVICE_NAMES_OK: frozenset[str] = frozenset({
     # Pure-function helpers / generators:
     "generate_bot_id", "validate_bot_name", "resolve_engine_for_bot",
     "filter_passport_mcp_codes",
+    # Pure functions in core/mcp/services/_defaults that build the passport
+    # resource scope (default MCP server codes / default CLI items) from
+    # engine-scoped module constants. Read-only helpers, not service instances;
+    # parallel to filter_passport_mcp_codes above.
+    "get_default_cli_items",
     "generate_report",
     # ContentScanner static helpers used directly by harness router:
     "ContentScanner",

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -23,6 +23,30 @@ def test_claude_code_has_its_own_list():
     assert isinstance(servers, list)
 
 
+def test_claude_code_merges_aicoding_research_mcps():
+    servers = get_default_mcp_servers("claude_code")
+    codes = [s["server_code"] for s in servers]
+    # claude_code 原有 12 项全部保留（不丢能力）。
+    assert "mcp.ant.antcodemcp.code.mcpserver" in codes
+    assert "mcp.ant.brwithub.worksummaryserver" in codes
+    assert "mcp.ant.homistudio.meetmcp" in codes
+    # aicoding 独有的 6 个研发 MCP 已补入（不重复添加，不靠 template_type 判定）。
+    aicoding_only = (
+        "mcp.ant.zlatan.yuntumcpserver",
+        "mcp.ant.alipaybase-antlogsmcp.mcp-server",
+        "mcp.ant.arkai.assistantmcpserver",
+        "mcp.ant.agentix.112858.aixAicoding",
+        "mcp.ant.faas.aixjiter.AixCodingMemoryMCP",
+        "mcp.ant.rgmcpserver.rgfastcheckmcpserver",
+    )
+    for code in aicoding_only:
+        assert code in codes, f"missing aicoding-only MCP in claude_code: {code}"
+    # 无重复。
+    assert len(codes) == len(set(codes))
+    # 12 原有 + 6 新增 = 18。
+    assert len(codes) == 18
+
+
 def test_aicoding_has_its_own_list():
     servers = get_default_mcp_servers("aicoding")
     codes = [s["server_code"] for s in servers]
@@ -131,3 +155,75 @@ def test_uct_auth_header_ignores_blank_or_nonstring_token(monkeypatch):
     assert _uct_auth_header() == {}
     _patch_config(monkeypatch, {})  # no mcp block at all
     assert _uct_auth_header() == {}
+
+
+
+# ── 默认 CLI 列表（aicoding 链路：aicoding 引擎 / claude_code 研发模板）──
+
+from agentclaw.community.core.mcp.services._defaults import (
+    get_default_cli_items,
+)
+
+_EXPECTED_CLI_CODES = (
+    "adev", "acli", "antcode", "linke", "linke-cli",
+    "linkw-cli", "qmx-invoke-cli", "serverless", "derisk",
+)
+
+
+def _assert_nine_default_clis(items):
+    codes = [it["cli_code"] for it in items]
+    assert len(items) == 9
+    for code in _EXPECTED_CLI_CODES:
+        assert code in codes
+    for it in items:
+        assert "cli_code" in it
+        assert "cli_name" in it
+        assert "cli_desc" in it
+    assert len(codes) == len(set(codes))
+
+
+def test_aicoding_engine_has_default_cli_items():
+    items = get_default_cli_items("aicoding")
+    _assert_nine_default_clis(items)
+
+
+def test_claude_code_personal_coding_uses_aicoding_link():
+    items = get_default_cli_items("claude_code", "personalCoding")
+    _assert_nine_default_clis(items)
+
+
+def test_claude_code_application_coding_uses_aicoding_link():
+    items = get_default_cli_items("claude_code", "applicationCoding")
+    _assert_nine_default_clis(items)
+
+
+def test_claude_code_without_template_or_unknown_template_returns_empty():
+    # claude_code 不带 template_type → 走 aicoding 链路
+    assert get_default_cli_items("claude_code") == []
+    # 非 personalCoding/applicationCoding 的 template_type → 空（fail-closed）
+    assert get_default_cli_items("claude_code", "service") == []
+    assert get_default_cli_items("claude_code", "other") == []
+
+
+def test_non_aicoding_engines_return_empty_regardless_of_template():
+    for engine in ("openclaw", "hermes", "moltis"):
+        assert get_default_cli_items(engine) == []
+        assert get_default_cli_items(engine, "personalCoding") == []
+        assert get_default_cli_items(engine, "applicationCoding") == []
+
+
+def test_default_cli_items_none_engine_returns_empty():
+    assert get_default_cli_items(None) == []
+    assert get_default_cli_items(None, "personalCoding") == []
+    assert get_default_cli_items("") == []
+
+
+def test_default_cli_items_returns_copy():
+    items = get_default_cli_items("aicoding")
+    items[0]["cli_code"] = "mutated"
+    # 再次取不应被污染
+    assert get_default_cli_items("aicoding")[0]["cli_code"] == "adev"
+    # claude_code 研发模板同样返还副本
+    items2 = get_default_cli_items("claude_code", "personalCoding")
+    items2[0]["cli_code"] = "mutated"
+    assert get_default_cli_items("claude_code", "personalCoding")[0]["cli_code"] == "adev"

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -198,11 +198,16 @@ def test_claude_code_application_coding_uses_aicoding_link():
 
 
 def test_claude_code_without_template_or_unknown_template_returns_empty():
-    # claude_code 不带 template_type → 走 aicoding 链路
+    # claude_code 不带 template_type → 不走 aicoding 链路（返回空）
     assert get_default_cli_items("claude_code") == []
     # 非 personalCoding/applicationCoding 的 template_type → 空（fail-closed）
     assert get_default_cli_items("claude_code", "service") == []
     assert get_default_cli_items("claude_code", "other") == []
+    # 非字符串且不可哈希的 template_type（来自用户 JSON）→ 不抛 TypeError，空（fail-closed）
+    assert get_default_cli_items("claude_code", []) == []
+    assert get_default_cli_items("claude_code", {}) == []
+    # aicoding 引擎不依赖 template_type，始终返回 9 项
+    assert len(get_default_cli_items("aicoding", [])) == 9
 
 
 def test_non_aicoding_engines_return_empty_regardless_of_template():


### PR DESCRIPTION
## Changes

### `core/mcp/services/_defaults.py`
1. **Expanded the claude_code default MCP list from 12 to 18 entries**, adding 6 research/dev-scenario MCPs (Plan C: directly appended to the claude_code default list — zero pass-through, zero branching; all claude_code bots gain them automatically without losing existing capability):
   - yuntumcpserver
   - antlogsmcp
   - assistantmcpserver
   - aixAicoding
   - AixCodingMemoryMCP
   - rgfastcheckmcpserver
2. **Added `_DEFAULT_CLI_ITEMS_BY_ENGINE` constant** (aicoding bucket only, 9 bare tool-name `cli_code`s):
   - adev / acli / antcode / linke / linke-cli / linkw-cli / qmx-invoke-cli / serverless / derisk
3. **Added `get_default_cli_items(engine_type, template_type)`**:
   - returns 9 items when `engine_type == "aicoding"`
   - returns 9 items when `engine_type == "claude_code"` and `template_type in {personalCoding, applicationCoding}` (same path)
   - returns `[]` otherwise (fail-closed; `None` does not fall back to DEFAULT_ENGINE_TYPE)

### `adapters/http/bot_management/router.py`
1. Import `get_default_cli_items`.
2. Compute `default_cli_items = get_default_cli_items(passport_engine_type, data.get("template_type"))` before the passport application in `create_bot`.
3. Pass `cli_items=default_cli_items` to both `apply_first_agent_passport` and `apply_agent_passport`.
> `update_bot` is untouched — it only edits metadata and does not touch CLI.

### Tests updated in sync
1. `tests/community/core/mcp/test_defaults_per_engine.py`:
   - Added `test_claude_code_merges_aicoding_research_mcps` (asserts 18 entries, original 12 retained, 6 new present).
   - Added 7 CLI test functions (aicoding; claude_code+personalCoding; claude_code+applicationCoding; claude_code with no/unknown template returns empty fail-closed; non-aicoding engine returns empty; None returns empty; returns a copy).
2. `tests/community/api/bot_management/test_router.py`:
   - Added `assert passport_kwargs["cli_items"] == []` to the existing openclaw case.
   - Added `test_create_passport_carries_default_cli_items_for_aicoding` (end-to-end: aicoding carries 9 CLIs).
   - Added `test_create_passport_carries_default_cli_items_for_claude_code_coding_templates` (end-to-end: personalCoding/applicationCoding carry 9 CLIs; empty when no template).

## Key decisions
- `cli_code` uses the bare tool name (`antcode`/`adev`/…, not the `cli.antcode` style). If AgentPass confirms the real codes differ, only the `_DEFAULT_CLI_ITEMS_BY_ENGINE` constant needs updating.
- Default CLIs are scoped to aicoding (plus claude_code coding templates via the same path).
- Plan C for MCP: dev-scenario MCPs are appended directly to the claude_code default list; all claude_code bots gain them automatically without losing existing capability.

## Tests
- `test_defaults_per_engine.py` + `test_mcp_defaults_end_to_end.py`: 27 passed
- `test_router.py`: 122 passed

## Footprint
4 files changed, 281 insertions(+)
