### PR TITLE
fix(bcs-cli): render current bot groups

### DIFF
--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -2670,14 +2670,18 @@ async fn main() -> Result<()> {
             for group in groups {
                 let id = group
                     .get("id")
+                    .or_else(|| group.get("group_id"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 let mode = group
                     .get("mode")
+                    .or_else(|| group.get("group_strategy"))
+                    .or_else(|| group.get("group_kind"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 let driver = group
                     .get("driver_bot")
+                    .or_else(|| group.get("coordinator_bot"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 println!("  - {} [{}] driver={}", id, mode, driver);

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
@@ -17,9 +17,12 @@ async fn list_groups_mine_uses_current_bot_from_session() {
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "bot_uuid": ctx.session.bot_uuid,
             "items": [{
-                "id": "group-for-current-bot",
-                "mode": "agent",
-                "driver_bot": "current-bot"
+                "group_id": "group-for-current-bot",
+                "coordinator_bot": "current-bot",
+                "participants": [],
+                "group_kind": "normal",
+                "group_strategy": "chat",
+                "visibility": "private"
             }],
             "total": 1,
             "offset": 0,
@@ -37,5 +40,9 @@ async fn list_groups_mine_uses_current_bot_from_session() {
 
     assert_success(&output);
     assert_output_contains(&output, "Groups for current bot");
-    assert_output_contains(&output, "group-for-current-bot");
+    assert_output_contains(
+        &output,
+        "group-for-current-bot [chat] driver=current-bot",
+    );
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("unknown"));
 }


### PR DESCRIPTION
## What changed

- Make `bcs-cli list-groups --mine` understand the per-bot group response fields: `group_id`, `coordinator_bot`, and `group_strategy`.
- Preserve compatibility with the global/legacy fields: `id`, `driver_bot`, and `mode`.
- Update the E2E fixture to match the real `/bots/{bot_uuid}/groups` response and fail if `unknown` is printed.

## Why

The per-bot endpoint returns a different item shape from `/groups`. The CLI rendered the per-bot result using the global response fields, so every row appeared as `unknown [unknown] driver=unknown`.

## User impact

`bcs-cli list-groups --mine` now prints the actual group ID, strategy, and coordinator.

## Validation

- `cargo test --package bcs-cli --test e2e` (7 passed, 1 ignored)
- `cargo check --package bcs-cli --all-targets`
- `git diff --check`