### PR TITLE
fix(dormant): verify passport token before bot start

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
@@ -5,7 +5,8 @@ Flow:
   2. REACTIVATING → friendly early return (idempotent).
   3. non-RECYCLED  → InvalidBotStateError.
   4. RECYCLED      → update_status(REACTIVATING) + spawn background thread
-                      that calls passport unfreeze then start_bot;
+                      that calls passport unfreeze, verifies the runtime token,
+                      then starts the bot;
                       on failure rolls back: passport freeze + RECYCLED.
 """
 from __future__ import annotations
@@ -121,6 +122,22 @@ class ActivateBotService:
             return
 
         try:
+            logger.info(
+                "[activate] passport token verify start bot_id=%s user_id=%s",
+                bot_id,
+                user_id,
+            )
+            token = self._passport.query_token(
+                bot_id=bot_id,
+                owner_workno=user_id,
+            )
+            if not token:
+                raise RuntimeError("passport token is unavailable after unfreeze")
+            logger.info(
+                "[activate] passport token verify success bot_id=%s user_id=%s",
+                bot_id,
+                user_id,
+            )
             # start_bot internally calls apply_device; on success sets status=ACTIVE.
             logger.info(
                 "[activate] start_bot start bot_id=%s user_id=%s nick_name=%s",

--- a/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
@@ -17,7 +17,7 @@ from injector import inject
 
 from agentclaw.community.core.bot_dormant.protocols import BotServiceProtocol
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.plugin_api.passport import PassportError, PassportPlugin
 
 
 logger = get_logger()
@@ -132,7 +132,7 @@ class ActivateBotService:
                 owner_workno=user_id,
             )
             if not token:
-                raise RuntimeError("passport token is unavailable after unfreeze")
+                raise PassportError("passport token is unavailable after unfreeze")
             logger.info(
                 "[activate] passport token verify success bot_id=%s user_id=%s",
                 bot_id,

--- a/src/backend/src/agentclaw/community/plugin_api/passport.py
+++ b/src/backend/src/agentclaw/community/plugin_api/passport.py
@@ -234,7 +234,12 @@ class PassportPlugin(Plugin, Protocol):
         owner_workno: str,
         reason: str,
     ) -> None:
-        """Set the bot's agent identity credential online."""
+        """Bring the credential online and make a runtime token queryable.
+
+        Implementations must return only after ``query_token`` can provide the
+        token required by device bootstrap, or raise when that postcondition
+        cannot be established.
+        """
         ...
 
     def offline_agent_identity_credential(

--- a/src/backend/tests/community/contracts/test_passport.py
+++ b/src/backend/tests/community/contracts/test_passport.py
@@ -88,3 +88,30 @@ def test_community_passport_issues_deterministic_envelope(community_world) -> No
     assert result["iframe_url"] is None
     # query_token agrees with the issued token (device bootstrap depends on it).
     assert plugin.query_token("bot_x", "alice") == "community-passport-bot_x"
+
+
+def test_local_unfreeze_leaves_runtime_token_queryable(world) -> None:
+    plugin = world.get(PassportPlugin)
+
+    plugin.unfreeze_agent_passport(
+        bot_id="bot_local",
+        owner_workno="alice",
+        reason="manual reactivate",
+    )
+
+    assert plugin.query_token("bot_local", "alice") == "mock_token_bot_local"
+
+
+def test_community_unfreeze_leaves_runtime_token_queryable(community_world) -> None:
+    plugin = community_world.get(PassportPlugin)
+
+    plugin.unfreeze_agent_passport(
+        bot_id="bot_community",
+        owner_workno="alice",
+        reason="manual reactivate",
+    )
+
+    assert (
+        plugin.query_token("bot_community", "alice")
+        == "community-passport-bot_community"
+    )

--- a/src/backend/tests/community/core/bot_dormant/test_activate.py
+++ b/src/backend/tests/community/core/bot_dormant/test_activate.py
@@ -1,12 +1,13 @@
 """Tests for ActivateBotService (Task 6).
 
-Five scenarios:
+Six scenarios:
   1. reject_active_bot          — ACTIVE → InvalidBotStateError
   2. reactivating_friendly      — REACTIVATING → friendly dict (no update_status call)
   3. recycled_kicks_async       — RECYCLED → update_status(REACTIVATING) + start_bot called
   4. rollback_on_passport_error — passport unfreeze raises → status=RECYCLED,
                                    start_bot NOT called
   5. rollback_on_start_bot_fail — start_bot raises → passport freeze + status=RECYCLED
+  6. missing_token_after_unfreeze — token absent → freeze + RECYCLED before start
 """
 from unittest.mock import MagicMock
 
@@ -41,6 +42,7 @@ def test_activate_recycled_kicks_async(monkeypatch):
     bot_service.get_bot.return_value = {"bot_id": "b1", "status": "RECYCLED"}
     passport_mock = MagicMock()
     passport_mock.unfreeze_agent_passport.return_value = None
+    passport_mock.query_token.return_value = "token-b1"
 
     svc = ActivateBotService(bot_service, passport_plugin=passport_mock)
 
@@ -69,6 +71,10 @@ def test_activate_recycled_kicks_async(monkeypatch):
         bot_id="b1",
         owner_workno="u1",
         reason="manual reactivate",
+    )
+    passport_mock.query_token.assert_called_once_with(
+        bot_id="b1",
+        owner_workno="u1",
     )
     bot_service.start_bot.assert_called_once()
     # Return value is REACTIVATING
@@ -136,6 +142,7 @@ def test_rollback_on_start_bot_failure(monkeypatch):
     """start_bot raises → passport freeze (rollback) + update_status(RECYCLED)."""
     passport_mock = MagicMock()
     passport_mock.unfreeze_agent_passport.return_value = None
+    passport_mock.query_token.return_value = "token-b1"
     passport_mock.freeze_agent_passport.return_value = None
 
     svc, bot_service = _make_svc_with_passport("RECYCLED", passport_mock)
@@ -165,4 +172,35 @@ def test_rollback_on_start_bot_failure(monkeypatch):
         bot_id="b1", user_id="u1", status="RECYCLED"
     )
     # Caller still gets REACTIVATING
+    assert result["status"] == "REACTIVATING"
+
+
+def test_missing_token_after_unfreeze_rolls_back_before_start(monkeypatch):
+    """Online success without a queryable token must not start the bot."""
+    passport_mock = MagicMock()
+    passport_mock.unfreeze_agent_passport.return_value = None
+    passport_mock.query_token.return_value = None
+    passport_mock.freeze_agent_passport.return_value = None
+
+    svc, bot_service = _make_svc_with_passport("RECYCLED", passport_mock)
+    monkeypatch.setattr(
+        "agentclaw.community.core.bot_dormant.activate_service.threading.Thread",
+        _SyncThread,
+    )
+
+    result = svc.activate(bot_id="b1", user_id="u1")
+
+    passport_mock.query_token.assert_called_once_with(
+        bot_id="b1",
+        owner_workno="u1",
+    )
+    bot_service.start_bot.assert_not_called()
+    passport_mock.freeze_agent_passport.assert_called_once_with(
+        bot_id="b1",
+        owner_workno="u1",
+        reason="reactivate rollback",
+    )
+    bot_service.update_status.assert_called_with(
+        bot_id="b1", user_id="u1", status="RECYCLED"
+    )
     assert result["status"] == "REACTIVATING"


### PR DESCRIPTION
## Summary

- define passport unfreeze as complete only when a runtime token is queryable
- verify the token before starting a recycled bot
- roll back the passport and bot status when online succeeds without a token
- add local/community passport contract coverage and activation regression tests

## Root cause

A dormant bot could be brought online at the credential layer while still having no valid runtime token. The activation worker then continued into device bootstrap, where the missing token caused a later failure and left recovery behavior ambiguous.

## Compatibility

The public activation endpoint and passport method signatures are unchanged. Existing implementations that already expose a token after unfreeze continue unchanged; implementations that violate that postcondition now fail before starting the bot and use the existing rollback path.

## Validation

- ruff check on all changed Python files
- 15 targeted dormant/passport/architecture tests
- Backend pre-push gate: 7610 passed, 81.95% line coverage, 100% change-line coverage (5/5)
- Singlebox coverage gate: 25 acceptance tests passed
