### PR TITLE
feat(bcs): allow organization admins to invoke member bots

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1058,6 +1058,7 @@ dependencies = [
  "bcs-domain",
  "bcs-organization-store",
  "bcs-service-api",
+ "bcs-test-support",
  "futures",
  "tempfile",
  "tokio",

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "bcs-user-directory-api",
  "futures",
  "hex",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
+++ b/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
@@ -36,6 +36,7 @@ urlencoding     = { workspace = true }
 uuid            = { workspace = true }
 sha2            = { workspace = true }
 hex             = { workspace = true }
+reqwest         = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
@@ -1,0 +1,265 @@
+use std::{net::IpAddr, sync::Arc};
+
+use bcs_protocol::BCN_PROVIDER_ID_HEADER;
+use bcs_route_security::{OutboundUrlError, OutboundUrlGuard};
+use bcs_service_api::{BotTerminalEvent, BotTerminalObserverPort, BotTerminalState};
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::state::{AdminInvocationRun, AdminInvocationStore};
+
+#[derive(Clone)]
+pub struct AdminInvocationTerminalObserver {
+    runs: Arc<AdminInvocationStore>,
+    outbound_url_guard: OutboundUrlGuard,
+}
+
+impl AdminInvocationTerminalObserver {
+    pub fn new(runs: Arc<AdminInvocationStore>, outbound_url_guard: OutboundUrlGuard) -> Self {
+        Self {
+            runs,
+            outbound_url_guard,
+        }
+    }
+
+    pub fn notify(&self, run_id: &str, state: BotTerminalState, text: &str) {
+        let Some(run) = self.runs.claim_callback(run_id) else {
+            return;
+        };
+        self.dispatch(run_id, run, state, text);
+    }
+
+    fn dispatch(&self, run_id: &str, run: AdminInvocationRun, state: BotTerminalState, text: &str) {
+        let Some(callback) = run.callback else {
+            return;
+        };
+        let body = if state == BotTerminalState::Final {
+            json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "completed", "message": { "role": "assistant", "content": [{ "type": "text", "text": text }] } })
+        } else {
+            json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "failed", "error": { "code": "ADMIN_INVOCATION_TARGET_FAILED", "message": text } })
+        };
+        let provider_id = run.provider_id;
+        let run_id = run_id.to_string();
+        let outbound_url_guard = self.outbound_url_guard.clone();
+        tokio::spawn(async move {
+            let callback_url = callback_url_for_log(&callback.url);
+            let guarded_url = match outbound_url_guard
+                .resolve_request_http_url(&callback.url)
+                .await
+            {
+                Ok(url) => url,
+                Err(error) => {
+                    warn!(
+                        run_id = %run_id,
+                        provider_id = %provider_id,
+                        callback_url = %callback_url,
+                        resolved_ip = ?callback_blocked_ip(&error),
+                        reason = %error,
+                        "organization admin terminal callback blocked by outbound URL policy"
+                    );
+                    return;
+                }
+            };
+            let mut client_builder = reqwest::Client::builder()
+                .no_proxy()
+                .redirect(reqwest::redirect::Policy::none());
+            if let Some((host, addresses)) = guarded_url.dns_override() {
+                client_builder = client_builder.resolve_to_addrs(host, addresses);
+            }
+            let client = match client_builder.build() {
+                Ok(client) => client,
+                Err(error) => {
+                    warn!(
+                        run_id = %run_id,
+                        provider_id = %provider_id,
+                        callback_url = %callback_url,
+                        error = %error,
+                        "organization admin terminal callback client creation failed"
+                    );
+                    return;
+                }
+            };
+            let response = client
+                .post(guarded_url.as_str())
+                .header("content-type", "application/json")
+                .header(BCN_PROVIDER_ID_HEADER, provider_id)
+                .bearer_auth(callback.bearer_token)
+                .json(&body)
+                .send()
+                .await;
+            match response {
+                Ok(response) if response.status().is_success() => {
+                    info!(run_id = %run_id, "organization admin terminal callback acknowledged")
+                }
+                Ok(response) => {
+                    warn!(run_id = %run_id, status = %response.status(), "organization admin terminal callback was not acknowledged")
+                }
+                Err(error) => {
+                    warn!(run_id = %run_id, error = %error, "organization admin terminal callback failed")
+                }
+            }
+        });
+    }
+}
+
+#[async_trait::async_trait]
+impl BotTerminalObserverPort for AdminInvocationTerminalObserver {
+    async fn observe(&self, event: BotTerminalEvent) {
+        let Some(run) = self
+            .runs
+            .claim_callback_for_bot(&event.run_id, &event.bot_uuid)
+        else {
+            return;
+        };
+        self.dispatch(&event.run_id, run, event.state, &event.text);
+    }
+}
+
+pub(crate) fn callback_blocked_ip(error: &OutboundUrlError) -> Option<IpAddr> {
+    match error {
+        OutboundUrlError::UnsafeAddress(address) => Some(*address),
+        _ => None,
+    }
+}
+
+pub(crate) fn callback_url_for_log(callback_url: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(callback_url) else {
+        return "<invalid callback URL>".to_string();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use bcs_service_api::BotTerminalObserverPort;
+    use bcs_test_support::contract::port::bot_terminal_observer_port_contract_tests;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::time::{Duration, timeout};
+
+    use super::*;
+    use crate::state::{AdminInvocationCallback, AdminInvocationRun};
+
+    fn admin_run(callback_url: String) -> AdminInvocationRun {
+        AdminInvocationRun {
+            provider_id: "admin-provider".to_string(),
+            organization_code: "org-1".to_string(),
+            target_bot_uuid: "target-bot".to_string(),
+            session_id: "session-1".to_string(),
+            detach: false,
+            expires_at_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64
+                + 60_000,
+            delivery_error: None,
+            callback: Some(AdminInvocationCallback {
+                url: callback_url,
+                bearer_token: "callback-token".to_string(),
+            }),
+            callback_claimed: false,
+        }
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Vec<u8> {
+        let mut request = Vec::new();
+        loop {
+            let mut chunk = [0; 1024];
+            let count = socket.read(&mut chunk).await.unwrap();
+            assert!(count > 0, "callback connection closed before request completed");
+            request.extend_from_slice(&chunk[..count]);
+            let Some(headers_end) = request.windows(4).position(|window| window == b"\r\n\r\n")
+            else {
+                continue;
+            };
+            let headers_end = headers_end + 4;
+            let headers = String::from_utf8_lossy(&request[..headers_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.split_once(':').and_then(|(name, value)| {
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().unwrap())
+                    })
+                })
+                .unwrap_or(0);
+            if request.len() >= headers_end + content_length {
+                return request;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn matching_bot_terminal_dispatches_callback_once() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let callback_url = format!("http://{}/callback", listener.local_addr().unwrap());
+        let runs = Arc::new(AdminInvocationStore::default());
+        runs.insert("run-1".to_string(), admin_run(callback_url));
+        let observer = AdminInvocationTerminalObserver::new(
+            runs,
+            OutboundUrlGuard::allowing_private_networks_for_tests(),
+        );
+        let event = BotTerminalEvent {
+            run_id: "run-1".to_string(),
+            bot_uuid: "target-bot".to_string(),
+            state: BotTerminalState::Final,
+            text: "websocket result".to_string(),
+        };
+
+        bot_terminal_observer_port_contract_tests(&observer, event.clone(), async {
+            let (mut socket, _) = timeout(Duration::from_secs(2), listener.accept())
+                .await
+                .unwrap()
+                .unwrap();
+            let request = timeout(Duration::from_secs(2), read_http_request(&mut socket))
+                .await
+                .unwrap();
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+            let request = String::from_utf8_lossy(&request);
+            request.contains("x-bcn-provider-id: admin-provider")
+                && request.contains("authorization: Bearer callback-token")
+                && request.contains("websocket result")
+        })
+        .await;
+
+        observer.observe(event).await;
+        assert!(
+            timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn mismatched_bot_does_not_claim_callback() {
+        let runs = Arc::new(AdminInvocationStore::default());
+        runs.insert(
+            "run-1".to_string(),
+            admin_run("http://127.0.0.1:1/callback".to_string()),
+        );
+        let observer = AdminInvocationTerminalObserver::new(
+            runs.clone(),
+            OutboundUrlGuard::allowing_private_networks_for_tests(),
+        );
+
+        observer
+            .observe(BotTerminalEvent {
+                run_id: "run-1".to_string(),
+                bot_uuid: "different-bot".to_string(),
+                state: BotTerminalState::Final,
+                text: "spoofed".to_string(),
+            })
+            .await;
+
+        assert!(runs.claim_callback_for_bot("run-1", "target-bot").is_some());
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
@@ -6,7 +6,10 @@ use bcs_service_api::{BotTerminalEvent, BotTerminalObserverPort, BotTerminalStat
 use serde_json::json;
 use tracing::{info, warn};
 
-use crate::state::{AdminInvocationRun, AdminInvocationStore};
+use crate::state::{
+    AdminInvocationRun, AdminInvocationStore, AdminInvocationTerminal,
+    AdminInvocationTerminalStatus,
+};
 
 #[derive(Clone)]
 pub struct AdminInvocationTerminalObserver {
@@ -23,20 +26,32 @@ impl AdminInvocationTerminalObserver {
     }
 
     pub fn notify(&self, run_id: &str, state: BotTerminalState, text: &str) {
-        let Some(run) = self.runs.claim_callback(run_id) else {
+        let terminal = terminal_from_bot_state(state, text);
+        let Some(run) = self.runs.record_terminal(run_id, terminal.clone()) else {
             return;
         };
-        self.dispatch(run_id, run, state, text);
+        self.dispatch(run_id, run, &terminal);
     }
 
-    fn dispatch(&self, run_id: &str, run: AdminInvocationRun, state: BotTerminalState, text: &str) {
+    pub fn notify_timeout(&self, run_id: &str, text: &str) {
+        let terminal = AdminInvocationTerminal {
+            status: AdminInvocationTerminalStatus::TimedOut,
+            text: text.to_string(),
+        };
+        let Some(run) = self.runs.record_terminal(run_id, terminal.clone()) else {
+            return;
+        };
+        self.dispatch(run_id, run, &terminal);
+    }
+
+    fn dispatch(&self, run_id: &str, run: AdminInvocationRun, terminal: &AdminInvocationTerminal) {
         let Some(callback) = run.callback else {
             return;
         };
-        let body = if state == BotTerminalState::Final {
-            json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "completed", "message": { "role": "assistant", "content": [{ "type": "text", "text": text }] } })
+        let body = if terminal.status == AdminInvocationTerminalStatus::Completed {
+            json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "completed", "message": { "role": "assistant", "content": [{ "type": "text", "text": terminal.text }] } })
         } else {
-            json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "failed", "error": { "code": "ADMIN_INVOCATION_TARGET_FAILED", "message": text } })
+            json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "failed", "error": { "code": "ADMIN_INVOCATION_TARGET_FAILED", "message": terminal.text } })
         };
         let provider_id = run.provider_id;
         let run_id = run_id.to_string();
@@ -105,13 +120,25 @@ impl AdminInvocationTerminalObserver {
 #[async_trait::async_trait]
 impl BotTerminalObserverPort for AdminInvocationTerminalObserver {
     async fn observe(&self, event: BotTerminalEvent) {
+        let terminal = terminal_from_bot_state(event.state, &event.text);
         let Some(run) = self
             .runs
-            .claim_callback_for_bot(&event.run_id, &event.bot_uuid)
+            .record_terminal_for_bot(&event.run_id, &event.bot_uuid, terminal.clone())
         else {
             return;
         };
-        self.dispatch(&event.run_id, run, event.state, &event.text);
+        self.dispatch(&event.run_id, run, &terminal);
+    }
+}
+
+fn terminal_from_bot_state(state: BotTerminalState, text: &str) -> AdminInvocationTerminal {
+    AdminInvocationTerminal {
+        status: if state == BotTerminalState::Final {
+            AdminInvocationTerminalStatus::Completed
+        } else {
+            AdminInvocationTerminalStatus::Failed
+        },
+        text: text.to_string(),
     }
 }
 
@@ -159,6 +186,7 @@ mod tests {
                 .as_millis() as u64
                 + 60_000,
             delivery_error: None,
+            terminal: None,
             callback: Some(AdminInvocationCallback {
                 url: callback_url,
                 bearer_token: "callback-token".to_string(),
@@ -260,6 +288,25 @@ mod tests {
             })
             .await;
 
-        assert!(runs.claim_callback_for_bot("run-1", "target-bot").is_some());
+        assert!(runs.get("run-1").unwrap().terminal.is_none());
+    }
+
+    #[test]
+    fn timeout_is_recorded_without_a_configured_callback() {
+        let runs = Arc::new(AdminInvocationStore::default());
+        let mut run = admin_run("http://127.0.0.1:1/callback".to_string());
+        run.detach = true;
+        run.callback = None;
+        runs.insert("run-timeout".to_string(), run);
+        let observer = AdminInvocationTerminalObserver::new(
+            runs.clone(),
+            OutboundUrlGuard::allowing_private_networks_for_tests(),
+        );
+
+        observer.notify_timeout("run-timeout", "target timed out");
+
+        let terminal = runs.get("run-timeout").unwrap().terminal.unwrap();
+        assert_eq!(terminal.status, AdminInvocationTerminalStatus::TimedOut);
+        assert_eq!(terminal.text, "target timed out");
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/lib.rs
@@ -1,6 +1,7 @@
 //! HTTP delivery adapter for BCS.
 
 mod chat_digest;
+pub mod admin_invocation_terminal;
 pub mod error;
 pub mod headers;
 pub mod mapping;

--- a/src/bcs/crates/adapters/http/bcs-http/src/router.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/router.rs
@@ -101,6 +101,14 @@ fn build_api_routes() -> Router<HttpAppState> {
             "/providers/{provider_id}/organization-candidate-bots",
             get(routes::organizations::candidate_bots),
         )
+        .route(
+            "/organizations/{organization_code}/admin-runs",
+            post(routes::admin_invocations::create_admin_run),
+        )
+        .route(
+            "/organizations/{organization_code}/admin-runs/{run_id}",
+            get(routes::admin_invocations::get_admin_run),
+        )
         .route("/bot/events", post(routes::bot_events::post_bot_event))
         .route(
             "/bot/events/coordination",

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -1,4 +1,7 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    net::IpAddr,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use axum::{
     Json,
@@ -8,6 +11,7 @@ use axum::{
 };
 use bcs_domain::ProviderRecord;
 use bcs_protocol::BCN_PROVIDER_ID_HEADER;
+use bcs_route_security::OutboundUrlError;
 use bcs_service_api::{
     AsyncA2aChatCommand, BotActor, CallerContext, ChatResponseMode, ChatRunQueryCommand,
     ServiceError,
@@ -366,9 +370,44 @@ pub fn notify_terminal_callback(
     };
     let provider_id = run.provider_id;
     let run_id = run_id.to_string();
+    let outbound_url_guard = state.outbound_url_guard.clone();
     tokio::spawn(async move {
-        let response = reqwest::Client::new()
-            .post(callback.url)
+        let callback_url = callback_url_for_log(&callback.url);
+        let guarded_url = match outbound_url_guard.resolve_request_http_url(&callback.url).await {
+            Ok(url) => url,
+            Err(error) => {
+                warn!(
+                    run_id = %run_id,
+                    provider_id = %provider_id,
+                    callback_url = %callback_url,
+                    resolved_ip = ?callback_blocked_ip(&error),
+                    reason = %error,
+                    "organization admin terminal callback blocked by outbound URL policy"
+                );
+                return;
+            }
+        };
+        let mut client_builder = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none());
+        if let Some((host, addresses)) = guarded_url.dns_override() {
+            client_builder = client_builder.resolve_to_addrs(host, addresses);
+        }
+        let client = match client_builder.build() {
+            Ok(client) => client,
+            Err(error) => {
+                warn!(
+                    run_id = %run_id,
+                    provider_id = %provider_id,
+                    callback_url = %callback_url,
+                    error = %error,
+                    "organization admin terminal callback client creation failed"
+                );
+                return;
+            }
+        };
+        let response = client
+            .post(guarded_url.as_str())
             .header("content-type", "application/json")
             .header(BCN_PROVIDER_ID_HEADER, provider_id)
             .bearer_auth(callback.bearer_token)
@@ -527,9 +566,34 @@ fn new_admin_run_id() -> String {
     format!("run-{}", Uuid::new_v4().simple())
 }
 
+fn callback_blocked_ip(error: &OutboundUrlError) -> Option<IpAddr> {
+    match error {
+        OutboundUrlError::UnsafeAddress(address) => Some(*address),
+        _ => None,
+    }
+}
+
+fn callback_url_for_log(callback_url: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(callback_url) else {
+        return "<invalid callback URL>".to_string();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{default_admin_session_id, new_admin_run_id, valid_session_id};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use bcs_route_security::OutboundUrlError;
+
+    use super::{
+        callback_blocked_ip, callback_url_for_log, default_admin_session_id, new_admin_run_id,
+        valid_session_id,
+    };
 
     #[test]
     fn admin_run_id_uses_hyphenated_prefix() {
@@ -553,6 +617,20 @@ mod tests {
         assert!(valid_session_id("Session_name.1:part-a"));
         assert!(!valid_session_id(""));
         assert!(!valid_session_id("session/name"));
+    }
+
+    #[test]
+    fn callback_block_log_fields_include_rejected_ip_without_query() {
+        let blocked_ip = IpAddr::V4(Ipv4Addr::new(10, 24, 0, 8));
+        let error = OutboundUrlError::UnsafeAddress(blocked_ip);
+
+        assert_eq!(callback_blocked_ip(&error), Some(blocked_ip));
+        assert_eq!(
+            callback_url_for_log(
+                "https://bearer-token@provider.example.com/callback?token=secret#fragment",
+            ),
+            "https://provider.example.com/callback"
+        );
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -10,7 +10,7 @@ use bcs_domain::ProviderRecord;
 use bcs_protocol::BCN_PROVIDER_ID_HEADER;
 use bcs_service_api::{
     AsyncA2aChatCommand, BotActor, CallerContext, ChatResponseMode, ChatRunQueryCommand,
-    BotTerminalState, ServiceError,
+    BotTerminalState, OrganizationAuth, ServiceError,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -87,6 +87,11 @@ struct AdminRunError {
     message: String,
 }
 
+struct AuthenticatedOrganizationManager {
+    provider: ProviderRecord,
+    auth: OrganizationAuth,
+}
+
 pub async fn create_admin_run(
     State(state): State<HttpAppState>,
     Path(organization_code): Path<String>,
@@ -94,10 +99,11 @@ pub async fn create_admin_run(
     Json(request): Json<CreateAdminRunRequest>,
 ) -> Response {
     let request_id = request_id();
-    let provider = match authenticate_manager(&state, &headers, &organization_code).await {
-        Ok(provider) => provider,
+    let manager = match authenticate_manager(&state, &headers, &organization_code).await {
+        Ok(manager) => manager,
         Err(error) => return error.into_response_with_id(request_id),
     };
+    let provider = manager.provider;
     let provider_id = provider.provider_id.clone();
     let text = match validate_message(request.message) {
         Ok(text) => text,
@@ -114,8 +120,12 @@ pub async fn create_admin_run(
     }
     if let Err(error) = state
         .services
-        .organization
-        .require_effective_member(&organization_code, &request.target_bot_uuid)
+        .organization_management
+        .require_invocable_member(
+            manager.auth,
+            &organization_code,
+            &request.target_bot_uuid,
+        )
         .await
     {
         return service_error(error, request_id);
@@ -238,11 +248,11 @@ pub async fn get_admin_run(
     headers: HeaderMap,
 ) -> Response {
     let request_id = request_id();
-    let provider = match authenticate_manager(&state, &headers, &organization_code).await {
-        Ok(provider) => provider,
+    let manager = match authenticate_manager(&state, &headers, &organization_code).await {
+        Ok(manager) => manager,
         Err(error) => return error.into_response_with_id(request_id),
     };
-    let provider_id = provider.provider_id;
+    let provider_id = manager.provider.provider_id;
     let Some(run) = state
         .admin_invocation_runs
         .get_for_provider(&run_id, &provider_id)
@@ -407,7 +417,7 @@ async fn authenticate_manager(
     state: &HttpAppState,
     headers: &HeaderMap,
     organization_code: &str,
-) -> Result<ProviderRecord, AdminRunRouteError> {
+) -> Result<AuthenticatedOrganizationManager, AdminRunRouteError> {
     let token = extract_bearer_token(headers).ok_or_else(|| {
         AdminRunRouteError::new(
             StatusCode::UNAUTHORIZED,
@@ -453,12 +463,21 @@ async fn authenticate_manager(
             "provider is disabled",
         ));
     }
+    let auth = OrganizationAuth {
+        provider_id: provider.provider_id.clone(),
+        provider_admin_token: token.to_string(),
+    };
     let organization = state
         .services
-        .organization
-        .get_for_manager(&provider.provider_id, organization_code)
+        .organization_management
+        .get(auth.clone(), organization_code)
         .await
         .map_err(|error| match error {
+            ServiceError::Unauthorized(_) => AdminRunRouteError::new(
+                StatusCode::UNAUTHORIZED,
+                40101,
+                "invalid provider admin token",
+            ),
             ServiceError::InvalidOperation { .. } => {
                 AdminRunRouteError::new(StatusCode::NOT_FOUND, 40401, "organization not found")
             }
@@ -480,7 +499,7 @@ async fn authenticate_manager(
             "organization manager required",
         ));
     }
-    Ok(provider)
+    Ok(AuthenticatedOrganizationManager { provider, auth })
 }
 
 async fn callback_snapshot(

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -119,10 +119,10 @@ pub async fn create_admin_run(
         return service_error(error, request_id);
     }
 
-    let run_id = format!("run_{}", Uuid::new_v4().simple());
+    let run_id = new_admin_run_id();
     let session_id = request
         .session_id
-        .unwrap_or_else(|| format!("admin:{run_id}"));
+        .unwrap_or_else(|| default_admin_session_id(&run_id));
     if !valid_session_id(&session_id) {
         return response_error(
             StatusCode::BAD_REQUEST,
@@ -516,7 +516,44 @@ fn valid_session_id(value: &str) -> bool {
     !value.is_empty()
         && value
             .chars()
-            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '-' | ':'))
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':'))
+}
+
+fn default_admin_session_id(run_id: &str) -> String {
+    format!("admin-{run_id}")
+}
+
+fn new_admin_run_id() -> String {
+    format!("run-{}", Uuid::new_v4().simple())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{default_admin_session_id, new_admin_run_id, valid_session_id};
+
+    #[test]
+    fn admin_run_id_uses_hyphenated_prefix() {
+        let run_id = new_admin_run_id();
+
+        assert!(run_id.starts_with("run-"));
+        assert!(!run_id.contains('_'));
+    }
+
+    #[test]
+    fn default_session_id_is_valid_and_derived_from_run_id() {
+        let run_id = "run-7f3a2b1c";
+        let session_id = default_admin_session_id(run_id);
+
+        assert_eq!(session_id, "admin-run-7f3a2b1c");
+        assert!(valid_session_id(&session_id));
+    }
+
+    #[test]
+    fn session_id_accepts_simple_identifier_characters() {
+        assert!(valid_session_id("Session_name.1:part-a"));
+        assert!(!valid_session_id(""));
+        assert!(!valid_session_id("session/name"));
+    }
 }
 
 fn schedule_timeout_callback(state: HttpAppState, run_id: String, timeout_ms: u64) {

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -1,7 +1,4 @@
-use std::{
-    net::IpAddr,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::{
     Json,
@@ -11,14 +8,13 @@ use axum::{
 };
 use bcs_domain::ProviderRecord;
 use bcs_protocol::BCN_PROVIDER_ID_HEADER;
-use bcs_route_security::OutboundUrlError;
 use bcs_service_api::{
     AsyncA2aChatCommand, BotActor, CallerContext, ChatResponseMode, ChatRunQueryCommand,
-    ServiceError,
+    BotTerminalState, ServiceError,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tracing::{info, warn};
+use tracing::info;
 use uuid::Uuid;
 
 use crate::{
@@ -354,78 +350,17 @@ pub fn notify_terminal_callback(
     terminal_state: &str,
     text: &str,
 ) {
-    if !matches!(terminal_state, "final" | "error" | "aborted") {
-        return;
-    }
-    let Some(run) = state.admin_invocation_runs.claim_callback(run_id) else {
-        return;
+    let terminal_state = match terminal_state {
+        "final" => BotTerminalState::Final,
+        "error" => BotTerminalState::Error,
+        "aborted" => BotTerminalState::Aborted,
+        _ => return,
     };
-    let Some(callback) = run.callback else {
-        return;
-    };
-    let body = if terminal_state == "final" {
-        json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "completed", "message": { "role": "assistant", "content": [{ "type": "text", "text": text }] } })
-    } else {
-        json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "failed", "error": { "code": "ADMIN_INVOCATION_TARGET_FAILED", "message": text } })
-    };
-    let provider_id = run.provider_id;
-    let run_id = run_id.to_string();
-    let outbound_url_guard = state.outbound_url_guard.clone();
-    tokio::spawn(async move {
-        let callback_url = callback_url_for_log(&callback.url);
-        let guarded_url = match outbound_url_guard.resolve_request_http_url(&callback.url).await {
-            Ok(url) => url,
-            Err(error) => {
-                warn!(
-                    run_id = %run_id,
-                    provider_id = %provider_id,
-                    callback_url = %callback_url,
-                    resolved_ip = ?callback_blocked_ip(&error),
-                    reason = %error,
-                    "organization admin terminal callback blocked by outbound URL policy"
-                );
-                return;
-            }
-        };
-        let mut client_builder = reqwest::Client::builder()
-            .no_proxy()
-            .redirect(reqwest::redirect::Policy::none());
-        if let Some((host, addresses)) = guarded_url.dns_override() {
-            client_builder = client_builder.resolve_to_addrs(host, addresses);
-        }
-        let client = match client_builder.build() {
-            Ok(client) => client,
-            Err(error) => {
-                warn!(
-                    run_id = %run_id,
-                    provider_id = %provider_id,
-                    callback_url = %callback_url,
-                    error = %error,
-                    "organization admin terminal callback client creation failed"
-                );
-                return;
-            }
-        };
-        let response = client
-            .post(guarded_url.as_str())
-            .header("content-type", "application/json")
-            .header(BCN_PROVIDER_ID_HEADER, provider_id)
-            .bearer_auth(callback.bearer_token)
-            .json(&body)
-            .send()
-            .await;
-        match response {
-            Ok(response) if response.status().is_success() => {
-                info!(run_id = %run_id, "organization admin terminal callback acknowledged")
-            }
-            Ok(response) => {
-                warn!(run_id = %run_id, status = %response.status(), "organization admin terminal callback was not acknowledged")
-            }
-            Err(error) => {
-                warn!(run_id = %run_id, error = %error, "organization admin terminal callback failed")
-            }
-        }
-    });
+    crate::admin_invocation_terminal::AdminInvocationTerminalObserver::new(
+        state.admin_invocation_runs.clone(),
+        state.outbound_url_guard.clone(),
+    )
+    .notify(run_id, terminal_state, text);
 }
 
 async fn authenticate_manager(
@@ -566,34 +501,15 @@ fn new_admin_run_id() -> String {
     format!("run-{}", Uuid::new_v4().simple())
 }
 
-fn callback_blocked_ip(error: &OutboundUrlError) -> Option<IpAddr> {
-    match error {
-        OutboundUrlError::UnsafeAddress(address) => Some(*address),
-        _ => None,
-    }
-}
-
-fn callback_url_for_log(callback_url: &str) -> String {
-    let Ok(mut url) = reqwest::Url::parse(callback_url) else {
-        return "<invalid callback URL>".to_string();
-    };
-    let _ = url.set_username("");
-    let _ = url.set_password(None);
-    url.set_query(None);
-    url.set_fragment(None);
-    url.to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     use bcs_route_security::OutboundUrlError;
 
-    use super::{
-        callback_blocked_ip, callback_url_for_log, default_admin_session_id, new_admin_run_id,
-        valid_session_id,
-    };
+    use crate::admin_invocation_terminal::{callback_blocked_ip, callback_url_for_log};
+
+    use super::{default_admin_session_id, new_admin_run_id, valid_session_id};
 
     #[test]
     fn admin_run_id_uses_hyphenated_prefix() {

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -19,7 +19,9 @@ use uuid::Uuid;
 
 use crate::{
     headers::extract_bearer_token,
-    state::{AdminInvocationCallback, AdminInvocationRun, HttpAppState},
+    state::{
+        AdminInvocationCallback, AdminInvocationRun, AdminInvocationTerminalStatus, HttpAppState,
+    },
 };
 
 const DEFAULT_TIMEOUT_MS: u64 = 30 * 60 * 1000;
@@ -148,7 +150,8 @@ pub async fn create_admin_run(
             detach: request.detach,
             expires_at_ms,
             delivery_error: None,
-            callback: if request.detach { None } else { callback },
+            terminal: None,
+            callback,
             callback_claimed: false,
         },
     );
@@ -195,15 +198,11 @@ pub async fn create_admin_run(
             state
                 .admin_invocation_runs
                 .set_delivery_error(&run_id, message);
-            if !request.detach {
-                notify_terminal_callback(&state, &run_id, "error", "target bot delivery failed");
-            }
+            notify_terminal_callback(&state, &run_id, "error", "target bot delivery failed");
             "delivery_failed".to_string()
         }
     };
-    if !request.detach {
-        schedule_timeout_callback(state.clone(), run_id.clone(), timeout_ms);
-    }
+    schedule_timeout_callback(state.clone(), run_id.clone(), timeout_ms);
     let location = format!("/organizations/{organization_code}/admin-runs/{run_id}");
     let mut response = (
         StatusCode::ACCEPTED,
@@ -264,16 +263,57 @@ pub async fn get_admin_run(
         );
     }
     if run.detach {
-        let (status, error) = match run.delivery_error {
-            Some(message) => (
-                "delivery_failed".to_string(),
-                Some(AdminRunError {
-                    code: "ADMIN_INVOCATION_DELIVERY_FAILED",
-                    message,
-                }),
-            ),
-            None => ("dispatched".to_string(), None),
-        };
+        if let Some(message) = run.delivery_error {
+            return Json(Envelope {
+                code: 20000,
+                message: "ok".to_string(),
+                data: AdminRunView {
+                    run_id,
+                    provider_id,
+                    organization_code,
+                    target_bot_uuid: run.target_bot_uuid,
+                    session_id: run.session_id,
+                    status: "delivery_failed".to_string(),
+                    message: None,
+                    error: Some(AdminRunError {
+                        code: "ADMIN_INVOCATION_DELIVERY_FAILED",
+                        message,
+                    }),
+                },
+                request_id,
+            })
+            .into_response();
+        }
+        if let Some(terminal) = run.terminal {
+            let completed = terminal.status == AdminInvocationTerminalStatus::Completed;
+            let timed_out = terminal.status == AdminInvocationTerminalStatus::TimedOut;
+            return Json(Envelope {
+                code: 20000,
+                message: "ok".to_string(),
+                data: AdminRunView {
+                    run_id,
+                    provider_id,
+                    organization_code,
+                    target_bot_uuid: run.target_bot_uuid,
+                    session_id: run.session_id,
+                    status: if completed {
+                        "completed"
+                    } else if timed_out {
+                        "timed_out"
+                    } else {
+                        "failed"
+                    }
+                    .to_string(),
+                    message: completed.then(|| json!({ "role": "assistant", "content": [{ "type": "text", "text": terminal.text }] })),
+                    error: (!completed).then(|| AdminRunError {
+                        code: "ADMIN_INVOCATION_TARGET_FAILED",
+                        message: terminal.text,
+                    }),
+                },
+                request_id,
+            })
+            .into_response();
+        }
         return Json(Envelope {
             code: 20000,
             message: "ok".to_string(),
@@ -283,9 +323,9 @@ pub async fn get_admin_run(
                 organization_code,
                 target_bot_uuid: run.target_bot_uuid,
                 session_id: run.session_id,
-                status,
+                status: "dispatched".to_string(),
                 message: None,
-                error,
+                error: None,
             },
             request_id,
         })
@@ -553,31 +593,14 @@ mod tests {
 fn schedule_timeout_callback(state: HttpAppState, run_id: String, timeout_ms: u64) {
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_millis(timeout_ms)).await;
-        let Some(run) = state.admin_invocation_runs.get(&run_id) else {
-            return;
-        };
-        let result = state
-            .services
-            .a2a_chat_runs
-            .get_run(ChatRunQueryCommand {
-                caller: CallerContext::Bot(BotActor {
-                    bot_uuid: run.target_bot_uuid,
-                }),
-                run_id: run_id.clone(),
-                wait_ms: 0,
-                since_version: 0,
-            })
-            .await;
-        if let Ok(result) = result {
-            if matches!(result.status.as_str(), "timeout" | "timed_out" | "failed") {
-                notify_terminal_callback(
-                    &state,
-                    &run_id,
-                    "error",
-                    "target bot did not complete the run before timeout",
-                );
-            }
-        }
+        crate::admin_invocation_terminal::AdminInvocationTerminalObserver::new(
+            state.admin_invocation_runs.clone(),
+            state.outbound_url_guard.clone(),
+        )
+        .notify_timeout(
+            &run_id,
+            "target bot did not complete the run before timeout",
+        );
     });
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -1,0 +1,647 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use bcs_domain::ProviderRecord;
+use bcs_protocol::BCN_PROVIDER_ID_HEADER;
+use bcs_service_api::{
+    AsyncA2aChatCommand, BotActor, CallerContext, ChatResponseMode, ChatRunQueryCommand,
+    ServiceError,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::{
+    headers::extract_bearer_token,
+    state::{AdminInvocationCallback, AdminInvocationRun, HttpAppState},
+};
+
+const DEFAULT_TIMEOUT_MS: u64 = 30 * 60 * 1000;
+const MAX_TIMEOUT_MS: u64 = 30 * 60 * 1000;
+const RETENTION_MS: u64 = 60 * 60 * 1000;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateAdminRunRequest {
+    pub target_bot_uuid: String,
+    pub message: AdminRunMessage,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub detach: bool,
+    #[serde(default)]
+    pub run_timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AdminRunMessage {
+    pub role: String,
+    pub content: Vec<AdminRunContent>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AdminRunContent {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct GetAdminRunQuery {
+    #[serde(default)]
+    pub wait_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct Envelope<T: Serialize> {
+    code: u32,
+    message: String,
+    data: T,
+    request_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminRunView {
+    run_id: String,
+    provider_id: String,
+    organization_code: String,
+    target_bot_uuid: String,
+    session_id: String,
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<AdminRunError>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminRunError {
+    code: &'static str,
+    message: String,
+}
+
+pub async fn create_admin_run(
+    State(state): State<HttpAppState>,
+    Path(organization_code): Path<String>,
+    headers: HeaderMap,
+    Json(request): Json<CreateAdminRunRequest>,
+) -> Response {
+    let request_id = request_id();
+    let provider = match authenticate_manager(&state, &headers, &organization_code).await {
+        Ok(provider) => provider,
+        Err(error) => return error.into_response_with_id(request_id),
+    };
+    let provider_id = provider.provider_id.clone();
+    let text = match validate_message(request.message) {
+        Ok(text) => text,
+        Err(message) => return response_error(StatusCode::BAD_REQUEST, 40001, message, request_id),
+    };
+    let timeout_ms = request.run_timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
+    if timeout_ms == 0 || timeout_ms > MAX_TIMEOUT_MS {
+        return response_error(
+            StatusCode::BAD_REQUEST,
+            40001,
+            format!("run_timeout_ms must be between 1 and {MAX_TIMEOUT_MS}"),
+            request_id,
+        );
+    }
+    if let Err(error) = state
+        .services
+        .organization
+        .require_effective_member(&organization_code, &request.target_bot_uuid)
+        .await
+    {
+        return service_error(error, request_id);
+    }
+
+    let run_id = format!("run_{}", Uuid::new_v4().simple());
+    let session_id = request
+        .session_id
+        .unwrap_or_else(|| format!("admin:{run_id}"));
+    if !valid_session_id(&session_id) {
+        return response_error(
+            StatusCode::BAD_REQUEST,
+            40001,
+            "invalid session_id".to_string(),
+            request_id,
+        );
+    }
+    let callback = match callback_snapshot(&state, &provider).await {
+        Ok(callback) => callback,
+        Err(error) => return service_error(error, request_id),
+    };
+    let expires_at_ms = now_ms()
+        .saturating_add(timeout_ms)
+        .saturating_add(RETENTION_MS);
+    state.admin_invocation_runs.insert(
+        run_id.clone(),
+        AdminInvocationRun {
+            provider_id: provider_id.clone(),
+            organization_code: organization_code.clone(),
+            target_bot_uuid: request.target_bot_uuid.clone(),
+            session_id: session_id.clone(),
+            detach: request.detach,
+            expires_at_ms,
+            delivery_error: None,
+            callback: if request.detach { None } else { callback },
+            callback_claimed: false,
+        },
+    );
+
+    let delivered = state
+        .services
+        .a2a_chat_runs
+        .start_async_chat(AsyncA2aChatCommand {
+            // The established run engine only accepts a bot caller. The target bot
+            // is used as a synthetic execution principal after this route has
+            // performed the manager and effective-membership authorization above.
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: request.target_bot_uuid.clone(),
+            }),
+            target_bot_id: request.target_bot_uuid.clone(),
+            message: text,
+            from_actor_id: Some("organization-admin".to_string()),
+            run_channel_from: None,
+            authenticated_staff_id: None,
+            run_id: run_id.clone(),
+            session_key: session_id.clone(),
+            timeout_ms,
+            client: Some("organization-admin".to_string()),
+            tags: Vec::new(),
+            response_mode: ChatResponseMode::Full,
+            caller_wait_mode: request.detach.then(|| "detached".to_string()),
+            organization_code: Some(organization_code.clone()),
+        })
+        .await;
+
+    let status = match delivered {
+        Ok(accepted) if request.detach => {
+            info!(run_id = %run_id, provider_id = %provider_id, "organization admin detached run dispatched");
+            if accepted.status == "failed" {
+                "delivery_failed"
+            } else {
+                "dispatched"
+            }
+            .to_string()
+        }
+        Ok(accepted) => accepted.status,
+        Err(error) => {
+            let message = error.to_string();
+            state
+                .admin_invocation_runs
+                .set_delivery_error(&run_id, message);
+            if !request.detach {
+                notify_terminal_callback(&state, &run_id, "error", "target bot delivery failed");
+            }
+            "delivery_failed".to_string()
+        }
+    };
+    if !request.detach {
+        schedule_timeout_callback(state.clone(), run_id.clone(), timeout_ms);
+    }
+    let location = format!("/organizations/{organization_code}/admin-runs/{run_id}");
+    let mut response = (
+        StatusCode::ACCEPTED,
+        Json(Envelope {
+            code: 20000,
+            message: "accepted".to_string(),
+            data: AdminRunView {
+                run_id,
+                provider_id,
+                organization_code,
+                target_bot_uuid: request.target_bot_uuid,
+                session_id,
+                status,
+                message: None,
+                error: None,
+            },
+            request_id,
+        }),
+    )
+        .into_response();
+    if let Ok(location) = axum::http::HeaderValue::from_str(&location) {
+        response
+            .headers_mut()
+            .insert(axum::http::header::LOCATION, location);
+    }
+    response
+}
+
+pub async fn get_admin_run(
+    State(state): State<HttpAppState>,
+    Path((organization_code, run_id)): Path<(String, String)>,
+    Query(query): Query<GetAdminRunQuery>,
+    headers: HeaderMap,
+) -> Response {
+    let request_id = request_id();
+    let provider = match authenticate_manager(&state, &headers, &organization_code).await {
+        Ok(provider) => provider,
+        Err(error) => return error.into_response_with_id(request_id),
+    };
+    let provider_id = provider.provider_id;
+    let Some(run) = state
+        .admin_invocation_runs
+        .get_for_provider(&run_id, &provider_id)
+    else {
+        return response_error(
+            StatusCode::NOT_FOUND,
+            40402,
+            "admin run not found".to_string(),
+            request_id,
+        );
+    };
+    if run.organization_code != organization_code {
+        return response_error(
+            StatusCode::NOT_FOUND,
+            40402,
+            "admin run not found".to_string(),
+            request_id,
+        );
+    }
+    if run.detach {
+        let (status, error) = match run.delivery_error {
+            Some(message) => (
+                "delivery_failed".to_string(),
+                Some(AdminRunError {
+                    code: "ADMIN_INVOCATION_DELIVERY_FAILED",
+                    message,
+                }),
+            ),
+            None => ("dispatched".to_string(), None),
+        };
+        return Json(Envelope {
+            code: 20000,
+            message: "ok".to_string(),
+            data: AdminRunView {
+                run_id,
+                provider_id,
+                organization_code,
+                target_bot_uuid: run.target_bot_uuid,
+                session_id: run.session_id,
+                status,
+                message: None,
+                error,
+            },
+            request_id,
+        })
+        .into_response();
+    }
+    if let Some(message) = run.delivery_error {
+        return Json(Envelope {
+            code: 20000,
+            message: "ok".to_string(),
+            data: AdminRunView {
+                run_id,
+                provider_id,
+                organization_code,
+                target_bot_uuid: run.target_bot_uuid,
+                session_id: run.session_id,
+                status: "failed".to_string(),
+                message: None,
+                error: Some(AdminRunError {
+                    code: "ADMIN_INVOCATION_DELIVERY_FAILED",
+                    message,
+                }),
+            },
+            request_id,
+        })
+        .into_response();
+    }
+    let result = state
+        .services
+        .a2a_chat_runs
+        .get_run(ChatRunQueryCommand {
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: run.target_bot_uuid.clone(),
+            }),
+            run_id: run_id.clone(),
+            wait_ms: query.wait_ms.min(state.async_chat_poll_wait_max_ms),
+            since_version: 0,
+        })
+        .await;
+    let view = match result {
+        Ok(result) => run_view_from_a2a(
+            run_id,
+            provider_id,
+            organization_code,
+            run,
+            result.status,
+            result.response,
+        ),
+        Err(error) => return service_error(error, request_id),
+    };
+    Json(Envelope {
+        code: 20000,
+        message: "ok".to_string(),
+        data: view,
+        request_id,
+    })
+    .into_response()
+}
+
+pub fn notify_terminal_callback(
+    state: &HttpAppState,
+    run_id: &str,
+    terminal_state: &str,
+    text: &str,
+) {
+    if !matches!(terminal_state, "final" | "error" | "aborted") {
+        return;
+    }
+    let Some(run) = state.admin_invocation_runs.claim_callback(run_id) else {
+        return;
+    };
+    let Some(callback) = run.callback else {
+        return;
+    };
+    let body = if terminal_state == "final" {
+        json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "completed", "message": { "role": "assistant", "content": [{ "type": "text", "text": text }] } })
+    } else {
+        json!({ "run_id": run_id, "provider_id": run.provider_id, "status": "failed", "error": { "code": "ADMIN_INVOCATION_TARGET_FAILED", "message": text } })
+    };
+    let provider_id = run.provider_id;
+    let run_id = run_id.to_string();
+    tokio::spawn(async move {
+        let response = reqwest::Client::new()
+            .post(callback.url)
+            .header("content-type", "application/json")
+            .header(BCN_PROVIDER_ID_HEADER, provider_id)
+            .bearer_auth(callback.bearer_token)
+            .json(&body)
+            .send()
+            .await;
+        match response {
+            Ok(response) if response.status().is_success() => {
+                info!(run_id = %run_id, "organization admin terminal callback acknowledged")
+            }
+            Ok(response) => {
+                warn!(run_id = %run_id, status = %response.status(), "organization admin terminal callback was not acknowledged")
+            }
+            Err(error) => {
+                warn!(run_id = %run_id, error = %error, "organization admin terminal callback failed")
+            }
+        }
+    });
+}
+
+async fn authenticate_manager(
+    state: &HttpAppState,
+    headers: &HeaderMap,
+    organization_code: &str,
+) -> Result<ProviderRecord, AdminRunRouteError> {
+    let token = extract_bearer_token(headers).ok_or_else(|| {
+        AdminRunRouteError::new(
+            StatusCode::UNAUTHORIZED,
+            40101,
+            "valid provider admin token is required",
+        )
+    })?;
+    let provider = state
+        .services
+        .provider_core
+        .authenticate_provider_admin(&token)
+        .await
+        .map_err(|_| {
+            AdminRunRouteError::new(
+                StatusCode::UNAUTHORIZED,
+                40101,
+                "invalid provider admin token",
+            )
+        })?;
+    let header_provider_id = headers
+        .get(BCN_PROVIDER_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            AdminRunRouteError::new(
+                StatusCode::BAD_REQUEST,
+                40001,
+                "X-BCN-Provider-Id header is required",
+            )
+        })?;
+    if header_provider_id != provider.provider_id {
+        return Err(AdminRunRouteError::new(
+            StatusCode::FORBIDDEN,
+            40301,
+            "provider header does not match token",
+        ));
+    }
+    if provider.disabled {
+        return Err(AdminRunRouteError::new(
+            StatusCode::FORBIDDEN,
+            40302,
+            "provider is disabled",
+        ));
+    }
+    let organization = state
+        .services
+        .organization
+        .get_for_manager(&provider.provider_id, organization_code)
+        .await
+        .map_err(|error| match error {
+            ServiceError::InvalidOperation { .. } => {
+                AdminRunRouteError::new(StatusCode::NOT_FOUND, 40401, "organization not found")
+            }
+            ServiceError::Forbidden(_) => AdminRunRouteError::new(
+                StatusCode::FORBIDDEN,
+                40302,
+                "organization manager required",
+            ),
+            _ => AdminRunRouteError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                50001,
+                "organization authorization failed",
+            ),
+        })?;
+    if organization.managing_provider_id != provider.provider_id {
+        return Err(AdminRunRouteError::new(
+            StatusCode::FORBIDDEN,
+            40302,
+            "organization manager required",
+        ));
+    }
+    Ok(provider)
+}
+
+async fn callback_snapshot(
+    state: &HttpAppState,
+    provider: &ProviderRecord,
+) -> Result<Option<AdminInvocationCallback>, ServiceError> {
+    let config: Value =
+        serde_json::from_str(&provider.config).map_err(|error| ServiceError::InvalidOperation {
+            message: format!("invalid provider config: {error}"),
+            request_id: None,
+        })?;
+    let Some(url) = config
+        .get("admin_callback_url")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return Ok(None);
+    };
+    let credential = state
+        .services
+        .provider_core
+        .get_downlink_credential(&provider.provider_id)
+        .await?;
+    Ok(Some(AdminInvocationCallback {
+        url,
+        bearer_token: credential.secret_value,
+    }))
+}
+
+fn validate_message(message: AdminRunMessage) -> Result<String, String> {
+    if message.role != "user" || message.content.len() != 1 || message.content[0].kind != "text" {
+        return Err("message must contain exactly one user text content block".to_string());
+    }
+    let text = message
+        .content
+        .into_iter()
+        .next()
+        .expect("checked length")
+        .text;
+    if text.trim().is_empty() {
+        return Err("message text must not be empty".to_string());
+    }
+    Ok(text)
+}
+
+fn valid_session_id(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '-' | ':'))
+}
+
+fn schedule_timeout_callback(state: HttpAppState, run_id: String, timeout_ms: u64) {
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(timeout_ms)).await;
+        let Some(run) = state.admin_invocation_runs.get(&run_id) else {
+            return;
+        };
+        let result = state
+            .services
+            .a2a_chat_runs
+            .get_run(ChatRunQueryCommand {
+                caller: CallerContext::Bot(BotActor {
+                    bot_uuid: run.target_bot_uuid,
+                }),
+                run_id: run_id.clone(),
+                wait_ms: 0,
+                since_version: 0,
+            })
+            .await;
+        if let Ok(result) = result {
+            if matches!(result.status.as_str(), "timeout" | "timed_out" | "failed") {
+                notify_terminal_callback(
+                    &state,
+                    &run_id,
+                    "error",
+                    "target bot did not complete the run before timeout",
+                );
+            }
+        }
+    });
+}
+
+fn run_view_from_a2a(
+    run_id: String,
+    provider_id: String,
+    organization_code: String,
+    run: AdminInvocationRun,
+    status: String,
+    response: Option<Value>,
+) -> AdminRunView {
+    let terminal_error = matches!(status.as_str(), "failed" | "timed_out" | "timeout");
+    let message = response.as_ref().and_then(|value| value.get("content").or_else(|| value.get("message"))).cloned().map(|text| json!({ "role": "assistant", "content": [{ "type": "text", "text": text.as_str().unwrap_or_default() }] }));
+    AdminRunView {
+        run_id,
+        provider_id,
+        organization_code,
+        target_bot_uuid: run.target_bot_uuid,
+        session_id: run.session_id,
+        status: if status == "timeout" {
+            "timed_out".to_string()
+        } else {
+            status
+        },
+        message: if terminal_error { None } else { message },
+        error: terminal_error.then(|| AdminRunError {
+            code: "ADMIN_INVOCATION_TARGET_FAILED",
+            message: "target bot did not complete the run".to_string(),
+        }),
+    }
+}
+
+#[derive(Debug)]
+struct AdminRunRouteError {
+    status: StatusCode,
+    code: u32,
+    message: String,
+}
+impl AdminRunRouteError {
+    fn new(status: StatusCode, code: u32, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+        }
+    }
+    fn into_response_with_id(self, request_id: String) -> Response {
+        response_error(self.status, self.code, self.message, request_id)
+    }
+}
+
+fn service_error(error: ServiceError, request_id: String) -> Response {
+    match error {
+        ServiceError::Forbidden(_) => response_error(
+            StatusCode::FORBIDDEN,
+            40303,
+            "target bot is not an effective organization member".to_string(),
+            request_id,
+        ),
+        ServiceError::InvalidOperation { message, .. } => {
+            response_error(StatusCode::BAD_REQUEST, 40001, message, request_id)
+        }
+        ServiceError::BotNotFound(_) => response_error(
+            StatusCode::NOT_FOUND,
+            40402,
+            "admin run not found".to_string(),
+            request_id,
+        ),
+        other => response_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            50001,
+            other.to_string(),
+            request_id,
+        ),
+    }
+}
+
+fn response_error(status: StatusCode, code: u32, message: String, request_id: String) -> Response {
+    (
+        status,
+        Json(Envelope {
+            code,
+            message,
+            data: json!({}),
+            request_id,
+        }),
+    )
+        .into_response()
+}
+fn request_id() -> String {
+    format!("req_{}", Uuid::new_v4().simple())
+}
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -564,11 +564,60 @@ fn new_admin_run_id() -> String {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
+    use axum::body::to_bytes;
+    use bcs_domain::ProviderRecord;
     use bcs_route_security::OutboundUrlError;
+    use bcs_service_api::ServiceError;
+    use bcs_services_container::Services;
+    use serde_json::{Value, json};
 
     use crate::admin_invocation_terminal::{callback_blocked_ip, callback_url_for_log};
+    use crate::state::{AdminInvocationRun, AdminInvocationTerminalStatus, HttpAppState};
 
-    use super::{default_admin_session_id, new_admin_run_id, valid_session_id};
+    use super::{
+        AdminRunContent, AdminRunMessage, callback_snapshot, default_admin_session_id,
+        new_admin_run_id, notify_terminal_callback, run_view_from_a2a, schedule_timeout_callback,
+        service_error, valid_session_id, validate_message,
+    };
+
+    fn test_state() -> HttpAppState {
+        HttpAppState::new(Services::builder().build_for_test())
+    }
+
+    fn provider_with_config(config: &str) -> ProviderRecord {
+        ProviderRecord {
+            provider_id: "provider-a".to_string(),
+            name: "Provider A".to_string(),
+            config: config.to_string(),
+            created_by: "admin".to_string(),
+            owners: "[]".to_string(),
+            disabled: false,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    fn stored_run(run_id: &str) -> AdminInvocationRun {
+        AdminInvocationRun {
+            provider_id: "provider-a".to_string(),
+            organization_code: "engineering".to_string(),
+            target_bot_uuid: "bot-target".to_string(),
+            session_id: format!("admin-{run_id}"),
+            detach: false,
+            expires_at_ms: u64::MAX,
+            delivery_error: None,
+            terminal: None,
+            callback: None,
+            callback_claimed: false,
+        }
+    }
+
+    async fn response_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        serde_json::from_slice(&bytes).expect("response JSON")
+    }
 
     #[test]
     fn admin_run_id_uses_hyphenated_prefix() {
@@ -605,6 +654,176 @@ mod tests {
                 "https://bearer-token@provider.example.com/callback?token=secret#fragment",
             ),
             "https://provider.example.com/callback"
+        );
+    }
+
+    #[test]
+    fn admin_message_requires_one_non_empty_user_text_block() {
+        let message = |role: &str, kind: &str, text: &str| AdminRunMessage {
+            role: role.to_string(),
+            content: vec![AdminRunContent {
+                kind: kind.to_string(),
+                text: text.to_string(),
+            }],
+        };
+
+        assert_eq!(
+            validate_message(message("user", "text", "review this")),
+            Ok("review this".to_string())
+        );
+        assert!(validate_message(message("assistant", "text", "review this")).is_err());
+        assert!(validate_message(message("user", "image", "review this")).is_err());
+        assert!(validate_message(message("user", "text", "  ")).is_err());
+        assert!(
+            validate_message(AdminRunMessage {
+                role: "user".to_string(),
+                content: Vec::new(),
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn a2a_run_view_maps_success_and_terminal_failures() {
+        let completed = run_view_from_a2a(
+            "run-completed".to_string(),
+            "provider-a".to_string(),
+            "engineering".to_string(),
+            stored_run("run-completed"),
+            "completed".to_string(),
+            Some(json!({ "content": "finished" })),
+        );
+        assert_eq!(completed.status, "completed");
+        assert_eq!(
+            completed.message,
+            Some(json!({
+                "role": "assistant",
+                "content": [{ "type": "text", "text": "finished" }]
+            }))
+        );
+        assert!(completed.error.is_none());
+
+        for status in ["failed", "timed_out", "timeout"] {
+            let view = run_view_from_a2a(
+                format!("run-{status}"),
+                "provider-a".to_string(),
+                "engineering".to_string(),
+                stored_run(&format!("run-{status}")),
+                status.to_string(),
+                Some(json!({ "message": "ignored on terminal error" })),
+            );
+            assert_eq!(
+                view.status,
+                if status == "timeout" {
+                    "timed_out"
+                } else {
+                    status
+                }
+            );
+            assert!(view.message.is_none());
+            let error = view.error.expect("terminal error");
+            assert_eq!(error.code, "ADMIN_INVOCATION_TARGET_FAILED");
+        }
+    }
+
+    #[tokio::test]
+    async fn service_errors_use_the_admin_run_envelope_contract() {
+        let cases = [
+            (
+                ServiceError::Forbidden("not a member".to_string()),
+                axum::http::StatusCode::FORBIDDEN,
+                40303,
+                "target bot is not an effective organization member",
+            ),
+            (
+                ServiceError::InvalidOperation {
+                    message: "invalid request".to_string(),
+                    request_id: None,
+                },
+                axum::http::StatusCode::BAD_REQUEST,
+                40001,
+                "invalid request",
+            ),
+            (
+                ServiceError::BotNotFound("bot-target".to_string()),
+                axum::http::StatusCode::NOT_FOUND,
+                40402,
+                "admin run not found",
+            ),
+            (
+                ServiceError::InternalError("storage unavailable".to_string()),
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                50001,
+                "Internal error: storage unavailable",
+            ),
+        ];
+
+        for (error, expected_status, expected_code, expected_message) in cases {
+            let response = service_error(error, "req-test".to_string());
+            assert_eq!(response.status(), expected_status);
+            let body = response_json(response).await;
+            assert_eq!(body["code"], expected_code);
+            assert_eq!(body["message"], expected_message);
+            assert_eq!(body["request_id"], "req-test");
+        }
+    }
+
+    #[tokio::test]
+    async fn callback_snapshot_validates_config_and_timeout_marks_the_run() {
+        let state = test_state();
+
+        assert!(
+            callback_snapshot(&state, &provider_with_config("not-json"))
+                .await
+                .is_err()
+        );
+        assert!(
+            callback_snapshot(&state, &provider_with_config("{}"))
+                .await
+                .expect("callback snapshot")
+                .is_none()
+        );
+        assert!(
+            callback_snapshot(
+                &state,
+                &provider_with_config(
+                    r#"{"admin_callback_url":"https://provider.example/callback"}"#
+                ),
+            )
+            .await
+            .is_err()
+        );
+
+        let run_id = "run-timeout";
+        state
+            .admin_invocation_runs
+            .insert(run_id.to_string(), stored_run(run_id));
+        schedule_timeout_callback(state.clone(), run_id.to_string(), 0);
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(terminal) = state
+                    .admin_invocation_runs
+                    .get_for_provider(run_id, "provider-a")
+                    .and_then(|run| run.terminal)
+                {
+                    break terminal;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("timeout terminal");
+        assert_eq!(terminal.status, AdminInvocationTerminalStatus::TimedOut);
+
+        notify_terminal_callback(&state, run_id, "unknown", "ignored");
+        let terminal_after_unknown = state
+            .admin_invocation_runs
+            .get_for_provider(run_id, "provider-a")
+            .and_then(|run| run.terminal)
+            .expect("timeout terminal remains");
+        assert_eq!(
+            terminal_after_unknown.status,
+            AdminInvocationTerminalStatus::TimedOut
         );
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -244,9 +244,6 @@ pub async fn post_bot_event(
         "provider callback: received bot event"
     );
     let credential = credential_from_headers(&state, &headers, &provider_id).await?;
-    let callback_run_id = req.run_id.clone();
-    let callback_state = effective_state.clone();
-    let callback_message_text = req.message.text.clone();
 
     let outcome = match state
         .services
@@ -277,18 +274,6 @@ pub async fn post_bot_event(
         delivered_count = %outcome.delivered_count,
         failed_count = %outcome.failed_count,
         "provider callback: bot event processed"
-    );
-
-    crate::routes::admin_invocations::notify_terminal_callback(
-        &state,
-        &callback_run_id,
-        match callback_state {
-            ChatEventState::Final => "final",
-            ChatEventState::Error => "error",
-            ChatEventState::Aborted => "aborted",
-            _ => "non_terminal",
-        },
-        &callback_message_text,
     );
 
     Ok(Json(json!({

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -244,6 +244,9 @@ pub async fn post_bot_event(
         "provider callback: received bot event"
     );
     let credential = credential_from_headers(&state, &headers, &provider_id).await?;
+    let callback_run_id = req.run_id.clone();
+    let callback_state = effective_state.clone();
+    let callback_message_text = req.message.text.clone();
 
     let outcome = match state
         .services
@@ -274,6 +277,18 @@ pub async fn post_bot_event(
         delivered_count = %outcome.delivered_count,
         failed_count = %outcome.failed_count,
         "provider callback: bot event processed"
+    );
+
+    crate::routes::admin_invocations::notify_terminal_callback(
+        &state,
+        &callback_run_id,
+        match callback_state {
+            ChatEventState::Final => "final",
+            ChatEventState::Error => "error",
+            ChatEventState::Aborted => "aborted",
+            _ => "non_terminal",
+        },
+        &callback_message_text,
     );
 
     Ok(Json(json!({
@@ -339,9 +354,8 @@ fn header_required(headers: &HeaderMap, name: &'static str) -> Result<String, Bo
 }
 
 fn bearer_token(headers: &HeaderMap) -> Result<String, BotEventRouteError> {
-    crate::headers::extract_bearer_token(headers).ok_or_else(|| {
-        BotEventRouteError::unauthorized("valid bot runtime token is required")
-    })
+    crate::headers::extract_bearer_token(headers)
+        .ok_or_else(|| BotEventRouteError::unauthorized("valid bot runtime token is required"))
 }
 
 async fn credential_from_headers(
@@ -381,9 +395,7 @@ fn coordination_kind_from_wire(
     kind: ProviderCoordinationEventKindDto,
 ) -> ProviderCoordinationEventKind {
     match kind {
-        ProviderCoordinationEventKindDto::ToolResult => {
-            ProviderCoordinationEventKind::ToolResult
-        }
+        ProviderCoordinationEventKindDto::ToolResult => ProviderCoordinationEventKind::ToolResult,
         ProviderCoordinationEventKindDto::CoordinationIntent => {
             ProviderCoordinationEventKind::CoordinationIntent
         }
@@ -395,25 +407,19 @@ fn bot_event_error(error: ProviderBotEventError) -> BotEventRouteError {
         ProviderBotEventError::Unauthorized(message) if message == "auth_mode_mismatch" => {
             BotEventRouteError::auth_mode_mismatch(message)
         }
-        ProviderBotEventError::Unauthorized(message) => {
-            BotEventRouteError::unauthorized(message)
-        }
+        ProviderBotEventError::Unauthorized(message) => BotEventRouteError::unauthorized(message),
         ProviderBotEventError::Forbidden(message) if message == "provider_id_mismatch" => {
             BotEventRouteError::provider_id_mismatch()
         }
         ProviderBotEventError::Forbidden(message) => BotEventRouteError::forbidden(message),
-        ProviderBotEventError::InvalidRequest(message) => {
-            BotEventRouteError::bad_request(message)
-        }
+        ProviderBotEventError::InvalidRequest(message) => BotEventRouteError::bad_request(message),
         ProviderBotEventError::RunNotFound(message) => BotEventRouteError::not_found(message),
         ProviderBotEventError::RunTerminated(message) => BotEventRouteError::gone(message),
         ProviderBotEventError::BotNotFound(bot_id) => {
             BotEventRouteError::bot_not_found(format!("bot not found: {bot_id}"))
         }
-        ProviderBotEventError::Internal(message) => BotEventRouteError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "internal_error",
-            message,
-        ),
+        ProviderBotEventError::Internal(message) => {
+            BotEventRouteError::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
+        }
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod actors;
+pub mod admin_invocations;
 pub mod assets;
 pub mod bot_chat;
 pub mod bot_events;

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -83,6 +83,7 @@ pub async fn register_provider(
         .register_provider(RegisterProviderCommand {
             name: req.name,
             webhook_url: req.webhook_url,
+            admin_callback_url: req.admin_callback_url,
             auth_mode: auth_mode_from_wire(req.auth.mode),
             created_by,
             protocol_version: req.protocol_version,
@@ -141,7 +142,9 @@ pub async fn get_provider(
         .get_provider(&provider_id, &provider_admin_token)
         .await
         .map_err(provider_error)?;
-    Ok(Json(provider_to_response(provider).map_err(provider_error)?))
+    Ok(Json(
+        provider_to_response(provider).map_err(provider_error)?,
+    ))
 }
 
 pub async fn patch_provider(
@@ -162,6 +165,7 @@ pub async fn patch_provider(
             authenticated_staff_id,
             name: req.name,
             webhook_url: req.webhook_url,
+            admin_callback_url: req.admin_callback_url,
             protocol_version: req.protocol_version,
             coordination: req.coordination.map(coordination_from_wire),
             organization_management: req
@@ -170,7 +174,9 @@ pub async fn patch_provider(
         })
         .await
         .map_err(provider_error)?;
-    Ok(Json(provider_to_response(provider).map_err(provider_error)?))
+    Ok(Json(
+        provider_to_response(provider).map_err(provider_error)?,
+    ))
 }
 
 pub async fn register_provider_bot(
@@ -362,7 +368,9 @@ async fn set_provider_disabled(
         )
         .await
         .map_err(provider_error)?;
-    Ok(Json(provider_to_response(provider).map_err(provider_error)?))
+    Ok(Json(
+        provider_to_response(provider).map_err(provider_error)?,
+    ))
 }
 
 fn auth_mode_from_wire(mode: ProviderAuthModeDto) -> ProviderAuthMode {
@@ -488,6 +496,10 @@ fn provider_to_response(provider: ProviderRecord) -> Result<ProviderInfoResponse
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_string();
+    let admin_callback_url = config
+        .get("admin_callback_url")
+        .and_then(Value::as_str)
+        .map(str::to_string);
     let auth_mode = downlink
         .get("auth_mode")
         .and_then(Value::as_str)
@@ -506,6 +518,7 @@ fn provider_to_response(provider: ProviderRecord) -> Result<ProviderInfoResponse
         provider_id: provider.provider_id,
         name: provider.name,
         webhook_url,
+        admin_callback_url,
         auth_mode,
         coordination,
         organization_management,
@@ -562,10 +575,7 @@ pub async fn switch_bot_delivery(
         });
     }
 
-    if !state
-        .allowed_switch_provider_ids
-        .contains(&provider_id)
-    {
+    if !state.allowed_switch_provider_ids.contains(&provider_id) {
         return Err(ProviderRouteError {
             status: StatusCode::FORBIDDEN,
             message: format!(
@@ -609,7 +619,10 @@ fn switch_delivery_error(error: BotUseCaseError) -> ProviderRouteError {
             status: StatusCode::NOT_FOUND,
             message: format!("Provider '{}' not found", p),
         },
-        BotUseCaseError::ProviderNotReadyForDownlink { provider_id, reason } => ProviderRouteError {
+        BotUseCaseError::ProviderNotReadyForDownlink {
+            provider_id,
+            reason,
+        } => ProviderRouteError {
             status: StatusCode::CONFLICT,
             message: format!("Provider '{}' downlink not ready: {}", provider_id, reason),
         },

--- a/src/bcs/crates/adapters/http/bcs-http/src/state.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/state.rs
@@ -360,6 +360,28 @@ impl AdminInvocationStore {
         Some(run.clone())
     }
 
+    pub fn claim_callback_for_bot(
+        &self,
+        run_id: &str,
+        target_bot_uuid: &str,
+    ) -> Option<AdminInvocationRun> {
+        let mut runs = self
+            .runs
+            .lock()
+            .expect("admin invocation store lock poisoned");
+        purge_expired(&mut runs);
+        let run = runs.get_mut(run_id)?;
+        if run.target_bot_uuid != target_bot_uuid
+            || run.detach
+            || run.callback.is_none()
+            || run.callback_claimed
+        {
+            return None;
+        }
+        run.callback_claimed = true;
+        Some(run.clone())
+    }
+
     pub fn set_delivery_error(&self, run_id: &str, error: String) {
         let mut runs = self
             .runs
@@ -647,6 +669,11 @@ impl HttpAppState {
 
     pub fn with_outbound_url_guard(mut self, outbound_url_guard: OutboundUrlGuard) -> Self {
         self.outbound_url_guard = outbound_url_guard;
+        self
+    }
+
+    pub fn with_admin_invocation_runs(mut self, runs: Arc<AdminInvocationStore>) -> Self {
+        self.admin_invocation_runs = runs;
         self
     }
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/state.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/state.rs
@@ -301,8 +301,22 @@ pub struct AdminInvocationRun {
     pub detach: bool,
     pub expires_at_ms: u64,
     pub delivery_error: Option<String>,
+    pub terminal: Option<AdminInvocationTerminal>,
     pub callback: Option<AdminInvocationCallback>,
     pub callback_claimed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdminInvocationTerminalStatus {
+    Completed,
+    Failed,
+    TimedOut,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdminInvocationTerminal {
+    pub status: AdminInvocationTerminalStatus,
+    pub text: String,
 }
 
 #[derive(Debug, Clone)]
@@ -346,24 +360,10 @@ impl AdminInvocationStore {
         runs.get(run_id).cloned()
     }
 
-    pub fn claim_callback(&self, run_id: &str) -> Option<AdminInvocationRun> {
-        let mut runs = self
-            .runs
-            .lock()
-            .expect("admin invocation store lock poisoned");
-        purge_expired(&mut runs);
-        let run = runs.get_mut(run_id)?;
-        if run.detach || run.callback.is_none() || run.callback_claimed {
-            return None;
-        }
-        run.callback_claimed = true;
-        Some(run.clone())
-    }
-
-    pub fn claim_callback_for_bot(
+    pub fn record_terminal(
         &self,
         run_id: &str,
-        target_bot_uuid: &str,
+        terminal: AdminInvocationTerminal,
     ) -> Option<AdminInvocationRun> {
         let mut runs = self
             .runs
@@ -371,15 +371,25 @@ impl AdminInvocationStore {
             .expect("admin invocation store lock poisoned");
         purge_expired(&mut runs);
         let run = runs.get_mut(run_id)?;
-        if run.target_bot_uuid != target_bot_uuid
-            || run.detach
-            || run.callback.is_none()
-            || run.callback_claimed
-        {
+        record_terminal_and_claim_callback(run, terminal)
+    }
+
+    pub fn record_terminal_for_bot(
+        &self,
+        run_id: &str,
+        target_bot_uuid: &str,
+        terminal: AdminInvocationTerminal,
+    ) -> Option<AdminInvocationRun> {
+        let mut runs = self
+            .runs
+            .lock()
+            .expect("admin invocation store lock poisoned");
+        purge_expired(&mut runs);
+        let run = runs.get_mut(run_id)?;
+        if run.target_bot_uuid != target_bot_uuid {
             return None;
         }
-        run.callback_claimed = true;
-        Some(run.clone())
+        record_terminal_and_claim_callback(run, terminal)
     }
 
     pub fn set_delivery_error(&self, run_id: &str, error: String) {
@@ -391,6 +401,21 @@ impl AdminInvocationStore {
             run.delivery_error = Some(error);
         }
     }
+}
+
+fn record_terminal_and_claim_callback(
+    run: &mut AdminInvocationRun,
+    terminal: AdminInvocationTerminal,
+) -> Option<AdminInvocationRun> {
+    if run.terminal.is_some() {
+        return None;
+    }
+    run.terminal = Some(terminal);
+    if run.callback.is_none() || run.callback_claimed {
+        return None;
+    }
+    run.callback_claimed = true;
+    Some(run.clone())
 }
 
 fn purge_expired(runs: &mut HashMap<String, AdminInvocationRun>) {

--- a/src/bcs/crates/adapters/http/bcs-http/src/state.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/state.rs
@@ -1,13 +1,17 @@
-use bcs_domain::BotCapabilities;
-use bcs_channel_api::ChannelHttpIngressRegistry;
-use bcs_config_api::ManifestConfig;
 use crate::service_key::ApiKeyRegistry;
 use bcs_auth_api::{AuthError, UserIdentityInfo};
+use bcs_channel_api::ChannelHttpIngressRegistry;
+use bcs_config_api::ManifestConfig;
+use bcs_domain::BotCapabilities;
 use bcs_route_security::OutboundUrlGuard;
-use bcs_service_api::{ProviderCredentialRepoPort, ProviderStreamGrayList};
 pub use bcs_service_api::{ChatRunCleanupPort, ChatRunEventPort};
+use bcs_service_api::{ProviderCredentialRepoPort, ProviderStreamGrayList};
 use bcs_services_container::Services;
 use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 #[async_trait::async_trait]
 pub trait HealthPort: Send + Sync {
@@ -89,10 +93,7 @@ impl ChainUserIdentityPort {
         Self { chain, inner: None }
     }
 
-    pub fn with_inner(
-        mut self,
-        inner: Arc<dyn bcs_auth_api::UserIdentityPort>,
-    ) -> Self {
+    pub fn with_inner(mut self, inner: Arc<dyn bcs_auth_api::UserIdentityPort>) -> Self {
         self.inner = Some(inner);
         self
     }
@@ -122,9 +123,16 @@ impl UserIdentityPort for ChainUserIdentityPort {
         env: &str,
     ) -> Result<String, AuthError> {
         match &self.inner {
-            Some(port) => port
-                .ensure_identity(auth_source, external_user_id, external_user_name, avatar, env)
-                .await,
+            Some(port) => {
+                port.ensure_identity(
+                    auth_source,
+                    external_user_id,
+                    external_user_name,
+                    avatar,
+                    env,
+                )
+                .await
+            }
             None => Err(AuthError::LookupFailed(
                 "no identity port configured".to_string(),
             )),
@@ -181,10 +189,7 @@ pub struct BcsHttpAuthBotRuntimeTokenResolver {
 }
 
 impl BcsHttpAuthBotRuntimeTokenResolver {
-    pub fn with_credentials(
-        mut self,
-        credentials: Arc<dyn ProviderCredentialRepoPort>,
-    ) -> Self {
+    pub fn with_credentials(mut self, credentials: Arc<dyn ProviderCredentialRepoPort>) -> Self {
         self.credentials = Some(credentials);
         self
     }
@@ -284,6 +289,96 @@ impl VisibilitySyncPort for NoopVisibilitySyncPort {
     async fn sync_visibility(&self, _request: VisibilitySyncRequest) {}
 }
 
+/// Process-local best-effort association for organization-admin invocations.
+/// It intentionally has no persistence or retry semantics; a process restart
+/// makes old runs unavailable to this management surface.
+#[derive(Debug, Clone)]
+pub struct AdminInvocationRun {
+    pub provider_id: String,
+    pub organization_code: String,
+    pub target_bot_uuid: String,
+    pub session_id: String,
+    pub detach: bool,
+    pub expires_at_ms: u64,
+    pub delivery_error: Option<String>,
+    pub callback: Option<AdminInvocationCallback>,
+    pub callback_claimed: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdminInvocationCallback {
+    pub url: String,
+    pub bearer_token: String,
+}
+
+#[derive(Debug, Default)]
+pub struct AdminInvocationStore {
+    runs: std::sync::Mutex<HashMap<String, AdminInvocationRun>>,
+}
+
+impl AdminInvocationStore {
+    pub fn insert(&self, run_id: String, run: AdminInvocationRun) {
+        let mut runs = self
+            .runs
+            .lock()
+            .expect("admin invocation store lock poisoned");
+        purge_expired(&mut runs);
+        runs.insert(run_id, run);
+    }
+
+    pub fn get_for_provider(&self, run_id: &str, provider_id: &str) -> Option<AdminInvocationRun> {
+        let mut runs = self
+            .runs
+            .lock()
+            .expect("admin invocation store lock poisoned");
+        purge_expired(&mut runs);
+        runs.get(run_id)
+            .filter(|run| run.provider_id == provider_id)
+            .cloned()
+    }
+
+    pub fn get(&self, run_id: &str) -> Option<AdminInvocationRun> {
+        let mut runs = self
+            .runs
+            .lock()
+            .expect("admin invocation store lock poisoned");
+        purge_expired(&mut runs);
+        runs.get(run_id).cloned()
+    }
+
+    pub fn claim_callback(&self, run_id: &str) -> Option<AdminInvocationRun> {
+        let mut runs = self
+            .runs
+            .lock()
+            .expect("admin invocation store lock poisoned");
+        purge_expired(&mut runs);
+        let run = runs.get_mut(run_id)?;
+        if run.detach || run.callback.is_none() || run.callback_claimed {
+            return None;
+        }
+        run.callback_claimed = true;
+        Some(run.clone())
+    }
+
+    pub fn set_delivery_error(&self, run_id: &str, error: String) {
+        let mut runs = self
+            .runs
+            .lock()
+            .expect("admin invocation store lock poisoned");
+        if let Some(run) = runs.get_mut(run_id) {
+            run.delivery_error = Some(error);
+        }
+    }
+}
+
+fn purge_expired(runs: &mut HashMap<String, AdminInvocationRun>) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    runs.retain(|_, run| run.expires_at_ms > now);
+}
+
 #[derive(Clone)]
 pub struct HttpAppState {
     pub services: Services,
@@ -326,6 +421,7 @@ pub struct HttpAppState {
     pub auth_chain: Option<Arc<bcs_auth_api::AuthPluginChain>>,
     pub auth_config: bcs_auth_api::AuthConfig,
     pub outbound_url_guard: OutboundUrlGuard,
+    pub admin_invocation_runs: Arc<AdminInvocationStore>,
 }
 
 impl HttpAppState {
@@ -373,6 +469,7 @@ impl HttpAppState {
             auth_chain: None,
             auth_config: bcs_auth_api::AuthConfig::default(),
             outbound_url_guard: OutboundUrlGuard::strict(),
+            admin_invocation_runs: Arc::new(AdminInvocationStore::default()),
         }
     }
 
@@ -564,10 +661,7 @@ impl HttpAppState {
     /// default to `["local"]`), resolve a non-JWT session token directly via the
     /// registry — mirroring the legacy `SessionTokenPlugin` non-JWT branch. JWT
     /// tokens without a chain are not resolvable (production always has a chain).
-    pub async fn bot_uuid_from_headers(
-        &self,
-        headers: &axum::http::HeaderMap,
-    ) -> Option<String> {
+    pub async fn bot_uuid_from_headers(&self, headers: &axum::http::HeaderMap) -> Option<String> {
         if let Some(chain) = self.auth_chain.as_ref() {
             if let Ok(result) = chain.authenticate(headers).await {
                 if let Some(bot_uuid) = result.principal.and_then(|p| p.bot_uuid) {
@@ -616,7 +710,10 @@ impl std::fmt::Debug for HttpAppState {
             .field("chat_run_events", &"<ChatRunEventPort>")
             .field("bot_request", &"<BotRequestPort>")
             .field("user_identity", &"<UserIdentityPort>")
-            .field("bot_runtime_token_resolver", &"<BotRuntimeTokenResolverPort>")
+            .field(
+                "bot_runtime_token_resolver",
+                &"<BotRuntimeTokenResolverPort>",
+            )
             .field("visibility_sync", &"<VisibilitySyncPort>")
             .field(
                 "strict_container_validation",
@@ -636,7 +733,10 @@ impl std::fmt::Debug for HttpAppState {
             .field("group_chat_delay_max_ms", &self.group_chat_delay_max_ms)
             .field("async_chat_run_timeout_ms", &self.async_chat_run_timeout_ms)
             .field("invite_token_secret", &"<redacted>")
-            .field("invite_default_ttl_seconds", &self.invite_default_ttl_seconds)
+            .field(
+                "invite_default_ttl_seconds",
+                &self.invite_default_ttl_seconds,
+            )
             .field("invite_base_url", &self.invite_base_url)
             .field("invite_group_link_url", &self.invite_group_link_url)
             .field("invite_session_link_url", &self.invite_session_link_url)

--- a/src/bcs/crates/adapters/http/bcs-http/tests/organizations_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/organizations_contract.rs
@@ -134,6 +134,23 @@ impl OrganizationManagementService for RecordingOrganizationManagement {
         }))
     }
 
+    async fn require_invocable_member(
+        &self,
+        auth: OrganizationAuth,
+        organization_code: &str,
+        bot_uuid: &str,
+    ) -> ServiceResult<OrganizationMember> {
+        self.record(format!(
+            "require_invocable_member:{}:{organization_code}:{bot_uuid}",
+            auth.provider_id
+        ))
+        .await?;
+        Ok(sample_member(
+            organization_code.to_string(),
+            bot_uuid.to_string(),
+        ))
+    }
+
     async fn list_members(
         &self,
         auth: OrganizationMemberAuth,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
@@ -1258,6 +1258,92 @@ async fn patch_provider_updates_name_and_webhook_url() {
 }
 
 #[tokio::test]
+async fn patch_provider_updates_and_returns_admin_callback_url() {
+    let TestApp { app, _temp_dir, .. } = test_app();
+    let provider = register_provider(
+        &app,
+        json!({
+            "mode": "static_bearer"
+        }),
+    )
+    .await;
+    let provider_id = provider["provider_id"].as_str().unwrap();
+    let admin_token = provider["provider_admin_token"].as_str().unwrap();
+    let callback_url = "https://provider.example.com/bcs/admin-callback";
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/providers/{provider_id}"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .body(Body::from(
+                    json!({
+                        "admin_callback_url": callback_url
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["admin_callback_url"], callback_url);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/providers/{provider_id}"))
+                .header("authorization", format!("Bearer {admin_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["admin_callback_url"], callback_url);
+}
+
+#[tokio::test]
+async fn organization_admin_run_requires_provider_admin_token_in_unified_envelope() {
+    let app = test_app();
+    let response = app
+        .app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/organizations/engineering/admin-runs")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "target_bot_uuid": "bot_target",
+                        "message": {
+                            "role": "user",
+                            "content": [{ "type": "text", "text": "please review" }]
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body = response_json(response).await;
+    assert_eq!(body["code"], 40101);
+    assert_eq!(body["message"], "valid provider admin token is required");
+    assert!(body["request_id"].as_str().is_some());
+}
+
+#[tokio::test]
 async fn patch_and_get_provider_use_typed_organization_management_config() {
     let TestApp { app, _temp_dir, .. } = test_app();
     let provider_a = register_provider_as(&app, "11111111").await;

--- a/src/bcs/crates/adapters/http/bcs-http/tests/route_boundary_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/route_boundary_contract.rs
@@ -25,6 +25,19 @@ fn selected_routes_are_still_present() {
 }
 
 #[test]
+fn bot_events_route_does_not_own_admin_terminal_callbacks() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let body = fs::read_to_string(root.join("src/routes/bot_events.rs"))
+        .expect("src/routes/bot_events.rs");
+
+    assert!(
+        !body.contains("notify_terminal_callback")
+            && !body.contains("admin_invocation_terminal"),
+        "bot events must reach admin terminal observers through message flow"
+    );
+}
+
+#[test]
 fn selected_routes_do_not_import_concrete_service_crates() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let forbidden = [

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{net::IpAddr, sync::Arc};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -11,7 +11,7 @@ use bcs_protocol::{
     ProviderWebhookSender, RequestFrame,
 };
 use bcs_protocol::stream::{ChatState, StreamEvent, parse_stream_event};
-use bcs_route_security::OutboundUrlGuard;
+use bcs_route_security::{OutboundUrlError, OutboundUrlGuard};
 use bcs_service_api::{
     BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort, BotDeliveryResult, BotEventCommand,
     BotRunContext, BotRunContextPort, ChatEventState, GroupHistoryBotRequestPort, MessageFlowService,
@@ -654,13 +654,23 @@ async fn send_provider_request(
             "not http provider target".to_string(),
         ));
     };
-    let guarded_url = url_guard
-        .resolve_request_http_url(webhook_url)
-        .await
-        .map_err(|error| ServiceError::InvalidOperation {
-            message: format!("provider webhook_url is not allowed: {error}"),
-            request_id: Some(body.id.clone()),
-        })?;
+    let guarded_url = match url_guard.resolve_request_http_url(webhook_url).await {
+        Ok(url) => url,
+        Err(error) => {
+            warn!(
+                provider_id = %body.to_bot.provider_id,
+                provider_bot_ref = %body.to_bot.provider_bot_ref,
+                webhook_url = %webhook_url_for_log(webhook_url),
+                resolved_ip = ?blocked_outbound_ip(&error),
+                reason = %error,
+                "provider downlink: webhook blocked by outbound URL policy"
+            );
+            return Err(ServiceError::InvalidOperation {
+                message: format!("provider webhook_url is not allowed: {error}"),
+                request_id: Some(body.id.clone()),
+            });
+        }
+    };
     let client_policy = ProviderClientPolicy::for_request(accept_sse);
     let pinned_client = provider_client_for_url(&guarded_url, client_policy).map_err(|error| {
         ServiceError::InternalError(format!("provider HTTP client build failed: {error}"))
@@ -792,6 +802,24 @@ async fn send_provider_request(
     }
 
     Ok(response)
+}
+
+fn blocked_outbound_ip(error: &OutboundUrlError) -> Option<IpAddr> {
+    match error {
+        OutboundUrlError::UnsafeAddress(address) => Some(*address),
+        _ => None,
+    }
+}
+
+fn webhook_url_for_log(webhook_url: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(webhook_url) else {
+        return "<invalid webhook URL>".to_string();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
 }
 
 fn provider_client_builder(policy: ProviderClientPolicy) -> reqwest::ClientBuilder {

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -73,6 +73,7 @@ where
                 "provider downlink: posting webhook"
                     | "provider downlink: response headers received"
                     | "provider downlink: history response"
+                    | "provider downlink: webhook blocked by outbound URL policy"
             )
         }) {
             self.events
@@ -277,6 +278,47 @@ async fn provider_delivery_rejects_private_webhook_url_before_request() {
         .expect_err("private webhook URL should be rejected before request");
 
     assert!(err.to_string().contains("provider webhook_url is not allowed"));
+}
+
+#[tokio::test]
+async fn provider_delivery_logs_policy_rejection_with_provider_url_ip_and_reason() {
+    let logs = install_log_capture();
+    logs.lock().unwrap().clear();
+
+    let transport = HttpProviderTransport::new();
+    let err = transport
+        .deliver(BotDeliveryCommand {
+            target: provider_target("http://127.0.0.1:1/webhook".to_string()),
+            run_id: "run-private-log".to_string(),
+            frame: BcsFrame::Request(RequestFrame::new(
+                "run-private-log",
+                "chat.send",
+                Some(json!({ "bcs_group_id": "group-1", "message": { "text": "hello" } })),
+            )),
+            delivery_kind: BotDeliveryKind::Send,
+            provider_transport: Default::default(),
+        })
+        .await
+        .expect_err("private webhook URL should be rejected before request");
+
+    assert!(err.to_string().contains("provider webhook_url is not allowed"));
+    let events = logs.lock().unwrap();
+    let event = events
+        .iter()
+        .find(|event| {
+            event.field("message").as_deref()
+                == Some("provider downlink: webhook blocked by outbound URL policy")
+        })
+        .expect("blocked provider webhook log");
+    assert_eq!(event.field("provider_id").as_deref(), Some("provider-1"));
+    assert_eq!(
+        event.field("webhook_url").as_deref(),
+        Some("http://127.0.0.1:1/webhook")
+    );
+    assert_eq!(event.field("resolved_ip").as_deref(), Some("Some(127.0.0.1)"));
+    assert!(event
+        .field("reason")
+        .is_some_and(|reason| reason.contains("not allowed for outbound callbacks")));
 }
 
 #[tokio::test]

--- a/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
@@ -142,6 +142,7 @@ pub(crate) async fn build_http_app_state(state: Arc<BcsServerState>) -> HttpAppS
         .with_channel_http_ingress(state.channel_http_ingress.clone())
         .with_auth_chain(state.auth_chain.clone(), state.auth_config.clone())
         .with_outbound_url_guard(state.outbound_url_guard.clone())
+        .with_admin_invocation_runs(state.admin_invocation_runs.clone())
         .with_user_identity(Arc::new(
             ChainUserIdentityPort::new(state.auth_chain.clone()),
         ))
@@ -445,6 +446,7 @@ mod tests {
             auth_config: bcs_auth_api::AuthConfig::default(),
             user_identity_port: None,
             outbound_url_guard: OutboundUrlGuard::allowing_private_networks_for_tests(),
+            admin_invocation_runs: Arc::new(bcs_http::state::AdminInvocationStore::default()),
         })
     }
 

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -3325,6 +3325,251 @@ fn direct_chat_run_lifecycle_hook(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
+    use bcs_protocol::{BcsFrame, EventFrame, RequestFrame};
+    use bcs_service_api::RegisterProviderCommand;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::time::{Duration, timeout};
+    use tower::ServiceExt;
+
+    async fn response_json(response: Response) -> serde_json::Value {
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Vec<u8> {
+        let mut request = Vec::new();
+        loop {
+            let mut chunk = [0; 1024];
+            let count = socket.read(&mut chunk).await.unwrap();
+            assert!(count > 0, "callback closed before request completed");
+            request.extend_from_slice(&chunk[..count]);
+            let Some(headers_end) = request.windows(4).position(|window| window == b"\r\n\r\n")
+            else {
+                continue;
+            };
+            let headers_end = headers_end + 4;
+            let headers = String::from_utf8_lossy(&request[..headers_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.split_once(':').and_then(|(name, value)| {
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().unwrap())
+                    })
+                })
+                .unwrap_or(0);
+            if request.len() >= headers_end + content_length {
+                return request;
+            }
+        }
+    }
+
+    struct AdminRunTestOrganization {
+        provider_id: String,
+    }
+
+    impl AdminRunTestOrganization {
+        fn organization(&self, code: &str) -> bcs_domain::Organization {
+            bcs_domain::Organization {
+                env: "local".to_string(),
+                code: code.to_string(),
+                name: "Admin WS Org".to_string(),
+                description: None,
+                managing_provider_id: self.provider_id.clone(),
+                disabled: false,
+                created_at: 1,
+                updated_at: 1,
+            }
+        }
+
+        fn member(&self, code: &str, bot_uuid: &str) -> bcs_domain::OrganizationMember {
+            bcs_domain::OrganizationMember {
+                env: "local".to_string(),
+                organization_code: code.to_string(),
+                bot_uuid: bot_uuid.to_string(),
+                role: None,
+                disabled: false,
+                created_at: 1,
+                updated_at: 1,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl OrganizationCoreService for AdminRunTestOrganization {
+        async fn create(
+            &self,
+            _managing_provider_id: &str,
+            code: &str,
+            _name: &str,
+            _description: Option<&str>,
+        ) -> bcs_service_api::ServiceResult<bcs_domain::Organization> {
+            Ok(self.organization(code))
+        }
+
+        async fn get_for_manager(
+            &self,
+            _managing_provider_id: &str,
+            code: &str,
+        ) -> bcs_service_api::ServiceResult<bcs_domain::Organization> {
+            Ok(self.organization(code))
+        }
+
+        async fn list_for_manager(
+            &self,
+            _managing_provider_id: &str,
+            _include_disabled: bool,
+        ) -> bcs_service_api::ServiceResult<Vec<bcs_domain::Organization>> {
+            Ok(Vec::new())
+        }
+
+        async fn update_for_manager(
+            &self,
+            _managing_provider_id: &str,
+            code: &str,
+            _name: Option<&str>,
+            _description: Option<Option<&str>>,
+            _disabled: Option<bool>,
+        ) -> bcs_service_api::ServiceResult<bcs_domain::Organization> {
+            Ok(self.organization(code))
+        }
+
+        async fn put_member(
+            &self,
+            _managing_provider_id: &str,
+            organization_code: &str,
+            bot_uuid: &str,
+            _role: Option<&str>,
+        ) -> bcs_service_api::ServiceResult<bcs_domain::OrganizationMember> {
+            Ok(self.member(organization_code, bot_uuid))
+        }
+
+        async fn delete_member(
+            &self,
+            _managing_provider_id: &str,
+            _organization_code: &str,
+            _bot_uuid: &str,
+        ) -> bcs_service_api::ServiceResult<()> {
+            Ok(())
+        }
+
+        async fn get_member_for_manager(
+            &self,
+            _managing_provider_id: &str,
+            organization_code: &str,
+            bot_uuid: &str,
+        ) -> bcs_service_api::ServiceResult<Option<bcs_domain::OrganizationMember>> {
+            Ok(Some(self.member(organization_code, bot_uuid)))
+        }
+
+        async fn list_members_for_manager(
+            &self,
+            _managing_provider_id: &str,
+            _organization_code: &str,
+            _include_disabled: bool,
+            _role: Option<&str>,
+        ) -> bcs_service_api::ServiceResult<Vec<bcs_domain::OrganizationMember>> {
+            Ok(Vec::new())
+        }
+
+        async fn candidate_bots(
+            &self,
+            _managing_provider_id: &str,
+            _query: bcs_service_api::OrganizationCandidateQuery,
+        ) -> bcs_service_api::ServiceResult<Vec<bcs_service_api::OrganizationCandidateBot>> {
+            Ok(Vec::new())
+        }
+
+        async fn require_effective_member(
+            &self,
+            organization_code: &str,
+            bot_uuid: &str,
+        ) -> bcs_service_api::ServiceResult<bcs_domain::OrganizationMember> {
+            Ok(self.member(organization_code, bot_uuid))
+        }
+
+        async fn list_effective_members(
+            &self,
+            _organization_code: &str,
+            _role: Option<&str>,
+        ) -> bcs_service_api::ServiceResult<Vec<bcs_domain::OrganizationMember>> {
+            Ok(Vec::new())
+        }
+
+        async fn require_runtime_member(
+            &self,
+            organization_code: &str,
+            bot_uuid: &str,
+        ) -> bcs_service_api::ServiceResult<bcs_domain::OrganizationMember> {
+            Ok(self.member(organization_code, bot_uuid))
+        }
+
+        async fn list_runtime_members(
+            &self,
+            _organization_code: &str,
+            _role: Option<&str>,
+        ) -> bcs_service_api::ServiceResult<Vec<bcs_domain::OrganizationMember>> {
+            Ok(Vec::new())
+        }
+
+        async fn authorize_pair(
+            &self,
+            organization_code: &str,
+            sender_bot_uuid: &str,
+            target_bot_uuid: &str,
+        ) -> bcs_service_api::ServiceResult<bcs_service_api::AuthorizedOrganizationPair> {
+            Ok(bcs_service_api::AuthorizedOrganizationPair {
+                organization: self.organization(organization_code),
+                sender: self.member(organization_code, sender_bot_uuid),
+                target: self.member(organization_code, target_bot_uuid),
+            })
+        }
+    }
+
+    struct AdminRunTestA2aRuns;
+
+    #[async_trait]
+    impl A2aChatRunService for AdminRunTestA2aRuns {
+        async fn run_blocking_chat(
+            &self,
+            _cmd: bcs_service_api::BlockingA2aChatCommand,
+        ) -> bcs_service_api::ServiceResult<bcs_service_api::BlockingA2aChatOutcome> {
+            unreachable!("admin run test only uses async chat")
+        }
+
+        async fn start_async_chat(
+            &self,
+            cmd: bcs_service_api::AsyncA2aChatCommand,
+        ) -> bcs_service_api::ServiceResult<bcs_service_api::AsyncA2aChatAccepted> {
+            Ok(bcs_service_api::AsyncA2aChatAccepted {
+                run_id: cmd.run_id,
+                bot_uuid: cmd.target_bot_id,
+                session_id: cmd.session_key,
+                status: "dispatched".to_string(),
+                expires_at_ms: u64::MAX,
+            })
+        }
+
+        async fn get_run(
+            &self,
+            cmd: bcs_service_api::ChatRunQueryCommand,
+        ) -> bcs_service_api::ServiceResult<bcs_service_api::A2aRunStatus> {
+            Ok(bcs_service_api::A2aRunStatus {
+                run_id: cmd.run_id,
+                status: "running".to_string(),
+                response: None,
+            })
+        }
+
+        async fn cancel_run(
+            &self,
+            _cmd: bcs_service_api::ChatRunCancelCommand,
+        ) -> bcs_service_api::ServiceResult<bcs_service_api::A2aRunStatus> {
+            unreachable!("admin run test does not cancel")
+        }
+    }
 
     #[test]
     fn judge_llm_provider_selection_uses_openai_compatible_type() {
@@ -3429,6 +3674,170 @@ mod tests {
             &first.coordination_processed,
             &second.coordination_processed
         ));
+    }
+
+    #[tokio::test]
+    async fn detached_admin_run_observes_websocket_terminal_and_callbacks_once() {
+        let callback_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let callback_url = format!(
+            "http://{}/admin-terminal",
+            callback_listener.local_addr().unwrap()
+        );
+        let mut config = BcsConfig::default();
+        config.async_chat_run_timeout_ms = 5_000;
+        let server = BcsServer::new_allowing_private_outbound_for_tests(config);
+
+        let provider = server
+            .state
+            .services
+            .provider_management
+            .register_provider(RegisterProviderCommand {
+                name: "Admin Provider".to_string(),
+                webhook_url: callback_url.clone(),
+                admin_callback_url: Some(callback_url),
+                auth_mode: bcs_domain::ProviderAuthMode::StaticBearer,
+                created_by: "admin-owner".to_string(),
+                protocol_version: None,
+                coordination: None,
+            })
+            .await
+            .unwrap();
+
+        let dispatch_state = bot_ws_dispatch_state(&server.state);
+        let (bot_tx, mut bot_rx) = tokio::sync::mpsc::channel(16);
+        let mut registered_bot_id = None;
+        let connect = BcsFrame::Request(RequestFrame::new(
+            "connect-1",
+            "bot.connect",
+            Some(serde_json::json!({
+                "bot_id": "ws-admin-target",
+                "protocol_version": 1
+            })),
+        ));
+        bcs_ws::bot::dispatch_frame(
+            &dispatch_state,
+            &serde_json::to_string(&connect).unwrap(),
+            &bot_tx,
+            &mut registered_bot_id,
+        )
+        .await
+        .unwrap();
+        assert_eq!(registered_bot_id.as_deref(), Some("ws-admin-target"));
+        let _connect_response = bot_rx.recv().await.unwrap();
+
+        let mut http_state = crate::http_adapter::build_http_app_state(server.state.clone()).await;
+        http_state.services.organization = Arc::new(AdminRunTestOrganization {
+            provider_id: provider.provider_id.clone(),
+        });
+        http_state.services.a2a_chat_runs = Arc::new(AdminRunTestA2aRuns);
+        let app = bcs_http::router::build_router(http_state);
+
+        let create_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/organizations/admin-ws-org/admin-runs")
+                    .header("content-type", "application/json")
+                    .header("x-bcn-provider-id", &provider.provider_id)
+                    .header(
+                        "authorization",
+                        format!("Bearer {}", provider.provider_admin_token),
+                    )
+                    .body(Body::from(
+                        serde_json::json!({
+                            "target_bot_uuid": "ws-admin-target",
+                            "message": {
+                                "role": "user",
+                                "content": [{"type": "text", "text": "run detached"}]
+                            },
+                            "detach": true,
+                            "run_timeout_ms": 5_000
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_response.status(), StatusCode::ACCEPTED);
+        let create_body = response_json(create_response).await;
+        let run_id = create_body["data"]["run_id"].as_str().unwrap().to_string();
+
+        let terminal = BcsFrame::Event(EventFrame::new(
+            "chat.event",
+            Some(serde_json::json!({
+                "run_id": run_id,
+                "bcs_group_id": "",
+                "state": "final",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "detached websocket result"}],
+                    "timestamp": 1
+                }
+            })),
+            Some(1),
+        ));
+        bcs_ws::bot::dispatch_frame(
+            &dispatch_state,
+            &serde_json::to_string(&terminal).unwrap(),
+            &bot_tx,
+            &mut registered_bot_id,
+        )
+        .await
+        .unwrap();
+        bcs_ws::bot::dispatch_frame(
+            &dispatch_state,
+            &serde_json::to_string(&terminal).unwrap(),
+            &bot_tx,
+            &mut registered_bot_id,
+        )
+        .await
+        .unwrap();
+
+        let get_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!(
+                        "/organizations/admin-ws-org/admin-runs/{run_id}"
+                    ))
+                    .header("x-bcn-provider-id", &provider.provider_id)
+                    .header(
+                        "authorization",
+                        format!("Bearer {}", provider.provider_admin_token),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(get_response.status(), StatusCode::OK);
+        let get_body = response_json(get_response).await;
+        assert_eq!(get_body["data"]["status"], "completed");
+        assert_eq!(
+            get_body["data"]["message"]["content"][0]["text"],
+            "detached websocket result"
+        );
+
+        let (mut callback_socket, _) = timeout(Duration::from_secs(2), callback_listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+        let callback_request = read_http_request(&mut callback_socket).await;
+        callback_socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+        let callback_request = String::from_utf8_lossy(&callback_request);
+        assert!(callback_request.contains("detached websocket result"));
+        assert!(callback_request.contains(&run_id));
+        assert!(
+            timeout(Duration::from_millis(100), callback_listener.accept())
+                .await
+                .is_err()
+        );
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1084,7 +1084,6 @@ impl Default for BcsServerState {
             .provider_core(provider_core)
             .provider_bot_core(provider_bot_core)
             .provider_management(provider_management)
-            .organization(organization_core)
             .organization_management(organization_management)
             .provider_bot_events(provider_bot_events)
             .group_management(group_management.clone())
@@ -2221,7 +2220,6 @@ impl BcsServer {
             .provider_core(provider_core)
             .provider_bot_core(provider_bot_core)
             .provider_management(provider_management)
-            .organization(organization_core)
             .organization_management(organization_management)
             .provider_bot_events(provider_bot_events)
             .group_management(maybe_wrap_group_management(&config, use_cases.group_management))
@@ -2760,7 +2758,6 @@ impl BcsServer {
             .provider_core(provider_core)
             .provider_bot_core(provider_bot_core)
             .provider_management(provider_management)
-            .organization(organization_core)
             .organization_management(organization_management)
             .provider_bot_events(provider_bot_events)
             .group_management(maybe_wrap_group_management(&config, use_cases.group_management))
@@ -3726,9 +3723,12 @@ mod tests {
         let _connect_response = bot_rx.recv().await.unwrap();
 
         let mut http_state = crate::http_adapter::build_http_app_state(server.state.clone()).await;
-        http_state.services.organization = Arc::new(AdminRunTestOrganization {
-            provider_id: provider.provider_id.clone(),
-        });
+        http_state.services.organization_management = Arc::new(OrganizationManagement::new(
+            http_state.services.provider_core.clone(),
+            Arc::new(AdminRunTestOrganization {
+                provider_id: provider.provider_id.clone(),
+            }),
+        ));
         http_state.services.a2a_chat_runs = Arc::new(AdminRunTestA2aRuns);
         let app = bcs_http::router::build_router(http_state);
 

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -50,6 +50,10 @@ use bcs_fuse_client::FuseClient;
 use bcs_fusion::{FuseClientService, FuseWorkerProfileService, LocalFusionService};
 use bcs_group::{GroupConfig, GroupCore, GroupManagement};
 use bcs_group_store::{MemoryGroupRepo, MySqlGroupStore};
+use bcs_http::{
+    admin_invocation_terminal::AdminInvocationTerminalObserver,
+    state::AdminInvocationStore,
+};
 use bcs_judge::{LlmJudgeService, NoopJudgeEvaluator};
 use bcs_leader_election::StandaloneLeaderElection;
 use bcs_llm_api::LlmChatCompletionPort;
@@ -81,7 +85,8 @@ use bcs_security_gateway_api::SecurityGatewayPort;
 use bcs_service_api::lifecycle::ServiceLifecycle;
 use bcs_service_api::{
     A2aChatRunService, A2aChatService, BotDeliveryPort, BotDeliveryTarget, BotRegistryCoreService,
-    BotMetricsSnapshotPort, BotRunContextPort, ChannelService, CollaborationTemplateService,
+    BotMetricsSnapshotPort, BotRunContextPort, BotTerminalObserverPort, ChannelService,
+    CollaborationTemplateService,
     DirectChatClientKind, DirectChatRunEvent, DirectChatRunLifecycleHook,
     DirectChatRunReason, DirectChatRunSnapshotPort, FrontendDeliveryPort, GroupCoreService,
     GroupHistoryBotRequestPort, GroupManagementService, GroupMessageHistoryService,
@@ -564,6 +569,9 @@ pub struct BcsServerState {
 
     /// User-controlled outbound HTTP URL security policy.
     pub outbound_url_guard: OutboundUrlGuard,
+
+    /// Process-local organization-admin invocation callback associations.
+    pub admin_invocation_runs: Arc<AdminInvocationStore>,
 }
 
 impl std::fmt::Debug for BcsServerState {
@@ -795,6 +803,7 @@ impl Default for BcsServerState {
     fn default() -> Self {
         let config = BcsConfig::default();
         let outbound_url_guard = outbound_url_guard_from_config(&config);
+        let admin_invocation_runs = Arc::new(AdminInvocationStore::default());
         let provider_repos = memory_provider_repos();
         let bot_repo = Arc::new(MemoryBotRepo::with_base_dir(config.bots_base_dir.clone()));
         let bot_metrics_snapshot: Arc<dyn BotMetricsSnapshotPort> = bot_repo.clone();
@@ -972,6 +981,10 @@ impl Default for BcsServerState {
             system_message.clone(),
             Some(message_repo.clone()),
             provider_stream_gray_list.clone(),
+            Arc::new(AdminInvocationTerminalObserver::new(
+                admin_invocation_runs.clone(),
+                outbound_url_guard.clone(),
+            )),
         );
         let group_management_impl = Arc::new(GroupManagement::new(
             sessions.clone(),
@@ -1144,6 +1157,7 @@ impl Default for BcsServerState {
             auth_config,
             user_identity_port,
             outbound_url_guard,
+            admin_invocation_runs,
         }
     }
 }
@@ -1476,6 +1490,7 @@ fn create_message_flow_services(
     system_message: Arc<dyn bcs_service_api::SystemMessageService>,
     message_repo: Option<Arc<dyn MessageRepoPort>>,
     provider_stream_gray_list: Arc<ProviderStreamGrayList>,
+    bot_terminal_observer: Arc<dyn BotTerminalObserverPort>,
 ) -> (Arc<dyn MessageFlowService>, ChannelSlot) {
     let mut message_flow = BcsMessageFlow::new(
         group,
@@ -1489,7 +1504,8 @@ fn create_message_flow_services(
     .with_session_management(session_management)
     .with_bot_run_context(bot_run_context)
     .with_system_message(system_message)
-    .with_provider_stream_gray_list(provider_stream_gray_list);
+    .with_provider_stream_gray_list(provider_stream_gray_list)
+    .with_bot_terminal_observer(bot_terminal_observer);
     if let Some(repo) = message_repo {
         message_flow = message_flow.with_message_repo(repo);
     }
@@ -1937,6 +1953,7 @@ impl BcsServer {
         provider_request_url_guard: OutboundUrlGuard,
         callback_url_guard: OutboundUrlGuard,
     ) -> Self {
+        let admin_invocation_runs = Arc::new(AdminInvocationStore::default());
         // Create service implementations (synchronous, in-memory mode)
         let provider_repos = memory_provider_repos();
         let bot_repo = Arc::new(MemoryBotRepo::with_base_dir(config.bots_base_dir.clone()));
@@ -2120,6 +2137,10 @@ impl BcsServer {
             use_cases.system_message.clone(),
             Some(message_repo.clone()),
             provider_stream_gray_list.clone(),
+            Arc::new(AdminInvocationTerminalObserver::new(
+                admin_invocation_runs.clone(),
+                callback_url_guard.clone(),
+            )),
         );
 
         let collaboration_store = Arc::new(MemoryCollaborationStore::new());
@@ -2265,6 +2286,7 @@ impl BcsServer {
             auth_config,
             user_identity_port,
             outbound_url_guard: callback_url_guard,
+            admin_invocation_runs,
         });
 
         Self { config, state }
@@ -2292,6 +2314,7 @@ impl BcsServer {
         use bcs_service_api::BotRegistryCoreService;
 
         let outbound_url_guard = outbound_url_guard_from_config(&config);
+        let admin_invocation_runs = Arc::new(AdminInvocationStore::default());
         let user_directory = match extensions.user_directory_plugin.clone() {
             Some(plugin) => Some(plugin),
             None => create_user_directory_plugin(&config)?,
@@ -2632,6 +2655,10 @@ impl BcsServer {
             use_cases.system_message.clone(),
             Some(message_repo.clone()),
             provider_stream_gray_list.clone(),
+            Arc::new(AdminInvocationTerminalObserver::new(
+                admin_invocation_runs.clone(),
+                outbound_url_guard.clone(),
+            )),
         );
         frontend_connections
             .set_bot_query(use_cases.bot_query.clone())
@@ -2803,6 +2830,7 @@ impl BcsServer {
             auth_config,
             user_identity_port,
             outbound_url_guard,
+            admin_invocation_runs,
         });
 
         Ok(Self { config, state })

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/provider.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/provider.rs
@@ -83,6 +83,11 @@ pub struct ProviderCoordinationEventRequest {
 pub struct RegisterProviderRequest {
     pub name: String,
     pub webhook_url: String,
+    /// Optional provider-level endpoint for terminal organization-admin run
+    /// notifications. This is intentionally separate from the bot downlink
+    /// webhook URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin_callback_url: Option<String>,
     pub auth: ProviderAuthDto,
     /// Downlink protocol version: "1.0" (callback, default) or "2.0" (streaming/SSE).
     /// Omitted = "1.0" for backward compatibility.
@@ -104,6 +109,8 @@ pub struct ProviderInfoResponse {
     pub provider_id: String,
     pub name: String,
     pub webhook_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin_callback_url: Option<String>,
     pub auth_mode: ProviderAuthModeDto,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coordination: Option<ProviderCoordinationConfigDto>,
@@ -120,6 +127,8 @@ pub struct PatchProviderRequest {
     pub name: Option<String>,
     #[serde(default)]
     pub webhook_url: Option<String>,
+    #[serde(default)]
+    pub admin_callback_url: Option<String>,
     /// Downlink protocol version ("1.0" | "2.0"). When present, updates the
     /// stored downlink config; controls whether SSE streaming is eligible.
     #[serde(default)]

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/organization.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/organization.rs
@@ -89,6 +89,14 @@ pub trait OrganizationManagementService: Send + Sync {
             .await?
             .map(|member| OrganizationMemberDetail { member, bot: None }))
     }
+
+    /// Authorize an organization owner to invoke an active, effective member.
+    async fn require_invocable_member(
+        &self,
+        auth: OrganizationAuth,
+        organization_code: &str,
+        bot_uuid: &str,
+    ) -> ServiceResult<OrganizationMember>;
     async fn list_members(
         &self,
         auth: OrganizationMemberAuth,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs
@@ -12,7 +12,9 @@ use super::message_flow::ChatEventState;
 #[derive(Clone)]
 pub enum ProviderBotEventCredential {
     StaticBearer(String),
-    AgentPass { agent_code: String },
+    AgentPass {
+        agent_code: String,
+    },
     ProviderAdmin {
         provider_admin_token: String,
         provider_bot_ref: String,
@@ -24,7 +26,9 @@ impl std::fmt::Debug for ProviderBotEventCredential {
         match self {
             Self::StaticBearer(_) => f.write_str("StaticBearer(***)"),
             Self::AgentPass { .. } => f.write_str("AgentPass(***)"),
-            Self::ProviderAdmin { provider_bot_ref, .. } => f
+            Self::ProviderAdmin {
+                provider_bot_ref, ..
+            } => f
                 .debug_struct("ProviderAdmin")
                 .field("provider_admin_token", &"***")
                 .field("provider_bot_ref", provider_bot_ref)
@@ -37,6 +41,7 @@ impl std::fmt::Debug for ProviderBotEventCredential {
 pub struct RegisterProviderCommand {
     pub name: String,
     pub webhook_url: String,
+    pub admin_callback_url: Option<String>,
     pub auth_mode: ProviderAuthMode,
     pub created_by: String,
     /// Downlink protocol version ("1.0" | "2.0"); None = "1.0".
@@ -58,6 +63,7 @@ pub struct UpdateProviderCommand {
     pub authenticated_staff_id: String,
     pub name: Option<String>,
     pub webhook_url: Option<String>,
+    pub admin_callback_url: Option<String>,
     pub protocol_version: Option<String>,
     pub coordination: Option<ProviderCoordinationConfig>,
     pub organization_management: Option<ProviderOrganizationManagementConfig>,

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/organization.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/organization.rs
@@ -204,26 +204,36 @@ pub trait OrganizationCoreService: Send + Sync {
             .unwrap_or_default();
         Ok(OrganizationCandidateBotPage { bots, total, offset: query.offset, limit: query.limit })
     }
+    /// Require membership plus the current provider/binding/delegation eligibility policy.
     async fn require_effective_member(
         &self,
         organization_code: &str,
         bot_uuid: &str,
     ) -> ServiceResult<OrganizationMember>;
+    /// List members that satisfy the current provider/binding/delegation eligibility policy.
     async fn list_effective_members(
         &self,
         organization_code: &str,
         role: Option<&str>,
     ) -> ServiceResult<Vec<OrganizationMember>>;
+    /// Require only active organization and member lifecycle state.
+    ///
+    /// This does not confer authority to access another bot. Authorization callers must use
+    /// `require_effective_member` or a use-case-specific application service instead.
     async fn require_runtime_member(
         &self,
         organization_code: &str,
         bot_uuid: &str,
     ) -> ServiceResult<OrganizationMember>;
+    /// List members by active organization/member lifecycle state only.
     async fn list_runtime_members(
         &self,
         organization_code: &str,
         role: Option<&str>,
     ) -> ServiceResult<Vec<OrganizationMember>>;
+    /// Return a store-optimized discovery snapshot when the repository supports it.
+    ///
+    /// Consumers remain responsible for applying the authorization semantics of their use case.
     async fn list_runtime_discovery_bots(
         &self,
         _organization_code: &str,
@@ -231,6 +241,7 @@ pub trait OrganizationCoreService: Send + Sync {
     ) -> ServiceResult<Option<Vec<OrganizationDiscoveryBot>>> {
         Ok(None)
     }
+    /// Authorize both participants for an organization-scoped A2A interaction.
     async fn authorize_pair(
         &self,
         organization_code: &str,

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/provider.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/provider.rs
@@ -48,7 +48,8 @@ pub trait ProviderCoreService: Send + Sync {
     ) -> ServiceResult<RegisteredProvider>;
 
     async fn authenticate_provider_admin(&self, token: &str) -> ServiceResult<ProviderRecord>;
-    async fn get_downlink_credential(&self, provider_id: &str) -> ServiceResult<ProviderCredential>;
+    async fn get_downlink_credential(&self, provider_id: &str)
+    -> ServiceResult<ProviderCredential>;
     async fn get_provider(
         &self,
         provider_id: &str,
@@ -65,6 +66,25 @@ pub trait ProviderCoreService: Send + Sync {
         coordination: Option<ProviderCoordinationConfig>,
         organization_management: Option<ProviderOrganizationManagementConfig>,
     ) -> ServiceResult<ProviderRecord>;
+
+    async fn update_provider_admin_callback_url(
+        &self,
+        provider_id: &str,
+        provider_admin_token: &str,
+        authenticated_staff_id: &str,
+        admin_callback_url: String,
+    ) -> ServiceResult<ProviderRecord> {
+        let _ = (
+            provider_id,
+            provider_admin_token,
+            authenticated_staff_id,
+            admin_callback_url,
+        );
+        Err(ServiceError::InvalidOperation {
+            message: "provider admin callback updates are not configured".to_string(),
+            request_id: None,
+        })
+    }
     async fn set_provider_disabled(
         &self,
         provider_id: &str,

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -141,7 +141,8 @@ pub use application::{
 pub use port::{
     BotConnectionControlPort, BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort,
     BotDeliveryResult, BotMetricCount, BotMetricsSnapshotPort, BotRepoPort, BotRunContext,
-    BotRunContextPort, ChatRunCleanupPort, ChatRunEventPort, ChatRunMetricCount, DeliveryBlockContext,
+    BotRunContextPort, BotTerminalEvent, BotTerminalObserverPort, BotTerminalState,
+    NoopBotTerminalObserver, ChatRunCleanupPort, ChatRunEventPort, ChatRunMetricCount, DeliveryBlockContext,
     DeliveryBlockReason, DeliveryBlockSurface, DeliveryMetricKind, DeliveryMetricTarget,
     DeliveryPolicyBlockInstrumentationHook, DirectChatClientKind, DirectChatRunEvent,
     DirectChatRunLifecycleHook, DirectChatRunReason, DirectChatRunSnapshotPort, DirectChatRunState,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/bot_terminal_observer.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/bot_terminal_observer.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+
+/// Transport-neutral terminal states accepted from an authenticated bot event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BotTerminalState {
+    Final,
+    Error,
+    Aborted,
+}
+
+/// A successfully handled terminal chat event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotTerminalEvent {
+    pub run_id: String,
+    pub bot_uuid: String,
+    pub state: BotTerminalState,
+    pub text: String,
+}
+
+/// Observes accepted bot terminal events without owning their domain handling.
+///
+/// Implementations must be best-effort: observation must not turn an accepted
+/// bot event into a transport failure.
+#[async_trait]
+pub trait BotTerminalObserverPort: Send + Sync {
+    async fn observe(&self, event: BotTerminalEvent);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopBotTerminalObserver;
+
+#[async_trait]
+impl BotTerminalObserverPort for NoopBotTerminalObserver {
+    async fn observe(&self, _event: BotTerminalEvent) {}
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
@@ -1,4 +1,5 @@
 pub mod bot_connection;
+pub mod bot_terminal_observer;
 pub mod chat_run;
 pub mod channel_delivery;
 pub mod delivery;
@@ -12,6 +13,9 @@ pub mod secret;
 pub mod session_callback;
 
 pub use bot_connection::{BotConnectionControlPort, KickReason};
+pub use bot_terminal_observer::{
+    BotTerminalEvent, BotTerminalObserverPort, BotTerminalState, NoopBotTerminalObserver,
+};
 pub use chat_run::{BotRunContext, BotRunContextPort, ChatRunCleanupPort, ChatRunEventPort};
 pub use channel_delivery::{
     ChannelBindingRef, ChannelDeliveryPort, ChannelDeliveryResult, ChannelOutboundEvent,

--- a/src/bcs/crates/service-api/bcs-services-container/src/services.rs
+++ b/src/bcs/crates/service-api/bcs-services-container/src/services.rs
@@ -13,7 +13,7 @@ use bcs_service_api::{
     FriendCoreService, FriendService, FrontendDeliveryPort,
     FusionCoreService, Group, GroupCoreService, GroupFusionService, GroupManagementService,
     GroupMessageHistoryService, GroupProposalService, GroupQueryService, HumanActorService,
-    MessageFlowService, OrganizationCoreService, OrganizationManagementService,
+    MessageFlowService, OrganizationManagementService,
     ProposalCoreService, ProviderBotCoreService, ProviderCoreService,
     ProviderBotEventService, ProviderManagementService, RelationCoreService, RoutingCoreService,
     SecretService, SessionManagementService, SystemMessageService, WorkbenchSessionService,
@@ -84,8 +84,6 @@ pub struct Services {
     pub provider_management: Arc<dyn ProviderManagementService>,
     /// Provider bot event application service.
     pub provider_bot_events: Arc<dyn ProviderBotEventService>,
-    /// Organization core service.
-    pub organization: Arc<dyn OrganizationCoreService>,
     /// Organization management application service.
     pub organization_management: Arc<dyn OrganizationManagementService>,
     /// Group query application service.
@@ -152,7 +150,6 @@ pub struct ServicesBuilder {
     provider_bot_core: Option<Arc<dyn ProviderBotCoreService>>,
     provider_management: Option<Arc<dyn ProviderManagementService>>,
     provider_bot_events: Option<Arc<dyn ProviderBotEventService>>,
-    organization: Option<Arc<dyn OrganizationCoreService>>,
     organization_management: Option<Arc<dyn OrganizationManagementService>>,
     group_query: Option<Arc<dyn GroupQueryService>>,
     group_management: Option<Arc<dyn GroupManagementService>>,
@@ -337,12 +334,6 @@ impl ServicesBuilder {
         self
     }
 
-    /// Set the organization core service.
-    pub fn organization(mut self, service: Arc<dyn OrganizationCoreService>) -> Self {
-        self.organization = Some(service);
-        self
-    }
-
     /// Set the organization management application service.
     pub fn organization_management(
         mut self,
@@ -445,7 +436,6 @@ impl ServicesBuilder {
             provider_bot_core: required(self.provider_bot_core, "provider_bot_core")?,
             provider_management: required(self.provider_management, "provider_management")?,
             provider_bot_events: required(self.provider_bot_events, "provider_bot_events")?,
-            organization: required(self.organization, "organization")?,
             organization_management: required(
                 self.organization_management,
                 "organization_management",
@@ -476,7 +466,7 @@ impl ServicesBuilder {
             NoopGroupFusionService, NoopGroupManagementService, NoopGroupMessageHistoryService,
             NoopGroupProposalService, NoopGroupQueryService, NoopHumanActorService,
             NoopCollaborationRuntimeService, NoopCollaborationTemplateService,
-            NoopMessageFlowService, NoopOrganizationCoreService, NoopOrganizationManagementService,
+            NoopMessageFlowService, NoopOrganizationManagementService,
             NoopProposalCoreService, NoopProviderBotCoreService, NoopProviderBotEventService,
             NoopProviderCoreService,
             NoopProviderManagementService, NoopRelationCoreService, NoopRoutingCoreService,
@@ -564,9 +554,6 @@ impl ServicesBuilder {
             provider_bot_events: self
                 .provider_bot_events
                 .unwrap_or_else(|| Arc::new(NoopProviderBotEventService)),
-            organization: self
-                .organization
-                .unwrap_or_else(|| Arc::new(NoopOrganizationCoreService)),
             organization_management: self
                 .organization_management
                 .unwrap_or_else(|| Arc::new(NoopOrganizationManagementService)),

--- a/src/bcs/crates/service-api/bcs-services-container/src/test_support.rs
+++ b/src/bcs/crates/service-api/bcs-services-container/src/test_support.rs
@@ -12,7 +12,7 @@ use bcs_test_support::{
     NoopFusionCoreService, NoopGroupCoreService, NoopGroupFusionService,
     NoopGroupManagementService, NoopGroupMessageHistoryService, NoopGroupProposalService,
     NoopGroupQueryService, NoopHumanActorService, NoopMessageFlowService,
-    NoopOrganizationCoreService, NoopOrganizationManagementService, NoopProposalCoreService,
+    NoopOrganizationManagementService, NoopProposalCoreService,
     NoopProviderBotCoreService, NoopProviderBotEventService, NoopProviderCoreService,
     NoopProviderManagementService, NoopRelationCoreService, NoopRoutingCoreService,
     NoopSessionManagementService, NoopSystemMessageService, NoopWorkbenchSessionService,
@@ -50,7 +50,6 @@ pub fn with_all_noop() -> ServicesBuilder {
         .provider_bot_core(Arc::new(NoopProviderBotCoreService))
         .provider_management(Arc::new(NoopProviderManagementService))
         .provider_bot_events(Arc::new(NoopProviderBotEventService))
-        .organization(Arc::new(NoopOrganizationCoreService))
         .organization_management(Arc::new(NoopOrganizationManagementService))
         .group_query(Arc::new(NoopGroupQueryService))
         .group_management(Arc::new(NoopGroupManagementService))

--- a/src/bcs/crates/service-api/bcs-services-container/tests/builder_fail_fast.rs
+++ b/src/bcs/crates/service-api/bcs-services-container/tests/builder_fail_fast.rs
@@ -9,7 +9,7 @@ use bcs_test_support::{
     NoopFusionCoreService, NoopGroupCoreService, NoopGroupFusionService,
     NoopGroupManagementService, NoopGroupMessageHistoryService, NoopGroupProposalService,
     NoopGroupQueryService, NoopHumanActorService, NoopMessageFlowService,
-    NoopOrganizationCoreService, NoopOrganizationManagementService, NoopProposalCoreService,
+    NoopOrganizationManagementService, NoopProposalCoreService,
     NoopProviderBotCoreService, NoopProviderBotEventService, NoopProviderCoreService,
     NoopProviderManagementService, NoopRelationCoreService, NoopRoutingCoreService,
     NoopSecretService, NoopSessionManagementService, NoopSystemMessageService,
@@ -27,17 +27,8 @@ fn build_fails_fast_when_required_service_unset() {
 }
 
 #[test]
-fn build_fails_fast_when_organization_core_unset() {
-    let result = fully_wired_builder_except_organization().build();
-    assert!(matches!(
-        result,
-        Err(BuilderError::MissingService(name)) if name == "organization"
-    ));
-}
-
-#[test]
 fn build_fails_fast_when_organization_management_unset() {
-    let result = fully_wired_builder_except_organization_management().build();
+    let result = fully_wired_builder_without_organization_management().build();
     assert!(matches!(
         result,
         Err(BuilderError::MissingService(name)) if name == "organization_management"
@@ -74,7 +65,6 @@ fn build_succeeds_when_all_required_services_set() {
         .provider_bot_core(Arc::new(NoopProviderBotCoreService))
         .provider_management(Arc::new(NoopProviderManagementService))
         .provider_bot_events(Arc::new(NoopProviderBotEventService))
-        .organization(Arc::new(NoopOrganizationCoreService))
         .organization_management(Arc::new(NoopOrganizationManagementService))
         .group_query(Arc::new(NoopGroupQueryService))
         .group_management(Arc::new(NoopGroupManagementService))
@@ -91,17 +81,7 @@ fn build_succeeds_when_all_required_services_set() {
     assert!(Arc::ptr_eq(&services.registry, &services.registry));
 }
 
-fn fully_wired_builder_except_organization() -> ServicesBuilder {
-    fully_wired_builder_without_organization_fields()
-        .organization_management(Arc::new(NoopOrganizationManagementService))
-}
-
-fn fully_wired_builder_except_organization_management() -> ServicesBuilder {
-    fully_wired_builder_without_organization_fields()
-        .organization(Arc::new(NoopOrganizationCoreService))
-}
-
-fn fully_wired_builder_without_organization_fields() -> ServicesBuilder {
+fn fully_wired_builder_without_organization_management() -> ServicesBuilder {
     ServicesBuilder::new()
         .registry(Arc::new(NoopBotRegistryCoreService))
         .group(Arc::new(NoopGroupCoreService))

--- a/src/bcs/crates/services/bcs-bot/src/application/provider.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bcs_user_directory_api::UserDirectoryPlugin;
 use bcs_service_api::{
-    BotRegistryCoreService, DeleteProviderBotCommand, DeleteProviderBotOutcome,
-    ProviderBotBinding, ProviderBotCoreService, ProviderCoreService, ProviderManagementService,
-    ProviderRecord, RegisterProviderBotCommand, RegisterProviderBotOutcome,
-    RegisterProviderBotParams, RegisterProviderCommand, RegisterProviderOutcome,
-    RelationCoreService, ServiceError, ServiceResult, UpdateProviderCommand,
+    BotRegistryCoreService, DeleteProviderBotCommand, DeleteProviderBotOutcome, ProviderBotBinding,
+    ProviderBotCoreService, ProviderCoreService, ProviderManagementService, ProviderRecord,
+    RegisterProviderBotCommand, RegisterProviderBotOutcome, RegisterProviderBotParams,
+    RegisterProviderCommand, RegisterProviderOutcome, RelationCoreService, ServiceError,
+    ServiceResult, UpdateProviderCommand,
 };
+use bcs_user_directory_api::UserDirectoryPlugin;
 
 #[derive(Clone)]
 pub struct ProviderManagement {
@@ -42,7 +42,9 @@ impl ProviderManagement {
 
     async fn ensure_owner_binding(&self, bot_uuid: &str, staff_no: &str) -> ServiceResult<()> {
         let nick_name = self.resolve_owner_nick_name(staff_no).await;
-        self.registry.ensure_human_actor(staff_no, &nick_name).await?;
+        self.registry
+            .ensure_human_actor(staff_no, &nick_name)
+            .await?;
         let human_id = format!("human_{}", staff_no);
         let env = bcs_config::resolve_env_str();
         self.relation
@@ -130,6 +132,7 @@ impl ProviderManagementService for ProviderManagement {
         &self,
         command: RegisterProviderCommand,
     ) -> ServiceResult<RegisterProviderOutcome> {
+        let admin_callback_url = command.admin_callback_url;
         let registered = self
             .provider_core
             .register_provider(
@@ -141,6 +144,16 @@ impl ProviderManagementService for ProviderManagement {
                 command.coordination,
             )
             .await?;
+        if let Some(admin_callback_url) = admin_callback_url {
+            self.provider_core
+                .update_provider_admin_callback_url(
+                    &registered.provider.provider_id,
+                    &registered.provider_admin_token,
+                    &registered.provider.created_by,
+                    admin_callback_url,
+                )
+                .await?;
+        }
         Ok(RegisterProviderOutcome {
             provider_id: registered.provider.provider_id,
             provider_admin_token: registered.provider_admin_token,
@@ -162,7 +175,9 @@ impl ProviderManagementService for ProviderManagement {
         &self,
         command: UpdateProviderCommand,
     ) -> ServiceResult<ProviderRecord> {
-        self.provider_core
+        let admin_callback_url = command.admin_callback_url;
+        let provider = self
+            .provider_core
             .update_provider(
                 &command.provider_id,
                 &command.provider_admin_token,
@@ -173,7 +188,20 @@ impl ProviderManagementService for ProviderManagement {
                 command.coordination,
                 command.organization_management,
             )
-            .await
+            .await?;
+        match admin_callback_url {
+            Some(admin_callback_url) => {
+                self.provider_core
+                    .update_provider_admin_callback_url(
+                        &provider.provider_id,
+                        &command.provider_admin_token,
+                        &command.authenticated_staff_id,
+                        admin_callback_url,
+                    )
+                    .await
+            }
+            None => Ok(provider),
+        }
     }
 
     async fn register_provider_bot(

--- a/src/bcs/crates/services/bcs-bot/src/core/provider_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/provider_core.rs
@@ -6,11 +6,12 @@ use serde_json::Value;
 use tracing::{info, warn};
 
 use bcs_service_api::{
-    BotCapabilities, BotRegistryCoreService, CoordinationMode, ProviderAuthMode, ProviderBotBinding,
-    ProviderBotBindingRepoPort, ProviderCoordinationConfig, ProviderBotCoreService, ProviderCoreService,
-    ProviderCredential, ProviderCredentialRepoPort, ProviderOrganizationManagementConfig,
-    ProviderRecord, ProviderRepoPort, RegisterProviderBotParams, RegisteredProvider,
-    RuntimeBotIdentity, ServiceError, ServiceResult,
+    BotCapabilities, BotRegistryCoreService, CoordinationMode, ProviderAuthMode,
+    ProviderBotBinding, ProviderBotBindingRepoPort, ProviderBotCoreService,
+    ProviderCoordinationConfig, ProviderCoreService, ProviderCredential,
+    ProviderCredentialRepoPort, ProviderOrganizationManagementConfig, ProviderRecord,
+    ProviderRepoPort, RegisterProviderBotParams, RegisteredProvider, RuntimeBotIdentity,
+    ServiceError, ServiceResult,
 };
 
 use super::ids::{new_bot_uuid, new_provider_id, new_session_token};
@@ -187,12 +188,7 @@ impl ProviderCore {
         )
         .then(|| session_token.clone());
         self.registry
-            .register_with_owner_and_token(
-                bot_uuid.clone(),
-                capabilities,
-                owner,
-                &session_token,
-            )
+            .register_with_owner_and_token(bot_uuid.clone(), capabilities, owner, &session_token)
             .await
             .inspect_err(|err| {
                 warn!(
@@ -294,9 +290,7 @@ pub(crate) fn parse_downlink_config(config: &str) -> ServiceResult<DownlinkConfi
     })
 }
 
-pub(crate) fn parse_coordination_config(
-    config: &str,
-) -> ServiceResult<ProviderCoordinationConfig> {
+pub(crate) fn parse_coordination_config(config: &str) -> ServiceResult<ProviderCoordinationConfig> {
     let value: Value = serde_json::from_str(config)?;
     let Some(coordination) = value.get("coordination") else {
         return Ok(ProviderCoordinationConfig::disabled());
@@ -309,8 +303,7 @@ pub(crate) fn parse_coordination_config(
 pub(crate) fn parse_organization_management_config(
     config: &str,
 ) -> ServiceResult<ProviderOrganizationManagementConfig> {
-    ProviderOrganizationManagementConfig::from_provider_config(config)
-        .map_err(ServiceError::from)
+    ProviderOrganizationManagementConfig::from_provider_config(config).map_err(ServiceError::from)
 }
 
 fn now_ms() -> u64 {
@@ -340,13 +333,13 @@ fn validate_external_id(kind: &str, value: &str) -> ServiceResult<()> {
     }
 }
 
-fn validate_webhook_url(guard: &OutboundUrlGuard, webhook_url: &str) -> ServiceResult<()> {
-    guard.validate_configured_http_url(webhook_url).map_err(|error| {
-        ServiceError::InvalidOperation {
-            message: format!("webhook_url is not allowed: {error}"),
+fn validate_outbound_url(guard: &OutboundUrlGuard, field: &str, url: &str) -> ServiceResult<()> {
+    guard
+        .validate_configured_http_url(url)
+        .map_err(|error| ServiceError::InvalidOperation {
+            message: format!("{field} is not allowed: {error}"),
             request_id: None,
-        }
-    })
+        })
 }
 
 fn validate_provider_coordination_config(
@@ -448,6 +441,21 @@ fn replace_webhook_url(config: &str, webhook_url: &str) -> ServiceResult<String>
     Ok(value.to_string())
 }
 
+fn replace_admin_callback_url(config: &str, admin_callback_url: &str) -> ServiceResult<String> {
+    let mut value: Value = serde_json::from_str(config)?;
+    let Some(config) = value.as_object_mut() else {
+        return Err(ServiceError::InvalidOperation {
+            message: "provider config is not an object".to_string(),
+            request_id: None,
+        });
+    };
+    config.insert(
+        "admin_callback_url".to_string(),
+        Value::String(admin_callback_url.to_string()),
+    );
+    Ok(value.to_string())
+}
+
 fn replace_protocol_version(config: &str, protocol_version: &str) -> ServiceResult<String> {
     // Same validation as register: only "1.0" / "2.0" are supported.
     let normalized = match protocol_version.trim() {
@@ -501,14 +509,15 @@ fn ensure_provider_owner(provider: &ProviderRecord, staff_no: &str) -> ServiceRe
             "valid human identity is required".to_string(),
         ));
     }
-    let owners: Vec<String> = serde_json::from_str(&provider.owners).map_err(|_| {
-        ServiceError::Forbidden("provider_owner_required".to_string())
-    })?;
+    let owners: Vec<String> = serde_json::from_str(&provider.owners)
+        .map_err(|_| ServiceError::Forbidden("provider_owner_required".to_string()))?;
     let is_owner = owners.iter().any(|owner| owner.trim() == staff_no);
     if is_owner {
         Ok(())
     } else {
-        Err(ServiceError::Forbidden("provider_owner_required".to_string()))
+        Err(ServiceError::Forbidden(
+            "provider_owner_required".to_string(),
+        ))
     }
 }
 
@@ -525,7 +534,7 @@ impl ProviderCoreService for ProviderCore {
     ) -> ServiceResult<RegisteredProvider> {
         let provider_id = new_provider_id();
         validate_external_id("provider_id", &provider_id)?;
-        validate_webhook_url(&self.webhook_url_guard, &webhook_url)?;
+        validate_outbound_url(&self.webhook_url_guard, "webhook_url", &webhook_url)?;
         let protocol_version = match protocol_version.as_deref().map(str::trim) {
             None | Some("") | Some("1.0") => "1.0",
             Some("2.0") => "2.0",
@@ -621,7 +630,9 @@ impl ProviderCoreService for ProviderCore {
             .credentials
             .get_credential_by_secret("provider_admin", token)
             .await?
-            .ok_or_else(|| ServiceError::Unauthorized("invalid provider admin token".to_string()))?;
+            .ok_or_else(|| {
+                ServiceError::Unauthorized("invalid provider admin token".to_string())
+            })?;
         if credential.disabled {
             return Err(ServiceError::Unauthorized(
                 "provider admin token is disabled".to_string(),
@@ -636,7 +647,10 @@ impl ProviderCoreService for ProviderCore {
             })
     }
 
-    async fn get_downlink_credential(&self, provider_id: &str) -> ServiceResult<ProviderCredential> {
+    async fn get_downlink_credential(
+        &self,
+        provider_id: &str,
+    ) -> ServiceResult<ProviderCredential> {
         let credential = self
             .credentials
             .get_credential_by_kind(provider_id, "downlink_bcs_to_provider")
@@ -680,7 +694,7 @@ impl ProviderCoreService for ProviderCore {
         ensure_provider_owner(&current, authenticated_staff_id)?;
         let mut config = match webhook_url {
             Some(webhook_url) => {
-                validate_webhook_url(&self.webhook_url_guard, &webhook_url)?;
+                validate_outbound_url(&self.webhook_url_guard, "webhook_url", &webhook_url)?;
                 Some(replace_webhook_url(&current.config, &webhook_url)?)
             }
             None => None,
@@ -700,13 +714,15 @@ impl ProviderCoreService for ProviderCore {
             organization_management
                 .authorized_manager_provider_ids
                 .retain(|manager_provider_id| manager_provider_id != provider_id);
-            organization_management.authorized_manager_provider_ids.sort();
-            organization_management.authorized_manager_provider_ids.dedup();
+            organization_management
+                .authorized_manager_provider_ids
+                .sort();
+            organization_management
+                .authorized_manager_provider_ids
+                .dedup();
             let manager_providers = self
                 .providers
-                .list_providers_by_ids(
-                    &organization_management.authorized_manager_provider_ids,
-                )
+                .list_providers_by_ids(&organization_management.authorized_manager_provider_ids)
                 .await?;
             if let Some(unknown_provider_id) = organization_management
                 .authorized_manager_provider_ids
@@ -729,12 +745,33 @@ impl ProviderCoreService for ProviderCore {
             )?);
         }
         self.providers
-            .update_provider_metadata(
-                provider_id,
-                name.as_deref(),
-                config.as_deref(),
-                now_ms(),
-            )
+            .update_provider_metadata(provider_id, name.as_deref(), config.as_deref(), now_ms())
+            .await?
+            .ok_or_else(|| ServiceError::InvalidOperation {
+                message: format!("provider '{}' not found", provider_id),
+                request_id: None,
+            })
+    }
+
+    async fn update_provider_admin_callback_url(
+        &self,
+        provider_id: &str,
+        provider_admin_token: &str,
+        authenticated_staff_id: &str,
+        admin_callback_url: String,
+    ) -> ServiceResult<ProviderRecord> {
+        let current = self
+            .provider_admin_for_path(provider_id, provider_admin_token)
+            .await?;
+        ensure_provider_owner(&current, authenticated_staff_id)?;
+        validate_outbound_url(
+            &self.webhook_url_guard,
+            "admin_callback_url",
+            &admin_callback_url,
+        )?;
+        let config = replace_admin_callback_url(&current.config, &admin_callback_url)?;
+        self.providers
+            .update_provider_metadata(provider_id, None, Some(&config), now_ms())
             .await?
             .ok_or_else(|| ServiceError::InvalidOperation {
                 message: format!("provider '{}' not found", provider_id),
@@ -869,7 +906,9 @@ impl ProviderBotCoreService for ProviderCore {
             .credentials
             .get_credential_by_secret("provider_admin", provider_admin_token)
             .await?
-            .ok_or_else(|| ServiceError::Unauthorized("invalid provider admin token".to_string()))?;
+            .ok_or_else(|| {
+                ServiceError::Unauthorized("invalid provider admin token".to_string())
+            })?;
         if credential.disabled {
             return Err(ServiceError::Unauthorized(
                 "provider admin token is disabled".to_string(),
@@ -901,10 +940,7 @@ impl ProviderBotCoreService for ProviderCore {
             .get_binding_by_provider_ref(&provider.provider_id, provider_bot_ref)
             .await?
             .ok_or_else(|| {
-                ServiceError::BotNotFound(format!(
-                    "provider bot '{}' not found",
-                    provider_bot_ref
-                ))
+                ServiceError::BotNotFound(format!("provider bot '{}' not found", provider_bot_ref))
             })?;
         if binding.disabled {
             return Err(ServiceError::InvalidOperation {

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -8,7 +8,8 @@ use bcs_protocol::{
 use bcs_service_api::application::channel::OutboundMessage;
 use bcs_service_api::{
     ActorStatus, BotDeliveryCommand, BotDeliveryKind, BotDeliveryResult, BotDeliveryTarget,
-    BotEventCommand, BotEventOutcome, ChannelOutboundEventKind, ChannelRenderHint,
+    BotEventCommand, BotEventOutcome, BotTerminalEvent, BotTerminalState,
+    ChannelOutboundEventKind, ChannelRenderHint,
     ChatEventRouting, ChatEventState, ChatResponseMode,
     DefaultDelivery, DeliveryType, FrontendDeliveryCommand, FrontendDeliveryKind,
     FrontendDeliveryResult, FrontendDeliveryTarget, Group, GroupKind, GroupStatus, GroupStrategy, MessageDeliveryResult,
@@ -136,6 +137,7 @@ pub async fn handle_bot_event(
 
     if let Some(task_id) = task_id_for_event {
         bot_deliveries.extend(handle_task_bot_event(flow, &cmd, &task_id).await?);
+        notify_terminal_observer(flow, &cmd).await;
         return Ok(BotEventOutcome {
             bot_deliveries,
             frontend_deliveries,
@@ -156,6 +158,7 @@ pub async fn handle_bot_event(
         bot_deliveries.extend(relay.bot_deliveries);
         frontend_deliveries.extend(relay.frontend_deliveries);
         flow.message_tracker.cleanup_run(&cmd.run_id).await;
+        notify_terminal_observer(flow, &cmd).await;
         return Ok(BotEventOutcome {
             bot_deliveries,
             frontend_deliveries,
@@ -167,6 +170,7 @@ pub async fn handle_bot_event(
         });
     }
 
+    notify_terminal_observer(flow, &cmd).await;
     Ok(BotEventOutcome {
         bot_deliveries,
         frontend_deliveries,
@@ -176,6 +180,39 @@ pub async fn handle_bot_event(
         failed_count: 0,
         delivery_results: Vec::new(),
     })
+}
+
+async fn notify_terminal_observer(flow: &BcsMessageFlow, cmd: &BotEventCommand) {
+    if !matches!(cmd.event_type.as_str(), "chat" | "chat.event") {
+        return;
+    }
+    let state = match cmd.state {
+        ChatEventState::Final => BotTerminalState::Final,
+        ChatEventState::Error => BotTerminalState::Error,
+        ChatEventState::Aborted => BotTerminalState::Aborted,
+        _ => return,
+    };
+    flow.bot_terminal_observer
+        .observe(BotTerminalEvent {
+            run_id: cmd.run_id.clone(),
+            bot_uuid: cmd.bot_id.clone(),
+            state,
+            text: terminal_event_text(&cmd.event_payload),
+        })
+        .await;
+}
+
+fn terminal_event_text(event: &Value) -> String {
+    let message = extract_message_text(event);
+    if !message.is_empty() {
+        return message;
+    }
+    event
+        .get("errorMessage")
+        .or_else(|| event.get("error_message"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
 }
 
 async fn try_channel_outbound(flow: &BcsMessageFlow, cmd: &BotEventCommand) {

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -10,6 +10,7 @@ use bcs_protocol::{
 use bcs_service_api::{
     ActorKind, ActorStatus, BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort,
     BotDeliveryResult, BotDeliveryTarget, BotEventCommand, BotEventOutcome, BotRunContext, BotRunContextPort,
+    BotTerminalObserverPort, NoopBotTerminalObserver,
     BotRegistryCoreService, CallerContext, ChatAbortCommand, ChatAbortOutcome,
     DeliveryBlockContext, DeliveryBlockReason,
     DeliveryBlockSurface, DeliveryMetricKind, DeliveryMetricTarget, DeliveryType,
@@ -57,6 +58,7 @@ pub struct BcsMessageFlow {
     pub message_tracker: Arc<crate::message_tracker::MessageTracker>,
     pub provider_stream_gray_list: Option<Arc<ProviderStreamGrayList>>,
     pub channel: Arc<OnceLock<Arc<dyn ChannelService>>>,
+    pub bot_terminal_observer: Arc<dyn BotTerminalObserverPort>,
 }
 
 impl BcsMessageFlow {
@@ -83,11 +85,20 @@ impl BcsMessageFlow {
             message_tracker: Arc::new(crate::message_tracker::MessageTracker::new()),
             provider_stream_gray_list: None,
             channel: Arc::new(OnceLock::new()),
+            bot_terminal_observer: Arc::new(NoopBotTerminalObserver),
         }
     }
 
     pub fn channel_slot(&self) -> Arc<OnceLock<Arc<dyn ChannelService>>> {
         self.channel.clone()
+    }
+
+    pub fn with_bot_terminal_observer(
+        mut self,
+        observer: Arc<dyn BotTerminalObserverPort>,
+    ) -> Self {
+        self.bot_terminal_observer = observer;
+        self
     }
 
     pub fn with_system_message(mut self, system_message: Arc<dyn SystemMessageService>) -> Self {

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -5,7 +5,8 @@ use bcs_message_flow::task_store::{new_task_entry, TaskLedgerStatus, TASK_TTL_MS
 use bcs_protocol::BcsFrame;
 use bcs_service_api::{
     ActorKind, BotDeliveryKind, BotDeliveryTarget, BotEventCommand, BotRegistryCoreService,
-    BotRunContextPort, ChannelOutboundEventKind, ChannelRenderHint, ChatEventState,
+    BotRunContextPort, BotTerminalEvent, BotTerminalObserverPort, BotTerminalState,
+    ChannelOutboundEventKind, ChannelRenderHint, ChatEventState,
     ChatResponseMode, DefaultDelivery,
     FrontendDeliveryTarget, GroupCoreService, GroupKind, GroupStatus, GroupStrategy,
     MessageFlowService, Participant, ParticipantMode, ParticipantRole,
@@ -33,6 +34,18 @@ struct RecordingSystemNotification {
     event: SystemMessageEvent,
     session_id: String,
     participants: Vec<Participant>,
+}
+
+#[derive(Default)]
+struct RecordingBotTerminalObserver {
+    events: Mutex<Vec<BotTerminalEvent>>,
+}
+
+#[async_trait::async_trait]
+impl BotTerminalObserverPort for RecordingBotTerminalObserver {
+    async fn observe(&self, event: BotTerminalEvent) {
+        self.events.lock().await.push(event);
+    }
 }
 
 #[derive(Default)]
@@ -114,6 +127,72 @@ impl SystemMessageService for RecordingSystemMessage {
         });
         Ok(1)
     }
+}
+
+#[tokio::test]
+async fn websocket_chat_events_notify_terminal_observer_only_for_terminal_states() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let observer = Arc::new(RecordingBotTerminalObserver::default());
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_bot_terminal_observer(observer.clone());
+
+    for (run_id, state, payload) in [
+        (
+            "run-websocket-final",
+            ChatEventState::Final,
+            json!({
+                "state": "final",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "websocket result"}],
+                },
+            }),
+        ),
+        (
+            "run-websocket-error",
+            ChatEventState::Error,
+            json!({"state": "error", "errorMessage": "websocket failed"}),
+        ),
+        (
+            "run-websocket-aborted",
+            ChatEventState::Aborted,
+            json!({"state": "aborted", "error_message": "websocket aborted"}),
+        ),
+        (
+            "run-websocket-delta",
+            ChatEventState::Delta,
+            json!({"state": "delta", "message": {"content": "partial"}}),
+        ),
+    ] {
+        flow.handle_bot_event(BotEventCommand {
+            bot_id: "bot-observer".to_string(),
+            run_id: run_id.to_string(),
+            group_id: "group-1".to_string(),
+            event_type: "chat.event".to_string(),
+            event_payload: payload,
+            state,
+            bcs_session_id: None,
+        })
+        .await
+        .unwrap();
+    }
+
+    let events = observer.events.lock().await;
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].run_id, "run-websocket-final");
+    assert_eq!(events[0].bot_uuid, "bot-observer");
+    assert_eq!(events[0].state, BotTerminalState::Final);
+    assert_eq!(events[0].text, "websocket result");
+    assert_eq!(events[1].state, BotTerminalState::Error);
+    assert_eq!(events[1].text, "websocket failed");
+    assert_eq!(events[2].state, BotTerminalState::Aborted);
+    assert_eq!(events[2].text, "websocket aborted");
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-organization-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-organization-store/src/lib.rs
@@ -354,7 +354,11 @@ impl OrganizationRepoPort for DbOrganizationStore {
         }
         let rows = self.db.query(DbStatement::with_params(sql, params)).await
             .map_err(|error| service_db_error("list_discovery_bots", error))?;
-        Ok(Some(rows.into_iter().filter_map(row_to_discovery_bot).collect()))
+        Ok(Some(
+            rows.into_iter()
+                .map(row_to_discovery_bot)
+                .collect::<ServiceResult<Vec<_>>>()?,
+        ))
     }
 
     async fn list_members_page(
@@ -447,29 +451,29 @@ fn row_to_member(row: DbRow) -> ServiceResult<OrganizationMember> {
     })
 }
 
-fn row_to_discovery_bot(row: DbRow) -> Option<OrganizationDiscoveryBot> {
-    let bot_uuid = optional_string(&row, "bot_uuid").ok().flatten()?;
-    let mut capabilities = optional_string(&row, "bot_info")
-        .ok()
-        .flatten()
-        .and_then(|bot_info| serde_json::from_str::<BotCapabilities>(&bot_info).ok())
-        .unwrap_or_default();
-    capabilities.name = optional_string(&row, "bot_name").ok().flatten();
-    if let Some(visibility) = optional_string(&row, "visibility").ok().flatten() {
+fn row_to_discovery_bot(row: DbRow) -> ServiceResult<OrganizationDiscoveryBot> {
+    let bot_uuid = required_string(&row, "bot_uuid")?;
+    let mut capabilities = match optional_string(&row, "bot_info")? {
+        Some(bot_info) => serde_json::from_str::<BotCapabilities>(&bot_info).map_err(|error| {
+            ServiceError::InternalError(format!(
+                "organization db bot_info: invalid capabilities JSON: {error}"
+            ))
+        })?,
+        None => BotCapabilities::default(),
+    };
+    capabilities.name = optional_string(&row, "bot_name")?;
+    if let Some(visibility) = optional_string(&row, "visibility")? {
         capabilities.visibility = visibility;
     }
-    capabilities.agent_code = optional_string(&row, "agent_code")
-        .ok()
-        .flatten()
-        .or(capabilities.agent_code);
+    capabilities.agent_code = optional_string(&row, "agent_code")?.or(capabilities.agent_code);
     capabilities.agent_token = None;
-    let actor_kind = match optional_string(&row, "actor_kind").ok().flatten().as_deref() {
+    let actor_kind = match optional_string(&row, "actor_kind")?.as_deref() {
         Some("human") => ActorKind::Human,
         _ => ActorKind::Bot,
     };
-    Some(OrganizationDiscoveryBot {
+    Ok(OrganizationDiscoveryBot {
         bot_uuid,
-        role: optional_string(&row, "role").ok().flatten(),
+        role: optional_string(&row, "role")?,
         capabilities,
         actor_kind,
     })
@@ -627,6 +631,18 @@ mod tests {
         DbRow::new(BTreeMap::from([("total".to_string(), DbValue::from(total))]))
     }
 
+    fn discovery_row(bot_info: DbValue) -> DbRow {
+        DbRow::new(BTreeMap::from([
+            ("bot_uuid".to_string(), DbValue::from("bot-a")),
+            ("role".to_string(), DbValue::from("planner")),
+            ("bot_name".to_string(), DbValue::from("Bot A")),
+            ("bot_info".to_string(), bot_info),
+            ("visibility".to_string(), DbValue::from("protected")),
+            ("actor_kind".to_string(), DbValue::from("bot")),
+            ("agent_code".to_string(), DbValue::Null),
+        ]))
+    }
+
     fn create_record() -> CreateOrganizationRecord {
         CreateOrganizationRecord {
             env: "contract".to_string(),
@@ -697,6 +713,46 @@ mod tests {
             Err(ServiceError::InternalError(message))
                 if message.contains("organization db set_member_disabled")
                     && message.contains("write unavailable")
+        ));
+    }
+
+    #[tokio::test]
+    async fn discovery_bot_rejects_malformed_capabilities_json() {
+        let db = Arc::new(RecordingDbPlugin::with_rows(vec![discovery_row(
+            DbValue::from("{not-json"),
+        )]));
+        let result = DbOrganizationStore::sqlite(db)
+            .list_discovery_bots("contract", "promo-2026", None)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ServiceError::InternalError(message))
+                if message.contains("organization db bot_info")
+                    && message.contains("invalid capabilities JSON")
+        ));
+    }
+
+    #[tokio::test]
+    async fn discovery_bot_propagates_column_type_errors() {
+        let row = DbRow::new(BTreeMap::from([
+            ("bot_uuid".to_string(), DbValue::from("bot-a")),
+            ("role".to_string(), DbValue::from("planner")),
+            ("bot_name".to_string(), DbValue::from(42_i64)),
+            ("bot_info".to_string(), DbValue::Null),
+            ("visibility".to_string(), DbValue::from("protected")),
+            ("actor_kind".to_string(), DbValue::from("bot")),
+            ("agent_code".to_string(), DbValue::Null),
+        ]));
+        let db = Arc::new(RecordingDbPlugin::with_rows(vec![row]));
+        let result = DbOrganizationStore::sqlite(db)
+            .list_discovery_bots("contract", "promo-2026", None)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ServiceError::InternalError(message))
+                if message.contains("organization db bot_name")
         ));
     }
 

--- a/src/bcs/crates/services/bcs-organization/Cargo.toml
+++ b/src/bcs/crates/services/bcs-organization/Cargo.toml
@@ -17,6 +17,7 @@ futures = { workspace = true }
 bcs-bot = { workspace = true }
 bcs-bot-store = { workspace = true }
 bcs-organization-store = { workspace = true }
+bcs-test-support = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 

--- a/src/bcs/crates/services/bcs-organization/src/application.rs
+++ b/src/bcs/crates/services/bcs-organization/src/application.rs
@@ -143,6 +143,27 @@ impl OrganizationManagementService for OrganizationManagement {
             .await
     }
 
+    async fn require_invocable_member(
+        &self,
+        auth: OrganizationAuth,
+        organization_code: &str,
+        bot_uuid: &str,
+    ) -> ServiceResult<OrganizationMember> {
+        self.authenticate(&auth).await?;
+        let organization = self
+            .core
+            .get_for_manager(&auth.provider_id, organization_code)
+            .await?;
+        if organization.managing_provider_id != auth.provider_id {
+            return Err(bcs_service_api::ServiceError::Forbidden(
+                "organization_manager_required".to_string(),
+            ));
+        }
+        self.core
+            .require_effective_member(organization_code, bot_uuid)
+            .await
+    }
+
     async fn list_members(
         &self,
         auth: OrganizationMemberAuth,

--- a/src/bcs/crates/services/bcs-organization/tests/management.rs
+++ b/src/bcs/crates/services/bcs-organization/tests/management.rs
@@ -241,6 +241,57 @@ async fn create_org(ctx: &TestContext, provider: &ProviderFixture) {
 }
 
 #[tokio::test]
+async fn organization_services_pass_conformance_contracts() {
+    let ctx = test_context().await;
+    let provider = register_provider(&ctx, "Contract Provider").await;
+
+    bcs_test_support::contract::core::organization_core_service_contract_tests(
+        ctx.core.as_ref(),
+        &provider.provider_id,
+        "core-contract-org",
+    )
+    .await;
+    bcs_test_support::contract::application::organization_management_service_contract_tests(
+        &ctx.service,
+        provider_auth(&provider),
+        bad_provider_auth(&provider),
+        "application-contract-org",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn organization_management_authorizes_invocable_member_for_owning_manager() {
+    let ctx = test_context().await;
+    let provider = register_provider(&ctx, "Provider A").await;
+    register_bot(&ctx, &provider, "bot-a").await;
+    create_org(&ctx, &provider).await;
+    ctx.service
+        .put_member(PutOrganizationMemberCommand {
+            auth: member_auth(&provider),
+            organization_code: "promo-2026".to_string(),
+            bot_uuid: "bot-a".to_string(),
+            role: None,
+        })
+        .await
+        .expect("put member");
+
+    let member = ctx
+        .service
+        .require_invocable_member(provider_auth(&provider), "promo-2026", "bot-a")
+        .await
+        .expect("authorize invocable member");
+
+    assert_eq!(member.bot_uuid, "bot-a");
+    assert!(matches!(
+        ctx.service
+            .require_invocable_member(bad_provider_auth(&provider), "promo-2026", "bot-a")
+            .await,
+        Err(ServiceError::Unauthorized(_))
+    ));
+}
+
+#[tokio::test]
 async fn put_member_allows_own_and_granted_provider_bots_and_restores_disabled_member() {
     let ctx = test_context().await;
     let provider_a = register_provider(&ctx, "Provider A").await;

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
@@ -5,6 +5,7 @@ use bcs_service_api::{
     BotManagementService, BotOnboardingService, BotQueryService, BotRuntimeConnectionService,
     FriendService, GroupFusionService, GroupManagementService, GroupMessageHistoryService,
     GroupProposalService, GroupQueryService, HumanActorService, MessageFlowService,
+    CreateOrganizationCommand, OrganizationAuth, OrganizationManagementService, ServiceError,
     SystemMessageService, WorkbenchSessionService, WorkerProfileService,
 };
 
@@ -50,6 +51,37 @@ pub async fn group_query_service_contract_tests<T: GroupQueryService + ?Sized>(_
 pub async fn human_actor_service_contract_tests<T: HumanActorService + ?Sized>(_svc: &T) {}
 
 pub async fn message_flow_service_contract_tests<T: MessageFlowService + ?Sized>(_svc: &T) {}
+
+pub async fn organization_management_service_contract_tests<
+    T: OrganizationManagementService + ?Sized,
+>(
+    svc: &T,
+    valid_auth: OrganizationAuth,
+    invalid_auth: OrganizationAuth,
+    organization_code: &str,
+) {
+    assert!(matches!(
+        svc.list(invalid_auth, false).await,
+        Err(ServiceError::Unauthorized(_))
+    ));
+
+    let created = svc
+        .create(CreateOrganizationCommand {
+            auth: valid_auth.clone(),
+            organization_code: organization_code.to_string(),
+            name: "Application Contract".to_string(),
+            description: None,
+        })
+        .await
+        .expect("create organization through application service");
+    assert_eq!(created.code, organization_code);
+
+    let fetched = svc
+        .get(valid_auth, organization_code)
+        .await
+        .expect("get organization through application service");
+    assert_eq!(fetched.name, "Application Contract");
+}
 
 pub async fn worker_profile_service_contract_tests<T: WorkerProfileService + ?Sized>(_svc: &T) {}
 

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/core/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/core/mod.rs
@@ -2,8 +2,9 @@
 
 use bcs_service_api::{
     BotRegistryCoreService, FriendCoreService, FriendRequestCoreService, FriendRequestDirection,
-    FusionCoreService, GroupCoreService, ProposalCoreService, RelationCoreService,
-    RoutingCoreService, ServiceError, SystemMessageDispatcherService, SystemMessageProducerService,
+    FusionCoreService, GroupCoreService, OrganizationCoreService, ProposalCoreService,
+    RelationCoreService, RoutingCoreService, ServiceError, SystemMessageDispatcherService,
+    SystemMessageProducerService,
 };
 
 pub async fn bot_registry_core_service_contract_tests<T: BotRegistryCoreService + ?Sized>(
@@ -61,6 +62,46 @@ pub async fn friend_request_core_service_contract_tests<T: FriendRequestCoreServ
 pub async fn fusion_core_service_contract_tests<T: FusionCoreService + ?Sized>(_svc: &T) {}
 
 pub async fn group_core_service_contract_tests<T: GroupCoreService + ?Sized>(_svc: &T) {}
+
+pub async fn organization_core_service_contract_tests<T: OrganizationCoreService + ?Sized>(
+    svc: &T,
+    managing_provider_id: &str,
+    organization_code: &str,
+) {
+    let created = svc
+        .create(
+            managing_provider_id,
+            organization_code,
+            "Organization Contract",
+            Some("created by the core contract"),
+        )
+        .await
+        .expect("create organization");
+    assert_eq!(created.code, organization_code);
+    assert_eq!(created.managing_provider_id, managing_provider_id);
+
+    let fetched = svc
+        .get_for_manager(managing_provider_id, organization_code)
+        .await
+        .expect("get organization");
+    assert_eq!(fetched.name, "Organization Contract");
+    assert!(svc
+        .list_for_manager(managing_provider_id, false)
+        .await
+        .expect("list organizations")
+        .iter()
+        .any(|organization| organization.code == organization_code));
+    assert!(matches!(
+        svc.create(managing_provider_id, organization_code, "Duplicate", None)
+            .await,
+        Err(ServiceError::Conflict(_))
+    ));
+    assert!(matches!(
+        svc.get_for_manager("contract-other-manager", organization_code)
+            .await,
+        Err(ServiceError::Forbidden(_))
+    ));
+}
 
 pub async fn proposal_core_service_contract_tests<T: ProposalCoreService + ?Sized>(_svc: &T) {}
 

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/port/bot_terminal_observer.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/port/bot_terminal_observer.rs
@@ -1,0 +1,23 @@
+//! Contract harness for terminal-event observer ports.
+
+use std::future::Future;
+
+use bcs_service_api::{BotTerminalEvent, BotTerminalObserverPort};
+
+/// Verifies that observing an event produces the implementation's externally
+/// observable effect. The probe future must inspect that effect rather than the
+/// observer's internal state.
+pub async fn bot_terminal_observer_port_contract_tests<T, F>(
+    port: &T,
+    event: BotTerminalEvent,
+    observed_effect: F,
+) where
+    T: BotTerminalObserverPort + ?Sized,
+    F: Future<Output = bool>,
+{
+    port.observe(event).await;
+    assert!(
+        observed_effect.await,
+        "terminal observer must produce its configured observable effect"
+    );
+}

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/port/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/port/mod.rs
@@ -1,6 +1,7 @@
 //! Port contract harnesses.
 
 pub mod metrics;
+pub mod bot_terminal_observer;
 
 use bcs_service_api::{
     BotDeliveryPort, ChatRunCleanupPort, ChatRunEventPort, FrontendDeliveryPort,
@@ -14,6 +15,7 @@ pub use metrics::{
     group_metrics_snapshot_port_contract_tests, group_session_metrics_snapshot_port_contract_tests,
     ws_lifecycle_instrumentation_hook_contract_tests,
 };
+pub use bot_terminal_observer::bot_terminal_observer_port_contract_tests;
 
 pub async fn bot_delivery_port_contract_tests<T: BotDeliveryPort + ?Sized>(_port: &T) {}
 

--- a/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
@@ -704,6 +704,15 @@ impl OrganizationManagementService for NoopOrganizationManagementService {
         Err(service_not_configured("organization service"))
     }
 
+    async fn require_invocable_member(
+        &self,
+        _auth: OrganizationAuth,
+        _organization_code: &str,
+        _bot_uuid: &str,
+    ) -> ServiceResult<OrganizationMember> {
+        Err(service_not_configured("organization service"))
+    }
+
     async fn list_members(
         &self,
         _auth: OrganizationMemberAuth,

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -809,6 +809,26 @@ print("1" if any(item.get("bot_uuid") == target for item in json.load(sys.stdin)
 ' "$provider_bot_uuid" 2>/dev/null || echo 0)
     assert_eq "organization member list includes the provider bot" "$listed_member" "1"
 
+    api_request_headers POST "/organizations/${organization_code}/admin-runs" \
+        "{\"target_bot_uuid\":\"${provider_bot_uuid}\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Review the E2E release plan\"}]},\"detach\":true}" \
+        "Authorization: Bearer ${admin_token}" \
+        "X-BCN-Provider-Id: ${provider_id}"
+    require_status "provider starts an organization admin run" "202" || return
+    local admin_run_id
+    admin_run_id=$(json_path "$RESPONSE" "data.run_id")
+    assert_not_empty "organization admin run returns a run id" "$admin_run_id"
+    assert_json_eq "organization admin run keeps its organization" "$RESPONSE" "data.organization_code" "$organization_code"
+    assert_json_eq "organization admin run keeps its target bot" "$RESPONSE" "data.target_bot_uuid" "$provider_bot_uuid"
+    [[ -n "$admin_run_id" ]] || return
+
+    api_request_headers GET "/organizations/${organization_code}/admin-runs/${admin_run_id}" "" \
+        "Authorization: Bearer ${admin_token}" \
+        "X-BCN-Provider-Id: ${provider_id}"
+    require_status "provider reads the organization admin run" "200" || return
+    assert_json_eq "organization admin run read keeps its run id" "$RESPONSE" "data.run_id" "$admin_run_id"
+    assert_json_eq "organization admin run read keeps its target bot" "$RESPONSE" "data.target_bot_uuid" "$provider_bot_uuid"
+    assert_json_not_empty "organization admin run read exposes status" "$RESPONSE" "data.status"
+
     api_request_headers DELETE "/organizations/${organization_code}/members/${provider_bot_uuid}" "" \
         "Authorization: Bearer ${admin_token}"
     require_status "provider removes its bot from the organization" "204" || return


### PR DESCRIPTION
## Summary
- add organization-scoped admin run endpoints for manager Providers
- support tracked polling, detached delivery, and optional provider-level terminal callbacks
- add `admin_callback_url` Provider configuration and contract coverage

## Validation
- `cargo test --manifest-path src/bcs/Cargo.toml --package bcs-http`
- BCS pre-push gate: 2252 tests passed (43 skipped)

Closes #141