### PR TITLE
Add @FreddieSun as owner for /src/backend and /src/engine in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,5 @@
 /src/frontend/ @zoii @ClaaaaaaaaaireR @greenishzyy
 /src/bcsfuse/ @archer910517-ctrl @wienyang
 /src/backend/ @totalfrank @xianmuyq @FreddieSun
-/src/engine/ @totalfrank @xianmuyq
+/src/engine/ @totalfrank @xianmuyq @FreddieSun
 /src/baas/ @cassiuscai @pfmiles @phoenixliu @xxxxpenny @EVASHINJI

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,6 @@
 /src/plugin/ @RaymondHX @vzvince @carolynli @questchaos @zoii
 /src/frontend/ @zoii @ClaaaaaaaaaireR @greenishzyy
 /src/bcsfuse/ @archer910517-ctrl @wienyang
-/src/backend/ @totalfrank @xianmuyq
+/src/backend/ @totalfrank @xianmuyq @juangua.swj
 /src/engine/ @totalfrank @xianmuyq
 /src/baas/ @cassiuscai @pfmiles @phoenixliu @xxxxpenny @EVASHINJI

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,6 @@
 /src/plugin/ @RaymondHX @vzvince @carolynli @questchaos @zoii
 /src/frontend/ @zoii @ClaaaaaaaaaireR @greenishzyy
 /src/bcsfuse/ @archer910517-ctrl @wienyang
-/src/backend/ @totalfrank @xianmuyq @juangua.swj
+/src/backend/ @totalfrank @xianmuyq @FreddieSun
 /src/engine/ @totalfrank @xianmuyq
 /src/baas/ @cassiuscai @pfmiles @phoenixliu @xxxxpenny @EVASHINJI


### PR DESCRIPTION
## Summary

Adds `@FreddieSun` as a code owner for the `/src/backend/` and `/src/engine/` paths in `.github/CODEOWNERS`.

## Changes

- `/src/backend/` owners are now `@totalfrank @xianmuyq @FreddieSun` (previously `@totalfrank @xianmuyq`).
- `/src/engine/` owners are now `@totalfrank @xianmuyq @FreddieSun` (previously `@totalfrank @xianmuyq`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)