### PR TITLE
fix(engine): fan out async chat.inject events to websocket subscribers

### DIFF
--- a/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
+++ b/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
@@ -1412,6 +1412,120 @@ class TestChatSubscribeFanout:
         assert server._inject_listener_refs == {}
         assert server._session_subscribers == {}
 
+    @pytest.mark.asyncio
+    async def test_drop_idle_inject_listeners_retains_active_listeners_and_drops_idle_ones(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client1 = MagicMock(name="OpenClawClient1")
+        client1.on_event = MagicMock()
+        client1.off_event = MagicMock()
+        client2 = MagicMock(name="OpenClawClient2")
+        client2.on_event = MagicMock()
+        client2.off_event = MagicMock()
+
+        async def mock_get(token):
+            return client1 if token == "tok-a" else client2
+
+        fake_engine.token_pool.get = AsyncMock(side_effect=mock_get)
+        server._conn_auth["conn-1"] = AuthContext(token="tok-a")
+        server._conn_auth["conn-2"] = AuthContext(token="tok-b")
+
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-2",
+            request=_req("chat.subscribe", {"sessionKey": "sk-2"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        await server._release_conn("conn-1")
+
+        assert client1.off_event.call_count == 2
+        assert [call.args[0] for call in client1.off_event.call_args_list] == [
+            "chat",
+            "agent",
+        ]
+        client2.off_event.assert_not_called()
+        assert ("tok-a", id(client1)) not in server._inject_listener_refs
+        assert ("tok-a", id(client1)) not in server._inject_listener_conns
+        assert ("tok-b", id(client2)) in server._inject_listener_refs
+        assert server._inject_listener_conns[("tok-b", id(client2))] == {"conn-2"}
+        assert server._session_subscribers == {"sk-2": {"conn-2"}}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_cleans_partial_listener_when_on_event_fails(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock(side_effect=[None, RuntimeError("on boom")])
+        client.off_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        server._conn_auth["conn-1"] = AuthContext(token="tok-a")
+
+        response, _events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload == {
+            "subscribed": True,
+            "sessionKey": "sk-1",
+            "liveInject": False,
+        }
+        assert [call.args[0] for call in client.off_event.call_args_list] == [
+            "chat",
+            "agent",
+        ]
+        assert ("tok-a", id(client)) not in server._inject_listener_refs
+        assert ("tok-a", id(client)) not in server._inject_listener_conns
+        assert server._session_subscribers == {"sk-1": {"conn-1"}}
+        assert server._conn_sessions == {"conn-1": {"sk-1"}}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_ignores_cleanup_error_after_partial_on_event_failure(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock(side_effect=[None, RuntimeError("on boom")])
+        client.off_event = MagicMock(side_effect=RuntimeError("off boom"))
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        server._conn_auth["conn-1"] = AuthContext(token="tok-a")
+
+        response, _events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload["liveInject"] is False
+        assert client.off_event.call_count == 2
+        assert ("tok-a", id(client)) not in server._inject_listener_refs
+        assert ("tok-a", id(client)) not in server._inject_listener_conns
+
+    def test_drop_idle_inject_listeners_removes_orphan_conn_mapping_without_ref(
+        self, server,
+    ):
+        server._inject_listener_conns[("tok-a", 123)] = {"conn-1"}
+        server._conn_sessions = {}
+
+        server._drop_idle_inject_listeners()
+
+        assert server._inject_listener_conns == {}
+        assert server._inject_listener_refs == {}
+
 
 class _FakeChatServiceWithInject:
     """Stand-in chat service whose class explicitly declares ``inject``.

--- a/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
+++ b/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
@@ -15,6 +15,8 @@ What's NOT covered here:
 """
 from __future__ import annotations
 
+import json
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -886,7 +888,9 @@ class TestDispatch:
 
         req = _req("chat.abort", {"sessionKey": "sk-1"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
         assert response is expected_response
@@ -901,7 +905,9 @@ class TestDispatch:
 
         req = _req("sessions.reset", {"sessionKey": "sk-1"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
         assert response is expected_response
@@ -920,7 +926,9 @@ class TestDispatch:
         # routes it through the relay plugin like any other unknown method.
         req = _req("exec.approval.resolve", {"sessionKey": "sk", "action": "ok"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
         assert response is expected_response
@@ -935,7 +943,9 @@ class TestDispatch:
         )
         req = _req("sessions.reset", {"sessionKey": "sk-1"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
         assert response.ok is False
@@ -967,7 +977,9 @@ class TestDispatch:
             "randomExtra": 42,
         })
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
 
@@ -981,6 +993,326 @@ class TestDispatch:
             "message": "hello",
             "label": "user-pin",
         }
+
+
+class TestChatSubscribeFanout:
+    @pytest.mark.asyncio
+    async def test_chat_subscribe_records_session_and_binds_openclaw_inject_listener(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+
+        req = _req("chat.subscribe", {"sessionKey": "sk-1"}, id="sub-1")
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload == {
+            "subscribed": True,
+            "sessionKey": "sk-1",
+            "liveInject": True,
+        }
+        assert events == []
+        assert server._session_subscribers == {"sk-1": {"conn-1"}}
+        assert server._conn_sessions == {"conn-1": {"sk-1"}}
+        fake_engine.token_pool.get.assert_awaited_once_with("tok-a")
+        assert client.on_event.call_args_list[0].args[0] == "chat"
+        assert client.on_event.call_args_list[1].args[0] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_inject_event_is_broadcast_only_to_subscribed_session(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        ws1 = MagicMock()
+        ws1.send_text = AsyncMock()
+        ws2 = MagicMock()
+        ws2.send_text = AsyncMock()
+        server._connections["conn-1"] = ws1
+        server._connections["conn-2"] = ws2
+        server._conn_auth["conn-2"] = AuthContext(token="tok-a")
+
+        await server._handle_request(
+            websocket=ws1,
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        await server._handle_request(
+            websocket=ws2,
+            conn_id="conn-2",
+            request=_req("chat.subscribe", {"sessionKey": "sk-2"}),
+            auth_gate_service=auth_gate_service,
+        )
+        listener = client.on_event.call_args_list[0].args[1]
+
+        await listener(
+            EventFrame(
+                event="chat",
+                payload={
+                    "sessionKey": "sk-1",
+                    "runId": "inject-abc",
+                    "state": "final",
+                    "message": {"content": [{"type": "text", "text": "progress"}]},
+                },
+            ),
+        )
+
+        ws1.send_text.assert_awaited_once()
+        sent = json.loads(ws1.send_text.await_args.args[0])
+        assert sent["event"] == "chat"
+        assert sent["payload"]["runId"] == "inject-abc"
+        assert sent["payload"]["sessionKey"] == "sk-1"
+        ws2.send_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_inject_or_missing_session_event_is_not_broadcast(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        ws = MagicMock()
+        ws.send_text = AsyncMock()
+        server._connections["conn-1"] = ws
+
+        await server._handle_request(
+            websocket=ws,
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        listener = client.on_event.call_args_list[0].args[1]
+
+        await listener(
+            EventFrame(
+                event="chat",
+                payload={"sessionKey": "sk-1", "runId": "aps-abc", "state": "delta"},
+            ),
+        )
+        await listener(
+            EventFrame(
+                event="chat",
+                payload={"runId": "inject-abc", "state": "final"},
+            ),
+        )
+
+        ws.send_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_release_conn_unsubscribes_and_removes_openclaw_listeners(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        client.off_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        await server._release_conn("conn-1")
+
+        assert server._session_subscribers == {}
+        assert server._conn_sessions == {}
+        assert client.off_event.call_args_list[0].args[0] == "chat"
+        assert client.off_event.call_args_list[1].args[0] == "agent"
+        fake_engine.on_connection_close.assert_awaited_once_with(AuthContext(token="tok-a"))
+
+    @pytest.mark.asyncio
+    async def test_chat_subscribe_missing_session_key_is_invalid_request(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is False
+        assert response.error.code == ErrorCodes.INVALID_REQUEST
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_chat_unsubscribe_removes_one_session_and_returns_ok(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        client.off_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-2"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.unsubscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload == {"unsubscribed": True, "sessionKey": "sk-1"}
+        assert events == []
+        assert server._session_subscribers == {"sk-2": {"conn-1"}}
+        assert server._conn_sessions == {"conn-1": {"sk-2"}}
+        client.off_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_unsubscribe_missing_session_key_is_invalid_request(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.unsubscribe", {}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is False
+        assert response.error.code == ErrorCodes.INVALID_REQUEST
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_non_openclaw_subscribe_is_safe_noop(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "hermes"
+
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload == {"subscribed": True, "sessionKey": "sk-1", "liveInject": False}
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_openclaw_listener_bind_failures_are_fail_closed(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        fake_engine.token_pool.get = AsyncMock(side_effect=RuntimeError("pool down"))
+
+        response, _events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload["liveInject"] is False
+
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock(side_effect=RuntimeError("bind down"))
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+
+        response, _events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-2"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload["liveInject"] is False
+
+    @pytest.mark.asyncio
+    async def test_reuses_existing_openclaw_inject_listener(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        server._conn_auth["conn-2"] = AuthContext(token="tok-a")
+
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        response, _events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-2",
+            request=_req("chat.subscribe", {"sessionKey": "sk-2"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert response.payload["liveInject"] is True
+        assert client.on_event.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_inject_fanout_drops_stale_or_failing_connections(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        ws = MagicMock()
+        ws.send_text = AsyncMock(side_effect=RuntimeError("closed"))
+        server._connections["conn-1"] = ws
+        server._conn_auth["conn-2"] = AuthContext(token="tok-a")
+
+        await server._handle_request(
+            websocket=ws,
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-2",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        listener = client.on_event.call_args_list[0].args[1]
+
+        await listener(
+            EventFrame(
+                event="chat",
+                payload={"sessionKey": "sk-1", "runId": "inject-abc"},
+            ),
+        )
+
+        assert server._session_subscribers == {}
+        assert server._conn_sessions == {}
 
 
 class _FakeChatServiceWithInject:
@@ -1027,7 +1359,9 @@ class TestChatInjectDispatch:
             "idempotencyKey": "stripped",
         })
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
 
@@ -1048,7 +1382,9 @@ class TestChatInjectDispatch:
 
         req = _req("chat.inject", {"message": "hello"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
 
@@ -1065,7 +1401,9 @@ class TestChatInjectDispatch:
 
         req = _req("chat.inject", {"sessionKey": "sk-1"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
 
@@ -1084,7 +1422,9 @@ class TestChatInjectDispatch:
 
         req = _req("chat.inject", {"sessionKey": "sk-1", "message": "hi"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
 
@@ -1100,7 +1440,9 @@ class TestChatInjectDispatch:
 
         req = _req("chat.inject", {"sessionKey": "sk-1", "message": "hi"})
         response, events = await server._handle_request(
-            websocket=MagicMock(), conn_id="conn-1", request=req,
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=req,
             auth_gate_service=auth_gate_service,
         )
 

--- a/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
+++ b/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
@@ -1314,6 +1314,104 @@ class TestChatSubscribeFanout:
         assert server._session_subscribers == {}
         assert server._conn_sessions == {}
 
+    @pytest.mark.asyncio
+    async def test_unsubscribe_conn_tolerates_missing_subscriber_entry(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        # _conn_sessions references a session already removed from
+        # _session_subscribers (race / partial cleanup). _unsubscribe_conn
+        # must `continue` past the None entry instead of crashing.
+        server._conn_sessions = {"conn-1": {"sk-1"}}
+        server._session_subscribers = {}  # sk-1 already gone
+
+        server._unsubscribe_conn("conn-1")
+
+        assert server._conn_sessions == {}
+        assert server._session_subscribers == {}
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_session_purges_conn_when_last_session_removed(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        client.off_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+
+        # only one session -> removing it must pop the conn from _conn_sessions
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.unsubscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert server._conn_sessions == {}
+        assert server._session_subscribers == {}
+
+    @pytest.mark.asyncio
+    async def test_fanout_injected_event_no_subscribers_returns_early(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        ws = MagicMock()
+        ws.send_text = AsyncMock()
+        server._connections["conn-1"] = ws
+
+        # subscribe sk-1, bind listener, then drop subscribers so the listener
+        # callback hits an empty subscriber set.
+        await server._handle_request(
+            websocket=ws,
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+        listener = client.on_event.call_args_list[0].args[1]
+        server._session_subscribers.clear()
+
+        await listener(
+            EventFrame(
+                event="chat",
+                payload={"sessionKey": "sk-1", "runId": "inject-abc"},
+            ),
+        )
+
+        ws.send_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_drop_idle_inject_listeners_tolerates_off_event_failure(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        client.off_event = MagicMock(side_effect=RuntimeError("off boom"))
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+
+        await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.subscribe", {"sessionKey": "sk-1"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        # Releasing the conn triggers _drop_idle_inject_listeners, which must
+        # swallow the off_event exception and still clear the refs.
+        await server._release_conn("conn-1")
+
+        assert server._inject_listener_refs == {}
+        assert server._session_subscribers == {}
+
 
 class _FakeChatServiceWithInject:
     """Stand-in chat service whose class explicitly declares ``inject``.

--- a/src/engine/src/engine/community/api/transport/ws_server.py
+++ b/src/engine/src/engine/community/api/transport/ws_server.py
@@ -152,6 +152,7 @@ class EngineWebSocketServer:
         self._inject_listener_refs: Dict[
             tuple[str | None, int], tuple[Any, Callable[[EventFrame], Any]]
         ] = {}
+        self._inject_listener_conns: Dict[tuple[str | None, int], set[str]] = {}
         self._seq = 0
         self._version = "1.0.0"
 
@@ -696,6 +697,7 @@ class EngineWebSocketServer:
             return False
 
         key = (token, id(client))
+        self._inject_listener_conns.setdefault(key, set()).add(conn_id)
         if key in self._inject_listener_refs:
             return True
 
@@ -707,6 +709,16 @@ class EngineWebSocketServer:
             client.on_event("agent", on_injected_event)
         except Exception as e:
             log.warning("chat.subscribe: client.on_event failed: %s", e)
+            for event_name in ("chat", "agent"):
+                try:
+                    client.off_event(event_name, on_injected_event)
+                except Exception:
+                    pass
+            conns = self._inject_listener_conns.get(key)
+            if conns is not None:
+                conns.discard(conn_id)
+                if not conns:
+                    self._inject_listener_conns.pop(key, None)
             return False
 
         self._inject_listener_refs[key] = (client, on_injected_event)
@@ -756,15 +768,22 @@ class EngineWebSocketServer:
             self._unsubscribe_conn(stale_conn_id)
 
     def _drop_idle_inject_listeners(self) -> None:
-        if self._session_subscribers:
-            return
-        for client, listener in list(self._inject_listener_refs.values()):
+        active_conns = set(self._conn_sessions.keys())
+        for key, conns in list(self._inject_listener_conns.items()):
+            conns.intersection_update(active_conns)
+            if conns:
+                continue
+
+            self._inject_listener_conns.pop(key, None)
+            ref = self._inject_listener_refs.pop(key, None)
+            if ref is None:
+                continue
+            client, listener = ref
             try:
                 client.off_event("chat", listener)
                 client.off_event("agent", listener)
             except Exception as e:
                 log.debug("chat.subscribe: off_event failed: %s", e)
-        self._inject_listener_refs.clear()
 
     # ── chat.send ──────────────────────────────────────────────────────────
 

--- a/src/engine/src/engine/community/api/transport/ws_server.py
+++ b/src/engine/src/engine/community/api/transport/ws_server.py
@@ -147,6 +147,11 @@ class EngineWebSocketServer:
         self._mcp_token_settings = load_mcp_token_settings()
         self._connections: Dict[str, WebSocket] = {}
         self._conn_auth: Dict[str, AuthContext] = {}
+        self._session_subscribers: Dict[str, set[str]] = {}
+        self._conn_sessions: Dict[str, set[str]] = {}
+        self._inject_listener_refs: Dict[
+            tuple[str | None, int], tuple[Any, Callable[[EventFrame], Any]]
+        ] = {}
         self._seq = 0
         self._version = "1.0.0"
 
@@ -213,7 +218,8 @@ class EngineWebSocketServer:
             log.info(f"WebSocket connection closed: {conn_id}")
 
     async def _release_conn(self, conn_id: str) -> None:
-        """Tell the active engine this connection is gone."""
+        """Tell the active engine this connection is gone and drop session subscriptions."""
+        self._unsubscribe_conn(conn_id)
         auth = self._conn_auth.pop(conn_id, None)
         if auth is None:
             return
@@ -435,6 +441,10 @@ class EngineWebSocketServer:
                 return response, []
             elif method == "chat.abort":
                 return await self._handle_chat_abort(conn_id, request, params)
+            elif method == "chat.subscribe":
+                return await self._handle_chat_subscribe(conn_id, request, params)
+            elif method == "chat.unsubscribe":
+                return await self._handle_chat_unsubscribe(conn_id, request, params)
             elif method == "sessions.reset":
                 response = await self._handle_session_reset(conn_id, request, params)
                 return response, []
@@ -600,6 +610,161 @@ class EngineWebSocketServer:
             seq=payload["seq"],
         )
         await websocket.send_text(event.to_json())
+
+
+    # ── chat.subscribe / injected event fanout ───────────────────────────────
+
+    async def _handle_chat_subscribe(
+        self,
+        conn_id: str,
+        request: RequestFrame,
+        params: Dict[str, Any],
+    ) -> tuple[ResponseFrame, list[tuple[str, Dict[str, Any]]]]:
+        session_key = params.get("sessionKey")
+        if not session_key:
+            return ResponseFrame.err_response(
+                request.id,
+                ErrorShape(ErrorCodes.INVALID_REQUEST, "Missing sessionKey"),
+            ), []
+
+        self._session_subscribers.setdefault(session_key, set()).add(conn_id)
+        self._conn_sessions.setdefault(conn_id, set()).add(session_key)
+        live_inject = await self._ensure_openclaw_inject_listener(conn_id)
+        return ResponseFrame.ok_response(
+            request.id,
+            {
+                "subscribed": True,
+                "sessionKey": session_key,
+                "liveInject": live_inject,
+            },
+        ), []
+
+    async def _handle_chat_unsubscribe(
+        self,
+        conn_id: str,
+        request: RequestFrame,
+        params: Dict[str, Any],
+    ) -> tuple[ResponseFrame, list[tuple[str, Dict[str, Any]]]]:
+        session_key = params.get("sessionKey")
+        if not session_key:
+            return ResponseFrame.err_response(
+                request.id,
+                ErrorShape(ErrorCodes.INVALID_REQUEST, "Missing sessionKey"),
+            ), []
+
+        self._unsubscribe_conn_from_session(conn_id, session_key)
+        self._drop_idle_inject_listeners()
+        return ResponseFrame.ok_response(
+            request.id,
+            {"unsubscribed": True, "sessionKey": session_key},
+        ), []
+
+    def _unsubscribe_conn(self, conn_id: str) -> None:
+        for session_key in list(self._conn_sessions.pop(conn_id, set())):
+            subscribers = self._session_subscribers.get(session_key)
+            if subscribers is None:
+                continue
+            subscribers.discard(conn_id)
+            if not subscribers:
+                self._session_subscribers.pop(session_key, None)
+        self._drop_idle_inject_listeners()
+
+    def _unsubscribe_conn_from_session(self, conn_id: str, session_key: str) -> None:
+        sessions = self._conn_sessions.get(conn_id)
+        if sessions is not None:
+            sessions.discard(session_key)
+            if not sessions:
+                self._conn_sessions.pop(conn_id, None)
+        subscribers = self._session_subscribers.get(session_key)
+        if subscribers is not None:
+            subscribers.discard(conn_id)
+            if not subscribers:
+                self._session_subscribers.pop(session_key, None)
+
+    async def _ensure_openclaw_inject_listener(self, conn_id: str) -> bool:
+        manager = EngineManager.get_instance()
+        if manager.engine != "openclaw":
+            return False
+
+        auth = self._auth_for(conn_id)
+        token = auth.token
+        try:
+            pool = getattr(manager._require_engine(), "token_pool")
+            client = await pool.get(token)
+        except Exception as e:
+            log.warning("chat.subscribe: failed to bind openclaw inject listener: %s", e)
+            return False
+
+        key = (token, id(client))
+        if key in self._inject_listener_refs:
+            return True
+
+        async def on_injected_event(event: EventFrame) -> None:
+            await self._fanout_injected_event(event)
+
+        try:
+            client.on_event("chat", on_injected_event)
+            client.on_event("agent", on_injected_event)
+        except Exception as e:
+            log.warning("chat.subscribe: client.on_event failed: %s", e)
+            return False
+
+        self._inject_listener_refs[key] = (client, on_injected_event)
+        return True
+
+    async def _fanout_injected_event(self, event: EventFrame) -> None:
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        session_key = payload.get("sessionKey")
+        run_id = payload.get("runId")
+        if not session_key:
+            return
+        if not (isinstance(run_id, str) and run_id.startswith("inject-")):
+            return
+
+        subscribers = list(self._session_subscribers.get(session_key) or [])
+        if not subscribers:
+            return
+
+        send_payload = dict(payload)
+        if "seq" not in send_payload:
+            send_payload["seq"] = self._next_seq()
+        if "ts" not in send_payload:
+            send_payload["ts"] = int(time.time() * 1000)
+        frame = EventFrame(
+            event=event.event,
+            payload=send_payload,
+            seq=send_payload["seq"],
+        )
+        raw = frame.to_json()
+        stale: list[str] = []
+        for subscriber_conn_id in subscribers:
+            websocket = self._connections.get(subscriber_conn_id)
+            if websocket is None:
+                stale.append(subscriber_conn_id)
+                continue
+            try:
+                await websocket.send_text(raw)
+            except Exception as e:
+                log.debug(
+                    "chat.subscribe: fanout failed conn=%s: %s",
+                    subscriber_conn_id,
+                    e,
+                )
+                stale.append(subscriber_conn_id)
+
+        for stale_conn_id in stale:
+            self._unsubscribe_conn(stale_conn_id)
+
+    def _drop_idle_inject_listeners(self) -> None:
+        if self._session_subscribers:
+            return
+        for client, listener in list(self._inject_listener_refs.values()):
+            try:
+                client.off_event("chat", listener)
+                client.off_event("agent", listener)
+            except Exception as e:
+                log.debug("chat.subscribe: off_event failed: %s", e)
+        self._inject_listener_refs.clear()
 
     # ── chat.send ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `chat.subscribe` / `chat.unsubscribe` handling in the community engine WebSocket server.
- Fan out async OpenClaw `chat.inject` events to WebSocket clients subscribed to the matching `sessionKey`.
- Add defensive cleanup/listener tests for subscription fanout paths.

## Test Plan
- `cd src/engine && uv run --with pytest-cov --with pytest-asyncio pytest src/engine/community/api/tests/transport/test_ws_server.py -q -o testpaths="" --cov=engine.community.api.transport.ws_server --cov-report=term-missing`
- Result: 62 passed.
- Changed-line coverage for this change: 100%.
