### PR TITLE
Fix CORP_TEST DeviceAccessor DI binding in TestingDevicesModule

### DIFF
--- a/src/backend/src/agentclaw/community/di/modules/testing_devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/testing_devices_module.py
@@ -53,6 +53,8 @@ from agentclaw.community.core.devices.services.device_service import (
     DeviceService,
 )
 from agentclaw.community.core.devices.services.device_service_router import DeviceServiceRouter
+from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.services.local_device_accessor import LocalDeviceAccessor
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.notify.protocol import NotifyBotLister
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
@@ -90,6 +92,8 @@ class TestingDevicesModule(Module):
             to=NoopDeviceConnectionManagerPlugin,
             scope=singleton,
         )
+        binder.bind(LocalDeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
+        binder.bind(DeviceAccessor, to=LocalDeviceAccessor, scope=singleton)
         # The device-filesystem resolver is now a neutral ``core`` binding in the
         # base ``DevicesModule`` (B9); the per-provider filesystems are driven by
         # test doubles / real-HTTP seams via the injected deps. No binding here.


### PR DESCRIPTION
## Summary

Fixes a DI regression in the `corp_test` device wiring introduced by the `governance-notify-abstraction` / device-binding refactor (`ef3317c`, "Lyp base dev 0711").

That refactor removed the `DeviceAccessor` provider from `TestingSkillCenterModule` (with the note that "`DeviceAccessor` and device lifecycle bindings live in the profile's device module") and added `binder.bind(DeviceAccessor, to=LocalDeviceAccessor)` to the corp-free test/singlebox device module `TestDevicesModule` — but **not** to its corp_test twin `TestingDevicesModule`, which is the device module the `CORP_TEST` profile installs (see the `DeployProfile.CORP_TEST` branch in `profile_modules.py`).

As a result, under `CORP_TEST` nothing bound `DeviceAccessor`, and `skill_center_module.py`'s `device_filesystem_dispatcher` (which does `injector.get(DeviceAccessor)`) failed with "Protocols cannot be instantiated" — cascading into ~12 corp e2e/endpoint/singlebox test failures downstream.

## Change

In `src/backend/src/agentclaw/community/di/modules/testing_devices_module.py`, mirror the sibling `TestDevicesModule`:

- Import `DeviceAccessor` and `LocalDeviceAccessor` alongside the other `core.devices.services` imports.
- In `TestingDevicesModule.configure()`, right after the `DeviceConnectionManagerPlugin` bind, add:
  - `binder.bind(LocalDeviceAccessor, to=LocalDeviceAccessor, scope=singleton)`
  - `binder.bind(DeviceAccessor, to=LocalDeviceAccessor, scope=singleton)`

Minimal 4-line change; no unrelated lines reformatted.

## Verification

`TestingDevicesModule` imports `agentclaw.corp.*`, so the `CORP_TEST` path can only be exercised from the ocb monorepo, not from this standalone repo. Here I confirmed:

- The edited module parses and its two new imports resolve (`DeviceAccessor` is a `Protocol`, `LocalDeviceAccessor` its impl).
- The community suite still passes: `DEPLOY_PROFILE=test uv run pytest tests/community -q` → **7688 passed, 3 skipped**.

Final corp_test validation happens back in the ocb monorepo after re-pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012qjrCqHVT4fDd7p1HNy5vf)_