### PR TITLE
fix: 补齐 BaaS 重启时的 BCN Provider 注册

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3365,12 +3365,39 @@ class BotService:
         if not bot_uuid:
             raise BotServiceError(f"Bot {bot_id} binding {binding_id} missing bot_uuid; cannot baas restart")
 
+        active_engine = (bot.get("active_engine") or "").strip()
+        bot_type = bot.get("bot_type") or "personal"
+        bot_template_type = (bot.get("template_type") or "").strip()
+
+        # BaaS 原地重启不会经过 start_bot，这里补齐启动链路的 BCN Provider 注册。
+        # 注册接口幂等：已注册时直接返回，也能重试创建阶段失败的注册。
+        if self._should_register_bcn_provider(
+            active_engine=active_engine,
+            bot_type=bot_type,
+            template_type=bot_template_type,
+        ):
+            logger.info(
+                "[bot_service._restart_bot_baas] register bot to BCN as provider: "
+                "bot_id=%s active_engine=%s bot_type=%s template_type=%s",
+                bot_id,
+                active_engine,
+                bot_type,
+                bot_template_type,
+            )
+            self._register_bot_to_bcn_as_provider(
+                bot_id=bot_id,
+                user_id=user_id,
+                owner_workno=bot.get("owner_id") or user_id,
+                bot_name=bot.get("bot_name") or bot_id,
+                bot_summary=bot.get("bot_desc") or "",
+            )
+
         # 普通 restart 入口只重启当前 bot，不使用发布态 build 产物目录。
         # 发布态 verify/online 的重启由 PublishFlowService.restart_bot(publish_id) 处理。
         mig: Optional[str] = None
         restart_stage = (
             PublishStage.DRAFT.value
-            if bot.get("bot_type") == "service"
+            if bot_type == "service"
             else None
         )
 
@@ -3392,8 +3419,6 @@ class BotService:
         # BOT_TYPE=model/runtime 即便在 update_bot 改过也不生效。引擎口径与 create_bot
         # 对齐（claude_code + aicoding），门控不命中时 extra_envs/template_config 保持
         # None，upgrade 行为与改动前完全一致（envs 退化为 AGENTCLAW_ENGINE 单值）。
-        active_engine = (bot.get("active_engine") or "").strip()
-        bot_template_type = (bot.get("template_type") or "").strip()
         extra_envs: Optional[Dict[str, Any]] = None
         device_template_config: Optional[Dict[str, Any]] = None
         if active_engine in ("claude_code", "aicoding") and bot_template_type in ("applicationCoding", "personalCoding"):

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -86,6 +86,9 @@ def _make_service(
     # _attach_template_uid_context 走真实方法会访问 _baas_template_resolver；
     # 这里只测透传，patch 成透传器即可。
     svc._baas_template_resolver = None
+    svc._drm_reader = MagicMock()
+    svc._drm_reader.read.return_value = None
+    svc._bcn_service = MagicMock()
 
     svc._task_queue_service = MagicMock()
     return svc, baas, device_service

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -158,6 +158,9 @@ def _make_service(
     svc._bot_publish_repo = bot_publish_repo if bot_publish_repo is not None else MagicMock()
     svc._baas_template_resolver = baas_template_resolver
     svc._task_queue_service = task_queue_service
+    svc._drm_reader = MagicMock()
+    svc._drm_reader.read.return_value = None
+    svc._bcn_service = MagicMock()
     return svc
 
 
@@ -418,6 +421,103 @@ class TestRestartGuardOrchestration:
         baas.upgrade_bot.assert_called_once()
         assert baas.upgrade_bot.call_args.kwargs["migration_path"] is None
         publish_repo.get_by_publish_bot_id.assert_not_called()
+
+    def test_restart_baas_aicoding_personal_coding_registers_bcn_before_upgrade(self):
+        """BaaS 原地重启不经过 start_bot，也必须补齐 AI Coding 的 BCN 注册。"""
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        svc._drm_reader.read.return_value = "true"
+        svc._template_service.get_template_config.return_value = {}
+        bot = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+            bot_type="personal",
+            active_engine="aicoding",
+            template_type="personalCoding",
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42, device_provider="baas", device_id="BOT-uuid-9",
+        )
+        svc._device_service_provider = lambda: device_service
+        call_order: list[str] = []
+        svc._bcn_service.register_provider_bot.side_effect = lambda **_: (
+            call_order.append("bcn")
+            or {
+                "bot_uuid": "bcn-bot-1",
+                "bot_runtime_token": "token",
+            }
+        )
+        baas = MagicMock()
+        baas.upgrade_bot.side_effect = lambda **_: call_order.append("upgrade") or {}
+        svc._baas_service_provider = lambda: baas
+
+        svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        svc._bcn_service.register_provider_bot.assert_called_once_with(
+            teamclaw_bot_uuid="bot001",
+            owner_workno="user001",
+            name="TestBot",
+            summary="",
+        )
+        baas.upgrade_bot.assert_called_once()
+        assert call_order == ["bcn", "upgrade"]
+
+    def test_restart_baas_ineligible_template_does_not_register_bcn(self):
+        """applicationCoding 不在 BCN Provider 注册范围内。"""
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        svc._drm_reader.read.return_value = "true"
+        svc._template_service.get_template_config.return_value = {}
+        bot = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+            bot_type="personal",
+            active_engine="aicoding",
+            template_type="applicationCoding",
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42, device_provider="baas", device_id="BOT-uuid-9",
+        )
+        svc._device_service_provider = lambda: device_service
+        baas = MagicMock()
+        svc._baas_service_provider = lambda: baas
+
+        svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        svc._bcn_service.register_provider_bot.assert_not_called()
+        baas.upgrade_bot.assert_called_once()
+
+    def test_restart_baas_bcn_registration_failure_does_not_block_upgrade(self):
+        """BCN 注册失败沿用既有 best-effort 语义，不阻塞 BaaS 重启。"""
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        svc._drm_reader.read.return_value = "true"
+        svc._template_service.get_template_config.return_value = {}
+        svc._bcn_service.register_provider_bot.side_effect = RuntimeError("bcn down")
+        bot = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+            bot_type="personal",
+            active_engine="aicoding",
+            template_type="personalCoding",
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42, device_provider="baas", device_id="BOT-uuid-9",
+        )
+        svc._device_service_provider = lambda: device_service
+        baas = MagicMock()
+        svc._baas_service_provider = lambda: baas
+
+        svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        svc._bcn_service.register_provider_bot.assert_called_once()
+        baas.upgrade_bot.assert_called_once()
 
     def test_restart_arca_still_uses_stop_start(self):
         """arca bot 仍走 stop+start，不进 baas 原地分支。"""


### PR DESCRIPTION
- 复用创建和启动链路的 BCN Provider 注册条件，在 BaaS 原地重启前执行幂等注册
- 保持既有 DRM 门控与注册失败不阻断重启的语义
- 补充 AI Coding 命中、非命中和注册失败场景测试