### PR TITLE
feat(bcs): support inbound image attachments

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
 name = "bcs-protocol"
 version = "0.1.0"
 dependencies = [
+ "bcs-domain",
  "serde",
  "serde_json",
  "tracing",

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use bcs_domain::BotDeliveryTarget;
 use bcs_protocol::{
-    AgentEventPayload, AgentStream, BCN_MESSAGE_ID_HEADER, BCN_PROTOCOL_VERSION_HEADER,
+    AgentEventPayload, AgentStream, Attachment, BCN_MESSAGE_ID_HEADER, BCN_PROTOCOL_VERSION_HEADER,
     BCN_TIMESTAMP_HEADER, BCN_TRANSPORT_HEADER, BcsFrame, ChatEventPayload,
     ChatEventState as WireChatState, ContentBlock, MessageContent,
     ProviderAckResponse, ProviderHistoryResponse, ProviderWebhookBotRef, ProviderWebhookRequest,
@@ -517,6 +517,16 @@ fn provider_request_from_frame(
     } else {
         timeout_ms
     };
+    let attachments = params
+        .get("attachments")
+        .cloned()
+        .map(serde_json::from_value::<Vec<Attachment>>)
+        .transpose()
+        .map_err(|error| ServiceError::InvalidOperation {
+            message: format!("provider attachment payload is invalid: {error}"),
+            request_id: Some(request.id.clone()),
+        })?
+        .unwrap_or_default();
 
     Ok(ProviderWebhookRequest {
         frame_type: "req".to_string(),
@@ -531,6 +541,7 @@ fn provider_request_from_frame(
         },
         from: provider_sender_from_params(&params),
         message: params.get("message").cloned(),
+        attachments,
         before: params.get("before").and_then(Value::as_u64),
         after: params.get("after").and_then(Value::as_u64),
         limit: params.get("limit").and_then(Value::as_u64),
@@ -811,7 +822,21 @@ fn provider_client_for_url(
 }
 
 fn provider_body_log(body: &ProviderWebhookRequest) -> String {
-    serde_json::to_string(body).unwrap_or_else(|error| {
+    let mut redacted = match serde_json::to_value(body) {
+        Ok(value) => value,
+        Err(error) => return format!("{{\"serialize_error\":\"{}\"}}", error),
+    };
+    if let Some(attachments) = redacted
+        .get_mut("attachments")
+        .and_then(Value::as_array_mut)
+    {
+        for attachment in attachments {
+            if let Some(url) = attachment.get_mut("url") {
+                *url = Value::String("<redacted>".to_string());
+            }
+        }
+    }
+    serde_json::to_string(&redacted).unwrap_or_else(|error| {
         format!("{{\"serialize_error\":\"{}\"}}", error)
     })
 }
@@ -1470,6 +1495,48 @@ mod client_policy_tests {
         assert_eq!(policy.total_timeout, Some(Duration::from_secs(65)));
         assert_eq!(policy.read_timeout, None);
         assert!(!policy.http2_only);
+    }
+
+    #[test]
+    fn provider_body_log_redacts_temporary_attachment_urls() {
+        let body = ProviderWebhookRequest {
+            frame_type: "event".to_string(),
+            id: "frame-1".to_string(),
+            method: "chat.send".to_string(),
+            session_id: "session-1".to_string(),
+            bcn_group_id: "group-1".to_string(),
+            to_bot: ProviderWebhookBotRef {
+                provider_id: "provider-1".to_string(),
+                provider_bot_ref: "bot-1".to_string(),
+                tags: Vec::new(),
+            },
+            from: None,
+            message: None,
+            attachments: vec![Attachment {
+                attachment_id: "att-1".to_string(),
+                attachment_type: bcs_protocol::AttachmentType::Image,
+                file_name: "image".to_string(),
+                mime_type: None,
+                size: None,
+                sha256: None,
+                url: "https://download.example.com/image?token=secret".to_string(),
+                expires_at: None,
+            }],
+            before: None,
+            after: None,
+            limit: None,
+            timeout_ms: 1_000,
+            extensions: None,
+        };
+
+        let logged = provider_body_log(&body);
+
+        assert!(logged.contains("\"url\":\"<redacted>\""));
+        assert!(!logged.contains("token=secret"));
+        assert_eq!(
+            body.attachments[0].url,
+            "https://download.example.com/image?token=secret"
+        );
     }
 
     #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -156,6 +156,16 @@ async fn provider_delivery_posts_bearer_token_and_chat_send_body() {
                     "message": {
                         "text": "hello"
                     },
+                    "attachments": [{
+                        "attachment_id": "att-1",
+                        "type": "image",
+                        "file_name": "diagram.png",
+                        "mime_type": "image/png",
+                        "size": 4,
+                        "sha256": "abcd",
+                        "url": "https://bcs.example.com/attachments?id=att-1&token=short",
+                        "expires_at": 1710960000000_u64
+                    }],
                     "timeout_ms": 1_800_000,
                     "tags": ["tag1", "tag2"]
                 })),
@@ -187,6 +197,8 @@ async fn provider_delivery_posts_bearer_token_and_chat_send_body() {
     assert_eq!(request.body["from"]["name"], "Sender Bot");
     assert_eq!(request.body["from"]["actor_id"], "sender-bot-id");
     assert_eq!(request.body["message"]["text"], "hello");
+    assert_eq!(request.body["attachments"][0]["attachment_id"], "att-1");
+    assert_eq!(request.body["attachments"][0]["type"], "image");
     assert_eq!(request.body["timeout_ms"], 1_800_000);
     assert!(request.body.get("extensions").is_none());
 
@@ -641,7 +653,17 @@ async fn provider_delivery_posts_chat_inject_body_with_bcn_group_id() {
                     },
                     "message": {
                         "text": "observe"
-                    }
+                    },
+                    "attachments": [{
+                        "attachment_id": "att-1",
+                        "type": "image",
+                        "file_name": "diagram.png",
+                        "mime_type": "image/png",
+                        "size": 4,
+                        "sha256": "abcd",
+                        "url": "https://bcs.example.com/attachments?id=att-1&token=short",
+                        "expires_at": 1710960000000_u64
+                    }]
                 })),
             )),
             delivery_kind: BotDeliveryKind::Inject,
@@ -660,6 +682,7 @@ async fn provider_delivery_posts_chat_inject_body_with_bcn_group_id() {
     assert_eq!(request.body["from"]["kind"], "bot");
     assert_eq!(request.body["from"]["name"], "Sender Bot");
     assert_eq!(request.body["message"]["text"], "observe");
+    assert_eq!(request.body["attachments"][0]["attachment_id"], "att-1");
 
     server.abort();
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/gateway/chat_types.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/gateway/chat_types.rs
@@ -3,6 +3,7 @@
 //! Parameter and result types for chat.send, chat.history, chat.abort.
 
 use serde::{Deserialize, Serialize};
+use bcs_protocol::Attachment;
 
 // ============================================================================
 // chat.history
@@ -68,7 +69,7 @@ pub struct ChatSendParams {
 
     /// Attachments.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub attachments: Option<Vec<serde_json::Value>>,
+    pub attachments: Option<Vec<Attachment>>,
 
     /// Timeout in milliseconds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -329,7 +330,16 @@ mod tests {
             "from": "user-1",
             "thinking": "high",
             "deliver": false,
-            "attachments": [{"type": "image", "url": "http://example.com/image.png"}],
+            "attachments": [{
+                "attachment_id": "att-1",
+                "type": "image",
+                "file_name": "image.png",
+                "mime_type": "image/png",
+                "size": 4,
+                "sha256": "abcd",
+                "url": "https://example.com/image.png",
+                "expires_at": 123
+            }],
             "timeout_ms": 30000,
             "idempotency_key": "run-unique"
         }"#;

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -235,7 +235,7 @@ struct ChatSendParams {
     thinking: Option<String>,
     #[serde(alias = "idempotencyKey")]
     idempotency_key: Option<String>,
-    attachments: Option<Vec<Value>>,
+    attachments: Option<Vec<bcs_protocol::Attachment>>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -321,7 +321,12 @@ async fn handle_chat_send(
             from_name: params.bot_name.clone(),
             message: params.message,
             mentions: params.mentions,
-            attachments: params.attachments,
+            attachments: params.attachments.map(|attachments| {
+                attachments
+                    .into_iter()
+                    .map(bcs_domain::Attachment::from)
+                    .collect()
+            }),
             thinking: params.thinking,
             idempotency_key: params.idempotency_key,
             sender_conn_id,

--- a/src/bcs/crates/contracts/bcs-domain/src/attachment.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/attachment.rs
@@ -1,0 +1,70 @@
+//! Channel-neutral attachment data used by inbound message use cases.
+
+use serde::{Deserialize, Serialize};
+
+/// Attachment categories supported by the BCS application model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentType {
+    Image,
+}
+
+/// A temporary attachment reference carried through the message flow.
+///
+/// The URL is an ephemeral capability and must not be persisted. Persisted
+/// message history should use [`Attachment::stable_metadata`] instead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attachment {
+    pub attachment_id: String,
+    #[serde(rename = "type")]
+    pub attachment_type: AttachmentType,
+    pub file_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+impl Attachment {
+    /// Stable metadata suitable for message history persistence.
+    pub fn stable_metadata(&self) -> serde_json::Value {
+        serde_json::json!({
+            "attachment_id": self.attachment_id,
+            "type": self.attachment_type,
+            "file_name": self.file_name,
+            "mime_type": self.mime_type,
+            "size": self.size,
+            "sha256": self.sha256,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Attachment, AttachmentType};
+
+    #[test]
+    fn stable_metadata_excludes_temporary_capability() {
+        let attachment = Attachment {
+            attachment_id: "att_1".to_string(),
+            attachment_type: AttachmentType::Image,
+            file_name: "image.png".to_string(),
+            mime_type: Some("image/png".to_string()),
+            size: Some(4),
+            sha256: Some("abcd".to_string()),
+            url: "https://download.example.com/image?token=temporary".to_string(),
+            expires_at: Some(123),
+        };
+
+        let stable = attachment.stable_metadata();
+        assert_eq!(stable["attachment_id"], "att_1");
+        assert!(stable.get("url").is_none());
+        assert!(stable.get("expires_at").is_none());
+        assert!(!stable.to_string().contains("token=temporary"));
+    }
+}

--- a/src/bcs/crates/contracts/bcs-domain/src/lib.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/lib.rs
@@ -10,6 +10,7 @@
 //! Phase 0 for the rationale.
 
 pub mod actor;
+pub mod attachment;
 pub mod channel;
 pub mod collaboration;
 pub mod friend;
@@ -28,6 +29,7 @@ pub mod system_message;
 pub mod task_ledger;
 
 pub use actor::{ActorKind, ActorStatus, EnsureHumanResult, EnsureOwnerEdgesResult, RelationEdge};
+pub use attachment::{Attachment, AttachmentType};
 pub use channel::{
     BindingStatus, BindingTarget, GroupChatScope, ChannelBinding, ChannelConfig, ChannelType,
     ConversationSessionMap, ImParticipantMap, SessionScope, Visibility,

--- a/src/bcs/crates/contracts/bcs-protocol/Cargo.toml
+++ b/src/bcs/crates/contracts/bcs-protocol/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+bcs-domain = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 tracing    = { workspace = true }

--- a/src/bcs/crates/contracts/bcs-protocol/src/attachment.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/attachment.rs
@@ -31,20 +31,49 @@ pub struct Attachment {
     pub expires_at: Option<u64>,
 }
 
-impl Attachment {
-    /// Stable metadata suitable for message history persistence.
-    ///
-    /// Short-lived URLs and their expiry are intentionally excluded so message
-    /// history never persists an upstream temporary capability URL.
-    pub fn stable_metadata(&self) -> serde_json::Value {
-        serde_json::json!({
-            "attachment_id": self.attachment_id,
-            "type": self.attachment_type,
-            "file_name": self.file_name,
-            "mime_type": self.mime_type,
-            "size": self.size,
-            "sha256": self.sha256,
-        })
+impl From<bcs_domain::Attachment> for Attachment {
+    fn from(value: bcs_domain::Attachment) -> Self {
+        Self {
+            attachment_id: value.attachment_id,
+            attachment_type: value.attachment_type.into(),
+            file_name: value.file_name,
+            mime_type: value.mime_type,
+            size: value.size,
+            sha256: value.sha256,
+            url: value.url,
+            expires_at: value.expires_at,
+        }
+    }
+}
+
+impl From<Attachment> for bcs_domain::Attachment {
+    fn from(value: Attachment) -> Self {
+        Self {
+            attachment_id: value.attachment_id,
+            attachment_type: value.attachment_type.into(),
+            file_name: value.file_name,
+            mime_type: value.mime_type,
+            size: value.size,
+            sha256: value.sha256,
+            url: value.url,
+            expires_at: value.expires_at,
+        }
+    }
+}
+
+impl From<bcs_domain::AttachmentType> for AttachmentType {
+    fn from(value: bcs_domain::AttachmentType) -> Self {
+        match value {
+            bcs_domain::AttachmentType::Image => Self::Image,
+        }
+    }
+}
+
+impl From<AttachmentType> for bcs_domain::AttachmentType {
+    fn from(value: AttachmentType) -> Self {
+        match value {
+            AttachmentType::Image => Self::Image,
+        }
     }
 }
 
@@ -53,7 +82,7 @@ mod tests {
     use super::{Attachment, AttachmentType};
 
     #[test]
-    fn attachment_wire_shape_and_stable_metadata() {
+    fn attachment_wire_shape_and_domain_conversion() {
         let attachment = Attachment {
             attachment_id: "att_1".to_string(),
             attachment_type: AttachmentType::Image,
@@ -69,10 +98,10 @@ mod tests {
         assert_eq!(wire["type"], "image");
         assert_eq!(wire["url"], attachment.url);
 
-        let stable = attachment.stable_metadata();
-        assert_eq!(stable["attachment_id"], "att_1");
-        assert!(stable.get("url").is_none());
-        assert!(stable.get("expires_at").is_none());
+        let domain: bcs_domain::Attachment = attachment.into();
+        assert_eq!(domain.attachment_id, "att_1");
+        assert_eq!(domain.attachment_type, bcs_domain::AttachmentType::Image);
+        assert_eq!(domain.url, "https://bcs.example.com/attachments?id=att_1&token=short");
     }
 
     #[test]

--- a/src/bcs/crates/contracts/bcs-protocol/src/attachment.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/attachment.rs
@@ -1,0 +1,94 @@
+//! Attachment DTOs shared by bot WebSocket and HTTP provider transports.
+
+use serde::{Deserialize, Serialize};
+
+/// Attachment categories supported by the public BCS protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentType {
+    Image,
+}
+
+/// A temporary attachment reference delivered alongside `chat.send`/`chat.inject`.
+///
+/// `url` may be a provider-issued short-lived capability URL. It must never
+/// contain a DingTalk download code, access token, or a long-lived BCS
+/// credential. Metadata unavailable from the provider is omitted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attachment {
+    pub attachment_id: String,
+    #[serde(rename = "type")]
+    pub attachment_type: AttachmentType,
+    pub file_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+impl Attachment {
+    /// Stable metadata suitable for message history persistence.
+    ///
+    /// Short-lived URLs and their expiry are intentionally excluded so message
+    /// history never persists an upstream temporary capability URL.
+    pub fn stable_metadata(&self) -> serde_json::Value {
+        serde_json::json!({
+            "attachment_id": self.attachment_id,
+            "type": self.attachment_type,
+            "file_name": self.file_name,
+            "mime_type": self.mime_type,
+            "size": self.size,
+            "sha256": self.sha256,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Attachment, AttachmentType};
+
+    #[test]
+    fn attachment_wire_shape_and_stable_metadata() {
+        let attachment = Attachment {
+            attachment_id: "att_1".to_string(),
+            attachment_type: AttachmentType::Image,
+            file_name: "image.png".to_string(),
+            mime_type: Some("image/png".to_string()),
+            size: Some(4),
+            sha256: Some("abcd".to_string()),
+            url: "https://bcs.example.com/attachments?id=att_1&token=short".to_string(),
+            expires_at: Some(123),
+        };
+
+        let wire = serde_json::to_value(&attachment).expect("serialize attachment");
+        assert_eq!(wire["type"], "image");
+        assert_eq!(wire["url"], attachment.url);
+
+        let stable = attachment.stable_metadata();
+        assert_eq!(stable["attachment_id"], "att_1");
+        assert!(stable.get("url").is_none());
+        assert!(stable.get("expires_at").is_none());
+    }
+
+    #[test]
+    fn accepts_temporary_image_url_without_unavailable_metadata() {
+        let attachment: Attachment = serde_json::from_value(serde_json::json!({
+            "attachment_id": "att_1",
+            "type": "image",
+            "file_name": "image",
+            "url": "https://download.example.com/temporary"
+        }))
+        .expect("deserialize temporary image attachment");
+
+        assert_eq!(attachment.attachment_type, AttachmentType::Image);
+        assert_eq!(attachment.mime_type, None);
+        assert_eq!(attachment.size, None);
+        assert_eq!(attachment.sha256, None);
+        assert_eq!(attachment.expires_at, None);
+    }
+}

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/provider.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/provider.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-use crate::{Skill, deserialize_skills};
+use crate::{Attachment, Skill, deserialize_skills};
 
 pub const BCN_PROTOCOL_VERSION_HEADER: &str = "X-BCN-Protocol-Version";
 pub const BCN_TRANSPORT_HEADER: &str = "X-BCN-Transport";
@@ -206,6 +206,8 @@ pub struct ProviderWebhookRequest {
     pub from: Option<ProviderWebhookSender>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<Attachment>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub before: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/bcs/crates/contracts/bcs-protocol/src/lib.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/lib.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub mod a2a;
+pub mod attachment;
 pub mod delivery;
 pub mod http;
 pub mod principal;
@@ -23,6 +24,7 @@ pub mod ws;
 pub mod stream;
 
 pub use a2a::A2aRunStatus;
+pub use attachment::{Attachment, AttachmentType};
 pub use delivery::{BotDeliveryKind, FrontendDeliveryKind, FrontendDeliveryTarget};
 pub use http::chat_run;
 pub use http::{

--- a/src/bcs/crates/contracts/bcs-protocol/src/ws/protocol.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/ws/protocol.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::Attachment;
+
 // ---------------------------------------------------------------------------
 // Protocol versioning
 // ---------------------------------------------------------------------------
@@ -553,6 +555,8 @@ pub struct ChatSendParams {
     pub bcs_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<Attachment>,
 }
 
 /// Response for chat.send request.
@@ -580,6 +584,8 @@ pub struct ChatInjectParams {
     /// BCS session layer id (`{group_id}:{8_hex}`). None when not pinned to a session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bcs_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<Attachment>,
 }
 
 /// Parameters for chat.abort request.
@@ -889,6 +895,7 @@ pub fn build_chat_inject_frame(
     from_bot_name: &str,
     mentions: &[String],
     target_bot: &str,
+    attachments: &Option<Vec<Attachment>>,
     is_self: bool,
     protocol_version: u32,
     from_bot_owner: Option<String>,
@@ -932,6 +939,7 @@ pub fn build_chat_inject_frame(
         } else {
             None
         },
+        attachments: attachments.clone().unwrap_or_default(),
     };
     let mut payload = serde_json::to_value(inject).unwrap_or_else(|error| {
         tracing::warn!(%error, "failed to serialize chat.inject params");
@@ -962,7 +970,7 @@ pub fn build_chat_send_frame(
     from_bot_name: &str,
     mentions: &[String],
     target_bot: &str,
-    attachments: &Option<Vec<Value>>,
+    attachments: &Option<Vec<Attachment>>,
     thinking: &Option<String>,
     is_self: bool,
     protocol_version: u32,
@@ -1014,6 +1022,7 @@ pub fn build_chat_send_frame(
             None
         },
         tags: Vec::new(),
+        attachments: attachments.clone().unwrap_or_default(),
     };
     let mut params = serde_json::to_value(send).unwrap_or_else(|error| {
         tracing::warn!(%error, "failed to serialize chat.send params");
@@ -1021,12 +1030,6 @@ pub fn build_chat_send_frame(
     });
     if let Some(obj) = params.as_object_mut() {
         obj.insert("deliver".to_string(), Value::Bool(true));
-        if let Some(attachments) = attachments {
-            obj.insert(
-                "attachments".to_string(),
-                Value::Array(attachments.clone()),
-            );
-        }
         if let Some(thinking) = thinking {
             obj.insert("thinking".to_string(), Value::String(thinking.clone()));
         }
@@ -1050,7 +1053,7 @@ pub fn build_direct_chat_send_frame(
     from_actor_id: &str,
     from_actor_name: &str,
     target_bot: &str,
-    attachments: &Option<Vec<Value>>,
+    attachments: &Option<Vec<Attachment>>,
     thinking: &Option<String>,
     protocol_version: u32,
     bcs_session_id: Option<&str>,
@@ -1091,6 +1094,7 @@ pub fn build_direct_chat_send_frame(
             None
         },
         tags: Vec::new(),
+        attachments: attachments.clone().unwrap_or_default(),
     };
     let mut params = serde_json::to_value(send).unwrap_or_else(|error| {
         tracing::warn!(%error, "failed to serialize direct chat.send params");
@@ -1098,12 +1102,6 @@ pub fn build_direct_chat_send_frame(
     });
     if let Some(obj) = params.as_object_mut() {
         obj.insert("deliver".to_string(), Value::Bool(true));
-        if let Some(attachments) = attachments {
-            obj.insert(
-                "attachments".to_string(),
-                Value::Array(attachments.clone()),
-            );
-        }
         if let Some(thinking) = thinking {
             obj.insert("thinking".to_string(), Value::String(thinking.clone()));
         }
@@ -1124,6 +1122,7 @@ pub fn build_direct_chat_inject_frame(
     from_actor_id: &str,
     from_actor_name: &str,
     target_bot: &str,
+    attachments: &Option<Vec<Attachment>>,
     protocol_version: u32,
     bcs_session_id: Option<&str>,
 ) -> BcsFrame {
@@ -1160,6 +1159,7 @@ pub fn build_direct_chat_inject_frame(
         } else {
             None
         },
+        attachments: attachments.clone().unwrap_or_default(),
     };
     let mut payload = serde_json::to_value(inject).unwrap_or_else(|error| {
         tracing::warn!(%error, "failed to serialize direct chat.inject params");
@@ -2062,7 +2062,7 @@ mod tests {
         let ctx = test_group_context_input();
         let frame = build_chat_inject_frame(
             "r1", "grp-test", &ctx, "hello", "b1", "Bot1", &[], "target",
-            false, 2, None, None, Some("grp-test:00000000"),
+            &None, false, 2, None, None, Some("grp-test:00000000"),
         );
         match frame {
             BcsFrame::Request(req) => {
@@ -2079,7 +2079,7 @@ mod tests {
         let ctx = test_group_context_input();
         let frame = build_chat_inject_frame(
             "r1", "grp-test", &ctx, "hello", "b1", "Bot1", &[], "target",
-            false, 3, None, None, Some("grp-test:abc12345"),
+            &None, false, 3, None, None, Some("grp-test:abc12345"),
         );
         match frame {
             BcsFrame::Request(req) => {

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/channel.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/channel.ts
@@ -142,7 +142,7 @@ export function createBcsPlugin(options: BcsChannelPluginOptions = {}) {
 
     capabilities: {
       chatTypes: [ 'group' as const ],
-      media: false,
+      media: true,
       threads: false,
       reactions: false,
       edit: false,

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -9,6 +9,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { rm } from 'node:fs/promises';
 import type { BcsWsClient } from './bcs-ws-client.js';
 import { resolveGatewayPort, scopesForGatewayMethod } from './gateway-security.js';
 import { getBcsRuntime } from './runtime.js';
@@ -19,6 +20,7 @@ import type {
   ChatHistoryParams,
   ChatHistoryMessage,
   ContentBlock,
+  Attachment,
   ChatEventPayload,
   ChatEventRouting,
   PendingRouteIntent,
@@ -37,6 +39,10 @@ const CHANNEL_ID = 'bcs';
 const OPENCLAW_GATEWAY_MIN_PROTOCOL = 3;
 const OPENCLAW_GATEWAY_MAX_PROTOCOL = 4;
 const NO_REPLY_TEXT = 'NO_REPLY';
+const MAX_IMAGE_ATTACHMENTS = 5;
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+const IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+const IMAGE_READ_IDLE_TIMEOUT_MS = 10_000;
 
 /** Extract sender name from [from:botName] prefix. Returns stripped text and sender name. */
 function extractFromPrefix(raw: string): { senderName: string; text: string } {
@@ -214,6 +220,267 @@ function extractText(content: ContentBlock[]): string {
     }
   }
   return parts.join('\n');
+}
+
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
+function extractImageAttachments(attachments: Attachment[] | undefined): Attachment[] {
+  return (attachments ?? []).filter(attachment => attachment.type === 'image');
+}
+
+function sanitizeAttachmentDisplay(value: string): string {
+  // COSEC: prevent untrusted filenames from breaking structured prompt notes.
+  return value
+    .replace(/[\p{Cc}\[\]]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200) || 'image';
+}
+
+function sanitizeAttachmentLogValue(value: string): string {
+  // COSEC: prevent control-character injection from untrusted attachment metadata in logs.
+  return value.replace(/[\p{Cc}]+/gu, ' ').trim().slice(0, 128) || 'unknown';
+}
+
+function attachmentFallbackText(attachments: Attachment[]): string {
+  return attachments.length === 1
+    ? `[Image: ${sanitizeAttachmentDisplay(attachments[0].file_name)}]`
+    : `[Images: ${attachments.map(attachment => sanitizeAttachmentDisplay(attachment.file_name)).join(', ')}]`;
+}
+
+function attachmentObservationText(attachments: Attachment[]): string {
+  return attachments.map(attachment => {
+    const metadata = [
+      `name=${sanitizeAttachmentDisplay(attachment.file_name)}`,
+      attachment.mime_type ? `type=${sanitizeAttachmentDisplay(attachment.mime_type)}` : undefined,
+      typeof attachment.size === 'number' ? `size=${attachment.size} bytes` : undefined,
+    ].filter(Boolean).join(', ');
+    return `[Image attachment: ${metadata}; image content is not available in this silent observation]`;
+  }).join('\n');
+}
+
+function buildInjectText(messageText: string, attachments: Attachment[]): string {
+  return [ messageText, attachmentObservationText(attachments) ].filter(Boolean).join('\n');
+}
+
+function normalizeMimeType(value?: string): string | undefined {
+  const normalized = value?.split(';')[0]?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function sniffSupportedImageMime(buffer: Buffer): string | undefined {
+  // COSEC: accept image content only when its magic bytes match a supported format.
+  if (
+    buffer.length >= 8
+    && buffer.subarray(0, 8).equals(Buffer.from([ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ]))
+  ) {
+    return 'image/png';
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (buffer.length >= 6) {
+    const signature = buffer.toString('ascii', 0, 6);
+    if (signature === 'GIF87a' || signature === 'GIF89a') return 'image/gif';
+  }
+  if (
+    buffer.length >= 12
+    && buffer.toString('ascii', 0, 4) === 'RIFF'
+    && buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+  return undefined;
+}
+
+type PreparedImage = {
+  path: string;
+  contentType: string;
+};
+
+type InboundImageErrorCode =
+  | 'TOO_MANY_IMAGES'
+  | 'IMAGE_EXPIRED'
+  | 'INVALID_IMAGE_URL'
+  | 'IMAGE_TOO_LARGE'
+  | 'IMAGE_DOWNLOAD_TIMEOUT'
+  | 'IMAGE_DOWNLOAD_FAILED'
+  | 'UNSUPPORTED_IMAGE_TYPE'
+  | 'IMAGE_STORE_FAILED'
+  | 'IMAGE_ABORTED';
+
+class InboundImageError extends Error {
+  constructor(
+    readonly code: InboundImageErrorCode,
+    readonly userMessage: string,
+    readonly attachmentId?: string,
+  ) {
+    super(code);
+    this.name = 'InboundImageError';
+  }
+}
+
+async function cleanupPreparedImages(images: PreparedImage[]): Promise<void> {
+  await Promise.all(images.map(async image => {
+    await rm(image.path, { force: true }).catch(() => undefined);
+  }));
+}
+
+function validateImageUrl(attachment: Attachment): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(attachment.url);
+  } catch {
+    throw new InboundImageError(
+      'INVALID_IMAGE_URL',
+      'The attached image has an invalid download URL.',
+      attachment.attachment_id,
+    );
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new InboundImageError(
+      'INVALID_IMAGE_URL',
+      'The attached image has an invalid download URL.',
+      attachment.attachment_id,
+    );
+  }
+}
+
+async function prepareImageAttachments(params: {
+  attachments: Attachment[];
+  abortSignal: AbortSignal;
+  runtime: ReturnType<typeof getBcsRuntime>;
+}): Promise<PreparedImage[]> {
+  if (params.attachments.length === 0) return [];
+
+  if (params.attachments.length > MAX_IMAGE_ATTACHMENTS) {
+    throw new InboundImageError(
+      'TOO_MANY_IMAGES',
+      `A message can contain at most ${MAX_IMAGE_ATTACHMENTS} images.`,
+    );
+  }
+
+  const media = params.runtime.channel?.media;
+  if (!media?.fetchRemoteMedia || !media?.saveMediaBuffer) {
+    throw new InboundImageError(
+      'IMAGE_STORE_FAILED',
+      'Image processing is unavailable in the current OpenClaw runtime.',
+    );
+  }
+
+  const prepared: PreparedImage[] = [];
+  try {
+    for (const attachment of params.attachments) {
+      if (typeof attachment.expires_at === 'number' && attachment.expires_at <= Date.now()) {
+        throw new InboundImageError(
+          'IMAGE_EXPIRED',
+          'The attached image download link has expired.',
+          attachment.attachment_id,
+        );
+      }
+      if (typeof attachment.size === 'number' && attachment.size > MAX_IMAGE_BYTES) {
+        throw new InboundImageError(
+          'IMAGE_TOO_LARGE',
+          'The attached image exceeds the 20 MB limit.',
+          attachment.attachment_id,
+        );
+      }
+      validateImageUrl(attachment);
+
+      const timeoutSignal = AbortSignal.timeout(IMAGE_DOWNLOAD_TIMEOUT_MS);
+      const downloadSignal = AbortSignal.any([ params.abortSignal, timeoutSignal ]);
+      let fetched: { buffer: Buffer; contentType?: string; fileName?: string };
+      try {
+        // OpenClaw's guarded media fetch applies SSRF checks to the initial URL and redirects.
+        fetched = await media.fetchRemoteMedia({
+          url: attachment.url,
+          filePathHint: attachment.file_name,
+          maxBytes: MAX_IMAGE_BYTES,
+          maxRedirects: 3,
+          readIdleTimeoutMs: IMAGE_READ_IDLE_TIMEOUT_MS,
+          requestInit: { signal: downloadSignal },
+        });
+      } catch (err) {
+        if (params.abortSignal.aborted) {
+          throw new InboundImageError(
+            'IMAGE_ABORTED',
+            'Image processing was aborted.',
+            attachment.attachment_id,
+          );
+        }
+        if (timeoutSignal.aborted) {
+          throw new InboundImageError(
+            'IMAGE_DOWNLOAD_TIMEOUT',
+            'The attached image download timed out.',
+            attachment.attachment_id,
+          );
+        }
+        if ((err as { code?: string })?.code === 'max_bytes') {
+          throw new InboundImageError(
+            'IMAGE_TOO_LARGE',
+            'The attached image exceeds the 20 MB limit.',
+            attachment.attachment_id,
+          );
+        }
+        throw new InboundImageError(
+          'IMAGE_DOWNLOAD_FAILED',
+          'The attached image could not be downloaded. The link may have expired.',
+          attachment.attachment_id,
+        );
+      }
+
+      const contentType = Buffer.isBuffer(fetched.buffer)
+        ? sniffSupportedImageMime(fetched.buffer)
+        : undefined;
+      if (!contentType) {
+        throw new InboundImageError(
+          'UNSUPPORTED_IMAGE_TYPE',
+          'Unsupported image format. Supported formats are JPEG, PNG, GIF, and WebP.',
+          attachment.attachment_id,
+        );
+      }
+
+      let saved: { path: string; size: number; contentType?: string };
+      try {
+        saved = await media.saveMediaBuffer(
+          fetched.buffer,
+          contentType,
+          'inbound',
+          MAX_IMAGE_BYTES,
+          fetched.fileName ?? attachment.file_name,
+        );
+      } catch {
+        throw new InboundImageError(
+          'IMAGE_STORE_FAILED',
+          'The attached image could not be prepared for analysis.',
+          attachment.attachment_id,
+        );
+      }
+
+      const savedContentType = normalizeMimeType(saved.contentType) ?? contentType;
+      if (!SUPPORTED_IMAGE_MIME_TYPES.has(savedContentType)) {
+        await rm(saved.path, { force: true }).catch(() => undefined);
+        throw new InboundImageError(
+          'UNSUPPORTED_IMAGE_TYPE',
+          'Unsupported image format. Supported formats are JPEG, PNG, GIF, and WebP.',
+          attachment.attachment_id,
+        );
+      }
+      prepared.push({
+        path: saved.path,
+        contentType: savedContentType,
+      });
+    }
+    return prepared;
+  } catch (err) {
+    await cleanupPreparedImages(prepared);
+    throw err;
+  }
 }
 
 function buildChatEventPayload(
@@ -446,7 +713,9 @@ export async function handleChatSend(
   const sessionContext = params.session_context;
 
   // Extract text from message content
-  const text = extractText(params.message?.content ?? []);
+  const imageAttachments = extractImageAttachments(params.attachments);
+  const messageText = extractText(params.message?.content ?? []);
+  const text = messageText || (imageAttachments.length > 0 ? attachmentFallbackText(imageAttachments) : '');
   if (!text) {
     client.sendResponse(request.id, false, undefined, {
       code: 'INVALID_REQUEST',
@@ -470,6 +739,7 @@ export async function handleChatSend(
   // Track active stream for abort support
   const abortController = new AbortController();
   activeStreams.set(runId, abortController);
+  let preparedImages: PreparedImage[] = [];
 
   // Track run context for agent event routing
   runContexts.set(runId, { groupId: bcsGroupId, client });
@@ -478,6 +748,11 @@ export async function handleChatSend(
   try {
     const rt = getBcsRuntime();
     const currentCfg = await rt.config.loadConfig();
+    preparedImages = await prepareImageAttachments({
+      attachments: imageAttachments,
+      abortSignal: abortController.signal,
+      runtime: rt,
+    });
 
     // Resolve agent route to find the correct agent for this session
     const route = rt.channel.routing.resolveAgentRoute({
@@ -534,6 +809,14 @@ export async function handleChatSend(
       ConversationLabel: bcsGroupId ? `BCS Group ${bcsGroupId}` : 'BCS Onboarding',
       Timestamp: Date.now(),
       CommandAuthorized: true,
+      MediaPath: preparedImages[0]?.path,
+      MediaType: preparedImages[0]?.contentType,
+      MediaPaths: preparedImages.length > 0
+        ? preparedImages.map(image => image.path)
+        : undefined,
+      MediaTypes: preparedImages.length > 0
+        ? preparedImages.map(image => image.contentType)
+        : undefined,
     });
 
     // Resolve store path for session storage using the resolved agentId
@@ -626,12 +909,19 @@ export async function handleChatSend(
       }
     }
   } catch (err: any) {
-    log?.error?.(`Error processing chat.send for run_id=${runId}: ${err?.message ?? err}`);
-    if (err?.stack) {
-      log?.error?.(`[DEBUG] Stack trace for run_id=${runId}:\n${err.stack}`);
-    }
-    if (err?.cause) {
-      log?.error?.(`[DEBUG] Error cause for run_id=${runId}:`, err.cause);
+    const imageError = err instanceof InboundImageError ? err : undefined;
+    if (imageError) {
+      log?.error?.(
+        `[BCS] Image preparation failed for run_id=${runId}, attachment_id=${sanitizeAttachmentLogValue(imageError.attachmentId ?? 'unknown')}, code=${imageError.code}`,
+      );
+    } else {
+      log?.error?.(`Error processing chat.send for run_id=${runId}: ${err?.message ?? err}`);
+      if (err?.stack) {
+        log?.error?.(`[DEBUG] Stack trace for run_id=${runId}:\n${err.stack}`);
+      }
+      if (err?.cause) {
+        log?.error?.(`[DEBUG] Error cause for run_id=${runId}:`, err.cause);
+      }
     }
 
     if (runContexts.get(runId)?.finalSent) {
@@ -644,13 +934,17 @@ export async function handleChatSend(
         state: 'error',
         message: {
           role: 'assistant',
-          content: [{ type: 'text', text: 'An error occurred while processing your message.' }],
+          content: [{
+            type: 'text',
+            text: imageError?.userMessage ?? 'An error occurred while processing your message.',
+          }],
           timestamp: Date.now(),
         },
       };
       client.sendEvent('chat.event', errorPayload as unknown as Record<string, unknown>, nextSeq(client));
     }
   } finally {
+    await cleanupPreparedImages(preparedImages);
     activeStreams.delete(runId);
     runContexts.delete(runId);
     visibleReplyByRunId.delete(runId);
@@ -848,7 +1142,9 @@ export async function handleChatInject(
   const sessionContext = params.session_context;
 
   // Extract text from message content
-  const text = extractText(params.message?.content ?? []);
+  const imageAttachments = extractImageAttachments(params.attachments);
+  const messageText = extractText(params.message?.content ?? []);
+  const text = buildInjectText(messageText, imageAttachments);
   if (!text) {
     client.sendResponse(request.id, false, undefined, {
       code: 'INVALID_REQUEST',

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/types.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/types.ts
@@ -109,6 +109,17 @@ export interface MessageContent {
   timestamp: number;
 }
 
+export interface Attachment {
+  attachment_id: string;
+  type: 'image';
+  file_name: string;
+  mime_type?: string;
+  size?: number;
+  sha256?: string;
+  url: string;
+  expires_at?: number;
+}
+
 export type ChannelSource = 'webui' | 'dingtalk' | 'api';
 
 export interface ChannelInfo {
@@ -187,6 +198,7 @@ export interface ChatSendParams {
   session_context: GroupContext;
   timeout_ms?: number;
   idempotency_key?: string;
+  attachments?: Attachment[];
 }
 
 /** Parameters for chat.inject - incoming message that bot should observe silently.
@@ -201,6 +213,7 @@ export interface ChatInjectParams {
   message: MessageContent;
   channel: ChannelInfo;
   session_context: GroupContext;
+  attachments?: Attachment[];
 }
 
 export interface ChatSendResponse {

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/gateway-protocol.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/gateway-protocol.test.ts
@@ -139,7 +139,11 @@ async function startGatewayStub() {
   };
 }
 
-function installRuntime(port: number, storePath: string) {
+function installRuntime(
+  port: number,
+  storePath: string,
+  capturedInbound?: { value?: Record<string, unknown> },
+) {
   setBcsRuntime({
     config: {
       async loadConfig() {
@@ -159,7 +163,8 @@ function installRuntime(port: number, storePath: string) {
         },
       },
       reply: {
-        finalizeInboundContext(ctx: unknown) {
+        finalizeInboundContext(ctx: Record<string, unknown>) {
+          if (capturedInbound) capturedInbound.value = ctx;
           return ctx;
         },
       },
@@ -241,7 +246,8 @@ describe('OpenClaw gateway protocol compatibility', () => {
     const gateway = await startGatewayStub();
     const dataDir = await mkdtemp(join(tmpdir(), 'bcn-inject-'));
     const storePath = join(dataDir, 'sessions', 'sessions.json');
-    installRuntime(gateway.port, storePath);
+    const capturedInbound: { value?: Record<string, unknown> } = {};
+    installRuntime(gateway.port, storePath, capturedInbound);
     const { client, responses } = createResponseClient();
 
     try {
@@ -253,7 +259,13 @@ describe('OpenClaw gateway protocol compatibility', () => {
           params: {
             session_key: 'group-1',
             bcs_group_id: 'group-1',
-            message: { content: [{ type: 'text', text: 'hello from inject' }] },
+            message: { content: [] },
+            attachments: [{
+              attachment_id: 'att-1',
+              type: 'image',
+              file_name: 'diagram.png',
+              url: 'https://download.dingtalk.example/temporary-image-token',
+            }],
             channel: { user_id: 'alice' },
             session_context: {
               from: 'alice',
@@ -269,12 +281,19 @@ describe('OpenClaw gateway protocol compatibility', () => {
 
       assert.equal(responses.length, 1);
       assert.equal(responses[0].ok, true);
+      const observationText = '[Image attachment: name=diagram.png; image content is not available in this silent observation]';
+      assert.equal(capturedInbound.value?.Body, observationText);
+      assert.equal(capturedInbound.value?.MediaUrl, undefined);
+      assert.equal(capturedInbound.value?.MediaUrls, undefined);
+      assert.equal(capturedInbound.value?.MediaPath, undefined);
+      assert.equal(capturedInbound.value?.MediaPaths, undefined);
 
       const connectFrame = gateway.frames.find(frame => frame.method === 'connect');
       assert.equal(connectFrame?.params?.minProtocol, 3);
       assert.equal(connectFrame?.params?.maxProtocol, REQUIRED_GATEWAY_PROTOCOL);
       assert.deepEqual(connectFrame?.params?.scopes, [ 'operator.admin' ]);
-      assert.ok(gateway.frames.some(frame => frame.method === 'chat.inject'));
+      const injectFrame = gateway.frames.find(frame => frame.method === 'chat.inject');
+      assert.equal(injectFrame?.params?.message, observationText);
     } finally {
       await gateway.close();
       await rm(dataDir, { recursive: true, force: true });

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -1,5 +1,7 @@
 import { strict as assert } from 'node:assert';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import plugin, { bcsPlugin, registerBcsCore, setBcsRuntime } from '../src/index.js';
@@ -389,7 +391,7 @@ describe('openclaw-channel-bcn', () => {
     assert.equal(plugin.id, 'openclaw-channel-bcn');
     assert.equal(bcsPlugin.id, 'bcs');
     assert.equal(bcsPlugin.meta.label, 'BCS');
-    assert.equal(bcsPlugin.capabilities.media, false);
+    assert.equal(bcsPlugin.capabilities.media, true);
   });
 
   it('does not synthesize a fallback reply when OpenClaw returns no text', () => {
@@ -399,10 +401,15 @@ describe('openclaw-channel-bcn', () => {
   });
 
   it('builds chat deltas and final from assistant agent events', async () => {
+    const mediaDir = await mkdtemp(join(tmpdir(), 'bcn-inbound-image-'));
+    const savedImagePath = join(mediaDir, 'diagram.png');
     const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
     const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
+    const fetchCalls: any[] = [];
+    const saveCalls: any[] = [];
     let agentEventHandler: ((evt: Record<string, unknown>) => boolean) | undefined;
     let capturedReplyOptions: Record<string, unknown> | undefined;
+    let capturedInboundContext: Record<string, unknown> | undefined;
     const client = {
       sendResponse(id: string, ok: boolean, payload?: Record<string, unknown>) {
         responses.push({ id, ok, payload });
@@ -442,6 +449,25 @@ describe('openclaw-channel-bcn', () => {
         },
       },
       channel: {
+        media: {
+          async fetchRemoteMedia(options: any) {
+            fetchCalls.push(options);
+            return {
+              buffer: Buffer.from([ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ]),
+              contentType: 'image/png',
+              fileName: 'diagram.png',
+            };
+          },
+          async saveMediaBuffer(...args: any[]) {
+            saveCalls.push(args);
+            writeFileSync(savedImagePath, 'stored-image');
+            return {
+              path: savedImagePath,
+              size: 3,
+              contentType: 'image/png',
+            };
+          },
+        },
         routing: {
           resolveAgentRoute() {
             return { agentId: 'agent-1', sessionKey: 'bcs:group-1' };
@@ -449,6 +475,7 @@ describe('openclaw-channel-bcn', () => {
         },
         reply: {
           finalizeInboundContext(ctx: Record<string, unknown>) {
+            capturedInboundContext = ctx;
             return ctx;
           },
           async dispatchReplyWithBufferedBlockDispatcher({ dispatcherOptions, replyOptions }: any) {
@@ -535,9 +562,15 @@ describe('openclaw-channel-bcn', () => {
         session_context: {},
         message: {
           role: 'user',
-          content: [{ type: 'text', text: 'run with tools' }],
+          content: [],
           timestamp: Date.now(),
         },
+        attachments: [{
+          attachment_id: 'att-1',
+          type: 'image',
+          file_name: 'diagram.png',
+          url: 'https://download.dingtalk.example/temporary-image-token',
+        }],
       },
     };
 
@@ -550,6 +583,26 @@ describe('openclaw-channel-bcn', () => {
       assert.equal(typeof runId, 'string');
       assert.equal(capturedReplyOptions?.disableBlockStreaming, false);
       assert.equal(capturedReplyOptions?.sourceReplyDeliveryMode, 'automatic');
+      assert.equal(capturedInboundContext?.Body, '[Image: diagram.png]');
+      assert.equal(capturedInboundContext?.MediaPath, savedImagePath);
+      assert.equal(capturedInboundContext?.MediaType, 'image/png');
+      assert.deepEqual(capturedInboundContext?.MediaPaths, [ savedImagePath ]);
+      assert.deepEqual(capturedInboundContext?.MediaTypes, [ 'image/png' ]);
+      assert.equal(capturedInboundContext?.MediaUrl, undefined);
+      assert.equal(capturedInboundContext?.MediaUrls, undefined);
+      assert.equal(fetchCalls.length, 1);
+      assert.equal(fetchCalls[0].url, 'https://download.dingtalk.example/temporary-image-token');
+      assert.equal(fetchCalls[0].filePathHint, 'diagram.png');
+      assert.equal(fetchCalls[0].maxBytes, 20 * 1024 * 1024);
+      assert.equal(fetchCalls[0].maxRedirects, 3);
+      assert.ok(fetchCalls[0].requestInit.signal instanceof AbortSignal);
+      assert.deepEqual(saveCalls[0].slice(1), [
+        'image/png',
+        'inbound',
+        20 * 1024 * 1024,
+        'diagram.png',
+      ]);
+      assert.equal(existsSync(savedImagePath), false);
       assert.equal(events.filter(item => item.event === 'agent').length, 9);
       const chatEvents = events.filter(item => item.event === 'chat.event');
       assert.deepEqual(chatEvents.map(item => item.payload.state), [ 'delta', 'delta', 'delta', 'final' ]);
@@ -565,6 +618,161 @@ describe('openclaw-channel-bcn', () => {
       assert.deepEqual(chatEvents.map(item => item.payload.run_id), [ runId, runId, runId, runId ]);
     } finally {
       cleanupAgentEventsSubscription();
+      abortAllStreams();
+      await rm(mediaDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an oversized downloaded image before starting an agent run', async () => {
+    const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
+    const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
+    let routeResolved = false;
+    let replyDispatched = false;
+    let mediaSaved = false;
+    const client = {
+      sendResponse(id: string, ok: boolean, payload?: Record<string, unknown>) {
+        responses.push({ id, ok, payload });
+      },
+      sendEvent(event: string, payload: Record<string, unknown>, seq: number) {
+        events.push({ event, payload, seq });
+      },
+    };
+    setBcsRuntime({
+      config: {
+        async loadConfig() {
+          return {};
+        },
+      },
+      channel: {
+        media: {
+          async fetchRemoteMedia() {
+            throw Object.assign(new Error('must not be exposed'), { code: 'max_bytes' });
+          },
+          async saveMediaBuffer() {
+            mediaSaved = true;
+          },
+        },
+        routing: {
+          resolveAgentRoute() {
+            routeResolved = true;
+            return { agentId: 'agent-1', sessionKey: 'bcs:group-1' };
+          },
+        },
+        reply: {
+          finalizeInboundContext(ctx: Record<string, unknown>) {
+            return ctx;
+          },
+          async dispatchReplyWithBufferedBlockDispatcher() {
+            replyDispatched = true;
+          },
+        },
+      },
+    } as any);
+
+    try {
+      await handleChatSend({
+        type: 'req',
+        id: 'chat-image-too-large',
+        method: 'chat.send',
+        params: {
+          bcs_group_id: 'group-1',
+          channel: { source: 'api', user_id: 'user-1' },
+          session_context: {},
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'analyze this image' }],
+            timestamp: Date.now(),
+          },
+          attachments: [{
+            attachment_id: 'att-too-large',
+            type: 'image',
+            file_name: 'large.png',
+            url: 'https://download.dingtalk.example/large-image-token',
+          }],
+        },
+      }, client as any, {
+        accountId: 'default',
+        botId: 'bot-1',
+      } as any);
+
+      assert.equal(responses.length, 1);
+      assert.equal(responses[0].ok, true);
+      assert.equal(typeof responses[0].payload?.run_id, 'string');
+      assert.equal(routeResolved, false);
+      assert.equal(replyDispatched, false);
+      assert.equal(mediaSaved, false);
+      assert.equal(events.length, 1);
+      assert.equal(events[0].event, 'chat.event');
+      assert.equal(events[0].payload.state, 'error');
+      assert.equal(
+        (events[0].payload.message as any).content[0].text,
+        'The attached image exceeds the 20 MB limit.',
+      );
+    } finally {
+      abortAllStreams();
+    }
+  });
+
+  it('rejects non-image bytes even when the URL and MIME claim PNG', async () => {
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    let routeResolved = false;
+    const client = {
+      sendResponse() {},
+      sendEvent(event: string, payload: Record<string, unknown>) {
+        events.push({ event, payload });
+      },
+    };
+    setBcsRuntime({
+      config: { async loadConfig() { return {}; } },
+      channel: {
+        media: {
+          async fetchRemoteMedia() {
+            return {
+              buffer: Buffer.from('not an image'),
+              contentType: 'image/png',
+              fileName: 'spoofed.png',
+            };
+          },
+          async saveMediaBuffer() {
+            throw new Error('must not save spoofed content');
+          },
+        },
+        routing: {
+          resolveAgentRoute() {
+            routeResolved = true;
+          },
+        },
+      },
+    } as any);
+
+    try {
+      await handleChatSend({
+        type: 'req',
+        id: 'chat-image-spoofed',
+        method: 'chat.send',
+        params: {
+          bcs_group_id: 'group-1',
+          channel: { source: 'api', user_id: 'user-1' },
+          session_context: {},
+          message: { role: 'user', content: [], timestamp: Date.now() },
+          attachments: [{
+            attachment_id: 'att-spoofed',
+            type: 'image',
+            file_name: 'spoofed.png',
+            mime_type: 'image/png',
+            url: 'https://download.dingtalk.example/spoofed.png',
+          }],
+        },
+      }, client as any, { accountId: 'default', botId: 'bot-1' } as any);
+
+      assert.equal(routeResolved, false);
+      assert.equal(events.length, 1);
+      assert.equal(events[0].payload.state, 'error');
+      assert.equal(
+        (events[0].payload.message as any).content[0].text,
+        'Unsupported image format. Supported formats are JPEG, PNG, GIF, and WebP.',
+      );
+    } finally {
       abortAllStreams();
     }
   });

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -4,6 +4,7 @@
 //! HTTP/CLI 管理 binding。实现在 `services/bcs-channel`。
 
 use async_trait::async_trait;
+use bcs_protocol::Attachment;
 
 use bcs_domain::{
     BindingTarget, GroupChatScope, ChannelBinding, ChannelConfig, ChannelType,
@@ -34,6 +35,8 @@ impl From<ServiceError> for ChannelUseCaseError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChannelInboundFailureKind {
     InvalidInbound,
+    UnsupportedAttachment,
+    AttachmentProcessingFailed,
     BindingNotFound,
     BindingLookupFailed,
     ActorResolutionFailed,
@@ -105,6 +108,8 @@ pub struct InboundMessage {
     pub im_user_id: String,
     pub im_user_nick: Option<String>,
     pub text: String,
+    /// Channel-normalized temporary attachments. The first rollout accepts images only.
+    pub attachments: Option<Vec<Attachment>>,
     /// 该消息是否 @ 了本机器人(isInAtList / atUsers 命中)。
     pub is_at_bot: bool,
     /// 去重用。

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -4,10 +4,9 @@
 //! HTTP/CLI 管理 binding。实现在 `services/bcs-channel`。
 
 use async_trait::async_trait;
-use bcs_protocol::Attachment;
 
 use bcs_domain::{
-    BindingTarget, GroupChatScope, ChannelBinding, ChannelConfig, ChannelType,
+    Attachment, BindingTarget, GroupChatScope, ChannelBinding, ChannelConfig, ChannelType,
     ParticipantRole, Visibility,
 };
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
@@ -1,6 +1,7 @@
 //! Message-flow use-case contracts.
 
 use async_trait::async_trait;
+use bcs_protocol::Attachment;
 use serde_json::Value;
 
 use crate::{
@@ -30,7 +31,7 @@ pub struct WebSendCommand {
     pub from_name: Option<String>,
     pub message: String,
     pub mentions: Vec<String>,
-    pub attachments: Option<Vec<Value>>,
+    pub attachments: Option<Vec<Attachment>>,
     pub thinking: Option<String>,
     pub idempotency_key: Option<String>,
     pub sender_conn_id: Option<u64>,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
@@ -1,7 +1,7 @@
 //! Message-flow use-case contracts.
 
 use async_trait::async_trait;
-use bcs_protocol::Attachment;
+use bcs_domain::Attachment;
 use serde_json::Value;
 
 use crate::{

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -648,7 +648,7 @@ impl ChannelService for BcsChannelService {
                     from_name: msg.im_user_nick,
                     message: msg.text,
                     mentions: Vec::new(),
-                    attachments: None,
+                    attachments: msg.attachments,
                     thinking: None,
                     idempotency_key: Some(dispatch_msg_id.clone()),
                     sender_conn_id: None,
@@ -2550,6 +2550,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inbound_image_attachment_reaches_message_flow() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        harness
+            .service
+            .create_binding(CreateBindingCommand {
+                channel_type: channel_type(),
+                account_ref: "robot_1".to_string(),
+                target: BindingTarget::Group {
+                    group_id: "group_1".to_string(),
+                },
+                group_chat_scope: Some(GroupChatScope::ConversationShared),
+                outbound_visibility: Visibility::FullTranscript,
+                env: "dev".to_string(),
+                created_by: Some("creator".to_string()),
+                config: dingtalk_config("robot_1"),
+            })
+            .await?;
+        let mut inbound = group_inbound("conv_group", "u1", Some("张三"), "msg-image", true);
+        inbound.attachments = Some(vec![serde_json::from_value(serde_json::json!({
+            "attachment_id": "att-1",
+            "type": "image",
+            "file_name": "image",
+            "url": "https://download.example.com/image?token=temporary"
+        }))?]);
+
+        harness.service.handle_inbound(inbound).await?;
+
+        let web_sends = harness.message_flow.web_sends.lock().await;
+        assert_eq!(web_sends.len(), 1);
+        let attachments = serde_json::to_value(&web_sends[0].attachments)?;
+        assert_eq!(attachments[0]["attachment_id"], "att-1");
+        assert_eq!(
+            attachments[0]["url"],
+            "https://download.example.com/image?token=temporary"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn direct_bot_group_chat_uses_bounded_channel_session_id() -> TestResult {
         let harness = TestHarness::new(manager_group("group_1")).await?;
         let binding_id = "0d86bd1b-6efd-4b5c-8906-1be1b5717c74";
@@ -2774,6 +2813,7 @@ mod tests {
             im_user_id: "u1".to_string(),
             im_user_nick: Some("张三".to_string()),
             text: "hello".to_string(),
+            attachments: None,
             is_at_bot: true,
             msg_id: "msg_meta".to_string(),
         };
@@ -3297,6 +3337,7 @@ mod tests {
             im_user_id: user_id.to_string(),
             im_user_nick: user_nick.map(str::to_string),
             text: "hello".to_string(),
+            attachments: None,
             is_at_bot: true,
             msg_id: msg_id.to_string(),
         }
@@ -3317,6 +3358,7 @@ mod tests {
             im_user_id: user_id.to_string(),
             im_user_nick: user_nick.map(str::to_string),
             text: "hello".to_string(),
+            attachments: None,
             is_at_bot,
             msg_id: msg_id.to_string(),
         }

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -1286,6 +1286,7 @@ fn build_chat_send_frame(
         idempotency_key: None,
         bcs_session_id: None,
         tags: tags.to_vec(),
+        attachments: Vec::new(),
     };
     let mut params = serde_json::to_value(params)?;
     if let Some(wait_mode) = caller_wait_mode.map(str::trim).filter(|mode| !mode.is_empty()) {

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use bcs_domain::{NewMessage, SenderType};
 use bcs_protocol::{
-    BcsFrame, RequestFrame, build_chat_inject_frame, build_chat_send_frame,
+    Attachment, BcsFrame, RequestFrame, build_chat_inject_frame, build_chat_send_frame,
     build_direct_chat_inject_frame, build_direct_chat_send_frame, build_session_key, now_ms,
 };
 use bcs_service_api::{
@@ -322,6 +322,47 @@ pub(crate) async fn try_persist_group_message(
     }
 }
 
+fn persisted_inbound_content(content: &str, attachments: Option<&[Attachment]>) -> Value {
+    let Some(attachments) = attachments.filter(|items| !items.is_empty()) else {
+        return Value::String(content.to_string());
+    };
+    serde_json::json!({
+        "text": content,
+        "attachments": attachments
+            .iter()
+            .map(Attachment::stable_metadata)
+            .collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod attachment_persistence_tests {
+    use bcs_protocol::{Attachment, AttachmentType};
+
+    use super::persisted_inbound_content;
+
+    #[test]
+    fn temporary_attachment_url_is_not_persisted_in_message_history() {
+        let attachment = Attachment {
+            attachment_id: "att-1".to_string(),
+            attachment_type: AttachmentType::Image,
+            file_name: "image".to_string(),
+            mime_type: None,
+            size: None,
+            sha256: None,
+            url: "https://download.example.com/image?token=temporary".to_string(),
+            expires_at: None,
+        };
+
+        let persisted = persisted_inbound_content("look", Some(&[attachment]));
+
+        assert_eq!(persisted["text"], "look");
+        assert_eq!(persisted["attachments"][0]["attachment_id"], "att-1");
+        assert!(persisted["attachments"][0].get("url").is_none());
+        assert!(!persisted.to_string().contains("token=temporary"));
+    }
+}
+
 pub(crate) async fn manager_worker_self_owner(
     flow: &BcsMessageFlow,
     group_id: &str,
@@ -449,7 +490,7 @@ pub async fn handle_web_send(
         &cmd.from_actor_id,
         sender_type,
         "chat",
-        Value::String(decision.cleaned_message.clone()),
+        persisted_inbound_content(&decision.cleaned_message, cmd.attachments.as_deref()),
         cmd.idempotency_key.as_deref(),
         None,
         "", // run_id: user messages don't associate with bot runs
@@ -2125,6 +2166,7 @@ async fn frame_for_target(
                     &cmd.from_actor_id,
                     sender_display_name,
                     &target.bot_uuid,
+                    &cmd.attachments,
                     protocol_version,
                     cmd.session_id.as_deref(),
                 );
@@ -2139,6 +2181,7 @@ async fn frame_for_target(
                 sender_display_name,
                 &decision.mentions,
                 &target.bot_uuid,
+                &cmd.attachments,
                 is_self,
                 protocol_version,
                 from_bot_owner,

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -1,10 +1,11 @@
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
-use bcs_domain::{NewMessage, SenderType};
+use bcs_domain::{Attachment, NewMessage, SenderType};
 use bcs_protocol::{
-    Attachment, BcsFrame, RequestFrame, build_chat_inject_frame, build_chat_send_frame,
-    build_direct_chat_inject_frame, build_direct_chat_send_frame, build_session_key, now_ms,
+    Attachment as WireAttachment, BcsFrame, RequestFrame, build_chat_inject_frame,
+    build_chat_send_frame, build_direct_chat_inject_frame, build_direct_chat_send_frame,
+    build_session_key, now_ms,
 };
 use bcs_service_api::{
     ActorKind, ActorStatus, BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort,
@@ -337,7 +338,7 @@ fn persisted_inbound_content(content: &str, attachments: Option<&[Attachment]>) 
 
 #[cfg(test)]
 mod attachment_persistence_tests {
-    use bcs_protocol::{Attachment, AttachmentType};
+    use bcs_domain::{Attachment, AttachmentType};
 
     use super::persisted_inbound_content;
 
@@ -2122,6 +2123,13 @@ async fn frame_for_target(
     );
     let context_projection =
         context_projection_for_delivery(flow, group, cmd.session_id.as_deref()).await;
+    let wire_attachments = cmd.attachments.as_ref().map(|attachments| {
+        attachments
+            .iter()
+            .cloned()
+            .map(WireAttachment::from)
+            .collect()
+    });
     match target.delivery_type {
         DeliveryType::Send => {
             if context_projection == ContextProjection::DirectBot {
@@ -2132,7 +2140,7 @@ async fn frame_for_target(
                     &cmd.from_actor_id,
                     sender_display_name,
                     &target.bot_uuid,
-                    &cmd.attachments,
+                    &wire_attachments,
                     &cmd.thinking,
                     protocol_version,
                     cmd.session_id.as_deref(),
@@ -2148,7 +2156,7 @@ async fn frame_for_target(
                 sender_display_name,
                 &decision.mentions,
                 &target.bot_uuid,
-                &cmd.attachments,
+                &wire_attachments,
                 &cmd.thinking,
                 is_self,
                 protocol_version,
@@ -2166,7 +2174,7 @@ async fn frame_for_target(
                     &cmd.from_actor_id,
                     sender_display_name,
                     &target.bot_uuid,
-                    &cmd.attachments,
+                    &wire_attachments,
                     protocol_version,
                     cmd.session_id.as_deref(),
                 );
@@ -2181,7 +2189,7 @@ async fn frame_for_target(
                 sender_display_name,
                 &decision.mentions,
                 &target.bot_uuid,
-                &cmd.attachments,
+                &wire_attachments,
                 is_self,
                 protocol_version,
                 from_bot_owner,

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
@@ -279,6 +279,7 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
                             BCS_SYSTEM_MESSAGE,
                             &[],
                             recipient,
+                            &None,
                             false,
                             protocol_version,
                             None,


### PR DESCRIPTION
## Summary

- add a typed image attachment contract shared by WebSocket and HTTP provider transports
- propagate attachments through channel ingress, chat.send/chat.inject, persistence-safe metadata, and provider SSE requests
- download chat.send images in openclaw-channel-bcn through guarded media APIs, validate magic bytes, and pass managed local MediaPath values to OpenClaw
- keep chat.inject text-only and redact temporary attachment URLs from logs/history

## Validation

- cargo test -p bcs-protocol -p bcs-provider-http -p bcs-channel -p bcs-message-flow
- npm run lint
- npm run test-local (49 passing)
- npm run prepublishOnly