### PR TITLE
fix: guard bot restart lifecycle states

### DIFF
--- a/.github/workflows/singlebox-coverage.yml
+++ b/.github/workflows/singlebox-coverage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - dev
       - main
+      - 'REL*'
     paths:
       - "scripts/**"
       - "src/backend/**"

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -14,7 +14,7 @@ import asyncio
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
 
-from fastapi import APIRouter, Query, Request, Depends, Path
+from fastapi import APIRouter, Query, Request, Response, Depends, Path
 from pydantic import BaseModel
 
 from agentclaw.community.adapters.http.auth.dependencies import require_operator, get_current_user
@@ -32,6 +32,7 @@ from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotServiceError,
+    BotInvalidLifecycleStateError,
     BotNotFoundError,
     BotPermissionError,
     DeviceAllocationError,
@@ -274,6 +275,7 @@ async def release_bot_for_others(
 @router.post("/restart-for-others", response_model=ApiResponse)
 async def restart_bot_for_others(
     request: Request,
+    response: Response,
     ctx: RequestContext = Depends(get_request_context),
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> ApiResponse:
@@ -343,6 +345,9 @@ async def restart_bot_for_others(
             nick_name=target_user_id,  # Use user_id as nick_name for admin operations
         )
 
+        if result.get("restart_in_progress"):
+            response.status_code = 202
+
         logger.info(f"[bot_router.restart_bot_for_others] Successfully restarted bot {target_bot_id} for {target_user_id}")
 
         return ApiResponse(
@@ -361,6 +366,17 @@ async def restart_bot_for_others(
             success=False,
             message=f"{str(e)}",
             error_code=404,
+            data=None,
+        )
+    except BotInvalidLifecycleStateError as e:
+        logger.warning(
+            f"[bot_router.restart_bot_for_others] Invalid lifecycle state: {e}"
+        )
+        response.status_code = 409
+        return ApiResponse(
+            success=False,
+            message=f"当前状态不允许重启Bot: {str(e)}",
+            error_code=409,
             data=None,
         )
     except BotServiceError as e:
@@ -384,6 +400,7 @@ async def restart_bot_for_others(
 @router.post("/restart-scheduler", response_model=ApiResponse)
 async def restart_scheduler(
     request: Request,
+    response: Response,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> ApiResponse:
     """
@@ -407,6 +424,9 @@ async def restart_scheduler(
             nick_name=target_user_id,  # Use user_id as nick_name for admin operations
         )
 
+        if result.get("restart_in_progress"):
+            response.status_code = 202
+
         logger.info(f"[bot_router.restart_scheduler] Successfully restarted bot {target_bot_id} for {target_user_id}")
 
         return ApiResponse(
@@ -425,6 +445,17 @@ async def restart_scheduler(
             success=False,
             message=f"{str(e)}",
             error_code=404,
+            data=None,
+        )
+    except BotInvalidLifecycleStateError as e:
+        logger.warning(
+            f"[bot_router.restart_scheduler] Invalid lifecycle state: {e}"
+        )
+        response.status_code = 409
+        return ApiResponse(
+            success=False,
+            message=f"当前状态不允许重启Bot: {str(e)}",
+            error_code=409,
             data=None,
         )
     except BotServiceError as e:
@@ -2658,6 +2689,7 @@ async def get_bot_config_dir(
 async def restart_bot(
     bot_id: str,
     request: Request,
+    response: Response,
     owner_id: Optional[str] = Query(None, description="Bot owner ID"),
     ctx: RequestContext = Depends(get_request_context),
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
@@ -2698,6 +2730,9 @@ async def restart_bot(
             nick_name=nick_name,
         )
 
+        if result.get("restart_in_progress"):
+            response.status_code = 202
+
         return ApiResponse(
             success=True,
             data=result,
@@ -2708,6 +2743,15 @@ async def restart_bot(
             success=False,
             message=f"Bot不存在: {bot_id}",
             error_code=404,
+            data=None,
+        )
+    except BotInvalidLifecycleStateError as e:
+        logger.warning(f"[bot_router.restart_bot] Invalid lifecycle state: {e}")
+        response.status_code = 409
+        return ApiResponse(
+            success=False,
+            message=f"当前状态不允许重启Bot: {str(e)}",
+            error_code=409,
             data=None,
         )
     except BotServiceError as e:

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -106,6 +106,17 @@ class BotServiceError(Exception):
     pass
 
 
+class BotInvalidLifecycleStateError(BotServiceError):
+    """The requested operation is not allowed in the bot's current state."""
+
+    def __init__(self, *, bot_id: str, current_status: str) -> None:
+        self.bot_id = bot_id
+        self.current_status = current_status
+        super().__init__(
+            f"Bot {bot_id} cannot be restarted while status is {current_status}"
+        )
+
+
 class BotNotFoundError(BotServiceError):
     """Bot not found error."""
     pass
@@ -3043,39 +3054,43 @@ class BotService:
             bot_id, user_id, status,
         )
 
-    def _resolve_current_device_provider(
+    def _resolve_current_device_restart_context(
         self,
         *,
         bot_id: str,
         binding_id: int,
-    ) -> str:
-        """Read the provider fact from the current binding before restart.
-
-        This is deliberately DB/binding based. Creation rollout only applies
-        to brand-new bots; restart must preserve the provider that created the
-        current container, otherwise an existing ARCA bot could be moved to
-        BaaS just because the owner later entered the whitelist.
-        """
+    ) -> tuple[str, str | None]:
+        """Return binding state while preserving its original provider."""
         try:
             service = self._device_service_provider()
             binding = service.get_device(binding_id=binding_id)
         except Exception as e:
             raise BotServiceError(
-                f"Bot {bot_id} binding {binding_id} cannot resolve device_provider: {e}"
+                f"Bot {bot_id} binding {binding_id} cannot resolve restart context: {e}"
             ) from e
 
-        provider = None
         if isinstance(binding, dict):
             provider = binding.get("device_provider")
+            binding_status = binding.get("status")
         else:
             provider = getattr(binding, "device_provider", None)
+            binding_status = getattr(binding, "status", None)
 
         if not provider:
             raise BotServiceError(
                 f"Bot {bot_id} binding {binding_id} missing device_provider; "
                 "restart aborted to avoid creation rollout migration"
             )
-        return str(provider)
+
+        return str(provider), str(binding_status) if binding_status else None
+
+    @staticmethod
+    def _activation_in_progress_result(bot: Dict[str, Any]) -> Dict[str, Any]:
+        """Return an idempotent response without mutating lifecycle state."""
+        current = dict(bot)
+        current["restart_in_progress"] = True
+        current["message"] = "Bot activation is in progress"
+        return current
 
     def is_teclaw_bot(self, active_engine: Optional[str]) -> bool:
         """Whether a bot with this engine runs in a teclaw container.
@@ -3239,6 +3254,36 @@ class BotService:
         if not bot:
             raise BotNotFoundError(f"Bot not found: {bot_id}")
 
+        if bot.get("bot_type") == "desktop":
+            raise BotServiceError(
+                f"Desktop bot {bot_id} cannot be stopped via BotService.stop_bot, "
+                "use DesktopBotService instead"
+            )
+
+        bot_status = str(bot.get("status") or "").upper()
+        if bot_status in {"REACTIVATING", "PENDING"}:
+            logger.info(
+                "[bot_service.restart_bot] skip restart while activation is in progress: "
+                "bot_id=%s user_id=%s bot_status=%s",
+                bot_id,
+                user_id,
+                bot_status,
+            )
+            return self._activation_in_progress_result(bot)
+
+        if bot_status != "ACTIVE":
+            logger.warning(
+                "[bot_service.restart_bot] reject restart for invalid lifecycle state: "
+                "bot_id=%s user_id=%s bot_status=%s",
+                bot_id,
+                user_id,
+                bot_status,
+            )
+            raise BotInvalidLifecycleStateError(
+                bot_id=bot_id,
+                current_status=bot_status or "UNKNOWN",
+            )
+
         env = get_current_env()
         entity_id = bot.get("entity_id")
         if not entity_id:
@@ -3255,10 +3300,36 @@ class BotService:
         current_device_provider = None
         binding_id = bot.get("binding_id")
         if binding_id:
-            current_device_provider = self._resolve_current_device_provider(
-                bot_id=bot_id,
-                binding_id=binding_id,
+            current_device_provider, binding_status = (
+                self._resolve_current_device_restart_context(
+                    bot_id=bot_id,
+                    binding_id=binding_id,
+                )
             )
+            if binding_status == DeviceBindingStatus.PENDING.value:
+                logger.info(
+                    "[bot_service.restart_bot] skip restart while binding is pending: "
+                    "bot_id=%s user_id=%s binding_id=%s",
+                    bot_id,
+                    user_id,
+                    binding_id,
+                )
+                current = self._activation_in_progress_result(bot)
+                current["status"] = "PENDING"
+                return current
+            if binding_status and binding_status != DeviceBindingStatus.ACTIVE.value:
+                logger.warning(
+                    "[bot_service.restart_bot] reject restart for invalid binding state: "
+                    "bot_id=%s user_id=%s binding_id=%s binding_status=%s",
+                    bot_id,
+                    user_id,
+                    binding_id,
+                    binding_status,
+                )
+                raise BotInvalidLifecycleStateError(
+                    bot_id=bot_id,
+                    current_status=f"BINDING_{binding_status}",
+                )
             logger.info(
                 f"[bot_service.restart_bot] preserve device_provider before restart: "
                 f"bot_id={bot_id}, user_id={user_id}, binding_id={binding_id}, "

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -13,6 +13,7 @@ from agentclaw.community.adapters.http.dependencies import RequestContext, get_r
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotService,
     BotServiceError,
+    BotInvalidLifecycleStateError,
     BotNotFoundError,
     DeviceAllocationError,
     BotNameExistsError,
@@ -762,6 +763,34 @@ class TestRestartBot:
         resp = tc.post("/api/bots/default/restart")
         assert resp.json()["error_code"] == 500
 
+    def test_recycled_bot_returns_conflict(self, client):
+        tc, svc, _ = client
+        svc.restart_bot.side_effect = BotInvalidLifecycleStateError(
+            bot_id="default",
+            current_status="RECYCLED",
+        )
+
+        resp = tc.post("/api/bots/default/restart")
+
+        assert resp.status_code == 409
+        assert resp.json()["success"] is False
+        assert resp.json()["error_code"] == 409
+
+    def test_activation_in_progress_returns_accepted(self, client):
+        tc, svc, _ = client
+        svc.restart_bot.return_value = {
+            **BOT_SAMPLE,
+            "status": "REACTIVATING",
+            "restart_in_progress": True,
+            "message": "Bot activation is in progress",
+        }
+
+        resp = tc.post("/api/bots/default/restart")
+
+        assert resp.status_code == 202
+        assert resp.json()["success"] is True
+        assert resp.json()["data"]["restart_in_progress"] is True
+
 
 # ---------------------------------------------------------------------------
 # POST /api/bots/switch-engine
@@ -819,6 +848,37 @@ class TestRestartScheduler:
         svc.restart_bot.side_effect = BotServiceError("fail")
         resp = tc.post("/api/bots/restart-scheduler", json={"user_id": "test_user", "bot_id": "default"})
         assert resp.json()["error_code"] == 500
+
+    def test_recycled_bot_returns_conflict(self, client):
+        tc, svc, _ = client
+        svc.restart_bot.side_effect = BotInvalidLifecycleStateError(
+            bot_id="default",
+            current_status="RECYCLED",
+        )
+
+        resp = tc.post(
+            "/api/bots/restart-scheduler",
+            json={"user_id": "test_user", "bot_id": "default"},
+        )
+
+        assert resp.status_code == 409
+        assert resp.json()["error_code"] == 409
+
+    def test_activation_in_progress_returns_accepted(self, client):
+        tc, svc, _ = client
+        svc.restart_bot.return_value = {
+            **BOT_SAMPLE,
+            "status": "PENDING",
+            "restart_in_progress": True,
+        }
+
+        resp = tc.post(
+            "/api/bots/restart-scheduler",
+            json={"user_id": "test_user", "bot_id": "default"},
+        )
+
+        assert resp.status_code == 202
+        assert resp.json()["success"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -884,6 +944,37 @@ class TestRestartForOthers:
         svc.restart_bot.side_effect = BotNotFoundError("nope")
         resp = tc.post("/api/bots/restart-for-others", json={"target_user_id": "u1", "target_bot_id": "missing"})
         assert resp.json()["error_code"] == 404
+
+    def test_recycled_bot_returns_conflict(self, admin_client):
+        tc, svc, _, _ = admin_client
+        svc.restart_bot.side_effect = BotInvalidLifecycleStateError(
+            bot_id="default",
+            current_status="RECYCLED",
+        )
+
+        resp = tc.post(
+            "/api/bots/restart-for-others",
+            json={"target_user_id": "u1", "target_bot_id": "default"},
+        )
+
+        assert resp.status_code == 409
+        assert resp.json()["error_code"] == 409
+
+    def test_activation_in_progress_returns_accepted(self, admin_client):
+        tc, svc, _, _ = admin_client
+        svc.restart_bot.return_value = {
+            **BOT_SAMPLE,
+            "status": "REACTIVATING",
+            "restart_in_progress": True,
+        }
+
+        resp = tc.post(
+            "/api/bots/restart-for-others",
+            json={"target_user_id": "u1", "target_bot_id": "default"},
+        )
+
+        assert resp.status_code == 202
+        assert resp.json()["success"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
+++ b/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
@@ -124,7 +124,7 @@ _CORE_SERVICE_MODULE_EXEMPT_SUFFIX: tuple[str, ...] = (
 _CORE_SERVICE_NAMES_OK: frozenset[str] = frozenset({
     # Errors raised by services that the router translates to HTTP:
     "FileTooLargeError",
-    "BotServiceError", "BotNotFoundError", "BotPermissionError",
+    "BotServiceError", "BotInvalidLifecycleStateError", "BotNotFoundError", "BotPermissionError",
     "BotLimitExceededError", "BotNameExistsError", "BotNameInvalidError",
     "DeviceAllocationError", "DeviceLimitError",
     # Multi-instance entry-resolution errors raised by DeviceServiceRouter and

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -25,6 +25,7 @@ import pytest
 
 from agentclaw.community.core.bot_management.services.bot_service import (
     RESTART_LOCK_TTL_SECONDS,
+    BotInvalidLifecycleStateError,
     BotNotFoundError,
     BotService,
     BotServiceError,
@@ -170,11 +171,107 @@ def _make_service(
 
 
 class TestRestartGuardOrchestration:
+    @pytest.mark.parametrize("status", ["REACTIVATING", "PENDING"])
+    def test_restart_during_activation_is_idempotent(self, status):
+        """Activation owns the lifecycle while the bot is starting."""
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        bot = _make_bot(status=status)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result["status"] == status
+        assert result["restart_in_progress"] is True
+        assert result["message"] == "Bot activation is in progress"
+        assert repo.acquire_calls == 0
+        stop.assert_not_called()
+        start.assert_not_called()
+
+    def test_recycled_bot_restart_is_rejected_without_side_effects(self):
+        """RECYCLED bots must only return through the explicit activate flow."""
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        svc = _make_service(repo, device_provider=device_service)
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="RECYCLED",
+            binding_id=42,
+        )
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            with pytest.raises(BotInvalidLifecycleStateError) as exc_info:
+                svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert exc_info.value.current_status == "RECYCLED"
+        assert repo.acquire_calls == 0
+        device_service.get_device.assert_not_called()
+        stop.assert_not_called()
+        start.assert_not_called()
+
+    def test_pending_binding_restart_is_idempotent(self):
+        """A newly-created binding may not be ready for BaaS update yet."""
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.get_device.return_value = {
+            "id": 42,
+            "device_provider": "baas",
+            "status": DeviceBindingStatus.PENDING,
+        }
+        baas = MagicMock()
+        svc = _make_service(
+            repo,
+            device_provider=device_service,
+            baas_service_provider=lambda: baas,
+        )
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+        )
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result["restart_in_progress"] is True
+        assert result["message"] == "Bot activation is in progress"
+        assert repo.acquire_calls == 0
+        baas.upgrade_bot.assert_not_called()
+        stop.assert_not_called()
+        start.assert_not_called()
+
+    def test_failed_binding_restart_is_rejected(self):
+        """A failed binding must not be released or replaced by restart."""
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+            status=DeviceBindingStatus.FAILED,
+        )
+        svc = _make_service(repo, device_provider=device_service)
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+        )
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            with pytest.raises(BotInvalidLifecycleStateError) as exc_info:
+                svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert exc_info.value.current_status == "BINDING_FAILED"
+        assert repo.acquire_calls == 0
+        stop.assert_not_called()
+        start.assert_not_called()
+
     def test_first_restart_acquires_and_runs_once(self):
         """First restart acquires the lock and triggers exactly one allocation."""
         repo = FakeRestartLockRepo()
         svc = _make_service(repo)
-        bot = _make_bot(status="PENDING")
+        bot = _make_bot(status="ACTIVE")
         svc._repository.get_by_id_and_owner.return_value = bot
 
         with patch.object(svc, "stop_bot", return_value=True) as stop, \
@@ -607,7 +704,7 @@ class TestRestartGuardOrchestration:
         """A second restart while one is in progress is suppressed (no rework)."""
         repo = FakeRestartLockRepo()
         svc = _make_service(repo)
-        bot = _make_bot(status="PENDING")
+        bot = _make_bot(status="ACTIVE")
         svc._repository.get_by_id_and_owner.return_value = bot
 
         # start_bot is mocked and never releases → lock stays held after #1.
@@ -645,6 +742,13 @@ class TestRestartGuardOrchestration:
         bot["binding_id"] = 42
         bot["device_id"] = "dev-1"
         svc._repository.get_by_id_and_owner.return_value = bot
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+            status=DeviceBindingStatus.ACTIVE,
+        )
+        svc._device_service_provider = lambda: device_service
         # Another request already holds the lock; its stop_bot hasn't run, so
         # the DB still reads ACTIVE with a live binding.
         repo.acquire(get_current_env(), "staff_user001", "bot001", "other_user")
@@ -661,7 +765,7 @@ class TestRestartGuardOrchestration:
         """Once allocation completes (lock released), a later restart is accepted."""
         repo = FakeRestartLockRepo()
         svc = _make_service(repo)
-        bot = _make_bot(status="PENDING")
+        bot = _make_bot(status="ACTIVE")
         svc._repository.get_by_id_and_owner.return_value = bot
 
         # start_bot simulates completion: release the lock it was handed.

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
@@ -632,6 +632,10 @@ class TestRestartBot:
     def test_calls_stop_then_start(self):
         """restart_bot 先调 stop_bot 再调 start_bot。"""
         svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="ACTIVE",
+            binding_id=None,
+        )
         call_order = []
 
         updated_bot = _make_bot(status="PENDING")
@@ -646,6 +650,10 @@ class TestRestartBot:
     def test_stop_failure_adds_restart_warning(self):
         """stop_bot 返回 False（设备释放失败）时，返回值含 restart_warning。"""
         svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="ACTIVE",
+            binding_id=None,
+        )
         updated_bot = _make_bot(status="PENDING")
 
         with patch.object(svc, "stop_bot", return_value=False), \
@@ -659,6 +667,10 @@ class TestRestartBot:
         from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
 
         svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="ACTIVE",
+            binding_id=None,
+        )
 
         with patch.object(svc, "stop_bot", side_effect=BotNotFoundError("not found")):
             with pytest.raises(BotNotFoundError):


### PR DESCRIPTION
## Summary

- reject restart requests when the bot is `RECYCLED` or another non-runnable lifecycle state
- treat `REACTIVATING`, bot `PENDING`, and binding `PENDING` as idempotent in-progress requests without calling stop/start or BaaS update
- return HTTP 202 for activation-in-progress and HTTP 409 for lifecycle conflicts across user, admin, and scheduler restart endpoints

## Root cause

The restart path resolved the device provider and entered the restart flow without validating the bot and binding lifecycle states. A restart racing with dormant reactivation could call BaaS update before the new bot was ready, while a restart against a recycled bot could bypass the activation flow and allocate a new container.

## Impact

Restart now has a backend safety boundary in addition to the product-side button guard. Recycled bots can only return through the explicit activation flow, and duplicate restart requests during activation do not mutate state or allocate another container.

## Validation

- bot management regression suite
- Ruff checks for changed files
- diff coverage: 100% (52/52 changed lines)
- repository pre-push CI gate
