### PR TITLE
fix(publish): drive rollback & retry-restart via the durable queue (#162)

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -17,6 +17,9 @@ from agentclaw.community.core.service_bot.services.bot_publish_service import (
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
+from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
+    enqueue_progress_poll,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
@@ -138,6 +141,15 @@ class RollbackOpsMixin:
             stage=PublishStage.ONLINE,
             request_id=request_id,
         )
+
+        # 8. Enqueue the durable progress poll on the TARGET record. Rollback parks
+        # the target at ONLINE_PUB with ext.publish.online set but never passes
+        # through verify_flow/online_release, so pre-#105 only user /sync polling
+        # ever finished it. The poll's advance_publish_progress reads
+        # ext.publish.online and drives ONLINE_PUB → SUCCESS (binding activation +
+        # supersede via _handle_sync_success), so the rollback self-completes with
+        # no user polling — and becomes crash-safe.
+        enqueue_progress_poll(self._task_queue_service, publish_id=target_publish_id)
 
         logger.info(
             f"[PublishFlowService.execute_rollback] Rollback deployment initiated: "

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -79,6 +79,7 @@ from agentclaw.community.core.service_bot.services.publish_flow.release_stage im
 )
 from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
     enqueue_online_release,
+    enqueue_progress_poll,
     enqueue_verify_flow,
 )
 from agentclaw.community.core.task_queue.services.task_queue_service import (
@@ -898,7 +899,15 @@ class PublishFlowService(
                 operator=operator,
             )
             success = restart_result.get("success", False)
-            if not success:
+            if success:
+                # The BaaS-restart branch parks the record in its *_PUB wait state
+                # without passing through verify_flow/online_release, so pre-#105 it
+                # advanced only via user /sync polling (retry redirect) or an explicit
+                # /restart_status poll. Enqueue the durable poll so the retried
+                # restart self-drives: the poll's retry-flag redirect routes it
+                # through sync_restart_progress and leaves the *_PUB state.
+                enqueue_progress_poll(self._task_queue_service, publish_id=publish_id)
+            else:
                 self._mutate_and_update_ext(
                     publish_id=publish_id,
                     mutator=self._clear_retry_flag,

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -13,6 +13,9 @@ from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
     PublishStatusInvalidError,
 )
+from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
+    PROGRESS_POLL_TASK,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
 
 
@@ -327,6 +330,133 @@ async def test_retry_clears_retry_flag_when_restart_submit_fails():
     cleared_ext = publish_service.update_publish_ext.call_args.kwargs['ext']
     assert 'retry' not in cleared_ext
     assert cleared_ext['source_status'] == PublishStatus.VALIDATE_PUB.value
+
+
+@pytest.mark.asyncio
+async def test_retry_restart_enqueues_progress_poll_on_success():
+    """Regression for #162 (secondary orphan): a successful BaaS-restart retry must
+    enqueue the durable progress poll so the retried *_PUB record self-drives out of
+    its wait state without user /sync (or /restart_status) polling."""
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
+
+    ext = {
+        'source_status': PublishStatus.VALIDATE_PUB.value,
+        'retry': False,
+        'binding': {'verify': 123},
+    }
+    records = [
+        _make_publish_record(status=PublishStatus.FAILED.value, ext=ext.copy()),
+        _make_publish_record(status=PublishStatus.FAILED.value, ext=ext.copy()),
+        _make_publish_record(status=PublishStatus.VALIDATE_PUB.value, ext={**ext, 'retry': True}),
+    ]
+    publish_service.get_publish_by_id.side_effect = records
+    publish_service.update_publish_status_with_ext.return_value = _make_publish_record(
+        status=PublishStatus.VALIDATE_PUB.value,
+        ext={**ext, 'retry': True},
+    )
+    svc.restart_bot = Mock(return_value={'success': True, 'message': 'ok', 'stage': 'verify'})
+
+    result = await svc.retry(publish_id=1, operator='u1')
+
+    assert result.action == 'restart'
+    # The poll was enqueued for this record; the retry flag was NOT cleared.
+    svc._task_queue_service.enqueue.assert_called_once()
+    args = svc._task_queue_service.enqueue.call_args.args
+    assert args[0] == PROGRESS_POLL_TASK
+    assert args[1] == {'publish_id': 1}
+    publish_service.update_publish_ext.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retry_restart_does_not_enqueue_poll_when_submit_fails():
+    """The poll must only be enqueued when the restart actually submitted; a failed
+    submit clears the retry flag and leaves the queue untouched."""
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
+
+    ext = {
+        'source_status': PublishStatus.VALIDATE_PUB.value,
+        'retry': False,
+        'binding': {'verify': 123},
+    }
+    records = [
+        _make_publish_record(status=PublishStatus.FAILED.value, ext=ext.copy()),
+        _make_publish_record(status=PublishStatus.FAILED.value, ext=ext.copy()),
+        _make_publish_record(status=PublishStatus.VALIDATE_PUB.value, ext={**ext, 'retry': True}),
+    ]
+    publish_service.get_publish_by_id.side_effect = records
+    publish_service.update_publish_status_with_ext.return_value = _make_publish_record(
+        status=PublishStatus.VALIDATE_PUB.value,
+        ext={**ext, 'retry': True},
+    )
+    svc.restart_bot = Mock(return_value={'success': False, 'message': 'submit failed'})
+
+    await svc.retry(publish_id=1, operator='u1')
+
+    svc._task_queue_service.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_rollback_enqueues_progress_poll_for_target():
+    """Regression for #162: execute_rollback must enqueue the durable progress poll
+    on the TARGET record after approving the BaaS publish, so the rollback advances
+    ONLINE_PUB → SUCCESS through the durable queue instead of depending on user
+    /sync polling (which became read-only in #105)."""
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    bot_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, bot_service, _arca_router(build_service))
+
+    target_id = 5319
+    current_id = 42
+    online_binding_id = 77
+    baas_publish_id = 999
+
+    target_record = _make_publish_record(
+        id=target_id, status=PublishStatus.SUCCESS.value, version=7,
+    )
+    current_record = _make_publish_record(
+        id=current_id, status=PublishStatus.DRAFT.value, source_bot_id='bot-source',
+    )
+    publish_service.get_publish_by_id.side_effect = lambda pid: {
+        target_id: target_record, current_id: current_record,
+    }[pid]
+
+    target_ext = {
+        'migration_path': '/tmp/m',
+        'config_artifact': {'schema_version': 3},
+        'binding': {PublishStage.ONLINE.value: online_binding_id},
+        'publish': {},
+    }
+    svc._get_latest_ext = Mock(return_value=target_ext)
+    publish_service.get_device_binding_by_id.return_value = Mock(device_id='BOT-online')
+    bot_service.get_bot.return_value = {'bot_id': 'bot-source'}
+    build_service.upgrade_async = AsyncMock(return_value={'publish_id': baas_publish_id})
+    build_service.generate_request_id.return_value = 'rid'
+    svc._update_publish_status = Mock()
+    svc.approve_baas_publish = Mock(return_value=True)
+
+    result = await svc.execute_rollback(
+        current_publish_id=current_id,
+        target_publish_id=target_id,
+        operator='u1',
+    )
+
+    assert result.publish_id == target_id
+    assert result.status == PublishStatus.ONLINE_PUB
+    # The poll targets the rollback TARGET (not the current) record and is enqueued
+    # after approve_baas_publish.
+    svc._task_queue_service.enqueue.assert_called_once()
+    args = svc._task_queue_service.enqueue.call_args.args
+    assert args[0] == PROGRESS_POLL_TASK
+    assert args[1] == {'publish_id': target_id}
+    svc.approve_baas_publish.assert_called_once()
 
 
 def test_handle_sync_failure_clears_retry_flag_and_stores_source_status_value():

--- a/src/backend/tests/community/endpoints/test_publish_durable_pipeline.py
+++ b/src/backend/tests/community/endpoints/test_publish_durable_pipeline.py
@@ -35,6 +35,16 @@ from tests.community.endpoints.test_service_bot_publish_flow import (
     _seed_validating,
     _status,
 )
+from tests.community.endpoints.test_service_bot_rollback import (
+    _HEADERS as _ROLLBACK_HEADERS,
+    _ROLLBACK,
+    _V1 as _RB_V1,
+    _V2 as _RB_V2,
+    _seed_v2_success_with_v1,
+)
+from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
+    BotPublishRepositoryProtocol,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -112,6 +122,49 @@ async def test_validating_process_drives_online_leg_to_success_via_worker(
     online_binding_id = _ext(world, _V1)["binding"]["online"]
     binding = world.get(DeviceBindingRepository).get_by_id(online_binding_id)
     assert binding.status == "ACTIVE", binding.status
+
+
+async def _post_rollback(app, publish_id: int) -> httpx.Response:
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post(
+            _ROLLBACK.format(publish_id=publish_id), headers=_ROLLBACK_HEADERS
+        )
+
+
+@pytest.mark.asyncio
+async def test_rollback_leg_drives_target_to_success_via_worker(
+    app_with_testing_modules, world
+):
+    """Regression for #162: a rollback parks the TARGET version at ONLINE_PUB and
+    (post-#105, with /sync read-only) has no driver but the durable queue. The
+    rollback now enqueues the progress poll, so the worker drives the target
+    ONLINE_PUB → SUCCESS (online binding ACTIVE) autonomously — no user /sync
+    polling. (This coverage mirrors the release leg above but for the rollback
+    path, which never passes through verify_flow/online_release.)"""
+    # V1 UPGRADED (rollback target), V2 SUCCESS (current). BaaS progress = SUCCESS.
+    _seed_v2_success_with_v1(world)
+
+    resp = await _post_rollback(app_with_testing_modules, _RB_V2)
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+    repo = world.get(BotPublishRepositoryProtocol)
+    # The endpoint moved current V2 → DRAFT and parked target V1 at ONLINE_PUB; the
+    # poll is enqueued but the test worker loop is off, so nothing has advanced yet.
+    assert repo.get_by_id(_RB_V2).status == PublishStatus.DRAFT.value
+    assert repo.get_by_id(_RB_V1).status == PublishStatus.ONLINE_PUB.value
+
+    await _drive_worker(world)
+
+    # The durable poll drove the TARGET (V1) to SUCCESS, with its online binding
+    # ACTIVE — the rollback completed with no user polling.
+    assert repo.get_by_id(_RB_V1).status == PublishStatus.SUCCESS.value
+    online_binding_id = repo.get_by_id(_RB_V1).ext["binding"]["online"]
+    binding = world.get(DeviceBindingRepository).get_by_id(online_binding_id)
+    assert binding.status == "ACTIVE", binding.status
+    # The rolled-back current version (V2) remains DRAFT.
+    assert repo.get_by_id(_RB_V2).status == PublishStatus.DRAFT.value
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
@@ -599,12 +599,16 @@ def offline_destroys_online():
     expect=ExpectSuccess(status=200, json_contains={"success": True}),
     extra_assertions=(
         _expect_post("/update"),                               # re-delivered, not re-created
-        _expect_status(_V1, PublishStatus.VALIDATE_PUB),       # rolled back
+        # #162 secondary orphan fix: the retry-restart now enqueues the durable poll,
+        # so the one drain tick drives the retried record out of its VALIDATE_PUB wait
+        # state (→ VALIDATING via sync_restart_progress) with no user /sync polling.
+        _expect_status(_V1, PublishStatus.VALIDATING),
     ),
 )
 def retry_restarts_after_verify_failure():
     """A publish FAILED at the verify-progress gate is retried: retry rolls back to
-    VALIDATE_PUB and restarts the container via update_teclaw_bot (re-deliver)."""
+    VALIDATE_PUB and restarts the container via update_teclaw_bot (re-deliver); the
+    durable poll then self-drives it to VALIDATING without user polling."""
 
 
 @endpoint_test(
@@ -658,7 +662,9 @@ def scale_status_error():
     expect=ExpectSuccess(status=200, json_contains={"success": True}),
     extra_assertions=(
         _expect_post("/update"),
-        _expect_status(_V1, PublishStatus.VALIDATE_PUB),
+        # As in retry_restarts_after_verify_failure: the durable poll enqueued by the
+        # restart drives the retried record VALIDATE_PUB → VALIDATING (#162 fix).
+        _expect_status(_V1, PublishStatus.VALIDATING),
     ),
 )
 def retry_for_others_success():

--- a/src/backend/tests/community/endpoints/test_service_bot_rollback.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_rollback.py
@@ -53,15 +53,21 @@ def _baas(world):
     return world.get(Annotated[HttpClient, QUALIFIER_BAAS])
 
 
-def _install_baas_for_rollback(world, *, create_success: bool = True) -> None:
-    """Stub BaaS for rollback operations."""
+def _install_baas_for_rollback(
+    world, *, create_success: bool = True, progress_status: str = "SUCCESS"
+) -> None:
+    """Stub BaaS for rollback operations.
+
+    ``progress_status`` drives the durable progress-poll flip: ``SUCCESS`` lets the
+    enqueued poll land the rollback target at ``SUCCESS``; ``PENDING`` keeps the
+    target parked at ``ONLINE_PUB`` (the poll reschedules)."""
     def _get(path, **_kw):
         if "/devices" in path:
             return http_envelope_response([{"items": [
                 {"provider_type": "TECLAW", "device_uuid": _SRC_UUID}]}])
         if "/progress" in path:
             return http_envelope_response(
-                {"status": "SUCCESS", "device_details": [],
+                {"status": progress_status, "device_details": [],
                  "overall_progress": {}, "failed_devices": []})
         return http_envelope_response({})
 
@@ -164,10 +170,10 @@ def _seed_v1_success(world) -> None:
     })
 
 
-def _seed_v2_success_with_v1(world) -> None:
+def _seed_v2_success_with_v1(world, *, progress_status: str = "SUCCESS") -> None:
     """Seed V1 (UPGRADED) and V2 (SUCCESS) with version chain."""
     bot = _seed_base(world)
-    _install_baas_for_rollback(world)
+    _install_baas_for_rollback(world, progress_status=progress_status)
 
     vbid1 = _binding(world, device_id=f"{_VERIFY_UUID}-1", status="ACTIVE")
     obid1 = _binding(world, device_id=f"{_ONLINE_UUID}-1", status="RELEASED")
@@ -200,6 +206,12 @@ def _seed_v2_success_with_v1(world) -> None:
             "config_artifact": _ARTIFACT,
         },
     })
+
+
+def _seed_v2_success_with_v1_pending(world) -> None:
+    """Same as ``_seed_v2_success_with_v1`` but the BaaS progress stays PENDING, so
+    the durable poll enqueued by the rollback keeps the target parked at ONLINE_PUB."""
+    _seed_v2_success_with_v1(world, progress_status="PENDING")
 
 
 def _seed_v2_no_v1_artifact(world) -> None:
@@ -289,6 +301,20 @@ def _expect_v2_draft(response, world):  # noqa: ARG001
     assert v2.status == PublishStatus.DRAFT, f"V2 should be DRAFT, got {v2.status}"
 
 
+def _expect_online_binding_active(pid: int):
+    """The publish's online device_binding should be ACTIVE (rollback re-activated it)."""
+    def _check(response, world):  # noqa: ARG001
+        repo = world.get(BotPublishRepositoryProtocol)
+        record = repo.get_by_id(pid)
+        assert record is not None, f"publish {pid} not found"
+        online_binding_id = (record.ext or {}).get("binding", {}).get("online")
+        assert online_binding_id, f"publish {pid} has no online binding: {record.ext}"
+        binding = world.get(DeviceBindingRepository).get_by_id(online_binding_id)
+        assert binding is not None, f"binding {online_binding_id} not found"
+        assert binding.status == "ACTIVE", f"expected ACTIVE, got {binding.status}"
+    return _check
+
+
 # ── can-rollback tests ─────────────────────────────────────────────────────────
 
 
@@ -350,9 +376,36 @@ def error_can_rollback_not_found():
     input=CaseInput(path_params={"publish_id": _V2}, headers=_HEADERS),
     seed=_seed_v2_success_with_v1, drain_background=True,
     expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    extra_assertions=(
+        # Regression for #162: the rollback endpoint enqueues the durable progress
+        # poll on the TARGET, so the sync-case's single worker tick drives the
+        # target (V1) ONLINE_PUB → SUCCESS with its online binding ACTIVE — no user
+        # /sync polling. The rolled-back current version (V2) is left at DRAFT.
+        _expect_publish_status(_V1, PublishStatus.SUCCESS),
+        _expect_online_binding_active(_V1),
+        _expect_v2_draft,
+    ),
 )
 def happy_rollback():
-    """Rollback V2 → endpoint returns success."""
+    """Rollback V2 → target self-drives to SUCCESS via the durable queue."""
+
+
+@endpoint_test(
+    method="POST", path=_ROLLBACK, scenario="rollback_target_parks_at_online_pub_until_baas_terminal",
+    input=CaseInput(path_params={"publish_id": _V2}, headers=_HEADERS),
+    seed=_seed_v2_success_with_v1_pending, drain_background=True,
+    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    extra_assertions=(
+        # BaaS still PENDING: the enqueued poll ran once and rescheduled, so the
+        # target stays at ONLINE_PUB (it will drain once BaaS reports terminal).
+        # This is the pre-#105 "stuck" shape — except now a durable driver exists,
+        # so it is transient rather than permanent.
+        _expect_publish_status(_V1, PublishStatus.ONLINE_PUB),
+        _expect_v2_draft,
+    ),
+)
+def rollback_target_parks_at_online_pub_until_baas_terminal():
+    """Rollback with BaaS not yet terminal → target parked at ONLINE_PUB, poll pending."""
 
 
 @endpoint_test(


### PR DESCRIPTION
## Summary

Fixes #162 — a regression from #105 where a rollback (and the retry BaaS-restart branch) sticks at `online_pub` forever.

Before #105, rollback completion was driven implicitly by user `/sync` polling. #105 made `/sync` read-only (the advancing engine moved to `advance_publish_progress`, reachable only from the durable progress-poll task). Since a rollback never passes through `verify_flow`/`online_release`, no poll task was ever enqueued for it, so the target record had **no driver** and stuck at `online_pub` indefinitely. The retry BaaS-restart branch had the same orphan.

## Changes

**`publish_flow/rollback_ops_mixin.py`** — `execute_rollback` now calls `enqueue_progress_poll(..., publish_id=target_publish_id)` after `approve_baas_publish`. The poll's `advance_publish_progress` at `ONLINE_PUB` reads `ext.publish.online` and drives `ONLINE_PUB → SUCCESS` (binding activation + supersede via `_handle_sync_success`). The rollback now self-completes with no user polling — and becomes crash-safe.

**`publish_flow_service.py`** — `retry()`'s BaaS-restart branch enqueues the poll on a **successful** `restart_bot` submit (a failed submit still clears the retry flag and enqueues nothing). The poll's existing retry-flag redirect routes it through `sync_restart_progress`, so retried restarts leave the `*_PUB` wait state on their own.

`/sync` remains read-only. The mixin's import of `enqueue_progress_poll` is cycle-free (`tasks.py` only TYPE_CHECKING-imports the facade).

## Tests (covering different scenarios)

- **Unit** (`test_publish_flow_service.py`): rollback enqueues the poll with the **target** id + `PROGRESS_POLL_TASK`; retry-restart enqueues on success; retry-restart does **not** enqueue when the submit fails.
- **E2E worker** (`test_publish_durable_pipeline.py`): a rollback leg driven through the real worker — endpoint parks the target at `ONLINE_PUB`, the worker drives it to `SUCCESS` with the online binding `ACTIVE`, the rolled-back current version left `DRAFT`.
- **Declarative endpoint** (`test_service_bot_rollback.py`): strengthened `happy_rollback` (asserts target → `SUCCESS`, online binding `ACTIVE`, current → `DRAFT`) and added a **PENDING** scenario proving the target parks at `ONLINE_PUB` until BaaS is terminal (the pre-#105 "stuck" shape — now transient, not permanent).
- Updated two pre-existing retry endpoint cases whose expectation legitimately shifted from `VALIDATE_PUB` → `VALIDATING`: that shift *is* the secondary-orphan fix (the record leaves the wait state without user polling).

## Acceptance criteria

- [x] A rollback reaches `SUCCESS` (online binding `ACTIVE`) with no user polling, driven by the durable queue.
- [x] A retried BaaS-restart record leaves the `*_PUB` wait state without user polling.
- [x] `/sync` remains read-only.
- [x] Full `tests/community` suite green (7786 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gdnt8MzzzFH7uQXjyNFgbi)_