### PR TITLE
fix(publish): deliver stored online channel overrides on rollback

### DIFF
--- a/src/backend/specs/2026-07-14-rollback-stored-channel-overrides/plan.md
+++ b/src/backend/specs/2026-07-14-rollback-stored-channel-overrides/plan.md
@@ -1,0 +1,83 @@
+# Plan: stored-slot override composition on the rollback delivery path
+
+Translation of the approved plan in
+[#168 (comment)](https://github.com/inclusionAI/Avernet/issues/168#issuecomment-4968630365).
+A validated implementation exists as a working patch (red-on-HEAD / green-with-fix
+verified); this plan documents it.
+
+## Root cause recap
+
+Three delivery paths compose the delivered artifact inconsistently:
+
+| Path | Overrides used | Where |
+|---|---|---|
+| Release | live re-fetch + `_artifact_for_stage` | `publish_flow/release_stage.py` |
+| Restart | stored `ext.engine_overrides_by_stage[stage]` + `_artifact_for_stage` | `publish_flow/restart_mixin.py:245-248` |
+| **Rollback** | **none — raw artifact** | `publish_flow/rollback_ops_mixin.py:76,114` |
+
+Not a regression: the pre-#105 monolith delivered the rollback artifact raw
+identically; #105 added stored-slot composition to release/restart only.
+
+## Change
+
+### 1. `publish_flow/rollback_ops_mixin.py` — `execute_rollback`
+
+Before the `upgrade_async` call (after the bot lookup), mirror restart:
+
+```python
+stored_overrides = (target_ext.get("engine_overrides_by_stage") or {}).get(
+    PublishStage.ONLINE.value
+)
+config_artifact = self._artifact_for_stage(
+    config_artifact, PublishStage.ONLINE, stored_overrides
+)
+```
+
+- Stored slot (what the target version promoted), **never** a live re-fetch.
+- `or {}` tolerates a JSON-null `engine_overrides_by_stage` in a raw ext blob
+  (same guard as restart).
+- Pre-feature record → `stored_overrides is None` → `apply_engine_overrides`
+  no-ops → raw artifact unchanged.
+- ARCA → `config_artifact is None` → `_artifact_for_stage` no-ops.
+- `restamp_stage` to `engine_ext.stage="release"` is benign (a previously-online
+  artifact already carries it) and makes the three paths uniform.
+- The composed artifact is delivery-only; `target_ext["config_artifact"]`
+  persisted at step 6 stays the raw stored snapshot (helpers never mutate input).
+
+### 2. Tests — `tests/community/core/service_bot/services/test_publish_flow_service.py`
+
+- **New** `test_execute_rollback_delivers_stored_online_overrides_not_live`:
+  target ext stores `verify`+`online` slots, base artifact carries stale draft
+  channels, a live reader mock would return wrong channels. Assert delivered
+  `engine_overrides` == stored online slot (card A), `engine_ext.stage ==
+  "release"`, and `reader.overrides_for_stage` not called.
+- **Rework** `test_execute_rollback_with_config_artifact` into the backward-compat
+  case: its artifact was an opaque string (`"s3://…"`), which cannot flow through
+  `_artifact_for_stage` (dict-typed, same contract restart already imposes) —
+  becomes a dict; assert delivered unchanged.
+
+### 3. Tests — `tests/community/endpoints/test_service_bot_rollback.py`
+
+New scenario `rollback_delivers_stored_online_channel_overrides` (pattern from
+`test_publish_per_stage_channels.py`): V1 ext stores online overrides with
+`card_template_id=card-A`; live channel table row holds `card-B`. Rollback V2 →
+assert the BaaS `/update` payload's
+`config.deploy_config.teclaw_bot_config.engine_overrides` carries card A and
+`engine_ext.stage == "release"`; V1 lands at SUCCESS.
+
+## Risks / edge cases
+
+- Stored artifact with un-enriched `engine_ext` (no `stage` key): `restamp_stage`
+  no-ops by design; overlay still applies.
+- `engine_overrides_by_stage` present but missing the `online` key: `.get` →
+  `None` → no-op (a never-promoted-online target cannot be a rollback target
+  anyway — it must have held an online binding).
+- Existing rollback scenarios (`_ARTIFACT` with `engine_ext: {}`, no stored slots)
+  are unaffected → proves no behavior change outside the new path.
+
+## Verification
+
+Targeted: the three touched test scopes. Full: `tests/community` suite.
+Delivery: commit on `claude/jolly-ptolemy-86ti1s`, push with
+`AVERNET_PRE_PUSH_MERGE_TARGET=origin/REL20260715`, draft PR → `REL20260715`
+(`Fixes #168`), then `subscribe_pr_activity`.

--- a/src/backend/specs/2026-07-14-rollback-stored-channel-overrides/spec.md
+++ b/src/backend/specs/2026-07-14-rollback-stored-channel-overrides/spec.md
@@ -1,0 +1,46 @@
+# Spec: Rollback restores the target version's DingTalk channel overrides
+
+**Issue:** inclusionAI/Avernet#168 · **Plan approved:** [issue comment](https://github.com/inclusionAI/Avernet/issues/168#issuecomment-4968630365) → ["Looks good. Let's fix it."](https://github.com/inclusionAI/Avernet/issues/168#issuecomment-4968877299)
+
+## Problem (WHAT is broken)
+
+Change the DingTalk channel's card template id (card A → card B), publish the bot
+(V2 delivers card B), then roll back to the previous version: the bot keeps using
+card B. The DingTalk channel config — including `card_template_id` — is not part
+of the build artifact; it rides in the per-stage `engine_overrides` overlay. The
+rollback delivery ships the target's stored artifact raw, so the container's
+channel state is never restored to what the target version had when it was online.
+
+## Why it matters
+
+Rollback's contract is "put the container back to the target version's online
+state". Channel config silently surviving a rollback breaks that contract in a
+user-visible way (wrong card renders in DingTalk) with no error anywhere.
+
+## Desired behavior
+
+- After a rollback, the container's DingTalk channel config (incl.
+  `card_template_id`) matches what the **target version** had when it was online —
+  i.e. the per-stage overrides persisted at that version's online promotion.
+- The rollback must **not** re-fetch live channel config: the live table holds the
+  post-change state (card B), which is exactly what is being rolled away from.
+- The channel **table** itself is user config, not versioned by publish: it still
+  holds card B after rollback, and the next publish correctly delivers B again.
+  Only the rollback *delivery* is in scope.
+
+## Non-goals / unchanged behavior
+
+- Release and restart delivery behavior unchanged.
+- Pre-feature publish records (no stored per-stage overrides) unchanged: raw
+  artifact delivered as before.
+- ARCA mount path (no `config_artifact`) unaffected.
+- Consolidating the per-path override-composition logic is explicitly deferred to
+  follow-up issue inclusionAI/Avernet#173 (assigned to totalfrank).
+
+## Acceptance criteria
+
+1. Rollback delivers the target's **stored** online `engine_overrides` (unit +
+   endpoint regression tests, red on unfixed HEAD).
+2. No live channel re-fetch on the rollback path (reader not called).
+3. Backward compat: target without stored overrides → artifact delivered unchanged.
+4. Full `tests/community` suite green.

--- a/src/backend/specs/2026-07-14-rollback-stored-channel-overrides/tasks.md
+++ b/src/backend/specs/2026-07-14-rollback-stored-channel-overrides/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: rollback stored channel overrides (#168)
+
+- [x] 1. Apply the fix to `publish_flow/rollback_ops_mixin.py::execute_rollback` —
+  stored-slot composition via `_artifact_for_stage` before `upgrade_async`.
+- [x] 2. Unit tests in `test_publish_flow_service.py`: new
+  `test_execute_rollback_delivers_stored_online_overrides_not_live`; rework
+  `test_execute_rollback_with_config_artifact` into the dict-artifact
+  backward-compat case.
+- [x] 3. Endpoint test in `test_service_bot_rollback.py`: seed helper
+  (`_seed_v2_success_with_v1_channel_overrides`), `/update`-payload assertion,
+  scenario `rollback_delivers_stored_online_channel_overrides`.
+- [x] 4. Verify red→green: new tests fail on unfixed HEAD (demonstrated during
+  triage), pass with the fix (119 unit / 12 endpoint scenarios green).
+- [x] 5. Run targeted suites: publish-flow unit tests + rollback & per-stage
+  channel endpoint scenarios.
+- [x] 6. Run full `tests/community` suite (7803 passed, 3 skipped).
+- [ ] 7. Commit to `claude/jolly-ptolemy-86ti1s` and push
+  (`AVERNET_PRE_PUSH_MERGE_TARGET=origin/REL20260715`).
+- [ ] 8. Open draft PR → base `REL20260715`, `Fixes #168`; subscribe to PR
+  activity.

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -101,6 +101,21 @@ class RollbackOpsMixin:
         if not bot:
             raise PublishFlowServiceError(f"Bot not found: {current_record.source_bot_id}")
 
+        # Compose the delivery artifact for ONLINE: overlay the target version's
+        # STORED online channel engine_overrides (DingTalk config incl.
+        # card_template_id), reproducing what that version had when it was
+        # promoted — NOT a live re-fetch, which would deliver the very channel
+        # state the user is rolling away from. Same per-stage slot restart reads.
+        # No stored overrides (pre-feature record) or no config_artifact (ARCA)
+        # → no-ops, preserving prior behavior.
+        # `or {}` (not a get-default): the key may hold JSON null in a raw ext blob.
+        stored_overrides = (target_ext.get("engine_overrides_by_stage") or {}).get(
+            PublishStage.ONLINE.value
+        )
+        config_artifact = self._artifact_for_stage(
+            config_artifact, PublishStage.ONLINE, stored_overrides
+        )
+
         # 5. Call the BaaS upgrade interface to re-deploy
         version = f"{target_record.version}"
         upgrade_result = await self._build_service.upgrade_async(

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -1663,7 +1663,9 @@ async def test_execute_rollback_missing_binding():
 
 @pytest.mark.asyncio
 async def test_execute_rollback_with_config_artifact():
-    """execute_rollback uses config_artifact (the teclaw scenario)."""
+    """execute_rollback uses config_artifact (the teclaw scenario); a target
+    without engine_overrides_by_stage (pre-feature record) delivers the raw
+    stored artifact unchanged (restamp/overlay no-op)."""
     publish_service = Mock()
     build_service = Mock()
     baas_service = Mock()
@@ -1682,13 +1684,15 @@ async def test_execute_rollback_with_config_artifact():
         source_bot_id="bot-456",
     )
 
-    # Target version has only config_artifact (no migration_path)
+    # Target version has only config_artifact (no migration_path); no stored
+    # per-stage overrides.
+    artifact = {"schema_version": 3, "engine_type": "teclaw", "engine_ext": {}}
     target_record = _make_publish_record(
         id=2,
         status=PublishStatus.SUCCESS.value,
         version=2,
         ext={
-            "config_artifact": "s3://bucket/artifact/v2.json",
+            "config_artifact": artifact,
             "binding": {"online": 200},
         },
     )
@@ -1713,13 +1717,94 @@ async def test_execute_rollback_with_config_artifact():
         operator="user1",
     )
 
-    # Verify upgrade_async used config_artifact
+    # Verify upgrade_async used config_artifact, unchanged (backward compat)
     upgrade_call = build_service.upgrade_async.call_args
-    assert upgrade_call.kwargs["config_artifact"] == "s3://bucket/artifact/v2.json"
+    assert upgrade_call.kwargs["config_artifact"] == artifact
     assert upgrade_call.kwargs["migration_path"] is None
 
     assert result.publish_id == 2
     assert result.status == PublishStatus.ONLINE_PUB
+
+
+@pytest.mark.asyncio
+async def test_execute_rollback_delivers_stored_online_overrides_not_live():
+    """Regression for #168: rollback must overlay the target version's STORED
+    online engine_overrides (DingTalk channels incl. card_template_id) onto the
+    delivered artifact — the per-stage slot persisted at that version's online
+    promotion — and must NOT re-fetch live channel config (which holds the state
+    being rolled away from)."""
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    bot_service = Mock()
+
+    build_service.upgrade_async = AsyncMock(return_value={"publish_id": 12345})
+    build_service.generate_request_id = Mock(return_value="req-rollback-3")
+    baas_service.approve_publish = Mock()
+
+    # A live reader that would deliver the WRONG (current) channels if consulted.
+    reader = Mock()
+    reader.overrides_for_stage.return_value = {
+        "channels": {"dingding": {"enabled": True, "accounts": [{"client_id": "live-wrong"}]}}
+    }
+
+    svc = _pf(
+        publish_service, build_service, baas_service, bot_service,
+        _arca_router(build_service), channel_overrides_reader=reader,
+    )
+
+    current_record = _make_publish_record(
+        id=3, status=PublishStatus.DRAFT.value, version=3, source_bot_id="bot-456",
+    )
+
+    stored_online = {
+        "channels": {
+            "dingding": {
+                "enabled": True,
+                "accounts": [{"client_id": "cid-1", "card_template_id": "card-A"}],
+            }
+        }
+    }
+    target_record = _make_publish_record(
+        id=2,
+        status=PublishStatus.SUCCESS.value,
+        version=2,
+        ext={
+            # Base artifact carries stale draft channels; the stored online slot wins.
+            "config_artifact": _enriched_artifact(
+                "release",
+                {"channels": {"dingding": {"accounts": [{"client_id": "draft"}]}}},
+            ),
+            "engine_overrides_by_stage": {"verify": _VERIFY_CH, "online": stored_online},
+            "binding": {"online": 200},
+        },
+    )
+
+    mock_binding = Mock()
+    mock_binding.device_id = "device-uuid-003"
+
+    def get_publish_side_effect(pk):
+        if pk == 2:
+            return target_record
+        elif pk == 3:
+            return current_record
+        return None
+
+    publish_service.get_publish_by_id = Mock(side_effect=get_publish_side_effect)
+    publish_service.get_device_binding_by_id.return_value = mock_binding
+    bot_service.get_bot.return_value = {"bot_id": "bot-456", "entity_id": "e2", "entity_type": "staff"}
+
+    await svc.execute_rollback(
+        current_publish_id=3,
+        target_publish_id=2,
+        operator="user1",
+    )
+
+    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    assert delivered["engine_overrides"] == stored_online
+    assert delivered["engine_ext"]["stage"] == "release"
+    # Stored slot, never a live re-fetch.
+    reader.overrides_for_stage.assert_not_called()
 
 
 # teclaw build-time file promotion moved to TeclawProviderBehavior; its test now

--- a/src/backend/tests/community/endpoints/test_service_bot_rollback.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_rollback.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.channel.services.repositories import ChannelRepository
 from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
 from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
     BotPublishRepositoryProtocol,
@@ -208,6 +209,73 @@ def _seed_v2_success_with_v1(world, *, progress_status: str = "SUCCESS") -> None
     })
 
 
+_ROLLBACK_CID = "cid-rollback"
+_CARD_A = "card-A"  # V1's promoted card template (stored per-stage slot)
+_CARD_B = "card-B"  # the current live channel config — the state rolled away from
+
+_V1_STORED_ONLINE = {
+    "channels": {"dingding": {"enabled": True, "accounts": [
+        {"client_id": _ROLLBACK_CID, "robot_code": _ROLLBACK_CID,
+         "card_template_id": _CARD_A}]}}
+}
+
+
+def _seed_v2_success_with_v1_channel_overrides(world) -> None:
+    """Same shape as ``_seed_v2_success_with_v1``, plus DingTalk channel state:
+    V1's ext stores online engine_overrides with card A (persisted at V1's
+    original online promotion), while the live channel table holds card B (the
+    user's current config, delivered by V2). Rollback must restore card A."""
+    bot = _seed_base(world)
+    _install_baas_for_rollback(world)
+
+    vbid1 = _binding(world, device_id=f"{_VERIFY_UUID}-1", status="ACTIVE")
+    obid1 = _binding(world, device_id=f"{_ONLINE_UUID}-1", status="RELEASED")
+    vbid2 = _binding(world, device_id=f"{_VERIFY_UUID}-2", status="ACTIVE")
+    obid2 = _binding(world, device_id=f"{_ONLINE_UUID}-2", status="ACTIVE")
+
+    repo = world.get(BotPublishRepositoryProtocol)
+
+    # V1: UPGRADED, with an enriched artifact and the stored online overrides slot.
+    v1_artifact = dict(
+        _ARTIFACT, engine_ext={"bot_id": _BOT_ID, "owner_id": _OWNER, "stage": "release"}
+    )
+    repo.insert({
+        "source_bot_pk": bot["id"], "source_bot_id": _BOT_ID, "publish_bot_id": _BOT_ID,
+        "name": "V1 Publish", "owner_id": _OWNER, "permission_owner": _OWNER,
+        "status": PublishStatus.UPGRADED, "version": 1, "env": "dev",
+        "ext": {
+            "binding": {"verify": vbid1, "online": obid1},
+            "publish": {"verify": _BAAS_PUB_ID, "online": _BAAS_PUB_ID},
+            "config_artifact": v1_artifact,
+            "engine_overrides_by_stage": {"online": _V1_STORED_ONLINE},
+        },
+    })
+
+    # V2: SUCCESS (current), linked to V1 via last_pub_id
+    repo.insert({
+        "source_bot_pk": bot["id"], "source_bot_id": _BOT_ID, "publish_bot_id": _BOT_ID,
+        "name": "V2 Publish", "owner_id": _OWNER, "permission_owner": _OWNER,
+        "status": PublishStatus.SUCCESS, "version": 2, "env": "dev",
+        "last_pub_id": _V1,
+        "ext": {
+            "binding": {"verify": vbid2, "online": obid2},
+            "publish": {"verify": _BAAS_PUB_ID, "online": _BAAS_PUB_ID},
+            "config_artifact": _ARTIFACT,
+        },
+    })
+
+    # Live channel table: card B. A (wrong) live re-fetch would deliver this.
+    world.get(ChannelRepository).insert_channel(
+        type="dingding",
+        description=None,
+        identity_id=_OWNER,
+        bind_bot_id=_BOT_ID,
+        config={"client_id": _ROLLBACK_CID, "card_template_id": _CARD_B},
+        status="1",
+        stage="online",
+    )
+
+
 def _seed_v2_success_with_v1_pending(world) -> None:
     """Same as ``_seed_v2_success_with_v1`` but the BaaS progress stays PENDING, so
     the durable poll enqueued by the rollback keeps the target parked at ONLINE_PUB."""
@@ -315,6 +383,20 @@ def _expect_online_binding_active(pid: int):
     return _check
 
 
+def _expect_update_delivers_stored_card_a(response, world):  # noqa: ARG001
+    """The rollback's BaaS ``/update`` payload must carry V1's STORED online
+    channel overrides (card A), not the live channel table's card B."""
+    update = next(
+        c for c in _baas(world).calls_to("post") if c.args[0].endswith("/update")
+    )
+    delivered = update.kwargs["json"]["config"]["deploy_config"]["teclaw_bot_config"]
+    accounts = delivered["engine_overrides"]["channels"]["dingding"]["accounts"]
+    assert [a.get("card_template_id") for a in accounts] == [_CARD_A], (
+        delivered["engine_overrides"]
+    )
+    assert delivered["engine_ext"]["stage"] == "release"
+
+
 # ── can-rollback tests ─────────────────────────────────────────────────────────
 
 
@@ -388,6 +470,24 @@ def error_can_rollback_not_found():
 )
 def happy_rollback():
     """Rollback V2 → target self-drives to SUCCESS via the durable queue."""
+
+
+@endpoint_test(
+    method="POST", path=_ROLLBACK, scenario="rollback_delivers_stored_online_channel_overrides",
+    input=CaseInput(path_params={"publish_id": _V2}, headers=_HEADERS),
+    seed=_seed_v2_success_with_v1_channel_overrides, drain_background=True,
+    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    extra_assertions=(
+        # Regression for #168: the rollback delivery must overlay V1's STORED
+        # online engine_overrides (card A) onto the artifact — not deliver the
+        # raw artifact (no channels) nor re-fetch the live channel table (card B).
+        _expect_update_delivers_stored_card_a,
+        _expect_publish_status(_V1, PublishStatus.SUCCESS),
+    ),
+)
+def rollback_delivers_stored_online_channel_overrides():
+    """Rollback restores the target version's promoted DingTalk channel config
+    (incl. card_template_id) from the stored per-stage slot."""
 
 
 @endpoint_test(


### PR DESCRIPTION
Fixes #168.

## What

Rollback delivered the target version's `config_artifact` **raw** — no `engine_ext.stage` restamp, no per-stage `engine_overrides` overlay — so the DingTalk channel config (incl. `card_template_id`) was absent from the rollback delivery and the container kept the rolled-away-from version's channel state (card B instead of card A).

This mirrors the restart path in `rollback_ops_mixin.execute_rollback`: compose the delivery via `_artifact_for_stage` with the target ext's **stored** `engine_overrides_by_stage.online` slot — what that version actually promoted — never a live re-fetch (live holds the state being rolled away from).

- Pre-feature records (no stored slot) → overlay no-ops → raw artifact delivered unchanged.
- ARCA mount path (no `config_artifact`) → everything no-ops.
- The persisted `target_ext["config_artifact"]` snapshot is untouched (composition is delivery-only).
- The channel **table** stays user-owned: next publish still delivers the live config. Only the rollback delivery is fixed.

Plan approved on the issue thread: [root-cause + plan](https://github.com/inclusionAI/Avernet/issues/168#issuecomment-4968630365) → [approval](https://github.com/inclusionAI/Avernet/issues/168#issuecomment-4968877299). Consolidating the per-path override composition is deferred to #173.

## Tests

Red on unfixed HEAD / green with the fix:

- **Unit** `test_execute_rollback_delivers_stored_online_overrides_not_live`: delivered `engine_overrides` == stored online slot, `engine_ext.stage == "release"`, live `ChannelEngineOverridesReader` **not** called.
- **Unit** `test_execute_rollback_with_config_artifact` (reworked): dict artifact, no stored slot → delivered unchanged (backward compat). Was an opaque string artifact, which cannot flow through the dict-typed `_artifact_for_stage` contract restart already imposes.
- **Endpoint** `rollback_delivers_stored_online_channel_overrides`: V1 stores online overrides with `card_template_id=card-A`, live channel table holds `card-B` → rollback's BaaS `/update` payload carries card A; V1 lands at SUCCESS.

Full `tests/community`: **7803 passed, 3 skipped**.

SDD artifacts: `src/backend/specs/2026-07-14-rollback-stored-channel-overrides/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhnmAdoRuf9sT6u5MtURxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhnmAdoRuf9sT6u5MtURxm)_