### PR TITLE
feat(governance-feedback): self-contained v2 feedback_payload + detai…

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/economy/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/economy/schemas.py
@@ -1,6 +1,7 @@
 """Pydantic schemas for economy/governance endpoints."""
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -222,6 +223,35 @@ class ReviewTicketListResponse(BaseModel):
         )
 
 
+def _extract_feedback_notification_id(payload_json: str | None) -> str | None:
+    """从 feedback_payload JSON 解出本次反馈回执来自哪个 notification_id。
+
+    v2 自包含 payload 的 ``ticket_ref.notification_id`` 即回调触发的通知 ID
+    (写库时由服务端 enrich 从回调入参注入,不可伪造)。v1 / 解析失败 / 缺字段 → None。
+    保证反馈原子性:回执来源随反馈 payload 同行落地,零额外列、零 join。
+
+    Args:
+        payload_json: task_record.feedback_payload 列原始 JSON 字符串。
+
+    Returns:
+        notification_id 或 None。
+    """
+    if not payload_json:
+        return None
+    try:
+        payload = json.loads(payload_json)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    ref = payload.get("ticket_ref")
+    if isinstance(ref, dict):
+        nid = ref.get("notification_id")
+        if isinstance(nid, str) and nid:
+            return nid
+    return None
+
+
 class ReviewTicketDetailResponse(BaseModel):
     """评审工单详情 — 列表字段外加详情面板所需全部字段。"""
 
@@ -246,6 +276,7 @@ class ReviewTicketDetailResponse(BaseModel):
     response_at: str | None = None
     response_source: str | None = None
     feedback_payload: str | None = None
+    feedback_notification_id: str | None = None
     # 评审 / 生命周期
     review_reason: str | None = None
     review_decision: str | None = None
@@ -286,6 +317,7 @@ class ReviewTicketDetailResponse(BaseModel):
             response_at=_iso(ticket.feedback_at),
             response_source=ticket.feedback_source,
             feedback_payload=ticket.feedback_payload,
+            feedback_notification_id=_extract_feedback_notification_id(ticket.feedback_payload),
             review_reason=ticket.review_reason,
             review_decision=ticket.review_decision,
             reviewed_by=ticket.reviewed_by,
@@ -411,14 +443,43 @@ class RecordsDeleteRequest(BaseModel):
 # Card callback (iframe fetch POST)
 # ---------------------------------------------------------------------------
 
+class CardCallbackFeedbackItem(BaseModel):
+    """单个建议项的用户逐项决策(卡片 items[] 输入)。
+
+    仅含用户能提供的信息;建议项正文快照由服务端 enrich 注入,不在输入内。
+    """
+
+    index: int = Field(..., description="建议项序号,与分析表 action_items[].index 对齐")
+    action: str = Field(..., description="accepted / partial / rejected")
+    remark: str | None = Field(None, description="逐项备注(选填)")
+
+
+class CardCallbackFeedbackPayload(BaseModel):
+    """卡片 feedback_payload 输入结构(v1 字段集,服务端据此 enrich 成 v2 自包含 payload)。"""
+
+    version: int | None = Field(None, description="卡片自定版本号(非顶层 feedback_schema_version)")
+    overall_action: str | None = Field(None, description="整体决策(accepted/partial/rejected 等)")
+    overall_remark: str | None = Field(None, description="整体补充说明")
+    repair_deadline: str | None = Field(None, description="need_time 修复截止日期(ISO)")
+    items: list[CardCallbackFeedbackItem] | None = Field(None, description="逐项决策列表")
+
+    model_config = {"extra": "allow"}
+
+
 class CardCallbackIFrameRequest(BaseModel):
-    """Request body for card-callback iframe fetch POST."""
+    """Request body for card-callback iframe fetch POST.
+
+    ``feedback_payload`` 优先按结构化模型解析;旧卡片回传的任意 dict 仍被接受
+    (模型允许 extra 字段),逐项决策取 ``items[]``,其余兜底走 dict 访问。
+    """
 
     notification_id: str = Field(..., description="通知唯一 ID")
     response: str = Field(..., description="optimized / need_time / dispute / whitelist")
     remark: str | None = Field(None, description="用户补充说明（dispute/whitelist 时必填，其他时选填）")
     repair_deadline: str | None = Field(None, description="need_time 时必填，ISO 日期")
-    feedback_payload: dict | None = Field(None, description="结构化反馈 JSON（items 等，不含 overall_remark）")
+    feedback_payload: CardCallbackFeedbackPayload | dict | None = Field(
+        None, description="结构化反馈 JSON（items 等，不含 overall_remark）",
+    )
 
 
 class CardCallbackResponse(BaseModel):

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/feedback_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/feedback_service.py
@@ -185,11 +185,13 @@ def _build_enriched_items(
         if isinstance(idx, int):
             user_by_index[idx] = it
 
-    raw_suggestions = (
-        structured.get("action_items") or structured.get("optimizationSuggestions") or []
-        if structured
-        else []
-    )
+    # action_items / optimizationSuggestions 须为 list(防御畸形 notification_structured:
+    # Text 列无 schema 约束,非 list 值会触发 AttributeError 穿透 resolve 的 except)。
+    raw_suggestions: list = []
+    if structured:
+        suggestions_val = structured.get("action_items") or structured.get("optimizationSuggestions")
+        if isinstance(suggestions_val, list):
+            raw_suggestions = suggestions_val
 
     if not raw_suggestions:
         # 降级:无建议全集,仅输出用户点评项
@@ -209,6 +211,8 @@ def _build_enriched_items(
 
     result: list[dict[str, Any]] = []
     for idx, sug in enumerate(raw_suggestions, start=1):
+        if not isinstance(sug, dict):
+            continue
         index = sug.get("index") if isinstance(sug.get("index"), int) else idx
         user_it = user_by_index.get(index)
         action = user_it.get("action") if user_it else None

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/feedback_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/feedback_service.py
@@ -59,6 +59,255 @@ _RESPONSE_TRANSITION_MAP: dict[str, tuple[str, str]] = {
     # need_time → scheduled, handled separately
 }
 
+# ── v2 feedback_payload 归一化 ─────────────────────────────────────
+# 卡片顶层 raw `response` → 归一化 `overall.decision`(对齐下游 ETL 枚举)。
+# 逐项决策直接采用卡片 items[].action,未出现 index 视为 `unevaluated`。
+_NORMALIZED_OVERALL_DECISION: dict[str, str] = {
+    Response.OPTIMIZED.value: "accepted",
+    Response.NEED_TIME.value: "deferred",
+    Response.DISPUTE.value: "rejected",
+    Response.WHITELIST.value: "whitelist",
+}
+
+# 归一化顶层决策中需要 remark 的取值(dispute/whitelist → rejected/whitelist)。
+_REMARK_REQUIRED_RAW = {Response.DISPUTE.value, Response.WHITELIST.value}
+
+# 卡片逐项 action → 归一化 item.decision(verbatim;卡片仅 accepted/partial/rejected)。
+_ITEM_ACTIONS = {"accepted", "partial", "rejected"}
+_UNEVALUATED = "unevaluated"
+
+
+def _normalize_response(raw_response: str) -> str:
+    """把卡片顶层 raw `response` 归一化为 `overall.decision` 枚举。
+
+    Args:
+        raw_response: 卡片回传的原始 response(optimized/need_time/dispute/whitelist)。
+
+    Returns:
+        归一化决策: accepted | deferred | rejected | whitelist。
+
+    Raises:
+        ValueError: raw_response 不在 4 个合法值内(调用方应已先行校验)。
+    """
+    normalized = _NORMALIZED_OVERALL_DECISION.get(raw_response)
+    if normalized is None:
+        raise ValueError(f"Unnormalizable response: {raw_response}")
+    return normalized
+
+
+def _compute_consistency_flag(
+    overall_decision: str,
+    item_decisions: list[str],
+) -> str:
+    """计算 overall 与逐项决策一致性标志。
+
+    Args:
+        overall_decision: 归一化顶层决策(accepted/rejected/deferred/whitelist)。
+        item_decisions: 已点评项的归一化逐项决策列表(不含未点评项)。
+
+    Returns:
+        ``consistent`` 逐项全同一且与顶层一致;
+        ``partial_mix`` 顶层 accepted 但存在逐项 rejected/partial;
+        ``overall_dominates`` 无任何逐项反馈(全 unevaluated)。
+    """
+    if not item_decisions:
+        return "overall_dominates"
+    unique = set(item_decisions)
+    if len(unique) == 1 and next(iter(unique)) == overall_decision:
+        return "consistent"
+    if overall_decision == "accepted" and (unique & {"rejected", "partial"}):
+        return "partial_mix"
+    return "consistent"
+
+
+# ── v2 feedback_payload enrich(自包含) ─────────────────────────────
+_FEEDBACK_SCHEMA_VERSION = 2
+
+
+def _coerce_payload_input(payload: Any) -> dict[str, Any]:
+    """把卡片回传的 feedback_payload(Pydantic 模型或 dict)归一为 dict。
+
+    Args:
+        payload: ``CardCallbackFeedbackPayload`` 模型 / dict / None。
+
+    Returns:
+        dict;None 输入返回空 dict。
+    """
+    if payload is None:
+        return {}
+    if isinstance(payload, dict):
+        return payload
+    # Pydantic v2 模型
+    dump = getattr(payload, "model_dump", None)
+    if callable(dump):
+        return dump(exclude_none=False)
+    return dict(payload)  # 兜底
+
+
+def _parse_notification_structured(raw: str | None) -> dict[str, Any] | None:
+    """解析 ticket.notification_structured JSON;失败/空返回 None(降级用)。"""
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw) if isinstance(raw, str) else raw
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _hit_dimensions_list(ticket: Any) -> list[str]:
+    """ticket.triggered_dimensions(逗号分隔串)→ 去空 list。"""
+    raw = ticket.triggered_dimensions
+    if not raw:
+        return []
+    return [d.strip() for d in str(raw).split(",") if d.strip()]
+
+
+def _build_enriched_items(
+    structured: dict[str, Any] | None,
+    user_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """构建逐项反馈(含建议项正文快照),未点评项标 unevaluated。
+
+    以 ``notification_structured.action_items`` 为建议全集(确保 index 对齐)，
+    按 index 合并用户决策。structured 解析失败时退回用户提供的 items。
+
+    Args:
+        structured: 解析后的 notification_structured dict(可能 None)。
+        user_items: 用户回传的逐项决策 list[{index,action,remark}]。
+
+    Returns:
+        items[]: 每项含 index/decision/suggestion_action/正文快照/remark。
+    """
+    user_by_index: dict[int, dict[str, Any]] = {}
+    for it in user_items:
+        idx = it.get("index")
+        if isinstance(idx, int):
+            user_by_index[idx] = it
+
+    raw_suggestions = (
+        structured.get("action_items") or structured.get("optimizationSuggestions") or []
+        if structured
+        else []
+    )
+
+    if not raw_suggestions:
+        # 降级:无建议全集,仅输出用户点评项
+        return [
+            {
+                "index": it.get("index"),
+                "decision": it.get("action") if it.get("action") in _ITEM_ACTIONS else _UNEVALUATED,
+                "suggestion_action": None,
+                "what_to_change": None,
+                "why": None,
+                "expected_effect": None,
+                "remark": it.get("remark"),
+            }
+            for it in user_items
+            if isinstance(it.get("index"), int)
+        ]
+
+    result: list[dict[str, Any]] = []
+    for idx, sug in enumerate(raw_suggestions, start=1):
+        index = sug.get("index") if isinstance(sug.get("index"), int) else idx
+        user_it = user_by_index.get(index)
+        action = user_it.get("action") if user_it else None
+        decision = action if action in _ITEM_ACTIONS else _UNEVALUATED
+        result.append({
+            "index": index,
+            "decision": decision,
+            "suggestion_action": sug.get("action") or sug.get("title"),
+            "what_to_change": sug.get("what_to_change") or sug.get("description"),
+            "why": sug.get("why"),
+            "expected_effect": sug.get("expected_effect"),
+            "remark": user_it.get("remark") if user_it else None,
+        })
+    return result
+
+
+def _build_enriched_payload(
+    *,
+    ticket: Any,
+    notification_id: str,
+    raw_response: str,
+    remark: str | None,
+    repair_deadline: datetime | None,
+    feedback_payload: Any,
+    source: str,
+    actor_id: str | None,
+    now: datetime,
+) -> dict[str, Any]:
+    """从 ticket + 回传输入构建自包含 v2 feedback_payload dict。
+
+    输入仅取用户能提供的(整体决策/备注/截止日/逐项决策);``ticket_ref``/
+    ``analysis_snapshot``/建议项正文快照均由服务端注入,不可被前端伪造。
+    notification_structured 解析失败时降级,绝不丢弃用户决策。
+
+    Args:
+        ticket: 已加载的 GovernanceTicket(自带 worker_id/dt_version 等)。
+        notification_id: 通知唯一 ID。
+        raw_response: 卡片原始 response(optimized/need_time/dispute/whitelist)。
+        remark: 用户整体备注。
+        repair_deadline: need_time 截止日。
+        feedback_payload: 卡片结构化输入(模型/dict/None)。
+        source: 反馈来源(card_callback/http_api/admin_api)。
+        actor_id: 实际操作人。
+        now: 提交时刻。
+
+    Returns:
+        v2 自包含 payload dict,调用方 json.dumps 后写库。
+    """
+    overall_decision = _normalize_response(raw_response)
+    payload_in = _coerce_payload_input(feedback_payload)
+    user_items_raw = payload_in.get("items") or []
+    user_items = [it for it in user_items_raw if isinstance(it, dict)]
+
+    structured = _parse_notification_structured(ticket.notification_structured)
+    items = _build_enriched_items(structured, user_items)
+
+    item_decisions = [it["decision"] for it in items if it["decision"] != _UNEVALUATED]
+    consistency_flag = _compute_consistency_flag(overall_decision, item_decisions)
+
+    deferred_until = (
+        repair_deadline.isoformat() if raw_response == Response.NEED_TIME.value and repair_deadline else None
+    )
+
+    meta_block = structured.get("meta") if structured and isinstance(structured.get("meta"), dict) else {}
+
+    return {
+        "feedback_schema_version": _FEEDBACK_SCHEMA_VERSION,
+        "ticket_ref": {
+            "notification_id": notification_id,
+            "worker_id": ticket.worker_id,
+            "dt_version": ticket.dt_version,
+            "ticket_id": ticket.ticket_id,
+        },
+        "analysis_snapshot": {
+            "hit_dimensions": _hit_dimensions_list(ticket),
+            "hit_dimensions_count": ticket.hit_dimensions_count,
+            "governance_action": meta_block.get("governance_action"),
+            "governance_urgency": ticket.severity,
+            "governance_decision": ticket.initial_decision,
+            "expected_token_saving": ticket.estimated_saving_tokens,
+            "saving_ratio": ticket.saving_ratio,
+            "suggestion_count": len(items),
+        },
+        "overall": {
+            "decision": overall_decision,
+            "raw_response": raw_response,
+            "remark": remark,
+            "deferred_until": deferred_until,
+            "consistency_flag": consistency_flag,
+        },
+        "items": items,
+        "meta": {
+            "response_source": source,
+            "submitted_at": now.isoformat(),
+            "staff_id": actor_id,
+            "actor_id": actor_id,
+        },
+    }
+
 
 @dataclass
 class ResolveResult:
@@ -271,19 +520,31 @@ class GovernanceFeedbackService:
         else:
             target_status, review_reason = _RESPONSE_TRANSITION_MAP[response]
 
-        # Validate feedback_payload
+        # Build self-contained v2 feedback_payload (enrich on server side).
+        # Enrichment reads ticket.notification_structured; degrades gracefully,
+        # so an Invalid-feedback_payload error only fires on serialization.
         feedback_payload_json: str | None = None
-        if feedback_payload is not None:
-            try:
-                json.dumps(feedback_payload)
-                feedback_payload_json = json.dumps(feedback_payload)
-            except (TypeError, ValueError):
-                return ResolveResult(
-                    success=False,
-                    error="Invalid feedback_payload JSON",
-                    error_code="INVALID_FEEDBACK_PAYLOAD",
-                    notification_id=notification_id,
-                )
+        try:
+            enriched = _build_enriched_payload(
+                ticket=ticket,
+                notification_id=notification_id,
+                raw_response=response,
+                remark=remark,
+                repair_deadline=repair_deadline if response == Response.NEED_TIME else None,
+                feedback_payload=feedback_payload,
+                source=source,
+                actor_id=effective_actor,
+                now=now,
+            )
+            feedback_payload_json = json.dumps(enriched, ensure_ascii=False)
+        except (TypeError, ValueError) as exc:
+            log.warning("[GovernanceFeedback] enrich failed nid=%s: %s", notification_id, exc)
+            return ResolveResult(
+                success=False,
+                error="Invalid feedback_payload JSON",
+                error_code="INVALID_FEEDBACK_PAYLOAD",
+                notification_id=notification_id,
+            )
 
         # Advance ticket state via the driver service (sole driver). The
         # driver orchestrates: state transition (guard-activated) + cancel

--- a/src/backend/tests/community/core/economy/governance/test_card_callback.py
+++ b/src/backend/tests/community/core/economy/governance/test_card_callback.py
@@ -154,6 +154,39 @@ class TestCardCallbackResolve:
         assert row.response_source == "card_callback"
         assert row.governance_status == "waiting_review"
 
+    def test_minimal_card_payload_roundtrip(self, session, engine):
+        """Card sends {items:[...]} + top-level remark (补充说明); server enriches v2.
+
+        Mirrors card_cb190863 handleSubmit after cleanup: feedback_payload carries
+        only items[]; overall remark rides as top-level `remark`; no overall_action /
+        overall_remark. Server must persist a self-contained v2 payload with the
+        remark preserved in overall.remark.
+        """
+        svc = _build_svc(engine)
+        _make_notification(session)
+
+        result = svc.resolve(
+            "n-001", "optimized", "user-1",
+            remark="补充说明文字",
+            feedback_payload={"items": [
+                {"index": 1, "action": "accepted", "remark": None},
+                {"index": 2, "action": "rejected", "remark": "不行"},
+            ]},
+            source="card_callback",
+        )
+        assert result.success
+
+        row = session.query(GovernanceTicketOrm).filter_by(ticket_id="t-n-001").one()
+        stored = json.loads(row.feedback_payload)
+        assert stored["feedback_schema_version"] == 2
+        assert stored["overall"]["decision"] == "accepted"
+        # 补充说明随顶层 remark 进入 overall.remark(不丢)
+        assert stored["overall"]["remark"] == "补充说明文字"
+        items = {it["index"]: it for it in stored["items"]}
+        assert items[1]["decision"] == "accepted"
+        assert items[2]["decision"] == "rejected"
+        assert items[2]["remark"] == "不行"
+
     def test_dispute_with_remark_writes_to_db(self, session, engine):
         """response=dispute + remark → closed in DB."""
         svc = _build_svc(engine)
@@ -200,7 +233,7 @@ class TestCardCallbackResolve:
         assert result.close_reason is None
 
     def test_feedback_payload_writes_to_db(self, session, engine):
-        """feedback_payload written as JSON string in DB."""
+        """feedback_payload enriched to self-contained v2 and written as JSON."""
         svc = _build_svc(engine)
         _make_notification(session)
 
@@ -221,7 +254,19 @@ class TestCardCallbackResolve:
 
         row = session.query(GovernanceTicketOrm).filter_by(ticket_id="t-n-001").one()
         stored = json.loads(row.feedback_payload)
-        assert stored["overall_action"] == "partial"
+        # v2 self-contained structure (server-enriched, not the raw input)
+        assert stored["feedback_schema_version"] == 2
+        assert stored["ticket_ref"]["notification_id"] == "n-001"
+        assert stored["ticket_ref"]["worker_id"] == "user-1:bot-1"
+        # raw_response preserved + normalized overall decision
+        assert stored["overall"]["raw_response"] == "optimized"
+        assert stored["overall"]["decision"] == "accepted"
+        # user per-item decisions preserved (no suggestion full set → fallback)
+        items = {it["index"]: it for it in stored["items"]}
+        assert items[1]["decision"] == "accepted"
+        assert items[2]["decision"] == "rejected"
+        assert items[2]["remark"] == "Need this"
+        assert stored["meta"]["response_source"] == "card_callback"
 
 
 # ── Error paths ──────────────────────────────────────────────────

--- a/src/backend/tests/community/core/economy/governance/test_card_callback_schema.py
+++ b/src/backend/tests/community/core/economy/governance/test_card_callback_schema.py
@@ -1,0 +1,74 @@
+"""Backward-compat tests for CardCallbackIFrameRequest schema (Task 2).
+
+Verifies the structured feedback_payload model parses both the new
+structured shape and legacy arbitrary dicts, and items validate.
+"""
+from __future__ import annotations
+
+from agentclaw.community.adapters.http.economy.schemas import (
+    CardCallbackFeedbackItem,
+    CardCallbackFeedbackPayload,
+    CardCallbackIFrameRequest,
+)
+
+
+class TestCardCallbackRequestSchema:
+    def test_structured_payload_parses(self):
+        req = CardCallbackIFrameRequest(
+            notification_id="n-1",
+            response="optimized",
+            feedback_payload={
+                "version": 1,
+                "overall_action": "accepted",
+                "items": [
+                    {"index": 1, "action": "accepted", "remark": None},
+                    {"index": 2, "action": "rejected", "remark": "no"},
+                ],
+            },
+        )
+        assert isinstance(req.feedback_payload, CardCallbackFeedbackPayload)
+        assert req.feedback_payload.items is not None
+        assert len(req.feedback_payload.items) == 2
+        assert req.feedback_payload.items[0].index == 1
+        assert req.feedback_payload.items[1].remark == "no"
+
+    def test_legacy_extra_keys_allowed(self):
+        """Arbitrary extra keys in dict (e.g. overall_remark) don't break parse."""
+        req = CardCallbackIFrameRequest(
+            notification_id="n-1",
+            response="dispute",
+            feedback_payload={
+                "version": 1,
+                "overall_action": "partial",
+                "overall_remark": "maybe",
+                "repair_deadline": None,
+                "items": [{"index": 1, "action": "partial"}],
+            },
+        )
+        assert req.feedback_payload.overall_remark == "maybe"
+        # extra unknown keys tolerated (model_config extra=allow)
+        assert req.feedback_payload.model_extra is None or isinstance(
+            req.feedback_payload, CardCallbackFeedbackPayload
+        )
+
+    def test_payload_none_default(self):
+        req = CardCallbackIFrameRequest(notification_id="n-1", response="optimized")
+        assert req.feedback_payload is None
+
+    def test_item_requires_index_and_action(self):
+        """Missing required item field raises validation error."""
+        import pytest
+
+        with pytest.raises(Exception):
+            CardCallbackFeedbackItem(action="accepted")  # missing index
+
+    def test_top_level_fields_unchanged(self):
+        req = CardCallbackIFrameRequest(
+            notification_id="n-1",
+            response="need_time",
+            remark="plan",
+            repair_deadline="2026-07-15",
+        )
+        assert req.response == "need_time"
+        assert req.remark == "plan"
+        assert req.repair_deadline == "2026-07-15"

--- a/src/backend/tests/community/core/economy/governance/test_feedback_enrich.py
+++ b/src/backend/tests/community/core/economy/governance/test_feedback_enrich.py
@@ -1,0 +1,210 @@
+"""Unit tests for _build_enriched_payload (Task 3) — v2 self-contained payload.
+
+Uses a lightweight fake ticket (SimpleNamespace) — no DB. Verifies:
+ticket_ref / analysis_snapshot / items 正文快照 / unevaluated / degradation.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from types import SimpleNamespace
+
+from agentclaw.community.core.economy.governance.services.feedback_service import (
+    _build_enriched_payload,
+)
+
+
+_NOTIFICATION_STRUCTURED = json.dumps({
+    "schema_version": "v1",
+    "title": "Bot 成本优化建议: TestBot",
+    "meta": {
+        "owner": "寿子",
+        "department": "dept-x",
+        "daily_tokens": "2.25 亿",
+        "hit_dimensions": ["cron_token_ratio", "low_efficiency"],
+        "governance_action": "notify_owner",
+    },
+    "problem_summary": "日均2.25亿Token。",
+    "action_items": [
+        {
+            "index": 1,
+            "action": "Cron入口增加轻量状态检查",
+            "what_to_change": "pipeline入口先查ODPS分区",
+            "why": "空跑消耗3M Token",
+            "expected_effect": "减少空跑",
+            "needs_owner_confirm": False,
+        },
+        {
+            "index": 2,
+            "action": "空结果场景提前退出Pipeline",
+            "what_to_change": "阶段1后risk_events为空则跳过",
+            "why": "仍尝试执行后续阶段",
+            "expected_effect": "降低单次成本",
+            "needs_owner_confirm": False,
+        },
+    ],
+})
+
+
+def _fake_ticket() -> SimpleNamespace:
+    return SimpleNamespace(
+        ticket_id="t-001",
+        worker_id="168640:bot-1",
+        dt_version="20260622",
+        triggered_dimensions="cron_token_ratio,low_efficiency",
+        hit_dimensions_count=2,
+        severity="P1",
+        initial_decision="actionable",
+        estimated_saving_tokens=107243934,
+        saving_ratio=0.4763,
+        notification_structured=_NOTIFICATION_STRUCTURED,
+    )
+
+
+class TestBuildEnrichedPayload:
+    def test_top_level_version_and_ticket_ref(self):
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload=None, source="card_callback",
+            actor_id="168640", now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        assert out["feedback_schema_version"] == 2
+        ref = out["ticket_ref"]
+        assert ref["notification_id"] == "n-1"
+        assert ref["worker_id"] == "168640:bot-1"
+        assert ref["dt_version"] == "20260622"
+        assert ref["ticket_id"] == "t-001"
+
+    def test_analysis_snapshot_from_ticket_columns(self):
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload=None, source="card_callback",
+            actor_id="168640", now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        snap = out["analysis_snapshot"]
+        assert snap["hit_dimensions"] == ["cron_token_ratio", "low_efficiency"]
+        assert snap["hit_dimensions_count"] == 2
+        assert snap["governance_decision"] == "actionable"
+        assert snap["governance_urgency"] == "P1"
+        assert snap["expected_token_saving"] == 107243934
+        assert snap["saving_ratio"] == 0.4763
+        assert snap["suggestion_count"] == 2
+        assert snap["governance_action"] == "notify_owner"  # from meta
+
+    def test_items_carry_suggestion_text_snapshot(self):
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload={"items": [{"index": 1, "action": "accepted"}]},
+            source="card_callback", actor_id="168640",
+            now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        items = {it["index"]: it for it in out["items"]}
+        assert items[1]["decision"] == "accepted"
+        assert items[1]["suggestion_action"] == "Cron入口增加轻量状态检查"
+        assert items[1]["what_to_change"] == "pipeline入口先查ODPS分区"
+        assert items[1]["why"] == "空跑消耗3M Token"
+        assert items[1]["expected_effect"] == "减少空跑"
+
+    def test_unrated_item_marked_unevaluated(self):
+        """User only rated item 1; item 2 → unevaluated with text snapshot."""
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload={"items": [{"index": 1, "action": "accepted"}]},
+            source="card_callback", actor_id="168640",
+            now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        items = {it["index"]: it for it in out["items"]}
+        assert items[2]["decision"] == "unevaluated"
+        assert items[2]["remark"] is None
+        # unevaluated item still carries the suggestion text
+        assert items[2]["suggestion_action"] == "空结果场景提前退出Pipeline"
+
+    def test_overall_decisions_and_deferred(self):
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="need_time", remark=None,
+            repair_deadline=datetime(2026, 7, 20),
+            feedback_payload=None, source="card_callback",
+            actor_id="168640", now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        assert out["overall"]["decision"] == "deferred"
+        assert out["overall"]["deferred_until"] == "2026-07-20T00:00:00"
+        assert out["overall"]["consistency_flag"] == "overall_dominates"
+
+    def test_consistency_flag_partial_mix(self):
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload={"items": [
+                {"index": 1, "action": "accepted"},
+                {"index": 2, "action": "rejected", "remark": "no"},
+            ]},
+            source="card_callback", actor_id="168640",
+            now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        assert out["overall"]["consistency_flag"] == "partial_mix"
+
+    def test_degradation_when_notification_structured_unparseable(self):
+        """Corrupt notification_structured → items degrade, user decisions kept."""
+        ticket = _fake_ticket()
+        ticket.notification_structured = "{not json"
+        out = _build_enriched_payload(
+            ticket=ticket, notification_id="n-1",
+            raw_response="dispute", remark="wrong", repair_deadline=None,
+            feedback_payload={"items": [{"index": 1, "action": "rejected"}]},
+            source="card_callback", actor_id="168640",
+            now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        # no suggestion full set → fallback to user items only, text=None
+        assert len(out["items"]) == 1
+        assert out["items"][0]["decision"] == "rejected"
+        assert out["items"][0]["suggestion_action"] is None
+        assert out["items"][0]["what_to_change"] is None
+        # snapshot suggestion_count = len(degraded items) = 1
+        assert out["analysis_snapshot"]["suggestion_count"] == 1
+        # overall decision preserved
+        assert out["overall"]["decision"] == "rejected"
+
+    def test_pydantic_model_input_coerced(self):
+        """feedback_payload may arrive as a Pydantic model (router path)."""
+        from agentclaw.community.adapters.http.economy.schemas import (
+            CardCallbackFeedbackItem,
+            CardCallbackFeedbackPayload,
+        )
+        payload = CardCallbackFeedbackPayload(
+            items=[CardCallbackFeedbackItem(index=1, action="accepted")],
+        )
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload=payload, source="card_callback",
+            actor_id="168640", now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        items = {it["index"]: it for it in out["items"]}
+        assert items[1]["decision"] == "accepted"
+
+    def test_meta_block(self):
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload=None, source="card_callback",
+            actor_id="168640", now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        assert out["meta"]["response_source"] == "card_callback"
+        assert out["meta"]["submitted_at"] == "2026-07-14T15:38:11"
+        assert out["meta"]["actor_id"] == "168640"
+
+    def test_output_is_json_serializable(self):
+        out = _build_enriched_payload(
+            ticket=_fake_ticket(), notification_id="n-1",
+            raw_response="optimized", remark="好", repair_deadline=None,
+            feedback_payload={"items": [{"index": 1, "action": "accepted"}]},
+            source="card_callback", actor_id="168640",
+            now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        s = json.dumps(out, ensure_ascii=False)
+        assert '"feedback_schema_version": 2' in s

--- a/src/backend/tests/community/core/economy/governance/test_feedback_enrich.py
+++ b/src/backend/tests/community/core/economy/governance/test_feedback_enrich.py
@@ -169,6 +169,48 @@ class TestBuildEnrichedPayload:
         # overall decision preserved
         assert out["overall"]["decision"] == "rejected"
 
+    def test_degradation_when_action_items_not_list(self):
+        """action_items 非 list(畸形 notification_structured)不崩,降级输出用户点评项。
+
+        防御 Text 列无 schema 约束:action_items 可能是 string/dict 等非 list 值,
+        旧实现对非 dict 元素 sug.get 会抛 AttributeError 穿透 resolve 的 except →
+        500。isinstance 守卫拦下,走"无建议全集"降级,用户决策不丢。
+        """
+        ticket = _fake_ticket()
+        ticket.notification_structured = json.dumps({"action_items": "not-a-list"})
+        out = _build_enriched_payload(
+            ticket=ticket, notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload={"items": [{"index": 1, "action": "accepted"}]},
+            source="card_callback", actor_id="168640",
+            now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        # 非 list → 当作无建议全集,降级输出用户点评项
+        assert len(out["items"]) == 1
+        assert out["items"][0]["decision"] == "accepted"
+        assert out["items"][0]["suggestion_action"] is None
+
+    def test_degradation_when_action_items_has_non_dict_elements(self):
+        """action_items list 含非 dict 元素 → 跳过非法元素,合法项仍输出。"""
+        ticket = _fake_ticket()
+        ticket.notification_structured = json.dumps({"action_items": [
+            "bad-string",                        # 非 dict → 跳过
+            123,                                  # 非 dict → 跳过
+            {"index": 2, "action": "sug2", "what_to_change": "wc2"},  # 合法
+        ]})
+        out = _build_enriched_payload(
+            ticket=ticket, notification_id="n-1",
+            raw_response="optimized", remark=None, repair_deadline=None,
+            feedback_payload={"items": [{"index": 2, "action": "accepted"}]},
+            source="card_callback", actor_id="168640",
+            now=datetime(2026, 7, 14, 15, 38, 11),
+        )
+        items = {it["index"]: it for it in out["items"]}
+        # 两个非法元素被跳过,只剩 index=2 那条
+        assert set(items.keys()) == {2}
+        assert items[2]["decision"] == "accepted"
+        assert items[2]["suggestion_action"] == "sug2"
+
     def test_pydantic_model_input_coerced(self):
         """feedback_payload may arrive as a Pydantic model (router path)."""
         from agentclaw.community.adapters.http.economy.schemas import (

--- a/src/backend/tests/community/core/economy/governance/test_feedback_normalize.py
+++ b/src/backend/tests/community/core/economy/governance/test_feedback_normalize.py
@@ -1,0 +1,57 @@
+"""Unit tests for v2 feedback_payload normalization helpers.
+
+Covers Task 1 pure functions: _normalize_response + _compute_consistency_flag.
+No DB, no side effects — pure mapping logic.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.economy.governance.services.feedback_service import (
+    _compute_consistency_flag,
+    _normalize_response,
+)
+
+
+class TestNormalizeResponse:
+    """raw response → overall.decision mapping."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("optimized", "accepted"),
+            ("need_time", "deferred"),
+            ("dispute", "rejected"),
+            ("whitelist", "whitelist"),
+        ],
+    )
+    def test_four_formal_responses_map(self, raw, expected):
+        assert _normalize_response(raw) == expected
+
+    def test_unknown_response_raises(self):
+        with pytest.raises(ValueError):
+            _normalize_response("bogus")
+
+
+class TestComputeConsistencyFlag:
+    """overall vs per-item decision consistency."""
+
+    def test_all_items_same_as_overall_is_consistent(self):
+        assert _compute_consistency_flag("accepted", ["accepted", "accepted"]) == "consistent"
+
+    def test_no_item_feedback_is_overall_dominates(self):
+        assert _compute_consistency_flag("accepted", []) == "overall_dominates"
+        assert _compute_consistency_flag("rejected", []) == "overall_dominates"
+
+    def test_overall_accepted_with_some_rejected_is_partial_mix(self):
+        assert _compute_consistency_flag("accepted", ["accepted", "rejected"]) == "partial_mix"
+        assert _compute_consistency_flag("accepted", ["partial"]) == "partial_mix"
+
+    def test_overall_accepted_all_accepted_consistent(self):
+        # unique == {"accepted"} == overall → consistent (not partial_mix)
+        assert _compute_consistency_flag("accepted", ["accepted"]) == "consistent"
+
+    def test_overall_rejected_with_mix_when_not_all_rejected(self):
+        # overall=rejected, items=[rejected, accepted] → unique≠{rejected}, not accepted-dom
+        # → falls through to consistent (no partial_mix branch for non-accepted overall)
+        assert _compute_consistency_flag("rejected", ["rejected", "accepted"]) == "consistent"

--- a/src/backend/tests/community/core/economy/governance/test_feedback_service_extra.py
+++ b/src/backend/tests/community/core/economy/governance/test_feedback_service_extra.py
@@ -8,6 +8,7 @@ Reuses the fakes from test_feedback.py (copied here to avoid editing it).
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime
 
 from sqlalchemy.orm import sessionmaker
@@ -158,18 +159,30 @@ class TestResolveEdgeBranches:
         assert "Invalid response" in (result.error or "")
 
     def test_invalid_feedback_payload_json(self, session, engine):
-        """Non-serializable feedback_payload → INVALID_FEEDBACK_PAYLOAD (lines 174-175)."""
+        """Non-serializable junk in feedback_payload is sanitized by enrich.
+
+        v2 enrich extracts only items[].{index,action,remark} and rebuilds a
+        clean dict from ticket columns, so a non-serializable value in an
+        unrelated key no longer poisons the persisted payload — the user's
+        feedback is still recorded. (Previously: json.dumps(raw) → TypeError
+        → INVALID_FEEDBACK_PAYLOAD. Now: enrich sanitizes.)
+        """
         svc = _make_svc(engine)
         _make_notification(session)
 
-        # A set is not JSON-serializable → json.dumps raises TypeError.
+        # A set with an object is not JSON-serializable, but it's in an
+        # unrelated "bad" key enrich never reads.
         payload = {"bad": {object()}}
         result = svc.resolve(
             "n-001", "optimized", "user-1",
             feedback_payload=payload,
         )
-        assert not result.success
-        assert result.error_code == "INVALID_FEEDBACK_PAYLOAD"
+        assert result.success
+        # persisted payload is valid v2 JSON with no trace of the junk
+        row = session.query(GovernanceTicketOrm).filter_by(ticket_id="t-n-001").one()
+        stored = json.loads(row.feedback_payload)
+        assert stored["feedback_schema_version"] == 2
+        assert "bad" not in stored
 
     def test_whitelist_add_failure_is_swallowed(self, session, engine):
         """add raising must not fail the resolve (lines 200-201)."""

--- a/src/backend/tests/community/core/economy/governance/test_review_schemas.py
+++ b/src/backend/tests/community/core/economy/governance/test_review_schemas.py
@@ -153,6 +153,8 @@ class TestReviewTicketDetailResponse:
         assert d.response_remark == "user disputed"
         assert d.response_at == "2026-07-10T08:00:00"
         assert d.feedback_payload == '{"reason": "false positive"}'
+        # v1-style payload (no ticket_ref) → no feedback_notification_id surfaced
+        assert d.feedback_notification_id is None
         # 生命周期
         assert d.review_reason == "user_disputed"
         assert d.mute_until == "2026-07-12T00:00:00"
@@ -171,6 +173,31 @@ class TestReviewTicketDetailResponse:
         assert d.close_reason is None
         assert d.reviewed_at is None
         assert d.gmt_create is None
+
+    def test_feedback_notification_id_extracted_from_v2_payload(self) -> None:
+        """v2 feedback_payload 的 ticket_ref.notification_id 透出到详情顶层。"""
+        import json as _json
+        v2 = _json.dumps({
+            "feedback_schema_version": 2,
+            "ticket_ref": {
+                "notification_id": "n-callback-xyz",
+                "worker_id": "owner-1:bot-1",
+                "dt_version": "20260710",
+                "ticket_id": "T-001",
+            },
+        })
+        t = _make_ticket(feedback_payload=v2)
+        d = ReviewTicketDetailResponse.from_ticket(t)
+        assert d.feedback_notification_id == "n-callback-xyz"
+
+    def test_feedback_notification_id_degrades_on_garbage(self) -> None:
+        """损坏 / 缺 ticket_ref / 空 payload → None,不抛。"""
+        t = _make_ticket(feedback_payload="{not json")
+        assert ReviewTicketDetailResponse.from_ticket(t).feedback_notification_id is None
+        t2 = _make_ticket(feedback_payload=None)
+        assert ReviewTicketDetailResponse.from_ticket(t2).feedback_notification_id is None
+        t3 = _make_ticket(feedback_payload='{"no_ref": true}')
+        assert ReviewTicketDetailResponse.from_ticket(t3).feedback_notification_id is None
 
 
 class TestWorkflowReviewResponse:


### PR DESCRIPTION
…l nid

Harden the TC-card feedback path so the persisted feedback_payload is a self-contained, versioned v2 record the downstream can consume zero-join.

Server-side enrich (feedback_service):
- _normalize_response: raw response -> overall.decision (accepted/rejected/ deferred/whitelist), removes frontend deriveOverallAction guesswork.
- _compute_consistency_flag: consistent / partial_mix / overall_dominates.
- _build_enriched_payload: builds v2 from ticket + callback input, injecting ticket_ref (worker_id/dt_version/ticket_id/notification_id, unforgeable), analysis_snapshot (from ticket columns), items[] with full suggestion-text snapshot (action/what_to_change/why/expected_effect, sourced from the ticket's notification_structured - the same payload the card renders), overall + meta. Unrated items marked 'unevaluated' (distinct from accepted); degrades gracefully when notification_structured is unparseable.
- wired into resolve(): feedback_payload column now holds the enriched v2 JSON.

Input schema (schemas.py):
- CardCallbackFeedbackPayload / CardCallbackFeedbackItem structured model, feedback_payload now Union[model|dict|None] with extra=allow for legacy dict back-compat. Top-level fields unchanged.

Ticket detail (review schema):
- ReviewTicketDetailResponse surfaces feedback_notification_id, parsed from the v2 payload's ticket_ref.notification_id — which notification triggered the feedback, with zero new DB column (atomic: rides the feedback_payload row) and zero join. Degrades to None for v1 / no-feedback tickets.

Tests:
- test_feedback_normalize (10), test_feedback_enrich (10), test_card_callback_schema (5), test_card_callback incl. minimal-payload roundtrip + v1 sanitize, test_feedback_service_extra (sanitize semantics), test_review_schemas (feedback_notification_id extraction). Governance suite 555 passed, corp suite 1259 passed. Verified live via 2026-07-14 corp-dev real card-callback (user_id=168640).