### PR TITLE
feat: 透传 chunk 的 engine_type 到流式消费端

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -332,38 +332,50 @@ class BotRunRequestExecutor:
 
         seq = 0
         delta_buffer: list[str] = []
+        delta_engine_type: str | None = None
         agent_buffer: list[dict] = []
+        agent_engine_type: str | None = None
         cache_key = f"run:{run.run_id}:seq"
 
         def _flush_delta() -> None:
             """将缓冲的 delta 合并为一条 chunk 写入。"""
-            nonlocal seq, delta_buffer
+            nonlocal seq, delta_buffer, delta_engine_type
             if not delta_buffer:
                 return
             merged = "".join(delta_buffer)
             delta_buffer.clear()
+            metadata_json = None
+            if delta_engine_type:
+                metadata_json = json.dumps({"engine_type": delta_engine_type})
+                delta_engine_type = None
             seq += 1
             self._chunk_repository.insert_chunk(
                 run_id=run.run_id,
                 seq=seq,
                 chunk_type="delta",
                 content=merged,
+                metadata=metadata_json,
             )
             self._cache_plugin.set(cache_key, f"{seq}:delta", ttl_seconds=120)
 
         def _flush_agent() -> None:
             """将缓冲的 agent 事件合并为一条 chunk（JSON array）写入。"""
-            nonlocal seq, agent_buffer
+            nonlocal seq, agent_buffer, agent_engine_type
             if not agent_buffer:
                 return
             merged = json.dumps(agent_buffer, ensure_ascii=False)
             agent_buffer.clear()
+            metadata_json = None
+            if agent_engine_type:
+                metadata_json = json.dumps({"engine_type": agent_engine_type})
+                agent_engine_type = None
             seq += 1
             self._chunk_repository.insert_chunk(
                 run_id=run.run_id,
                 seq=seq,
                 chunk_type="agent",
                 content=merged,
+                metadata=metadata_json,
             )
             self._cache_plugin.set(cache_key, f"{seq}:agent", ttl_seconds=120)
 
@@ -377,9 +389,10 @@ class BotRunRequestExecutor:
             nonlocal seq
             _flush_buffers()
             seq += 1
-            metadata_json = (
-                json.dumps(stream_chunk.metadata) if stream_chunk.metadata else None
-            )
+            meta = dict(stream_chunk.metadata) if stream_chunk.metadata else {}
+            if stream_chunk.engine_type:
+                meta["engine_type"] = stream_chunk.engine_type
+            metadata_json = json.dumps(meta) if meta else None
             self._chunk_repository.insert_chunk(
                 run_id=run.run_id,
                 seq=seq,
@@ -403,11 +416,15 @@ class BotRunRequestExecutor:
             ):
                 if chunk.type == "delta":
                     delta_buffer.append(chunk.content)
+                    if chunk.engine_type:
+                        delta_engine_type = chunk.engine_type
                     if time.monotonic() - last_flush_ts >= self._stream_flush_interval:
                         _flush_buffers()
                         last_flush_ts = time.monotonic()
                 elif chunk.type == "agent":
                     agent_buffer.append(chunk.metadata or {})
+                    if chunk.engine_type:
+                        agent_engine_type = chunk.engine_type
                     if time.monotonic() - last_flush_ts >= self._stream_flush_interval:
                         _flush_buffers()
                         last_flush_ts = time.monotonic()

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -347,7 +347,6 @@ class BotRunRequestExecutor:
             metadata_json = None
             if delta_engine_type:
                 metadata_json = json.dumps({"engine_type": delta_engine_type})
-                delta_engine_type = None
             seq += 1
             self._chunk_repository.insert_chunk(
                 run_id=run.run_id,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -368,7 +368,6 @@ class BotRunRequestExecutor:
             metadata_json = None
             if agent_engine_type:
                 metadata_json = json.dumps({"engine_type": agent_engine_type})
-                agent_engine_type = None
             seq += 1
             self._chunk_repository.insert_chunk(
                 run_id=run.run_id,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_queue_task_message_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_queue_task_message_dispatcher.py
@@ -235,23 +235,38 @@ class QueueTaskMessageDispatcher:
                                 frames = json.loads(chunk_rec.content or "[]")
                             except (json.JSONDecodeError, TypeError):
                                 frames = []
+                            engine_type = None
+                            if chunk_rec.metadata:
+                                try:
+                                    meta = json.loads(chunk_rec.metadata)
+                                    if isinstance(meta, dict):
+                                        engine_type = meta.get("engine_type")
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
                             for frame in frames:
                                 yield StreamChunk(
                                     type="agent",
                                     content="",
                                     metadata=frame,
+                                    engine_type=engine_type,
                                 )
                         else:
                             metadata = None
+                            engine_type = None
                             if chunk_rec.metadata:
                                 try:
                                     metadata = json.loads(chunk_rec.metadata)
+                                    if isinstance(metadata, dict):
+                                        engine_type = metadata.pop("engine_type", None)
+                                        if not metadata:
+                                            metadata = None
                                 except (json.JSONDecodeError, TypeError):
                                     pass
                             yield StreamChunk(
                                 type=chunk_rec.chunk_type,
                                 content=chunk_rec.content or "",
                                 metadata=metadata,
+                                engine_type=engine_type,
                             )
                         if chunk_rec.chunk_type in terminal_types:
                             return

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
@@ -460,6 +460,196 @@ async def test_executor_stream_error_flushes_agent_buffer():
     repo.update_error.assert_called_once_with("re", "stream execution failed")
 
 
+# ----------------------------- stream engine_type 透传 -----------------------------
+
+
+async def test_executor_stream_engine_type_in_delta():
+    """delta chunk 携带 engine_type 时，flush 写入 metadata JSON。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-et-d",
+        bot_id="bot-1:ent",
+        metadata={"request_type": "chat", "stream": "true"},
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    chunks = [
+        StreamChunk(type="delta", content="hi", engine_type="openclaw"),
+        StreamChunk(type="final", content="done"),
+    ]
+
+    async def _stream_gen(*a, **kw):
+        for c in chunks:
+            yield c
+
+    bot_svc = MagicMock()
+    bot_svc.send_message_stream = _stream_gen
+    selector.select.return_value = bot_svc
+
+    chunk_repo = MagicMock()
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo()
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-et-d", bot_id="bot-1:ent", session_id="sess-d")
+    )
+
+    delta_calls = [
+        c for c in chunk_repo.insert_chunk.call_args_list
+        if c[1]["chunk_type"] == "delta"
+    ]
+    assert len(delta_calls) == 1
+    meta = json.loads(delta_calls[0][1]["metadata"])
+    assert meta["engine_type"] == "openclaw"
+
+
+async def test_executor_stream_engine_type_in_agent():
+    """agent chunk 携带 engine_type 时，flush 写入 metadata JSON。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-et-a",
+        bot_id="bot-1:ent",
+        metadata={"request_type": "chat", "stream": "true"},
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    chunks = [
+        StreamChunk(
+            type="agent",
+            content="",
+            metadata={"frame": 1},
+            engine_type="dify",
+        ),
+        StreamChunk(type="final", content="done"),
+    ]
+
+    async def _stream_gen(*a, **kw):
+        for c in chunks:
+            yield c
+
+    bot_svc = MagicMock()
+    bot_svc.send_message_stream = _stream_gen
+    selector.select.return_value = bot_svc
+
+    chunk_repo = MagicMock()
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo()
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-et-a", bot_id="bot-1:ent", session_id="sess-a")
+    )
+
+    agent_calls = [
+        c for c in chunk_repo.insert_chunk.call_args_list
+        if c[1]["chunk_type"] == "agent"
+    ]
+    assert len(agent_calls) == 1
+    meta = json.loads(agent_calls[0][1]["metadata"])
+    assert meta["engine_type"] == "dify"
+
+
+async def test_executor_stream_engine_type_in_final_with_metadata():
+    """final chunk 同时携带 metadata 和 engine_type 时，合并写入 metadata。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-et-f",
+        bot_id="bot-1:ent",
+        metadata={"request_type": "chat", "stream": "true"},
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    chunks = [
+        StreamChunk(
+            type="final",
+            content="result",
+            metadata={"extra": "val"},
+            engine_type="openclaw",
+        ),
+    ]
+
+    async def _stream_gen(*a, **kw):
+        for c in chunks:
+            yield c
+
+    bot_svc = MagicMock()
+    bot_svc.send_message_stream = _stream_gen
+    selector.select.return_value = bot_svc
+
+    chunk_repo = MagicMock()
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo()
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-et-f", bot_id="bot-1:ent", session_id="sess-f")
+    )
+
+    final_calls = [
+        c for c in chunk_repo.insert_chunk.call_args_list
+        if c[1]["chunk_type"] == "final"
+    ]
+    assert len(final_calls) == 1
+    meta = json.loads(final_calls[0][1]["metadata"])
+    assert meta["extra"] == "val"
+    assert meta["engine_type"] == "openclaw"
+
+
+async def test_executor_stream_engine_type_in_error_with_metadata():
+    """error chunk 携带 metadata + engine_type 时，合并写入 metadata。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-et-e",
+        bot_id="bot-1:ent",
+        metadata={"request_type": "chat", "stream": "true"},
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    chunks = [
+        StreamChunk(
+            type="error",
+            content="boom",
+            metadata={"code": 500},
+            engine_type="dify",
+        ),
+    ]
+
+    async def _stream_gen(*a, **kw):
+        for c in chunks:
+            yield c
+
+    bot_svc = MagicMock()
+    bot_svc.send_message_stream = _stream_gen
+    selector.select.return_value = bot_svc
+
+    chunk_repo = MagicMock()
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo()
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-et-e", bot_id="bot-1:ent", session_id="sess-e")
+    )
+
+    error_calls = [
+        c for c in chunk_repo.insert_chunk.call_args_list
+        if c[1]["chunk_type"] == "error"
+    ]
+    assert len(error_calls) == 1
+    meta = json.loads(error_calls[0][1]["metadata"])
+    assert meta["code"] == 500
+    assert meta["engine_type"] == "dify"
+
+
 # ----------------------------- 背压（队列深度 → 429） -----------------------------
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
@@ -498,7 +498,8 @@ async def test_executor_stream_engine_type_in_delta():
     )
 
     delta_calls = [
-        c for c in chunk_repo.insert_chunk.call_args_list
+        c
+        for c in chunk_repo.insert_chunk.call_args_list
         if c[1]["chunk_type"] == "delta"
     ]
     assert len(delta_calls) == 1
@@ -546,7 +547,8 @@ async def test_executor_stream_engine_type_in_agent():
     )
 
     agent_calls = [
-        c for c in chunk_repo.insert_chunk.call_args_list
+        c
+        for c in chunk_repo.insert_chunk.call_args_list
         if c[1]["chunk_type"] == "agent"
     ]
     assert len(agent_calls) == 1
@@ -593,7 +595,8 @@ async def test_executor_stream_engine_type_in_final_with_metadata():
     )
 
     final_calls = [
-        c for c in chunk_repo.insert_chunk.call_args_list
+        c
+        for c in chunk_repo.insert_chunk.call_args_list
         if c[1]["chunk_type"] == "final"
     ]
     assert len(final_calls) == 1
@@ -641,7 +644,8 @@ async def test_executor_stream_engine_type_in_error_with_metadata():
     )
 
     error_calls = [
-        c for c in chunk_repo.insert_chunk.call_args_list
+        c
+        for c in chunk_repo.insert_chunk.call_args_list
         if c[1]["chunk_type"] == "error"
     ]
     assert len(error_calls) == 1

--- a/src/baas/tests/unit/core/service/bot_run/test_queue_task_message_dispatcher_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_queue_task_message_dispatcher_coverage.py
@@ -188,6 +188,149 @@ class TestDispatchInject:
             )
 
 
+class TestDispatchSendStreamEngineType:
+    """engine_type 从 chunk 表 metadata 还原到 StreamChunk 的测试。"""
+
+    @pytest.mark.asyncio
+    async def test_agent_chunk_with_engine_type(self):
+        """agent chunk 的 metadata 含 engine_type 时，还原到 StreamChunk。"""
+        d = _make_dispatcher()
+        d._cache_plugin.get.return_value = "1:agent"
+        chunk_rec = MagicMock()
+        chunk_rec.seq = 1
+        chunk_rec.chunk_type = "agent"
+        chunk_rec.content = json.dumps([{"frame": 1}])
+        chunk_rec.metadata = json.dumps({"engine_type": "dify"})
+        d._chunk_repository.get_chunks_after.return_value = [chunk_rec]
+        run = MagicMock()
+        run.status = "FAILED"
+        d._run_repository.get_by_run_id.return_value = run
+
+        chunks = []
+        async for c in d.dispatch_send_stream(
+            bot_service=MagicMock(),
+            run_id="run-1",
+            session_id="sess-1",
+            message="hello",
+            binding_info=_make_binding_info(),
+            bot_id="bot-1",
+        ):
+            chunks.append(c)
+        agent_chunks = [c for c in chunks if c.type == "agent"]
+        assert len(agent_chunks) == 1
+        assert agent_chunks[0].engine_type == "dify"
+
+    @pytest.mark.asyncio
+    async def test_agent_chunk_engine_type_invalid_metadata_json(self):
+        """agent chunk 的 metadata 非法 JSON 时，engine_type 为 None。"""
+        d = _make_dispatcher()
+        d._cache_plugin.get.return_value = "1:agent"
+        chunk_rec = MagicMock()
+        chunk_rec.seq = 1
+        chunk_rec.chunk_type = "agent"
+        chunk_rec.content = json.dumps([{"frame": 1}])
+        chunk_rec.metadata = "bad json"
+        d._chunk_repository.get_chunks_after.return_value = [chunk_rec]
+        run = MagicMock()
+        run.status = "FAILED"
+        d._run_repository.get_by_run_id.return_value = run
+
+        chunks = []
+        async for c in d.dispatch_send_stream(
+            bot_service=MagicMock(),
+            run_id="run-1",
+            session_id="sess-1",
+            message="hello",
+            binding_info=_make_binding_info(),
+            bot_id="bot-1",
+        ):
+            chunks.append(c)
+        agent_chunks = [c for c in chunks if c.type == "agent"]
+        assert len(agent_chunks) == 1
+        assert agent_chunks[0].engine_type is None
+
+    @pytest.mark.asyncio
+    async def test_non_agent_chunk_engine_type_only_metadata(self):
+        """非 agent chunk 的 metadata 仅含 engine_type 时，pop 后 metadata 为 None。"""
+        d = _make_dispatcher()
+        d._cache_plugin.get.return_value = "1:final"
+        chunk_rec = MagicMock()
+        chunk_rec.seq = 1
+        chunk_rec.chunk_type = "final"
+        chunk_rec.content = "done"
+        chunk_rec.metadata = json.dumps({"engine_type": "openclaw"})
+        d._chunk_repository.get_chunks_after.return_value = [chunk_rec]
+        d._run_repository.get_by_run_id.return_value = None
+
+        chunks = []
+        async for c in d.dispatch_send_stream(
+            bot_service=MagicMock(),
+            run_id="run-1",
+            session_id="sess-1",
+            message="hello",
+            binding_info=_make_binding_info(),
+            bot_id="bot-1",
+        ):
+            chunks.append(c)
+        assert len(chunks) == 1
+        assert chunks[0].engine_type == "openclaw"
+        assert chunks[0].metadata is None
+
+    @pytest.mark.asyncio
+    async def test_non_agent_chunk_engine_type_with_other_metadata(self):
+        """非 agent chunk 的 metadata 同时含 engine_type 和其他字段时，保留剩余 metadata。"""
+        d = _make_dispatcher()
+        d._cache_plugin.get.return_value = "1:final"
+        chunk_rec = MagicMock()
+        chunk_rec.seq = 1
+        chunk_rec.chunk_type = "final"
+        chunk_rec.content = "done"
+        chunk_rec.metadata = json.dumps({"engine_type": "openclaw", "extra": "val"})
+        d._chunk_repository.get_chunks_after.return_value = [chunk_rec]
+        d._run_repository.get_by_run_id.return_value = None
+
+        chunks = []
+        async for c in d.dispatch_send_stream(
+            bot_service=MagicMock(),
+            run_id="run-1",
+            session_id="sess-1",
+            message="hello",
+            binding_info=_make_binding_info(),
+            bot_id="bot-1",
+        ):
+            chunks.append(c)
+        assert len(chunks) == 1
+        assert chunks[0].engine_type == "openclaw"
+        assert chunks[0].metadata == {"extra": "val"}
+
+    @pytest.mark.asyncio
+    async def test_non_agent_chunk_engine_type_invalid_metadata_json(self):
+        """非 agent chunk 的 metadata 非法 JSON 时，engine_type 为 None。"""
+        d = _make_dispatcher()
+        d._cache_plugin.get.return_value = "1:final"
+        chunk_rec = MagicMock()
+        chunk_rec.seq = 1
+        chunk_rec.chunk_type = "final"
+        chunk_rec.content = "done"
+        chunk_rec.metadata = "bad json"
+        d._chunk_repository.get_chunks_after.return_value = [chunk_rec]
+        d._run_repository.get_by_run_id.return_value = None
+
+        chunks = []
+        async for c in d.dispatch_send_stream(
+            bot_service=MagicMock(),
+            run_id="run-1",
+            session_id="sess-1",
+            message="hello",
+            binding_info=_make_binding_info(),
+            bot_id="bot-1",
+        ):
+            chunks.append(c)
+        assert len(chunks) == 1
+        assert chunks[0].engine_type is None
+        assert chunks[0].metadata is None
+
+
 class TestDispatchSendStream:
     @pytest.mark.asyncio
     async def test_stream_basic_with_final(self):


### PR DESCRIPTION
利用现有 metadata JSON 字段传递 engine_type，无需改表结构。
    
- 写入端(_executor.py): delta/agent buffer flush 时将 engine_type
- 写入 metadata JSON；_write_chunk 合并 engine_type 到 metadata。
- 读取端(_queue_task_message_dispatcher.py): 从 metadata 解析并回填engine_type 到 StreamChunk。