### PR TITLE
feat: repair default bot passport control plane

### DIFF
--- a/docs/superpowers/plans/2026-07-14-target-env-passport-repair.md
+++ b/docs/superpowers/plans/2026-07-14-target-env-passport-repair.md
@@ -1,0 +1,122 @@
+# Target Environment Passport Repair Implementation Plan
+
+> **执行方式：** 使用 `implement` 技能逐项落地；每项先写失败测试，再写最小实现，最后运行受影响回归。
+
+**Goal:** 允许部署在预发的 OCB 运维接口显式传入 `target_env=prod`，并让 tcauthmng 在共享数据库中按生产环境命名空间完成 default bot 的 Passport 查询、首次申请、回查和 AgentHub 注册，同时保持未传环境的正常创建链路行为不变。
+
+**Architecture:** `DefaultBotPassportRepairService` 是唯一发起显式目标环境的业务入口。Avernet 的 `PassportPlugin` 将 `target_env` 作为可选关键字参数加入协议；OCB prod adapter 把它序列化为 tcauthmng DTO 的 `env`；tcauthmng 在 Facade 边界只解析一次目标环境，并把同一个值传给 DB agentId、记录 env 字段和 AgentHub AppEnv。ACM 不传环境也不修改，因为预发与生产共用同一套 ACM 数据。
+
+**Tech Stack:** Python 3.12、pytest、Ruff、Java 8、JUnit 5、Mockito、Maven、Hessian/Layotto DTO。
+
+---
+
+## Task 1：锁定 Avernet 修复服务的目标环境契约
+
+**Files:**
+
+- Modify: `src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py`
+- Modify: `src/backend/tests/community/contracts/test_passport.py`
+- Modify: `src/backend/tests/community/plugins/community/test_passport.py`
+- Modify: `src/backend/src/agentclaw/community/plugin_api/passport.py`
+- Modify: `src/backend/src/agentclaw/community/plugins/local/passport.py`
+- Modify: `src/backend/src/agentclaw/community/plugins/community/passport.py`
+- Modify: `src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py`
+
+1. 在修复服务测试中断言初始查询、`apply_first_agent_passport` 和申请后回查都收到 `target_env="prod"`。
+2. 在协议/实现测试中覆盖：显式 `pre`/`prod` 可用；未传参数保持现有行为；非法显式环境在调用边界失败。
+3. 运行 RED：
+
+   ```bash
+   cd src/backend
+   uv run pytest -q tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py tests/community/contracts/test_passport.py tests/community/plugins/community/test_passport.py
+   ```
+
+4. 为四个运维所需方法增加关键字参数 `target_env: str | None = None`：`apply_first_agent_passport`、`query_auth_status`、`query_token`、`query_agent_passport`。
+5. 修复服务所有 Passport 调用显式传 `target_env`；local/community 实现验证显式值但不改变自签发语义。
+6. 重跑同一命令至 GREEN，并运行 Ruff。
+
+## Task 2：让 OCB prod adapter 把目标环境写入 Hessian DTO
+
+**Files:**
+
+- Modify: `src/backend/tests/corp/plugins/test_passport_admins.py`
+- Modify: `src/backend/src/agentclaw/corp/plugins/prod/passport.py`
+
+1. 增加 DTO 测试：`ApplyAgentPassportRequestDTO` 和 `BotRequestDTO` 显式 `prod` 时序列化 `env`，参数为 `None` 时不出现 `env`。
+2. 增加 adapter 测试：Apply First 与三种查询方法均把 `target_env` 传入对应 DTO。
+3. 运行 RED：
+
+   ```bash
+   cd src/backend
+   uv run pytest -q tests/corp/plugins/test_passport_admins.py
+   ```
+
+4. 给两个 DTO 增加可选 `env` 字段，并仅在非 `None` 时序列化。
+5. 对齐 `PassportPlugin` 新签名；只在 Apply First 与三种查询调用中使用 `target_env`，正常 `apply_agent_passport` 保持旧行为。
+6. 重跑同一命令至 GREEN，并运行 Ruff。
+
+## Task 3：让 tcauthmng Facade 按目标环境访问共享 DB
+
+**Files:**
+
+- Modify: `facade/common-facade/src/main/java/com/alipay/tcauthmng/common/facade/model/passport/ApplyAgentPassportRequestDTO.java`
+- Modify: `biz/biz-service/src/test/java/com/alipay/tcauthmng/biz/service/facadeimpl/AgentPassportFacadeImplApplyAgentPassportTest.java`
+- Modify: `biz/biz-service/src/test/java/com/alipay/tcauthmng/biz/service/facadeimpl/AgentPassportFacadeImplQueryTokenTest.java`
+- Modify: `biz/biz-service/src/test/java/com/alipay/tcauthmng/biz/service/facadeimpl/AgentPassportFacadeImplQueryAuthStatusTest.java`
+- Modify: `biz/biz-service/src/test/java/com/alipay/tcauthmng/biz/service/facadeimpl/AgentPassportFacadeImplQueryAgentPassportTest.java`
+- Modify: `biz/biz-service/src/main/java/com/alipay/tcauthmng/biz/service/facadeimpl/AgentPassportFacadeImpl.java`
+
+1. 在 Apply DTO 增加 `env` 字段。
+2. 新增跨环境测试：运行环境为 PREPUB、请求 `env=prod` 时，Apply First 和三种查询均使用 `prod|owner|bot`；新增非法显式环境提前失败的测试。
+3. 对新写入 token/user passport/agent passport/registry 记录，捕获模型并断言 `env=prod`、`agentId=prod|owner|bot`。
+4. 运行 RED：
+
+   ```bash
+   mvn -pl biz/biz-service -am \
+     -Dtest=AgentPassportFacadeImplApplyAgentPassportTest,AgentPassportFacadeImplQueryTokenTest,AgentPassportFacadeImplQueryAuthStatusTest,AgentPassportFacadeImplQueryAgentPassportTest \
+     -Dsurefire.failIfNoSpecifiedTests=false test
+   ```
+
+5. 新增目标环境解析函数：缺省回退当前运行环境；显式值只接受 `pre`、`prod`，并在任何 DB/ACM/AgentHub 副作用前验证。
+6. Apply First、Apply、Query Auth Status、Query Token、Query Agent Passport 在入口解析一次，并把结果贯穿所有递归 helper；禁止 helper 再次读取当前环境。
+7. 所有 DB agentId 与新记录 `env` 使用解析后的目标环境；ACM 调用保持原样。
+8. 重跑同一命令至 GREEN。
+
+## Task 4：让 AgentHub 注册使用目标 AppEnv
+
+**Files:**
+
+- Modify: `biz/biz-service/src/main/java/com/alipay/tcauthmng/biz/service/HubService.java`
+- Modify: `biz/biz-service/src/main/java/com/alipay/tcauthmng/biz/service/impl/HubServiceImpl.java`
+- Test: `biz/biz-service/src/test/java/com/alipay/tcauthmng/biz/service/impl/HubServiceImplTest.java`
+- Modify: `biz/biz-service/src/main/java/com/alipay/tcauthmng/biz/service/facadeimpl/AgentPassportFacadeImpl.java`
+
+1. 新增测试捕获 `AgentHubFacade.register` 请求，断言预发进程显式 `prod` 时 `AgentApp.appEnv=PROD`，未传时仍按当前环境解析。
+2. 运行 RED：
+
+   ```bash
+   mvn -pl biz/biz-service -am -Dtest=HubServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test
+   ```
+
+3. 为 `registerAgentV2` 增加带 `targetEnv` 的重载，旧签名委托新签名以保持兼容。
+4. `AgentPassportFacadeImpl#getOrRegisterAgentCode` 把同一个已解析环境传给 HubService；`pre` 映射 `AppEnvEnum.PRE`，`prod` 映射 `AppEnvEnum.PROD`。
+5. 重跑同一命令至 GREEN。
+
+## Task 5：跨仓库回归、代码审查与提交
+
+1. Avernet：运行上述三组测试、相关 bot management tests、Ruff 和类型检查（若仓库现有命令可用）。
+2. OCB：运行 corp Passport adapter tests、关系插件 tests 和 Ruff。
+3. tcauthmng：运行四个 Facade 测试、HubService 测试，再运行 `biz-service` 模块测试。
+4. 手工审查完整 diff：确认正常创建链路未传 `target_env` 时语义不变；确认 ACM 无改动；确认无 URL、token、环境硬编码泄漏。
+5. 分仓库提交。tcauthmng 提交时排除工作区原有的无关空白改动。
+
+## 部署与验收顺序
+
+1. 先在预发部署 tcauthmng 新版本，再部署包含 Avernet 新接口和 OCB prod adapter 的 OCB 预发镜像。
+2. 用单个生产 default bot 调运维接口，传 `target_env=prod`。
+3. 验证接口结果：`passport.status=ISSUED`、`token_present=true`、`ext_agent_code_verified=true`、owner relationship verified。
+4. 验证共享 DB：相关表记录的 `agent_id` 前缀和 `env` 均为 `prod`；不存在同 bot 的新增 `pre|...` 记录。
+5. 验证 AgentHub 新注册数据为 PROD；ACM 授权关系可查询。
+6. 对同一 bot 重复调用，结果应为已验证/幂等，不新增重复记录。
+7. 批量处理目标用户后，在线上环境重启对应 bot，使 agentCode 写入 Arca 容器 credential 文件。
+

--- a/docs/superpowers/specs/2026-07-14-default-bot-passport-repair-ops-design.md
+++ b/docs/superpowers/specs/2026-07-14-default-bot-passport-repair-ops-design.md
@@ -1,0 +1,342 @@
+# Default Bot Passport Repair Operations API
+
+Date: 2026-07-14
+
+## Background
+
+`POST /api/bots/create-for-others` creates a target user's default bot by
+calling `BotService.create_bot` directly. It bypasses the Passport and owner
+authorization work performed by regular `POST /api/bots` creation. Existing
+active bots are skipped, so calling it again does not repair identity state.
+
+The repair endpoint is deployed and invoked in pre-production while the target
+Bot row can belong to either `ac_bots.env=pre` or `ac_bots.env=prod`. The five
+reported owners currently each have one active `bot_id=default`, `env=prod`,
+`bot_type=personal`, `active_engine=openclaw`, `device_provider=baas` record
+without Passport data in `ext`.
+
+## Decision: Two Separate Phases
+
+The workflow is deliberately split:
+
+1. The pre-production operations endpoint repairs and verifies identity
+   control-plane state only.
+2. An operator subsequently restarts the Bot through the existing online
+   lifecycle. Online container bootstrap updates outbound rules and writes
+   runtime credentials.
+
+The pre-production endpoint must not hot-update or restart a prod Bot. Existing
+BaaS clients and outbound-rule construction are bound to the deployment
+environment, and hot update does not write `/home/admin/.credentials` or
+refresh process-local credential caches.
+
+## Goal
+
+Add an administrator-only, synchronous, idempotent operation that:
+
+1. selects exactly one live `bot_id=default` by owner and explicit
+   `target_env`;
+2. obtains a Passport only through
+   `PassportPlugin.apply_first_agent_passport`;
+3. rejects an empty token instead of returning an authorization URL;
+4. verifies the issued Passport and merges `ext.passport.agent_code` without
+   replacing unrelated `ext` keys;
+5. ensures and verifies the owner-to-agent relationship in `target_env`; and
+6. returns structured control-plane evidence plus
+   `runtime.restart_required=true`, without returning the raw token.
+
+## Non-goals
+
+- Repairing a non-default Bot or accepting a caller-supplied `bot_id`.
+- Calling `apply_agent_passport`; it can require interactive authorization.
+- Creating, restarting, releasing, or hot-updating a Bot.
+- Calling BaaS/ARCA or writing container files from pre-production.
+- Pretending to pass `target_env` to an upstream protocol that has no such
+  field.
+- Bulk repair. Operators invoke one owner at a time for auditability.
+
+## HTTP Contract
+
+### Request
+
+`POST /api/bots/repair-default-passport-for-others`
+
+```json
+{
+  "target_user_id": "172168",
+  "target_env": "prod"
+}
+```
+
+Rules:
+
+- The authenticated caller must be in `super_admin()`.
+- `target_user_id` is required and trimmed before use.
+- `target_env` is required and accepts only `pre` or `prod`.
+- `bot_id` is not accepted; the service always uses `default`.
+- The target is exactly
+  `(target_env, target_user_id, default, is_delete=0)`.
+- Zero or multiple live matches is an error.
+
+### Success response
+
+```json
+{
+  "success": true,
+  "message": "default bot Passport 修复并校验成功，需在目标环境重启",
+  "error_code": 200,
+  "data": {
+    "target_user_id": "172168",
+    "bot_id": "default",
+    "target_env": "prod",
+    "action": "repaired",
+    "passport": {
+      "status": "ISSUED",
+      "agent_code": "agent_xxx",
+      "credential_id": "credential_xxx",
+      "token_present": true,
+      "source": "applied"
+    },
+    "owner_relationship": {
+      "verified": true,
+      "created": true,
+      "auth_id": 123
+    },
+    "database": {
+      "ext_agent_code_verified": true
+    },
+    "runtime": {
+      "restart_required": true,
+      "restart_environment": "prod"
+    }
+  }
+}
+```
+
+`action` is `repaired` when this call changes state and `verified` when all
+required identity state already exists. `passport.source` is `applied` or
+`existing`. The API never returns a Passport token, cookie, iframe URL, or
+redirect URL.
+
+### Failure semantics
+
+The endpoint uses the existing `ApiResponse` envelope and returns
+`success=false` for incomplete control-plane repair.
+
+| Case | `error_code` | Meaning |
+| --- | ---: | --- |
+| Invalid or missing input | 400 | Required owner/target-env contract was not met |
+| Caller is not a super administrator | 403 | Operation is forbidden |
+| Exact default Bot is absent | 404 | No target exists in `target_env` |
+| More than one live exact target | 409 | Data invariant is violated; no external mutation is attempted |
+| First Passport apply returns no token | 5401 | Operations flow cannot complete interactive authorization |
+| Passport apply/query or verification fails | 5400 | Identity was not proven |
+| Owner relationship create/re-query fails | 5402 | Authorization was not proven |
+| Database write/read-back fails | 500 | `ext` was not safely persisted |
+
+External services and the database cannot share a transaction. A failure may
+leave a completed workflow prefix. Every completed prefix is safe to retry;
+the next call resumes from the first missing verified state.
+
+## Architecture
+
+The HTTP adapter owns authentication, input validation, error mapping, and
+serialization only. Repair policy lives in a dedicated core service exposed by
+a Service API protocol.
+
+### Service API
+
+```python
+class DefaultBotPassportRepairServiceProtocol(Protocol):
+    def repair(
+        self,
+        *,
+        target_user_id: str,
+        target_env: str,
+        operator_user_id: str,
+        operator_name: str,
+    ) -> dict[str, Any]: ...
+```
+
+The concrete service consumes:
+
+- the Bot repository contract for exact env-scoped read and `ext` update;
+- `PassportPlugin` for first apply and verification queries;
+- `AuthRelationshipPlugin` for target-env query/create/re-query;
+- `SkillSetServiceFactory` for the normal creation MCP scope; and
+- the existing default CLI policy for the target Bot engine.
+
+It does not consume `BotServiceProtocol`, `DeviceService`, BaaS, or a container
+filesystem API.
+
+### Explicit `target_env`
+
+Existing Bot repository operations use `get_current_env()` and cannot safely
+serve this endpoint. Add required-env operations instead of widening existing
+contracts with optional parameters:
+
+```python
+def get_live_by_id_owner_and_env(
+    self, *, bot_id: str, owner_id: str, env: str
+) -> list[dict[str, Any]]: ...
+
+def update_ext_by_id_owner_and_env(
+    self, *, bot_id: str, owner_id: str, env: str, ext: dict[str, Any]
+) -> dict[str, Any]: ...
+```
+
+The read returns all exact live matches so the service can distinguish zero,
+one, and duplicate rows. The update must affect exactly one live row; otherwise
+it raises and rolls back. All env-scoped OCB reads needed to construct MCP
+scope also receive `target_env` explicitly and never fall back to the runtime
+deployment env.
+
+AceAgent is environment-specific, but the current production plugin captures
+its base URL from the deployment environment. Add explicit target-env
+operations to the plugin contract and implementations. The production
+implementation selects the pre/prod URL per call and must not mutate a
+singleton's cached base URL. Community/local implementations preserve their
+existing no-op semantics while accepting and validating `target_env`.
+
+`PassportPlugin.apply_first_agent_passport` and downstream
+`ApplyAgentPassportRequestDTO` have no environment field. The repair calls the
+existing operation unchanged. `target_env` remains explicit through request,
+service, target selection, audit logs, MCP data reads, persistence, and
+AceAgent operations; no fake locally ignored Passport parameter is added.
+
+## Phase 1 Repair Workflow
+
+1. Validate `target_env` at the HTTP and service boundaries against
+   `pre|prod`.
+2. Load exact live target `(target_env, target_user_id, default)`.
+3. Derive owner/entity metadata, active engine, Bot name/description,
+   workspace, target-env MCP codes, and default CLI items from stored state.
+4. Query the existing Agent Passport.
+   - If token, agent code, credential ID, and issued status are proven, reuse
+     it.
+   - Otherwise call `apply_first_agent_passport` once using the same metadata
+     rules as normal default-Bot creation.
+   - Never call `apply_agent_passport`.
+5. Require a non-empty token and agent code. An iframe/redirect response with
+   no token is a hard `PASSPORT_FIRST_APPLY_FAILED` error.
+6. Re-query `query_agent_passport`, `query_auth_status`, and `query_token`.
+   Require a credential ID, matching agent code, issued status, and token.
+7. Merge `ext.passport.agent_code` into the latest stored `ext`, write through
+   the exact-env method, then read it back and compare.
+8. Query the relationship by
+   `(target_env, agent_code, target_user_id)`.
+   - Reuse a matching relationship.
+   - Otherwise create it with the target owner as `work_no` and the
+     authenticated administrator as operator.
+   - Re-query and require a matching relationship. A create response alone is
+     not proof.
+9. Return success only when Passport, target-env owner relationship, and
+   database read-back are verified. Always return
+   `runtime.restart_required=true`.
+
+## Phase 2 Online Runtime Reconciliation
+
+After phase 1 succeeds, restart the Bot through the existing online lifecycle.
+For the current BaaS personal Bots, the existing BaaS in-place restart
+preserves the logical Bot/binding identity. The online container startup then:
+
+1. calls the prod `/api/v1/devices/callback/bootstrap-auth`;
+2. resolves the repaired agent code from `ac_bots.ext` and queries the token;
+3. updates all BaaS-managed physical devices' outbound rules;
+4. returns agent code to `start_service.sh`;
+5. writes `AGENT_CODE` into `/home/admin/.credentials`; and
+6. exports it before runtime processes start.
+
+The online restart is not implemented or triggered by this endpoint.
+
+## Idempotency and Concurrency
+
+- Query-before-apply avoids replacing a complete existing Passport.
+- First apply is treated as an ensure operation and is always verified by
+  query.
+- Relationship query-before-create plus re-query tolerates already-existing
+  relationships and concurrent creators.
+- `ext` is merged from the latest row and the write requires exactly one row.
+- A per-process keyed lock on `(target_env, owner, default)` avoids duplicate
+  work inside one application instance. Cross-replica correctness relies on
+  query/ensure/re-query semantics, not that lock.
+- Retry never calls `apply_agent_passport`, BaaS, hot update, or restart.
+
+## Logging and Security
+
+Every stage logs request ID, operator, target owner, target env, fixed Bot ID,
+action, and verification outcome. Logs and responses must not contain the raw
+Passport token, cookies, or authorization URLs.
+
+## Test Plan
+
+Tests are written before implementation.
+
+### Core service
+
+- rejects target env outside `pre|prod`;
+- always targets `bot_id=default` and only the requested env;
+- fails before external mutation for zero or duplicate target rows;
+- reuses a complete Passport without either apply call;
+- calls only `apply_first_agent_passport` when Passport is missing/incomplete;
+- treats token-empty plus authorization URL as a hard failure;
+- rejects missing/mismatched agent code, credential ID, status, or token;
+- merges `ext.passport.agent_code` while preserving unrelated fields;
+- propagates write errors and rejects failed read-back;
+- reuses an existing relationship or creates then re-queries a missing one;
+- passes target env to every env-aware dependency;
+- never calls BaaS, device hot update, restart, or container filesystem APIs;
+- supports retry after each partial-failure boundary; and
+- returns `runtime.restart_required=true` for repaired and verified results.
+
+### Repository and plugin contracts
+
+- exact-env Bot read never falls back to `get_current_env()`;
+- pre/prod rows with the same owner/Bot ID remain isolated;
+- exact-env `ext` update affects exactly one selected live row;
+- zero/multiple update matches fail;
+- target-env AuthRelationship calls select the requested endpoint per call;
+- existing current-env relationship callers retain their behavior; and
+- Passport contract remains unchanged.
+
+### HTTP and architecture
+
+- validates required `target_user_id` and enum `target_env`;
+- denies non-super-admin callers;
+- forwards authenticated operator identity;
+- exposes no caller-supplied Bot ID;
+- maps typed service errors to the documented response;
+- exposes no raw token or authorization URL;
+- Service API and repository/plugin protocols conform; and
+- backend architecture boundary and forbidden-import tests pass.
+
+## Acceptance
+
+Run one canary owner before the remaining owners.
+
+### Phase 1 in pre-production
+
+1. Use ODC to capture the exact prod/default Bot row, including status,
+   binding, and `ext`.
+2. Invoke the pre-production endpoint with `target_env=prod` and retain request
+   ID and non-secret response.
+3. Require Passport, relationship, and database verification fields to pass,
+   and `runtime.restart_required=true`.
+4. Confirm through ODC that only the exact prod/default row changed and
+   unrelated `ext` fields were preserved.
+5. Invoke again and require `action=verified`, unchanged Passport identity,
+   and no duplicate relationship.
+
+### Phase 2 online
+
+1. Restart that Bot through the existing online lifecycle.
+2. Wait for Bot and binding status to return to `ACTIVE`.
+3. Verify online bootstrap logs contain the expected non-empty agent code and
+   token-present result.
+4. Verify BaaS outbound-rule update succeeded.
+5. Verify the new runtime has the same non-empty `AGENT_CODE` in
+   `/home/admin/.credentials`.
+
+After the canary passes both phases, repeat for owners `317312`, `136450`,
+`382425`, and `210231`.
+

--- a/docs/superpowers/specs/2026-07-14-default-bot-passport-repair-ops-design.md
+++ b/docs/superpowers/specs/2026-07-14-default-bot-passport-repair-ops-design.md
@@ -15,6 +15,19 @@ reported owners currently each have one active `bot_id=default`, `env=prod`,
 `bot_type=personal`, `active_engine=openclaw`, `device_provider=baas` record
 without Passport data in `ext`.
 
+The cross-environment Passport design relies on two confirmed deployment
+facts:
+
+- pre-production and production tcauthmng use the same physical database,
+  `tcauthmng#sec_gzcom4x#sec_tcauthmng0_17629`, and distinguish records by the
+  logical `env` field plus the `env|owner|bot` agent ID; and
+- Agent ACM is not data-isolated between pre-production and production. Calls
+  made through the pre-production ACM client can create and update the same
+  credential state used by production.
+
+Therefore `target_env` selects the tcauthmng logical namespace and persistence
+records. It does not select a different ACM client or endpoint.
+
 ## Decision: Two Separate Phases
 
 The workflow is deliberately split:
@@ -51,8 +64,8 @@ Add an administrator-only, synchronous, idempotent operation that:
 - Calling `apply_agent_passport`; it can require interactive authorization.
 - Creating, restarting, releasing, or hot-updating a Bot.
 - Calling BaaS/ARCA or writing container files from pre-production.
-- Pretending to pass `target_env` to an upstream protocol that has no such
-  field.
+- Adding a second ACM client, routing to production tcauthmng, or changing ACM
+  endpoint selection.
 - Bulk repair. Operators invoke one owner at a time for auditability.
 
 ## HTTP Contract
@@ -198,11 +211,68 @@ implementation selects the pre/prod URL per call and must not mutate a
 singleton's cached base URL. Community/local implementations preserve their
 existing no-op semantics while accepting and validating `target_env`.
 
-`PassportPlugin.apply_first_agent_passport` and downstream
-`ApplyAgentPassportRequestDTO` have no environment field. The repair calls the
-existing operation unchanged. `target_env` remains explicit through request,
-service, target selection, audit logs, MCP data reads, persistence, and
-AceAgent operations; no fake locally ignored Passport parameter is added.
+Passport operations evolve compatibly to accept an optional explicit target
+environment:
+
+```python
+def apply_first_agent_passport(
+    ...,
+    *,
+    target_env: str | None = None,
+) -> dict[str, Any] | None: ...
+
+def query_agent_passport(
+    bot_id: str,
+    owner_workno: str,
+    *,
+    target_env: str | None = None,
+) -> dict[str, Any] | None: ...
+```
+
+`query_auth_status` and `query_token` follow the same rule. Omitting
+`target_env` retains the existing current-deployment behavior for normal Bot
+creation and lifecycle callers. Supplying it requires `pre|prod`; invalid
+values fail before any external or persistence side effect.
+
+The production OCB adapter serializes `target_env` as the Java DTO field
+`env`. `ApplyAgentPassportRequestDTO` gains the field; `BotRequestDTO` already
+has it. The repair service supplies `target_env` to all initial queries, first
+apply, and verification queries. Local implementations and contract tests
+preserve the same fallback and validation semantics.
+
+### tcauthmng target-environment execution
+
+tcauthmng resolves the execution environment once at each facade entry:
+
+```text
+non-empty request.env -> normalized request.env
+empty request.env     -> current deployment environment
+```
+
+All recursive first-apply stages consume that resolved value. They must not
+re-read `EnvToolUtil` independently:
+
+- `getOrRefreshToken`;
+- `getOrRefreshUserPassport`;
+- `getOrRefreshAgentPassport`; and
+- `getOrRegisterAgentCode`.
+
+For a pre-production call with `env=prod`, every lookup and write uses
+`agentId=prod|<owner>|default`. New Agent Passport, User Passport, and Token
+records store `env=prod`; Agent Registry is isolated by the same prefixed
+agent ID. `queryToken`, `queryAgentPassport`, and `queryAuthStatus` use the
+same resolver so apply and verification cannot select different namespaces.
+
+AgentHub registration is part of the same logical environment selection.
+When a new agent code is needed, `HubService.registerAgentV2` receives the
+resolved environment and submits `AppEnv.PROD` for `prod` rather than deriving
+`AppEnv.PRE` from the pre-production process.
+
+ACM integration remains unchanged. `AcmClientServiceImpl`, its singleton
+client, configured domain, and the calls to `registerAgentPrincipal`,
+`issueDelegationCredential`, `issueExecutionCredential`, and
+`getDelegationCredentialStatus` are not made environment-aware. They operate
+on the confirmed shared ACM state using the target-scoped agent identity.
 
 ## Phase 1 Repair Workflow
 
@@ -211,16 +281,18 @@ AceAgent operations; no fake locally ignored Passport parameter is added.
 2. Load exact live target `(target_env, target_user_id, default)`.
 3. Derive owner/entity metadata, active engine, Bot name/description,
    workspace, target-env MCP codes, and default CLI items from stored state.
-4. Query the existing Agent Passport.
+4. Query the existing Agent Passport, authorization status, and token with
+   `target_env`.
    - If token, agent code, credential ID, and issued status are proven, reuse
      it.
-   - Otherwise call `apply_first_agent_passport` once using the same metadata
-     rules as normal default-Bot creation.
+   - Otherwise call `apply_first_agent_passport` once with `target_env` and the
+     same metadata rules as normal default-Bot creation.
    - Never call `apply_agent_passport`.
 5. Require a non-empty token and agent code. An iframe/redirect response with
    no token is a hard `PASSPORT_FIRST_APPLY_FAILED` error.
-6. Re-query `query_agent_passport`, `query_auth_status`, and `query_token`.
-   Require a credential ID, matching agent code, issued status, and token.
+6. Re-query `query_agent_passport`, `query_auth_status`, and `query_token` with
+   the same `target_env`. Require a credential ID, matching agent code, issued
+   status, and token.
 7. Merge `ext.passport.agent_code` into the latest stored `ext`, write through
    the exact-env method, then read it back and compare.
 8. Query the relationship by
@@ -279,6 +351,7 @@ Tests are written before implementation.
 - fails before external mutation for zero or duplicate target rows;
 - reuses a complete Passport without either apply call;
 - calls only `apply_first_agent_passport` when Passport is missing/incomplete;
+- passes `target_env` to every Passport query and first-apply call;
 - treats token-empty plus authorization URL as a hard failure;
 - rejects missing/mismatched agent code, credential ID, status, or token;
 - merges `ext.passport.agent_code` while preserving unrelated fields;
@@ -296,8 +369,14 @@ Tests are written before implementation.
 - exact-env `ext` update affects exactly one selected live row;
 - zero/multiple update matches fail;
 - target-env AuthRelationship calls select the requested endpoint per call;
-- existing current-env relationship callers retain their behavior; and
-- Passport contract remains unchanged.
+- existing current-env relationship callers retain their behavior;
+- Passport calls without `target_env` retain current-environment behavior;
+- Passport calls with `target_env=prod` serialize `env=prod` for tcauthmng;
+- tcauthmng first apply uses `prod|owner|bot` for every recursive stage;
+- tcauthmng query and apply paths resolve the same target environment;
+- tcauthmng writes target `env` rather than the process environment;
+- AgentHub receives the target `AppEnv`; and
+- invalid target environments fail before DB, AgentHub, or ACM calls.
 
 ### HTTP and architecture
 
@@ -322,9 +401,12 @@ Run one canary owner before the remaining owners.
    ID and non-secret response.
 3. Require Passport, relationship, and database verification fields to pass,
    and `runtime.restart_required=true`.
-4. Confirm through ODC that only the exact prod/default row changed and
+4. Confirm in tcauthmng that Agent Registry, Agent Passport, User Passport,
+   and Token state use `agentId=prod|<owner>|default`; all records with an
+   `env` column use `prod`, and no new `pre|<owner>|default` identity exists.
+5. Confirm through ODC that only the exact prod/default Bot row changed and
    unrelated `ext` fields were preserved.
-5. Invoke again and require `action=verified`, unchanged Passport identity,
+6. Invoke again and require `action=verified`, unchanged Passport identity,
    and no duplicate relationship.
 
 ### Phase 2 online
@@ -339,4 +421,3 @@ Run one canary owner before the remaining owners.
 
 After the canary passes both phases, repeat for owners `317312`, `136450`,
 `382425`, and `210231`.
-

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -12,10 +12,10 @@ Each bot is associated with an entity (staff, proj, team) and has its own device
 """
 import asyncio
 from datetime import datetime, timedelta
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
 from fastapi import APIRouter, Query, Request, Response, Depends, Path
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
 from agentclaw.community.adapters.http.auth.dependencies import require_operator, get_current_user
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
@@ -23,6 +23,9 @@ from agentclaw.community.core.access.admin_scopes import super_admin
 from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.api.data_init_service import DataInitServiceProtocol
+from agentclaw.community.api.default_bot_passport_repair_service import (
+    DefaultBotPassportRepairServiceProtocol,
+)
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
 from agentclaw.community.core.bot_collaborator.interceptor import (
     CollaboratorPermissionInterceptor,
@@ -42,6 +45,9 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     DeviceLimitError,
     generate_bot_id,
     validate_bot_name,
+)
+from agentclaw.community.core.bot_management.errors import (
+    DefaultBotPassportRepairError,
 )
 from agentclaw.community.core.bot_management.utils import (
     clear_baas_publish_failure_ext as _clear_baas_publish_failure_ext,
@@ -161,6 +167,23 @@ class UpdateBotExtForOthersRequest(BaseModel):
     target_user_id: str
     target_bot_id: str
     ext_update: dict
+
+
+class RepairDefaultPassportForOthersRequest(BaseModel):
+    """Strict operations request; the bot ID is intentionally fixed in core."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_user_id: str
+    target_env: Literal["pre", "prod"]
+
+    @field_validator("target_user_id")
+    @classmethod
+    def validate_target_user_id(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("target_user_id must not be blank")
+        return trimmed
 
 
 @router.post("/release-for-others", response_model=ApiResponse)
@@ -471,6 +494,112 @@ async def restart_scheduler(
         return ApiResponse(
             success=False,
             message=f"重启Bot失败: {str(e)}",
+            error_code=500,
+            data=None,
+        )
+
+
+@router.post(
+    "/repair-default-passport-for-others",
+    response_model=ApiResponse,
+)
+async def repair_default_passport_for_others(
+    request: Request,
+    ctx: RequestContext = Depends(get_request_context),
+    repair_service: DefaultBotPassportRepairServiceProtocol = Injected(
+        DefaultBotPassportRepairServiceProtocol
+    ),
+) -> ApiResponse:
+    """Repair and verify control-plane identity for one default bot."""
+    if ctx.user_id not in super_admin():
+        return ApiResponse(
+            success=False,
+            message="权限不足：您没有权限调用此接口",
+            error_code=403,
+            data=None,
+        )
+
+    try:
+        payload = RepairDefaultPassportForOthersRequest.model_validate(
+            await request.json()
+        )
+    except (ValidationError, ValueError, TypeError):
+        return ApiResponse(
+            success=False,
+            message="参数错误：target_user_id 必填，target_env 仅支持 pre 或 prod",
+            error_code=400,
+            data=None,
+        )
+
+    request_id = request.headers.get("X-Request-ID")
+    trace_id = getattr(request.state, "trace_id", None)
+    logger.info(
+        "[bot_router.repair_default_passport_for_others] start "
+        "request_id=%s trace_id=%s operator=%s target=%s env=%s bot_id=default",
+        request_id,
+        trace_id,
+        ctx.user_id,
+        payload.target_user_id,
+        payload.target_env,
+    )
+    try:
+        result = repair_service.repair(
+            target_user_id=payload.target_user_id,
+            target_env=payload.target_env,
+            operator_user_id=ctx.user_id,
+            operator_name=ctx.nick_name or ctx.user_id,
+        )
+        logger.info(
+            "[bot_router.repair_default_passport_for_others] complete "
+            "request_id=%s trace_id=%s operator=%s target=%s env=%s "
+            "bot_id=default action=%s passport_source=%s "
+            "owner_relationship_verified=%s ext_agent_code_verified=%s",
+            request_id,
+            trace_id,
+            ctx.user_id,
+            payload.target_user_id,
+            payload.target_env,
+            result.get("action"),
+            (result.get("passport") or {}).get("source"),
+            (result.get("owner_relationship") or {}).get("verified"),
+            (result.get("database") or {}).get("ext_agent_code_verified"),
+        )
+        return ApiResponse(
+            success=True,
+            message="default bot Passport 修复并校验成功，需在目标环境重启",
+            data=result,
+        )
+    except DefaultBotPassportRepairError as exc:
+        logger.warning(
+            "[bot_router.repair_default_passport_for_others] request_id=%s "
+            "trace_id=%s operator=%s target=%s env=%s error_code=%s error=%s",
+            request_id,
+            trace_id,
+            ctx.user_id,
+            payload.target_user_id,
+            payload.target_env,
+            exc.error_code,
+            exc,
+        )
+        return ApiResponse(
+            success=False,
+            message=str(exc),
+            error_code=exc.error_code,
+            data=None,
+        )
+    except Exception:
+        logger.exception(
+            "[bot_router.repair_default_passport_for_others] unexpected failure: "
+            "request_id=%s trace_id=%s operator=%s target=%s env=%s",
+            request_id,
+            trace_id,
+            ctx.user_id,
+            payload.target_user_id,
+            payload.target_env,
+        )
+        return ApiResponse(
+            success=False,
+            message="default bot Passport 修复失败",
             error_code=500,
             data=None,
         )

--- a/src/backend/src/agentclaw/community/api/default_bot_passport_repair_service.py
+++ b/src/backend/src/agentclaw/community/api/default_bot_passport_repair_service.py
@@ -1,0 +1,19 @@
+"""Service API for the default-bot Passport repair operation."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DefaultBotPassportRepairServiceProtocol(Protocol):
+    """Transport-independent repair service consumed by HTTP adapters."""
+
+    def repair(
+        self,
+        *,
+        target_user_id: str,
+        target_env: str,
+        operator_user_id: str,
+        operator_name: str,
+    ) -> dict[str, Any]: ...

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -14,9 +14,11 @@ provides:
   - "RenderScreenService"
   - "TeclawProvisionService"
   - "TeclawPublishTaskLifecycle"
+  - "DefaultBotPassportRepairService"
 consumes:
   - "DeviceAccessor"
   - "PassportPlugin"
+  - "AuthRelationshipPlugin"
   - "DeviceService"
   - "ResourceService"
   - "BotPublishService"
@@ -32,6 +34,7 @@ internal_dependencies:
   - agentclaw.community.core.config_compose
   - agentclaw.community.core.cron.services.aicoding.cron_auto_setup
   - agentclaw.community.core.desktop_bot
+  - agentclaw.community.core.mcp
   - agentclaw.community.core.devices
   - agentclaw.community.core.resources
   - agentclaw.community.core.service_bot
@@ -46,6 +49,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.drm
   - agentclaw.community.plugin_api.http_client
   - agentclaw.community.plugin_api.passport
+  - agentclaw.community.plugin_api.auth_relationship
   - agentclaw.community.utils.env_utils
   - agentclaw.community.utils.secret_utils
 ```

--- a/src/backend/src/agentclaw/community/core/bot_management/errors.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/errors.py
@@ -1,0 +1,9 @@
+"""Domain errors owned by the bot-management context."""
+
+
+class DefaultBotPassportRepairError(Exception):
+    """Stable repair failure that the delivery adapter can serialize."""
+
+    def __init__(self, message: str, *, error_code: int) -> None:
+        super().__init__(message)
+        self.error_code = error_code

--- a/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
@@ -25,6 +25,23 @@ class BotRepository(Protocol):
         """Get bot by bot_id and owner_id."""
         ...
 
+    def get_live_by_id_owner_and_env(
+        self, *, bot_id: str, owner_id: str, env: str
+    ) -> list[dict[str, Any]]:
+        """Get all live exact matches in an explicitly selected environment."""
+        ...
+
+    def update_ext_by_id_owner_and_env(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+        ext: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Update ``ext`` only when exactly one live explicit-env row matches."""
+        ...
+
     def get_by_id(self, bot_id: str) -> Optional[Dict[str, Any]]:
         """Get bot by bot_id only (no owner check).
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
@@ -1,0 +1,331 @@
+"""Repair control-plane Passport state for an existing default bot."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from threading import Lock
+from typing import Any
+
+from agentclaw.community.core.bot_management.errors import (
+    DefaultBotPassportRepairError,
+)
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.mcp.services._defaults import get_default_cli_items
+from agentclaw.community.core.mcp.services.passport_scope import (
+    filter_passport_mcp_codes,
+)
+from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
+from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
+from agentclaw.community.plugin_api.passport import PassportPlugin
+
+
+class DefaultBotPassportRepairService:
+    """Repair Passport and owner authorization without touching bot runtime."""
+
+    def __init__(
+        self,
+        *,
+        repository: BotRepository,
+        passport_plugin: PassportPlugin,
+        auth_relationship_plugin: AuthRelationshipPlugin,
+        skill_set_factory: SkillSetServiceFactory,
+    ) -> None:
+        self._repository = repository
+        self._passport_plugin = passport_plugin
+        self._auth_relationship_plugin = auth_relationship_plugin
+        self._skill_set_factory = skill_set_factory
+        self._target_locks_guard = Lock()
+        self._target_locks: dict[tuple[str, str, str], Any] = {}
+
+    def repair(
+        self,
+        *,
+        target_user_id: str,
+        target_env: str,
+        operator_user_id: str,
+        operator_name: str,
+    ) -> dict[str, Any]:
+        if target_env not in {"pre", "prod"}:
+            raise DefaultBotPassportRepairError(
+                "target_env must be pre or prod", error_code=400
+            )
+        lock_key = (target_env, target_user_id, "default")
+        with self._target_locks_guard:
+            target_lock = self._target_locks.get(lock_key)
+            if target_lock is None:
+                target_lock = Lock()
+                self._target_locks[lock_key] = target_lock
+        with target_lock:
+            return self._repair_target(
+                target_user_id=target_user_id,
+                target_env=target_env,
+                operator_user_id=operator_user_id,
+                operator_name=operator_name,
+            )
+
+    def _repair_target(
+        self,
+        *,
+        target_user_id: str,
+        target_env: str,
+        operator_user_id: str,
+        operator_name: str,
+    ) -> dict[str, Any]:
+        bots = self._repository.get_live_by_id_owner_and_env(
+            bot_id="default",
+            owner_id=target_user_id,
+            env=target_env,
+        )
+        if not bots:
+            raise DefaultBotPassportRepairError(
+                "default bot not found in target environment", error_code=404
+            )
+        if len(bots) != 1:
+            raise DefaultBotPassportRepairError(
+                "multiple live default bots found in target environment",
+                error_code=409,
+            )
+        bot = bots[0]
+
+        try:
+            passport = self._passport_plugin.query_agent_passport(
+                bot_id="default",
+                owner_workno=target_user_id,
+            )
+            auth_status = self._passport_plugin.query_auth_status(
+                bot_id="default",
+                owner_workno=target_user_id,
+            )
+            token = self._passport_plugin.query_token(
+                bot_id="default",
+                owner_workno=target_user_id,
+            )
+        except Exception as exc:
+            raise DefaultBotPassportRepairError(
+                "Passport query failed", error_code=5400
+            ) from exc
+
+        source = "existing"
+        if not self._passport_complete(passport, auth_status, token):
+            try:
+                skill_set_service = self._skill_set_factory.create(
+                    user_id=target_user_id,
+                    entity_id=bot.get("entity_id") or target_user_id,
+                    bot_id="default",
+                    entity_type=bot.get("entity_type") or "staff",
+                    engine_type=bot.get("active_engine"),
+                )
+                mcp_codes = skill_set_service.get_bot_mcp_codes_for_env(
+                    entity_id=bot.get("entity_id") or target_user_id,
+                    bot_id="default",
+                    user_id=target_user_id,
+                    entity_type=bot.get("entity_type") or "staff",
+                    engine_type=bot.get("active_engine"),
+                    target_env=target_env,
+                )
+                mcp_codes = filter_passport_mcp_codes(mcp_codes)
+                apply_result = self._passport_plugin.apply_first_agent_passport(
+                    bot_id="default",
+                    owner_workno=target_user_id,
+                    mcp_codes=mcp_codes,
+                    cli_items=get_default_cli_items(
+                        bot.get("active_engine"), bot.get("template_type")
+                    ),
+                    bot_name=bot.get("bot_name"),
+                    bot_desc=bot.get("bot_desc"),
+                    engine_type=bot.get("active_engine"),
+                    access_mode="RESTRICTED",
+                    workspace_path="/home/admin/.openclaw",
+                )
+            except Exception as exc:
+                raise DefaultBotPassportRepairError(
+                    "Passport first apply failed", error_code=5400
+                ) from exc
+            if not isinstance(apply_result, Mapping) or not apply_result.get("token"):
+                raise DefaultBotPassportRepairError(
+                    "apply_first_agent_passport returned no token", error_code=5401
+                )
+
+            try:
+                passport = self._passport_plugin.query_agent_passport(
+                    bot_id="default",
+                    owner_workno=target_user_id,
+                )
+                auth_status = self._passport_plugin.query_auth_status(
+                    bot_id="default",
+                    owner_workno=target_user_id,
+                )
+                token = self._passport_plugin.query_token(
+                    bot_id="default",
+                    owner_workno=target_user_id,
+                )
+            except Exception as exc:
+                raise DefaultBotPassportRepairError(
+                    "Passport verification query failed", error_code=5400
+                ) from exc
+            applied_agent_code = apply_result.get("agent_code")
+            queried_agent_code = (
+                passport.get("agent_code") if isinstance(passport, Mapping) else None
+            )
+            if applied_agent_code and applied_agent_code != queried_agent_code:
+                raise DefaultBotPassportRepairError(
+                    "Passport agent_code verification failed", error_code=5400
+                )
+            source = "applied"
+
+        if not self._passport_complete(passport, auth_status, token):
+            raise DefaultBotPassportRepairError(
+                "Passport verification failed", error_code=5400
+            )
+
+        assert isinstance(passport, Mapping)
+        agent_code = str(passport["agent_code"])
+        ext = dict(bot.get("ext") or {})
+        ext_passport = dict(ext.get("passport") or {})
+        database_changed = ext_passport.get("agent_code") != agent_code
+        ext_passport["agent_code"] = agent_code
+        ext["passport"] = ext_passport
+        try:
+            if database_changed:
+                self._repository.update_ext_by_id_owner_and_env(
+                    bot_id="default",
+                    owner_id=target_user_id,
+                    env=target_env,
+                    ext=ext,
+                )
+            persisted_matches = self._repository.get_live_by_id_owner_and_env(
+                bot_id="default",
+                owner_id=target_user_id,
+                env=target_env,
+            )
+            if len(persisted_matches) != 1:
+                raise RuntimeError("database read-back did not return one row")
+            persisted = persisted_matches[0]
+        except Exception as exc:
+            raise DefaultBotPassportRepairError(
+                "Bot Passport agent_code persistence failed", error_code=500
+            ) from exc
+        persisted_agent_code = ((persisted.get("ext") or {}).get("passport") or {}).get(
+            "agent_code"
+        )
+        if persisted_agent_code != agent_code:
+            raise DefaultBotPassportRepairError(
+                "Bot Passport agent_code persistence verification failed",
+                error_code=500,
+            )
+
+        try:
+            relationships = self._auth_relationship_plugin.query_relationships_for_env(
+                target_env=target_env,
+                agent_code=agent_code,
+                work_no=target_user_id,
+            )
+            created = False
+            if not self._has_owner_relationship(
+                relationships, work_no=target_user_id, agent_code=agent_code
+            ):
+                self._auth_relationship_plugin.create_relationship_for_env(
+                    target_env=target_env,
+                    work_no=target_user_id,
+                    agent_code=agent_code,
+                    description="Bot owner default authorization",
+                    operator_work_no=operator_user_id,
+                    operator_name=operator_name,
+                )
+                relationships = (
+                    self._auth_relationship_plugin.query_relationships_for_env(
+                        target_env=target_env,
+                        agent_code=agent_code,
+                        work_no=target_user_id,
+                    )
+                )
+                created = True
+        except Exception as exc:
+            raise DefaultBotPassportRepairError(
+                "Owner authorization relationship operation failed",
+                error_code=5402,
+            ) from exc
+        relationship = self._find_owner_relationship(
+            relationships, work_no=target_user_id, agent_code=agent_code
+        )
+        if relationship is None:
+            raise DefaultBotPassportRepairError(
+                "Owner authorization relationship verification failed",
+                error_code=5402,
+            )
+
+        return {
+            "target_user_id": target_user_id,
+            "bot_id": "default",
+            "action": (
+                "repaired"
+                if source == "applied" or created or database_changed
+                else "verified"
+            ),
+            "target_env": target_env,
+            "passport": {
+                "status": auth_status["status"],
+                "agent_code": agent_code,
+                "credential_id": passport["credential_id"],
+                "token_present": bool(token),
+                "source": source,
+            },
+            "owner_relationship": {
+                "verified": True,
+                "created": created,
+                "auth_id": relationship.get("auth_id", relationship.get("authId")),
+            },
+            "database": {"ext_agent_code_verified": True},
+            "runtime": {
+                "restart_required": True,
+                "restart_environment": target_env,
+            },
+        }
+
+    @staticmethod
+    def _passport_complete(
+        passport: object, auth_status: object, token: object
+    ) -> bool:
+        return bool(
+            isinstance(passport, Mapping)
+            and passport.get("agent_code")
+            and passport.get("credential_id")
+            and isinstance(auth_status, Mapping)
+            and auth_status.get("status") == "ISSUED"
+            and token
+        )
+
+    @classmethod
+    def _has_owner_relationship(
+        cls,
+        relationships: object,
+        *,
+        work_no: str,
+        agent_code: str,
+    ) -> bool:
+        return (
+            cls._find_owner_relationship(
+                relationships, work_no=work_no, agent_code=agent_code
+            )
+            is not None
+        )
+
+    @staticmethod
+    def _find_owner_relationship(
+        relationships: object,
+        *,
+        work_no: str,
+        agent_code: str,
+    ) -> Mapping[str, Any] | None:
+        if not isinstance(relationships, list):
+            return None
+        for relationship in relationships:
+            if not isinstance(relationship, Mapping):
+                continue
+            actual_work_no = relationship.get("work_no", relationship.get("workNo"))
+            actual_agent_code = relationship.get(
+                "agent_code", relationship.get("agentCode")
+            )
+            if str(actual_work_no) == work_no and actual_agent_code == agent_code:
+                return relationship
+        return None

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
@@ -106,14 +106,17 @@ class DefaultBotPassportRepairService:
             passport = self._passport_plugin.query_agent_passport(
                 bot_id="default",
                 owner_workno=target_user_id,
+                target_env=target_env,
             )
             auth_status = self._passport_plugin.query_auth_status(
                 bot_id="default",
                 owner_workno=target_user_id,
+                target_env=target_env,
             )
             token = self._passport_plugin.query_token(
                 bot_id="default",
                 owner_workno=target_user_id,
+                target_env=target_env,
             )
         except Exception as exc:
             raise DefaultBotPassportRepairError(
@@ -151,6 +154,7 @@ class DefaultBotPassportRepairService:
                     engine_type=bot.get("active_engine"),
                     access_mode="RESTRICTED",
                     workspace_path="/home/admin/.openclaw",
+                    target_env=target_env,
                 )
             except Exception as exc:
                 raise DefaultBotPassportRepairError(
@@ -165,14 +169,17 @@ class DefaultBotPassportRepairService:
                 passport = self._passport_plugin.query_agent_passport(
                     bot_id="default",
                     owner_workno=target_user_id,
+                    target_env=target_env,
                 )
                 auth_status = self._passport_plugin.query_auth_status(
                     bot_id="default",
                     owner_workno=target_user_id,
+                    target_env=target_env,
                 )
                 token = self._passport_plugin.query_token(
                     bot_id="default",
                     owner_workno=target_user_id,
+                    target_env=target_env,
                 )
             except Exception as exc:
                 raise DefaultBotPassportRepairError(

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
@@ -19,6 +19,14 @@ from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlu
 from agentclaw.community.plugin_api.passport import PassportPlugin
 
 
+class _TargetLockEntry:
+    """One keyed repair lock and the number of callers using or waiting on it."""
+
+    def __init__(self) -> None:
+        self.lock = Lock()
+        self.users = 0
+
+
 class DefaultBotPassportRepairService:
     """Repair Passport and owner authorization without touching bot runtime."""
 
@@ -35,7 +43,7 @@ class DefaultBotPassportRepairService:
         self._auth_relationship_plugin = auth_relationship_plugin
         self._skill_set_factory = skill_set_factory
         self._target_locks_guard = Lock()
-        self._target_locks: dict[tuple[str, str, str], Any] = {}
+        self._target_locks: dict[tuple[str, str, str], _TargetLockEntry] = {}
 
     def repair(
         self,
@@ -51,17 +59,24 @@ class DefaultBotPassportRepairService:
             )
         lock_key = (target_env, target_user_id, "default")
         with self._target_locks_guard:
-            target_lock = self._target_locks.get(lock_key)
-            if target_lock is None:
-                target_lock = Lock()
-                self._target_locks[lock_key] = target_lock
-        with target_lock:
-            return self._repair_target(
-                target_user_id=target_user_id,
-                target_env=target_env,
-                operator_user_id=operator_user_id,
-                operator_name=operator_name,
-            )
+            lock_entry = self._target_locks.get(lock_key)
+            if lock_entry is None:
+                lock_entry = _TargetLockEntry()
+                self._target_locks[lock_key] = lock_entry
+            lock_entry.users += 1
+        try:
+            with lock_entry.lock:
+                return self._repair_target(
+                    target_user_id=target_user_id,
+                    target_env=target_env,
+                    operator_user_id=operator_user_id,
+                    operator_name=operator_name,
+                )
+        finally:
+            with self._target_locks_guard:
+                lock_entry.users -= 1
+                if lock_entry.users == 0:
+                    self._target_locks.pop(lock_key, None)
 
     def _repair_target(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
@@ -153,6 +153,12 @@ class SkillSetRepository(Protocol):
     def get_mcp_servers_in_set(self, skill_set_id: str) -> list[dict]:
         ...
 
+    def get_mcp_servers_in_set_for_env(
+        self, skill_set_id: str, *, env: str
+    ) -> list[dict]:
+        """Return associations belonging to one explicit environment."""
+        ...
+
     def remove_mcp_from_set(self, skill_set_id: str, server_code: str) -> bool:
         ...
 
@@ -187,6 +193,17 @@ class SkillSetRepository(Protocol):
         bolt_id: str | None = None,
         engine_type: str | None = None,
     ) -> list[dict]:
+        ...
+
+    def get_all_active_skill_sets_for_env(
+        self,
+        *,
+        user_id: str | None = None,
+        bolt_id: str | None = None,
+        engine_type: str | None = None,
+        env: str,
+    ) -> list[dict]:
+        """Return active sets using an explicit environment, never runtime env."""
         ...
 
     def activate_skill_set(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1688,6 +1688,48 @@ class SkillSetService:
         mcps = self.collect_bot_active_mcps(entity_id, bot_id, user_id, entity_type, engine_type)
         return [m.get("server_code") for m in mcps if m.get("server_code")]
 
+    def get_bot_mcp_codes_for_env(
+        self,
+        entity_id: str,
+        bot_id: str,
+        user_id: str,
+        entity_type: str,
+        engine_type: str | None,
+        target_env: str,
+    ) -> list[str]:
+        """Collect Passport MCP scope from explicitly env-scoped skill-set data."""
+        if target_env not in {"pre", "prod"}:
+            raise ValueError("target_env must be pre or prod")
+        effective_engine = engine_type if engine_type is not None else self.engine_type
+        active_skill_sets = self.skill_set_repo.get_all_active_skill_sets_for_env(
+            user_id=entity_id,
+            bolt_id=bot_id,
+            engine_type=effective_engine,
+            env=target_env,
+        )
+
+        codes: list[str] = []
+        seen: set[str] = set()
+        for skill_set in active_skill_sets:
+            associations = self.skill_set_repo.get_mcp_servers_in_set_for_env(
+                str(skill_set["id"]), env=target_env
+            )
+            for association in associations:
+                code = association.get("server_code")
+                if code and code not in seen:
+                    seen.add(code)
+                    codes.append(code)
+
+        excluded_codes = set(
+            self.skill_set_repo.get_all_excluded_mcps(user_id, bot_id)
+        )
+        for default_mcp in get_default_mcp_servers(effective_engine):
+            code = default_mcp["server_code"]
+            if code not in excluded_codes and code not in seen:
+                seen.add(code)
+                codes.append(code)
+        return codes
+
     def get_active_skill_sets_mcp_summary(
         self,
         entity_id: str,

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -31,6 +31,9 @@ from injector import (
 
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.api.data_init_service import DataInitServiceProtocol
+from agentclaw.community.api.default_bot_passport_repair_service import (
+    DefaultBotPassportRepairServiceProtocol,
+)
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
 from agentclaw.community.api.render_screen_service import RenderScreenServiceProtocol
 from agentclaw.community.core.bot_collaborator.protocols import (
@@ -50,6 +53,9 @@ from agentclaw.community.core.bot_management.services.bcn_service import BcnServ
 from agentclaw.community.core.bot_management.services.bot_service import BotService
 from agentclaw.community.core.bot_management.services.cleanup_service import BotCleanupService
 from agentclaw.community.core.bot_management.services.data_init_service import DataInitService
+from agentclaw.community.core.bot_management.services.default_bot_passport_repair_service import (
+    DefaultBotPassportRepairService,
+)
 from agentclaw.community.core.bot_management.services.aicoding.workspace_hosting_service import WorkspaceHostingService
 from agentclaw.community.core.bot_management.services.teclaw_provision_service import (
     TeclawProvisionService,
@@ -91,6 +97,7 @@ from agentclaw.community.log import get_logger
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.drm import DRMReaderPlugin
+from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
 from agentclaw.community.plugin_api.http_client import QUALIFIER_BCN, HttpClient
 from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
@@ -187,6 +194,8 @@ class BotManagementModule(Module):
             {
                 "insert": "BotRepository create/read/search/update/delete",
                 "get_by_id_and_owner": "BotRepository create/read/search/update/delete",
+                "get_live_by_id_owner_and_env": "BotRepository explicit-env passport repair",
+                "update_ext_by_id_owner_and_env": "BotRepository explicit-env passport repair",
                 "get_by_id": "BotRepository create/read/search/update/delete",
                 "list_by_owner": "BotRepository create/read/search/update/delete",
                 "list_by_owner_or_collaborator": "BotRepository create/read/search/update/delete",
@@ -205,6 +214,23 @@ class BotManagementModule(Module):
                 "get_device_provider_by_bot_id": "BotRepository create/read/search/update/delete",
                 "search_bots": "BotRepository create/read/search/update/delete",
             },
+        )
+
+    @singleton
+    @provider
+    @inject
+    def default_bot_passport_repair_service(
+        self,
+        repository: BotRepository,
+        passport_plugin: PassportPlugin,
+        auth_relationship_plugin: AuthRelationshipPlugin,
+        skill_set_factory: SkillSetServiceFactory,
+    ) -> DefaultBotPassportRepairServiceProtocol:
+        return DefaultBotPassportRepairService(
+            repository=repository,
+            passport_plugin=passport_plugin,
+            auth_relationship_plugin=auth_relationship_plugin,
+            skill_set_factory=skill_set_factory,
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/plugin_api/auth_relationship.py
+++ b/src/backend/src/agentclaw/community/plugin_api/auth_relationship.py
@@ -14,6 +14,12 @@ class AuthRelationshipError(Exception):
     pass
 
 
+def validate_auth_relationship_target_env(target_env: str) -> None:
+    """Fail closed before routing an explicit-environment AceAgent call."""
+    if target_env not in {"pre", "prod"}:
+        raise ValueError("target_env must be pre or prod")
+
+
 @runtime_checkable
 class AuthRelationshipPlugin(Plugin, Protocol):
     """Plugin for user-agent authorization relationship management."""
@@ -33,6 +39,20 @@ class AuthRelationshipPlugin(Plugin, Protocol):
         """
         ...
 
+    def create_relationship_for_env(
+        self,
+        *,
+        target_env: str,
+        work_no: str,
+        agent_code: str,
+        operator_work_no: str,
+        operator_name: str,
+        source: str = "tcauthmng",
+        description: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Create a relationship through the explicitly selected environment."""
+        ...
+
     def query_relationships(
         self,
         agent_code: str,
@@ -45,6 +65,19 @@ class AuthRelationshipPlugin(Plugin, Protocol):
 
         Returns a list of AuthRelationshipResult dicts.
         """
+        ...
+
+    def query_relationships_for_env(
+        self,
+        *,
+        target_env: str,
+        agent_code: str,
+        source: str = "tcauthmng",
+        work_no: str | None = None,
+        page_num: int = 1,
+        page_size: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Query relationships through the explicitly selected environment."""
         ...
 
     def delete_relationship(

--- a/src/backend/src/agentclaw/community/plugin_api/passport.py
+++ b/src/backend/src/agentclaw/community/plugin_api/passport.py
@@ -17,6 +17,12 @@ class PassportError(Exception):
     pass
 
 
+def validate_passport_target_env(target_env: str | None) -> None:
+    """Validate an explicitly selected Passport environment."""
+    if target_env is not None and target_env not in {"pre", "prod"}:
+        raise ValueError("target_env must be 'pre' or 'prod'")
+
+
 @dataclass
 class SubResourceItem:
     """Neutral second-level resource item for :meth:`PassportPlugin.save_sub_resources`.
@@ -124,6 +130,8 @@ class PassportPlugin(Plugin, Protocol):
         workspace_path: str | None = None,
         admins: list[str] | None = None,
         cli_items: list[CliItem] | None = None,
+        *,
+        target_env: str | None = None,
     ) -> dict[str, Any] | None:
         """Apply for an agent passport (first time)."""
         ...
@@ -150,15 +158,33 @@ class PassportPlugin(Plugin, Protocol):
         """Destroy the passport for a bot."""
         ...
 
-    def query_auth_status(self, bot_id: str, owner_workno: str) -> dict[str, Any] | None:
+    def query_auth_status(
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: str | None = None,
+    ) -> dict[str, Any] | None:
         """Query the current passport auth status."""
         ...
 
-    def query_token(self, bot_id: str, owner_workno: str) -> str | None:
+    def query_token(
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: str | None = None,
+    ) -> str | None:
         """Query the current passport token."""
         ...
 
-    def query_agent_passport(self, bot_id: str, owner_workno: str) -> dict[str, Any] | None:
+    def query_agent_passport(
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: str | None = None,
+    ) -> dict[str, Any] | None:
         """Query the full agent passport details."""
         ...
 

--- a/src/backend/src/agentclaw/community/plugins/bot_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_repository.py
@@ -148,6 +148,55 @@ class BotRepository:
             )
             return bot.to_dict() if bot else None
 
+    def get_live_by_id_owner_and_env(
+        self, *, bot_id: str, owner_id: str, env: str
+    ) -> list[dict[str, Any]]:
+        """Return every live exact match without consulting runtime env."""
+        with self._db.orm_session() as db:
+            bots = (
+                db.query(self.Model)
+                .filter(
+                    self.Model.bot_id == bot_id,
+                    self.Model.owner_id == owner_id,
+                    self.Model.is_delete == 0,
+                    self.Model.env == env,
+                )
+                .order_by(self.Model.id.asc())
+                .all()
+            )
+            return [bot.to_dict() for bot in bots]
+
+    def update_ext_by_id_owner_and_env(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+        ext: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Atomically update one live exact-env row or roll back."""
+        with self._db.orm_session() as db:
+            exact = db.query(self.Model).filter(
+                self.Model.bot_id == bot_id,
+                self.Model.owner_id == owner_id,
+                self.Model.is_delete == 0,
+                self.Model.env == env,
+            )
+            rowcount = exact.update(
+                {
+                    self.Model.ext: json.dumps(ext),
+                    self.Model.gmt_modified: func.now(),
+                },
+                synchronize_session=False,
+            )
+            if rowcount != 1:
+                raise RuntimeError(
+                    "explicit-env bot ext update must affect exactly one live row; "
+                    f"affected={rowcount}"
+                )
+            bot = exact.one()
+            return bot.to_dict()
+
     def get_by_id(self, bot_id: str) -> Optional[Dict[str, Any]]:
         """Query bot by bot_id only (no owner check).
 

--- a/src/backend/src/agentclaw/community/plugins/community/auth_relationship.py
+++ b/src/backend/src/agentclaw/community/plugins/community/auth_relationship.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
+from agentclaw.community.plugin_api.auth_relationship import (
+    AuthRelationshipPlugin,
+    validate_auth_relationship_target_env,
+)
 
 
 class CommunityAuthRelationshipPlugin(AuthRelationshipPlugin):
@@ -30,6 +33,27 @@ class CommunityAuthRelationshipPlugin(AuthRelationshipPlugin):
     ) -> dict[str, Any] | None:
         return {"auth_id": 0}
 
+    def create_relationship_for_env(
+        self,
+        *,
+        target_env: str,
+        work_no: str,
+        agent_code: str,
+        operator_work_no: str,
+        operator_name: str,
+        source: str = "tcauthmng",
+        description: str | None = None,
+    ) -> dict[str, Any] | None:
+        validate_auth_relationship_target_env(target_env)
+        return self.create_relationship(
+            work_no=work_no,
+            agent_code=agent_code,
+            operator_work_no=operator_work_no,
+            operator_name=operator_name,
+            source=source,
+            description=description,
+        )
+
     def query_relationships(
         self,
         agent_code: str,
@@ -39,6 +63,25 @@ class CommunityAuthRelationshipPlugin(AuthRelationshipPlugin):
         page_size: int = 100,
     ) -> list[dict[str, Any]]:
         return []
+
+    def query_relationships_for_env(
+        self,
+        *,
+        target_env: str,
+        agent_code: str,
+        source: str = "tcauthmng",
+        work_no: str | None = None,
+        page_num: int = 1,
+        page_size: int = 100,
+    ) -> list[dict[str, Any]]:
+        validate_auth_relationship_target_env(target_env)
+        return self.query_relationships(
+            agent_code=agent_code,
+            source=source,
+            work_no=work_no,
+            page_num=page_num,
+            page_size=page_size,
+        )
 
     def delete_relationship(
         self,

--- a/src/backend/src/agentclaw/community/plugins/community/passport.py
+++ b/src/backend/src/agentclaw/community/plugins/community/passport.py
@@ -23,6 +23,7 @@ from agentclaw.community.plugin_api.passport import (
     SubResourceItem,
     extract_cli_items,
     unpack_resource_scope,
+    validate_passport_target_env,
 )
 
 
@@ -67,7 +68,10 @@ class SelfIssuedPassportPlugin(PassportPlugin):
         workspace_path: Optional[str] = None,
         admins: Optional[list[str]] = None,
         cli_items: Optional[list[CliItem]] = None,
+        *,
+        target_env: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
+        validate_passport_target_env(target_env)
         return self._issue(bot_id)
 
     def apply_agent_passport(
@@ -92,16 +96,33 @@ class SelfIssuedPassportPlugin(PassportPlugin):
         return None
 
     def query_auth_status(
-        self, bot_id: str, owner_workno: str
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
+        validate_passport_target_env(target_env)
         return {"status": "ISSUED", "token": _token_for(bot_id)}
 
-    def query_token(self, bot_id: str, owner_workno: str) -> Optional[str]:
+    def query_token(
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: Optional[str] = None,
+    ) -> Optional[str]:
+        validate_passport_target_env(target_env)
         return _token_for(bot_id)
 
     def query_agent_passport(
-        self, bot_id: str, owner_workno: str
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
+        validate_passport_target_env(target_env)
         return {
             "agent_id": bot_id,
             "agent_code": bot_id,

--- a/src/backend/src/agentclaw/community/plugins/local/auth_relationship.py
+++ b/src/backend/src/agentclaw/community/plugins/local/auth_relationship.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from typing import Any
 
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
+from agentclaw.community.plugin_api.auth_relationship import (
+    AuthRelationshipPlugin,
+    validate_auth_relationship_target_env,
+)
 from agentclaw.community.plugin_api.impl_registry import Flavor, Mode, plugin_impl
 from agentclaw.community.plugins.local._mock_seam import MockSeam
 
@@ -34,6 +37,27 @@ class LocalAuthRelationshipPlugin(MockSeam, AuthRelationshipPlugin):
         )
         return {"auth_id": 0}
 
+    def create_relationship_for_env(
+        self,
+        *,
+        target_env: str,
+        work_no: str,
+        agent_code: str,
+        operator_work_no: str,
+        operator_name: str,
+        source: str = "tcauthmng",
+        description: str | None = None,
+    ) -> dict[str, Any] | None:
+        validate_auth_relationship_target_env(target_env)
+        return self.create_relationship(
+            work_no=work_no,
+            agent_code=agent_code,
+            operator_work_no=operator_work_no,
+            operator_name=operator_name,
+            source=source,
+            description=description,
+        )
+
     def query_relationships(
         self,
         agent_code: str,
@@ -47,6 +71,25 @@ class LocalAuthRelationshipPlugin(MockSeam, AuthRelationshipPlugin):
             agent_code, work_no,
         )
         return []
+
+    def query_relationships_for_env(
+        self,
+        *,
+        target_env: str,
+        agent_code: str,
+        source: str = "tcauthmng",
+        work_no: str | None = None,
+        page_num: int = 1,
+        page_size: int = 100,
+    ) -> list[dict[str, Any]]:
+        validate_auth_relationship_target_env(target_env)
+        return self.query_relationships(
+            agent_code=agent_code,
+            source=source,
+            work_no=work_no,
+            page_num=page_num,
+            page_size=page_size,
+        )
 
     def delete_relationship(
         self,

--- a/src/backend/src/agentclaw/community/plugins/local/passport.py
+++ b/src/backend/src/agentclaw/community/plugins/local/passport.py
@@ -12,6 +12,7 @@ from agentclaw.community.plugin_api.passport import (
     SubResourceItem,
     extract_cli_items,
     unpack_resource_scope,
+    validate_passport_target_env,
 )
 from agentclaw.community.plugins.local._mock_seam import MockSeam
 
@@ -71,7 +72,10 @@ class LocalPassportPlugin(MockSeam, PassportPlugin):
         workspace_path: str | None = None,
         admins: list[str] | None = None,
         cli_items: list[CliItem] | None = None,
+        *,
+        target_env: str | None = None,
     ) -> dict[str, Any] | None:
+        validate_passport_target_env(target_env)
         logger.info(
             "[LocalPassportUpdate] apply_first_agent_passport: bot_id=%s, "
             "owner_workno=%s, engine_type=%s, access_mode=%s, device_token=%s, "
@@ -134,7 +138,14 @@ class LocalPassportPlugin(MockSeam, PassportPlugin):
             owner_workno,
         )
 
-    def query_auth_status(self, bot_id: str, owner_workno: str) -> dict[str, Any] | None:
+    def query_auth_status(
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: str | None = None,
+    ) -> dict[str, Any] | None:
+        validate_passport_target_env(target_env)
         logger.info(
             "[LocalPassportUpdate] query_auth_status: bot_id=%s, owner_workno=%s",
             bot_id,
@@ -145,7 +156,14 @@ class LocalPassportPlugin(MockSeam, PassportPlugin):
             "token": f"mock_token_status_{bot_id}",
         }
 
-    def query_token(self, bot_id: str, owner_workno: str) -> str | None:
+    def query_token(
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: str | None = None,
+    ) -> str | None:
+        validate_passport_target_env(target_env)
         logger.info(
             "[LocalPassportUpdate] query_token: bot_id=%s, owner_workno=%s",
             bot_id,
@@ -153,7 +171,14 @@ class LocalPassportPlugin(MockSeam, PassportPlugin):
         )
         return f"mock_token_{bot_id}"
 
-    def query_agent_passport(self, bot_id: str, owner_workno: str) -> dict[str, Any] | None:
+    def query_agent_passport(
+        self,
+        bot_id: str,
+        owner_workno: str,
+        *,
+        target_env: str | None = None,
+    ) -> dict[str, Any] | None:
+        validate_passport_target_env(target_env)
         logger.info(
             "[LocalPassportUpdate] query_agent_passport: bot_id=%s, owner_workno=%s",
             bot_id,

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -1177,6 +1177,21 @@ class SkillSetRepository:
             )
             return [_mcp_assoc_to_dict(m) for m in rows]
 
+    def get_mcp_servers_in_set_for_env(
+        self, skill_set_id: str, *, env: str
+    ) -> list[dict]:
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(self.SkillSetMCPServer)
+                .filter(
+                    self.SkillSetMCPServer.skill_set_id == int(skill_set_id),
+                    self.SkillSetMCPServer.env == env,
+                )
+                .order_by(self.SkillSetMCPServer.gmt_created)
+                .all()
+            )
+            return [_mcp_assoc_to_dict(m) for m in rows]
+
     def remove_mcp_from_set(
         self, skill_set_id: str, server_code: str
     ) -> bool:
@@ -1676,6 +1691,42 @@ class SkillSetRepository:
             )
             if enabled is None or enabled == 1:
                 active_sets.append(default_set)
+        return active_sets
+
+    def get_all_active_skill_sets_for_env(
+        self,
+        *,
+        user_id: Optional[str] = None,
+        bolt_id: Optional[str] = None,
+        engine_type: Optional[str] = None,
+        env: str,
+    ) -> List[dict]:
+        effective_bolt_id = bolt_id if bolt_id else "default"
+        parsed = _normalize_user_id(user_id)
+        active_sets: list[dict] = []
+        with self._db.orm_session() as db:
+            query = db.query(self.SkillSet).filter(
+                self.SkillSet.is_active == True,  # noqa: E712
+                self.SkillSet.is_default == False,  # noqa: E712
+                self.SkillSet.env == env,
+                self.SkillSet.bolt_id == effective_bolt_id,
+            )
+            if engine_type is not None:
+                query = query.filter(self.SkillSet.engine_type == engine_type)
+            if user_id:
+                query = query.filter(self.SkillSet.user_id == parsed)
+            else:
+                query = query.filter(self.SkillSet.user_id.is_(None))
+            active_sets.extend(_skill_set_to_dict(ss) for ss in query.all())
+
+        default_set = self.get_default(
+            user_id=None,
+            bolt_id=None,
+            engine_type=engine_type,
+            env=env,
+        )
+        if default_set:
+            active_sets.append(default_set)
         return active_sets
 
     def _get_user_default_enabled(

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -36,14 +36,23 @@ def _bind_bot_service(
     auth_rel=None,
     skill_set_factory=None,
     policy_service=None,
+    default_bot_passport_repair_service=None,
 ):
     from agentclaw.community.core.bot_management.repository.protocol import BotRepository
     from agentclaw.community.api.bot_service import BotServiceProtocol
+    from agentclaw.community.api.default_bot_passport_repair_service import (
+        DefaultBotPassportRepairServiceProtocol,
+    )
 
     class _M(Module):
         def configure(self, binder):
             binder.bind(BotService, to=svc)
             binder.bind(BotServiceProtocol, to=svc)
+            if default_bot_passport_repair_service is not None:
+                binder.bind(
+                    DefaultBotPassportRepairServiceProtocol,
+                    to=default_bot_passport_repair_service,
+                )
             if bot_repo is not None:
                 binder.bind(BotRepository, to=bot_repo)
             if passport is not None:
@@ -159,6 +168,8 @@ def client(mock_bot_service, mock_passport):
             requested_entity_id, requested_entity_type,
         )
     )
+    repair_service = MagicMock()
+    app.state.default_bot_passport_repair_service = repair_service
     attach_injector(app, Injector([_bind_bot_service(
         mock_bot_service,
         bot_repo=MagicMock(),
@@ -166,6 +177,7 @@ def client(mock_bot_service, mock_passport):
         auth=mock_auth,
         auth_rel=MagicMock(),
         skill_set_factory=_stub_skill_set_factory(),
+        default_bot_passport_repair_service=repair_service,
     )]))
 
     with patch.object(router_module, "generate_bot_id", return_value="default"):
@@ -187,6 +199,8 @@ def admin_client(mock_bot_service, mock_passport):
     app.dependency_overrides[get_request_context] = lambda: _make_ctx(user_id=admin_id)
     mock_repo = MagicMock()
     mock_repo.exists_by_owner_and_bot_id.return_value = False
+    repair_service = MagicMock()
+    app.state.default_bot_passport_repair_service = repair_service
     attach_injector(app, Injector([_bind_bot_service(
         mock_bot_service,
         bot_repo=mock_repo,
@@ -194,6 +208,7 @@ def admin_client(mock_bot_service, mock_passport):
         auth=MagicMock(),
         auth_rel=MagicMock(),
         skill_set_factory=_stub_skill_set_factory(),
+        default_bot_passport_repair_service=repair_service,
     )]))
 
     with patch.object(router_module, "generate_bot_id", return_value="default"):
@@ -1024,6 +1039,121 @@ class TestCreateForOthers:
         svc.create_bot.side_effect = DeviceAllocationError("alloc fail")
         resp = tc.post("/api/bots/create-for-others", json={"target_user_id": "u1", "target_nick_name": "Alice"})
         assert resp.json()["error_code"] == 500
+
+
+# ---------------------------------------------------------------------------
+# POST /api/bots/repair-default-passport-for-others  (admin only)
+# ---------------------------------------------------------------------------
+
+class TestRepairDefaultPassportForOthers:
+    def test_permission_denied(self, client):
+        tc, _, _ = client
+        resp = tc.post(
+            "/api/bots/repair-default-passport-for-others",
+            json={"target_user_id": "172168", "target_env": "prod"},
+        )
+        assert resp.json()["error_code"] == 403
+
+    def test_success_forwards_trimmed_target_and_authenticated_operator(
+        self, admin_client
+    ):
+        tc, _, _, _ = admin_client
+        repair_service = tc.app.state.default_bot_passport_repair_service
+        repair_service.repair.return_value = {
+            "target_user_id": "172168",
+            "bot_id": "default",
+            "target_env": "prod",
+            "action": "repaired",
+            "runtime": {
+                "restart_required": True,
+                "restart_environment": "prod",
+            },
+        }
+
+        resp = tc.post(
+            "/api/bots/repair-default-passport-for-others",
+            json={"target_user_id": " 172168 ", "target_env": "prod"},
+        )
+
+        data = resp.json()
+        assert data["success"] is True
+        assert data["data"]["bot_id"] == "default"
+        assert data["data"]["runtime"]["restart_required"] is True
+        repair_service.repair.assert_called_once_with(
+            target_user_id="172168",
+            target_env="prod",
+            operator_user_id="100000",
+            operator_name="Test User",
+        )
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"target_user_id": "172168"},
+            {"target_user_id": "172168", "target_env": "gray"},
+            {"target_user_id": " ", "target_env": "prod"},
+            {
+                "target_user_id": "172168",
+                "target_env": "prod",
+                "bot_id": "another-bot",
+            },
+        ],
+    )
+    def test_invalid_request_returns_400_without_calling_service(
+        self, admin_client, payload
+    ):
+        tc, _, _, _ = admin_client
+        repair_service = tc.app.state.default_bot_passport_repair_service
+
+        resp = tc.post(
+            "/api/bots/repair-default-passport-for-others", json=payload
+        )
+
+        assert resp.json()["error_code"] == 400
+        repair_service.repair.assert_not_called()
+
+    def test_maps_typed_service_error(self, admin_client):
+        from agentclaw.community.core.bot_management.errors import (
+            DefaultBotPassportRepairError,
+        )
+
+        tc, _, _, _ = admin_client
+        repair_service = tc.app.state.default_bot_passport_repair_service
+        repair_service.repair.side_effect = DefaultBotPassportRepairError(
+            "owner relationship verification failed", error_code=5402
+        )
+
+        resp = tc.post(
+            "/api/bots/repair-default-passport-for-others",
+            json={"target_user_id": "172168", "target_env": "prod"},
+        )
+
+        assert resp.json() == {
+            "success": False,
+            "message": "owner relationship verification failed",
+            "error_code": 5402,
+            "data": None,
+        }
+
+    def test_operator_name_falls_back_to_authenticated_user_id(self, admin_client):
+        tc, _, _, _ = admin_client
+        tc.app.dependency_overrides[get_request_context] = lambda: RequestContext(
+            user_id="100000", nick_name=None
+        )
+        repair_service = tc.app.state.default_bot_passport_repair_service
+        repair_service.repair.return_value = {
+            "target_user_id": "172168",
+            "bot_id": "default",
+            "target_env": "prod",
+        }
+
+        resp = tc.post(
+            "/api/bots/repair-default-passport-for-others",
+            json={"target_user_id": "172168", "target_env": "prod"},
+        )
+
+        assert resp.json()["success"] is True
+        assert repair_service.repair.call_args.kwargs["operator_name"] == "100000"
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/community/contracts/test_auth_relationship.py
+++ b/src/backend/tests/community/contracts/test_auth_relationship.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
 
+import pytest
+
 
 def test_local_auth_relationship_create_returns_mock_envelope(world) -> None:
     plugin = world.get(AuthRelationshipPlugin)
@@ -34,6 +36,32 @@ def test_local_auth_relationship_create_returns_mock_envelope(world) -> None:
 def test_local_auth_relationship_query_returns_empty(world) -> None:
     plugin = world.get(AuthRelationshipPlugin)
     assert plugin.query_relationships(agent_code="bot_x") == []
+
+
+def test_local_auth_relationship_explicit_env_operations_preserve_noop_contract(
+    world,
+) -> None:
+    plugin = world.get(AuthRelationshipPlugin)
+    assert plugin.create_relationship_for_env(
+        target_env="prod",
+        work_no="alice",
+        agent_code="bot_x",
+        operator_work_no="operator",
+        operator_name="Operator",
+    ) == {"auth_id": 0}
+    assert plugin.query_relationships_for_env(
+        target_env="pre", agent_code="bot_x", work_no="alice"
+    ) == []
+
+
+def test_local_auth_relationship_explicit_env_rejects_unknown_environment(
+    world,
+) -> None:
+    plugin = world.get(AuthRelationshipPlugin)
+    with pytest.raises(ValueError, match="target_env"):
+        plugin.query_relationships_for_env(
+            target_env="staging", agent_code="bot_x", work_no="alice"
+        )
 
 
 # ── community impl (B4) — no external registry, succeeds vacuously ──

--- a/src/backend/tests/community/contracts/test_passport.py
+++ b/src/backend/tests/community/contracts/test_passport.py
@@ -17,6 +17,8 @@ plugin would not produce that exact string.
 """
 from __future__ import annotations
 
+import pytest
+
 from agentclaw.community.plugin_api.passport import PassportPlugin
 
 
@@ -31,6 +33,31 @@ def test_apply_first_agent_passport_returns_local_mock_envelope(world) -> None:
     # Fingerprint only the local impl produces.
     assert result["token"] == "mock_token_first_bot_x"
     assert result["agent_code"] == "local_bot_x"
+
+
+def test_local_passport_accepts_explicit_target_env(world) -> None:
+    plugin = world.get(PassportPlugin)
+
+    result = plugin.apply_first_agent_passport(
+        bot_id="bot_prod",
+        owner_workno="alice",
+        mcp_codes=[],
+        target_env="prod",
+    )
+
+    assert result is not None
+    assert result["token"] == "mock_token_first_bot_prod"
+    assert (
+        plugin.query_token("bot_prod", "alice", target_env="prod")
+        == "mock_token_bot_prod"
+    )
+
+
+def test_local_passport_rejects_invalid_explicit_target_env(world) -> None:
+    plugin = world.get(PassportPlugin)
+
+    with pytest.raises(ValueError, match="target_env"):
+        plugin.query_agent_passport("bot_x", "alice", target_env="staging")
 
 
 def test_apply_agent_passport_returns_local_mock_envelope(world) -> None:

--- a/src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py
@@ -1,0 +1,500 @@
+from threading import Event, Lock, Thread
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipError
+from agentclaw.community.plugin_api.passport import PassportError
+
+
+def _bot(*, ext=None):
+    return {
+        "bot_id": "default",
+        "owner_id": "172168",
+        "entity_id": "172168",
+        "entity_type": "staff",
+        "bot_name": "Default Bot",
+        "bot_desc": "default vault",
+        "active_engine": "openclaw",
+        "template_type": None,
+        "ext": ext or {"avatar_url": "https://example.test/avatar.png"},
+    }
+
+
+def _service(*, repository=None, passport=None, relationship=None):
+    from agentclaw.community.core.bot_management.services.default_bot_passport_repair_service import (
+        DefaultBotPassportRepairService,
+    )
+
+    repository = repository or MagicMock()
+    passport = passport or MagicMock()
+    relationship = relationship or MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes_for_env.return_value = ["mcp.one", "hitl"]
+    skill_set_factory = MagicMock()
+    skill_set_factory.create.return_value = skill_set_service
+    return (
+        DefaultBotPassportRepairService(
+            repository=repository,
+            passport_plugin=passport,
+            auth_relationship_plugin=relationship,
+            skill_set_factory=skill_set_factory,
+        ),
+        repository,
+        passport,
+        relationship,
+    )
+
+
+def _repair(service):
+    return service.repair(
+        target_user_id="172168",
+        target_env="prod",
+        operator_user_id="admin-1",
+        operator_name="Admin One",
+    )
+
+
+def test_repair_missing_passport_uses_first_apply_and_verifies_control_plane():
+    from agentclaw.community.core.bot_management.services.default_bot_passport_repair_service import (
+        DefaultBotPassportRepairService,
+    )
+
+    repository = MagicMock()
+    before = _bot(
+        ext={
+            "avatar_url": "https://example.test/avatar.png",
+            "passport": {"legacy": "preserved"},
+        }
+    )
+    after = _bot(
+        ext={
+            "avatar_url": "https://example.test/avatar.png",
+            "passport": {"legacy": "preserved", "agent_code": "agent-172168"},
+        }
+    )
+    repository.get_live_by_id_owner_and_env.side_effect = [[before], [after]]
+    repository.update_ext_by_id_owner_and_env.return_value = after
+
+    passport = MagicMock()
+    passport.query_agent_passport.side_effect = [
+        None,
+        {
+            "agent_code": "agent-172168",
+            "credential_id": "credential-172168",
+        },
+    ]
+    passport.query_auth_status.side_effect = [None, {"status": "ISSUED"}]
+    passport.query_token.side_effect = [None, "verified-token"]
+    passport.apply_first_agent_passport.return_value = {
+        "token": "applied-token",
+        "agent_code": "agent-172168",
+    }
+
+    relationship = MagicMock()
+    relationship.query_relationships_for_env.side_effect = [
+        [],
+        [{"authId": 42, "workNo": "172168", "agentCode": "agent-172168"}],
+    ]
+    relationship.create_relationship_for_env.return_value = {"auth_id": 42}
+
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes_for_env.return_value = ["mcp.one", "hitl"]
+    skill_set_factory = MagicMock()
+    skill_set_factory.create.return_value = skill_set_service
+
+    service = DefaultBotPassportRepairService(
+        repository=repository,
+        passport_plugin=passport,
+        auth_relationship_plugin=relationship,
+        skill_set_factory=skill_set_factory,
+    )
+
+    result = service.repair(
+        target_user_id="172168",
+        target_env="prod",
+        operator_user_id="admin-1",
+        operator_name="Admin One",
+    )
+
+    assert result["action"] == "repaired"
+    assert result["target_user_id"] == "172168"
+    assert result["bot_id"] == "default"
+    assert result["target_env"] == "prod"
+    assert result["passport"] == {
+        "status": "ISSUED",
+        "agent_code": "agent-172168",
+        "credential_id": "credential-172168",
+        "token_present": True,
+        "source": "applied",
+    }
+    assert result["owner_relationship"] == {
+        "verified": True,
+        "created": True,
+        "auth_id": 42,
+    }
+    assert result["database"] == {"ext_agent_code_verified": True}
+    assert result["runtime"] == {
+        "restart_required": True,
+        "restart_environment": "prod",
+    }
+
+    passport.apply_first_agent_passport.assert_called_once()
+    apply_kwargs = passport.apply_first_agent_passport.call_args.kwargs
+    assert apply_kwargs["bot_id"] == "default"
+    assert apply_kwargs["owner_workno"] == "172168"
+    assert apply_kwargs["mcp_codes"] == ["mcp.one"]
+    passport.apply_agent_passport.assert_not_called()
+
+    update_kwargs = repository.update_ext_by_id_owner_and_env.call_args.kwargs
+    assert update_kwargs["env"] == "prod"
+    assert update_kwargs["bot_id"] == "default"
+    assert update_kwargs["owner_id"] == "172168"
+    assert update_kwargs["ext"]["avatar_url"] == "https://example.test/avatar.png"
+    assert update_kwargs["ext"]["passport"] == {
+        "legacy": "preserved",
+        "agent_code": "agent-172168",
+    }
+
+    relationship.create_relationship_for_env.assert_called_once_with(
+        target_env="prod",
+        work_no="172168",
+        agent_code="agent-172168",
+        description="Bot owner default authorization",
+        operator_work_no="admin-1",
+        operator_name="Admin One",
+    )
+
+
+def test_repair_rejects_invalid_target_env_before_reading_data():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    service, repository, passport, relationship = _service()
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        service.repair(
+            target_user_id="172168",
+            target_env="staging",
+            operator_user_id="admin-1",
+            operator_name="Admin One",
+        )
+
+    assert exc_info.value.error_code == 400
+    repository.get_live_by_id_owner_and_env.assert_not_called()
+    passport.apply_first_agent_passport.assert_not_called()
+    relationship.create_relationship_for_env.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("matches", "expected_error_code"),
+    [([], 404), ([_bot(), _bot()], 409)],
+)
+def test_repair_requires_exactly_one_live_default_bot(matches, expected_error_code):
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    repository.get_live_by_id_owner_and_env.return_value = matches
+    service, _, passport, relationship = _service(repository=repository)
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == expected_error_code
+    passport.query_agent_passport.assert_not_called()
+    passport.apply_first_agent_passport.assert_not_called()
+    relationship.create_relationship_for_env.assert_not_called()
+
+
+def test_repair_rejects_authorization_page_without_token():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    repository.get_live_by_id_owner_and_env.return_value = [_bot()]
+    passport = MagicMock()
+    passport.query_agent_passport.return_value = None
+    passport.query_auth_status.return_value = None
+    passport.query_token.return_value = None
+    passport.apply_first_agent_passport.return_value = {
+        "token": "",
+        "iframe_url": "https://authorization.invalid/iframe",
+    }
+    service, _, _, relationship = _service(repository=repository, passport=passport)
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == 5401
+    assert "authorization.invalid" not in str(exc_info.value)
+    repository.update_ext_by_id_owner_and_env.assert_not_called()
+    relationship.create_relationship_for_env.assert_not_called()
+    passport.apply_agent_passport.assert_not_called()
+
+
+def test_repair_reuses_complete_passport_and_existing_relationship():
+    repository = MagicMock()
+    stored = _bot(ext={"passport": {"agent_code": "agent-172168"}})
+    repository.get_live_by_id_owner_and_env.side_effect = [[stored], [stored]]
+    repository.update_ext_by_id_owner_and_env.return_value = stored
+    passport = MagicMock()
+    passport.query_agent_passport.return_value = {
+        "agent_code": "agent-172168",
+        "credential_id": "credential-172168",
+    }
+    passport.query_auth_status.return_value = {"status": "ISSUED"}
+    passport.query_token.return_value = "verified-token"
+    relationship = MagicMock()
+    relationship.query_relationships_for_env.return_value = [
+        {"auth_id": 42, "work_no": "172168", "agent_code": "agent-172168"}
+    ]
+    service, _, _, _ = _service(
+        repository=repository, passport=passport, relationship=relationship
+    )
+
+    result = _repair(service)
+
+    assert result["action"] == "verified"
+    assert result["passport"]["source"] == "existing"
+    assert result["owner_relationship"]["created"] is False
+    passport.apply_first_agent_passport.assert_not_called()
+    passport.apply_agent_passport.assert_not_called()
+    relationship.create_relationship_for_env.assert_not_called()
+    repository.update_ext_by_id_owner_and_env.assert_not_called()
+
+
+def test_repair_rejects_post_apply_agent_code_mismatch():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    repository.get_live_by_id_owner_and_env.return_value = [_bot()]
+    passport = MagicMock()
+    passport.query_agent_passport.side_effect = [
+        None,
+        {"agent_code": "different-agent", "credential_id": "credential-172168"},
+    ]
+    passport.query_auth_status.side_effect = [None, {"status": "ISSUED"}]
+    passport.query_token.side_effect = [None, "verified-token"]
+    passport.apply_first_agent_passport.return_value = {
+        "token": "applied-token",
+        "agent_code": "agent-172168",
+    }
+    service, _, _, relationship = _service(repository=repository, passport=passport)
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == 5400
+    repository.update_ext_by_id_owner_and_env.assert_not_called()
+    relationship.create_relationship_for_env.assert_not_called()
+
+
+def test_repair_rejects_database_readback_mismatch():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    repository.get_live_by_id_owner_and_env.side_effect = [
+        [_bot()],
+        [_bot(ext={"passport": {"agent_code": "stale-agent"}})],
+    ]
+    passport = MagicMock()
+    passport.query_agent_passport.return_value = {
+        "agent_code": "agent-172168",
+        "credential_id": "credential-172168",
+    }
+    passport.query_auth_status.return_value = {"status": "ISSUED"}
+    passport.query_token.return_value = "verified-token"
+    service, _, _, relationship = _service(repository=repository, passport=passport)
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == 500
+    relationship.create_relationship_for_env.assert_not_called()
+
+
+def test_repair_requires_owner_relationship_requery_to_match():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    stored = _bot(ext={"passport": {"agent_code": "agent-172168"}})
+    repository.get_live_by_id_owner_and_env.side_effect = [[stored], [stored]]
+    passport = MagicMock()
+    passport.query_agent_passport.return_value = {
+        "agent_code": "agent-172168",
+        "credential_id": "credential-172168",
+    }
+    passport.query_auth_status.return_value = {"status": "ISSUED"}
+    passport.query_token.return_value = "verified-token"
+    relationship = MagicMock()
+    relationship.query_relationships_for_env.side_effect = [[], []]
+    relationship.create_relationship_for_env.return_value = {"auth_id": 42}
+    service, _, _, _ = _service(
+        repository=repository, passport=passport, relationship=relationship
+    )
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == 5402
+
+
+def test_repair_maps_passport_failures_to_identity_error():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    repository.get_live_by_id_owner_and_env.return_value = [_bot()]
+    passport = MagicMock()
+    passport.query_agent_passport.side_effect = PassportError("upstream unavailable")
+    service, _, _, relationship = _service(repository=repository, passport=passport)
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == 5400
+    repository.update_ext_by_id_owner_and_env.assert_not_called()
+    relationship.create_relationship_for_env.assert_not_called()
+
+
+def test_repair_maps_database_write_failure_to_persistence_error():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    repository.get_live_by_id_owner_and_env.return_value = [_bot()]
+    repository.update_ext_by_id_owner_and_env.side_effect = RuntimeError("write failed")
+    passport = MagicMock()
+    passport.query_agent_passport.return_value = {
+        "agent_code": "agent-172168",
+        "credential_id": "credential-172168",
+    }
+    passport.query_auth_status.return_value = {"status": "ISSUED"}
+    passport.query_token.return_value = "verified-token"
+    service, _, _, relationship = _service(repository=repository, passport=passport)
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == 500
+    relationship.query_relationships_for_env.assert_not_called()
+
+
+def test_repair_maps_relationship_failure_to_authorization_error():
+    from agentclaw.community.core.bot_management.errors import (
+        DefaultBotPassportRepairError,
+    )
+
+    repository = MagicMock()
+    stored = _bot(ext={"passport": {"agent_code": "agent-172168"}})
+    repository.get_live_by_id_owner_and_env.side_effect = [[stored], [stored]]
+    passport = MagicMock()
+    passport.query_agent_passport.return_value = {
+        "agent_code": "agent-172168",
+        "credential_id": "credential-172168",
+    }
+    passport.query_auth_status.return_value = {"status": "ISSUED"}
+    passport.query_token.return_value = "verified-token"
+    relationship = MagicMock()
+    relationship.query_relationships_for_env.side_effect = AuthRelationshipError(
+        "aceagent unavailable"
+    )
+    service, _, _, _ = _service(
+        repository=repository, passport=passport, relationship=relationship
+    )
+
+    with pytest.raises(DefaultBotPassportRepairError) as exc_info:
+        _repair(service)
+
+    assert exc_info.value.error_code == 5402
+
+
+def test_repair_serializes_same_target_to_avoid_duplicate_first_apply():
+    class Repository:
+        def __init__(self):
+            self._lock = Lock()
+            self._bot = _bot()
+
+        def get_live_by_id_owner_and_env(self, **_kwargs):
+            with self._lock:
+                return [dict(self._bot)]
+
+        def update_ext_by_id_owner_and_env(self, *, ext, **_kwargs):
+            with self._lock:
+                self._bot = {**self._bot, "ext": ext}
+
+    class Passport:
+        def __init__(self):
+            self.complete = False
+            self.apply_count = 0
+            self.apply_started = Event()
+            self.release_apply = Event()
+
+        def query_agent_passport(self, **_kwargs):
+            if not self.complete:
+                return None
+            return {
+                "agent_code": "agent-172168",
+                "credential_id": "credential-172168",
+            }
+
+        def query_auth_status(self, **_kwargs):
+            return {"status": "ISSUED"} if self.complete else None
+
+        def query_token(self, **_kwargs):
+            return "verified-token" if self.complete else None
+
+        def apply_first_agent_passport(self, **_kwargs):
+            self.apply_count += 1
+            self.apply_started.set()
+            assert self.release_apply.wait(timeout=2)
+            self.complete = True
+            return {"token": "applied-token", "agent_code": "agent-172168"}
+
+    repository = Repository()
+    passport = Passport()
+    relationship = MagicMock()
+    relationship.query_relationships_for_env.return_value = [
+        {"auth_id": 42, "work_no": "172168", "agent_code": "agent-172168"}
+    ]
+    service, _, _, _ = _service(
+        repository=repository, passport=passport, relationship=relationship
+    )
+    results = []
+    failures = []
+
+    def run_repair():
+        try:
+            results.append(_repair(service))
+        except Exception as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    first = Thread(target=run_repair)
+    second = Thread(target=run_repair)
+    first.start()
+    assert passport.apply_started.wait(timeout=2)
+    second.start()
+    second.join(timeout=0.1)
+
+    assert second.is_alive()
+    assert passport.apply_count == 1
+
+    passport.release_apply.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not failures
+    assert len(results) == 2
+    assert passport.apply_count == 1

--- a/src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py
@@ -498,3 +498,4 @@ def test_repair_serializes_same_target_to_avoid_duplicate_first_apply():
     assert not failures
     assert len(results) == 2
     assert passport.apply_count == 1
+    assert service._target_locks == {}

--- a/src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py
@@ -144,7 +144,26 @@ def test_repair_missing_passport_uses_first_apply_and_verifies_control_plane():
     assert apply_kwargs["bot_id"] == "default"
     assert apply_kwargs["owner_workno"] == "172168"
     assert apply_kwargs["mcp_codes"] == ["mcp.one"]
+    assert apply_kwargs["target_env"] == "prod"
     passport.apply_agent_passport.assert_not_called()
+
+    expected_query = {
+        "bot_id": "default",
+        "owner_workno": "172168",
+        "target_env": "prod",
+    }
+    assert [call.kwargs for call in passport.query_agent_passport.call_args_list] == [
+        expected_query,
+        expected_query,
+    ]
+    assert [call.kwargs for call in passport.query_auth_status.call_args_list] == [
+        expected_query,
+        expected_query,
+    ]
+    assert [call.kwargs for call in passport.query_token.call_args_list] == [
+        expected_query,
+        expected_query,
+    ]
 
     update_kwargs = repository.update_ext_by_id_owner_and_env.call_args.kwargs
     assert update_kwargs["env"] == "prod"

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -477,6 +477,54 @@ class TestCollectBotActiveMcps:
         codes = {r["server_code"] for r in result}
         assert "mcp.ant.antprocessai.anttaskmcp" not in codes
 
+    def test_get_bot_mcp_codes_for_env_uses_only_explicit_env_repository_reads(self):
+        from agentclaw.community.core.skill_center.services.skill_set_service import (
+            SkillSetService,
+        )
+
+        mock_repo = MagicMock()
+        mock_repo.get_all_active_skill_sets_for_env.return_value = [
+            {"id": "2", "name": "Prod Set", "is_default": False}
+        ]
+        mock_repo.get_mcp_servers_in_set_for_env.return_value = [
+            {"id": "10", "server_code": "mcp.prod.only", "name": "prod"}
+        ]
+        mock_repo.get_all_excluded_mcps.return_value = []
+        with patch(
+            "agentclaw.community.core.skill_center.services.skill_set_service.WorkspacePathFactory"
+        ):
+            svc = SkillSetService(
+                skill_repo=MagicMock(),
+                skill_set_repo=mock_repo,
+                mcp_center=MagicMock(),
+                mcp_config_service=MagicMock(),
+                skill_service=MagicMock(),
+                bot_repo=MagicMock(),
+                path_factory=MagicMock(),
+            )
+
+        codes = svc.get_bot_mcp_codes_for_env(
+            entity_id="172168",
+            bot_id="default",
+            user_id="172168",
+            entity_type="staff",
+            engine_type="openclaw",
+            target_env="prod",
+        )
+
+        assert "mcp.prod.only" in codes
+        mock_repo.get_all_active_skill_sets_for_env.assert_called_once_with(
+            user_id="172168",
+            bolt_id="default",
+            engine_type="openclaw",
+            env="prod",
+        )
+        mock_repo.get_mcp_servers_in_set_for_env.assert_called_once_with(
+            "2", env="prod"
+        )
+        mock_repo.get_all_active_skill_sets.assert_not_called()
+        mock_repo.get_mcp_servers_in_set.assert_not_called()
+
 
 
 

--- a/src/backend/tests/community/di/test_bot_management_module_wiring.py
+++ b/src/backend/tests/community/di/test_bot_management_module_wiring.py
@@ -36,3 +36,26 @@ def test_bot_service_provider_threads_task_queue_service() -> None:
         keyword.arg == "task_queue_service"
         for keyword in bot_service_calls[0].keywords
     ), "BotService must receive TaskQueueService for restart publish tasks"
+
+
+def test_default_bot_passport_repair_service_is_composed_without_device_service() -> None:
+    module_path = Path(bot_management_module.__file__)
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    providers = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "default_bot_passport_repair_service"
+    ]
+    assert providers
+    provider = providers[0]
+    arg_names = [arg.arg for arg in provider.args.args]
+    assert arg_names == [
+        "self",
+        "repository",
+        "passport_plugin",
+        "auth_relationship_plugin",
+        "skill_set_factory",
+    ]
+    assert "device_service" not in arg_names
+    assert "baas_service" not in arg_names

--- a/src/backend/tests/community/endpoints/test_default_bot_passport_repair.py
+++ b/src/backend/tests/community/endpoints/test_default_bot_passport_repair.py
@@ -1,0 +1,98 @@
+"""Endpoint coverage for the default Bot Passport repair operation."""
+
+from agentclaw.community.api.default_bot_passport_repair_service import (
+    DefaultBotPassportRepairServiceProtocol,
+)
+from tests.community.factories.access import make_staff_user
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+
+_PATH = "/api/bots/repair-default-passport-for-others"
+_ADMIN = "100000"
+
+
+class _StubRepairService:
+    def repair(self, **kwargs):
+        return {
+            "target_user_id": kwargs["target_user_id"],
+            "bot_id": "default",
+            "action": "repaired",
+            "target_env": kwargs["target_env"],
+            "passport": {
+                "status": "ISSUED",
+                "agent_code": "agent-172168",
+                "credential_id": "credential-172168",
+                "token_present": True,
+                "source": "applied",
+            },
+            "owner_relationship": {
+                "verified": True,
+                "created": True,
+                "auth_id": 42,
+            },
+            "database": {"ext_agent_code_verified": True},
+            "runtime": {
+                "restart_required": True,
+                "restart_environment": kwargs["target_env"],
+            },
+        }
+
+
+def _seed_admin_with_repair_service(world):
+    make_staff_user(world, user_id=_ADMIN)
+    world.injector.binder.bind(
+        DefaultBotPassportRepairServiceProtocol,
+        to=_StubRepairService(),
+        scope=None,
+    )
+
+
+@endpoint_test(
+    method="POST",
+    path=_PATH,
+    scenario="repair_prod_default_bot",
+    seed=_seed_admin_with_repair_service,
+    input=CaseInput(
+        headers={"x-user-id": _ADMIN, "X-Request-ID": "repair-test"},
+        json_body={"target_user_id": "172168", "target_env": "prod"},
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {
+                "target_user_id": "172168",
+                "bot_id": "default",
+                "target_env": "prod",
+                "passport": {"status": "ISSUED", "token_present": True},
+                "owner_relationship": {"verified": True},
+                "runtime": {"restart_required": True},
+            },
+        },
+    ),
+)
+def repair_prod_default_bot():
+    """A super admin can repair one prod default Bot from pre deployment."""
+
+
+@endpoint_test(
+    method="POST",
+    path=_PATH,
+    scenario="reject_invalid_target_env",
+    seed=_seed_admin_with_repair_service,
+    input=CaseInput(
+        headers={"x-user-id": _ADMIN},
+        json_body={"target_user_id": "172168", "target_env": "staging"},
+    ),
+    expect=ExpectError(
+        status=200,
+        json_contains={"success": False, "error_code": 400},
+    ),
+)
+def reject_invalid_target_env():
+    """Only the explicit pre and prod targets are accepted."""

--- a/src/backend/tests/community/plugins/community/test_auth_relationship.py
+++ b/src/backend/tests/community/plugins/community/test_auth_relationship.py
@@ -1,6 +1,8 @@
 """Unit tests for the community CommunityAuthRelationshipPlugin (B4 T8)."""
 from __future__ import annotations
 
+import pytest
+
 from agentclaw.community.plugins.community.auth_relationship import (
     CommunityAuthRelationshipPlugin,
 )
@@ -30,3 +32,24 @@ def test_not_a_mock_seam():
     from agentclaw.community.plugins.local._mock_seam import MockSeam
 
     assert not issubclass(CommunityAuthRelationshipPlugin, MockSeam)
+
+
+def test_explicit_env_operations_delegate_to_vacuous_contract():
+    plugin = CommunityAuthRelationshipPlugin()
+    assert plugin.create_relationship_for_env(
+        target_env="prod",
+        work_no="u1",
+        agent_code="a1",
+        operator_work_no="admin",
+        operator_name="Admin",
+    ) == {"auth_id": 0}
+    assert plugin.query_relationships_for_env(
+        target_env="pre", agent_code="a1", work_no="u1"
+    ) == []
+
+
+def test_explicit_env_operations_reject_unknown_environment():
+    with pytest.raises(ValueError, match="target_env"):
+        CommunityAuthRelationshipPlugin().query_relationships_for_env(
+            target_env="gray", agent_code="a1"
+        )

--- a/src/backend/tests/community/plugins/community/test_passport.py
+++ b/src/backend/tests/community/plugins/community/test_passport.py
@@ -50,6 +50,21 @@ def test_auth_status_always_issued(passport):
     assert status["token"] == "community-passport-bot-4"
 
 
+def test_explicit_target_env_keeps_self_issued_semantics(passport):
+    issued = passport.apply_first_agent_passport(
+        "bot-prod", "owner", [], target_env="prod"
+    )
+
+    assert passport.query_token(
+        "bot-prod", "owner", target_env="prod"
+    ) == issued["token"]
+
+
+def test_invalid_explicit_target_env_is_rejected(passport):
+    with pytest.raises(ValueError, match="target_env"):
+        passport.query_auth_status("bot-4", "owner", target_env="staging")
+
+
 def test_query_passport_clis_empty(passport):
     assert passport.query_passport_clis("bot-5", "owner") == []
 

--- a/src/backend/tests/community/plugins/test_bot_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_repository_unified.py
@@ -146,6 +146,57 @@ def test_get_env_scoped(repo, db):
     assert repo.exists_by_owner_and_bot_id("emp1", "bot-1") is False
 
 
+def test_explicit_env_default_bot_read_and_ext_update_are_isolated(repo, db):
+    pre = repo.insert(_data(bot_id="default", ext={"source": "pre"}))
+    prod = repo.insert(_data(bot_id="default", ext={"source": "prod"}))
+    with db.orm_session() as s:
+        s.query(BotModel).filter(BotModel.id == pre["id"]).update(
+            {BotModel.env: "pre"}
+        )
+        s.query(BotModel).filter(BotModel.id == prod["id"]).update(
+            {BotModel.env: "prod"}
+        )
+
+    matches = repo.get_live_by_id_owner_and_env(
+        bot_id="default", owner_id="emp1", env="prod"
+    )
+    assert [row["id"] for row in matches] == [prod["id"]]
+
+    updated = repo.update_ext_by_id_owner_and_env(
+        bot_id="default",
+        owner_id="emp1",
+        env="prod",
+        ext={"passport": {"agent_code": "agent-prod"}},
+    )
+    assert updated["id"] == prod["id"]
+    assert updated["ext"] == {"passport": {"agent_code": "agent-prod"}}
+    assert repo.get_live_by_id_owner_and_env(
+        bot_id="default", owner_id="emp1", env="pre"
+    )[0]["ext"] == {"source": "pre"}
+
+
+def test_explicit_env_ext_update_rolls_back_when_multiple_rows_match(repo, db):
+    first = repo.insert(_data(bot_id="default", ext={"row": 1}))
+    second = repo.insert(_data(bot_id="default", ext={"row": 2}))
+    with db.orm_session() as s:
+        s.query(BotModel).filter(BotModel.id.in_([first["id"], second["id"]])).update(
+            {BotModel.env: "prod"}, synchronize_session=False
+        )
+
+    with pytest.raises(RuntimeError, match="exactly one"):
+        repo.update_ext_by_id_owner_and_env(
+            bot_id="default",
+            owner_id="emp1",
+            env="prod",
+            ext={"passport": {"agent_code": "must-rollback"}},
+        )
+
+    rows = repo.get_live_by_id_owner_and_env(
+        bot_id="default", owner_id="emp1", env="prod"
+    )
+    assert [row["ext"] for row in rows] == [{"row": 1}, {"row": 2}]
+
+
 def test_list_and_count(repo):
     repo.insert(_data(bot_id="b1"))
     repo.insert(_data(bot_id="b2"))

--- a/src/backend/tests/community/plugins/test_skill_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_skill_repository_unified.py
@@ -258,6 +258,52 @@ def test_mcp_in_set(sets):
     assert sets.get_mcp_servers_in_set(ss["id"]) == []
 
 
+def test_explicit_env_active_skill_sets_and_mcps_are_isolated(sets, db):
+    pre = sets.create(
+        {
+            "name": "pre-set",
+            "user_id": "172168",
+            "bolt_id": "default",
+            "engine_type": "openclaw",
+            "is_active": True,
+        }
+    )
+    prod = sets.create(
+        {
+            "name": "prod-set",
+            "user_id": "172168",
+            "bolt_id": "default",
+            "engine_type": "openclaw",
+            "is_active": True,
+        }
+    )
+    with db.orm_session() as s:
+        s.query(SkillSet).filter(SkillSet.id == int(pre["id"])).update(
+            {SkillSet.env: "pre"}
+        )
+        s.query(SkillSet).filter(SkillSet.id == int(prod["id"])).update(
+            {SkillSet.env: "prod"}
+        )
+    sets.add_mcp_to_set(pre["id"], "mcp.pre", "Pre", env="pre")
+    sets.add_mcp_to_set(prod["id"], "mcp.prod", "Prod", env="prod")
+
+    active = sets.get_all_active_skill_sets_for_env(
+        user_id="172168",
+        bolt_id="default",
+        engine_type="openclaw",
+        env="prod",
+    )
+
+    assert [row["id"] for row in active] == [prod["id"]]
+    assert sets.get_mcp_servers_in_set_for_env(prod["id"], env="prod") == [
+        {
+            **sets.get_mcp_servers_in_set(prod["id"])[0],
+            "env": "prod",
+        }
+    ]
+    assert sets.get_mcp_servers_in_set_for_env(pre["id"], env="prod") == []
+
+
 def test_add_default_mcp_exclusion_upsert_idempotent(sets, db):
     ok = sets.add_default_mcp_exclusion("u1", "bot1", 7, "mcp.z")
     assert ok is True


### PR DESCRIPTION
## Summary

Add an operations endpoint that repairs and verifies control-plane Passport state for an existing default Bot in an explicitly selected `pre` or `prod` environment.

## Changes

- Call only `apply_first_agent_passport` when Passport state is incomplete.
- Pass the explicit target environment through Passport query, Apply First, and verification calls.
- Extend the Passport plugin contract with an optional keyword-only `target_env`, preserving current-environment behavior for normal bot creation.
- Reject unsupported explicit Passport environments before external calls.
- Verify issued status, token presence, agent code, credential ID, and database read-back.
- Ensure and re-query the owner authorization relationship in the target environment.
- Scope Bot and skill-set persistence reads and writes to the explicit target environment.
- Keep runtime restart out of this endpoint and report it as a required follow-up.
- Add idempotency, same-target concurrency protection, endpoint coverage, contract tests, and architecture metadata.

## Deployment integration

- The OCB adapter serializes `target_env` into the tcauthmng Hessian DTO.
- tcauthmng uses the explicit environment for DB namespace selection and AgentHub AppEnv.
- ACM behavior is unchanged because the confirmed ACM deployment is shared across pre-production and production.

## Test Plan

- `uv run pytest -q tests/community/core/bot_management tests/community/contracts/test_passport.py tests/community/plugins/community/test_passport.py` — 638 passed
- Ruff checks for the changed Passport protocol, implementations, repair service, and tests
- `git diff --check`
