### PR TITLE
refactor(publish-flow): consolidate per-stage engine_overrides composition into one delivery seam

### DIFF
--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/plan.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/plan.md
@@ -1,0 +1,166 @@
+# Plan: Consolidate engine_overrides composition into one delivery seam
+
+## Approach
+
+Introduce a single **delivery-composition seam** with three parts:
+
+1. **A `DeliveryArtifact` value object** — the composed payload handed to BaaS,
+   plus the stage overrides that produced it (the release path persists those).
+   Lives in the `deploy` layer so both the seam (publish-flow) and
+   `BotBuildService` can import it with no cycle.
+2. **Two producers on `PublishExtState`** — `compose_live` (release + eval) and
+   `compose_stored` (restart + rollback). These are the *only* place flow code
+   reads `ext['config_artifact']` for delivery, and they make the one legitimate
+   per-path choice (live channel re-fetch vs. stored per-stage slot) explicit.
+3. **A type-enforced BaaS boundary** — `BotBuildService.release / release_async /
+   upgrade / upgrade_async` accept `delivery: DeliveryArtifact` instead of
+   `config_artifact: dict | None`, so a raw artifact is un-passable from flow code.
+
+All four delivery call sites are rewritten to obtain a `DeliveryArtifact` from the
+seam and pass it through. The restamp/overlay/store primitives
+(`restamp_stage`, `apply_engine_overrides`, `artifact_for_stage`,
+`store_stage_overrides`, `stamp_stage_on_stored_artifact`) are unchanged and stay
+the building blocks the seam composes with. The dead facade delegators
+(`_stage_overrides`, `_artifact_for_stage`) are removed.
+
+Composition is behavior-preserving on the release/restart/eval paths (same source,
+same primitives, just relocated behind the seam). Rollback changes: it moves from
+"ship raw" to `compose_stored(target_ext, ONLINE)` — folding in #168.
+
+## The `DeliveryArtifact` type
+
+New, in the `deploy` layer (alongside the composition vocabulary it belongs to):
+
+```python
+@dataclass(frozen=True)
+class DeliveryArtifact:
+    """The composed artifact handed to the BaaS delivery boundary for one stage,
+    plus the stage overrides that produced it.
+
+    ``config_artifact`` is the fully composed payload — engine_ext.stage restamped
+    to the target stage and that stage's DingTalk channel engine_overrides overlaid.
+    It is the ONLY thing flow code may hand to BotBuildService.release/upgrade; a
+    DeliveryArtifact is obtainable only from the PublishExtState seam. ``overrides``
+    is the stage's engine_overrides (or None) that the release path also persists
+    via persist_stage_promotion; the BaaS layer ignores it. Both fields are None
+    for the ARCA mount path (no config_artifact)."""
+    config_artifact: dict | None
+    overrides: dict | None
+```
+
+**Placement decision:** `services/deploy/engine_ext_stage.py`. That module already
+owns the delivery vocabulary this type belongs to (`restamp_stage`,
+`apply_engine_overrides`, the `PublishStage → engine stage-string` map), and
+`bot_build_service` already imports from `deploy/` (`provider_resolver`), so this
+introduces no new cross-layer dependency and no import cycle (publish-flow →
+bot_build_service → deploy; deploy imports neither).
+
+## The seam (producers on `PublishExtState`)
+
+```python
+def compose_live(self, publish_record, stage) -> DeliveryArtifact:
+    """LIVE re-fetch of the stage's channels (release + eval)."""
+    overrides = self.stage_overrides(publish_record, stage)
+    base = (publish_record.ext or {}).get("config_artifact")
+    return DeliveryArtifact(self.artifact_for_stage(base, stage, overrides), overrides)
+
+def compose_stored(self, ext, stage) -> DeliveryArtifact:
+    """STORED per-stage slot (restart + rollback) — reproduce what was promoted."""
+    overrides = (ext.get("engine_overrides_by_stage") or {}).get(stage.value)
+    base = ext.get("config_artifact")
+    return DeliveryArtifact(self.artifact_for_stage(base, stage, overrides), overrides)
+```
+
+- `compose_live` preserves the exact logic release/eval use today (`stage_overrides`
+  already returns `None` for ARCA → `artifact_for_stage(None, …)` → `None`).
+- `compose_stored` preserves restart's exact logic today
+  (`restart_mixin.py:245‑248`), including the `or {}` guard against a JSON-null slot.
+- Both return `DeliveryArtifact(None, None)` for ARCA — the boundary's teclaw guard
+  (`if not delivery.config_artifact`) is only reached on the teclaw branch, so ARCA
+  (non-teclaw) ignores it exactly as today.
+
+## The BaaS boundary retype
+
+`BotBuildService` (`bot_build_service.py`) — the four delivery methods swap
+`config_artifact: Optional[Dict]` for `delivery: DeliveryArtifact` and read
+`delivery.config_artifact` internally:
+
+- `release(…, delivery: DeliveryArtifact, ext_info=…)` — `release:428`; internal
+  `config_artifact = delivery.config_artifact`; teclaw guard becomes
+  `if not delivery.config_artifact:` (`release:491`).
+- `release_async(…, delivery, ext_info=…)` — `release_async:582`; forwards `delivery`.
+- `upgrade(…, delivery: DeliveryArtifact)` — `upgrade:1057`; same internal swap +
+  guard (`upgrade:1098`).
+- `upgrade_async(…, delivery)` — `upgrade_async:1227`; forwards `delivery`.
+
+No internal callers of the sync `release`/`upgrade` exist (verified), so the only
+callers to update are the async wrappers (self-forward) and the flow call sites.
+
+## Key files & functions
+
+| File | Change |
+|---|---|
+| `services/deploy/engine_ext_stage.py` | **Add** `DeliveryArtifact` dataclass. |
+| `publish_flow/ext_state.py` | **Add** `compose_live` / `compose_stored`; import `DeliveryArtifact`. Primitives unchanged. |
+| `services/bot_build_service.py` | Retype `release`/`release_async`/`upgrade`/`upgrade_async` to `delivery: DeliveryArtifact`; internal `delivery.config_artifact`; guards. |
+| `publish_flow/release_stage.py` | `first_release` + `upgrade_release`: `delivery = ext_state.compose_live(...)`; pass `delivery`; persist `delivery.overrides`. Drop the `PublishExtState.artifact_for_stage` static call. |
+| `publish_flow/eval_publish_mixin.py` | `delivery = self._ext_state.compose_live(...)`; pass `delivery`. (Keep the raw `config_artifact` read for the build-artifact presence guard only.) |
+| `publish_flow/restart_mixin.py` | `delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage)`; pass `delivery` on both the upgrade and the BOT_NOT_FOUND release fallback. |
+| `publish_flow/rollback_ops_mixin.py` | `delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)`; pass `delivery`. (Keep the raw read for the presence guard only.) **Behavior change (#168).** |
+| `publish_flow_service.py` | **Remove** dead `_stage_overrides` / `_artifact_for_stage` delegators. |
+
+`persist_stage_promotion` / `record_release_ext` / `store_stage_overrides` /
+`stamp_stage_on_stored_artifact` are unchanged — the release path still passes the
+stage overrides to persistence, now via `delivery.overrides`.
+
+## Data model changes
+
+None. The `ext` JSON keys (`config_artifact`, `engine_overrides_by_stage`,
+`binding`, `publish`, …) written and read are unchanged. No migration.
+
+## Test strategy
+
+- **`tests/community/endpoints/test_publish_per_stage_channels.py`** — the #168-style
+  end-to-end proof; asserts on the real BaaS HTTP payload (`_delivered_artifact`
+  digs into the create call's JSON), not on kwargs. **Unchanged, must stay green** —
+  the strongest evidence the release/restart paths are behavior-preserving.
+- **`tests/…/services/test_publish_flow_service.py`** — the many
+  `…await_args.kwargs["config_artifact"]` assertions become
+  `kwargs["delivery"].config_artifact` (verify/online first-release + upgrade,
+  restart, eval, ARCA). Mechanical, value-preserving.
+  - `test_execute_rollback_with_config_artifact` — currently asserts a raw
+    `"s3://…"` string passes through; **reworked** to a dict artifact asserting
+    composed delivery (`engine_ext.stage == "release"` + stored online overrides
+    overlaid).
+  - **Add** rollback unit coverage mirroring #168: (a) stored online overrides are
+    delivered + reader not called (stored, not live); (b) target with no
+    `engine_overrides_by_stage` → base delivered unchanged (restamp only).
+- **`tests/…/services/test_bot_build_service_teclaw_routing.py`** — calls sync
+  `release`/`upgrade` directly: wrap `_ARTIFACT` in `DeliveryArtifact(_ARTIFACT, …)`;
+  the no-artifact-raises cases pass `DeliveryArtifact(None, None)`. Assertions on the
+  downstream `create_teclaw_bot`/`update_teclaw_bot` `config_artifact` kwarg unchanged.
+- **`test_provider_behavior.py`** — check for any `config_artifact` kwarg on delivery
+  mocks; update if present (persist-side is untouched, so likely no change).
+- Full `tests/community` suite green before push; run the verify skill on the
+  rollback path (the one behavior change) to observe composed delivery end-to-end.
+
+## Risks & mitigations
+
+- **Broad but mechanical test churn** from renaming the boundary kwarg. Mitigation:
+  the value assertions are preserved; the end-to-end payload test is untouched and
+  pins real behavior.
+- **Rollback behavior change** could surprise if a caller depended on raw delivery.
+  Mitigation: this is the #168 fix, approved; realistic online artifacts are already
+  `stage=release`, so the restamp is idempotent and only the (previously dropped)
+  channel overlay is added.
+- **Layer placement of `DeliveryArtifact`.** Mitigation: placed in `deploy/`, the
+  layer both sides already depend on downward — no cycle.
+
+## Alternatives considered
+
+- **Convention-only seam** (call sites pass `delivery.config_artifact`, BaaS keeps
+  its dict signature). Rejected in issue #173: does not make raw un-passable.
+- **Compose inside `release_async`/`upgrade_async`** (boundary takes
+  `(base, stage, overrides_source)`). Rejected: pushes the live-vs-stored channel
+  decision and the channel reader dependency down into `BotBuildService`, widening
+  its responsibilities; the seam-on-`PublishExtState` keeps that in the flow layer.

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/plan.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/plan.md
@@ -4,10 +4,9 @@
 
 Introduce a single **delivery-composition seam** with three parts:
 
-1. **A `DeliveryArtifact` value object** — the composed payload handed to BaaS,
-   plus the stage overrides that produced it (the release path persists those).
-   Lives in the `deploy` layer so both the seam (publish-flow) and
-   `BotBuildService` can import it with no cycle.
+1. **A `DeliveryArtifact` value object** — a *pure* wrapper of the composed payload
+   handed to BaaS (`config_artifact` only). Lives in the `deploy` layer so both the
+   seam (publish-flow) and `BotBuildService` can import it with no cycle.
 2. **Two producers on `PublishExtState`** — `compose_live` (release + eval) and
    `compose_stored` (restart + rollback). These are the *only* place flow code
    reads `ext['config_artifact']` for delivery, and they make the one legitimate
@@ -17,35 +16,50 @@ Introduce a single **delivery-composition seam** with three parts:
    `config_artifact: dict | None`, so a raw artifact is un-passable from flow code.
 
 All four delivery call sites are rewritten to obtain a `DeliveryArtifact` from the
-seam and pass it through. The restamp/overlay/store primitives
-(`restamp_stage`, `apply_engine_overrides`, `artifact_for_stage`,
-`store_stage_overrides`, `stamp_stage_on_stored_artifact`) are unchanged and stay
-the building blocks the seam composes with. The dead facade delegators
-(`_stage_overrides`, `_artifact_for_stage`) are removed.
+seam and pass it through. The restamp/overlay/store primitives (`restamp_stage`,
+`apply_engine_overrides`, `store_stage_overrides`, `stamp_stage_on_stored_artifact`)
+are unchanged and stay the building blocks the seam composes with. The former
+combiner `PublishExtState.artifact_for_stage` is **folded into**
+`DeliveryArtifact.compose` and removed, along with the dead facade delegators
+(`_stage_overrides`, `_artifact_for_stage`).
 
 Composition is behavior-preserving on the release/restart/eval paths (same source,
 same primitives, just relocated behind the seam). Rollback changes: it moves from
 "ship raw" to `compose_stored(target_ext, ONLINE)` — folding in #168.
 
+**Overrides ownership (decision B).** Only the **release** path persists the applied
+overlay into `engine_overrides_by_stage` (for a future restart/rollback to
+reproduce). Rather than bundle that raw overlay onto the delivery payload — where
+eval/restart/rollback would ignore it — `DeliveryArtifact` stays a pure payload and
+the live producer hands the overrides back **only to the caller that needs them**:
+`compose_live` returns `(DeliveryArtifact, overrides)`; the release path unpacks
+both, eval discards the second; `compose_stored` returns a bare `DeliveryArtifact`
+(restart/rollback never persist). The asymmetry lives where the real asymmetry is
+(only release persists), not on the boundary type.
+
 ## The `DeliveryArtifact` type
 
-New, in the `deploy` layer (alongside the composition vocabulary it belongs to):
+New, in the `deploy` layer (alongside the composition vocabulary it belongs to). A
+pure payload wrapper whose `compose` classmethod is the single combiner (restamp +
+overlay), so the raw `overrides` is passed exactly once:
 
 ```python
 @dataclass(frozen=True)
 class DeliveryArtifact:
-    """The composed artifact handed to the BaaS delivery boundary for one stage,
-    plus the stage overrides that produced it.
+    """The composed artifact handed to the BaaS delivery boundary for one stage.
 
     ``config_artifact`` is the fully composed payload — engine_ext.stage restamped
     to the target stage and that stage's DingTalk channel engine_overrides overlaid.
-    It is the ONLY thing flow code may hand to BotBuildService.release/upgrade; a
-    DeliveryArtifact is obtainable only from the PublishExtState seam. ``overrides``
-    is the stage's engine_overrides (or None) that the release path also persists
-    via persist_stage_promotion; the BaaS layer ignores it. Both fields are None
-    for the ARCA mount path (no config_artifact)."""
+    It is the ONLY thing flow code may hand to BotBuildService.release/upgrade, and a
+    DeliveryArtifact is obtainable only via ``compose`` (from the PublishExtState
+    seam). ``None`` for the ARCA mount path (no config_artifact)."""
     config_artifact: dict | None
-    overrides: dict | None
+
+    @classmethod
+    def compose(cls, base, stage, overrides) -> "DeliveryArtifact":
+        """Restamp engine_ext.stage for ``stage`` and overlay ``overrides``' channels.
+        No-ops (payload stays ``base``) for ARCA / no stored overrides."""
+        return cls(apply_engine_overrides(restamp_stage(base, stage), overrides))
 ```
 
 **Placement decision:** `services/deploy/engine_ext_stage.py`. That module already
@@ -58,24 +72,26 @@ bot_build_service → deploy; deploy imports neither).
 ## The seam (producers on `PublishExtState`)
 
 ```python
-def compose_live(self, publish_record, stage) -> DeliveryArtifact:
-    """LIVE re-fetch of the stage's channels (release + eval)."""
+def compose_live(self, publish_record, stage) -> tuple[DeliveryArtifact, dict | None]:
+    """LIVE re-fetch of the stage's channels (release + eval). Returns the composed
+    payload AND the raw overrides applied, so the release path can persist them
+    without a second read; eval discards the second element."""
     overrides = self.stage_overrides(publish_record, stage)
     base = (publish_record.ext or {}).get("config_artifact")
-    return DeliveryArtifact(self.artifact_for_stage(base, stage, overrides), overrides)
+    return DeliveryArtifact.compose(base, stage, overrides), overrides
 
 def compose_stored(self, ext, stage) -> DeliveryArtifact:
-    """STORED per-stage slot (restart + rollback) — reproduce what was promoted."""
+    """STORED per-stage slot (restart + rollback) — reproduce what was promoted.
+    These paths only read the slot; they never persist, so no overrides handback."""
     overrides = (ext.get("engine_overrides_by_stage") or {}).get(stage.value)
-    base = ext.get("config_artifact")
-    return DeliveryArtifact(self.artifact_for_stage(base, stage, overrides), overrides)
+    return DeliveryArtifact.compose(ext.get("config_artifact"), stage, overrides)
 ```
 
 - `compose_live` preserves the exact logic release/eval use today (`stage_overrides`
-  already returns `None` for ARCA → `artifact_for_stage(None, …)` → `None`).
+  already returns `None` for ARCA → `compose(None, …)` → `config_artifact=None`).
 - `compose_stored` preserves restart's exact logic today
   (`restart_mixin.py:245‑248`), including the `or {}` guard against a JSON-null slot.
-- Both return `DeliveryArtifact(None, None)` for ARCA — the boundary's teclaw guard
+- Both yield `config_artifact=None` for ARCA — the boundary's teclaw guard
   (`if not delivery.config_artifact`) is only reached on the teclaw branch, so ARCA
   (non-teclaw) ignores it exactly as today.
 
@@ -100,18 +116,18 @@ callers to update are the async wrappers (self-forward) and the flow call sites.
 
 | File | Change |
 |---|---|
-| `services/deploy/engine_ext_stage.py` | **Add** `DeliveryArtifact` dataclass. |
-| `publish_flow/ext_state.py` | **Add** `compose_live` / `compose_stored`; import `DeliveryArtifact`. Primitives unchanged. |
+| `services/deploy/engine_ext_stage.py` | **Add** `DeliveryArtifact` (pure `config_artifact` wrapper + `compose` classmethod, folding in the former `artifact_for_stage`). |
+| `publish_flow/ext_state.py` | **Add** `compose_live` (→ `(DeliveryArtifact, overrides)`) / `compose_stored` (→ `DeliveryArtifact`); import `DeliveryArtifact`. **Remove** `artifact_for_stage` (folded into `compose`). `stage_overrides` / `store_stage_overrides` / `stamp_stage_on_stored_artifact` unchanged. |
 | `services/bot_build_service.py` | Retype `release`/`release_async`/`upgrade`/`upgrade_async` to `delivery: DeliveryArtifact`; internal `delivery.config_artifact`; guards. |
-| `publish_flow/release_stage.py` | `first_release` + `upgrade_release`: `delivery = ext_state.compose_live(...)`; pass `delivery`; persist `delivery.overrides`. Drop the `PublishExtState.artifact_for_stage` static call. |
-| `publish_flow/eval_publish_mixin.py` | `delivery = self._ext_state.compose_live(...)`; pass `delivery`. (Keep the raw `config_artifact` read for the build-artifact presence guard only.) |
+| `publish_flow/release_stage.py` | `first_release` + `upgrade_release`: `delivery, overrides = ext_state.compose_live(...)`; pass `delivery`; persist `overrides`. Drop the `PublishExtState.artifact_for_stage` static call. |
+| `publish_flow/eval_publish_mixin.py` | `delivery, _ = self._ext_state.compose_live(...)`; pass `delivery`. (Keep the raw `config_artifact` read for the build-artifact presence guard only.) |
 | `publish_flow/restart_mixin.py` | `delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage)`; pass `delivery` on both the upgrade and the BOT_NOT_FOUND release fallback. |
 | `publish_flow/rollback_ops_mixin.py` | `delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)`; pass `delivery`. (Keep the raw read for the presence guard only.) **Behavior change (#168).** |
 | `publish_flow_service.py` | **Remove** dead `_stage_overrides` / `_artifact_for_stage` delegators. |
 
 `persist_stage_promotion` / `record_release_ext` / `store_stage_overrides` /
 `stamp_stage_on_stored_artifact` are unchanged — the release path still passes the
-stage overrides to persistence, now via `delivery.overrides`.
+stage overrides to persistence, now via the second element of `compose_live`.
 
 ## Data model changes
 

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/plan.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/plan.md
@@ -62,6 +62,14 @@ class DeliveryArtifact:
         return cls(apply_engine_overrides(restamp_stage(base, stage), overrides))
 ```
 
+**On `dict | None` (CLAUDE.md rule).** The field is *required* — no default, so a
+`DeliveryArtifact` can never be built without it. The value is nullable only because
+`None` is an intentional contract state: the **ARCA mount path has no composed
+artifact** (it delivers via `migration_path`; BaaS ignores `config_artifact` on the
+non-teclaw branch). That is the exact carve-out CLAUDE.md allows for `T | None`
+(`None` is a real state, not a missing-required-value). Making it non-optional would
+force ARCA to fabricate an empty dict or bypass the type — strictly worse.
+
 **Placement decision:** `services/deploy/engine_ext_stage.py`. That module already
 owns the delivery vocabulary this type belongs to (`restamp_stage`,
 `apply_engine_overrides`, the `PublishStage → engine stage-string` map), and

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/spec.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/spec.md
@@ -1,0 +1,119 @@
+# Consolidate per-stage engine_overrides composition into one delivery seam
+
+## Summary
+Before a build artifact is handed to the BaaS layer for delivery, each publish
+stage must have its per-stage `engine_overrides` composed onto it: the
+`engine_ext.stage` field restamped to the target stage, and that stage's DingTalk
+channel config overlaid. Today this composition is **repeated at every delivery
+call site** — release, restart, rollback, and eval each remember (or forget) to
+do it independently. This has already produced the same class of bug twice: a
+delivery path that omits the step silently ships the raw artifact, dropping the
+stage's channels. This change moves the composition to a **single seam** that
+every delivery path goes through, so a call site can no longer skip it. It is a
+pure refactor of the composing paths, with the one behavior change that the
+rollback path — which currently ships the raw artifact — begins composing like
+the others (folding in the fix tracked separately as #168).
+
+## Motivation
+The per-stage channel overlay (`engine_overrides.channels`, carrying e.g. the
+DingTalk `card_template_id`) is not part of the build artifact — it rides in an
+overlay applied at delivery time. Because applying it is **opt-in per call site**,
+the four delivery paths compose inconsistently:
+
+- Release (first-release / upgrade) — composes from a **live** re-fetch of the
+  stage's channels.
+- Restart — composes from the **stored** per-stage slot.
+- Eval — composes from a **live** re-fetch.
+- Rollback — **does not compose**; it ships the stored artifact raw.
+
+This "single-config-slot hazard" has bitten twice: restart before it was fixed,
+and rollback (the subject of #168). Each occurrence is a delivery path that
+forgot the composition and therefore delivered the wrong (or missing) channel
+config to the container. The root problem is structural: nothing forces a
+delivery path to compose, so every new or existing path is one oversight away
+from the same bug. The fix is to make composition the only way to obtain a
+deliverable artifact — a seam every path must pass through — rather than a step
+each path is trusted to remember.
+
+## User Stories
+- As a backend engineer adding or changing a delivery path, I want it to be
+  impossible to hand the BaaS layer a raw, un-composed artifact by accident, so
+  that the class of bug that hit restart and rollback cannot recur.
+- As a backend engineer, I want the one legitimate per-path difference — whether
+  a path composes from the live channel table or from the stored per-stage slot —
+  to be an explicit, named choice at the call site, not logic re-derived and
+  re-typed in each path.
+- As a user who rolls back a bot after changing its DingTalk card template, I want
+  the rollback to restore the target version's channel config (including the card
+  id), so that rolling back actually reverts the channel state.
+- As a maintainer, I want the composition logic (restamp + overlay + the
+  live-vs-stored source choice) to live in one place, so that a change to how
+  artifacts are composed is made once and applies to every delivery path.
+
+## Acceptance Criteria
+- [ ] All four delivery paths (release first/upgrade, restart, rollback, eval)
+      obtain their delivery artifact from the single composition seam; none reads
+      the raw stored artifact and passes it to the BaaS layer directly.
+- [ ] It is not possible for publish-flow code to pass a raw, un-composed artifact
+      to the BaaS delivery boundary — the boundary accepts only a composed
+      delivery artifact produced by the seam.
+- [ ] The live-vs-stored overrides choice is explicit per path: release and eval
+      compose from a live channel re-fetch; restart and rollback compose from the
+      stored per-stage slot. This matches today's behavior for release, restart,
+      and eval.
+- [ ] **(Intended change) Rollback composes.** Rollback now restamps the online
+      stage and overlays the target version's stored online channel overrides,
+      instead of shipping the raw artifact. After a rollback, the container's
+      DingTalk channel config (including `card_template_id`) matches what the
+      target version had when it was online. This folds in the fix tracked as
+      #168.
+- [ ] The ARCA mount path (no stored artifact, `migration_path` only) remains a
+      no-op through the seam — nothing is fetched, restamped, or overlaid, and the
+      artifact delivered stays absent as today.
+- [ ] Pre-feature records with no stored per-stage overrides continue to deliver
+      the base artifact unchanged (restamp only, no overlay), on the paths that
+      compose from the stored slot.
+- [ ] The stored record shape is unchanged: the `ext` JSON keys
+      (`config_artifact`, `engine_overrides_by_stage`, …) written and read are
+      byte-for-byte compatible with existing records; no data migration.
+- [ ] Existing behavior is preserved and verified: the per-stage channel
+      end-to-end suite (`test_publish_per_stage_channels.py`) and the publish-flow
+      unit suite stay green (updated only where the delivery boundary's shape
+      changed), and the rollback path gains unit coverage for the newly-composed
+      behavior (stored overrides delivered; pre-feature record → no overlay).
+
+## In Scope
+- Introducing a single delivery-composition seam that every publish delivery path
+  routes through, with the live-vs-stored overrides choice made explicit per path.
+- Making the BaaS delivery boundary accept only a composed delivery artifact, so a
+  raw artifact cannot be passed from flow code.
+- Routing all four delivery paths (release, restart, rollback, eval) through the
+  seam, and removing the per-path composition copies.
+- Folding the rollback composition (#168) into the shared seam rather than as a
+  separate inline patch.
+- Removing now-dead composition helpers left behind on the flow facade.
+- Updating the unit tests whose expectations reference the delivery boundary's
+  shape, and adding rollback coverage for the newly-composed behavior.
+
+## Out of Scope
+- Any change to how per-stage channel overrides are *read* or *stored* (the
+  channel reader, the `engine_overrides_by_stage` persistence, the restamp/overlay
+  primitives) beyond relocating/wrapping them behind the seam.
+- Any change to externally observable behavior other than the intended rollback
+  composition — endpoints, state-machine semantics, messages, and stored record
+  shape are preserved.
+- The channel table itself is user config, not versioned by publish; reverting the
+  channel row on rollback stays out of scope (only the rollback *delivery* is
+  fixed, matching #168).
+- Refactoring the BaaS/deploy collaborators beyond the minimal surface needed to
+  type the delivery boundary.
+
+## Open Questions
+- **Relationship to #168.** *(Resolved — approved in issue #173.)* #168's rollback
+  fix is not yet merged to `dev`; routing rollback through the shared seam subsumes
+  it, so this change composes rollback and closes both. The one rollback unit test
+  that asserted raw pass-through is reworked to assert composed delivery.
+- **Boundary enforcement strength.** *(Resolved — approved in issue #173.)* The
+  type is pushed all the way to the BaaS delivery boundary (it accepts only the
+  composed delivery artifact), rather than relying on a call-site convention, so a
+  raw artifact is un-passable from flow code.

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
@@ -53,7 +53,7 @@
   - [ ] Full suite green.
 - **Depends on:** Task 1
 
-## Review A: `/code-review` on the Group A diff — [ ]
+## Review A: `/code-review` on the Group A diff — [x]
 - **Goal:** Review the new `DeliveryArtifact` type + seam producers before anything
   depends on them.
 - **Done when:**
@@ -63,7 +63,7 @@
 
 # Group B — Cutover (type-enforce the boundary, route all paths, rollback behavior)
 
-## Task 3: Type-enforce the BaaS boundary + route all four paths through the seam — [ ]
+## Task 3: Type-enforce the BaaS boundary + route all four paths through the seam — [x]
 - **Goal:** Make `BotBuildService`'s delivery methods take `delivery: DeliveryArtifact`
   and rewrite every delivery call site to obtain it from the seam. Atomic: the
   signature change and all call-site migrations land together. Rollback begins
@@ -106,7 +106,7 @@
   - [ ] Full suite green.
 - **Depends on:** Task 2
 
-## Task 4: Rollback regression coverage (folds in #168) — [ ]
+## Task 4: Rollback regression coverage (folds in #168) — [x]
 - **Goal:** Lock in the newly-composed rollback behavior with unit tests mirroring
   #168, so the subsumed fix is regression-covered in this repo.
 - **Files:** `tests/.../services/test_publish_flow_service.py`.
@@ -119,7 +119,7 @@
   - [ ] Full suite green.
 - **Depends on:** Task 3
 
-## Review B: `/code-review` on the Group B diff — [ ]
+## Review B: `/code-review` on the Group B diff — [x]
 - **Goal:** Review the boundary retype + the four rewritten call sites + the
   rollback behavior change — the highest-risk group.
 - **Done when:**

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
@@ -1,0 +1,128 @@
+# Tasks: Consolidate engine_overrides composition into one delivery seam
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+>
+> Base branch: `dev`. Branch: `claude/engine-overrides-composition-seam-rogld5`.
+> Every task must leave the full `tests/community` suite green (`pytest` under the
+> `test` profile) and touch only what it names.
+>
+> **Behavior-pinning safety net:** `tests/community/endpoints/test_publish_per_stage_channels.py`
+> asserts per-stage channel delivery on the **real BaaS HTTP payload** (not on
+> mocked kwargs). It must stay green and **unmodified** across every task — it is
+> the proof that the release/restart paths remain behavior-preserving.
+
+## Task 1: Add `DeliveryArtifact` payload type + `compose` — [ ]
+- **Goal:** Introduce the pure delivery-payload wrapper and the single combiner
+  (restamp + overlay), with no callers yet. Additive, suite stays green.
+- **Files:** `core/service_bot/services/deploy/engine_ext_stage.py`;
+  `tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py`
+  (new, or the existing engine_ext_stage test module if present).
+- **Done when:**
+  - [ ] `@dataclass(frozen=True) DeliveryArtifact` with a single field
+        `config_artifact: dict | None`, in `engine_ext_stage.py`.
+  - [ ] `DeliveryArtifact.compose(base, stage, overrides)` returns
+        `cls(apply_engine_overrides(restamp_stage(base, stage), overrides))`.
+  - [ ] Unit tests: compose restamps `engine_ext.stage`; overlays channels when
+        overrides present; no-ops to `config_artifact=None` for `base=None` (ARCA);
+        pre-feature (`overrides=None`) → restamp only, base channels unchanged.
+  - [ ] Full suite green.
+- **Depends on:** —
+
+## Task 2: Add the seam producers on `PublishExtState` — [ ]
+- **Goal:** Add `compose_live` / `compose_stored` — the only place flow code reads
+  `ext['config_artifact']` for delivery. Additive (old `artifact_for_stage` stays
+  until Task 5), suite stays green.
+- **Files:** `core/service_bot/services/publish_flow/ext_state.py`;
+  `tests/community/core/service_bot/services/test_publish_flow_service.py`
+  (or a focused ext_state test).
+- **Done when:**
+  - [ ] `compose_live(publish_record, stage) -> tuple[DeliveryArtifact, dict | None]`
+        — reads `stage_overrides` (live), composes, returns `(delivery, overrides)`.
+  - [ ] `compose_stored(ext, stage) -> DeliveryArtifact` — reads the stored slot
+        (`(ext.get("engine_overrides_by_stage") or {}).get(stage.value)`), composes.
+  - [ ] Unit tests: `compose_live` returns the applied overrides as element 2 and a
+        composed payload; ARCA (no config_artifact) → `config_artifact=None`,
+        overrides `None`; `compose_stored` reads the slot, tolerates JSON-null slot,
+        pre-feature (no slot) → base restamped only.
+  - [ ] Full suite green.
+- **Depends on:** Task 1
+
+## Task 3: Type-enforce the BaaS boundary + route all four paths through the seam — [ ]
+- **Goal:** Make `BotBuildService`'s delivery methods take `delivery: DeliveryArtifact`
+  and rewrite every delivery call site to obtain it from the seam. Atomic: the
+  signature change and all call-site migrations land together. Rollback begins
+  composing here (the #168 behavior change). Suite green at task end.
+- **Files:** `services/bot_build_service.py`; `publish_flow/release_stage.py`,
+  `publish_flow/eval_publish_mixin.py`, `publish_flow/restart_mixin.py`,
+  `publish_flow/rollback_ops_mixin.py`;
+  `tests/.../services/test_bot_build_service_teclaw_routing.py`,
+  `tests/.../services/test_publish_flow_service.py`.
+- **Done when:**
+  - [ ] `release` / `release_async` / `upgrade` / `upgrade_async` take
+        `delivery: DeliveryArtifact` (not `config_artifact`); internal
+        `config_artifact = delivery.config_artifact`; teclaw guards become
+        `if not delivery.config_artifact:`. Async wrappers self-forward `delivery`.
+  - [ ] `release_stage.first_release` + `upgrade_release`:
+        `delivery, overrides = self._ext_state.compose_live(publish_record, spec.stage)`;
+        pass `delivery=delivery`; persist via `record_release_ext(engine_overrides=overrides)`
+        and `persist_stage_promotion(engine_overrides=overrides)`.
+  - [ ] `eval_publish_mixin`: `delivery, _ = self._ext_state.compose_live(...)`; pass
+        `delivery=delivery` (keep the raw `config_artifact` read for the presence guard).
+  - [ ] `restart_mixin._restart_bot_async`:
+        `delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage)`;
+        pass `delivery=delivery` on the upgrade **and** the BOT_NOT_FOUND release fallback.
+  - [ ] `rollback_ops_mixin.execute_rollback`:
+        `delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)`;
+        pass `delivery=delivery` (keep the raw read for the presence guard).
+  - [ ] `test_bot_build_service_teclaw_routing.py`: wrap `_ARTIFACT` in
+        `DeliveryArtifact(_ARTIFACT)`; the no-artifact-raises cases pass
+        `DeliveryArtifact(None)`; downstream `create_teclaw_bot`/`update_teclaw_bot`
+        `config_artifact` assertions unchanged.
+  - [ ] `test_publish_flow_service.py`: the `...await_args.kwargs["config_artifact"]`
+        assertions (verify/online first-release + upgrade, restart, eval, ARCA)
+        become `kwargs["delivery"].config_artifact`; `test_provider_behavior.py`
+        checked and updated only if it asserts a delivery kwarg.
+  - [ ] `test_execute_rollback_with_config_artifact` reworked from a raw `"s3://…"`
+        string to a dict artifact asserting composed delivery
+        (`delivery.config_artifact["engine_ext"]["stage"] == "release"` + stored
+        online overrides overlaid).
+  - [ ] `test_publish_per_stage_channels.py` still green **unmodified**.
+  - [ ] Full suite green.
+- **Depends on:** Task 2
+
+## Task 4: Rollback regression coverage (folds in #168) — [ ]
+- **Goal:** Lock in the newly-composed rollback behavior with unit tests mirroring
+  #168, so the subsumed fix is regression-covered in this repo.
+- **Files:** `tests/.../services/test_publish_flow_service.py`.
+- **Done when:**
+  - [ ] Test: rollback delivers the target's **stored** online overrides (card id)
+        and the live `ChannelEngineOverridesReader` is **not** called (stored, not
+        live — the card-A-not-B guarantee).
+  - [ ] Test: target with no `engine_overrides_by_stage` → base delivered
+        unchanged (restamp only, no overlay) — pre-feature backward-compat.
+  - [ ] Full suite green.
+- **Depends on:** Task 3
+
+## Task 5: Remove the now-dead composition helpers — [ ]
+- **Goal:** Delete the per-path composition copies the seam replaced, so there is
+  one composition path and no way back to the old inline style.
+- **Files:** `publish_flow/ext_state.py`, `publish_flow_service.py`.
+- **Done when:**
+  - [ ] `PublishExtState.artifact_for_stage` removed (folded into
+        `DeliveryArtifact.compose`); no remaining callers.
+  - [ ] Facade `_stage_overrides` / `_artifact_for_stage` delegators removed;
+        no remaining callers (grep clean across `src/` and `tests/`).
+  - [ ] Full suite green.
+- **Depends on:** Task 3
+
+## Task 6: Whole-suite verification, end-to-end check, draft PR — [ ]
+- **Goal:** Prove the change end-to-end and open the PR.
+- **Files:** — (verification + PR).
+- **Done when:**
+  - [ ] Full `tests/community` suite green under the `test` profile.
+  - [ ] `verify` skill run on the rollback path (the one behavior change): drive a
+        rollback and observe the composed delivery (stored online channels + `release`
+        stamp) reach the BaaS payload.
+  - [ ] Draft PR opened linking `Fixes #173` (and `#168`), subscribed via
+        `subscribe_pr_activity`.
+- **Depends on:** Tasks 3–5

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
@@ -17,7 +17,7 @@
 
 # Group A — Foundation (new type + seam, additive, no call sites changed)
 
-## Task 1: Add `DeliveryArtifact` payload type + `compose` — [ ]
+## Task 1: Add `DeliveryArtifact` payload type + `compose` — [x]
 - **Goal:** Introduce the pure delivery-payload wrapper and the single combiner
   (restamp + overlay), with no callers yet. Additive, suite stays green.
 - **Files:** `core/service_bot/services/deploy/engine_ext_stage.py`;
@@ -34,7 +34,7 @@
   - [ ] Full suite green.
 - **Depends on:** —
 
-## Task 2: Add the seam producers on `PublishExtState` — [ ]
+## Task 2: Add the seam producers on `PublishExtState` — [x]
 - **Goal:** Add `compose_live` / `compose_stored` — the only place flow code reads
   `ext['config_artifact']` for delivery. Additive (old `artifact_for_stage` stays
   until Task 5), suite stays green.

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
@@ -150,7 +150,7 @@
   - [ ] Suite green.
 - **Depends on:** Task 5
 
-## Task 6: Whole-suite verification, end-to-end check, draft PR — [ ]
+## Task 6: Whole-suite verification, end-to-end check, draft PR — [x]
 - **Goal:** Prove the change end-to-end and open the PR.
 - **Files:** — (verification + PR).
 - **Done when:**

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
@@ -10,6 +10,12 @@
 > asserts per-stage channel delivery on the **real BaaS HTTP payload** (not on
 > mocked kwargs). It must stay green and **unmodified** across every task — it is
 > the proof that the release/restart paths remain behavior-preserving.
+>
+> **Review cadence:** tasks are grouped; after each group's tasks are done and the
+> suite is green, run `/code-review` (the `code-review` skill) on that group's diff
+> and resolve findings before starting the next group.
+
+# Group A — Foundation (new type + seam, additive, no call sites changed)
 
 ## Task 1: Add `DeliveryArtifact` payload type + `compose` — [ ]
 - **Goal:** Introduce the pure delivery-payload wrapper and the single combiner
@@ -46,6 +52,16 @@
         pre-feature (no slot) → base restamped only.
   - [ ] Full suite green.
 - **Depends on:** Task 1
+
+## Review A: `/code-review` on the Group A diff — [ ]
+- **Goal:** Review the new `DeliveryArtifact` type + seam producers before anything
+  depends on them.
+- **Done when:**
+  - [ ] `/code-review` run on the Group A diff (Tasks 1–2); findings triaged.
+  - [ ] Real findings fixed (or consciously deferred with a note); suite still green.
+- **Depends on:** Tasks 1–2
+
+# Group B — Cutover (type-enforce the boundary, route all paths, rollback behavior)
 
 ## Task 3: Type-enforce the BaaS boundary + route all four paths through the seam — [ ]
 - **Goal:** Make `BotBuildService`'s delivery methods take `delivery: DeliveryArtifact`
@@ -103,6 +119,18 @@
   - [ ] Full suite green.
 - **Depends on:** Task 3
 
+## Review B: `/code-review` on the Group B diff — [ ]
+- **Goal:** Review the boundary retype + the four rewritten call sites + the
+  rollback behavior change — the highest-risk group.
+- **Done when:**
+  - [ ] `/code-review` (medium/high effort) run on the Group B diff (Tasks 3–4);
+        findings triaged.
+  - [ ] Real findings fixed; `test_publish_per_stage_channels.py` still green and
+        unmodified; suite green.
+- **Depends on:** Tasks 3–4
+
+# Group C — Cleanup + verification
+
 ## Task 5: Remove the now-dead composition helpers — [ ]
 - **Goal:** Delete the per-path composition copies the seam replaced, so there is
   one composition path and no way back to the old inline style.
@@ -115,6 +143,13 @@
   - [ ] Full suite green.
 - **Depends on:** Task 3
 
+## Review C: `/code-review` on the Group C diff — [ ]
+- **Goal:** Review the deletions (no dangling references, no behavior change).
+- **Done when:**
+  - [ ] `/code-review` run on the Group C diff (Task 5); findings triaged and fixed.
+  - [ ] Suite green.
+- **Depends on:** Task 5
+
 ## Task 6: Whole-suite verification, end-to-end check, draft PR — [ ]
 - **Goal:** Prove the change end-to-end and open the PR.
 - **Files:** — (verification + PR).
@@ -125,4 +160,4 @@
         stamp) reach the BaaS payload.
   - [ ] Draft PR opened linking `Fixes #173` (and `#168`), subscribed via
         `subscribe_pr_activity`.
-- **Depends on:** Tasks 3–5
+- **Depends on:** Reviews A–C (all group reviews resolved)

--- a/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
+++ b/src/backend/specs/2026-07-14-engine-overrides-composition-seam/tasks.md
@@ -131,7 +131,7 @@
 
 # Group C — Cleanup + verification
 
-## Task 5: Remove the now-dead composition helpers — [ ]
+## Task 5: Remove the now-dead composition helpers — [x]
 - **Goal:** Delete the per-path composition copies the seam replaced, so there is
   one composition path and no way back to the old inline style.
 - **Files:** `publish_flow/ext_state.py`, `publish_flow_service.py`.
@@ -143,7 +143,7 @@
   - [ ] Full suite green.
 - **Depends on:** Task 3
 
-## Review C: `/code-review` on the Group C diff — [ ]
+## Review C: `/code-review` on the Group C diff — [x]
 - **Goal:** Review the deletions (no dangling references, no behavior change).
 - **Done when:**
   - [ ] `/code-review` run on the Group C diff (Task 5); findings triaged and fixed.

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -31,6 +31,9 @@ from agentclaw.community.core.service_bot.services.baas_service import (
     ENGINE_DIR_MOUNT_WHITELIST_PARAM_CODE,
     BaasService,
 )
+from agentclaw.community.core.service_bot.services.deploy.engine_ext_stage import (
+    DeliveryArtifact,
+)
 from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
     TECLAW_DEVICE_PROVIDER,
 )
@@ -425,7 +428,7 @@ class BotBuildService:
         device_count: int = 1,
         publish_stage: PublishStage = PublishStage.VERIFY,
         version: str = "1",
-        config_artifact: Optional[Dict[str, Any]] = None,
+        delivery: DeliveryArtifact = DeliveryArtifact(None),
         ext_info: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """发布 Bot 到 BaaS 层。
@@ -440,7 +443,9 @@ class BotBuildService:
             device_count: 设备数量，默认 1
             publish_stage: 发布推进阶段，默认验证阶段
             version: 迁移版本号（字符串），默认 "1"
-            config_artifact: 配置 Artifact
+            delivery: 组合后的交付 Artifact（DeliveryArtifact）。只能由
+                PublishExtState 的 compose seam 产生，流程层无法直接传原始
+                config_artifact；ARCA 挂载路径为 config_artifact=None。
             ext_info: Dict[str, Any] = None,
 
         Returns:
@@ -488,16 +493,16 @@ class BotBuildService:
                 # which forwards it to the external container. No migration_path.
                 # The artifact IS the delivery payload, so fail loudly if it is
                 # missing rather than provisioning a container with empty config.
-                if not config_artifact:
+                if not delivery.config_artifact:
                     raise BotBuildServiceError(
                         "teclaw release requires a composed config_artifact; "
-                        f"got {config_artifact!r}"
+                        f"got {delivery.config_artifact!r}"
                     )
                 new_bot = self._baas_service.create_teclaw_bot(
                     bot,
                     owner_id=user_id,
                     request_id=request_id,
-                    config_artifact=config_artifact,
+                    config_artifact=delivery.config_artifact,
                     template_uuid=self._teclaw_template_uuid,
                     device_count=1,
                 )
@@ -579,7 +584,7 @@ class BotBuildService:
         device_count: int = 1,
         publish_stage: PublishStage = PublishStage.VERIFY,
         version: str = "1",
-        config_artifact: Optional[Dict[str, Any]] = None,
+        delivery: DeliveryArtifact = DeliveryArtifact(None),
         ext_info: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """异步发布 Bot 到 BaaS 层。
@@ -594,7 +599,7 @@ class BotBuildService:
             device_count: 设备数量，默认 1
             publish_stage: 发布推进阶段，默认验证阶段
             version: str = "1",发布单版本
-            config_artifact: 配置 Artifact
+            delivery: 组合后的交付 Artifact（DeliveryArtifact）；见 release()。
             ext_info: Optional[Dict[str, Any]] = None,
 
         Returns:
@@ -610,7 +615,7 @@ class BotBuildService:
         # 使用 asyncio.to_thread 在线程池中执行同步方法
         return await asyncio.to_thread(
             self.release, bot, user_id, migration_path, device_count, publish_stage, version,
-            config_artifact, ext_info,
+            delivery, ext_info,
         )
 
     def _sync_skill_links(
@@ -1054,7 +1059,7 @@ class BotBuildService:
             device_count: int = 1,
             publish_stage: PublishStage = PublishStage.ONLINE,
             version: str = "1",
-            config_artifact: Optional[Dict[str, Any]] = None,
+            delivery: DeliveryArtifact = DeliveryArtifact(None),
     ) -> Dict[str, Any]:
         """升级 Bot 到 BaaS 层（复用现有 Bot）。
 
@@ -1070,6 +1075,7 @@ class BotBuildService:
             device_count: 设备数量，默认 1
             publish_stage: 发布推进阶段，默认 ONLINE
             version: str = "1", 发布版本
+            delivery: 组合后的交付 Artifact（DeliveryArtifact）；见 release()。
 
         Returns:
             dict: BaaS 层返回的 Bot 信息（包含 bot_uuid, publish_id）
@@ -1095,17 +1101,17 @@ class BotBuildService:
                 # existing container (non-mount). No migration_path. The artifact
                 # IS the delivery payload, so fail loudly if it is missing rather
                 # than re-delivering empty config to the existing container.
-                if not config_artifact:
+                if not delivery.config_artifact:
                     raise BotBuildServiceError(
                         "teclaw upgrade requires a composed config_artifact; "
-                        f"got {config_artifact!r}"
+                        f"got {delivery.config_artifact!r}"
                     )
                 upgrade_result = self._baas_service.update_teclaw_bot(
                     bot_uuid,
                     bot,
                     owner_id=user_id,
                     request_id=request_id,
-                    config_artifact=config_artifact,
+                    config_artifact=delivery.config_artifact,
                     template_uuid=self._teclaw_template_uuid,
                     device_count=1,
                 )
@@ -1224,7 +1230,7 @@ class BotBuildService:
         device_count: int = 1,
         publish_stage: PublishStage = PublishStage.ONLINE,
         version: str = "1",
-        config_artifact: Optional[Dict[str, Any]] = None,
+        delivery: DeliveryArtifact = DeliveryArtifact(None),
     ) -> Dict[str, Any]:
         """异步升级 Bot 到 BaaS 层。
 
@@ -1238,5 +1244,5 @@ class BotBuildService:
         # 使用 asyncio.to_thread 在线程池中执行同步方法
         return await asyncio.to_thread(
             self.upgrade, bot_uuid, bot, user_id, migration_path, device_count, publish_stage, version,
-            config_artifact,
+            delivery,
         )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/engine_ext_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/engine_ext_stage.py
@@ -12,6 +12,7 @@ This module is the single source of truth for those key names and for the
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from agentclaw.community.core.service_bot.types import PublishStage
@@ -114,3 +115,40 @@ def apply_engine_overrides(
     applied = dict(config_artifact)
     applied["engine_overrides"] = merged
     return applied
+
+
+@dataclass(frozen=True)
+class DeliveryArtifact:
+    """The composed artifact handed to the BaaS delivery boundary for one stage.
+
+    ``config_artifact`` is the fully composed delivery payload — ``engine_ext.stage``
+    restamped to the target stage and that stage's DingTalk channel
+    ``engine_overrides`` overlaid. It is the single value the publish flow hands to
+    ``BotBuildService.release`` / ``upgrade``, and a ``DeliveryArtifact`` is only
+    obtainable via :meth:`compose` (driven by the ``PublishExtState`` seam), so flow
+    code cannot pass a raw, un-composed artifact to BaaS.
+
+    The field is required (no default) but its value is nullable: ``None`` is the
+    intentional ARCA mount-path state — that path pins ``migration_path`` and carries
+    no ``config_artifact``, and the non-teclaw BaaS branch ignores it. (Per the
+    repository's ``T | None`` rule, ``None`` here is a real contract state, not a
+    missing required value.)
+    """
+
+    config_artifact: dict[str, Any] | None
+
+    @classmethod
+    def compose(
+        cls,
+        config_artifact: dict[str, Any] | None,
+        stage: PublishStage,
+        overrides: dict[str, Any] | None,
+    ) -> "DeliveryArtifact":
+        """Compose the delivery payload for ``stage``: restamp ``engine_ext.stage``
+        and overlay ``overrides``' channel config onto ``config_artifact``.
+
+        The single combiner of :func:`restamp_stage` and :func:`apply_engine_overrides`.
+        No-ops (payload stays ``config_artifact``) when there is no artifact (ARCA) or
+        no ``overrides`` (pre-feature record); ``config_artifact=None`` in → out.
+        """
+        return cls(apply_engine_overrides(restamp_stage(config_artifact, stage), overrides))

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -1,25 +1,18 @@
 """Eval-environment publish/teardown + status query, mixed in."""
 from __future__ import annotations
 
-import asyncio
-import time
 from typing import Any, Dict
 
-from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.service_bot.repository.models import (
-    BotPublishRecord,
     PublishStatus,
 )
-from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
-    PublishStatusInvalidError,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
-from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -70,12 +63,10 @@ class EvalPublishMixin:
         if not bot:
             raise PublishFlowServiceError(f"Bot not found: {publish_record.source_bot_id}")
 
-        eval_overrides = self._stage_overrides(publish_record, publish_stage)
-        eval_artifact = self._artifact_for_stage(
-            config_artifact,
-            publish_stage,
-            eval_overrides,
-        )
+        # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
+        # config_artifact read above is only the build-artifact presence guard. Eval
+        # does not persist, so the applied overrides are discarded.
+        delivery, _ = self._ext_state.compose_live(publish_record, publish_stage)
 
         ext_info = {}
         if biz_id:
@@ -89,7 +80,7 @@ class EvalPublishMixin:
             device_count=1,
             publish_stage=publish_stage,
             version=str(publish_record.version or 1),
-            config_artifact=eval_artifact,
+            delivery=delivery,
             ext_info=ext_info,
         )
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
@@ -19,6 +19,7 @@ from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
 from agentclaw.community.core.service_bot.services.deploy.engine_ext_stage import (
+    DeliveryArtifact,
     apply_engine_overrides,
     restamp_stage,
 )
@@ -150,6 +151,45 @@ class PublishExtState:
         overlay that stage's channel ``engine_overrides``. No-ops for the ARCA
         mount path (no ``config_artifact``)."""
         return apply_engine_overrides(restamp_stage(config_artifact, stage), overrides)
+
+    # ── delivery-composition seam ────────────────────────────────────────
+    # The single boundary between a stored build artifact and what BaaS receives.
+    # Every delivery path (release, restart, rollback, eval) composes through one of
+    # these two producers rather than reading ``ext['config_artifact']`` itself, so a
+    # path cannot skip the per-stage stamp+overlay and silently ship the raw artifact
+    # (the "single-config-slot hazard" that bit restart and rollback). The two differ
+    # only in *where the stage overrides come from* — the one legitimate per-path
+    # choice, made explicit here instead of re-derived at each call site.
+    def compose_live(
+        self, publish_record: BotPublishRecord, stage: PublishStage
+    ) -> tuple[DeliveryArtifact, dict | None]:
+        """Compose the delivery artifact for ``stage`` using a LIVE re-fetch of that
+        stage's channel ``engine_overrides`` from the channel reader.
+
+        Used by the release (first/upgrade) and eval paths, which run *at promotion
+        time* and want the stage's currently-active channels. Returns the composed
+        ``DeliveryArtifact`` *and* the raw overrides applied — the release path
+        persists the latter (``store_stage_overrides``) so a future restart/rollback
+        can reproduce it, avoiding a second channel read; eval discards it. Both
+        no-op for the ARCA mount path (``config_artifact=None``, ``overrides=None``)."""
+        overrides = self.stage_overrides(publish_record, stage)
+        base = (publish_record.ext or {}).get("config_artifact")
+        return DeliveryArtifact.compose(base, stage, overrides), overrides
+
+    def compose_stored(self, ext: dict, stage: PublishStage) -> DeliveryArtifact:
+        """Compose the delivery artifact for ``stage`` from the STORED per-stage
+        overrides slot (``ext['engine_overrides_by_stage'][stage]``).
+
+        Used by the restart and rollback paths, which must *reproduce* what was
+        promoted at release time rather than re-derive it live — restarting or
+        rolling back to a non-latest stage must deliver that stage's own channels,
+        never the currently-live ones. These paths only read the slot (they never
+        persist), so no overrides are handed back. ``or {}`` (not a get-default):
+        the slot may hold JSON ``null`` in a raw ext blob. No stored overrides
+        (pre-feature record) or no ``config_artifact`` (ARCA) → the stamp+overlay
+        no-ops, preserving the base."""
+        overrides = (ext.get("engine_overrides_by_stage") or {}).get(stage.value)
+        return DeliveryArtifact.compose(ext.get("config_artifact"), stage, overrides)
 
     @staticmethod
     def store_stage_overrides(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
@@ -20,7 +20,6 @@ from agentclaw.community.core.service_bot.services.bot_publish_service import (
 )
 from agentclaw.community.core.service_bot.services.deploy.engine_ext_stage import (
     DeliveryArtifact,
-    apply_engine_overrides,
     restamp_stage,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
@@ -140,17 +139,6 @@ class PublishExtState:
             bot_id=publish_record.source_bot_id,
             accept_stages={stage.value},
         )
-
-    @staticmethod
-    def artifact_for_stage(
-        config_artifact: dict | None,
-        stage: PublishStage,
-        overrides: dict | None,
-    ) -> dict | None:
-        """The artifact to deliver for ``stage``: stamp ``engine_ext.stage`` and
-        overlay that stage's channel ``engine_overrides``. No-ops for the ARCA
-        mount path (no ``config_artifact``)."""
-        return apply_engine_overrides(restamp_stage(config_artifact, stage), overrides)
 
     # ── delivery-composition seam ────────────────────────────────────────
     # The single boundary between a stored build artifact and what BaaS receives.

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -153,12 +153,10 @@ class ReleaseStageRunner:
         publish_id = publish_record.id
         owner_id = self._ext_state.owner_id(publish_record)
 
-        overrides = self._ext_state.stage_overrides(publish_record, spec.stage)
-        config_artifact = PublishExtState.artifact_for_stage(
-            (publish_record.ext or {}).get("config_artifact"),
-            spec.stage,
-            overrides,
-        )
+        # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
+        # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
+        # overlay, persisted below so a future restart/rollback can reproduce it.
+        delivery, overrides = self._ext_state.compose_live(publish_record, spec.stage)
         release_kwargs = dict(
             bot=bot,
             user_id=owner_id,
@@ -169,7 +167,7 @@ class ReleaseStageRunner:
             # downstream (release_async / build service) branches on the container
             # provider to interpret config_artifact. Push that decision behind the
             # provider seam in a follow-up; tracked separately.
-            config_artifact=config_artifact,
+            delivery=delivery,
         )
         if spec.first_release_passes_version:
             release_kwargs["version"] = f"{publish_record.version}"
@@ -246,12 +244,10 @@ class ReleaseStageRunner:
         version = f"{publish_record.version}"
         owner_id = self._ext_state.owner_id(publish_record)
 
-        overrides = self._ext_state.stage_overrides(publish_record, spec.stage)
-        config_artifact = PublishExtState.artifact_for_stage(
-            (publish_record.ext or {}).get("config_artifact"),
-            spec.stage,
-            overrides,
-        )
+        # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
+        # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
+        # overlay, persisted below via the provider's stage-promotion write.
+        delivery, overrides = self._ext_state.compose_live(publish_record, spec.stage)
         upgrade_result = await self._build_service.upgrade_async(
             bot_uuid=bot_uuid,
             bot=bot,
@@ -260,7 +256,7 @@ class ReleaseStageRunner:
             migration_path=migration_path,
             publish_stage=spec.stage,
             version=version,
-            config_artifact=config_artifact,
+            delivery=delivery,
         )
 
         if (

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -2,24 +2,16 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from typing import Any, Dict
 
-from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
     PublishStatus,
-)
-from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
-from agentclaw.community.core.service_bot.services.bot_publish_service import (
-    PublishNotFoundError,
-    PublishStatusInvalidError,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
-from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -233,19 +225,12 @@ class RestartMixin:
             )
             version = f"{publish_record.version}"
 
-            # Compose the delivery artifact for THIS stage: stamp engine_ext.stage
-            # to the restarted stage and overlay that stage's stored channel
-            # engine_overrides (reproducing what was promoted, NOT a live re-fetch).
-            # Reading the per-stage slot fixes the single-config-slot hazard — a
-            # restart of a non-latest stage no longer delivers another stage's
-            # channels. No stored overrides (pre-feature record) or no
-            # config_artifact (ARCA) → no-ops, preserving prior behavior.
-            ext = publish_record.ext or {}
-            # `or {}` (not a get-default): the key may hold JSON null in a raw ext blob.
-            stored_overrides = (ext.get("engine_overrides_by_stage") or {}).get(stage.value)
-            config_artifact = self._artifact_for_stage(
-                ext.get("config_artifact"), stage, stored_overrides
-            )
+            # Compose the delivery artifact for THIS stage through the single seam
+            # (STORED overrides slot: reproduce what was promoted, NOT a live
+            # re-fetch). The seam reproduces the per-stage channels + stage stamp so a
+            # restart of a non-latest stage never delivers another stage's channels —
+            # the single-config-slot hazard is closed at the boundary.
+            delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage)
             restart_result = await self._build_service.upgrade_async(
                 bot_uuid=bot_uuid,
                 bot=bot,
@@ -254,7 +239,7 @@ class RestartMixin:
                 migration_path=migration_path,
                 publish_stage=stage,
                 version=version,
-                config_artifact=config_artifact,
+                delivery=delivery,
             )
 
             if restart_result.get("success") is False and restart_result.get("error_code") == "BOT_NOT_FOUND":
@@ -270,9 +255,9 @@ class RestartMixin:
                     device_count=1,
                     publish_stage=stage,
                     version=version,
-                    # teclaw: the fallback must carry the frozen artifact too,
+                    # teclaw: the fallback must carry the same composed artifact,
                     # else create_teclaw_bot would receive an empty config.
-                    config_artifact=config_artifact,
+                    delivery=delivery,
                 )
 
             restart_publish_id = restart_result.get("publish_id")

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -1,9 +1,6 @@
 """Rollback deploy + BaaS bot teardown, mixed into PublishFlowService."""
 from __future__ import annotations
 
-import asyncio
-import time
-from typing import Any, Dict
 
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
@@ -12,13 +9,11 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
-    PublishStatusInvalidError,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
-from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -98,8 +93,14 @@ class RollbackOpsMixin:
         if not bot:
             raise PublishFlowServiceError(f"Bot not found: {current_record.source_bot_id}")
 
-        # 5. Call the BaaS upgrade interface to re-deploy
+        # 5. Call the BaaS upgrade interface to re-deploy. Compose the delivery
+        # artifact for the online stage through the single seam (STORED overrides
+        # slot: reproduce the target version's promoted online channels + release
+        # stamp). The raw config_artifact read above is only the build-artifact
+        # presence guard — what BaaS receives is composed here, so a rollback can no
+        # longer silently ship the raw artifact (the single-config-slot hazard).
         version = f"{target_record.version}"
+        delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)
         upgrade_result = await self._build_service.upgrade_async(
             bot_uuid=bot_uuid,
             bot=bot,
@@ -108,7 +109,7 @@ class RollbackOpsMixin:
             migration_path=migration_path,
             publish_stage=PublishStage.ONLINE,
             version=version,
-            config_artifact=config_artifact,
+            delivery=delivery,
         )
 
         baas_publish_id = upgrade_result.get("publish_id")

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -5,7 +5,6 @@ Advances the different stages of the publish flow based on the publish record st
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -253,19 +252,6 @@ class PublishFlowService(
         # release) are enqueued as persisted, crash-safe tasks instead of
         # fire-and-forget asyncio tasks. See publish_flow/tasks.py.
         self._task_queue_service = task_queue_service
-
-    def _stage_overrides(
-        self, publish_record: BotPublishRecord, stage: PublishStage
-    ) -> dict | None:
-        return self._ext_state.stage_overrides(publish_record, stage)
-
-    @staticmethod
-    def _artifact_for_stage(
-        config_artifact: dict | None,
-        stage: PublishStage,
-        overrides: dict | None,
-    ) -> dict | None:
-        return PublishExtState.artifact_for_stage(config_artifact, stage, overrides)
 
     def refresh_publish_handle(self, binding_id, publish_id) -> None:
         """Refresh the baas ``publish_id`` stashed in a reused binding's

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py
@@ -5,6 +5,7 @@ import pytest
 
 from agentclaw.community.core.service_bot.services.deploy.engine_ext_stage import (
     STAGE_VALUE,
+    DeliveryArtifact,
     apply_engine_overrides,
     enrich_engine_ext,
     restamp_stage,
@@ -196,3 +197,43 @@ def test_apply_does_not_mutate_input() -> None:
     # output is a distinct object
     assert out is not artifact
     assert out["engine_overrides"] is not base_eo
+
+
+# ── DeliveryArtifact.compose (restamp + overlay, the single combiner) ────────
+
+
+@pytest.mark.unit
+def test_compose_restamps_stage_and_overlays_channels() -> None:
+    base = {
+        "engine_ext": {"bot_id": "b", "stage": "draft"},
+        "engine_overrides": {
+            "channels": {"dingding": {"enabled": True, "accounts": [{"client_id": "draft"}]}}
+        },
+    }
+    out = DeliveryArtifact.compose(base, PublishStage.VERIFY, _VERIFY_CHANNELS)
+    assert out.config_artifact["engine_ext"]["stage"] == "canary"  # restamped
+    assert out.config_artifact["engine_overrides"] == _VERIFY_CHANNELS  # overlaid
+
+
+@pytest.mark.unit
+def test_compose_none_overrides_restamps_only() -> None:
+    # Pre-feature record: no stored overrides → base channels kept, stage restamped.
+    base_channels = {"channels": {"dingding": {"accounts": [{"client_id": "base"}]}}}
+    base = {"engine_ext": {"stage": "draft"}, "engine_overrides": base_channels}
+    out = DeliveryArtifact.compose(base, PublishStage.ONLINE, None)
+    assert out.config_artifact["engine_ext"]["stage"] == "release"
+    assert out.config_artifact["engine_overrides"] == base_channels  # unchanged
+
+
+@pytest.mark.unit
+def test_compose_none_config_artifact_is_none() -> None:
+    # ARCA mount path: no composed artifact in, config_artifact None out.
+    assert DeliveryArtifact.compose(None, PublishStage.VERIFY, _VERIFY_CHANNELS).config_artifact is None
+
+
+@pytest.mark.unit
+def test_compose_does_not_mutate_input() -> None:
+    engine_ext = {"bot_id": "b", "stage": "draft"}
+    base = {"engine_ext": engine_ext, "engine_overrides": {}}
+    DeliveryArtifact.compose(base, PublishStage.VERIFY, _VERIFY_CHANNELS)
+    assert engine_ext == {"bot_id": "b", "stage": "draft"}  # input untouched

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
@@ -15,6 +15,9 @@ from agentclaw.community.core.service_bot.services.bot_build_service import (
     BotBuildService,
     BotBuildServiceError,
 )
+from agentclaw.community.core.service_bot.services.deploy.engine_ext_stage import (
+    DeliveryArtifact,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.core.devices.services.baas_template_resolver import (
     BaasTemplateResolution,
@@ -67,7 +70,7 @@ def test_release_routes_teclaw_to_create_teclaw_bot():
     svc, baas = _svc("teclaw")
     svc.release(
         _BOT, user_id="u1", migration_path="", publish_stage=PublishStage.VERIFY,
-        config_artifact=_ARTIFACT,
+        delivery=DeliveryArtifact(_ARTIFACT),
     )
     baas.create_teclaw_bot.assert_called_once()
     ck = baas.create_teclaw_bot.call_args
@@ -89,7 +92,7 @@ def test_release_teclaw_continues_when_agent_pass_rule_update_fails():
 
     result = svc.release(
         _BOT, user_id="u1", migration_path="", publish_stage=PublishStage.VERIFY,
-        config_artifact=_ARTIFACT,
+        delivery=DeliveryArtifact(_ARTIFACT),
     )
 
     assert result == {"bot_uuid": "BOT-t", "publish_id": 5}
@@ -161,7 +164,7 @@ def test_upgrade_routes_teclaw_to_update_teclaw_bot():
     svc, baas = _svc("teclaw")
     svc.upgrade(
         "BOT-t", _BOT, user_id="u1", migration_path="",
-        publish_stage=PublishStage.ONLINE, config_artifact=_ARTIFACT,
+        publish_stage=PublishStage.ONLINE, delivery=DeliveryArtifact(_ARTIFACT),
     )
     baas.update_teclaw_bot.assert_called_once()
     uk = baas.update_teclaw_bot.call_args
@@ -220,7 +223,7 @@ def test_upgrade_teclaw_keeps_token_out_of_update_payload_when_query_fails():
 
     result = svc.upgrade(
         "BOT-t", _BOT, user_id="u1", migration_path="",
-        publish_stage=PublishStage.ONLINE, config_artifact=_ARTIFACT,
+        publish_stage=PublishStage.ONLINE, delivery=DeliveryArtifact(_ARTIFACT),
     )
 
     assert result == {"bot_uuid": "BOT-t", "publish_id": 6}
@@ -359,7 +362,7 @@ def test_release_device_count_does_not_apply_to_teclaw_path():
         migration_path="",
         device_count=9,
         publish_stage=PublishStage.VERIFY,
-        config_artifact=_ARTIFACT,
+        delivery=DeliveryArtifact(_ARTIFACT),
     )
 
     assert baas.create_teclaw_bot.call_args.kwargs["device_count"] == 1
@@ -378,7 +381,7 @@ def test_upgrade_device_count_does_not_apply_to_teclaw_path():
         migration_path="",
         device_count=9,
         publish_stage=PublishStage.ONLINE,
-        config_artifact=_ARTIFACT,
+        delivery=DeliveryArtifact(_ARTIFACT),
     )
 
     assert baas.update_teclaw_bot.call_args.kwargs["device_count"] == 1

--- a/src/backend/tests/community/core/service_bot/services/test_ext_state_compose.py
+++ b/src/backend/tests/community/core/service_bot/services/test_ext_state_compose.py
@@ -1,0 +1,124 @@
+"""Unit tests for the PublishExtState delivery-composition seam.
+
+``compose_live`` (release/eval, LIVE channel re-fetch) and ``compose_stored``
+(restart/rollback, STORED per-stage slot) are the single boundary through which
+every delivery path composes its artifact. These tests pin the two producers'
+behavior directly, independent of the flow facade.
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services.deploy.engine_ext_stage import (
+    DeliveryArtifact,
+)
+from agentclaw.community.core.service_bot.services.publish_flow.ext_state import (
+    PublishExtState,
+)
+from agentclaw.community.core.service_bot.types import PublishStage
+
+_CH = {"channels": {"dingding": {"enabled": True, "accounts": [{"client_id": "c1"}]}}}
+
+
+def _artifact(stage="draft", channels=None):
+    art = {"engine_type": "teclaw", "engine_ext": {"bot_id": "b", "owner_id": "u1", "stage": stage}}
+    if channels is not None:
+        art["engine_overrides"] = channels
+    return art
+
+
+def _record(ext):
+    rec = Mock()
+    rec.ext = ext
+    rec.owner_id = "u1"
+    rec.source_bot_id = "bot-1"
+    return rec
+
+
+def _ext_state(reader_result=_CH):
+    reader = Mock()
+    reader.overrides_for_stage.return_value = reader_result
+    return PublishExtState(Mock(), reader), reader
+
+
+# ── compose_live (LIVE re-fetch) ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_compose_live_overlays_live_channels_and_returns_overrides():
+    seam, reader = _ext_state(reader_result=_CH)
+    record = _record({"config_artifact": _artifact("draft")})
+
+    delivery, overrides = seam.compose_live(record, PublishStage.VERIFY)
+
+    assert isinstance(delivery, DeliveryArtifact)
+    assert delivery.config_artifact["engine_ext"]["stage"] == "canary"  # restamped
+    assert delivery.config_artifact["engine_overrides"] == _CH  # live channels overlaid
+    assert overrides == _CH  # handed back for the release path to persist
+    reader.overrides_for_stage.assert_called_once()
+
+
+@pytest.mark.unit
+def test_compose_live_arca_no_config_artifact_is_noop_and_skips_reader():
+    # ARCA mount path: ext has no config_artifact → no fetch, nothing composed.
+    seam, reader = _ext_state()
+    record = _record({"migration_path": "/tmp/m"})
+
+    delivery, overrides = seam.compose_live(record, PublishStage.ONLINE)
+
+    assert delivery.config_artifact is None
+    assert overrides is None
+    reader.overrides_for_stage.assert_not_called()
+
+
+# ── compose_stored (STORED slot) ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_compose_stored_delivers_the_slot_not_live_channels():
+    # Regression shape (#168 / restart retry-hole): the base carries stale channels
+    # and BOTH stages are stored; composing VERIFY must deliver the VERIFY slot.
+    verify_ch = {"channels": {"dingding": {"accounts": [{"client_id": "verify"}]}}}
+    online_ch = {"channels": {"dingding": {"accounts": [{"client_id": "online"}]}}}
+    seam, reader = _ext_state()
+    ext = {
+        "config_artifact": _artifact("release", {"channels": {"dingding": {"accounts": [{"client_id": "stale"}]}}}),
+        "engine_overrides_by_stage": {"verify": verify_ch, "online": online_ch},
+    }
+
+    delivery = seam.compose_stored(ext, PublishStage.VERIFY)
+
+    assert delivery.config_artifact["engine_overrides"] == verify_ch
+    assert delivery.config_artifact["engine_ext"]["stage"] == "canary"
+    reader.overrides_for_stage.assert_not_called()  # stored, never live
+
+
+@pytest.mark.unit
+def test_compose_stored_pre_feature_record_restamps_base_only():
+    base_ch = {"channels": {"dingding": {"accounts": [{"client_id": "base"}]}}}
+    seam, _ = _ext_state()
+    ext = {"config_artifact": _artifact("release", base_ch)}  # no engine_overrides_by_stage
+
+    delivery = seam.compose_stored(ext, PublishStage.VERIFY)
+
+    assert delivery.config_artifact["engine_overrides"] == base_ch  # unchanged (no overlay)
+    assert delivery.config_artifact["engine_ext"]["stage"] == "canary"  # restamped
+
+
+@pytest.mark.unit
+def test_compose_stored_tolerates_json_null_slot():
+    seam, _ = _ext_state()
+    ext = {"config_artifact": _artifact("release"), "engine_overrides_by_stage": None}
+
+    delivery = seam.compose_stored(ext, PublishStage.VERIFY)
+
+    assert delivery.config_artifact["engine_ext"]["stage"] == "canary"
+
+
+@pytest.mark.unit
+def test_compose_stored_arca_no_config_artifact_is_none():
+    seam, _ = _ext_state()
+    delivery = seam.compose_stored({"migration_path": "/tmp/m"}, PublishStage.ONLINE)
+    assert delivery.config_artifact is None

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -549,7 +549,7 @@ async def test_restart_fallback_threads_config_artifact():
     except Exception:
         pass  # downstream approve/status flow not under test
 
-    assert build_service.release_async.await_args.kwargs["config_artifact"] == artifact
+    assert build_service.release_async.await_args.kwargs["delivery"].config_artifact == artifact
 
 
 # ── Task 9: restart reads stored per-stage overrides ─────────────────────────
@@ -591,7 +591,7 @@ async def test_restart_verify_delivers_stored_verify_overrides_not_online():
         stage=PublishStage.VERIFY, operator="op",
     )
 
-    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_overrides"] == _VERIFY_CH
     assert delivered["engine_ext"]["stage"] == "canary"
 
@@ -618,7 +618,7 @@ async def test_restart_no_stored_overrides_delivers_restamped_base():
         stage=PublishStage.VERIFY, operator="op",
     )
 
-    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_overrides"] == base_channels  # unchanged (no overlay)
     assert delivered["engine_ext"]["stage"] == "canary"    # still restamped
 
@@ -644,7 +644,7 @@ async def test_restart_tolerates_null_engine_overrides_by_stage():
         stage=PublishStage.VERIFY, operator="op",
     )
 
-    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_ext"]["stage"] == "canary"
 
 
@@ -892,7 +892,7 @@ async def test_verify_first_release_stamps_canary_delivered_and_persisted():
         bot={"bot_id": "b2", "owner_id": "u1"},
     )
 
-    delivered = build_service.release_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.release_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_ext"]["stage"] == "canary"
     # identity keys stable across the promotion
     assert delivered["engine_ext"]["bot_id"] == "b2"
@@ -931,7 +931,7 @@ async def test_verify_upgrade_stamps_canary_delivered_and_persisted():
         verify_binding_id=123,
     )
 
-    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_ext"]["stage"] == "canary"
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]["config_artifact"]
     assert persisted["engine_ext"]["stage"] == "canary"
@@ -1016,7 +1016,7 @@ async def test_verify_first_release_overlays_and_stores_stage_channels():
     # fetched for the VERIFY stage only
     assert reader.overrides_for_stage.call_args.kwargs["accept_stages"] == {"verify"}
     # delivered artifact carries the verify channels
-    delivered = build_service.release_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.release_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_overrides"] == _VERIFY_CH
     assert delivered["engine_ext"]["stage"] == "canary"
     # persisted per-stage map
@@ -1050,7 +1050,7 @@ async def test_verify_upgrade_overlays_and_stores_stage_channels():
         bot={"bot_id": "b2", "owner_id": "u1"}, bot_uuid="BOT-old", verify_binding_id=123,
     )
 
-    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_overrides"] == _VERIFY_CH
     assert delivered["engine_ext"]["stage"] == "canary"
     persisted_ext = svc._ext_state.update_status.call_args.kwargs["ext"]
@@ -1112,7 +1112,7 @@ async def test_verify_first_release_arca_skips_channel_fetch_and_store():
     )
 
     reader.overrides_for_stage.assert_not_called()
-    assert build_service.release_async.await_args.kwargs["config_artifact"] is None
+    assert build_service.release_async.await_args.kwargs["delivery"].config_artifact is None
     persisted_ext = svc._ext_state.update_status.call_args.kwargs["ext"]
     assert "engine_overrides_by_stage" not in persisted_ext
 
@@ -1145,7 +1145,7 @@ async def test_online_first_release_stamps_release_delivered_and_persisted():
         bot={"bot_id": "b2", "owner_id": "u1"},
     )
 
-    delivered = build_service.release_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.release_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_ext"]["stage"] == "release"
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]["config_artifact"]
     assert persisted["engine_ext"]["stage"] == "release"
@@ -1185,7 +1185,7 @@ async def test_online_upgrade_stamps_release_delivered_and_persisted():
         bot={"bot_id": "b2", "owner_id": "u1"},
     )
 
-    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_ext"]["stage"] == "release"
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]["config_artifact"]
     assert persisted["engine_ext"]["stage"] == "release"
@@ -1267,7 +1267,7 @@ async def test_online_first_release_overlays_and_stores_stage_channels():
     )
 
     assert reader.overrides_for_stage.call_args.kwargs["accept_stages"] == {"online"}
-    delivered = build_service.release_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.release_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_overrides"] == _ONLINE_CH
     assert delivered["engine_ext"]["stage"] == "release"
     persisted_ext = svc._ext_state.update_status.call_args.kwargs["ext"]
@@ -1305,7 +1305,7 @@ async def test_online_upgrade_overlays_and_stores_stage_channels():
         bot={"bot_id": "b2", "owner_id": "u1"},
     )
 
-    delivered = build_service.upgrade_async.await_args.kwargs["config_artifact"]
+    delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_overrides"] == _ONLINE_CH
     assert delivered["engine_ext"]["stage"] == "release"
     persisted_ext = svc._ext_state.update_status.call_args.kwargs["ext"]
@@ -1342,7 +1342,7 @@ async def test_arca_path_has_no_config_artifact_and_is_not_restamped():
         bot={"bot_id": "b2", "owner_id": "u1"},
     )
 
-    assert build_service.release_async.await_args.kwargs["config_artifact"] is None
+    assert build_service.release_async.await_args.kwargs["delivery"].config_artifact is None
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]
     assert "config_artifact" not in persisted
 
@@ -1532,8 +1532,11 @@ async def test_execute_rollback_missing_binding():
 
 
 @pytest.mark.asyncio
-async def test_execute_rollback_with_config_artifact():
-    """execute_rollback uses config_artifact (the teclaw scenario)."""
+async def test_execute_rollback_composes_stored_online_delivery():
+    """execute_rollback composes the delivery through the seam (teclaw scenario):
+    the target version's frozen artifact is restamped to the online (release) stage
+    and its STORED online channel overrides are overlaid — the raw artifact is never
+    delivered. This is the #168 behavior, folded into the shared seam."""
     publish_service = Mock()
     build_service = Mock()
     baas_service = Mock()
@@ -1552,13 +1555,17 @@ async def test_execute_rollback_with_config_artifact():
         source_bot_id="bot-456",
     )
 
-    # Target version has only config_artifact (no migration_path)
+    # Target version carries a frozen artifact (last stamped canary, with stale
+    # channels) + the online channels promoted at its online release; no migration_path.
     target_record = _make_publish_record(
         id=2,
         status=PublishStatus.SUCCESS.value,
         version=2,
         ext={
-            "config_artifact": "s3://bucket/artifact/v2.json",
+            "config_artifact": _enriched_artifact(
+                "canary", {"channels": {"dingding": {"accounts": [{"client_id": "stale"}]}}}
+            ),
+            "engine_overrides_by_stage": {"online": _ONLINE_CH},
             "binding": {"online": 200},
         },
     )
@@ -1583,13 +1590,79 @@ async def test_execute_rollback_with_config_artifact():
         operator="user1",
     )
 
-    # Verify upgrade_async used config_artifact
+    # The seam restamped to the online (release) stage and overlaid the stored online
+    # channels — the raw canary/stale artifact is never delivered.
     upgrade_call = build_service.upgrade_async.call_args
-    assert upgrade_call.kwargs["config_artifact"] == "s3://bucket/artifact/v2.json"
+    delivered = upgrade_call.kwargs["delivery"].config_artifact
+    assert delivered["engine_ext"]["stage"] == "release"
+    assert delivered["engine_overrides"] == _ONLINE_CH
     assert upgrade_call.kwargs["migration_path"] is None
 
     assert result.publish_id == 2
     assert result.status == PublishStatus.ONLINE_PUB
+
+
+def _rollback_svc(target_ext, *, reader=None):
+    """Wire a PublishFlowService for an execute_rollback(3 → 2) call, with the target
+    (id=2) carrying ``target_ext`` and an online binding. Returns (svc, build_service)."""
+    publish_service = Mock()
+    build_service = Mock()
+    build_service.upgrade_async = AsyncMock(return_value={"publish_id": 12345})
+    build_service.generate_request_id = Mock(return_value="req")
+    bot_service = Mock()
+    kw = {"channel_overrides_reader": reader} if reader is not None else {}
+    svc = _pf(publish_service, build_service, Mock(), bot_service, _arca_router(build_service), **kw)
+
+    current = _make_publish_record(id=3, status=PublishStatus.DRAFT.value, version=3, source_bot_id="bot-1")
+    target = _make_publish_record(id=2, status=PublishStatus.SUCCESS.value, version=2, ext=target_ext)
+    publish_service.get_publish_by_id = Mock(side_effect=lambda pk: {2: target, 3: current}.get(pk))
+    binding = Mock()
+    binding.device_id = "BOT-online"
+    publish_service.get_device_binding_by_id.return_value = binding
+    bot_service.get_bot.return_value = {"bot_id": "bot-1", "entity_id": "e", "entity_type": "staff"}
+    return svc, build_service
+
+
+@pytest.mark.asyncio
+async def test_execute_rollback_reads_stored_slot_not_live_channels():
+    # Regression (#168): rollback must reproduce the target's promoted channels from
+    # the STORED slot — never re-fetch live (live holds the post-change card the user
+    # is rolling away from). The live reader must not be consulted.
+    reader = Mock()
+    reader.overrides_for_stage = Mock()
+    svc, build_service = _rollback_svc(
+        {
+            "config_artifact": _enriched_artifact("release"),
+            "engine_overrides_by_stage": {"online": _ONLINE_CH},
+            "binding": {"online": 200},
+        },
+        reader=reader,
+    )
+
+    await svc.execute_rollback(current_publish_id=3, target_publish_id=2, operator="u1")
+
+    delivered = build_service.upgrade_async.call_args.kwargs["delivery"].config_artifact
+    assert delivered["engine_overrides"] == _ONLINE_CH  # stored slot delivered
+    reader.overrides_for_stage.assert_not_called()  # never live
+
+
+@pytest.mark.asyncio
+async def test_execute_rollback_pre_feature_target_delivers_base_restamped_only():
+    # Pre-feature target (no engine_overrides_by_stage): overlay no-ops, base channels
+    # delivered unchanged; engine_ext.stage still restamped to release. Backward-compat.
+    base_ch = {"channels": {"dingding": {"accounts": [{"client_id": "base"}]}}}
+    svc, build_service = _rollback_svc(
+        {
+            "config_artifact": _enriched_artifact("release", base_ch),
+            "binding": {"online": 200},
+        }
+    )
+
+    await svc.execute_rollback(current_publish_id=3, target_publish_id=2, operator="u1")
+
+    delivered = build_service.upgrade_async.call_args.kwargs["delivery"].config_artifact
+    assert delivered["engine_overrides"] == base_ch  # unchanged (no overlay)
+    assert delivered["engine_ext"]["stage"] == "release"  # still restamped
 
 
 # teclaw build-time file promotion moved to TeclawProviderBehavior; its test now

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -1795,7 +1795,6 @@ def test_scale_bot_teclaw_returns_supported_message_without_baas_call():
 
 @pytest.mark.unit
 def test_scale_bot_invalid_status():
-    from agentclaw.community.core.service_bot.services.bot_publish_service import PublishStatusInvalidError
     publish_service = Mock()
     build_service = Mock()
     baas_service = Mock()

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -2447,7 +2447,7 @@ def _svc_with_record(
 
 
 _CREATE_TASK = (
-    "agentclaw.community.core.service_bot.services.publish_flow_service.asyncio.create_task"
+    "agentclaw.community.core.service_bot.services.publish_flow.restart_mixin.asyncio.create_task"
 )
 
 

--- a/src/backend/tests/community/endpoints/test_service_bot_rollback.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_rollback.py
@@ -93,7 +93,6 @@ def _seed_base(world) -> dict:
         SkillSetRepository,
     )
     from agentclaw.community.core.resources.repository.protocol import ResourceRepositoryProtocol
-    from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
     from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
 
     world.get(SkillRepoSyncPlugin).set_override("get_local_skills_root", lambda: None)
@@ -373,3 +372,89 @@ def error_rollback_not_found():
 )
 def error_rollback_invalid_status():
     """Rollback a DRAFT publish → service error (invalid status)."""
+
+
+# ── per-stage channel restore on rollback (end-to-end #168 acceptance) ─────────
+
+# V1 (rollback target) frozen artifact, last stamped at verify (canary); rollback
+# must restamp it to the online (release) stage.
+_ENRICHED_V1 = {
+    **_ARTIFACT,
+    "engine_ext": {"bot_id": _BOT_ID, "owner_id": _OWNER, "stage": "canary"},
+}
+# The online channel config V1 promoted (card-A), stored in its per-stage slot.
+_STORED_ONLINE_CARD_A = {
+    "channels": {"dingding": {"enabled": True,
+                              "accounts": [{"client_id": "dt", "card_template_id": "card-A"}]}}
+}
+
+
+def _seed_rollback_stored_online_channel(world) -> None:
+    """V1 UPGRADED (rollback target) carries a stored online slot with card-A; the
+    LIVE channel table holds card-B (the post-change state being rolled away from).
+    V2 SUCCESS is the current version. Rolling back V2 must deliver card-A, not card-B."""
+    bot = _seed_base(world)
+    _install_baas_for_rollback(world)
+
+    from agentclaw.community.core.channel.services.repositories import ChannelRepository
+    # Live table now holds card-B — rollback must NOT consult it (compose_stored).
+    world.get(ChannelRepository).insert_channel(
+        type="dingding", description=None, identity_id=_OWNER, bind_bot_id=_BOT_ID,
+        config={"client_id": "dt", "card_template_id": "card-B"}, status="1", stage="online",
+    )
+
+    vbid1 = _binding(world, device_id=f"{_VERIFY_UUID}-1", status="ACTIVE")
+    obid1 = _binding(world, device_id=f"{_ONLINE_UUID}-1", status="RELEASED")
+    vbid2 = _binding(world, device_id=f"{_VERIFY_UUID}-2", status="ACTIVE")
+    obid2 = _binding(world, device_id=f"{_ONLINE_UUID}-2", status="ACTIVE")
+
+    repo = world.get(BotPublishRepositoryProtocol)
+    repo.insert({
+        "source_bot_pk": bot["id"], "source_bot_id": _BOT_ID, "publish_bot_id": _BOT_ID,
+        "name": "V1 Publish", "owner_id": _OWNER, "permission_owner": _OWNER,
+        "status": PublishStatus.UPGRADED, "version": 1, "env": "dev",
+        "ext": {
+            "binding": {"verify": vbid1, "online": obid1},
+            "publish": {"verify": _BAAS_PUB_ID, "online": _BAAS_PUB_ID},
+            "config_artifact": _ENRICHED_V1,
+            "engine_overrides_by_stage": {"online": _STORED_ONLINE_CARD_A},
+        },
+    })
+    repo.insert({
+        "source_bot_pk": bot["id"], "source_bot_id": _BOT_ID, "publish_bot_id": _BOT_ID,
+        "name": "V2 Publish", "owner_id": _OWNER, "permission_owner": _OWNER,
+        "status": PublishStatus.SUCCESS, "version": 2, "env": "dev", "last_pub_id": _V1,
+        "ext": {
+            "binding": {"verify": vbid2, "online": obid2},
+            "publish": {"verify": _BAAS_PUB_ID, "online": _BAAS_PUB_ID},
+            "config_artifact": _ENRICHED_V1,
+        },
+    })
+
+
+def _delivered_update_artifact(world) -> dict:
+    update = next(c for c in _baas(world).calls_to("post") if "/update" in c.args[0])
+    return update.kwargs["json"]["config"]["deploy_config"]["teclaw_bot_config"]
+
+
+def _expect_rollback_delivers_stored_card_a(response, world):  # noqa: ARG001
+    art = _delivered_update_artifact(world)
+    accounts = art["engine_overrides"]["channels"]["dingding"]["accounts"]
+    # Delivered the STORED online card-A, never the live table's card-B.
+    assert [a.get("card_template_id") for a in accounts] == ["card-A"], art["engine_overrides"]
+    # Restamped from the stored canary stamp to the online (release) stage.
+    assert art["engine_ext"]["stage"] == "release", art["engine_ext"]
+
+
+@endpoint_test(
+    method="POST", path=_ROLLBACK, scenario="rollback_restores_stored_online_channel",
+    input=CaseInput(path_params={"publish_id": _V2}, headers=_HEADERS),
+    seed=_seed_rollback_stored_online_channel, drain_background=True,
+    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    extra_assertions=(_expect_rollback_delivers_stored_card_a,),
+)
+def rollback_restores_stored_online_channel():
+    """Rolling back V2 → V1 composes V1's STORED online channel overrides (card-A)
+    onto the delivered artifact and restamps engine_ext.stage=release; the live
+    channel table's post-change card-B is never consulted. End-to-end proof of the
+    #168 fix on the real BaaS /update payload."""


### PR DESCRIPTION
## What & why

Consolidates the per-stage `engine_overrides` composition (restamp `engine_ext.stage` + overlay the stage's DingTalk channels) into a **single delivery seam** every publish delivery path routes through, so a call site can no longer skip it and silently ship the raw artifact — the "single-config-slot hazard" that has bitten twice (restart, and rollback in #168).

Closes #173. **Fixes #168** — routing rollback through the shared stored-slot seam *is* its fix; #168 was not yet merged to `dev`, so this composes rollback and closes both.

Approved plan: https://github.com/inclusionAI/Avernet/issues/173#issuecomment-4971051408 · SDD artifacts under `src/backend/specs/2026-07-14-engine-overrides-composition-seam/`.

## Approach

- **`DeliveryArtifact`** — a pure value object in the `deploy` layer wrapping the composed payload, with a `compose(base, stage, overrides)` combiner (folds in the old `artifact_for_stage`).
- **Composition seam on `PublishExtState`** — two explicit producers making the one legitimate per-path choice explicit:
  - `compose_live` (release + eval) → live channel re-fetch; returns `(DeliveryArtifact, overrides)` so only the release path persists the applied overlay.
  - `compose_stored` (restart + rollback) → the stored per-stage slot, reproducing what was promoted.
- **Type-enforced BaaS boundary** — `BotBuildService.release`/`release_async`/`upgrade`/`upgrade_async` now accept `delivery: DeliveryArtifact` instead of a raw `config_artifact`, so flow code *cannot* hand an un-composed artifact to BaaS.
- Removed the now-dead per-path helpers (`artifact_for_stage`, facade `_stage_overrides`/`_artifact_for_stage`).

## Behavior change

Pure refactor except **rollback now composes**: it restamps the online stage and overlays the target version's stored online channel overrides (the #168 fix), so a rollback restores the container's DingTalk channel config (incl. `card_template_id`) instead of shipping the raw artifact. ARCA (`migration_path`, no `config_artifact`) stays a no-op path; stored `ext` shape is unchanged (no migration).

## Tests

- New unit coverage: `DeliveryArtifact.compose`, the `compose_live`/`compose_stored` seam, and rollback (stored-not-live; pre-feature no-op).
- **End-to-end (#168 acceptance):** `test_service_bot_rollback.py::rollback_restores_stored_online_channel` — live table holds card-B, rollback delivers the stored card-A restamped to `release` on the real BaaS `/update` payload.
- The behavior-pinning `test_publish_per_stage_channels.py` (real-payload per-stage delivery) stays green and **unmodified**.
- Full `tests/community` suite: **7826 passed, 3 skipped**. Changed files lint-clean (`ruff`).

## Notes

- Also drops a handful of pre-existing dead imports in the source/test files this PR already touches, and fixes one stale test patch target (`publish_flow_service.asyncio` → `restart_mixin.asyncio`, where `restart_bot`'s `create_task` has lived since the #105 split).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)