### PR TITLE
feat(baas): remove legacy allow-all from parse_policy

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/dependencies.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/dependencies.py
@@ -185,8 +185,8 @@ def validate_policy(
     """根据 API Key 的 policy 校验对目标 bot 的访问权限
 
     policy 语义（parse_policy 归一化后）：
-    - allowed_bots 含 "*"：允许访问所有 bot（含历史未配置的存量 key）。
-    - allowed_bots 为空（含历史 ["NONE"] 哨兵）：拒绝所有 bot（fail-closed）。
+    - allowed_bots 含 "*"：允许访问所有 bot（显式配置）。
+    - allowed_bots 为空（含历史 ["NONE"] 哨兵 / 未配置 policy / 缺少 allowed_bots key）：拒绝所有 bot（fail-closed）。
     - 否则：白名单匹配，仅命中的 bot 放行。
 
     Args:
@@ -204,7 +204,7 @@ def validate_policy(
     policy = parse_policy(api_key_record.policy)
 
     if APIKeyPolicy.ALL in policy.allowed_bots:
-        # 显式 allow-all（含历史未配置存量 key 的归一结果）
+        # 显式 allow-all
         return target_bot_id
 
     matched = match_allowed_bots(target_bot_id, policy.allowed_bots)

--- a/src/baas/src/secbaas/community/api/api_gateway/_policy.py
+++ b/src/baas/src/secbaas/community/api/api_gateway/_policy.py
@@ -8,11 +8,10 @@ Policy semantics (read after :func:`parse_policy` normalization):
   therefore normalizes to empty = deny all).
 - otherwise → whitelist: only bots listed in ``allowed_bots`` are allowed.
 
-Historical compatibility: a key whose ``policy`` is ``NULL``/empty or whose
-JSON object lacks the ``allowed_bots`` key historically meant "allow all".
-This is preserved by normalizing those forms to ``["*"]`` on read, so legacy
-unchanged keys keep working. New code writes explicit, structured policies
-(empty list = deny all).
+A key whose ``policy`` is ``NULL``/empty or whose JSON object lacks the
+``allowed_bots`` key is treated as deny-all (fail-closed). The historical
+allow-all behavior for these forms has been removed — all keys must now
+carry an explicit, structured policy.
 """
 
 from __future__ import annotations
@@ -48,8 +47,8 @@ def parse_policy(policy: str | None) -> APIKeyPolicy:
 
     Normalization rules:
 
-    - ``None`` / empty string → ``allowed_bots=["*"]`` (legacy allow-all).
-    - dict without ``allowed_bots`` key → ``["*"]`` (legacy allow-all).
+    - ``None`` / empty string → ``allowed_bots=[]`` (deny all, fail-closed).
+    - dict without ``allowed_bots`` key → ``[]`` (deny all, fail-closed).
     - dict with ``allowed_bots`` containing the ``"NONE"`` sentinel → the
       sentinel is filtered out (a lone ``["NONE"]`` becomes empty = deny all;
       ``["NONE", "bot-1"]`` keeps ``["bot-1"]``).
@@ -63,7 +62,7 @@ def parse_policy(policy: str | None) -> APIKeyPolicy:
         Normalized :class:`APIKeyPolicy`.
     """
     if not policy or not policy.strip():
-        return APIKeyPolicy(allowed_bots=[APIKeyPolicy.ALL])
+        return APIKeyPolicy()  # fail-closed: deny all
     try:
         result = json.loads(policy)
     except (json.JSONDecodeError, TypeError):
@@ -71,7 +70,7 @@ def parse_policy(policy: str | None) -> APIKeyPolicy:
     if not isinstance(result, dict):
         return APIKeyPolicy()  # fail-closed: deny all
     if "allowed_bots" not in result:
-        return APIKeyPolicy(allowed_bots=[APIKeyPolicy.ALL])  # legacy allow-all
+        return APIKeyPolicy()  # fail-closed: deny all
     raw = result.get("allowed_bots")
     if not isinstance(raw, list):
         return APIKeyPolicy()  # fail-closed: deny all

--- a/src/baas/tests/unit/adapters/web/open_api/test_dependencies.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_dependencies.py
@@ -372,16 +372,19 @@ class TestBotServiceSelector:
 
 
 class TestValidatePolicy:
-    def test_no_policy_returns_target_bot_id(self):
-        """None policy → 允许所有，返回原始 target_bot_id。"""
+    def test_no_policy_denies_all(self):
+        """None policy → deny all (fail-closed)，返回 403。"""
         record = _make_api_key_record(policy=None)
-        result = validate_policy(record, "bot-1:entity-1")
-        assert result == "bot-1:entity-1"
+        with pytest.raises(HTTPException) as exc:
+            validate_policy(record, "any-bot")
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_empty_policy_string_returns_target_bot_id(self):
+    def test_empty_policy_string_denies_all(self):
+        """空 policy → deny all (fail-closed)，返回 403。"""
         record = _make_api_key_record(policy="")
-        result = validate_policy(record, "bot-1:entity-1")
-        assert result == "bot-1:entity-1"
+        with pytest.raises(HTTPException) as exc:
+            validate_policy(record, "any-bot")
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
     def test_empty_allowed_bots_list_denies_all(self):
         """Empty allowed_bots → deny all (fail-closed)，返回 403。"""
@@ -403,11 +406,12 @@ class TestValidatePolicy:
         result = validate_policy(record, "any-bot")
         assert result == "any-bot"
 
-    def test_no_allowed_bots_key_allows_all(self):
-        """Policy without allowed_bots key → legacy allow-all，返回原始 target_bot_id。"""
+    def test_no_allowed_bots_key_denies_all(self):
+        """Policy without allowed_bots key → deny all (fail-closed)，返回 403。"""
         record = _make_api_key_record(policy='{"other_key": "value"}')
-        result = validate_policy(record, "any-bot")
-        assert result == "any-bot"
+        with pytest.raises(HTTPException) as exc:
+            validate_policy(record, "any-bot")
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
     def test_bot_id_in_allowed_list_returns_matched_bot_id(self):
         """匹配时返回 allowed_bots 中的权威 bot_id。"""

--- a/src/baas/tests/unit/adapters/web/test_api_gateway_router.py
+++ b/src/baas/tests/unit/adapters/web/test_api_gateway_router.py
@@ -842,11 +842,11 @@ class TestGetAllowedBots:
         self,
         sample_app_key_response: APIKeyResponse,
     ) -> None:
-        """Key with None policy → legacy allow-all, normalized to ['*']."""
+        """Key with None policy → deny-all, normalized to []."""
         key = sample_app_key_response.model_copy(update={"policy": None})
         result = await get_allowed_bots("sk-app", key)
         assert isinstance(result, ApiResponse)
-        assert result.data == {"allowed_bots": ["*"]}
+        assert result.data == {"allowed_bots": []}
 
     @pytest.mark.asyncio
     async def test_none_sentinel_filtered_out(

--- a/src/baas/tests/unit/adapters/web/test_open_api_error_handling.py
+++ b/src/baas/tests/unit/adapters/web/test_open_api_error_handling.py
@@ -57,7 +57,7 @@ def _make_api_key_record(app_type="baas", app_id=BOT_UUID, tenant=TENANT):
         env="test",
         creator="test",
         modifier=None,
-        policy=None,
+        policy='{"allowed_bots":["*"]}',
     )
 
 

--- a/src/baas/tests/unit/core/service/api_gateway/test_policy.py
+++ b/src/baas/tests/unit/core/service/api_gateway/test_policy.py
@@ -1,7 +1,7 @@
 """Unit tests for policy parsing module.
 
 Covers:
-- parse_policy normalization: legacy allow-all (None/empty/missing key),
+- parse_policy normalization: fail-closed (None/empty/missing key),
   explicit allow-all ("*"), deny-all (empty / NONE sentinel / mixed),
   whitelist parsing, fail-closed on bad input.
 - APIKeyPolicy: to_json round-trip, NONE/ALL sentinel constants
@@ -51,23 +51,23 @@ class TestParsePolicy:
         assert isinstance(result, APIKeyPolicy)
         assert result.allowed_bots == ["bot1:e1", "bot2:e2"]
 
-    # --- legacy allow-all compatibility (NULL / empty / missing key) ---
-    def test_none_input_legacy_allow_all(self):
+    # --- fail-closed: None / empty / missing key deny all ---
+    def test_none_input_denies_all(self):
         result = parse_policy(None)
-        assert result.allowed_bots == ["*"]
+        assert result.allowed_bots == []
 
-    def test_empty_string_legacy_allow_all(self):
+    def test_empty_string_denies_all(self):
         result = parse_policy("")
-        assert result.allowed_bots == ["*"]
+        assert result.allowed_bots == []
 
-    def test_whitespace_string_legacy_allow_all(self):
+    def test_whitespace_string_denies_all(self):
         result = parse_policy("   ")
-        assert result.allowed_bots == ["*"]
+        assert result.allowed_bots == []
 
-    def test_missing_allowed_bots_key_legacy_allow_all(self):
-        """dict without allowed_bots key → legacy allow-all."""
+    def test_missing_allowed_bots_key_denies_all(self):
+        """dict without allowed_bots key → deny all (fail-closed)."""
         result = parse_policy('{"other_key": "value"}')
-        assert result.allowed_bots == ["*"]
+        assert result.allowed_bots == []
 
     # --- explicit allow-all ---
     def test_explicit_allow_all(self):


### PR DESCRIPTION
BREAKING CHANGE: parse_policy now treats None/empty policy and missing allowed_bots key as deny-all (403) instead of allow-all. Historical compatibility logic has been removed as data migration is complete.

- _policy.py: None/empty → deny-all; missing allowed_bots → deny-all
- dependencies.py: update validate_policy docstring
- test_policy.py: 4 cases updated from allow-all to deny-all
- test_dependencies.py: 3 validate_policy cases updated to expect 403