### PR TITLE
feat(governance): ticket review contract + feedback verdict + pending…

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/economy/admin_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/economy/admin_router.py
@@ -2,20 +2,21 @@
 
 All admin/ops endpoints under ``/api/economy/governance/admin/*``:
 
-  - /admin/tickets:close          关闭工单(单/多,body ticket_ids 循环 emergency_close)
-  - /admin/tickets:close-all      全部关单(dispatch:cancel_pending / close_all_open)
   - /admin/tickets:deliver        按 worker_id 精准投递(不重跑状态机)
   - /admin/whitelist:delete       删除白名单条目
   - /admin/whitelist:bulk-add     批量加白名单
+  - /admin/whitelist (GET)        白名单只读分页列表(全量/筛选/默认排除过期)
   - /admin/brake (POST)           全局制动 toggle(pause/resume)
   - /admin/brake (GET)            查询制动状态
   - /admin/records:delete         数据维护/清理 (record_daily / notify_log)
   - /admin/trigger-scan           手动触发 cron tick (§7.3)
   - /admin/scan-and-deliver       扫描+投递 (指定收件人, 可 dry-run)
 
-审批能力(review)已迁出至 ``workflow_router``(见
-``/api/economy/governance/workflow/*``)。emergency 命名已退场:
-真正的制动只是 ``/admin/brake``,工单直关归 ``/admin/tickets:close``。
+审批能力(review)已迁出至 ``workflow_router``。关单能力(tickets:close /
+tickets:close-all + emergency_close/cancel_pending/close_all_open service 方法)
+亦按"工单运营 vs 运维"边界迁至 workflow_router / workflow_service(见
+``/api/economy/governance/workflow/*``)。本 router 留 deliver/brake/records/
+scan/whitelist 等纯运维。
 
 路径风格:全 body/query 驱动,零 path 参数。
 
@@ -35,8 +36,6 @@ from agentclaw.community.adapters.http.economy.schemas import (
     BrakeStateResponse,
     BrakeToggleRequest,
     RecordsDeleteRequest,
-    TicketsCloseAllRequest,
-    TicketsCloseRequest,
     TicketsDeliverRequest,
     WhitelistBulkAddRequest,
     WhitelistDeleteRequest,
@@ -44,6 +43,7 @@ from agentclaw.community.adapters.http.economy.schemas import (
 from agentclaw.community.api.governance_service import (
     GovernanceAdminServiceProtocol,
     GovernanceBotServiceProtocol,
+    GovernanceWhitelistServiceProtocol,
 )
 from agentclaw.community.di import Injected
 
@@ -61,6 +61,7 @@ admin_router = APIRouter(
 
 _AdminSvc = GovernanceAdminServiceProtocol
 _ScanService = GovernanceBotServiceProtocol
+_WhitelistSvc = GovernanceWhitelistServiceProtocol
 
 
 # ---------------------------------------------------------------------------
@@ -85,71 +86,6 @@ def _raise_on_admin_error(result: dict | object) -> None:
             error_code = getattr(result, "error_code", "")
             status_code = 404 if error_code == "NOT_FOUND" else 400
             raise HTTPException(status_code=status_code, detail=error)
-
-
-# ── Tickets: close (单/多) ────────────────────────────────────────────────
-
-
-@admin_router.post(
-    "/admin/tickets:close",
-    summary="关闭工单(单/多,body ticket_ids 循环 emergency_close)",
-)
-async def tickets_close(
-    body: TicketsCloseRequest,
-    ctx: RequestContext = Depends(get_request_context),
-    admin_svc: _AdminSvc = Injected(_AdminSvc),
-) -> ApiResponse:
-    """Close one or more governance tickets (emergency_close 循环)。
-
-    单条/批量统一入参:handler 循环调 ``admin_svc.emergency_close``(已委托
-    ``lifecycle_svc``,关工单 + cancel_pending 由 driver 编排)。禁止直调 repo。
-    """
-    operator = ctx.user_id
-
-    def _close_all():
-        results = []
-        for ticket_id in body.ticket_ids:
-            result = admin_svc.emergency_close(
-                ticket_id=ticket_id,
-                admin_id=operator,
-                reason=body.reason,
-            )
-            results.append(result.to_dict())
-        return results
-
-    results = await asyncio.to_thread(_close_all)
-    return ApiResponse(success=True, data=results)
-
-
-# ── Tickets: close-all (dispatch 复用状态机收口后的两方法) ──────────────
-
-
-@admin_router.post(
-    "/admin/tickets:close-all",
-    summary="全部关单(dispatch:cancel_pending 仅未响应 / close_all_open 全量)",
-)
-async def tickets_close_all(
-    body: TicketsCloseAllRequest,
-    ctx: RequestContext = Depends(get_request_context),
-    admin_svc: _AdminSvc = Injected(_AdminSvc),
-) -> ApiResponse:
-    """Close all active governance tickets (emergency bulk)。
-
-    ``only_unresponded=true`` → ``cancel_pending``(仅未响应,EMERGENCY_CLOSED,
-    label=cancelled);否则 → ``close_all_open``(全量含已响应,ADMIN_CLOSED,
-    label=closed)。两方法经状态机 Task 8 已联合编排 task_record 主体 +
-    notify_log 通知 + audit。cooldown_days 走 config(无入参)。
-    """
-    operator = ctx.user_id
-    if body.only_unresponded:
-        result = await asyncio.to_thread(
-            admin_svc.cancel_pending, reason=body.reason, operator=operator,
-        )
-    else:
-        result = await asyncio.to_thread(
-            admin_svc.close_all_open, reason=body.reason, operator=operator,
-        )
-    return ApiResponse(success=True, data=result.to_dict())
 
 
 # ── Tickets: deliver by worker (精准投递,不重跑状态机) ──────────────────
@@ -189,7 +125,7 @@ async def tickets_deliver(
 async def delete_whitelist(
     body: WhitelistDeleteRequest,
     ctx: RequestContext = Depends(get_request_context),
-    admin_svc: _AdminSvc = Injected(_AdminSvc),
+    whitelist_svc: _WhitelistSvc = Injected(_WhitelistSvc),
 ) -> ApiResponse:
     """Delete governance whitelist entries by (bot_id, owner_id) pairs."""
     if not body.bot_owner_pairs or len(body.bot_owner_pairs) == 0:
@@ -201,7 +137,7 @@ async def delete_whitelist(
     def _delete_all():
         results = []
         for pair in body.bot_owner_pairs:
-            result = admin_svc.delete_whitelist_entry(
+            result = whitelist_svc.delete_whitelist_entry(
                 bot_id=pair.bot_id,
                 owner_id=pair.owner_id,
                 reason=body.reason,
@@ -221,12 +157,12 @@ async def delete_whitelist(
 async def whitelist_bulk_add(
     body: WhitelistBulkAddRequest,
     ctx: RequestContext = Depends(get_request_context),
-    admin_svc: _AdminSvc = Injected(_AdminSvc),
+    whitelist_svc: _WhitelistSvc = Injected(_WhitelistSvc),
 ) -> ApiResponse:
-    """Bulk whitelist bots — delegates to ``admin_svc.bulk_whitelist``."""
+    """Bulk whitelist bots — delegates to ``whitelist_svc.bulk_whitelist``."""
     operator = ctx.user_id
     result = await asyncio.to_thread(
-        admin_svc.bulk_whitelist,
+        whitelist_svc.bulk_whitelist,
         bot_ids=body.bot_ids,
         reason=body.reason,
         operator=operator,
@@ -272,6 +208,56 @@ async def brake_state(
     return ApiResponse(
         success=True,
         data=BrakeStateResponse(**state.to_dict()).model_dump(),
+    )
+
+
+# ── Whitelist read (只读分页列表) ─────────────────────────────────────────
+
+
+@admin_router.get(
+    "/admin/whitelist",
+    summary="白名单只读分页列表(全量/按 owner·bot·类型筛选,默认排除过期)",
+)
+async def list_whitelist(
+    ctx: RequestContext = Depends(get_request_context),
+    whitelist_svc: _WhitelistSvc = Injected(_WhitelistSvc),
+    owner_id: str | None = Query(None, description="按负责人 owner_id 精确筛选"),
+    bot_id: str | None = Query(None, description="按 bot_id 精确筛选"),
+    whitelist_type: str = Query(
+        "governance", description="白名单类型,缺省 governance",
+    ),
+    include_expired: bool = Query(
+        False, description="True=返回含已过期条目的全量视图",
+    ),
+    limit: int = Query(50, ge=1, le=200, description="分页上限 1~200"),
+    offset: int = Query(0, ge=0, description="分页偏移"),
+) -> ApiResponse:
+    """只读分页白名单列表。
+
+    复用 ``whitelist_service.list_all``(可选 owner/bot 精确筛选 + 过期开关 +
+    total)。default 排除已过期项。只读:无 audit、无副作用;鉴权走
+    ``get_request_context``(同他端点)。item 经领域模型 ``to_dict()`` 序列化
+    (含 bot_id/owner_id/whitelist_type/source/reason/created_by/expires_at
+    /gmt_create/gmt_modified)。
+    """
+    del ctx  # RequestContext 仅用于走 AuthPlugin 鉴权链路
+    entries, total = await asyncio.to_thread(
+        whitelist_svc.list_all,
+        whitelist_type=whitelist_type,
+        owner_id=owner_id,
+        bot_id=bot_id,
+        include_expired=include_expired,
+        limit=limit,
+        offset=offset,
+    )
+    return ApiResponse(
+        success=True,
+        data={
+            "items": [e.to_dict() for e in entries],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        },
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/economy/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/economy/schemas.py
@@ -140,7 +140,7 @@ class WorkflowReviewResponse(BaseModel):
         """从 TicketActionOutcome 领域返回值构造响应(显式序列化,非裸 dict)。
 
         Args:
-            outcome: review_ticket / emergency_close 返回的领域 I/O 对象。
+            outcome: review_ticket / admin_close 返回的领域 I/O 对象。
 
         Returns:
             审批响应,status 取 enum 的 value 字符串。
@@ -167,6 +167,7 @@ class ReviewTicketItem(BaseModel):
     """评审工单列表单行 — 字段贴合 governance-admin.html 三栏展示。"""
 
     ticket_id: str | None = None
+    id: int | None = None
     bot_name: str | None = None
     owner_id: str | None = None
     governance_status: str = ""
@@ -176,6 +177,8 @@ class ReviewTicketItem(BaseModel):
     response: str | None = None
     review_reason: str | None = None
     gmt_create: str | None = None
+    gmt_modified: str | None = None
+    delivery_status: str | None = None
 
     @classmethod
     def from_ticket(cls, ticket: GovernanceTicket) -> ReviewTicketItem:
@@ -184,6 +187,7 @@ class ReviewTicketItem(BaseModel):
         status = ticket.governance_status
         return cls(
             ticket_id=ticket.ticket_id,
+            id=ticket.id,
             bot_name=ticket.bot_name,
             owner_id=ticket.owner_id,
             governance_status=status.value if hasattr(status, "value") else str(status or ""),
@@ -193,6 +197,8 @@ class ReviewTicketItem(BaseModel):
             response=ticket.user_feedback,
             review_reason=ticket.review_reason,
             gmt_create=_iso(ticket.gmt_create),
+            gmt_modified=_iso(ticket.gmt_modified),
+            delivery_status=ticket.delivery_status,
         )
 
 
@@ -272,6 +278,7 @@ class ReviewTicketDetailResponse(BaseModel):
 
     # 基础信息
     ticket_id: str | None = None
+    id: int | None = None
     worker_id: str | None = None
     bot_id: str | None = None
     owner_id: str | None = None
@@ -296,6 +303,10 @@ class ReviewTicketDetailResponse(BaseModel):
         default_factory=list,
         description="当前可做 review 动作(按用户反馈派生,前端动态渲染)",
     )
+    # 白名单状态(单点查询,仅详情;列表接口不查以防 N+1)
+    in_whitelist: bool = False
+    # 投递状态(回写自 notify_log)
+    delivery_status: str | None = None
     # 评审 / 生命周期
     review_reason: str | None = None
     review_decision: str | None = None
@@ -326,12 +337,24 @@ class ReviewTicketDetailResponse(BaseModel):
         ]
 
     @classmethod
-    def from_ticket(cls, ticket: GovernanceTicket) -> ReviewTicketDetailResponse:
-        """从 GovernanceTicket 领域模型构造详情(读 snapshot 委托 + 实体字段,datetime→ISO)。"""
+    def from_ticket(
+        cls,
+        ticket: GovernanceTicket,
+        *,
+        in_whitelist: bool = False,
+    ) -> ReviewTicketDetailResponse:
+        """从 GovernanceTicket 领域模型构造详情(读 snapshot 委托 + 实体字段,datetime→ISO)。
+
+        Args:
+            ticket: 工单领域模型。
+            in_whitelist: 该工单 (bot_id, owner_id) 是否在治理白名单中
+                (由 service 层单点查询传入,默认 False;列表接口不传以防 N+1)。
+        """
         s = ticket.snapshot
         status = ticket.governance_status
         return cls(
             ticket_id=ticket.ticket_id,
+            id=ticket.id,
             worker_id=ticket.worker_id,
             bot_id=ticket.bot_id,
             owner_id=ticket.owner_id,
@@ -351,6 +374,8 @@ class ReviewTicketDetailResponse(BaseModel):
             feedback_payload=ticket.feedback_payload,
             feedback_notification_id=_extract_feedback_notification_id(ticket.feedback_payload),
             available_actions=cls._build_available_actions(ticket),
+            in_whitelist=in_whitelist,
+            delivery_status=ticket.delivery_status,
             review_reason=ticket.review_reason,
             review_decision=ticket.review_decision,
             reviewed_by=ticket.reviewed_by,
@@ -391,7 +416,7 @@ class WhitelistDeleteRequest(BaseModel):
 
 # ---------------------------------------------------------------------------
 # Admin: 制动 (brake) / 工单批量管理 / 白名单批量 / 按 worker 投递
-# 拆自原 5-action EmergencyRequest(action 开关分发多资源),全 body 驱动。
+# 拆自原 5-action 统一 action 端点(action 开关分发多资源,已退场),全 body 驱动。
 # ---------------------------------------------------------------------------
 
 class BrakeToggleRequest(BaseModel):
@@ -407,7 +432,7 @@ class TicketsCloseRequest(BaseModel):
     """Request body for closing one or more governance tickets.
 
     单条/批量统一入参:把要关的 ticket_id 放进列表,handler 循环调
-    ``admin_svc.emergency_close``(已委托 ``lifecycle_svc``,关工单+cancel_pending
+    ``admin_svc.admin_close``(已委托 ``lifecycle_svc``,关工单+cancel_pending
     由 driver 编排)。禁止直调 repo。
     """
     reason: str = Field(..., description="Close reason for audit")
@@ -415,10 +440,10 @@ class TicketsCloseRequest(BaseModel):
 
 
 class TicketsCloseAllRequest(BaseModel):
-    """Request body for closing all active governance tickets (emergency bulk).
+    """Request body for closing all active governance tickets (admin bulk).
 
     handler dispatch 复用状态机收口后的两方法:
-    ``only_unresponded=true`` → ``admin_svc.cancel_pending``(仅未响应,EMERGENCY_CLOSED);
+    ``only_unresponded=true`` → ``admin_svc.cancel_pending``(仅未响应,ADMIN_CLOSED);
     否则 → ``admin_svc.close_all_open``(全量含已响应,ADMIN_CLOSED)。两方法已联合编排
     task_record 工单主体 + notify_log 通知 + audit(状态机 Task 8 口径对齐)。
    cooldown_days 走 config.cool_down_days,无入参。
@@ -463,7 +488,7 @@ class BrakeStateResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 class RecordsDeleteRequest(BaseModel):
-    """Request body for emergency records / notifications delete."""
+    """Request body for admin records / notifications delete."""
     table: str = Field(..., description="record_daily | notify_log")
     dt_versions: list[str] | None = Field(None, description="按 dt_version 删除 (record_daily)")
     ids: list[int] | None = Field(None, description="按主键 ID 批量删除 (record_daily)")

--- a/src/backend/src/agentclaw/community/adapters/http/economy/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/economy/schemas.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from agentclaw.community.core.economy.governance.domain.enums import GovernanceStatus
 from agentclaw.community.core.economy.governance.domain.record import GovernanceRecord
+from agentclaw.community.core.economy.governance.domain.ticket import compute_available_actions
 
 if TYPE_CHECKING:
     from agentclaw.community.core.economy.governance.domain.ticket import (
@@ -252,6 +254,19 @@ def _extract_feedback_notification_id(payload_json: str | None) -> str | None:
     return None
 
 
+class TicketActionInfo(BaseModel):
+    """单个可做 review 动作(后端下发,前端动态渲染)。
+
+    后端成动作单一事实源:按用户反馈返回可做动作集 + 差异化 label + endpoint +
+    remark_required。前端据此渲染,不硬编码动作/文案/状态-动作映射。
+    """
+
+    value: str = Field(..., description="动作枚举值(approve_close/approve_scheduled/approve_whitelist/reject_for_reopen)")
+    label: str = Field(..., description="中文展示文案(按用户反馈差异化)")
+    endpoint: str = Field(..., description="POST 端点路径")
+    remark_required: bool = Field(False, description="备注是否必填")
+
+
 class ReviewTicketDetailResponse(BaseModel):
     """评审工单详情 — 列表字段外加详情面板所需全部字段。"""
 
@@ -277,6 +292,10 @@ class ReviewTicketDetailResponse(BaseModel):
     response_source: str | None = None
     feedback_payload: str | None = None
     feedback_notification_id: str | None = None
+    available_actions: list[TicketActionInfo] = Field(
+        default_factory=list,
+        description="当前可做 review 动作(按用户反馈派生,前端动态渲染)",
+    )
     # 评审 / 生命周期
     review_reason: str | None = None
     review_decision: str | None = None
@@ -292,6 +311,19 @@ class ReviewTicketDetailResponse(BaseModel):
     # 元信息
     gmt_create: str | None = None
     gmt_modified: str | None = None
+
+    @classmethod
+    def _build_available_actions(cls, ticket: GovernanceTicket) -> list[TicketActionInfo]:
+        """按工单当前状态构造可做 review 动作(仅 waiting_review 下发,其余空)。
+
+        委托领域层 ``compute_available_actions(user_feedback)``(按反馈派生)。
+        非 waiting_review(open/scheduled/closed)不发动作。
+        """
+        if ticket.governance_status != GovernanceStatus.WAITING_REVIEW:
+            return []
+        return [
+            TicketActionInfo(**a) for a in compute_available_actions(ticket.user_feedback)
+        ]
 
     @classmethod
     def from_ticket(cls, ticket: GovernanceTicket) -> ReviewTicketDetailResponse:
@@ -318,6 +350,7 @@ class ReviewTicketDetailResponse(BaseModel):
             response_source=ticket.feedback_source,
             feedback_payload=ticket.feedback_payload,
             feedback_notification_id=_extract_feedback_notification_id(ticket.feedback_payload),
+            available_actions=cls._build_available_actions(ticket),
             review_reason=ticket.review_reason,
             review_decision=ticket.review_decision,
             reviewed_by=ticket.reviewed_by,

--- a/src/backend/src/agentclaw/community/adapters/http/economy/workflow_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/economy/workflow_router.py
@@ -30,6 +30,8 @@ from agentclaw.community.adapters.http.economy.schemas import (
     ApiResponse,
     ReviewTicketDetailResponse,
     ReviewTicketListResponse,
+    TicketsCloseAllRequest,
+    TicketsCloseRequest,
     WorkflowReviewRequest,
     WorkflowReviewResponse,
 )
@@ -163,10 +165,13 @@ async def get_review_ticket_detail(
     只读 GET;工单不存在 → 404。ticket_id 走 query(与 admin 写操作零 path 参数风格统一)。
     """
     del ctx  # RequestContext 仅用于走 AuthPlugin 鉴权链路
-    ticket = await asyncio.to_thread(admin_svc.get_review_ticket_detail, ticket_id)
-    if ticket is None:
+    detail = await asyncio.to_thread(
+        admin_svc.build_review_ticket_detail, ticket_id,
+    )
+    if detail is None:
         raise HTTPException(status_code=404, detail="Ticket not found")
-    data = ReviewTicketDetailResponse.from_ticket(ticket)
+    ticket, in_whitelist = detail
+    data = ReviewTicketDetailResponse.from_ticket(ticket, in_whitelist=in_whitelist)
     return ApiResponse(success=True, data=data.model_dump())
 
 
@@ -223,3 +228,65 @@ async def review_ticket(
     _raise_on_admin_error(result)
     data = WorkflowReviewResponse.from_outcome(result)
     return ApiResponse(success=True, data=data.model_dump())
+
+
+# ── Workflow: 关单(从 admin_router 迁入,工单运营归属) ─────────────────
+
+
+@workflow_router.post(
+    "/tickets:close",
+    summary="关闭工单(单/多,body ticket_ids 循环 emergency_close)",
+)
+async def tickets_close(
+    body: TicketsCloseRequest,
+    ctx: RequestContext = Depends(get_request_context),
+    admin_svc: _AdminSvc = Injected(_AdminSvc),
+) -> ApiResponse:
+    """Close one or more governance tickets (emergency_close 循环)。
+
+    单条/批量统一入参:handler 循环调 ``admin_svc.emergency_close``(已委托
+    ``lifecycle_svc``,关工单 + cancel_pending 由 driver 编排)。禁止直调 repo。
+    """
+    operator = ctx.user_id
+
+    def _close_all():
+        results = []
+        for ticket_id in body.ticket_ids:
+            result = admin_svc.emergency_close(
+                ticket_id=ticket_id,
+                admin_id=operator,
+                reason=body.reason,
+            )
+            results.append(result.to_dict())
+        return results
+
+    results = await asyncio.to_thread(_close_all)
+    return ApiResponse(success=True, data=results)
+
+
+@workflow_router.post(
+    "/tickets:close-all",
+    summary="全部关单(dispatch:cancel_pending 仅未响应 / close_all_open 全量)",
+)
+async def tickets_close_all(
+    body: TicketsCloseAllRequest,
+    ctx: RequestContext = Depends(get_request_context),
+    admin_svc: _AdminSvc = Injected(_AdminSvc),
+) -> ApiResponse:
+    """Close all active governance tickets (emergency bulk)。
+
+    ``only_unresponded=true`` → ``cancel_pending``(仅未响应,EMERGENCY_CLOSED,
+    label=cancelled);否则 → ``close_all_open``(全量含已响应,ADMIN_CLOSED,
+    label=closed)。两方法经状态机 Task 8 已联合编排 task_record 主体 +
+    notify_log 通知 + audit。cooldown_days 走 config(无入参)。
+    """
+    operator = ctx.user_id
+    if body.only_unresponded:
+        result = await asyncio.to_thread(
+            admin_svc.cancel_pending, reason=body.reason, operator=operator,
+        )
+    else:
+        result = await asyncio.to_thread(
+            admin_svc.close_all_open, reason=body.reason, operator=operator,
+        )
+    return ApiResponse(success=True, data=result.to_dict())

--- a/src/backend/src/agentclaw/community/adapters/http/economy/workflow_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/economy/workflow_router.py
@@ -170,6 +170,31 @@ async def get_review_ticket_detail(
     return ApiResponse(success=True, data=data.model_dump())
 
 
+# ── Workflow: 待回复通知查询 ─────────────────────────────────────────────
+
+
+@workflow_router.get(
+    "/tickets/pending-notification",
+    summary="查工单待回复通知(notification_id)",
+)
+async def get_pending_notification(
+    ticket_id: str = Query(..., description="工单 ID"),
+    ctx: RequestContext = Depends(get_request_context),
+    admin_svc: _AdminSvc = Injected(_AdminSvc),
+) -> ApiResponse:
+    """查工单当前通知的 notification_id。
+
+    open 工单(用户未反馈)的 notification_id 在 notify_log,不在 task_record。
+    前端 admin review / card-callback 推进状态时需此 ID。
+    优先返回 pending/sending(待回复);无则最近一条 sent。
+    """
+    del ctx  # RequestContext 仅用于走 AuthPlugin 鉴权链路
+    result = await asyncio.to_thread(admin_svc.get_pending_notification, ticket_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="No notification found for ticket")
+    return ApiResponse(success=True, data=result)
+
+
 # ── Workflow: 审批动作 ────────────────────────────────────────────────────
 
 

--- a/src/backend/src/agentclaw/community/core/economy/governance/domain/enums.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/domain/enums.py
@@ -76,6 +76,7 @@ class AuditAction(str, Enum):
 
     # ── Admin review (new) ────────────────────────────
     REVIEW_APPROVE_CLOSE = "review_approve_close"       # 管理员审核通过关闭 (§7.5.2)
+    REVIEW_APPROVE_SCHEDULED = "review_approve_scheduled"  # 管理员审核同意排期 → scheduled (§7.5.2)
     REVIEW_APPROVE_WHITELIST = "review_approve_whitelist"  # 管理员审核通过加白 (§7.5.2)
     REVIEW_REJECT_FOR_REOPEN = "review_reject_for_reopen"  # 管理员打回, 释放 active_worker (§7.5.2)
 
@@ -154,6 +155,22 @@ class Response(str, Enum):
     NEED_TIME = "need_time"
     DISPUTE = "dispute"
     WHITELIST = "whitelist"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class TicketAction(str, Enum):
+    """管理员 review 动作 — 对用户反馈的裁决(§7.5.2 + need_time 待审扩展)。
+
+    按用户反馈类型分发不同"同意"动作,驳回通用。加白(approve_whitelist)是 whitelist
+    反馈的同意裁决(与运维独立一键加白 /admin/whitelist 出发点不同,并存)。
+    """
+
+    APPROVE_CLOSE = "approve_close"            # 同意(optimized/dispute)→ closed
+    APPROVE_SCHEDULED = "approve_scheduled"    # 同意(need_time)→ scheduled [新]
+    APPROVE_WHITELIST = "approve_whitelist"    # 同意(whitelist)→ 加白 + closed
+    REJECT_FOR_REOPEN = "reject_for_reopen"    # 驳回(通用)→ closed(review_rejected, scan 重建)
 
     def __str__(self) -> str:
         return self.value

--- a/src/backend/src/agentclaw/community/core/economy/governance/domain/protocols.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/domain/protocols.py
@@ -376,3 +376,16 @@ class WhitelistRepositoryProtocol(Protocol):
     ) -> int:
         """Count whitelist entries of a given type."""
         ...
+
+    def list_all(
+        self,
+        *,
+        whitelist_type: str = "governance",
+        owner_id: str | None = None,
+        bot_id: str | None = None,
+        include_expired: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[WhitelistEntry], int]:
+        """全量分页查询白名单(可选 owner/bot 筛选 + 过期开关 + total)。"""
+        ...

--- a/src/backend/src/agentclaw/community/core/economy/governance/domain/ticket.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/domain/ticket.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from datetime import datetime
+from typing import Any
 
 from agentclaw.community.core.economy.governance.domain.base import _iso
 from agentclaw.community.core.economy.governance.domain.enums import (
     GovernanceStatus,
+    Response,
+    TicketAction,
 )
 
 
@@ -82,6 +85,132 @@ TICKET_TRANSITIONS: dict[GovernanceStatus, frozenset[GovernanceStatus]] = {
     }),
     GovernanceStatus.CLOSED: frozenset(),
 }
+
+
+# ── feedback_verdict 纯函数(user⊗admin 成对派生,零跨层依赖) ──────
+# pair 表直接用 response 原值(optimized/dispute/whitelist/need_time),不做中间
+# 归一化翻译——系统别处不用的中间词只会增加理解负担。离线侧可直接 import 复用。
+
+# (response, review_decision) → verdict(双流齐备的成对结果)
+# review 四态:approve_close/approve_scheduled[新]/approve_whitelist/reject_for_reopen。
+# 命名贴合四反馈语义;need_time 同意走 approve_scheduled(→schedule_confirmed),
+# approve_close 对 need_time 不作正常路径(available_actions 不下发)落 other。
+_VERDICT_PAIR: dict[tuple[str, str], str] = {
+    ("optimized", "approve_close"): "confirmed",
+    ("optimized", "reject_for_reopen"): "optimized_rejected",
+    ("optimized", "approve_whitelist"): "admin_overroled_whitelist",
+    ("dispute", "approve_close"): "dispute_accepted",
+    ("dispute", "reject_for_reopen"): "dispute_rejected",
+    ("whitelist", "approve_whitelist"): "whitelist_confirmed",
+    ("whitelist", "reject_for_reopen"): "whitelist_denied",
+    ("whitelist", "approve_close"): "whitelist_dismissed",
+    ("need_time", "approve_scheduled"): "schedule_confirmed",
+    ("need_time", "reject_for_reopen"): "schedule_rejected",
+}
+
+# response → pending_review_* (review 缺席时,按用户决策细分)
+_VERDICT_PENDING: dict[str, str] = {
+    "optimized": "pending_review_optimized",
+    "whitelist": "pending_review_whitelist",
+    "dispute": "pending_review_dispute",
+    "need_time": "pending_review_need_time",
+}
+
+
+def compute_feedback_verdict(
+    response: str | None,
+    review_decision: str | None,
+    governance_status: GovernanceStatus | str | None,
+) -> str:
+    """用户反馈 ⊗ 管理员 review 的成对裁决结果(读时派生,纯函数,不落库)。
+
+    输入三个既有 task_record 字段,产出成对 verdict 字符串。review 缺席
+    (review_decision 空)走 ``pending_review_*``;用户未反馈走
+    ``awaiting_user_feedback``/``admin_only_*``;缺省落 ``other``。
+
+    纯函数:无 self/session/DB 依赖,在线自循环与离线侧 import 同源复用。
+
+    Args:
+        response: 用户原始反馈(optimized/need_time/dispute/whitelist),None=未反馈。
+        review_decision: 管理员审批(approve_close/approve_scheduled/approve_whitelist/
+                reject_for_reopen),None=未审。
+        governance_status: 工单状态(open/scheduled/waiting_review/closed)。
+
+    Returns:
+        verdict 字符串(见模块 ``_VERDICT_PAIR`` / ``_VERDICT_PENDING`` 系列)。
+    """
+    if review_decision:
+        if not response:
+            return f"admin_only_{review_decision}"
+        return _VERDICT_PAIR.get((response, review_decision), "other")
+    # review 缺席:待审或未到 review 阶段
+    if not response:
+        return "awaiting_user_feedback"
+    return _VERDICT_PENDING.get(response, "other")
+
+
+# ── available_actions 纯函数(按用户反馈下发可做 review 动作) ──────
+# review 覆盖四种反馈(need_time 改为进 waiting_review 待审)。按反馈给不同"同意"
+# 动作 + 通用 reject。加白(approve_whitelist)是 whitelist 反馈的同意裁决,与运维
+# 独立一键加白(/admin/whitelist)出发点不同、并存。label 按反馈差异化,后端下发。
+
+_REVIEW_ENDPOINT = "POST /api/economy/governance/workflow/tickets/review"
+
+# 同意动作的 label 按反馈差异化(避免笼统"批准关闭"丢语义)
+_APPROVE_LABEL: dict[str, str] = {
+    "optimized": "确认已优化",
+    "dispute": "采纳申诉",
+    "whitelist": "同意加白",
+    "need_time": "同意排期",
+}
+# 驳回 label 按反馈差异化
+_REJECT_LABEL: dict[str, str] = {
+    "optimized": "不认可,重开",
+    "dispute": "驳回申诉,重开",
+    "whitelist": "驳回加白,重开",
+    "need_time": "不认可,重开",
+}
+# 各反馈的"同意"动作
+_APPROVE_ACTION: dict[str, TicketAction] = {
+    "optimized": TicketAction.APPROVE_CLOSE,
+    "dispute": TicketAction.APPROVE_CLOSE,
+    "whitelist": TicketAction.APPROVE_WHITELIST,
+    "need_time": TicketAction.APPROVE_SCHEDULED,
+}
+
+
+def _action_info(
+    action: TicketAction, label: str, remark_required: bool,
+) -> dict[str, Any]:
+    """构造单个动作描述(前端动态渲染用)。"""
+    return {
+        "value": action.value,
+        "label": label,
+        "endpoint": _REVIEW_ENDPOINT,
+        "remark_required": remark_required,
+    }
+
+
+def compute_available_actions(user_feedback: str | None) -> list[dict[str, Any]]:
+    """按用户反馈类型返回可做的 review 动作列表(纯函数,在线/离线复用同源)。
+
+    Args:
+        user_feedback: 用户原始反馈(optimized/need_time/dispute/whitelist);
+            None 或未知值 → [](非 review 流程不发动作)。
+
+    Returns:
+        动作 dict 列表,每项含 value/label/endpoint/remark_required。 approve 类
+        动作在前(同意),reject_for_reopen 在后(驳回)。
+    """
+    approve = _APPROVE_ACTION.get(user_feedback)
+    if approve is None:
+        return []  # 无反馈或非四种反馈 → 不在 review 流程
+    approve_label = _APPROVE_LABEL[user_feedback]
+    reject_label = _REJECT_LABEL[user_feedback]
+    return [
+        _action_info(approve, approve_label, remark_required=False),
+        _action_info(TicketAction.REJECT_FOR_REOPEN, reject_label, remark_required=True),
+    ]
 
 
 @dataclass(slots=True)
@@ -246,6 +375,30 @@ class GovernanceTicket:
         """§7.4.1: 仅 open + 未反馈 才接受。"""
         return self.governance_status == GovernanceStatus.OPEN and self.user_feedback is None
 
+    @property
+    def feedback_verdict(self) -> str:
+        """用户反馈 ⊗ 管理员 review 的成对裁决结果(读时派生委托纯函数,不落库)。
+
+        委托模块级 :func:`compute_feedback_verdict`,输入既有 task_record 三字段
+        (``user_feedback``/``review_decision``/``governance_status``)。在线自循环与
+        离线侧复用同源规则。
+        """
+        return compute_feedback_verdict(
+            self.user_feedback,
+            self.review_decision,
+            self.governance_status,
+        )
+
+    @property
+    def available_actions(self) -> list[dict[str, Any]]:
+        """该工单当前可做的 review 动作(按用户反馈派生,读时算不落库)。
+
+        委托模块级 :func:`compute_available_actions`,按 ``user_feedback`` 返回对应
+        同意+驳回动作。前端据此动态渲染,后端成动作单一事实源。非 review 流程
+        (无反馈/非四种反馈)→ []。
+        """
+        return compute_available_actions(self.user_feedback)
+
     # ── 状态机行为 ──────────────────────────────────────
 
     def transition_to(self, target: GovernanceStatus) -> None:
@@ -355,36 +508,42 @@ class GovernanceTicket:
         close_reason: str | None = None,
         cooldown_until: datetime | None = None,
     ) -> None:
-        """管理员审核 — WAITING_REVIEW → CLOSED(三态分支)。
+        """管理员审核 — WAITING_REVIEW → CLOSED/SCHEDULED(四态分支)。
 
         Args:
-            review_decision: 审核决策(approve_close / approve_whitelist /
-                reject_for_reopen)。
+            review_decision: 审核决策(approve_close / approve_scheduled /
+                approve_whitelist / reject_for_reopen)。
             reviewed_by: 审核人 ID。
             reviewed_at: 审核时间(None → 取 now)。
             review_remark: 审核备注。
             close_reason: 关闭原因(None 时按 review_decision 取默认)。
             cooldown_until: 冷却截止时间(仅 approve_close 可带)。
 
-        逐字段对齐 repo ``review_ticket`` L310-341:
-          - review_decision / reviewed_by / reviewed_at(默认 now) /
-            review_remark / remind_at=None(无条件清,L314)
-          - 三态分支:
-            approve_close    → close_reason=close_reason|'approve_close',
+        分支:
+          approve_close     → CLOSED,close_reason=close_reason|'approve_close',
                               可带 cooldown_until
-            approve_whitelist→ close_reason='whitelisted'
-            reject_for_reopen→ close_reason='review_rejected'(打回仍关闭,
+          approve_scheduled → SCHEDULED(同意排期,不关单),close_reason='schedule_approved',
+                              保留 repair_deadline;不释放 active_worker(仍 active 观察)
+          approve_whitelist → CLOSED,close_reason='whitelisted'
+          reject_for_reopen → CLOSED,close_reason='review_rejected'(打回仍关闭,
                               下个 scan 重建 open 单)
-          - 共性:closed_at=now、active_worker=None(释放,L320/327/336/341)
         """
-        self.transition_to(GovernanceStatus.CLOSED)
         now = datetime.now()
         self.review_decision = review_decision
         self.reviewed_by = reviewed_by
         self.reviewed_at = reviewed_at or now
         self.review_remark = review_remark
+        self.remind_at = None  # 无条件清
+
+        if review_decision == "approve_scheduled":
+            # 同意排期 → SCHEDULED(不关单,继续排期观察),不释放 active_worker
+            self.transition_to(GovernanceStatus.SCHEDULED)
+            self.close_reason = close_reason or "schedule_approved"
+            return
+
+        # 其余三态 → CLOSED
+        self.transition_to(GovernanceStatus.CLOSED)
         self.closed_at = now
-        self.remind_at = None  # 无条件清,对齐 repo L314
         self.assignee = None   # 释放 active_worker
         if review_decision == "approve_close":
             self.close_reason = close_reason or "approve_close"

--- a/src/backend/src/agentclaw/community/core/economy/governance/domain/ticket.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/domain/ticket.py
@@ -67,6 +67,7 @@ class MutableSnapshot:
     last_decision_dt_version: str | None
     last_seen_at: datetime | None
     last_sync_at: datetime | None
+    delivery_status: str = "none"  # 最近通知投递状态: none/first_send:sent/reminder:failed/...
 
 
 # ── 状态机转换表(工单) ─────────────────────────
@@ -259,6 +260,7 @@ class GovernanceTicket:
     feedback_payload: str | None
     actor_id: str | None
     # ── 基础元信息(只读,由 from_orm 从 sealed 列灌入) ───
+    id: int | None = None             # 自增主键(只读,from_orm 灌入;to_orm 不写回)
     gmt_create: datetime | None = None
     gmt_modified: datetime | None = None
 
@@ -345,6 +347,11 @@ class GovernanceTicket:
     def last_sync_at(self) -> datetime | None:
         """最近一次离线同步时间 — 快照委托。"""
         return self._snapshot.last_sync_at
+
+    @property
+    def delivery_status(self) -> str:
+        """最近通知投递状态 — 快照委托(none/first_send:sent/reminder:failed/...)。"""
+        return self._snapshot.delivery_status
 
     # ── 业务 property ──────────────────────────────
 
@@ -669,6 +676,7 @@ class GovernanceTicket:
                 last_decision_dt_version=obj.last_decision_dt_version,
                 last_seen_at=obj.last_seen_at,
                 last_sync_at=obj.last_sync_at,
+                delivery_status=getattr(obj, "delivery_status", None) or "none",
             ),
             # 生命周期态
             governance_status=GovernanceStatus(obj.governance_status or "open"),
@@ -691,6 +699,7 @@ class GovernanceTicket:
             remind_count=obj.remind_count or 0,
             feedback_payload=obj.feedback_payload,
             actor_id=obj.actor_id,
+            id=getattr(obj, "id", None),
             gmt_create=getattr(obj, "gmt_create", None),
             gmt_modified=getattr(obj, "gmt_modified", None),
         )
@@ -756,6 +765,7 @@ class GovernanceTicket:
         row.remind_count = self.remind_count
         row.feedback_payload = self.feedback_payload
         row.actor_id = self.actor_id
+        row.delivery_status = self.delivery_status
         return row
 
     def apply_to(self, row: object) -> None:
@@ -786,6 +796,7 @@ class GovernanceTicket:
         row.remind_count = self.remind_count
         row.feedback_payload = self.feedback_payload
         row.actor_id = self.actor_id
+        row.delivery_status = self.delivery_status
 
     def to_dict(self) -> dict:
         """API 序列化 — router 直接 ``data=[t.to_dict() for t in items]``。

--- a/src/backend/src/agentclaw/community/core/economy/governance/domain/whitelist.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/domain/whitelist.py
@@ -15,7 +15,8 @@ class WhitelistEntry:
 
     对应 ORM: WhitelistEntryOrm (ac_bot_whitelist)。
     frozen: 白名单条目创建后不可变,修改走删除+重建。
-    sealed 列 (id, env, gmt_create, gmt_modified) 不在本模型上。
+    sealed 列 id/env 不在本模型上;gmt_create/gmt_modified 作为只读元信息
+    (创建/修改时间)开放,供列表序列化展示。
     """
 
     bot_id: str
@@ -25,6 +26,8 @@ class WhitelistEntry:
     reason: str
     created_by: str
     expires_at: datetime | None
+    gmt_create: datetime | None = None
+    gmt_modified: datetime | None = None
 
     # ── 业务 property ──────────────────────────────
 
@@ -37,7 +40,7 @@ class WhitelistEntry:
 
     @classmethod
     def from_orm(cls, obj: object) -> WhitelistEntry:
-        """读翻译: ORM → 领域模型。sealed 列不映射。"""
+        """读翻译: ORM → 领域模型。id/env sealed 列不映射;时间元信息映射。"""
         return cls(
             bot_id=obj.bot_id,
             owner_id=obj.owner_id,
@@ -46,6 +49,8 @@ class WhitelistEntry:
             reason=obj.reason or "",
             created_by=obj.created_by or "",
             expires_at=obj.expires_at,
+            gmt_create=getattr(obj, "gmt_create", None),
+            gmt_modified=getattr(obj, "gmt_modified", None),
         )
 
     def to_orm(self, row: object | None = None) -> object:
@@ -73,4 +78,6 @@ class WhitelistEntry:
             "reason": self.reason,
             "created_by": self.created_by,
             "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "gmt_create": self.gmt_create.isoformat() if self.gmt_create else None,
+            "gmt_modified": self.gmt_modified.isoformat() if self.gmt_modified else None,
         }

--- a/src/backend/src/agentclaw/community/core/economy/governance/repositories/notify_log_repo.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/repositories/notify_log_repo.py
@@ -2,7 +2,7 @@
 
 Collects notification-log SELECT/INSERT access that was previously
 scattered as raw ``session.query(...)`` across the scan, feedback and
-emergency services.
+admin services.
 
 Audit access has been moved to ``GovernanceAuditRepository``
 (see ``audit_repo.py``) — one repo per table (R2).
@@ -26,12 +26,33 @@ from agentclaw.community.core.economy.governance.domain.enums import (
 from agentclaw.community.core.economy.governance.domain.notification import GovernanceNotification
 from agentclaw.community.core.economy.governance.repositories.orm import (
     GovernanceNotificationOrm,
+    GovernanceTicketOrm,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.utils.env_utils import get_current_env
 
 log = get_logger(__name__)
+
+
+def _update_ticket_delivery_status(
+    session: object, ticket_id: str, status: str,
+) -> None:
+    """同 session 回写 task_record.delivery_status(投递链路状态变更后调)。
+
+    Args:
+        session: 已开启的 ORM session(不自行管理事务,复用调用方的 orm_session)。
+        ticket_id: 工单稳定 UUID。
+        status: 投递状态(如 ``first_send:sent`` / ``reminder:failed`` / ``cancelled``)。
+    """
+    if not ticket_id:
+        return
+    session.query(GovernanceTicketOrm).filter(
+        GovernanceTicketOrm.ticket_id == ticket_id,
+    ).update(
+        {GovernanceTicketOrm.delivery_status: status},
+        synchronize_session=False,
+    )
 
 
 class NotifyLogRepository:
@@ -140,7 +161,7 @@ class NotifyLogRepository:
             return [GovernanceNotification.from_orm(r) for r in rows]
 
     # ------------------------------------------------------------------
-    # notify_log — emergency-scope queries
+    # notify_log — admin-scope queries
     # ------------------------------------------------------------------
 
     def count_pending(
@@ -326,6 +347,8 @@ class NotifyLogRepository:
                     synchronize_session="fetch",
                 )
             )
+            if count > 0:
+                _update_ticket_delivery_status(s, ticket_id, "cancelled")
             return count
 
     def has_pending_or_sending_reminder(
@@ -377,6 +400,14 @@ class NotifyLogRepository:
                     synchronize_session="fetch",
                 )
             )
+            if result == 1:
+                row = s.query(GovernanceNotificationOrm).filter(
+                    GovernanceNotificationOrm.notification_id == notification_id,
+                ).first()
+                if row and row.ticket_id:
+                    _update_ticket_delivery_status(
+                        s, row.ticket_id, f"{row.notify_type}:sending",
+                    )
             return result == 1
 
     def mark_sent(
@@ -404,6 +435,14 @@ class NotifyLogRepository:
                     synchronize_session="fetch",
                 )
             )
+            if result == 1:
+                row = s.query(GovernanceNotificationOrm).filter(
+                    GovernanceNotificationOrm.notification_id == notification_id,
+                ).first()
+                if row and row.ticket_id:
+                    _update_ticket_delivery_status(
+                        s, row.ticket_id, f"{row.notify_type}:sent",
+                    )
             return result == 1
 
     def mark_send_failed(
@@ -434,6 +473,13 @@ class NotifyLogRepository:
                     synchronize_session="fetch",
                 )
             )
+            if result == 1:
+                row = s.query(GovernanceNotificationOrm).filter(
+                    GovernanceNotificationOrm.notification_id == notification_id,
+                ).first()
+                if row and row.ticket_id:
+                    status = f"{row.notify_type}:failed" if is_terminal else f"{row.notify_type}:pending"
+                    _update_ticket_delivery_status(s, row.ticket_id, status)
             return result == 1
 
     # ------------------------------------------------------------------
@@ -506,7 +552,7 @@ class NotifyLogRepository:
             session.flush()
 
     # ------------------------------------------------------------------
-    # Delete path (admin emergency) — self-managed session
+    # Delete path (admin) — self-managed session
     # ------------------------------------------------------------------
 
     def delete_by_notification_ids(

--- a/src/backend/src/agentclaw/community/core/economy/governance/repositories/notify_log_repo.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/repositories/notify_log_repo.py
@@ -110,6 +110,35 @@ class NotifyLogRepository:
             )
             return [GovernanceNotification.from_orm(r) for r in rows]
 
+    def list_by_ticket(
+        self,
+        ticket_id: str,
+        *,
+        only_pending: bool = False,
+    ) -> list[GovernanceNotification]:
+        """A ticket's notify_log rows (all notify types), newest first — domain models.
+
+        Args:
+            ticket_id: 工单稳定 UUID。
+            only_pending: True → 仅 pending/sending(待回复)通知。
+
+        Returns:
+            该 ticket 关联的通知列表(notification_id/notify_status/...)。
+        """
+        _env = get_current_env()
+        with self._db.orm_session() as s:
+            s.expire_on_commit = False
+            q = s.query(GovernanceNotificationOrm).filter(
+                GovernanceNotificationOrm.ticket_id == ticket_id,
+                GovernanceNotificationOrm.env == _env,
+            )
+            if only_pending:
+                q = q.filter(
+                    GovernanceNotificationOrm.notify_status.in_(("pending", "sending")),
+                )
+            rows = q.order_by(GovernanceNotificationOrm.gmt_create.desc()).all()
+            return [GovernanceNotification.from_orm(r) for r in rows]
+
     # ------------------------------------------------------------------
     # notify_log — emergency-scope queries
     # ------------------------------------------------------------------

--- a/src/backend/src/agentclaw/community/core/economy/governance/repositories/orm.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/repositories/orm.py
@@ -243,7 +243,7 @@ class GovernanceNotificationOrm(Base):
 class AuditLogOrm(Base):
     """Append-only audit trail for governance operations.
 
-    Every scan run, user feedback, and emergency action writes
+    Every scan run, user feedback, and admin action writes
     a row here. The ``run_id`` ties all audit rows from a single
     scan together (UUID4).
 
@@ -264,7 +264,7 @@ class AuditLogOrm(Base):
     hit_dimensions = Column(String(512))
     expected_token_saving = Column(BigInteger, nullable=True)
     saving_ratio = Column(Numeric(10, 4), nullable=True)
-    action_taken = Column(String(64))  # enqueued/whitelist_filtered/muted/cooldown_filtered/auto_resolved/mute_expired/out_of_scope/reminded/expired_unresolved/data_not_ready/error/user_resolved/emergency_*
+    action_taken = Column(String(64))  # enqueued/whitelist_filtered/muted/cooldown_filtered/auto_resolved/mute_expired/out_of_scope/reminded/expired_unresolved/data_not_ready/error/user_resolved/admin_*
     source = Column(String(32), default="daily_scan")
     error_msg = Column(Text, nullable=True)
     actor_id = Column(String(64), nullable=True, comment="实际操作人ID — owner自操作=owner_id，admin代操作=admin_id，系统行为=NULL")
@@ -336,7 +336,7 @@ class WhitelistEntryOrm(Base):
     bot_id = Column(String(64), nullable=False)
     owner_id = Column(String(64), nullable=False)
     whitelist_type = Column(String(32), nullable=False)  # governance / dormant (reserved)
-    source = Column(String(64), default="manual")  # system / owner / admin / manual / emergency / card_callback / http_api / owner_feedback
+    source = Column(String(64), default="manual")  # system / owner / admin / manual / card_callback / http_api / owner_feedback
     reason = Column(String(512))
     created_by = Column(String(64))
     expires_at = Column(TIMESTAMP, nullable=True)  # NULL = permanent
@@ -475,6 +475,7 @@ class GovernanceTicketOrm(Base):
     # --- 其它 ---
     feedback_payload = Column(Text, nullable=True, comment="结构化反馈 JSON")
     actor_id = Column(String(64), nullable=True, comment="实际操作人ID")
+    delivery_status = Column(String(32), default="none", comment="最近通知投递状态: none/first_send:sent/reminder:failed/...")
 
     def to_dict(self) -> dict:
         """Convert to plain dict — safe to use after session closes.

--- a/src/backend/src/agentclaw/community/core/economy/governance/repositories/task_record_repo.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/repositories/task_record_repo.py
@@ -245,7 +245,7 @@ class TaskRecordRepository(TaskRecordQueryMixin):
             return count
 
     # ------------------------------------------------------------------
-    # Admin delete / count (emergency delete endpoint, §7.5)
+    # Admin delete / count (admin delete endpoint, §7.5)
     # ------------------------------------------------------------------
 
     def count_by_dt_versions(
@@ -350,3 +350,24 @@ class TaskRecordRepository(TaskRecordQueryMixin):
         with self._db.orm_session() as session:
             session.add(row)
             session.flush()
+
+    def update_delivery_status(self, ticket_id: str, status: str) -> bool:
+        """Update a single ticket's delivery_status (self-managed session).
+
+        Args:
+            ticket_id: 工单稳定 UUID。
+            status: 投递状态(none/first_send:pending/reminder:sent/...)。
+
+        Returns:
+            True if 1 row updated, False otherwise.
+        """
+        with self._db.orm_session() as session:
+            result = (
+                session.query(GovernanceTicketOrm)
+                .filter(GovernanceTicketOrm.ticket_id == ticket_id)
+                .update(
+                    {GovernanceTicketOrm.delivery_status: status},
+                    synchronize_session=False,
+                )
+            )
+            return result == 1

--- a/src/backend/src/agentclaw/community/core/economy/governance/repositories/whitelist_repo.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/repositories/whitelist_repo.py
@@ -242,6 +242,65 @@ class GovernanceWhitelistRepository:
                 .count()
             )
 
+    def list_all(
+        self,
+        *,
+        whitelist_type: str = "governance",
+        owner_id: str | None = None,
+        bot_id: str | None = None,
+        include_expired: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[WhitelistEntry], int]:
+        """全量分页查询白名单(可选 owner/bot 筛选 + 过期开关 + total)。
+
+        Args:
+            whitelist_type: 白名单类型(默认 ``governance``)。
+            owner_id: 可选,按负责人精确筛选。
+            bot_id: 可选,按 bot 精确筛选。
+            include_expired: False(默认)排除已过期项(基于 ``expires_at``);
+                True 返回含过期项的全量视图。
+            limit: 分页大小。
+            offset: 偏移量。
+
+        Returns:
+            ``(条目领域模型列表, 筛选条件下的总数)``。
+        """
+        _env = get_current_env()
+        now = datetime.now()
+        with self._db.orm_session() as s:
+            s.expire_on_commit = False
+            base_filters = [
+                WhitelistEntryOrm.whitelist_type == whitelist_type,
+                WhitelistEntryOrm.env == _env,
+            ]
+            if owner_id is not None:
+                base_filters.append(WhitelistEntryOrm.owner_id == owner_id)
+            if bot_id is not None:
+                base_filters.append(WhitelistEntryOrm.bot_id == bot_id)
+            if not include_expired:
+                base_filters.append(
+                    or_(
+                        WhitelistEntryOrm.expires_at.is_(None),
+                        WhitelistEntryOrm.expires_at > now,
+                    )
+                )
+
+            total = (
+                s.query(WhitelistEntryOrm)
+                .filter(*base_filters)
+                .count()
+            )
+            rows = (
+                s.query(WhitelistEntryOrm)
+                .filter(*base_filters)
+                .order_by(WhitelistEntryOrm.gmt_create.desc())
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            return [WhitelistEntry.from_orm(r) for r in rows], total
+
     @staticmethod
     def _parse_expires_at(value: object) -> datetime | None:
         """Parse expires_at from various formats."""

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/admin_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/admin_service.py
@@ -2,17 +2,17 @@
 
 Covers(对 admin_router):
   - Emergency brake (pause/resume) — cross-pod distributed cache
-  - bulk_whitelist — delegate to :class:`GovernanceWhitelistService`
-  - cancel_pending / close_all_open — emergency bulk operations
   - pause_ticket — admin pause to waiting_review (§7.5.1)
-  - emergency_close — immediate ticket close without cooldown
   - delete_records — emergency delete for record_daily / notify_log
-  - delete_whitelist_entry — delegate to :class:`GovernanceWhitelistService`
   - deliver_pending / deliver_by_worker — manual delivery pipeline
     (_run_delivery 内部实现,原 delivery_runner 已并回)
 
-审批面(list_review_tickets / get_review_ticket_detail / review_ticket)已按
-路由边界拆至 :class:`GovernanceWorkflowService`(对应 workflow_router)。
+白名单读写不再经本服务转发:admin_router 直连 GovernanceWhitelistService。
+
+关单能力(emergency_close / cancel_pending / close_all_open)已按"工单运营 vs 运维"
+边界迁至 :class:`GovernanceWorkflowService`(对应 workflow_router);本服务仅保留
+_deliver/pause/resume 等运维职责。审批面(list_review_tickets /
+get_review_ticket_detail / review_ticket)亦按路由边界拆至 WorkflowService。
 
 All ticket lifecycle transitions land on ``task_record`` — never on
 ``notify_log`` (§4.2.3 读写路由规则). Close paths cancel pending
@@ -251,104 +251,6 @@ class GovernanceAdminService:
                 run_id,
             )
 
-    def bulk_whitelist(
-        self,
-        bot_ids: list[str],
-        reason: str,
-        operator: str,
-    ) -> dict:
-        """Batch whitelist + cancel pending — delegates to WhitelistService."""
-        return self._whitelist_service.bulk_whitelist(bot_ids, reason, operator)
-
-    def cancel_pending(self, reason: str, operator: str) -> BulkOperationResult:
-        """Cancel ALL pending notifications (emergency close) + close the
-        matching ``task_record`` subjects (Task 8 口径对齐).
-
-        通知侧 cancel scope = open/muted 且 response IS NULL。工单侧按被关
-        通知的 ``ticket_id`` 集合关 —— **不可裸用全量** :meth:`bulk_close_open`
-        (会多关已反馈的 scheduled 单)。逐条走 :meth:`emergency_close` 链路
-        激活领域模型守卫、幂等。
-
-        Returns ``BulkOperationResult(affected=N, label="cancelled")``。
-        """
-        now = datetime.now()
-        cooldown_days = self._config.cooldown_days
-
-        # Step 1: pre-collect the ticket_id set scoped to the same filter as
-        # the notify bulk-cancel (only_unresponded=True), before the cancel
-        # mutates rows. 无 None(record_process 创建处恒非空,且查询已剔 None)。
-        ticket_ids = self._notify_repo.list_ticket_ids_open_muted(
-            only_unresponded=True,
-        )
-
-        # Step 2: notify-side bulk cancel (behavior unchanged) — mirrors
-        # notify_status/governance_status/close_reason/closed_at/cooldown_until.
-        cancelled = self._notify_repo.bulk_close_open_muted(
-            close_reason=CloseReason.EMERGENCY_CLOSED,
-            closed_at=now,
-            cooldown_until=now + timedelta(days=cooldown_days),
-            only_unresponded=True,
-        )
-
-        # Step 3: ticket-side close — per-ticket guard-activated, idempotent.
-        # Driver's emergency_close uses EMERGENCY_CLOSED (aligns notify side).
-        self._lifecycle_svc.bulk_close_by_ticket_ids(ticket_ids, now=now)
-
-        self._write_emergency_audit(
-            action_taken=AuditAction.ADMIN_CANCEL_PENDING,
-            actor_id=operator,
-            error_msg=f"reason={reason}; operator={operator}",
-        )
-        log.info(
-            "[GovernanceEmergency] cancel_pending by %s: cancelled=%d, tickets_closed_by=%d",
-            operator, cancelled, len(ticket_ids),
-        )
-        return BulkOperationResult(affected=cancelled, label="cancelled")
-
-    def close_all_open(self, reason: str, operator: str) -> BulkOperationResult:
-        """Close ALL open/muted records, including already-responded ones,
-        + close all open/scheduled ``task_record`` subjects (Task 8 口径对齐).
-
-        Unlike :meth:`cancel_pending` which only touches ``response IS NULL``
-        records, this closes **every** open/muted notification regardless of
-        whether the user has already responded (e.g. ``need_time`` → muted).
-
-        工单侧用全量 :meth:`bulk_close_open`(WHERE status IN (open,scheduled))
-        ——与通知侧 ``governance_status IN (open,muted)`` 口径天然对齐(全量
-        关,不区分反馈)。Existing notify ``response`` / ``response_source`` /
-        ``mute_until`` preserved.
-
-        Returns ``BulkOperationResult(affected=N, label="closed")``。
-        """
-        now = datetime.now()
-        cooldown_days = self._config.cooldown_days
-
-        # Step 1: notify-side bulk close (behavior unchanged).
-        closed = self._notify_repo.bulk_close_open_muted(
-            close_reason=CloseReason.ADMIN_CLOSED,
-            closed_at=now,
-            cooldown_until=now + timedelta(days=cooldown_days),
-            only_unresponded=False,
-        )
-
-        # Step 2: ticket-side full close (ADMIN_CLOSED). bulk_close_open's
-        # WHERE status IN (open,scheduled) + active_worker IS NOT NULL
-        # predicate is the state-legality guard (per-spec bulk exemption).
-        tickets_closed = self._lifecycle_svc.bulk_close_open(
-            close_reason=CloseReason.ADMIN_CLOSED, now=now,
-        )
-
-        self._write_emergency_audit(
-            action_taken=AuditAction.ADMIN_CLOSE_ALL,
-            actor_id=operator,
-            error_msg=f"reason={reason}; operator={operator}",
-        )
-        log.info(
-            "[GovernanceAdmin] close_all_open by %s: notify_closed=%d, tickets_closed=%d",
-            operator, closed, tickets_closed,
-        )
-        return BulkOperationResult(affected=closed, label="closed")
-
     # -- Ticket-level admin operations (§7.5) ----------------------------------
 
     def pause_ticket(
@@ -390,51 +292,6 @@ class GovernanceAdminService:
             ticket_id=ticket_id,
             status=GovernanceStatus.WAITING_REVIEW,
             review_reason="admin_paused",
-        )
-
-    def emergency_close(
-        self, ticket_id: str, admin_id: str, reason: str = "",
-    ) -> TicketActionOutcome:
-        """Immediate ticket close without cooldown (§6.3)."""
-        ticket = self._task_repo.find_by_ticket_id(ticket_id)
-        if not ticket:
-            return TicketActionOutcome(
-                ticket_id=ticket_id, status=GovernanceStatus.OPEN,
-                error="Ticket not found", error_code="NOT_FOUND",
-            )
-
-        if ticket.governance_status == GovernanceStatus.CLOSED:
-            return TicketActionOutcome(
-                ticket_id=ticket_id,
-                status=GovernanceStatus.CLOSED,
-                close_reason=ticket.close_reason,
-            )
-
-        now = datetime.now()
-
-        # Advance via driver service (sole driver). Driver orchestrates the
-        # CLOSE + cancel-pending. The audit row (with reason + actor_id=
-        # admin_id) is owned by admin_service below — the driver does not
-        # duplicate it, matching pause_ticket / review_ticket siblings.
-        self._lifecycle_svc.emergency_close(
-            ticket_id, now=now,
-        )
-
-        self._audit_repo.add_audit(
-            "admin-emergency-close",
-            bot_id=ticket.bot_id,
-            owner_id=ticket.owner_id,
-            actor_id=admin_id,
-            action_taken=AuditAction.ADMIN_CLOSE_ALL,
-            source="admin_api",
-            error_msg=f"ticket_id={ticket_id}; reason={reason}",
-            dry_run=0,
-        )
-
-        return TicketActionOutcome(
-            ticket_id=ticket_id,
-            status=GovernanceStatus.CLOSED,
-            close_reason=CloseReason.EMERGENCY_CLOSED,
         )
 
     # -- Records delete (emergency) — moved from router ------------------------
@@ -549,23 +406,6 @@ class GovernanceAdminService:
             "deleted": deleted,
             "not_found": not_found,
         }
-
-# ------------------------------------------------------------------
-    # Whitelist delete — delegates to GovernanceWhitelistService
-    # ------------------------------------------------------------------
-
-    def delete_whitelist_entry(
-        self,
-        *,
-        bot_id: str,
-        owner_id: str,
-        reason: str,
-        operator: str,
-    ) -> dict:
-        """Delete a single whitelist entry — delegates to WhitelistService."""
-        return self._whitelist_service.delete_whitelist_entry(
-            bot_id=bot_id, owner_id=owner_id, reason=reason, operator=operator,
-        )
 
     # -- Deliver pending — moved from router (scan_and_deliver Phase 2-5) ------
 

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/feedback_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/feedback_service.py
@@ -52,11 +52,13 @@ _FORMAL_RESPONSES = {e.value for e in Response}
 _BLOCKED_STATUSES = {GovernanceStatus.SCHEDULED, GovernanceStatus.WAITING_REVIEW, GovernanceStatus.CLOSED}
 
 # response → (target_status, review_reason) — all go to waiting_review (§7.4.2)
+# need_time 也进 waiting_review 待审(管理员用 approve_scheduled 同意排期 → scheduled);
+# repair_deadline 仍记录供 approve_scheduled 用,但反馈时不再直接 mute。
 _RESPONSE_TRANSITION_MAP: dict[str, tuple[str, str]] = {
     Response.OPTIMIZED: (GovernanceStatus.WAITING_REVIEW, "user_optimized"),
+    Response.NEED_TIME: (GovernanceStatus.WAITING_REVIEW, "user_need_time"),
     Response.DISPUTE: (GovernanceStatus.WAITING_REVIEW, "user_disputed"),
     Response.WHITELIST: (GovernanceStatus.WAITING_REVIEW, "user_whitelisted"),
-    # need_time → scheduled, handled separately
 }
 
 # ── v2 feedback_payload 归一化 ─────────────────────────────────────
@@ -510,19 +512,12 @@ class GovernanceFeedbackService:
                 notification_id=notification_id,
             )
 
-        # Apply feedback (§7.4.2)
+        # Apply feedback (§7.4.2) — 四种反馈均进 waiting_review 待审。
+        # need_time 的 repair_deadline 记录到 ticket(供 approve_scheduled 用),
+        # 但反馈时不直接 mute(改由管理员 approve_scheduled 审批后进 scheduled)。
         now = datetime.now()
-        target_status: str
-        review_reason: str | None = None
+        target_status, review_reason = _RESPONSE_TRANSITION_MAP[response]
         mute_until: datetime | None = None
-
-        if response == Response.NEED_TIME:
-            target_status = GovernanceStatus.SCHEDULED
-            mute_until = repair_deadline + timedelta(
-                days=self._config.cooldown_days,
-            )
-        else:
-            target_status, review_reason = _RESPONSE_TRANSITION_MAP[response]
 
         # Build self-contained v2 feedback_payload (enrich on server side).
         # Enrichment reads ticket.notification_structured; degrades gracefully,
@@ -562,8 +557,8 @@ class GovernanceFeedbackService:
             target_status=target_status,
             feedback_remark=remark,
             repair_deadline=repair_deadline if response == Response.NEED_TIME else None,
-            resume_at=mute_until if response == Response.NEED_TIME else None,
-            review_reason=review_reason if response != Response.NEED_TIME else None,
+            resume_at=None,  # waiting_review 不 mute;mute 改由 approve_scheduled 审批后决定
+            review_reason=review_reason,
             actor_id=effective_actor,
             feedback_payload=feedback_payload_json,
         )
@@ -623,7 +618,7 @@ class GovernanceFeedbackService:
             notification_id=notification_id,
             governance_status=target_status,
             close_reason=ticket.close_reason,
-            mute_until=mute_until if response == Response.NEED_TIME else None,
+            mute_until=None,  # waiting_review 不 mute;mute 由 approve_scheduled 决定
             response=response,
             response_source=source,
         )

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/record_process_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/record_process_service.py
@@ -63,6 +63,36 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
+# ── 上次反馈成对裁决(feedback_verdict)强信号 → 通知提示文案 ──────────
+# 建单时若上一工单 feedback_verdict 属强信号,通知带一句提示 + 审计带 verdict/remark,
+# 让在线自循环消费 user⊗admin 成对结果(§review-feedback-loop)。
+_STRONG_VERDICT_HINT: dict[str, str] = {
+    "whitelist_denied": "上次用户申请加白已被管理员驳回,本次继续按治理建议跟进。",
+    "dispute_accepted": "上次用户申诉已被管理员采纳关单,本次重新冒头请复核。",
+    "schedule_confirmed": "上次用户排期已被管理员批准,观察是否按期改善。",
+    "whitelist_confirmed": "上次用户加白已被管理员确认(误判),本次冒头请谨慎。",
+}
+
+
+def _build_last_feedback_audit(verdict: str, review_remark: str | None) -> str | None:
+    """构造建单审计的 last_feedback 片段:强信号 verdict + 非空 review_remark。
+
+    Args:
+        verdict: 上一工单 feedback_verdict(空串=无上一工单/无 verdict)。
+        review_remark: 上一工单管理员裁决备注(None=无)。
+
+    Returns:
+        审计片段(如 ``last_verdict=whitelist_denied; last_review_remark=...``),
+        verdict 非强信号且 remark 空 → None(不写入)。
+    """
+    if not verdict or verdict == "other":
+        return None
+    parts = [f"last_verdict={verdict}"]
+    if review_remark:
+        remark = review_remark if len(review_remark) <= 120 else review_remark[:119] + "…"
+        parts.append(f"last_review_remark={remark}")
+    return "; ".join(parts)
+
 
 # ── Result types ─────────────────────────────────────────────────────────
 
@@ -595,12 +625,27 @@ class GovernanceRecordService:
                 or latest_closed.closed_at
             )
 
+        # 上次反馈成对裁决(feedback_verdict):强信号时通知带一句"上次反馈提示"
+        # + 审计带 verdict/remark,让在线自循环消费 user⊗admin 成对结果。
+        last_verdict = latest_closed.feedback_verdict if latest_closed else ""
+        last_review_remark = (
+            latest_closed.review_remark if latest_closed else None
+        )
+        last_feedback_hint = _STRONG_VERDICT_HINT.get(last_verdict)
+
         # Render notification markdown
         notification_md = self._render_svc.render_first_notification_md(
             record,
             dt_version=dt_version,
             use_reopen_template=use_reopen_template,
             reopen_ref_time=reopen_ref_time,
+        )
+        if last_feedback_hint:
+            notification_md = f"{notification_md}\n\n> 💡 {last_feedback_hint}"
+
+        # 审计上下文:强信号 verdict + 非空 review_remark 进 error_msg(可追溯)
+        last_feedback_audit = _build_last_feedback_audit(
+            last_verdict, last_review_remark,
         )
 
         if dry_run:
@@ -611,6 +656,7 @@ class GovernanceRecordService:
                 governance_decision=record.governance_decision,
                 hit_dimensions=record.hit_dimensions,
                 action_taken=AuditAction.ENQUEUED,
+                error_msg=last_feedback_audit,
                 dry_run=1,
             )
             return RecordProcessResult(
@@ -690,6 +736,7 @@ class GovernanceRecordService:
             expected_token_saving=record.expected_token_saving,
             saving_ratio=record.saving_ratio,
             action_taken=AuditAction.ENQUEUED,
+            error_msg=last_feedback_audit,
             dry_run=0,
         )
 

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/record_process_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/record_process_service.py
@@ -694,6 +694,7 @@ class GovernanceRecordService:
                 last_decision_dt_version=dt_version,
                 last_seen_at=now,
                 last_sync_at=now,
+                delivery_status="none",  # 工单刚建,尚无通知投递
             ),
         )
         # Remind chained by scan after first_send; None until then (§7.3.3).
@@ -725,6 +726,8 @@ class GovernanceRecordService:
         )
         # env auto-filled by ORM default=get_current_env (not in constructor)
         self._notify_repo.add_notification(notify_row)
+        # 回写工单投递状态:first_send:pending(通知已建待发)
+        self._task_repo.update_delivery_status(ticket_id, "first_send:pending")
 
         # Audit enqueued (self-managed session)
         self._audit_repo.add_audit(

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/service_protocols.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/service_protocols.py
@@ -436,6 +436,10 @@ class GovernanceWorkflowServiceProtocol(Protocol):
         """评审工单详情(单工单领域模型)。"""
         ...
 
+    def get_pending_notification(self, ticket_id: str) -> dict | None:
+        """查工单待回复通知(notification_id + 元信息)。"""
+        ...
+
     def review_ticket(
         self, ticket_id: str, action: str, admin_id: str, remark: str = "",
     ) -> TicketActionOutcome:

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/service_protocols.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/service_protocols.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         GovernanceTicket,
     )
     from agentclaw.community.core.economy.governance.services.admin_service import (
+        BulkOperationResult,
         TicketActionOutcome,
     )
 
@@ -54,26 +55,7 @@ class GovernanceAdminServiceProtocol(Protocol):
     def resume(self, reason: str, operator: str) -> None:
         ...
 
-    def bulk_whitelist(
-        self,
-        bot_ids: list[str],
-        reason: str,
-        operator: str,
-    ) -> dict:
-        ...
-
-    def cancel_pending(self, reason: str, operator: str) -> dict:
-        ...
-
-    def close_all_open(self, reason: str, operator: str) -> dict:
-        ...
-
     def pause_ticket(
-        self, ticket_id: str, admin_id: str, reason: str = "",
-    ) -> TicketActionOutcome:
-        ...
-
-    def emergency_close(
         self, ticket_id: str, admin_id: str, reason: str = "",
     ) -> TicketActionOutcome:
         ...
@@ -81,16 +63,6 @@ class GovernanceAdminServiceProtocol(Protocol):
     def delete_records(
         self,
         body: dict,
-        operator: str,
-    ) -> dict:
-        ...
-
-    def delete_whitelist_entry(
-        self,
-        *,
-        bot_id: str,
-        owner_id: str,
-        reason: str,
         operator: str,
     ) -> dict:
         ...
@@ -187,6 +159,19 @@ class GovernanceWhitelistServiceProtocol(Protocol):
         ...
 
     def count_by_type(self, *, whitelist_type: str = "governance") -> int:
+        ...
+
+    def list_all(
+        self,
+        *,
+        whitelist_type: str = "governance",
+        owner_id: str | None = None,
+        bot_id: str | None = None,
+        include_expired: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Any], int]:
+        """全量分页查询白名单(可选 owner/bot 筛选 + 过期开关 + total)。"""
         ...
 
 
@@ -433,7 +418,17 @@ class GovernanceWorkflowServiceProtocol(Protocol):
     def get_review_ticket_detail(
         self, ticket_id: str,
     ) -> GovernanceTicket | None:
-        """评审工单详情(单工单领域模型)。"""
+        """评审工单详情(单工单领域模型,纯本体,不含跨聚合派生)。"""
+        ...
+
+    def build_review_ticket_detail(
+        self, ticket_id: str,
+    ) -> tuple[GovernanceTicket, bool] | None:
+        """组装工单详情视图:工单本体 + 是否在治理白名单中(跨聚合派生位)。
+
+        Returns ``(ticket, in_whitelist)``;工单不存在返回 None;
+        工单缺 bot_id/owner_id 时 in_whitelist=False。
+        """
         ...
 
     def get_pending_notification(self, ticket_id: str) -> dict | None:
@@ -444,4 +439,22 @@ class GovernanceWorkflowServiceProtocol(Protocol):
         self, ticket_id: str, action: str, admin_id: str, remark: str = "",
     ) -> TicketActionOutcome:
         """审批:approve_close / approve_whitelist / reject_for_reopen(§7.5.2)。"""
+        ...
+
+    def emergency_close(
+        self, ticket_id: str, admin_id: str, reason: str = "",
+    ) -> TicketActionOutcome:
+        """立即关单(无 cooldown),从 admin_service 迁入(工单运营归属)。"""
+        ...
+
+    def cancel_pending(
+        self, reason: str, operator: str,
+    ) -> BulkOperationResult:
+        """取消全部未响应待通知 + 关对应工单(从 admin_service 迁入)。"""
+        ...
+
+    def close_all_open(
+        self, reason: str, operator: str,
+    ) -> BulkOperationResult:
+        """关闭全部 open/muted(含已响应)+ 关全部 open/scheduled 工单(迁入)。"""
         ...

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/whitelist_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/whitelist_service.py
@@ -177,6 +177,30 @@ class GovernanceWhitelistService:
         """Count whitelist entries of a given type (delegates to repo)."""
         return self._whitelist_repo.count_by_type(whitelist_type=whitelist_type)
 
+    def list_all(
+        self,
+        *,
+        whitelist_type: str = "governance",
+        owner_id: str | None = None,
+        bot_id: str | None = None,
+        include_expired: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[WhitelistEntry], int]:
+        """全量分页查询白名单(delegates to repo)。
+
+        可选 owner_id / bot_id 精确筛选;include_expired=False 默认排除已过期;
+        返回 (领域模型列表, 筛选条件下总数)。
+        """
+        return self._whitelist_repo.list_all(
+            whitelist_type=whitelist_type,
+            owner_id=owner_id,
+            bot_id=bot_id,
+            include_expired=include_expired,
+            limit=limit,
+            offset=offset,
+        )
+
     def add(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/workflow_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/workflow_service.py
@@ -41,6 +41,9 @@ if TYPE_CHECKING:
     from agentclaw.community.core.economy.governance.repositories.task_record_repo import (
         TaskRecordRepository,
     )
+    from agentclaw.community.core.economy.governance.repositories.notify_log_repo import (
+        NotifyLogRepository,
+    )
 
 log = get_logger(__name__)
 
@@ -60,12 +63,14 @@ class GovernanceWorkflowService:
         config: Any,  # EconomyGovernanceConfig
         lifecycle_svc: GovernanceLifecycleServiceProtocol,
         whitelist_service: GovernanceWhitelistServiceProtocol,
+        notify_repo: NotifyLogRepository,
     ) -> None:
         self._task_repo = task_repo
         self._audit_repo = audit_repo
         self._config = config
         self._lifecycle_svc = lifecycle_svc
         self._whitelist_service = whitelist_service
+        self._notify_repo = notify_repo
 
     def list_review_tickets(
         self,
@@ -111,6 +116,32 @@ class GovernanceWorkflowService:
         """
         return self._task_repo.find_by_ticket_id(ticket_id)
 
+    def get_pending_notification(self, ticket_id: str) -> dict | None:
+        """查工单待回复(sent/pending)通知,返回 notification_id + 元信息。
+
+        前端 admin review 时需拿到 notification_id 用于 card-callback 推进状态。
+        open 工单的 notification_id 不在 task_record,在 notify_log(正向查)。
+
+        Args:
+            ticket_id: 工单稳定 UUID。
+
+        Returns:
+            ``{notification_id, notify_status, notify_type, gmt_create}`` 或 None。
+        """
+        # 优先 pending/sending(待回复);若无,取最近一条 sent(已发未反馈)
+        notifies = self._notify_repo.list_by_ticket(ticket_id, only_pending=True)
+        if not notifies:
+            notifies = self._notify_repo.list_by_ticket(ticket_id)
+        if not notifies:
+            return None
+        n = notifies[0]  # 最新
+        return {
+            "notification_id": n.notification_id,
+            "notify_status": n.delivery_status.value if n.delivery_status else None,
+            "notify_type": n.notify_type.value if n.notify_type else None,
+            "sent_at": n.sent_at.isoformat() if n.sent_at else None,
+        }
+
     def review_ticket(
         self, ticket_id: str, action: str, admin_id: str, remark: str = "",
     ) -> TicketActionOutcome:
@@ -118,7 +149,9 @@ class GovernanceWorkflowService:
 
         Actions: approve_close / approve_whitelist / reject_for_reopen.
         """
-        valid_actions = {"approve_close", "approve_whitelist", "reject_for_reopen"}
+        valid_actions = {
+            "approve_close", "approve_scheduled", "approve_whitelist", "reject_for_reopen",
+        }
         if action not in valid_actions:
             return TicketActionOutcome(
                 ticket_id=ticket_id, status=GovernanceStatus.WAITING_REVIEW,
@@ -150,6 +183,11 @@ class GovernanceWorkflowService:
             review_reason = ticket.review_reason or "unknown"
             close_reason = f"{review_reason}_approved"
             cooldown_until = now + timedelta(days=cooldown_days)
+        elif action == "approve_scheduled":
+            # 同意排期 → SCHEDULED(不关单),close_reason 作 review 标记;
+            # 不设 cooldown,保留 ticket.repair_deadline(need_time 反馈时记录)
+            close_reason = "schedule_approved"
+            cooldown_until = None
         elif action == "approve_whitelist":
             close_reason = "whitelist_approved"
             cooldown_until = None
@@ -188,6 +226,7 @@ class GovernanceWorkflowService:
 
         audit_action_map = {
             "approve_close": AuditAction.REVIEW_APPROVE_CLOSE,
+            "approve_scheduled": AuditAction.REVIEW_APPROVE_SCHEDULED,
             "approve_whitelist": AuditAction.REVIEW_APPROVE_WHITELIST,
             "reject_for_reopen": AuditAction.REVIEW_REJECT_FOR_REOPEN,
         }
@@ -202,8 +241,12 @@ class GovernanceWorkflowService:
             dry_run=0,
         )
 
+        outcome_status = (
+            GovernanceStatus.SCHEDULED if action == "approve_scheduled"
+            else GovernanceStatus.CLOSED
+        )
         return TicketActionOutcome(
             ticket_id=ticket_id,
-            status=GovernanceStatus.CLOSED,
+            status=outcome_status,
             close_reason=close_reason,
         )

--- a/src/backend/src/agentclaw/community/core/economy/governance/services/workflow_service.py
+++ b/src/backend/src/agentclaw/community/core/economy/governance/services/workflow_service.py
@@ -20,9 +20,11 @@ from injector import inject
 
 from agentclaw.community.core.economy.governance.domain.enums import (
     AuditAction,
+    CloseReason,
     GovernanceStatus,
 )
 from agentclaw.community.core.economy.governance.services.admin_service import (
+    BulkOperationResult,
     TicketActionOutcome,
 )
 from agentclaw.community.core.economy.governance.services.service_protocols import (
@@ -49,10 +51,14 @@ log = get_logger(__name__)
 
 
 class GovernanceWorkflowService:
-    """工单审批服务 — list / detail / review(§7.5.2)。
+    """工单运营服务 — list / detail / review / 关单(§7.5.2)。
 
     review 三分支走 lifecycle_svc.review_ticket(状态机唯一驱动) + 审批副作用
-    (approve_whitelist 加白名单)+ 审计。零反向依赖 admin_service。
+    (approve_whitelist 加白名单)+ 审计。关单方法(emergency_close /
+    cancel_pending / close_all_open,从 admin_service 迁入)同走状态机 +
+    audit;依赖复用本服务既有注入(task_repo/audit_repo/config/lifecycle_svc
+    /notify_repo),零依赖补。仅 import admin_service 的
+    TicketActionOutcome / BulkOperationResult 数据类(单向,无循环)。
     """
 
     @inject
@@ -106,7 +112,10 @@ class GovernanceWorkflowService:
     def get_review_ticket_detail(
         self, ticket_id: str,
     ) -> GovernanceTicket | None:
-        """评审工单详情:取单个工单领域模型,供详情面板展示。
+        """评审工单详情:取单个工单领域模型。
+
+        纯取工单本体(task_record 映射),不含跨聚合派生状态(如白名单)——
+        白名单等派生位由 :meth:`build_review_ticket_detail` 组装。
 
         Args:
             ticket_id: 工单稳定 UUID。
@@ -115,6 +124,32 @@ class GovernanceWorkflowService:
             :class:`GovernanceTicket` 或 None(不存在)。
         """
         return self._task_repo.find_by_ticket_id(ticket_id)
+
+    def build_review_ticket_detail(
+        self, ticket_id: str,
+    ) -> tuple[GovernanceTicket, bool] | None:
+        """组装工单详情视图:工单本体 + 是否在治理白名单中(跨聚合派生位)。
+
+        in_whitelist 不是 ticket 领域模型的固有状态(它来自 ac_bot_whitelist
+        另一聚合),故不塞进 :class:`GovernanceTicket`,而在此组装方法里算出
+        随工单一并返回。复用既有 ``self._whitelist_service`` 注入,
+        ``is_whitelisted`` 已含 type+env+未过期判定,只点查一次。
+
+        Args:
+            ticket_id: 工单稳定 UUID。
+
+        Returns:
+            ``(ticket, in_whitelist)``;工单不存在返回 None。
+            工单缺 bot_id/owner_id 时 in_whitelist=False(防御兜底)。
+        """
+        ticket = self._task_repo.find_by_ticket_id(ticket_id)
+        if ticket is None:
+            return None
+        bot_id = getattr(ticket, "bot_id", None)
+        owner_id = getattr(ticket, "owner_id", None)
+        if not bot_id or not owner_id:
+            return ticket, False
+        return ticket, self._whitelist_service.is_whitelisted(bot_id, owner_id)
 
     def get_pending_notification(self, ticket_id: str) -> dict | None:
         """查工单待回复(sent/pending)通知,返回 notification_id + 元信息。
@@ -250,3 +285,167 @@ class GovernanceWorkflowService:
             status=outcome_status,
             close_reason=close_reason,
         )
+
+    # ── 关单方法(从 admin_service 迁入,工单运营面归属) ─────────────────
+
+
+    def emergency_close(
+        self, ticket_id: str, admin_id: str, reason: str = "",
+    ) -> TicketActionOutcome:
+        """Immediate ticket close without cooldown (§6.3)."""
+        ticket = self._task_repo.find_by_ticket_id(ticket_id)
+        if not ticket:
+            return TicketActionOutcome(
+                ticket_id=ticket_id, status=GovernanceStatus.OPEN,
+                error="Ticket not found", error_code="NOT_FOUND",
+            )
+
+        if ticket.governance_status == GovernanceStatus.CLOSED:
+            return TicketActionOutcome(
+                ticket_id=ticket_id,
+                status=GovernanceStatus.CLOSED,
+                close_reason=ticket.close_reason,
+            )
+
+        now = datetime.now()
+
+        # Advance via driver service (sole driver). Driver orchestrates the
+        # CLOSE + cancel-pending. The audit row (with reason + actor_id=
+        # admin_id) is owned by this service below — the driver does not
+        # duplicate it, matching pause_ticket / review_ticket siblings.
+        self._lifecycle_svc.emergency_close(
+            ticket_id, now=now,
+        )
+
+        self._audit_repo.add_audit(
+            "admin-emergency-close",
+            bot_id=ticket.bot_id,
+            owner_id=ticket.owner_id,
+            actor_id=admin_id,
+            action_taken=AuditAction.ADMIN_CLOSE_ALL,
+            source="admin_api",
+            error_msg=f"ticket_id={ticket_id}; reason={reason}",
+            dry_run=0,
+        )
+
+        return TicketActionOutcome(
+            ticket_id=ticket_id,
+            status=GovernanceStatus.CLOSED,
+            close_reason=CloseReason.EMERGENCY_CLOSED,
+        )
+
+    def cancel_pending(self, reason: str, operator: str) -> BulkOperationResult:
+        """Cancel ALL pending notifications (emergency close) + close the
+        matching ``task_record`` subjects (Task 8 口径对齐).
+
+        通知侧 cancel scope = open/muted 且 response IS NULL。工单侧按被关
+        通知的 ``ticket_id`` 集合关 —— **不可裸用全量** :meth:`bulk_close_open`
+        (会多关已反馈的 scheduled 单)。逐条走 :meth:`emergency_close` 链路
+        激活领域模型守卫、幂等。
+
+        Returns ``BulkOperationResult(affected=N, label="cancelled")``。
+        """
+        now = datetime.now()
+        cooldown_days = self._config.cooldown_days
+
+        # Step 1: pre-collect the ticket_id set scoped to the same filter as
+        # the notify bulk-cancel (only_unresponded=True), before the cancel
+        # mutates rows. 无 None(record_process 创建处恒非空,且查询已剔 None)。
+        ticket_ids = self._notify_repo.list_ticket_ids_open_muted(
+            only_unresponded=True,
+        )
+
+        # Step 2: notify-side bulk cancel (behavior unchanged) — mirrors
+        # notify_status/governance_status/close_reason/closed_at/cooldown_until.
+        cancelled = self._notify_repo.bulk_close_open_muted(
+            close_reason=CloseReason.EMERGENCY_CLOSED,
+            closed_at=now,
+            cooldown_until=now + timedelta(days=cooldown_days),
+            only_unresponded=True,
+        )
+
+        # Step 3: ticket-side close — per-ticket guard-activated, idempotent.
+        # Driver's emergency_close uses EMERGENCY_CLOSED (aligns notify side).
+        self._lifecycle_svc.bulk_close_by_ticket_ids(ticket_ids, now=now)
+
+        self._write_emergency_audit(
+            action_taken=AuditAction.ADMIN_CANCEL_PENDING,
+            actor_id=operator,
+            error_msg=f"reason={reason}; operator={operator}",
+        )
+        log.info(
+            "[GovernanceEmergency] cancel_pending by %s: cancelled=%d, tickets_closed_by=%d",
+            operator, cancelled, len(ticket_ids),
+        )
+        return BulkOperationResult(affected=cancelled, label="cancelled")
+
+    def close_all_open(self, reason: str, operator: str) -> BulkOperationResult:
+        """Close ALL open/muted records, including already-responded ones,
+        + close all open/scheduled ``task_record`` subjects (Task 8 口径对齐).
+
+        Unlike :meth:`cancel_pending` which only touches ``response IS NULL``
+        records, this closes **every** open/muted notification regardless of
+        whether the user has already responded (e.g. ``need_time`` → muted).
+
+        工单侧用全量 :meth:`bulk_close_open`(WHERE status IN (open,scheduled))
+        ——与通知侧 ``governance_status IN (open,muted)`` 口径天然对齐(全量
+        关,不区分反馈)。Existing notify ``response`` / ``response_source`` /
+        ``mute_until`` preserved.
+
+        Returns ``BulkOperationResult(affected=N, label="closed")``。
+        """
+        now = datetime.now()
+        cooldown_days = self._config.cooldown_days
+
+        # Step 1: notify-side bulk close (behavior unchanged).
+        closed = self._notify_repo.bulk_close_open_muted(
+            close_reason=CloseReason.ADMIN_CLOSED,
+            closed_at=now,
+            cooldown_until=now + timedelta(days=cooldown_days),
+            only_unresponded=False,
+        )
+
+        # Step 2: ticket-side full close (ADMIN_CLOSED). bulk_close_open's
+        # WHERE status IN (open,scheduled) + active_worker IS NOT NULL
+        # predicate is the state-legality guard (per-spec bulk exemption).
+        tickets_closed = self._lifecycle_svc.bulk_close_open(
+            close_reason=CloseReason.ADMIN_CLOSED, now=now,
+        )
+
+        self._write_emergency_audit(
+            action_taken=AuditAction.ADMIN_CLOSE_ALL,
+            actor_id=operator,
+            error_msg=f"reason={reason}; operator={operator}",
+        )
+        log.info(
+            "[GovernanceAdmin] close_all_open by %s: notify_closed=%d, tickets_closed=%d",
+            operator, closed, tickets_closed,
+        )
+        return BulkOperationResult(affected=closed, label="closed")
+
+    # ── 关单:私有 audit helper(随关单方法从 admin_service 迁入) ──────
+
+
+    def _write_emergency_audit(
+        self,
+        *,
+        action_taken: str,
+        actor_id: str | None = None,
+        error_msg: str = "",
+    ) -> None:
+        """Best-effort audit write for emergency operations.
+
+        Delegates to :meth:`GovernanceAuditRepository.add_audit` with the
+        emergency-specific ``run_id`` and ``source``.
+        """
+        try:
+            self._audit_repo.add_audit(
+                "emergency",
+                action_taken=action_taken,
+                actor_id=actor_id,
+                error_msg=error_msg,
+                source="admin_api",
+                dry_run=0,
+            )
+        except Exception:
+            log.exception("[GovernanceEmergency] Failed to write audit for %s", action_taken)

--- a/src/backend/src/agentclaw/community/di/modules/economy_governance_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/economy_governance_module.py
@@ -263,6 +263,7 @@ class EconomyGovernanceModule(Module):
         config: EconomyGovernanceConfig,
         lifecycle_service: GovernanceLifecycleService,
         whitelist_service: GovernanceWhitelistService,
+        notify_repo: NotifyLogRepository,
     ) -> GovernanceWorkflowService:
         """Construct GovernanceWorkflowService — 工单审批(从 admin 按路由边界拆出)。
 
@@ -275,6 +276,7 @@ class EconomyGovernanceModule(Module):
             config=config,
             lifecycle_svc=lifecycle_service,
             whitelist_service=whitelist_service,
+            notify_repo=notify_repo,
         )
 
     @singleton

--- a/src/backend/tests/community/core/economy/governance/test_admin_service.py
+++ b/src/backend/tests/community/core/economy/governance/test_admin_service.py
@@ -1,5 +1,10 @@
-"""Tests for GovernanceAdminService — close_all_open, cancel_pending,
-pause_ticket, review_ticket, emergency_close, get_state."""
+"""Tests for governance admin/workflow services.
+
+Admin-service tests: pause_ticket, get_state, deliver_by_worker(留 admin)。
+Workflow-service tests(关单方法从 admin 迁入后改 _build_workflow_svc 构造):
+close_all_open / cancel_pending / emergency_close / close-vs-cancel 区分 /
+ticket-notify 对齐。review/list/detail/build_detail 亦属 workflow。
+"""
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -185,11 +190,11 @@ def _build_workflow_svc(engine):
 
 
 class TestCloseAllOpen:
-    """Test GovernanceAdminService.close_all_open()."""
+    """Test GovernanceWorkflowService.close_all_open()(从 admin 迁入)。"""
 
     def test_closes_all_open_records(self, session, engine):
         """All open tickets → closed with close_reason=admin_closed."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(session, notification_id="n-open-1", governance_status="open")
         _make_notification(session, notification_id="n-open-2", governance_status="open")
 
@@ -206,7 +211,7 @@ class TestCloseAllOpen:
 
     def test_closes_scheduled_records(self, session, engine):
         """Scheduled records (e.g. need_time) → also closed."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(
             session, notification_id="n-sched-1", governance_status="muted",
             response="need_time",
@@ -223,7 +228,7 @@ class TestCloseAllOpen:
 
     def test_preserves_user_response(self, session, engine):
         """Existing response/response_source are NOT overwritten."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(
             session, notification_id="n-responded", governance_status="muted",
             response="need_time", response_source="card_callback",
@@ -240,7 +245,7 @@ class TestCloseAllOpen:
 
     def test_cancels_pending_notify_status(self, session, engine):
         """Pending notify_status → cancelled; already-sent → preserved."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(
             session, notification_id="n-pending",
             notify_status="pending", governance_status="open",
@@ -259,7 +264,7 @@ class TestCloseAllOpen:
 
     def test_skips_closed_records(self, session, engine):
         """Already-closed records are not affected."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(
             session, notification_id="n-closed", governance_status="closed",
             close_reason="user_optimized", closed_at=datetime.now(),
@@ -278,7 +283,7 @@ class TestCloseAllOpen:
 
     def test_writes_audit(self, session, engine):
         """close_all_open writes AuditLogOrm."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(session, notification_id="n-1", governance_status="open")
 
         svc.close_all_open(reason="emergency test", operator="admin-123")
@@ -290,14 +295,14 @@ class TestCloseAllOpen:
 
     def test_empty_set_is_idempotent(self, session, engine):
         """No active tickets → returns closed=0, no error."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
 
         result = svc.close_all_open(reason="test", operator="admin")
         assert result.affected == 0
 
     def test_cooldown_applied(self, session, engine):
         """Each closed ticket gets cooldown_until = now + cooldown_days."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(session, notification_id="n-1", governance_status="open")
 
         before = datetime.now()
@@ -320,7 +325,7 @@ class TestCancelPendingVsCloseAllOpen:
 
     def test_cancel_pending_closes_all_active(self, session, engine):
         """cancel_pending closes unresponded open/muted notifications with emergency_closed."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(session, notification_id="n-no-resp", governance_status="open")
         _make_notification(
             session, notification_id="n-no-resp-2", governance_status="muted",
@@ -337,7 +342,7 @@ class TestCancelPendingVsCloseAllOpen:
 
     def test_close_all_open_includes_responded(self, session, engine):
         """close_all_open closes ALL open/muted records, even with response, and applies cooldown."""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(session, notification_id="n-no-resp", governance_status="open")
         _make_notification(
             session, notification_id="n-responded", governance_status="muted",
@@ -368,7 +373,7 @@ class TestEmergencyTicketNotifyAlignment:
         """close_all_open:open/muted 通知对应的 open/scheduled 工单 → CLOSED(admin_closed)。
         用全量 bulk_close_open(WHERE status IN (open,scheduled) 口径天然对齐通知侧
         governance_status IN (open,muted))。"""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(session, notification_id="n-a", governance_status="open", ticket_id="t-a")
         _make_notification(session, notification_id="n-b", governance_status="muted",
                            response="need_time", ticket_id="t-b")
@@ -389,7 +394,7 @@ class TestEmergencyTicketNotifyAlignment:
         """cancel_pending:仅取消 response IS NULL 的通知,按被关通知的 ticket_id
         集合关工单(逐条 domain guard)—— **不可裸用全量 bulk_close_open**(会
         多关已反馈的 scheduled 单)。已反馈的 scheduled 工单保留(口径精确)。"""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         # unresponded open → 取消通知 + 关工单(emergency_closed)
         _make_notification(session, notification_id="n-unresp", governance_status="open",
                            ticket_id="t-unresp")
@@ -411,7 +416,7 @@ class TestEmergencyTicketNotifyAlignment:
 
     def test_cancel_pending_idempotent_on_already_closed_ticket(self, session, engine):
         """工单已 closed → driver emergency_close 幂等跳过,不重复审计/不报错。"""
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_notification(session, notification_id="n-dup", governance_status="open",
                            ticket_id="t-closed")
         _make_task_record(session, ticket_id="t-closed", governance_status="closed")
@@ -573,10 +578,10 @@ class TestReviewTicket:
 
 
 class TestEmergencyClose:
-    """Test GovernanceAdminService.emergency_close()."""
+    """Test GovernanceWorkflowService.emergency_close()(从 admin 迁入)。"""
 
     def test_open_to_closed(self, session, engine):
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_task_record(session, ticket_id="t-em-1", governance_status="open")
 
         result = svc.emergency_close("t-em-1", admin_id="admin-1", reason="urgent")
@@ -589,7 +594,7 @@ class TestEmergencyClose:
             assert ticket.active_worker is None
 
     def test_waiting_review_to_closed(self, session, engine):
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_task_record(
             session, ticket_id="t-em-2", governance_status="waiting_review",
         )
@@ -598,7 +603,7 @@ class TestEmergencyClose:
         assert result.status.value == "closed"
 
     def test_not_found(self, session, engine):
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         result = svc.emergency_close("nonexistent", admin_id="admin-1")
         assert result.error_code == "NOT_FOUND"
 
@@ -610,7 +615,7 @@ class TestEmergencyClose:
         review), so exactly ONE audit row with action=ADMIN_CLOSE_ALL is
         emitted, and it carries actor_id=admin_id.
         """
-        svc, db, _ = _build_svc(engine)
+        svc, db = _build_workflow_svc(engine)
         _make_task_record(session, ticket_id="t-em-audit", governance_status="open")
 
         result = svc.emergency_close("t-em-audit", admin_id="admin-77", reason="uh")
@@ -701,7 +706,7 @@ class TestListReviewTickets:
 
 
 class TestGetReviewTicketDetail:
-    """get_review_ticket_detail: 单工单领域模型, 不存在返回 None。"""
+    """get_review_ticket_detail: 纯取工单本体,不携带白名单派生位。"""
 
     def test_found(self, session, engine):
         svc, _ = _build_workflow_svc(engine)
@@ -716,6 +721,42 @@ class TestGetReviewTicketDetail:
     def test_not_found_returns_none(self, session, engine):
         svc, _ = _build_workflow_svc(engine)
         assert svc.get_review_ticket_detail("nonexistent") is None
+
+
+class TestBuildReviewTicketDetail:
+    """build_review_ticket_detail: 工单本体 + in_whitelist 组装(跨聚合派生)。"""
+
+    def test_assembles_default_not_whitelisted(self, session, engine):
+        svc, db = _build_workflow_svc(engine)
+        _make_task_record(
+            session, ticket_id="t-detail", governance_status="waiting_review",
+        )
+        result = svc.build_review_ticket_detail("t-detail")
+        assert result is not None
+        t, in_wl = result
+        assert type(t).__name__ == "GovernanceTicket"
+        # bot/owner seeded via _make_task_record 默认非白名单 → False
+        assert in_wl is False
+
+    def test_assembles_in_whitelist_true(self, session, engine):
+        """工单的 (bot_id, owner_id) 已在白名单 → in_whitelist=True。"""
+        svc, db = _build_workflow_svc(engine)
+        _make_task_record(
+            session, ticket_id="t-wl",
+            bot_id="bot-wl", owner_id="owner-wl", governance_status="open",
+        )
+        wl_repo = GovernanceWhitelistRepository(db=db)
+        wl_repo.add(
+            bot_id="bot-wl", owner_id="owner-wl", created_by="tester",
+        )
+        result = svc.build_review_ticket_detail("t-wl")
+        assert result is not None
+        _, in_wl = result
+        assert in_wl is True
+
+    def test_not_found_returns_none(self, session, engine):
+        svc, _ = _build_workflow_svc(engine)
+        assert svc.build_review_ticket_detail("nonexistent") is None
 
 
 class TestDeliverByWorker:

--- a/src/backend/tests/community/core/economy/governance/test_admin_service.py
+++ b/src/backend/tests/community/core/economy/governance/test_admin_service.py
@@ -176,6 +176,7 @@ def _build_workflow_svc(engine):
         config=FakeGovernanceConfig(),
         lifecycle_svc=lifecycle_svc,
         whitelist_service=whitelist_service,
+        notify_repo=notify_repo,
     )
     return svc, db
 
@@ -530,6 +531,20 @@ class TestReviewTicket:
 
         with db.orm_session() as s:
             ticket = s.query(GovernanceTicketOrm).first()
+            assert ticket.cooldown_until is None
+
+    def test_approve_scheduled(self, session, engine):
+        """approve_scheduled → status=scheduled(不关单),close_reason=schedule_approved。"""
+        svc, db = self._setup_waiting_review(engine)
+        result = svc.review_ticket(
+            "t-review", action="approve_scheduled", admin_id="admin-1",
+        )
+        assert result.status.value == "scheduled"
+        assert result.close_reason == "schedule_approved"
+
+        with db.orm_session() as s:
+            ticket = s.query(GovernanceTicketOrm).first()
+            assert ticket.governance_status == "scheduled"
             assert ticket.cooldown_until is None
 
     def test_invalid_action(self, session, engine):

--- a/src/backend/tests/community/core/economy/governance/test_admin_service_extra.py
+++ b/src/backend/tests/community/core/economy/governance/test_admin_service_extra.py
@@ -11,13 +11,11 @@ from datetime import datetime
 
 from .test_admin_service import (  # noqa: E402  (relative import within test package)
     _build_svc,
-    _make_notification,
 )
 
 from agentclaw.community.core.economy.governance.domain.enums import AuditAction
 from agentclaw.community.core.economy.governance.repositories.orm import (
     AuditLogOrm,
-    GovernanceNotificationOrm,
     GovernanceTicketOrm,
 )
 
@@ -181,77 +179,6 @@ class TestResume:
                 if a.action_taken == AuditAction.ADMIN_RESUME
             ]
             assert len(audits) == 1
-
-
-# ── bulk_whitelist ───────────────────────────────────────────────
-
-
-class TestBulkWhitelist:
-    """Cover bulk_whitelist — cancels pending notifications for specified bots."""
-
-    def test_whitelists_and_cancels_pending(self, session, engine):
-        """Bots with pending notifications → whitelisted + cancelled."""
-        svc, db, _ = _build_svc(engine)
-        _make_notification(
-            session, notification_id="n-1",
-            bot_id="bot-a", owner_id="owner-a", governance_status="open",
-            ticket_id="t-1",
-        )
-        _make_notification(
-            session, notification_id="n-2",
-            bot_id="bot-b", owner_id="owner-b", governance_status="open",
-            ticket_id="t-2",
-        )
-
-        result = svc.bulk_whitelist(
-            bot_ids=["bot-a", "bot-b"], reason="cleanup", operator="admin",
-        )
-
-        # Two distinct (bot, owner) pairs → 2 whitelisted.
-        assert result["whitelisted"] == 2
-        assert result["cancelled"] == 2
-
-        with db.orm_session() as s:
-            notif_rows = s.query(GovernanceNotificationOrm).all()
-            for n in notif_rows:
-                assert n.notify_status == "cancelled"
-                assert n.governance_status == "closed"
-
-    def test_no_matching_bots_skips_whitelist(self, session, engine):
-        """Unknown bot ids → no owner pairs → whitelisted=0, cancelled=0."""
-        svc, db, _ = _build_svc(engine)
-        _make_notification(
-            session, notification_id="n-1",
-            bot_id="bot-known", owner_id="owner-1", governance_status="open",
-        )
-
-        result = svc.bulk_whitelist(
-            bot_ids=["bot-unknown"], reason="x", operator="admin",
-        )
-
-        assert result["whitelisted"] == 0
-        assert result["cancelled"] == 0
-
-    def test_skips_already_closed_notifications(self, session, engine):
-        """Already-closed/sent notifications are not affected by bulk_whitelist."""
-        svc, db, _ = _build_svc(engine)
-        _make_notification(
-            session, notification_id="n-open",
-            bot_id="bot-x", owner_id="owner-x", governance_status="open",
-            ticket_id="t-open",
-        )
-        _make_notification(
-            session, notification_id="n-closed",
-            bot_id="bot-x", owner_id="owner-x", governance_status="closed",
-            ticket_id="t-closed", notify_status="sent",
-        )
-
-        result = svc.bulk_whitelist(
-            bot_ids=["bot-x"], reason="x", operator="admin",
-        )
-
-        # Only the open/pending notification is cancelled.
-        assert result["cancelled"] == 1
 
 
 # ── _read_pause_info non-str + error branches ────────────────────

--- a/src/backend/tests/community/core/economy/governance/test_card_callback.py
+++ b/src/backend/tests/community/core/economy/governance/test_card_callback.py
@@ -205,7 +205,7 @@ class TestCardCallbackResolve:
         assert row.response_remark == "This is wrong"
 
     def test_need_time_writes_to_db(self, session, engine):
-        """response=need_time + repair_deadline → scheduled in DB."""
+        """response=need_time + repair_deadline → waiting_review (待审, no auto mute)."""
         svc = _build_svc(engine)
         _make_notification(session)
 
@@ -214,11 +214,11 @@ class TestCardCallbackResolve:
             repair_deadline=datetime(2026, 7, 15), source="card_callback",
         )
         assert result.success
-        assert result.governance_status == "scheduled"
+        assert result.governance_status == "waiting_review"
 
         row = session.query(GovernanceTicketOrm).filter_by(ticket_id="t-n-001").one()
-        assert row.repair_deadline is not None
-        assert row.mute_until is not None
+        assert row.repair_deadline is not None  # 记录供 approve_scheduled 用
+        assert row.mute_until is None  # 待审不 mute;mute 由 approve_scheduled 决定
 
     def test_whitelist_with_remark_writes_to_db(self, session, engine):
         """response=whitelist + remark → closed in DB + whitelist add."""
@@ -504,7 +504,7 @@ class TestCardCallbackNoAuth:
         assert row.actor_id == "user-explicit"  # explicit user_id used
 
     def test_empty_user_id_need_time_resolves_owner(self, session, engine):
-        """user_id="" + need_time → owner_id resolved, mute_until set."""
+        """user_id="" + need_time → owner_id resolved, waiting_review (no auto mute)."""
         svc = _build_svc(engine)
         _make_notification(session, owner_id="staff-999888")
 
@@ -513,11 +513,11 @@ class TestCardCallbackNoAuth:
             repair_deadline=datetime(2026, 7, 15), source="card_callback",
         )
         assert result.success
-        assert result.governance_status == "scheduled"
+        assert result.governance_status == "waiting_review"
 
         row = session.query(GovernanceTicketOrm).filter_by(ticket_id="t-n-001").one()
         assert row.actor_id == "staff-999888"
-        assert row.mute_until is not None
+        assert row.mute_until is None  # 待审不 mute
 
     def test_empty_user_id_dispute_with_remark_resolves_owner(self, session, engine):
         """user_id="" + dispute + remark → owner_id resolved."""

--- a/src/backend/tests/community/core/economy/governance/test_feedback.py
+++ b/src/backend/tests/community/core/economy/governance/test_feedback.py
@@ -248,7 +248,11 @@ class TestFeedback:
         assert "repair_deadline" in (result.error or "").lower()
 
     def test_need_time_sets_scheduled_and_mute_until(self, session, engine):
-        """response=need_time → scheduled + mute_until = repair_deadline + cooldown_days."""
+        """response=need_time → waiting_review (待审); repair_deadline recorded.
+
+        need_time 不再直接 scheduled+mute,改为进 waiting_review 等管理员 approve_scheduled
+        审批后再进 scheduled。repair_deadline 记录供 approve_scheduled 用。
+        """
         svc, db = _build_svc(engine)
         _make_notification(session)
 
@@ -258,9 +262,9 @@ class TestFeedback:
             repair_deadline=deadline,
         )
         assert result.success
-        assert result.governance_status == "scheduled"
-        # mute_until = 2026-07-15 + cooldown_days(14) = 2026-07-29
-        assert result.mute_until == datetime(2026, 7, 29)
+        assert result.governance_status == "waiting_review"
+        # 待审不 mute;mute 由管理员 approve_scheduled 审批后决定
+        assert result.mute_until is None
 
     def test_owner_check_currently_bypassed(self, session, engine):
         """Owner check temporarily disabled — any user_id can resolve."""
@@ -473,6 +477,7 @@ class TestStateTransitions:
         assert result.governance_status == "waiting_review"
 
     def test_need_time_to_scheduled(self, session, engine):
+        """need_time → waiting_review 待审(不再直接 scheduled+mute)。"""
         svc, db = _build_svc(engine)
 
         repair_deadline = datetime.now() + timedelta(days=7)
@@ -496,5 +501,6 @@ class TestStateTransitions:
             s.commit()
 
         assert result.success is True
-        assert result.governance_status == "scheduled"
-        assert result.mute_until is not None
+        # need_time 改为进 waiting_review 待审(管理员 approve_scheduled 后才 scheduled)
+        assert result.governance_status == "waiting_review"
+        assert result.mute_until is None  # 待审不 mute

--- a/src/backend/tests/community/core/economy/governance/test_governance_delete.py
+++ b/src/backend/tests/community/core/economy/governance/test_governance_delete.py
@@ -186,8 +186,8 @@ class FakeGovernanceConfig:
 
 
 class FakeAdminService:
-    """Delegates delete_records / delete_whitelist_entry to real
-    GovernanceAdminService logic backed by in-memory fakes.
+    """Delegates delete_records to real GovernanceAdminService logic
+    backed by in-memory fakes.
 
     This lets the router-level tests exercise the full service path
     (router → admin_svc.delete_records) without a real database.
@@ -251,13 +251,6 @@ class FakeAdminService:
 
     def delete_records(self, body: dict, operator: str) -> dict:
         return self._real_svc.delete_records(body, operator)
-
-    def delete_whitelist_entry(
-        self, *, bot_id: str, owner_id: str, reason: str, operator: str,
-    ) -> dict:
-        return self._real_svc.delete_whitelist_entry(
-            bot_id=bot_id, owner_id=owner_id, reason=reason, operator=operator,
-        )
 
 
 # ===========================================================================

--- a/src/backend/tests/community/core/economy/governance/test_governance_enums.py
+++ b/src/backend/tests/community/core/economy/governance/test_governance_enums.py
@@ -56,6 +56,6 @@ def test_all_action_values_are_unique_strings():
         for k, v in vars(AuditAction).items()
         if not k.startswith("_") and isinstance(v, str)
     ]
-    assert len(values) == 52
+    assert len(values) == 53
     assert all(isinstance(v, str) for v in values)
     assert len(set(values)) == len(values)

--- a/src/backend/tests/community/core/economy/governance/test_lifecycle_service.py
+++ b/src/backend/tests/community/core/economy/governance/test_lifecycle_service.py
@@ -287,6 +287,20 @@ class TestPauseReviewEmergency:
         assert t.review_decision == "approve_close"
         assert t.reviewed_by == "admin-1"
 
+    def test_review_approve_scheduled_to_scheduled(self) -> None:
+        """approve_scheduled → SCHEDULED(不关单),close_reason='schedule_approved'。"""
+        svc, db, _ = _build_svc()
+        _seed_ticket(db, ticket_id="T-sch", status="waiting_review")
+        assert svc.review_ticket(
+            "T-sch", review_decision="approve_scheduled",
+            reviewed_by="admin-1", review_remark="排期 ok",
+        ) is True
+        t = svc._task_repo.find_by_ticket_id("T-sch")  # noqa: SLF001
+        assert t.governance_status == GovernanceStatus.SCHEDULED
+        assert t.review_decision == "approve_scheduled"
+        assert t.close_reason == "schedule_approved"
+        assert t.reviewed_by == "admin-1"
+
     def test_emergency_close_open_to_closed(self) -> None:
         svc, db, _ = _build_svc()
         _seed_ticket(db, ticket_id="T-emg", status="open")

--- a/src/backend/tests/community/core/economy/governance/test_record_process_service.py
+++ b/src/backend/tests/community/core/economy/governance/test_record_process_service.py
@@ -278,6 +278,110 @@ class TestProcessRecord:
         assert result.action == "cooldown_filtered"
 
 
+# --- Tests: feedback_verdict strong-signal consumption (review-feedback-loop) ---
+
+
+class TestFeedbackVerdictConsumption:
+    """建单消费上次工单 feedback_verdict 强信号:通知带提示 + 审计带 verdict/remark。"""
+
+    def _seed_closed_with_verdict(
+        self, session, *, response, review_decision, close_reason="review_rejected",
+        review_remark=None,
+    ):
+        """种一条 closed 工单(带 user feedback + admin review),cooldown 过期。
+        verdict = compute_feedback_verdict(response, review_decision, 'closed')。"""
+        row = GovernanceTicketOrm(
+            ticket_id=uuid.uuid4().hex,
+            worker_id="staff-001:bot-001",
+            active_worker=None,  # closed 释放
+            governance_status="closed",
+            governance_decision="actionable",
+            latest_decision="actionable",
+            close_reason=close_reason,
+            env="dev",
+            bot_id="bot-001",
+            owner_id="staff-001",
+            dt_version="20260705",
+            bot_name="TestBot",
+            consecutive_normal_days=0,
+            remind_count=0,
+            last_sync_at=datetime.now(),
+            response=response,
+            review_decision=review_decision,
+            reviewed_by="admin-1",
+            reviewed_at=datetime.now(),
+            review_remark=review_remark,
+            cooldown_until=datetime.now() - timedelta(days=1),  # 过期,不被 cooldown 过滤
+        )
+        session.add(row)
+        session.commit()
+        return row
+
+    def test_whitelist_denied_strong_signal_hint_and_audit(self, session, engine):
+        """whitelist_denied(用户加白被驳回)→ 新单通知带提示 + 审计带 last_verdict。"""
+        svc, db = _build_svc(engine)
+        self._seed_closed_with_verdict(
+            session, response="whitelist", review_decision="reject_for_reopen",
+            review_remark="加白理由不充分",
+        )
+        result = svc.process_record(
+            _sample_record(), run_id="run-vd", notify_source="offline_batch",
+            dry_run=True,
+        )
+        assert result.action == "would_create"
+        assert "上次用户申请加白已被管理员驳回" in (result.notification_md_preview or "")
+        # 审计(自管 session,经 audit_repo 写入)
+        with db.orm_session() as s:
+            audit = s.query(AuditLogOrm).filter_by(run_id="run-vd").first()
+            assert audit is not None
+            assert "last_verdict=whitelist_denied" in (audit.error_msg or "")
+            assert "last_review_remark=加白理由不充分" in (audit.error_msg or "")
+
+    def test_dispute_accepted_strong_signal(self, session, engine):
+        svc, db = _build_svc(engine)
+        self._seed_closed_with_verdict(
+            session, response="dispute", review_decision="approve_close",
+            close_reason="approve_close",
+        )
+        result = svc.process_record(
+            _sample_record(), run_id="run-vd2", notify_source="offline_batch",
+            dry_run=True,
+        )
+        assert "上次用户申诉已被管理员采纳关单" in (result.notification_md_preview or "")
+        with db.orm_session() as s:
+            audit = s.query(AuditLogOrm).filter_by(run_id="run-vd2").first()
+            assert "last_verdict=dispute_accepted" in (audit.error_msg or "")
+
+    def test_non_strong_signal_no_hint(self, session, engine):
+        """非强信号(confirmed)→ 通知无提示句;审计 last_verdict 仍记录(verdict 非 other)。"""
+        svc, db = _build_svc(engine)
+        self._seed_closed_with_verdict(
+            session, response="optimized", review_decision="approve_close",
+            close_reason="approve_close",
+        )
+        result = svc.process_record(
+            _sample_record(), run_id="run-vd3", notify_source="offline_batch",
+            dry_run=True,
+        )
+        assert "💡" not in (result.notification_md_preview or "")
+        # confirmed 非 other → 审计仍记 last_verdict(但不带提示)
+        with db.orm_session() as s:
+            audit = s.query(AuditLogOrm).filter_by(run_id="run-vd3").first()
+            assert "last_verdict=confirmed" in (audit.error_msg or "")
+
+    def test_no_prior_closed_no_audit_fragment(self, session, engine):
+        """无上一 closed 工单 → 审计 error_msg 不含 last_verdict。"""
+        svc, db = _build_svc(engine)
+        svc.process_record(
+            _sample_record(), run_id="run-vd4", notify_source="offline_batch",
+            dry_run=True,
+        )
+        with db.orm_session() as s:
+            audit = s.query(AuditLogOrm).filter_by(run_id="run-vd4").first()
+            assert audit is not None
+            assert audit.error_msg is None or "last_verdict" not in (audit.error_msg or "")
+
+
 # --- Tests: process_offline_batch ---
 
 

--- a/src/backend/tests/community/core/economy/governance/test_review_schemas.py
+++ b/src/backend/tests/community/core/economy/governance/test_review_schemas.py
@@ -199,6 +199,45 @@ class TestReviewTicketDetailResponse:
         t3 = _make_ticket(feedback_payload='{"no_ref": true}')
         assert ReviewTicketDetailResponse.from_ticket(t3).feedback_notification_id is None
 
+    def test_available_actions_on_waiting_review_whitelist(self) -> None:
+        """waiting_review + whitelist 反馈 → 同意加白 + reject 动作下发。"""
+        t = _make_ticket(
+            governance_status=GovernanceStatus.WAITING_REVIEW,
+            user_feedback="whitelist",
+        )
+        d = ReviewTicketDetailResponse.from_ticket(t)
+        assert [a.value for a in d.available_actions] == [
+            "approve_whitelist", "reject_for_reopen",
+        ]
+        assert d.available_actions[0].label == "同意加白"
+        assert d.available_actions[1].remark_required is True
+
+    def test_available_actions_on_need_time_uses_approve_scheduled(self) -> None:
+        t = _make_ticket(
+            governance_status=GovernanceStatus.WAITING_REVIEW,
+            user_feedback="need_time",
+        )
+        d = ReviewTicketDetailResponse.from_ticket(t)
+        assert [a.value for a in d.available_actions] == [
+            "approve_scheduled", "reject_for_reopen",
+        ]
+
+    def test_available_actions_empty_when_not_waiting_review(self) -> None:
+        """非 waiting_review(open/scheduled/closed)→ 不下发动作。"""
+        from agentclaw.community.core.economy.governance.domain.enums import GovernanceStatus as GS
+        for status in (GS.OPEN, GS.SCHEDULED, GS.CLOSED):
+            t = _make_ticket(governance_status=status, user_feedback="optimized")
+            assert ReviewTicketDetailResponse.from_ticket(t).available_actions == []
+
+    def test_available_actions_each_has_endpoint(self) -> None:
+        t = _make_ticket(
+            governance_status=GovernanceStatus.WAITING_REVIEW,
+            user_feedback="dispute",
+        )
+        d = ReviewTicketDetailResponse.from_ticket(t)
+        for a in d.available_actions:
+            assert a.endpoint == "POST /api/economy/governance/workflow/tickets/review"
+
 
 class TestWorkflowReviewResponse:
     def test_from_outcome_success(self) -> None:

--- a/src/backend/tests/community/core/economy/governance/test_ticket_action_availability.py
+++ b/src/backend/tests/community/core/economy/governance/test_ticket_action_availability.py
@@ -1,0 +1,136 @@
+"""Unit tests for available_actions — 按用户反馈下发 review 动作(Task 1)。
+
+覆盖:
+- compute_available_actions 四反馈动作集 + label 差异化 + remark_required
+- GovernanceTicket.available_actions @property 委托纯函数
+- 纯函数无在线依赖(可离线复用)
+"""
+from __future__ import annotations
+
+from agentclaw.community.core.economy.governance.domain.enums import (
+    GovernanceStatus,
+    TicketAction,
+)
+from agentclaw.community.core.economy.governance.domain.ticket import (
+    GovernanceTicket,
+    MutableSnapshot,
+    compute_available_actions,
+)
+from datetime import datetime
+
+
+def _make_ticket(**overrides) -> GovernanceTicket:
+    snapshot = overrides.pop("snapshot", None) or MutableSnapshot(
+        dt_version="20260710", initial_decision="actionable", current_decision="actionable",
+        triggered_dimensions="token_usage", hit_dimensions_count=1, severity="P1",
+        estimated_saving_tokens=5000, saving_ratio=0.5, task_summary="s",
+        notification_structured="{}", analysis_status="done", consecutive_normal_days=0,
+        last_decision_dt_version=None, last_seen_at=None, last_sync_at=None,
+    )
+    defaults = dict(
+        ticket_id="T-001", worker_id="o:b", bot_id="b", owner_id="o", bot_name="B",
+        _snapshot=snapshot, governance_status=GovernanceStatus.WAITING_REVIEW,
+        assignee=None, user_feedback=None, feedback_at=None, feedback_remark=None,
+        feedback_source=None, close_reason=None, closed_at=None, cooldown_until=None,
+        review_reason=None, review_decision=None, reviewed_by=None, reviewed_at=None,
+        review_remark=None, repair_deadline=None, resume_at=None, remind_at=None,
+        remind_count=0, feedback_payload=None, actor_id=None,
+        gmt_create=None, gmt_modified=None,
+    )
+    defaults.update(overrides)
+    return GovernanceTicket(**defaults)
+
+
+REVIEW_ENDPOINT = "POST /api/economy/governance/workflow/tickets/review"
+
+
+class TestComputeAvailableActions:
+    """纯函数:按反馈返回动作集。"""
+
+    def test_optimized(self):
+        actions = compute_available_actions("optimized")
+        assert [a["value"] for a in actions] == [
+            TicketAction.APPROVE_CLOSE.value, TicketAction.REJECT_FOR_REOPEN.value,
+        ]
+        assert actions[0]["label"] == "确认已优化"
+        assert actions[1]["label"] == "不认可,重开"
+
+    def test_dispute(self):
+        actions = compute_available_actions("dispute")
+        assert [a["value"] for a in actions] == [
+            TicketAction.APPROVE_CLOSE.value, TicketAction.REJECT_FOR_REOPEN.value,
+        ]
+        assert actions[0]["label"] == "采纳申诉"
+        assert actions[1]["label"] == "驳回申诉,重开"
+
+    def test_whitelist(self):
+        actions = compute_available_actions("whitelist")
+        assert [a["value"] for a in actions] == [
+            TicketAction.APPROVE_WHITELIST.value, TicketAction.REJECT_FOR_REOPEN.value,
+        ]
+        assert actions[0]["label"] == "同意加白"
+        assert actions[1]["label"] == "驳回加白,重开"
+
+    def test_need_time(self):
+        actions = compute_available_actions("need_time")
+        assert [a["value"] for a in actions] == [
+            TicketAction.APPROVE_SCHEDULED.value, TicketAction.REJECT_FOR_REOPEN.value,
+        ]
+        assert actions[0]["label"] == "同意排期"
+        assert actions[1]["label"] == "不认可,重开"
+
+    def test_no_feedback_returns_empty(self):
+        assert compute_available_actions(None) == []
+
+    def test_unknown_feedback_returns_empty(self):
+        assert compute_available_actions("bogus") == []
+
+    def test_remark_required_only_on_reject(self):
+        for fb in ("optimized", "dispute", "whitelist", "need_time"):
+            actions = compute_available_actions(fb)
+            # 同意动作(approve 类)remark_required=False
+            assert actions[0]["remark_required"] is False
+            # reject 必填
+            assert actions[1]["remark_required"] is True
+
+    def test_all_actions_carry_review_endpoint(self):
+        for fb in ("optimized", "dispute", "whitelist", "need_time"):
+            for a in compute_available_actions(fb):
+                assert a["endpoint"] == REVIEW_ENDPOINT
+
+    def test_no_online_dependencies(self):
+        """纯函数仅标量入参、可独立调用(离线复用契约)。"""
+        import inspect
+        params = list(inspect.signature(compute_available_actions).parameters)
+        assert params == ["user_feedback"]
+        assert compute_available_actions("whitelist")[0]["value"] == "approve_whitelist"
+
+
+class TestTicketAvailableActionsProperty:
+    """@property 委托纯函数,输入 GovernanceTicket.user_feedback。"""
+
+    def test_optimized_ticket(self):
+        t = _make_ticket(user_feedback="optimized")
+        assert [a["value"] for a in t.available_actions] == [
+            "approve_close", "reject_for_reopen",
+        ]
+
+    def test_need_time_ticket(self):
+        t = _make_ticket(user_feedback="need_time")
+        assert [a["value"] for a in t.available_actions] == [
+            "approve_scheduled", "reject_for_reopen",
+        ]
+
+    def test_whitelist_ticket(self):
+        t = _make_ticket(user_feedback="whitelist")
+        assert [a["value"] for a in t.available_actions] == [
+            "approve_whitelist", "reject_for_reopen",
+        ]
+
+    def test_no_feedback_empty(self):
+        t = _make_ticket(user_feedback=None)
+        assert t.available_actions == []
+
+    def test_property_equals_pure_function(self):
+        t = _make_ticket(user_feedback="dispute")
+        assert t.available_actions == compute_available_actions("dispute")

--- a/src/backend/tests/community/core/economy/governance/test_ticket_feedback_verdict.py
+++ b/src/backend/tests/community/core/economy/governance/test_ticket_feedback_verdict.py
@@ -1,0 +1,153 @@
+"""Unit tests for feedback_verdict — user⊗admin 成对裁决派生(Task 1)。
+
+覆盖:
+- 纯函数 compute_feedback_verdict 全分支(pending_review_* / 双流成对 / admin_only_* /
+  awaiting_user_feedback / other)
+- GovernanceTicket.feedback_verdict @property 委托纯函数
+- 离线复用契约:纯函数无 self/session/DB 依赖,可独立 import 调用
+"""
+from __future__ import annotations
+
+from agentclaw.community.core.economy.governance.domain.enums import GovernanceStatus
+from agentclaw.community.core.economy.governance.domain.ticket import (
+    GovernanceTicket,
+    MutableSnapshot,
+    compute_feedback_verdict,
+)
+from datetime import datetime
+
+
+def _make_ticket(**overrides) -> GovernanceTicket:
+    snapshot = overrides.pop("snapshot", None) or MutableSnapshot(
+        dt_version="20260710", initial_decision="actionable", current_decision="actionable",
+        triggered_dimensions="token_usage", hit_dimensions_count=1, severity="P1",
+        estimated_saving_tokens=5000, saving_ratio=0.5, task_summary="s",
+        notification_structured="{}", analysis_status="done", consecutive_normal_days=0,
+        last_decision_dt_version=None, last_seen_at=None, last_sync_at=None,
+    )
+    defaults = dict(
+        ticket_id="T-001", worker_id="o:b", bot_id="b", owner_id="o", bot_name="B",
+        _snapshot=snapshot, governance_status=GovernanceStatus.WAITING_REVIEW,
+        assignee=None, user_feedback=None, feedback_at=None, feedback_remark=None,
+        feedback_source=None, close_reason=None, closed_at=None, cooldown_until=None,
+        review_reason=None, review_decision=None, reviewed_by=None, reviewed_at=None,
+        review_remark=None, repair_deadline=None, resume_at=None, remind_at=None,
+        remind_count=0, feedback_payload=None, actor_id=None,
+        gmt_create=None, gmt_modified=None,
+    )
+    defaults.update(overrides)
+    return GovernanceTicket(**defaults)
+
+
+class TestComputeFeedbackVerdictPureFunction:
+    """纯函数:输入三标量,无在线依赖(离线可复用)。"""
+
+    def test_no_response_no_review(self):
+        assert compute_feedback_verdict(None, None, "open") == "awaiting_user_feedback"
+        assert compute_feedback_verdict(None, None, GovernanceStatus.WAITING_REVIEW) == "awaiting_user_feedback"
+
+    def test_review_absent_pending_by_user_decision(self):
+        assert compute_feedback_verdict("optimized", None, "waiting_review") == "pending_review_optimized"
+        assert compute_feedback_verdict("whitelist", None, "open") == "pending_review_whitelist"
+        assert compute_feedback_verdict("dispute", None, "scheduled") == "pending_review_dispute"
+        assert compute_feedback_verdict("need_time", None, "waiting_review") == "pending_review_need_time"
+
+    def test_pair_confirmed(self):
+        assert compute_feedback_verdict("optimized", "approve_close", "closed") == "confirmed"
+
+    def test_pair_whitelist_confirmed(self):
+        assert compute_feedback_verdict("whitelist", "approve_whitelist", "closed") == "whitelist_confirmed"
+
+    def test_pair_admin_overroled_whitelist(self):
+        assert compute_feedback_verdict("optimized", "approve_whitelist", "closed") == "admin_overroled_whitelist"
+
+    def test_pair_dispute_rejected(self):
+        # 用户申诉 + 管理员驳回重开 = 驳回申诉
+        assert compute_feedback_verdict("dispute", "reject_for_reopen", "closed") == "dispute_rejected"
+
+    def test_pair_dispute_accepted(self):
+        # 用户申诉 + 管理员 approve_close(采纳申诉关单)= 强误判信号
+        assert compute_feedback_verdict("dispute", "approve_close", "closed") == "dispute_accepted"
+
+    def test_pair_whitelist_denied(self):
+        # 用户加白 + 管理员 reject_for_reopen(驳回加白)
+        assert compute_feedback_verdict("whitelist", "reject_for_reopen", "closed") == "whitelist_denied"
+
+    def test_pair_schedule_confirmed(self):
+        """need_time + approve_scheduled(同意排期)→ schedule_confirmed(ticket-review 新对)。"""
+        assert compute_feedback_verdict("need_time", "approve_scheduled", "closed") == "schedule_confirmed"
+
+    def test_pair_schedule_rejected(self):
+        """need_time + reject_for_reopen(驳回排期)→ schedule_rejected。"""
+        assert compute_feedback_verdict("need_time", "reject_for_reopen", "closed") == "schedule_rejected"
+
+    def test_pair_optimized_rejected(self):
+        """optimized + reject_for_reopen(不认可'已优化')→ optimized_rejected。"""
+        assert compute_feedback_verdict("optimized", "reject_for_reopen", "closed") == "optimized_rejected"
+
+    def test_pair_whitelist_dismissed(self):
+        """whitelist + approve_close(不加白直接关=静默驳回加白)→ whitelist_dismissed。"""
+        assert compute_feedback_verdict("whitelist", "approve_close", "closed") == "whitelist_dismissed"
+
+    def test_pair_need_time_approve_close_is_other(self):
+        """need_time + approve_close 落 other(approve_close 不在 need_time 下发集,非正常路径)。"""
+        assert compute_feedback_verdict("need_time", "approve_close", "closed") == "other"
+
+    def test_admin_only(self):
+        # 用户未反馈 + 管理员直接裁
+        assert compute_feedback_verdict(None, "approve_close", "closed") == "admin_only_approve_close"
+        assert compute_feedback_verdict(None, "approve_whitelist", "closed") == "admin_only_approve_whitelist"
+
+    def test_other_on_unknown_response(self):
+        assert compute_feedback_verdict("bogus", "approve_close", "closed") == "other"
+        assert compute_feedback_verdict("bogus", None, "open") == "other"
+
+    def test_other_on_unmapped_pair(self):
+        # dispute + approve_scheduled 未在 _VERDICT_PAIR → other
+        assert compute_feedback_verdict("dispute", "approve_scheduled", "closed") == "other"
+
+    def test_no_online_dependencies(self):
+        """纯函数仅三标量入参、可在无 DB/session 上下文下独立调用(离线复用契约)。"""
+        import inspect
+        params = list(inspect.signature(compute_feedback_verdict).parameters)
+        assert params == ["response", "review_decision", "governance_status"]
+        # 仅传字符串/None 即可算出结果,不需 ticket 实例 / DB / session
+        assert compute_feedback_verdict("whitelist", "reject_for_reopen", "closed") == "whitelist_denied"
+
+
+class TestTicketFeedbackVerdictProperty:
+    """@property 委托纯函数,输入 GovernanceTicket 既有字段。"""
+
+    def test_pending_review_on_waiting_review_no_admin(self):
+        t = _make_ticket(user_feedback="whitelist", review_decision=None,
+                         governance_status=GovernanceStatus.WAITING_REVIEW)
+        assert t.feedback_verdict == "pending_review_whitelist"
+
+    def test_whitelist_denied_after_review(self):
+        t = _make_ticket(user_feedback="whitelist", review_decision="reject_for_reopen",
+                         governance_status=GovernanceStatus.CLOSED,
+                         review_remark="加白理由不充分")
+        assert t.feedback_verdict == "whitelist_denied"
+
+    def test_dispute_accepted_after_review(self):
+        t = _make_ticket(user_feedback="dispute", review_decision="approve_close",
+                         governance_status=GovernanceStatus.CLOSED)
+        assert t.feedback_verdict == "dispute_accepted"
+
+    def test_awaiting_when_no_feedback_no_review(self):
+        t = _make_ticket(user_feedback=None, review_decision=None,
+                         governance_status=GovernanceStatus.OPEN)
+        assert t.feedback_verdict == "awaiting_user_feedback"
+
+    def test_admin_only_when_user_silent_admin_reviewed(self):
+        t = _make_ticket(user_feedback=None, review_decision="approve_whitelist",
+                         governance_status=GovernanceStatus.CLOSED)
+        assert t.feedback_verdict == "admin_only_approve_whitelist"
+
+    def test_property_equals_pure_function(self):
+        """@property 与纯函数结果一致(委托正确)。"""
+        t = _make_ticket(user_feedback="optimized", review_decision="approve_close",
+                         governance_status=GovernanceStatus.CLOSED)
+        assert t.feedback_verdict == compute_feedback_verdict(
+            "optimized", "approve_close", GovernanceStatus.CLOSED,
+        )

--- a/src/backend/tests/community/core/economy/governance/test_whitelist_repo.py
+++ b/src/backend/tests/community/core/economy/governance/test_whitelist_repo.py
@@ -255,6 +255,106 @@ class TestListByOwner:
         assert rows[0].expires_at is None
 
 
+# ── list_all ─────────────────────────────────────────────
+
+
+class TestListAll:
+    """GovernanceWhitelistRepository.list_all() — 全量分页 + 筛选 + 过期开关 + total."""
+
+    def test_returns_domain_models_with_total(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        repo.add(bot_id="bot-1", owner_id="user-1", created_by="admin", reason="r1")
+        repo.add(bot_id="bot-2", owner_id="user-2", created_by="admin")
+        rows, total = repo.list_all()
+        assert total == 2
+        assert len(rows) == 2
+        assert all(r.whitelist_type == "governance" for r in rows)
+        # to_dict 序列化含新开的时间元信息字段(Task 1)
+        d = rows[0].to_dict()
+        assert "gmt_create" in d and "gmt_modified" in d
+
+    def test_filters_by_whitelist_type(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        repo.add(bot_id="bot-1", owner_id="user-1", created_by="admin")
+        repo.add(
+            bot_id="bot-2", owner_id="user-1",
+            created_by="admin", whitelist_type="dormant",
+        )
+        rows_gov, total_gov = repo.list_all(whitelist_type="governance")
+        assert total_gov == 1
+        assert rows_gov[0].whitelist_type == "governance"
+        rows_dor, total_dor = repo.list_all(whitelist_type="dormant")
+        assert total_dor == 1
+        assert rows_dor[0].whitelist_type == "dormant"
+
+    def test_filters_by_owner(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        repo.add(bot_id="bot-1", owner_id="user-1", created_by="admin")
+        repo.add(bot_id="bot-2", owner_id="user-2", created_by="admin")
+        rows, total = repo.list_all(owner_id="user-1")
+        assert total == 1
+        assert all(r.owner_id == "user-1" for r in rows)
+
+    def test_filters_by_bot(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        repo.add(bot_id="bot-1", owner_id="user-1", created_by="admin")
+        repo.add(bot_id="bot-2", owner_id="user-1", created_by="admin")
+        rows, total = repo.list_all(bot_id="bot-1")
+        assert total == 1
+        assert all(r.bot_id == "bot-1" for r in rows)
+
+    def test_default_excludes_expired(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        past = datetime.now() - timedelta(days=1)
+        future = datetime.now() + timedelta(days=1)
+        repo.add(bot_id="bot-perm", owner_id="u", created_by="admin")
+        repo.add(bot_id="bot-future", owner_id="u", created_by="admin", expires_at=future)
+        repo.add(bot_id="bot-past", owner_id="u", created_by="admin", expires_at=past)
+        rows, total = repo.list_all()  # include_expired 默认 False
+        bot_ids = {r.bot_id for r in rows}
+        assert total == 2
+        assert "bot-perm" in bot_ids
+        assert "bot-future" in bot_ids
+        assert "bot-past" not in bot_ids
+
+    def test_include_expired_returns_all(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        past = datetime.now() - timedelta(days=1)
+        repo.add(bot_id="bot-perm", owner_id="u", created_by="admin")
+        repo.add(bot_id="bot-past", owner_id="u", created_by="admin", expires_at=past)
+        rows, total = repo.list_all(include_expired=True)
+        assert total == 2
+        assert {r.bot_id for r in rows} == {"bot-perm", "bot-past"}
+
+    def test_pagination(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        for i in range(5):
+            repo.add(bot_id=f"bot-{i}", owner_id="user-1", created_by="admin")
+        page1, total = repo.list_all(limit=2, offset=0)
+        page2, _ = repo.list_all(limit=2, offset=2)
+        assert total == 5
+        assert len(page1) == 2
+        assert len(page2) == 2
+        # 按 gmt_create 倒序:且两页不重叠
+        assert {r.bot_id for r in page1}.isdisjoint({r.bot_id for r in page2})
+
+    def test_empty_db_returns_zero(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        rows, total = repo.list_all()
+        assert rows == []
+        assert total == 0
+
+    def test_combined_filters(self, engine, tables):
+        repo, _ = _build_repo(engine)
+        repo.add(bot_id="bot-1", owner_id="user-1", created_by="admin")
+        repo.add(bot_id="bot-1", owner_id="user-2", created_by="admin")
+        repo.add(bot_id="bot-2", owner_id="user-1", created_by="admin")
+        rows, total = repo.list_all(owner_id="user-1", bot_id="bot-1")
+        assert total == 1
+        assert rows[0].owner_id == "user-1"
+        assert rows[0].bot_id == "bot-1"
+
+
 # ── remove ────────────────────────────────────────────────
 
 

--- a/src/backend/tests/community/endpoints/test_governance_admin_endpoints.py
+++ b/src/backend/tests/community/endpoints/test_governance_admin_endpoints.py
@@ -1,16 +1,20 @@
 """Endpoint coverage for governance admin router endpoints (7.5 / 6.3 / 7.3).
 
 规整后 admin router 端点(全 body/query,零 path 参数):
-  - /admin/tickets:close          关闭工单(单/多,body ticket_ids 循环 emergency_close)
-  - /admin/tickets:close-all      全部关单(dispatch:cancel_pending / close_all_open)
   - /admin/tickets:deliver        按 worker_id 精准投递(不重跑状态机)
   - /admin/whitelist:delete       删除白名单条目
   - /admin/whitelist:bulk-add     批量加白
+  - /admin/admin_whitelist (GET)  白名单只读分页列表
   - /admin/brake (POST)           全局制动 toggle(pause/resume)
   - /admin/brake (GET)            查询制动状态
   - /admin/records:delete         数据维护/清理
   - /admin/trigger-scan           手动触发 cron tick
   - /admin/scan-and-deliver       扫描+投递(测试工具)
+
+注:tickets:close / tickets:close-all 已迁至 workflow_router(路径 /workflow/tickets:close
+/ /workflow/tickets:close-all),其端点 case 路径已改 /workflow,仍在本文件注册由
+endpoint_runner 统一跑;close/close-all service 方法(emergency_close/cancel_pending/
+close_all_open)已迁 GovernanceWorkflowService。
 
 Uses real DI services and in-memory SQLite -- no MagicMock / unittest.mock.
 Each seed function inserts real data via repo methods so the endpoint handler
@@ -252,7 +256,7 @@ def _assert_brake_paused(response, world) -> None:
 
 @endpoint_test(
     method="POST",
-    path="/api/economy/governance/admin/tickets:close",
+    path="/api/economy/governance/workflow/tickets:close",
     scenario="ok_multi",
     input=CaseInput(
         headers=_USER_HEADER,
@@ -271,7 +275,7 @@ def tickets_close_multi_ok():
 
 @endpoint_test(
     method="POST",
-    path="/api/economy/governance/admin/tickets:close",
+    path="/api/economy/governance/workflow/tickets:close",
     scenario="not_found_returns_outcome",
     input=CaseInput(
         headers=_USER_HEADER,
@@ -294,7 +298,7 @@ def tickets_close_not_found_returns_outcome():
 
 @endpoint_test(
     method="POST",
-    path="/api/economy/governance/admin/tickets:close-all",
+    path="/api/economy/governance/workflow/tickets:close-all",
     scenario="ok_full_close_all_open",
     input=CaseInput(
         headers=_USER_HEADER,
@@ -310,7 +314,7 @@ def tickets_close_all_full_ok():
 
 @endpoint_test(
     method="POST",
-    path="/api/economy/governance/admin/tickets:close-all",
+    path="/api/economy/governance/workflow/tickets:close-all",
     scenario="ok_only_unresponded_cancel_pending",
     input=CaseInput(
         headers=_USER_HEADER,
@@ -566,7 +570,7 @@ def brake_get_no_auth():
 
 @endpoint_test(
     method="POST",
-    path="/api/economy/governance/admin/tickets:close",
+    path="/api/economy/governance/workflow/tickets:close",
     scenario="error_empty_ticket_ids",
     input=CaseInput(
         headers=_USER_HEADER,
@@ -580,7 +584,7 @@ def tickets_close_error_empty_ids():
 
 @endpoint_test(
     method="POST",
-    path="/api/economy/governance/admin/tickets:close-all",
+    path="/api/economy/governance/workflow/tickets:close-all",
     scenario="error_missing_reason",
     input=CaseInput(
         headers=_USER_HEADER,
@@ -632,3 +636,108 @@ def whitelist_bulk_add_error_empty_bot_ids():
 )
 def brake_toggle_error_missing_enabled():
     """Error path: missing required enabled field -> 422."""
+
+
+# ---------------------------------------------------------------------------
+# 12. /admin/whitelist (GET — 只读分页列表)
+# ---------------------------------------------------------------------------
+
+
+def _seed_whitelist_list(world) -> None:
+    """Seed mixed whitelist entries: two active + one expired (governance).
+
+    共 3 条 governance: bot-wl-1/user-wl-1(永久)、bot-wl-2/user-wl-2(永久)、
+    bot-wl-exp/user-wl-1(已过期)。默认查询应返回前两条,total=2。
+    """
+    from datetime import datetime, timedelta
+
+    wl_repo = world.get(GovernanceWhitelistRepository)
+    wl_repo.add(
+        bot_id="bot-wl-1", owner_id="user-wl-1", reason="r1", created_by="88888",
+    )
+    wl_repo.add(
+        bot_id="bot-wl-2", owner_id="user-wl-2", reason="r2", created_by="88888",
+    )
+    wl_repo.add(
+        bot_id="bot-wl-exp",
+        owner_id="user-wl-1",
+        reason="expired",
+        created_by="88888",
+        expires_at=datetime.now() - timedelta(days=1),
+    )
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/admin/whitelist",
+    scenario="ok_default_excludes_expired",
+    input=CaseInput(headers=_USER_HEADER),
+    seed=_seed_whitelist_list,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"total": 2}},
+    ),
+)
+def whitelist_get_ok_default_excludes_expired():
+    """Happy path: 默认排除过期,返回有效条目(total=2)。"""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/admin/whitelist",
+    scenario="ok_filter_by_owner",
+    input=CaseInput(
+        headers=_USER_HEADER,
+        query_params={"owner_id": "user-wl-1"},
+    ),
+    seed=_seed_whitelist_list,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"total": 1}},
+    ),
+)
+def whitelist_get_ok_filter_by_owner():
+    """Filter path: 按 owner 筛选(user-wl-1 有效条目仅 1 条,过期被排除)。"""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/admin/whitelist",
+    scenario="ok_include_expired",
+    input=CaseInput(
+        headers=_USER_HEADER,
+        query_params={"include_expired": "true"},
+    ),
+    seed=_seed_whitelist_list,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"total": 3}},
+    ),
+)
+def whitelist_get_ok_include_expired():
+    """Filter path: include_expired=true 返回全 3 条(含过期)。"""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/admin/whitelist",
+    scenario="error_limit_too_large",
+    input=CaseInput(
+        headers=_USER_HEADER,
+        query_params={"limit": "201"},
+    ),
+    expect=ExpectError(status=422),
+)
+def whitelist_get_error_limit_too_large():
+    """Error path: limit 超上限 200 -> 422。"""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/admin/whitelist",
+    scenario="no_auth",
+    input=CaseInput(),  # no x-user-id → LocalAuth raises Unauthorized
+    expect=ExpectError(status=401),
+)
+def whitelist_get_no_auth():
+    """Error path: 无鉴权 -> 401。"""

--- a/src/backend/tests/community/endpoints/test_governance_workflow_endpoints.py
+++ b/src/backend/tests/community/endpoints/test_governance_workflow_endpoints.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 from datetime import datetime
 
 from agentclaw.community.core.economy.governance.repositories.orm import (
+    GovernanceNotificationOrm,
     GovernanceTicketOrm,
+)
+from agentclaw.community.core.economy.governance.repositories.notify_log_repo import (
+    NotifyLogRepository,
 )
 from agentclaw.community.core.economy.governance.repositories.task_record_repo import (
     TaskRecordRepository,
@@ -471,3 +475,75 @@ def _seed_review_open_ticket(world) -> None:
 )
 def review_action_invalid_status_error():
     """Error path: review on non-waiting_review ticket → 400."""
+
+
+# ---------------------------------------------------------------------------
+# 4. GET /workflow/tickets/pending-notification — query notification_id
+# ---------------------------------------------------------------------------
+
+
+def _seed_ticket_with_notify(world) -> None:
+    """Seed a ticket + a notify_log row so pending-notification finds it."""
+    ticket_id = "tkt-pn-1"
+    _insert_ticket(
+        world, ticket_id=ticket_id,
+        governance_status="open",
+        bot_id="bot-pn",
+    )
+    worker_id = "owner-1:bot-pn"
+    notify_repo = world.get(NotifyLogRepository)
+    notify_repo.insert_notification(
+        GovernanceNotificationOrm(
+            notification_id="nid-pn-test-1",
+            ticket_id=ticket_id,
+            bot_id="bot-pn",
+            bot_name="bot-alpha",
+            owner_id="owner-1",
+            worker_id=worker_id,
+            dt_version="20260705",
+            governance_decision="actionable",
+            governance_cycle_id=ticket_id,
+            governance_status="open",
+            notify_status="sent",
+            notify_type="first_send",
+            notify_source="offline_batch",
+            send_attempt_count=1,
+        ),
+    )
+
+
+def _assert_pending_notification_found(response, world) -> None:
+    data = response.json()
+    assert data["success"] is True
+    assert data["data"]["notification_id"] == "nid-pn-test-1"
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/workflow/tickets/pending-notification",
+    scenario="ok",
+    input=CaseInput(
+        headers=_USER_HEADER,
+        query_params={"ticket_id": "tkt-pn-1"},
+    ),
+    seed=_seed_ticket_with_notify,
+    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    extra_assertions=(_assert_pending_notification_found,),
+)
+def pending_notification_ok():
+    """Happy path: returns notification_id for ticket with notify_log row."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/workflow/tickets/pending-notification",
+    scenario="not_found",
+    input=CaseInput(
+        headers=_USER_HEADER,
+        query_params={"ticket_id": "tkt-no-notify-999"},
+    ),
+    # No seed — ticket has no notify_log row → 404
+    expect=ExpectError(status=404),
+)
+def pending_notification_not_found_error():
+    """Error path: ticket with no notification → 404."""

--- a/src/backend/tests/community/endpoints/test_governance_workflow_endpoints.py
+++ b/src/backend/tests/community/endpoints/test_governance_workflow_endpoints.py
@@ -23,6 +23,9 @@ from agentclaw.community.core.economy.governance.repositories.notify_log_repo im
 from agentclaw.community.core.economy.governance.repositories.task_record_repo import (
     TaskRecordRepository,
 )
+from agentclaw.community.core.economy.governance.repositories.whitelist_repo import (
+    GovernanceWhitelistRepository,
+)
 from tests.community.framework import (
     CaseInput,
     ExpectError,
@@ -105,6 +108,19 @@ def _seed_detail(world) -> None:
     )
 
 
+def _seed_detail_whitelisted(world) -> None:
+    """Seed a ticket whose (bot_id, owner_id) is also in the whitelist."""
+    _insert_ticket(
+        world, ticket_id="tkt-detail-wl",
+        bot_id="bot-wl-detail", owner_id="owner-wl-detail",
+        governance_status="waiting_review",
+    )
+    world.get(GovernanceWhitelistRepository).add(
+        bot_id="bot-wl-detail", owner_id="owner-wl-detail",
+        created_by="tester",
+    )
+
+
 def _seed_review_waiting(world) -> None:
     """Seed a waiting_review ticket for approve_close."""
     _insert_ticket(
@@ -176,6 +192,8 @@ def _assert_detail_found(response, world) -> None:
         "feedback_payload", "gmt_create",
     ):
         assert k in data, f"detail response missing field {k!r}"
+    # 白名单位(单点查询):seed 未加白 → False
+    assert data["in_whitelist"] is False
 
 
 def _assert_review_approved_closed(response, world) -> None:
@@ -308,6 +326,24 @@ def review_detail_ok():
 )
 def review_detail_not_found_error():
     """Error path: detail on missing ticket → 404."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/economy/governance/workflow/tickets/detail",
+    scenario="ok_in_whitelist",
+    input=CaseInput(
+        headers=_USER_HEADER,
+        query_params={"ticket_id": "tkt-detail-wl"},
+    ),
+    seed=_seed_detail_whitelisted,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"in_whitelist": True}},
+    ),
+)
+def review_detail_in_whitelist_ok():
+    """Whitelist path: detail.in_whitelist=True when (bot,owner) whitelisted."""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…-notification

Two SDDs squashed into one commit (lyp_on_REL20260715, based on REL20260715):

ticket-review-frontend-contract:
- TicketAction enum (approve_close/approve_scheduled[新]/approve_whitelist/ reject_for_reopen) — backend single source of truth for review actions
- compute_available_actions(user_feedback) — per-feedback verdict action set (optimized/dispute→approve_close, need_time→approve_scheduled, whitelist→approve_whitelist + universal reject_for_reopen), labels differentiated per feedback (确认已优化/采纳申诉/同意加白/同意排期)
- ReviewTicketDetailResponse surfaces available_actions (gated on waiting_review); frontend renders dynamically
- Need_time feedback now enters waiting_review (not straight scheduled); approve_scheduled action transitions waiting_review→scheduled
- GET /workflow/tickets/pending-notification?ticket_id=... — query the notification_id for a ticket's latest notify_log row (open tickets' nid lives in notify_log, not task_record); needed for card-callback and admin review

review-feedback-loop:
- compute_feedback_verdict(response, review_decision, governance_status) — pure function deriving user⊗admin paired verdict (4 feedbacks × 4 review actions incl approve_scheduled), no new column/table
- GovernanceTicket.feedback_verdict @property delegates; offline can import same pure function (aware interface)
- Verdict set: pending_review_*, confirmed, dispute_accepted/rejected, whitelist_confirmed/denied/dismissed, schedule_confirmed/rejected, admin_only_*, other
- record_process: on new-ticket creation reads latest_closed. feedback_verdict + review_remark; strong signals (whitelist_denied, dispute_accepted, schedule_confirmed, whitelist_confirmed) append a 上次反馈提示 to notification_md + carry verdict/remark in audit
- review_remark now has a consumer (audit error_msg), no longer 落了无消费

Tests: governance 607 / corp 1259 passed. 19 files, +864 -44.