### PR TITLE
feat(cron): add 14:00 to autoInitiate schedule and embed default maxTaskNum=3

### DIFF
--- a/src/backend/src/agentclaw/community/core/cron/services/aicoding/cron_auto_setup.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/aicoding/cron_auto_setup.py
@@ -75,10 +75,10 @@ def _frequency_to_cron(frequency: str) -> str:
     """将 trigger_frequency 转换为 cron 表达式"""
     mapping = {
         "hourly": "0 * * * *",          # 每小时
-        "daily": "0 10,14,18 * * *",    # 每天10点、14点、18点
-        "weekly": "0 10,14,18 * * 1",   # 每周一10点、14点、18点
+        "daily": DEFAULT_CRON_SCHEDULE,  # 每天10点、14点、18点
+        "weekly": "0 10,14,18 * * 1",    # 每周一10点、14点、18点
     }
-    return mapping.get(frequency, "0 10,14,18 * * *")
+    return mapping.get(frequency, DEFAULT_CRON_SCHEDULE)
 
 
 def _build_cron_name(bot_name: str, bot_id: str) -> str:

--- a/src/backend/src/agentclaw/community/core/cron/services/aicoding/cron_auto_setup.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/aicoding/cron_auto_setup.py
@@ -13,10 +13,11 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 # 定时任务默认配置
-DEFAULT_CRON_SCHEDULE = "0 10,18 * * *"  # 每天上午10点、下午18点各一次
+DEFAULT_CRON_SCHEDULE = "0 10,14,18 * * *"  # 每天10点、14点、18点各一次
 DEFAULT_CRON_TIMEZONE = "Asia/Shanghai"
 DEFAULT_CRON_TIMEOUT_SECS = 86400  # 24小时
 DEFAULT_CRON_MODEL = None  # 使用引擎默认模型
+DEFAULT_MAX_TASK_NUM = 3  # 单次触发最多发起任务数，写死默认值 3
 
 
 def _build_cron_command(
@@ -38,6 +39,8 @@ def _build_cron_command(
         kind: 任务类型 (autoInitiate 或 agentTurn)
         workflow: Devflow 工作流名称
         append_message: 补充说明，拼接在发起消息末尾
+    
+    注：命令末尾固定带 |maxTaskNum:3（单次触发最多发起 3 个任务）。
     """
     prefix = f"查询dima空间{dima_space_id}的待开发需求，开启7*24小时自动研发"
     parts = [
@@ -52,6 +55,8 @@ def _build_cron_command(
         parts.append(f"message:{message}")
     if append_message:
         parts.append(f"append_message:{append_message}")
+    # maxTaskNum 写死默认 3：创建任务时显式嵌入，使引擎 cap 限制可见、可追溯。
+    parts.append(f"maxTaskNum:{DEFAULT_MAX_TASK_NUM}")
     return f"{prefix}|{'|'.join(parts)}"
 
 
@@ -70,10 +75,10 @@ def _frequency_to_cron(frequency: str) -> str:
     """将 trigger_frequency 转换为 cron 表达式"""
     mapping = {
         "hourly": "0 * * * *",          # 每小时
-        "daily": "0 10,18 * * *",       # 每天10点和18点
-        "weekly": "0 10,18 * * 1",      # 每周一10点和18点
+        "daily": "0 10,14,18 * * *",    # 每天10点、14点、18点
+        "weekly": "0 10,14,18 * * 1",   # 每周一10点、14点、18点
     }
-    return mapping.get(frequency, "0 10,18 * * *")
+    return mapping.get(frequency, "0 10,14,18 * * *")
 
 
 def _build_cron_name(bot_name: str, bot_id: str) -> str:

--- a/src/backend/tests/community/core/cron/test_cron_auto_setup.py
+++ b/src/backend/tests/community/core/cron/test_cron_auto_setup.py
@@ -62,19 +62,19 @@ class TestFrequencyToCron:
     """Tests for _frequency_to_cron helper."""
 
     def test_daily(self):
-        assert _frequency_to_cron("daily") == "0 10,18 * * *"
+        assert _frequency_to_cron("daily") == "0 10,14,18 * * *"
 
     def test_hourly(self):
         assert _frequency_to_cron("hourly") == "0 * * * *"
 
     def test_weekly(self):
-        assert _frequency_to_cron("weekly") == "0 10,18 * * 1"
+        assert _frequency_to_cron("weekly") == "0 10,14,18 * * 1"
 
     def test_unknown_defaults_to_daily(self):
-        assert _frequency_to_cron("custom") == "0 10,18 * * *"
+        assert _frequency_to_cron("custom") == "0 10,14,18 * * *"
 
     def test_empty_defaults_to_daily(self):
-        assert _frequency_to_cron("") == "0 10,18 * * *"
+        assert _frequency_to_cron("") == "0 10,14,18 * * *"
 
 
 class TestBuildCronName:
@@ -152,6 +152,7 @@ class TestBuildCronCommand:
             "|user:user_dima_bot_1|agent:bot_personal_dima_1"
             "|kind:autoInitiate"
             "|message:开始编码"
+            "|maxTaskNum:3"
         )
 
     def test_empty_message_not_included(self):
@@ -202,6 +203,7 @@ class TestBuildCronCommand:
             "|workflow:devflow"
             "|message:开始编码"
             "|append_message:注意代码质量"
+            "|maxTaskNum:3"
         )
 
 
@@ -338,7 +340,7 @@ class TestCronAutoSetupService:
         assert call_kwargs["path"] == "/api/cron"
         body = call_kwargs["body"]
         assert body["name"] == "7*24小时自动生码_TestBot_bot1"
-        assert body["schedule"] == "0 10,18 * * *"
+        assert body["schedule"] == "0 10,14,18 * * *"
         # 新格式命令：查询dima空间{space_id}的待开发需求，开启7*24小时自动研发|space:{space_id}|user:{user_id}|agent:{agent_id}
         assert body["command"].startswith("查询dima空间")
         assert f"space:{dima_space_id}" in body["command"]


### PR DESCRIPTION
## Summary
- Add `14:00` to the autoInitiate cron schedule (`daily`/`weekly`/default hours: `10,18` → `10,14,18`).
- Embed a fixed `|maxTaskNum:3` segment in the cron command prompt so the per-run task cap is explicit and traceable.

## Changes
- `cron_auto_setup.py`: `DEFAULT_CRON_SCHEDULE` and `_frequency_to_cron` updated to `0 10,14,18 * * *` (daily) / `0 10,14,18 * * 1` (weekly); `_build_cron_command` now appends `|maxTaskNum:3` (new `DEFAULT_MAX_TASK_NUM = 3` constant).
- `test_cron_auto_setup.py`: synced assertions.

## Test
- \`pytest tests/community/core/cron/test_cron_auto_setup.py\` → 79 passed.