### PR TITLE
fix(publish): describe terminal statuses in process() instead of raising

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -117,9 +117,10 @@ _DESCRIBE_STATUS_MESSAGES = {
     PublishStatus.SUCCESS: "Publish complete",
 }
 
-# The read-only /sync status report covers every status, including the ones
-# process() handles as advance points or rejects — keep these out of
-# _DESCRIBE_STATUS_MESSAGES so process() behavior stays unchanged.
+# Statuses ``process()`` never advances *through*: DRAFT/VALIDATING are its advance
+# points (intercepted before describe-dispatch); UPGRADED/RELEASED are terminal.
+# Both describe paths (_describe_publish_status, describe_publish) fall back through
+# this table so a superseded/offline record reports a friendly message, not an error.
 _SYNC_ONLY_STATUS_MESSAGES = {
     PublishStatus.DRAFT: "Draft, publish not started",
     PublishStatus.VALIDATING: "Verify environment ready, awaiting online publish confirmation",
@@ -426,8 +427,8 @@ class PublishFlowService(
             action="sync",
         )
 
+    @staticmethod
     def _describe_publish_status(
-        self,
         publish_record: BotPublishRecord,
         current_status: PublishStatus,
     ) -> PublishFlowResult:
@@ -444,7 +445,11 @@ class PublishFlowService(
                 action="process",
             )
 
-        message = _DESCRIBE_STATUS_MESSAGES.get(current_status)
+        # Fall back through _SYNC_ONLY_STATUS_MESSAGES: a record can reach a terminal
+        # state (UPGRADED/RELEASED) concurrently — describe it, don't raise.
+        message = _DESCRIBE_STATUS_MESSAGES.get(
+            current_status
+        ) or _SYNC_ONLY_STATUS_MESSAGES.get(current_status)
         if message is None:
             raise PublishStatusInvalidError(f"Unknown publish status: {current_status}")
         return PublishFlowResult(

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -2679,6 +2679,29 @@ async def test_process_describe_only_states_do_not_mutate(status, fragment):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,fragment",
+    [
+        (PublishStatus.UPGRADED, "Superseded"),
+        (PublishStatus.RELEASED, "Taken offline"),
+    ],
+)
+async def test_process_terminal_states_describe_instead_of_raising(status, fragment):
+    # A record can reach a terminal state concurrently (superseded by a newer
+    # publish / taken offline) while a process() call is in flight. process()
+    # describes these gracefully via the _SYNC_ONLY fallback instead of raising
+    # PublishStatusInvalidError.
+    record = _make_publish_record(status=status.value)
+    tq = Mock()
+    svc, publish_service = _svc_with_record(record, task_queue_service=tq)
+    result = await svc.process(publish_id=1, operator="op")
+    assert result.status == status
+    assert fragment in result.message
+    tq.enqueue.assert_not_called()
+    publish_service.update_publish_status.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_process_failed_reports_error_message():
     record = _make_publish_record(
         status=PublishStatus.FAILED.value, ext={"error_message": "boom"}


### PR DESCRIPTION
## Summary

`PublishFlowService.process()` routes every non-advance-point status through `_describe_publish_status`, which only consulted `_DESCRIBE_STATUS_MESSAGES`. A publish record can reach a terminal state (`UPGRADED`/`RELEASED`) concurrently with an in-flight `process()` call — superseded by a newer publish, or taken offline — and those statuses are deliberately absent from that table, so `process()` raised `PublishStatusInvalidError("Unknown publish status: ...")` for a perfectly known state.

This makes `_describe_publish_status` fall back through `_SYNC_ONLY_STATUS_MESSAGES` (the same table `describe_publish` already uses), so a superseded/offline record reports a friendly message instead of raising.

## Changes

- `_describe_publish_status` now falls back to `_SYNC_ONLY_STATUS_MESSAGES` when a status isn't in `_DESCRIBE_STATUS_MESSAGES`. Only `UPGRADED`/`RELEASED` change behavior — `DRAFT`/`VALIDATING` are intercepted as advance points and never reach this path, and the CAS-loss re-read only ever sees post-advance statuses.
- Made `_describe_publish_status` a `@staticmethod` (it uses no instance state).
- Updated the `_SYNC_ONLY_STATUS_MESSAGES` comment to reflect that both describe paths now share the fallback.
- Added a parametrized test asserting `process()` describes `UPGRADED`/`RELEASED` without mutating or raising.

## Testing

`uv run python -m pytest tests/community/core/service_bot/services/test_publish_flow_service.py` — 121 passed.

## Notes

This came out of a review that raised five points; the other four are intentionally not code changes:
- The `is_online_release_recorded` guard in `publish_flow/tasks.py` is required (online release runs within `ONLINE_PUB` with no self-advance, so it needs the `ext.publish.online` marker as its idempotency checkpoint; verify release doesn't need one because its `BUILT → VALIDATE_PUB` transition serves that role).
- `refresh_publish_handle` and every other method in `PublishFlowService` are used in production, so there's no dead code to remove.
- The submit-time vs poll-time `BUILDING` message wording ("Build started …" vs "Build in progress …") is a deliberate, consistent pattern (mirrored for `ONLINE_PUB`); left pending a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bkr9bgEZhmm2ZkchDNZ6Lh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bkr9bgEZhmm2ZkchDNZ6Lh)_