### PR TITLE
fix: allow failed bots to restart

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3271,7 +3271,7 @@ class BotService:
             )
             return self._activation_in_progress_result(bot)
 
-        if bot_status != "ACTIVE":
+        if bot_status not in {"ACTIVE", "FAILED"}:
             logger.warning(
                 "[bot_service.restart_bot] reject restart for invalid lifecycle state: "
                 "bot_id=%s user_id=%s bot_status=%s",
@@ -3295,8 +3295,9 @@ class BotService:
         # Restart is a lifecycle operation, not a fresh create rollout. When a
         # current binding exists, preserve its provider so an existing ARCA bot
         # cannot be migrated to BaaS merely because the owner later entered the
-        # create whitelist. If there is no binding, there is no provider fact to
-        # preserve and start_bot falls back to the normal allocation path.
+        # create whitelist. An ACTIVE bot without a binding retains the legacy
+        # fallback to normal allocation. A FAILED bot without a binding cannot
+        # safely recover because its historical provider is unknown.
         current_device_provider = None
         binding_id = bot.get("binding_id")
         if binding_id:
@@ -3317,7 +3318,10 @@ class BotService:
                 current = self._activation_in_progress_result(bot)
                 current["status"] = "PENDING"
                 return current
-            if binding_status and binding_status != DeviceBindingStatus.ACTIVE.value:
+            if binding_status and binding_status not in {
+                DeviceBindingStatus.ACTIVE.value,
+                DeviceBindingStatus.FAILED.value,
+            }:
                 logger.warning(
                     "[bot_service.restart_bot] reject restart for invalid binding state: "
                     "bot_id=%s user_id=%s binding_id=%s binding_status=%s",
@@ -3334,6 +3338,17 @@ class BotService:
                 f"[bot_service.restart_bot] preserve device_provider before restart: "
                 f"bot_id={bot_id}, user_id={user_id}, binding_id={binding_id}, "
                 f"device_provider={current_device_provider}"
+            )
+        elif bot_status == "FAILED":
+            logger.warning(
+                "[bot_service.restart_bot] reject failed bot without binding: "
+                "bot_id=%s user_id=%s",
+                bot_id,
+                user_id,
+            )
+            raise BotInvalidLifecycleStateError(
+                bot_id=bot_id,
+                current_status="FAILED_WITHOUT_BINDING",
             )
         else:
             logger.info(

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -242,8 +242,9 @@ class TestRestartGuardOrchestration:
         stop.assert_not_called()
         start.assert_not_called()
 
-    def test_failed_binding_restart_is_rejected(self):
-        """A failed binding must not be released or replaced by restart."""
+    @pytest.mark.parametrize("bot_status", ["ACTIVE", "FAILED"])
+    def test_failed_arca_binding_restart_recovers_in_place(self, bot_status):
+        """Arca failures are recoverable through the existing stop/start path."""
         repo = FakeRestartLockRepo()
         device_service = MagicMock()
         device_service.get_device.return_value = SimpleNamespace(
@@ -252,8 +253,85 @@ class TestRestartGuardOrchestration:
             status=DeviceBindingStatus.FAILED,
         )
         svc = _make_service(repo, device_provider=device_service)
+        bot = _make_bot(
+            status=bot_status,
+            binding_id=42,
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot", return_value=True) as stop, \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result == bot
+        stop.assert_called_once()
+        start.assert_called_once()
+        assert start.call_args.kwargs["device_provider"] == "arca"
+
+    def test_failed_bot_with_failed_baas_binding_restarts_in_place(self):
+        """A failed BaaS bot keeps its binding and uses the BaaS update path."""
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="baas",
+            device_id="BOT-uuid-9",
+            status=DeviceBindingStatus.FAILED,
+        )
+        svc = _make_service(
+            repo,
+            device_provider=device_service,
+            baas_service_provider=lambda: MagicMock(),
+        )
+        bot = _make_bot(status="FAILED", binding_id=42)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "_restart_bot_baas", return_value=bot) as restart_baas, \
+             patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result == bot
+        restart_baas.assert_called_once_with(
+            bot_id="bot001",
+            user_id="user001",
+            binding_id=42,
+            bot=bot,
+        )
+        stop.assert_not_called()
+        start.assert_not_called()
+
+    def test_failed_bot_without_binding_is_rejected(self):
+        """A failed bot without provider history must not re-enter create rollout."""
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
         svc._repository.get_by_id_and_owner.return_value = _make_bot(
-            status="ACTIVE",
+            status="FAILED",
+            binding_id=None,
+        )
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            with pytest.raises(BotInvalidLifecycleStateError) as exc_info:
+                svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert exc_info.value.current_status == "FAILED_WITHOUT_BINDING"
+        assert repo.acquire_calls == 0
+        stop.assert_not_called()
+        start.assert_not_called()
+
+    def test_released_binding_restart_is_rejected(self):
+        """A released binding no longer identifies a live runtime to restart."""
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+            status=DeviceBindingStatus.RELEASED,
+        )
+        svc = _make_service(repo, device_provider=device_service)
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="FAILED",
             binding_id=42,
         )
 
@@ -262,7 +340,7 @@ class TestRestartGuardOrchestration:
             with pytest.raises(BotInvalidLifecycleStateError) as exc_info:
                 svc.restart_bot(bot_id="bot001", user_id="user001")
 
-        assert exc_info.value.current_status == "BINDING_FAILED"
+        assert exc_info.value.current_status == "BINDING_RELEASED"
         assert repo.acquire_calls == 0
         stop.assert_not_called()
         start.assert_not_called()


### PR DESCRIPTION
## Summary

- allow `FAILED` bots to use the existing restart recovery flow
- allow `FAILED` device bindings while preserving the original Arca/BaaS provider
- keep `RECYCLED`, `RELEASED`, unknown states, and `FAILED` bots without binding history rejected

## Validation

- targeted restart regression: 44 passed
- related restart/router regression: 233 passed
- full backend pre-push suite: 7916 passed
- changed executable line coverage: 5/5 (100%)
- singlebox coverage: 32 acceptance tests passed; coverage gate passed
