### PR TITLE
feat(bcs): session collection — collect/uncollect/collected list

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/router.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/router.rs
@@ -255,6 +255,11 @@ fn build_api_routes() -> Router<HttpAppState> {
             post(routes::sessions::complete_session),
         )
         .route(
+            "/sessions/{sid}/collect",
+            post(routes::sessions::collect_session)
+                .delete(routes::sessions::uncollect_session),
+        )
+        .route(
             "/sessions/{sid}/members",
             post(routes::sessions::add_session_participant),
         )

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -529,6 +529,9 @@ pub struct ListSessionsQuery {
     /// Filter sessions by participant (bot_uuid or human actor_id).
     #[serde(default)]
     pub participant: Option<String>,
+    /// When true, return only sessions collected by `participant` (requires participant).
+    #[serde(default)]
+    pub collected: Option<bool>,
     #[serde(default)]
     pub offset: u64,
     #[serde(default = "default_limit")]
@@ -546,6 +549,72 @@ pub async fn list_sessions_for_group(
     headers: HeaderMap,
     uri: Uri,
 ) -> impl IntoResponse {
+    // collected filter: requires participant, returns only sessions the bot
+    // has collected in this group. Does NOT run the legacy auto-create path.
+    if params.collected == Some(true) {
+        let bot_uuid = match params.participant.as_deref() {
+            Some(p) => p,
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "invalid_params",
+                        "message": "collected filter requires participant"
+                    })),
+                )
+                    .into_response();
+            }
+        };
+        // Authorization: the caller must be authorized to act as (and therefore
+        // view the collections of) the requested `participant` bot. A bot token
+        // resolves to itself; a human caller must own the named bot. Without
+        // this check any caller could enumerate any bot's collected sessions
+        // in any group (BOLA).
+        match resolve_collector_bot(&state, &headers, &uri, Some(bot_uuid)).await {
+            Ok(authorized_bot) => {
+                if authorized_bot != bot_uuid {
+                    return (
+                        StatusCode::FORBIDDEN,
+                        Json(serde_json::json!({
+                            "error": "forbidden",
+                            "message": format!(
+                                "caller is not authorized to view collections for bot {}",
+                                bot_uuid
+                            )
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+            Err(resp) => return resp,
+        }
+        let collected_sessions = match state
+            .services
+            .session_management
+            .list_collected_by_group(
+                &group_id,
+                bot_uuid,
+                params.status,
+                params.q.as_deref(),
+                params.offset,
+                params.limit,
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return session_error_to_response(&e),
+        };
+        let items: Vec<Value> = collected_sessions
+            .iter()
+            .map(|s| session_to_json(s))
+            .collect();
+        return Json(serde_json::json!({
+            "items": items,
+            "group_id": group_id,
+        }))
+        .into_response();
+    }
+
     let sessions = match state
         .services
         .session_management
@@ -1636,6 +1705,113 @@ pub async fn delete_session(
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"error": "not_found", "message": "session not found"})),
         ).into_response(),
+        Err(e) => session_error_to_response(&e),
+    }
+}
+
+// ---------------------------------------------------------------
+// POST /sessions/{sid}/collect
+// DELETE /sessions/{sid}/collect
+//
+// Mark / unmark a session as collected by a bot. Caller resolves via
+// resolve_group_chat_caller (bot token -> that bot; human cookie -> must
+// supply an owned bot via the `participant` body/query field, ownership
+// checked via registry.list_bots_by_creator).
+// ---------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Default)]
+pub struct CollectSessionRequest {
+    /// Target bot that performs the collect. Required for human callers;
+    /// ignored (defaults to the calling bot) when a bot token is used.
+    #[serde(default)]
+    pub participant: Option<String>,
+}
+
+async fn resolve_collector_bot(
+    state: &HttpAppState,
+    headers: &HeaderMap,
+    uri: &Uri,
+    participant: Option<&str>,
+) -> Result<String, Response> {
+    let caller = match resolve_group_chat_caller(state, headers, uri).await {
+        Ok(c) => c,
+        Err(_) => {
+            return Err(
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({"error": "unauthorized"})),
+                )
+                    .into_response(),
+            )
+        }
+    };
+    match caller {
+        GroupChatCaller::Bot { bot_uuid } => Ok(bot_uuid),
+        GroupChatCaller::Human(h) => {
+            let bot_uuid = participant.ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "invalid_params",
+                        "message": "human caller must supply participant"
+                    })),
+                )
+                    .into_response()
+            })?;
+            let owns = state
+                .services
+                .registry
+                .list_bots_by_creator(&h.staff_no)
+                .await
+                .iter()
+                .any(|b| b.bot_uuid == bot_uuid);
+            if !owns {
+                return Err(
+                    (
+                        StatusCode::FORBIDDEN,
+                        Json(serde_json::json!({
+                            "error": "forbidden",
+                            "message": format!("caller does not own bot {}", bot_uuid)
+                        })),
+                    )
+                        .into_response(),
+                );
+            }
+            Ok(bot_uuid.to_string())
+        }
+    }
+}
+
+pub async fn collect_session(
+    State(state): State<HttpAppState>,
+    Path(sid): Path<String>,
+    headers: HeaderMap,
+    uri: Uri,
+    Json(body): Json<CollectSessionRequest>,
+) -> impl IntoResponse {
+    let collector = match resolve_collector_bot(&state, &headers, &uri, body.participant.as_deref()).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+    match state.services.session_management.collect(&sid, &collector).await {
+        Ok(()) => Json(serde_json::json!({"collected": true, "session_id": sid})).into_response(),
+        Err(e) => session_error_to_response(&e),
+    }
+}
+
+pub async fn uncollect_session(
+    State(state): State<HttpAppState>,
+    Path(sid): Path<String>,
+    headers: HeaderMap,
+    uri: Uri,
+    Query(body): Query<CollectSessionRequest>,
+) -> impl IntoResponse {
+    let collector = match resolve_collector_bot(&state, &headers, &uri, body.participant.as_deref()).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+    match state.services.session_management.uncollect(&sid, &collector).await {
+        Ok(()) => Json(serde_json::json!({"collected": false, "session_id": sid})).into_response(),
         Err(e) => session_error_to_response(&e),
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_collection_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_collection_contract.rs
@@ -1,0 +1,995 @@
+//! HTTP contract tests for session collection (collect/uncollect/collected list).
+//!
+//! Exercises the three endpoints added in Task 8:
+//!   GET  /groups/{id}/sessions?collected=true&participant=<bot>
+//!   POST /sessions/{sid}/collect
+//!   DELETE /sessions/{sid}/collect
+//!
+//! Mirrors the app-state wiring from `session_list_contract.rs` with a
+//! self-contained mock `CollectionMock` that records collections in memory.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::{
+    body::{Body, to_bytes},
+    http::{HeaderMap, Request, StatusCode},
+};
+use bcs_auth_api::{AuthError, UserIdentityInfo};
+use bcs_bot::BotCore;
+use bcs_group::GroupStore;
+use bcs_http::{
+    router::build_router,
+    state::{HttpAppState, HttpUserIdentity, UserIdentityPort},
+};
+use bcs_service_api::{
+    ActorKind, BotCapabilities, BotRegistryCoreService, CreateOrReactivateCommand,
+    CreateOrReactivateOutcome, Group, GroupCoreService, Participant, ParticipantMode,
+    ParticipantRole, Session, SessionKind, SessionManagementService, SessionStatus,
+    SessionUseCaseError,
+};
+use bcs_services_container::Services;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// mock service
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct CollectionMock {
+    sessions: Mutex<Vec<Session>>,
+    collected: Mutex<HashSet<(String, String)>>, // (session_id, bot_uuid)
+}
+
+#[async_trait]
+impl SessionManagementService for CollectionMock {
+    async fn create_or_reactivate(
+        &self,
+        cmd: CreateOrReactivateCommand,
+    ) -> Result<CreateOrReactivateOutcome, SessionUseCaseError> {
+        let id = cmd
+            .params
+            .id
+            .clone()
+            .unwrap_or_else(|| format!("{}:abcdef12", cmd.group_id));
+        let session = Session {
+            id: id.clone(),
+            group_id: cmd.group_id.clone(),
+            session_title: cmd.params.session_title.clone(),
+            env: None,
+            status: SessionStatus::Running,
+            session_kind: cmd.params.session_kind,
+            participants: cmd.params.participants.clone(),
+            group_version: cmd.params.group_version,
+            caller_id: cmd.params.caller_id.clone(),
+            input: cmd.params.input.clone(),
+            output: None,
+            error_message: None,
+            callback_status: None,
+            activation_count: 1,
+            caller_principal: cmd.params.caller_principal.clone(),
+            created_by: cmd.params.created_by.clone(),
+            created_at: 1,
+            updated_at: 1,
+            completed_at: None,
+            meta: cmd.params.meta.clone(),
+            current_msg_seq: 0,
+            participant_join_seq: None,
+        };
+        self.sessions.lock().await.push(session.clone());
+        Ok(CreateOrReactivateOutcome {
+            session,
+            created: true,
+        })
+    }
+
+    async fn get(&self, sid: &str) -> Result<Option<Session>, SessionUseCaseError> {
+        Ok(self
+            .sessions
+            .lock()
+            .await
+            .iter()
+            .find(|s| s.id == sid)
+            .cloned())
+    }
+
+    async fn belongs_to_group(
+        &self,
+        session_id: &str,
+        group_id: &str,
+    ) -> Result<bool, SessionUseCaseError> {
+        Ok(self
+            .sessions
+            .lock()
+            .await
+            .iter()
+            .any(|s| s.id == session_id && s.group_id == group_id))
+    }
+
+    async fn list_by_group(
+        &self,
+        group_id: &str,
+        _status: Option<SessionStatus>,
+        _offset: u64,
+        _limit: u64,
+        _title_contains: Option<&str>,
+        _participant_id: Option<&str>,
+    ) -> Result<Vec<Session>, SessionUseCaseError> {
+        Ok(self
+            .sessions
+            .lock()
+            .await
+            .iter()
+            .filter(|s| s.group_id == group_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn count_running_service(&self, _group_id: &str) -> Result<u64, SessionUseCaseError> {
+        Ok(0)
+    }
+
+    async fn list_running_service(
+        &self,
+        _offset: u64,
+        _limit: u64,
+    ) -> Result<Vec<Session>, SessionUseCaseError> {
+        Ok(Vec::new())
+    }
+
+    async fn update_callback_status(
+        &self,
+        _session_id: &str,
+        _status: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        Ok(())
+    }
+
+    async fn complete_if_running(
+        &self,
+        _session_id: &str,
+        _output: Option<Value>,
+        _error: Option<String>,
+    ) -> Result<Option<Session>, SessionUseCaseError> {
+        Ok(None)
+    }
+
+    async fn add_participant(
+        &self,
+        _session_id: &str,
+        _participant: Participant,
+    ) -> Result<Session, SessionUseCaseError> {
+        unimplemented!("not used by collection tests")
+    }
+
+    async fn remove_participant(
+        &self,
+        _session_id: &str,
+        _bot_uuid: &str,
+    ) -> Result<Session, SessionUseCaseError> {
+        unimplemented!("not used by collection tests")
+    }
+
+    async fn update_participant_mode(
+        &self,
+        _session_id: &str,
+        _bot_uuid: &str,
+        _mode: ParticipantMode,
+    ) -> Result<Session, SessionUseCaseError> {
+        unimplemented!("not used by collection tests")
+    }
+
+    async fn update_title(
+        &self,
+        _session_id: &str,
+        _title: Option<String>,
+    ) -> Result<Session, SessionUseCaseError> {
+        unimplemented!("not used by collection tests")
+    }
+
+    async fn list_group_ids_by_session_participant(
+        &self,
+        _bot_uuid: &str,
+    ) -> Result<Vec<String>, SessionUseCaseError> {
+        Ok(Vec::new())
+    }
+
+    async fn delete(&self, _session_id: &str) -> Result<bool, SessionUseCaseError> {
+        Ok(false)
+    }
+
+    // ── collection overrides ──────────────────────────────────────────
+
+    async fn collect(
+        &self,
+        session_id: &str,
+        bot_uuid: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        let exists = self
+            .sessions
+            .lock()
+            .await
+            .iter()
+            .any(|s| s.id == session_id);
+        if !exists {
+            return Err(SessionUseCaseError::NotFound(session_id.to_string()));
+        }
+        self.collected
+            .lock()
+            .await
+            .insert((session_id.to_string(), bot_uuid.to_string()));
+        Ok(())
+    }
+
+    async fn uncollect(
+        &self,
+        session_id: &str,
+        bot_uuid: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        let exists = self
+            .sessions
+            .lock()
+            .await
+            .iter()
+            .any(|s| s.id == session_id);
+        if !exists {
+            return Err(SessionUseCaseError::NotFound(session_id.to_string()));
+        }
+        self.collected
+            .lock()
+            .await
+            .remove(&(session_id.to_string(), bot_uuid.to_string()));
+        Ok(())
+    }
+
+    async fn list_collected_by_group(
+        &self,
+        group_id: &str,
+        bot_uuid: &str,
+        _status: Option<SessionStatus>,
+        _title_contains: Option<&str>,
+        _offset: u64,
+        _limit: u64,
+    ) -> Result<Vec<Session>, SessionUseCaseError> {
+        let sessions = self.sessions.lock().await;
+        let collected = self.collected.lock().await;
+        let mut out: Vec<Session> = sessions
+            .iter()
+            .filter(|s| {
+                s.group_id == group_id
+                    && collected.contains(&(s.id.clone(), bot_uuid.to_string()))
+            })
+            .cloned()
+            .collect();
+        out.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+        Ok(out)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+/// 1. `GET ...?collected=true` without participant → 400
+#[tokio::test]
+async fn collected_true_without_participant_returns_400() {
+    let (app, _mock, _temp_dir, _registry) = test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/groups/group-1/sessions?collected=true")
+                .header("authorization", "Bearer driver-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["error"], "invalid_params");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("participant"),
+        "expected message about missing participant, got: {}",
+        body
+    );
+}
+
+/// 2. Collect (bot token) → 200 `{collected:true}`; collected list returns
+///    the session; repeat collect is idempotent.
+#[tokio::test]
+async fn collect_and_list_collected_via_bot_token() {
+    let (app, mock, _temp_dir, _registry) = test_app().await;
+
+    // Pre-seed a session.
+    let sid = "group-1:aaaaaaaa";
+    mock.sessions.lock().await.push(Session {
+        id: sid.to_string(),
+        group_id: "group-1".to_string(),
+        session_title: Some("Test session".to_string()),
+        env: None,
+        status: SessionStatus::Running,
+        session_kind: SessionKind::Chat,
+        participants: vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+        group_version: Some(1),
+        caller_id: None,
+        input: None,
+        output: None,
+        error_message: None,
+        callback_status: None,
+        activation_count: 1,
+        caller_principal: None,
+        created_by: None,
+        created_at: 1,
+        updated_at: 1,
+        completed_at: None,
+        meta: None,
+        current_msg_seq: 0,
+        participant_join_seq: None,
+    });
+
+    // POST /sessions/{sid}/collect with bot token
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/sessions/{sid}/collect"))
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer driver-token")
+                .body(Body::from(json!({}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["collected"], true);
+    assert_eq!(body["session_id"], sid);
+
+    // GET collected list — must now contain the session.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/groups/group-1/sessions?participant=driver-bot&collected=true"
+                ))
+                .header("authorization", "Bearer driver-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    let items = body["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1, "collected list must contain the session");
+    assert_eq!(items[0]["session_id"], sid);
+
+    // Repeat collect — idempotent (still 200).
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/sessions/{sid}/collect"))
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer driver-token")
+                .body(Body::from(json!({}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["collected"], true);
+}
+
+/// 2b. BOLA guard: a bot must not enumerate another bot's collected
+///     sessions. `intruder-bot` requests driver-bot's collected list ->
+///     403, even when driver-bot has actually collected sessions.
+#[tokio::test]
+async fn collected_list_rejects_unauthorized_participant() {
+    let (app, mock, _temp_dir, _registry) = test_app().await;
+
+    // Seed a session collected by driver-bot.
+    let sid = "group-1:cafebabe";
+    mock.sessions.lock().await.push(Session {
+        id: sid.to_string(),
+        group_id: "group-1".to_string(),
+        session_title: Some("Collected by driver".to_string()),
+        env: None,
+        status: SessionStatus::Running,
+        session_kind: SessionKind::Chat,
+        participants: vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+        group_version: Some(1),
+        caller_id: None,
+        input: None,
+        output: None,
+        error_message: None,
+        callback_status: None,
+        activation_count: 1,
+        caller_principal: None,
+        created_by: None,
+        created_at: 1,
+        updated_at: 1,
+        completed_at: None,
+        meta: None,
+        current_msg_seq: 0,
+        participant_join_seq: None,
+    });
+    mock.collected
+        .lock()
+        .await
+        .insert((sid.to_string(), "driver-bot".to_string()));
+
+    // intruder-bot queries driver-bot's collected list -> 403.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(
+                    "/groups/group-1/sessions?participant=driver-bot&collected=true",
+                )
+                .header("authorization", "Bearer intruder-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a bot must not view another bot's collected sessions"
+    );
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["error"], "forbidden");
+
+    // driver-bot can still view its own collected list -> 200, 1 item.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(
+                    "/groups/group-1/sessions?participant=driver-bot&collected=true",
+                )
+                .header("authorization", "Bearer driver-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    let items = body["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["session_id"], sid);
+}
+
+/// 3. DELETE /sessions/{sid}/collect → 200 `{collected:false}`;
+///    collected list is empty afterwards.
+#[tokio::test]
+async fn uncollect_removes_from_collected_list() {
+    let (app, mock, _temp_dir, _registry) = test_app().await;
+
+    let sid = "group-1:bbbbbbbb";
+    mock.sessions.lock().await.push(Session {
+        id: sid.to_string(),
+        group_id: "group-1".to_string(),
+        session_title: Some("To be uncollected".to_string()),
+        env: None,
+        status: SessionStatus::Running,
+        session_kind: SessionKind::Chat,
+        participants: vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+        group_version: Some(1),
+        caller_id: None,
+        input: None,
+        output: None,
+        error_message: None,
+        callback_status: None,
+        activation_count: 1,
+        caller_principal: None,
+        created_by: None,
+        created_at: 1,
+        updated_at: 1,
+        completed_at: None,
+        meta: None,
+        current_msg_seq: 0,
+        participant_join_seq: None,
+    });
+
+    // Collect first.
+    mock.collected
+        .lock()
+        .await
+        .insert((sid.to_string(), "driver-bot".to_string()));
+
+    // DELETE uncollect with bot token (participant via query param for bot is
+    // optional, so we omit it — the bot token resolves the collector).
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/sessions/{sid}/collect"))
+                .header("authorization", "Bearer driver-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["collected"], false);
+    assert_eq!(body["session_id"], sid);
+
+    // GET collected list — must be empty now.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/groups/group-1/sessions?participant=driver-bot&collected=true"
+                ))
+                .header("authorization", "Bearer driver-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    let items = body["items"].as_array().expect("items array");
+    assert!(
+        items.is_empty(),
+        "collected list must be empty after uncollect"
+    );
+}
+
+/// 4. Collect on a non-existent session → 404.
+#[tokio::test]
+async fn collect_nonexistent_session_returns_404() {
+    let (app, _mock, _temp_dir, _registry) = test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions/nonexistent-sid/collect")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer driver-token")
+                .body(Body::from(json!({}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("nonexistent"),
+        "expected error mentioning the session id, got: {}",
+        body
+    );
+}
+
+/// 5. Human caller without participant → 400; human with a non-owned bot → 403.
+#[tokio::test]
+async fn human_caller_collect_enforces_participant_and_ownership() {
+    let (app, mock, _temp_dir, _registry) = human_app("alice", &["owned-bot"]).await;
+
+    let sid = "group-1:cccccccc";
+    mock.sessions.lock().await.push(Session {
+        id: sid.to_string(),
+        group_id: "group-1".to_string(),
+        session_title: Some("Human test session".to_string()),
+        env: None,
+        status: SessionStatus::Running,
+        session_kind: SessionKind::Chat,
+        participants: vec![Participant::bot("owned-bot", ParticipantRole::Driver)],
+        group_version: Some(1),
+        caller_id: None,
+        input: None,
+        output: None,
+        error_message: None,
+        callback_status: None,
+        activation_count: 1,
+        caller_principal: None,
+        created_by: None,
+        created_at: 1,
+        updated_at: 1,
+        completed_at: None,
+        meta: None,
+        current_msg_seq: 0,
+        participant_join_seq: None,
+    });
+
+    // Human without participant → 400.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/sessions/{sid}/collect"))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "human without participant must get 400"
+    );
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["error"], "invalid_params");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("participant"),
+        "expected message about missing participant"
+    );
+
+    // Human with a non-owned bot → 403.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/sessions/{sid}/collect"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"participant": "unauthorized-bot"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "human with non-owned bot must get 403"
+    );
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["error"], "forbidden");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("does not own"),
+        "expected ownership error message, got: {}",
+        body
+    );
+}
+
+/// 6. Human caller uncollects via `?participant=<owned-bot>` query string.
+///    The DELETE endpoint reads `participant` from the query (DELETE bodies are
+///    unreliable across proxies); the human must own the named bot. Covers the
+///    ownership check on the uncollect path, which the bot-token tests above do
+///    not exercise.
+#[tokio::test]
+async fn human_caller_uncollect_via_query_enforces_ownership() {
+    let (app, mock, _temp_dir, _registry) = human_app("alice", &["owned-bot"]).await;
+
+    let sid = "group-1:dddddddd";
+    mock.sessions.lock().await.push(Session {
+        id: sid.to_string(),
+        group_id: "group-1".to_string(),
+        session_title: Some("Uncollect via query".to_string()),
+        env: None,
+        status: SessionStatus::Running,
+        session_kind: SessionKind::Chat,
+        participants: vec![Participant::bot("owned-bot", ParticipantRole::Driver)],
+        group_version: Some(1),
+        caller_id: None,
+        input: None,
+        output: None,
+        error_message: None,
+        callback_status: None,
+        activation_count: 1,
+        caller_principal: None,
+        created_by: None,
+        created_at: 1,
+        updated_at: 1,
+        completed_at: None,
+        meta: None,
+        current_msg_seq: 0,
+        participant_join_seq: None,
+    });
+    // Seed as collected.
+    mock.collected
+        .lock()
+        .await
+        .insert((sid.to_string(), "owned-bot".to_string()));
+
+    // Human uncollect naming a bot the human does NOT own -> 403.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/sessions/{sid}/collect?participant=unauthorized-bot"))
+                .header("content-type", "application/json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["error"], "forbidden");
+
+    // Human uncollect naming an OWNED bot via the query string -> 200.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/sessions/{sid}/collect?participant=owned-bot"))
+                .header("content-type", "application/json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(body["collected"], false);
+    assert_eq!(body["session_id"], sid);
+
+    // Idempotent repeat -> 200, and the collected entry is gone.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/sessions/{sid}/collect?participant=owned-bot"))
+                .header("content-type", "application/json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        !mock.collected
+            .lock()
+            .await
+            .contains(&(sid.to_string(), "owned-bot".to_string())),
+        "collected set must be empty after uncollect"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+async fn test_app() -> (
+    axum::Router,
+    Arc<CollectionMock>,
+    TempDir,
+    Arc<BotCore>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
+    register_bot(&registry, "driver-bot", "Driver").await;
+    registry
+        .store_token_mapping("driver-token".to_string(), "driver-bot".to_string())
+        .await;
+    // A second, distinct bot used to assert BOLA on the collected-list filter.
+    register_bot(&registry, "intruder-bot", "Intruder").await;
+    registry
+        .store_token_mapping("intruder-token".to_string(), "intruder-bot".to_string())
+        .await;
+
+    let group_store = Arc::new(GroupStore::new());
+    group_store
+        .upsert(Group::new(
+            "group-1",
+            "driver-bot",
+            vec![Participant {
+                bot_uuid: "driver-bot".to_string(),
+                bot_name: Some("Driver".to_string()),
+                kind: None,
+                role: ParticipantRole::Driver,
+                actor_kind: ActorKind::Bot,
+                mode: Some(ParticipantMode::default_for(ActorKind::Bot)),
+            }],
+        ))
+        .await
+        .unwrap();
+
+    let sessions = Arc::new(CollectionMock::default());
+
+    let mut services = Services::noop();
+    services.registry = registry.clone();
+    services.group = group_store;
+    services.session_management = sessions.clone();
+
+    let app = build_router(HttpAppState::new(services));
+    (app, sessions, temp_dir, registry)
+}
+
+async fn human_app(
+    staff_no: &str,
+    owned_bot_ids: &[&str],
+) -> (
+    axum::Router,
+    Arc<CollectionMock>,
+    TempDir,
+    Arc<BotCore>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
+
+    // Register the human's owned bots and set created_by.
+    for bot_id in owned_bot_ids {
+        register_bot(&registry, bot_id, bot_id).await;
+        registry
+            .save_created_by(bot_id, staff_no, true)
+            .await
+            .unwrap();
+    }
+
+    // Register an unauthorized bot (not owned by this human).
+    register_bot(&registry, "unauthorized-bot", "Unauthorized").await;
+    registry
+        .save_created_by("unauthorized-bot", "someone-else", true)
+        .await
+        .unwrap();
+
+    let group_store = Arc::new(GroupStore::new());
+    let driver = owned_bot_ids.first().copied().unwrap_or("owned-bot");
+    let participants: Vec<Participant> = owned_bot_ids
+        .iter()
+        .map(|bid| Participant {
+            bot_uuid: bid.to_string(),
+            bot_name: Some(bid.to_string()),
+            kind: None,
+            role: if *bid == driver {
+                ParticipantRole::Driver
+            } else {
+                ParticipantRole::Consultant
+            },
+            actor_kind: ActorKind::Bot,
+            mode: Some(ParticipantMode::default_for(ActorKind::Bot)),
+        })
+        .collect();
+    group_store
+        .upsert(Group::new("group-1", driver, participants))
+        .await
+        .unwrap();
+
+    let sessions = Arc::new(CollectionMock::default());
+
+    let mut services = Services::noop();
+    services.registry = registry.clone();
+    services.group = group_store;
+    services.session_management = sessions.clone();
+
+    let identity_port: Arc<dyn UserIdentityPort + Send + Sync> = Arc::new(StaticHumanIdentity {
+        staff_no: Some(staff_no.to_string()),
+    });
+    let app = build_router(HttpAppState::new(services).with_user_identity(identity_port));
+    (app, sessions, temp_dir, registry)
+}
+
+async fn register_bot(registry: &BotCore, bot_id: &str, name: &str) {
+    registry
+        .register(
+            bot_id.to_string(),
+            BotCapabilities {
+                name: Some(name.to_string()),
+                summary: Some(format!("{name} summary")),
+                visibility: "public".to_string(),
+                ..BotCapabilities::default()
+            },
+        )
+        .await
+        .unwrap();
+}
+
+#[derive(Default)]
+struct StaticHumanIdentity {
+    staff_no: Option<String>,
+}
+
+#[async_trait]
+impl UserIdentityPort for StaticHumanIdentity {
+    async fn extract(
+        &self,
+        _headers: &HeaderMap,
+        _uri: &axum::http::Uri,
+    ) -> Option<HttpUserIdentity> {
+        self.staff_no.as_ref().map(|sn| HttpUserIdentity {
+            staff_no: Some(sn.clone()),
+            nick_name: Some("Test".to_string()),
+        })
+    }
+
+    async fn ensure_identity(
+        &self,
+        _auth_source: &str,
+        _external_user_id: &str,
+        _external_user_name: Option<&str>,
+        _avatar: Option<&str>,
+        _env: &str,
+    ) -> Result<String, AuthError> {
+        Ok("noop-identity".to_string())
+    }
+
+    async fn get_identity_by_token(
+        &self,
+        _token: &str,
+    ) -> Result<Option<UserIdentityInfo>, AuthError> {
+        Ok(None)
+    }
+
+    async fn get_identity_by_user_id(
+        &self,
+        _user_id: &str,
+    ) -> Result<Option<UserIdentityInfo>, AuthError> {
+        Ok(None)
+    }
+
+    async fn update_token(
+        &self,
+        _user_id: &str,
+        _token: &str,
+        _expire_at: u64,
+    ) -> Result<(), AuthError> {
+        Ok(())
+    }
+}

--- a/src/bcs/crates/bootstrap/bcs/src/migrations.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/migrations.rs
@@ -322,7 +322,8 @@ const SQLITE_DDL_STATEMENTS: &[&str] = &[
         group_id TEXT NOT NULL,
         bot_uuid TEXT NOT NULL,
         role TEXT NOT NULL,
-        env TEXT NOT NULL DEFAULT 'prod'
+        env TEXT NOT NULL DEFAULT 'prod',
+        collected INTEGER NOT NULL DEFAULT 0
     )",
     "CREATE UNIQUE INDEX IF NOT EXISTS uk_session_participants_env_session_bot ON bcs_session_participants(env, session_id, bot_uuid)",
     "CREATE INDEX IF NOT EXISTS idx_session_participants_bot ON bcs_session_participants(env, bot_uuid)",
@@ -674,6 +675,10 @@ const SQLITE_VERSIONED_MIGRATIONS: &[SqliteMigration] = &[
         version: 3,
         name: "add_organizations",
     },
+    SqliteMigration {
+        version: 4,
+        name: "add_session_collection",
+    },
 ];
 
 pub fn sqlite_target_version() -> i64 {
@@ -683,6 +688,7 @@ pub fn sqlite_target_version() -> i64 {
         .unwrap_or(0)
 }
 
+#[allow(dead_code)]
 pub fn sqlite_migration_count() -> usize {
     SQLITE_VERSIONED_MIGRATIONS.len()
 }
@@ -772,6 +778,7 @@ pub async fn run_sqlite_bootstrap_tables(db: &dyn DbPlugin) -> DbResult<()> {
         }
     }
     ensure_sqlite_message_owner_bot_id(db).await?;
+    ensure_sqlite_session_collected_column(db).await?;
     Ok(())
 }
 
@@ -793,6 +800,25 @@ async fn ensure_sqlite_message_owner_bot_id(db: &dyn DbPlugin) -> DbResult<()> {
     db.execute(DbStatement::new(
         "CREATE INDEX IF NOT EXISTS idx_messages_session_owner_created \
          ON bcs_messages(session_id, owner_bot_id, created_at, session_seq)",
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn ensure_sqlite_session_collected_column(db: &dyn DbPlugin) -> DbResult<()> {
+    if !table_exists(db, "bcs_session_participants").await? {
+        return Ok(());
+    }
+    let columns = sqlite_table_columns(db, "bcs_session_participants").await?;
+    if !columns.iter().any(|column| column == "collected") {
+        db.execute(DbStatement::new(
+            "ALTER TABLE bcs_session_participants ADD COLUMN collected INTEGER NOT NULL DEFAULT 0",
+        ))
+        .await?;
+    }
+    db.execute(DbStatement::new(
+        "CREATE INDEX IF NOT EXISTS idx_collected \
+         ON bcs_session_participants(env, group_id, bot_uuid, collected)",
     ))
     .await?;
     Ok(())
@@ -851,6 +877,9 @@ async fn apply_sqlite_migration_body(
         2 => repair_sqlite_channel_bindings_audit_schema(db).await,
         // Startup creates any missing organization tables before recording version 3.
         3 => Ok(()),
+        // collected column is added by ensure_sqlite_session_collected_column in
+        // run_sqlite_bootstrap_tables; version 4 only records progress.
+        4 => Ok(()),
         _ => Ok(()),
     }
 }
@@ -1070,7 +1099,8 @@ mod tests {
                     "channel_binding_audit_timestamps".to_string(),
                     "sqlite".to_string()
                 ),
-                (3, "add_organizations".to_string(), "sqlite".to_string())
+                (3, "add_organizations".to_string(), "sqlite".to_string()),
+                (4, "add_session_collection".to_string(), "sqlite".to_string())
             ]
         );
         Ok(())
@@ -1082,7 +1112,7 @@ mod tests {
 
         let report = check_sqlite_migrations(&db).await?;
 
-        assert_eq!(report.pending_versions.len(), 3);
+        assert_eq!(report.pending_versions.len(), 4);
         assert_eq!(report.pending_versions[0].version, 1);
         assert_eq!(report.pending_versions[0].name, "init_schema");
         assert!(report.pending_versions[0].statements.is_empty());
@@ -1094,6 +1124,8 @@ mod tests {
         );
         assert_eq!(report.pending_versions[2].version, 3);
         assert_eq!(report.pending_versions[2].name, "add_organizations");
+        assert_eq!(report.pending_versions[3].version, 4);
+        assert_eq!(report.pending_versions[3].name, "add_session_collection");
         Ok(())
     }
 
@@ -1113,7 +1145,8 @@ mod tests {
                     "channel_binding_audit_timestamps".to_string(),
                     "sqlite".to_string()
                 ),
-                (3, "add_organizations".to_string(), "sqlite".to_string())
+                (3, "add_organizations".to_string(), "sqlite".to_string()),
+                (4, "add_session_collection".to_string(), "sqlite".to_string())
             ]
         );
         Ok(())
@@ -1222,5 +1255,47 @@ mod tests {
 
         assert!(err.to_string().contains("checksum mismatch"));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod collection_migration_tests {
+    use super::*;
+    use bcs_db_local::LocalSqliteDbPlugin;
+
+    async fn fresh_db() -> LocalSqliteDbPlugin {
+        let db = LocalSqliteDbPlugin::new().expect("open in-memory sqlite");
+        run_sqlite_bootstrap_tables(&db).await.expect("bootstrap");
+        run_sqlite_versioned_migrations(&db).await.expect("versioned");
+        db
+    }
+
+    #[tokio::test]
+    async fn fresh_db_has_session_participants_collected_column() {
+        let db = fresh_db().await;
+        let cols = sqlite_table_columns(&db, "bcs_session_participants").await.unwrap();
+        assert!(cols.iter().any(|c| c == "collected"),
+            "bcs_session_participants must have a collected column on fresh DB; got {cols:?}");
+    }
+
+    #[tokio::test]
+    async fn ensure_function_adds_collected_to_legacy_table() {
+        let db = LocalSqliteDbPlugin::new().expect("open in-memory sqlite");
+        db.execute(DbStatement::new(
+            "CREATE TABLE bcs_session_participants (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                session_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                bot_uuid TEXT NOT NULL,
+                role TEXT NOT NULL,
+                env TEXT NOT NULL DEFAULT 'prod'
+            )"
+        )).await.unwrap();
+        run_sqlite_bootstrap_tables(&db).await.expect("bootstrap repairs legacy table");
+        let cols = sqlite_table_columns(&db, "bcs_session_participants").await.unwrap();
+        assert!(cols.iter().any(|c| c == "collected"),
+            "ensure function must add collected to legacy bcs_session_participants; got {cols:?}");
     }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/session.rs
@@ -141,4 +141,39 @@ pub trait SessionManagementService: Send + Sync {
     ) -> Result<Vec<String>, SessionUseCaseError>;
 
     async fn delete(&self, session_id: &str) -> Result<bool, SessionUseCaseError>;
+
+    // ── session collection (收藏) ──────────────────────────────
+    /// Mark a session as collected by `bot_uuid`. The bot must be a
+    /// participant of the session (the side-table row exists).
+    async fn collect(
+        &self,
+        _session_id: &str,
+        _bot_uuid: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        Err(SessionUseCaseError::Internal(ServiceError::InternalError(
+            "collect not implemented for this SessionManagementService".into(),
+        )))
+    }
+    /// Remove the collection mark. Idempotent: only session-not-found is an
+    /// error; non-participant / not-collected returns Ok.
+    async fn uncollect(
+        &self,
+        _session_id: &str,
+        _bot_uuid: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        Err(SessionUseCaseError::Internal(ServiceError::InternalError(
+            "uncollect not implemented for this SessionManagementService".into(),
+        )))
+    }
+    async fn list_collected_by_group(
+        &self,
+        _group_id: &str,
+        _bot_uuid: &str,
+        _status: Option<SessionStatus>,
+        _title_contains: Option<&str>,
+        _offset: u64,
+        _limit: u64,
+    ) -> Result<Vec<Session>, SessionUseCaseError> {
+        Ok(Vec::new())
+    }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/session.rs
@@ -4,6 +4,7 @@
 
 use async_trait::async_trait;
 
+use crate::core::ServiceError;
 use crate::types::{
     Participant, ParticipantMode, ServiceResult, Session, SessionKind, SessionStatus,
 };
@@ -77,4 +78,29 @@ pub trait SessionRepoPort: Send + Sync {
     async fn update_title(&self, session_id: &str, title: Option<String>) -> ServiceResult<Session>;
     async fn list_group_ids_by_session_participant(&self, bot_uuid: &str) -> Vec<String>;
     async fn delete(&self, session_id: &str) -> ServiceResult<bool>;
+
+    // ── session collection (收藏) ──────────────────────────────
+    // Default impls keep existing test mocks compiling; real impls in
+    // mysql + memory override these (see bcs-session-store).
+    async fn collect(&self, _session_id: &str, _bot_uuid: &str) -> ServiceResult<()> {
+        Err(ServiceError::InternalError(
+            "collect not implemented for this SessionRepoPort".into(),
+        ))
+    }
+    async fn uncollect(&self, _session_id: &str, _bot_uuid: &str) -> ServiceResult<()> {
+        Err(ServiceError::InternalError(
+            "uncollect not implemented for this SessionRepoPort".into(),
+        ))
+    }
+    async fn list_collected_by_group(
+        &self,
+        _group_id: &str,
+        _bot_uuid: &str,
+        _status: Option<SessionStatus>,
+        _title_contains: Option<&str>,
+        _offset: u64,
+        _limit: u64,
+    ) -> Vec<Session> {
+        Vec::new()
+    }
 }

--- a/src/bcs/crates/services/bcs-session-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/memory.rs
@@ -44,6 +44,7 @@ fn initial_callback_status(kind: SessionKind) -> Option<String> {
 #[derive(Default)]
 struct MemoryState {
     sessions: HashMap<String, Session>,
+    collected: std::collections::HashSet<(String, String)>,
 }
 
 // ---------------------------------------------------------------------------
@@ -400,7 +401,11 @@ impl SessionRepoPort for MemorySessionRepo {
             )));
         }
         sess.updated_at = now;
-        Ok(sess.clone())
+        let updated = sess.clone();
+        // collection mark is per-participant; leaving drops it
+        st.collected
+            .retain(|(sid, bid)| !(sid == session_id && bid == bot_uuid));
+        Ok(updated)
     }
 
     async fn update_participant_mode(
@@ -468,7 +473,71 @@ impl SessionRepoPort for MemorySessionRepo {
 
     async fn delete(&self, session_id: &str) -> ServiceResult<bool> {
         let mut st = self.state.write().await;
-        Ok(st.sessions.remove(session_id).is_some())
+        let existed = st.sessions.remove(session_id).is_some();
+        if existed {
+            st.collected.retain(|(sid, _)| sid != session_id);
+        }
+        Ok(existed)
+    }
+
+    async fn collect(&self, session_id: &str, bot_uuid: &str) -> ServiceResult<()> {
+        let mut st = self.state.write().await;
+        let session = st
+            .sessions
+            .get(session_id)
+            .ok_or_else(|| ServiceError::SessionNotFound(session_id.to_string()))?;
+        if !session.participants.iter().any(|p| p.bot_uuid == bot_uuid) {
+            return Err(ServiceError::SessionNotFound(format!(
+                "participant {bot_uuid} not in session {session_id}"
+            )));
+        }
+        st.collected.insert((session_id.to_string(), bot_uuid.to_string()));
+        Ok(())
+    }
+
+    async fn uncollect(&self, session_id: &str, bot_uuid: &str) -> ServiceResult<()> {
+        let mut st = self.state.write().await;
+        // Idempotent: session must exist; otherwise no-op removal.
+        if !st.sessions.contains_key(session_id) {
+            return Err(ServiceError::SessionNotFound(session_id.to_string()));
+        }
+        st.collected.remove(&(session_id.to_string(), bot_uuid.to_string()));
+        Ok(())
+    }
+
+    async fn list_collected_by_group(
+        &self,
+        group_id: &str,
+        bot_uuid: &str,
+        status: Option<SessionStatus>,
+        title_contains: Option<&str>,
+        offset: u64,
+        limit: u64,
+    ) -> Vec<Session> {
+        let st = self.state.read().await;
+        let q = title_contains.map(|s| s.to_ascii_lowercase());
+        let mut v: Vec<_> = st
+            .sessions
+            .values()
+            .filter(|s| s.group_id == group_id)
+            .filter(|s| {
+                st.collected
+                    .contains(&(s.id.clone(), bot_uuid.to_string()))
+            })
+            .filter(|s| status.map(|want| s.status == want).unwrap_or(true))
+            .filter(|s| {
+                q.as_ref().map_or(true, |q| {
+                    s.session_title
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_ascii_lowercase()
+                        .contains(q)
+                })
+            })
+            .cloned()
+            .collect();
+        v.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+        v.into_iter().skip(offset as usize).take(limit as usize).collect()
     }
 }
 
@@ -581,5 +650,143 @@ mod tests {
         let sessions = repo.list_by_group("g1", None, 0, 5, None, Some(target)).await;
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_title.as_deref(), Some("Target Session"));
+    }
+
+    #[tokio::test]
+    async fn collection_collect_then_list_then_uncollect() {
+        let repo = MemorySessionRepo::new();
+        let gid = "col-group";
+        let sess = repo
+            .create(
+                gid,
+                NewSessionParams {
+                    session_kind: SessionKind::Chat,
+                    participants: vec![Participant::bot("bot1", bcs_service_api::ParticipantRole::Driver)],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create");
+
+        // not collected yet
+        let listed = repo.list_collected_by_group(gid, "bot1", None, None, 0, 10).await;
+        assert!(listed.is_empty());
+
+        repo.collect(&sess.id, "bot1").await.expect("collect");
+        let listed = repo.list_collected_by_group(gid, "bot1", None, None, 0, 10).await;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, sess.id);
+
+        // other bot does not see bot1's collection
+        let other = repo.list_collected_by_group(gid, "bot2", None, None, 0, 10).await;
+        assert!(other.is_empty());
+
+        repo.uncollect(&sess.id, "bot1").await.expect("uncollect");
+        let listed = repo.list_collected_by_group(gid, "bot1", None, None, 0, 10).await;
+        assert!(listed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn collection_non_participant_collect_errors() {
+        let repo = MemorySessionRepo::new();
+        let gid = "col-group2";
+        let sess = repo
+            .create(
+                gid,
+                NewSessionParams {
+                    session_kind: SessionKind::Chat,
+                    participants: vec![Participant::bot("bot1", bcs_service_api::ParticipantRole::Driver)],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create");
+        let err = repo.collect(&sess.id, "not-a-participant").await;
+        assert!(err.is_err(), "collect by non-participant must error");
+    }
+
+    #[tokio::test]
+    async fn collection_uncollect_idempotent_for_non_participant() {
+        let repo = MemorySessionRepo::new();
+        let gid = "col-group3";
+        let sess = repo
+            .create(
+                gid,
+                NewSessionParams {
+                    session_kind: SessionKind::Chat,
+                    participants: vec![Participant::bot("bot1", bcs_service_api::ParticipantRole::Driver)],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create");
+        // uncollect a never-collected, still-participant session -> Ok
+        repo.uncollect(&sess.id, "bot1").await.expect("uncollect not collected ok");
+        // uncollect a non-participant -> Ok (idempotent)
+        repo.uncollect(&sess.id, "nobody").await.expect("uncollect non-participant ok");
+    }
+
+    #[tokio::test]
+    async fn collection_respects_status_and_title_filter() {
+        let repo = MemorySessionRepo::new();
+        let gid = "col-group4";
+        let s_running = repo
+            .create(gid, NewSessionParams {
+                session_kind: SessionKind::Chat,
+                session_title: Some("Alpha Report".into()),
+                participants: vec![Participant::bot("bot1", bcs_service_api::ParticipantRole::Driver)],
+                ..Default::default()
+            })
+            .await
+            .expect("create");
+        let s_to_complete = repo
+            .create(gid, NewSessionParams {
+                session_kind: SessionKind::Chat,
+                session_title: Some("Beta Note".into()),
+                participants: vec![Participant::bot("bot1", bcs_service_api::ParticipantRole::Driver)],
+                ..Default::default()
+            })
+            .await
+            .expect("create");
+        repo.complete_if_running(&s_to_complete.id, None, None).await.expect("complete");
+        repo.collect(&s_running.id, "bot1").await.expect("collect running");
+        repo.collect(&s_to_complete.id, "bot1").await.expect("collect completed");
+
+        let only_running = repo.list_collected_by_group(
+            gid, "bot1", Some(SessionStatus::Running), None, 0, 10,
+        ).await;
+        assert_eq!(only_running.len(), 1);
+        assert_eq!(only_running[0].id, s_running.id);
+
+        let only_alpha = repo.list_collected_by_group(
+            gid, "bot1", None, Some("alpha"), 0, 10,
+        ).await;
+        assert_eq!(only_alpha.len(), 1);
+        assert_eq!(only_alpha[0].id, s_running.id);
+    }
+
+    #[tokio::test]
+    async fn collection_lost_when_participant_removed() {
+        let repo = MemorySessionRepo::new();
+        let gid = "col-group5";
+        let sess = repo
+            .create(gid, NewSessionParams {
+                session_kind: SessionKind::Chat,
+                participants: vec![Participant::bot("bot1", bcs_service_api::ParticipantRole::Driver)],
+                ..Default::default()
+            })
+            .await
+            .expect("create");
+        repo.collect(&sess.id, "bot1").await.expect("collect");
+        assert_eq!(
+            repo.list_collected_by_group(gid, "bot1", None, None, 0, 10).await.len(),
+            1
+        );
+        repo.remove_participant(&sess.id, "bot1").await.expect("remove");
+        // after leaving, collection mark is gone (memory set must be pruned)
+        assert!(repo
+            .list_collected_by_group(gid, "bot1", None, None, 0, 10)
+            .await
+            .is_empty());
     }
 }

--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -1142,4 +1142,131 @@ impl SessionRepoPort for MySqlSessionStore {
             Err(_) => Ok(false),
         }
     }
+
+    async fn collect(&self, session_id: &str, bot_uuid: &str) -> ServiceResult<()> {
+        // Existence check via SELECT, NOT affected_rows: the MySQL connection does
+        // not set CLIENT_FOUND_ROWS (see bcs-config-api/src/mysql.rs to_mysql_url and
+        // bcs-db-mysql/src/manager.rs), so mysql_async reports CHANGED rows. A repeat
+        // collect (collected already 1) would yield affected_rows=0 and falsely look
+        // like a non-participant. SELECTing the side-table row first lets us
+        // distinguish non-participant (row absent) from already-collected (row present)
+        // independent of changed-rows semantics; the subsequent unconditional UPDATE is
+        // then idempotent by construction.
+        let check_sql = "SELECT 1 FROM bcs_session_participants \
+                         WHERE env = ? AND session_id = ? AND bot_uuid = ? LIMIT 1";
+        let rows = self
+            .db
+            .query(DbStatement::with_params(
+                check_sql,
+                vec![
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(session_id),
+                    DbValue::from(bot_uuid),
+                ],
+            ))
+            .await
+            .map_err(|e| ServiceError::InternalError(format!("session db: {e}")))?;
+        if rows.is_empty() {
+            return Err(ServiceError::SessionNotFound(format!(
+                "participant {bot_uuid} not in session {session_id}"
+            )));
+        }
+        let update_sql = "UPDATE bcs_session_participants \
+                          SET collected = 1 \
+                          WHERE env = ? AND session_id = ? AND bot_uuid = ?";
+        self.db
+            .execute(DbStatement::with_params(
+                update_sql,
+                vec![
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(session_id),
+                    DbValue::from(bot_uuid),
+                ],
+            ))
+            .await
+            .map_err(|e| ServiceError::InternalError(format!("session db: {e}")))?;
+        Ok(())
+    }
+
+    async fn uncollect(&self, session_id: &str, bot_uuid: &str) -> ServiceResult<()> {
+        // Idempotent: the only caller-facing error is session-not-found, which
+        // the application layer checks via get() before calling. Here we run the
+        // UPDATE regardless of whether a side-table row / collected flag exists.
+        let sql = "UPDATE bcs_session_participants \
+                   SET collected = 0 \
+                   WHERE env = ? AND session_id = ? AND bot_uuid = ?";
+        self.db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(session_id),
+                    DbValue::from(bot_uuid),
+                ],
+            ))
+            .await
+            .map_err(|e| ServiceError::InternalError(format!("session db: {e}")))?;
+        Ok(())
+    }
+
+    async fn list_collected_by_group(
+        &self,
+        group_id: &str,
+        bot_uuid: &str,
+        status: Option<SessionStatus>,
+        title_contains: Option<&str>,
+        offset: u64,
+        limit: u64,
+    ) -> Vec<Session> {
+        let mut conditions: Vec<String> = vec![
+            "s.env = ?".to_string(),
+            "s.group_id = ?".to_string(),
+            "sp.group_id = ?".to_string(),
+            "sp.bot_uuid = ?".to_string(),
+            "sp.collected = 1".to_string(),
+        ];
+        let mut params: Vec<DbValue> = vec![
+            DbValue::from(self.env.as_str()),
+            DbValue::from(group_id),
+            DbValue::from(group_id),
+            DbValue::from(bot_uuid),
+        ];
+
+        if let Some(s) = status {
+            let status_str = match s {
+                SessionStatus::Running => "running",
+                SessionStatus::Completed => "completed",
+            };
+            conditions.push("s.status = ?".to_string());
+            params.push(DbValue::from(status_str));
+        }
+
+        if let Some(q) = title_contains {
+            conditions.push("s.session_title LIKE ?".to_string());
+            params.push(DbValue::from(format!("%{}%", q)));
+        }
+
+        params.push(DbValue::U64(limit));
+        params.push(DbValue::U64(offset));
+
+        let select_cols = self.select_cols_prefixed();
+        let sql = format!(
+            "SELECT {select_cols} FROM bcs_group_sessions s \
+             JOIN bcs_session_participants sp \
+               ON sp.env = s.env AND sp.session_id = s.session_id \
+             WHERE {where_clause} \
+             ORDER BY s.gmt_create DESC LIMIT ? OFFSET ?",
+            select_cols = select_cols,
+            where_clause = conditions.join(" AND "),
+        );
+
+        let rows = match self.db.query(DbStatement::with_params(&sql, params)).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "list_collected_by_group query failed");
+                return Vec::new();
+            }
+        };
+        rows.iter().filter_map(|r| row_to_session(r).ok()).collect()
+    }
 }

--- a/src/bcs/crates/services/bcs-session/src/application.rs
+++ b/src/bcs/crates/services/bcs-session/src/application.rs
@@ -217,4 +217,43 @@ impl SessionManagementService for SessionManagementServiceImpl {
     async fn delete(&self, session_id: &str) -> Result<bool, SessionUseCaseError> {
         Ok(self.repo.delete(session_id).await?)
     }
+
+    async fn collect(
+        &self,
+        session_id: &str,
+        bot_uuid: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        if self.repo.get(session_id).await.is_none() {
+            return Err(SessionUseCaseError::NotFound(session_id.to_string()));
+        }
+        self.repo.collect(session_id, bot_uuid).await?;
+        Ok(())
+    }
+
+    async fn uncollect(
+        &self,
+        session_id: &str,
+        bot_uuid: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        if self.repo.get(session_id).await.is_none() {
+            return Err(SessionUseCaseError::NotFound(session_id.to_string()));
+        }
+        self.repo.uncollect(session_id, bot_uuid).await?;
+        Ok(())
+    }
+
+    async fn list_collected_by_group(
+        &self,
+        group_id: &str,
+        bot_uuid: &str,
+        status: Option<SessionStatus>,
+        title_contains: Option<&str>,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<Session>, SessionUseCaseError> {
+        Ok(self
+            .repo
+            .list_collected_by_group(group_id, bot_uuid, status, title_contains, offset, limit)
+            .await)
+    }
 }

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
@@ -765,6 +765,71 @@ pub async fn session_repo_contract_tests<T: SessionRepoPort + ?Sized>(repo: &T) 
     // list_group_ids_by_session_participant
     let groups = repo.list_group_ids_by_session_participant("bot1").await;
     assert!(groups.contains(&group_id.to_string()));
+
+    // ── session collection (收藏) contract ───────────────────
+    // Create a second participant so we can assert per-bot isolation.
+    let collect_session: Session = repo
+        .create(
+            &svc.group_id,
+            NewSessionParams {
+                session_kind: SessionKind::Chat,
+                participants: vec![
+                    Participant::bot("bot-collector", ParticipantRole::Driver),
+                    Participant::bot("bot-other", ParticipantRole::Consultant),
+                ],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create session for collection contract");
+
+    // Not collected yet
+    assert!(repo
+        .list_collected_by_group(&svc.group_id, "bot-collector", None, None, 0, 10)
+        .await
+        .is_empty());
+
+    // collect by a participant
+    repo.collect(&collect_session.id, "bot-collector")
+        .await
+        .expect("collect by participant");
+    let collected = repo
+        .list_collected_by_group(&svc.group_id, "bot-collector", None, None, 0, 10)
+        .await;
+    assert_eq!(collected.len(), 1);
+    assert_eq!(collected[0].id, collect_session.id);
+
+    // per-bot isolation: other participant sees nothing
+    assert!(repo
+        .list_collected_by_group(&svc.group_id, "bot-other", None, None, 0, 10)
+        .await
+        .is_empty());
+
+    // collect by non-participant errors
+    let err = repo.collect(&collect_session.id, "bot-stranger").await;
+    assert!(err.is_err(), "collect by non-participant must error");
+
+    // repeat collect is idempotent (no error)
+    repo.collect(&collect_session.id, "bot-collector")
+        .await
+        .expect("repeat collect idempotent");
+
+    // uncollect removes it
+    repo.uncollect(&collect_session.id, "bot-collector")
+        .await
+        .expect("uncollect");
+    assert!(repo
+        .list_collected_by_group(&svc.group_id, "bot-collector", None, None, 0, 10)
+        .await
+        .is_empty());
+
+    // uncollect of a never-collected / non-participant is idempotent Ok
+    repo.uncollect(&collect_session.id, "bot-collector")
+        .await
+        .expect("uncollect not-collected idempotent");
+    repo.uncollect(&collect_session.id, "bot-stranger")
+        .await
+        .expect("uncollect non-participant idempotent");
 }
 
 pub async fn session_repo_port_contract_tests<T: SessionRepoPort + ?Sized>(repo: &T) {

--- a/src/bcs/migrations/mysql/004_add_session_collection.sql
+++ b/src/bcs/migrations/mysql/004_add_session_collection.sql
@@ -1,0 +1,8 @@
+-- Session collection (收藏): per-participant collected flag on the side table.
+-- Standard MySQL syntax (no MariaDB-only `IF NOT EXISTS`); migrations run once
+-- against the recorded migration history, so idempotency is handled there.
+ALTER TABLE `bcs_session_participants`
+  ADD COLUMN `collected` tinyint(4) NOT NULL DEFAULT '0';
+
+CREATE INDEX `idx_collected`
+  ON `bcs_session_participants` (`env`, `group_id`, `bot_uuid`, `collected`);

--- a/src/bcs/scripts/e2e-test/group.sh
+++ b/src/bcs/scripts/e2e-test/group.sh
@@ -27,6 +27,8 @@ E2E_TESTS_GROUP=(
     # --- session lifecycle (session = a group's instantiated run) ---
     "test_session_invite_join"
     "test_session_lifecycle"
+    # --- session collection (收藏: collect / uncollect / collected list) ---
+    "test_session_collection"
 )
 
 # ============================================================================
@@ -448,6 +450,35 @@ _api_delete_session() {
     api_delete "/sessions/$1?bot_id=${BOT_PM_UUID}"
 }
 
+# Count items in a collected-list (`GET .../sessions?...&collected=true`)
+# response body held in $RESPONSE. Prints 0 on any parse error.
+_collected_count() {
+    printf '%s' "$RESPONSE" | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin)
+    items=d.get('items') or d.get('sessions') or (d if isinstance(d,list) else [])
+    print(len(items))
+except Exception:
+    print('0')
+" 2>/dev/null || echo 0
+}
+
+# Print 1 if $1 (session id) is present in the collected-list response body
+# held in $RESPONSE, else 0 (also 0 on parse error).
+_collected_contains() {
+    printf '%s' "$RESPONSE" | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin)
+    items=d.get('items') or d.get('sessions') or (d if isinstance(d,list) else [])
+    ids=[i.get('session_id') or i.get('id') for i in items]
+    print('1' if sys.argv[1] in ids else '0')
+except Exception:
+    print('0')
+" "$1" 2>/dev/null || echo 0
+}
+
 # POST /sessions/join/{token} — the standard "human joins a session" flow.
 # Builds on the bcs-cli session invite-link test: create a session, mint an
 # invite token, then have the mock human join it, verifying the closed
@@ -607,5 +638,129 @@ except Exception:
         fail "session $sid deletion NOT verified (HTTP=$HTTP_STATUS body=$(printf '%s' "$RESPONSE" | head -c 100))"; TESTS_FAILED=$((TESTS_FAILED+1))
     fi
     TESTS_TOTAL=$((TESTS_TOTAL+1))
+    _cli_delete_group "$gid"
+}
+
+# Session collection (收藏): a bot marks/unmarks a session as collected and
+# lists collected sessions. Flow: collected list empty -> collected=true needs
+# participant (400) -> collect as PM (200) -> idempotent repeat -> list shows
+# it -> per-bot isolation (ENG sees nothing) -> collect by non-participant QA
+# (404) -> uncollect as PM (200) -> idempotent repeat -> list empty again.
+# _cli_create_group seeds {PM(driver), ENG}; QA is not a group member, so it is
+# not a session participant — the non-participant collect -> 404 case.
+test_session_collection() {
+    info "Session(收藏): collect / uncollect / collected=true list"
+    ensure_cli_token PM || { skip_case "no PM token"; TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+    local gid; gid="$(_cli_create_group)"
+    [[ -z "$gid" ]] && { fail "setup create-group failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
+
+    local sid; sid="$(_api_create_session "$gid" collect-sess)"
+    if [[ -z "$sid" ]]; then
+        fail "session create failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+        _cli_delete_group "$gid"; return
+    fi
+    pass "session created ($sid)"; TESTS_PASSED=$((TESTS_PASSED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (A) collected list is empty before any collect.
+    api_get "/groups/${gid}/sessions?participant=${BOT_PM_UUID}&collected=true"
+    if [[ "$HTTP_STATUS" = "200" ]] && [ "$(_collected_count)" = "0" ]; then
+        pass "collected list empty before collect"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "collected list not empty before collect (HTTP=$HTTP_STATUS count=$(_collected_count))"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (B) collected=true without participant -> 400.
+    api_get "/groups/${gid}/sessions?collected=true"
+    if [[ "$HTTP_STATUS" = "400" ]]; then
+        pass "collected=true without participant rejected (400)"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "collected=true without participant returned $HTTP_STATUS (expected 400)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (C) collect as PM (bot token; PM is a session participant).
+    bot_post "/sessions/${sid}/collect" PM '{}'
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "POST /sessions/{sid}/collect as PM returned 200"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "collect as PM returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 120)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (D) repeat collect is idempotent (still 200, not 404).
+    bot_post "/sessions/${sid}/collect" PM '{}'
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "repeat collect idempotent (200)"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "repeat collect returned $HTTP_STATUS (expected 200 idempotent)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (E) collected list now contains the session.
+    api_get "/groups/${gid}/sessions?participant=${BOT_PM_UUID}&collected=true"
+    if [[ "$HTTP_STATUS" = "200" ]] && [ "$(_collected_contains "$sid")" = "1" ]; then
+        pass "collected list contains $sid after collect"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "collected list missing $sid (HTTP=$HTTP_STATUS contains=$(_collected_contains "$sid"))"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (F) per-bot isolation: ENG has not collected, sees nothing.
+    api_get "/groups/${gid}/sessions?participant=${BOT_ENG_UUID}&collected=true"
+    if [[ "$HTTP_STATUS" = "200" ]] && [ "$(_collected_contains "$sid")" = "0" ]; then
+        pass "per-bot isolation: ENG collected list empty for PM's collection"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "ENG collected list unexpectedly contains $sid (HTTP=$HTTP_STATUS)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (G) collect by a non-participant (QA) -> 404. QA is not a group member.
+    ensure_cli_token QA >/dev/null 2>&1 || true
+    bot_post "/sessions/${sid}/collect" QA '{}'
+    if [[ "$HTTP_STATUS" = "404" ]]; then
+        pass "collect by non-participant QA rejected (404)"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "collect by non-participant QA returned $HTTP_STATUS (expected 404): $(printf '%s' "$RESPONSE" | head -c 120)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (H) uncollect as PM -> 200.
+    bot_delete "/sessions/${sid}/collect" PM
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "DELETE /sessions/{sid}/collect as PM returned 200"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "uncollect as PM returned $HTTP_STATUS: $(printf '%s' "$RESPONSE" | head -c 120)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (I) repeat uncollect idempotent (still 200).
+    bot_delete "/sessions/${sid}/collect" PM
+    if [[ "$HTTP_STATUS" = "200" ]]; then
+        pass "repeat uncollect idempotent (200)"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "repeat uncollect returned $HTTP_STATUS (expected 200 idempotent)"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
+    # (J) collected list empty again after uncollect.
+    api_get "/groups/${gid}/sessions?participant=${BOT_PM_UUID}&collected=true"
+    if [[ "$HTTP_STATUS" = "200" ]] && [ "$(_collected_count)" = "0" ]; then
+        pass "collected list empty after uncollect"
+        TESTS_PASSED=$((TESTS_PASSED+1))
+    else
+        fail "collected list not empty after uncollect (HTTP=$HTTP_STATUS count=$(_collected_count))"; TESTS_FAILED=$((TESTS_FAILED+1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL+1))
+
     _cli_delete_group "$gid"
 }

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -337,13 +337,15 @@ _story_group_proposal_confirmation() {
 # Flow:
 #   Create a group session -> list and inspect it -> share group/session invitations
 #   -> join them -> manage session members and messages -> complete a chat session
-#   -> expose the group as a service -> invoke and inspect a service session -> clean up.
+#   -> expose the group as a service -> invoke and inspect a service session -> clean up
+#   -> collect and uncollect a session and list collected sessions.
 #
 # Critical assertions:
 #   - Invite tokens lead to the intended group or session and created sessions are queryable.
 #   - Completion status and output survive an independent read-back.
 #   - Service sessions preserve kind, group, title, and caller isolation.
 #   - Cross-caller reads and use of the wrong completion API are rejected with 403.
+#   - Collection (collect/uncollect/list) follows per-bot isolation and idempotency.
 story_user_runs_and_shares_sessions() {
     info "Story: a team creates, shares, completes, and invokes collaboration sessions"
     test_group_session_via_cli
@@ -353,6 +355,10 @@ story_user_runs_and_shares_sessions() {
     test_session_invite_join
     test_session_lifecycle
     _story_complete_and_invoke_sessions || return
+    # 收藏 (collection): a participant bot collects / uncollects a session and
+    # lists collected sessions; non-participant collect is rejected. Exercises
+    # POST/DELETE /sessions/{sid}/collect and the collected=true list filter.
+    test_session_collection
 }
 
 _story_complete_and_invoke_sessions() {


### PR DESCRIPTION
## Summary

Implements session collection for BCS: a bot (or a human acting through an owned bot) can collect/uncollect a session and list the sessions a given bot has collected within a group. Squashed from the `feat/session-collection2` feature branch (15 commits → 1); spec/plan design docs intentionally excluded from this commit.

## Changes

- **service-api**: add `collect` / `uncollect` / `list_collected_by_group` to the session repo port + application service, with default impls.
- **session application service**: `collect` / `uncollect` / `list_collected_by_group` orchestration.
- **stores**: memory + MySQL `collect`/`uncollect`/`list_collected_by_group`. MySQL `collect` idempotency via **SELECT-before-UPDATE** (changed-rows safe).
- **migrations**: `collected` column — MySQL migration `004_add_session_collection.sql`, plus SQLite path for both fresh and existing DBs (`ensure_sqlite_session_collected_column` repair on legacy tables, version-4 migration records progress).
- **HTTP**: collected-list filter (`?collected=true&participant=<bot>`) on `GET /groups/{id}/sessions`, plus `POST /sessions/{sid}/collect` and `DELETE /sessions/{sid}/collect`. Router wiring included.
- **tests**: session repo contract harness assertions, HTTP contract tests covering all three endpoints + idempotency + human-caller ownership/`participant` enforcement, and e2e coverage (human-caller uncollect via `?participant=` query string).

## API surface (frontend-facing)

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/sessions/{sid}/collect` | Collect a session (`participant` in JSON body; required for human callers) |
| `DELETE` | `/sessions/{sid}/collect` | Uncollect (`participant` via query string; required for human callers) |
| `GET` | `/groups/{id}/sessions?collected=true&participant=<bot>` | List sessions a bot has collected in a group |

Collection is a `(session_id, bot_uuid)` pair. Both collect/uncollect are **idempotent**.

## Notes

- The `sqlite_migration_count` helper is `#[allow(dead_code)]`-annotated: it is genuinely used by `bcs-admin`, but the function lives in `migrations.rs` which other test crates pull in via `#[path=...]`, triggering a dead_code warning in those compile contexts.
- Design spec and implementation plan docs are kept as local untracked files and are **not** in this commit by design.
