### PR TITLE
fix(dormant): isolate scans by environment

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_dormant/candidates.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/candidates.py
@@ -4,7 +4,7 @@ Extracted from service.py to keep that module under the 1000-line guard.
 
 Exposes:
   ``Candidate`` — frozen dataclass representing a bot that passed both stages.
-  ``filter_candidates(session, N)`` — Stage-1/2 SQL + in-memory filter.
+  ``filter_candidates(session, N, env)`` — Stage-1/2 SQL + in-memory filter.
 """
 from __future__ import annotations
 
@@ -53,13 +53,14 @@ def partition_by_protected_owner(
     return protected, unprotected
 
 
-def filter_candidates(session: Session, N: int) -> list[Candidate]:
+def filter_candidates(session: Session, N: int, env: str) -> list[Candidate]:
     """Return bots eligible for dormancy governance.
 
     Args:
         session: SQLAlchemy session (works with both SQLite and MySQL).
         N: Age threshold in days. Bots created fewer than N days ago
            are excluded.
+        env: Runtime environment whose bots are eligible for this scan.
 
     Returns:
         List of :class:`Candidate` after both filter stages.
@@ -73,6 +74,7 @@ def filter_candidates(session: Session, N: int) -> list[Candidate]:
             BotModel.status == "ACTIVE",
             BotModel.is_delete == 0,
             BotModel.bot_type == "personal",
+            BotModel.env == env,
             BotModel.gmt_create < cutoff,
         )
         .order_by(BotModel.gmt_modified.desc(), BotModel.id.desc())

--- a/src/backend/src/agentclaw/community/core/bot_dormant/ops_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/ops_service.py
@@ -10,6 +10,7 @@ from agentclaw.community.core.bot_dormant.service import Candidate, DormantBotSe
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.utils.env_utils import get_current_env
 
 
 logger = get_logger()
@@ -86,12 +87,14 @@ class DormantOpsService:
             run_id, bot_id, owner_id, dry_run, reason,
         )
         with self._dormant_service._db.orm_session() as session:
+            env = get_current_env()
             bot = (
                 session.query(BotModel)
                 .filter(
                     BotModel.bot_id == bot_id,
                     BotModel.owner_id == owner_id,
                     BotModel.is_delete == 0,
+                    BotModel.env == env,
                 )
                 .order_by(BotModel.gmt_modified.desc(), BotModel.id.desc())
                 .first()

--- a/src/backend/src/agentclaw/community/core/bot_dormant/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/service.py
@@ -465,16 +465,14 @@ class DormantBotService:
         )
 
     def _process_external_inputs(self, session, dry_run: bool, summary: RunSummary,
-                                 run_id: str, protected_owner_ids: frozenset[str]) -> None:
+                                 run_id: str, protected_owner_ids: frozenset[str], env: str) -> None:
         """Two-stage governance for external_input rows.
 
         Each row triggers warns daily until days_since_input >= M, then a final
         recycle. Per-row try/except isolates failures.
 
-        Audit: every branch (whitelist skip / missing bot / invalid dt /
-        future date / warn / recycle / unexpected exception) writes a
-        DormantCheckAudit row with source='external_input' so the run is
-        fully observable in the audit table.
+        Every branch writes a DormantCheckAudit row with source='external_input'
+        so the external-input run is fully observable.
         """
         from datetime import date as _date
         from datetime import datetime as _datetime
@@ -533,6 +531,7 @@ class DormantBotService:
                     .filter(
                         BotModel.bot_id == row.bot_id,
                         BotModel.owner_id == row.owner_id,
+                        BotModel.env == env,
                     )
                     .first()
                 )
@@ -839,7 +838,7 @@ class DormantBotService:
         # After internal-scan loop completes, also process external_input rows.
         try:
             self._process_external_inputs(
-                session, dry_run, summary, run_id, protected_owner_ids
+                session, dry_run, summary, run_id, protected_owner_ids, env
             )
         except Exception:
             logger.exception(

--- a/src/backend/src/agentclaw/community/core/bot_dormant/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/service.py
@@ -1,7 +1,7 @@
 """Dormant bot candidate filtering and scan/decision service.
 
 Exposes:
-  ``filter_candidates(session, N)`` — Stage-1/2 SQL+in-memory filter.
+  ``filter_candidates(session, N, env)`` — Stage-1/2 SQL+in-memory filter.
   ``DormantBotService`` — orchestrates a full scan run with single-signal
       active detection (/alive session check only).
 
@@ -711,7 +711,7 @@ class DormantBotService:
         the service safe for long-lived cron use.
 
         Steps:
-        1. filter_candidates(N) to get eligible bots.
+        1. filter_candidates(N, env) to get eligible bots.
         2. For each candidate: check_alive (N+M window) — single-signal /alive.
            unknown → skip; alive.result=='true' → active/none;
            else days_inactive from max(alive.last_session_time, gmt_create):
@@ -763,7 +763,7 @@ class DormantBotService:
         )
 
         # Step 1: gather candidates
-        candidates = filter_candidates(session, self._N)
+        candidates = filter_candidates(session, self._N, env)
         protected_candidates, candidates = partition_by_protected_owner(
             candidates, protected_owner_ids
         )

--- a/src/backend/tests/community/core/bot_dormant/test_decide.py
+++ b/src/backend/tests/community/core/bot_dormant/test_decide.py
@@ -30,10 +30,11 @@ from agentclaw.community.core.bot_dormant.baas_client import (
     AliveResult,
     BaasDormantClient,
 )
+from agentclaw.community.core.bot_dormant import ops_service as ops_service_module
+from agentclaw.community.core.bot_dormant.ops_service import DormantOpsService
 from agentclaw.community.core.common_config import CommonWhiteListService
 from agentclaw.community.core.common_config.models import CommonConfigRecord
 from agentclaw.community.core.common_config.service import CommonConfigService
-from agentclaw.community.core.bot_dormant.ops_service import DormantOpsService
 from agentclaw.community.core.bot_dormant.service import (
     Candidate,
     DormantBotService,
@@ -216,8 +217,9 @@ def _insert_bot_record(
     bot_type: str = "personal",
     bot_name: str = "Test Bot",
     gmt_create: datetime | None = None,
+    env: str | None = None,
 ) -> BotModel:
-    bot = BotModel(
+    values = dict(
         bot_id=bot_id,
         entity_id=entity_id,
         entity_type="user",
@@ -230,6 +232,9 @@ def _insert_bot_record(
         gmt_create=gmt_create or (_now() - timedelta(days=30)),
         gmt_modified=_now(),
     )
+    if env is not None:
+        values["env"] = env
+    bot = BotModel(**values)
     session.add(bot)
     session.commit()
     return bot
@@ -244,12 +249,14 @@ def test_internal_scan_filters_protected_owner_before_alive_check(caplog, monkey
         bot_id="protected_bot",
         owner_id="protected_owner",
         entity_id="100001",
+        env="prod",
     )
     _insert_bot_record(
         session,
         bot_id="normal_bot",
         owner_id="normal_owner",
         entity_id="100002",
+        env="prod",
     )
     baas = AsyncMock(spec=BaasDormantClient)
     baas.check_alive = AsyncMock(
@@ -459,6 +466,44 @@ def test_manual_recycle_one_rejects_missing_bot():
             owner_id="owner1",
             dry_run=False,
         )
+
+
+@pytest.mark.unit
+def test_manual_recycle_one_rejects_cross_environment_bot_before_side_effects(
+    monkeypatch,
+):
+    """A pre ops request must not enqueue or recycle a prod-only bot."""
+    session = _make_session()
+    _insert_bot_record(
+        session,
+        bot_id="prod_only",
+        owner_id="owner1",
+        env="prod",
+    )
+    service = _make_service(session)
+    service._enqueue_recycle = MagicMock()
+    service._execute_recycle = MagicMock()
+    service._write_audit = MagicMock()
+    ops_service = DormantOpsService(service, MagicMock())
+    monkeypatch.setattr(
+        ops_service_module,
+        "get_current_env",
+        lambda: "pre",
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="bot not found"):
+        ops_service.recycle_one(
+            bot_id="prod_only",
+            owner_id="owner1",
+            dry_run=False,
+        )
+
+    service._enqueue_recycle.assert_not_called()
+    service._execute_recycle.assert_not_called()
+    service._write_audit.assert_not_called()
+    assert session.query(DormantCheckAudit).count() == 0
+    assert session.query(DormantNotifyLog).count() == 0
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/bot_dormant/test_external_input.py
+++ b/src/backend/tests/community/core/bot_dormant/test_external_input.py
@@ -45,11 +45,18 @@ class FakeDB:
     def orm_session(self): yield self._session
 
 
-def _insert_bot(session, bot_id="bot1", entity_id="123", owner_id="ow"):
+def _insert_bot(
+    session,
+    bot_id="bot1",
+    entity_id="123",
+    owner_id="ow",
+    env=None,
+):
     session.add(BotModel(
         bot_id=bot_id, entity_id=entity_id, entity_type="staff",
         creator_id=owner_id, owner_id=owner_id, bot_name=bot_id,
         bot_type="personal", status="ACTIVE", is_delete=0,
+        **({"env": env} if env is not None else {}),
         gmt_create=_now() - timedelta(days=30),
         gmt_modified=_now(),
     ))
@@ -352,6 +359,38 @@ def test_external_processed_when_no_internal_candidates():
         DormantNotifyLog.notify_type == "warn",
     ).all()
     assert len(logs) == 1
+
+
+@pytest.mark.unit
+def test_external_input_rejects_bot_from_another_environment(monkeypatch):
+    """A pre scan must not act on a prod-only bot referenced by external input."""
+    session = _make_session()
+    _insert_bot(session, bot_id="shared_bot", owner_id="shared_owner", env="prod")
+    row_id = _insert_external(
+        session,
+        bot_id="shared_bot",
+        owner_id="shared_owner",
+        dt_str=(date.today() - timedelta(days=M)).strftime("%Y%m%d"),
+    )
+    monkeypatch.setattr(
+        "agentclaw.community.core.bot_dormant.service.get_current_env",
+        lambda: "pre",
+    )
+
+    service = _make_service(session)
+    _run(service.process_run(dry_run=False))
+
+    row = session.query(DormantExternalInput).filter_by(id=row_id).one()
+    audit = session.query(DormantCheckAudit).filter_by(
+        source="external_input",
+        bot_id="shared_bot",
+        owner_id="shared_owner",
+    ).one()
+    assert row.processed == 0
+    assert audit.check_result == "missing_bot"
+    assert audit.action_taken == "skipped"
+    assert session.query(DormantNotifyLog).count() == 0
+    service._bot_service.stop_bot.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/community/core/bot_dormant/test_filter.py
+++ b/src/backend/tests/community/core/bot_dormant/test_filter.py
@@ -21,6 +21,7 @@ from agentclaw.community.core.bot_dormant.candidates import (
 )
 from agentclaw.community.core.bot_dormant.sqlite_models import DormantWhitelist
 from agentclaw.community.plugin_api.models import Base, BotModel
+from agentclaw.community.utils.env_utils import get_current_env
 
 
 def _make_session():
@@ -159,7 +160,7 @@ def test_filter_candidates_returns_only_qualifying_bots():
     session.add(wl_entry)
     session.commit()
 
-    candidates = filter_candidates(session, N)
+    candidates = filter_candidates(session, N, env=get_current_env())
 
     candidate_ids = {c.bot_id for c in candidates}
 
@@ -183,6 +184,65 @@ def test_filter_candidates_returns_only_qualifying_bots():
         assert c.owner_id
         assert c.bot_name is not None  # may be empty string but should exist
 
+    session.close()
+
+
+@pytest.mark.integration
+def test_filter_candidates_only_uses_rows_from_requested_environment():
+    """A newer prod duplicate must not shadow the pre row during a pre scan."""
+    session = _make_session()
+    now = _now()
+    old_create = now - timedelta(days=60)
+    pre_bot = BotModel(
+        bot_id="shared_bot",
+        bot_name="Pre Bot",
+        entity_id="111",
+        entity_type="user",
+        creator_id="owner1",
+        owner_id="owner1",
+        status="ACTIVE",
+        is_delete=0,
+        bot_type="personal",
+        env="pre",
+        gmt_create=old_create,
+        gmt_modified=now - timedelta(days=1),
+    )
+    prod_bot = BotModel(
+        bot_id="shared_bot",
+        bot_name="Prod Bot",
+        entity_id="222",
+        entity_type="user",
+        creator_id="owner1",
+        owner_id="owner1",
+        status="ACTIVE",
+        is_delete=0,
+        bot_type="personal",
+        env="prod",
+        gmt_create=old_create,
+        gmt_modified=now,
+    )
+    prod_only = BotModel(
+        bot_id="prod_only",
+        bot_name="Prod Only",
+        entity_id="333",
+        entity_type="user",
+        creator_id="owner2",
+        owner_id="owner2",
+        status="ACTIVE",
+        is_delete=0,
+        bot_type="personal",
+        env="prod",
+        gmt_create=old_create,
+        gmt_modified=now,
+    )
+    session.add_all([pre_bot, prod_bot, prod_only])
+    session.commit()
+
+    candidates = filter_candidates(session, 30, env="pre")
+
+    assert [(c.bot_id, c.owner_id, c.entity_id) for c in candidates] == [
+        ("shared_bot", "owner1", "111"),
+    ]
     session.close()
 
 
@@ -237,7 +297,7 @@ def test_filter_candidates_deduplicates_same_bot_owner_pair():
     session.add_all([first, latest, other_owner])
     session.commit()
 
-    candidates = filter_candidates(session, N)
+    candidates = filter_candidates(session, N, env=get_current_env())
 
     dup_candidates = [
         c for c in candidates
@@ -279,7 +339,7 @@ def test_filter_candidates_empty_when_all_excluded():
     session.add(wl)
     session.commit()
 
-    candidates = filter_candidates(session, N)
+    candidates = filter_candidates(session, N, env=get_current_env())
     assert candidates == []
     session.close()
 
@@ -309,7 +369,7 @@ def test_filter_candidates_excludes_non_personal():
     session.add(team_bot)
     session.commit()
 
-    candidates = filter_candidates(session, N)
+    candidates = filter_candidates(session, N, env=get_current_env())
     assert not any(c.bot_id == "team_bot" for c in candidates)
     session.close()
 
@@ -339,6 +399,6 @@ def test_filter_candidates_excludes_deleted():
     session.add(deleted_bot)
     session.commit()
 
-    candidates = filter_candidates(session, N)
+    candidates = filter_candidates(session, N, env=get_current_env())
     assert not any(c.bot_id == "deleted_bot" for c in candidates)
     session.close()


### PR DESCRIPTION
## 问题

沉寂扫描候选查询没有按当前运行环境过滤。当 pre/prod 存在相同 `bot_id + owner_id`，或预发调用运维回收接口传入仅存在于生产的 Bot 时，预发可能读取到生产数据并继续产生通知、审计或回收副作用。

## 修复

- 候选查询显式接收当前环境，并增加 `BotModel.env == env` 条件。
- 定时扫描从运行环境获取 env，并传入候选查询。
- `recycle_one` 的首次 Bot 查询增加当前环境条件，在通知、审计、设备操作之前拒绝跨环境 Bot。
- 增加 pre/prod 同 key 和 prod-only 运维请求的回归测试。

本次不改表结构，也不向审计表新增 env 字段。

## 验证

- Backend full suite: `7833 passed`
- Dormant targeted suite: `152 passed`
- Ruff changed files: passed
- Change line coverage: `100.00% (4/4)`
- Pre-push SAST and Backend gate: passed
- Local singlebox coverage was skipped via the supported hook flag because bcsfuse wheels do not support the local Python 3.13 runtime; GitHub CI remains enabled.