### PR TITLE
fix(channel): resolve bot names in channel replies

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -16,7 +16,7 @@ use bcs_service_api::{
     MessageLogTargetSummary, MESSAGE_LOG_SCHEMA_VERSION, message_log_json,
     RouteParticipantOverlay, ResponseMode, RoutingDecision, RoutingMode, RoutingTarget,
     RunFallbackDelivery, ServiceError, ServiceResult, SystemMessageEvent, TaskCompleteCommand,
-    TaskDispatchCommand, TaskMessageCommand, backfill_bot_names,
+    TaskDispatchCommand, TaskMessageCommand, backfill_bot_names, backfill_participant_names,
 };
 use serde_json::Value;
 use tracing::{info, warn};
@@ -186,23 +186,7 @@ async fn try_channel_outbound(flow: &BcsMessageFlow, cmd: &BotEventCommand) {
         return;
     };
 
-    let (sender_role, sender_label) = match flow.group.get(&cmd.group_id).await {
-        Some(group) => group
-            .participants
-            .into_iter()
-            .find(|participant| participant.bot_uuid == cmd.bot_id)
-            .map(|participant| {
-                (
-                    participant.role,
-                    participant
-                        .bot_name
-                        .filter(|name| !name.trim().is_empty())
-                        .unwrap_or_else(|| cmd.bot_id.clone()),
-                )
-            })
-            .unwrap_or((bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone())),
-        None => (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone()),
-    };
+    let (sender_role, sender_label) = resolve_channel_sender(flow, cmd).await;
     let text = channel_outbound_text(kind, cmd);
     let raw_payload = if kind == ChannelOutboundEventKind::System {
         serde_json::json!({ "state": channel_terminal_state(&cmd.state) })
@@ -237,6 +221,53 @@ async fn try_channel_outbound(flow: &BcsMessageFlow, cmd: &BotEventCommand) {
     {
         warn!(run_id = %cmd.run_id, error = %error, "channel outbound hook failed");
     }
+}
+
+async fn resolve_channel_sender(
+    flow: &BcsMessageFlow,
+    cmd: &BotEventCommand,
+) -> (bcs_domain::ParticipantRole, String) {
+    let Some(group) = flow.group.get(&cmd.group_id).await else {
+        return (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone());
+    };
+    let Some(mut participant) = group
+        .participants
+        .into_iter()
+        .find(|participant| participant.bot_uuid == cmd.bot_id)
+    else {
+        return (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone());
+    };
+    let sender_role = participant.role;
+    if let Some(label) = participant_display_name(&participant) {
+        return (sender_role, label);
+    }
+    if let Some(label) = flow
+        .message_tracker
+        .channel_sender_label(&cmd.run_id)
+        .await
+    {
+        return (sender_role, label);
+    }
+
+    backfill_participant_names(
+        flow.registry.as_ref(),
+        std::slice::from_mut(&mut participant),
+    )
+    .await;
+    let label = participant_display_name(&participant).unwrap_or_else(|| cmd.bot_id.clone());
+    flow.message_tracker
+        .cache_channel_sender_label(&cmd.run_id, label.clone())
+        .await;
+    (sender_role, label)
+}
+
+fn participant_display_name(participant: &bcs_service_api::Participant) -> Option<String> {
+    participant
+        .bot_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty() && *name != participant.bot_uuid)
+        .map(str::to_string)
 }
 
 fn channel_event_kind(cmd: &BotEventCommand) -> Option<ChannelOutboundEventKind> {

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -227,38 +227,44 @@ async fn resolve_channel_sender(
     flow: &BcsMessageFlow,
     cmd: &BotEventCommand,
 ) -> (bcs_domain::ParticipantRole, String) {
-    let Some(group) = flow.group.get(&cmd.group_id).await else {
-        return (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone());
-    };
-    let Some(mut participant) = group
-        .participants
-        .into_iter()
-        .find(|participant| participant.bot_uuid == cmd.bot_id)
-    else {
-        return (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone());
-    };
-    let sender_role = participant.role;
-    if let Some(label) = participant_display_name(&participant) {
-        return (sender_role, label);
-    }
-    if let Some(label) = flow
+    if let Some(info) = flow
         .message_tracker
-        .channel_sender_label(&cmd.run_id)
+        .channel_sender_info(&cmd.run_id)
         .await
     {
-        return (sender_role, label);
+        return info;
     }
 
-    backfill_participant_names(
-        flow.registry.as_ref(),
-        std::slice::from_mut(&mut participant),
-    )
-    .await;
-    let label = participant_display_name(&participant).unwrap_or_else(|| cmd.bot_id.clone());
+    let info = match flow.group.get(&cmd.group_id).await {
+        Some(group) => match group
+            .participants
+            .into_iter()
+            .find(|participant| participant.bot_uuid == cmd.bot_id)
+        {
+            Some(mut participant) => {
+                let sender_role = participant.role;
+                let label = match participant_display_name(&participant) {
+                    Some(label) => label,
+                    None => {
+                        backfill_participant_names(
+                            flow.registry.as_ref(),
+                            std::slice::from_mut(&mut participant),
+                        )
+                        .await;
+                        participant_display_name(&participant)
+                            .unwrap_or_else(|| cmd.bot_id.clone())
+                    }
+                };
+                (sender_role, label)
+            }
+            None => (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone()),
+        },
+        None => (bcs_domain::ParticipantRole::Observer, cmd.bot_id.clone()),
+    };
     flow.message_tracker
-        .cache_channel_sender_label(&cmd.run_id, label.clone())
+        .cache_channel_sender_info(&cmd.run_id, info.clone())
         .await;
-    (sender_role, label)
+    info
 }
 
 fn participant_display_name(participant: &bcs_service_api::Participant) -> Option<String> {

--- a/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
@@ -44,6 +44,13 @@ pub struct MessageTracker {
     /// tool blocks. BCS rebuilds segment-local thinking text from `data.delta`
     /// and clears this buffer whenever a non-thinking stream event is observed.
     streaming_thinking_buf: Mutex<HashMap<String, String>>,
+    /// run_id → channel sender display name resolved from the bot registry.
+    ///
+    /// Provider bots do not heartbeat like WebSocket bots, so their registry
+    /// memory entry can expire while the persisted record remains available.
+    /// Cache the display-only lookup for the run instead of querying storage on
+    /// every streaming delta.
+    channel_sender_labels: Mutex<HashMap<String, String>>,
 }
 
 impl MessageTracker {
@@ -54,6 +61,7 @@ impl MessageTracker {
             streaming_chat_buf: Mutex::new(HashMap::new()),
             chat_delta_mode: Mutex::new(HashSet::new()),
             streaming_thinking_buf: Mutex::new(HashMap::new()),
+            channel_sender_labels: Mutex::new(HashMap::new()),
         }
     }
 
@@ -121,6 +129,17 @@ impl MessageTracker {
         self.streaming_thinking_buf.lock().await.remove(run_id);
     }
 
+    pub async fn channel_sender_label(&self, run_id: &str) -> Option<String> {
+        self.channel_sender_labels.lock().await.get(run_id).cloned()
+    }
+
+    pub async fn cache_channel_sender_label(&self, run_id: &str, label: String) {
+        self.channel_sender_labels
+            .lock()
+            .await
+            .insert(run_id.to_string(), label);
+    }
+
     /// Whether the run has received any `delta_text` frame (SSE self-accumulate
     /// mode). At `final`, delta-mode runs flush their accumulated buffer instead
     /// of overriding with the final frame's cumulative full text.
@@ -157,6 +176,7 @@ impl MessageTracker {
     pub async fn cleanup_run(&self, run_id: &str) -> Option<String> {
         self.chat_delta_mode.lock().await.remove(run_id);
         self.streaming_thinking_buf.lock().await.remove(run_id);
+        self.channel_sender_labels.lock().await.remove(run_id);
         self.streaming_chat_buf.lock().await.remove(run_id)
     }
 }

--- a/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
@@ -44,13 +44,13 @@ pub struct MessageTracker {
     /// tool blocks. BCS rebuilds segment-local thinking text from `data.delta`
     /// and clears this buffer whenever a non-thinking stream event is observed.
     streaming_thinking_buf: Mutex<HashMap<String, String>>,
-    /// run_id → channel sender display name resolved from the bot registry.
+    /// run_id → (sender role, channel sender display name).
     ///
     /// Provider bots do not heartbeat like WebSocket bots, so their registry
     /// memory entry can expire while the persisted record remains available.
-    /// Cache the display-only lookup for the run instead of querying storage on
-    /// every streaming delta.
-    channel_sender_labels: Mutex<HashMap<String, String>>,
+    /// Cache sender metadata for the run instead of reading the group and bot
+    /// registry on every streaming delta.
+    channel_sender_info: Mutex<HashMap<String, (bcs_domain::ParticipantRole, String)>>,
 }
 
 impl MessageTracker {
@@ -61,7 +61,7 @@ impl MessageTracker {
             streaming_chat_buf: Mutex::new(HashMap::new()),
             chat_delta_mode: Mutex::new(HashSet::new()),
             streaming_thinking_buf: Mutex::new(HashMap::new()),
-            channel_sender_labels: Mutex::new(HashMap::new()),
+            channel_sender_info: Mutex::new(HashMap::new()),
         }
     }
 
@@ -129,15 +129,22 @@ impl MessageTracker {
         self.streaming_thinking_buf.lock().await.remove(run_id);
     }
 
-    pub async fn channel_sender_label(&self, run_id: &str) -> Option<String> {
-        self.channel_sender_labels.lock().await.get(run_id).cloned()
+    pub async fn channel_sender_info(
+        &self,
+        run_id: &str,
+    ) -> Option<(bcs_domain::ParticipantRole, String)> {
+        self.channel_sender_info.lock().await.get(run_id).cloned()
     }
 
-    pub async fn cache_channel_sender_label(&self, run_id: &str, label: String) {
-        self.channel_sender_labels
+    pub async fn cache_channel_sender_info(
+        &self,
+        run_id: &str,
+        info: (bcs_domain::ParticipantRole, String),
+    ) {
+        self.channel_sender_info
             .lock()
             .await
-            .insert(run_id.to_string(), label);
+            .insert(run_id.to_string(), info);
     }
 
     /// Whether the run has received any `delta_text` frame (SSE self-accumulate
@@ -176,7 +183,7 @@ impl MessageTracker {
     pub async fn cleanup_run(&self, run_id: &str) -> Option<String> {
         self.chat_delta_mode.lock().await.remove(run_id);
         self.streaming_thinking_buf.lock().await.remove(run_id);
-        self.channel_sender_labels.lock().await.remove(run_id);
+        self.channel_sender_info.lock().await.remove(run_id);
         self.streaming_chat_buf.lock().await.remove(run_id)
     }
 }

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -731,6 +731,7 @@ async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
     let recording_channel = Arc::new(RecordingChannelService::default());
     let channel: Arc<dyn ChannelService> = recording_channel.clone();
     assert!(flow.channel_slot().set(channel).is_ok());
+    let group_get_count_before = support.group.get_count("group-1").await;
 
     for delta in ["你", "好"] {
         flow.handle_bot_event(BotEventCommand {
@@ -759,6 +760,11 @@ async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
             .await,
         1,
         "streaming deltas should resolve a missing provider bot name only once per run"
+    );
+    assert_eq!(
+        support.group.get_count("group-1").await - group_get_count_before,
+        1,
+        "streaming deltas should resolve sender role and name from the group only once per run"
     );
     assert_eq!(outbound[0].text.as_deref(), Some("你"));
     assert_eq!(outbound[0].raw_payload["message"]["content"][0]["text"], "你");
@@ -815,6 +821,13 @@ async fn bot_final_channel_outbound_resolves_missing_sender_name() {
     assert_eq!(outbound[0].kind, ChannelOutboundEventKind::ChatFinal);
     assert_eq!(outbound[0].sender_label, "Observer");
     assert_eq!(outbound[0].text.as_deref(), Some("你好"));
+    assert!(
+        flow.message_tracker
+            .channel_sender_info("run-channel-final")
+            .await
+            .is_none(),
+        "terminal run cleanup should remove cached channel sender metadata"
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -713,6 +713,14 @@ async fn terminal_cleanup_clears_thinking_delta_buffer_for_reused_run_id() {
 #[tokio::test]
 async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let mut group = support.group.get("group-1").await.unwrap();
+    group
+        .participants
+        .iter_mut()
+        .find(|participant| participant.bot_uuid == "bot-observer")
+        .unwrap()
+        .bot_name = None;
+    support.group.upsert(group).await.unwrap();
     let flow = BcsMessageFlow::new(
         support.group.clone(),
         support.routing.clone(),
@@ -743,6 +751,15 @@ async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
 
     let outbound = recording_channel.outbound().await;
     assert_eq!(outbound.len(), 2);
+    assert_eq!(outbound[0].sender_label, "Observer");
+    assert_eq!(
+        support
+            .registry
+            .including_deleted_get_count("bot-observer")
+            .await,
+        1,
+        "streaming deltas should resolve a missing provider bot name only once per run"
+    );
     assert_eq!(outbound[0].text.as_deref(), Some("你"));
     assert_eq!(outbound[0].raw_payload["message"]["content"][0]["text"], "你");
     assert_eq!(
@@ -751,6 +768,53 @@ async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
         "ChatDelta sent to channel adapters must stay incremental even when BCS synthesizes cumulative message.content for frontend rendering"
     );
     assert_eq!(outbound[1].raw_payload["message"]["content"][0]["text"], "你好");
+}
+
+#[tokio::test]
+async fn bot_final_channel_outbound_resolves_missing_sender_name() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let mut group = support.group.get("group-1").await.unwrap();
+    group
+        .participants
+        .iter_mut()
+        .find(|participant| participant.bot_uuid == "bot-observer")
+        .unwrap()
+        .bot_name = Some("bot-observer".to_string());
+    support.group.upsert(group).await.unwrap();
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+    let recording_channel = Arc::new(RecordingChannelService::default());
+    let channel: Arc<dyn ChannelService> = recording_channel.clone();
+    assert!(flow.channel_slot().set(channel).is_ok());
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-channel-final".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "chat.event".to_string(),
+        event_payload: json!({
+            "state": "final",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "你好"}],
+            },
+        }),
+        state: ChatEventState::Final,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .unwrap();
+
+    let outbound = recording_channel.outbound().await;
+    assert_eq!(outbound.len(), 1);
+    assert_eq!(outbound[0].kind, ChannelOutboundEventKind::ChatFinal);
+    assert_eq!(outbound[0].sender_label, "Observer");
+    assert_eq!(outbound[0].text.as_deref(), Some("你好"));
 }
 
 #[tokio::test]

--- a/src/bcs/crates/test-support/message_flow_contract_support.rs
+++ b/src/bcs/crates/test-support/message_flow_contract_support.rs
@@ -76,6 +76,7 @@ fn bot_participant(id: &str, name: &str, role: ParticipantRole) -> Participant {
 #[derive(Default)]
 pub struct FakeGroupCoreService {
     groups: RwLock<HashMap<String, Group>>,
+    get_counts: RwLock<HashMap<String, usize>>,
     message_counts: RwLock<HashMap<String, usize>>,
     fail_add_message: RwLock<bool>,
 }
@@ -83,6 +84,15 @@ pub struct FakeGroupCoreService {
 impl FakeGroupCoreService {
     pub async fn fail_add_message(&self) {
         *self.fail_add_message.write().await = true;
+    }
+
+    pub async fn get_count(&self, id: &str) -> usize {
+        self.get_counts
+            .read()
+            .await
+            .get(id)
+            .copied()
+            .unwrap_or_default()
     }
 }
 
@@ -94,6 +104,9 @@ impl GroupCoreService for FakeGroupCoreService {
     }
 
     async fn get(&self, id: &str) -> Option<Group> {
+        let mut counts = self.get_counts.write().await;
+        *counts.entry(id.to_string()).or_default() += 1;
+        drop(counts);
         self.groups.read().await.get(id).cloned()
     }
 

--- a/src/bcs/crates/test-support/message_flow_contract_support.rs
+++ b/src/bcs/crates/test-support/message_flow_contract_support.rs
@@ -416,6 +416,7 @@ pub struct FakeRegistryService {
     bots: RwLock<HashMap<String, RegisteredBot>>,
     protocol_versions: RwLock<HashMap<String, u32>>,
     delivery_targets: RwLock<HashMap<String, BotDeliveryTarget>>,
+    including_deleted_gets: RwLock<HashMap<String, usize>>,
 }
 
 impl FakeRegistryService {
@@ -441,6 +442,15 @@ impl FakeRegistryService {
                 status: ActorStatus::Online,
             },
         );
+    }
+
+    pub async fn including_deleted_get_count(&self, id: &str) -> usize {
+        self.including_deleted_gets
+            .read()
+            .await
+            .get(id)
+            .copied()
+            .unwrap_or_default()
     }
 
     pub async fn set_visibility(&self, id: &str, visibility: &str) {
@@ -499,6 +509,13 @@ impl BotRegistryCoreService for FakeRegistryService {
 
     async fn get(&self, bot_id: &str) -> Option<RegisteredBot> {
         self.bots.read().await.get(bot_id).cloned()
+    }
+
+    async fn get_including_deleted(&self, bot_id: &str) -> Option<RegisteredBot> {
+        let mut gets = self.including_deleted_gets.write().await;
+        *gets.entry(bot_id.to_string()).or_default() += 1;
+        drop(gets);
+        self.get(bot_id).await
     }
 
     async fn get_agent_credentials(&self, bot_id: &str) -> Option<AgentCredentials> {


### PR DESCRIPTION
## Summary

- Resolve channel outbound sender labels from the bot registry when the group participant name is missing or still equals the bot UUID.
- Cache the resolved display name per run so provider-backed streaming replies do not query storage for every delta.
- Clear the sender-label cache together with the existing terminal run cleanup.
- Cover both streaming delta and final-only channel delivery paths.

## Root cause

Provider bots are inserted into the process registry cache when registered, but they do not send WebSocket heartbeats. Their in-memory registration expires after five minutes, while `get_including_deleted` falls back to the persisted bot record without repopulating that cache. The channel outbound path did not perform the canonical name backfill and therefore fell back to the bot UUID. A naive per-delta backfill would also cause repeated database reads for streaming responses.

## Testing

- `cargo test -p bcs-message-flow`
- 193 tests passed.