### PR TITLE
fix(harness): reject unknown bots before diagnosis

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/harness/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/harness/router.py
@@ -94,6 +94,7 @@ from agentclaw.community.core.bot_collaborator.interceptor import (
     CollaboratorPermissionInterceptor,
     with_interceptors,
 )
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 
 logger = get_logger()
 
@@ -858,10 +859,14 @@ async def diagnose(
     scanner: ContentScannerProtocol = Injected(ContentScannerProtocol),
     scan_repo: HarnessScanRecordRepository = Injected(HarnessScanRecordRepository),
     patch_planner: PatchPlannerProtocol = Injected(PatchPlannerProtocol),
+    bot_repo: BotRepository = Injected(BotRepository),
 ):
     """Start an async diagnostic scan. Returns scan_id for polling."""
     if not body.bot_id or not body.entity_id:
         raise HTTPException(status_code=400, detail="bot_id and entity_id are required")
+
+    if not bot_repo.get_by_id_and_owner(body.bot_id, body.entity_id):
+        raise HTTPException(status_code=404, detail=f"Bot not found: {body.bot_id}")
 
     # Dedup check: reject if there is an unfinished scan created within 5 minutes
     if scan_repo.has_active_scan(

--- a/src/backend/tests/community/endpoints/test_harness_router.py
+++ b/src/backend/tests/community/endpoints/test_harness_router.py
@@ -1,0 +1,73 @@
+"""Tests for collaborator-protected Harness endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentclaw.community.core.harness.repository_protocol import (
+    HarnessScanRecordRepository,
+)
+from tests.community.factories.access import make_staff_user
+from tests.community.factories.bot_collaborator import make_bot
+
+
+@pytest.fixture
+def client(app_with_testing_modules):
+    return TestClient(app_with_testing_modules)
+
+
+def _discard_background_task(coroutine):
+    coroutine.close()
+
+
+def test_diagnose_rejects_nonexistent_bot_without_creating_scan(client, world):
+    make_staff_user(world, user_id="u_owner")
+    scan_repo = world.get(HarnessScanRecordRepository)
+
+    with (
+        patch.object(scan_repo, "create", wraps=scan_repo.create) as create_scan,
+        patch(
+            "agentclaw.community.adapters.http.harness.router.asyncio.create_task",
+            side_effect=_discard_background_task,
+        ) as create_task,
+    ):
+        response = client.post(
+            "/api/harness/diagnose",
+            headers={"x-user-id": "u_owner"},
+            json={
+                "bot_id": "nonexistent_bot",
+                "entity_id": "u_owner",
+                "entity_type": "staff",
+            },
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Bot not found: nonexistent_bot"
+    create_scan.assert_not_called()
+    create_task.assert_not_called()
+
+
+def test_diagnose_starts_scan_for_existing_bot(client, world):
+    make_staff_user(world, user_id="u_owner")
+    make_bot(world, bot_id="bot_test", owner_id="u_owner")
+
+    with patch(
+        "agentclaw.community.adapters.http.harness.router.asyncio.create_task",
+        side_effect=_discard_background_task,
+    ) as create_task:
+        response = client.post(
+            "/api/harness/diagnose",
+            headers={"x-user-id": "u_owner"},
+            json={
+                "bot_id": "bot_test",
+                "entity_id": "u_owner",
+                "entity_type": "staff",
+            },
+        )
+
+    assert response.status_code == 202
+    assert response.json()["status"] == "scanning"
+    create_task.assert_called_once()


### PR DESCRIPTION
## 问题

`POST /api/harness/diagnose` 只校验 `bot_id` 非空并检查重复扫描，没有确认该 Bot 是否真实存在且属于当前用户。不存在的 `bot_id` 因此仍会创建扫描记录并启动后台任务。

## 修复

- 在创建扫描记录前，通过 `BotRepository.get_by_id_and_owner` 校验 Bot 归属与存在性。
- Bot 不存在时返回 HTTP 404，且不创建扫描记录、不启动后台任务。
- 补充不存在 Bot 与正常 Bot 两条端点回归测试。

## 验证

- 定向端点测试：15 passed
- Backend 全量门禁：7922 passed
- changed-line coverage：100%
- singlebox live acceptance / coverage gate：passed

## 关联工作项

- https://project.alipay.com/space/W26001113566/sprint/detail?workItemView=2300100000023&sprintId=S26001084781&openWorkItemId=2026071500117452182&status=status
