### PR TITLE
feat(engine): support session-key lookup and inject event delivery

### DIFF
--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -109,6 +109,7 @@ def _message_to_dict(msg) -> Dict:
 async def list_sessions(
     user_id: Optional[str] = None,
     agent_id: Optional[str] = None,
+    session_key: str | None = None,
     limit: int = 20,
     offset: int = 0,
     engine: Optional[str] = None,
@@ -118,7 +119,11 @@ async def list_sessions(
     try:
         api = _get_session_api(engine)
         sessions = await api.list(SessionListRequest(
-            user_id=user_id, agent_id=agent_id, limit=limit, offset=offset,
+            user_id=user_id,
+            agent_id=agent_id,
+            session_key=session_key,
+            limit=limit,
+            offset=offset,
         ))
         log.info(f"[list_sessions] 查询完成, 返回 {len(sessions)} 条会话")
         return ApiResponse(

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -95,6 +95,12 @@ class TestListSessions:
         assert call_args.limit == 5
         assert call_args.offset == 10
 
+    def test_session_key_query_param_forwarded(self, client, mock_session_api):
+        resp = client.get("/api/sessions?session_key=session%3Atarget")
+        assert resp.status_code == 200
+        call_args = mock_session_api.list.call_args[0][0]
+        assert call_args.session_key == "session:target"
+
     def test_service_error_returns_500(self, client, mock_session_api):
         mock_session_api.list.side_effect = RuntimeError("db error")
         resp = client.get("/api/sessions")

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -92,6 +92,7 @@ class TestListSessions:
         call_args = mock_session_api.list.call_args[0][0]
         assert call_args.user_id == "u1"
         assert call_args.agent_id == "a1"
+        assert call_args.session_key is None
         assert call_args.limit == 5
         assert call_args.offset == 10
 

--- a/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
+++ b/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
@@ -1726,6 +1726,51 @@ class TestChatInjectDispatch:
         assert response.ok is False
         assert response.error.code == "METHOD_NOT_SUPPORTED"
         assert "no handler" in response.error.message
+        assert server._session_subscribers == {}
+        assert server._conn_sessions == {}
+
+    @pytest.mark.asyncio
+    async def test_inject_failure_keeps_existing_auto_subscription(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        fake_engine.chat = _FakeChatServiceWithInject(return_value={
+            "ok": False,
+            "error": {"code": "METHOD_NOT_SUPPORTED", "message": "no handler"},
+        })
+        server._session_subscribers = {"sk-1": {"conn-1"}}
+        server._conn_sessions = {"conn-1": {"sk-1"}}
+
+        response, _events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.inject", {"sessionKey": "sk-1", "message": "hi"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is False
+        assert server._session_subscribers == {"sk-1": {"conn-1"}}
+        assert server._conn_sessions == {"conn-1": {"sk-1"}}
+
+    @pytest.mark.asyncio
+    async def test_inject_dispatch_exception_removes_new_auto_subscription(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        server._forward_chat_inject_with_session_autocreate = AsyncMock(
+            side_effect=RuntimeError("relay down"),
+        )
+
+        response, _events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.inject", {"sessionKey": "sk-1", "message": "hi"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is False
+        assert response.error.code == "INTERNAL_ERROR"
+        assert server._session_subscribers == {}
+        assert server._conn_sessions == {}
 
     @pytest.mark.asyncio
     async def test_inject_service_exception_surfaces_internal_error(

--- a/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
+++ b/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
@@ -1612,6 +1612,32 @@ class TestChatInjectDispatch:
         ]
 
     @pytest.mark.asyncio
+    async def test_invalid_openclaw_inject_keeps_legacy_forwarding_without_subscription(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        expected_response = ResponseFrame.ok_response("r-1", {})
+        server._forward_chat_inject_with_session_autocreate = AsyncMock(
+            return_value=(expected_response, []),
+        )
+
+        request = _req("chat.inject", {"message": "hello"})
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=request,
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response is expected_response
+        assert events == []
+        server._forward_chat_inject_with_session_autocreate.assert_awaited_once_with(
+            "conn-1", request,
+        )
+        assert server._session_subscribers == {}
+        assert server._conn_sessions == {}
+
+    @pytest.mark.asyncio
     async def test_inject_success_forwards_to_service(self, server, fake_engine, auth_gate_service):
         fake_chat = _FakeChatServiceWithInject(
             return_value={"ok": True, "payload": {"injected": True}},

--- a/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
+++ b/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
@@ -1557,6 +1557,61 @@ class TestChatInjectDispatch:
     """覆盖 chat.inject 分支调用 ChatService.inject 的成功 / 失败 / 兜底路径."""
 
     @pytest.mark.asyncio
+    async def test_inject_auto_subscribes_connection_before_dispatch(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        fake_chat = _FakeChatServiceWithInject()
+        bind_listener = AsyncMock(return_value=True)
+        server._ensure_openclaw_inject_listener = bind_listener
+
+        async def inject(**_kwargs):
+            assert server._session_subscribers == {"sk-1": {"conn-1"}}
+            assert server._conn_sessions == {"conn-1": {"sk-1"}}
+            bind_listener.assert_awaited_once_with("conn-1")
+            return {"ok": True, "payload": {"injected": True}}
+
+        fake_chat.inject = inject
+        fake_engine.chat = fake_chat
+
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.inject", {"sessionKey": "sk-1", "message": "hello"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_openclaw_inject_auto_binds_live_event_listener(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        EngineManager.get_instance()._engine = "openclaw"
+        client = MagicMock(name="OpenClawClient")
+        client.on_event = MagicMock()
+        fake_engine.token_pool.get = AsyncMock(return_value=client)
+        fake_engine.relay.forward_request = AsyncMock(
+            return_value=ResponseFrame.ok_response("r-1", {"injected": True}),
+        )
+
+        response, events = await server._handle_request(
+            websocket=MagicMock(),
+            conn_id="conn-1",
+            request=_req("chat.inject", {"sessionKey": "sk-1", "message": "hello"}),
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        assert events == []
+        assert server._session_subscribers == {"sk-1": {"conn-1"}}
+        assert server._conn_sessions == {"conn-1": {"sk-1"}}
+        assert [call.args[0] for call in client.on_event.call_args_list] == [
+            "chat",
+            "agent",
+        ]
+
+    @pytest.mark.asyncio
     async def test_inject_success_forwards_to_service(self, server, fake_engine, auth_gate_service):
         fake_chat = _FakeChatServiceWithInject(
             return_value={"ok": True, "payload": {"injected": True}},
@@ -1604,6 +1659,8 @@ class TestChatInjectDispatch:
         assert response.error is not None
         # 缺 sessionKey: dispatch 层立即拒绝, service 不应被调到
         assert fake_engine.chat.calls == []
+        assert server._session_subscribers == {}
+        assert server._conn_sessions == {}
 
     @pytest.mark.asyncio
     async def test_inject_missing_message_returns_invalid_request(

--- a/src/engine/src/engine/community/api/transport/ws_server.py
+++ b/src/engine/src/engine/community/api/transport/ws_server.py
@@ -458,20 +458,10 @@ class EngineWebSocketServer:
                     k: v for k, v in params.items() if k in allowed and v is not None
                 }
                 session_key = request.params.get("sessionKey")
-                if not session_key:
-                    return ResponseFrame.err_response(
-                        request.id,
-                        ErrorShape(ErrorCodes.INVALID_REQUEST, "Missing sessionKey"),
-                    ), []
-                if not request.params.get("message"):
-                    return ResponseFrame.err_response(
-                        request.id,
-                        ErrorShape(ErrorCodes.INVALID_REQUEST, "Missing message"),
-                    ), []
-
-                # An inject event may arrive before its RPC response. Subscribe before
-                # dispatching so the originating connection cannot miss that event.
-                await self._subscribe_conn_to_session(conn_id, session_key)
+                if session_key and request.params.get("message"):
+                    # An inject event may arrive before its RPC response. Subscribe before
+                    # dispatching so the originating connection cannot miss that event.
+                    await self._subscribe_conn_to_session(conn_id, session_key)
                 # 优先调用 active engine 的 chat plugin.inject (claude_code 走 RPC 透传到 relay,
                 # 同时给业务层提供统一入口); 不实现 inject 的 engine (openclaw 走 gateway
                 # 原生 chat.inject) 仍走 _forward_request 透传分支.

--- a/src/engine/src/engine/community/api/transport/ws_server.py
+++ b/src/engine/src/engine/community/api/transport/ws_server.py
@@ -457,6 +457,21 @@ class EngineWebSocketServer:
                 request.params = {
                     k: v for k, v in params.items() if k in allowed and v is not None
                 }
+                session_key = request.params.get("sessionKey")
+                if not session_key:
+                    return ResponseFrame.err_response(
+                        request.id,
+                        ErrorShape(ErrorCodes.INVALID_REQUEST, "Missing sessionKey"),
+                    ), []
+                if not request.params.get("message"):
+                    return ResponseFrame.err_response(
+                        request.id,
+                        ErrorShape(ErrorCodes.INVALID_REQUEST, "Missing message"),
+                    ), []
+
+                # An inject event may arrive before its RPC response. Subscribe before
+                # dispatching so the originating connection cannot miss that event.
+                await self._subscribe_conn_to_session(conn_id, session_key)
                 # 优先调用 active engine 的 chat plugin.inject (claude_code 走 RPC 透传到 relay,
                 # 同时给业务层提供统一入口); 不实现 inject 的 engine (openclaw 走 gateway
                 # 原生 chat.inject) 仍走 _forward_request 透传分支.
@@ -628,9 +643,7 @@ class EngineWebSocketServer:
                 ErrorShape(ErrorCodes.INVALID_REQUEST, "Missing sessionKey"),
             ), []
 
-        self._session_subscribers.setdefault(session_key, set()).add(conn_id)
-        self._conn_sessions.setdefault(conn_id, set()).add(session_key)
-        live_inject = await self._ensure_openclaw_inject_listener(conn_id)
+        live_inject = await self._subscribe_conn_to_session(conn_id, session_key)
         return ResponseFrame.ok_response(
             request.id,
             {
@@ -659,6 +672,12 @@ class EngineWebSocketServer:
             request.id,
             {"unsubscribed": True, "sessionKey": session_key},
         ), []
+
+    async def _subscribe_conn_to_session(self, conn_id: str, session_key: str) -> bool:
+        """Register a connection for one session and bind its live inject listener."""
+        self._session_subscribers.setdefault(session_key, set()).add(conn_id)
+        self._conn_sessions.setdefault(conn_id, set()).add(session_key)
+        return await self._ensure_openclaw_inject_listener(conn_id)
 
     def _unsubscribe_conn(self, conn_id: str) -> None:
         for session_key in list(self._conn_sessions.pop(conn_id, set())):

--- a/src/engine/src/engine/community/api/transport/ws_server.py
+++ b/src/engine/src/engine/community/api/transport/ws_server.py
@@ -458,9 +458,13 @@ class EngineWebSocketServer:
                     k: v for k, v in params.items() if k in allowed and v is not None
                 }
                 session_key = request.params.get("sessionKey")
+                auto_subscription_added = False
                 if session_key and request.params.get("message"):
                     # An inject event may arrive before its RPC response. Subscribe before
                     # dispatching so the originating connection cannot miss that event.
+                    auto_subscription_added = conn_id not in self._session_subscribers.get(
+                        session_key, set()
+                    )
                     await self._subscribe_conn_to_session(conn_id, session_key)
                 # 优先调用 active engine 的 chat plugin.inject (claude_code 走 RPC 透传到 relay,
                 # 同时给业务层提供统一入口); 不实现 inject 的 engine (openclaw 走 gateway
@@ -469,9 +473,27 @@ class EngineWebSocketServer:
                 # __dict__ 检查, 避免 MagicMock 自动属性误触发新分支.
                 # 排查日志关键字: [ws_server chat.inject]
                 chat_plugin = EngineManager.get_instance().chat
-                if chat_plugin is not None and _chat_plugin_supports_inject(chat_plugin):
-                    return await self._handle_chat_inject(conn_id, request, request.params)
-                return await self._forward_chat_inject_with_session_autocreate(conn_id, request)
+                try:
+                    if chat_plugin is not None and _chat_plugin_supports_inject(chat_plugin):
+                        result = await self._handle_chat_inject(
+                            conn_id, request, request.params
+                        )
+                    else:
+                        result = await self._forward_chat_inject_with_session_autocreate(
+                            conn_id, request
+                        )
+                except Exception:
+                    if auto_subscription_added:
+                        # Preserve an earlier successful inject subscription for this session.
+                        self._unsubscribe_conn_from_session(conn_id, session_key)
+                        self._drop_idle_inject_listeners()
+                    raise
+
+                if auto_subscription_added and not result[0].ok:
+                    # Failed injects must not retain subscriptions created only for this request.
+                    self._unsubscribe_conn_from_session(conn_id, session_key)
+                    self._drop_idle_inject_listeners()
+                return result
             else:
                 return await self._forward_request(conn_id, request)
         except Exception as e:

--- a/src/engine/src/engine/community/core/adapters/openclaw/session.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/session.py
@@ -199,9 +199,10 @@ class OpenClawSessionAdapter(SessionService):
         """List sessions matching the request filter.
 
         The port handles the complete legacy ordering: sessions.list RPC →
-        bcs:group filter → agent_id filter → paginate → chat.history (page only)
-        → Bot 初始化配置 filter → model normalisation.  The adapter receives
-        the already-filtered, already-paginated page and only builds DTOs.
+        bcs:group filter → agent_id/session_key filters → paginate →
+        chat.history (page only) → Bot 初始化配置 filter → model normalisation.
+        The adapter receives the already-filtered, already-paginated page and
+        only builds DTOs.
         """
         token = auth.token if auth is not None else None
         log.info("[list] user_id=%s, agent_id=%s", request.user_id, request.agent_id)
@@ -211,6 +212,7 @@ class OpenClawSessionAdapter(SessionService):
             offset=request.offset,
             limit=request.limit,
             agent_id=request.agent_id,
+            session_key=request.session_key,
         )
 
         sessions: list[Session] = []

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_session.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_session.py
@@ -136,15 +136,24 @@ class _FakeSessionPort:
         offset: int = 0,
         limit: int = 50,
         agent_id: str | None = None,
+        session_key: str | None = None,
     ) -> list[dict]:
         self.sessions_list_calls.append(
-            {"token": token, "offset": offset, "limit": limit, "agent_id": agent_id}
+            {
+                "token": token,
+                "offset": offset,
+                "limit": limit,
+                "agent_id": agent_id,
+                "session_key": session_key,
+            }
         )
-        # Mirror the real port: pagination + agent_id filtering happen HERE
+        # Mirror the real port: request filtering happens before pagination.
         # (the adapter forwards the primitives and only builds DTOs).
         result = self._sessions_list_result
         if agent_id is not None:
             result = [s for s in result if s.get("agentId") == agent_id]
+        if session_key and session_key.strip():
+            result = [s for s in result if s.get("key") == session_key]
         return result[offset : offset + limit]
 
     async def session_create(
@@ -250,6 +259,16 @@ async def test_list_forwards_pagination_to_port():
     assert len(sessions) == 2
     assert sessions[0].key == "session:2:user:default"
     assert sessions[1].key == "session:3:user:default"
+
+
+@pytest.mark.asyncio
+async def test_list_forwards_session_key_to_port():
+    port = _FakeSessionPort()
+    adapter = OpenClawSessionAdapter(port)
+
+    await adapter.list(SessionListRequest(session_key="session:target"))
+
+    assert port.sessions_list_calls[0]["session_key"] == "session:target"
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/core/session/models.py
+++ b/src/engine/src/engine/community/core/session/models.py
@@ -53,6 +53,7 @@ class Message(BaseModel):
 class SessionListRequest(BaseModel):
     user_id: str | None = None
     agent_id: str | None = None
+    session_key: str | None = None
     status: Literal["active", "archived", "all"] = "active"
     limit: int = 20
     offset: int = 0

--- a/src/engine/src/engine/community/local/openclaw/plugin_impl.py
+++ b/src/engine/src/engine/community/local/openclaw/plugin_impl.py
@@ -155,8 +155,13 @@ class LocalOpenClawPluginImpl(OpenClawPlugin):
         offset: int = 0,
         limit: int = 50,
         agent_id: str | None = None,
+        session_key: str | None = None,
     ) -> list[dict]:
         items = list(self._sessions.values())
+        requested_session_key = session_key if session_key and session_key.strip() else None
+        if requested_session_key is not None:
+            # Keep local mode aligned with production: filter before pagination.
+            items = [item for item in items if item.get("key") == requested_session_key]
         return items[offset: offset + limit]
 
     async def session_create(

--- a/src/engine/src/engine/community/plugin_api/openclaw/session.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/session.py
@@ -26,6 +26,7 @@ class OpenClawSessionPort(Protocol):
         offset: int = 0,
         limit: int = 50,
         agent_id: str | None = None,
+        session_key: str | None = None,
     ) -> list[dict]:
         """Orchestrate `sessions.list` + bcs filter + paginate + chat.history + init filter.
 
@@ -33,11 +34,12 @@ class OpenClawSessionPort(Protocol):
           1. `sessions.list` RPC → raw sessions
           2. Filter out `bcs:group` sessions (keep `bcs:group:bcs-cli`)
           3. Filter by `agent_id` if provided (request-param-driven but primitive)
-          4. Paginate: slice `[offset : offset+limit]`
-          5. Fetch `chat.history` ONLY for the paginated page sessions
-          6. Filter out single-message "Bot 初始化配置" sessions from the page
-          7. Normalise model strings via `providers.available` (cached)
-          8. Return the final page dicts (with `_messages` and `_message_count` populated)
+          4. Filter by exact non-blank `session_key` if provided
+          5. Paginate: slice `[offset : offset+limit]`
+          6. Fetch `chat.history` ONLY for the paginated page sessions
+          7. Filter out single-message "Bot 初始化配置" sessions from the page
+          8. Normalise model strings via `providers.available` (cached)
+          9. Return the final page dicts (with `_messages` and `_message_count` populated)
 
         Pagination is performed BEFORE the per-session `chat.history` RPCs so
         that history is fetched only for the visible page — matching legacy

--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -102,6 +102,7 @@ class _SessionPortMixin:
         offset: int = 0,
         limit: int = 50,
         agent_id: str | None = None,
+        session_key: str | None = None,
     ) -> list[dict[str, Any]]:
         """Orchestrate session listing with the exact legacy ordering.
 
@@ -109,11 +110,12 @@ class _SessionPortMixin:
           1. `sessions.list` RPC → raw sessions
           2. Filter `bcs:group` sessions (gateway-cleanup, fixed)
           3. Filter by `agent_id` if provided
-          4. Paginate: slice `[offset : offset+limit]` — BEFORE history fetch
-          5. Fetch `chat.history` ONLY for the paginated page sessions
-          6. Filter "Bot 初始化配置" single-message sessions from the page
-          7. Normalise model strings (cached provider map)
-          8. Return the final page dicts with `_messages`/`_message_count` set
+          4. Filter by exact non-blank `session_key` if provided
+          5. Paginate: slice `[offset : offset+limit]` — BEFORE history fetch
+          6. Fetch `chat.history` ONLY for the paginated page sessions
+          7. Filter "Bot 初始化配置" single-message sessions from the page
+          8. Normalise model strings (cached provider map)
+          9. Return the final page dicts with `_messages`/`_message_count` set
 
         Returns `[]` on gateway error.  A page may return fewer than `limit`
         items when "Bot 初始化配置" sessions fall within it (exact legacy
@@ -160,14 +162,19 @@ class _SessionPortMixin:
         if agent_id is not None:
             raw_sessions = [s for s in raw_sessions if s.get("agentId") == agent_id]
 
-        # Step 4: Paginate BEFORE history fetch (legacy ordering).
+        requested_session_key = session_key if session_key and session_key.strip() else None
+        if requested_session_key is not None:
+            # Filter before pagination so a copied key can be found beyond the current page.
+            raw_sessions = [s for s in raw_sessions if s.get("key") == requested_session_key]
+
+        # Step 5: Paginate BEFORE history fetch (legacy ordering).
         page = raw_sessions[offset: offset + limit]
 
         # Build/retrieve the cached provider map (FIX 2 — at most one RPC ever).
         provider_map = await self._get_provider_map(client)
 
-        # Step 5: Fetch chat.history ONLY for the page sessions.
-        # Step 6: Filter "Bot 初始化配置" single-message init sessions from page.
+        # Step 6: Fetch chat.history ONLY for the page sessions.
+        # Step 7: Filter "Bot 初始化配置" single-message init sessions from page.
         enriched: list[dict[str, Any]] = []
         for s in page:
             key = s.get("key", "")
@@ -194,7 +201,7 @@ class _SessionPortMixin:
 
             enriched.append(s)
 
-        # Step 7: Normalise model strings in place.
+        # Step 8: Normalise model strings in place.
         # gateway 的 sessions.list 每行已经把 provider 拆到独立字段 modelProvider
         # （见 openclaw session-utils.ts resolveSessionDisplayModelIdentityRef:
         # 非 CLI provider 原样返回），model 字段是 bare id。优先用 row 上现成的

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -224,6 +224,55 @@ class TestSessionsList:
         assert history_calls[0][1]["sessionKey"] == "s2"
         assert history_calls[1][1]["sessionKey"] == "s3"
 
+    async def test_session_key_filter_applied_before_pagination(self):
+        sessions = [
+            {"key": f"s{i}", "label": f"Session {i}", "model": None}
+            for i in range(21)
+        ]
+        impl, client = _make_impl({
+            "sessions.list": self._sessions_payload(sessions),
+            "chat.history": self._history_payload([
+                {"id": "m1", "role": "user", "content": "hi"},
+            ]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(token="tok", session_key="s20", limit=1)
+
+        assert [session["key"] for session in result] == ["s20"]
+        history_calls = [call for call in client.calls if call[0] == "chat.history"]
+        assert [call[1]["sessionKey"] for call in history_calls] == ["s20"]
+
+    async def test_session_key_filter_returns_empty_list_for_no_match(self):
+        impl, client = _make_impl({
+            "sessions.list": self._sessions_payload([
+                {"key": "s1", "label": "Session 1", "model": None},
+            ]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(token="tok", session_key="missing")
+
+        assert result == []
+        assert not [call for call in client.calls if call[0] == "chat.history"]
+
+    async def test_blank_session_key_keeps_existing_pagination(self):
+        sessions = [
+            {"key": "s0", "label": "Session 0", "model": None},
+            {"key": "s1", "label": "Session 1", "model": None},
+        ]
+        impl, _ = _make_impl({
+            "sessions.list": self._sessions_payload(sessions),
+            "chat.history": self._history_payload([
+                {"id": "m1", "role": "user", "content": "hi"},
+            ]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(token="tok", session_key="   ", offset=1, limit=1)
+
+        assert [session["key"] for session in result] == ["s1"]
+
     async def test_model_normalization_present(self):
         """_normalized_model is set for each returned session dict."""
         sessions = [{"key": "s1", "label": "S1", "model": "qwen-plus"}]

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_local_plugin.py
@@ -91,6 +91,9 @@ async def test_local_openclaw_plugin_stateful_ports_and_error_branches():
     await plugin.session_create("s1", label="one", model="m1")
     await plugin.session_create("s2", label="two", model="m2")
     assert [s["key"] for s in await plugin.sessions_list(offset=1, limit=1)] == ["s2"]
+    assert [s["key"] for s in await plugin.sessions_list(session_key="s2", limit=1)] == ["s2"]
+    assert await plugin.sessions_list(session_key="missing") == []
+    assert [s["key"] for s in await plugin.sessions_list(session_key="   ", limit=1)] == ["s1"]
     await plugin.session_patch_then_get("s1", label="patched")
     assert (await plugin.sessions_list())[0]["label"] == "patched"
     await plugin.session_patch_then_get("new", model="m3")


### PR DESCRIPTION
## Summary
- Add optional `session_key` lookup to `GET /api/sessions` for OpenClaw, applying exact matching before pagination.
- Automatically subscribe valid `chat.inject` callers before dispatch so inject events cannot race ahead of the RPC response.
- Preserve existing behavior when `session_key` is omitted or blank, for malformed OpenClaw inject requests, and for clients that still explicitly call `chat.subscribe`.

## Validation
- `188 passed` across the affected session, OpenClaw port, local-plugin contract, and WebSocket transport suites.
- Changed-line coverage: `100%` (92/92) against `origin/dev`.
- Ruff and `git diff --check` passed (aside from a pre-existing unused import warning in the session-router test file).