### PR TITLE
feat: integrate ClawMind as LOCAL/stdio MCP Server for claude_code en…

### DIFF
--- a/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
+++ b/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
@@ -9,3 +9,10 @@ servers:
     command: "python3"
     args:
       - "/home/admin/hitl/hitl_mcp_server.py"
+  clawmind:
+    command: "node"
+    args:
+      - "/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js"
+    env:
+      MCP_TRANSPORT: "stdio"
+      CCT_SOP_MCP_SERVER_MODE: "prod"

--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -59,6 +59,7 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
         {"server_code": "mcp.ant.faas.aixjiter.AixCodingMemoryMCP"},
         {"server_code": "mcp.ant.rgmcpserver.rgfastcheckmcpserver"},
         {"server_code": "hitl"},
+        {"server_code": "clawmind"},
     ],
     "hermes": [
         {"server_code": "mcp.ant.antprocessai.anttaskmcp"},

--- a/src/backend/tests/community/core/mcp/services/test_local_mcp_registry.py
+++ b/src/backend/tests/community/core/mcp/services/test_local_mcp_registry.py
@@ -132,6 +132,23 @@ def test_default_config_path_loads_repo_hitl_config():
     assert detail["stdioConfigs"][0]["arguments"] == ["/home/admin/hitl/hitl_mcp_server.py"]
 
 
+def test_default_config_path_loads_repo_clawmind_config():
+    detail = LocalMCPRegistry().get_mcp_detail("clawmind")
+
+    assert detail is not None
+    assert detail["serverCode"] == "clawmind"
+    assert detail["runMode"] == "LOCAL"
+    assert detail["stdioConfigs"][0]["command"] == "node"
+    assert detail["stdioConfigs"][0]["arguments"] == [
+        "/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js"
+    ]
+    env = detail["stdioConfigs"][0].get("envVariables", {})
+    assert env.get("MCP_TRANSPORT") == "stdio"
+    assert env.get("CCT_SOP_MCP_SERVER_MODE") == "prod"
+    # SKILL_ROOT, DATABASE_MODE and CLAWWEB_API_URL come from ClawMind's own
+    # configs/application.yaml / process.cwd() fallback, not from mcporter.json env
+
+
 def test_default_config_path_falls_back_when_repo_marker_missing(monkeypatch):
     monkeypatch.setattr("agentclaw.community.core.mcp.services.local_mcp_registry.Path", _NoRepoPath)
 

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -43,8 +43,8 @@ def test_claude_code_merges_aicoding_research_mcps():
         assert code in codes, f"missing aicoding-only MCP in claude_code: {code}"
     # 无重复。
     assert len(codes) == len(set(codes))
-    # 12 原有 + 6 新增 = 18。
-    assert len(codes) == 18
+    # 12 原有 + 6 新增 + 1 clawmind = 19。
+    assert len(codes) == 19
 
 
 def test_aicoding_has_its_own_list():
@@ -73,6 +73,13 @@ def test_hitl_is_default_for_mcp_enabled_engines():
     assert "hitl" in get_default_mcp_server_codes("hermes")
     assert "hitl" in get_default_mcp_server_codes("aicoding")
     assert "hitl" not in get_default_mcp_server_codes("moltis")
+
+
+def test_clawmind_is_default_for_claude_code_only():
+    assert "clawmind" in get_default_mcp_server_codes("claude_code")
+    assert "clawmind" not in get_default_mcp_server_codes("openclaw")
+    assert "clawmind" not in get_default_mcp_server_codes("hermes")
+    assert "clawmind" not in get_default_mcp_server_codes("aicoding")
 
 
 def test_bcs_mcp_is_default_for_mcp_enabled_engines():

--- a/src/engine/src/engine/community/claude_code_gateway/test/mcp.test.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/test/mcp.test.ts
@@ -104,6 +104,74 @@ describe('McpStore', () => {
     assert.equal(s.list().length, 0);
   });
 
+  it('stdio create with env round-trips through disk intact', async () => {
+    const s = new McpStore(p, { writeDebounceMs: 0 });
+    // SKILL_ROOT, DATABASE_MODE and CLAWWEB_API_URL come from ClawMind's own
+    // configs/application.yaml / process.cwd() fallback, not from mcporter.json env
+    const env = {
+      MCP_TRANSPORT: 'stdio',
+      CCT_SOP_MCP_SERVER_MODE: 'prod',
+    };
+    const created = s.create({
+      serverCode: 'clawmind',
+      type: 'stdio',
+      command: 'node',
+      args: ['/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js'],
+      env,
+      headers: {},
+      timeout_seconds: 30,
+      enabled: true,
+      description: 'ClawMind workflow engine',
+    });
+    assert.equal(created.serverCode, 'clawmind');
+    assert.equal(created.type, 'stdio');
+    assert.equal(created.command, 'node');
+    assert.deepEqual(created.args, ['/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js']);
+    assert.deepEqual(created.env, env);
+    assert.equal('CallerToken' in created.headers, false, 'stdio should not get CallerToken on create');
+
+    await s.flush();
+    const s2 = new McpStore(p, { writeDebounceMs: 0 });
+    const loaded = s2.get('clawmind');
+    assert.ok(loaded);
+    assert.equal(loaded.type, 'stdio');
+    assert.equal(loaded.command, 'node');
+    assert.deepEqual(loaded.args, ['/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js']);
+    assert.deepEqual(loaded.env, env, 'env must survive disk round-trip');
+    assert.equal('CallerToken' in loaded.headers, false, 'stdio should not get CallerToken after reload');
+
+    // Verify on-disk JSON has the env keys
+    const disk = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const entry = disk.mcpServers.clawmind;
+    assert.ok(entry.env);
+    assert.equal(entry.env.MCP_TRANSPORT, 'stdio');
+    assert.equal(entry.env.CCT_SOP_MCP_SERVER_MODE, 'prod');
+    // SKILL_ROOT, DATABASE_MODE, CLAWWEB_API_URL not in mcporter env
+    assert.equal('SKILL_ROOT' in entry.env, false);
+    assert.equal('DATABASE_MODE' in entry.env, false);
+    assert.equal('CLAWWEB_API_URL' in entry.env, false);
+  });
+
+  it('stdio update preserves env and does not inject CallerToken', async () => {
+    const s = new McpStore(p, { writeDebounceMs: 0 });
+    s.create({
+      serverCode: 'clawmind',
+      type: 'stdio',
+      command: 'node',
+      args: ['/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js'],
+      env: { MCP_TRANSPORT: 'stdio', CCT_SOP_MCP_SERVER_MODE: 'prod' },
+      headers: {},
+      timeout_seconds: 30,
+      enabled: true,
+    });
+    const updated = s.update('clawmind', { timeout_seconds: 60 });
+    assert.equal(updated.timeout_seconds, 60);
+    assert.equal(updated.command, 'node'); // preserved
+    assert.equal(updated.env.MCP_TRANSPORT, 'stdio'); // preserved
+    assert.equal(updated.env.CCT_SOP_MCP_SERVER_MODE, 'prod'); // preserved
+    assert.equal('CallerToken' in updated.headers, false, 'stdio update should not inject CallerToken');
+  });
+
   it('preserves legacy key variants on disk', async () => {
     // Simulate an mcporter.json that uses `baseUrl`/`transport`/`timeoutSeconds`
     fs.mkdirSync(path.dirname(p), { recursive: true });


### PR DESCRIPTION
…gine

Add ClawMind workflow engine as a default LOCAL/stdio MCP Server for the claude_code engine only. When a Claude Code bot is created, the MCPSyncService chain automatically writes clawmind into ~/.mcporter/mcporter.json, giving the bot workflow orchestration capabilities (create/monitor/approve workflows, query state).

Changes:
- local-mcp-servers.yaml: Add clawmind entry with command/args/env (node /home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js, SKILL_ROOT, DATABASE_MODE, SQLITE_PATH, MCP_TRANSPORT, CCT_SOP_MCP_SERVER_MODE)
- _defaults.py: Add {server_code: clawmind} to claude_code list only (not openclaw/hermes/aicoding)
- test_defaults_per_engine.py: Add test_clawmind_is_default_for_claude_code_only, update count to 19
- test_local_mcp_registry.py: Add test_default_config_path_loads_repo_clawmind_config verifying yaml loading, env completeness
- mcp.test.ts: Add two McpStore tests for stdio env round-trip and update preserving env without CallerToken injection