### PR TITLE
feat: 支持按 Bot/Group 查询渠道绑定

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/router.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/router.rs
@@ -119,6 +119,10 @@ fn build_api_routes() -> Router<HttpAppState> {
             get(routes::channel::list_bindings).post(routes::channel::create_binding),
         )
         .route(
+            "/channels/bindings/by-target",
+            get(routes::channel::list_bindings_by_target),
+        )
+        .route(
             "/channels/bindings/{id}",
             patch(routes::channel::set_binding_status)
                 .delete(routes::channel::delete_binding),

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/channel.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/channel.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json, body::{Body, Bytes},
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, Method, Response, Uri},
 };
 use bcs_channel_api::{
@@ -63,6 +63,20 @@ impl From<ChannelBinding> for BindingResponse {
 #[derive(Debug, Serialize)]
 pub struct BindingListResponse {
     pub items: Vec<BindingResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BindingTargetType {
+    Bot,
+    Group,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListBindingsByTargetQuery {
+    pub target_type: BindingTargetType,
+    pub target_id: String,
+    pub channel_type: Option<ChannelType>,
 }
 
 pub async fn provider_http_ingress(
@@ -140,6 +154,24 @@ pub async fn list_bindings(
         .services
         .channel
         .list_bindings()
+        .await
+        .map_err(channel_error)?;
+    let items = items.into_iter().map(BindingResponse::from).collect();
+    Ok(Json(BindingListResponse { items }))
+}
+
+pub async fn list_bindings_by_target(
+    State(state): State<HttpAppState>,
+    headers: HeaderMap,
+    uri: Uri,
+    Query(query): Query<ListBindingsByTargetQuery>,
+) -> Result<Json<BindingListResponse>, HttpAdapterError> {
+    let _staff_no = require_staff_no(&state, &headers, &uri).await?;
+    let (target, channel_type) = normalize_target_query(query)?;
+    let items = state
+        .services
+        .channel
+        .list_bindings_by_target(target, channel_type)
         .await
         .map_err(channel_error)?;
     let items = items.into_iter().map(BindingResponse::from).collect();
@@ -258,6 +290,30 @@ fn channel_error(error: ChannelUseCaseError) -> HttpAdapterError {
     }
 }
 
+fn normalize_target_query(
+    query: ListBindingsByTargetQuery,
+) -> Result<(BindingTarget, Option<ChannelType>), HttpAdapterError> {
+    let target_id = query.target_id.trim();
+    if target_id.is_empty() {
+        return Err(HttpAdapterError::BadRequest(
+            "target_id is required".to_string(),
+        ));
+    }
+    let channel_type = query
+        .channel_type
+        .map(|channel_type| channel_type.trim().to_string())
+        .filter(|channel_type| !channel_type.is_empty());
+    let target = match query.target_type {
+        BindingTargetType::Bot => BindingTarget::Bot {
+            bot_id: target_id.to_string(),
+        },
+        BindingTargetType::Group => BindingTarget::Group {
+            group_id: target_id.to_string(),
+        },
+    };
+    Ok((target, channel_type))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -312,5 +368,38 @@ mod tests {
         .expect("create binding request should not require client env");
 
         assert!(request.env.is_none());
+    }
+
+    #[test]
+    fn target_query_builds_trimmed_bot_target_and_channel_filter() {
+        let (target, channel_type) = normalize_target_query(ListBindingsByTargetQuery {
+            target_type: BindingTargetType::Bot,
+            target_id: " bot_1:user_1 ".to_string(),
+            channel_type: Some(" dingtalk ".to_string()),
+        })
+        .expect("valid target query");
+
+        assert_eq!(
+            target,
+            BindingTarget::Bot {
+                bot_id: "bot_1:user_1".to_string()
+            }
+        );
+        assert_eq!(channel_type.as_deref(), Some("dingtalk"));
+    }
+
+    #[test]
+    fn target_query_rejects_blank_target_id() {
+        let error = normalize_target_query(ListBindingsByTargetQuery {
+            target_type: BindingTargetType::Group,
+            target_id: "   ".to_string(),
+            channel_type: None,
+        })
+        .expect_err("blank target id must fail");
+
+        assert!(matches!(
+            error,
+            HttpAdapterError::BadRequest(message) if message == "target_id is required"
+        ));
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/channel_provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/channel_provider_routes_contract.rs
@@ -5,12 +5,17 @@ use axum::{
     body::{Body, Bytes, to_bytes},
     http::{Request, StatusCode},
 };
+use bcs_auth_api::{AuthPluginChain, AuthPrincipal};
+use bcs_auth_local::StaticAuthPlugin;
 use bcs_channel_api::{
     ChannelHttpIngressPort, ChannelHttpIngressRegistry, ChannelHttpMethod, ChannelHttpRequest,
     ChannelHttpResponse, ChannelHttpRouteSpec, ChannelInboundSink, ChannelIngressError,
     ChannelProvider, ChannelProviderRegistry, ChannelProviderResult,
 };
-use bcs_http::{router::build_router, state::HttpAppState};
+use bcs_http::{
+    router::build_router,
+    state::{ChainUserIdentityPort, HttpAppState},
+};
 use bcs_service_api::{
     ServiceResult,
     application::InboundMessage,
@@ -21,6 +26,17 @@ use bcs_service_api::{
 use bcs_services_container::Services;
 use tokio::sync::Mutex;
 use tower::ServiceExt;
+
+fn static_auth_chain(staff_no: &str) -> Arc<AuthPluginChain> {
+    let principal = AuthPrincipal {
+        user_id: Some(staff_no.to_string()),
+        user_name: Some(staff_no.to_string()),
+        ..Default::default()
+    };
+    Arc::new(AuthPluginChain::new(vec![Box::new(
+        StaticAuthPlugin::with_principal(principal),
+    )]))
+}
 
 #[tokio::test]
 async fn provider_declared_http_route_is_mounted_and_dispatched() {
@@ -98,6 +114,13 @@ async fn channel_binding_management_routes_require_human_identity() {
             .body(Body::empty())
             .unwrap(),
         Request::builder()
+            .method("GET")
+            .uri(
+                "/channels/bindings/by-target?target_type=bot&target_id=bot_1&channel_type=dingtalk",
+            )
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
             .method("PATCH")
             .uri("/channels/bindings/binding_1")
             .header("content-type", "application/json")
@@ -118,6 +141,33 @@ async fn channel_binding_management_routes_require_human_identity() {
         let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(body["error"], "valid human identity is required");
     }
+}
+
+#[tokio::test]
+async fn channel_binding_target_query_is_mounted_for_human_identity() {
+    let chain = static_auth_chain("alice");
+    let app = build_router(
+        HttpAppState::new(Services::noop())
+            .with_user_identity(Arc::new(ChainUserIdentityPort::new(chain))),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(
+                    "/channels/bindings/by-target?target_type=group&target_id=group_1&channel_type=dingtalk",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body, serde_json::json!({ "items": [] }));
 }
 
 #[derive(Clone)]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -209,6 +209,17 @@ impl ChannelService for DisabledChannelService {
         Ok(Vec::new())
     }
 
+    async fn list_bindings_by_target(
+        &self,
+        _target: bcs_domain::BindingTarget,
+        _channel_type: Option<bcs_domain::ChannelType>,
+    ) -> std::result::Result<
+        Vec<bcs_domain::ChannelBinding>,
+        bcs_service_api::application::channel::ChannelUseCaseError,
+    > {
+        Ok(Vec::new())
+    }
+
     async fn set_binding_status(
         &self,
         _id: &str,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -163,6 +163,11 @@ pub trait ChannelService: Send + Sync {
         cmd: CreateBindingCommand,
     ) -> Result<ChannelBinding, ChannelUseCaseError>;
     async fn list_bindings(&self) -> Result<Vec<ChannelBinding>, ChannelUseCaseError>;
+    async fn list_bindings_by_target(
+        &self,
+        target: BindingTarget,
+        channel_type: Option<ChannelType>,
+    ) -> Result<Vec<ChannelBinding>, ChannelUseCaseError>;
     async fn set_binding_status(&self, id: &str, active: bool)
         -> Result<(), ChannelUseCaseError>;
     async fn update_binding_config(

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/channel.rs
@@ -5,7 +5,8 @@
 use async_trait::async_trait;
 
 use bcs_domain::{
-    ChannelBinding, ChannelType, ConversationSessionMap, ImParticipantMap, SessionScope,
+    BindingTarget, ChannelBinding, ChannelType, ConversationSessionMap, ImParticipantMap,
+    SessionScope,
 };
 
 use crate::types::ServiceResult;
@@ -22,6 +23,12 @@ pub trait ChannelBindingRepoPort: Send + Sync {
         account_ref: &str,
     ) -> ServiceResult<Option<ChannelBinding>>;
     async fn list(&self) -> ServiceResult<Vec<ChannelBinding>>;
+    /// 管理查询：按 Bot/Group target 隔离，可选进一步限定 channel type。
+    async fn list_by_target(
+        &self,
+        target: &BindingTarget,
+        channel_type: Option<&str>,
+    ) -> ServiceResult<Vec<ChannelBinding>>;
     async fn set_status(&self, id: &str, active: bool) -> ServiceResult<()>;
     async fn set_config(&self, id: &str, config: serde_json::Value) -> ServiceResult<()>;
     async fn delete(&self, id: &str) -> ServiceResult<()>;

--- a/src/bcs/crates/services/bcs-channel-store/src/db.rs
+++ b/src/bcs/crates/services/bcs-channel-store/src/db.rs
@@ -200,6 +200,31 @@ impl ChannelBindingRepoPort for DbChannelBindingStore {
         rows.iter().map(row_to_binding).collect()
     }
 
+    async fn list_by_target(
+        &self,
+        target: &BindingTarget,
+        channel_type: Option<&str>,
+    ) -> ServiceResult<Vec<ChannelBinding>> {
+        let target_json = serde_json::to_string(target)?;
+        let statement = match channel_type {
+            Some(channel_type) => DbStatement::with_params(
+                "SELECT id, channel_type, account_ref, target_json, group_chat_scope, \
+                 visibility, env, status, created_by, config_json \
+                 FROM bcs_channel_bindings \
+                 WHERE target_json = ? AND channel_type = ? ORDER BY id",
+                vec![DbValue::from(target_json), DbValue::from(channel_type)],
+            ),
+            None => DbStatement::with_params(
+                "SELECT id, channel_type, account_ref, target_json, group_chat_scope, \
+                 visibility, env, status, created_by, config_json \
+                 FROM bcs_channel_bindings WHERE target_json = ? ORDER BY id",
+                vec![DbValue::from(target_json)],
+            ),
+        };
+        let rows = self.query("list_bindings_by_target", statement).await?;
+        rows.iter().map(row_to_binding).collect()
+    }
+
     async fn set_status(&self, id: &str, active: bool) -> ServiceResult<()> {
         let status = if active {
             BindingStatus::Active
@@ -851,6 +876,42 @@ mod tests {
 
         binding_repo.delete("binding_1").await?;
         assert_eq!(binding_repo.get("binding_1").await?, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sqlite_binding_list_by_target_filters_target_and_channel() -> ServiceResult<()> {
+        let (binding_repo, _, _) = sqlite_stores().await?;
+
+        let group_dingtalk = binding();
+        binding_repo.create(group_dingtalk).await?;
+
+        let mut group_other_channel = binding();
+        group_other_channel.id = "binding_other_channel".to_string();
+        group_other_channel.account_ref = "account_2".to_string();
+        group_other_channel.channel_type = "test_im".to_string();
+        binding_repo.create(group_other_channel).await?;
+
+        let mut other_group = binding();
+        other_group.id = "binding_other_group".to_string();
+        other_group.account_ref = "robot_2".to_string();
+        other_group.target = BindingTarget::Group {
+            group_id: "group_2".to_string(),
+        };
+        binding_repo.create(other_group).await?;
+
+        let group_target = BindingTarget::Group {
+            group_id: "group_1".to_string(),
+        };
+        let all_channels = binding_repo.list_by_target(&group_target, None).await?;
+        assert_eq!(all_channels.len(), 2);
+
+        let dingtalk = binding_repo
+            .list_by_target(&group_target, Some("dingtalk"))
+            .await?;
+        assert_eq!(dingtalk.len(), 1);
+        assert_eq!(dingtalk[0].id, "binding_1");
 
         Ok(())
     }

--- a/src/bcs/crates/services/bcs-channel-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-channel-store/src/memory.rs
@@ -7,8 +7,8 @@ use tokio::sync::RwLock;
 use tracing::info;
 
 use bcs_domain::{
-    BindingStatus, ChannelBinding, ChannelType, ConversationSessionMap, ImParticipantMap,
-    SessionScope,
+    BindingStatus, BindingTarget, ChannelBinding, ChannelType, ConversationSessionMap,
+    ImParticipantMap, SessionScope,
 };
 use bcs_service_api::ServiceResult;
 use bcs_service_api::port::repo::{
@@ -106,6 +106,24 @@ impl ChannelBindingRepoPort for MemoryChannelBindingRepo {
 
     async fn list(&self) -> ServiceResult<Vec<ChannelBinding>> {
         Ok(self.bindings.read().await.clone())
+    }
+
+    async fn list_by_target(
+        &self,
+        target: &BindingTarget,
+        channel_type: Option<&str>,
+    ) -> ServiceResult<Vec<ChannelBinding>> {
+        let bindings = self.bindings.read().await;
+        Ok(bindings
+            .iter()
+            .filter(|binding| {
+                binding.target == *target
+                    && channel_type
+                        .map(|expected| binding.channel_type == expected)
+                        .unwrap_or(true)
+            })
+            .cloned()
+            .collect())
     }
 
     async fn set_status(&self, id: &str, active: bool) -> ServiceResult<()> {

--- a/src/bcs/crates/services/bcs-channel-store/tests/repo_contract.rs
+++ b/src/bcs/crates/services/bcs-channel-store/tests/repo_contract.rs
@@ -227,6 +227,63 @@ async fn binding_repo_lifecycle_filters_active_bindings() -> ServiceResult<()> {
 }
 
 #[tokio::test]
+async fn binding_repo_lists_only_requested_target_and_optional_channel() -> ServiceResult<()> {
+    let repo = MemoryChannelBindingRepo::new();
+
+    let mut group_dingtalk = binding("group_dingtalk", "robot_1", BindingStatus::Active);
+    group_dingtalk.target = BindingTarget::Group {
+        group_id: "group_1".to_string(),
+    };
+    repo.create(group_dingtalk).await?;
+
+    let mut group_other_channel = binding(
+        "group_other_channel",
+        "account_2",
+        BindingStatus::Active,
+    );
+    group_other_channel.target = BindingTarget::Group {
+        group_id: "group_1".to_string(),
+    };
+    group_other_channel.channel_type = "test_im".to_string();
+    repo.create(group_other_channel).await?;
+
+    let mut other_group = binding("other_group", "robot_2", BindingStatus::Active);
+    other_group.target = BindingTarget::Group {
+        group_id: "group_2".to_string(),
+    };
+    repo.create(other_group).await?;
+
+    let mut bot_binding = binding("bot_binding", "robot_3", BindingStatus::Active);
+    bot_binding.target = BindingTarget::Bot {
+        bot_id: "bot_1:user_1".to_string(),
+    };
+    repo.create(bot_binding).await?;
+
+    let group_target = BindingTarget::Group {
+        group_id: "group_1".to_string(),
+    };
+    let group_all_channels = repo.list_by_target(&group_target, None).await?;
+    assert_eq!(group_all_channels.len(), 2);
+
+    let group_dingtalk = repo
+        .list_by_target(&group_target, Some("dingtalk"))
+        .await?;
+    assert_eq!(group_dingtalk.len(), 1);
+    assert_eq!(group_dingtalk[0].id, "group_dingtalk");
+
+    let bot_target = BindingTarget::Bot {
+        bot_id: "bot_1:user_1".to_string(),
+    };
+    let bot_bindings = repo
+        .list_by_target(&bot_target, Some("dingtalk"))
+        .await?;
+    assert_eq!(bot_bindings.len(), 1);
+    assert_eq!(bot_bindings[0].id, "bot_binding");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn binding_repo_preserves_generic_channel_type_and_config() -> ServiceResult<()> {
     let repo = MemoryChannelBindingRepo::new();
     let mut binding = binding("binding_generic", "account_1", BindingStatus::Active);

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -13,7 +13,7 @@ use bcs_channel_api::{
     ChannelInboundSink, ChannelProvider, ChannelProviderRegistry,
 };
 use bcs_domain::{
-    ActorKind, BindingStatus, BindingTarget, ChannelBinding, ConversationSessionMap,
+    ActorKind, BindingStatus, BindingTarget, ChannelBinding, ChannelType, ConversationSessionMap,
     Group, GroupChatScope, GroupStrategy, ImParticipantMap, Participant, ParticipantMode,
     ParticipantRole, Session, SessionKind, SessionScope, SessionStatus, SystemMessageEvent,
     Visibility,
@@ -940,14 +940,19 @@ impl ChannelService for BcsChannelService {
 
     async fn list_bindings(&self) -> Result<Vec<ChannelBinding>, ChannelUseCaseError> {
         let bindings = self.bindings.list().await?;
-        bindings
-            .into_iter()
-            .map(|mut binding| {
-                let provider = self.provider_for(&binding.channel_type)?;
-                binding.config = provider.redact_config(&binding.config);
-                Ok(binding)
-            })
-            .collect()
+        self.redact_bindings(bindings)
+    }
+
+    async fn list_bindings_by_target(
+        &self,
+        target: BindingTarget,
+        channel_type: Option<ChannelType>,
+    ) -> Result<Vec<ChannelBinding>, ChannelUseCaseError> {
+        let bindings = self
+            .bindings
+            .list_by_target(&target, channel_type.as_deref())
+            .await?;
+        self.redact_bindings(bindings)
     }
 
     async fn set_binding_status(
@@ -1002,6 +1007,20 @@ impl ChannelService for BcsChannelService {
 }
 
 impl BcsChannelService {
+    fn redact_bindings(
+        &self,
+        bindings: Vec<ChannelBinding>,
+    ) -> Result<Vec<ChannelBinding>, ChannelUseCaseError> {
+        bindings
+            .into_iter()
+            .map(|mut binding| {
+                let provider = self.provider_for(&binding.channel_type)?;
+                binding.config = provider.redact_config(&binding.config);
+                Ok(binding)
+            })
+            .collect()
+    }
+
     fn provider_for(
         &self,
         channel_type: &str,
@@ -1311,6 +1330,14 @@ mod tests {
             panic!("outbound delivery must not scan all channel bindings")
         }
 
+        async fn list_by_target(
+            &self,
+            target: &BindingTarget,
+            channel_type: Option<&str>,
+        ) -> ServiceResult<Vec<ChannelBinding>> {
+            self.inner.list_by_target(target, channel_type).await
+        }
+
         async fn set_status(&self, id: &str, active: bool) -> ServiceResult<()> {
             self.inner.set_status(id, active).await
         }
@@ -1345,6 +1372,14 @@ mod tests {
         }
 
         async fn list(&self) -> ServiceResult<Vec<ChannelBinding>> {
+            unreachable!("inbound binding lookup test only calls find_active_by_account")
+        }
+
+        async fn list_by_target(
+            &self,
+            _target: &BindingTarget,
+            _channel_type: Option<&str>,
+        ) -> ServiceResult<Vec<ChannelBinding>> {
             unreachable!("inbound binding lookup test only calls find_active_by_account")
         }
 
@@ -2004,6 +2039,49 @@ mod tests {
             .await?
             .expect("stored binding");
         assert_eq!(stored.config["client_secret"], "secret");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_bindings_by_target_filters_and_redacts_provider_config() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        harness
+            .binding_repo
+            .create(active_binding(
+                "binding_1",
+                "robot_1",
+                BindingTarget::Group {
+                    group_id: "group_1".to_string(),
+                },
+                Visibility::FullTranscript,
+            ))
+            .await?;
+        harness
+            .binding_repo
+            .create(active_binding(
+                "binding_2",
+                "robot_2",
+                BindingTarget::Group {
+                    group_id: "group_2".to_string(),
+                },
+                Visibility::FullTranscript,
+            ))
+            .await?;
+
+        let bindings = harness
+            .service
+            .list_bindings_by_target(
+                BindingTarget::Group {
+                    group_id: "group_1".to_string(),
+                },
+                Some("dingtalk".to_string()),
+            )
+            .await?;
+
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].id, "binding_1");
+        assert_eq!(bindings[0].config["client_secret"], "<redacted>");
 
         Ok(())
     }

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -89,6 +89,14 @@ impl ChannelService for RecordingChannelService {
         Ok(Vec::new())
     }
 
+    async fn list_bindings_by_target(
+        &self,
+        _target: bcs_domain::BindingTarget,
+        _channel_type: Option<bcs_domain::ChannelType>,
+    ) -> Result<Vec<bcs_domain::ChannelBinding>, ChannelUseCaseError> {
+        Ok(Vec::new())
+    }
+
     async fn set_binding_status(
         &self,
         _id: &str,

--- a/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
@@ -1890,6 +1890,14 @@ impl ChannelService for NoopChannelService {
         Ok(Vec::new())
     }
 
+    async fn list_bindings_by_target(
+        &self,
+        _target: bcs_domain::BindingTarget,
+        _channel_type: Option<bcs_domain::ChannelType>,
+    ) -> Result<Vec<ChannelBinding>, ChannelUseCaseError> {
+        Ok(Vec::new())
+    }
+
     async fn set_binding_status(
         &self,
         _id: &str,

--- a/src/bcs/docs/superpowers/specs/2026-07-16-channel-binding-target-query-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-07-16-channel-binding-target-query-design.md
@@ -41,3 +41,4 @@ GET /channels/bindings/by-target?target_type=group&target_id=group_1&channel_typ
 - service：目标查询结果的 provider 配置脱敏。
 - HTTP contract：新路由的人类身份认证。
 - route unit：目标类型转换与空目标校验。
+- e2e story：登录用户按 Bot target 查询绑定并获得稳定的 `items` 响应。

--- a/src/bcs/docs/superpowers/specs/2026-07-16-channel-binding-target-query-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-07-16-channel-binding-target-query-design.md
@@ -1,0 +1,43 @@
+# Channel Binding 按目标查询设计
+
+- 日期：2026-07-16
+- 状态：已完成
+- 范围：Channel binding 管理查询接口
+
+## 背景
+
+现有 `GET /channels/bindings` 返回全部绑定，适合管理 CLI，但 Bot 和群管理页面只需要当前目标的绑定。前端拉取全量数据后再过滤会扩大不必要的数据暴露范围，也让页面结果依赖客户端过滤。
+
+## 决策
+
+1. 保留现有全量查询接口，兼容 CLI 和既有管理调用方。
+2. 新增 `GET /channels/bindings/by-target`，必须指定 `target_type=bot|group` 与非空 `target_id`，可选 `channel_type`。
+3. HTTP adapter 将查询参数转换为领域 `BindingTarget`，application service 调用 repository 的目标查询能力，并沿用 provider 配置脱敏。
+4. repository 负责在存储层按目标筛选；数据库实现使用参数化查询，内存实现遵循相同语义。
+5. 第一版沿用现有 binding 管理接口的人类身份认证边界，不在本次改造中新增 Bot owner 或群成员授权模型。
+
+## 验收标准
+
+- 当请求缺少合法的人类身份时，按目标查询应该返回未授权。
+- 当 `target_id` 为空白时，按目标查询应该返回参数错误。
+- 当指定 Bot 目标时，响应只包含该 Bot 的绑定。
+- 当指定 Group 目标时，响应只包含该 Group 的绑定。
+- 当额外指定 `channel_type` 时，响应只包含该渠道类型的目标绑定。
+- 当返回 provider 配置时，敏感字段应该保持脱敏。
+- 当旧调用方继续请求 `GET /channels/bindings` 时，行为应该保持不变。
+
+## 接口
+
+```http
+GET /channels/bindings/by-target?target_type=bot&target_id=bot_1%3Auser_1&channel_type=dingtalk
+GET /channels/bindings/by-target?target_type=group&target_id=group_1&channel_type=dingtalk
+```
+
+响应继续使用现有 `BindingListResponse`。
+
+## 测试
+
+- repository contract：Bot/Group 目标隔离与可选渠道过滤。
+- service：目标查询结果的 provider 配置脱敏。
+- HTTP contract：新路由的人类身份认证。
+- route unit：目标类型转换与空目标校验。

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -843,12 +843,12 @@ print("1" if any(item.get("bot_uuid") == target for item in json.load(sys.stdin)
 # User story: A user validates channel behavior before an external provider is installed.
 #
 # Flow:
-#   Attempt to create a binding -> inspect configured bindings -> pause and delete
-#   a missing binding through the disabled bridge -> inspect bindings again.
+#   Attempt to create a binding -> inspect all and target-scoped bindings -> pause
+#   and delete a missing binding through the disabled bridge -> inspect bindings again.
 #
 # Critical assertions:
 #   - Binding creation fails with the explicit disabled-bridge bad-request contract.
-#   - Binding reads always expose a well-formed items array.
+#   - Full and target-scoped binding reads always expose a well-formed items array.
 #   - Disabled-bridge pause and delete follow their documented no-op acknowledgements.
 #   - No phantom binding appears after the rejected and no-op operations.
 story_user_validates_external_channel_setup() {
@@ -865,6 +865,12 @@ story_user_validates_external_channel_setup() {
     local items_is_array
     items_is_array=$(printf '%s' "$RESPONSE" | python3 -c 'import json,sys; print("1" if isinstance(json.load(sys.stdin).get("items"), list) else "0")' 2>/dev/null || echo 0)
     assert_eq "channel binding list exposes an items array" "$items_is_array" "1"
+
+    local encoded_bot_id
+    encoded_bot_id=$(urlencode "$BOT_CEO_UUID")
+    api_get "/channels/bindings/by-target?target_type=bot&target_id=${encoded_bot_id}&channel_type=e2e-uninstalled-channel"
+    require_status "user can inspect bindings for one bot target" "200" || return
+    assert_json_eq "target-scoped channel binding list remains empty" "$RESPONSE" "items" "[]"
 
     local missing_binding="missing-binding-$$"
     api_patch "/channels/bindings/${missing_binding}" '{"active":false}'


### PR DESCRIPTION
## Summary

- 新增 `GET /channels/bindings/by-target`，支持通过 `target_type=bot|group`、`target_id` 和可选 `channel_type` 查询绑定。
- 在 application service 与 repository port 中增加按目标查询能力，并为 SQLite/内存存储实现一致的过滤语义。
- 保留既有 `GET /channels/bindings` 全量接口，兼容 CLI 和现有管理调用方。
- 沿用 provider 配置脱敏，查询结果不会回传原始 `client_secret`。

## Why

Bot 和群管理页面只需要当前目标的绑定。此前页面必须拉取全部绑定再在客户端过滤，扩大了不必要的数据返回范围，也让结果正确性依赖前端过滤。

## Impact

前端可以使用目标查询接口只获取当前 Bot 或 Group 的绑定。第一版保持现有的人类身份认证边界，不修改绑定唯一性规则，也不改变旧全量管理接口的行为。

## Validation

- `cargo check --workspace`
- `cargo test -p bcs-channel-store -p bcs-channel`
- `cargo test -p bcs-http --lib routes::channel::tests`
- `cargo test -p bcs-http --test channel_provider_routes_contract`
