### PR TITLE
fix(engine): auto-subscribe chat.send sessions to inject events

### DIFF
--- a/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
+++ b/src/engine/src/engine/community/api/tests/transport/test_ws_server.py
@@ -116,6 +116,46 @@ def _req(method: str, params: dict, id: str = "r-1") -> RequestFrame:
 
 class TestHandleChatSend:
     @pytest.mark.asyncio
+    async def test_auto_subscribes_session_without_client_subscribe_request(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        websocket = MagicMock()
+        stream = AsyncMock()
+        subscribe = AsyncMock(return_value=True)
+        server._stream_chat_events = stream
+        server._subscribe_conn_to_session = subscribe
+        auth_gate_service.enabled = False
+        params = {"sessionKey": "agent:main:user:165137", "message": "hello"}
+
+        response = await server._handle_chat_send(
+            websocket, "conn-1", _req("chat.send", params), params,
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        subscribe.assert_awaited_once_with("conn-1", "agent:main:user:165137")
+        stream.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_subscription_failure_does_not_reject_chat_send(
+        self, server, fake_engine, auth_gate_service,
+    ):
+        websocket = MagicMock()
+        stream = AsyncMock()
+        server._stream_chat_events = stream
+        server._subscribe_conn_to_session = AsyncMock(side_effect=RuntimeError("listener down"))
+        auth_gate_service.enabled = False
+        params = {"sessionKey": "agent:main:user:165137", "message": "hello"}
+
+        response = await server._handle_chat_send(
+            websocket, "conn-1", _req("chat.send", params), params,
+            auth_gate_service=auth_gate_service,
+        )
+
+        assert response.ok is True
+        stream.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_rejects_missing_iam_token(self, server, fake_engine, auth_gate_service):
         websocket = MagicMock()
         params = {"sessionKey": "agent:main:user:165137", "message": "hello"}
@@ -393,6 +433,40 @@ class TestHandleChatSend:
         auth_gate.assert_not_called()
         stream.assert_called_once()
         assert stream.call_args.args[-1] == "community-noop-run"
+
+
+class TestChatSendStream:
+    def test_connection_without_session_subscription_has_no_live_listener(self, server):
+        server._inject_listener_conns = {("tok-a", 1): {"conn-1"}}
+
+        assert server._connection_has_live_inject_listener("conn-1", "sk-1") is False
+
+    @pytest.mark.asyncio
+    async def test_live_listener_prevents_duplicate_inject_stream_event(self, server, fake_engine):
+        websocket = MagicMock()
+        websocket.send_text = AsyncMock()
+        server._session_subscribers = {"sk-1": {"conn-1"}}
+        server._inject_listener_conns = {("tok-a", 1): {"conn-1"}}
+
+        async def stream(*_args, **_kwargs):
+            yield EventFrame(
+                event="chat",
+                payload={"runId": "inject-1", "state": "final"},
+            )
+            yield EventFrame(
+                event="chat",
+                payload={"runId": "chat-1", "state": "final"},
+            )
+
+        fake_engine.chat.stream = stream
+
+        await server._stream_chat_events(
+            websocket, "conn-1", "sk-1", "hello", timeout_ms=None,
+        )
+
+        websocket.send_text.assert_awaited_once()
+        sent = json.loads(websocket.send_text.await_args.args[0])
+        assert sent["payload"]["runId"] == "chat-1"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/engine/src/engine/community/api/transport/ws_server.py
+++ b/src/engine/src/engine/community/api/transport/ws_server.py
@@ -755,6 +755,11 @@ class EngineWebSocketServer:
         self._inject_listener_refs[key] = (client, on_injected_event)
         return True
 
+    def _connection_has_live_inject_listener(self, conn_id: str, session_key: str) -> bool:
+        if conn_id not in self._session_subscribers.get(session_key, set()):
+            return False
+        return any(conn_id in conns for conns in self._inject_listener_conns.values())
+
     async def _fanout_injected_event(self, event: EventFrame) -> None:
         payload = event.payload if isinstance(event.payload, dict) else {}
         session_key = payload.get("sessionKey")
@@ -890,6 +895,14 @@ class EngineWebSocketServer:
         else:
             params.setdefault("idempotencyKey", uuid.uuid4().hex)
 
+        # The browser only sends chat.send. Bind this connection before starting
+        # the stream so OpenClaw-originated inject events can reach the session.
+        try:
+            await self._subscribe_conn_to_session(conn_id, session_key)
+        except Exception as e:
+            # Listener binding is best-effort and must not reject a valid chat.send.
+            log.warning("chat.send: failed to bind inject listener: %s", e)
+
         # ack first, then stream events in the background
         response = ResponseFrame.ok_response(request.id, {"accepted": True})
 
@@ -958,15 +971,25 @@ class EngineWebSocketServer:
                 event_name = event_frame.event
                 event_data = event_frame.payload
                 state = event_data.get("state", "")
+                run_id = event_data.get("runId", "")
 
                 # seq/ts stamping happens inside _send_event (guarded so
                 # pre-populated payloads are preserved).
                 event_data.setdefault("sessionKey", session_key)
 
+                # The live listener already fans this frame out to the current
+                # connection. Avoid sending the same inject event a second time
+                # through the foreground chat stream.
+                if (
+                    isinstance(run_id, str)
+                    and run_id.startswith("inject-")
+                    and self._connection_has_live_inject_listener(conn_id, session_key)
+                ):
+                    continue
+
                 await self._send_event(websocket, event_name, event_data)
 
                 if state in ("final", "error", "aborted"):
-                    run_id = event_data.get("runId", "")
                     if isinstance(run_id, str) and run_id.startswith("inject-"):
                         continue
                     log.info(f"[stream] chat stream ended: conn={conn_id}, reason={state}, total_events={event_count}")


### PR DESCRIPTION
## Summary

- Automatically bind the active WebSocket connection to the session's inject listener when processing `chat.send`.
- Deliver OpenClaw-originated `chat.inject` events without requiring the Web client to send `chat.subscribe`.
- Avoid duplicate inject frames when the foreground chat stream and listener observe the same event.

## Compatibility

- No Backend API change.
- No Web client protocol change: clients continue to send only `chat.send`.

## Validation

- `PYTHONPATH=src uv run --project src/engine --with pytest --with pytest-asyncio python -m pytest src/engine/src/engine/community/api/tests/transport/test_ws_server.py -q` (`75 passed`)
- `ruff check` for the changed Engine source and tests
- Diff coverage: `100%` (`53/53` changed lines)
