### PR TITLE
feat(tracer): extract trace context propagation into TracerPlugin SPI

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -21,12 +21,9 @@ import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
-from opentelemetry import context as otel_context
-from opentelemetry import trace as otel_trace
-from opentelemetry.context import Context
-
 from secbaas.community.api.sse import StreamChunk
 from secbaas.community.logger import get_logger
+from secbaas.community.tracer import get_tracer_plugin
 
 from ._bot_websocket_client import BotWebSocketClient
 from ._session_key_matcher import SessionKeyMatcher
@@ -35,24 +32,20 @@ from ._session_state import _SessionState
 logger = get_logger("core-bot-run")
 
 
-def _capture_trace_context() -> Context | None:
-    """捕获当前 OTel context，供后续回调中恢复。
+def _capture_trace_context() -> Any:
+    """捕获当前 trace context，供后续回调中恢复。
 
     在 send_message 注册 session 时调用，保存当前请求的 trace context。
-    返回值是不透明的 context 对象，传给 _attach_trace_context 恢复。
+    返回值是不透明的 context 对象，传给 _with_session_trace 恢复。
     """
-    ctx = otel_context.get_current()
-    span = otel_trace.get_current_span(ctx)
-    if span is not None and span.get_span_context().is_valid:
-        return ctx
-    return None
+    return get_tracer_plugin().capture_context()
 
 
 def _with_session_trace(method_name: str = "_on_event") -> Callable[..., Any]:
     """装饰器：从 payload 中查找 session state，恢复 trace context 后执行方法。
 
     适用于 _on_chat / _on_agent 等 WS 回调，这些回调在 _recv_loop 后台 Task
-    中执行，无 OTel span context。装饰器自动：
+    中执行，无 active trace context。装饰器自动：
       1. 从 payload.sessionKey 查找 _SessionState（支持模糊匹配）
       2. 恢复 state 中保存的 trace context，使日志 traceid 关联原始请求
       3. 将 state 作为关键字参数传入被装饰方法
@@ -76,17 +69,18 @@ def _with_session_trace(method_name: str = "_on_event") -> Callable[..., Any]:
             )
             state = match_result.state if match_result else None
 
-            otel_token = None
+            tracer = get_tracer_plugin()
+            token = None
             if state is not None and state.trace_context is not None:
-                otel_token = otel_context.attach(state.trace_context)
+                token = tracer.attach_context(state.trace_context)
             try:
                 if event_name is not None:
                     fn(self, event_name, payload, session_key=session_key, state=state)
                 else:
                     fn(self, payload, session_key=session_key, state=state)
             finally:
-                if otel_token is not None:
-                    otel_context.detach(otel_token)
+                if token is not None:
+                    tracer.detach_context(token)
 
         wrapper.__name__ = method_name
         wrapper.__qualname__ = f"AsyncChatClient.{method_name}"
@@ -579,8 +573,8 @@ class AsyncChatClient:
             self._active_sessions.clear()
             self._condition.notify_all()
 
+    @staticmethod
     async def _drain_stream_queue(
-        self,
         queue: asyncio.Queue[StreamChunk],
         timeout: int | None,
     ) -> AsyncIterator[StreamChunk]:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
@@ -9,8 +9,6 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
-from opentelemetry.context import Context
-
 
 @dataclass
 class _SessionState:
@@ -22,8 +20,9 @@ class _SessionState:
     last_stream_is_assistant: bool = False
     chat_complete: asyncio.Event = field(default_factory=asyncio.Event)
     agent_complete: asyncio.Event = field(default_factory=asyncio.Event)
-    # 请求注册时的 OTel trace context，用于回调中恢复 trace 关联
-    trace_context: Context | None = None
+    # 请求注册时的 trace context，用于回调中恢复 trace 关联。
+    # 类型由 TracerPlugin 实现决定（OTel Context / OpenTracing span 等）。
+    trace_context: Any = None
     # 流式模式专用：_on_chat/_on_agent push StreamChunk 到此 queue，
     # send_message_stream 从中消费。仅流式请求时创建，非流式为 None。
     stream_queue: asyncio.Queue[Any] | None = None

--- a/src/baas/src/secbaas/community/plugins/tracer/bare/__init__.py
+++ b/src/baas/src/secbaas/community/plugins/tracer/bare/__init__.py
@@ -80,3 +80,29 @@ class BareTracerPlugin(TracerPlugin):
             if ctx is not None and ctx.is_valid:
                 return format(ctx.trace_id, "032x")
         return "-"
+
+    def capture_context(self) -> Any:
+        """Capture the current OTel context for later restoration."""
+        from opentelemetry import context as otel_context
+        from opentelemetry import trace as otel_trace
+
+        ctx = otel_context.get_current()
+        span = otel_trace.get_current_span(ctx)
+        if span is not None and span.get_span_context().is_valid:
+            return ctx
+        return None
+
+    def attach_context(self, ctx: Any) -> Any:
+        """Activate a previously captured OTel context.
+
+        Returns a detach token to be passed to :meth:`detach_context`.
+        """
+        from opentelemetry import context as otel_context
+
+        return otel_context.attach(ctx)
+
+    def detach_context(self, token: Any) -> None:
+        """Restore the previous OTel context."""
+        from opentelemetry import context as otel_context
+
+        otel_context.detach(token)

--- a/src/baas/src/secbaas/community/spi/tracer/_protocols.py
+++ b/src/baas/src/secbaas/community/spi/tracer/_protocols.py
@@ -1,8 +1,9 @@
 """Tracer plugin Protocol — distributed tracing abstraction.
 
-Implementations provide ``setup``, ``install_middleware``, and
-``get_trace_id`` so that the application can initialise tracing
-independently of the backend (SOFA RPC native tracing or
+Implementations provide ``setup``, ``install_middleware``,
+``get_trace_id``, and trace-context propagation methods so that the
+application can initialise tracing and propagate context across async
+boundaries independently of the backend (SOFA RPC native tracing or
 OpenTelemetry).
 """
 
@@ -42,5 +43,32 @@ class TracerPlugin(Protocol):
         Returns:
             A 32-character hex trace ID string, or ``"-"`` if no
             active span exists.
+        """
+        ...
+
+    def capture_context(self) -> Any:
+        """Capture the current trace context for later restoration.
+
+        Called on the request side to snapshot the active trace context
+        so it can be restored in a different async task (e.g. WebSocket
+        callbacks).  Returns an opaque object whose type is specific to
+        the tracing backend, or ``None`` when no valid span is active.
+        """
+        ...
+
+    def attach_context(self, ctx: Any) -> Any:
+        """Restore a previously captured trace context.
+
+        Activates the given context as the current trace context.
+        Returns an opaque *token* that must be passed to
+        :meth:`detach_context` to restore the previous context.
+        """
+        ...
+
+    def detach_context(self, token: Any) -> None:
+        """Restore the previous trace context.
+
+        Args:
+            token: The value returned by :meth:`attach_context`.
         """
         ...

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -193,6 +193,35 @@ class TestWithSessionTrace:
         client._on_chat({"sessionKey": "", "state": "final"})
         # Should not raise, state should be None
 
+    @pytest.mark.asyncio
+    async def test_wrapper_attaches_and_detaches_trace_context(self, mock_bot_ws):
+        """Cover lines 75/83: attach_context / detach_context are called
+        when the matched session has a non-None trace_context."""
+        sentinel_ctx = object()
+        sentinel_token = object()
+        mock_tracer = MagicMock()
+        mock_tracer.attach_context.return_value = sentinel_token
+        mock_tracer.detach_context = MagicMock()
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client, "sk1")
+        state.trace_context = sentinel_ctx
+
+        with patch(
+            "secbaas.community.core.service.bot_run._async_chat_client.get_tracer_plugin",
+            return_value=mock_tracer,
+        ):
+            client._on_chat(
+                {
+                    "sessionKey": "sk1",
+                    "state": "final",
+                    "message": {"content": [{"text": "hi"}]},
+                }
+            )
+
+        mock_tracer.attach_context.assert_called_once_with(sentinel_ctx)
+        mock_tracer.detach_context.assert_called_once_with(sentinel_token)
+
 
 def _patch_decorator_test(fn):
     """Helper to verify decorator name-setting logic."""

--- a/src/baas/tests/unit/spi/tracer/test_tracer_plugins_bare.py
+++ b/src/baas/tests/unit/spi/tracer/test_tracer_plugins_bare.py
@@ -21,6 +21,9 @@ def _has_tracer_plugin_attrs(obj: object) -> bool:
         hasattr(obj, "setup")
         and hasattr(obj, "install_middleware")
         and hasattr(obj, "get_trace_id")
+        and hasattr(obj, "capture_context")
+        and hasattr(obj, "attach_context")
+        and hasattr(obj, "detach_context")
     )
 
 
@@ -121,3 +124,56 @@ class TestOtlpTracerPlugin:
             opentelemetry.trace, "get_current_span", return_value=mock_span
         ):
             assert BareTracerPlugin().get_trace_id() == "-"
+
+    def test_capture_context_returns_none_when_no_valid_span(self) -> None:
+        import opentelemetry.context
+        import opentelemetry.trace
+
+        mock_span = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.is_valid = False
+        mock_span.get_span_context.return_value = mock_ctx
+
+        with (
+            patch.object(opentelemetry.context, "get_current", return_value={}),
+            patch.object(
+                opentelemetry.trace, "get_current_span", return_value=mock_span
+            ),
+        ):
+            assert BareTracerPlugin().capture_context() is None
+
+    def test_capture_context_returns_context_when_valid_span(self) -> None:
+        import opentelemetry.context
+        import opentelemetry.trace
+
+        mock_ctx = MagicMock()
+        mock_ctx.is_valid = True
+        mock_span = MagicMock()
+        mock_span.get_span_context.return_value = mock_ctx
+
+        sentinel_ctx = object()
+        with (
+            patch.object(
+                opentelemetry.context, "get_current", return_value=sentinel_ctx
+            ),
+            patch.object(
+                opentelemetry.trace, "get_current_span", return_value=mock_span
+            ),
+        ):
+            assert BareTracerPlugin().capture_context() is sentinel_ctx
+
+    def test_attach_and_detach_context(self) -> None:
+        import opentelemetry.context
+
+        sentinel_token = object()
+        with patch.object(
+            opentelemetry.context, "attach", return_value=sentinel_token
+        ) as mock_attach:
+            plugin = BareTracerPlugin()
+            token = plugin.attach_context({"fake": "ctx"})
+            assert token is sentinel_token
+            mock_attach.assert_called_once_with({"fake": "ctx"})
+
+        with patch.object(opentelemetry.context, "detach") as mock_detach:
+            plugin.detach_context(sentinel_token)
+            mock_detach.assert_called_once_with(sentinel_token)


### PR DESCRIPTION
Extract OTel trace context capture/attach/detach logic from _async_chat_client into the TracerPlugin protocol, making trace context propagation backend-agnostic instead of hardcoded to OpenTelemetry.

- Add capture_context / attach_context / detach_context to TracerPlugin
- Implement these methods in BareTracerPlugin (delegates to opentelemetry.context)
- Change _SessionState.trace_context type from Context | None to Any
- Refactor _async_chat_client to call tracer plugin via get_tracer_plugin()
- Make _drain_stream_queue a staticmethod (does not use self)
- Add unit tests for BareTracerPlugin new methods