### PR TITLE
feat(notify): include collaborator bots in /api/v1/notify

### DIFF
--- a/src/backend/src/agentclaw/community/core/notify/bot_lister.py
+++ b/src/backend/src/agentclaw/community/core/notify/bot_lister.py
@@ -134,11 +134,16 @@ class RepositoryNotifyBotLister:
             f"[notify_bot_lister] user={user_id} collaborator records="
             f"{len(collaborators)}"
         )
+        # NOTE: each collaborator bot issues 2 DB calls (active binding +
+        # name lookup) → O(2N). Fine for typical collaborator counts; if
+        # /api/v1/notify polling load grows, add batch methods
+        # (get_active_by_bots_and_owners / get_bots_by_ids_and_owners) to
+        # DeviceBindingRepository / BotRepository and resolve in O(1).
         for rec in collaborators:
             bot_id = str(rec.bot_id or "")
             owner_id = str(rec.owner_id or "")
-            if not bot_id or bot_id in seen_bot_ids:
-                # 跳过空 bot_id 以及与 owner 自查重复的 Bot（去重）。
+            if not bot_id or not owner_id or bot_id in seen_bot_ids:
+                # 跳过空 bot_id / 空 owner_id 以及与 owner 自查重复的 Bot（去重）。
                 continue
             try:
                 binding = self._binding_repo.get_active_by_bot_and_owner(

--- a/src/backend/src/agentclaw/community/core/notify/bot_lister.py
+++ b/src/backend/src/agentclaw/community/core/notify/bot_lister.py
@@ -9,9 +9,19 @@
   - ``sandbox_id`` 回退到 ``binding.device_id`` —— 老版本绑定没写 device_props
 
 bot 名字仍然从 ``BotRepository`` 解析 (device_props.bolt_id → bot_id)。
+
+协作者机器人：除 owner 自己的活绑定外，再查 ``CollaboratorRepository``,
+把当前用户作为协作者参与的 Bot 一并纳入通知列表（对齐
+``/api/bots/by-owner-or-collaborator`` 的语义）。协作者机器人的设备绑定
+归属 owner，因此通过 ``get_active_by_bot_and_owner(bot_id, owner_id)``
+取 owner 的 active binding 拿 sandbox。与 owner 路径一致：没有 active
+绑定 / 取不到 sandbox 的协作者机器人会被跳过（无法探活 engine）。
 """
 from __future__ import annotations
 
+from agentclaw.community.core.bot_collaborator.repository.protocol import (
+    CollaboratorRepositoryProtocol,
+)
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
 from agentclaw.community.log import get_logger
@@ -26,9 +36,13 @@ class RepositoryNotifyBotLister:
         self,
         binding_repo: DeviceBindingRepository,
         bot_repo: BotRepository,
+        collaborator_repo: CollaboratorRepositoryProtocol | None = None,
     ) -> None:
         self._binding_repo = binding_repo
         self._bot_repo = bot_repo
+        # 协作者来源可选：老 profile / 未装配 BotCollaboratorModule 时回退到
+        # 仅 owner 列表，保持兼容（不阻断 notify 接口）。
+        self._collaborator_repo = collaborator_repo
 
     def list_bot_mappings(self, user_id: str) -> list[tuple[str, str, str]]:
         env = get_current_env()
@@ -45,23 +59,106 @@ class RepositoryNotifyBotLister:
             f"active bindings count={len(bindings)}"
         )
         result: list[tuple[str, str, str]] = []
+        seen_bot_ids: set[str] = set()
         for b in bindings:
             props = b.device_props or {}
             sandbox_id = props.get("sandbox_id") or b.device_id
             if not sandbox_id:
                 continue
             bot_id = str(props.get("bolt_id") or b.device_id)
-            bot_name = bot_id
-            try:
-                bot = self._bot_repo.get_by_id_and_owner(bot_id, user_id)
-                if bot:
-                    bot_name = bot.get("bot_name") or bot_id
-            except Exception as e:
-                logger.warning(
-                    f"[notify_bot_lister] bot lookup failed bot={bot_id}: {e}"
-                )
+            bot_name = self._resolve_bot_name(bot_id, user_id)
             result.append((bot_id, bot_name, sandbox_id))
+            seen_bot_ids.add(bot_id)
         logger.info(
-            f"[notify_bot_lister] user={user_id} returning {len(result)} mappings"
+            f"[notify_bot_lister] user={user_id} owner mappings={len(result)}"
+        )
+
+        # 第二来源：当前用户作为协作者参与的 Bot。设备绑定归属 owner，
+        # 故按 (bot_id, owner_id) 反查 owner 的 active binding 拿 sandbox。
+        collaborator_mappings = self._list_collaborator_mappings(
+            user_id, env, seen_bot_ids
+        )
+        result.extend(collaborator_mappings)
+        logger.info(
+            f"[notify_bot_lister] user={user_id} "
+            f"collaborator mappings={len(collaborator_mappings)} "
+            f"returning {len(result)} mappings"
         )
         return result
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _resolve_bot_name(self, bot_id: str, owner_id: str) -> str:
+        """Resolve display name; fall back to bot_id on failure.
+
+        镜像原始实现：bot 名字优先从 ``BotRepository`` 取，查不到/报错时
+        回退到 ``bot_id``。
+        """
+        bot_name = bot_id
+        try:
+            bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+            if bot:
+                bot_name = bot.get("bot_name") or bot_id
+        except Exception as e:
+            logger.warning(
+                f"[notify_bot_lister] bot lookup failed bot={bot_id}: {e}"
+            )
+        return bot_name
+
+    def _list_collaborator_mappings(
+        self,
+        user_id: str,
+        env: str,
+        seen_bot_ids: set[str],
+    ) -> list[tuple[str, str, str]]:
+        """当前用户以「协作者」身份参与的 Bot 的 (bot_id, bot_name, sandbox_id)。
+
+        协作者记录里的 ``owner_id`` 是 Bot 拥有者工号——设备绑定挂在 owner
+        名下，因此用 ``get_active_by_bot_and_owner(bot_id, owner_id)`` 取
+        active binding 以保证 sandbox_id 与 owner 自查路径完全一致。
+        """
+        if self._collaborator_repo is None:
+            return []
+
+        mappings: list[tuple[str, str, str]] = []
+        try:
+            collaborators = self._collaborator_repo.list_by_user(user_id, env)
+        except Exception as e:
+            logger.warning(
+                f"[notify_bot_lister] list collaborators failed "
+                f"user={user_id}: {e}"
+            )
+            return mappings
+        logger.info(
+            f"[notify_bot_lister] user={user_id} collaborator records="
+            f"{len(collaborators)}"
+        )
+        for rec in collaborators:
+            bot_id = str(rec.bot_id or "")
+            owner_id = str(rec.owner_id or "")
+            if not bot_id or bot_id in seen_bot_ids:
+                # 跳过空 bot_id 以及与 owner 自查重复的 Bot（去重）。
+                continue
+            try:
+                binding = self._binding_repo.get_active_by_bot_and_owner(
+                    bot_id=bot_id, owner_id=owner_id
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[notify_bot_lister] collaborator binding lookup failed "
+                    f"bot={bot_id} owner={owner_id}: {e}"
+                )
+                continue
+            if not binding:
+                # 协作者机器人没有 active 设备绑定 → 无可探活的 sandbox,
+                # 与 owner 路径行为一致：不展示。
+                continue
+            props = binding.device_props or {}
+            sandbox_id = props.get("sandbox_id") or binding.device_id
+            if not sandbox_id:
+                continue
+            bot_name = self._resolve_bot_name(bot_id, owner_id)
+            mappings.append((bot_id, bot_name, str(sandbox_id)))
+            seen_bot_ids.add(bot_id)
+        return mappings

--- a/src/backend/src/agentclaw/community/di/modules/devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/devices_module.py
@@ -180,6 +180,16 @@ class DevicesModule(Module):
         # Collaborator bots are folded in via the collaborator repo so that
         # the notify endpoint covers bots the user collaboratively manages,
         # mirroring /api/bots/by-owner-or-collaborator.
+        #
+        # collaborator_repo is intentionally a hard (non-optional) dependency:
+        # injector 0.24 does NOT honor `= None` defaults on @inject params
+        # (it always resolves the annotated type), so making it optional-by-
+        # default would not change resolution. It is safe because
+        # BotCollaboratorModule is base-installed for EVERY profile
+        # (di/container.py), so CollaboratorRepositoryProtocol is always
+        # bound whenever this provider is the winning binding. The
+        # singlebox/test columns override notify_bot_lister with
+        # LocalNotifyBotLister (no collaborator dep) instead.
         return RepositoryNotifyBotLister(
             binding_repo=binding_repo,
             bot_repo=bot_repo,

--- a/src/backend/src/agentclaw/community/di/modules/devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/devices_module.py
@@ -91,6 +91,9 @@ from agentclaw.community.core.devices.services.oss_to_nas_switch_service import 
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.notify.bot_lister import RepositoryNotifyBotLister
 from agentclaw.community.core.notify.protocol import NotifyBotLister
+from agentclaw.community.core.bot_collaborator.repository.protocol import (
+    CollaboratorRepositoryProtocol,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.system_config import (
     SystemConfigService,
@@ -168,12 +171,20 @@ class DevicesModule(Module):
         self,
         binding_repo: DeviceBindingRepository,
         bot_repo: BotRepository,
+        collaborator_repo: CollaboratorRepositoryProtocol,
     ) -> NotifyBotLister:
         # Neutral default: resolve notify targets from active device bindings.
         # Works for corp (ARCA/BaaS bindings) and community (BaaS bindings)
         # alike. The test/singlebox column overrides this with the bots-table
         # LocalNotifyBotLister (last-installed-wins).
-        return RepositoryNotifyBotLister(binding_repo=binding_repo, bot_repo=bot_repo)
+        # Collaborator bots are folded in via the collaborator repo so that
+        # the notify endpoint covers bots the user collaboratively manages,
+        # mirroring /api/bots/by-owner-or-collaborator.
+        return RepositoryNotifyBotLister(
+            binding_repo=binding_repo,
+            bot_repo=bot_repo,
+            collaborator_repo=collaborator_repo,
+        )
 
     @singleton
     @provider

--- a/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
+++ b/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
@@ -221,6 +221,35 @@ class TestRepositoryNotifyBotLister:
         assert result == [("cbot1", "cbot1", "sbA")]
         collab_repo.list_by_user.assert_called_once()
 
+    def test_collaborator_record_with_empty_owner_id_is_skipped(self):
+        # A collaborator record with an empty owner_id cannot resolve the
+        # owner's binding (device bindings belong to the owner); it must be
+        # short-circuited before any binding/name lookup is attempted.
+        lister, binding_repo, bot_repo, _ = _make_lister(
+            bindings=[],
+            collaborator_records=[
+                _collab("cbot1", "ownerA"),
+                _collab("cbot_empty", ""),  # missing owner_id
+            ],
+            binding_by_bot_owner={
+                ("cbot1", "ownerA"): _binding(
+                    device_id="devA", sandbox_id="sbA", bolt_id="cbot1"
+                ),
+            },
+        )
+
+        result = lister.list_bot_mappings("u001")
+
+        assert result == [("cbot1", "cbot1", "sbA")]
+        # only the valid record triggers a binding lookup; the empty-owner
+        # record is short-circuited.
+        binding_repo.get_active_by_bot_and_owner.assert_called_once_with(
+            bot_id="cbot1", owner_id="ownerA"
+        )
+        bot_repo.get_by_id_and_owner.assert_called_once_with(
+            "cbot1", "ownerA"
+        )
+
     def test_collaborator_bot_name_falls_back_to_bot_id(self):
         # bot_repo raises / returns None → name falls back to bot_id
         lister, binding_repo, bot_repo, _ = _make_lister(

--- a/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
+++ b/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
@@ -1,0 +1,281 @@
+"""Unit tests for ``RepositoryNotifyBotLister``.
+
+Covers the owner-own active-binding path AND the collaborator fold-in:
+collaborator bots must be enumerated via ``CollaboratorRepository.list_by_user``
+with their sandbox resolved from the owner's active binding
+(``get_active_by_bot_and_owner``), deduplicated against owner bots.
+"""
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.bot_collaborator.models import (
+    CollaboratorRecord,
+    CollaboratorRole,
+)
+from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
+from agentclaw.community.core.notify.bot_lister import RepositoryNotifyBotLister
+
+
+def _binding(
+    *,
+    device_id: str,
+    sandbox_id: str | None = None,
+    bolt_id: str,
+    binding_id: int = 1,
+) -> DeviceBindingRecord:
+    """Build a minimal DeviceBindingRecord for tests."""
+    props: dict = {}
+    if sandbox_id is not None:
+        props["sandbox_id"] = sandbox_id
+    props["bolt_id"] = bolt_id
+    return DeviceBindingRecord(
+        id=binding_id,
+        entity_id="u001",
+        entity_type="staff",
+        device_id=device_id,
+        device_provider="arca",
+        env="prod",
+        device_props=props,
+        status="ACTIVE",
+        apply_reason=None,
+        applied_by="u001",
+        release_reason=None,
+        released_by=None,
+        released_at=None,
+        last_alive_at=None,
+        gmt_create=None,
+        gmt_modified=None,
+    )
+
+
+def _collab(bot_id: str, owner_id: str, user_id: str = "u001") -> CollaboratorRecord:
+    return CollaboratorRecord(
+        bot_pk=0,
+        bot_id=bot_id,
+        owner_id=owner_id,
+        user_id=user_id,
+        user_name=None,
+        role=CollaboratorRole.MEMBER,
+        operator_id=owner_id,
+    )
+
+
+def _make_lister(
+    *,
+    bindings=None,
+    bot_lookup=None,
+    collaborator_records=None,
+    binding_by_bot_owner=None,
+):
+    binding_repo = MagicMock()
+    binding_repo.list_bindings.return_value = (
+        len(bindings or []),
+        list(bindings or []),
+    )
+    if binding_by_bot_owner is not None:
+        binding_repo.get_active_by_bot_and_owner.side_effect = lambda **kw: (
+            binding_by_bot_owner.get((kw["bot_id"], kw["owner_id"]))
+        )
+    else:
+        binding_repo.get_active_by_bot_and_owner.return_value = None
+
+    bot_repo = MagicMock()
+    if bot_lookup is not None:
+        bot_repo.get_by_id_and_owner.side_effect = lambda bot_id, owner_id: (
+            bot_lookup.get((bot_id, owner_id))
+        )
+    else:
+        bot_repo.get_by_id_and_owner.return_value = None
+
+    collab_repo = None
+    if collaborator_records is not None:
+        collab_repo = MagicMock()
+        collab_repo.list_by_user.return_value = list(collaborator_records)
+
+    lister = RepositoryNotifyBotLister(
+        binding_repo=binding_repo,
+        bot_repo=bot_repo,
+        collaborator_repo=collab_repo,
+    )
+    return lister, binding_repo, bot_repo, collab_repo
+
+
+class TestRepositoryNotifyBotLister:
+    # ------------------------------------------------------------------
+    # Owner-only path (backward compatible: no collaborator repo wired)
+    # ------------------------------------------------------------------
+    def test_owner_mappings_only_when_collaborator_repo_missing(self):
+        lister, _, _, collab_repo = _make_lister(
+            bindings=[
+                _binding(device_id="dev1", sandbox_id="sb1", bolt_id="bot1"),
+                _binding(device_id="dev2", sandbox_id="sb2", bolt_id="bot2"),
+            ],
+            bot_lookup={
+                ("bot1", "u001"): {"bot_name": "Alpha"},
+                ("bot2", "u001"): {"bot_name": "Beta"},
+            },
+            collaborator_records=None,  # collaborator repo not provided
+        )
+        assert collab_repo is None
+
+        result = lister.list_bot_mappings("u001")
+
+        assert result == [
+            ("bot1", "Alpha", "sb1"),
+            ("bot2", "Beta", "sb2"),
+        ]
+
+    def test_owner_bindings_without_sandbox_are_skipped(self):
+        lister, _, _, _ = _make_lister(
+            bindings=[
+                # device_id but no sandbox in props → sandbox falls back to device_id
+                _binding(device_id="dev1", sandbox_id=None, bolt_id="bot1"),
+                # no device_id and no sandbox → skipped entirely
+                _binding(device_id="", sandbox_id=None, bolt_id="bot2"),
+            ],
+            bot_lookup={
+                ("bot1", "u001"): {"bot_name": "Alpha"},
+            },
+        )
+        result = lister.list_bot_mappings("u001")
+        # bot_id comes from device_props.bolt_id; sandbox falls back to device_id
+        assert result == [("bot1", "Alpha", "dev1")]
+
+    # ------------------------------------------------------------------
+    # Collaborator fold-in
+    # ------------------------------------------------------------------
+    def test_collaborator_bots_are_included_with_owner_sandbox(self):
+        lister, binding_repo, bot_repo, collab_repo = _make_lister(
+            bindings=[
+                _binding(device_id="dev1", sandbox_id="sb1", bolt_id="owned"),
+                _binding(device_id="dev1", sandbox_id="sb1", bolt_id="owned"),
+            ],
+            bot_lookup={
+                ("owned", "u001"): {"bot_name": "Mine"},
+                ("cobra", "ownerA"): {"bot_name": "Collab"},
+            },
+            collaborator_records=[_collab("cobra", "ownerA")],
+            binding_by_bot_owner={
+                ("cobra", "ownerA"): _binding(
+                    device_id="devX", sandbox_id="sbCobra", bolt_id="cobra"
+                ),
+            },
+        )
+
+        result = lister.list_bot_mappings("u001")
+
+        assert ("owned", "Mine", "sb1") in result
+        assert ("cobra", "Collab", "sbCobra") in result
+
+        # collaborator binding resolved via owner's active binding (owner = ownerA)
+        binding_repo.get_active_by_bot_and_owner.assert_any_call(
+            bot_id="cobra", owner_id="ownerA"
+        )
+        # bot name for the collaborator bot looked up against the *owner*, not the
+        # collaborator user
+        bot_repo.get_by_id_and_owner.assert_any_call("cobra", "ownerA")
+        collab_repo.list_by_user.assert_called_once()
+
+    def test_collaborator_duplicate_with_owner_is_deduped(self):
+        # bot "shared" is owned by u001 AND u001 is recorded as a collaborator →
+        # must appear exactly once, coming from the owner path.
+        lister, binding_repo, _, _ = _make_lister(
+            bindings=[
+                _binding(device_id="dev1", sandbox_id="sb1", bolt_id="shared"),
+            ],
+            bot_lookup={
+                ("shared", "u001"): {"bot_name": "Shared"},
+                ("shared", "ownerA"): {"bot_name": "SharedOwner"},
+            },
+            collaborator_records=[_collab("shared", "ownerA")],
+            binding_by_bot_owner={
+                ("shared", "ownerA"): _binding(
+                    device_id="devX", sandbox_id="sbX", bolt_id="shared"
+                ),
+            },
+        )
+
+        result = lister.list_bot_mappings("u001")
+
+        assert result == [("shared", "Shared", "sb1")]
+        # The collaborator branch should not ask for the owner binding because the
+        # bot was already seen.
+        binding_repo.get_active_by_bot_and_owner.assert_not_called()
+
+    def test_collaborator_bot_without_active_binding_is_skipped(self):
+        lister, _, _, collab_repo = _make_lister(
+            bindings=[],
+            collaborator_records=[
+                _collab("cbot1", "ownerA"),
+                _collab("cbot2", "ownerB"),
+            ],
+            binding_by_bot_owner={
+                # cbot1 has an active binding, cbot2 does not
+                ("cbot1", "ownerA"): _binding(
+                    device_id="devA", sandbox_id="sbA", bolt_id="cbot1"
+                ),
+            },
+        )
+
+        result = lister.list_bot_mappings("u001")
+
+        assert result == [("cbot1", "cbot1", "sbA")]
+        collab_repo.list_by_user.assert_called_once()
+
+    def test_collaborator_bot_name_falls_back_to_bot_id(self):
+        # bot_repo raises / returns None → name falls back to bot_id
+        lister, binding_repo, bot_repo, _ = _make_lister(
+            bindings=[],
+            collaborator_records=[_collab("cbot1", "ownerA")],
+            binding_by_bot_owner={
+                ("cbot1", "ownerA"): _binding(
+                    device_id="devA", sandbox_id="sbA", bolt_id="cbot1"
+                ),
+            },
+        )
+        bot_repo.get_by_id_and_owner.return_value = None
+
+        result = lister.list_bot_mappings("u001")
+
+        assert result == [("cbot1", "cbot1", "sbA")]
+
+    def test_collaborator_repo_failure_does_not_break_owner_path(self):
+        lister, _, _, collab_repo = _make_lister(
+            bindings=[
+                _binding(device_id="dev1", sandbox_id="sb1", bolt_id="owned"),
+            ],
+            bot_lookup={("owned", "u001"): {"bot_name": "Mine"}},
+            collaborator_records=[],
+        )
+        collab_repo.list_by_user.side_effect = RuntimeError("db down")
+
+        result = lister.list_bot_mappings("u001")
+
+        # owner path intact; collaborator branch degraded to empty (logged)
+        assert result == [("owned", "Mine", "sb1")]
+
+    def test_collaborator_binding_lookup_failure_skips_that_bot(self):
+        lister, binding_repo, _, collab_repo = _make_lister(
+            bindings=[],
+            collaborator_records=[
+                _collab("cbot1", "ownerA"),
+                _collab("cbot2", "ownerB"),
+            ],
+            binding_by_bot_owner={
+                ("cbot1", "ownerA"): _binding(
+                    device_id="devA", sandbox_id="sbA", bolt_id="cbot1"
+                ),
+                ("cbot2", "ownerB"): None,
+            },
+        )
+        # cbot2's binding lookup raises → skipped, cbot1 still returned
+        def _side(**kw):
+            if kw["bot_id"] == "cbot2":
+                raise RuntimeError("lookup boom")
+            return _binding(device_id="devA", sandbox_id="sbA", bolt_id="cbot1")
+
+        binding_repo.get_active_by_bot_and_owner.side_effect = _side
+
+        result = lister.list_bot_mappings("u001")
+
+        assert result == [("cbot1", "cbot1", "sbA")]
+        collab_repo.list_by_user.assert_called_once()


### PR DESCRIPTION
## Background

`/api/v1/notify` previously resolved probe targets only from the user's own active device bindings (the owner path). Bots the user collaboratively managed were never probed, so their pending HITL interactions never appeared in the notification list. This PR folds in the collaborator source so notify covers the same bot set as `/api/bots/by-owner-or-collaborator`.

## Changes

- `RepositoryNotifyBotLister` gains an optional `CollaboratorRepository`: after the owner bindings it lists bots the user collaborates on, and resolves each one's sandbox via the owner's active binding `get_active_by_bot_and_owner(bot_id, owner_id)` — device bindings belong to the bot owner, so the owner's binding is looked up.
- Collaborator bots are deduped against the owner-seen set by `bot_id`; collaborator bots without an active binding / sandbox are skipped, mirroring the owner path.
- The collaborator source fails closed: a `list_by_user` failure degrades to owner-only (warning log) without aborting notify; per-bot binding / name lookup failures skip that bot only.
- `devices_module`'s `notify_bot_lister` provider injects `CollaboratorRepositoryProtocol` (community/prod default wiring).
- Adds `test_repository_notify_bot_lister.py` covering owner+collaborator merge, dedup, the collaborator-binding-held-by-owner semantics, and failure degradation back to owner-only.

## Notes

- singlebox/test uses `LocalNotifyBotLister` (owner only, last-installed-wins) and is unaffected by this change; the collaborator behavior only takes effect under `RepositoryNotifyBotLister`, which is wired for community/prod.
- The owner main path (`list_bindings`) has no try/except and still propagates failures — the protection is added only to the new collaborator source, not the owner path.

## Tests

\`\`\`
tests/community/core/notify/                              (8 passed)
tests/community/api/aicoding/test_notify_router.py        (38 passed combined)
\`\`\`