### PR TITLE
Update organization API paths and candidate bot responses

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/router.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/router.rs
@@ -79,7 +79,7 @@ fn build_api_routes() -> Router<HttpAppState> {
                 .post(routes::organizations::create_organization),
         )
         .route(
-            "/providers/{provider_id}/organizations/{organization_code}",
+            "/organizations/{organization_code}",
             get(routes::organizations::get_organization)
                 .patch(routes::organizations::patch_organization),
         )

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -10,7 +10,7 @@ use bcs_domain::ProviderRecord;
 use bcs_protocol::BCN_PROVIDER_ID_HEADER;
 use bcs_service_api::{
     AsyncA2aChatCommand, BotActor, CallerContext, ChatResponseMode, ChatRunQueryCommand,
-    BotTerminalState, OrganizationAuth, ServiceError,
+    BotTerminalState, OrganizationAuth, OrganizationMemberAuth, ServiceError,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -470,7 +470,12 @@ async fn authenticate_manager(
     let organization = state
         .services
         .organization_management
-        .get(auth.clone(), organization_code)
+        .get(
+            OrganizationMemberAuth {
+                provider_admin_token: token.to_string(),
+            },
+            organization_code,
+        )
         .await
         .map_err(|error| match error {
             ServiceError::Unauthorized(_) => AdminRunRouteError::new(

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/organizations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/organizations.rs
@@ -72,10 +72,10 @@ pub async fn create_organization(
 
 pub async fn get_organization(
     State(state): State<HttpAppState>,
-    Path((provider_id, organization_code)): Path<(String, String)>,
+    Path(organization_code): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<OrganizationResponse>, HttpAdapterError> {
-    let auth = organization_auth(provider_id, &headers)?;
+    let auth = organization_member_auth(&headers)?;
     let organization = state
         .services
         .organization_management
@@ -105,11 +105,11 @@ pub async fn list_organizations(
 
 pub async fn patch_organization(
     State(state): State<HttpAppState>,
-    Path((provider_id, organization_code)): Path<(String, String)>,
+    Path(organization_code): Path<String>,
     headers: HeaderMap,
     Json(req): Json<PatchOrganizationRequest>,
 ) -> Result<Json<OrganizationResponse>, HttpAdapterError> {
-    let auth = organization_auth(provider_id, &headers)?;
+    let auth = organization_member_auth(&headers)?;
     let organization = state
         .services
         .organization_management
@@ -375,6 +375,6 @@ fn candidate_to_response(bot: OrganizationCandidateBot) -> OrganizationCandidate
     OrganizationCandidateBotResponse {
         bot_uuid: bot.bot_uuid,
         provider_id: bot.provider_id,
-        capabilities: to_wire_capabilities(bot.capabilities),
+        name: bot.capabilities.name,
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/organizations_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/organizations_contract.rs
@@ -42,6 +42,7 @@ fn test_app() -> TestApp {
 struct RecordingOrganizationManagement {
     calls: Mutex<Vec<String>>,
     next_error: Mutex<Option<ServiceError>>,
+    candidate_name_missing: AtomicBool,
     member_bot_missing: AtomicBool,
     member_missing: AtomicBool,
 }
@@ -72,9 +73,13 @@ impl OrganizationManagementService for RecordingOrganizationManagement {
         Ok(sample_org(command.auth.provider_id, command.organization_code))
     }
 
-    async fn get(&self, auth: OrganizationAuth, code: &str) -> ServiceResult<Organization> {
-        self.record(format!("get:{}:{code}", auth.provider_id)).await?;
-        Ok(sample_org(auth.provider_id, code.to_string()))
+    async fn get(
+        &self,
+        auth: OrganizationMemberAuth,
+        code: &str,
+    ) -> ServiceResult<Organization> {
+        self.record(format!("get:{}:{code}", auth.provider_admin_token)).await?;
+        Ok(sample_org("provider-a".to_string(), code.to_string()))
     }
 
     async fn list(
@@ -87,8 +92,8 @@ impl OrganizationManagementService for RecordingOrganizationManagement {
     }
 
     async fn update(&self, command: UpdateOrganizationCommand) -> ServiceResult<Organization> {
-        self.record(format!("update:{}:{}", command.auth.provider_id, command.organization_code)).await?;
-        Ok(sample_org(command.auth.provider_id, command.organization_code))
+        self.record(format!("update:{}:{}", command.auth.provider_admin_token, command.organization_code)).await?;
+        Ok(sample_org("provider-a".to_string(), command.organization_code))
     }
 
     async fn put_member(
@@ -224,7 +229,11 @@ impl OrganizationManagementService for RecordingOrganizationManagement {
         Ok(vec![OrganizationCandidateBot {
             bot_uuid: "bot-b".to_string(),
             provider_id: "provider-b".to_string(),
-            capabilities: bcs_service_api::BotCapabilities::default(),
+            capabilities: bcs_service_api::BotCapabilities {
+                name: (!self.candidate_name_missing.load(Ordering::Relaxed))
+                    .then(|| "Bot B".to_string()),
+                ..bcs_service_api::BotCapabilities::default()
+            },
         }])
     }
 }
@@ -355,13 +364,13 @@ async fn get_member_returns_not_found_when_member_is_missing() {
 }
 
 #[tokio::test]
-async fn provider_scoped_organization_routes_call_application_service() {
+async fn organization_routes_call_application_service() {
     let app = test_app();
     let cases = [
         ("POST", "/providers/provider-a/organizations", Some(json!({"organization_code":"promo-2026","name":"Promo 2026","description":"campaign"})), StatusCode::OK),
-        ("GET", "/providers/provider-a/organizations/promo-2026", None, StatusCode::OK),
+        ("GET", "/organizations/promo-2026", None, StatusCode::OK),
         ("GET", "/providers/provider-a/organizations?include_disabled=true", None, StatusCode::OK),
-        ("PATCH", "/providers/provider-a/organizations/promo-2026", Some(json!({"name":"Promo 2026 updated","description":null,"disabled":false})), StatusCode::OK),
+        ("PATCH", "/organizations/promo-2026", Some(json!({"name":"Promo 2026 updated","description":null,"disabled":false})), StatusCode::OK),
         ("PUT", "/organizations/promo-2026/members/bot-b", Some(json!({"role":"traffic"})), StatusCode::OK),
         ("DELETE", "/organizations/promo-2026/members/bot-b", None, StatusCode::NO_CONTENT),
         ("GET", "/organizations/promo-2026/members", None, StatusCode::OK),
@@ -372,6 +381,25 @@ async fn provider_scoped_organization_routes_call_application_service() {
     for (method, uri, body, expected_status) in cases {
         let response = request(&app.app, method, uri, Some("provider-token"), body).await;
         assert_eq!(response.status(), expected_status, "{method} {uri}");
+    }
+}
+
+#[tokio::test]
+async fn provider_prefixed_organization_detail_routes_are_removed() {
+    let app = test_app();
+    for (method, body) in [
+        ("GET", None),
+        ("PATCH", Some(json!({"name": "Promo 2026 updated"}))),
+    ] {
+        let response = request(
+            &app.app,
+            method,
+            "/providers/provider-a/organizations/promo-2026",
+            Some("provider-token"),
+            body,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{method}");
     }
 }
 
@@ -490,6 +518,50 @@ async fn patch_member_profile_requires_admin_token_and_maps_service_errors() {
         .await;
         assert_eq!(response.status(), expected_status);
     }
+}
+
+#[tokio::test]
+async fn candidate_bots_response_exposes_name_without_capabilities() {
+    let app = test_app();
+    let response = request(
+        &app.app,
+        "GET",
+        "/providers/provider-a/organization-candidate-bots?q=traffic",
+        Some("provider-token"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await;
+    assert_eq!(
+        json["bots"][0],
+        json!({
+            "bot_uuid": "bot-b",
+            "provider_id": "provider-b",
+            "name": "Bot B"
+        })
+    );
+    assert!(json["bots"][0].get("capabilities").is_none());
+}
+
+#[tokio::test]
+async fn candidate_bots_response_keeps_missing_name_as_null() {
+    let app = test_app();
+    app.recording.candidate_name_missing.store(true, Ordering::Relaxed);
+    let response = request(
+        &app.app,
+        "GET",
+        "/providers/provider-a/organization-candidate-bots",
+        Some("provider-token"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await;
+    assert_eq!(json["bots"][0]["name"], Value::Null);
+    assert!(json["bots"][0].get("capabilities").is_none());
 }
 
 #[tokio::test]
@@ -613,12 +685,12 @@ async fn member_page_service_contract_applies_page_query() {
 }
 
 #[tokio::test]
-async fn provider_scoped_organization_routes_reject_missing_bearer_token() {
+async fn organization_detail_routes_reject_missing_bearer_token() {
     let app = test_app();
     let response = request(
         &app.app,
         "GET",
-        "/providers/provider-a/organizations/promo-2026",
+        "/organizations/promo-2026",
         None,
         None,
     )
@@ -627,7 +699,7 @@ async fn provider_scoped_organization_routes_reject_missing_bearer_token() {
 }
 
 #[tokio::test]
-async fn provider_scoped_organization_routes_map_service_errors() {
+async fn organization_detail_routes_map_service_errors() {
     let app = test_app();
     let cases = [
         (ServiceError::Unauthorized("bad token".to_string()), StatusCode::UNAUTHORIZED),
@@ -644,7 +716,7 @@ async fn provider_scoped_organization_routes_map_service_errors() {
         let response = request(
             &app.app,
             "GET",
-            "/providers/provider-a/organizations/promo-2026",
+            "/organizations/promo-2026",
             Some("provider-token"),
             None,
         )

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/organizations.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/organizations.rs
@@ -106,7 +106,7 @@ pub struct OrganizationMemberListResponse {
 pub struct OrganizationCandidateBotResponse {
     pub bot_uuid: String,
     pub provider_id: String,
-    pub capabilities: BotCapabilities,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/organization.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/organization.rs
@@ -29,7 +29,7 @@ pub struct CreateOrganizationCommand {
 
 #[derive(Debug, Clone)]
 pub struct UpdateOrganizationCommand {
-    pub auth: OrganizationAuth,
+    pub auth: OrganizationMemberAuth,
     pub organization_code: String,
     pub name: Option<String>,
     pub description: Option<Option<String>>,
@@ -55,7 +55,11 @@ pub struct UpdateOrganizationMemberProfileCommand {
 #[async_trait]
 pub trait OrganizationManagementService: Send + Sync {
     async fn create(&self, command: CreateOrganizationCommand) -> ServiceResult<Organization>;
-    async fn get(&self, auth: OrganizationAuth, code: &str) -> ServiceResult<Organization>;
+    async fn get(
+        &self,
+        auth: OrganizationMemberAuth,
+        code: &str,
+    ) -> ServiceResult<Organization>;
     async fn list(
         &self,
         auth: OrganizationAuth,

--- a/src/bcs/crates/services/bcs-organization/src/application.rs
+++ b/src/bcs/crates/services/bcs-organization/src/application.rs
@@ -60,9 +60,13 @@ impl OrganizationManagementService for OrganizationManagement {
             .await
     }
 
-    async fn get(&self, auth: OrganizationAuth, code: &str) -> ServiceResult<Organization> {
-        self.authenticate(&auth).await?;
-        self.core.get_for_manager(&auth.provider_id, code).await
+    async fn get(
+        &self,
+        auth: OrganizationMemberAuth,
+        code: &str,
+    ) -> ServiceResult<Organization> {
+        let provider_id = self.authenticate_member(&auth).await?;
+        self.core.get_for_manager(&provider_id, code).await
     }
 
     async fn list(
@@ -77,10 +81,10 @@ impl OrganizationManagementService for OrganizationManagement {
     }
 
     async fn update(&self, command: UpdateOrganizationCommand) -> ServiceResult<Organization> {
-        self.authenticate(&command.auth).await?;
+        let provider_id = self.authenticate_member(&command.auth).await?;
         self.core
             .update_for_manager(
-                &command.auth.provider_id,
+                &provider_id,
                 &command.organization_code,
                 command.name.as_deref(),
                 command

--- a/src/bcs/crates/services/bcs-organization/tests/management.rs
+++ b/src/bcs/crates/services/bcs-organization/tests/management.rs
@@ -666,7 +666,7 @@ async fn put_member_rejects_disabled_organization_before_bot_checks() {
     create_org(&ctx, &provider_a).await;
     ctx.service
         .update(UpdateOrganizationCommand {
-            auth: provider_auth(&provider_a),
+            auth: member_auth(&provider_a),
             organization_code: "promo-2026".to_string(),
             name: None,
             description: None,
@@ -731,7 +731,7 @@ async fn organization_management_rejects_wrong_manager_and_bad_auth() {
 
     let wrong_manager = ctx
         .service
-        .get(provider_auth(&provider_b), "promo-2026")
+        .get(member_auth(&provider_b), "promo-2026")
         .await
         .expect_err("wrong manager should be rejected");
     assert!(matches!(wrong_manager, ServiceError::Forbidden(reason) if reason == "organization_manager_required"));
@@ -778,7 +778,7 @@ async fn validation_rejects_invalid_code_invalid_role_and_patch_without_fields()
     let patch_without_fields = ctx
         .service
         .update(UpdateOrganizationCommand {
-            auth: provider_auth(&provider_a),
+            auth: member_auth(&provider_a),
             organization_code: "promo-2026".to_string(),
             name: None,
             description: None,
@@ -996,7 +996,7 @@ async fn effective_membership_rejects_disabled_org_disabled_member_and_nonmember
 
     ctx.service
         .update(UpdateOrganizationCommand {
-            auth: provider_auth(&provider_a),
+            auth: member_auth(&provider_a),
             organization_code: "promo-2026".to_string(),
             name: None,
             description: None,

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
@@ -5,8 +5,9 @@ use bcs_service_api::{
     BotManagementService, BotOnboardingService, BotQueryService, BotRuntimeConnectionService,
     FriendService, GroupFusionService, GroupManagementService, GroupMessageHistoryService,
     GroupProposalService, GroupQueryService, HumanActorService, MessageFlowService,
-    CreateOrganizationCommand, OrganizationAuth, OrganizationManagementService, ServiceError,
-    SystemMessageService, WorkbenchSessionService, WorkerProfileService,
+    CreateOrganizationCommand, OrganizationAuth, OrganizationManagementService,
+    OrganizationMemberAuth, ServiceError, SystemMessageService, WorkbenchSessionService,
+    WorkerProfileService,
 };
 
 pub async fn a2a_chat_service_contract_tests<T: A2aChatService + ?Sized>(_svc: &T) {}
@@ -77,7 +78,12 @@ pub async fn organization_management_service_contract_tests<
     assert_eq!(created.code, organization_code);
 
     let fetched = svc
-        .get(valid_auth, organization_code)
+        .get(
+            OrganizationMemberAuth {
+                provider_admin_token: valid_auth.provider_admin_token,
+            },
+            organization_code,
+        )
         .await
         .expect("get organization through application service");
     assert_eq!(fetched.name, "Application Contract");

--- a/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
@@ -663,7 +663,11 @@ impl OrganizationManagementService for NoopOrganizationManagementService {
         Err(service_not_configured("organization service"))
     }
 
-    async fn get(&self, _auth: OrganizationAuth, _code: &str) -> ServiceResult<Organization> {
+    async fn get(
+        &self,
+        _auth: OrganizationMemberAuth,
+        _code: &str,
+    ) -> ServiceResult<Organization> {
         Err(service_not_configured("organization service"))
     }
 

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -765,12 +765,12 @@ print("1" if any(item.get("organization_code") == target for item in json.load(s
 ' "$organization_code" 2>/dev/null || echo 0)
     assert_eq "organization list includes the created organization" "$listed_organization" "1"
 
-    api_request_headers GET "/providers/${provider_id}/organizations/${organization_code}" "" \
+    api_request_headers GET "/organizations/${organization_code}" "" \
         "Authorization: Bearer ${admin_token}"
     require_status "provider reads its organization" "200" || return
     assert_json_eq "organization read keeps its name" "$RESPONSE" "name" "E2E release organization"
 
-    api_request_headers PATCH "/providers/${provider_id}/organizations/${organization_code}" \
+    api_request_headers PATCH "/organizations/${organization_code}" \
         '{"name":"E2E release organization updated"}' \
         "Authorization: Bearer ${admin_token}"
     require_status "provider updates its organization" "200" || return


### PR DESCRIPTION
## Summary

- Move organization lookup and update from `GET/PATCH /providers/{provider}/organizations/{organization_code}` to `GET/PATCH /organizations/{organization_code}`, removing the legacy routes.
- Preserve the existing provider-admin token behavior by resolving the provider identity from the supplied token; no new authentication type is introduced.
- Change organization candidate bot responses to return `bot_uuid`, `provider_id`, and nullable `name`, while omitting `capabilities` from the HTTP response.
- Update the HTTP contract tests, organization service tests, application contracts, test support, and E2E story paths.

## Motivation

Organization lookup and update should be addressed directly by organization code instead of requiring a redundant provider path segment. Candidate bot discovery should expose only the fields needed by clients and avoid leaking the complete capabilities document.

## Validation

- `cargo test -p bcs-http --test organizations_contract` — 18 passed
- `cargo test -p bcs-organization --test management` — 24 passed
- `cargo check -p bcs-http -p bcs-organization -p bcs-service-api -p bcs-protocol`
- `bash -n src/bcs/scripts/e2e-test/stories.sh`
- `git diff --check`

The local full pre-push run completed 2,299 of 2,315 tests successfully. The remaining 16 process-spawning BCS/CLI tests were interrupted or exceeded their local startup window; all tests directly covering this change passed.
