### PR TITLE
fix(bcs): decouple CLI and downstream timeouts

### DIFF
--- a/docs/bot-provider-integration.md
+++ b/docs/bot-provider-integration.md
@@ -106,7 +106,7 @@ Core downstream body fields:
 | `to_bot.provider_bot_ref` | Same as above | Provider-local bot identifier used to route to the Provider's bot runtime. |
 | `session_id` | `chat.send` / `chat.inject` / `chat.history` / `chat.abort` | Session identifier. The Provider maintains context by this value. |
 | `message` | `chat.send` / `chat.inject` | Current downstream message. |
-| `timeout_ms` | `chat.send` / `chat.inject` / `chat.history` | Timeout for BCS to wait for Provider acknowledgement or callback. |
+| `timeout_ms` | `chat.send` / `chat.inject` / `chat.history` | Downstream operation timeout. For direct A2A `chat.send` submitted by `bcs-cli chat`, BCS sends a fixed 2-hour execution budget (`7200000` ms), independent of the CLI polling timeout. |
 
 ## Calling BCS back
 

--- a/docs/bot-provider-integration.zh-CN.md
+++ b/docs/bot-provider-integration.zh-CN.md
@@ -87,7 +87,7 @@ X-BCN-Timestamp: <unix-ms>
 | `to_bot.provider_bot_ref` | 同上 | Provider 内部 bot 标识，用于路由到自己的 bot runtime。 |
 | `session_id` | `chat.send` / `chat.inject` / `chat.history` / `chat.abort` | 会话标识，Provider 按它维护上下文。 |
 | `message` | `chat.send` / `chat.inject` | 当前下发消息。 |
-| `timeout_ms` | `chat.send` / `chat.inject` / `chat.history` | BCS 等待 Provider 确认或回调的超时时间。 |
+| `timeout_ms` | `chat.send` / `chat.inject` / `chat.history` | 下游操作超时。对于 `bcs-cli chat` 发起的 A2A 直聊 `chat.send`，BCS 固定下发 2 小时执行预算（`7200000` 毫秒），与 CLI 的轮询超时相互独立。 |
 
 ## 回调 BCS
 

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -292,7 +292,7 @@ pub struct BcsConfig {
 
     /// Async chat run (bcs-cli chat-async) — max wall-clock a single run may
     /// be pending/running before the cleanup task marks it failed("timeout").
-    /// Default 2 h, configurable up to 24 h.
+    /// Default 2 h 5 min, configurable up to 24 h.
     #[serde(default = "default_async_chat_run_timeout_ms")]
     pub async_chat_run_timeout_ms: u64,
 
@@ -404,7 +404,7 @@ fn default_register_path() -> String {
 }
 
 fn default_async_chat_run_timeout_ms() -> u64 {
-    2 * 60 * 60 * 1_000
+    (2 * 60 + 5) * 60 * 1_000
 }
 
 fn default_async_chat_run_retention_ms() -> u64 {
@@ -1055,7 +1055,7 @@ mod tests {
         assert_eq!(config.bots_base_dir, PathBuf::from("/bots"));
         assert!(config.fusion_provider.is_none());
         assert_eq!(config.max_history_per_session, 1000);
-        assert_eq!(config.async_chat_run_timeout_ms, 7_200_000);
+        assert_eq!(config.async_chat_run_timeout_ms, 7_500_000);
         assert!(config.security.outbound_url.block_private_networks);
         assert!(!config.security.outbound_url.allow_loopback);
     }

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -292,7 +292,7 @@ pub struct BcsConfig {
 
     /// Async chat run (bcs-cli chat-async) — max wall-clock a single run may
     /// be pending/running before the cleanup task marks it failed("timeout").
-    /// Default 30 min, configurable up to 24 h.
+    /// Default 2 h, configurable up to 24 h.
     #[serde(default = "default_async_chat_run_timeout_ms")]
     pub async_chat_run_timeout_ms: u64,
 
@@ -404,7 +404,7 @@ fn default_register_path() -> String {
 }
 
 fn default_async_chat_run_timeout_ms() -> u64 {
-    30 * 60 * 1_000
+    2 * 60 * 60 * 1_000
 }
 
 fn default_async_chat_run_retention_ms() -> u64 {
@@ -1055,6 +1055,7 @@ mod tests {
         assert_eq!(config.bots_base_dir, PathBuf::from("/bots"));
         assert!(config.fusion_provider.is_none());
         assert_eq!(config.max_history_per_session, 1000);
+        assert_eq!(config.async_chat_run_timeout_ms, 7_200_000);
         assert!(config.security.outbound_url.block_private_networks);
         assert!(!config.security.outbound_url.allow_loopback);
     }

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -25,6 +25,8 @@ use bcs_service_api::{
 use serde_json::Value;
 use tokio::sync::mpsc;
 
+const A2A_DOWNSTREAM_EXECUTION_TIMEOUT_MS: u64 = 2 * 60 * 60 * 1_000;
+
 pub use event_parser::{
     DetachDeliveryCallback, DrainOutcome, classify_detach_delivery_callback,
     drain_chat_event, drain_chat_event_with_mode,
@@ -522,7 +524,6 @@ impl A2aChatService for A2aChat {
             &from_bot_name,
             cmd.from_actor_id.as_deref().unwrap_or(&from_bot_id),
             &cmd.message,
-            timeout_ms,
             &cmd.tags,
             cmd.caller_wait_mode.as_deref(),
         )?;
@@ -1240,7 +1241,6 @@ fn build_chat_send_frame(
     from_bot_name: &str,
     from_actor_id: &str,
     message: &str,
-    timeout_ms: u64,
     tags: &[String],
     caller_wait_mode: Option<&str>,
 ) -> ServiceResult<BcsFrame> {
@@ -1282,7 +1282,9 @@ fn build_chat_send_frame(
             routing_mode: None,
             group_type: None,
         },
-        timeout_ms: Some(timeout_ms),
+        // Downstream execution has its own budget and must not inherit the
+        // caller's local polling deadline or the BCS run lifecycle deadline.
+        timeout_ms: Some(A2A_DOWNSTREAM_EXECUTION_TIMEOUT_MS),
         idempotency_key: None,
         bcs_session_id: None,
         tags: tags.to_vec(),

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
@@ -322,7 +322,7 @@ async fn async_chat_creates_run_and_delivers_chat_send_frame() {
     assert_eq!(chat_send["channel"]["actor_name"], "Source Bot");
     assert_eq!(chat_send["session_context"]["from"], "api-user");
     assert_eq!(chat_send["session_context"]["from_bot_id"], "bot-source");
-    assert_eq!(chat_send["timeout_ms"], serde_json::json!(10_000));
+    assert_eq!(chat_send["timeout_ms"], serde_json::json!(7_200_000));
     assert_eq!(chat_send["tags"], serde_json::json!(["tag1", "tag2"]));
     assert_eq!(chat_send["extensions"]["caller_wait_mode"], "detached");
 }

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/bot.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/bot.md
@@ -158,8 +158,8 @@ bcs chat --bot-uuid "<目标Bot UUID>" --message "<消息内容>" [--session-id 
 - `--bot-uuid`: 目标 Bot 的 UUID（**必需**）
 - `--message`: 消息内容（**必需**）
 - `--session-id`: 指定稳定会话 ID。多次调用传入同一个 `session_id` 时，会落到目标 Bot 侧同一会话中，共享上下文。
-- `--detach`: 目标 Bot 首次确认收到消息后立即返回，不等待完整回复；服务端 run 会继续执行。适合长耗时任务。
-- `--timeout-ms`: 总等待预算（毫秒）。阻塞模式默认 30 分钟；配合 `--detach` 时默认等待首次确认 60 秒。
+- `--detach`: BCS 接受并启动 run 后立即返回，不等待完整回复；服务端 run 会继续执行。适合长耗时任务。
+- `--timeout-ms`: CLI 本地轮询预算（毫秒）。阻塞模式默认 30 分钟；配合 `--detach` 时默认等待首次确认 60 秒。该值不会改变 BCS run 生命周期，也不会传给 Provider 或下游 Bot。
 
 **示例：**
 

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -944,12 +944,14 @@ impl BcsClient {
     fn chat_payload(
         message: &str,
         from: Option<&str>,
+        effective_timeout_ms: u64,
         session_id: Option<&str>,
         tags: &[String],
     ) -> serde_json::Value {
         let mut payload = serde_json::json!({
             "message": message,
             "from": from,
+            "timeout_ms": effective_timeout_ms,
         });
         if let Some(sid) = session_id {
             if let Some(obj) = payload.as_object_mut() {
@@ -993,8 +995,8 @@ impl BcsClient {
     ///
     /// BCS looks up the target bot's URL and forwards the message.
     /// This ensures fresh URLs and centralized logging.
-    /// `timeout_ms` only limits this client's HTTP wait and is not included in
-    /// the BCS request body or forwarded as a downstream execution timeout.
+    /// `timeout_ms` limits the legacy BCS blocking wait and this client's HTTP
+    /// wait. BCS does not forward it as the downstream execution timeout.
     pub async fn chat(
         &self,
         bot_id: &str,
@@ -1030,14 +1032,14 @@ impl BcsClient {
 
         let url = format!("{}/bots/{}/chat", self.base_url, bot_id);
 
-        let payload = Self::chat_payload(message, from, session_id, tags);
+        let payload = Self::chat_payload(message, from, effective_timeout_ms, session_id, tags);
 
         debug!(
             bot_id = %bot_id,
             from = ?from,
             session_id = ?session_id,
             tags = ?Self::normalize_tags(tags),
-            client_wait_timeout_ms = effective_timeout_ms,
+            timeout_ms = effective_timeout_ms,
             message_len = message.len(),
             "Sending chat message via BCS"
         );
@@ -3050,26 +3052,26 @@ mod tests {
     }
 
     #[test]
-    fn test_chat_payload_omits_client_wait_timeout() {
-        let payload = BcsClient::chat_payload("hello", Some("bot_a"), None, &[]);
+    fn test_chat_payload_includes_legacy_bcs_wait_timeout() {
+        let payload = BcsClient::chat_payload("hello", Some("bot_a"), 12_345, None, &[]);
 
         assert_eq!(payload["message"], serde_json::json!("hello"));
         assert_eq!(payload["from"], serde_json::json!("bot_a"));
-        assert!(payload.get("timeout_ms").is_none());
+        assert_eq!(payload["timeout_ms"], serde_json::json!(12_345));
         assert!(payload.get("session_id").is_none());
         assert!(payload.get("tags").is_none());
     }
 
     #[test]
     fn test_chat_payload_includes_session_id_when_present() {
-        let payload = BcsClient::chat_payload("hi", None, Some("sess-1"), &[]);
+        let payload = BcsClient::chat_payload("hi", None, 9_000, Some("sess-1"), &[]);
         assert_eq!(payload["session_id"], serde_json::json!("sess-1"));
     }
 
     #[test]
     fn test_chat_payload_includes_tags_when_present() {
         let tags = vec![" tag1 ".to_string(), "".to_string(), "tag2".to_string()];
-        let payload = BcsClient::chat_payload("hi", None, None, &tags);
+        let payload = BcsClient::chat_payload("hi", None, 9_000, None, &tags);
         assert_eq!(payload["tags"], serde_json::json!(["tag1", "tag2"]));
     }
 
@@ -3119,7 +3121,7 @@ mod tests {
     #[test]
     fn test_chat_request_builder_applies_request_timeout() {
         let client = BcsClient::new("http://localhost:21000");
-        let payload = BcsClient::chat_payload("hello", Some("bot_a"), None, &[]);
+        let payload = BcsClient::chat_payload("hello", Some("bot_a"), 12_345, None, &[]);
         let request = client
             .chat_request_builder(
                 "http://localhost:21000/bots/bot-123/chat",

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -944,14 +944,12 @@ impl BcsClient {
     fn chat_payload(
         message: &str,
         from: Option<&str>,
-        effective_timeout_ms: u64,
         session_id: Option<&str>,
         tags: &[String],
     ) -> serde_json::Value {
         let mut payload = serde_json::json!({
             "message": message,
             "from": from,
-            "timeout_ms": effective_timeout_ms,
         });
         if let Some(sid) = session_id {
             if let Some(obj) = payload.as_object_mut() {
@@ -995,6 +993,8 @@ impl BcsClient {
     ///
     /// BCS looks up the target bot's URL and forwards the message.
     /// This ensures fresh URLs and centralized logging.
+    /// `timeout_ms` only limits this client's HTTP wait and is not included in
+    /// the BCS request body or forwarded as a downstream execution timeout.
     pub async fn chat(
         &self,
         bot_id: &str,
@@ -1030,14 +1030,14 @@ impl BcsClient {
 
         let url = format!("{}/bots/{}/chat", self.base_url, bot_id);
 
-        let payload = Self::chat_payload(message, from, effective_timeout_ms, session_id, tags);
+        let payload = Self::chat_payload(message, from, session_id, tags);
 
         debug!(
             bot_id = %bot_id,
             from = ?from,
             session_id = ?session_id,
             tags = ?Self::normalize_tags(tags),
-            timeout_ms = effective_timeout_ms,
+            client_wait_timeout_ms = effective_timeout_ms,
             message_len = message.len(),
             "Sending chat message via BCS"
         );
@@ -1066,9 +1066,9 @@ impl BcsClient {
     /// Submit a chat run without waiting for the response. Returns immediately
     /// with a `run_id` that can be polled via [`Self::chat_run_status`].
     ///
-    /// `run_timeout_ms` is the server-side wall-clock budget (pending +
-    /// running) before the run is auto-expired. Pass `None` to accept the
-    /// server default (30 min).
+    /// Polling budgets are intentionally not part of this request. The BCS
+    /// server owns the run lifecycle independently from how long this CLI
+    /// waits for status updates.
     pub async fn chat_async(
         &self,
         bot_id: &str,
@@ -1077,8 +1077,6 @@ impl BcsClient {
         session_id: Option<&str>,
         tags: &[String],
         response_mode: Option<&str>,
-        caller_wait_mode: Option<&str>,
-        run_timeout_ms: Option<u64>,
         organization_code: Option<&str>,
     ) -> Result<ChatRunSubmitResponse> {
         let url = format!("{}/bots/{}/chat-async", self.base_url, bot_id);
@@ -1088,8 +1086,6 @@ impl BcsClient {
             session_id,
             tags,
             response_mode,
-            caller_wait_mode,
-            run_timeout_ms,
             organization_code,
         );
 
@@ -1123,20 +1119,12 @@ impl BcsClient {
         session_id: Option<&str>,
         tags: &[String],
         response_mode: Option<&str>,
-        caller_wait_mode: Option<&str>,
-        run_timeout_ms: Option<u64>,
         organization_code: Option<&str>,
     ) -> serde_json::Value {
         let mut payload = serde_json::json!({
             "message": message,
             "from": from,
         });
-        if let Some(ms) = run_timeout_ms {
-            payload
-                .as_object_mut()
-                .unwrap()
-                .insert("timeout_ms".to_string(), serde_json::json!(ms));
-        }
         if let Some(sid) = session_id {
             payload.as_object_mut().unwrap().insert(
                 "session_id".to_string(),
@@ -1155,14 +1143,6 @@ impl BcsClient {
                 "response_mode".to_string(),
                 serde_json::Value::String(mode.to_string()),
             );
-        }
-        if let Some(mode) = caller_wait_mode.map(str::trim).filter(|mode| !mode.is_empty()) {
-            if let Some(object) = payload.as_object_mut() {
-                object.insert(
-                    "caller_wait_mode".to_string(),
-                    serde_json::Value::String(mode.to_string()),
-                );
-            }
         }
         if let Some(code) = organization_code.map(str::trim).filter(|code| !code.is_empty()) {
             if let Some(object) = payload.as_object_mut() {
@@ -1234,8 +1214,8 @@ impl BcsClient {
     /// a JSON value shaped like the legacy [`Self::chat`] response plus a few
     /// additive fields (`run_id`, `state`, `session_id`, `error_message`).
     ///
-    /// `overall_timeout_ms` caps the total wall-clock spent polling. On
-    /// overflow the run is best-effort cancelled and an error is returned.
+    /// `overall_timeout_ms` caps the total wall-clock spent polling. Reaching
+    /// the budget stops only local polling; the server-side run keeps executing.
     /// `poll_wait_ms` controls each long-poll HTTP hop (default 15 s, capped
     /// at the server's configured max).
     pub async fn chat_polling(
@@ -1261,8 +1241,6 @@ impl BcsClient {
                 session_id,
                 tags,
                 response_mode,
-                None,
-                overall_timeout_ms,
                 organization_code,
             )
             .await?;
@@ -1279,11 +1257,11 @@ impl BcsClient {
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
-                warn!(run_id = %run_id, "chat_polling: overall timeout, cancelling run");
-                let _ = self.chat_run_cancel(&run_id).await;
+                warn!(run_id = %run_id, "chat_polling: local polling timeout; run left active");
                 return Err(anyhow!(
-                    "chat_polling: overall timeout after {} ms",
-                    overall_timeout.as_millis()
+                    "chat_polling: local polling timeout after {} ms; run {} is still active",
+                    overall_timeout.as_millis(),
+                    run_id,
                 ));
             }
             let wait_ms = remaining.as_millis().min(poll_wait_ms as u128) as u64;
@@ -1319,10 +1297,9 @@ impl BcsClient {
         }
     }
 
-    /// Submit a chat run and detach once the server observes an acknowledgement
-    /// state for the caller's wait mode. For chat schema v2, `submitted` means
-    /// the Provider accepted the request but has not confirmed downstream
-    /// delivery yet, so this waits until `running` (or a legacy `completed`).
+    /// Submit a chat run and detach once BCS reports it as `running` (or a
+    /// legacy `completed`). Detach is a local waiting policy and is not sent to
+    /// the server or Provider.
     ///
     /// `overall_timeout_ms` caps the total wall-clock spent waiting for the
     /// detach acknowledgement. On overflow the run is left running on the
@@ -1351,8 +1328,6 @@ impl BcsClient {
                 session_id,
                 tags,
                 response_mode,
-                Some("detached"),
-                overall_timeout_ms,
                 organization_code,
             )
             .await?;
@@ -1371,11 +1346,12 @@ impl BcsClient {
             if remaining.is_zero() {
                 warn!(
                     run_id = %run_id,
-                    "chat_polling_detach: overall timeout before first ack"
+                    "chat_polling_detach: local timeout before first ack"
                 );
                 return Err(anyhow!(
-                    "chat_polling_detach: timed out after {} ms waiting for detach ack",
-                    overall_timeout.as_millis()
+                    "chat_polling_detach: timed out after {} ms waiting for detach ack; run {} is still active",
+                    overall_timeout.as_millis(),
+                    run_id,
                 ));
             }
             let wait_ms = remaining.as_millis().min(poll_wait_ms as u128) as u64;
@@ -2974,6 +2950,75 @@ mod tests {
         assert_eq!(result["state"], "running");
     }
 
+    #[tokio::test]
+    async fn test_chat_polling_timeout_leaves_server_run_active() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/bots/bot-target/chat-async"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "run_id": "run-local-timeout",
+                "bot_uuid": "bot-target",
+                "session_id": "session-1",
+                "status": "running",
+                "expires_at_ms": 9_999_999_u64,
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chat/runs/run-local-timeout"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "run_id": "run-local-timeout",
+                "bot_uuid": "bot-target",
+                "from_bot_id": "bot-source",
+                "session_id": "session-1",
+                "state": "running",
+                "response": {"content": ""},
+                "created_at_ms": 1_u64,
+                "updated_at_ms": 2_u64,
+                "expires_at_ms": 9_999_999_u64,
+                "version": 2_u64,
+                "content_truncated": false,
+                "is_terminal": false,
+            })))
+            .mount(&server)
+            .await;
+
+        let client = BcsClient::new(server.uri());
+        let error = client
+            .chat_polling(
+                "bot-target",
+                "hello",
+                None,
+                None,
+                &[],
+                None,
+                Some(20),
+                Some(5),
+                None,
+            )
+            .await
+            .expect_err("local polling should time out");
+
+        assert!(error.to_string().contains("local polling timeout"));
+        assert!(error.to_string().contains("run-local-timeout is still active"));
+        let requests = server.received_requests().await.unwrap();
+        let submit = requests
+            .iter()
+            .find(|request| request.url.path() == "/bots/bot-target/chat-async")
+            .expect("chat submit request");
+        let payload: serde_json::Value = serde_json::from_slice(&submit.body).unwrap();
+        assert!(payload.get("timeout_ms").is_none());
+        assert!(payload.get("caller_wait_mode").is_none());
+        assert!(requests
+            .iter()
+            .all(|request| request.url.path() != "/chat/runs/run-local-timeout/cancel"));
+    }
+
     #[test]
     fn test_non_chat_headers_omit_chat_version() {
         let client = BcsClient::new("http://localhost:21000");
@@ -3005,58 +3050,41 @@ mod tests {
     }
 
     #[test]
-    fn test_chat_payload_includes_timeout_ms() {
-        let payload = BcsClient::chat_payload("hello", Some("bot_a"), 12_345, None, &[]);
+    fn test_chat_payload_omits_client_wait_timeout() {
+        let payload = BcsClient::chat_payload("hello", Some("bot_a"), None, &[]);
 
         assert_eq!(payload["message"], serde_json::json!("hello"));
         assert_eq!(payload["from"], serde_json::json!("bot_a"));
-        assert_eq!(payload["timeout_ms"], serde_json::json!(12_345));
+        assert!(payload.get("timeout_ms").is_none());
         assert!(payload.get("session_id").is_none());
         assert!(payload.get("tags").is_none());
     }
 
     #[test]
     fn test_chat_payload_includes_session_id_when_present() {
-        let payload = BcsClient::chat_payload("hi", None, 9_000, Some("sess-1"), &[]);
+        let payload = BcsClient::chat_payload("hi", None, Some("sess-1"), &[]);
         assert_eq!(payload["session_id"], serde_json::json!("sess-1"));
     }
 
     #[test]
     fn test_chat_payload_includes_tags_when_present() {
         let tags = vec![" tag1 ".to_string(), "".to_string(), "tag2".to_string()];
-        let payload = BcsClient::chat_payload("hi", None, 9_000, None, &tags);
+        let payload = BcsClient::chat_payload("hi", None, None, &tags);
         assert_eq!(payload["tags"], serde_json::json!(["tag1", "tag2"]));
     }
 
     #[test]
-    fn test_chat_async_payload_includes_caller_wait_mode_when_present() {
+    fn test_chat_async_payload_omits_cli_wait_controls() {
         let payload = BcsClient::chat_async_payload(
             "hi",
             None,
             None,
             &[],
             Some("after-last-tool-call"),
-            Some("detached"),
-            Some(60_000),
             None,
         );
 
-        assert_eq!(payload["caller_wait_mode"], serde_json::json!("detached"));
-    }
-
-    #[test]
-    fn test_chat_async_payload_omits_blank_caller_wait_mode() {
-        let payload = BcsClient::chat_async_payload(
-            "hi",
-            None,
-            None,
-            &[],
-            None,
-            Some("  "),
-            None,
-            None,
-        );
-
+        assert!(payload.get("timeout_ms").is_none());
         assert!(payload.get("caller_wait_mode").is_none());
     }
 
@@ -3067,8 +3095,6 @@ mod tests {
             None,
             None,
             &[],
-            None,
-            None,
             None,
             Some(" promo-2026 "),
         );
@@ -3084,8 +3110,6 @@ mod tests {
             None,
             &[],
             None,
-            None,
-            None,
             Some("  "),
         );
 
@@ -3095,7 +3119,7 @@ mod tests {
     #[test]
     fn test_chat_request_builder_applies_request_timeout() {
         let client = BcsClient::new("http://localhost:21000");
-        let payload = BcsClient::chat_payload("hello", Some("bot_a"), 12_345, None, &[]);
+        let payload = BcsClient::chat_payload("hello", Some("bot_a"), None, &[]);
         let request = client
             .chat_request_builder(
                 "http://localhost:21000/bots/bot-123/chat",

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -1028,10 +1028,11 @@ enum Commands {
         #[arg(short, long)]
         message: String,
 
-        /// Overall wait budget in milliseconds (up to 24 hours).
+        /// Local polling budget in milliseconds (up to 24 hours).
         ///
+        /// This never changes the BCS run or downstream bot execution timeout.
         /// Defaults to 30 minutes for the blocking flow, or 60 seconds when
-        /// `--detach` is set (the budget for waiting on the bot's first ack).
+        /// `--detach` is set (the local budget for observing the first ack).
         #[arg(long, value_parser = clap::value_parser!(u64).range(1..=86_400_000))]
         timeout_ms: Option<u64>,
 
@@ -1052,9 +1053,8 @@ enum Commands {
         #[arg(long, default_value_t = 15_000u64, hide = true)]
         poll_wait_ms: u64,
 
-        /// Detach after the bot acknowledges the message (first chat event).
-        /// The run keeps executing on the server; the CLI returns without
-        /// waiting for the full response.
+        /// Detach after BCS accepts and starts the run. The run keeps executing
+        /// on the server; the CLI returns without waiting for the full response.
         #[arg(long, default_value_t = false)]
         detach: bool,
 
@@ -2762,7 +2762,7 @@ async fn main() -> Result<()> {
                 oauth_headers.as_ref(),
             );
 
-            let effective_timeout_ms = timeout_ms.unwrap_or(if detach {
+            let client_wait_timeout_ms = timeout_ms.unwrap_or(if detach {
                 60_000
             } else {
                 1_800_000
@@ -2775,7 +2775,7 @@ async fn main() -> Result<()> {
                 json!({
                     "message": &message,
                     "from": serde_json::Value::Null,
-                    "timeout_ms": effective_timeout_ms,
+                    "client_wait_timeout_ms": client_wait_timeout_ms,
                     "session_id": &session_id,
                     "tags": &tags,
                     "response_mode": &response_mode,
@@ -2793,7 +2793,7 @@ async fn main() -> Result<()> {
                         session_id.as_deref(),
                         &tags,
                         response_mode.as_deref(),
-                        Some(effective_timeout_ms),
+                        Some(client_wait_timeout_ms),
                         Some(poll_wait_ms),
                         organization_code.as_deref(),
                     )
@@ -2807,7 +2807,7 @@ async fn main() -> Result<()> {
                         session_id.as_deref(),
                         &tags,
                         response_mode.as_deref(),
-                        Some(effective_timeout_ms),
+                        Some(client_wait_timeout_ms),
                         Some(poll_wait_ms),
                         organization_code.as_deref(),
                     )

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -2775,12 +2775,9 @@ async fn main() -> Result<()> {
                 json!({
                     "message": &message,
                     "from": serde_json::Value::Null,
-                    "client_wait_timeout_ms": client_wait_timeout_ms,
                     "session_id": &session_id,
                     "tags": &tags,
                     "response_mode": &response_mode,
-                    "poll_wait_ms": poll_wait_ms,
-                    "detach": detach,
                     "organization_code": &organization_code,
                 })
             );


### PR DESCRIPTION
## Summary

- keep `bcs-cli chat --timeout-ms` as a local polling budget only
- stop forwarding CLI wait controls to the BCS run or downstream provider
- leave the server-side run active when local polling times out
- set the A2A downstream execution timeout to 2 hours
- set the default BCS async-chat run TTL to 2 hours 5 minutes, leaving a 5-minute callback buffer
- keep SecBaaS unchanged

## Why

The CLI's blocking and detach wait budgets previously also became downstream execution timeouts. In particular, `--detach` could pass a 1-minute timeout to SecBaaS/OpenClaw and terminate long-running work prematurely.

## Impact

The CLI may stop waiting without cancelling execution. The downstream bot retains a 2-hour execution budget, while BCS keeps the run alive for an additional 5 minutes so callbacks at the downstream timeout boundary are still accepted.

## Validation

- `cargo test -p bcs-cli`
- `cargo test -p bcs-message-flow --test contract_a2a_chat`
- `cargo test -p bcs-http --test bot_chat_contract`
- `cargo test -p bcs --lib config::tests::test_default_config`
- `cargo test -p bcs --test provider_downlink_integration`
- `BCS_BASE_REF=origin/dev bash scripts/ci/check-baseline-not-growing.sh`