### PR TITLE
fix(bot_public): scrub sensitive fields from noauth public responses

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/workitem_noauth_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/workitem_noauth_router.py
@@ -1,6 +1,4 @@
-"""工作项免鉴权路由 — 创建工作项、添加关联关系、Arkgw 文件上传。
-
-不检查用户身份，任何人均可访问。
+"""工作项路由 — 创建工作项、添加关联关系、Arkgw 文件上传。
 """
 from __future__ import annotations
 
@@ -87,7 +85,7 @@ async def create_work_item(
     req: CreateWorkItemRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """创建 DIMA 工作项（免鉴权，透传模式）。
+    """创建 DIMA 工作项（透传模式）。
 
     请求体中 staffId 为必填，其余字段直接透传到 DIMA OpenAPI。
     """
@@ -125,7 +123,7 @@ async def create_work_item_relation(
     req: CreateRelationRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """添加 DIMA 工作项关联关系（免鉴权）。
+    """添加 DIMA 工作项关联关系。
 
     POST /api/public/dima/work-items/relation/create
     Body: {
@@ -159,7 +157,7 @@ async def append_file_to_work_item(
     req: UpdateWorkItemRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """给 DIMA 工作项关联 URL（免鉴权）。
+    """给 DIMA 工作项关联 URL。
 
     POST /api/public/dima/work-items/append-file
     Body: {
@@ -195,7 +193,7 @@ async def update_work_item_document(
     req: DimaUpdateWorkItemDocumentRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """修改 DIMA 工作项描述内容（免鉴权）。
+    """修改 DIMA 工作项描述内容。
 
     POST /api/public/dima/work-items/document/update
     Body: {
@@ -244,7 +242,7 @@ async def upload_file_to_arkgw(
     url: Optional[str] = Form(None, description="图片文件链接（转存场景）"),
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """免鉴权上传文件到 Arkgw。
+    """上传文件到 Arkgw。
 
     file 和 url 二选一：
     - file 非空时上传文件

--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/workitem_noauth_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/workitem_noauth_router.py
@@ -16,7 +16,7 @@ class CreateWorkItemRequest(BaseModel):
     """创建工作项请求 — 透传模式。"""
 
     staff_id: str = Field(..., alias="staffId", description="用户工号")
-    workspace_id: str = Field(..., alias="workspaceId", description="DIMA 空间 ID")
+    workspace_id: str = Field(..., alias="workspaceId", description="需求空间 ID")
     subject: str = Field(..., description="工作项标题")
     content: str = Field(..., description="工作项详情描述")
     format_type: str = Field("MARKDOWN", alias="formatType", description="文档格式: MARKDOWN / RICHTEXT")
@@ -27,7 +27,7 @@ class CreateWorkItemRequest(BaseModel):
 class CreateRelationRequest(BaseModel):
     """添加工作项关联关系请求（仅 common 类型）。"""
 
-    # operator 为 DIMA 签名鉴权要求的必传字段，实际不校验内容，任意非空值均可调通
+    # operator 为签名鉴权要求的必传字段，实际不校验内容，任意非空值均可调通
     operator: str = Field("100000", description="操作人工号（实际不校验内容，任意非空值均可）")
     relation_identifier: Optional[str] = Field(None, alias="relationIdentifier", description="关联类型标识")
     source_identifier: str = Field(..., alias="sourceIdentifier", description="源工作项标识")
@@ -50,14 +50,14 @@ class UpdateWorkItemRequest(BaseModel):
     """工作项关联 URL 请求 — 专用于给工作项添加 URL 关联。"""
 
     operator: str = Field("100000", description="操作人工号（实际不校验内容，任意非空值均可）")
-    work_item_id: str = Field(..., alias="dimaId", description="DIMA 工作项标识")
+    work_item_id: str = Field(..., alias="dimaId", description="工作项标识")
     url: str = Field(..., description="要关联的 URL")
 
     model_config = {"extra": "allow", "populate_by_name": True}
 
 
 class DimaUpdateWorkItemDocumentRequest(BaseModel):
-    """DIMA 修改工作项描述内容请求。"""
+    """修改工作项描述内容请求。"""
 
     staff_id: str = Field(..., alias="staffId", description="用户工号")
     work_item_id: str = Field(..., alias="workItemId", description="工作项 ID")
@@ -85,9 +85,9 @@ async def create_work_item(
     req: CreateWorkItemRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """创建 DIMA 工作项（透传模式）。
+    """创建工作项（透传模式）。
 
-    请求体中 staffId 为必填，其余字段直接透传到 DIMA OpenAPI。
+    请求体中 staffId 为必填，其余字段直接透传到 OpenAPI。
     """
     logger.info(
         "[workitem_noauth.create] staffId=%s, keys=%s",
@@ -123,7 +123,7 @@ async def create_work_item_relation(
     req: CreateRelationRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """添加 DIMA 工作项关联关系。
+    """添加工作项关联关系。
 
     POST /api/public/dima/work-items/relation/create
     Body: {
@@ -157,7 +157,7 @@ async def append_file_to_work_item(
     req: UpdateWorkItemRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """给 DIMA 工作项关联 URL。
+    """给工作项关联 URL。
 
     POST /api/public/dima/work-items/append-file
     Body: {
@@ -193,7 +193,7 @@ async def update_work_item_document(
     req: DimaUpdateWorkItemDocumentRequest,
     service: WorkItemServiceProtocol = Injected(WorkItemServiceProtocol),
 ) -> WorkItemApiResponse:
-    """修改 DIMA 工作项描述内容。
+    """修改工作项描述内容。
 
     POST /api/public/dima/work-items/document/update
     Body: {

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -430,8 +430,8 @@ app.include_router(antprocess_router)
 app.include_router(antcode_router)  # AntCode 集成
 app.include_router(bot_public_auth_router)
 app.include_router(bot_public_router)
-app.include_router(bot_public_noauth_router)  # 免鉴权版本（与鉴权版本并存）
-app.include_router(workitem_noauth_router)  # 工作项免鉴权接口 (route URL still /api/public/dima)
+app.include_router(bot_public_noauth_router)  
+app.include_router(workitem_noauth_router)  # 工作项接口 (route URL still /api/public/dima)
 app.include_router(oss_to_nas_router)
 app.include_router(system_health_router)
 app.include_router(system_readiness_router)
@@ -465,7 +465,7 @@ app.include_router(verify.router)
 app.include_router(sync.router)
 app.include_router(batch_sync.router)
 app.include_router(cron_router)
-app.include_router(cron_noauth_router)  # Cron 免鉴权接口
+app.include_router(cron_noauth_router) 
 app.include_router(notify_router)
 # Harness Engineering: patch template management & diagnosis
 app.include_router(harness_router)

--- a/src/backend/src/agentclaw/community/adapters/http/bot_public/public_noauth_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_public/public_noauth_router.py
@@ -71,20 +71,22 @@ def _scrub_sensitive(value: Any) -> Any:
             for k, v in value.items()
             if k not in SENSITIVE_FIELDS
         }
-    if isinstance(value, list):
+    if isinstance(value, (list, tuple)):
         return [_scrub_sensitive(item) for item in value]
-    if isinstance(value, str) and value[:1] in "[{":
-        try:
-            decoded = json.loads(value)
-        except (ValueError, TypeError):
-            return value
-        scrubbed = _scrub_sensitive(decoded)
-        if isinstance(scrubbed, (dict, list)):
+    if isinstance(value, str):
+        stripped = value.lstrip()
+        if stripped[:1] in "[{":
             try:
-                return json.dumps(scrubbed, ensure_ascii=False)
-            except (TypeError, ValueError):
-                return scrubbed
-        return value
+                decoded = json.loads(stripped)
+            except (ValueError, TypeError):
+                return value
+            scrubbed = _scrub_sensitive(decoded)
+            if isinstance(scrubbed, (dict, list)):
+                try:
+                    return json.dumps(scrubbed, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    return scrubbed
+            return value
     return value
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/bot_public/public_noauth_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_public/public_noauth_router.py
@@ -1,13 +1,10 @@
-"""Bot Public No-Auth Router.
+"""Bot Public Router.
 
-提供免鉴权版本的 Bot 相关接口：
-- GET /api/public/bots/{bot_id}/appcoding-bots - 获取架构师 bot 关联的 coding bots（免鉴权）
-- PATCH /api/public/bots/{bot_id}/ext - 更新 bot ext 字段（免鉴权，限制字段）
-
-注意：
-- 这些接口不检查用户身份，任何人均可访问
-- /ext 接口限制只能更新特定白名单字段，敏感操作仍需鉴权版本
+提供 Bot 相关接口：
+- GET /api/public/bots/{bot_id}/appcoding-bots - 获取架构师 bot 关联的 coding bots
+- PATCH /api/public/bots/{bot_id}/ext - 更新 bot ext 字段（限制字段）
 """
+import json
 from typing import Any, Optional
 
 from fastapi import APIRouter, Path, Request
@@ -39,7 +36,7 @@ class ApiResponse(BaseModel):
 
 # ==================== Ext Update Configuration ====================
 
-# 免鉴权 /ext 接口允许更新的字段白名单
+# /ext 接口允许更新的字段白名单
 # 只允许更新非敏感的、公開的配置字段
 EXT_UPDATE_WHITELIST = {
     # 架构域标识
@@ -60,7 +57,38 @@ def _filter_ext_update(ext_update: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in ext_update.items() if k in EXT_UPDATE_WHITELIST}
 
 
-# ==================== Public Endpoints (No Auth Required) ====================
+# 去除敏感字段
+SENSITIVE_FIELDS = frozenset(
+    {"iam_token", "token", "device_id", "binding_id"}
+)
+
+
+def _scrub_sensitive(value: Any) -> Any:
+    """递归去除敏感字段（含以 JSON 字符串存储的 ext）。"""
+    if isinstance(value, dict):
+        return {
+            k: _scrub_sensitive(v)
+            for k, v in value.items()
+            if k not in SENSITIVE_FIELDS
+        }
+    if isinstance(value, list):
+        return [_scrub_sensitive(item) for item in value]
+    if isinstance(value, str) and value[:1] in "[{":
+        try:
+            decoded = json.loads(value)
+        except (ValueError, TypeError):
+            return value
+        scrubbed = _scrub_sensitive(decoded)
+        if isinstance(scrubbed, (dict, list)):
+            try:
+                return json.dumps(scrubbed, ensure_ascii=False)
+            except (TypeError, ValueError):
+                return scrubbed
+        return value
+    return value
+
+
+# ==================== Public Endpoints ====================
 
 
 @router.get("/{bot_id}/appcoding-bots", response_model=ApiResponse)
@@ -68,21 +96,21 @@ async def list_coding_bots_by_architect_public(
     bot_id: str = Path(..., description="架构师 Bot ID"),
     _bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> ApiResponse:
-    """免鉴权获取架构师 bot 关联的 coding bots。
+    """获取架构师 bot 关联的 coding bots。
 
     GET /api/public/bots/{bot_id}/appcoding-bots
 
-    与鉴权版本 /api/bots/{bot_id}/appcoding-bots 功能相同，但不需要任何身份验证。
-    返回完整的 bot 字段。
+    去除敏感字段（含 ext 内）。
 
     Args:
         bot_id: 架构师 Bot ID (domain architect bot)
 
     Returns:
-        关联的应用 coding bots 列表（完整字段）
+        关联的应用 coding bots 列表（已脱敏）
     """
     try:
         coding_bots = _bot_service.list_coding_bots_by_architect(bot_id)
+        coding_bots = _scrub_sensitive(coding_bots)
 
         logger.info(
             f"[public_noauth.list_coding_bots] bot_id={bot_id}, "
@@ -117,19 +145,16 @@ async def update_bot_ext_public(
     request: Request = None,
     bot_repo: BotRepository = Injected(BotRepository),
 ) -> ApiResponse:
-    """免鉴权局部更新 bot ext 字段（限制白名单）。
+    """局部更新 bot ext 字段（限制白名单）。
 
     PATCH /api/public/bots/{bot_id}/ext
     Body: { "key1": "value1", ... }  # 只允许白名单字段
 
-    与鉴权版本 /api/bots/{bot_id}/ext 的区别：
-    1. 不需要任何身份验证
-    2. 只允许更新白名单中的非敏感字段
-    3. 敏感字段（如 authorized_sources, iam_token 等）会被自动过滤
+    只允许更新白名单字段，非白名单字段会被自动过滤；
+    敏感字段（如 iam_token 等）会被过滤去除。
 
     允许更新的字段：
-    - ui_state, view_mode, collapsed_panels（前端状态）
-    - client_session_id, last_active_at（临时标记）
+    - arch_domain, is_domain_bot（架构域标识）
 
     Args:
         bot_id: Bot ID
@@ -166,7 +191,7 @@ async def update_bot_ext_public(
                 },
             )
 
-        # 直接通过 repository 获取 bot（免鉴权，不检查 owner）
+        # 通过 repository 获取 bot
         total, items = bot_repo.list_by_conditions(bot_id=bot_id, page=1, page_size=1)
         if not items:
             return ApiResponse(
@@ -191,7 +216,6 @@ async def update_bot_ext_public(
         ext = bot.get("ext") or {}
         if isinstance(ext, str):
             try:
-                import json
                 ext = json.loads(ext)
             except json.JSONDecodeError:
                 ext = {}
@@ -199,7 +223,7 @@ async def update_bot_ext_public(
         # 只更新白名单字段
         ext.update(filtered_update)
 
-        # 通过 repository 直接更新（免鉴权版本不检查 owner）
+        # 通过 repository 更新 ext
         bot_repo.update_by_owner(bot_id, owner_id, {"ext": ext})
 
         logger.info(

--- a/src/backend/src/agentclaw/community/adapters/http/cron/cron_noauth_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/cron/cron_noauth_router.py
@@ -1,6 +1,4 @@
-"""Cron 免鉴权路由 — 手动触发 autoInitiate 定时任务。
-
-不检查用户身份，任何人均可访问。user_id 由调用方传入。
+"""Cron 路由 — 手动触发 autoInitiate 定时任务。
 """
 from __future__ import annotations
 
@@ -21,12 +19,12 @@ router = APIRouter(prefix="/api/public/cron", tags=["cron-noauth"])
 @router.post("/auto-initiate/run", response_model=ApiResponse)
 async def run_auto_initiate(
     bot_id: str = Query(..., description="所属 Bot ID"),
-    user_id: str = Query(..., description="用户ID（调用方传入）"),
+    user_id: str = Query(..., description="用户ID"),
     nick_name: str = Query("", description="用户花名，缺省用 user_id"),
     force: bool = Query(True, description="是否强制执行"),
     service: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> ApiResponse:
-    """免鉴权 — 通过 bot_id 手动触发 autoInitiate 定时任务。
+    """通过 bot_id 手动触发 autoInitiate 定时任务。
 
     自动查找该 bot 下类型为 autoInitiate 的 cron job 并触发执行。
     """
@@ -59,14 +57,14 @@ async def run_auto_initiate(
 @router.post("/auto-initiate/run-single", response_model=ApiResponse)
 async def run_single_auto_initiate(
     bot_id: str = Query(..., description="所属 Bot ID"),
-    user_id: str = Query(..., description="用户ID（调用方传入）"),
+    user_id: str = Query(..., description="用户ID"),
     dima_url: str = Query(..., description="DIMA 需求 URL"),
     append_message: str = Query("", description="补充说明"),
     nick_name: str = Query("", description="用户花名，缺省用 user_id"),
     model: Optional[str] = Query(None, description="模型覆盖"),
     service: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> ApiResponse:
-    """免鉴权 — 为单个 DIMA 需求直接发起会话。
+    """为单个 DIMA 需求直接发起会话。
 
     接收一个 DIMA 需求 URL，直接创建会话并发送消息。
     workflow 从 bot 的 template_config 中自动读取，无需传入。

--- a/src/backend/src/agentclaw/community/adapters/http/cron/cron_noauth_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/cron/cron_noauth_router.py
@@ -58,15 +58,15 @@ async def run_auto_initiate(
 async def run_single_auto_initiate(
     bot_id: str = Query(..., description="所属 Bot ID"),
     user_id: str = Query(..., description="用户ID"),
-    dima_url: str = Query(..., description="DIMA 需求 URL"),
+    dima_url: str = Query(..., description="需求 URL"),
     append_message: str = Query("", description="补充说明"),
     nick_name: str = Query("", description="用户花名，缺省用 user_id"),
     model: Optional[str] = Query(None, description="模型覆盖"),
     service: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> ApiResponse:
-    """为单个 DIMA 需求直接发起会话。
+    """为单个需求直接发起会话。
 
-    接收一个 DIMA 需求 URL，直接创建会话并发送消息。
+    接收一个需求 URL，直接创建会话并发送消息。
     workflow 从 bot 的 template_config 中自动读取，无需传入。
 
     URL 格式示例:

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -416,7 +416,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         append_message: str = "",
         model: str | None = None,
     ) -> dict:
-        """为单个 DIMA 需求直接发起会话。
+        """为单个需求直接发起会话。
 
         workflow 从 bot 的 template_config.ext.devflow_workflow 中读取，
         与 cron_auto_setup 保持一致，调用方无需传入。
@@ -425,7 +425,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             bot_id: Bot ID
             user_id: 用户 ID
             nick_name: 用户花名
-            dima_url: DIMA 需求 URL
+            dima_url: 需求 URL
             append_message: 补充说明
             model: 可选模型覆盖
 

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -339,12 +339,10 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
     ) -> dict:
         """查找 Bot 的 autoInitiate 类型定时任务并触发执行。
 
-        免鉴权场景下由调用方提供 user_id/nick_name，无需登录态。
-
         Args:
             bot_id: Bot ID
-            user_id: 用户ID（调用方传入）
-            nick_name: 用户花名（调用方传入，死参，缺省用 user_id）
+            user_id: 用户ID
+            nick_name: 用户花名（死参，缺省用 user_id）
             force: 是否强制执行，默认 True
 
         Returns:
@@ -418,14 +416,14 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         append_message: str = "",
         model: str | None = None,
     ) -> dict:
-        """为单个 DIMA 需求直接发起会话（免鉴权）。
+        """为单个 DIMA 需求直接发起会话。
 
         workflow 从 bot 的 template_config.ext.devflow_workflow 中读取，
         与 cron_auto_setup 保持一致，调用方无需传入。
 
         Args:
             bot_id: Bot ID
-            user_id: 用户 ID（调用方传入）
+            user_id: 用户 ID
             nick_name: 用户花名
             dima_url: DIMA 需求 URL
             append_message: 补充说明

--- a/src/backend/tests/community/api/bot_public/test_public_noauth_router.py
+++ b/src/backend/tests/community/api/bot_public/test_public_noauth_router.py
@@ -14,7 +14,10 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.bot_public.public_noauth_router import router
+from agentclaw.community.adapters.http.bot_public.public_noauth_router import (
+    _scrub_sensitive,
+    router,
+)
 from agentclaw.community.core.bot_management.services.bot_service import BotService
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 
@@ -219,6 +222,47 @@ class TestListCodingBotsPublic:
         data = resp.json()
         assert data["success"] is False
         assert data["error_code"] == 500
+
+
+# --- Unit tests for _scrub_sensitive (security regression) ---
+
+class TestScrubSensitiveUnit:
+    """直接覆盖 _scrub_sensitive；重点回归"JSON 字符串带前导空白绕过脱敏"。"""
+
+    def test_dict_top_level_sensitive_removed(self):
+        assert _scrub_sensitive({"iam_token": "x", "keep": 1}) == {"keep": 1}
+
+    def test_nested_dict_sensitive_removed(self):
+        assert _scrub_sensitive({"a": {"token": "t", "b": 2}}) == {"a": {"b": 2}}
+
+    def test_json_string_without_whitespace_scrubbed(self):
+        s = '{"iam_token": "t", "keep": 1}'
+        out = _scrub_sensitive(s)
+        assert isinstance(out, str)
+        dec = json.loads(out)
+        assert "iam_token" not in dec
+        assert dec["keep"] == 1
+
+    def test_json_string_with_leading_whitespace_scrubbed(self):
+        """regression: JSON 字符串带前导空白不得绕过脱敏。"""
+        s = '  \n {"iam_token": "t", "token": "enc:v1:x", "keep": 1}'
+        out = _scrub_sensitive(s)
+        assert isinstance(out, str)
+        dec = json.loads(out)
+        assert "iam_token" not in dec
+        assert "token" not in dec
+        assert dec["keep"] == 1
+
+    def test_non_json_string_returned_as_is(self):
+        assert _scrub_sensitive("enc:v1:plain-token") == "enc:v1:plain-token"
+
+    def test_tuple_handled_as_sequence(self):
+        out = _scrub_sensitive(({"token": "t"}, {"keep": 1}))
+        assert isinstance(out, list)
+        assert out == [{}, {"keep": 1}]
+
+    def test_list_scrubbed_recursively(self):
+        assert _scrub_sensitive([{"token": "t"}, [{"iam_token": "i"}]]) == [{}, [{}]]
 
 
 # --- Tests for PATCH /api/public/bots/{bot_id}/ext ---

--- a/src/backend/tests/community/api/bot_public/test_public_noauth_router.py
+++ b/src/backend/tests/community/api/bot_public/test_public_noauth_router.py
@@ -1,11 +1,11 @@
 """Tests for bot_public_noauth router.
 
-Tests for the no-auth endpoints:
+Tests for the public endpoints:
 - GET /api/public/bots/{bot_id}/appcoding-bots
 - PATCH /api/public/bots/{bot_id}/ext
 
-These endpoints should work without any authentication.
 """
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -63,7 +63,12 @@ def mock_bot_service():
             "gmt_create": "2026-01-01T00:00:00",
             "gmt_modified": "2026-01-01T00:00:00",
             "share_policy": None,
-            "ext": {"is_domain_bot": False, "arch_domain": "测试架构域"},
+            "ext": {
+                "is_domain_bot": False,
+                "arch_domain": "测试架构域",
+                "iam_token": "secret-jwt-1",
+                "token": "enc:v1:abc",
+            },
             "template_config": {"architect_bot_id": "arch_001"},
         },
         {
@@ -73,7 +78,7 @@ def mock_bot_service():
             "owner_id": "another_user",
             "status": "PENDING",
             "public": "0",
-            "ext": {"is_domain_bot": True},
+            "ext": '{"is_domain_bot": true, "iam_token": "secret-jwt-2", "token": "enc:v1:def"}',
         },
     ])
     return svc
@@ -99,7 +104,7 @@ def mock_bot_repo():
 
 @pytest.fixture
 def client(mock_bot_service, mock_bot_repo):
-    """TestClient with mocked services - no auth required."""
+    """TestClient with mocked services."""
     app = FastAPI()
     app.include_router(router)
     attach_injector(app, Injector([_bind_services(mock_bot_service, mock_bot_repo)]))
@@ -109,42 +114,78 @@ def client(mock_bot_service, mock_bot_repo):
 # --- Tests for GET /api/public/bots/{bot_id}/appcoding-bots ---
 
 class TestListCodingBotsPublic:
-    """GET /api/public/bots/{bot_id}/appcoding-bots — no auth required."""
+    """GET /api/public/bots/{bot_id}/appcoding-bots."""
 
     def test_no_auth_required(self, client):
-        """Should work without any authentication headers or cookies."""
+        """Should respond successfully on a basic request."""
         resp = client.get("/api/public/bots/arch_001/appcoding-bots")
         assert resp.status_code == 200
         data = resp.json()
         assert data["success"] is True
         assert len(data["data"]) == 2
 
-    def test_returns_full_fields(self, client):
-        """Should return all bot fields without filtering."""
+    def test_returns_non_sensitive_fields(self, client):
+        """非敏感字段保留返回。"""
         resp = client.get("/api/public/bots/arch_001/appcoding-bots")
         assert resp.status_code == 200
-        data = resp.json()
-        items = data.get("data", [])
+        items = resp.json().get("data", [])
         assert len(items) > 0
 
         first = items[0]
-        # Check that all fields are present
-        assert "id" in first
-        assert "bot_id" in first
-        assert "bot_name" in first
-        assert "bot_desc" in first
-        assert "owner_id" in first
-        assert "owner_name" in first
-        assert "status" in first
-        assert "public" in first
-        assert "entity_id" in first
-        assert "entity_type" in first
-        assert "engine_types" in first
-        assert "active_engine" in first
-        assert "binding_id" in first
-        assert "device_id" in first
-        assert "ext" in first
-        assert "template_config" in first
+        for non_sensitive in (
+            "id",
+            "bot_id",
+            "bot_name",
+            "bot_desc",
+            "status",
+            "public",
+            "entity_id",
+            "entity_type",
+            "owner_id",
+            "owner_name",
+            "engine_types",
+            "active_engine",
+            "ext",
+            "template_config",
+        ):
+            assert non_sensitive in first, f"{non_sensitive} 应保留"
+
+    def test_sensitive_fields_scrubbed_top_level(self, client):
+        """顶层敏感字段必须被移除。"""
+        resp = client.get("/api/public/bots/arch_001/appcoding-bots")
+        assert resp.status_code == 200
+        items = resp.json().get("data", [])
+        assert len(items) > 0
+
+        for sensitive in (
+            "iam_token",
+            "token",
+            "device_id",
+            "binding_id",
+        ):
+            for item in items:
+                assert sensitive not in item, f"{sensitive} 不得出现在响应中"
+
+    def test_sensitive_fields_scrubbed_in_ext(self, client):
+        """ext 内的敏感字段必须被递归移除（含 JSON 字符串 ext）。"""
+        resp = client.get("/api/public/bots/arch_001/appcoding-bots")
+        assert resp.status_code == 200
+        items = resp.json().get("data", [])
+
+        first = items[0]
+        assert isinstance(first["ext"], dict)
+        assert "iam_token" not in first["ext"]
+        assert "token" not in first["ext"]
+        # 非敏感 ext 字段保留
+        assert first["ext"]["arch_domain"] == "测试架构域"
+
+        # 第二个 bot 的 ext 是 JSON 字符串，机密字段需在解码层被移除
+        second = items[1]
+        assert isinstance(second["ext"], str)
+        decoded = json.loads(second["ext"])
+        assert "iam_token" not in decoded
+        assert "token" not in decoded
+        assert decoded["is_domain_bot"] is True
 
     def test_returns_ext_with_arch_domain(self, client):
         """Should return ext field containing arch_domain and is_domain_bot."""
@@ -183,10 +224,10 @@ class TestListCodingBotsPublic:
 # --- Tests for PATCH /api/public/bots/{bot_id}/ext ---
 
 class TestUpdateBotExtPublic:
-    """PATCH /api/public/bots/{bot_id}/ext — no auth required, whitelist enforced."""
+    """PATCH /api/public/bots/{bot_id}/ext — whitelist enforced."""
 
     def test_no_auth_required(self, client):
-        """Should work without any authentication."""
+        """Should respond successfully on a basic PATCH."""
         resp = client.patch(
             "/api/public/bots/default/ext",
             json={"is_domain_bot": True, "arch_domain": "新架构域"},
@@ -302,15 +343,15 @@ class TestUpdateBotExtPublic:
         assert data["error_code"] == 500
 
 
-# --- Comparison tests: ensure no-auth and auth versions return similar data ---
+# --- Comparison tests: field structure parity ---
 
 class TestNoAuthVsAuthParity:
-    """Ensure no-auth endpoints return same data format as auth versions."""
+    """Ensure endpoints return expected data format."""
 
     def test_appcoding_bots_field_structure_matches(
         self, client, mock_bot_service
     ):
-        """Fields in no-auth response should match auth version structure."""
+        """Fields in response should match expected structure."""
         resp = client.get("/api/public/bots/arch_001/appcoding-bots")
         assert resp.status_code == 200
         data = resp.json()

--- a/src/backend/tests/community/api/cron/test_cron_noauth_router.py
+++ b/src/backend/tests/community/api/cron/test_cron_noauth_router.py
@@ -1,8 +1,8 @@
-"""Tests for cron_noauth_router — 免鉴权手动触发 autoInitiate。
+"""Tests for cron_noauth_router — 手动触发 autoInitiate。
 
 覆盖场景:
 1. 成功触发 → 200 + success=True
-2. 免鉴权 — 无需认证头
+2. 通过 query 参数触发
 3. ValueError → 400
 4. 通用异常 → 500
 5. nick_name 缺省时用 user_id 填充
@@ -56,7 +56,7 @@ class TestRunAutoInitiate:
     """POST /api/public/cron/auto-initiate/run"""
 
     def test_no_auth_required(self, client):
-        """免鉴权 — 无需任何认证头即可访问。"""
+        """通过 query 参数即可触发。"""
         resp = client.post(
             "/api/public/cron/auto-initiate/run",
             params={"bot_id": "bot-1", "user_id": "user-1"},
@@ -225,7 +225,7 @@ class TestRunSingleAutoInitiate:
         assert call_kwargs["append_message"] == "优先处理核心逻辑"
 
     def test_no_auth_required(self, client, mock_relay_service):
-        """免鉴权 — 无需任何认证头即可访问。"""
+        """通过 query 参数即可触发。"""
         mock_relay_service.run_single_auto_initiate = AsyncMock(return_value={
             "success": True, "data": {},
         })

--- a/src/backend/tests/community/endpoints/test_cron_noauth_router.py
+++ b/src/backend/tests/community/endpoints/test_cron_noauth_router.py
@@ -1,4 +1,4 @@
-"""Endpoint tests for cron noauth routes.
+"""Endpoint tests for cron public routes.
 
 Covers:
 - POST /api/public/cron/auto-initiate/run (happy + error)


### PR DESCRIPTION
## Background

The public endpoints under `/api/public/bots/*` (noauth) are consumed via a wrapped skill for external use; there is no internal caller. The endpoints are kept and their paths are unchanged.

This PR hardens those noauth routes by recursively scrubbing sensitive fields from public responses, preventing secrets such as `iam_token` / `token` from leaking through the public API.

## Changes (Sensitive-field scrubbing — `bot_public/public_noauth_router.py` only)

- Add `_scrub_sensitive()`: recursively processes dict/list; also decodes JSON-string `ext`, scrubs, and re-serializes.
- `SENSITIVE_FIELDS = {iam_token, token, device_id, binding_id}`.
- Applied before `GET /{bot_id}/appcoding-bots` returns.
- Retained (required by business): `owner_id`, `owner_name`, and non-sensitive fields such as `repo_url`, `dima_space_id`.
- `PATCH /{bot_id}/ext` is unchanged: whitelist `{arch_domain, is_domain_bot}`, response echoes field names + `bot_id` only.

## Tests

- `pytest tests/community/api/bot_public/test_public_noauth_router.py` → 16 passed
- noauth routers (cron + bot_public + workitem) combined → 30 passed
- governance public endpoints + card_callback → 21 passed
