### PR TITLE
fix: reuse cached config for engine paths

### DIFF
--- a/docs/superpowers/specs/2026-07-17-engine-path-config-cache-design.md
+++ b/docs/superpowers/specs/2026-07-17-engine-path-config-cache-design.md
@@ -1,0 +1,45 @@
+# Bot 列表 Engine Path 配置加载优化设计
+
+日期：2026-07-17  
+状态：已确认，进入实现
+
+## 背景
+
+生产 `GET /api/bots/by-owner-or-collaborator` Trace 显示，列表为每个
+Bot/Engine 构造路径时都会调用 `_get_aidesktop_root()`。旧实现随后重新扫描、打开并
+`yaml.safe_load` 配置文件。30 次路径解析可占用 2180ms，成为接口第一主瓶颈。
+
+## 目标
+
+- 一次进程启动只通过统一配置 Provider 加载配置，不在路径计算中重复解析 YAML。
+- 保持 `AIDESKTOP_ROOT` 环境变量高于配置文件的现有优先级。
+- 保持所有路径返回值与当前实现一致。
+- 让所有调用路径工厂的入口受益，不引入列表接口专属缓存。
+
+## 方案
+
+`_get_aidesktop_root()` 先读取 `AIDESKTOP_ROOT`。未设置时，调用现有
+`core.config.provider.load_config()`，从其 `user_config.aidesktop_root` 读取配置；字段
+缺失时继续使用 `/aidesktop`。
+
+`load_config()` 已在 composition root 注册 Provider，并对 `AppConfig` 做进程级缓存；
+测试通过替换 Provider 或 `load_config()` 保持隔离。因此删除路径工厂中重复的 YAML
+扫描逻辑，不增加第二套缓存及缓存清理 API。
+
+不采用：
+
+- `_get_config_value()` 上增加 `lru_cache`：会复制已有配置缓存，并使环境变量或测试
+  Provider 切换产生额外失效语义。
+- 仅在列表请求中预计算根路径：只能优化一个入口，并要求扩大 BotService 接口。
+
+## 验证
+
+1. 回归测试连续计算多个 Bot Engine 路径，断言配置 Provider 只读取一次。
+2. 覆盖环境变量覆盖、配置值与默认值三种语义。
+3. 运行 path factory、Bot 列表 endpoint 目标测试及完整 backend 测试。
+4. 灰度后检查慢请求 Trace：`_get_config_value` 的逐 Engine 日志应消失，耗时不再随
+   Engine 数量线性增加。
+
+## 非目标
+
+本次不改 `can_edit_bot` 的逐 Bot 发布记录查询；该 DB/OSS N+1 作为后续优化独立处理。

--- a/src/backend/src/agentclaw/community/core/workspace/path_factory.py
+++ b/src/backend/src/agentclaw/community/core/workspace/path_factory.py
@@ -45,87 +45,14 @@ BAAS_ENGINE_SKILLS_ROOT = Path("/home/admin/.openclaw/workspace/skills")
 BAAS_ENGINE_SKILLS_ROOT = Path("/home/admin/.openclaw/workspace/skills")
 
 
-def _get_config_value(key: str, default_value: Path, env_var: Optional[str] = None) -> Path:
-    """从环境变量或 application.yaml 读取配置值。
-
-    优先级:
-    1. 环境变量（env_var 指定）
-    2. configs/application-dev.yaml 或 application.yaml 的 user_config.{key}
-    3. default_value
-
-    Args:
-        key: user_config 下的 key 名
-        default_value: 找不到时的默认值
-        env_var: 环境变量名（可选）
-
-    Returns:
-        Path
-    """
-    if env_var:
-        env_value = os.getenv(env_var)
-        if env_value:
-            if env_value.startswith("~"):
-                env_value = str(Path.home()) + env_value[1:]
-            logger.info(f"[_get_config_value] {key} loaded from env {env_var}: {env_value}")
-            return Path(env_value)
-
-    try:    
-        import yaml
-
-        # Overlay selection mirrors the yaml provider's: the test suite
-        # (DEPLOY_PROFILE=test, SERVER_ENV unset) reads the neutral community
-        # application-test.yaml instead of the corp application-dev.yaml. An
-        # explicitly set SERVER_ENV always wins (dev/stable → dev overlay; else base
-        # only), so tests that set SERVER_ENV to exercise a specific env are unaffected.
-        profile = (os.getenv("DEPLOY_PROFILE") or "").lower()
-        # Match yaml_provider._select_overlay_name's env resolution exactly (incl. the
-        # REAL_SERVER_ENV fallback the container supplies) so the two sites never
-        # disagree on the overlay within one process.
-        env = (os.getenv("SERVER_ENV") or os.getenv("REAL_SERVER_ENV") or "").lower()
-        if env == "" and profile in ("test", "corp_test"):
-            config_names = ["application-test.yaml", "application.yaml"]
-        elif env in ("dev", "stable", ""):
-            config_names = ["application-dev.yaml", "application.yaml"]
-        else:
-            config_names = ["application.yaml"]
-
-        # B11: configs live in the community subtree (agentclaw/community/configs);
-        # a deploy's assembled runtime `configs/` (cwd) holds them too.
-        config_dirs = [
-            Path.cwd() / "configs",
-            Path(__file__).resolve().parents[2] / "configs",  # agentclaw/community/configs
-        ]
-
-        for config_dir in config_dirs:
-            for config_name in config_names:
-                config_path = config_dir / config_name
-                if config_path.exists():
-                    try:
-                        with open(config_path, "r", encoding="utf-8") as f:
-                            config = yaml.safe_load(f)
-                            if config and "user_config" in config:
-                                user_config = config["user_config"]
-                                if key in user_config:
-                                    value = user_config[key]
-                                    if value.startswith("~"):
-                                        value = str(Path.home()) + value[1:]
-                                    logger.info(f"[_get_config_value] {key} loaded from {config_path}: {value}")
-                                    return Path(value)
-                    except Exception as e:
-                        logger.warning(f"[_get_config_value] Failed to read {config_path}: {e}")
-                        continue
-    except ImportError:
-        logger.warning(f"[_get_config_value] yaml not installed, using default for {key}")
-    except Exception as e:
-        logger.warning(f"[_get_config_value] Error reading config for {key}: {e}")
-
-    logger.info(f"[_get_config_value] {key} using default: {default_value}")
-    return default_value
-
-
 def _get_aidesktop_root() -> Path:
-    """读取 aidesktop_root（优先 AIDESKTOP_ROOT 环境变量，其次 yaml，默认 /aidesktop）。"""
-    return _get_config_value("aidesktop_root", DEFAULT_AIDESKTOP_ROOT, "AIDESKTOP_ROOT")
+    """Read aidesktop_root from env, then the process-cached config provider."""
+    value = os.getenv("AIDESKTOP_ROOT")
+    if not value:
+        from agentclaw.community.core.config.provider import load_config
+
+        value = load_config().user_config.get("aidesktop_root")
+    return Path(value).expanduser() if value else DEFAULT_AIDESKTOP_ROOT
 
 
 def _get_aidesktop_env_folder() -> str:

--- a/src/backend/tests/community/core/workspace/test_path_factory.py
+++ b/src/backend/tests/community/core/workspace/test_path_factory.py
@@ -18,6 +18,80 @@ def test_get_bolt_base_dir_structure():
             assert result == Path("/aidesktop/aidesktop_dev/bolt_data")
 
 
+def test_engine_paths_reuse_cached_config_provider(monkeypatch, tmp_path):
+    from agentclaw.community.core.config import provider as config_provider
+    from agentclaw.community.core.config.provider import AppConfig
+    from agentclaw.community.core.workspace.path_factory import get_bot_engine_dir
+
+    class CountingProvider:
+        def __init__(self):
+            self.loads = 0
+
+        def load(self):
+            self.loads += 1
+            return AppConfig(
+                user_config={
+                    "aidesktop_root": str(tmp_path),
+                    "workspace": {"env_folder": "aidesktop_prod"},
+                },
+                raw={},
+                app_name="agentclaw",
+                delegate=None,
+            )
+
+    provider = CountingProvider()
+    monkeypatch.delenv("AIDESKTOP_ROOT", raising=False)
+    monkeypatch.setattr(config_provider, "_provider", provider)
+    monkeypatch.setattr(config_provider, "_cached", None)
+    paths = [
+        get_bot_engine_dir("user-1", f"bot-{index}", "openclaw")
+        for index in range(40)
+    ]
+
+    assert provider.loads == 1
+    assert paths[0] == (
+        tmp_path
+        / "aidesktop_prod"
+        / "bolt_data"
+        / "staff_user-1"
+        / "bot-0"
+        / "openclaw"
+    )
+
+
+def test_aidesktop_root_uses_default_when_config_is_absent(monkeypatch):
+    from agentclaw.community.core.config.provider import AppConfig
+    from agentclaw.community.core.workspace.path_factory import (
+        DEFAULT_AIDESKTOP_ROOT,
+        _get_aidesktop_root,
+    )
+
+    config = AppConfig(user_config={}, raw={}, app_name="agentclaw", delegate=None)
+    monkeypatch.delenv("AIDESKTOP_ROOT", raising=False)
+    monkeypatch.setattr(
+        "agentclaw.community.core.config.provider.load_config",
+        lambda: config,
+    )
+
+    assert _get_aidesktop_root() == DEFAULT_AIDESKTOP_ROOT
+
+
+def test_aidesktop_root_env_overrides_config(monkeypatch, tmp_path):
+    from agentclaw.community.core.workspace.path_factory import _get_aidesktop_root
+
+    def fail_if_config_is_read():
+        raise AssertionError("config provider must not be read when env is set")
+
+    expected = tmp_path / "from-env"
+    monkeypatch.setenv("AIDESKTOP_ROOT", str(expected))
+    monkeypatch.setattr(
+        "agentclaw.community.core.config.provider.load_config",
+        fail_if_config_is_read,
+    )
+
+    assert _get_aidesktop_root() == expected
+
+
 def test_singlebox_workspace_folder_is_profile_field(monkeypatch, tmp_path):
     from agentclaw.community.core.workspace.path_factory import get_bolt_base_dir
     from agentclaw.community.core.config.provider import AppConfig


### PR DESCRIPTION
## Summary

- reuse the process-cached `ConfigProvider` when resolving `aidesktop_root`
- eliminate repeated YAML open/parse work for every Bot/Engine path on the bot-list path
- preserve the existing priority: `AIDESKTOP_ROOT` > `user_config.aidesktop_root` > `/aidesktop`, including `~` expansion

## Root cause

Production traces showed that resolving 30 engine paths consumed about 2180 ms out of a 2698 ms request. The old `path_factory` implementation independently scanned, opened, and parsed YAML each time a path was resolved, even though the application already has a process-cached config provider.

## Validation

- TDD regression reproduced the old behavior: configured provider root was ignored and YAML resolution repeated per path
- path-factory tests: 16 passed
- relevant combined tests: 34 passed
- backend full suite: 8082 passed
- backend total line coverage: 82.68%
- changed-line coverage: 100% (5/5)
- SAST gate: passed
- singlebox acceptance: 32 passed
- singlebox coverage gate: passed
- local 10,000-path benchmark: provider loaded once, about 40 ms total (about 4 microseconds/path)

## Out of scope

The remaining `can_edit_bot` DB/OSS N+1 work is a separate follow-up and is intentionally not included in this P0 fix.
