### PR TITLE
feat(group): add namespaced generated group IDs

### DIFF
--- a/src/bcs/crates/contracts/bcs-domain/src/group_id.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/group_id.rs
@@ -47,7 +47,7 @@ pub fn channel_group_id(
 
     let token = opaque_token(source_id);
     let group_id = compose_group_id(Some(channel_type), group_kind, &token);
-    if group_id.chars().count() > MAX_GENERATED_GROUP_ID_CHARS {
+    if group_id.len() > MAX_GENERATED_GROUP_ID_CHARS {
         return Err(GroupIdBuildError::SessionIdTooLong);
     }
     Ok(group_id)

--- a/src/bcs/crates/contracts/bcs-domain/src/group_id.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/group_id.rs
@@ -1,0 +1,165 @@
+//! Canonical identifiers for BCS-managed groups.
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::GroupKind;
+
+pub const GROUP_ID_PREFIX: &str = "bcs_grp_";
+pub const GENERATED_SESSION_ID_SUFFIX_CHARS: usize = 9;
+pub const MAX_SESSION_ID_CHARS: usize = 64;
+pub const MAX_GENERATED_GROUP_ID_CHARS: usize =
+    MAX_SESSION_ID_CHARS - GENERATED_SESSION_ID_SUFFIX_CHARS;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum GroupIdBuildError {
+    #[error("channel_type must use lowercase ASCII letters, digits, '-' or '_'")]
+    InvalidChannelType,
+    #[error("group id source must not be empty")]
+    EmptySourceId,
+    #[error(
+        "generated group id cannot produce a session id within {MAX_SESSION_ID_CHARS} characters"
+    )]
+    SessionIdTooLong,
+}
+
+/// Generate a native BCS group id with a fresh opaque token.
+pub fn generated_group_id(group_kind: GroupKind) -> String {
+    let token = Uuid::new_v4().simple().to_string();
+    compose_group_id(None, group_kind, &token)
+}
+
+/// Build a deterministic BCS-owned group id for an external Channel.
+pub fn channel_group_id(
+    channel_type: &str,
+    group_kind: GroupKind,
+    source_id: &str,
+) -> Result<String, GroupIdBuildError> {
+    let channel_type = channel_type.trim();
+    if !valid_channel_type(channel_type) {
+        return Err(GroupIdBuildError::InvalidChannelType);
+    }
+    let source_id = source_id.trim();
+    if source_id.is_empty() {
+        return Err(GroupIdBuildError::EmptySourceId);
+    }
+
+    let token = opaque_token(source_id);
+    let group_id = compose_group_id(Some(channel_type), group_kind, &token);
+    if group_id.chars().count() > MAX_GENERATED_GROUP_ID_CHARS {
+        return Err(GroupIdBuildError::SessionIdTooLong);
+    }
+    Ok(group_id)
+}
+
+fn compose_group_id(channel_type: Option<&str>, group_kind: GroupKind, token: &str) -> String {
+    match (channel_type, group_kind) {
+        (None, GroupKind::Normal) => format!("{GROUP_ID_PREFIX}{token}"),
+        (None, GroupKind::Dm) => format!("{GROUP_ID_PREFIX}dm_{token}"),
+        (Some(channel), GroupKind::Normal) => format!("{GROUP_ID_PREFIX}{channel}_{token}"),
+        (Some(channel), GroupKind::Dm) => format!("{GROUP_ID_PREFIX}{channel}_dm_{token}"),
+    }
+}
+
+fn valid_channel_type(channel_type: &str) -> bool {
+    // COSEC: Keep ':' and other delimiters out of generated IDs so a plugin
+    // identifier cannot change the `{group_id}:{8_hex}` session boundary.
+    !channel_type.is_empty()
+        && channel_type
+            .bytes()
+            .all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || byte == b'-'
+                    || byte == b'_'
+            })
+}
+
+fn opaque_token(source_id: &str) -> String {
+    if let Ok(uuid) = Uuid::parse_str(source_id) {
+        return uuid.simple().to_string();
+    }
+
+    let digest = Sha256::digest(source_id.as_bytes());
+    let mut token = String::with_capacity(32);
+    for byte in &digest[..16] {
+        use std::fmt::Write;
+        let _ = write!(token, "{byte:02x}");
+    }
+    token
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UUID: &str = "bc7d5297-4947-474d-a2f1-cdea1c5642b6";
+
+    #[test]
+    fn native_group_ids_include_kind_when_needed() {
+        assert_eq!(
+            compose_group_id(None, GroupKind::Normal, "bc7d52974947474da2f1cdea1c5642b6"),
+            "bcs_grp_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        assert_eq!(
+            compose_group_id(None, GroupKind::Dm, "bc7d52974947474da2f1cdea1c5642b6"),
+            "bcs_grp_dm_bc7d52974947474da2f1cdea1c5642b6"
+        );
+    }
+
+    #[test]
+    fn channel_group_ids_include_channel_and_kind() -> Result<(), GroupIdBuildError> {
+        assert_eq!(
+            channel_group_id("dingtalk", GroupKind::Normal, UUID)?,
+            "bcs_grp_dingtalk_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        assert_eq!(
+            channel_group_id("dingtalk", GroupKind::Dm, UUID)?,
+            "bcs_grp_dingtalk_dm_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn dingtalk_dm_group_leaves_room_for_session_suffix() -> Result<(), GroupIdBuildError> {
+        let group_id = channel_group_id("dingtalk", GroupKind::Dm, UUID)?;
+        let session_id = format!("{group_id}:abcdef12");
+
+        assert_eq!(session_id.chars().count(), 61);
+        assert!(session_id.chars().count() <= MAX_SESSION_ID_CHARS);
+        Ok(())
+    }
+
+    #[test]
+    fn max_channel_namespace_fits_session_id_limit() -> Result<(), GroupIdBuildError> {
+        let group_id = channel_group_id("wechat_work", GroupKind::Dm, UUID)?;
+        let session_id = format!("{group_id}:abcdef12");
+
+        assert_eq!(group_id.chars().count(), MAX_GENERATED_GROUP_ID_CHARS);
+        assert_eq!(session_id.chars().count(), MAX_SESSION_ID_CHARS);
+        Ok(())
+    }
+
+    #[test]
+    fn non_uuid_source_is_canonicalized_to_bounded_token() -> Result<(), GroupIdBuildError> {
+        let first = channel_group_id("dingtalk", GroupKind::Dm, &"x".repeat(500))?;
+        let second = channel_group_id("dingtalk", GroupKind::Dm, &"x".repeat(500))?;
+
+        assert_eq!(first, second);
+        assert_eq!(first.chars().count(), 52);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_invalid_or_overlong_channel_namespace() {
+        assert_eq!(
+            channel_group_id("ding:talk", GroupKind::Normal, UUID),
+            Err(GroupIdBuildError::InvalidChannelType)
+        );
+        assert_eq!(
+            channel_group_id("channel_name", GroupKind::Dm, UUID),
+            Err(GroupIdBuildError::SessionIdTooLong)
+        );
+    }
+}

--- a/src/bcs/crates/contracts/bcs-domain/src/lib.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/lib.rs
@@ -16,6 +16,7 @@ pub mod collaboration;
 pub mod friend;
 pub mod fusion;
 pub mod group;
+pub mod group_id;
 pub mod invite;
 pub mod message;
 pub mod organization;
@@ -55,6 +56,11 @@ pub use group::{
     DefaultDelivery, Group, GroupKind, GroupStatus, GroupStrategy, Participant, ParticipantKind,
     ParticipantMode, ParticipantRole, RoutingMode, RoutingPolicy, SenderRoutesValidationError,
     Workspace,
+};
+pub use group_id::{
+    GENERATED_SESSION_ID_SUFFIX_CHARS, GROUP_ID_PREFIX, GroupIdBuildError,
+    MAX_GENERATED_GROUP_ID_CHARS, MAX_SESSION_ID_CHARS, channel_group_id,
+    generated_group_id,
 };
 pub use message::{
     AuditEntry, DeliveryType, GroupMessage, GroupMessageType, MessageOwnerFilter, MessagePage, MessageQuery,

--- a/src/bcs/crates/contracts/bcs-protocol/src/ws/protocol.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/ws/protocol.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::Attachment;
+pub use bcs_domain::GROUP_ID_PREFIX;
 
 // ---------------------------------------------------------------------------
 // Protocol versioning
@@ -844,20 +845,11 @@ pub struct ChatEventPayload {
 // Frame-building helpers (shared by bcs-message-flow, bcs-system-message, etc.)
 // ---------------------------------------------------------------------------
 
-/// Prefix prepended to auto-generated group IDs so downstream engines can
-/// recognize a session as BCS-originated. Must match the value used when
-/// generating new group IDs in the group service.
-pub const GROUP_ID_PREFIX: &str = "bcs_grp_";
-
-/// Build the short `session_key` (`group:<8 chars>`) sent to bots.
+/// Build the short, stable `session_key` sent to bots.
 ///
-/// The 8-char window keeps the key compact, but a BCS-originated `wire_id`
-/// (e.g. `bcs_grp_demo-group-alpha`) carries an 8-char prefix that would otherwise
-/// consume the entire window and collapse every group to `group:bcs_grp_`.
-/// When the prefix is present we keep it and take 8 chars from the id *after*
-/// it, yielding `group:bcs_grp_demo-gro`. Legacy ids without the prefix are
-/// truncated exactly as before (`group:legacy-g`), so existing groups are
-/// unaffected.
+/// New generated IDs preserve the complete Channel / DM namespace and opaque
+/// token. Existing prefixed and unprefixed IDs retain the legacy
+/// first-8-character behavior so their engine histories remain addressable.
 ///
 /// Slicing uses `char_indices` to stay on UTF-8 boundaries; group ids are
 /// ASCII today, but this avoids a latent panic if that ever changes.
@@ -866,11 +858,27 @@ pub fn build_session_key(wire_id: &str) -> String {
         Some(rest) => (GROUP_ID_PREFIX, rest),
         None => ("", wire_id),
     };
+    if !prefix.is_empty() {
+        if let Some(group_id) = canonical_generated_group_id(rest) {
+            return format!("group:{prefix}{group_id}");
+        }
+    }
     let take = match rest.char_indices().nth(8) {
         Some((idx, _)) => &rest[..idx],
         None => rest,
     };
     format!("group:{}{}", prefix, take)
+}
+
+fn canonical_generated_group_id(rest: &str) -> Option<&str> {
+    let group_id = rest.split_once(':').map_or(rest, |(group_id, _)| group_id);
+    let token = group_id
+        .rsplit_once('_')
+        .map_or(group_id, |(_, token)| token);
+    if token.len() != 32 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(group_id)
 }
 
 /// Current time in milliseconds since Unix epoch.
@@ -1446,6 +1454,36 @@ mod tests {
         assert_eq!(
             build_session_key("bcs_grp_demo-group-alpha:demo-run-marker"),
             "group:bcs_grp_demo-gro"
+        );
+    }
+
+    #[test]
+    fn build_session_key_preserves_generated_group_namespace() {
+        assert_eq!(
+            build_session_key("bcs_grp_bc7d52974947474da2f1cdea1c5642b6"),
+            "group:bcs_grp_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        assert_eq!(
+            build_session_key("bcs_grp_dingtalk_bc7d52974947474da2f1cdea1c5642b6"),
+            "group:bcs_grp_dingtalk_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        assert_eq!(
+            build_session_key("bcs_grp_dingtalk_dm_bc7d52974947474da2f1cdea1c5642b6"),
+            "group:bcs_grp_dingtalk_dm_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        assert_eq!(
+            build_session_key("bcs_grp_dm_bc7d52974947474da2f1cdea1c5642b6"),
+            "group:bcs_grp_dm_bc7d52974947474da2f1cdea1c5642b6"
+        );
+    }
+
+    #[test]
+    fn build_session_key_namespaced_session_form_ignores_session_suffix() {
+        assert_eq!(
+            build_session_key(
+                "bcs_grp_dingtalk_dm_bc7d52974947474da2f1cdea1c5642b6:abcdef12"
+            ),
+            "group:bcs_grp_dingtalk_dm_bc7d52974947474da2f1cdea1c5642b6"
         );
     }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/session.rs
@@ -1,7 +1,7 @@
 //! Session core business rules（无 IO）。
 
 use crate::types::{SessionKind, SessionStatus};
-use bcs_domain::MAX_SESSION_ID_CHARS;
+use bcs_domain::{MAX_GENERATED_GROUP_ID_CHARS, MAX_SESSION_ID_CHARS};
 
 /// 校验 session_id 格式：`{group_id}:{8_hex}`。
 /// 合法 legacy：`{group_id}:00000000`。
@@ -22,6 +22,9 @@ pub fn validate_session_id(session_id: &str, group_id: &str) -> bool {
 /// 生成新 session_id：`{group_id}:{8_hex}`。
 /// 随机 u32 冲突概率 1/2^32；store 层用 `uk_session_id` 唯一索引兜底。
 pub fn new_session_id(group_id: &str) -> Result<String, &'static str> {
+    if group_id.chars().count() > MAX_GENERATED_GROUP_ID_CHARS {
+        return Err("generated session_id exceeds the 64-character limit");
+    }
     let session_id = format!("{}:{:08x}", group_id, fastrand::u32(..));
     if validate_session_id(&session_id, group_id) {
         Ok(session_id)
@@ -88,6 +91,17 @@ mod tests {
 
         assert_eq!(session_id.chars().count(), 64);
         assert!(validate_session_id(&session_id, &group_id));
+    }
+
+    #[test]
+    fn session_id_limit_counts_unicode_characters_not_bytes() {
+        let group_id = "群".repeat(MAX_GENERATED_GROUP_ID_CHARS);
+        let session_id = format!("{group_id}:abcdef12");
+
+        assert_eq!(session_id.chars().count(), MAX_SESSION_ID_CHARS);
+        assert!(session_id.len() > MAX_SESSION_ID_CHARS);
+        assert!(validate_session_id(&session_id, &group_id));
+        assert!(new_session_id(&group_id).is_ok());
     }
 
     #[test]

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/session.rs
@@ -1,10 +1,14 @@
 //! Session core business rules（无 IO）。
 
 use crate::types::{SessionKind, SessionStatus};
+use bcs_domain::MAX_SESSION_ID_CHARS;
 
 /// 校验 session_id 格式：`{group_id}:{8_hex}`。
 /// 合法 legacy：`{group_id}:00000000`。
 pub fn validate_session_id(session_id: &str, group_id: &str) -> bool {
+    if session_id.chars().count() > MAX_SESSION_ID_CHARS {
+        return false;
+    }
     if !session_id.starts_with(group_id) {
         return false;
     }
@@ -17,8 +21,13 @@ pub fn validate_session_id(session_id: &str, group_id: &str) -> bool {
 
 /// 生成新 session_id：`{group_id}:{8_hex}`。
 /// 随机 u32 冲突概率 1/2^32；store 层用 `uk_session_id` 唯一索引兜底。
-pub fn new_session_id(group_id: &str) -> String {
-    format!("{}:{:08x}", group_id, fastrand::u32(..))
+pub fn new_session_id(group_id: &str) -> Result<String, &'static str> {
+    let session_id = format!("{}:{:08x}", group_id, fastrand::u32(..));
+    if validate_session_id(&session_id, group_id) {
+        Ok(session_id)
+    } else {
+        Err("generated session_id exceeds the 64-character limit")
+    }
 }
 
 /// 唤醒前置：服务化 session 必须 Completed 且 callback_status 已是终态。
@@ -54,8 +63,31 @@ mod tests {
 
     #[test]
     fn generated_session_id_passes_validation() {
-        let id = new_session_id("group-123");
+        let id = new_session_id("group-123").expect("bounded group id");
         assert!(validate_session_id(&id, "group-123"));
+    }
+
+    #[test]
+    fn generated_session_id_rejects_overlong_group_id() {
+        assert!(new_session_id(&"g".repeat(56)).is_err());
+    }
+
+    #[test]
+    fn session_id_rejects_more_than_64_characters() {
+        let group_id = "g".repeat(56);
+        let session_id = format!("{group_id}:abcdef12");
+
+        assert_eq!(session_id.chars().count(), 65);
+        assert!(!validate_session_id(&session_id, &group_id));
+    }
+
+    #[test]
+    fn session_id_accepts_exactly_64_characters() {
+        let group_id = "g".repeat(55);
+        let session_id = format!("{group_id}:abcdef12");
+
+        assert_eq!(session_id.chars().count(), 64);
+        assert!(validate_session_id(&session_id, &group_id));
     }
 
     #[test]

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -219,7 +219,10 @@ pub use core::{
 };
 
 pub use bcs_domain::{
+    GENERATED_SESSION_ID_SUFFIX_CHARS, GROUP_ID_PREFIX, GroupIdBuildError,
     InviteTokenPayload, InviteTokenError,
+    MAX_GENERATED_GROUP_ID_CHARS, MAX_SESSION_ID_CHARS, channel_group_id,
+    generated_group_id,
     invite_token_encode, invite_token_decode_and_verify, invite_token_decode_no_expiry,
 };
 

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -14,9 +14,9 @@ use bcs_channel_api::{
 };
 use bcs_domain::{
     ActorKind, BindingStatus, BindingTarget, ChannelBinding, ChannelType, ConversationSessionMap,
-    Group, GroupChatScope, GroupStrategy, ImParticipantMap, Participant, ParticipantMode,
+    Group, GroupChatScope, GroupKind, GroupStrategy, ImParticipantMap, Participant, ParticipantMode,
     ParticipantRole, Session, SessionKind, SessionScope, SessionStatus, SystemMessageEvent,
-    Visibility,
+    Visibility, channel_group_id,
 };
 use bcs_service_api::application::channel::{
     ChannelInboundError, ChannelInboundFailureKind, ChannelService, ChannelUseCaseError,
@@ -41,8 +41,6 @@ use bcs_service_api::{
 pub use visibility::visibility_allows;
 
 const DEFAULT_INBOUND_DEDUP_LIMIT: usize = 4096;
-const MAX_CHANNEL_SESSION_ID_CHARS: usize = 64;
-const GENERATED_SESSION_ID_SUFFIX_CHARS: usize = 9;
 
 /// Channel application service implementation.
 pub struct BcsChannelService {
@@ -206,7 +204,11 @@ impl BcsChannelService {
         msg: &InboundMessage,
         actor_id: &str,
     ) -> Result<String, ChannelUseCaseError> {
-        let group_id = channel_owned_group_id(&binding.channel_type, &(self.new_id)())?;
+        let group_id = channel_owned_group_id(
+            &binding.channel_type,
+            GroupKind::Dm,
+            &(self.new_id)(),
+        )?;
         let label = msg
             .im_user_nick
             .as_ref()
@@ -239,9 +241,17 @@ impl BcsChannelService {
         binding: &ChannelBinding,
         bot_id: &str,
     ) -> Result<String, ChannelUseCaseError> {
-        let group_id = channel_owned_group_id(&binding.channel_type, &binding.id)?;
+        let group_id = channel_owned_group_id(
+            &binding.channel_type,
+            GroupKind::Normal,
+            &binding.id,
+        )?;
         if self.groups.get(&group_id).await.is_some() {
             return Ok(group_id);
+        }
+        let legacy_group_id = legacy_channel_owned_group_id(&binding.channel_type, &binding.id);
+        if self.groups.get(&legacy_group_id).await.is_some() {
+            return Ok(legacy_group_id);
         }
         let mut group = Group::new(
             group_id.clone(),
@@ -907,7 +917,7 @@ impl ChannelService for BcsChannelService {
         provider.validate_config(&cmd.config).map_err(provider_error)?;
         let binding_id = (self.new_id)();
         if matches!(&target, BindingTarget::Bot { .. }) {
-            channel_owned_group_id(&cmd.channel_type, &binding_id)?;
+            channel_owned_group_id(&cmd.channel_type, GroupKind::Dm, &binding_id)?;
         }
         if self
             .bindings
@@ -1163,21 +1173,18 @@ fn normalize_required<'a>(
 
 fn channel_owned_group_id(
     channel_type: &str,
+    group_kind: GroupKind,
     owner_id: &str,
 ) -> Result<String, ChannelUseCaseError> {
     let channel_type = normalize_required(channel_type, "channel_type")?;
     let owner_id = normalize_required(owner_id, "channel group owner id")?;
-    let group_id = format!("{channel_type}_{owner_id}");
-    if group_id.chars().count() + GENERATED_SESSION_ID_SUFFIX_CHARS
-        > MAX_CHANNEL_SESSION_ID_CHARS
-    {
-        return Err(ChannelUseCaseError::Internal(ServiceError::InternalError(
-            format!(
-                "generated channel group id cannot produce a session id within {MAX_CHANNEL_SESSION_ID_CHARS} characters"
-            ),
-        )));
-    }
-    Ok(group_id)
+    channel_group_id(channel_type, group_kind, owner_id).map_err(|error| {
+        ChannelUseCaseError::Internal(ServiceError::InternalError(error.to_string()))
+    })
+}
+
+fn legacy_channel_owned_group_id(channel_type: &str, owner_id: &str) -> String {
+    format!("{}_{}", channel_type.trim(), owner_id.trim())
 }
 
 fn human_actor_id(staff_no: &str) -> String {
@@ -1253,7 +1260,7 @@ mod tests {
     };
     use bcs_domain::{
         ActorKind, BindingStatus, BindingTarget, BotCapabilities, BotDynamicStatus,
-        ChannelBinding, ChannelConfig, ChannelType, Group, GroupChatScope, Participant,
+        ChannelBinding, ChannelConfig, ChannelType, Group, GroupChatScope, GroupKind, Participant,
         ParticipantMode, ParticipantRole, RegisteredBot, Session, SessionKind, SessionScope,
         SessionStatus, Skill, StateMachineRun, StateMachineRunStatus, SystemMessageEvent,
         Visibility,
@@ -1833,15 +1840,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_direct_bot_binding_rejects_overlong_generated_session_id_before_persisting(
-    ) -> TestResult {
+    async fn create_direct_bot_binding_canonicalizes_long_internal_owner_id() -> TestResult {
         let harness = TestHarness::new_with_generated_id(
             manager_group("group_1"),
             "x".repeat(55),
         )
         .await?;
 
-        let result = harness
+        let binding = harness
             .service
             .create_binding(CreateBindingCommand {
                 channel_type: channel_type(),
@@ -1855,22 +1861,68 @@ mod tests {
                 created_by: Some("creator".to_string()),
                 config: dingtalk_config("robot_1"),
             })
-            .await;
+            .await?;
 
-        assert!(matches!(
-            result,
-            Err(ChannelUseCaseError::Internal(ServiceError::InternalError(_)))
-        ));
-        assert!(harness.binding_repo.list().await?.is_empty());
+        let group_id = channel_owned_group_id(
+            &binding.channel_type,
+            GroupKind::Dm,
+            &binding.id,
+        )?;
+        assert!(format!("{group_id}:abcdef12").chars().count() <= 64);
+        assert_eq!(harness.binding_repo.list().await?.len(), 1);
 
         Ok(())
     }
 
     #[test]
     fn channel_owned_group_id_rejects_overlong_session_id() {
-        let result = channel_owned_group_id("dingtalk", &"x".repeat(55));
+        let result = channel_owned_group_id(
+            "channel_name",
+            GroupKind::Dm,
+            "bc7d5297-4947-474d-a2f1-cdea1c5642b6",
+        );
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn channel_owned_group_id_encodes_channel_and_group_kind() -> TestResult {
+        let source_id = "bc7d5297-4947-474d-a2f1-cdea1c5642b6";
+
+        assert_eq!(
+            channel_owned_group_id("dingtalk", GroupKind::Normal, source_id)?,
+            "bcs_grp_dingtalk_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        let dm_group_id = channel_owned_group_id("dingtalk", GroupKind::Dm, source_id)?;
+        assert_eq!(
+            dm_group_id,
+            "bcs_grp_dingtalk_dm_bc7d52974947474da2f1cdea1c5642b6"
+        );
+        assert_eq!(format!("{dm_group_id}:abcdef12").chars().count(), 61);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn managed_bot_group_reuses_legacy_channel_group_id() -> TestResult {
+        let legacy_group_id = "dingtalk_binding_bot";
+        let harness = TestHarness::new(manager_group(legacy_group_id)).await?;
+        let binding = active_binding(
+            "binding_bot",
+            "robot_1",
+            BindingTarget::Bot {
+                bot_id: "target_bot".to_string(),
+            },
+            Visibility::FullTranscript,
+        );
+
+        let group_id = harness
+            .service
+            .ensure_managed_single_bot_group(&binding, "target_bot")
+            .await?;
+
+        assert_eq!(group_id, legacy_group_id);
+        Ok(())
     }
 
     #[tokio::test]
@@ -2858,7 +2910,7 @@ mod tests {
             .get(binding_id, "conv_group", SessionScope::PerSender, Some("u1"))
             .await?
             .ok_or_else(|| ServiceError::InternalError("missing conversation".to_string()))?;
-        assert!(mapped.bcs_session_id.starts_with("dingtalk_"));
+        assert!(mapped.bcs_session_id.starts_with("bcs_grp_dingtalk_"));
         assert!(mapped.bcs_session_id.len() <= 64);
 
         Ok(())

--- a/src/bcs/crates/services/bcs-group-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/memory.rs
@@ -13,7 +13,7 @@ use bcs_service_api::{GroupMetricCount, GroupMetricsSnapshotPort};
 use bcs_service_api::{
     Group as DomainGroup, GroupKind, GroupMessage, GroupStatus, GroupStrategy, Participant,
     ParticipantMode,
-    ServiceError, ServiceResult, ServiceSpec, Workspace,
+    ServiceError, ServiceResult, ServiceSpec, Workspace, generated_group_id,
 };
 
 /// In-memory implementation of [`GroupRepoPort`].
@@ -484,7 +484,9 @@ impl GroupBuilder {
 
     /// Build the group.
     pub fn build(self) -> DomainGroup {
-        let id = self.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let id = self
+            .id
+            .unwrap_or_else(|| generated_group_id(GroupKind::Normal));
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
@@ -520,6 +522,14 @@ impl GroupBuilder {
 mod tests {
     use super::*;
     use bcs_domain::{GroupMessageType, MessageRole, ParticipantRole};
+
+    #[test]
+    fn group_builder_uses_canonical_generated_id() {
+        let group = GroupBuilder::new("driver").build();
+
+        assert!(group.id.starts_with("bcs_grp_"));
+        assert_eq!(group.id.chars().count(), 40);
+    }
 
     #[tokio::test]
     async fn test_group_store_crud() {

--- a/src/bcs/crates/services/bcs-group/src/application/management.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/management.rs
@@ -22,6 +22,7 @@ use bcs_service_api::{
     WorkbenchChatAuthorizationCommand, WorkbenchConnectCommand, WorkbenchConnectOutcome,
     WorkbenchParticipantView, WorkbenchSessionService, WorkbenchUseCaseError,
     backfill_bot_names, validate_sender_routes, CallbackChannelConfig,
+    generated_group_id,
 };
 use tracing::warn;
 use crate::core::validate_service_spec_patch;
@@ -707,7 +708,9 @@ impl GroupManagementService for GroupManagement {
 
         let is_human_originator = originator.starts_with("human_");
 
-        let group_id = cmd.group_id.unwrap_or_else(generated_group_id);
+        let group_id = cmd
+            .group_id
+            .unwrap_or_else(|| generated_group_id(GroupKind::Normal));
         let mut requested = Vec::new();
         for participant in cmd.participants {
             requested.push((participant.bot_id, participant.role));
@@ -949,7 +952,9 @@ impl GroupManagementService for GroupManagement {
             ));
         }
 
-        let group_id = cmd.group_id.unwrap_or_else(generated_group_id);
+        let group_id = cmd
+            .group_id
+            .unwrap_or_else(|| generated_group_id(GroupKind::Dm));
         let label = dm_label(cmd.label, cmd.topic.as_deref(), caller, &target.bot_uuid);
 
         let (actor_a, actor_b, legacy_driver_bot, originator_actor_id) = match caller_actor.actor_kind {
@@ -1860,15 +1865,6 @@ fn participant_role_to_wire(role: ParticipantRole) -> &'static str {
         ParticipantRole::Worker => "worker",
         ParticipantRole::Observer => "observer",
     }
-}
-
-/// Prefix prepended to auto-generated group IDs so downstream engines
-/// (OpenClaw / Moltis) can recognize a session as BCS-originated from its
-/// session key. Caller-supplied group IDs are left untouched.
-const GROUP_ID_PREFIX: &str = "bcs_grp_";
-
-fn generated_group_id() -> String {
-    format!("{}{}", GROUP_ID_PREFIX, uuid::Uuid::new_v4())
 }
 
 fn dm_label(

--- a/src/bcs/crates/services/bcs-group/tests/management.rs
+++ b/src/bcs/crates/services/bcs-group/tests/management.rs
@@ -69,6 +69,27 @@ async fn create_group_authorizes_human_caller_with_any_driver() {
 }
 
 #[tokio::test]
+async fn create_group_without_explicit_id_uses_native_namespace() {
+    let fixture = Fixture::new().with_bot("driver", "Driver", "public", None);
+    let service = fixture.service_with_limits(5, 10, 10);
+    let mut cmd = create_cmd(
+        Some("driver"),
+        "driver",
+        vec![participant("driver", Some("driver"))],
+    );
+    cmd.group_id = None;
+
+    let created = service
+        .create_group(cmd)
+        .await
+        .expect("generated group should be created");
+
+    assert!(created.group_id.starts_with("bcs_grp_"));
+    assert!(!created.group_id.starts_with("bcs_grp_dm_"));
+    assert_eq!(created.group_id.chars().count(), 40);
+}
+
+#[tokio::test]
 async fn create_group_human_caller_with_ownerless_driver_ok() {
     // Human can designate ownerless bot as driver (no owner restriction).
     let fixture = Fixture::new().with_bot("driver", "Driver", "public", None);
@@ -1200,6 +1221,33 @@ async fn create_dm_creates_and_reuses_human_bot_pair() {
     assert!(!reused.created);
     assert_eq!(reused.group.group_id, "dm-under-test");
     assert_eq!(reused.group.context.as_deref(), Some("dm context"));
+}
+
+#[tokio::test]
+async fn create_dm_without_explicit_id_uses_dm_namespace() {
+    let fixture = Fixture::new().with_human("human_alice", "Alice").with_bot(
+        "assistant",
+        "Assistant",
+        "public",
+        Some("alice"),
+    );
+    let service = fixture.service_with_limits(5, 10, 10);
+
+    let created = service
+        .create_dm(DmCreateCommand {
+            group_id: None,
+            caller_actor_id: Some("human_alice".to_string()),
+            driver_bot: None,
+            target_actor_id: "assistant".to_string(),
+            label: None,
+            topic: None,
+            context: None,
+        })
+        .await
+        .expect("owner human should create generated Human-Bot DM");
+
+    assert!(created.group.group_id.starts_with("bcs_grp_dm_"));
+    assert_eq!(created.group.group_id.chars().count(), 43);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-proposal/src/application/proposal.rs
+++ b/src/bcs/crates/services/bcs-proposal/src/application/proposal.rs
@@ -5,10 +5,10 @@ use bcs_service_api::{
     BotRegistryCoreService, CreateOrReactivateCommand, FriendCoreService, Group,
     GroupChatProposal, GroupCoreService, GroupProposalConfirmCommand, GroupProposalConfirmResult,
     GroupProposalCreateCommand, GroupProposalCreateResult, GroupProposalPreviewCommand,
-    GroupProposalPreviewResult, GroupProposalService, GroupStatus, GroupUseCaseError,
+    GroupProposalPreviewResult, GroupProposalService, GroupKind, GroupStatus, GroupUseCaseError,
     NewSessionParams, Participant, ParticipantMode, ParticipantRole, ProposalCoreService,
     RegisteredBot, ServiceError, SessionKind, SessionManagementService, SystemMessageEvent,
-    SystemMessageService,
+    SystemMessageService, generated_group_id,
 };
 use tokio::sync::Mutex;
 
@@ -296,7 +296,7 @@ impl GroupProposalService for GroupProposalUseCases {
             });
         }
 
-        let group_id = uuid::Uuid::new_v4().to_string();
+        let group_id = generated_group_id(GroupKind::Normal);
         let mut group = Group::new(&group_id, proposal.driver_bot.clone(), participants);
         group.label = Some(format!("Group: {}", proposal.reason));
         self.group.upsert(group.clone()).await?;

--- a/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
+++ b/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
@@ -223,6 +223,8 @@ async fn confirm_proposal_consumes_the_token_and_creates_group() {
         .unwrap();
 
     assert!(confirmed.created);
+    assert!(confirmed.group_id.starts_with("bcs_grp_"));
+    assert_eq!(confirmed.group_id.chars().count(), 40);
     assert_eq!(confirmed.driver_bot_id, "driver");
     assert_eq!(confirmed.participant_bot_ids, ["driver", "dba"]);
     assert!(fixture.proposal.get("proposal-token").await.is_none());

--- a/src/bcs/crates/services/bcs-session-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/memory.rs
@@ -141,12 +141,9 @@ impl SessionRepoPort for MemorySessionRepo {
 
         // Auto-generated id: retry 3 times to handle the ~0 probability collision.
         for _attempt in 0..3 {
-            let id = new_session_id(group_id);
-            if !validate_session_id(&id, group_id) {
-                return Err(ServiceError::SessionInvalidParams(format!(
-                    "generated session_id {id} failed format validation"
-                )));
-            }
+            let id = new_session_id(group_id).map_err(|error| {
+                ServiceError::SessionInvalidParams(error.to_string())
+            })?;
             let mut st = self.state.write().await;
             if st.sessions.contains_key(&id) {
                 continue;

--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -455,7 +455,9 @@ impl SessionRepoPort for MySqlSessionStore {
 
         // Auto-generate path: up to 3 retries on uk_session_id collision.
         for _ in 0..3 {
-            let id = new_session_id(group_id);
+            let id = new_session_id(group_id).map_err(|error| {
+                ServiceError::SessionInvalidParams(error.to_string())
+            })?;
             match self
                 .insert_session(id, group_id.to_string(), params.clone(), current_millis())
                 .await


### PR DESCRIPTION
## Summary

- add a shared generator for native and Channel-owned Group IDs
- encode immutable Channel and DM namespaces while keeping opaque 32-hex identifiers
- enforce the 64-character Session ID limit in validation and both session stores
- preserve complete generated Group IDs in `session_key` while retaining legacy conversion behavior
- reuse existing legacy Channel-owned groups instead of creating duplicates

## Why

Generated Group IDs previously used inconsistent formats, making native, DM, and external IM groups difficult to distinguish. Channel IDs also need to leave enough space for the `:<8_hex>` Session ID suffix.

The canonical formats make source and group kind visible for diagnostics while keeping the actual identity opaque and bounded.

## Validation

- `cargo test -p bcs-domain -p bcs-protocol -p bcs-service-api -p bcs-session-store -p bcs-group-store -p bcs-group -p bcs-proposal -p bcs-channel`
- `cargo test -p bcs-ws --lib`
- `cargo check -p bcs`
- `git diff --check`

## Notes

`cargo clippy --all-targets -- -D warnings` remains blocked by pre-existing warnings in `bcs-domain` and `bcs-db-local`; no reported Clippy finding points to this change.