### PR TITLE
fix(service_bot): clear stale online release refs on rollback to DRAFT

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_rollback_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_rollback_mixin.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Callable
 
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
+from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
@@ -158,6 +159,19 @@ class PublishRollbackMixin:
             "rollback_reason": reason,
             "target_publish_id": current_record.last_pub_id,
         }
+        # Clear this version's online release refs before it re-enters DRAFT. The refs
+        # (ext.publish.online = BaaS publish id, ext.binding.online = device binding)
+        # are from this version's earlier go-live; left in place, a later re-publish
+        # would see is_online_release_recorded() == True and skip execute_release_phase
+        # — the upgrade that re-points the shared online bot/binding at this version —
+        # so production would never actually change. Drop both together so the record
+        # is consistently un-published (never one without the other). The shared binding
+        # still lives on the rollback target's record, so the next upgrade re-resolves
+        # it from last_pub_id.
+        for _section in ("publish", "binding"):
+            _refs = current_ext.get(_section)
+            if isinstance(_refs, dict):
+                _refs.pop(PublishStage.ONLINE.value, None)
         self.update_publish_status_with_ext(
             publish_id=publish_id,
             target_status=PublishStatus.DRAFT,

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -2046,6 +2046,62 @@ class TestRollbackPublish:
         assert second_ext["migration_path"] == "/tmp/build"
         assert second_ext["rollback_restored_from"] == 3
 
+    @pytest.mark.asyncio
+    async def test_rollback_publish_clears_online_release_refs(self):
+        """回滚后当前版本回到 DRAFT，应清除其线上发布/绑定引用。
+
+        否则再次发布时 is_online_release_recorded() 会因残留的 ext.publish.online
+        判定为已发布，从而跳过 execute_release_phase（不再执行 upgrade 把共享的线上
+        bot/binding 指向本版本）。清除后，重新发布才会真正重新执行 upgrade。
+        """
+        mock_repo = Mock()
+        current_record = _create_mock_record(
+            record_id=3,
+            status=PublishStatus.SUCCESS,
+            version=3,
+            last_pub_id=2,
+            ext={
+                "existing_key": "existing_value",
+                # 本版本上线时写入的引用（应被清除）
+                "publish": {"online": 9001, "verify": 8001},
+                "binding": {"online": 501, "verify": 401},
+            },
+        )
+        target_record = _create_mock_record(
+            record_id=2,
+            status=PublishStatus.UPGRADED,
+            version=2,
+            ext={"migration_path": "/tmp/build"},
+        )
+
+        mock_repo.get_by_id.side_effect = [current_record, target_record, current_record, target_record]
+        mock_repo.get_by_last_pub_id.return_value = None
+        mock_repo.update_status_with_ext.return_value = current_record
+
+        mock_flow_service = MagicMock()
+        mock_flow_service.execute_rollback = AsyncMock(return_value=MagicMock(
+            status=PublishStatus.ONLINE_PUB,
+            message="回滚发布已提交",
+        ))
+        service = _make_service(
+            bot_publish_repo=mock_repo,
+            publish_flow_service_provider=lambda: mock_flow_service,
+        )
+
+        await service.rollback_publish(publish_id=3, operator="user_001")
+
+        first_call = mock_repo.update_status_with_ext.call_args_list[0]
+        first_ext = first_call[0][2]  # ext 是第三个位置参数
+
+        # 线上发布/绑定引用被清除（一并清除，保持一致）
+        assert first_ext.get("publish", {}).get("online") is None
+        assert first_ext.get("binding", {}).get("online") is None
+        # verify 阶段引用及其他字段保留
+        assert first_ext["publish"]["verify"] == 8001
+        assert first_ext["binding"]["verify"] == 401
+        assert first_ext["existing_key"] == "existing_value"
+        assert "rollback" in first_ext
+
 
 class TestGetBotStageBindingInfo:
     def test_personal_bot_success(self):


### PR DESCRIPTION
## What & why

Fixes #255.

After a service-bot **rollback**, re-driving the rolled-back version's online publish silently skipped the online release: the publish record advanced to `SUCCESS` while the live BaaS bot was never upgraded — recorded state and the deployed bot diverged, with no error.

**Root cause.** `rollback_publish` moves the current version's record back to `DRAFT` but left its `ext.publish.online` (BaaS publish id) and `ext.binding.online` (device binding) markers in place. `is_online_release_recorded()` reads `ext.publish.online` as the crash-resume idempotency guard, so on a later re-publish the `online_release` task saw the stale marker and skipped `execute_release_phase` — the only step that re-points the live online bot/binding at the version via `upgrade_async`.

This is a regression from the durable-task-pipeline refactor (PR #105): before it, `process()` at `VALIDATING` called the release phase unconditionally.

## The fix

When the current record re-enters `DRAFT` during rollback, clear both the online publish id and online binding refs so it becomes a genuinely un-released version. Both are dropped together for consistency (never one without the other).

The guard is deliberately **kept** — it's load-bearing for crash-resume idempotency (a lease-expiry re-run must not create a second BaaS bot) and for retry strategy selection. The bug was that the marker leaked *across* publish lifecycles because rollback reuses the record; clearing it at the rollback→DRAFT seam is the one place that only fires on rollback (a fresh record starts DRAFT-empty, and `ONLINE_PUB` re-entered via retry must keep the marker). The shared binding still lives on the rollback target's record, so the next upgrade re-resolves it from `last_pub_id`.

## Changes

- `publish_rollback_mixin.py`: clear `ext.publish.online` and `ext.binding.online` when resetting the current record to `DRAFT`.
- `test_bot_publish_service.py`: new `test_rollback_publish_clears_online_release_refs` asserting the online refs are cleared while `verify`-stage refs and other ext keys are preserved.

## Testing

`test_bot_publish_service.py`, `test_publish_tasks.py`, `test_publish_flow_service.py` — 233 passed. The new test fails on the pre-fix code and passes with the fix (confirmed it exercises the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWJ3sZiNMa3r7Xq6CJK4UR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWJ3sZiNMa3r7Xq6CJK4UR)_