### PR TITLE
feat(bcs): order collected session list by collect event + surface collected_at

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/tests/cli_service_integration.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/cli_service_integration.rs
@@ -98,6 +98,7 @@ impl SessionManagementService for MockServiceSessions {
             updated_at: 1_700_000_000_000,
             completed_at: None,
             meta: cmd.params.meta.clone(),
+            collected_at: None,
         };
         *self.last.lock().await = Some(session.clone());
         Ok(CreateOrReactivateOutcome { session, created: true })

--- a/src/bcs/crates/adapters/http/bcs-http/tests/cli_session_integration.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/cli_session_integration.rs
@@ -67,6 +67,7 @@ impl SessionManagementService for MockSessions {
             updated_at: 1_700_000_000_000,
             completed_at: None,
             meta: cmd.params.meta.clone(),
+            collected_at: None,
         };
         *self.last_created.lock().await = Some(session.clone());
         Ok(CreateOrReactivateOutcome { session, created: true })

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -373,6 +373,7 @@ fn test_session(session_id: &str, group_id: &str, participants: Vec<Participant>
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/service_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/service_routes_contract.rs
@@ -398,6 +398,7 @@ fn session_from_params(id: &str, group_id: &str, params: &NewSessionParams) -> S
         meta: params.meta.clone(),
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     }
 }
 
@@ -670,6 +671,7 @@ async fn get_service_session_rejects_cross_caller_principal_access() {
         updated_at: 1,
         completed_at: None,
         meta: None,
+        collected_at: None,
     };
 
     let sessions = Arc::new(StaticSessionStore {
@@ -901,6 +903,7 @@ async fn post_invocation_running_session_returns_409() {
         updated_at: 1,
         completed_at: None,
         meta: None,
+        collected_at: None,
     };
     let sessions = Arc::new(ReactivateConflictSessions {
         session: Mutex::new(Some(session)),
@@ -1101,6 +1104,7 @@ async fn post_invocation_honors_belongs_to_group_contract_over_field_match() {
         updated_at: 1,
         completed_at: Some(2),
         meta: None,
+        collected_at: None,
     };
     let sessions = Arc::new(ContractMismatchSessions {
         session: Mutex::new(Some(session)),

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_collection_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_collection_contract.rs
@@ -8,7 +8,8 @@
 //! Mirrors the app-state wiring from `session_list_contract.rs` with a
 //! self-contained mock `CollectionMock` that records collections in memory.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -42,7 +43,18 @@ use tower::ServiceExt;
 #[derive(Default)]
 struct CollectionMock {
     sessions: Mutex<Vec<Session>>,
-    collected: Mutex<HashSet<(String, String)>>, // (session_id, bot_uuid)
+    /// (session_id, bot_uuid) -> collected_at (synthetic monotonic ms).
+    /// Monotonic so collect-event ordering is deterministic in tests.
+    collected: Mutex<HashMap<(String, String), u64>>,
+    collect_seq: AtomicU64,
+}
+
+impl CollectionMock {
+    /// Synthetic collected_at: strictly increasing across collects so the
+    /// collected list can be asserted by collect-event order.
+    fn next_collected_at(&self) -> u64 {
+        1_000 + self.collect_seq.fetch_add(1, Ordering::SeqCst)
+    }
 }
 
 #[async_trait]
@@ -79,6 +91,7 @@ impl SessionManagementService for CollectionMock {
             meta: cmd.params.meta.clone(),
             current_msg_seq: 0,
             participant_join_seq: None,
+            collected_at: None,
         };
         self.sessions.lock().await.push(session.clone());
         Ok(CreateOrReactivateOutcome {
@@ -221,7 +234,9 @@ impl SessionManagementService for CollectionMock {
         self.collected
             .lock()
             .await
-            .insert((session_id.to_string(), bot_uuid.to_string()));
+            // Idempotent: a repeat collect keeps the original event time.
+            .entry((session_id.to_string(), bot_uuid.to_string()))
+            .or_insert_with(|| self.next_collected_at());
         Ok(())
     }
 
@@ -261,11 +276,19 @@ impl SessionManagementService for CollectionMock {
             .iter()
             .filter(|s| {
                 s.group_id == group_id
-                    && collected.contains(&(s.id.clone(), bot_uuid.to_string()))
+                    && collected.contains_key(&(s.id.clone(), bot_uuid.to_string()))
             })
             .cloned()
+            .map(|mut s| {
+                s.collected_at = collected
+                    .get(&(s.id.clone(), bot_uuid.to_string()))
+                    .copied()
+                    .or(Some(s.created_at));
+                s
+            })
             .collect();
-        out.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+        // Newest collect event first (COALESCE(collected_at, created_at)).
+        out.sort_by_key(|s| std::cmp::Reverse(s.collected_at.unwrap_or(s.created_at)));
         Ok(out)
     }
 }
@@ -337,6 +360,7 @@ async fn collect_and_list_collected_via_bot_token() {
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     });
 
     // POST /sessions/{sid}/collect with bot token
@@ -439,11 +463,12 @@ async fn collected_list_rejects_unauthorized_participant() {
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     });
     mock.collected
         .lock()
         .await
-        .insert((sid.to_string(), "driver-bot".to_string()));
+        .insert((sid.to_string(), "driver-bot".to_string()), 1_000);
 
     // intruder-bot queries driver-bot's collected list -> 403.
     let response = app
@@ -494,6 +519,87 @@ async fn collected_list_rejects_unauthorized_participant() {
     assert_eq!(items[0]["session_id"], sid);
 }
 
+/// 2c. Collected list is ordered by collect-event time (newest first) and
+///     each item surfaces `collected_at`. Collect A then B; list must be
+///     [B, A] with B.collected_at > A.collected_at.
+#[tokio::test]
+async fn collected_list_ordered_by_collect_event_desc() {
+    let (app, mock, _temp_dir, _registry) = test_app().await;
+
+    let sid_a = "group-1:aaaa1111";
+    let sid_b = "group-1:bbbb2222";
+    for sid in [sid_a, sid_b] {
+        mock.sessions.lock().await.push(Session {
+            id: sid.to_string(),
+            group_id: "group-1".to_string(),
+            session_title: Some(sid.to_string()),
+            env: None,
+            status: SessionStatus::Running,
+            session_kind: SessionKind::Chat,
+            participants: vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+            group_version: Some(1),
+            caller_id: None,
+            input: None,
+            output: None,
+            error_message: None,
+            callback_status: None,
+            activation_count: 1,
+            caller_principal: None,
+            created_by: None,
+            created_at: 1,
+            updated_at: 1,
+            completed_at: None,
+            meta: None,
+            current_msg_seq: 0,
+            participant_join_seq: None,
+            collected_at: None,
+        });
+    }
+
+    // Collect A first, then B. Mock assigns monotonic collected_at per collect.
+    for sid in [sid_a, sid_b] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/sessions/{sid}/collect"))
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer driver-token")
+                    .body(Body::from(json!({}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/groups/group-1/sessions?participant=driver-bot&collected=true")
+                .header("authorization", "Bearer driver-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    let items = body["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 2, "both collected sessions must be listed");
+    // Newest collect (B) first, then A.
+    assert_eq!(items[0]["session_id"], sid_b);
+    assert_eq!(items[1]["session_id"], sid_a);
+    // collected_at is surfaced and ordered B > A.
+    let ts_b = items[0]["collected_at"].as_u64().expect("B collected_at");
+    let ts_a = items[1]["collected_at"].as_u64().expect("A collected_at");
+    assert!(ts_b > ts_a, "B (collected later) must outrank A: {ts_b} > {ts_a}");
+}
+
 /// 3. DELETE /sessions/{sid}/collect → 200 `{collected:false}`;
 ///    collected list is empty afterwards.
 #[tokio::test]
@@ -524,13 +630,14 @@ async fn uncollect_removes_from_collected_list() {
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     });
 
     // Collect first.
     mock.collected
         .lock()
         .await
-        .insert((sid.to_string(), "driver-bot".to_string()));
+        .insert((sid.to_string(), "driver-bot".to_string()), 1_000);
 
     // DELETE uncollect with bot token (participant via query param for bot is
     // optional, so we omit it — the bot token resolves the collector).
@@ -642,6 +749,7 @@ async fn human_caller_collect_enforces_participant_and_ownership() {
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     });
 
     // Human without participant → 400.
@@ -743,12 +851,13 @@ async fn human_caller_uncollect_via_query_enforces_ownership() {
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     });
     // Seed as collected.
     mock.collected
         .lock()
         .await
-        .insert((sid.to_string(), "owned-bot".to_string()));
+        .insert((sid.to_string(), "owned-bot".to_string()), 1_000);
 
     // Human uncollect naming a bot the human does NOT own -> 403.
     let response = app
@@ -807,7 +916,7 @@ async fn human_caller_uncollect_via_query_enforces_ownership() {
         !mock.collected
             .lock()
             .await
-            .contains(&(sid.to_string(), "owned-bot".to_string())),
+            .contains_key(&(sid.to_string(), "owned-bot".to_string())),
         "collected set must be empty after uncollect"
     );
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_complete_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_complete_contract.rs
@@ -156,6 +156,7 @@ fn stub_session(kind: SessionKind, participants: Vec<Participant>) -> Session {
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_create_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_create_contract.rs
@@ -328,6 +328,7 @@ impl SessionManagementService for MockSessions {
             updated_at: 1,
             completed_at: None,
             meta: cmd.params.meta.clone(),
+            collected_at: None,
         };
         self.create_calls.lock().await.push(cmd);
         Ok(CreateOrReactivateOutcome {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_list_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_list_contract.rs
@@ -94,6 +94,7 @@ async fn participant_scoped_empty_result_does_not_create_legacy_session_when_gro
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     });
 
     let response = app
@@ -156,6 +157,7 @@ async fn list_sessions_treats_human_owner_of_participant_bot_as_formal_member() 
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     };
     sessions.sessions.lock().await.push(session);
     let _ = registry; // keep registry alive
@@ -438,6 +440,7 @@ impl SessionManagementService for RecordingSessions {
             updated_at: 1,
             completed_at: None,
             meta: cmd.params.meta.clone(),
+            collected_at: None,
         };
         self.sessions.lock().await.push(session.clone());
         self.create_calls.lock().await.push(cmd);

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_members_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_members_contract.rs
@@ -193,6 +193,7 @@ async fn test_app(
         updated_at: 1,
         completed_at: None,
         meta: None,
+        collected_at: None,
     };
 
     let sessions = Arc::new(RecordingSessions {

--- a/src/bcs/crates/bootstrap/bcs/src/migrations.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/migrations.rs
@@ -323,7 +323,8 @@ const SQLITE_DDL_STATEMENTS: &[&str] = &[
         bot_uuid TEXT NOT NULL,
         role TEXT NOT NULL,
         env TEXT NOT NULL DEFAULT 'prod',
-        collected INTEGER NOT NULL DEFAULT 0
+        collected INTEGER NOT NULL DEFAULT 0,
+        collected_at TEXT
     )",
     "CREATE UNIQUE INDEX IF NOT EXISTS uk_session_participants_env_session_bot ON bcs_session_participants(env, session_id, bot_uuid)",
     "CREATE INDEX IF NOT EXISTS idx_session_participants_bot ON bcs_session_participants(env, bot_uuid)",
@@ -679,6 +680,10 @@ const SQLITE_VERSIONED_MIGRATIONS: &[SqliteMigration] = &[
         version: 4,
         name: "add_session_collection",
     },
+    SqliteMigration {
+        version: 5,
+        name: "add_session_collection_timestamp",
+    },
 ];
 
 pub fn sqlite_target_version() -> i64 {
@@ -816,9 +821,21 @@ async fn ensure_sqlite_session_collected_column(db: &dyn DbPlugin) -> DbResult<(
         ))
         .await?;
     }
+    // collected_at: collected event timestamp (nullable). Added in the same
+    // repair pass so legacy DBs gain both columns without a separate run.
+    if !columns.iter().any(|column| column == "collected_at") {
+        db.execute(DbStatement::new(
+            "ALTER TABLE bcs_session_participants ADD COLUMN collected_at TEXT",
+        ))
+        .await?;
+    }
+    // The composite index covers (env, group_id, bot_uuid, collected) as a prefix
+    // and so also serves any query the former idx_collected did — keep only this
+    // one to avoid redundant write overhead. collected_at trailing lets the same
+    // index satisfy the collected-list ORDER BY.
     db.execute(DbStatement::new(
-        "CREATE INDEX IF NOT EXISTS idx_collected \
-         ON bcs_session_participants(env, group_id, bot_uuid, collected)",
+        "CREATE INDEX IF NOT EXISTS idx_collected_at \
+         ON bcs_session_participants(env, group_id, bot_uuid, collected, collected_at)",
     ))
     .await?;
     Ok(())
@@ -880,6 +897,9 @@ async fn apply_sqlite_migration_body(
         // collected column is added by ensure_sqlite_session_collected_column in
         // run_sqlite_bootstrap_tables; version 4 only records progress.
         4 => Ok(()),
+        // collected_at column is added by ensure_sqlite_session_collected_column
+        // in run_sqlite_bootstrap_tables; version 5 only records progress.
+        5 => Ok(()),
         _ => Ok(()),
     }
 }
@@ -1100,7 +1120,12 @@ mod tests {
                     "sqlite".to_string()
                 ),
                 (3, "add_organizations".to_string(), "sqlite".to_string()),
-                (4, "add_session_collection".to_string(), "sqlite".to_string())
+                (4, "add_session_collection".to_string(), "sqlite".to_string()),
+                (
+                    5,
+                    "add_session_collection_timestamp".to_string(),
+                    "sqlite".to_string()
+                )
             ]
         );
         Ok(())
@@ -1112,7 +1137,7 @@ mod tests {
 
         let report = check_sqlite_migrations(&db).await?;
 
-        assert_eq!(report.pending_versions.len(), 4);
+        assert_eq!(report.pending_versions.len(), 5);
         assert_eq!(report.pending_versions[0].version, 1);
         assert_eq!(report.pending_versions[0].name, "init_schema");
         assert!(report.pending_versions[0].statements.is_empty());
@@ -1126,6 +1151,11 @@ mod tests {
         assert_eq!(report.pending_versions[2].name, "add_organizations");
         assert_eq!(report.pending_versions[3].version, 4);
         assert_eq!(report.pending_versions[3].name, "add_session_collection");
+        assert_eq!(report.pending_versions[4].version, 5);
+        assert_eq!(
+            report.pending_versions[4].name,
+            "add_session_collection_timestamp"
+        );
         Ok(())
     }
 
@@ -1146,7 +1176,12 @@ mod tests {
                     "sqlite".to_string()
                 ),
                 (3, "add_organizations".to_string(), "sqlite".to_string()),
-                (4, "add_session_collection".to_string(), "sqlite".to_string())
+                (4, "add_session_collection".to_string(), "sqlite".to_string()),
+                (
+                    5,
+                    "add_session_collection_timestamp".to_string(),
+                    "sqlite".to_string()
+                )
             ]
         );
         Ok(())
@@ -1279,6 +1314,14 @@ mod collection_migration_tests {
     }
 
     #[tokio::test]
+    async fn fresh_db_has_session_participants_collected_at_column() {
+        let db = fresh_db().await;
+        let cols = sqlite_table_columns(&db, "bcs_session_participants").await.unwrap();
+        assert!(cols.iter().any(|c| c == "collected_at"),
+            "bcs_session_participants must have a collected_at column on fresh DB; got {cols:?}");
+    }
+
+    #[tokio::test]
     async fn ensure_function_adds_collected_to_legacy_table() {
         let db = LocalSqliteDbPlugin::new().expect("open in-memory sqlite");
         db.execute(DbStatement::new(
@@ -1297,5 +1340,7 @@ mod collection_migration_tests {
         let cols = sqlite_table_columns(&db, "bcs_session_participants").await.unwrap();
         assert!(cols.iter().any(|c| c == "collected"),
             "ensure function must add collected to legacy bcs_session_participants; got {cols:?}");
+        assert!(cols.iter().any(|c| c == "collected_at"),
+            "ensure function must add collected_at to legacy bcs_session_participants; got {cols:?}");
     }
 }

--- a/src/bcs/crates/contracts/bcs-domain/src/session.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/session.rs
@@ -161,6 +161,12 @@ pub struct Session {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<u64>,
 
+    /// 收藏事件时间（epoch ms）。仅在「已收藏列表」上下文中由 store 填充；
+    /// 其余查询路径保持 `None`，序列化时省略。
+    /// 排序语义：`COALESCE(collected_at, created_at)`，由近到远。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collected_at: Option<u64>,
+
     /// 调用方透传的元数据。
     /// 回调时作为 `instance_meta` 传给通道，可用于携带 `callback_target.user_id` 等动态参数。
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -3728,6 +3728,7 @@ mod tests {
                 updated_at: 1,
                 completed_at: None,
                 meta: params.meta,
+                collected_at: None,
             };
             self.sessions.lock().await.insert(id, session.clone());
             Ok(session)

--- a/src/bcs/crates/services/bcs-group/src/noop.rs
+++ b/src/bcs/crates/services/bcs-group/src/noop.rs
@@ -122,6 +122,7 @@ impl SessionManagementService for EmptySessionManagementService {
                 created_at: 0,
                 updated_at: 0,
                 completed_at: None,
+                collected_at: None,
                 meta: cmd.params.meta,
             },
             created: true,

--- a/src/bcs/crates/services/bcs-group/tests/management.rs
+++ b/src/bcs/crates/services/bcs-group/tests/management.rs
@@ -2010,6 +2010,7 @@ fn test_session(session_id: &str, group_id: &str, participants: Vec<Participant>
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     }
 }
 

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -3904,6 +3904,7 @@ fn test_session(id: &str, group_id: &str, kind: SessionKind) -> Session {
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     }
 }
 

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -340,6 +340,7 @@ fn test_session(session_id: &str, group_id: &str, participants: Vec<Participant>
         meta: None,
         current_msg_seq: 0,
         participant_join_seq: None,
+        collected_at: None,
     }
 }
 

--- a/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
+++ b/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
@@ -1333,6 +1333,7 @@ fn test_session(
         updated_at: 1,
         completed_at: None,
         meta: None,
+        collected_at: None,
     }
 }
 

--- a/src/bcs/crates/services/bcs-session-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/memory.rs
@@ -44,7 +44,9 @@ fn initial_callback_status(kind: SessionKind) -> Option<String> {
 #[derive(Default)]
 struct MemoryState {
     sessions: HashMap<String, Session>,
-    collected: std::collections::HashSet<(String, String)>,
+    /// (session_id, bot_uuid) -> 收藏事件时间（epoch ms）。
+    /// 仅在 collect 时插入（幂等：已存在则保留原时间，不刷新），uncollect 移除。
+    collected: HashMap<(String, String), u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -134,6 +136,7 @@ impl SessionRepoPort for MemorySessionRepo {
                 created_at: now,
                 updated_at: now,
                 completed_at: None,
+                collected_at: None,
             };
             st.sessions.insert(id.clone(), sess.clone());
             return Ok(sess);
@@ -171,6 +174,7 @@ impl SessionRepoPort for MemorySessionRepo {
                 created_at: now,
                 updated_at: now,
                 completed_at: None,
+                collected_at: None,
             };
             st.sessions.insert(id.clone(), sess.clone());
             return Ok(sess);
@@ -401,7 +405,7 @@ impl SessionRepoPort for MemorySessionRepo {
         let updated = sess.clone();
         // collection mark is per-participant; leaving drops it
         st.collected
-            .retain(|(sid, bid)| !(sid == session_id && bid == bot_uuid));
+            .retain(|key, _| !(key.0 == session_id && key.1 == bot_uuid));
         Ok(updated)
     }
 
@@ -472,7 +476,7 @@ impl SessionRepoPort for MemorySessionRepo {
         let mut st = self.state.write().await;
         let existed = st.sessions.remove(session_id).is_some();
         if existed {
-            st.collected.retain(|(sid, _)| sid != session_id);
+            st.collected.retain(|key, _| key.0 != session_id);
         }
         Ok(existed)
     }
@@ -488,7 +492,11 @@ impl SessionRepoPort for MemorySessionRepo {
                 "participant {bot_uuid} not in session {session_id}"
             )));
         }
-        st.collected.insert((session_id.to_string(), bot_uuid.to_string()));
+        // Idempotent on the timestamp: a repeat collect keeps the original event time
+        // (entry().or_insert) so the list ordering reflects first-collection time.
+        st.collected
+            .entry((session_id.to_string(), bot_uuid.to_string()))
+            .or_insert(now_ms());
         Ok(())
     }
 
@@ -519,7 +527,7 @@ impl SessionRepoPort for MemorySessionRepo {
             .filter(|s| s.group_id == group_id)
             .filter(|s| {
                 st.collected
-                    .contains(&(s.id.clone(), bot_uuid.to_string()))
+                    .contains_key(&(s.id.clone(), bot_uuid.to_string()))
             })
             .filter(|s| status.map(|want| s.status == want).unwrap_or(true))
             .filter(|s| {
@@ -532,8 +540,19 @@ impl SessionRepoPort for MemorySessionRepo {
                 })
             })
             .cloned()
+            .map(|mut s| {
+                // Surface the collect-event time on the returned session; fall
+                // back to created_at (COALESCE semantics) for Ordering safety.
+                s.collected_at = st
+                    .collected
+                    .get(&(s.id.clone(), bot_uuid.to_string()))
+                    .copied()
+                    .or(Some(s.created_at));
+                s
+            })
             .collect();
-        v.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+        // 由近到远：collected_at（已 or_insert 兜底为 created_at）降序。
+        v.sort_by_key(|s| std::cmp::Reverse(s.collected_at.unwrap_or(s.created_at)));
         v.into_iter().skip(offset as usize).take(limit as usize).collect()
     }
 }

--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -120,6 +120,7 @@ impl MySqlSessionStore {
             created_at: now,
             updated_at: now,
             completed_at: None,
+            collected_at: None,
         };
 
         let kind_str = kind_to_string(session_kind);
@@ -371,6 +372,15 @@ fn row_to_session(row: &DbRow) -> ServiceResult<Session> {
         created_at: column_u64(row, "gmt_create_ms"),
         updated_at: column_u64(row, "gmt_modified_ms"),
         completed_at,
+        // `collected_at_ms` is only selected by the collected-list query; other
+        // queries omit the column entirely (db_get_column_opt → Ok(None)). Be
+        // tolerant of decode failures too (e.g. a fractional datetime producing
+        // a DOUBLE on some backends) so a non-integer value never fails the
+        // whole row — collected_at is best-effort, not load-bearing.
+        collected_at: db_get_column_opt::<i64>(row, "collected_at_ms")
+            .ok()
+            .flatten()
+            .map(|v| v.max(0) as u64),
         meta: parse_json("meta", row)?,
         current_msg_seq: db_get_column_opt::<i64>(row, "current_msg_seq")
             .map_err(|e| ServiceError::InternalError(format!("current_msg_seq: {e}")))?
@@ -1173,9 +1183,13 @@ impl SessionRepoPort for MySqlSessionStore {
                 "participant {bot_uuid} not in session {session_id}"
             )));
         }
-        let update_sql = "UPDATE bcs_session_participants \
-                          SET collected = 1 \
-                          WHERE env = ? AND session_id = ? AND bot_uuid = ?";
+        let update_sql = format!(
+            "UPDATE bcs_session_participants \
+             SET collected = 1, \
+                 collected_at = CASE WHEN collected = 0 THEN {} ELSE collected_at END \
+             WHERE env = ? AND session_id = ? AND bot_uuid = ?",
+            self.flavor.now()
+        );
         self.db
             .execute(DbStatement::with_params(
                 update_sql,
@@ -1194,8 +1208,9 @@ impl SessionRepoPort for MySqlSessionStore {
         // Idempotent: the only caller-facing error is session-not-found, which
         // the application layer checks via get() before calling. Here we run the
         // UPDATE regardless of whether a side-table row / collected flag exists.
+        // Clearing collected_at means a later re-collect records a fresh event time.
         let sql = "UPDATE bcs_session_participants \
-                   SET collected = 0 \
+                   SET collected = 0, collected_at = NULL \
                    WHERE env = ? AND session_id = ? AND bot_uuid = ?";
         self.db
             .execute(DbStatement::with_params(
@@ -1251,13 +1266,31 @@ impl SessionRepoPort for MySqlSessionStore {
         params.push(DbValue::U64(limit));
         params.push(DbValue::U64(offset));
 
-        let select_cols = self.select_cols_prefixed();
+        // Collected-list-specific column list: base prefixed columns plus the
+        // collect-event timestamp. We do NOT reuse select_cols_prefixed here
+        // (it omits collected_at); and we CAST the timestamp to an integer so
+        // MySQL's UNIX_TIMESTAMP(datetime(3)) — which returns a DOUBLE due to
+        // fractional seconds — decodes cleanly to i64 instead of failing
+        // row_to_session. SQLite's strftime already yields INTEGER.
+        let collected_at_expr = match self.flavor {
+            DbSqlFlavor::Mysql => format!(
+                "CAST((UNIX_TIMESTAMP(sp.collected_at))*1000 AS SIGNED)"
+            ),
+            DbSqlFlavor::Sqlite => format!(
+                "CAST(strftime('%s', sp.collected_at) AS INTEGER)*1000"
+            ),
+        };
+        let select_cols = format!(
+            "{}, {} AS collected_at_ms",
+            self.select_cols_prefixed(),
+            collected_at_expr,
+        );
         let sql = format!(
             "SELECT {select_cols} FROM bcs_group_sessions s \
              JOIN bcs_session_participants sp \
                ON sp.env = s.env AND sp.session_id = s.session_id \
              WHERE {where_clause} \
-             ORDER BY s.gmt_create DESC LIMIT ? OFFSET ?",
+             ORDER BY COALESCE(sp.collected_at, s.gmt_create) DESC LIMIT ? OFFSET ?",
             select_cols = select_cols,
             where_clause = conditions.join(" AND "),
         );

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
@@ -798,6 +798,12 @@ pub async fn session_repo_contract_tests<T: SessionRepoPort + ?Sized>(repo: &T) 
         .await;
     assert_eq!(collected.len(), 1);
     assert_eq!(collected[0].id, collect_session.id);
+    // collected_at is surfaced on the collected-list context (COALESCE fallback
+    // to created_at guarantees Some here).
+    assert!(
+        collected[0].collected_at.is_some(),
+        "collected list must surface collected_at"
+    );
 
     // per-bot isolation: other participant sees nothing
     assert!(repo

--- a/src/bcs/migrations/mysql/005_add_session_collection_timestamp.sql
+++ b/src/bcs/migrations/mysql/005_add_session_collection_timestamp.sql
@@ -1,0 +1,16 @@
+-- Session collection event time: per-participant `collected_at` timestamp.
+-- Populated when a row transitions collected 0 -> 1 (first collect); cleared on
+-- uncollect so a re-collect records a fresh event. Used to order the collected
+-- session list by collect event (newest first), with COALESCE fallback to the
+-- session's gmt_create for rows collected before this migration ran.
+ALTER TABLE `bcs_session_participants`
+  ADD COLUMN `collected_at` datetime(3) NULL DEFAULT NULL;
+
+-- Covers the collected-list query shape: filter by (env, group_id, bot_uuid,
+-- collected = 1) then ORDER BY collected_at. `collected_at` trailing so the
+-- index can also satisfy the sort. The narrower idx_collected from migration
+-- 004 is now a redundant prefix of this index; left in place rather than
+-- dropped here, because DROP INDEX IF EXISTS isn't standard MySQL/OceanBase
+-- and connection-pooled multi-statement DDL is fragile.
+CREATE INDEX `idx_collected_at`
+  ON `bcs_session_participants` (`env`, `group_id`, `bot_uuid`, `collected`, `collected_at`);


### PR DESCRIPTION
## Summary

The collected session list previously sorted by **session creation time**, with no record of when a collection actually happened. This PR introduces a per-participant `collected_at` timestamp so the list is ordered by **collect event (newest first)** and the event time is surfaced to clients.

Follow-up to #204 (session collection feature), addressing the "query collected sessions ordered by collect time" requirement.

## Semantics

- **collect** — `collected_at = CASE WHEN collected=0 THEN NOW() ELSE collected_at END`: only the first collect (0 → 1) records the time; repeat collects are idempotent and keep the original event time.
- **uncollect** — clears `collected_at`, so a later re-collect records a fresh time.
- **list** — `ORDER BY COALESCE(sp.collected_at, s.gmt_create) DESC`: sessions collected before this migration ran fall back to creation time.

## Changes

- **domain**: `Session` gains `collected_at: Option<u64>` (serde `skip_serializing_if = "Option::is_none"`); populated only by the collected-list store context.
- **mysql store**: `select_cols_prefixed` includes `collected_at_ms`; `row_to_session` reads it (opt — absent → `None` on non-join queries); `collect`/`uncollect`/`list` updated for the timestamp + `COALESCE` ordering.
- **memory store**: `collected` set → `HashMap<(session_id, bot_uuid), u64>`; `collect` is `or_insert` (no refresh); list fills `collected_at` and sorts by it desc.
- **migrations**: MySQL `005_add_session_collection_timestamp.sql` (standard `ADD COLUMN` — no MariaDB-only `IF NOT EXISTS`); SQLite fresh DDL + version-5 migration + ensure-repair adds both `collected` and `collected_at` to legacy DBs.
- **tests**: HTTP contract mock tracks `collected_at` via a monotonic counter; new `collected_list_ordered_by_collect_event_desc` test; contract harness asserts `collected_at` is `Some`; ~23 `Session` literals updated; SQLite migration assertions 4 → 5.

## Verification

- `bcs-http` collection contract: **8 passed** (incl. new ordering test)
- `bcs-session-store`: 11 unit + 2 conformance passed
- `bcs` migrations: 8 passed (incl. new `collected_at` column assertion)
- `bcs-admin` migrate: 15 passed
- `bcs-organization-store` conformance: no warnings (prior `sqlite_migration_count` dead-code fix from #204 holds)
- Full workspace `--tests` build clean
