### PR TITLE
feat(aicoding): add session issue outputs API

### DIFF
--- a/src/engine/src/engine/community/api/aicoding_sessions/router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/router.py
@@ -1,6 +1,6 @@
 """HTTP routes for AICoding session workspace inspection.
 
-Nine read-only endpoints, all served directly by the engine running inside
+Ten read-only endpoints, all served directly by the engine running inside
 the aicoding container:
 
 * ``GET /api/aicoding/sessions``                     — sessions list + run_status enrich
@@ -11,12 +11,13 @@ the aicoding container:
 * ``GET /api/aicoding/sessions/runs``                — devflow runs for a session
 * ``GET /api/aicoding/sessions/phases``              — phase detail for a run
 * ``GET /api/aicoding/sessions/runs/pull-requests``  — PR outputs for a session
+* ``GET /api/aicoding/sessions/runs/issues``         — issue outputs for a session
 * ``GET /api/aicoding/sessions/worktree-status``     — .worktree.json existence/status
 
 The workspace-inspection endpoints (file-tree / files/preview / git-diff /
-files/diff / worktree-status / runs / phases / runs/pull-requests) accept an
-optional ``cwd`` query parameter: when provided it is validated
-(``WorkspaceService.validate_cwd`` / ``_validate_cwd_prefix``) and used directly
+files/diff / worktree-status / runs / phases / runs/pull-requests /
+runs/issues) accept an optional ``cwd`` query parameter: when provided it is
+validated (``WorkspaceService.validate_cwd`` / ``_validate_cwd_prefix``) and used directly
 as the session workspace root; when omitted, the legacy ``base/{session_id}``
 derivation serves as a fallback (full backwards compatibility). ``session_id``
 stays required for response correlation and fallback.
@@ -44,9 +45,11 @@ from engine.community.api.aicoding_sessions.schemas import (
     FileTreeResponse,
     GitDiffResponse,
     GitProjectDiffSchema,
+    IssueOutputInfo,
     PullRequestOutputInfo,
     RunPhaseStatusData,
     RunPhaseStatusResponse,
+    SessionIssuesResponse,
     SessionPullRequestsResponse,
     SessionRunsResponse,
     WorktreeStatusResponse,
@@ -399,6 +402,36 @@ async def list_session_pull_requests(
         success=True,
         session_id=session_id,
         pull_requests=[PullRequestOutputInfo(**o) for o in items],
+    )
+
+
+@router.get("/runs/issues", response_model=SessionIssuesResponse)
+async def list_session_issues(
+    session_id: str = Query(..., description="AICoding session ID"),
+    cwd: str | None = Query(
+        None,
+        description="可选：前端直传工作目录绝对路径，"
+        "缺省回退 base/{session_id}",
+    ),
+) -> SessionIssuesResponse:
+    """返回 session 工作空间下所有 run 产出的 issue outputs。
+
+    执行 ``aix run output list --kind issue --json --filter <workspace>``，按
+    ``at`` (unix ms) 倒序排列。不做 pull-request / issue 融合，单独返回
+    ``issues`` 列表。
+    """
+    check_capability(Capability.BASH_EXEC)
+    service = _runstatus_service()
+    try:
+        items = await service.get_session_issues(session_id, cwd)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return SessionIssuesResponse(
+        success=True,
+        session_id=session_id,
+        issues=[IssueOutputInfo(**o) for o in items],
     )
 
 

--- a/src/engine/src/engine/community/api/aicoding_sessions/schemas.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/schemas.py
@@ -214,13 +214,40 @@ class PullRequestOutputInfo(BaseModel):
     url: str = Field(description="PR 链接")
     title: Optional[str] = Field(None, description="PR 标题")
     at: Optional[int] = Field(None, description="生成时间 unix ms")
-    project_dir: Optional[str] = Field(None, alias="projectDir", description="项目目录")
+    project_dir: Optional[str] = Field(
+        None, alias="projectDir", description="项目目录"
+    )
 
 
 class SessionPullRequestsResponse(BaseModel):
     success: bool = True
     session_id: str
     pull_requests: List[PullRequestOutputInfo] = Field(default_factory=list)
+
+
+# ── API: session issue outputs ───────────────────────────────────────
+
+
+class IssueOutputInfo(BaseModel):
+    """aix run output list --kind issue 单条记录（透传 aix 原生字段）。"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    run_id: Optional[str] = Field(None, alias="runId", description="关联的 Run ID")
+    kind: str = Field(description="output 类型，固定为 'issue'")
+    provider: Optional[str] = Field(None, description="工作项平台，如 'generic'")
+    url: str = Field(description="Issue / 工作项链接")
+    title: Optional[str] = Field(None, description="Issue / 工作项标题")
+    at: Optional[int] = Field(None, description="生成时间 unix ms")
+    project_dir: Optional[str] = Field(
+        None, alias="projectDir", description="项目目录"
+    )
+
+
+class SessionIssuesResponse(BaseModel):
+    success: bool = True
+    session_id: str
+    issues: List[IssueOutputInfo] = Field(default_factory=list)
 
 
 # ── API: worktree status ─────────────────────────────────────────────
@@ -253,5 +280,7 @@ __all__ = [
     "RunPhaseStatusResponse",
     "PullRequestOutputInfo",
     "SessionPullRequestsResponse",
+    "IssueOutputInfo",
+    "SessionIssuesResponse",
     "WorktreeStatusResponse",
 ]

--- a/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
@@ -103,6 +103,8 @@ class FakeRunStatusService:
     phase_raise: Optional[BaseException] = None
     pr_return: Any = None
     pr_raise: Optional[BaseException] = None
+    issue_return: Any = None
+    issue_raise: Optional[BaseException] = None
     calls: list[tuple[str, dict]] = field(default_factory=list)
 
     async def enrich_with_run_status(self, sessions):
@@ -137,6 +139,14 @@ class FakeRunStatusService:
         if self.pr_raise:
             raise self.pr_raise
         return self.pr_return or []
+
+    async def get_session_issues(self, session_id: str, cwd: str | None = None):
+        self.calls.append(
+            ("get_session_issues", {"session_id": session_id, "cwd": cwd})
+        )
+        if self.issue_raise:
+            raise self.issue_raise
+        return self.issue_return or []
 
 
 @dataclass
@@ -658,6 +668,57 @@ def test_pull_requests_propagates_500_on_aix_failure(client, runstatus_svc):
     )
     resp = client.get(
         "/api/aicoding/sessions/runs/pull-requests",
+        params={"session_id": "s1"},
+    )
+    assert resp.status_code == 500
+    assert "boom" in resp.json()["detail"]
+
+
+# ── /runs/issues ────────────────────────────────────────────────────────────
+
+
+def test_issues_success(client, runstatus_svc):
+    runstatus_svc.issue_return = [
+        {
+            "runId": "r-issue-1",
+            "kind": "issue",
+            "provider": "generic",
+            "url": (
+                "https://issues.example.com/"
+                "work-items/2026071700117528182"
+            ),
+            "title": "评测实例增加字段：运行时长",
+            "at": 1784295500923,
+            "projectDir": (
+                "/home/admin/.aicoding/workspace/"
+                "07644ab3-1f06-4516-93c4-a68e0b0485f7"
+            ),
+        }
+    ]
+    resp = client.get(
+        "/api/aicoding/sessions/runs/issues",
+        params={"session_id": "s1"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["issues"][0]["kind"] == "issue"
+    assert body["issues"][0]["provider"] == "generic"
+    assert body["issues"][0]["runId"] == "r-issue-1"
+    assert body["issues"][0]["projectDir"].endswith(
+        "07644ab3-1f06-4516-93c4-a68e0b0485f7"
+    )
+    assert runstatus_svc.calls[-1] == (
+        "get_session_issues",
+        {"session_id": "s1", "cwd": None},
+    )
+
+
+def test_issues_propagates_500_on_aix_failure(client, runstatus_svc):
+    runstatus_svc.issue_raise = HTTPException(
+        status_code=500, detail="aix run output list failed: boom"
+    )
+    resp = client.get(
+        "/api/aicoding/sessions/runs/issues",
         params={"session_id": "s1"},
     )
     assert resp.status_code == 500

--- a/src/engine/src/engine/community/core/aicoding/runstatus_service.py
+++ b/src/engine/src/engine/community/core/aicoding/runstatus_service.py
@@ -266,7 +266,18 @@ class RunStatusService:
         - JSON 解析失败 → 抛 500。
         """
         workspace_root = WorkspaceService.resolve_workspace(session_id, cwd)
-        return await self._aix_run_output_list(workspace_root)
+        return await self._aix_run_output_list(workspace_root, kind="pull-request")
+
+    async def get_session_issues(
+        self, session_id: str, cwd: str | None = None
+    ) -> list[dict]:
+        """返回 session 工作空间下所有 run 产出的 issue outputs，按 at 倒序。
+
+        与 :meth:`get_session_pull_requests` 保持同样的错误语义，只是执行
+        ``aix run output list --kind issue --json --filter <workspace_root>``。
+        """
+        workspace_root = WorkspaceService.resolve_workspace(session_id, cwd)
+        return await self._aix_run_output_list(workspace_root, kind="issue")
 
     # ── internal ──────────────────────────────────────────────────────────────
 
@@ -373,8 +384,10 @@ class RunStatusService:
         except json.JSONDecodeError:
             return None
 
-    async def _aix_run_output_list(self, workspace_root: str) -> list[dict]:
-        """单次 ``aix run output list --kind pull-request --json --filter <workspace_root>``。
+    async def _aix_run_output_list(
+        self, workspace_root: str, kind: str = "pull-request"
+    ) -> list[dict]:
+        """单次 ``aix run output list --kind <kind> --json --filter <workspace_root>``。
 
         ``--filter`` 让 aix 自己向下递归找 ``.aix/``，service 不再需要预先 find +
         多目录串行调用 + 合并步骤。失败时抛 HTTPException。
@@ -385,7 +398,7 @@ class RunStatusService:
         - JSON 解析失败 → 500。
         """
         cmd = (
-            f"aix run output list --kind pull-request --json"
+            f"aix run output list --kind {shlex.quote(kind)} --json"
             f" --filter {shlex.quote(workspace_root)}"
         )
         res = await self._safe_exec(cmd, workspace_root, OUTPUT_LIST_TIMEOUT)

--- a/src/engine/src/engine/community/core/aicoding/tests/test_runstatus_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_runstatus_service.py
@@ -992,6 +992,48 @@ async def test_get_session_pull_requests_empty_outputs_returns_empty_list() -> N
     assert items == []
 
 
+async def test_get_session_issues_success_and_sort() -> None:
+    """issue outputs 使用 --kind issue，返回字段透传并按 at 倒序。"""
+    plugin = FakeBashPlugin()
+    plugin.add(
+        "aix run output list --kind issue",
+        WORKSPACE,
+        BashExecResult(
+            stdout=_pr_outputs_payload(
+                [
+                    {
+                        "runId": "r-old",
+                        "kind": "issue",
+                        "provider": "generic",
+                        "url": "https://issues.example.com/work-items/1",
+                        "title": "old issue",
+                        "at": 1_000,
+                        "projectDir": PROJECT_DIR,
+                    },
+                    {
+                        "runId": "r-new",
+                        "kind": "issue",
+                        "provider": "generic",
+                        "url": "https://issues.example.com/work-items/2",
+                        "title": "new issue",
+                        "at": 2_000,
+                        "projectDir": PROJECT_DIR,
+                    },
+                ]
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    service = _make_service(plugin)
+    items = await service.get_session_issues(SESSION_ID)
+
+    assert [o["runId"] for o in items] == ["r-new", "r-old"]
+    assert items[0]["provider"] == "generic"
+    assert "--kind issue" in plugin.calls[0][0]
+
+
 async def test_get_session_pull_requests_500_when_cmd_fails() -> None:
     """aix run output list exit_code != 0 → 500，detail 含 stderr。"""
     plugin = FakeBashPlugin()


### PR DESCRIPTION
## Summary
- add independent `GET /api/aicoding/sessions/runs/issues` endpoint
- query `aix run output list --kind issue --json --filter <workspace>`
- keep pull-request API unchanged; only reuse internal output-list service logic
- use OSS-neutral provider/url examples to satisfy architecture guards

## Tests
- `cd ocb-public/src/engine && env -u http_proxy -u https_proxy -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY bash scripts/ci_test.sh --base REL20260717`
- 1816 passed, 5 deselected, 12 warnings
- case pass rate 100%; change line coverage 96.67%