### PR TITLE
fix(bcs): write collected_at on MySQL via COALESCE, not cross-column CASE

### DIFF
--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -1183,10 +1183,20 @@ impl SessionRepoPort for MySqlSessionStore {
                 "participant {bot_uuid} not in session {session_id}"
             )));
         }
+        // First-collect-writes-time, repeat-collect-keeps-it (idempotent), expressed
+        // via the NULL-ness of collected_at itself: COALESCE writes `now` only when
+        // collected_at is NULL (never collected, or cleared by a prior uncollect) and
+        // preserves the existing value otherwise. This is dialect-portable: do NOT
+        // rewrite as `CASE WHEN collected = 0 THEN now ...` — MySQL evaluates a single
+        // UPDATE's SET left-to-right (so `collected` is already 1 by the time the CASE
+        // reads it) while SQLite evaluates all SET RHS against the pre-update row, so
+        // the CASE form silently never sets collected_at on MySQL while working on
+        // SQLite. Relying on collected_at's own NULL-ness avoids any cross-column
+        // old-value dependency.
         let update_sql = format!(
             "UPDATE bcs_session_participants \
              SET collected = 1, \
-                 collected_at = CASE WHEN collected = 0 THEN {} ELSE collected_at END \
+                 collected_at = COALESCE(collected_at, {}) \
              WHERE env = ? AND session_id = ? AND bot_uuid = ?",
             self.flavor.now()
         );


### PR DESCRIPTION
## Summary

Follow-up fix to #260. On MySQL/OceanBase, `collect` never populated `collected_at` (it stayed `NULL` forever), so the collected session list could not order by collect event on MySQL. SQLite worked — but only by accident.

## Root cause

`collect` used:
```sql
SET collected = 1,
    collected_at = CASE WHEN collected = 0 THEN NOW() ELSE collected_at END
```
This is dialect-dependent in a silent, data-corrupting way:

- **SQLite** evaluates all `SET` right-hand sides against the **pre-update** row, so `collected` reads as `0` → CASE true → `collected_at = NOW()`. Worked.
- **MySQL/OceanBase** evaluate a single UPDATE's `SET` **left-to-right**, so `collected` is already `1` by the time the CASE reads it → CASE always false → `collected_at` stays `NULL` forever.

SQLite's "working" relied on its old-row-snapshot semantics; the behavior was never consistent across the two backends.

## Fix

```sql
SET collected = 1,
    collected_at = COALESCE(collected_at, NOW())
```
Write `now` only when `collected_at` is `NULL` (never collected, or cleared by a prior `uncollect`); preserve the existing value otherwise. Expressing the guard via `collected_at`'s own NULL-ness removes the cross-column old-value dependency entirely — behavior is now identical on MySQL and SQLite.

Semantics unchanged from the intended design:
- first collect records the time
- repeat collects are idempotent (no refresh)
- `uncollect` clears `collected_at`, so a re-collect records a fresh time

A comment is added in `collect` documenting the dialect trap so the CASE form isn't reintroduced.

## Verification

- `bcs-session-store` tests: green (SQLite path, semantics-equivalent)
- MySQL path exercised by CI e2e on this PR
