### PR TITLE
fix(service_bot): exclude node_modules from teclaw file promotion

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/teclaw_file_promotion.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/teclaw_file_promotion.py
@@ -59,7 +59,7 @@ _EXCLUDED_DIR_SEGMENTS = frozenset({"node_modules"})
 
 def _has_excluded_segment(engine_path: str) -> bool:
     """True if any path segment of ``engine_path`` names an excluded directory."""
-    return any(seg in _EXCLUDED_DIR_SEGMENTS for seg in engine_path.split("/"))
+    return not _EXCLUDED_DIR_SEGMENTS.isdisjoint(engine_path.split("/"))
 
 
 class TeclawFilePromotionError(Exception):
@@ -142,13 +142,10 @@ class TeclawFilePromotion:
                 # Regenerable dependency/build dirs (``node_modules``) are not
                 # content and their symlinked entries (``*.js.map`` etc.) list but
                 # do not read — skip them so promotion neither bloats OSS nor
-                # hard-fails on an unreadable non-content file.
+                # hard-fails on an unreadable non-content file. No per-file log: a
+                # node_modules tree can hold tens of thousands of entries; the
+                # end-of-sweep summary covers what was actually staged.
                 if _has_excluded_segment(engine_path):
-                    logger.debug(
-                        "[TeclawFilePromotion] skipping excluded path %r "
-                        "(regenerable dependency/build dir, not a content snapshot)",
-                        engine_path,
-                    )
                     continue
                 logical = engine_path.lstrip("/")  # "workspace/sub/x.csv"
                 content = await device_fs.read_file(logical)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/teclaw_file_promotion.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/teclaw_file_promotion.py
@@ -22,6 +22,9 @@ Reads go through the source bot's :class:`DeviceFileSystem` using
 namespace-relative logical paths (``"workspace"`` / ``"identity"`` for listing,
 ``"workspace/<rel>"`` for reading), which the teclaw mapper turns into the
 engine-relative ``/workspace`` · ``/identity`` form.
+
+Regenerable dependency/build directories (``node_modules``) are excluded from the
+sweep — see ``_EXCLUDED_DIR_SEGMENTS``.
 """
 from __future__ import annotations
 
@@ -42,6 +45,21 @@ _NAMESPACES = (WORKSPACE_NS, IDENTITY_NS)
 
 # The composer store id whose base is ``teclaw/{env}/bolt_data``.
 _BOT_DATA_STORE = "bot-data"
+
+# Regenerable dependency/build directories that must never be part of a content
+# snapshot. They are large, symlink-heavy (symlinks cannot round-trip through
+# per-file OSS staging), and reinstalled at container build — they are not user
+# content to carry across publish stages. Sweeping into them also makes promotion
+# fragile: ``node_modules`` routinely holds entries (e.g. ``*.js.map`` files and
+# package symlinks) that ``list_dir`` reports but the engine cannot ``read_file``,
+# which the source-of-truth contract below turns into a hard build failure.
+# Skipping them by path segment (at any depth) avoids both problems.
+_EXCLUDED_DIR_SEGMENTS = frozenset({"node_modules"})
+
+
+def _has_excluded_segment(engine_path: str) -> bool:
+    """True if any path segment of ``engine_path`` names an excluded directory."""
+    return any(seg in _EXCLUDED_DIR_SEGMENTS for seg in engine_path.split("/"))
 
 
 class TeclawFilePromotionError(Exception):
@@ -119,6 +137,17 @@ class TeclawFilePromotion:
                     logger.warning(
                         "[TeclawFilePromotion] listing for ns=%s returned "
                         "out-of-namespace path %r; skipping", ns, engine_path,
+                    )
+                    continue
+                # Regenerable dependency/build dirs (``node_modules``) are not
+                # content and their symlinked entries (``*.js.map`` etc.) list but
+                # do not read — skip them so promotion neither bloats OSS nor
+                # hard-fails on an unreadable non-content file.
+                if _has_excluded_segment(engine_path):
+                    logger.debug(
+                        "[TeclawFilePromotion] skipping excluded path %r "
+                        "(regenerable dependency/build dir, not a content snapshot)",
+                        engine_path,
                     )
                     continue
                 logical = engine_path.lstrip("/")  # "workspace/sub/x.csv"

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_teclaw_file_promotion.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_teclaw_file_promotion.py
@@ -160,6 +160,63 @@ async def test_out_of_namespace_path_skipped():
 
 
 @pytest.mark.asyncio
+async def test_node_modules_files_are_excluded_from_snapshot():
+    # node_modules is regenerable dependency content, not a user file to carry
+    # across stages: it is swept over but never read or staged, at any depth.
+    fs = _FakeDeviceFs(
+        listings={
+            "workspace": [
+                {"path": "/workspace/app.py", "is_dir": False},
+                {"path": "/workspace/node_modules", "is_dir": True},
+                {"path": "/workspace/node_modules/rxjs/dist/esm/index.js", "is_dir": False},
+                {"path": "/workspace/sub/node_modules/pkg/a.js", "is_dir": False},
+            ],
+            "identity": [],
+        },
+        contents={
+            "workspace/app.py": b"code",
+            # node_modules contents present but must not be read/staged
+            "workspace/node_modules/rxjs/dist/esm/index.js": b"js",
+            "workspace/sub/node_modules/pkg/a.js": b"js",
+        },
+    )
+    oss = _oss_ok()
+    refs = await _promo(oss).stage_files(device_fs=fs, **_ARGS)
+    assert [r["name"] for r in refs.resources] == ["app.py"]
+    # node_modules files were never read nor written to OSS (any depth)
+    assert fs.read_calls == ["workspace/app.py"]
+    assert {c.args[0] for c in oss.put_object.call_args_list} == {
+        f"teclaw/pre/bolt_data/{_PREFIX}/workspace/app.py",
+    }
+
+
+@pytest.mark.asyncio
+async def test_unreadable_node_modules_map_does_not_fail_build():
+    # Reproduces the production alert: a source-map under node_modules that
+    # list_dir reports but read_file cannot read (dangling symlink → None). It
+    # must be skipped as excluded content, not turned into a hard build failure.
+    fs = _FakeDeviceFs(
+        listings={
+            "workspace": [
+                {"path": "/workspace/report.csv", "is_dir": False},
+                {
+                    "path": "/workspace/node_modules/rxjs/dist/esm/internal/"
+                    "operators/single.js.map",
+                    "is_dir": False,
+                },
+            ],
+            "identity": [],
+        },
+        contents={"workspace/report.csv": b"csv"},  # the .map has no content
+    )
+    oss = _oss_ok()
+    refs = await _promo(oss).stage_files(device_fs=fs, **_ARGS)
+    assert [r["name"] for r in refs.resources] == ["report.csv"]
+    assert "workspace/node_modules/rxjs/dist/esm/internal/operators/single.js.map" \
+        not in fs.read_calls
+
+
+@pytest.mark.asyncio
 async def test_unreadable_source_file_raises():
     fs = _FakeDeviceFs(
         listings={"workspace": [{"path": "/workspace/x", "is_dir": False}], "identity": []},


### PR DESCRIPTION
## Summary

Fixes the staging (预发) production alert:

```
[BuildStageRunner] Build failed: teclaw promotion: source file unreadable:
/workspace/node_modules/rxjs/dist/esm/internal/operators/single.js.map
```

## Root cause

`TeclawFilePromotion.stage_files` sweeps a teclaw bot's **entire** `/workspace` (`list_dir(recursive=True)`), then reads and stages every file to OSS. By design a **listed-but-unreadable** file is a hard failure — there is no DB mirror to fall back on, so a silent skip could ship an incomplete snapshot.

When a bot's workspace contains an in-workspace `node_modules/` tree, the listing includes source-map / package entries (e.g. `rxjs/.../single.js.map`) that `list_dir` reports but the engine's `read_file` cannot read (dangling symlink → 404 → `None`). That unreadable entry trips the hard-fail contract and the whole promotion (`BUILDING → BUILT`) goes `FAILED`.

`node_modules` is regenerable dependency content, not a user snapshot: it is large, symlink-heavy (symlinks cannot round-trip through per-file OSS staging anyway), and reinstalled at container build.

## Change

- Exclude `node_modules` from the promotion sweep by path segment (any depth) via a new `_EXCLUDED_DIR_SEGMENTS` constant in `teclaw_file_promotion.py`. Excluded entries are neither read nor staged, so promotion no longer bloats OSS with dependency trees nor hard-fails on an unreadable non-content file.
- The intentional hard-fail contract for genuine **user** content is unchanged (an unreadable non-excluded file still raises).

## Tests

Added two unit tests in `test_teclaw_file_promotion.py`:
- `test_node_modules_files_are_excluded_from_snapshot` — node_modules files (at any depth) are never read nor written to OSS.
- `test_unreadable_node_modules_map_does_not_fail_build` — reproduces the production alert: an unreadable `single.js.map` under `node_modules` is skipped rather than failing the build.

Full deploy + publish-flow suites pass (185 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tfx957zVRzneHVjJLNskWC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tfx957zVRzneHVjJLNskWC)_