### PR TITLE
feat(teclaw): include bot_name in engine_ext of delivered config_artifact

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/engine_ext_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/engine_ext_stage.py
@@ -1,9 +1,10 @@
 """Stage vocabulary + re-stamp for the artifact's ``engine_ext`` payload.
 
-The external-container publish path enriches ``engine_ext`` with three
-backend-owned keys (``bot_id`` / ``owner_id`` / ``stage``). ``bot_id`` and
-``owner_id`` are constant for an artifact; ``stage`` is re-stamped as the version
-is promoted across environments (draft → canary → release).
+The external-container publish path enriches ``engine_ext`` with four
+backend-owned keys (``bot_id`` / ``owner_id`` / ``bot_name`` / ``stage``).
+``bot_id``, ``owner_id`` and ``bot_name`` are constant for an artifact; ``stage``
+is re-stamped as the version is promoted across environments
+(draft → canary → release).
 
 This module is the single source of truth for those key names and for the
 ``PublishStage`` → engine-facing stage-string mapping, and exposes a pure
@@ -21,6 +22,7 @@ from agentclaw.community.core.service_bot.types import PublishStage
 #: engine's opaque payload).
 KEY_BOT_ID = "bot_id"
 KEY_OWNER_ID = "owner_id"
+KEY_BOT_NAME = "bot_name"
 KEY_STAGE = "stage"
 
 #: ``PublishStage`` → the engine-facing ``engine_ext.stage`` string. The engine
@@ -38,20 +40,22 @@ def enrich_engine_ext(
     *,
     bot_id: Any,
     owner_id: Any,
+    bot_name: Any,
     stage: PublishStage,
 ) -> dict[str, Any]:
     """Merge the backend-owned identity/stage keys onto a copy of ``engine_ext``.
 
-    The three keys are written **last** so they are explicit and deterministically
-    win on collision with the engine's opaque payload. ``None`` ids normalize to
-    ``""``. Used by both the publish producer (stage=draft at build, promoted later)
-    and the teclaw device-sync plugin (runtime edits, always stage=draft) so the two
-    paths agree on the vocabulary.
+    The four keys are written **last** so they are explicit and deterministically
+    win on collision with the engine's opaque payload. ``None`` ids/name normalize
+    to ``""``. Used by both the publish producer (stage=draft at build, promoted
+    later) and the teclaw device-sync plugin (runtime edits, always stage=draft) so
+    the two paths agree on the vocabulary.
     """
     return {
         **engine_ext,
         KEY_BOT_ID: "" if bot_id is None else str(bot_id),
         KEY_OWNER_ID: "" if owner_id is None else owner_id,
+        KEY_BOT_NAME: "" if bot_name is None else str(bot_name),
         KEY_STAGE: STAGE_VALUE[stage],
     }
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/external_compose_producer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/external_compose_producer.py
@@ -81,13 +81,15 @@ class ExternalComposeProducer(DeployArtifactProducer):
         """
         artifact = self._composer.compose(self._compose_request(bot, version))
         # Enrich the engine's opaque payload with the backend-owned identity + stage
-        # keys. ``bot_id`` / ``owner_id`` come from the same bot-row fields
-        # ``_compose_request`` reads; build is always the draft stage (verify/online
-        # re-stamp later). Shared with the runtime device-sync plugin via the helper.
+        # keys. ``bot_id`` / ``owner_id`` / ``bot_name`` come from the same bot-row
+        # fields ``_compose_request`` reads; build is always the draft stage
+        # (verify/online re-stamp later). Shared with the runtime device-sync plugin
+        # via the helper.
         engine_ext = enrich_engine_ext(
             self._fetch_engine_ext(bot),
             bot_id=bot.get("bot_id", ""),
             owner_id=bot.get("owner_id", ""),
+            bot_name=bot.get("bot_name", ""),
             stage=PublishStage.DRAFT,
         )
         return dataclasses.replace(artifact, engine_ext=engine_ext)

--- a/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
+++ b/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
@@ -252,11 +252,12 @@ def test_frozen_artifact_with_opaque_engine_ext_still_conforms() -> None:
     pinned = result.ext["config_artifact"]
     jsonschema.validate(instance=pinned, schema=_schema())
     # opaque engine payload carried verbatim, plus the backend identity/stage keys
-    # (owner_id defaults to "" — the bot row here carries no owner_id).
+    # (owner_id / bot_name default to "" — the bot row here carries neither).
     assert pinned["engine_ext"] == {
         "memory_ref": "oss://ws/MEMORY.md",
         "nested": {"x": [1, 2]},
         "bot_id": "bot7",
         "owner_id": "",
+        "bot_name": "",
         "stage": "draft",
     }

--- a/src/backend/tests/community/contracts/test_engine_ext_client.py
+++ b/src/backend/tests/community/contracts/test_engine_ext_client.py
@@ -76,10 +76,11 @@ def test_consumer_surfaces_empty_engine_ext_from_local_noop() -> None:
 
     assert result.success is True
     # Engine payload empty (Noop); producer injects identity + draft stage (owner_id
-    # defaults to "" — no owner_id on this bot row).
+    # / bot_name default to "" — neither on this bot row).
     assert result.ext["config_artifact"]["engine_ext"] == {
         "bot_id": "b1",
         "owner_id": "",
+        "bot_name": "",
         "stage": "draft",
     }
     # ...and the plugin was actually consulted (MockSeam records the call) — no bypass.
@@ -116,6 +117,7 @@ def test_consumer_carries_mock_engine_ext_verbatim() -> None:
         **opaque,
         "bot_id": "b2",
         "owner_id": "",
+        "bot_name": "",
         "stage": "draft",
     }
     # the engine-owned keys are untouched (opacity preserved)...

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py
@@ -16,12 +16,17 @@ from agentclaw.community.core.service_bot.types import PublishStage
 @pytest.mark.unit
 def test_enrich_adds_keys_with_stage_value() -> None:
     out = enrich_engine_ext(
-        {"memory_ref": "nas://m"}, bot_id="b7", owner_id="u1", stage=PublishStage.DRAFT
+        {"memory_ref": "nas://m"},
+        bot_id="b7",
+        owner_id="u1",
+        bot_name="Support Bot",
+        stage=PublishStage.DRAFT,
     )
     assert out == {
         "memory_ref": "nas://m",
         "bot_id": "b7",
         "owner_id": "u1",
+        "bot_name": "Support Bot",
         "stage": "draft",
     }
 
@@ -29,19 +34,29 @@ def test_enrich_adds_keys_with_stage_value() -> None:
 @pytest.mark.unit
 def test_enrich_backend_keys_win_collision_and_default_none() -> None:
     out = enrich_engine_ext(
-        {"bot_id": "ENGINE", "stage": "x", "keep": "me"},
+        {"bot_id": "ENGINE", "bot_name": "ENGINE", "stage": "x", "keep": "me"},
         bot_id=None,
         owner_id=None,
+        bot_name=None,
         stage=PublishStage.VERIFY,
     )
-    assert out == {"keep": "me", "bot_id": "", "owner_id": "", "stage": "canary"}
+    assert out == {
+        "keep": "me",
+        "bot_id": "",
+        "owner_id": "",
+        "bot_name": "",
+        "stage": "canary",
+    }
 
 
 @pytest.mark.unit
 def test_enrich_stringifies_bot_id_and_does_not_mutate_input() -> None:
     src = {"a": 1}
-    out = enrich_engine_ext(src, bot_id=7, owner_id="u1", stage=PublishStage.ONLINE)
+    out = enrich_engine_ext(
+        src, bot_id=7, owner_id="u1", bot_name="Bot 7", stage=PublishStage.ONLINE
+    )
     assert out["bot_id"] == "7"
+    assert out["bot_name"] == "Bot 7"
     assert out["stage"] == "release"
     assert src == {"a": 1}  # input untouched
 

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_external_compose_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_external_compose_producer.py
@@ -55,13 +55,16 @@ def test_engine_ext_from_subclass_is_injected_verbatim() -> None:
     composer = _StubComposer(_artifact(engine_ext={}))
     producer = _Teclaw(composer=composer)
 
-    built = producer._compose_with_engine_ext({"bot_id": "b", "owner_id": "u1"}, 7)
+    built = producer._compose_with_engine_ext(
+        {"bot_id": "b", "owner_id": "u1", "bot_name": "Support Bot"}, 7
+    )
 
     # engine_ext carried verbatim, plus the backend-owned identity/stage keys.
     assert built.engine_ext == {
         **opaque,
         "bot_id": "b",
         "owner_id": "u1",
+        "bot_name": "Support Bot",
         "stage": "draft",
     }
     assert built.engine_type == "teclaw"
@@ -131,24 +134,32 @@ def test_produce_artifact_pins_refs_only_artifact() -> None:
         "memory_ref": "nas://ws/MEMORY.md",
         "bot_id": "b",
         "owner_id": "u1",
+        "bot_name": "",
         "stage": "draft",
     }
 
 
 @pytest.mark.unit
 def test_backend_keys_injected_with_defaults_and_win_collision() -> None:
-    # Engine payload tries to set bot_id/stage; backend keys are written last and win.
+    # Engine payload tries to set bot_id/bot_name/stage; backend keys are written
+    # last and win.
     producer = _ExtProducer(
         composer=_StubComposer(_artifact()),
-        ext={"bot_id": "ENGINE_WINS_NOT", "stage": "engine-set", "keep": "me"},
+        ext={
+            "bot_id": "ENGINE_WINS_NOT",
+            "bot_name": "ENGINE_WINS_NOT",
+            "stage": "engine-set",
+            "keep": "me",
+        },
     )
 
-    # owner_id absent on the bot row → defaults to "".
+    # owner_id / bot_name absent on the bot row → default to "".
     built = producer._compose_with_engine_ext({"bot_id": "b7"}, 1)
 
     assert built.engine_ext == {
         "keep": "me",
         "bot_id": "b7",
         "owner_id": "",
+        "bot_name": "",
         "stage": "draft",
     }

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_teclaw_compose_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_teclaw_compose_producer.py
@@ -42,17 +42,20 @@ def test_engine_ext_fetched_via_plugin_and_frozen_verbatim() -> None:
     producer = TeclawComposeProducer(_StubComposer(_artifact()), client)
 
     result = producer.produce_artifact(
-        {"bot_id": "b", "entity_id": "u", "owner_id": "u1"}, 3
+        {"bot_id": "b", "entity_id": "u", "owner_id": "u1", "bot_name": "Support Bot"}, 3
     )
 
     # plugin consulted with the bot dict
-    assert client.calls == [{"bot_id": "b", "entity_id": "u", "owner_id": "u1"}]
+    assert client.calls == [
+        {"bot_id": "b", "entity_id": "u", "owner_id": "u1", "bot_name": "Support Bot"}
+    ]
     # engine_ext payload carried verbatim, alongside the backend identity/stage keys.
     frozen = result.ext["config_artifact"]
     assert frozen["engine_ext"] == {
         **opaque,
         "bot_id": "b",
         "owner_id": "u1",
+        "bot_name": "Support Bot",
         "stage": "draft",
     }
     assert frozen["engine_type"] == "teclaw"
@@ -68,6 +71,7 @@ def test_empty_engine_ext_from_noop_client() -> None:
     assert result.ext["config_artifact"]["engine_ext"] == {
         "bot_id": "b",
         "owner_id": "",
+        "bot_name": "",
         "stage": "draft",
     }
     assert result.success is True


### PR DESCRIPTION
## Summary

For **teclaw** bots, the delivered `config_artifact` now carries the bot's `bot_name` inside `engine_ext`, alongside the existing backend-owned identity/stage keys (`bot_id` / `owner_id` / `stage`). This gives the external teclaw engine a human-readable name for every bot it runs, carried verbatim in each `DeliveryArtifact`.

Closes #273.

## Changes

- **`engine_ext_stage.py`** — add `KEY_BOT_NAME = "bot_name"` and a `bot_name` parameter to `enrich_engine_ext`, the single sanctioned injection point for backend-owned `engine_ext` keys. It is written last (so it wins on collision with the engine's opaque payload) and normalizes `None` → `""`, mirroring the existing id keys.
- **`external_compose_producer.py`** — pass `bot.get("bot_name", "")` at the build injection site. The value comes from the `bot` row already in scope there (the same row `bot_id` / `owner_id` are read from), so no new data plumbing is required.

From there the value flows unchanged through `DeliveryArtifact` → `BotBuildService.release` / `upgrade` → `BaasService.create_teclaw_bot` / `update_teclaw_bot` to the teclaw container.

## Design notes

- **engine_ext opacity preserved.** The backend *writes* `bot_name` but never *reads into* or branches on `engine_ext` contents; the AST-based opacity guard (`test_engine_ext_opacity.py`) still passes.
- **Single source of truth.** Only `enrich_engine_ext` knows the backend-owned key names; adding one key there is the whole surface of the change.
- **No schema change.** `engine_ext` is an open, free-form object; `bot_name` rides the same open object as the other injected keys.

## Testing

- Extended the `enrich_engine_ext` unit tests to cover the new key: added-with-value, `None` → `""` default, and backend-wins-collision.
- Updated the producer/contract assertions that pin the full enriched `engine_ext` dict (`test_external_compose_producer.py`, `test_teclaw_compose_producer.py`, `test_engine_ext_client.py`, `test_bot_config_artifact_schema.py`), threading a real `bot_name` value through one teclaw producer path to prove it is carried verbatim.
- `ruff check` clean on all touched files.
- Ran the deploy + publish/teclaw flow suites locally (`309` tests) — all green.

## Acceptance criteria

- [x] Delivered teclaw `config_artifact` contains `engine_ext.bot_name`.
- [x] `bot_name` normalizes to `""` when the bot has no name.
- [x] Backend-owned `bot_name` wins on collision with an engine-supplied `bot_name`.
- [x] Existing `bot_id` / `owner_id` / `stage` enrichment and `restamp_stage` behavior unchanged.
- [x] Unit tests cover the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pNvuxRMQQugMj9uCAawRB

---
_Generated by [Claude Code](https://claude.ai/code/session_018pNvuxRMQQugMj9uCAawRB)_