### PR TITLE
fix: backport stopped binding restart support to REL20260717

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/devices/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/devices/schemas.py
@@ -54,6 +54,7 @@ class DeviceBindingStatus(StrEnum):
     """Device binding status enumeration."""
     PENDING = "PENDING"
     ACTIVE = "ACTIVE"
+    STOPPED = "STOPPED"
     FAILED = "FAILED"
     RELEASED = "RELEASED"
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -2924,6 +2924,7 @@ class BotService:
                 if binding and binding.status in [
                     DeviceBindingStatus.ACTIVE.value,
                     DeviceBindingStatus.PENDING.value,
+                    DeviceBindingStatus.FAILED.value,
                     DeviceBindingStatus.STOPPED.value,
                 ]:
                     # Release the device

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3413,6 +3413,7 @@ class BotService:
             if binding_status and binding_status not in {
                 DeviceBindingStatus.ACTIVE.value,
                 DeviceBindingStatus.FAILED.value,
+                DeviceBindingStatus.STOPPED.value,
             }:
                 logger.warning(
                     "[bot_service.restart_bot] reject restart for invalid binding state: "

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -863,6 +863,7 @@ class BotService:
                         DeviceBindingStatus.ACTIVE.value,
                         DeviceBindingStatus.PENDING.value,
                         DeviceBindingStatus.FAILED.value,
+                        DeviceBindingStatus.STOPPED.value,
                     ]:
                         active_device_count += 1
                         bot_info = bot_binding_map.get(binding_id, {})
@@ -2922,7 +2923,8 @@ class BotService:
                 binding = service.get_device(binding_id=binding_id)
                 if binding and binding.status in [
                     DeviceBindingStatus.ACTIVE.value,
-                    DeviceBindingStatus.PENDING.value
+                    DeviceBindingStatus.PENDING.value,
+                    DeviceBindingStatus.STOPPED.value,
                 ]:
                     # Release the device
                     operator = _compose_operator_context(
@@ -3103,7 +3105,12 @@ class BotService:
             try:
                 service = self._device_service_provider()
                 binding = service.get_device(binding_id=binding_id)
-                if binding and binding.status in [DeviceBindingStatus.ACTIVE.value, DeviceBindingStatus.PENDING.value, DeviceBindingStatus.FAILED.value]:
+                if binding and binding.status in [
+                    DeviceBindingStatus.ACTIVE.value,
+                    DeviceBindingStatus.PENDING.value,
+                    DeviceBindingStatus.FAILED.value,
+                    DeviceBindingStatus.STOPPED.value,
+                ]:
                     operator = _compose_operator_context(user_id, resolved_nick_name)
                     service.release_device(
                         binding_id=binding_id,

--- a/src/backend/src/agentclaw/community/core/devices/models.py
+++ b/src/backend/src/agentclaw/community/core/devices/models.py
@@ -49,6 +49,7 @@ class DeviceBindingStatus(StrEnum):
     """Device binding status enumeration."""
     PENDING = "PENDING"
     ACTIVE = "ACTIVE"
+    STOPPED = "STOPPED"
     FAILED = "FAILED"
     RELEASED = "RELEASED"
 

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -771,8 +771,11 @@ class DeviceService:
             DeviceBindingStatus.ACTIVE.value,
             DeviceBindingStatus.PENDING.value,
             DeviceBindingStatus.FAILED.value,
+            DeviceBindingStatus.STOPPED.value,
         ]:
-            raise InvalidDeviceStatusError("only ACTIVE/PENDING/FAILED devices can be released")
+            raise InvalidDeviceStatusError(
+                "only ACTIVE/PENDING/FAILED/STOPPED devices can be released"
+            )
 
         entity_id = current.entity_id
         entity_type = current.entity_type

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_validation.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_validation.py
@@ -289,6 +289,21 @@ class TestCheckDeviceLimitUsesCeiling:
         with pytest.raises(DeviceLimitError):
             svc._check_device_limit(entity_id="u1", entity_type="staff", owner_id="u1")
 
+    def test_stopped_binding_counts_toward_device_limit(self):
+        """STOPPED bindings remain restartable, so they still consume a device slot."""
+        ps = MagicMock()
+        ps.get_bots_ceiling.return_value = 1
+        svc = _make_service(max_bots=5, policy_service=ps)
+        svc._repository.list_by_owner.return_value = (1, [_bound_bot(0)])
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            status=DeviceBindingStatus.STOPPED.value,
+        )
+        svc._device_service_provider = lambda: device_service
+
+        with pytest.raises(DeviceLimitError):
+            svc._check_device_limit(entity_id="u1", entity_type="staff", owner_id="u1")
+
     def test_device_limit_skipped_when_ceiling_non_positive(self):
         """ceiling<=0（config 无效）→ 提前放行，不因 >=0 恒真拦住第一个 bot"""
         ps = MagicMock()

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -459,6 +459,24 @@ class TestDeleteBot:
         assert result is True
         mock_device_service.release_device.assert_called_once()
 
+    def test_releases_failed_device_before_deleting(self):
+        svc = _make_service()
+        bot = _make_bot(binding_id=42)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        mock_binding = MagicMock()
+        mock_binding.status = DeviceBindingStatus.FAILED.value
+        mock_device_service = MagicMock()
+        mock_device_service.get_device.return_value = mock_binding
+        svc._device_service_provider = lambda: mock_device_service
+        svc._passport_plugin.destroy_passport.return_value = None
+        svc._repository.soft_delete_by_owner.return_value = True
+
+        result = svc.delete_bot("bot001", "user001")
+
+        assert result is True
+        mock_device_service.release_device.assert_called_once()
+
     def test_device_release_failure_blocks_deletion(self):
         svc = _make_service()
         bot = _make_bot(binding_id=42)

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotServiceError,
     generate_bot_id,
 )
+from agentclaw.community.core.devices.models import DeviceBindingStatus
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +438,24 @@ class TestDeleteBot:
         svc._repository.soft_delete_by_owner.return_value = True
 
         result = svc.delete_bot("bot001", "user001")
+        assert result is True
+        mock_device_service.release_device.assert_called_once()
+
+    def test_releases_stopped_device_before_deleting(self):
+        svc = _make_service()
+        bot = _make_bot(binding_id=42)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        mock_binding = MagicMock()
+        mock_binding.status = DeviceBindingStatus.STOPPED.value
+        mock_device_service = MagicMock()
+        mock_device_service.get_device.return_value = mock_binding
+        svc._device_service_provider = lambda: mock_device_service
+        svc._passport_plugin.destroy_passport.return_value = None
+        svc._repository.soft_delete_by_owner.return_value = True
+
+        result = svc.delete_bot("bot001", "user001")
+
         assert result is True
         mock_device_service.release_device.assert_called_once()
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -301,6 +301,61 @@ class TestRestartGuardOrchestration:
         stop.assert_not_called()
         start.assert_not_called()
 
+    def test_active_bot_with_stopped_arca_binding_restarts_with_preserved_provider(self):
+        """A stopped ARCA runtime can be replaced without changing providers."""
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+            status=DeviceBindingStatus.STOPPED,
+        )
+        svc = _make_service(repo, device_provider=device_service)
+        bot = _make_bot(status="ACTIVE", binding_id=42)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot", return_value=True) as stop, \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result == bot
+        stop.assert_called_once()
+        start.assert_called_once()
+        assert start.call_args.kwargs["device_provider"] == "arca"
+
+    def test_active_bot_with_stopped_baas_binding_restarts_in_place(self):
+        """A stopped BaaS runtime keeps its binding and uses the update path."""
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="baas",
+            device_id="BOT-uuid-9",
+            status=DeviceBindingStatus.STOPPED,
+        )
+        svc = _make_service(
+            repo,
+            device_provider=device_service,
+            baas_service_provider=lambda: MagicMock(),
+        )
+        bot = _make_bot(status="ACTIVE", binding_id=42)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "_restart_bot_baas", return_value=bot) as restart_baas, \
+             patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result == bot
+        restart_baas.assert_called_once_with(
+            bot_id="bot001",
+            user_id="user001",
+            binding_id=42,
+            bot=bot,
+        )
+        stop.assert_not_called()
+        start.assert_not_called()
+
     def test_failed_bot_without_binding_is_rejected(self):
         """A failed bot without provider history must not re-enter create rollout."""
         repo = FakeRestartLockRepo()

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
@@ -113,6 +113,27 @@ class TestStopBot:
         )
         assert result is True
 
+    def test_releases_stopped_device_and_resets_status(self):
+        """STOPPED binding is finalized before restart allocates a replacement."""
+        svc = _make_service()
+        bot = _make_bot()
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        mock_device_service = MagicMock()
+        mock_device_service.get_device.return_value = _make_binding(
+            status=DeviceBindingStatus.STOPPED.value,
+        )
+        svc._device_service_provider = lambda: mock_device_service
+
+        result = svc.stop_bot(bot_id="bot001", user_id="user001")
+
+        mock_device_service.release_device.assert_called_once()
+        svc._repository.update_by_owner.assert_called_once_with(
+            "bot001", "user001",
+            {"status": "PENDING", "binding_id": None, "device_id": None},
+        )
+        assert result is True
+
     def test_returns_true_when_no_binding(self):
         """没有 binding_id 时跳过释放，直接重置状态，返回 True。"""
         svc = _make_service()

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -439,6 +439,22 @@ class TestReleaseDevice:
         )
         assert result is released_record
 
+    def test_release_stopped_device(self):
+        record = _make_record(status=DeviceBindingStatus.STOPPED.value)
+        released_record = _make_record(status=DeviceBindingStatus.RELEASED.value)
+        repo = MagicMock()
+        repo.get_by_id.side_effect = [record, released_record]
+        svc = _make_service(repo=repo)
+
+        result = svc.release_device(
+            binding_id=1,
+            release_reason="finalize stopped binding",
+            operator=_make_operator(),
+        )
+
+        assert result is released_record
+        repo.release_binding.assert_called_once()
+
     def test_release_released_device_raises(self):
         record = _make_record(status=DeviceBindingStatus.RELEASED.value)
         repo = MagicMock()


### PR DESCRIPTION
## Summary
- Backport Avernet PR #218 to `REL20260717`.
- Permit a `STOPPED` device binding to enter the restart lifecycle while retaining validation for other invalid binding states.
- Cover restart idempotency, create validation, stop/start, misc lifecycle, and device service behavior.

## Validation
- `uv run pytest tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py tests/community/core/bot_management/services/test_bot_service_create_validation.py tests/community/core/bot_management/services/test_bot_service_misc.py tests/community/core/bot_management/services/test_bot_service_stop_start.py tests/community/core/devices/services/test_device_service.py`
  - 250 passed

Full backend regression is running locally after PR creation.