### PR TITLE
fix: recover failed bots with historical provider

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3490,6 +3490,20 @@ class BotService:
                     nick_name=nick_name,
                     release_reason=f"Bot {bot_id} restarted",
                 )
+            else:
+                # There is no current binding to release, but the asynchronous
+                # allocation can take time. Publish PENDING before spawning it
+                # so status polling does not continue to report the old FAILED
+                # state while recovery is underway.
+                self._repository.update_by_owner(
+                    bot_id,
+                    user_id,
+                    {
+                        "status": "PENDING",
+                        "binding_id": None,
+                        "device_id": None,
+                    },
+                )
             updated_bot = self.start_bot(
                 bot_id=bot_id,
                 user_id=user_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3091,6 +3091,62 @@ class BotService:
 
         return str(provider), str(binding_status) if binding_status else None
 
+    def _resolve_historical_unbound_restart_provider(
+        self,
+        *,
+        bot_id: str,
+        entity_id: str,
+        entity_type: str,
+        env: str,
+    ) -> str | None:
+        """Return a safe provider for a failed bot whose current binding is lost."""
+        page = 1
+        page_size = 100
+        while True:
+            total, bindings = self._device_binding_repo.list_bindings(
+                env=env,
+                entity_id=entity_id,
+                entity_type=entity_type,
+                status=None,
+                page=page,
+                page_size=page_size,
+            )
+            for binding in bindings:
+                if (binding.device_props or {}).get("bolt_id") != bot_id:
+                    continue
+
+                status = str(binding.status or "").upper()
+                if status not in {
+                    DeviceBindingStatus.RELEASED.value,
+                    DeviceBindingStatus.FAILED.value,
+                    DeviceBindingStatus.STOPPED.value,
+                }:
+                    logger.warning(
+                        "[bot_service.restart_bot] reject unbound recovery with live historical binding: "
+                        "bot_id=%s binding_id=%s binding_status=%s",
+                        bot_id,
+                        binding.id,
+                        status or "UNKNOWN",
+                    )
+                    return None
+
+                provider = str(binding.device_provider or "")
+                if provider:
+                    logger.info(
+                        "[bot_service.restart_bot] recover failed unbound bot from historical provider: "
+                        "bot_id=%s binding_id=%s provider=%s binding_status=%s",
+                        bot_id,
+                        binding.id,
+                        provider,
+                        status,
+                    )
+                    return provider
+                return None
+
+            if not bindings or page * page_size >= total:
+                return None
+            page += 1
+
     @staticmethod
     def _activation_in_progress_result(bot: Dict[str, Any]) -> Dict[str, Any]:
         """Return an idempotent response without mutating lifecycle state."""
@@ -3303,10 +3359,11 @@ class BotService:
         # current binding exists, preserve its provider so an existing ARCA bot
         # cannot be migrated to BaaS merely because the owner later entered the
         # create whitelist. An ACTIVE bot without a binding retains the legacy
-        # fallback to normal allocation. A FAILED bot without a binding cannot
-        # safely recover because its historical provider is unknown.
+        # fallback to normal allocation. FAILED bots require a trustworthy
+        # historical provider because their current binding may be lost.
         current_device_provider = None
         binding_id = bot.get("binding_id")
+        recovered_without_binding = False
         if binding_id:
             current_device_provider, binding_status = (
                 self._resolve_current_device_restart_context(
@@ -3348,16 +3405,24 @@ class BotService:
                 f"device_provider={current_device_provider}"
             )
         elif bot_status == "FAILED":
-            logger.warning(
-                "[bot_service.restart_bot] reject failed bot without binding: "
-                "bot_id=%s user_id=%s",
-                bot_id,
-                user_id,
-            )
-            raise BotInvalidLifecycleStateError(
+            current_device_provider = self._resolve_historical_unbound_restart_provider(
                 bot_id=bot_id,
-                current_status="FAILED_WITHOUT_BINDING",
+                entity_id=str(entity_id),
+                entity_type=bot.get("entity_type", "staff"),
+                env=env,
             )
+            if not current_device_provider:
+                logger.warning(
+                    "[bot_service.restart_bot] reject failed bot without recoverable binding: "
+                    "bot_id=%s user_id=%s",
+                    bot_id,
+                    user_id,
+                )
+                raise BotInvalidLifecycleStateError(
+                    bot_id=bot_id,
+                    current_status="FAILED_WITHOUT_BINDING",
+                )
+            recovered_without_binding = True
         else:
             logger.info(
                 f"[bot_service.restart_bot] no binding provider to preserve: "
@@ -3404,7 +3469,11 @@ class BotService:
         lock_key = (env, entity_id, bot_id, lock.lock_token)
         handed_off = False
         try:
-            if current_device_provider == "baas" and self._baas_service_provider is not None:
+            if (
+                binding_id
+                and current_device_provider == "baas"
+                and self._baas_service_provider is not None
+            ):
                 # BaaS 原地重启：不 destroy、不 release binding，bot_uuid/device_uuid 不变,
                 # session NAS 目录复用，历史 session 留存。arca 永不进此支(provider 取自 binding 表)。
                 # 同步完成、无 async 接管，handed_off 保持 False → finally 当场释放锁。
@@ -3413,7 +3482,14 @@ class BotService:
                 )
                 logger.info(f"[bot_service.restart_bot] Bot {bot_id} in-place restart via BaaS, binding preserved")
                 return updated_bot
-            release_ok = self.stop_bot(bot_id=bot_id, user_id=user_id, nick_name=nick_name, release_reason=f"Bot {bot_id} restarted")
+            release_ok = True
+            if not recovered_without_binding:
+                release_ok = self.stop_bot(
+                    bot_id=bot_id,
+                    user_id=user_id,
+                    nick_name=nick_name,
+                    release_reason=f"Bot {bot_id} restarted",
+                )
             updated_bot = self.start_bot(
                 bot_id=bot_id,
                 user_id=user_id,

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -356,10 +356,124 @@ class TestRestartGuardOrchestration:
         stop.assert_not_called()
         start.assert_not_called()
 
-    def test_failed_bot_without_binding_is_rejected(self):
-        """A failed bot without provider history must not re-enter create rollout."""
+    def test_failed_bot_without_binding_restarts_with_historical_provider(self):
+        """A failed unbound bot allocates a replacement from its own history."""
         repo = FakeRestartLockRepo()
-        svc = _make_service(repo)
+        binding_repo = MagicMock()
+        binding_repo.list_bindings.return_value = (
+            2,
+            [
+                SimpleNamespace(
+                    id=43,
+                    device_provider="arca",
+                    device_props={"bolt_id": "another-bot"},
+                    status=DeviceBindingStatus.RELEASED.value,
+                ),
+                SimpleNamespace(
+                    id=42,
+                    device_provider="arca",
+                    device_props={"bolt_id": "bot001"},
+                    status=DeviceBindingStatus.RELEASED.value,
+                ),
+            ],
+        )
+        svc = _make_service(repo, device_binding_repo=binding_repo)
+        bot = _make_bot(status="FAILED", binding_id=None)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result == bot
+        binding_repo.list_bindings.assert_called_once_with(
+            env="dev",
+            entity_id="staff_user001",
+            entity_type="staff",
+            status=None,
+            page=1,
+            page_size=100,
+        )
+        stop.assert_not_called()
+        start.assert_called_once()
+        assert start.call_args.kwargs["device_provider"] == "arca"
+
+    def test_failed_bot_without_binding_is_rejected_without_historical_provider(self):
+        """A failed bot without trusted provider history must not re-enter rollout."""
+        repo = FakeRestartLockRepo()
+        binding_repo = MagicMock()
+        binding_repo.list_bindings.return_value = (0, [])
+        svc = _make_service(repo, device_binding_repo=binding_repo)
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(
+            status="FAILED",
+            binding_id=None,
+        )
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            with pytest.raises(BotInvalidLifecycleStateError) as exc_info:
+                svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert exc_info.value.current_status == "FAILED_WITHOUT_BINDING"
+        assert repo.acquire_calls == 0
+        stop.assert_not_called()
+        start.assert_not_called()
+
+    def test_failed_bot_without_binding_allocates_new_baas_device_from_history(self):
+        """Historical BaaS provider creates a new binding, never an in-place upgrade."""
+        repo = FakeRestartLockRepo()
+        binding_repo = MagicMock()
+        binding_repo.list_bindings.return_value = (
+            1,
+            [
+                SimpleNamespace(
+                    id=42,
+                    device_provider="baas",
+                    device_props={"bolt_id": "bot001"},
+                    status=DeviceBindingStatus.FAILED.value,
+                ),
+            ],
+        )
+        svc = _make_service(
+            repo,
+            device_binding_repo=binding_repo,
+            baas_service_provider=lambda: MagicMock(),
+        )
+        bot = _make_bot(status="FAILED", binding_id=None)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "_restart_bot_baas") as restart_baas, \
+             patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result == bot
+        restart_baas.assert_not_called()
+        stop.assert_not_called()
+        assert start.call_args.kwargs["device_provider"] == "baas"
+
+    def test_failed_bot_without_binding_rejects_live_historical_binding(self):
+        """An unbound bot must not duplicate a provider that is still live."""
+        repo = FakeRestartLockRepo()
+        binding_repo = MagicMock()
+        binding_repo.list_bindings.return_value = (
+            2,
+            [
+                SimpleNamespace(
+                    id=43,
+                    device_provider="arca",
+                    device_props={"bolt_id": "bot001"},
+                    status=DeviceBindingStatus.ACTIVE.value,
+                ),
+                SimpleNamespace(
+                    id=42,
+                    device_provider="arca",
+                    device_props={"bolt_id": "bot001"},
+                    status=DeviceBindingStatus.RELEASED.value,
+                ),
+            ],
+        )
+        svc = _make_service(repo, device_binding_repo=binding_repo)
         svc._repository.get_by_id_and_owner.return_value = _make_bot(
             status="FAILED",
             binding_id=None,

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -381,11 +381,12 @@ class TestRestartGuardOrchestration:
         bot = _make_bot(status="FAILED", binding_id=None)
         svc._repository.get_by_id_and_owner.return_value = bot
 
+        pending_bot = {**bot, "status": "PENDING"}
         with patch.object(svc, "stop_bot") as stop, \
-             patch.object(svc, "start_bot", return_value=bot) as start:
+             patch.object(svc, "start_bot", return_value=pending_bot) as start:
             result = svc.restart_bot(bot_id="bot001", user_id="user001")
 
-        assert result == bot
+        assert result == pending_bot
         binding_repo.list_bindings.assert_called_once_with(
             env="dev",
             entity_id="staff_user001",
@@ -395,6 +396,15 @@ class TestRestartGuardOrchestration:
             page_size=100,
         )
         stop.assert_not_called()
+        svc._repository.update_by_owner.assert_called_once_with(
+            "bot001",
+            "user001",
+            {
+                "status": "PENDING",
+                "binding_id": None,
+                "device_id": None,
+            },
+        )
         start.assert_called_once()
         assert start.call_args.kwargs["device_provider"] == "arca"
 


### PR DESCRIPTION
## 问题

FAILED Bot 在当前 binding 丢失时，原实现无法确认 device provider，因此直接拒绝重启。历史故障可能让 `ac_bots.device_id` 指向其他用户的旧设备，不能以它作为恢复依据。

## 修复

- 仅对 `FAILED + 无当前 binding` 查询同 owner、同环境、同 entity 的历史 binding。
- 只接受 `device_props.bolt_id` 精确匹配当前 bot，且最新匹配记录为 `RELEASED/FAILED/STOPPED`。
- 历史 binding 仍处于运行态时拒绝，避免重复申请资源。
- 使用历史 provider 走新的 `start_bot` 分配；BaaS 不走依赖当前 binding 的原地升级。
- 保留原有 ACTIVE 无 binding 路径及无可信历史时的拒绝行为。

## 验证

- `pytest test_bot_service_restart_idempotency.py test_bot_service_restart_baas_envs.py test_bot_service_stop_start.py -q`: 99 passed
- 后端全量社区测试：8008/8008 passed，line coverage 82.53%
- singlebox coverage：acceptance 32 passed，summary status=passed