### PR TITLE
fix: tolerate externally destroyed ARCA sandboxes

### DIFF
--- a/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
@@ -492,11 +492,15 @@ class ArcaPaasService(PaasService):
             )
         except ArcaSandboxError as e:
             error_str = str(e).lower()
-            # Only "not found" / "does not exist" are idempotent.
-            # "failed to connect" is NOT idempotent — it may be a transient
-            # network error and the sandbox is still running.
+            # ARCA reports an externally reclaimed sandbox as either "not
+            # found", "does not exist", or "sandbox destroyed". All three
+            # mean there is no resource left to destroy. Other connection
+            # failures remain non-idempotent because the sandbox may still be
+            # running.
             if "sandbox" in error_str and (
-                "not found" in error_str or "does not exist" in error_str
+                "not found" in error_str
+                or "does not exist" in error_str
+                or "destroyed" in error_str
             ):
                 self._logger.warning(
                     "Sandbox %s not found during destroy, "

--- a/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
@@ -500,7 +500,7 @@ class ArcaPaasService(PaasService):
             if "sandbox" in error_str and (
                 "not found" in error_str
                 or "does not exist" in error_str
-                or "destroyed" in error_str
+                or "sandbox destroyed" in error_str
             ):
                 self._logger.warning(
                     "Sandbox %s not found during destroy, "

--- a/src/baas/tests/unit/core/service/paas/test_arca_paas_service.py
+++ b/src/baas/tests/unit/core/service/paas/test_arca_paas_service.py
@@ -187,6 +187,39 @@ class TestDestroyDeviceWithStorage:
         assert mock_plugin.connect_sync_sandbox.call_count == 2
         mock_plugin.delete_storage.assert_not_called()
 
+    def test__destroy_device_sync__destroyed_sandbox_connection_is_idempotent(
+        self, arca_credentials, mock_plugin, caplog
+    ):
+        """An ARCA-scheduled sandbox deletion is equivalent to not found."""
+        mock_plugin.connect_sync_sandbox.side_effect = ArcaSandboxError(
+            "Failed to connect sync sandbox: sandbox destroyed"
+        )
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("destroyed-device-id")
+
+        assert result is True
+        assert mock_plugin.connect_sync_sandbox.call_count == 2
+        mock_plugin.delete_storage.assert_not_called()
+        assert "treating as successful (already destroyed)" in caplog.text
+
+    def test__destroy_device_sync__connection_failure_is_not_idempotent(
+        self, arca_credentials, mock_plugin
+    ):
+        """A connection failure without an explicit destroyed state must surface."""
+        mock_plugin.connect_sync_sandbox.side_effect = ArcaSandboxError(
+            "Failed to connect sync sandbox: connection refused"
+        )
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with pytest.raises(PaasError, match="connection refused"):
+            service._destroy_device_sync("unreachable-device-id")
+
     def test__destroy_device_sync__delete_storage_exception_is_best_effort(
         self, arca_credentials, mock_plugin, mock_sandbox, caplog
     ):


### PR DESCRIPTION
## 问题
ARCA 调度层已回收 sandbox 时，SDK 返回 `sandbox destroyed`。BaaS 仅将 `not found` / `does not exist` 视为幂等删除，导致重启 UPDATE 额外记录 `DEVICE_DESTROY_FAILED`。

## 改动
- 将带有明确 `sandbox destroyed` 语义的 ARCA destroy 错误按已删除处理。
- 保持普通连接异常（例如 `connection refused`）为失败，避免吞掉真实可用性故障。
- 补充连接阶段返回 destroyed 与真实连接失败两类单测。

## 验证
- `uv run pytest tests/unit/core/service/paas/test_arca_paas_service.py tests/unit/core/service/paas/test_arca_paas_service_coverage.py -q` (127 passed)
- `uv run ruff check ...`
- destroy/update 相关回归：14 passed（4 deselected）

> 注：本改动只消除已销毁旧 sandbox 的 destroy warning；`create_device` 的 ARCA template 创建失败仍需平台侧独立排查。