### PR TITLE
Remove redundant premature teclaw outbound-rule call in BotBuildService.release

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -534,27 +534,6 @@ class BotBuildService:
                 f"target_bot_uuid={bot_uuid}, publish_id={publish_id}"
             )
 
-            # All-auto approval (#197): the BaaS workflow is auto-approved
-            # server-side (auto_approve_publish=True in the create payload) — the
-            # client no longer sends an approve here. The teclaw MCP outbound rule
-            # push is a *separate* side effect (not approval): it must still run
-            # once a teclaw create returns a bot_uuid. Best-effort; a failure does
-            # not fail the release.
-            if is_teclaw_release and bot_uuid:
-                try:
-                    self._baas_service.update_teclaw_outbound_rule_by_bot_uuid(
-                        bot_uuid,
-                        agent_pass_token=agent_pass_token,
-                    )
-                except Exception as update_err:
-                    logger.warning(
-                        "[BotBuildService.release] Teclaw outbound rule update failed: "
-                        "bot_id=%s, bot_uuid=%s, error=%s",
-                        bot_id,
-                        bot_uuid,
-                        update_err,
-                    )
-
             return new_bot
 
         except Exception as e:

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
@@ -78,29 +78,7 @@ def test_release_routes_teclaw_to_create_teclaw_bot():
     assert ck.kwargs["template_uuid"] == "teclaw-tpl"
     assert "agent_pass_token" not in ck.kwargs
     svc._passport_plugin.query_token.assert_called_once_with("b", "u")
-    baas.update_teclaw_outbound_rule_by_bot_uuid.assert_called_once_with(
-        "BOT-t",
-        agent_pass_token=svc._passport_plugin.query_token.return_value,
-    )
     baas.create_bot.assert_not_called()
-
-
-@pytest.mark.unit
-def test_release_teclaw_continues_when_agent_pass_rule_update_fails():
-    svc, baas = _svc("teclaw")
-    baas.update_teclaw_outbound_rule_by_bot_uuid.side_effect = RuntimeError("rule down")
-
-    result = svc.release(
-        _BOT, user_id="u1", migration_path="", publish_stage=PublishStage.VERIFY,
-        delivery=DeliveryArtifact(_ARTIFACT),
-    )
-
-    assert result == {"bot_uuid": "BOT-t", "publish_id": 5}
-    # The teclaw outbound-rule push is attempted (and its failure swallowed) even
-    # though #197 all-auto removed the client approve — the rule push is a
-    # separate side effect, not approval.
-    baas.update_teclaw_outbound_rule_by_bot_uuid.assert_called_once()
-    baas.approve_publish.assert_not_called()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

Remove the inline teclaw outbound-rule call in `BotBuildService.release` (the sync method behind `release_async`) that fired `update_teclaw_outbound_rule_by_bot_uuid(...)` in a best-effort try/except right after `create_teclaw_bot(...)`.

## Why

The inline call was premature and redundant:

- `create_teclaw_bot` only *submits* the create (returns `bot_uuid`/`publish_id` as soon as BaaS accepts it); it does not wait for the bot to become READY/ACTIVE.
- `update_teclaw_outbound_rule_by_bot_uuid` needs BaaS to have registered the bot's device(s) with a `provider_device_id` — it lists devices then PUTs the outbound rule. Right after create the device usually isn't registered yet, so it logs "No devices found" and returns `[]` — a silent no-op.
- The outbound rule is reliably (re-)written by the poll-success handler: `ProgressSyncMixin._handle_sync_success` → `_refresh_provider_mcp_after_success` → teclaw `TeclawProviderBehavior.refresh_after_upgrade` → `BotBuildService.refresh_teclaw_mcp_outbound_rule` → the same BaaS method. That fires on observed deploy SUCCESS (bot ready, devices registered), runs for both first-release and upgrade, and is idempotent. The `upgrade` path already relies solely on this.

## Changes

- `bot_build_service.py` `release`: delete the `if is_teclaw_release and bot_uuid:` block, its `update_teclaw_outbound_rule_by_bot_uuid` call, the best-effort try/except, and the explanatory comment. The rest of the teclaw branch (`create_teclaw_bot`, field extraction, logging, `return new_bot`) is unchanged. The `agent_pass_token` fetch is kept — it is still passed to the ARCA `create_bot` path.
- Tests (`test_bot_build_service_teclaw_routing.py`): drop the `update_teclaw_outbound_rule_by_bot_uuid` assertion from `test_release_routes_teclaw_to_create_teclaw_bot` (create-routing assertions and the `query_token` assertion kept); delete `test_release_teclaw_continues_when_agent_pass_rule_update_fails` (no inline call remains to fail/swallow).

Not touched: `refresh_teclaw_mcp_outbound_rule` and the poll-success path (the mechanism relied on). `TeclawProvisionService.provision` is left alone — a separate flow, flagged as a possible follow-up.

## Verification

- `test_bot_build_service_teclaw_routing.py`: 18 passed.
- `tests/community/core/service_bot/` + `tests/community/core/bot_public/`: 698 passed.
- Full `tests/community/`: 8342 passed, 3 skipped.
- Grep confirms remaining `update_teclaw_outbound_rule_by_bot_uuid` invocations are only `refresh_teclaw_mcp_outbound_rule` and `teclaw_provision_service` (plus the method/protocol definitions).

## Follow-up

Consider auditing `TeclawProvisionService.provision`, which has its own outbound-rule call in a separate provisioning flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3BxyYURNareXqdndCrXzM

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3BxyYURNareXqdndCrXzM)_