### PR TITLE
feat(engine): add session favorites and harden session recovery

### DIFF
--- a/src/engine/docs/session-favorites-api.zh-CN.md
+++ b/src/engine/docs/session-favorites-api.zh-CN.md
@@ -1,0 +1,156 @@
+# 会话收藏接口
+
+## 适用范围
+
+接口由 Engine Adapter 统一提供，和 OpenClaw、Hermes、Claude Code 等具体引擎无关。前端仍通过当前 Bot 对应的 Engine Proxy 调用，不需要直连具体引擎。
+
+收藏仅保存会话键和用户标识，不复制标题、消息或其他会话内容。查询时由 Adapter 读取当前引擎的真实会话数据，因此响应与 `/api/sessions` 的会话结构一致。
+
+## 作用域
+
+- 收藏按 `user_id` 隔离。
+- `user_id` 为必填 query 参数，前端传入当前登录用户的 ID。
+- 同一用户收藏同一会话是幂等操作。
+- 取消一个不存在的收藏也是幂等操作，仍返回成功。
+- 删除会话成功后，Adapter 会同步清理该会话的全部收藏记录。
+
+## 会话键编码
+
+收藏和取消收藏使用 path 参数 `session_id`。前端应复用现有会话接口的 URL-safe Base64 编码方式：
+
+```ts
+const encodedSessionId = encodeToUrlSafeBase64(sessionId);
+```
+
+例如原始会话键：
+
+```text
+agent:main:session:2d20edc1-2f84-4524-8486-15bbd7078d42:user:165137
+```
+
+不要手工截断、拼接或按引擎类型转换会话键；直接使用会话列表返回的 `id`。
+
+## 接口
+
+### 查询已收藏会话
+
+```http
+GET /api/session-favorites?user_id={user_id}
+```
+
+响应：
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "agent:main:session:xxx:user:165137",
+      "title": "会话标题",
+      "user_id": "165137",
+      "agent_id": "main",
+      "model": "qwen-plus",
+      "permission_mode": "default",
+      "cwd": "/home/admin/.openclaw/workspace",
+      "gmt_created": "2026-07-21T10:00:00",
+      "gmt_modified": "2026-07-21T10:30:00",
+      "message_count": 12,
+      "runtime": "openclaw",
+      "last_message": {
+        "id": "message-001",
+        "session_id": "agent:main:session:xxx:user:165137",
+        "role": "assistant",
+        "content": "这是最后一条回复。",
+        "metadata": {
+          "model": "qwen-plus"
+        },
+        "gmt_created": "2026-07-21T10:30:00",
+        "history_meta": {
+          "summary": "会话摘要"
+        }
+      },
+      "ext_info": {
+        "source": "web"
+      }
+    }
+  ],
+  "total": null,
+  "message": null,
+  "warning": null
+}
+```
+
+`data` 为完整会话对象，字段与 `GET /api/sessions` 返回的单条会话一致。`last_message` 存在时，其字段为 `id`、`session_id`、`role`、`content`、`metadata`、`gmt_created`，并可能包含 `history_meta`。
+
+`runtime`、`last_message`、`ext_info` 仅在引擎返回对应数据时出现；其他字段始终存在，但部分字段值可能为 `null` 或空字符串。接口只返回仍存在的会话；已删除或已不存在的收藏不会出现在结果中。
+
+支持与会话列表相同的分页和 Agent 筛选参数：
+
+```http
+GET /api/session-favorites?user_id={user_id}&agent_id={agent_id}&limit=20&offset=0
+```
+
+分页针对“已收藏”会话集合生效。前端直接用 `data` 渲染“已收藏”列表；不要以该接口的返回顺序影响“全部”列表排序。
+
+### 收藏会话
+
+```http
+PUT /api/session-favorites/{encoded_session_id}?user_id={user_id}
+```
+
+响应：
+
+```json
+{
+  "success": true,
+  "data": null,
+  "message": "Session favorited",
+  "warning": null,
+  "total": null
+}
+```
+
+重复调用不会重复创建收藏记录，仍返回 `200`。
+
+### 取消收藏
+
+```http
+DELETE /api/session-favorites/{encoded_session_id}?user_id={user_id}
+```
+
+响应：
+
+```json
+{
+  "success": true,
+  "data": null,
+  "message": "Session unfavorited",
+  "warning": null,
+  "total": null
+}
+```
+
+即使会话原本未被当前用户收藏，也返回 `200`。
+
+## 错误处理
+
+`user_id` 缺失或为空时，三个接口均返回：
+
+```http
+422 Unprocessable Entity
+```
+
+SQLite 读写异常时返回：
+
+```http
+500 Internal Server Error
+```
+
+前端可沿用现有 Engine API 的统一错误处理逻辑。
+
+## 前端接入建议
+
+1. 获取“全部”会话时，维持既有 `/api/sessions` 或 AICoding 会话列表调用和排序逻辑。
+2. 同时调用收藏查询接口，得到收藏 session key 集合。
+3. 用该集合过滤原始会话列表，渲染“已收藏”列表；不要改变“全部”列表顺序。
+4. 用户点击收藏或取消收藏后，调用写接口并更新本地收藏集合，或重新拉取收藏列表。

--- a/src/engine/src/engine/community/api/app.py
+++ b/src/engine/src/engine/community/api/app.py
@@ -73,6 +73,7 @@ from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 
 from engine.community.api.cron.router import router as cron  # noqa: E402
 from engine.community.api.session.router import router as session_router  # noqa: E402
+from engine.community.api.session_favorites import router as session_favorites_router  # noqa: E402
 from engine.community.manager import EngineManager  # noqa: E402
 from engine.community.di import Injected  # noqa: E402
 from engine.community.plugin_api.auth_gate.protocol import AuthGateService  # noqa: E402
@@ -239,6 +240,7 @@ attach_injector(app, _INJECTOR)
 
 app.include_router(engine_router)
 app.include_router(session_router)
+app.include_router(session_favorites_router)
 app.include_router(models)
 app.include_router(cron)
 app.include_router(approvals)

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -132,6 +132,9 @@ async def list_sessions(
             data=[_session_to_dict(s) for s in sessions],
             warning=warning,
         )
+    except (ConnectionError, TimeoutError) as e:
+        log.error(f"[list_sessions] gateway unavailable: {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail="Session gateway unavailable") from e
     except Exception as e:
         log.error(f"[list_sessions] 执行异常: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -197,6 +197,9 @@ async def get_session(session_id: str, engine: Optional[str] = None) -> ApiRespo
         return ApiResponse(success=True, data=_session_to_dict(session), warning=warning)
     except HTTPException:
         raise
+    except (ConnectionError, TimeoutError) as error:
+        log.error(f"[get_session] gateway unavailable: {error}", exc_info=True)
+        raise HTTPException(status_code=503, detail="Session gateway unavailable") from error
     except Exception as e:
         log.error(f"[get_session] 执行异常: session_id={session_id}, error={e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -6,6 +6,7 @@ Uses EngineManager for default engine, falls back to factory for explicit engine
 from __future__ import annotations
 
 import json
+import asyncio
 import logging
 from datetime import datetime
 from typing import Dict, Optional
@@ -24,6 +25,7 @@ from engine.community.core.session.models import (
     SessionListRequest,
     SessionUpdateRequest,
 )
+from engine.community.core.session_favorite import get_session_favorite_repository
 from engine.community.shared.utils import decode_session_key
 
 log = logging.getLogger("web-sessions")
@@ -211,6 +213,16 @@ async def delete_session(session_id: str, force: bool = False, engine: Optional[
         if not ok:
             log.warning(f"[delete_session] 删除失败或会话不存在: session_id={session_id}")
             raise HTTPException(status_code=404, detail="Session not found or delete failed")
+        try:
+            await asyncio.to_thread(get_session_favorite_repository().remove_session, session_id)
+        except Exception as cleanup_error:
+            # The engine has already deleted the session. Do not misreport that
+            # successful destructive operation because local metadata cleanup failed.
+            log.warning(
+                "[delete_session] 收藏记录清理失败: session_id=%s, error=%s",
+                session_id,
+                cleanup_error,
+            )
         log.info(f"[delete_session] 删除成功: session_id={session_id}")
         return ApiResponse(success=True, message="Session deleted", warning=warning)
     except HTTPException:

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -164,7 +164,9 @@ async def create_session(body: CreateSessionBody) -> ApiResponse:
 async def get_session(session_id: str, engine: Optional[str] = None) -> ApiResponse:
     log.info(f"[get_session] 收到请求: session_id={session_id}, engine={engine}")
     # Uses the underlying list() plugin method to find one session; SESSION_LIST
-    # is the matching capability.
+    # is the matching capability. The plugin filters a session_key before
+    # pagination, so an inactive conversation cannot be mistaken for missing
+    # merely because it falls outside the first page.
     warning = check_capability(Capability.SESSION_LIST)
     decoded_id = decode_session_key(session_id)
     if decoded_id != session_id:
@@ -172,8 +174,12 @@ async def get_session(session_id: str, engine: Optional[str] = None) -> ApiRespo
     session_id = decoded_id
     try:
         api = _get_session_api(engine)
-        sessions = await api.list(SessionListRequest(limit=100, offset=0))
-        log.info(f"[get_session] 列表查询返回 {len(sessions)} 条, 正在匹配 session_id={session_id}")
+        sessions = await api.list(
+            SessionListRequest(session_key=session_id, limit=1, offset=0)
+        )
+        log.info(
+            f"[get_session] 精确查询返回 {len(sessions)} 条, session_id={session_id}"
+        )
         session = next(
             (
                 s

--- a/src/engine/src/engine/community/api/session/router.py
+++ b/src/engine/src/engine/community/api/session/router.py
@@ -176,12 +176,12 @@ async def get_session(session_id: str, engine: Optional[str] = None) -> ApiRespo
     session_id = decoded_id
     try:
         api = _get_session_api(engine)
+        # Engines that support exact lookup filter before pagination. Engines that
+        # do not yet support it retain the previous first-100 fallback behavior.
         sessions = await api.list(
-            SessionListRequest(session_key=session_id, limit=1, offset=0)
+            SessionListRequest(session_key=session_id, limit=100, offset=0)
         )
-        log.info(
-            f"[get_session] 精确查询返回 {len(sessions)} 条, session_id={session_id}"
-        )
+        log.info(f"[get_session] 列表查询返回 {len(sessions)} 条, 正在匹配 session_id={session_id}")
         session = next(
             (
                 s

--- a/src/engine/src/engine/community/api/session_favorites/__init__.py
+++ b/src/engine/src/engine/community/api/session_favorites/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP API for adapter-owned session favorites."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/engine/src/engine/community/api/session_favorites/router.py
+++ b/src/engine/src/engine/community/api/session_favorites/router.py
@@ -66,6 +66,11 @@ async def list_session_favorites(
             data=[_session_to_dict(session) for session in paged_sessions],
             warning=warning,
         )
+    except (ConnectionError, TimeoutError) as exc:
+        log.error(
+            "Session favorites gateway unavailable: %s", exc, exc_info=True
+        )
+        raise HTTPException(status_code=503, detail="Session gateway unavailable") from exc
     except Exception as exc:
         log.error("Failed to list session favorites: %s", exc, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to list session favorites") from exc

--- a/src/engine/src/engine/community/api/session_favorites/router.py
+++ b/src/engine/src/engine/community/api/session_favorites/router.py
@@ -1,0 +1,105 @@
+"""Engine-neutral REST API for a user's favorite sessions."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+
+from engine.community.api.caps import check_capability
+from engine.community.api.response import ApiResponse
+from engine.community.api.session.router import _get_session_api, _session_to_dict
+from engine.community.core.engine.capability import Capability
+from engine.community.core.session.models import SessionListRequest
+from engine.community.core.session_favorite import get_session_favorite_repository
+from engine.community.shared.utils import decode_session_key
+
+log = logging.getLogger("session-favorites")
+
+router = APIRouter(prefix="/api/session-favorites", tags=["session-favorites"])
+
+# Engine SessionService implementations paginate in memory. Fetching this bounded
+# set lets the adapter apply pagination after it filters by the SQLite metadata.
+_FAVORITE_SESSION_SCAN_LIMIT = 10_000
+
+
+def _require_user_id(user_id: str | None) -> str:
+    if user_id is None or not user_id.strip():
+        raise HTTPException(status_code=422, detail="user_id is required")
+    return user_id.strip()
+
+
+@router.get("")
+async def list_session_favorites(
+    user_id: str | None = Query(None, description="Current user ID"),
+    agent_id: str | None = Query(None, description="Agent ID"),
+    limit: int = Query(20, description="Maximum sessions to return"),
+    offset: int = Query(0, description="Favorite sessions offset"),
+    engine: str | None = Query(None, description="Active engine type"),
+) -> ApiResponse:
+    """Return favorited sessions in the same shape as ``GET /api/sessions``."""
+    resolved_user_id = _require_user_id(user_id)
+    warning = check_capability(Capability.SESSION_LIST)
+    try:
+        repository = get_session_favorite_repository()
+        favorite_session_ids = set(
+            await asyncio.to_thread(repository.list_session_ids, resolved_user_id)
+        )
+        if not favorite_session_ids:
+            return ApiResponse(success=True, data=[], warning=warning)
+
+        api = _get_session_api(engine)
+        sessions = await api.list(
+            SessionListRequest(
+                user_id=resolved_user_id,
+                agent_id=agent_id,
+                limit=_FAVORITE_SESSION_SCAN_LIMIT,
+                offset=0,
+            )
+        )
+        favorite_sessions = [
+            session for session in sessions if session.id in favorite_session_ids
+        ]
+        paged_sessions = favorite_sessions[offset:offset + limit]
+        return ApiResponse(
+            success=True,
+            data=[_session_to_dict(session) for session in paged_sessions],
+            warning=warning,
+        )
+    except Exception as exc:
+        log.error("Failed to list session favorites: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to list session favorites") from exc
+
+
+@router.put("/{session_id}")
+async def add_session_favorite(
+    session_id: str,
+    user_id: str | None = Query(None, description="Current user ID"),
+) -> ApiResponse:
+    """Mark one session as a favorite for the current user."""
+    resolved_user_id = _require_user_id(user_id)
+    decoded_session_id = decode_session_key(session_id)
+    try:
+        repository = get_session_favorite_repository()
+        await asyncio.to_thread(repository.add, resolved_user_id, decoded_session_id)
+        return ApiResponse(success=True, message="Session favorited")
+    except Exception as exc:
+        log.error("Failed to favorite session: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to favorite session") from exc
+
+
+@router.delete("/{session_id}")
+async def remove_session_favorite(
+    session_id: str,
+    user_id: str | None = Query(None, description="Current user ID"),
+) -> ApiResponse:
+    """Remove one user's favorite marker without deleting the session."""
+    resolved_user_id = _require_user_id(user_id)
+    decoded_session_id = decode_session_key(session_id)
+    try:
+        repository = get_session_favorite_repository()
+        await asyncio.to_thread(repository.remove, resolved_user_id, decoded_session_id)
+        return ApiResponse(success=True, message="Session unfavorited")
+    except Exception as exc:
+        log.error("Failed to remove session favorite: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to remove session favorite") from exc

--- a/src/engine/src/engine/community/api/session_favorites/tests/__init__.py
+++ b/src/engine/src/engine/community/api/session_favorites/tests/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP tests for session favorites."""

--- a/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
+++ b/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from engine.community.api.session_favorites.router import router
+from engine.community.shared.utils import encode_session_key
+
+
+@pytest.fixture()
+def repository():
+    with patch("engine.community.api.session_favorites.router.get_session_favorite_repository") as factory:
+        repository = MagicMock()
+        factory.return_value = repository
+        yield repository
+
+
+def _make_session(session_id: str):
+    session = MagicMock()
+    session.id = session_id
+    session.title = f"Title for {session_id}"
+    session.user_id = "user-a"
+    session.agent_id = "main"
+    session.model = None
+    session.permission_mode = None
+    session.cwd = None
+    session.created_at = None
+    session.updated_at = None
+    session.message_count = 0
+    session.runtime = None
+    session.last_message = None
+    session.ext_info = None
+    return session
+
+
+@pytest.fixture()
+def session_api():
+    api = MagicMock()
+    with patch("engine.community.api.session_favorites.router._get_session_api", return_value=api):
+        yield api
+
+
+@pytest.fixture()
+def client(repository, session_api) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_list_returns_full_session_data_for_current_users_favorites(
+    client,
+    repository,
+    session_api,
+):
+    repository.list_session_ids.return_value = ["session-1", "session-3"]
+    session_api.list = AsyncMock(return_value=[
+        _make_session("session-1"),
+        _make_session("session-2"),
+        _make_session("session-3"),
+    ])
+
+    response = client.get(
+        "/api/session-favorites",
+        params={"user_id": "user-a", "agent_id": "main", "limit": 1, "offset": 1},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["data"] == [{
+        "id": "session-3",
+        "title": "Title for session-3",
+        "user_id": "user-a",
+        "agent_id": "main",
+        "model": None,
+        "permission_mode": None,
+        "cwd": None,
+        "gmt_created": "",
+        "gmt_modified": "",
+        "message_count": 0,
+    }]
+    repository.list_session_ids.assert_called_once_with("user-a")
+    request = session_api.list.call_args.args[0]
+    assert request.user_id == "user-a"
+    assert request.agent_id == "main"
+    assert request.limit == 10_000
+    assert request.offset == 0
+
+
+def test_list_skips_engine_query_when_user_has_no_favorites(client, repository, session_api):
+    repository.list_session_ids.return_value = []
+
+    response = client.get("/api/session-favorites", params={"user_id": "user-a"})
+
+    assert response.status_code == 200
+    assert response.json()["data"] == []
+    session_api.list.assert_not_called()
+
+
+@pytest.mark.parametrize("method,path", [
+    ("get", "/api/session-favorites"),
+    ("put", "/api/session-favorites/session-1"),
+    ("delete", "/api/session-favorites/session-1"),
+])
+def test_user_id_is_required(client, method, path):
+    response = getattr(client, method)(path)
+
+    assert response.status_code == 422
+
+
+def test_add_decodes_session_key_and_is_idempotent(client, repository):
+    raw_session_id = "agent:main:session:123:user:user-a"
+    encoded_session_id = encode_session_key(raw_session_id)
+
+    response = client.put(
+        f"/api/session-favorites/{encoded_session_id}",
+        params={"user_id": "user-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Session favorited"
+    repository.add.assert_called_once_with("user-a", raw_session_id)
+
+
+def test_remove_only_removes_calling_users_favorite(client, repository):
+    response = client.delete(
+        "/api/session-favorites/session-1",
+        params={"user_id": "user-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Session unfavorited"
+    repository.remove.assert_called_once_with("user-a", "session-1")
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "repository_method"),
+    [
+        ("get", "/api/session-favorites", "list_session_ids"),
+        ("put", "/api/session-favorites/session-1", "add"),
+        ("delete", "/api/session-favorites/session-1", "remove"),
+    ],
+)
+def test_repository_errors_return_a_generic_server_error(
+    client,
+    repository,
+    method,
+    path,
+    repository_method,
+):
+    getattr(repository, repository_method).side_effect = RuntimeError("database unavailable")
+
+    response = getattr(client, method)(path, params={"user_id": "user-a"})
+
+    assert response.status_code == 500
+    assert response.json()["detail"].startswith("Failed to")
+
+
+def test_engine_error_returns_a_generic_server_error(client, repository, session_api):
+    repository.list_session_ids.return_value = ["session-1"]
+    session_api.list.side_effect = RuntimeError("engine unavailable")
+
+    response = client.get("/api/session-favorites", params={"user_id": "user-a"})
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to list session favorites"

--- a/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
+++ b/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
@@ -167,3 +167,14 @@ def test_engine_error_returns_a_generic_server_error(client, repository, session
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Failed to list session favorites"
+
+
+@pytest.mark.parametrize("error", [ConnectionError("disconnected"), TimeoutError("timed out")])
+def test_engine_transport_error_returns_503(client, repository, session_api, error):
+    repository.list_session_ids.return_value = ["session-1"]
+    session_api.list.side_effect = error
+
+    response = client.get("/api/session-favorites", params={"user_id": "user-a"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Session gateway unavailable"

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -247,6 +247,17 @@ class TestGetSession:
         resp = client.get("/api/sessions/sess-1")
         assert resp.status_code == 500
 
+    @pytest.mark.parametrize(
+        "error", [ConnectionError("disconnected"), TimeoutError("timed out")]
+    )
+    def test_transport_error_returns_503(self, client, mock_session_api, error):
+        mock_session_api.list.side_effect = error
+
+        resp = client.get("/api/sessions/sess-1")
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Session gateway unavailable"
+
 
 # ── DELETE /api/sessions/{session_id} ────────────────────────────────────────
 

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -68,7 +68,17 @@ def mock_session_api():
 
 
 @pytest.fixture()
-def client(mock_session_api) -> TestClient:
+def mock_favorite_repository():
+    repository = MagicMock()
+    with patch(
+        "engine.community.api.session.router.get_session_favorite_repository",
+        return_value=repository,
+    ):
+        yield repository
+
+
+@pytest.fixture()
+def client(mock_session_api, mock_favorite_repository) -> TestClient:
     app = FastAPI()
     app.include_router(router)
     return TestClient(app)
@@ -229,16 +239,30 @@ class TestGetSession:
 # ── DELETE /api/sessions/{session_id} ────────────────────────────────────────
 
 class TestDeleteSession:
-    def test_success(self, client, mock_session_api):
+    def test_success(self, client, mock_session_api, mock_favorite_repository):
         resp = client.delete("/api/sessions/sess-1")
         assert resp.status_code == 200
         assert resp.json()["success"] is True
         assert "deleted" in resp.json()["message"].lower()
+        mock_favorite_repository.remove_session.assert_called_once_with("sess-1")
 
-    def test_not_found_returns_404(self, client, mock_session_api):
+    def test_not_found_returns_404(self, client, mock_session_api, mock_favorite_repository):
         mock_session_api.delete.return_value = False
         resp = client.delete("/api/sessions/missing")
         assert resp.status_code == 404
+        mock_favorite_repository.remove_session.assert_not_called()
+
+    def test_favorite_cleanup_error_does_not_make_delete_fail(
+        self,
+        client,
+        mock_favorite_repository,
+    ):
+        mock_favorite_repository.remove_session.side_effect = RuntimeError("sqlite unavailable")
+
+        resp = client.delete("/api/sessions/sess-1")
+
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
 
     def test_force_param_forwarded(self, client, mock_session_api):
         client.delete("/api/sessions/sess-1?force=true")

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -199,6 +199,11 @@ class TestGetSession:
         assert resp.status_code == 200
         assert resp.json()["data"]["id"] == "sess-1"
 
+        request = mock_session_api.list.call_args.args[0]
+        assert request.session_key == "sess-1"
+        assert request.limit == 1
+        assert request.offset == 0
+
     def test_not_found_returns_404(self, client, mock_session_api):
         mock_session_api.list.return_value = []
         resp = client.get("/api/sessions/missing")

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -208,11 +208,23 @@ class TestGetSession:
         resp = client.get("/api/sessions/sess-1")
         assert resp.status_code == 200
         assert resp.json()["data"]["id"] == "sess-1"
-
         request = mock_session_api.list.call_args.args[0]
         assert request.session_key == "sess-1"
-        assert request.limit == 1
+        assert request.limit == 100
         assert request.offset == 0
+
+    def test_found_uses_exact_key_filter_before_pagination(
+        self, client, mock_session_api
+    ):
+        """A session beyond a legacy first-100 window must still be reusable."""
+        mock_session_api.list.return_value = [_make_session("sess-101")]
+
+        resp = client.get("/api/sessions/sess-101")
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["id"] == "sess-101"
+        request = mock_session_api.list.call_args.args[0]
+        assert request.session_key == "sess-101"
 
     def test_not_found_returns_404(self, client, mock_session_api):
         mock_session_api.list.return_value = []

--- a/src/engine/src/engine/community/api/tests/test_session_router.py
+++ b/src/engine/src/engine/community/api/tests/test_session_router.py
@@ -8,7 +8,6 @@ directly so no real engine runtime is needed.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -107,6 +106,17 @@ class TestListSessions:
         resp = client.get("/api/sessions")
         assert resp.status_code == 500
         assert "db error" in resp.json()["detail"]
+
+    @pytest.mark.parametrize(
+        "error", [ConnectionError("disconnected"), TimeoutError("timed out")]
+    )
+    def test_transport_error_returns_503(self, client, mock_session_api, error):
+        mock_session_api.list.side_effect = error
+
+        resp = client.get("/api/sessions")
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Session gateway unavailable"
 
 
 # ── POST /api/sessions ────────────────────────────────────────────────────────

--- a/src/engine/src/engine/community/core/session_favorite/__init__.py
+++ b/src/engine/src/engine/community/core/session_favorite/__init__.py
@@ -1,0 +1,5 @@
+"""Adapter-owned session favorite metadata."""
+
+from .repository import SessionFavoriteRepository, get_session_favorite_repository
+
+__all__ = ["SessionFavoriteRepository", "get_session_favorite_repository"]

--- a/src/engine/src/engine/community/core/session_favorite/repository.py
+++ b/src/engine/src/engine/community/core/session_favorite/repository.py
@@ -1,0 +1,119 @@
+"""SQLite persistence for session favorites owned by the adapter."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+from pathlib import Path
+
+
+def _default_database_path() -> Path:
+    """Return the adapter state database path without depending on an engine."""
+    state_dir = os.getenv("ENGINE_ADAPTER_STATE_DIR", "").strip()
+    base_dir = Path(state_dir).expanduser() if state_dir else Path.home() / ".engine-adapter"
+    return base_dir / "session_favorites.sqlite3"
+
+
+class SessionFavoriteRepository:
+    """Persist a user's session favorites in an adapter-local SQLite database."""
+
+    def __init__(self, database_path: Path | None = None) -> None:
+        self._database_path = database_path or _default_database_path()
+        self._initialization_lock = threading.Lock()
+        self._initialized = False
+
+    def list_session_ids(self, user_id: str) -> list[str]:
+        self._ensure_initialized()
+        with self._connect() as connection:
+            # 以下为安全注释COSEC：使用参数化查询防止 SQL 注入，禁止字符串拼接
+            rows = connection.execute(
+                """
+                SELECT session_id
+                FROM session_favorites
+                WHERE user_id = ?
+                ORDER BY created_at ASC
+                """,
+                (user_id,),
+            ).fetchall()
+        return [row["session_id"] for row in rows]
+
+    def add(self, user_id: str, session_id: str) -> None:
+        self._ensure_initialized()
+        with self._connect() as connection:
+            # 以下为安全注释COSEC：使用参数化查询防止 SQL 注入，禁止字符串拼接
+            connection.execute(
+                """
+                INSERT INTO session_favorites (user_id, session_id)
+                VALUES (?, ?)
+                ON CONFLICT(user_id, session_id) DO NOTHING
+                """,
+                (user_id, session_id),
+            )
+
+    def remove(self, user_id: str, session_id: str) -> bool:
+        self._ensure_initialized()
+        with self._connect() as connection:
+            # 以下为安全注释COSEC：使用参数化查询防止 SQL 注入，禁止字符串拼接
+            cursor = connection.execute(
+                "DELETE FROM session_favorites WHERE user_id = ? AND session_id = ?",
+                (user_id, session_id),
+            )
+        return cursor.rowcount > 0
+
+    def remove_session(self, session_id: str) -> int:
+        """Remove every user's favorite record after the engine deletes a session."""
+        self._ensure_initialized()
+        with self._connect() as connection:
+            # 以下为安全注释COSEC：使用参数化查询防止 SQL 注入，禁止字符串拼接
+            cursor = connection.execute(
+                "DELETE FROM session_favorites WHERE session_id = ?",
+                (session_id,),
+            )
+        return cursor.rowcount
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+        with self._initialization_lock:
+            if self._initialized:
+                return
+            self._database_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._connect() as connection:
+                connection.execute("PRAGMA journal_mode=WAL")
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS session_favorites (
+                        user_id TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (user_id, session_id)
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_session_favorites_session_id
+                    ON session_favorites (session_id)
+                    """
+                )
+            self._initialized = True
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._database_path, timeout=5)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout = 5000")
+        return connection
+
+
+_repository: SessionFavoriteRepository | None = None
+_repository_lock = threading.Lock()
+
+
+def get_session_favorite_repository() -> SessionFavoriteRepository:
+    """Return the process-wide adapter metadata repository."""
+    global _repository
+    if _repository is None:
+        with _repository_lock:
+            if _repository is None:
+                _repository = SessionFavoriteRepository()
+    return _repository

--- a/src/engine/src/engine/community/core/session_favorite/repository.py
+++ b/src/engine/src/engine/community/core/session_favorite/repository.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import os
 import sqlite3
 import threading
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -98,11 +100,16 @@ class SessionFavoriteRepository:
                 )
             self._initialized = True
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connect(self) -> Generator[sqlite3.Connection, None, None]:
         connection = sqlite3.connect(self._database_path, timeout=5)
         connection.row_factory = sqlite3.Row
         connection.execute("PRAGMA busy_timeout = 5000")
-        return connection
+        try:
+            with connection:
+                yield connection
+        finally:
+            connection.close()
 
 
 _repository: SessionFavoriteRepository | None = None

--- a/src/engine/src/engine/community/core/session_favorite/tests/__init__.py
+++ b/src/engine/src/engine/community/core/session_favorite/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for adapter-owned session favorite metadata."""

--- a/src/engine/src/engine/community/core/session_favorite/tests/test_repository.py
+++ b/src/engine/src/engine/community/core/session_favorite/tests/test_repository.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import engine.community.core.session_favorite.repository as repository_module
+from engine.community.core.session_favorite.repository import SessionFavoriteRepository
+
+
+def test_add_list_and_remove_are_scoped_to_user(tmp_path):
+    repository = SessionFavoriteRepository(tmp_path / "favorites.sqlite3")
+
+    repository.add("user-a", "session-1")
+    repository.add("user-a", "session-2")
+    repository.add("user-b", "session-1")
+
+    assert repository.list_session_ids("user-a") == ["session-1", "session-2"]
+    assert repository.list_session_ids("user-b") == ["session-1"]
+
+    assert repository.remove("user-a", "session-1") is True
+    assert repository.remove("user-a", "session-1") is False
+    assert repository.list_session_ids("user-a") == ["session-2"]
+    assert repository.list_session_ids("user-b") == ["session-1"]
+
+
+def test_add_is_idempotent(tmp_path):
+    repository = SessionFavoriteRepository(tmp_path / "favorites.sqlite3")
+
+    repository.add("user-a", "session-1")
+    repository.add("user-a", "session-1")
+
+    assert repository.list_session_ids("user-a") == ["session-1"]
+
+
+def test_remove_session_cleans_all_users(tmp_path):
+    repository = SessionFavoriteRepository(tmp_path / "favorites.sqlite3")
+    repository.add("user-a", "session-1")
+    repository.add("user-b", "session-1")
+    repository.add("user-a", "session-2")
+
+    assert repository.remove_session("session-1") == 2
+    assert repository.list_session_ids("user-a") == ["session-2"]
+    assert repository.list_session_ids("user-b") == []
+
+
+def test_default_database_path_supports_adapter_state_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("ENGINE_ADAPTER_STATE_DIR", str(tmp_path))
+
+    assert repository_module._default_database_path() == tmp_path / "session_favorites.sqlite3"
+
+    monkeypatch.delenv("ENGINE_ADAPTER_STATE_DIR")
+    assert repository_module._default_database_path().name == "session_favorites.sqlite3"
+
+
+def test_repository_singleton_uses_configured_adapter_state_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(repository_module, "_repository", None)
+    monkeypatch.setenv("ENGINE_ADAPTER_STATE_DIR", str(tmp_path))
+
+    first = repository_module.get_session_favorite_repository()
+    second = repository_module.get_session_favorite_repository()
+
+    assert first is second
+    assert first._database_path == tmp_path / "session_favorites.sqlite3"

--- a/src/engine/src/engine/community/core/session_favorite/tests/test_repository.py
+++ b/src/engine/src/engine/community/core/session_favorite/tests/test_repository.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
+import pytest
+
 import engine.community.core.session_favorite.repository as repository_module
 from engine.community.core.session_favorite.repository import SessionFavoriteRepository
 
@@ -58,3 +62,26 @@ def test_repository_singleton_uses_configured_adapter_state_dir(monkeypatch, tmp
 
     assert first is second
     assert first._database_path == tmp_path / "session_favorites.sqlite3"
+
+
+def test_connection_is_closed_after_operation(monkeypatch, tmp_path):
+    connection = MagicMock()
+    monkeypatch.setattr(repository_module.sqlite3, "connect", lambda *_args, **_kwargs: connection)
+    repository = SessionFavoriteRepository(tmp_path / "favorites.sqlite3")
+
+    with repository._connect() as actual_connection:
+        assert actual_connection is connection
+
+    connection.close.assert_called_once()
+
+
+def test_connection_is_closed_when_operation_fails(monkeypatch, tmp_path):
+    connection = MagicMock()
+    monkeypatch.setattr(repository_module.sqlite3, "connect", lambda *_args, **_kwargs: connection)
+    repository = SessionFavoriteRepository(tmp_path / "favorites.sqlite3")
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        with repository._connect():
+            raise RuntimeError("write failed")
+
+    connection.close.assert_called_once()

--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -117,18 +117,19 @@ class _SessionPortMixin:
           8. Normalise model strings (cached provider map)
           9. Return the final page dicts with `_messages`/`_message_count` set
 
-        Returns `[]` on gateway error.  A page may return fewer than `limit`
-        items when "Bot 初始化配置" sessions fall within it (exact legacy
-        behaviour).
+        Returns `[]` for gateway business errors. Transport failures propagate
+        so callers never mistake an unavailable gateway for an empty session
+        collection. A page may return fewer than `limit` items when "Bot 初始化配置"
+        sessions fall within it (exact legacy behaviour).
         """
         client = await self._pooled_client(token)
 
         # Step 1: sessions.list RPC
         try:
             response = await client.send_request("sessions.list", {})
-        except ConnectionError as e:
-            log.error("[sessions_list] connection failed: %s", e)
-            return []
+        except (ConnectionError, TimeoutError):
+            # An empty list is a valid answer, so it must not mask an upstream outage.
+            raise
         except Exception as e:
             log.exception("[sessions_list] unexpected error: %s", e)
             return []

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -138,6 +138,25 @@ class TestSessionsList:
         result = await impl.sessions_list(token="tok")
         assert result == []
 
+    @pytest.mark.parametrize(
+        "error", [ConnectionError("disconnected"), TimeoutError("timed out")]
+    )
+    async def test_propagates_transport_failures(self, error: Exception):
+        class _TransportErrorClient:
+            connected = True
+
+            async def send_request(self, method, params=None, timeout=None):
+                raise error
+
+        class _TransportErrorPool:
+            async def get(self, token=None):
+                return _TransportErrorClient()
+
+        impl = OpenClawPluginImpl(pool=_TransportErrorPool())
+
+        with pytest.raises(type(error), match=str(error)):
+            await impl.sessions_list(token="tok")
+
     async def test_basic_session_returned_with_messages(self):
         sessions = [{"key": "s1", "label": "Test", "model": "qwen-plus"}]
         messages = [{"id": "m1", "role": "user", "content": "hi"}]


### PR DESCRIPTION
## Summary

- Add an engine-agnostic SQLite-backed session favorites API, including persistent favorite records, listing with the standard session response shape, and best-effort cleanup when a session is deleted.
- Preserve private-chat continuity by resolving saved session keys before pagination while retaining the legacy first-100 fallback for engines that do not yet implement exact filtering.
- Surface unavailable OpenClaw session gateways as retryable service-unavailable responses instead of internal errors.

## Impact

- Frontend integration is additive: existing private-chat requests and responses remain unchanged.
- OpenClaw and Hermes can accurately recover older saved sessions; engines without exact-key filtering keep their prior lookup behavior.

## Validation

- `62 passed`: session router, session favorites router, and session favorite repository tests; targeted coverage `96%`.
- `79 passed`: OpenClaw session adapter and session port tests.
- `ruff check` for all changed engine source and tests.