### PR TITLE
perf(aicoding): speed up NAS file tree scan

### DIFF
--- a/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
@@ -274,6 +274,26 @@ def test_file_tree_success(client, workspace_svc):
     assert body["tree"][0]["children"][0]["name"] == "README.md"
 
 
+def test_file_tree_keeps_size_field_when_service_leaves_it_unset(
+    client, workspace_svc,
+):
+    workspace_svc.list_file_tree_return = [
+        FileTreeNode(
+            name="README.md",
+            path="README.md",
+            is_dir=False,
+        ),
+    ]
+
+    resp = client.get(
+        "/api/aicoding/sessions/file-tree",
+        params={"session_id": "s1"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["tree"][0]["size"] is None
+
+
 def test_file_tree_accepts_cwd_with_blank_session_id(client, workspace_svc):
     workspace_svc.list_file_tree_return = []
     cwd = "/home/admin/.aicoding/workspace/direct"

--- a/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
@@ -280,44 +280,30 @@ SESSION_ID = "sess-1"
 
 async def test_list_file_tree_prunes_mounts_and_returns_sorted_tree(
     workspace_dir: Path,
-    monkeypatch,
 ) -> None:
-    """Root mounts are never entered; project-local ``skills`` remains visible."""
-    project = workspace_dir / "project-fe"
-    (project / "src").mkdir(parents=True)
-    (project / "skills").mkdir()
-    (project / ".git").mkdir()
-    (project / "node_modules").mkdir()
-    (project / "README.md").write_text("readme")
-    (project / "src" / "index.ts").write_text("index")
-    (project / "skills" / "SKILL.md").write_text("skill")
-    (project / ".git" / "config").write_text("git")
-    (project / "node_modules" / "package.js").write_text("module")
-
-    root_skills = workspace_dir / "skills"
-    root_repos = workspace_dir / ".repos"
-    (root_skills / "skills-repo").mkdir(parents=True)
-    (root_skills / "skills-repo" / "remote.md").write_text("remote")
-    root_repos.mkdir()
-    (root_repos / "internal.git").write_text("internal")
-
-    # Prove pruning happens before recursion rather than filtering the result
-    # after an expensive OSS walk.
-    real_scandir = os.scandir
-
-    def guarded_scandir(path):  # noqa: ANN001
-        scanned = os.path.normpath(os.fspath(path))
-        assert scanned not in {
-            os.path.normpath(str(root_skills)),
-            os.path.normpath(str(root_repos)),
-            os.path.normpath(str(project / ".git")),
-            os.path.normpath(str(project / "node_modules")),
-        }
-        return real_scandir(path)
-
-    monkeypatch.setattr(os, "scandir", guarded_scandir)
+    """The find result is sorted into a tree; command prunes infrastructure."""
     file_plugin = FakeFilePlugin()
-    service = _make_service(file_plugin=file_plugin)
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(
+            stdout=(
+                "f\0project-fe/README.md\0"
+                "d\0project-fe/src\0"
+                "f\0project-fe/src/index.ts\0"
+                "d\0project-fe/skills\0"
+                "f\0project-fe/skills/SKILL.md\0"
+                "d\0project-fe\0"
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    service = _make_service(
+        file_plugin=file_plugin,
+        bash_plugin=bash_plugin,
+    )
 
     tree = await service.list_file_tree(SESSION_ID)
 
@@ -333,29 +319,137 @@ async def test_list_file_tree_prunes_mounts_and_returns_sorted_tree(
     assert [node.name for node in project_node.children[0].children] == [
         "SKILL.md"
     ]
+    command, cwd, timeout = bash_plugin.calls[0]
+    assert cwd == str(workspace_dir)
+    assert timeout == 30
+    assert "-name .git" in command
+    assert "-name node_modules" in command
+    assert "-path './skills'" in command
+    assert "-path './.repos'" in command
+    assert "%s" not in command
     assert file_plugin.calls == []
 
 
-async def test_list_file_tree_tolerates_stat_race(
+async def test_list_file_tree_leaves_size_unset(
     workspace_dir: Path,
-    monkeypatch,
 ) -> None:
-    """A file disappearing after readdir keeps the node and does not fail."""
-    target = workspace_dir / "volatile.txt"
-    target.write_text("soon gone")
-    real_stat = os.stat
+    """find does not return size, so file nodes retain the None default."""
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(
+            stdout="f\0README.md\0",
+            stderr="",
+            exit_code=0,
+        ),
+    )
 
-    def flaky_stat(path, *args, **kwargs):  # noqa: ANN001
-        if os.path.normpath(os.fspath(path)) == os.path.normpath(str(target)):
-            raise OSError("object disappeared")
-        return real_stat(path, *args, **kwargs)
+    tree = await _make_service(bash_plugin=bash_plugin).list_file_tree(
+        SESSION_ID
+    )
 
-    monkeypatch.setattr(os, "stat", flaky_stat)
-    tree = await _make_service().list_file_tree(SESSION_ID)
+    assert len(tree) == 1
+    assert tree[0].name == "README.md"
+    assert tree[0].is_dir is False
+    assert tree[0].size is None
 
-    volatile = next(node for node in tree if node.name == "volatile.txt")
-    assert volatile.is_dir is False
-    assert volatile.size is None
+
+async def test_list_file_tree_returns_symlinks_without_following_target(
+    workspace_dir: Path,
+) -> None:
+    """GNU find type ``l`` is exposed as a non-directory node."""
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(
+            stdout=(
+                "l\0link-file\0"
+                "l\0link-dir\0"
+                "l\0broken-link\0"
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    tree = await _make_service(bash_plugin=bash_plugin).list_file_tree(
+        SESSION_ID
+    )
+
+    assert [node.name for node in tree] == [
+        "broken-link",
+        "link-dir",
+        "link-file",
+    ]
+    assert all(node.is_dir is False for node in tree)
+    assert all(node.size is None for node in tree)
+    assert all(node.children is None for node in tree)
+
+
+async def test_list_file_tree_preserves_special_characters(
+    workspace_dir: Path,
+) -> None:
+    """NUL framing keeps spaces, Unicode and newlines in paths intact."""
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(
+            stdout=(
+                "d\0目录 with space\0"
+                "f\0目录 with space/line\nbreak.txt\0"
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    tree = await _make_service(bash_plugin=bash_plugin).list_file_tree(
+        SESSION_ID
+    )
+
+    assert tree[0].name == "目录 with space"
+    assert tree[0].children is not None
+    assert tree[0].children[0].name == "line\nbreak.txt"
+    assert tree[0].children[0].path == "目录 with space/line\nbreak.txt"
+
+
+async def test_list_file_tree_raises_when_find_fails(
+    workspace_dir: Path,
+) -> None:
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(
+            stdout="",
+            stderr="find: Permission denied",
+            exit_code=1,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="file-tree find failed"):
+        await _make_service(bash_plugin=bash_plugin).list_file_tree(SESSION_ID)
+
+
+async def test_list_file_tree_rejects_malformed_find_output(
+    workspace_dir: Path,
+) -> None:
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(
+            stdout="f\0missing-path-pair\0d",
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid file-tree find output"):
+        await _make_service(bash_plugin=bash_plugin).list_file_tree(SESSION_ID)
 
 
 @pytest.mark.parametrize(
@@ -969,11 +1063,25 @@ async def test_list_file_tree_uses_cwd_as_workspace_root(
     (custom / "cwd-only.txt").write_text("ok")
     monkeypatch.setenv("AICODING_CWD_ALLOW_ROOTS", str(tmp_path))
     file_plugin = FakeFilePlugin()
-    service = _make_service(file_plugin=file_plugin)
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(custom),
+        BashExecResult(
+            stdout="f\0cwd-only.txt\0",
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    service = _make_service(
+        file_plugin=file_plugin,
+        bash_plugin=bash_plugin,
+    )
 
     tree = await service.list_file_tree("   ", cwd=str(custom))
 
     assert [node.name for node in tree] == ["cwd-only.txt"]
+    assert bash_plugin.calls[0][1] == str(custom)
     assert file_plugin.calls == []
 
 

--- a/src/engine/src/engine/community/core/aicoding/workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/workspace_service.py
@@ -2,8 +2,9 @@
 
 Composes :class:`engine.community.core.file.protocol.FileService` and
 :class:`engine.community.core.bash.protocol.BashService` for workspace file
-and git operations.  The file-tree endpoint scans the container-local AICoding
-workspace directly so it can prune root-level OSS mounts before traversal.
+and git operations.  The file-tree endpoint invokes GNU ``find`` inside the
+container-local AICoding workspace so it can prune infrastructure mounts before
+traversal without issuing a separate size ``stat`` for every file.
 
 The container workspace base path is ``/home/admin/.aicoding/workspace``
 (matches the relay ``DEFAULT_CWD`` and the AiCodingFileService
@@ -25,7 +26,6 @@ from engine.community.core.aicoding.models import (
     GitDiffResult,
     GitDiffTreeResult,
     GitProjectDiff,
-    _FILTERED_DIRS,
     build_diff_tree,
     build_file_tree,
     parse_porcelain_status,
@@ -45,11 +45,17 @@ CONTAINER_WORKSPACE_BASE = "/home/admin/.aicoding/workspace"
 # 10 MiB cap for inline preview to keep responses bounded.
 PREVIEW_MAX_BYTES = 10 * 1024 * 1024
 
-# AICoding workspace infrastructure directories that must never be exposed by
-# the file-tree endpoint.  ``skills`` contains the OSS-mounted skills-repo and
-# ``.repos`` contains shared worktree internals; both are root-only exclusions
-# so project-local directories with the same names remain visible.
-_FILE_TREE_ROOT_EXCLUDED_DIRS = {"skills", ".repos"}
+# Keep this command static and pass the validated workspace separately as
+# BashService.cwd.  GNU find's ``%y`` supplies the entry type and ``%P`` the
+# workspace-relative path; NUL delimiters preserve whitespace/newlines in file
+# names.  Deliberately omit ``%s`` so NAS-backed workspaces do not pay one
+# explicit size metadata lookup per file.
+_FILE_TREE_FIND_COMMAND = (
+    r"find -P . -ignore_readdir_race -mindepth 1 "
+    r"\( -type d \( -name .git -o -name node_modules "
+    r"-o -path './skills' -o -path './.repos' \) -prune \) "
+    r"-o -printf '%y\0%P\0'"
+)
 
 
 def _resolve_workspace_base() -> str:
@@ -61,70 +67,33 @@ def _resolve_workspace_base() -> str:
     return raw or CONTAINER_WORKSPACE_BASE
 
 
-def _scan_file_tree_entries(workspace: str) -> list[dict]:
-    """Return file-tree entries while pruning AICoding infrastructure mounts.
+def _parse_find_file_tree_entries(
+    output: str,
+    workspace: str,
+) -> list[dict]:
+    """Parse ``type\0relative-path\0`` pairs emitted by GNU ``find``."""
+    fields = output.split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+    if len(fields) % 2 != 0:
+        raise RuntimeError("invalid file-tree find output")
 
-    The root ``skills`` directory contains an OSS-mounted ``skills-repo``.  On
-    ossfs, merely walking that mount performs remote object listings and can
-    take several seconds.  Pruning ``dirs`` in-place prevents ``os.walk`` from
-    entering it at all.  ``.repos`` is likewise internal worktree storage.
-
-    A file may disappear between directory listing and ``stat`` on eventually
-    consistent mounts.  Such a race must not fail the entire file-tree request;
-    the node is retained with an unknown size instead.
-    """
     workspace_norm = os.path.normpath(workspace)
     entries: list[dict] = []
+    for index in range(0, len(fields), 2):
+        file_type = fields[index]
+        relative_path = fields[index + 1]
+        if not relative_path:
+            raise RuntimeError("invalid empty path in file-tree find output")
 
-    for root, dirs, filenames in os.walk(
-        workspace_norm,
-        topdown=True,
-        followlinks=False,
-    ):
-        root_norm = os.path.normpath(root)
-        at_workspace_root = root_norm == workspace_norm
-        dirs[:] = [
-            dirname
-            for dirname in dirs
-            if dirname not in _FILTERED_DIRS
-            and not (
-                at_workspace_root
-                and dirname in _FILE_TREE_ROOT_EXCLUDED_DIRS
-            )
-        ]
-
-        for dirname in dirs:
-            full_path = os.path.join(root, dirname)
-            entries.append(
-                {
-                    "name": dirname,
-                    "path": full_path,
-                    "relative_path": os.path.relpath(full_path, workspace_norm),
-                    "is_dir": True,
-                    "size": 0,
-                }
-            )
-
-        for filename in filenames:
-            full_path = os.path.join(root, filename)
-            try:
-                size: int | None = os.stat(full_path).st_size
-            except OSError as exc:
-                log.debug(
-                    "file-tree stat skipped for %s: %s",
-                    full_path,
-                    exc,
-                )
-                size = None
-            entries.append(
-                {
-                    "name": filename,
-                    "path": full_path,
-                    "relative_path": os.path.relpath(full_path, workspace_norm),
-                    "is_dir": False,
-                    "size": size,
-                }
-            )
+        entries.append(
+            {
+                "name": os.path.basename(relative_path),
+                "path": os.path.join(workspace_norm, relative_path),
+                "relative_path": relative_path,
+                "is_dir": file_type == "d",
+            }
+        )
 
     return entries
 
@@ -294,7 +263,19 @@ class WorkspaceService:
             normalized_session_id or "",
             normalized_cwd,
         )
-        return build_file_tree(_scan_file_tree_entries(workspace))
+        result = await self._bash.exec(
+            cmd=_FILE_TREE_FIND_COMMAND,
+            cwd=workspace,
+            timeout=30,
+        )
+        if result.exit_code != 0:
+            detail = (
+                result.stderr.strip() or f"exit code {result.exit_code}"
+            )[:1000]
+            raise RuntimeError(f"file-tree find failed: {detail}")
+
+        entries = _parse_find_file_tree_entries(result.stdout, workspace)
+        return build_file_tree(entries)
 
     # ── file preview ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- replace the AICoding file-tree `os.walk` plus per-file `stat` scan with GNU `find`
- preserve the existing full-tree request contract and filtering behavior
- keep the `size` field while leaving it unset (`null`) to avoid NAS metadata lookups
- emit and parse NUL-delimited type/path pairs so whitespace and newlines in paths remain safe
- do not follow symlinks; expose symlinks as non-directory nodes

## Behavior

- `.git` and `node_modules` directories are pruned at every level
- root `skills` and `.repos` directories are pruned before traversal
- project-local `skills` and `.repos` remain visible
- directories remain sorted before files, then alphabetically

## Tests

- `142 passed, 1 warning`
- `git diff --check`
- Python `compileall`

The warning is the existing Starlette/httpx deprecation warning.
