### PR TITLE
fix(singlebox): prepare BaaS bots for local BCN

### DIFF
--- a/scripts/modules/all.sh
+++ b/scripts/modules/all.sh
@@ -7,8 +7,9 @@ _ALL_SH_LOADED=1
 # toolchain is NOT included here — use `install-tools` command separately.
 #
 # Full singlebox stack: BAAS/backend create the developer runtime, BCS runs
-# collaboration, bots starts the 5 local profiles, demo_bot onboards the
-# backend-created developer bot, then frontend exposes the workbench.
+# collaboration, bots starts the 5 local profiles, demo_bot starts the
+# backend-created developer bot, then frontend exposes the workbench. BCN
+# onboarding remains an explicit product action.
 SETUP_ORDER=(baas backend bcs bcsfuse bots frontend)
 START_ORDER=(baas backend bcs bcsfuse bots demo_bot frontend)
 STOP_ORDER=(frontend demo_bot bots bcsfuse bcs backend baas)

--- a/scripts/modules/baas.sh
+++ b/scripts/modules/baas.sh
@@ -149,6 +149,17 @@ baas_start() {
 
     cd "${BAAS_APP_DIR}"
 
+    # BaaS creates OpenClaw's per-bot config later, when a Bot is allocated.
+    # Build and resolve the BCN plugin before launching BaaS so that creation
+    # always writes channels.bcs and the plugin entry into that config.
+    setup_bcn_plugin || return 1
+    local bcn_plugin_path
+    bcn_plugin_path="$(bots_bcn_plugin_load_dir)" || return 1
+    if [ ! -f "${bcn_plugin_path}/dist/esm/index.js" ]; then
+        log_error "BCN plugin is not built at ${bcn_plugin_path}; cannot start BAAS"
+        return 1
+    fi
+
     # Start baas (singlebox mode)
     # app.sh internally includes health check, no external retry needed
     log_info "Starting BAAS with singlebox mode..."
@@ -193,8 +204,10 @@ baas_start() {
         CHAT_ENGINE="${CHAT_ENGINE}"
         LOCAL_AIDESKTOP_ROOT="${LOCAL_AIDESKTOP_DIR}"
         SINGLEBOX_MODEL_CONFIG_FILE="${SINGLEBOX_MODEL_CONFIG_FILE:-}"
+        BCN_PLUGIN_PATH="${bcn_plugin_path}"
+        BCS_PORT="${BCS_PORT}"
     )
-    log_info "BAAS env: DATABASE_URL=${DATABASE_URL}, CHAT_ENGINE=${CHAT_ENGINE}, LOCAL_AIDESKTOP_ROOT=${LOCAL_AIDESKTOP_DIR}"
+    log_info "BAAS env: DATABASE_URL=${DATABASE_URL}, CHAT_ENGINE=${CHAT_ENGINE}, LOCAL_AIDESKTOP_ROOT=${LOCAL_AIDESKTOP_DIR}, BCS_PORT=${BCS_PORT}, BCN_PLUGIN_PATH=${bcn_plugin_path}"
 
     if ! env "${baas_env_args[@]}" "${BAAS_APP_DIR}/scripts/app.sh" start --singlebox >> "${BAAS_LOG}" 2>&1; then
         log_error "Failed to start BAAS. Check logs at ${BAAS_LOG}"

--- a/scripts/modules/demo_bot.sh
+++ b/scripts/modules/demo_bot.sh
@@ -181,8 +181,9 @@ demo_bot_admin_onboard_bcs() {
     printf '%s\n' "$response" | jq -e '.onboarded == true' >/dev/null 2>&1
 }
 
-# Return 0 when the BCS entry is exact, 1 when it is missing or repairable by
-# admin onboard, and 2 for fatal transport, authentication, or contract errors.
+# Return 0 when the BCS entry is exact, 1 when it is missing or requires
+# product-side onboarding, and 2 for fatal transport, authentication, or
+# contract errors.
 demo_bot_verify_bcn() {
     local backend_bot_id="$1"
     local bcs_bot_id base_url response_file response http_status curl_rc actual_bot_id actual_name actual_summary
@@ -265,9 +266,8 @@ demo_bot_ensure_bcn() {
         return "$verify_rc"
     fi
 
-    log_info "Registering demo bot in local BCS: ${bcs_bot_id}"
-    demo_bot_admin_onboard_bcs "$backend_bot_id" || return 1
-    demo_bot_verify_bcn "$backend_bot_id"
+    log_warn "Demo bot is not onboarded in BCS yet: ${bcs_bot_id}. Use the product Onboard action after the BCN plugin connects."
+    return 1
 }
 
 demo_bot_start() {
@@ -303,19 +303,14 @@ demo_bot_start() {
         return 1
     fi
 
-    if ! demo_bot_ensure_bcn "$backend_bot_id"; then
-        log_error "Failed to verify demo bot in local BCS/BCN: $(demo_bot_bcs_bot_id "$backend_bot_id"). Check ${DEMO_BOT_LOG}"
-        return 1
-    fi
-
-    log_info "Singlebox demo bot ready: $(demo_bot_bcs_bot_id "$backend_bot_id")"
+    log_info "Singlebox demo bot started: $(demo_bot_bcs_bot_id "$backend_bot_id"). The BCN plugin will self-register; use the product Onboard action to complete network onboarding."
 }
 
 demo_bot_ready() {
     demo_bot_defaults
     local backend_bot_id
     backend_bot_id="$(demo_bot_find_existing)"
-    [ -n "$backend_bot_id" ] && demo_bot_verify_bcn "$backend_bot_id"
+    [ -n "$backend_bot_id" ] && demo_bot_wait_ready "$backend_bot_id"
 }
 
 demo_bot_prereqs() {
@@ -339,13 +334,13 @@ demo_bot_status() {
     demo_bot_defaults
     local backend_bot_id
     backend_bot_id="$(demo_bot_find_existing)"
-    if [ -n "$backend_bot_id" ] && demo_bot_verify_bcn "$backend_bot_id"; then
-        echo "  Demo Bot:  Ready ($(demo_bot_bcs_bot_id "$backend_bot_id"))"
+    if [ -n "$backend_bot_id" ]; then
+        echo "  Demo Bot:  Started ($(demo_bot_bcs_bot_id "$backend_bot_id"); onboarding is user-triggered)"
     else
         echo "  Demo Bot:  Not ready"
     fi
 }
 
 demo_bot_help() {
-    echo "demo_bot - backend-created mock demo bot onboarded to local BCS"
+    echo "demo_bot - backend-created mock demo bot; onboarding is triggered in the product"
 }

--- a/scripts/test_singlebox_demo_bot.sh
+++ b/scripts/test_singlebox_demo_bot.sh
@@ -455,7 +455,7 @@ test_ensure_skips_connect_when_already_visible() {
   demo_bot_ensure_bcn "default"
 }
 
-test_ensure_onboards_minimal_runtime_entry() {
+test_ensure_reports_missing_bot_without_auto_onboard() {
   setup_env
   # shellcheck source=/dev/null
   source "$MODULE"
@@ -463,53 +463,18 @@ test_ensure_onboards_minimal_runtime_entry() {
   : > "${DEMO_BOT_LOG}"
 
   sequence_file="$(mktemp)"
-  verify_count=0
   demo_bot_verify_bcn() {
-    verify_count=$((verify_count + 1))
     printf '%s\n' "verify" >> "$sequence_file"
-    if [ "$verify_count" -eq 1 ]; then
-      return 1
-    fi
-    return 0
-  }
-  demo_bot_connect_bcs() {
-    printf '%s\n' "connect:$1" >> "$sequence_file"
-  }
-  demo_bot_admin_onboard_bcs() {
-    printf '%s\n' "onboard:$1" >> "$sequence_file"
-  }
-
-  demo_bot_ensure_bcn "default"
-  assert_eq $'verify\nonboard:default\nverify' "$(cat "$sequence_file")" "minimal runtime entry should still onboard"
-}
-
-test_ensure_onboards_without_connect_when_bcs_entry_missing() {
-  setup_env
-  # shellcheck source=/dev/null
-  source "$MODULE"
-  demo_bot_defaults
-  : > "${DEMO_BOT_LOG}"
-
-  sequence_file="$(mktemp)"
-  verify_count=0
-  demo_bot_verify_bcn() {
-    verify_count=$((verify_count + 1))
-    printf '%s\n' "verify" >> "$sequence_file"
-    if [ "$verify_count" -eq 1 ]; then
-      return 1
-    fi
-    return 0
-  }
-  demo_bot_connect_bcs() {
-    printf '%s\n' "connect:$1" >> "$sequence_file"
     return 1
   }
-  demo_bot_admin_onboard_bcs() {
-    printf '%s\n' "onboard:$1" >> "$sequence_file"
-  }
 
-  demo_bot_ensure_bcn "default"
-  assert_eq $'verify\nonboard:default\nverify' "$(cat "$sequence_file")" "missing BCS entry should onboard without pre-connect"
+  if demo_bot_ensure_bcn "default"; then
+    fail "missing bot must remain pending for product-side onboarding"
+  else
+    rc=$?
+  fi
+  assert_eq "1" "$rc" "missing bot return code"
+  assert_eq "verify" "$(cat "$sequence_file")" "missing bot must not auto-onboard"
 }
 
 test_ensure_does_not_onboard_after_fatal_verification_error() {
@@ -536,31 +501,7 @@ test_ensure_does_not_onboard_after_fatal_verification_error() {
   assert_eq "verify" "$(cat "$sequence_file")" "fatal verification should not mutate BCS"
 }
 
-test_ensure_fails_when_metadata_is_still_wrong_after_onboard() {
-  setup_env
-  # shellcheck source=/dev/null
-  source "$MODULE"
-  demo_bot_defaults
-
-  sequence_file="$(mktemp)"
-  demo_bot_verify_bcn() {
-    printf '%s\n' "verify" >> "$sequence_file"
-    return 1
-  }
-  demo_bot_admin_onboard_bcs() {
-    printf '%s\n' "onboard:$1" >> "$sequence_file"
-  }
-
-  if demo_bot_ensure_bcn "default"; then
-    fail "ensure should fail when post-onboard metadata still mismatches"
-  else
-    rc=$?
-  fi
-  assert_eq "1" "$rc" "persistent metadata mismatch return code"
-  assert_eq $'verify\nonboard:default\nverify' "$(cat "$sequence_file")" "post-onboard verification sequence"
-}
-
-test_start_waits_for_backend_ready_before_bcn_onboard() {
+test_start_waits_for_backend_ready_without_auto_onboard() {
   setup_env
   # shellcheck source=/dev/null
   source "$MODULE"
@@ -574,20 +515,18 @@ test_start_waits_for_backend_ready_before_bcn_onboard() {
   demo_bot_wait_ready() {
     printf '%s\n' "wait:$1" >> "$sequence_file"
   }
-  demo_bot_ensure_bcn() {
-    printf '%s\n' "ensure:$1" >> "$sequence_file"
-  }
+  demo_bot_ensure_bcn() { fail "demo bot startup must not auto-onboard"; }
 
   demo_bot_start
-  assert_eq $'create\nwait:default\nensure:default' "$(cat "$sequence_file")" "demo bot start order"
+  assert_eq $'create\nwait:default' "$(cat "$sequence_file")" "demo bot start order"
 }
 
 test_all_order_includes_bots_and_demo_before_frontend() {
   setup_env
   # shellcheck source=/dev/null
   source "${ROOT}/scripts/modules/all.sh"
-  assert_eq "baas backend bcs bots demo_bot frontend" "${START_ORDER[*]}" "all start order"
-  assert_eq "frontend demo_bot bots bcs backend baas" "${STOP_ORDER[*]}" "all stop order"
+  assert_eq "baas backend bcs bcsfuse bots demo_bot frontend" "${START_ORDER[*]}" "all start order"
+  assert_eq "frontend demo_bot bots bcsfuse bcs backend baas" "${STOP_ORDER[*]}" "all stop order"
 }
 
 test_backend_ready_function_exists() {
@@ -618,11 +557,9 @@ test_verify_reports_missing_bot_as_repairable
 test_connect_posts_fixed_bcs_bot_id
 test_admin_onboard_posts_demo_metadata
 test_ensure_skips_connect_when_already_visible
-test_ensure_onboards_minimal_runtime_entry
-test_ensure_onboards_without_connect_when_bcs_entry_missing
+test_ensure_reports_missing_bot_without_auto_onboard
 test_ensure_does_not_onboard_after_fatal_verification_error
-test_ensure_fails_when_metadata_is_still_wrong_after_onboard
-test_start_waits_for_backend_ready_before_bcn_onboard
+test_start_waits_for_backend_ready_without_auto_onboard
 test_all_order_includes_bots_and_demo_before_frontend
 test_backend_ready_function_exists
 

--- a/scripts/test_singlebox_service_guards.sh
+++ b/scripts/test_singlebox_service_guards.sh
@@ -311,12 +311,17 @@ test_baas_start_refuses_root_bots_dir() (
   # shellcheck source=/dev/null
   source "${ROOT}/scripts/modules/baas.sh"
 
-  local events_file result
+  local events_file plugin_dir result
   events_file="$(mktemp)"
+  plugin_dir="$(mktemp -d)"
+  mkdir -p "${plugin_dir}/dist/esm"
+  : > "${plugin_dir}/dist/esm/index.js"
   stop_port_processes_if_owned() { return 0; }
   stop_matching_processes_if_owned() { return 0; }
   require_port_available_after_owned_stop() { return 0; }
   check_directory_exists() { return 0; }
+  setup_bcn_plugin() { return 0; }
+  bots_bcn_plugin_load_dir() { printf '%s\n' "$plugin_dir"; }
   baas_prepare_bcs_session_backup() { return 0; }
   baas_restore_bcs_sessions() { return 0; }
   rm() { printf 'rm %s\n' "$*" >> "$events_file"; }
@@ -331,6 +336,65 @@ test_baas_start_refuses_root_bots_dir() (
 
   [ "$result" -ne 0 ] || fail "baas_start should reject a root LOCAL_BOTS_DIR"
   [ ! -s "$events_file" ] || fail "baas_start must reject root before calling rm"
+)
+
+test_baas_start_passes_bcn_runtime_configuration() (
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  export LOCAL_AIDESKTOP_DIR="$(mktemp -d)"
+  export LOCAL_MODE=false
+  export CHAT_ENGINE="openclaw"
+  export BCS_PORT="21099"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  local plugin_dir captured_env sequence_file
+  plugin_dir="$(mktemp -d)"
+  mkdir -p "${plugin_dir}/dist/esm"
+  : > "${plugin_dir}/dist/esm/index.js"
+  captured_env="$(mktemp)"
+  sequence_file="$(mktemp)"
+
+  stop_port_processes_if_owned() { return 0; }
+  stop_matching_processes_if_owned() { return 0; }
+  require_port_available_after_owned_stop() { return 0; }
+  check_directory_exists() { return 0; }
+  setup_bcn_plugin() { printf '%s\n' "setup" >> "$sequence_file"; }
+  bots_bcn_plugin_load_dir() { printf '%s\n' "resolve" >> "$sequence_file"; printf '%s\n' "$plugin_dir"; }
+  env() { printf '%s\n' "start" >> "$sequence_file"; printf '%s\n' "$*" > "$captured_env"; return 0; }
+
+  baas_start
+
+  grep -F "BCN_PLUGIN_PATH=${plugin_dir}" "$captured_env" >/dev/null || \
+    fail "baas_start must pass the built BCN plugin path to BAAS"
+  grep -F "BCS_PORT=21099" "$captured_env" >/dev/null || \
+    fail "baas_start must pass the selected BCS port to BAAS"
+  assert_eq $'setup\nresolve\nstart' "$(cat "$sequence_file")" \
+    "baas_start must prepare the BCN plugin before launching BAAS"
+)
+
+test_baas_start_aborts_when_bcn_plugin_setup_fails() (
+  setup_env
+  export RUNTIME_DATA_DIR="$(mktemp -d)"
+  export LOCAL_AIDESKTOP_DIR="$(mktemp -d)"
+  export LOCAL_MODE=false
+  export CHAT_ENGINE="openclaw"
+  export BCS_PORT="21000"
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/modules/baas.sh"
+
+  local started=false
+  stop_port_processes_if_owned() { return 0; }
+  stop_matching_processes_if_owned() { return 0; }
+  require_port_available_after_owned_stop() { return 0; }
+  check_directory_exists() { return 0; }
+  setup_bcn_plugin() { return 1; }
+  env() { started=true; return 0; }
+
+  if baas_start; then
+    fail "baas_start must fail when BCN plugin setup fails"
+  fi
+  [ "$started" = false ] || fail "BAAS must not launch after BCN plugin setup failure"
 )
 
 test_5bot_openclaw_config_is_written_private() {
@@ -386,6 +450,8 @@ test_baas_session_backup_refuses_to_overwrite_stale_backup
 test_baas_session_backup_recovers_stale_backup_before_snapshot
 test_baas_session_scan_failure_keeps_source_and_backup
 test_baas_start_refuses_root_bots_dir
+test_baas_start_passes_bcn_runtime_configuration
+test_baas_start_aborts_when_bcn_plugin_setup_fails
 test_5bot_openclaw_config_is_written_private
 test_ready_banner_describes_full_stack
 test_backend_separates_profile_env_and_workspace_folder

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -467,11 +467,10 @@ class LocalProcessManager:
         hermes_port = 0
 
         try:
-            # Step 1: Write credentials BEFORE spawning openclaw.
-            # The BCN plugin reads ~/.credentials on startup to determine
-            # bot_id for BCS connection. If this file doesn't exist when
-            # openclaw starts, the plugin sends bot_id=none and BCS
-            # assigns a random bot_uuid that won't match the onboard call.
+            # Step 1: Write runtime credentials before spawning OpenClaw.
+            # BCS identity is deliberately not derived from these credentials:
+            # create_openclaw_config() writes the per-bot channels.bcs.botId
+            # before this process is started.
             self._write_credentials(
                 device_id=device_id,
                 bot_id=bot_id,
@@ -992,11 +991,9 @@ class LocalProcessManager:
         credentials_path.write_text(content)
         credentials_path.chmod(0o600)
 
-        # Also write ~/.credentials so the BCN plugin (openclaw-channel-bcn)
-        # can discover the bot_id. The plugin hardcodes ~/.credentials and does
-        # not read CREDENTIALS_PATH. Without this, the plugin sends
-        # bot_id=none, BCS assigns a random bot_uuid, and onboard fails with
-        # "Bot 未在协作网络注册" because the bot_uuid doesn't match.
+        # Retain the production-compatible home credential location for
+        # runtime tools. BCN identity comes from channels.bcs.botId in the
+        # per-bot OpenClaw configuration, not from this shared file.
         home_credentials = Path.home() / ".credentials"
         home_credentials.write_text(content)
         home_credentials.chmod(0o600)

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -1103,8 +1103,18 @@ class LocalProcessManager:
     def _resolve_engine_python(engine_src_dir: Path) -> str:
         """Resolve the Python executable for the engine adapter.
 
-        Prefers the engine's own venv, falls back to current interpreter.
+        Prefers an explicitly configured interpreter, then the engine's own
+        venv, and finally the current interpreter.
         """
+        configured = os.environ.get("LOCAL_ENGINE_PYTHON")
+        if configured:
+            candidate = Path(configured).expanduser()
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+            raise DeviceAllocateError(
+                f"Configured LOCAL_ENGINE_PYTHON is not executable: {candidate}"
+            )
+
         engine_venv = engine_src_dir.parent / ".venv" / "bin" / "python"
         if engine_venv.exists():
             return str(engine_venv)

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -1105,7 +1105,7 @@ class LocalProcessManager:
         """
         configured = os.environ.get("LOCAL_ENGINE_PYTHON")
         if configured:
-            candidate = Path(configured).expanduser()
+            candidate = Path(configured).expanduser().resolve()
             if candidate.is_file() and os.access(candidate, os.X_OK):
                 return str(candidate)
             raise DeviceAllocateError(

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
@@ -1266,6 +1266,23 @@ class TestResolveConfigTemplatePath:
 
 
 class TestResolveEnginePython:
+    def test_resolve_engine_python_normalizes_relative_configured_override(
+        self, monkeypatch, tmp_path
+    ):
+        """A configured relative interpreter is returned as an absolute path."""
+        engine_src_dir = tmp_path / "engine" / "src"
+        engine_src_dir.mkdir(parents=True)
+        configured_python = tmp_path / "runtime" / "bin" / "python"
+        configured_python.parent.mkdir(parents=True)
+        configured_python.touch()
+        configured_python.chmod(configured_python.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LOCAL_ENGINE_PYTHON", "runtime/bin/python")
+
+        result = pm.LocalProcessManager._resolve_engine_python(engine_src_dir)
+
+        assert result == str(configured_python)
+
     def test_resolve_engine_python_uses_configured_override(self, monkeypatch, tmp_path):
         """Configured LOCAL_ENGINE_PYTHON takes precedence over a colocated venv."""
         engine_src_dir = tmp_path / "engine" / "src"

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
@@ -52,6 +52,7 @@ def _clean_env(monkeypatch):
         "BCS_PORT",
         "LOCAL_HERMES_DIR",
         "LOCAL_ENGINE_SRC_DIR",
+        "LOCAL_ENGINE_PYTHON",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -1265,6 +1266,46 @@ class TestResolveConfigTemplatePath:
 
 
 class TestResolveEnginePython:
+    def test_resolve_engine_python_uses_configured_override(self, monkeypatch, tmp_path):
+        """Configured LOCAL_ENGINE_PYTHON takes precedence over a colocated venv."""
+        engine_src_dir = tmp_path / "engine" / "src"
+        engine_src_dir.mkdir(parents=True)
+        configured_python = tmp_path / "runtime" / "bin" / "python"
+        configured_python.parent.mkdir(parents=True)
+        configured_python.touch()
+        configured_python.chmod(configured_python.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setenv("LOCAL_ENGINE_PYTHON", str(configured_python))
+
+        result = pm.LocalProcessManager._resolve_engine_python(engine_src_dir)
+
+        assert result == str(configured_python)
+
+    def test_resolve_engine_python_rejects_missing_configured_override(
+        self, monkeypatch, tmp_path
+    ):
+        """A configured but missing LOCAL_ENGINE_PYTHON fails clearly."""
+        engine_src_dir = tmp_path / "engine" / "src"
+        engine_src_dir.mkdir(parents=True)
+        missing_python = tmp_path / "missing" / "bin" / "python"
+        monkeypatch.setenv("LOCAL_ENGINE_PYTHON", str(missing_python))
+
+        with pytest.raises(DeviceAllocateError, match="LOCAL_ENGINE_PYTHON"):
+            pm.LocalProcessManager._resolve_engine_python(engine_src_dir)
+
+    def test_resolve_engine_python_rejects_non_executable_override(
+        self, monkeypatch, tmp_path
+    ):
+        """A configured interpreter must be executable."""
+        engine_src_dir = tmp_path / "engine" / "src"
+        engine_src_dir.mkdir(parents=True)
+        non_executable = tmp_path / "runtime" / "bin" / "python"
+        non_executable.parent.mkdir(parents=True)
+        non_executable.touch()
+        monkeypatch.setenv("LOCAL_ENGINE_PYTHON", str(non_executable))
+
+        with pytest.raises(DeviceAllocateError, match="not executable"):
+            pm.LocalProcessManager._resolve_engine_python(engine_src_dir)
+
     def test_resolve_engine_python_venv(self, tmp_path):
         """When venv exists, returns venv python."""
         engine_src_dir = tmp_path / "engine" / "src"

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
@@ -75,7 +75,16 @@ class SingleboxBaasDeviceService(BaasDeviceService):
 
     @staticmethod
     def _is_loopback_target(target: str) -> bool:
-        host = urlsplit(f"//{target}").hostname
+        if not target:
+            return False
+        try:
+            host = urlsplit(f"//{target}").hostname
+        except ValueError:
+            host = None
+        if host is None and target.count(":") >= 2:
+            host = target.rsplit(":", 1)[0]
+            if host.startswith("[") and host.endswith("]"):
+                host = host[1:-1]
         return host in {"localhost", "127.0.0.1", "::1"}
 
     def get_device_connection(

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
@@ -2,13 +2,28 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import cast  # noqa: UP035 - injector binding key matches provider side
+from urllib.parse import urlsplit
 
 from injector import Binder, Module, inject, provider, singleton
 
+from agentclaw.community.core.bot_management.services.bot_service import BotService
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
-from agentclaw.community.core.devices.protocols import BotQueryProtocol
-from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.core.bot_management.token_vault import TokenVault
+from agentclaw.community.core.devices.models import (
+    DeviceConnectionInfo,
+    OperatorContext,
+)
+from agentclaw.community.core.devices.protocols import (
+    BotQueryProtocol,
+    BotSyncProtocol,
+    McpSyncProtocol,
+)
+from agentclaw.community.core.devices.repository.protocol import (
+    DeviceBindingRepository,
+    OssToNasRecordRepository,
+)
 from agentclaw.community.core.devices.services.arca_bot_create_baas_rollout_policy import (
     ArcaBotCreateBaasRolloutDecision,
     ArcaBotCreateBaasRolloutPolicy,
@@ -19,16 +34,25 @@ from agentclaw.community.core.devices.services.baas_device_accessor import (
 from agentclaw.community.core.devices.services.baas_device_service import (
     BaasDeviceService,
 )
+from agentclaw.community.core.devices.services.baas_template_resolver import (
+    SystemConfigBaasTemplateResolver,
+)
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
 from agentclaw.community.core.devices.services.device_service import (
     BAAS_DEVICE_PROVIDER,
+    LOCAL_DEVICE_PROVIDER,
     DeviceService,
 )
 from agentclaw.community.core.devices.services.device_service_router import (
     DeviceServiceRouter,
 )
 from agentclaw.community.core.notify.protocol import NotifyBotLister
+from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
+from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.system_config import SystemConfigService
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
 from agentclaw.community.di import config as cfg
 from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
     BotPublishRepositoryProtocol,
@@ -44,6 +68,40 @@ from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
 from agentclaw.community.di.modules.infrastructure.singlebox.template_config import (
     SingleboxBaasTemplateConfigLifecycle,
 )
+
+
+class SingleboxBaasDeviceService(BaasDeviceService):
+    """Project loopback BaaS connections onto the frontend local transport."""
+
+    @staticmethod
+    def _is_loopback_target(target: str) -> bool:
+        host = urlsplit(f"//{target}").hostname
+        return host in {"localhost", "127.0.0.1", "::1"}
+
+    def get_device_connection(
+        self,
+        *,
+        binding_id: int,
+        operator: OperatorContext,
+        port: int | None = None,
+        ttl: int | None = None,
+        device_uuid: str | None = None,
+        ws_conn_mode: str | None = None,
+    ) -> DeviceConnectionInfo:
+        connection = super().get_device_connection(
+            binding_id=binding_id,
+            operator=operator,
+            port=port,
+            ttl=ttl,
+            device_uuid=device_uuid,
+            ws_conn_mode=ws_conn_mode,
+        )
+        if (
+            connection.type == BAAS_DEVICE_PROVIDER
+            and self._is_loopback_target(connection.target)
+        ):
+            return replace(connection, type=LOCAL_DEVICE_PROVIDER)
+        return connection
 
 
 class _SingleboxAllBaasRolloutPolicy(ArcaBotCreateBaasRolloutPolicy):
@@ -99,6 +157,34 @@ class SingleboxDevicesModule(Module):
     def device_accessor(self, accessor: BaasDeviceAccessor) -> DeviceAccessor:
         """Expose the concrete singleton through the device-access boundary."""
         return accessor
+
+    @singleton
+    @provider
+    @inject
+    def baas_device_service(
+        self,
+        repository: DeviceBindingRepository,
+        baas_service: BaasService,
+        system_config_service: SystemConfigService,
+        oss_record_repo: OssToNasRecordRepository,
+        bot_repository: BotRepository,
+        bot_service: BotService,
+        mcp_sync_service: MCPSyncService,
+        token_vault: TokenVault,
+        task_queue_service: TaskQueueService,
+    ) -> BaasDeviceService:
+        """Keep BaaS lifecycle wiring while projecting local engine connections."""
+        return SingleboxBaasDeviceService(
+            repository=repository,
+            baas_service=baas_service,
+            bot_query=cast(BotQueryProtocol, bot_repository),
+            bot_sync=cast(BotSyncProtocol, bot_service),
+            oss_record_repo=oss_record_repo,
+            mcp_sync=cast(McpSyncProtocol, mcp_sync_service),
+            template_resolver=SystemConfigBaasTemplateResolver(system_config_service),
+            vault=token_vault,
+            task_queue_service=task_queue_service,
+        )
 
     @singleton
     @provider

--- a/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
+++ b/src/backend/tests/community/acceptance/devices/test_device_query_lifecycle.py
@@ -180,7 +180,7 @@ def test_device_live_baas_provider_lifecycle(live_backend):
             client.get(f"/api/v1/devices/{binding_id}/connection")
         )["data"]
         assert connection["available"] is True
-        assert connection["type"] == "remote"
+        assert connection["type"] == "local"
         assert connection["target"]
         assert connection["token"]
 

--- a/src/backend/tests/community/di/test_profile_and_modules_for.py
+++ b/src/backend/tests/community/di/test_profile_and_modules_for.py
@@ -33,6 +33,9 @@ from agentclaw.community.di.modules.http_client_module import HttpClientModule
 from agentclaw.community.di.modules.infrastructure.test.http_client import (
     TestHttpClientModule,
 )
+from agentclaw.community.di.modules.infrastructure.singlebox.devices import (
+    SingleboxBaasDeviceService,
+)
 from agentclaw.community.di.profile import DeployProfile, validate_deploy_environment
 from agentclaw.community.di.profile_modules import modules_for
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
@@ -217,6 +220,7 @@ def test_singlebox_profile_resolves_baas_only_device_runtime():
     assert isinstance(service, DeviceServiceRouter)
     assert set(service._providers) == {"baas"}
     assert isinstance(service._providers["baas"], BaasDeviceService)
+    assert isinstance(service._providers["baas"], SingleboxBaasDeviceService)
     assert injector.get(DeviceAccessor) is baas_device_accessor
     participant_names = {
         type(participant).__name__

--- a/src/backend/tests/community/di/test_singlebox_devices.py
+++ b/src/backend/tests/community/di/test_singlebox_devices.py
@@ -64,6 +64,10 @@ def test_singlebox_projects_loopback_baas_connection_as_local() -> None:
     assert connection.token == "connection-token"
 
 
+def test_singlebox_recognizes_unbracketed_ipv6_loopback_with_port() -> None:
+    assert SingleboxBaasDeviceService._is_loopback_target("::1:20010") is True
+
+
 def test_singlebox_keeps_non_loopback_connection_as_baas() -> None:
     service = _service(target="engine.example.test:20010")
 

--- a/src/backend/tests/community/di/test_singlebox_devices.py
+++ b/src/backend/tests/community/di/test_singlebox_devices.py
@@ -1,0 +1,72 @@
+"""Singlebox device-connection projection tests."""
+
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.devices.models import OperatorContext
+from agentclaw.community.core.devices.services.baas_template_resolver import (
+    BaasTemplateResolution,
+)
+from agentclaw.community.di.modules.infrastructure.singlebox.devices import (
+    SingleboxBaasDeviceService,
+)
+
+
+def _operator() -> OperatorContext:
+    return OperatorContext(
+        staff_id="u001",
+        staff="u001",
+        nick_name="User",
+        operator_name="User",
+    )
+
+
+def _service(*, target: str) -> SingleboxBaasDeviceService:
+    baas = MagicMock()
+    baas._baas_api_base = "http://baas.local"
+    baas.get_ws_info.return_value = MagicMock(
+        target=target,
+        token="connection-token",
+        baas_base_url="http://baas.local",
+        bot_uuid="BOT-1",
+        tenant="team_claw",
+        engine_port=20010,
+    )
+    bot_query = MagicMock()
+    bot_query.get_by_binding_id.return_value = {
+        "bot_id": "bot-1",
+        "bot_type": "personal",
+        "active_engine": "openclaw",
+    }
+    template_resolver = MagicMock()
+    template_resolver.resolve_template.return_value = BaasTemplateResolution(
+        template_uid="default_template",
+        template_uuid="TEMPLATE-test",
+        source="test",
+    )
+    return SingleboxBaasDeviceService(
+        repository=MagicMock(),
+        baas_service=baas,
+        bot_query=bot_query,
+        bot_sync=MagicMock(),
+        oss_record_repo=MagicMock(),
+        mcp_sync=MagicMock(),
+        template_resolver=template_resolver,
+    )
+
+
+def test_singlebox_projects_loopback_baas_connection_as_local() -> None:
+    service = _service(target="localhost:20010")
+
+    connection = service.get_device_connection(binding_id=7, operator=_operator())
+
+    assert connection.type == "local"
+    assert connection.target == "localhost:20010"
+    assert connection.token == "connection-token"
+
+
+def test_singlebox_keeps_non_loopback_connection_as_baas() -> None:
+    service = _service(target="engine.example.test:20010")
+
+    connection = service.get_device_connection(binding_id=7, operator=_operator())
+
+    assert connection.type == "baas"


### PR DESCRIPTION
## Summary

Prepare the singlebox BaaS runtime before default-bot allocation so its OpenClaw configuration can load the BCN plugin and connect directly to local BCS.

## Changes

- Treat loopback BaaS device endpoints as local transport.
- Build and resolve the BCN plugin before starting BaaS, then pass the plugin path and BCS port to per-bot configuration generation.
- Preserve BCS session state across local BaaS cleanup and add regression coverage for the singlebox startup sequence.

## Validation

- `scripts/test_baas_module.sh`
- `pytest tests/community/di/test_singlebox_devices.py tests/community/di/test_profile_and_modules_for.py tests/community/plugins/local/test_process_manager.py -q` (29 passed)