### PR TITLE
fix(bcn): finalize queued replies from agent events

### DIFF
--- a/src/bcs/crates/plugins/openclaw-channel-bcn/README.md
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/README.md
@@ -48,7 +48,7 @@ Select with the flag or env var (flag wins):
 BCN_PLUGIN_SOURCE=npm ./scripts/singlebox.sh
 
 # pin a version in npm mode (default: latest)
-BCN_PLUGIN_SOURCE=npm BCN_PLUGIN_VERSION=1.0.16 ./scripts/singlebox.sh
+BCN_PLUGIN_SOURCE=npm BCN_PLUGIN_VERSION=1.0.18 ./scripts/singlebox.sh
 ```
 
 ## Configure

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/package.json
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avernet-plugin/openclaw-channel-bcn",
-  "version": "1.0.16",
+  "version": "1.0.18",
   "description": "Installable OpenClaw BCS WebSocket channel plugin package.",
   "dependencies": {
     "ws": "^8.18.3"

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -43,6 +43,7 @@ const MAX_IMAGE_ATTACHMENTS = 5;
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 const IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
 const IMAGE_READ_IDLE_TIMEOUT_MS = 10_000;
+const RUN_TERMINAL_TIMEOUT_MS = 15 * 60 * 1000;
 
 /** Extract sender name from [from:botName] prefix. Returns stripped text and sender name. */
 function extractFromPrefix(raw: string): { senderName: string; text: string } {
@@ -62,11 +63,17 @@ type RunContext = {
   groupId: string;
   client: BcsWsClient;
   sessionKey?: string;
+  agentRunId?: string;
   finalSent?: boolean;
+  preparedImages?: PreparedImage[];
+  terminalTimer?: ReturnType<typeof setTimeout>;
 };
 
 /** Run context for agent event routing: run_id -> context used for BCS event emission. */
 const runContexts = new Map<string, RunContext>();
+
+/** Actual OpenClaw agent run ID -> BCS-visible run ID. */
+const bcsRunIdByAgentRunId = new Map<string, string>();
 
 interface VisibleReplyState {
   text: string;
@@ -329,6 +336,88 @@ async function cleanupPreparedImages(images: PreparedImage[]): Promise<void> {
   await Promise.all(images.map(async image => {
     await rm(image.path, { force: true }).catch(() => undefined);
   }));
+}
+
+function bindAgentRun(
+  runId: string,
+  agentRunId: string,
+  log?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void },
+): boolean {
+  const context = runContexts.get(runId);
+  if (!context) return false;
+
+  const existingRunId = bcsRunIdByAgentRunId.get(agentRunId);
+  if (existingRunId && existingRunId !== runId) {
+    log?.warn?.(`[BCS] Refusing to remap agent run_id=${agentRunId} from BCS run_id=${existingRunId} to run_id=${runId}`);
+    return false;
+  }
+  if (context.agentRunId && context.agentRunId !== agentRunId) {
+    log?.warn?.(`[BCS] Refusing to replace agent run_id=${context.agentRunId} for BCS run_id=${runId} with run_id=${agentRunId}`);
+    return false;
+  }
+
+  context.agentRunId = agentRunId;
+  bcsRunIdByAgentRunId.set(agentRunId, runId);
+  if (context.sessionKey) {
+    activeRunIdForSession.set(context.sessionKey, runId);
+  }
+  if (agentRunId !== runId) {
+    log?.info?.(`[BCS] Bound OpenClaw agent run_id=${agentRunId} to BCS run_id=${runId}`);
+  }
+  return true;
+}
+
+function cleanupRunContext(
+  runId: string,
+  log?: { info: (...args: unknown[]) => void },
+): void {
+  const context = runContexts.get(runId);
+  if (!context) return;
+
+  if (context.terminalTimer) {
+    clearTimeout(context.terminalTimer);
+  }
+  activeStreams.delete(runId);
+  runContexts.delete(runId);
+  visibleReplyByRunId.delete(runId);
+  pendingRouteByRunId.delete(runId);
+
+  if (context.agentRunId && bcsRunIdByAgentRunId.get(context.agentRunId) === runId) {
+    bcsRunIdByAgentRunId.delete(context.agentRunId);
+  }
+  if (context.sessionKey && activeRunIdForSession.get(context.sessionKey) === runId) {
+    activeRunIdForSession.delete(context.sessionKey);
+    pendingRouteBySessionKey.delete(context.sessionKey);
+  }
+
+  const preparedImages = context.preparedImages ?? [];
+  context.preparedImages = [];
+  if (preparedImages.length > 0) {
+    void cleanupPreparedImages(preparedImages).then(() => {
+      log?.info?.(`[BCS] Cleaned ${preparedImages.length} prepared image(s) for run_id=${runId}`);
+    });
+  }
+}
+
+function armRunTerminalTimeout(
+  runId: string,
+  log?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void },
+): void {
+  const context = runContexts.get(runId);
+  if (!context) return;
+
+  const timer = setTimeout(() => {
+    if (!runContexts.has(runId)) return;
+    sendRunErrorOnce(
+      runId,
+      'Agent response timed out before completion.',
+      log,
+      `terminal lifecycle timeout after ${RUN_TERMINAL_TIMEOUT_MS}ms`,
+    );
+    cleanupRunContext(runId, log);
+  }, RUN_TERMINAL_TIMEOUT_MS);
+  timer.unref?.();
+  context.terminalTimer = timer;
 }
 
 function validateImageUrl(attachment: Attachment): void {
@@ -653,6 +742,7 @@ function sendFinalVisibleReplyOnce(
   options?: {
     source?: string;
     deliveredText?: string;
+    allowDeliveredTextFallback?: boolean;
     finalDeliveredPartsCount?: number;
     noReplyDetail?: string;
   },
@@ -661,10 +751,15 @@ function sendFinalVisibleReplyOnce(
   if (!context || context.finalSent) return false;
 
   const visibleText = finishVisibleReply(runId, log);
-  const combinedText = visibleText ?? NO_REPLY_TEXT;
+  const deliveredText = options?.allowDeliveredTextFallback
+    ? options.deliveredText?.trim() || undefined
+    : undefined;
+  const combinedText = visibleText ?? deliveredText ?? NO_REPLY_TEXT;
 
-  if (!visibleText) {
+  if (!visibleText && !deliveredText) {
     log?.warn?.(`[BCS] No assistant agent text for run_id=${runId}, sending ${NO_REPLY_TEXT} final${options?.noReplyDetail ? ` ${options.noReplyDetail}` : ''}`);
+  } else if (!visibleText && deliveredText) {
+    log?.info?.(`[BCS] Using dispatcher final for non-agent run_id=${runId}`);
   } else if (options?.deliveredText && options.deliveredText !== visibleText) {
     log?.warn?.(`[BCS] Agent-event final differs from dispatcher deliver buffer for run_id=${runId}; using agent-event text`);
   } else if ((options?.finalDeliveredPartsCount ?? 0) > 1) {
@@ -683,6 +778,26 @@ function sendFinalVisibleReplyOnce(
     log?.info?.(`[BCS] Sent chat.event final for run_id=${runId}${source}`);
   }
 
+  return true;
+}
+
+function sendRunErrorOnce(
+  runId: string,
+  userMessage: string,
+  log?: { warn: (...args: unknown[]) => void },
+  detail?: string,
+): boolean {
+  const context = runContexts.get(runId);
+  if (!context || context.finalSent) return false;
+
+  const errorPayload = buildChatEventPayload(runId, context.groupId, 'error', userMessage);
+  context.client.sendEvent(
+    'chat.event',
+    errorPayload as unknown as Record<string, unknown>,
+    nextSeq(context.client),
+  );
+  context.finalSent = true;
+  log?.warn?.(`[BCS] Sent chat.event error for run_id=${runId}${detail ? ` (${detail})` : ''}`);
   return true;
 }
 
@@ -744,6 +859,7 @@ export async function handleChatSend(
   // Track run context for agent event routing
   runContexts.set(runId, { groupId: bcsGroupId, client });
   ensureVisibleReplyState(runId);
+  armRunTerminalTimeout(runId, log);
 
   try {
     const rt = getBcsRuntime();
@@ -753,6 +869,10 @@ export async function handleChatSend(
       abortSignal: abortController.signal,
       runtime: rt,
     });
+    const preparedImageContext = runContexts.get(runId);
+    if (preparedImageContext) {
+      preparedImageContext.preparedImages = preparedImages;
+    }
 
     // Resolve agent route to find the correct agent for this session
     const route = rt.channel.routing.resolveAgentRoute({
@@ -784,9 +904,6 @@ export async function handleChatSend(
     if (sessionContext?.routing_mode) {
       sessionRoutingMode.set(route.sessionKey, sessionContext.routing_mode);
     }
-
-    // 9.4: Map sessionKey → runId so bcs_route tool can find the active run
-    activeRunIdForSession.set(route.sessionKey, runId);
 
     // Build inbound context using SDK's finalizeInboundContext
     // Use bcsGroupId for To/OriginatingTo so agent's outbound messages route correctly
@@ -890,24 +1007,42 @@ export async function handleChatSend(
         abortSignal: abortController.signal,
         disableBlockStreaming: false,
         sourceReplyDeliveryMode: 'automatic',
+        onAgentRunStart: (agentRunId: string) => {
+          bindAgentRun(runId, agentRunId, log);
+        },
       },
     });
 
-    // After dispatch completes, send one combined final chat.event
-    if (!abortController.signal.aborted) {
-      const combinedFinalText = combineDeliveredReplyParts(finalDeliveredParts);
-      const combinedBlockText = combineDeliveredReplyParts(blockDeliveredParts);
-      const deliveredText = combinedFinalText ?? combinedBlockText;
-      const sent = sendFinalVisibleReplyOnce(runId, log, {
-        source: 'dispatcher',
-        deliveredText,
-        finalDeliveredPartsCount: finalDeliveredParts.length,
-        noReplyDetail: `(block deliver parts=${blockDeliveredParts.length}, final deliver parts=${finalDeliveredParts.length})`,
-      });
-      if (!sent) {
-        log?.info?.(`[BCS] Skipped duplicate chat.event final for run_id=${runId} (source=dispatcher)`);
-      }
+    const settledContext = runContexts.get(runId);
+    if (!settledContext) {
+      await cleanupPreparedImages(preparedImages);
+      log?.info?.(`[BCS] Dispatcher settled after terminal lifecycle for run_id=${runId}`);
+      return;
     }
+    if (abortController.signal.aborted) {
+      cleanupRunContext(runId, log);
+      await cleanupPreparedImages(preparedImages);
+      return;
+    }
+
+    const combinedFinalText = combineDeliveredReplyParts(finalDeliveredParts);
+    if (!settledContext.agentRunId && combinedFinalText) {
+      sendFinalVisibleReplyOnce(runId, log, {
+        source: 'dispatcher_non_agent',
+        deliveredText: combinedFinalText,
+        allowDeliveredTextFallback: true,
+        finalDeliveredPartsCount: finalDeliveredParts.length,
+      });
+      cleanupRunContext(runId, log);
+      await cleanupPreparedImages(preparedImages);
+      return;
+    }
+
+    log?.info?.(
+      settledContext.agentRunId
+        ? `[BCS] Dispatcher settled for run_id=${runId}; waiting for terminal lifecycle from agent run_id=${settledContext.agentRunId}`
+        : `[BCS] Dispatcher settled without an agent start for run_id=${runId}; retaining context for a queued agent run (block deliver parts=${blockDeliveredParts.length}, final deliver parts=${finalDeliveredParts.length})`,
+    );
   } catch (err: any) {
     const imageError = err instanceof InboundImageError ? err : undefined;
     if (imageError) {
@@ -924,35 +1059,18 @@ export async function handleChatSend(
       }
     }
 
-    if (runContexts.get(runId)?.finalSent) {
+    if (!runContexts.has(runId) || runContexts.get(runId)?.finalSent) {
       log?.warn?.(`[BCS] Dispatcher failed after final was already sent for run_id=${runId}; suppressing duplicate error event`);
     } else {
-      // Send error event to BCS
-      const errorPayload: ChatEventPayload = {
-        run_id: runId,
-        bcs_group_id: bcsGroupId,
-        state: 'error',
-        message: {
-          role: 'assistant',
-          content: [{
-            type: 'text',
-            text: imageError?.userMessage ?? 'An error occurred while processing your message.',
-          }],
-          timestamp: Date.now(),
-        },
-      };
-      client.sendEvent('chat.event', errorPayload as unknown as Record<string, unknown>, nextSeq(client));
+      sendRunErrorOnce(
+        runId,
+        imageError?.userMessage ?? 'An error occurred while processing your message.',
+        log,
+        'dispatcher failure',
+      );
     }
-  } finally {
+    cleanupRunContext(runId, log);
     await cleanupPreparedImages(preparedImages);
-    activeStreams.delete(runId);
-    runContexts.delete(runId);
-    visibleReplyByRunId.delete(runId);
-    pendingRouteByRunId.delete(runId);
-    // Clean up sessionKey → runId mapping (find by value)
-    for (const [ sk, rid ] of activeRunIdForSession) {
-      if (rid === runId) { activeRunIdForSession.delete(sk); break; }
-    }
   }
 }
 
@@ -1581,8 +1699,12 @@ export function abortAllStreams(): void {
   for (const controller of activeStreams.values()) {
     controller.abort();
   }
+  for (const runId of [ ...runContexts.keys() ]) {
+    cleanupRunContext(runId);
+  }
   activeStreams.clear();
   runContexts.clear();
+  bcsRunIdByAgentRunId.clear();
   visibleReplyByRunId.clear();
   pendingRouteByRunId.clear();
   pendingRouteBySessionKey.clear();
@@ -1926,8 +2048,19 @@ const TERMINAL_LIFECYCLE_VALUES = new Set([
   'succeeded',
 ]);
 
-function isTerminalLifecycleEvent(evt: SdkAgentEventPayload): boolean {
-  if (evt.stream !== 'lifecycle') return false;
+const ERROR_LIFECYCLE_VALUES = new Set([
+  'abort',
+  'aborted',
+  'cancel',
+  'cancelled',
+  'canceled',
+  'error',
+  'fail',
+  'failed',
+]);
+
+function terminalLifecycleOutcome(evt: SdkAgentEventPayload): 'final' | 'error' | undefined {
+  if (evt.stream !== 'lifecycle') return undefined;
 
   const value =
     stringField(evt.data, 'phase') ??
@@ -1935,7 +2068,11 @@ function isTerminalLifecycleEvent(evt: SdkAgentEventPayload): boolean {
     stringField(evt.data, 'state') ??
     stringField(evt.data, 'type');
 
-  return value ? TERMINAL_LIFECYCLE_VALUES.has(value.toLowerCase()) : false;
+  if (!value) return undefined;
+  const normalized = value.toLowerCase();
+  if (TERMINAL_LIFECYCLE_VALUES.has(normalized)) return 'final';
+  if (ERROR_LIFECYCLE_VALUES.has(normalized)) return 'error';
+  return undefined;
 }
 
 /** Unsubscribe function for agent events */
@@ -1956,30 +2093,29 @@ export function initAgentEventsSubscription(log?: {
   agentEventUnsubscribe = rt.events.onAgentEvent((evt: SdkAgentEventPayload) => {
     // log?.debug?.(`[BCS] onAgentEvent RAW: runId=${evt.runId}, stream=${evt.stream}, seq=${evt.seq}`);
 
-    // Find the run context to get the BCS group ID and client
-    let context = runContexts.get(evt.runId);
-    let resolvedRunId = evt.runId;
-
-    // Fallback: SDK followup runs generate new runId; look up via sessionKey
-    // to find the original runId that corresponds to the user's chat.send
-    if (!context && evt.sessionKey) {
-      const ourRunId = activeRunIdForSession.get(evt.sessionKey);
-      if (ourRunId) {
-        context = runContexts.get(ourRunId);
-        if (context) {
-          log?.info?.(`[BCS] onAgentEvent: mapped SDK runId=${evt.runId} → our runId=${ourRunId} via sessionKey=${evt.sessionKey}`);
-          resolvedRunId = ourRunId;
-        }
-      }
+    // onAgentRunStart binds queued OpenClaw run IDs to the BCS-visible run ID.
+    // Direct runs normally keep the requested ID and can be bound lazily here.
+    const resolvedRunId = runContexts.has(evt.runId)
+      ? evt.runId
+      : bcsRunIdByAgentRunId.get(evt.runId);
+    if (resolvedRunId && evt.runId === resolvedRunId) {
+      bindAgentRun(resolvedRunId, evt.runId, log);
     }
+    const context = resolvedRunId ? runContexts.get(resolvedRunId) : undefined;
 
-    if (!context) {
+    if (!resolvedRunId || !context) {
       // This event is not for a BCS-managed run, skip it
       log?.warn?.(`[BCS] No run context for runId=${evt.runId}, skipping`);
       return true; // Indicate event was handled (skipped)
     }
 
+    if (context.sessionKey && evt.sessionKey && context.sessionKey !== evt.sessionKey) {
+      log?.warn?.(`[BCS] Agent event session mismatch for runId=${evt.runId}: expected=${context.sessionKey}, received=${evt.sessionKey}`);
+      return true;
+    }
+
     const { groupId, client } = context;
+    const terminalOutcome = terminalLifecycleOutcome(evt);
 
     if (!context.finalSent) {
       if (evt.stream === 'assistant') {
@@ -1989,8 +2125,15 @@ export function initAgentEventsSubscription(log?: {
         markVisibleReplySegmentBoundary(resolvedRunId);
       }
 
-      if (isTerminalLifecycleEvent(evt)) {
+      if (terminalOutcome === 'final') {
         sendFinalVisibleReplyOnce(resolvedRunId, log, { source: 'agent_lifecycle' });
+      } else if (terminalOutcome === 'error') {
+        sendRunErrorOnce(
+          resolvedRunId,
+          'Agent run failed before completing a reply.',
+          log,
+          `agent lifecycle ${stringField(evt.data, 'phase') ?? 'error'}`,
+        );
       }
     }
 
@@ -2010,6 +2153,9 @@ export function initAgentEventsSubscription(log?: {
     log?.info?.(
       `[BCS] Forwarded agent event: runId=${evt.runId}, stream=${evt.stream}, groupId=${groupId}`,
     );
+    if (terminalOutcome) {
+      cleanupRunContext(resolvedRunId, log);
+    }
     return true; // Indicate event was handled
   }) as (() => boolean) | null;
 

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -75,6 +75,9 @@ const runContexts = new Map<string, RunContext>();
 /** Actual OpenClaw agent run ID -> BCS-visible run ID. */
 const bcsRunIdByAgentRunId = new Map<string, string>();
 
+/** In-flight prepared-image cleanup keyed by BCS-visible run ID. */
+const cleanupPromiseByRunId = new Map<string, Promise<void>>();
+
 interface VisibleReplyState {
   text: string;
   flushedOffset: number;
@@ -370,9 +373,12 @@ function bindAgentRun(
 function cleanupRunContext(
   runId: string,
   log?: { info: (...args: unknown[]) => void },
-): void {
+): Promise<void> {
+  const existingCleanup = cleanupPromiseByRunId.get(runId);
+  if (existingCleanup) return existingCleanup;
+
   const context = runContexts.get(runId);
-  if (!context) return;
+  if (!context) return Promise.resolve();
 
   if (context.terminalTimer) {
     clearTimeout(context.terminalTimer);
@@ -392,11 +398,19 @@ function cleanupRunContext(
 
   const preparedImages = context.preparedImages ?? [];
   context.preparedImages = [];
-  if (preparedImages.length > 0) {
-    void cleanupPreparedImages(preparedImages).then(() => {
+  if (preparedImages.length === 0) return Promise.resolve();
+
+  const cleanupPromise = cleanupPreparedImages(preparedImages)
+    .then(() => {
       log?.info?.(`[BCS] Cleaned ${preparedImages.length} prepared image(s) for run_id=${runId}`);
+    })
+    .finally(() => {
+      if (cleanupPromiseByRunId.get(runId) === cleanupPromise) {
+        cleanupPromiseByRunId.delete(runId);
+      }
     });
-  }
+  cleanupPromiseByRunId.set(runId, cleanupPromise);
+  return cleanupPromise;
 }
 
 function armRunTerminalTimeout(
@@ -414,7 +428,7 @@ function armRunTerminalTimeout(
       log,
       `terminal lifecycle timeout after ${RUN_TERMINAL_TIMEOUT_MS}ms`,
     );
-    cleanupRunContext(runId, log);
+    void cleanupRunContext(runId, log);
   }, RUN_TERMINAL_TIMEOUT_MS);
   timer.unref?.();
   context.terminalTimer = timer;
@@ -1015,13 +1029,12 @@ export async function handleChatSend(
 
     const settledContext = runContexts.get(runId);
     if (!settledContext) {
-      await cleanupPreparedImages(preparedImages);
+      await cleanupRunContext(runId, log);
       log?.info?.(`[BCS] Dispatcher settled after terminal lifecycle for run_id=${runId}`);
       return;
     }
     if (abortController.signal.aborted) {
-      cleanupRunContext(runId, log);
-      await cleanupPreparedImages(preparedImages);
+      await cleanupRunContext(runId, log);
       return;
     }
 
@@ -1033,8 +1046,7 @@ export async function handleChatSend(
         allowDeliveredTextFallback: true,
         finalDeliveredPartsCount: finalDeliveredParts.length,
       });
-      cleanupRunContext(runId, log);
-      await cleanupPreparedImages(preparedImages);
+      await cleanupRunContext(runId, log);
       return;
     }
 
@@ -1069,8 +1081,7 @@ export async function handleChatSend(
         'dispatcher failure',
       );
     }
-    cleanupRunContext(runId, log);
-    await cleanupPreparedImages(preparedImages);
+    await cleanupRunContext(runId, log);
   }
 }
 
@@ -1700,7 +1711,7 @@ export function abortAllStreams(): void {
     controller.abort();
   }
   for (const runId of [ ...runContexts.keys() ]) {
-    cleanupRunContext(runId);
+    void cleanupRunContext(runId);
   }
   activeStreams.clear();
   runContexts.clear();
@@ -2154,7 +2165,7 @@ export function initAgentEventsSubscription(log?: {
       `[BCS] Forwarded agent event: runId=${evt.runId}, stream=${evt.stream}, groupId=${groupId}`,
     );
     if (terminalOutcome) {
-      cleanupRunContext(resolvedRunId, log);
+      void cleanupRunContext(resolvedRunId, log);
     }
     return true; // Indicate event was handled
   }) as (() => boolean) | null;

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -212,9 +212,13 @@ describe('openclaw-channel-bcn', () => {
       readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
     ) as {
       dependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+      openclaw?: { compat?: { pluginApi?: string } };
     };
 
     assert.equal(pkg.dependencies?.ws, '^8.18.3');
+    assert.equal(pkg.peerDependencies?.openclaw, '>=2026.3.28');
+    assert.equal(pkg.openclaw?.compat?.pluginApi, '>=2026.3.28');
   });
 
   it('does not ship internal-only implementation details in public source files', () => {
@@ -916,7 +920,7 @@ describe('openclaw-channel-bcn', () => {
     }
   });
 
-  it('sends NO_REPLY final when no assistant agent text is observed', async () => {
+  it('sends NO_REPLY only after terminal lifecycle when no assistant agent text is observed', async () => {
     const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
     const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
     let agentEventHandler: ((evt: Record<string, unknown>) => boolean) | undefined;
@@ -968,7 +972,7 @@ describe('openclaw-channel-bcn', () => {
           finalizeInboundContext(ctx: Record<string, unknown>) {
             return ctx;
           },
-          async dispatchReplyWithBufferedBlockDispatcher({ dispatcherOptions }: any) {
+          async dispatchReplyWithBufferedBlockDispatcher({ dispatcherOptions, replyOptions }: any) {
             agentEventHandler?.({
               runId: 'unrelated-run',
               stream: 'assistant',
@@ -977,6 +981,15 @@ describe('openclaw-channel-bcn', () => {
             });
             await dispatcherOptions.deliver({ text: 'visible part 1' }, { kind: 'block' });
             await dispatcherOptions.deliver({ text: 'visible part 2' }, { kind: 'block' });
+            const agentRunId = 'queued-agent-run';
+            replyOptions.onAgentRunStart(agentRunId);
+            agentEventHandler?.({
+              runId: agentRunId,
+              sessionKey: 'bcs:group-1',
+              stream: 'lifecycle',
+              ts: 2,
+              data: { phase: 'end' },
+            });
           },
         },
         session: {
@@ -1020,6 +1033,142 @@ describe('openclaw-channel-bcn', () => {
         [ 'NO_REPLY' ],
       );
       assert.deepEqual(chatEvents.map(item => item.payload.run_id), [ runId ]);
+    } finally {
+      cleanupAgentEventsSubscription();
+      abortAllStreams();
+    }
+  });
+
+  it('keeps a queued run context after dispatcher settlement and binds the later agent run exactly', async () => {
+    const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
+    const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
+    let agentEventHandler: ((evt: Record<string, unknown>) => boolean) | undefined;
+    let notifyAgentRunStart: ((runId: string) => void) | undefined;
+    const client = {
+      sendResponse(id: string, ok: boolean, payload?: Record<string, unknown>) {
+        responses.push({ id, ok, payload });
+      },
+      sendEvent(event: string, payload: Record<string, unknown>, seq: number) {
+        events.push({ event, payload, seq });
+      },
+    };
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: 'ws://bcs.test/ws/bot',
+      botId: 'bot-1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60000,
+      reconnectIntervalMs: 5000,
+      connectionTimeoutMs: 10000,
+    };
+    const runtime = {
+      config: {
+        async loadConfig() {
+          return {};
+        },
+      },
+      events: {
+        onAgentEvent(handler: (evt: Record<string, unknown>) => boolean) {
+          agentEventHandler = handler;
+          return () => {
+            agentEventHandler = undefined;
+          };
+        },
+      },
+      channel: {
+        routing: {
+          resolveAgentRoute() {
+            return { agentId: 'agent-1', sessionKey: 'bcs:queued-group' };
+          },
+        },
+        reply: {
+          finalizeInboundContext(ctx: Record<string, unknown>) {
+            return ctx;
+          },
+          async dispatchReplyWithBufferedBlockDispatcher({ replyOptions }: any) {
+            notifyAgentRunStart = replyOptions.onAgentRunStart;
+          },
+        },
+        session: {
+          resolveStorePath() {
+            return '/tmp/openclaw-bcn-test';
+          },
+          async recordInboundSession() {
+            return undefined;
+          },
+        },
+      },
+    };
+    setBcsRuntime(runtime as any);
+    initAgentEventsSubscription();
+
+    try {
+      await handleChatSend({
+        type: 'req',
+        id: 'chat-queued',
+        method: 'chat.send',
+        params: {
+          bcs_group_id: 'queued-group',
+          channel: { source: 'api', user_id: 'user-1' },
+          session_context: {},
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'wait behind the active run' }],
+            timestamp: Date.now(),
+          },
+        },
+      }, client as any, account);
+
+      const bcsRunId = responses[0].payload?.run_id;
+      assert.equal(typeof bcsRunId, 'string');
+      assert.equal(events.filter(item => item.event === 'chat.event').length, 0);
+
+      agentEventHandler?.({
+        runId: 'unrelated-active-run',
+        sessionKey: 'bcs:queued-group',
+        stream: 'assistant',
+        ts: 1,
+        data: { delta: 'must not be claimed by the queued BCS run' },
+      });
+      assert.equal(events.filter(item => item.event === 'chat.event').length, 0);
+
+      assert.ok(notifyAgentRunStart, 'dispatcher should expose onAgentRunStart');
+      notifyAgentRunStart('actual-queued-agent-run');
+      agentEventHandler?.({
+        runId: 'actual-queued-agent-run',
+        sessionKey: 'bcs:queued-group',
+        stream: 'assistant',
+        ts: 2,
+        data: { delta: 'queued answer' },
+      });
+      agentEventHandler?.({
+        runId: 'actual-queued-agent-run',
+        sessionKey: 'bcs:queued-group',
+        stream: 'lifecycle',
+        ts: 3,
+        data: { phase: 'end' },
+      });
+
+      const chatEvents = events.filter(item => item.event === 'chat.event');
+      assert.deepEqual(chatEvents.map(item => item.payload.state), [ 'delta', 'final' ]);
+      assert.deepEqual(
+        chatEvents.map(item => (item.payload.message as any).content[0].text),
+        [ 'queued answer', 'queued answer' ],
+      );
+      assert.deepEqual(chatEvents.map(item => item.payload.run_id), [ bcsRunId, bcsRunId ]);
+      assert.deepEqual(
+        events
+          .filter(item => item.event === 'agent')
+          .map(item => item.payload.run_id),
+        [ bcsRunId, bcsRunId ],
+      );
     } finally {
       cleanupAgentEventsSubscription();
       abortAllStreams();


### PR DESCRIPTION
## Summary

- bind each queued OpenClaw Agent run ID to the original BCS run ID through `onAgentRunStart`
- keep queued `chat.send` contexts after dispatcher settlement and derive delta/final/error delivery from Agent events
- prevent same-session events from being claimed through an unsafe session-only fallback
- send `NO_REPLY` only after a successful terminal lifecycle with no visible assistant text
- add terminal error/timeout cleanup and bump the BCN plugin package to `1.0.18`

## Root cause

`dispatchReplyWithBufferedBlockDispatcher` may settle while a same-session message is still queued. Treating dispatcher settlement as terminal finalized the BCS run too early, emitted `NO_REPLY`, and removed the context before the actual Agent run started.

## Validation

- `npm run lint`
- `npm run prepublishOnly`
- `npm run test-local` (50 passing)
- `npm run cov` (76.57% statements, 60.84% branches)
- `bash scripts/test_bcn_plugin_source.sh`
- `bash scripts/test_singlebox_default_mode.sh`

The repository pre-push Rust gate was also attempted: 2,356 tests passed and 27 unrelated BCS/CLI process-start tests failed. The branch was pushed with `--no-verify` as requested.