### PR TITLE
fix(bcn): emit empty final for tool-only runs

### DIFF
--- a/src/bcs/crates/plugins/openclaw-channel-bcn/package.json
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avernet-plugin/openclaw-channel-bcn",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Installable OpenClaw BCS WebSocket channel plugin package.",
   "dependencies": {
     "ws": "^8.18.3"

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -65,6 +65,7 @@ type RunContext = {
   sessionKey?: string;
   agentRunId?: string;
   finalSent?: boolean;
+  sawToolEvent: boolean;
   preparedImages?: PreparedImage[];
   terminalTimer?: ReturnType<typeof setTimeout>;
 };
@@ -590,18 +591,20 @@ function buildChatEventPayload(
   runId: string,
   bcsGroupId: string,
   state: ChatEventPayload['state'],
-  text: string,
+  text?: string,
   routeIntent?: PendingRouteIntent,
 ): ChatEventPayload {
   return {
     run_id: runId,
     bcs_group_id: bcsGroupId,
     state,
-    message: {
-      role: 'assistant',
-      content: [{ type: 'text', text }],
-      timestamp: Date.now(),
-    },
+    ...(text !== undefined ? {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text }],
+        timestamp: Date.now(),
+      },
+    } : {}),
     ...(routeIntent ? {
       routing: {
         responders: routeIntent.responders,
@@ -768,9 +771,13 @@ function sendFinalVisibleReplyOnce(
   const deliveredText = options?.allowDeliveredTextFallback
     ? options.deliveredText?.trim() || undefined
     : undefined;
-  const combinedText = visibleText ?? deliveredText ?? NO_REPLY_TEXT;
+  const assistantText = visibleText ?? deliveredText;
+  const toolOnlyEmpty = assistantText === undefined && context.sawToolEvent;
+  const combinedText = assistantText ?? (toolOnlyEmpty ? undefined : NO_REPLY_TEXT);
 
-  if (!visibleText && !deliveredText) {
+  if (toolOnlyEmpty) {
+    log?.info?.(`[BCS] Tool activity completed without assistant text for run_id=${runId}, sending message-less final${options?.noReplyDetail ? ` ${options.noReplyDetail}` : ''}`);
+  } else if (!visibleText && !deliveredText) {
     log?.warn?.(`[BCS] No assistant agent text for run_id=${runId}, sending ${NO_REPLY_TEXT} final${options?.noReplyDetail ? ` ${options.noReplyDetail}` : ''}`);
   } else if (!visibleText && deliveredText) {
     log?.info?.(`[BCS] Using dispatcher final for non-agent run_id=${runId}`);
@@ -781,7 +788,13 @@ function sendFinalVisibleReplyOnce(
   }
 
   const routeIntent = consumeRouteIntent(runId, context.sessionKey);
-  const chatPayload = buildChatEventPayload(runId, context.groupId, 'final', combinedText, routeIntent);
+  const chatPayload = buildChatEventPayload(
+    runId,
+    context.groupId,
+    'final',
+    combinedText,
+    routeIntent,
+  );
   context.client.sendEvent('chat.event', chatPayload as unknown as Record<string, unknown>, nextSeq(context.client));
   context.finalSent = true;
 
@@ -871,7 +884,7 @@ export async function handleChatSend(
   let preparedImages: PreparedImage[] = [];
 
   // Track run context for agent event routing
-  runContexts.set(runId, { groupId: bcsGroupId, client });
+  runContexts.set(runId, { groupId: bcsGroupId, client, sawToolEvent: false });
   ensureVisibleReplyState(runId);
   armRunTerminalTimeout(runId, log);
 
@@ -2127,6 +2140,9 @@ export function initAgentEventsSubscription(log?: {
 
     const { groupId, client } = context;
     const terminalOutcome = terminalLifecycleOutcome(evt);
+    if (evt.stream === 'tool') {
+      context.sawToolEvent = true;
+    }
 
     if (!context.finalSent) {
       if (evt.stream === 'assistant') {

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -920,10 +920,11 @@ describe('openclaw-channel-bcn', () => {
     }
   });
 
-  it('sends NO_REPLY only after terminal lifecycle when no assistant agent text is observed', async () => {
+  it('uses a message-less final only for tool runs without assistant text', async () => {
     const responses: Array<{ id: string; ok: boolean; payload?: Record<string, unknown> }> = [];
     const events: Array<{ event: string; payload: Record<string, unknown>; seq: number }> = [];
     let agentEventHandler: ((evt: Record<string, unknown>) => boolean) | undefined;
+    let dispatchCount = 0;
     const client = {
       sendResponse(id: string, ok: boolean, payload?: Record<string, unknown>) {
         responses.push({ id, ok, payload });
@@ -972,22 +973,33 @@ describe('openclaw-channel-bcn', () => {
           finalizeInboundContext(ctx: Record<string, unknown>) {
             return ctx;
           },
-          async dispatchReplyWithBufferedBlockDispatcher({ dispatcherOptions, replyOptions }: any) {
-            agentEventHandler?.({
-              runId: 'unrelated-run',
-              stream: 'assistant',
-              ts: 1,
-              data: { text: 'ignored text', delta: 'ignored text' },
-            });
-            await dispatcherOptions.deliver({ text: 'visible part 1' }, { kind: 'block' });
-            await dispatcherOptions.deliver({ text: 'visible part 2' }, { kind: 'block' });
-            const agentRunId = 'queued-agent-run';
+          async dispatchReplyWithBufferedBlockDispatcher({ replyOptions }: any) {
+            dispatchCount += 1;
+            const agentRunId = `queued-agent-run-${dispatchCount}`;
             replyOptions.onAgentRunStart(agentRunId);
+            if (dispatchCount !== 2) {
+              agentEventHandler?.({
+                runId: agentRunId,
+                sessionKey: 'bcs:group-1',
+                stream: 'tool',
+                ts: 2,
+                data: { phase: 'start', name: 'noop' },
+              });
+            }
+            if (dispatchCount === 3) {
+              agentEventHandler?.({
+                runId: agentRunId,
+                sessionKey: 'bcs:group-1',
+                stream: 'assistant',
+                ts: 3,
+                data: { delta: 'NO_REPLY' },
+              });
+            }
             agentEventHandler?.({
               runId: agentRunId,
               sessionKey: 'bcs:group-1',
               stream: 'lifecycle',
-              ts: 2,
+              ts: 4,
               data: { phase: 'end' },
             });
           },
@@ -1005,34 +1017,50 @@ describe('openclaw-channel-bcn', () => {
     setBcsRuntime(runtime as any);
     initAgentEventsSubscription();
 
-    const request: RequestFrame = {
-      type: 'req',
-      id: 'chat-1',
-      method: 'chat.send',
-      params: {
-        bcs_group_id: 'group-1',
-        channel: { source: 'api', user_id: 'user-1' },
-        session_context: {},
-        message: {
-          role: 'user',
-          content: [{ type: 'text', text: 'run with block reply' }],
-          timestamp: Date.now(),
+    function request(id: string, text: string): RequestFrame {
+      return {
+        type: 'req',
+        id,
+        method: 'chat.send',
+        params: {
+          bcs_group_id: 'group-1',
+          channel: { source: 'api', user_id: 'user-1' },
+          session_context: {},
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text }],
+            timestamp: Date.now(),
+          },
         },
-      },
-    };
+      };
+    }
 
     try {
-      await handleChatSend(request, client as any, account);
+      await handleChatSend(request('chat-tool-only', 'run a tool without replying'), client as any, account);
+      await handleChatSend(request('chat-no-tool', 'finish without tool or reply'), client as any, account);
+      await handleChatSend(request('chat-tool-text', 'run a tool and mention NO_REPLY'), client as any, account);
 
-      assert.equal(responses.length, 1);
-      const runId = responses[0].payload?.run_id;
+      assert.equal(responses.length, 3);
+      const runIds = responses.map(response => response.payload?.run_id);
       const chatEvents = events.filter(item => item.event === 'chat.event');
-      assert.deepEqual(chatEvents.map(item => item.payload.state), [ 'final' ]);
+      assert.deepEqual(chatEvents.map(item => item.payload.state), [ 'final', 'final', 'delta', 'final' ]);
+      assert.equal(chatEvents[0].payload.message, undefined);
+      assert.equal(chatEvents[0].payload.stop_reason, undefined);
+      assert.equal((chatEvents[1].payload.message as any).content[0].text, 'NO_REPLY');
       assert.deepEqual(
-        chatEvents.map(item => (item.payload.message as any).content[0].text),
-        [ 'NO_REPLY' ],
+        chatEvents.slice(2).map(item => (item.payload.message as any).content[0].text),
+        [ 'NO_REPLY', 'NO_REPLY' ],
       );
-      assert.deepEqual(chatEvents.map(item => item.payload.run_id), [ runId ]);
+      assert.deepEqual(chatEvents.map(item => item.payload.run_id), [
+        runIds[0],
+        runIds[1],
+        runIds[2],
+        runIds[2],
+      ]);
+      assert.deepEqual(
+        events.filter(item => item.event === 'agent').map(item => item.payload.stream),
+        [ 'tool', 'lifecycle', 'lifecycle', 'tool', 'assistant', 'lifecycle' ],
+      );
     } finally {
       cleanupAgentEventsSubscription();
       abortAllStreams();

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -1718,14 +1718,62 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 run.group_id
             )))?;
         let now = bcs_protocol::now_ms();
+        if matches!(cmd.state, ChatEventState::Final)
+            && extract_text(&cmd.event_payload).is_none()
+        {
+            // A message-less final completes the bot attempt without an
+            // artifact. It must advance the node into the normal failure/retry
+            // path instead of leaving the node Running after an InvalidRequest.
+            let error = "bot completed without visible output".to_string();
+            let failed = self
+                .runs
+                .fail_node_attempt(
+                    &correlation.state_machine_run_id,
+                    &correlation.node_id,
+                    correlation.attempt,
+                    error.clone(),
+                    now,
+                )
+                .await?;
+            let view = if failed {
+                warn!(
+                    run_id = %correlation.state_machine_run_id,
+                    group_id = %run.group_id,
+                    session_id = %run.session_id,
+                    node_id = %correlation.node_id,
+                    attempt = correlation.attempt,
+                    error = %error,
+                    "state_machine: node failed"
+                );
+                log_state_machine_node_result(
+                    &run,
+                    &correlation,
+                    MessageLogStatus::Failed,
+                    None,
+                    Some(&error),
+                    None,
+                );
+                self.fail_node_or_schedule_retry(
+                    &compiled,
+                    &group,
+                    &run,
+                    &correlation.node_id,
+                    correlation.attempt,
+                    error,
+                )
+                .await?
+            } else {
+                self.run_view(&run.run_id).await?
+            };
+            return Ok(HandleBotTerminalEventOutcome {
+                consumed: true,
+                view,
+            });
+        }
         let mut view = None;
         match cmd.state {
             ChatEventState::Final => {
-                let text = extract_text(&cmd.event_payload).ok_or_else(|| {
-                    CollaborationRuntimeError::InvalidRequest(
-                        "final state-machine bot event must include text".to_string(),
-                    )
-                })?;
+                let text = extract_text(&cmd.event_payload).unwrap_or_default();
                 let artifact_len = text.len();
                 if node_uses_judge(&compiled, &correlation.node_id)
                     && !self

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -428,6 +428,106 @@ async fn start_run_fails_and_marks_node_failed_when_delivery_returns_not_deliver
 }
 
 #[tokio::test]
+async fn message_less_final_fails_attempt_and_schedules_retry() {
+    let group = Arc::new(GroupStore::new());
+    group.upsert(test_group()).await.expect("seed group");
+    let sessions = test_sessions();
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let delivery = Arc::new(RecordingDelivery::default());
+    let frontend_delivery = Arc::new(RecordingFrontendDelivery::default());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        group,
+        sessions,
+        delivery.clone(),
+        noop_judge(),
+    )
+    .with_frontend_delivery(frontend_delivery.clone());
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: Some(single_node_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"question": "empty final should retry"}),
+            caller_id: None,
+        })
+        .await
+        .expect("start run");
+    let first_delivery_run_id = delivery.commands.lock().await[0].run_id.clone();
+
+    let tool_event = runtime
+        .handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
+            bot_id: "driver-bot".to_string(),
+            run_id: first_delivery_run_id.clone(),
+            event_type: "agent".to_string(),
+            event_payload: json!({
+                "run_id": first_delivery_run_id.clone(),
+                "stream": "tool",
+                "data": {
+                    "name": "lookup",
+                    "phase": "result",
+                    "toolCallId": "tool-1",
+                },
+            }),
+            state: ChatEventState::ToolCallEnd,
+            bcs_session_id: Some(started.view.run.session_id.clone()),
+        })
+        .await
+        .expect("handle tool event");
+    assert!(tool_event.consumed);
+
+    let handled = runtime
+        .handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
+            bot_id: "driver-bot".to_string(),
+            run_id: first_delivery_run_id,
+            event_type: "chat.event".to_string(),
+            event_payload: json!({"state": "final"}),
+            state: ChatEventState::Final,
+            bcs_session_id: Some(started.view.run.session_id.clone()),
+        })
+        .await
+        .expect("message-less final should enter retry flow");
+
+    assert!(handled.consumed);
+    let view = handled.view.expect("run view after retry scheduling");
+    assert_eq!(view.run.status, StateMachineRunStatus::Running);
+    assert_eq!(view.nodes[0].status, StateMachineNodeStatus::Running);
+    assert_eq!(view.nodes[0].attempt, 1);
+    assert_eq!(delivery.commands.lock().await.len(), 2);
+
+    let frontend_commands = frontend_delivery.commands.lock().await;
+    assert_eq!(frontend_commands.len(), 3);
+    let tool_event: Value =
+        serde_json::from_str(&frontend_commands[1].event_json).expect("tool event json");
+    assert_eq!(tool_event["event"], "agent");
+    assert_eq!(tool_event["payload"]["stream"], "tool");
+    assert_eq!(tool_event["payload"]["data"]["phase"], "result");
+    let final_event: Value =
+        serde_json::from_str(&frontend_commands[2].event_json).expect("empty final event json");
+    assert_eq!(final_event["event"], "chat");
+    assert_eq!(final_event["payload"]["state"], "final");
+    assert!(final_event["payload"].get("message").is_none());
+    assert!(final_event["payload"].get("stop_reason").is_none());
+
+    let retry_events = CollaborationEventRepoPort::list_events_by_run_node_and_type(
+        &*store,
+        &started.view.run.run_id,
+        "answer",
+        "state_machine.node.retry_scheduled",
+    )
+    .await
+    .expect("list retry events");
+    assert_eq!(retry_events.len(), 1);
+    assert_eq!(retry_events[0].payload["reason"], "bot completed without visible output");
+}
+
+#[tokio::test]
 async fn state_machine_completion_dispatches_service_callback() {
     let group = Arc::new(GroupStore::new());
     let mut seeded_group = test_group();


### PR DESCRIPTION
## Summary

- track correlated OpenClaw `tool` agent events for each BCS-visible run
- when a run has tool activity but no assistant text, emit a terminal `chat.event` with `state: "final"` and no `message` or `stop_reason`
- preserve existing behavior for no-tool/no-text runs and for assistant text whose exact value is `NO_REPLY`
- make state-machine runs fail the empty-output attempt and enter the existing retry/failure flow instead of remaining `Running`

## Root cause

The BCN plugin used `NO_REPLY` as the fallback whenever a run completed without assistant text. That fallback also applied after tool-only runs, exposing an internal control token as visible chat content even though the run had produced meaningful tool activity.

## Behavior and history impact

For a tool-only run, the plugin now sends:

```json
{
  "state": "final"
}
```

BCS already accepts a final without `message`.

- Ordinary group chat: a tool `result` remains persisted as a `tool_call` history row; the empty final does not create an assistant/chat row and is not relayed to other bots.
- A tool `start` without a matching result is only cached and does not create history.
- ManagerWorker task handling is intentionally unchanged: its existing empty-response fallback still produces `[no response]` task history.
- State-machine handling stores no empty artifact; it marks the attempt failed and applies the configured retry/failure policy.

No frontend, provider ingress, generic legacy-token normalization, history filtering, or documentation behavior is changed in this PR.

## Validation

- BCN plugin: `npm run lint`
- BCN plugin: `npm run prepublishOnly`
- BCN plugin: `npm run test-local` (50 passing)
- `cargo test -p bcs-collaboration-runtime` (31 passing)
- `cargo test -p bcs-ws bot_chat_event_frame_is_forwarded_to_message_flow`
- `cargo test -p bcs-message-flow agent_tool_result_persists_worker_owner_and_public_manager_owner_for_manager_worker`
- `git diff --check aefe1c18d..HEAD`
