### PR TITLE
refactor(publish): make RELEASED offline an idempotent no-op

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -937,25 +937,21 @@ class BotPublishService(PublishRollbackMixin):
         # Step 2: 根据状态判断 stage
         current_status = publish_record.status
 
-        # (#197) Crash-resume: a prior online offline already flipped
-        # SUCCESS→RELEASED but may have crashed before the durable destroy was
-        # enqueued (the flip and the enqueue are not atomic). Re-enqueue so the
-        # online bot is never leaked. execute_offline_destroy short-circuits when
-        # the destroy already COMPLETED, so this re-enqueue is a true no-op then.
+        # RELEASED is terminal — the offline already ran. Return an idempotent
+        # no-op so a duplicate submit or a durable-task re-run lands cleanly
+        # instead of falling through to _resolve_offline_stage and raising.
+        # Recovering the narrow flip-then-crash window (record RELEASED but the
+        # durable destroy never enqueued) is handled separately, not here.
         if current_status == PublishStatus.RELEASED:
-            publish_flow_service.enqueue_offline_destroy(
-                publish_id=publish_id, stage=PublishStage.ONLINE, operator="system"
-            )
             logger.info(
-                f"[offline_publish] Re-enqueued destroy for already-RELEASED record "
-                f"(crash-resume): publish_id={publish_id}"
+                f"[offline_publish] Record already RELEASED, no-op: publish_id={publish_id}"
             )
             return {
                 "success": True,
                 "bot_destroyed": False,
                 "new_publish_id": None,
                 "new_publish_version": None,
-                "message": f"下线销毁已重新提交（崩溃恢复）: publish_id={publish_id}",
+                "message": f"发布单已下线: publish_id={publish_id}",
             }
 
         stage = self._resolve_offline_stage(current_status, publish_id)

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -301,9 +301,9 @@ class TestOfflinePublish:
         )
 
     @pytest.mark.asyncio
-    async def test_offline_publish_released_record_reenqueues_destroy(self):
-        """(#197 H1) 崩溃恢复：记录已是 RELEASED（前一次下线已翻转状态但可能在
-        入队销毁前崩溃）→ 重新入队销毁，避免线上 bot 泄漏。销毁任务侧幂等去重。"""
+    async def test_offline_publish_released_record_is_noop(self):
+        """记录已是 RELEASED（下线已完成）→ 幂等 no-op：不翻转状态、不入队销毁，
+        直接返回成功，避免重复提交或 durable 任务重跑时报错。"""
         mock_repo = Mock()
         mock_record = _create_mock_record(record_id=1, status=PublishStatus.RELEASED)
         mock_repo.get_by_id.return_value = mock_record
@@ -317,11 +317,9 @@ class TestOfflinePublish:
         result = await service.offline_publish(publish_id=1)
 
         assert result["success"] is True
-        # 不再翻转状态（已是 RELEASED），只重新入队销毁。
+        # 幂等 no-op：既不翻转状态也不入队销毁。
         mock_repo.update_status.assert_not_called()
-        mock_publish_flow_service.enqueue_offline_destroy.assert_called_once_with(
-            publish_id=1, stage=PublishStage.ONLINE, operator="system"
-        )
+        mock_publish_flow_service.enqueue_offline_destroy.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_offline_publish_success_without_non_terminal_records(self):


### PR DESCRIPTION
## What

`offline_publish` previously re-enqueued a durable offline destroy whenever it was
called on an already-`RELEASED` record (the "crash-resume" block added in #197).
This replaces that with a plain **idempotent no-op**: the `RELEASED` early-return
stays, but the re-enqueue is dropped.

```python
if current_status == PublishStatus.RELEASED:
    # idempotent no-op: return success, do not flip status, do not enqueue
    return {"success": True, "bot_destroyed": False, ...}
```

## Why

The re-enqueue was only ever exercised on a **hard crash**. Tracing the callers:

- The only path that re-drives `offline_publish` is the durable `APPROVAL_TRIGGER_TASK`,
  and only via a lease reclaim after an abrupt process death.
- A **soft** failure (an exception between the `SUCCESS→RELEASED` flip and
  `enqueue_offline_destroy`) is caught and swallowed in `_trigger_offline`, so the
  handler returns `Complete()` and the task is never retried — the re-enqueue never
  ran for that case anyway.

So the re-enqueue guarded only the narrow hard-crash window while adding a durable
task on every RELEASED call. Keeping the early-return preserves the useful properties
(a duplicate submit or a durable-task re-run lands cleanly instead of falling through
to `_resolve_offline_stage` and raising); dropping the re-enqueue removes machinery
that didn't robustly cover the leak it was meant to.

Proper recovery of the flip-then-crash window (record `RELEASED` but destroy never
enqueued) is deliberately **out of scope** here and will be handled separately as part
of the broader offline idempotency fix — e.g. not swallowing in `_trigger_offline`, or
a reconciler that sweeps `RELEASED` records whose stage binding is not yet released.

## Tests

- Renamed `test_offline_publish_released_record_reenqueues_destroy` →
  `test_offline_publish_released_record_is_noop`; it now asserts no status flip and no
  `enqueue_offline_destroy` call.
- `test_bot_publish_service.py` + `test_publish_approval_service.py`: 132 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQp2ePgrPn113aaDaneYwi)_