### PR TITLE
fix(engine): show BCS DM sessions

### DIFF
--- a/src/engine/src/engine/community/core/adapters/openclaw/session.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/session.py
@@ -199,7 +199,7 @@ class OpenClawSessionAdapter(SessionService):
         """List sessions matching the request filter.
 
         The port handles the complete legacy ordering: sessions.list RPC →
-        bcs:group filter → agent_id/session_key filters → paginate →
+        bcs:group filter (keeping bcs_grp DM/bcs-cli) → agent_id/session_key filters → paginate →
         chat.history (page only) → Bot 初始化配置 filter → model normalisation.
         The adapter receives the already-filtered, already-paginated page and
         only builds DTOs.

--- a/src/engine/src/engine/community/plugin_api/openclaw/session.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/session.py
@@ -32,7 +32,7 @@ class OpenClawSessionPort(Protocol):
 
         Exact ordering (matches legacy `engines/openclaw/session.py:list`):
           1. `sessions.list` RPC → raw sessions
-          2. Filter out `bcs:group` sessions (keep `bcs:group:bcs-cli`)
+          2. Filter out `bcs:group` sessions (keep `bcs_grp_*_dm_*` and bcs-cli)
           3. Filter by `agent_id` if provided (request-param-driven but primitive)
           4. Filter by exact non-blank `session_key` if provided
           5. Paginate: slice `[offset : offset+limit]`

--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -12,6 +12,17 @@ from engine.community.openclaw.client.gateway_client import OpenClawGatewayClien
 
 log = logging.getLogger("openclaw-port")
 
+_BCS_GROUP_SESSION_MARKER = "bcs:group:"
+
+
+def _is_bcs_dm_session_key(key: str) -> bool:
+    """Return whether an OpenClaw key belongs to a namespaced BCS DM group."""
+    marker_index = key.rfind(_BCS_GROUP_SESSION_MARKER)
+    if marker_index < 0:
+        return False
+    group_id = key[marker_index + len(_BCS_GROUP_SESSION_MARKER):]
+    return group_id.startswith("bcs_grp_") and "_dm_" in group_id
+
 
 class _SessionPortMixin:
     """Domain mixin: session CRUD + chat_history + model normalisation (pooled)."""
@@ -108,7 +119,7 @@ class _SessionPortMixin:
 
         Exact sequence (mirrors `engines/openclaw/session.py:list`):
           1. `sessions.list` RPC → raw sessions
-          2. Filter `bcs:group` sessions (gateway-cleanup, fixed)
+          2. Filter `bcs:group` sessions, keeping `bcs_grp_*_dm_*` and bcs-cli
           3. Filter by `agent_id` if provided
           4. Filter by exact non-blank `session_key` if provided
           5. Paginate: slice `[offset : offset+limit]` — BEFORE history fetch
@@ -150,12 +161,13 @@ class _SessionPortMixin:
 
         raw_sessions = [s for s in raw_sessions if isinstance(s, dict)]
 
-        # Step 2: Filter bcs:group sessions (fixed gateway-cleanup).
+        # Step 2: Hide BCS group chats while keeping user-visible DM sessions.
         raw_sessions = [
             s for s in raw_sessions
             if (
                 "bcs:group" not in s.get("key", "")
                 or "bcs:group:bcs-cli" in s.get("key", "")
+                or _is_bcs_dm_session_key(s.get("key", ""))
             )
         ]
 

--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -24,6 +24,18 @@ def _is_bcs_dm_session_key(key: str) -> bool:
     return group_id.startswith("bcs_grp_") and "_dm_" in group_id
 
 
+def _should_keep_session(session: dict[str, Any]) -> bool:
+    """Return whether a valid gateway session should remain visible."""
+    key = session.get("key")
+    if not isinstance(key, str):
+        return False
+    return (
+        "bcs:group" not in key
+        or "bcs:group:bcs-cli" in key
+        or _is_bcs_dm_session_key(key)
+    )
+
+
 class _SessionPortMixin:
     """Domain mixin: session CRUD + chat_history + model normalisation (pooled)."""
 
@@ -162,14 +174,7 @@ class _SessionPortMixin:
         raw_sessions = [s for s in raw_sessions if isinstance(s, dict)]
 
         # Step 2: Hide BCS group chats while keeping user-visible DM sessions.
-        raw_sessions = [
-            s for s in raw_sessions
-            if (
-                "bcs:group" not in s.get("key", "")
-                or "bcs:group:bcs-cli" in s.get("key", "")
-                or _is_bcs_dm_session_key(s.get("key", ""))
-            )
-        ]
+        raw_sessions = [s for s in raw_sessions if _should_keep_session(s)]
 
         # Step 3: Filter by agent_id if provided (primitive, not DTO-driven).
         if agent_id is not None:

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -180,6 +180,8 @@ class TestSessionsList:
         native_dm_key = f"agent:main:bcs:group:bcs_grp_dm_{token}"
         flexible_dm_key = "agent:main:bcs:group:bcs_grp_dingtalk_dm_not-a-token"
         sessions = [
+            {"key": None, "label": "Null key"},
+            {"label": "Missing key"},
             {"key": "bcs:group:room-42", "label": "Group"},
             {
                 "key": f"agent:main:bcs:group:bcs_grp_dingtalk_{token}",
@@ -192,7 +194,7 @@ class TestSessionsList:
             {"key": "bcs:group:bcs-cli", "label": "CLI"},  # allowed through
             {"key": "normal-session", "label": "Normal"},
         ]
-        impl, _ = _make_impl({
+        impl, client = _make_impl({
             "sessions.list": self._sessions_payload(sessions),
             "chat.history": self._history_payload([{"id": "m1", "role": "user", "content": "x"}]),
             "providers.available": self._providers_payload(),
@@ -209,6 +211,12 @@ class TestSessionsList:
             "bcs:group:bcs-cli",
             "normal-session",
         ]
+        history_keys = [
+            params["sessionKey"]
+            for method, params, _ in client.calls
+            if method == "chat.history"
+        ]
+        assert history_keys == keys
 
     async def test_bot_init_config_single_message_filtered_out(self):
         """Sessions labelled 'Bot 初始化配置' with exactly one message are filtered."""

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -6,7 +6,8 @@ Session DTOs — those are covered by core/adapters/openclaw/tests/test_session.
 
 Coverage preserved from engines/openclaw/tests/test_session.py (legacy):
   - sessions_list: sessions.list + per-page chat.history + providers.available
-  - sessions_list: bcs:group filter, "Bot 初始化配置" filter
+  - sessions_list: bcs:group filter with bcs_grp DM/bcs-cli exceptions,
+    "Bot 初始化配置" filter
   - sessions_list: pagination (offset/limit BEFORE history fetch)
   - sessions_list: model normalization via _normalized_model key
   - session_create: sessions.patch RPC method + params + raw return
@@ -172,10 +173,22 @@ class TestSessionsList:
         assert s["_message_count"] == 1
         assert s["_messages"] == messages
 
-    async def test_bcs_group_sessions_filtered_out(self):
-        """Sessions whose key contains 'bcs:group' (but not 'bcs:group:bcs-cli') are dropped."""
+    async def test_bcs_group_sessions_hide_group_chats_and_keep_dm_sessions(self):
+        """BCS group chats are hidden while bcs_grp DM sessions remain visible."""
+        token = "bc7d52974947474da2f1cdea1c5642b6"
+        channel_dm_key = f"agent:main:bcs:group:bcs_grp_dingtalk_dm_{token}"
+        native_dm_key = f"agent:main:bcs:group:bcs_grp_dm_{token}"
+        flexible_dm_key = "agent:main:bcs:group:bcs_grp_dingtalk_dm_not-a-token"
         sessions = [
             {"key": "bcs:group:room-42", "label": "Group"},
+            {
+                "key": f"agent:main:bcs:group:bcs_grp_dingtalk_{token}",
+                "label": "DingTalk group",
+            },
+            {"key": channel_dm_key, "label": "DingTalk DM"},
+            {"key": native_dm_key, "label": "Native DM"},
+            {"key": flexible_dm_key, "label": "Flexible DM"},
+            {"key": "agent:main:bcs:group:legacy_dm_session", "label": "Legacy group"},
             {"key": "bcs:group:bcs-cli", "label": "CLI"},  # allowed through
             {"key": "normal-session", "label": "Normal"},
         ]
@@ -187,8 +200,15 @@ class TestSessionsList:
         result = await impl.sessions_list(token="tok")
         keys = [s["key"] for s in result]
         assert "bcs:group:room-42" not in keys
-        assert "bcs:group:bcs-cli" in keys
-        assert "normal-session" in keys
+        assert f"agent:main:bcs:group:bcs_grp_dingtalk_{token}" not in keys
+        assert "agent:main:bcs:group:legacy_dm_session" not in keys
+        assert keys == [
+            channel_dm_key,
+            native_dm_key,
+            flexible_dm_key,
+            "bcs:group:bcs-cli",
+            "normal-session",
+        ]
 
     async def test_bot_init_config_single_message_filtered_out(self):
         """Sessions labelled 'Bot 初始化配置' with exactly one message are filtered."""


### PR DESCRIPTION
## Summary

- keep OpenClaw BCS DM sessions visible when their group ID starts with `bcs_grp_` and contains `_dm_`
- continue hiding non-DM BCS group sessions while preserving the existing `bcs-cli` exception
- update the OpenClaw session contract documentation and regression coverage

## Why

OpenClaw currently filters every `bcs:group` session except `bcs-cli`, which also hides direct-message sessions such as `bcs_grp_dingtalk_dm_*`.

## Impact

This is a backward-compatible visibility change for OpenClaw session listing. Regular BCS group chats remain hidden.

## Structural impact

- Contract: backward-compatible Plugin API behavior expansion; signature unchanged
- Consumer: OpenClaw session adapter
- Implementation: OpenClaw session plugin
- Migration or waiver: none

## Validation

- targeted OpenClaw, contract, and architecture tests: 85 passed
- Ruff checks passed
- pre-push Engine CI: 1862 passed, 100% pass rate
- line coverage: 92.20%
- changed-line coverage: 93.33%