### PR TITLE
fix(harness): map gmt_create/gmt_modified in HarnessPatch _row_to_domain

### DIFF
--- a/src/backend/src/agentclaw/community/plugins/harness_patch_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/harness_patch_repository.py
@@ -44,6 +44,8 @@ class HarnessPatchRepository:
             advise=row.advise,
             is_applied=(row.is_applied == "Y"),
             env=row.env or "dev",
+            gmt_create=row.gmt_create,
+            gmt_modified=row.gmt_modified,
         )
 
     def create(self, patch: PatchDefinition) -> int:


### PR DESCRIPTION
_row_to_domain omitted gmt_create/gmt_modified when converting the ORM row to PatchDefinition, so the dataclass fell back to its datetime.utcnow default. API consumers (e.g. /diagnose/dim-history) therefore received a freshly-minted UTC timestamp instead of the DB row's real creation time. Pass the ORM columns through.