### PR TITLE
feat(callback): add Origin header and response body logging to HttpCallback

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -67,6 +67,7 @@ user_config:
     acquire_timeout: 0               # acquire 等待槽位超时秒数（0=不限）
     task_timeout: 660.0              # 单任务最大执行秒数（0=不限，默认660=10分钟+1分钟缓冲）
     default_timeout: 30.0            # 请求默认超时秒数（metadata 未指定 timeout 时使用）
+    origin: "https://teamclaw.example.com"
 
   # BotRun 队列 Worker 配置
   bot_run_queue:

--- a/src/baas/packages/community/src/secbaas/adapters/web/routers/bot_service/file_transfer_router.py
+++ b/src/baas/packages/community/src/secbaas/adapters/web/routers/bot_service/file_transfer_router.py
@@ -83,6 +83,7 @@ async def get_upload_url(
             device_affinity=device_affinity,
             file_size=request.file_size,
             part_size=request.part_size,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -180,6 +181,7 @@ async def get_download_url(
             device_path=request.device_path,
             expire_seconds=request.expire_seconds,
             device_affinity=device_affinity,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -532,7 +534,6 @@ async def get_transfer_status(
 
     Returns the transfer's status along with conditional fields:
     - download_url when status == DONE
-    - upload_url when status == CREATED
     - error_message when status == FAILED
     """
     logger.info(
@@ -544,9 +545,15 @@ async def get_transfer_status(
         result = await dispatcher.dispatch_get_transfer_status(
             transfer_id=transfer_id,
             tenant=tenant,
+            bot_uuid=bot_uuid,
         )
         return ApiResponse(data=result)
 
+    except BotNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "BOT_NOT_FOUND", "message": str(e), "bot_uuid": bot_uuid},
+        )
     except TransferNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/baas/packages/community/src/secbaas/api/bot_runtime/__init__.py
+++ b/src/baas/packages/community/src/secbaas/api/bot_runtime/__init__.py
@@ -1,0 +1,7 @@
+"""Bot runtime API — public exports for packages tree."""
+
+from ._exceptions import TransferStateConflictError
+
+__all__ = [
+    "TransferStateConflictError",
+]

--- a/src/baas/packages/community/src/secbaas/api/bot_runtime/_exceptions.py
+++ b/src/baas/packages/community/src/secbaas/api/bot_runtime/_exceptions.py
@@ -1,0 +1,38 @@
+"""API-layer exceptions for file transfer operations.
+
+Defines the BotServiceError base and TransferStateConflictError for the
+packages tree (secbaas.* import convention).  These classes exist so the
+repo-layer TransferStateConflictError can inherit from the API-layer
+definition via diamond inheritance — otherwise dispatcher except clauses
+catching the API class cannot handle repo-originated instances.
+"""
+
+
+class BotServiceError(Exception):
+    """Base exception for bot service errors.
+
+    All bot service API exceptions inherit from this class.
+    """
+
+    error_code: str = "BOT_SERVICE_ERROR"
+    http_status: int = 400
+
+    def __init__(self, message: str = "") -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class TransferStateConflictError(BotServiceError):
+    """Raised when an invalid state transition is attempted on a file transfer.
+
+    This is the API-layer definition imported by adapters (routers).
+    The repo-layer equivalent inherits from this class so that except
+    clauses catching the API class also handle repo-originated instances.
+    """
+
+    error_code: str = "TRANSFER_STATE_CONFLICT"
+    http_status: int = 409
+
+    def __init__(self, message: str = "") -> None:
+        self.message = message
+        super().__init__(message)

--- a/src/baas/packages/community/src/secbaas/api/bot_runtime/_file_transfer_models.py
+++ b/src/baas/packages/community/src/secbaas/api/bot_runtime/_file_transfer_models.py
@@ -51,6 +51,11 @@ class GetUploadUrlRequest(BaseModel):
         ge=1048576,
         description="Custom part size in bytes for multipart, defaults to 10MB if file_size >= threshold.",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this upload",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -109,6 +114,11 @@ class GetDownloadUrlRequest(BaseModel):
         le=86400,
         description="Pre-signed URL validity duration in seconds (60–86400, default 3600)",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this download",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -132,7 +142,6 @@ class GetTransferStatusResponse(BaseModel):
 
     Maps from TicketRecord.  Conditional fields:
     - download_url: only present when status == DONE
-    - upload_url: only present when status == CREATED (resume support)
     - expires_at: intentionally null for transfer queries; OSS presigned URLs
       embed their own expiry via the Expires query parameter
     - error_message: only present when status == FAILED
@@ -144,11 +153,14 @@ class GetTransferStatusResponse(BaseModel):
     filename: str
     device_path: str | None
     download_url: str | None = None
-    upload_url: str | None = None
-    expires_at: str | None = None
+    expires_at: str | None = Field(
+        default=None,
+        description="Intentionally null for transfer queries; OSS presigned URLs embed their own expiry via the Expires query parameter. Only populated in direct upload/download URL generation responses.",
+    )
     error_message: str | None = None
     created_at: str
     updated_at: str
+    operator: str
 
     model_config = {"from_attributes": True}
 

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_model.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_model.py
@@ -34,9 +34,9 @@ class FileTransferTicketModel(Base):
     fileservice_staging_path = Column(String(1024), nullable=False)
     error_message = Column(Text, nullable=True)
     download_url = Column(String(2048), nullable=True)
-    upload_url = Column(String(2048), nullable=True)
     multipart_session_id = Column(String(256), nullable=True)
     env = Column(String(16), nullable=False)
+    operator = Column(String(256), nullable=False, server_default="unknown")
 
     __table_args__ = (
         UniqueConstraint("transfer_id", "env", name="uk_ft_transfer_id_env"),
@@ -59,7 +59,7 @@ class FileTransferTicketModel(Base):
             fileservice_staging_path=self.fileservice_staging_path,
             error_message=self.error_message,
             download_url=self.download_url,
-            upload_url=self.upload_url,
             multipart_session_id=self.multipart_session_id,
             env=self.env,
+            operator=self.operator,
         )

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_repository.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_repository.py
@@ -71,6 +71,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         log.info(
             "create_ticket: transfer_id=%s, direction=%s, multipart_session_id=%s",
@@ -92,6 +93,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
             error_message=error_message,
             multipart_session_id=multipart_session_id,
             env=env,
+            operator=operator,
         )
         self._session.add(row)
         self._session.flush()
@@ -235,13 +237,13 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
+        download_url_preview = (download_url[:200]) if download_url else None
         log.info(
-            "update_urls: transfer_id=%s, download_url=%s, upload_url=%s",
+            "update_urls: transfer_id=%s, download_url=%s, download_url_preview=%s",
             transfer_id,
             bool(download_url),
-            bool(upload_url),
+            download_url_preview,
         )
         from sqlalchemy import func
 
@@ -249,11 +251,11 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         update_kwargs: dict = {"gmt_modified": func.now()}
         if download_url is not None:
             update_kwargs["download_url"] = download_url
-        if upload_url is not None:
-            update_kwargs["upload_url"] = upload_url
-
-        if "download_url" not in update_kwargs and "upload_url" not in update_kwargs:
-            return  # no-op: both None
+        else:
+            log.debug(
+                "update_urls: transfer_id=%s, download_url is None, no-op", transfer_id
+            )
+            return  # no-op
 
         result = (
             self._session.query(FileTransferTicketModel)

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_protocol.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_protocol.py
@@ -2,6 +2,9 @@
 
 from typing import Protocol, runtime_checkable
 
+from secbaas.api.bot_runtime import (
+    TransferStateConflictError as ApiTransferStateConflictError,
+)
 from secbaas.api.bot_runtime._file_transfer_models import (
     TransferNotFoundError as ApiTransferNotFoundError,
 )
@@ -27,16 +30,29 @@ class TransferNotFoundError(FileTransferRepositoryError, ApiTransferNotFoundErro
     """
 
     def __init__(self, transfer_id: str) -> None:
+        message = f"Transfer ticket {transfer_id} not found"
+        self.message = message  # Set explicitly — cooperative MRO stops at RuntimeError
         super().__init__(
-            f"Transfer ticket {transfer_id} not found",
+            message,
             error_code="FILE_TRANSFER_NOT_FOUND",
         )
 
 
-class TransferStateConflictError(FileTransferRepositoryError):
-    """Raised when an invalid state transition is attempted."""
+class TransferStateConflictError(
+    FileTransferRepositoryError, ApiTransferStateConflictError
+):
+    """Raised when an invalid state transition is attempted on a file transfer.
+
+    Inherits from both FileTransferRepositoryError (repo-layer base) and
+    the API-layer TransferStateConflictError so that except clauses catching
+    the API class also handle repo-originated instances (e.g. from
+    update_status in race conditions).
+    """
 
     def __init__(self, message: str) -> None:
+        self.message = (
+            message  # Set explicitly — BotServiceError.__init__ unreachable via MRO
+        )
         super().__init__(message, error_code="FILE_TRANSFER_STATE_CONFLICT")
 
 
@@ -62,6 +78,7 @@ class TicketRepository(Protocol):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         """Insert a new transfer ticket record. Returns the new record ID."""
         ...
@@ -83,7 +100,8 @@ class TicketRepository(Protocol):
         Uses a CAS (Compare-And-Swap) SQL UPDATE: only modifies the row if
         its current status is one of the allowed source states for new_status.
         Same-state transitions are idempotent.
-        Raises DeviceCreationError on invalid transition or not found.
+        Raises TransferStateConflictError on invalid state transition.
+        Raises TransferNotFoundError if no ticket with the given transfer_id exists.
         """
         ...
 
@@ -116,10 +134,9 @@ class TicketRepository(Protocol):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
-        """Update download_url and/or upload_url on a ticket.
+        """Update download_url on a ticket.
 
-        Updates only the fields that are not None. Both None is a no-op.
+        Returns early (no-op) when download_url is None.
         """
         ...

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_record.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_record.py
@@ -11,11 +11,11 @@ class TicketRecord:
     Columns per DDL schema (17 fields):
     id, gmt_create, gmt_modified, transfer_id, tenant, paas_device_id,
     direction, status, staging_subdir, filename, device_path,
-    fileservice_staging_path, error_message, download_url, upload_url,
-    multipart_session_id, env
+    fileservice_staging_path, error_message, download_url,
+    multipart_session_id, env, operator
 
     Nullable fields: staging_subdir, device_path, error_message, download_url,
-    upload_url, multipart_session_id.
+    multipart_session_id.
     """
 
     id: int
@@ -32,6 +32,6 @@ class TicketRecord:
     fileservice_staging_path: str
     error_message: str | None
     download_url: str | None
-    upload_url: str | None
     multipart_session_id: str | None
     env: str
+    operator: str

--- a/src/baas/packages/community/src/secbaas/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from secbaas.api.bot_runtime import (
     BotFileTransferDispatcher,
+    BotNotFoundError,
     CancelUploadResponse,
     CompleteUploadResponse,
     GetDownloadUrlResponse,
@@ -81,6 +82,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_affinity: str | None = None,
         file_size: int = 0,
         part_size: int | None = None,
+        operator: str | None = None,
     ) -> GetUploadUrlResponse:
         """Orchestrate upload URL generation (v1.5: D-01/D-02/D-05 flow).
 
@@ -103,6 +105,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             tenant,
             file_size,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         # D-05: Retention mode — device_path is None, skip device resolution
         if device_path is not None:
@@ -208,6 +213,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 fileservice_staging_path=staging_path,
                 error_message=None,
                 multipart_session_id=multipart_session.session_id,
+                operator=operator,
             )
 
             logger.info(
@@ -250,6 +256,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 device_path=device_path,
                 fileservice_staging_path=staging_path,
                 error_message=None,
+                operator=operator,
             )
 
             logger.info(
@@ -270,6 +277,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_path: str,
         expire_seconds: int = 3600,
         device_affinity: str | None = None,
+        operator: str | None = None,
     ) -> GetDownloadUrlResponse:
         """Orchestrate download URL request (D-10 flow).
 
@@ -288,6 +296,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path,
             tenant,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         _, _, paas_device_id = await self._resolve_bot_device(
             bot_uuid=bot_uuid,
@@ -342,6 +353,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path=device_path,
             fileservice_staging_path=staging_path,
             error_message=None,
+            operator=operator,
         )
 
         logger.info("Ticket created: transfer_id=%s, direction=DOWNLOAD", transfer_id)
@@ -371,12 +383,23 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         self,
         transfer_id: str,
         tenant: str | None = None,
+        bot_uuid: str | None = None,
     ) -> GetTransferStatusResponse:
         """Query a transfer ticket by transfer_id (D-12 query flow).
 
         Maps TicketRecord fields to GetTransferStatusResponse with
         conditional URL/error fields based on ticket status.
+
+        When bot_uuid is provided, validates that the bot exists and belongs
+        to the specified tenant before returning the transfer status.
         """
+        # Validate bot ownership when bot_uuid is provided
+        if bot_uuid is not None and tenant is not None:
+            env = get_current_env()
+            bots = self._bot_repo.list_by_bot_uuid(bot_uuid, tenant, env)
+            if not bots:
+                raise BotNotFoundError(bot_uuid)
+
         record = self._ticket_repo.get_by_transfer_id(
             transfer_id,
             tenant=tenant,
@@ -386,7 +409,6 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
 
         # Conditional fields per status
         download_url = record.download_url if record.status == "DONE" else None
-        upload_url = record.upload_url if record.status == "CREATED" else None
         # OSS presigned URLs embed their own expiry — expires_at is null for transfer queries
         expires_at: str | None = None
 
@@ -399,11 +421,11 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             filename=record.filename,
             device_path=record.device_path,
             download_url=download_url,
-            upload_url=upload_url,
             expires_at=expires_at,
             error_message=error_message,
             created_at=record.gmt_create.isoformat(),
             updated_at=record.gmt_modified.isoformat(),
+            operator=record.operator,
         )
 
     # ------------------------------------------------------------------

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -67,6 +67,7 @@ user_config:
     acquire_timeout: 0               # acquire 等待槽位超时秒数（0=不限）
     task_timeout: 660.0              # 单任务最大执行秒数（0=不限，默认660=10分钟+1分钟缓冲）
     default_timeout: 30.0            # 请求默认超时秒数（metadata 未指定 timeout 时使用）
+    origin: "https://teamclaw.example.com"
 
   teamclaw:
     base_url: "https://teamclaw.example.com"

--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/file_transfer_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/file_transfer_router.py
@@ -84,6 +84,7 @@ async def get_upload_url(
             device_affinity=device_affinity,
             file_size=request.file_size,
             part_size=request.part_size,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -181,6 +182,7 @@ async def get_download_url(
             device_path=request.device_path,
             expire_seconds=request.expire_seconds,
             device_affinity=device_affinity,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -533,7 +535,6 @@ async def get_transfer_status(
 
     Returns the transfer's status along with conditional fields:
     - download_url when status == DONE
-    - upload_url when status == CREATED
     - error_message when status == FAILED
     """
     logger.info(

--- a/src/baas/src/secbaas/community/api/bot_runtime/_file_transfer_models.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_file_transfer_models.py
@@ -51,6 +51,11 @@ class GetUploadUrlRequest(BaseModel):
         ge=1048576,
         description="Custom part size in bytes for multipart, defaults to 10MB if file_size >= threshold.",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this upload",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -109,6 +114,11 @@ class GetDownloadUrlRequest(BaseModel):
         le=86400,
         description="Pre-signed URL validity duration in seconds (60–86400, default 3600)",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this download",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -132,7 +142,6 @@ class GetTransferStatusResponse(BaseModel):
 
     Maps from TicketRecord.  Conditional fields:
     - download_url: only present when status == DONE
-    - upload_url: only present when status == CREATED (resume support)
     - expires_at: intentionally null for transfer queries; OSS presigned URLs
       embed their own expiry via the Expires query parameter
     - error_message: only present when status == FAILED
@@ -144,11 +153,14 @@ class GetTransferStatusResponse(BaseModel):
     filename: str
     device_path: str | None
     download_url: str | None = None
-    upload_url: str | None = None
-    expires_at: str | None = None
+    expires_at: str | None = Field(
+        default=None,
+        description="Intentionally null for transfer queries; OSS presigned URLs embed their own expiry via the Expires query parameter. Only populated in direct upload/download URL generation responses.",
+    )
     error_message: str | None = None
     created_at: str
     updated_at: str
+    operator: str
 
     model_config = {"from_attributes": True}
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
@@ -136,6 +136,7 @@ class BotFileTransferDispatcher(Protocol):
         device_affinity: str | None = None,
         file_size: int = 0,
         part_size: int | None = None,
+        operator: str | None = None,
     ) -> GetUploadUrlResponse: ...
 
     async def dispatch_get_download_url(
@@ -145,6 +146,7 @@ class BotFileTransferDispatcher(Protocol):
         device_path: str,
         expire_seconds: int = 3600,
         device_affinity: str | None = None,
+        operator: str | None = None,
     ) -> GetDownloadUrlResponse: ...
 
     async def dispatch_get_transfer_status(

--- a/src/baas/src/secbaas/community/bootstrap/_configs.py
+++ b/src/baas/src/secbaas/community/bootstrap/_configs.py
@@ -299,6 +299,7 @@ class BotRunnerConfig(ConfigSchema):
         gt=0,
         description="请求默认超时秒数，metadata 未指定 timeout 时使用",
     )
+    origin: str = Field(default="", description="设置请求的origin header")
 
 
 class BcnUplinkConfigSchema(BaseModel):

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -563,6 +563,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
     http_callback = providers.Singleton(
         HttpCallback,
         run_repository=bot_run_repository,
+        origin=config.bot_runner.origin,
     )
 
     task_message_dispatcher = providers.Singleton(

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_model.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_model.py
@@ -35,9 +35,9 @@ class FileTransferTicketModel(Base):
     fileservice_staging_path = Column(String(1024), nullable=False)
     error_message = Column(Text, nullable=True)
     download_url = Column(String(2048), nullable=True)
-    upload_url = Column(String(2048), nullable=True)
     multipart_session_id = Column(String(256), nullable=True)
     env = Column(String(16), nullable=False)
+    operator = Column(String(256), nullable=False, server_default="unknown")
 
     __table_args__ = (
         UniqueConstraint("transfer_id", "env", name="uk_ft_transfer_id_env"),
@@ -60,7 +60,7 @@ class FileTransferTicketModel(Base):
             fileservice_staging_path=self.fileservice_staging_path,
             error_message=self.error_message,
             download_url=self.download_url,
-            upload_url=self.upload_url,
             multipart_session_id=self.multipart_session_id,
             env=self.env,
+            operator=self.operator,
         )

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_repository.py
@@ -71,6 +71,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         log.info(
             "create_ticket: transfer_id=%s, direction=%s, multipart_session_id=%s",
@@ -92,6 +93,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
             error_message=error_message,
             multipart_session_id=multipart_session_id,
             env=env,
+            operator=operator,
         )
         self._session.add(row)
         self._session.flush()
@@ -235,13 +237,13 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
+        download_url_preview = (download_url[:200]) if download_url else None
         log.info(
-            "update_urls: transfer_id=%s, download_url=%s, upload_url=%s",
+            "update_urls: transfer_id=%s, download_url=%s, download_url_preview=%s",
             transfer_id,
             bool(download_url),
-            bool(upload_url),
+            download_url_preview,
         )
         from sqlalchemy import func
 
@@ -249,11 +251,11 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         update_kwargs: dict = {"gmt_modified": func.now()}
         if download_url is not None:
             update_kwargs["download_url"] = download_url
-        if upload_url is not None:
-            update_kwargs["upload_url"] = upload_url
-
-        if "download_url" not in update_kwargs and "upload_url" not in update_kwargs:
-            return  # no-op: both None
+        else:
+            log.debug(
+                "update_urls: transfer_id=%s, download_url is None, no-op", transfer_id
+            )
+            return  # no-op
 
         result = (
             self._session.query(FileTransferTicketModel)

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_protocol.py
@@ -30,8 +30,10 @@ class TransferNotFoundError(FileTransferRepositoryError, ApiTransferNotFoundErro
     """
 
     def __init__(self, transfer_id: str) -> None:
+        message = f"Transfer ticket {transfer_id} not found"
+        self.message = message  # Set explicitly — cooperative MRO stops at RuntimeError
         super().__init__(
-            f"Transfer ticket {transfer_id} not found",
+            message,
             error_code="FILE_TRANSFER_NOT_FOUND",
         )
 
@@ -47,6 +49,9 @@ class TransferStateConflictError(
     """
 
     def __init__(self, message: str) -> None:
+        self.message = (
+            message  # Set explicitly — BotServiceError.__init__ unreachable via MRO
+        )
         super().__init__(message, error_code="FILE_TRANSFER_STATE_CONFLICT")
 
 
@@ -72,6 +77,7 @@ class TicketRepository(Protocol):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         """Insert a new transfer ticket record. Returns the new record ID."""
         ...
@@ -93,7 +99,8 @@ class TicketRepository(Protocol):
         Uses a CAS (Compare-And-Swap) SQL UPDATE: only modifies the row if
         its current status is one of the allowed source states for new_status.
         Same-state transitions are idempotent.
-        Raises DeviceCreationError on invalid transition or not found.
+        Raises TransferStateConflictError on invalid state transition.
+        Raises TransferNotFoundError if no ticket with the given transfer_id exists.
         """
         ...
 
@@ -126,10 +133,9 @@ class TicketRepository(Protocol):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
-        """Update download_url and/or upload_url on a ticket.
+        """Update download_url on a ticket.
 
-        Updates only the fields that are not None. Both None is a no-op.
+        Returns early (no-op) when download_url is None.
         """
         ...

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_record.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_record.py
@@ -11,11 +11,11 @@ class TicketRecord:
     Columns per DDL schema (17 fields):
     id, gmt_create, gmt_modified, transfer_id, tenant, paas_device_id,
     direction, status, staging_subdir, filename, device_path,
-    fileservice_staging_path, error_message, download_url, upload_url,
-    multipart_session_id, env
+    fileservice_staging_path, error_message, download_url,
+    multipart_session_id, env, operator
 
     Nullable fields: staging_subdir, device_path, error_message, download_url,
-    upload_url, multipart_session_id.
+    multipart_session_id.
     """
 
     id: int
@@ -32,6 +32,6 @@ class TicketRecord:
     fileservice_staging_path: str
     error_message: str | None
     download_url: str | None
-    upload_url: str | None
     multipart_session_id: str | None
     env: str
+    operator: str

--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
@@ -82,6 +82,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_affinity: str | None = None,
         file_size: int = 0,
         part_size: int | None = None,
+        operator: str | None = None,
     ) -> GetUploadUrlResponse:
         """Orchestrate upload URL generation (v1.5: D-01/D-02/D-05 flow).
 
@@ -104,6 +105,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             tenant,
             file_size,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         # D-05: Retention mode — device_path is None, skip device resolution
         if device_path is not None:
@@ -209,6 +213,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 fileservice_staging_path=staging_path,
                 error_message=None,
                 multipart_session_id=multipart_session.session_id,
+                operator=operator,
             )
 
             logger.info(
@@ -251,6 +256,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 device_path=device_path,
                 fileservice_staging_path=staging_path,
                 error_message=None,
+                operator=operator,
             )
 
             logger.info(
@@ -271,6 +277,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_path: str,
         expire_seconds: int = 3600,
         device_affinity: str | None = None,
+        operator: str | None = None,
     ) -> GetDownloadUrlResponse:
         """Orchestrate download URL request (D-10 flow).
 
@@ -289,6 +296,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path,
             tenant,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         _, _, paas_device_id = await self._resolve_bot_device(
             bot_uuid=bot_uuid,
@@ -343,6 +353,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path=device_path,
             fileservice_staging_path=staging_path,
             error_message=None,
+            operator=operator,
         )
 
         logger.info("Ticket created: transfer_id=%s, direction=DOWNLOAD", transfer_id)
@@ -398,7 +409,6 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
 
         # Conditional fields per status
         download_url = record.download_url if record.status == "DONE" else None
-        upload_url = record.upload_url if record.status == "CREATED" else None
         # OSS presigned URLs embed their own expiry — expires_at is null for transfer queries
         expires_at: str | None = None
 
@@ -411,11 +421,11 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             filename=record.filename,
             device_path=record.device_path,
             download_url=download_url,
-            upload_url=upload_url,
             expires_at=expires_at,
             error_message=error_message,
             created_at=record.gmt_create.isoformat(),
             updated_at=record.gmt_modified.isoformat(),
+            operator=record.operator,
         )
 
     # ------------------------------------------------------------------

--- a/src/baas/src/secbaas/community/core/service/callback/_http_callback.py
+++ b/src/baas/src/secbaas/community/core/service/callback/_http_callback.py
@@ -44,9 +44,11 @@ class HttpCallback:
         run_repository: BotRunRepository,
         *,
         default_timeout: float = _DEFAULT_TIMEOUT,
+        origin: str | None = None,
     ) -> None:
         self._run_repository = run_repository
         self._default_timeout = default_timeout
+        self._origin = origin
 
     async def __call__(self, run_id: str) -> None:
         """PostRunCallback 入口：查库、构造 payload、发送。"""
@@ -102,7 +104,11 @@ class HttpCallback:
     ) -> CallbackResult:
         """执行一次 POST，返回 CallbackResult。"""
         body = json.dumps(payload.to_dict(), ensure_ascii=False)
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+        }
+        if self._origin:
+            headers["Origin"] = self._origin
 
         try:
             async with httpx.AsyncClient(timeout=self._default_timeout) as client:
@@ -112,6 +118,15 @@ class HttpCallback:
                 "[callback] error: run_id=%s, url=%s, %s", payload.run_id, url, e
             )
             return CallbackResult(success=False, message=str(e))
+
+        resp_body = resp.text
+        logger.info(
+            "[callback] response: run_id=%s, url=%s, status=%s, body=%s",
+            payload.run_id,
+            url,
+            resp.status_code,
+            resp_body,
+        )
 
         success = 200 <= resp.status_code < 300
         if success:

--- a/src/baas/tests/e2e/mock_paas_failure/test_hook_execution_failure.py
+++ b/src/baas/tests/e2e/mock_paas_failure/test_hook_execution_failure.py
@@ -17,6 +17,7 @@ Requires:
   (just restart-mock-failure-hook)
 """
 
+import asyncio
 import uuid
 
 import pytest
@@ -115,6 +116,19 @@ class TestDestroyHookFailure:
         )
         await activate_bot(api, bot)
 
+        # Ensure bot is in terminal state before destroy to avoid 409
+        # (CREATE publish must reach SUCCESS/FAILED before a new DESTROY
+        # publish can be created; PublishConflictError otherwise).
+        for _ in range(10):
+            resp = await api.client.get(
+                api.bot_url(bot["bot_uuid"]), params=api.params()
+            )
+            if resp.status_code == 200:
+                status = resp.json()["data"]["status"]
+                if status in ("ACTIVE", "FAILED"):
+                    break
+            await asyncio.sleep(0.2)
+
         # Destroy the bot
         resp = await api.client.post(
             api.bot_url(bot["bot_uuid"]) + "/destroy",
@@ -153,6 +167,19 @@ class TestRestartHookFailure:
         bot = await create_and_activate_bot(
             api, f"restart-hook-fail-{unique_id}", device_count=1
         )
+
+        # Ensure bot is in terminal state before restart to avoid 409
+        # (CREATE publish must reach SUCCESS/FAILED before a new RESTART
+        # publish can be created; PublishConflictError otherwise).
+        for _ in range(10):
+            resp = await api.client.get(
+                api.bot_url(bot["bot_uuid"]), params=api.params()
+            )
+            if resp.status_code == 200:
+                status = resp.json()["data"]["status"]
+                if status in ("ACTIVE", "FAILED"):
+                    break
+            await asyncio.sleep(0.2)
 
         # Restart the bot
         resp = await api.client.post(

--- a/src/baas/tests/unit/adapters/web/routers/bot_service/test_file_transfer_router.py
+++ b/src/baas/tests/unit/adapters/web/routers/bot_service/test_file_transfer_router.py
@@ -658,6 +658,7 @@ async def test_get_transfer_status_success(mock_dispatcher):
         download_url="https://oss.example.com/dl",
         created_at="2025-01-01T00:00:00",
         updated_at="2025-01-01T00:00:00",
+        operator="unknown",
     )
     resp = await _get("/api/v1/bots/t1/bot-001/files/transfers/tf-001")
 

--- a/src/baas/tests/unit/adapters/web/routers/bot_service/test_transfer_query_router.py
+++ b/src/baas/tests/unit/adapters/web/routers/bot_service/test_transfer_query_router.py
@@ -46,10 +46,10 @@ async def test_get_transfer_status_success(mock_dispatcher):
             filename="data.csv",
             device_path="/home/data.csv",
             download_url="https://oss.example.com/dl?token=abc",
-            upload_url=None,
             expires_at="2099-01-01T00:00:00",
             created_at="2025-01-01T00:00:00",
             updated_at="2025-01-01T00:01:00",
+            operator="unknown",
         )
     )
 

--- a/src/baas/tests/unit/core/repository/file_transfer_ticket/test_orm_ticket_repository.py
+++ b/src/baas/tests/unit/core/repository/file_transfer_ticket/test_orm_ticket_repository.py
@@ -1,0 +1,408 @@
+"""
+OrmTicketRepository unit tests.
+
+Uses pytest + MagicMock ORM session pattern matching existing
+test_orm_bot_repository.py tests.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from secbaas.community.core.repository.file_transfer_ticket import (
+    OrmTicketRepository,
+    TicketRecord,
+    TransferNotFoundError,
+    TransferStateConflictError,
+)
+
+# ==================== Fixtures ====================
+
+
+@pytest.fixture
+def mock_session():
+    """Mock SQLAlchemy ORM session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_database(mock_session):
+    """Mock database that yields a mock ORM session via @with_orm_session."""
+    database = MagicMock()
+    database.orm_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    database.orm_session.return_value.__exit__ = MagicMock(return_value=False)
+    return database
+
+
+@pytest.fixture(autouse=True)
+def _patch_model():
+    """Patch FileTransferTicketModel so constructor returns a mock with .id=42 pre-set."""
+    with patch(
+        "secbaas.community.core.repository.file_transfer_ticket._orm_repository.FileTransferTicketModel",
+        autospec=False,
+    ) as mock_cls:
+
+        def _make_model(**kwargs):
+            model = MagicMock()
+            model.id = 42
+            for k, v in kwargs.items():
+                setattr(model, k, v)
+            return model
+
+        mock_cls.side_effect = _make_model
+        yield mock_cls
+
+
+@pytest.fixture
+def repo(mock_database):
+    """Create an OrmTicketRepository instance with mock database."""
+    return OrmTicketRepository(mock_database)
+
+
+# ==================== TestCreateTicket ====================
+
+
+class TestCreateTicket:
+    def test_create_returns_id(self, repo, mock_session):
+        result = repo.create_ticket(
+            transfer_id="tf-001",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
+            error_message=None,
+            operator="test-user",
+        )
+
+        assert result is not None
+        mock_session.add.assert_called_once()
+        mock_session.flush.assert_called_once()
+
+    def test_create_model_fields(self, repo, mock_session):
+        repo.create_ticket(
+            transfer_id="tf-001",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir="my-subdir",
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
+            error_message=None,
+            multipart_session_id="upload-123",
+            operator="test-user",
+        )
+
+        mock_session.add.assert_called_once()
+        model = mock_session.add.call_args[0][0]
+        assert model.transfer_id == "tf-001"
+        assert model.tenant == "t1"
+        assert model.paas_device_id == "sandbox@42"
+        assert model.direction == "UPLOAD"
+        assert model.status == "CREATED"
+        assert model.staging_subdir == "my-subdir"
+        assert model.filename == "data.csv"
+        assert model.device_path == "/home/data.csv"
+        assert model.fileservice_staging_path == "file-transfers/t1/tf-001/data.csv"
+        assert model.error_message is None
+        assert model.multipart_session_id == "upload-123"
+        assert model.operator == "test-user"
+
+    def test_create_default_operator(self, repo, mock_session):
+        """When operator is not provided, defaults to 'unknown'."""
+        repo.create_ticket(
+            transfer_id="tf-002",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="DOWNLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-002/data.csv",
+            error_message=None,
+            operator="unknown",
+        )
+
+        model = mock_session.add.call_args[0][0]
+        assert model.operator == "unknown"
+
+    def test_create_nullable_fields(self, repo, mock_session):
+        """Verify nullable fields can be passed as None."""
+        repo.create_ticket(
+            transfer_id="tf-003",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path=None,
+            fileservice_staging_path="file-transfers/t1/tf-003/data.csv",
+            error_message=None,
+            multipart_session_id=None,
+            operator="unknown",
+        )
+
+        model = mock_session.add.call_args[0][0]
+        assert model.staging_subdir is None
+        assert model.device_path is None
+        assert model.multipart_session_id is None
+        assert model.error_message is None
+
+
+# ==================== TestGetByTransferId ====================
+
+
+class TestGetByTransferId:
+    def test_found(self, repo, mock_session):
+        now = datetime.now()
+        record = TicketRecord(
+            id=5,
+            gmt_create=now,
+            gmt_modified=now,
+            transfer_id="tf-xyz",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-xyz/data.csv",
+            error_message=None,
+            download_url=None,
+            multipart_session_id=None,
+            env="test",
+            operator="unknown",
+        )
+        model = MagicMock()
+        model.to_record.return_value = record
+        mock_session.query.return_value.filter.return_value.first.return_value = model
+
+        result = repo.get_by_transfer_id("tf-xyz")
+
+        assert result is not None
+        assert result.id == 5
+        assert result.transfer_id == "tf-xyz"
+        mock_session.query.assert_called_once()
+
+    def test_not_found(self, repo, mock_session):
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        result = repo.get_by_transfer_id("nonexistent")
+
+        assert result is None
+
+    def test_with_tenant_filter(self, repo, mock_session):
+        """Verify that when tenant is passed, the filter chain includes tenant condition."""
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        repo.get_by_transfer_id("tf-xyz", tenant="t1")
+
+        assert mock_session.query.return_value.filter.call_count >= 1
+
+
+# ==================== TestUpdateStatus ====================
+
+
+class TestUpdateStatus:
+    def test_valid_transition(self, repo, mock_session):
+        """CAS update returns 1 — valid transition succeeds."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        # Should not raise
+        repo.update_status("tf-001", "UPLOADING")
+
+    def test_invalid_transition(self, repo, mock_session):
+        """CAS update returns 0, fallback query finds ticket with conflicting status."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 0
+        # Fallback first() returns a model with status=DONE (terminal)
+        fallback_row = MagicMock()
+        fallback_row.status = "DONE"
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            fallback_row
+        )
+
+        with pytest.raises(TransferStateConflictError):
+            repo.update_status("tf-001", "UPLOADING")
+
+    def test_not_found(self, repo, mock_session):
+        """CAS update returns 0, fallback query returns None → TransferNotFoundError."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 0
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(TransferNotFoundError, match="not found"):
+            repo.update_status("nonexistent", "DONE")
+
+    def test_same_state_idempotent(self, repo, mock_session):
+        """Same-state transition is idempotent (CREATED→CREATED allowed)."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        # Should not raise
+        repo.update_status("tf-001", "CREATED")
+
+    def test_with_error_message(self, repo, mock_session):
+        """Verify error_message is passed through to update_kwargs."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        repo.update_status("tf-001", "FAILED", error_message="timeout")
+
+        call_kwargs = (
+            mock_session.query.return_value.filter.return_value.update.call_args
+        )
+        update_dict = call_kwargs[0][0]
+        assert update_dict["error_message"] == "timeout"
+        assert update_dict["status"] == "FAILED"
+
+
+# ==================== TestUpdateUrls ====================
+
+
+class TestUpdateUrls:
+    def test_update_download_url(self, repo, mock_session):
+        """Setting download_url triggers an UPDATE query."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        repo.update_urls("tf-001", download_url="https://oss.example.com/dl")
+
+        call_kwargs = (
+            mock_session.query.return_value.filter.return_value.update.call_args
+        )
+        update_dict = call_kwargs[0][0]
+        assert update_dict["download_url"] == "https://oss.example.com/dl"
+
+    def test_noop_when_none(self, repo, mock_session):
+        """When download_url is None, the method returns early — no query."""
+        repo.update_urls("tf-001")
+
+        # session.query should NOT be called (early return guard)
+        mock_session.query.assert_not_called()
+
+    def test_not_found(self, repo, mock_session):
+        """update() returns 0 — TransferNotFoundError is raised."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 0
+
+        with pytest.raises(TransferNotFoundError):
+            repo.update_urls("tf-001", download_url="https://oss.example.com/dl")
+
+
+# ==================== TestListPendingUploads ====================
+
+
+class TestListPendingUploads:
+    def test_returns_tickets(self, repo, mock_session):
+        now = datetime.now()
+
+        def _make_record(transfer_id, status):
+            return TicketRecord(
+                id=1,
+                gmt_create=now,
+                gmt_modified=now,
+                transfer_id=transfer_id,
+                tenant="t1",
+                paas_device_id="sandbox@42",
+                direction="UPLOAD",
+                status=status,
+                staging_subdir=None,
+                filename="data.csv",
+                device_path="/home/data.csv",
+                fileservice_staging_path=f"file-transfers/t1/{transfer_id}/data.csv",
+                error_message=None,
+                download_url=None,
+                multipart_session_id=None,
+                env="test",
+                operator="unknown",
+            )
+
+        model1 = MagicMock()
+        model1.to_record.return_value = _make_record("tf-001", "UPLOADING")
+        model2 = MagicMock()
+        model2.to_record.return_value = _make_record("tf-002", "UPLOADING")
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [
+            model1,
+            model2,
+        ]
+
+        result = repo.list_pending_uploads(["CREATED", "UPLOADING"], 10)
+
+        assert len(result) == 2
+        assert result[0].transfer_id == "tf-001"
+        assert result[1].transfer_id == "tf-002"
+
+    def test_empty_result(self, repo, mock_session):
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+
+        result = repo.list_pending_uploads(["CREATED"], 10)
+
+        assert result == []
+
+    def test_respects_limit(self, repo, mock_session):
+        """Verify the limit argument is passed to the query chain."""
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+
+        repo.list_pending_uploads(["CREATED"], 5)
+
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.assert_called_once_with(
+            5
+        )
+
+
+# ==================== TestGetByFileserviceStagingPath ====================
+
+
+class TestGetByFileserviceStagingPath:
+    def test_found(self, repo, mock_session):
+        now = datetime.now()
+        record = TicketRecord(
+            id=5,
+            gmt_create=now,
+            gmt_modified=now,
+            transfer_id="tf-xyz",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-xyz/data.csv",
+            error_message=None,
+            download_url=None,
+            multipart_session_id=None,
+            env="test",
+            operator="unknown",
+        )
+        model = MagicMock()
+        model.to_record.return_value = record
+        mock_session.query.return_value.filter.return_value.first.return_value = model
+
+        result = repo.get_by_fileservice_staging_path(
+            "file-transfers/t1/tf-xyz/data.csv"
+        )
+
+        assert result is not None
+        assert result.transfer_id == "tf-xyz"
+
+    def test_not_found(self, repo, mock_session):
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        result = repo.get_by_fileservice_staging_path("nonexistent/path")
+
+        assert result is None
+
+    def test_with_tenant_filter(self, repo, mock_session):
+        """Verify that when tenant is passed, the filter chain includes tenant condition."""
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        repo.get_by_fileservice_staging_path(
+            "file-transfers/t1/tf-xyz/data.csv", tenant="t1"
+        )
+
+        assert mock_session.query.return_value.filter.call_count >= 1

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_dispatcher.py
@@ -48,9 +48,9 @@ def _make_ticket(**overrides):
         fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
         error_message=None,
         download_url=None,
-        upload_url=None,
         multipart_session_id=None,
         env="test",
+        operator="unknown",
     )
     defaults.update(overrides)
     return TicketRecord(**defaults)
@@ -303,13 +303,10 @@ class TestDispatchGetTransferStatus:
 
     @pytest.mark.asyncio
     async def test_status_created(self, dispatcher, ticket_repo):
-        ticket = _make_ticket(
-            status="CREATED", upload_url="https://oss.example.com/put"
-        )
+        ticket = _make_ticket(status="CREATED")
         ticket_repo.get_by_transfer_id.return_value = ticket
         result = await dispatcher.dispatch_get_transfer_status("tf-001", tenant="t1")
         assert result.status == "CREATED"
-        assert result.upload_url == "https://oss.example.com/put"
 
     @pytest.mark.asyncio
     async def test_status_failed(self, dispatcher, ticket_repo):

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_operator.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_operator.py
@@ -1,0 +1,281 @@
+"""Unit tests for operator field — normalization, passthrough, and status response."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from secbaas.community.api.bot_runtime import (
+    GetDownloadUrlRequest,
+    GetUploadUrlRequest,
+)
+from secbaas.community.core.repository.file_transfer_ticket import TicketRecord
+from secbaas.community.core.service.bot_runtime.dispatcher._file_transfer_dispatcher import (
+    DefaultBotFileTransferDispatcher,
+)
+from secbaas.community.spi.file_transfer import (
+    MultipartSession,
+    ObjectListing,
+    PartInfo,
+)
+
+
+def _make_ticket(**overrides):
+    now = datetime.now()
+    defaults = dict(
+        id=1,
+        gmt_create=now,
+        gmt_modified=now,
+        transfer_id="tf-001",
+        tenant="test-tenant",
+        paas_device_id="sandbox@42",
+        direction="UPLOAD",
+        status="CREATED",
+        staging_subdir=None,
+        filename="data.csv",
+        device_path="/home/data.csv",
+        fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
+        error_message=None,
+        download_url=None,
+        multipart_session_id=None,
+        env="test",
+        operator="unknown",
+    )
+    defaults.update(overrides)
+    return TicketRecord(**defaults)
+
+
+@pytest.fixture
+def bot_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def device_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def paas_facade():
+    facade = MagicMock()
+    facade.push_file = AsyncMock()
+    return facade
+
+
+@pytest.fixture
+def file_backend():
+    backend = MagicMock()
+    backend.generate_upload_url.return_value = "https://oss.example.com/put?token=abc"
+    backend.generate_download_url.return_value = "https://oss.example.com/get?token=abc"
+    backend.check_object_exists.return_value = True
+    backend.build_staging_path.return_value = "file-transfers/t1/tf-001/data.csv"
+    backend.build_staging_prefix.return_value = "file-transfers/t1/"
+    backend.list_objects.return_value = ObjectListing(
+        items=[], truncated=False, next_marker=None
+    )
+    backend.initiate_multipart_upload.return_value = MultipartSession(
+        session_id="mp-session-1",
+        part_count=2,
+        parts=[
+            PartInfo(part_number=1, upload_url="https://oss.example.com/part1"),
+            PartInfo(part_number=2, upload_url="https://oss.example.com/part2"),
+        ],
+    )
+    backend.list_parts.return_value = [
+        PartInfo(part_number=1, upload_url="", etag="etag-1"),
+    ]
+    return backend
+
+
+@pytest.fixture
+def ticket_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def dispatcher(bot_repo, device_repo, paas_facade, file_backend, ticket_repo):
+    return DefaultBotFileTransferDispatcher(
+        bot_repo=bot_repo,
+        device_repo=device_repo,
+        paas_facade=paas_facade,
+        file_transfer_backend=file_backend,
+        ticket_repo=ticket_repo,
+    )
+
+
+def _setup_resolve_bot_device(dispatcher, bot_repo, device_repo):
+    mock_bot = MagicMock()
+    mock_bot.id = 1
+    mock_bot.bot_uuid = "bot-001"
+    mock_bot.tenant = "test-tenant"
+    bot_repo.get_by_bot_uuid.return_value = mock_bot
+    mock_device = MagicMock()
+    mock_device.id = 1
+    mock_device.device_uuid = "dev-001"
+    mock_device.provider_device_id = "sandbox@42"
+    mock_device.status = "ACTIVE"
+    device_repo.list_by_bot_id.return_value = [mock_device]
+
+
+# ── Test 1: operator=None normalizes to "unknown" (D-04) ─────────────
+
+
+class TestOperatorNoneNormalization:
+    @pytest.mark.asyncio
+    async def test_upload_operator_none(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator=None in dispatch_get_upload_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator=None,
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_download_operator_none(
+        self, dispatcher, bot_repo, device_repo, ticket_repo, paas_facade
+    ):
+        """operator=None in dispatch_get_download_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_download_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            operator=None,
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+
+# ── Test 2: operator="" normalizes to "unknown" (D-04) ───────────────
+
+
+class TestOperatorEmptyStringNormalization:
+    @pytest.mark.asyncio
+    async def test_upload_operator_empty_string(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator="" in dispatch_get_upload_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator="",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_download_operator_empty_string(
+        self, dispatcher, bot_repo, device_repo, ticket_repo, paas_facade
+    ):
+        """operator="" in dispatch_get_download_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_download_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            operator="",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+
+# ── Test 3: operator="   " normalizes to "unknown" (D-04) ────────────
+
+
+class TestOperatorWhitespaceNormalization:
+    @pytest.mark.asyncio
+    async def test_upload_operator_whitespace_only(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator="   " in dispatch_get_upload_url → .strip() → 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator="   ",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+
+# ── Test 4: operator="user123" passes through unchanged ───────────────
+
+
+class TestOperatorPassthrough:
+    @pytest.mark.asyncio
+    async def test_upload_operator_passthrough(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator='user123' in upload → create_ticket called with 'user123'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator="user123",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "user123"
+
+    @pytest.mark.asyncio
+    async def test_download_operator_passthrough(
+        self, dispatcher, bot_repo, device_repo, ticket_repo, paas_facade
+    ):
+        """operator='bob' in download → create_ticket called with 'bob'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_download_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            operator="bob",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "bob"
+
+
+# ── Test 5: GetTransferStatusResponse includes operator field (D-05) ──
+
+
+class TestTransferStatusOperator:
+    @pytest.mark.asyncio
+    async def test_status_response_includes_operator(self, dispatcher, ticket_repo):
+        """dispatch_get_transfer_status returns operator from TicketRecord."""
+        ticket = _make_ticket(status="DONE", operator="alice")
+        ticket_repo.get_by_transfer_id.return_value = ticket
+        result = await dispatcher.dispatch_get_transfer_status("tf-001", tenant="t1")
+        assert result.operator == "alice"
+
+
+# ── Test 6: Pydantic model default value (D-03) ──────────────────────
+
+
+class TestPydanticModelDefaults:
+    def test_upload_request_default_operator(self):
+        """GetUploadUrlRequest without operator → defaults to 'unknown'."""
+        req = GetUploadUrlRequest(device_path="/home/data.csv")
+        assert req.operator == "unknown"
+
+    def test_download_request_default_operator(self):
+        """GetDownloadUrlRequest without operator → defaults to 'unknown'."""
+        req = GetDownloadUrlRequest(device_path="/home/data.csv")
+        assert req.operator == "unknown"
+
+    def test_upload_request_explicit_operator(self):
+        """GetUploadUrlRequest with explicit operator → preserves value."""
+        req = GetUploadUrlRequest(device_path="/home/data.csv", operator="mybot")
+        assert req.operator == "mybot"
+
+    def test_download_request_explicit_operator(self):
+        """GetDownloadUrlRequest with explicit operator → preserves value."""
+        req = GetDownloadUrlRequest(device_path="/home/data.csv", operator="mybot")
+        assert req.operator == "mybot"

--- a/src/baas/tests/unit/core/service/callback/test_http_callback.py
+++ b/src/baas/tests/unit/core/service/callback/test_http_callback.py
@@ -439,3 +439,117 @@ class TestHttpCallbackSendOnce:
             )
 
         mock_client_cls.assert_called_once_with(timeout=30.0)
+
+
+# ── origin / Origin header / response body log ──────────────
+
+
+class TestHttpCallbackOrigin:
+    @pytest.mark.asyncio
+    async def test_origin_header_set_when_origin_provided(self):
+        cb = HttpCallback(_make_repo(), origin="https://my.origin")
+        mock_resp = _make_response(status_code=200, text="OK")
+        with patch(
+            "secbaas.community.core.service.callback._http_callback.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            await cb._send_once(
+                "http://example.com/cb",
+                CallbackPayload(
+                    run_id="r1",
+                    bot_id="b1",
+                    status="COMPLETED",
+                ),
+            )
+
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers["Origin"] == "https://my.origin"
+        assert headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_no_origin_header_when_origin_is_none(self):
+        cb = HttpCallback(_make_repo())
+        mock_resp = _make_response(status_code=200, text="OK")
+        with patch(
+            "secbaas.community.core.service.callback._http_callback.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            await cb._send_once(
+                "http://example.com/cb",
+                CallbackPayload(
+                    run_id="r1",
+                    bot_id="b1",
+                    status="COMPLETED",
+                ),
+            )
+
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert "Origin" not in headers
+
+    @pytest.mark.asyncio
+    async def test_response_body_logged(self):
+        cb = HttpCallback(_make_repo())
+        mock_resp = _make_response(status_code=200, text="all good")
+        with patch(
+            "secbaas.community.core.service.callback._http_callback.httpx.AsyncClient"
+        ) as mock_client_cls, patch(
+            "secbaas.community.core.service.callback._http_callback.logger"
+        ) as mock_logger:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            await cb._send_once(
+                "http://example.com/cb",
+                CallbackPayload(
+                    run_id="r1",
+                    bot_id="b1",
+                    status="COMPLETED",
+                ),
+            )
+
+        resp_log_call = mock_logger.info.call_args_list[0]
+        assert resp_log_call.args[0] == "[callback] response: run_id=%s, url=%s, status=%s, body=%s"
+        assert "all good" in resp_log_call.args
+
+    @pytest.mark.asyncio
+    async def test_response_body_logged_on_failure(self):
+        cb = HttpCallback(_make_repo())
+        mock_resp = _make_response(status_code=500, text="server error")
+        with patch(
+            "secbaas.community.core.service.callback._http_callback.httpx.AsyncClient"
+        ) as mock_client_cls, patch(
+            "secbaas.community.core.service.callback._http_callback.logger"
+        ) as mock_logger:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            await cb._send_once(
+                "http://example.com/cb",
+                CallbackPayload(
+                    run_id="r1",
+                    bot_id="b1",
+                    status="COMPLETED",
+                ),
+            )
+
+        log_messages = [
+            call.args[0] for call in mock_logger.info.call_args_list
+        ]
+        assert any("response:" in msg for msg in log_messages)
+        assert any("failed:" in call.args[0] for call in mock_logger.error.call_args_list)

--- a/src/baas/tests/unit/core/service/scheduler/test_file_transfer_poller.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_file_transfer_poller.py
@@ -50,7 +50,6 @@ def _make_ticket(**overrides):
         fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
         error_message=None,
         download_url=None,
-        upload_url=None,
         multipart_session_id=None,
         env="test",
     )

--- a/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
@@ -1,34 +1,22 @@
-import asyncio
-from typing import Any
+"""Token exchange HTTP boundary; Caller policy lives in application services."""
 
 from fastapi import APIRouter, Query, Request, Response
 from fastapi.responses import JSONResponse
 
-from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
 from agentclaw.community.api.caller_credential import (
     CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
     CALLER_CREDENTIAL_REQUEST_INVALID,
-    CALLER_OUTBOUND_UPDATE_FAILED,
-    CallerCredentialError,
-    CallerRuntimeUpdater,
-    CallerTokenProvider,
 )
-from agentclaw.community.api.caller_identity_service import (
-    CallerIdentityServiceProtocol,
-    CallerIdentityStage,
-)
-from agentclaw.community.core.caller_identity.contracts import (
-    CallerIdentityAmbiguousError,
-    CallerIdentityPermissionError,
-)
+from agentclaw.community.api.caller_identity_service import CallerIdentityStage
 from agentclaw.community.di import Injected
-from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.auth import AuthPlugin, AuthRequestContext
-from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.plugin_api.auth import AuthRequestContext
 from agentclaw.community.plugin_api.token_exchange import TokenExchangePlugin
 
+
 router = APIRouter()
-logger = get_logger()
 
 
 def _cors_headers(request: Request) -> dict[str, str]:
@@ -39,59 +27,24 @@ def _cors_headers(request: Request) -> dict[str, str]:
     }
 
 
-def _success_iam_response(iam_token: str, headers: dict[str, str]) -> Response:
-    return JSONResponse(
-        content={"success": True, "iam_token": iam_token},
-        headers=headers,
-    )
-
-
-def _request_injector(request: Request):
-    return getattr(getattr(request, "app", None), "state", None).injector
-
-
-def _get_optional_dependency(
-    request: Request,
-    dependency: Any,
-    error_code: str,
-):
-    try:
-        return _request_injector(request).get(dependency)
-    except Exception as exc:
-        logger.warning("caller_token_dependency_unavailable code=%s", error_code)
-        raise CallerCredentialError(error_code) from exc
-
-
-def _build_auth_context(request: Request) -> AuthRequestContext:
+def _auth_request(request: Request) -> AuthRequestContext:
     return AuthRequestContext(
         cookies=dict(request.cookies),
-        headers={k: v for k, v in request.headers.items()},
+        headers=dict(request.headers),
         query_params=dict(request.query_params),
         base_url=str(request.base_url),
     )
 
 
-async def _resolve_current_user(request: Request):
-    auth_plugin = _get_optional_dependency(
-        request,
-        AuthPlugin,
-        CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-    )
-    identity = await auth_plugin.resolve_user_from_request(_build_auth_context(request))
-    return AuthenticatedUser(
-        id=identity.id,
-        staffId=identity.staffId,
-        operatorName=identity.operatorName,
-        nickName=identity.nickName,
-        tenantId=identity.tenantId,
-    )
-
-
-def _caller_error_status(code: str) -> int:
-    if code == CALLER_CREDENTIAL_REQUEST_INVALID:
+def _caller_error_status(error: str) -> int:
+    if error == CALLER_CREDENTIAL_REQUEST_INVALID or error == "IAM_TOKEN cookie not found":
         return 400
-    if code == CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE:
+    if error == CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE:
         return 503
+    if error == "CALLER_IDENTITY_AMBIGUOUS":
+        return 409
+    if error == "CALLER_IDENTITY_FORBIDDEN":
+        return 403
     return 502
 
 
@@ -114,13 +67,10 @@ async def token_exchange(
     request: Request,
     plugin: TokenExchangePlugin = Injected(TokenExchangePlugin),
 ) -> Response:
-    headers = _cors_headers(request)
-    # Plugin owns the per-runtime policy: Local returns a mock; Prod
-    # reads IAM_TOKEN and calls Buservice. Missing cookie / upstream
-    # failures raise DomainError subclasses mapped to 400/500 by the
-    # global handler in api/app.py.
-    content = await plugin.exchange_from_request(request)
-    return JSONResponse(content=content, headers=headers)
+    return JSONResponse(
+        content=await plugin.exchange_from_request(request),
+        headers=_cors_headers(request),
+    )
 
 
 @router.options("/api/v1/token/iam")
@@ -145,190 +95,24 @@ async def get_iam_token(
     publish_id: int | None = Query(default=None),
     entity_id: str | None = Query(default=None),
     is_test_exchange: bool = False,
+    service: CallerIamTokenServiceProtocol = Injected(CallerIamTokenServiceProtocol),
 ) -> Response:
-    headers = _cors_headers(request)
-    iam_token = request.cookies.get("IAM_TOKEN") or ""
-    if not iam_token:
-        return JSONResponse(
-            content={"success": False, "error": "IAM_TOKEN cookie not found"},
-            status_code=400,
-            headers=headers,
-        )
-    if is_test_exchange and not bot_id:
-        logger.warning("caller_test_exchange_rejected reason=bot_id_missing")
-        return JSONResponse(
-            content={"success": False, "error": CALLER_CREDENTIAL_REQUEST_INVALID},
-            status_code=400,
-            headers=headers,
-        )
-    if not bot_id:
-        return _success_iam_response(iam_token, headers)
-
-    try:
-        caller_identity = _get_optional_dependency(
-            request,
-            CallerIdentityServiceProtocol,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-    except CallerCredentialError:
-        logger.warning(
-            "caller_token_context_unavailable bot_id=%s stage=%s "
-            "reason=identity_service_missing",
-            bot_id,
-            stage.value,
-        )
-        return _success_iam_response(iam_token, headers)
-    try:
-        token_context = await asyncio.to_thread(
-            caller_identity.get_iam_token_context,
-            bot_id=bot_id,
-            stage=stage,
-            publish_id=publish_id,
-            entity_id=entity_id,
-            is_test_exchange=is_test_exchange,
-        )
-    except CallerIdentityAmbiguousError as exc:
-        logger.warning(
-            "caller_token_context_ambiguous bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.detail},
-            status_code=409,
-            headers=headers,
-        )
-    except CallerIdentityPermissionError as exc:
-        logger.warning(
-            "caller_token_context_forbidden bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.detail},
-            status_code=403,
-            headers=headers,
-        )
-    except Exception:
-        logger.warning(
-            "caller_token_context_unavailable bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return _success_iam_response(iam_token, headers)
-    if not token_context.should_exchange_caller_token:
-        logger.info(
-            "caller_token_exchange_skipped bot_id=%s stage=%s call_type=%s "
-            "test_exchange=%s",
-            bot_id,
-            stage.value,
-            token_context.bot_call_type.value,
-            is_test_exchange,
-        )
-        return _success_iam_response(iam_token, headers)
-    if not token_context.owner_id:
-        logger.warning(
-            "caller_token_exchange_failed bot_id=%s stage=%s reason=owner_missing "
-            "test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": CALLER_CREDENTIAL_REQUEST_INVALID},
-            status_code=400,
-            headers=headers,
-        )
-
-    try:
-        current_user = await _resolve_current_user(request)
-        if is_test_exchange:
-            caller_identity.authorize_iam_token_exchange(
-                caller_user_id=current_user.staffId,
-                owner_user_id=token_context.owner_id,
-                is_test_exchange=True,
-            )
-        passport = _get_optional_dependency(
-            request,
-            PassportPlugin,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-        provider = _get_optional_dependency(
-            request,
-            CallerTokenProvider,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-        updater = _get_optional_dependency(
-            request,
-            CallerRuntimeUpdater,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-        exchange_kwargs = {
-            "iam_token": iam_token,
-            "caller_user_id": current_user.staffId,
-            "bot_id": bot_id,
-            "owner_user_id": token_context.owner_id,
-            "passport": passport,
-            "token_provider": provider,
-            "runtime_updater": updater,
-            "stage": stage.value,
-            "publish_id": publish_id,
-            "entity_id": entity_id,
-            "binding_id": token_context.binding_id,
-        }
-        if is_test_exchange:
-            exchange_kwargs["is_test_exchange"] = True
-        await asyncio.to_thread(
-            caller_identity.exchange_caller_identity,
-            **exchange_kwargs,
-        )
-    except CallerCredentialError as exc:
-        logger.warning(
-            "caller_token_exchange_failed bot_id=%s stage=%s code=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            exc.code,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.code},
-            status_code=_caller_error_status(exc.code),
-            headers=headers,
-        )
-    except CallerIdentityPermissionError as exc:
-        logger.warning(
-            "caller_token_exchange_forbidden bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.detail},
-            status_code=403,
-            headers=headers,
-        )
-    except Exception:
-        logger.warning(
-            "caller_runtime_update_failed bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": CALLER_OUTBOUND_UPDATE_FAILED},
-            status_code=502,
-            headers=headers,
-        )
-
-    logger.info(
-        "caller_token_exchange_succeeded bot_id=%s stage=%s test_exchange=%s",
-        bot_id,
-        stage.value,
-        is_test_exchange,
+    result = await service.get_iam_token(
+        iam_token=request.cookies.get("IAM_TOKEN") or "",
+        auth_request=_auth_request(request),
+        bot_id=bot_id,
+        stage=stage,
+        publish_id=publish_id,
+        entity_id=entity_id,
+        is_test_exchange=is_test_exchange,
     )
-    # COSEC: the Caller credential is written to BaaS only. Returning it to
-    # the browser would turn a server-side runtime credential into an API secret.
-    return _success_iam_response(iam_token, headers)
+    content = {"success": result.error is None}
+    if result.error is None:
+        content["iam_token"] = result.iam_token
+    else:
+        content["error"] = result.error
+    return JSONResponse(
+        content=content,
+        status_code=200 if result.error is None else _caller_error_status(result.error),
+        headers=_cors_headers(request),
+    )

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -66,6 +66,7 @@ internal_dependencies:
   - agentclaw.community.core.service_bot.services.baas_service  # BotWsConnectionInfoResponse / HttpConnectionInfo — typed in baas_service.py (BaasService is a plain core service)
   - agentclaw.community.core.service_bot.types       # PublishStage enum — typed in baas_service.py
   - agentclaw.community.kernel.device_dto            # OutBoundOperationRule — typed in baas_service.py Protocol (B6)
+  - agentclaw.community.plugin_api.auth              # AuthRequestContext — typed in caller_iam_token_service.py
   - agentclaw.community.plugin_api.passport          # PassportPlugin — typed in caller_identity_service.py
 ```
 

--- a/src/backend/src/agentclaw/community/api/caller_credential.py
+++ b/src/backend/src/agentclaw/community/api/caller_credential.py
@@ -34,11 +34,28 @@ class CallerTokenProvider(Protocol):
         *,
         auth_context: AuthContext,
         iam_token: str,
-        delegation_credential: str,
+        bot_id: str,
+        owner_user_id: str,
         task_metadata: Mapping[str, str],
     ) -> CallerToken:
         """Issue one non-retried Caller execution credential."""
         ...
+
+
+class UnavailableCallerTokenProvider:
+    """Stable non-Corp binding that fails closed without Injector errors."""
+
+    def exchange(
+        self,
+        *,
+        auth_context: AuthContext,
+        iam_token: str,
+        bot_id: str,
+        owner_user_id: str,
+        task_metadata: Mapping[str, str],
+    ) -> CallerToken:
+        del auth_context, iam_token, bot_id, owner_user_id, task_metadata
+        raise CallerCredentialError(CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE)
 
 
 @runtime_checkable
@@ -52,15 +69,13 @@ class CallerRuntimeUpdater(Protocol):
         owner_user_id: str,
         caller_user_id: str,
         caller_token: CallerToken,
-        agent_pass_token: str,
-        agent_code: str,
         stage: str,
         publish_id: int | None,
         entity_id: str | None = None,
         binding_id: int | None = None,
         is_test_exchange: bool = False,
     ) -> None:
-        """Replace the device's complete outbound rule with Caller overlay."""
+        """Append the Caller overlay to the exact runtime device."""
         ...
 
 
@@ -78,4 +93,5 @@ __all__ = [
     "CallerRuntimeUpdater",
     "CallerToken",
     "CallerTokenProvider",
+    "UnavailableCallerTokenProvider",
 ]

--- a/src/backend/src/agentclaw/community/api/caller_iam_token_service.py
+++ b/src/backend/src/agentclaw/community/api/caller_iam_token_service.py
@@ -1,0 +1,26 @@
+"""Application boundary for IAM-token Caller identity updates."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenOutcome,
+    CallerIdentityStage,
+)
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+
+
+@runtime_checkable
+class CallerIamTokenServiceProtocol(Protocol):
+    async def get_iam_token(
+        self,
+        *,
+        iam_token: str,
+        auth_request: AuthRequestContext,
+        bot_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        is_test_exchange: bool,
+    ) -> CallerIamTokenOutcome: ...

--- a/src/backend/src/agentclaw/community/api/caller_identity_service.py
+++ b/src/backend/src/agentclaw/community/api/caller_identity_service.py
@@ -24,7 +24,6 @@ from agentclaw.community.core.caller_identity.contracts import (
     McpCallType,
     McpCallTypeUpdateResult,
 )
-from agentclaw.community.plugin_api.passport import PassportPlugin
 
 
 @runtime_checkable
@@ -90,7 +89,6 @@ class CallerIdentityServiceProtocol(Protocol):
         caller_user_id: str,
         bot_id: str,
         owner_user_id: str,
-        passport: PassportPlugin,
         token_provider: CallerTokenProviderProtocol,
         runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -558,6 +558,48 @@ class BotService:
             )
             return None
 
+    def _list_bot_members(
+        self, bot_id: str, owner_id: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        """List a bot's members (collaborators) for the appcoding-bots response.
+
+        Reads the ``ac_bot_collaborator`` table (added admin/member
+        collaborators) scoped to the current env. The bot owner is intentionally
+        not synthesized as a member here: owner identity lives on the bot record
+        itself (``owner_id`` / ``owner_name``); callers wanting the full roster
+        should combine that with this list.
+
+        Returns an empty list when there are no collaborators, when ``owner_id``
+        is missing, or when the lookup itself fails — member enrichment must
+        never break the coding-bots listing.
+
+        Args:
+            bot_id: Bot ID of the coding bot.
+            owner_id: Bot owner's work number (filters the collaborator index).
+
+        Returns:
+            A list of member dicts with ``user_id`` and ``user_name`` only
+            (operator_id / role / timestamps are not exposed on this public
+            surface).
+        """
+        if not owner_id:
+            return []
+        try:
+            env = get_current_env()
+            collaborators = self._collaborator_repo.list_by_bot(
+                bot_id=bot_id, owner_id=owner_id, env=env,
+            )
+            return [
+                {"user_id": c.user_id, "user_name": c.user_name}
+                for c in collaborators
+            ]
+        except Exception as e:
+            logger.warning(
+                "[bot_service._list_bot_members] Failed: bot_id=%s, owner_id=%s, error=%s",
+                bot_id, owner_id, e,
+            )
+            return []
+
     def _try_acquire_restart_lock(
         self, env: str, entity_id: str, bot_id: str, holder_user_id: str
     ) -> Optional[BotRestartLockRecord]:
@@ -1662,6 +1704,16 @@ class BotService:
                     ext = template_ext_map.get(bot_id)
                     if ext is not None:
                         bot["template_config"] = ext
+                    # Attach bot member (collaborator) information. The owner
+                    # is intentionally NOT included here: it lives on the bot
+                    # record itself (owner_id / owner_name); only added admin/
+                    # member collaborators are returned. Failure is non-fatal:
+                    # an empty list is attached so enrichment never breaks the
+                    # coding-bots list.
+                    bot["members"] = self._list_bot_members(
+                        bot_id=bot_id,
+                        owner_id=bot.get("owner_id"),
+                    )
                     coding_bots.append(bot)
             except Exception as e:
                 logger.warning(

--- a/src/backend/src/agentclaw/community/core/caller_identity/contracts.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/contracts.py
@@ -90,6 +90,14 @@ class CallerIamTokenContext:
     binding_id: int | None = None
 
 
+@dataclass(frozen=True)
+class CallerIamTokenOutcome:
+    """HTTP-neutral result of optional Caller identity installation."""
+
+    iam_token: str
+    error: str | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class CallerContext:
     capability: str

--- a/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
@@ -1,0 +1,113 @@
+"""Core application service for optional Caller identity installation."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agentclaw.community.core.caller_identity.credential import (
+    CALLER_CREDENTIAL_REQUEST_INVALID,
+    CALLER_OUTBOUND_UPDATE_FAILED,
+    CallerCredentialError,
+)
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIdentityAmbiguousError,
+    CallerIamTokenOutcome,
+    CallerIdentityPermissionError,
+    CallerIdentityStage,
+)
+from agentclaw.community.core.caller_identity.protocols import (
+    CallerIdentityTokenExchangeProtocol,
+    CallerRuntimeUpdaterProtocol,
+    CallerTokenProviderProtocol,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.auth import AuthPlugin, AuthRequestContext
+
+
+logger = get_logger()
+
+
+class CallerIamTokenService:
+    """Keep Caller exchange policy out of the HTTP router."""
+
+    def __init__(
+        self,
+        *,
+        caller_identity: CallerIdentityTokenExchangeProtocol,
+        auth_plugin: AuthPlugin,
+        token_provider: CallerTokenProviderProtocol,
+        runtime_updater: CallerRuntimeUpdaterProtocol,
+    ) -> None:
+        self._caller_identity = caller_identity
+        self._auth_plugin = auth_plugin
+        self._token_provider = token_provider
+        self._runtime_updater = runtime_updater
+
+    async def get_iam_token(
+        self,
+        *,
+        iam_token: str,
+        auth_request: AuthRequestContext,
+        bot_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        is_test_exchange: bool,
+    ) -> CallerIamTokenOutcome:
+        if not iam_token:
+            return CallerIamTokenOutcome(iam_token="", error="IAM_TOKEN cookie not found")
+        if is_test_exchange and not bot_id:
+            return CallerIamTokenOutcome(iam_token="", error=CALLER_CREDENTIAL_REQUEST_INVALID)
+        if not bot_id:
+            return CallerIamTokenOutcome(iam_token=iam_token)
+        try:
+            context = await asyncio.to_thread(
+                self._caller_identity.get_iam_token_context,
+                bot_id=bot_id,
+                stage=stage,
+                publish_id=publish_id,
+                entity_id=entity_id,
+                is_test_exchange=is_test_exchange,
+            )
+        except CallerIdentityAmbiguousError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.detail)
+        except CallerIdentityPermissionError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.detail)
+        except Exception:
+            logger.warning("caller_token_context_unavailable bot_id=%s stage=%s", bot_id, stage.value)
+            return CallerIamTokenOutcome(iam_token=iam_token)
+        if not context.should_exchange_caller_token:
+            return CallerIamTokenOutcome(iam_token=iam_token)
+        if not context.owner_id:
+            return CallerIamTokenOutcome(iam_token="", error=CALLER_CREDENTIAL_REQUEST_INVALID)
+        try:
+            identity = await self._auth_plugin.resolve_user_from_request(auth_request)
+            if is_test_exchange:
+                self._caller_identity.authorize_iam_token_exchange(
+                    caller_user_id=identity.staffId,
+                    owner_user_id=context.owner_id,
+                    is_test_exchange=True,
+                )
+            await asyncio.to_thread(
+                self._caller_identity.exchange_caller_identity,
+                iam_token=iam_token,
+                caller_user_id=identity.staffId,
+                bot_id=bot_id,
+                owner_user_id=context.owner_id,
+                token_provider=self._token_provider,
+                runtime_updater=self._runtime_updater,
+                stage=stage.value,
+                publish_id=publish_id,
+                entity_id=entity_id,
+                binding_id=context.binding_id,
+                is_test_exchange=is_test_exchange,
+            )
+        except CallerCredentialError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.code)
+        except CallerIdentityPermissionError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.detail)
+        except Exception:
+            logger.warning("caller_runtime_update_failed bot_id=%s stage=%s", bot_id, stage.value)
+            return CallerIamTokenOutcome(iam_token="", error=CALLER_OUTBOUND_UPDATE_FAILED)
+        logger.info("caller_token_exchange_succeeded bot_id=%s stage=%s", bot_id, stage.value)
+        return CallerIamTokenOutcome(iam_token=iam_token)

--- a/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
-from agentclaw.community.core.caller_identity.credential import (
-    AuthContext,
-    CallerToken,
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenContext,
+    CallerIdentityStage,
 )
+from agentclaw.community.core.caller_identity.credential import AuthContext, CallerToken
 
 
 @runtime_checkable
@@ -37,7 +38,8 @@ class CallerTokenProviderProtocol(Protocol):
         *,
         auth_context: AuthContext,
         iam_token: str,
-        delegation_credential: str,
+        bot_id: str,
+        owner_user_id: str,
         task_metadata: Mapping[str, str],
     ) -> CallerToken: ...
 
@@ -53,8 +55,44 @@ class CallerRuntimeUpdaterProtocol(Protocol):
         owner_user_id: str,
         caller_user_id: str,
         caller_token: CallerToken,
-        agent_pass_token: str,
-        agent_code: str,
+        stage: str,
+        publish_id: int | None,
+        entity_id: str | None = None,
+        binding_id: int | None = None,
+        is_test_exchange: bool = False,
+    ) -> None: ...
+
+
+@runtime_checkable
+class CallerIdentityTokenExchangeProtocol(Protocol):
+    """Core port for the Caller IAM-token exchange use case."""
+
+    def get_iam_token_context(
+        self,
+        bot_id: str,
+        stage: CallerIdentityStage,
+        publish_id: int | None = None,
+        entity_id: str | None = None,
+        is_test_exchange: bool = False,
+    ) -> CallerIamTokenContext: ...
+
+    def authorize_iam_token_exchange(
+        self,
+        *,
+        caller_user_id: str,
+        owner_user_id: str,
+        is_test_exchange: bool,
+    ) -> None: ...
+
+    def exchange_caller_identity(
+        self,
+        *,
+        iam_token: str,
+        caller_user_id: str,
+        bot_id: str,
+        owner_user_id: str,
+        token_provider: CallerTokenProviderProtocol,
+        runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,
         publish_id: int | None,
         entity_id: str | None = None,
@@ -65,6 +103,7 @@ class CallerRuntimeUpdaterProtocol(Protocol):
 
 __all__ = [
     "CallerMcpSyncProtocol",
+    "CallerIdentityTokenExchangeProtocol",
     "CallerRuntimeUpdaterProtocol",
     "CallerTokenProviderProtocol",
 ]

--- a/src/backend/src/agentclaw/community/core/caller_identity/service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/service.py
@@ -31,9 +31,7 @@ from agentclaw.community.core.caller_identity.contracts import (
 )
 from agentclaw.community.core.caller_identity.credential import (
     CALLER_CHAT_TASK,
-    CALLER_CREDENTIAL_REQUEST_INVALID,
     AuthContext,
-    CallerCredentialError,
 )
 from agentclaw.community.core.caller_identity.protocols import (
     CallerMcpSyncProtocol,
@@ -47,7 +45,6 @@ from agentclaw.community.core.caller_identity.repository import (
 )
 from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -335,7 +332,6 @@ class CallerIdentityService:
         caller_user_id: str,
         bot_id: str,
         owner_user_id: str,
-        passport: PassportPlugin,
         token_provider: CallerTokenProviderProtocol,
         runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,
@@ -345,21 +341,11 @@ class CallerIdentityService:
         is_test_exchange: bool = False,
     ) -> None:
         """Exchange and install the Caller credential for one chat request."""
-        delegation_credential = passport.query_token(bot_id, owner_user_id) or ""
-        if not delegation_credential:
-            raise CallerCredentialError(CALLER_CREDENTIAL_REQUEST_INVALID)
-
-        passport_detail = passport.query_agent_passport(bot_id, owner_user_id)
-        agent_code_value = (
-            passport_detail.get("agent_code")
-            if isinstance(passport_detail, Mapping)
-            else None
-        )
-        agent_code = agent_code_value if isinstance(agent_code_value, str) else ""
         caller_token = token_provider.exchange(
             auth_context=AuthContext(user_id=caller_user_id),
             iam_token=iam_token,
-            delegation_credential=delegation_credential,
+            bot_id=bot_id,
+            owner_user_id=owner_user_id,
             task_metadata=CALLER_CHAT_TASK,
         )
         runtime_update_kwargs: dict[str, Any] = {
@@ -367,8 +353,6 @@ class CallerIdentityService:
             "owner_user_id": owner_user_id,
             "caller_user_id": caller_user_id,
             "caller_token": caller_token,
-            "agent_pass_token": delegation_credential,
-            "agent_code": agent_code,
             "stage": stage,
             "publish_id": publish_id,
             "entity_id": entity_id,

--- a/src/backend/src/agentclaw/community/core/service_bot/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/repository/models.py
@@ -275,6 +275,36 @@ class PublishOperationKind(StrEnum):
         """
         return _KIND_BAAS_PUBLISH_TYPES[self]
 
+    @property
+    def sets_deployed_version(self) -> bool:
+        """Whether a *successful* op of this kind sets/replaces which application
+        version is running on its target bot.
+
+        ``True`` for the deploy kinds (first release, upgrade, rollback re-deploy,
+        eval publish); ``False`` for the lifecycle kinds that leave the deployed
+        version unchanged (restart, scale, eval teardown). This is the fence for
+        the online-release liveness scan: a record's completed online release is
+        still the *live* deployment on the shared online bot only while no later
+        ``sets_deployed_version`` op has landed on that bot — a newer upgrade or a
+        rollback re-deploy supersedes it, but a restart / scale does not.
+
+        Every kind is partitioned into exactly one of
+        ``_KINDS_SET_DEPLOYED_VERSION`` / ``_KINDS_PRESERVE_DEPLOYED_VERSION``;
+        ``test_publish_operation_kind_deploy_partition`` asserts the partition, so a
+        newly added kind fails CI until it is classified here.
+        """
+        return self in _KINDS_SET_DEPLOYED_VERSION
+
+    @classmethod
+    def version_setting_kinds(cls) -> frozenset["PublishOperationKind"]:
+        """Kinds whose successful op sets/replaces the deployed version (deploys)."""
+        return _KINDS_SET_DEPLOYED_VERSION
+
+    @classmethod
+    def version_preserving_kinds(cls) -> frozenset["PublishOperationKind"]:
+        """Kinds that leave the deployed version unchanged (restart/scale/teardown)."""
+        return _KINDS_PRESERVE_DEPLOYED_VERSION
+
 
 # The BaaS publish_type(s) each kind's workflow can carry — the adopt-by-query
 # type fence, co-located with the kind it describes (exposed via
@@ -288,6 +318,24 @@ _KIND_BAAS_PUBLISH_TYPES: Dict[PublishOperationKind, frozenset[str]] = {
     PublishOperationKind.EVAL_PUBLISH: frozenset({"CREATE"}),
     PublishOperationKind.EVAL_TEARDOWN: frozenset({"DESTROY", "STOP"}),
 }
+
+# Deploy vs lifecycle partition of every kind (exposed via
+# ``PublishOperationKind.sets_deployed_version``). A deploy kind's completed op
+# marks which version is live on its bot; a lifecycle kind leaves it unchanged.
+# The two sets MUST partition every ``PublishOperationKind`` (asserted by
+# ``test_publish_operation_kind_deploy_partition``): a new kind must be classified
+# into exactly one, or the liveness scan silently mistreats it.
+_KINDS_SET_DEPLOYED_VERSION: frozenset[PublishOperationKind] = frozenset({
+    PublishOperationKind.FIRST_RELEASE,
+    PublishOperationKind.UPGRADE,
+    PublishOperationKind.ROLLBACK_DEPLOY,
+    PublishOperationKind.EVAL_PUBLISH,
+})
+_KINDS_PRESERVE_DEPLOYED_VERSION: frozenset[PublishOperationKind] = frozenset({
+    PublishOperationKind.RESTART,
+    PublishOperationKind.SCALE,
+    PublishOperationKind.EVAL_TEARDOWN,
+})
 
 
 class PublishOperationState(StrEnum):

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3147,6 +3147,45 @@ class BaasService:  # pragma: no cover
                 f"BaaS API error: {e.response.status_code} - {e.response.text}"
             )
 
+    def append_caller_outbound_rule(
+        self,
+        paas_device_id: str,
+        caller_rule: OutBoundOperationRule,
+    ) -> bool:
+        """Append one validated Caller overlay without replacing base rules."""
+        payload = self._outbound_rule_to_dict(caller_rule)
+        logger.info(
+            "caller_outbound_append_started rule_count=%s",
+            len(caller_rule.header_operation_rules),
+        )
+        try:
+            response = self._http.put(
+                f"/api/v1/paas/devices/{paas_device_id}/outbound-rule?mode=append",
+                json=payload,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            response_data = response.json()
+            if response_data.get("code") != 0:
+                logger.warning("caller_outbound_append_rejected")
+                raise BaasServiceError("BaaS Caller outbound append rejected")
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "caller_outbound_append_http_failed status_code=%s",
+                exc.response.status_code,
+            )
+            raise BaasServiceError("BaaS Caller outbound append failed") from exc
+        except BaasServiceError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "caller_outbound_append_failed error_type=%s",
+                type(exc).__name__,
+            )
+            raise BaasServiceError("BaaS Caller outbound append failed") from exc
+        logger.info("caller_outbound_append_succeeded")
+        return True
+
     def update_caller_identity(
         self,
         *,
@@ -3154,8 +3193,6 @@ class BaasService:  # pragma: no cover
         owner_user_id: str,
         caller_user_id: str,
         caller_token: CallerToken,
-        agent_pass_token: str,
-        agent_code: str,
         stage: str,
         publish_id: int | None,
         entity_id: str | None = None,
@@ -3166,7 +3203,6 @@ class BaasService:  # pragma: no cover
         if (
             not caller_token.access_token
             or caller_token.subject_user_id != caller_user_id
-            or not agent_pass_token
         ):
             raise CallerCredentialError(CALLER_CREDENTIAL_REQUEST_INVALID)
 
@@ -3222,37 +3258,24 @@ class BaasService:  # pragma: no cover
         if not self._is_valid_paas_device_id(paas_device_id):
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
 
-        base_rule = self._build_outbound_operation_rule(
-            bot_id=bot_id,
-            owner_id=owner_user_id,
-            agent_pass_token=agent_pass_token,
-            agent_code=agent_code,
-        )
         caller_rule = self._outbound_rule_provider.build_caller_rule(
             caller_token=caller_token.access_token,
         )
         if not self._is_valid_caller_rule(caller_rule, caller_token.access_token):
             raise CallerCredentialError(CALLER_OUTBOUND_INVALID)
         assert caller_rule is not None
-        complete_rule = OutBoundOperationRule(
-            header_operation_rules=(
-                base_rule.header_operation_rules
-                + caller_rule.header_operation_rules
-            )
-        )
-
         logger.info(
             "caller_outbound_update_started bot_id=%s stage=%s rule_count=%s "
             "entity_scoped=%s supplied_binding_id=%s test_exchange=%s",
             bot_id,
             stage,
-            len(complete_rule.header_operation_rules),
+            len(caller_rule.header_operation_rules),
             entity_id is not None,
             use_supplied_binding_id,
             is_test_exchange,
         )
         try:
-            updated = self.update_device_outbound_rule(paas_device_id, complete_rule)
+            updated = self.append_caller_outbound_rule(paas_device_id, caller_rule)
         except Exception as exc:
             logger.warning(
                 "caller_outbound_update_failed bot_id=%s stage=%s error_type=%s "

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
     BotPublishRecord,
     PublishOperationKind,
+    PublishOperationRecord,
     PublishOperationState,
 )
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
@@ -864,35 +865,90 @@ class PublishFlowService(
         return self._publish_service.get_publish_by_id(publish_id)
 
     def is_online_release_recorded(self, publish_id: int) -> bool:
-        """True once this record's online release is fully recorded — i.e. the
-        binding + ``ext.publish.online`` were written, not merely the BaaS
-        workflow id.
+        """True when this record's online release is the *live* deployment on its
+        bot — i.e. the latest version-setting op that has landed on the shared
+        online bot belongs to this publish.
 
-        This is the crash-resume guard for the online leg, which runs *within*
-        ONLINE_PUB with no status transition to guard it, so the threshold must
-        be the *completed* release, not just the created workflow. Both consumers
-        need this threshold:
+        Purely ledger-driven (#197): the ledger is the source of truth for what is
+        deployed. The question is answered from the bot's op timeline alone, in two
+        steps:
 
-        * the online_release task gate (``tasks.py``) skips re-running the release
-          only when it is fully done; at ``ID_RECORDED``-but-not-complete a re-run
-          MUST re-enter (the runner then resumes: reuses the in-flight op + binding
-          and finishes the ext write) — gating on the mere workflow id would strand
-          the record with an orphaned bot (binding/ext never written).
-        * ``retry`` chooses BaaS-restart only for a completed release (a BaaS-side
-          failure); a partial release re-runs the release work instead.
+        1. This record's own online release op (first-release / upgrade) must be
+           ``COMPLETED`` — a completed BaaS deploy that landed a binding + ext.
+           Anything short of that (no op, or an ``ID_RECORDED`` deploy still
+           mid-flight) is *not* recorded: the online_release gate must re-enter so
+           the runner resumes the same op (no second bot), and ``retry`` must re-run
+           the release work rather than restart.
+        2. That completed release must still be the latest deploy on the bot. A
+           ``COMPLETED`` op genuinely completed and is never rewritten; what makes it
+           stale is a *later* version-setting op landing on the same bot. Rollback
+           demotes this record to DRAFT and re-deploys the previous version onto the
+           bot (a ``ROLLBACK_DEPLOY`` with a higher, globally-monotonic
+           ``baas_publish_id``), so the demoted record's release is no longer the
+           latest deploy and a re-publish must run again. A restart / scale lands on
+           the bot too but does not set the version (``sets_deployed_version``), so
+           it never supersedes a release.
 
-        Ledger-driven (#197): the latest online-stage release op (first-release or
-        upgrade) is ``COMPLETED``. The ``ext.publish.online`` marker (written in the
-        release's ext step, one step before ``complete_operation``) is a transitional
-        fallback — it covers both the tiny record-ext→complete window and any record
-        that predates the ledger during rollout."""
+        Consumers: the online_release gate (``tasks.py``) skips the release only
+        when it is the live deployment; ``retry`` chooses BaaS-restart only for a
+        completed, still-live release (a BaaS-side wait failure) and otherwise
+        re-runs the release work."""
+        release_op = self._completed_online_release_op(publish_id)
+        if release_op is None or not release_op.bot_uuid:
+            return False
+
+        return not self._online_release_superseded(release_op)
+
+    def _completed_online_release_op(
+        self, publish_id: int
+    ) -> PublishOperationRecord | None:
+        """This record's completed online release op (first-release or upgrade),
+        or ``None`` if it has no completed online deploy yet.
+
+        Reads the latest attempt of each release kind and keeps the COMPLETED one.
+        An ``UPGRADE`` that hit ``BOT_NOT_FOUND`` is ABANDONED and a
+        ``FIRST_RELEASE`` fallback completes, so both kinds can coexist for one
+        publish; only the completed one is the record's real release. A still
+        in-flight (``ID_RECORDED``) or absent op yields ``None`` — the caller
+        treats that as not-yet-recorded (re-enter / re-run rather than skip)."""
+        completed = []
         for kind in (PublishOperationKind.FIRST_RELEASE, PublishOperationKind.UPGRADE):
             op = self._publish_operation_repo.get_latest_by_kind(
                 publish_id, kind, PublishStage.ONLINE.value
             )
-            if op is not None and op.state == PublishOperationState.COMPLETED.value:
+            if (
+                op is not None
+                and op.state == PublishOperationState.COMPLETED.value
+                and op.baas_publish_id is not None
+            ):
+                completed.append(op)
+        if not completed:
+            return None
+        return max(completed, key=lambda o: o.baas_publish_id)
+
+    def _online_release_superseded(self, release_op: PublishOperationRecord) -> bool:
+        """True if a later version-setting deploy has landed on the same online bot
+        — i.e. ``release_op`` is no longer the live deployment.
+
+        Scans the shared bot's ledger timeline for a ``sets_deployed_version`` op
+        (a newer upgrade, or a rollback re-deploy of another version) whose workflow
+        landed after this release (higher, globally-monotonic ``baas_publish_id``).
+        A landed op is one that reached ``ID_RECORDED``/``COMPLETED`` (a workflow was
+        issued); ``FAILED``/``ABANDONED`` deploys never took, so they do not
+        supersede. Restart / scale are skipped — they do not set the version."""
+        landed = {
+            PublishOperationState.ID_RECORDED.value,
+            PublishOperationState.COMPLETED.value,
+        }
+        for op in self._publish_operation_repo.list_by_bot(
+            release_op.bot_uuid, release_op.env
+        ):
+            if (
+                op.baas_publish_id is not None
+                and op.baas_publish_id > release_op.baas_publish_id
+                and op.state in landed
+                and PublishOperationKind(op.operation_kind).sets_deployed_version
+            ):
                 return True
-        record = self.get_publish_record(publish_id)
-        ext = (record.ext or {}) if record else {}
-        return bool(ext.get("publish", {}).get(PublishStage.ONLINE.value))
+        return False
 

--- a/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
@@ -7,7 +7,14 @@ from injector import Binder, Module, inject, provider, singleton
 from agentclaw.community.api.caller_identity_service import (
     CallerIdentityServiceProtocol,
 )
-from agentclaw.community.api.caller_credential import CallerRuntimeUpdater
+from agentclaw.community.api.caller_credential import (
+    CallerRuntimeUpdater,
+    CallerTokenProvider,
+    UnavailableCallerTokenProvider,
+)
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
 from agentclaw.community.api.mcp_sync_service import MCPSyncServiceProtocol
 from agentclaw.community.core.bot_collaborator.repository.protocol import (
     BotCollabLockRepositoryProtocol,
@@ -18,11 +25,15 @@ from agentclaw.community.core.caller_identity.repository import (
     CallerIdentityRepositoryProtocol,
 )
 from agentclaw.community.core.caller_identity.service import CallerIdentityService
+from agentclaw.community.core.caller_identity.iam_token_service import (
+    CallerIamTokenService,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.plugins.caller_identity_repository import (
     CallerIdentityRepository,
 )
+from agentclaw.community.plugin_api.auth import AuthPlugin
 
 
 class CallerIdentityModule(Module):
@@ -32,6 +43,11 @@ class CallerIdentityModule(Module):
         binder.bind(
             CallerIdentityRepositoryProtocol,
             to=CallerIdentityRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            CallerTokenProvider,
+            to=UnavailableCallerTokenProvider,
             scope=singleton,
         )
 
@@ -75,3 +91,20 @@ class CallerIdentityModule(Module):
     ) -> CallerRuntimeUpdater:
         """Use the existing BaaS singleton for the Caller outbound PUT."""
         return baas_service
+
+    @singleton
+    @provider
+    @inject
+    def caller_iam_token_service(
+        self,
+        caller_identity: CallerIdentityServiceProtocol,
+        auth_plugin: AuthPlugin,
+        token_provider: CallerTokenProvider,
+        runtime_updater: CallerRuntimeUpdater,
+    ) -> CallerIamTokenServiceProtocol:
+        return CallerIamTokenService(
+            caller_identity=caller_identity,
+            auth_plugin=auth_plugin,
+            token_provider=token_provider,
+            runtime_updater=runtime_updater,
+        )

--- a/src/backend/src/agentclaw/community/kernel/device_dto.py
+++ b/src/backend/src/agentclaw/community/kernel/device_dto.py
@@ -98,6 +98,7 @@ class HeaderOperationRule:
     header_name: str
     value: str
     placeholder: str | None = None
+    separator: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -106,6 +107,7 @@ class HeaderOperationRule:
             "header_name": self.header_name,
             "value": self.value,
             "placeholder": self.placeholder,
+            "separator": self.separator,
         }
 
 

--- a/src/backend/tests/community/api/test_caller_iam_token.py
+++ b/src/backend/tests/community/api/test_caller_iam_token.py
@@ -1,207 +1,80 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from agentclaw.community.adapters.http.token_exchange.router import get_iam_token
-from agentclaw.community.api.caller_credential import (
-    CallerRuntimeUpdater,
-    CallerTokenProvider,
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
 )
-from agentclaw.community.api.caller_identity_service import (
-    CallerIdentityServiceProtocol,
-    CallerIdentityStage,
-)
-from agentclaw.community.core.caller_identity.contracts import (
-    CallerIamTokenContext,
-    CallerIdentityAmbiguousError,
-    CallerIdentityPermissionError,
-    McpCallType,
-)
-from agentclaw.community.core.caller_identity.credential import CallerToken
-from agentclaw.community.plugin_api.auth import AuthPlugin
-from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.api.caller_identity_service import CallerIdentityStage
+from agentclaw.community.core.caller_identity.contracts import CallerIamTokenOutcome
 
 
 class _Request:
-    def __init__(self, dependencies: dict[object, object]) -> None:
-        self.cookies = {"IAM_TOKEN": "iam-token"}
-        self.headers: dict[str, str] = {}
-        self.query_params: dict[str, str] = {}
-        self.base_url = "http://test/"
-        self.app = SimpleNamespace(
-            state=SimpleNamespace(
-                injector=SimpleNamespace(
-                    get=lambda dependency: dependencies[dependency]
-                )
-            )
-        )
+    cookies = {"IAM_TOKEN": "iam-token"}
+    headers: dict[str, str] = {}
+    query_params: dict[str, str] = {}
+    base_url = "http://test/"
+
+
+def _service(*, iam_token: str = "iam-token", error: str | None = None) -> MagicMock:
+    service = MagicMock(spec=CallerIamTokenServiceProtocol)
+    service.get_iam_token = AsyncMock(
+        return_value=CallerIamTokenOutcome(iam_token=iam_token, error=error)
+    )
+    return service
 
 
 @pytest.mark.asyncio
 async def test_iam_route_delegates_caller_exchange_without_returning_token() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.return_value = CallerIamTokenContext(
-        bot_id="bot-1",
-        owner_id="owner-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        bot_call_type=McpCallType.CALLER,
-        should_exchange_caller_token=True,
-        binding_id=9,
-    )
-    auth = MagicMock()
-    auth.resolve_user_from_request = AsyncMock(
-        return_value=SimpleNamespace(
-            id="id-1",
-            staffId="caller-1",
-            operatorName="Caller",
-            nickName="Caller",
-            tenantId="tenant-1",
-        )
-    )
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
-    token_provider = MagicMock()
-    token_provider.exchange.return_value = CallerToken(
-        access_token="caller-token",
-        subject_user_id="caller-1",
-        expires_at=datetime.now(),
-        fingerprint="ignored",
-    )
-    runtime_updater = MagicMock()
-    request = _Request(
-        {
-            CallerIdentityServiceProtocol: identity,
-            AuthPlugin: auth,
-            PassportPlugin: passport,
-            CallerTokenProvider: token_provider,
-            CallerRuntimeUpdater: runtime_updater,
-        }
-    )
+    service = _service()
 
     response = await get_iam_token(
-        request,
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id="entity-1",
+        service=service,
     )
 
     assert response.status_code == 200
     assert json.loads(response.body) == {"success": True, "iam_token": "iam-token"}
-    identity.get_iam_token_context.assert_called_once_with(
-        bot_id="bot-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        entity_id="entity-1",
-        is_test_exchange=False,
-    )
-    identity.exchange_caller_identity.assert_called_once()
-    exchange_kwargs = identity.exchange_caller_identity.call_args.kwargs
-    assert exchange_kwargs["caller_user_id"] == "caller-1"
-    assert exchange_kwargs["token_provider"] is token_provider
-    assert exchange_kwargs["runtime_updater"] is runtime_updater
-    assert exchange_kwargs["entity_id"] == "entity-1"
-    assert exchange_kwargs["binding_id"] == 9
+    assert service.get_iam_token.call_args.kwargs["bot_id"] == "bot-1"
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_forces_exchange_for_non_caller_context() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.return_value = CallerIamTokenContext(
-        bot_id="bot-1",
-        owner_id="owner-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        bot_call_type=McpCallType.OWNER,
-        should_exchange_caller_token=True,
-    )
-    auth = MagicMock()
-    auth.resolve_user_from_request = AsyncMock(
-        return_value=SimpleNamespace(
-            id="id-1",
-            staffId="owner-1",
-            operatorName="Caller",
-            nickName="Caller",
-            tenantId="tenant-1",
-        )
-    )
-    request = _Request(
-        {
-            CallerIdentityServiceProtocol: identity,
-            AuthPlugin: auth,
-            PassportPlugin: MagicMock(),
-            CallerTokenProvider: MagicMock(),
-            CallerRuntimeUpdater: MagicMock(),
-        }
-    )
+    service = _service()
 
     response = await get_iam_token(
-        request,
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=service,
     )
 
     assert response.status_code == 200
     assert json.loads(response.body) == {"success": True, "iam_token": "iam-token"}
-    identity.get_iam_token_context.assert_called_once_with(
-        bot_id="bot-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        entity_id=None,
-        is_test_exchange=True,
-    )
-    identity.exchange_caller_identity.assert_called_once()
-    assert (
-        identity.exchange_caller_identity.call_args.kwargs["is_test_exchange"]
-        is True
-    )
+    assert service.get_iam_token.call_args.kwargs["is_test_exchange"] is True
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_rejects_non_owner() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.return_value = CallerIamTokenContext(
-        bot_id="bot-1",
-        owner_id="owner-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        bot_call_type=McpCallType.OWNER,
-        should_exchange_caller_token=True,
-    )
-    auth = MagicMock()
-    auth.resolve_user_from_request = AsyncMock(
-        return_value=SimpleNamespace(
-            id="id-1",
-            staffId="caller-1",
-            operatorName="Caller",
-            nickName="Caller",
-            tenantId="tenant-1",
-        )
-    )
-    identity.authorize_iam_token_exchange.side_effect = CallerIdentityPermissionError()
-
     response = await get_iam_token(
-        _Request(
-            {
-                CallerIdentityServiceProtocol: identity,
-                AuthPlugin: auth,
-            }
-        ),
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=_service(error="CALLER_IDENTITY_FORBIDDEN"),
     )
 
     assert response.status_code == 403
@@ -209,21 +82,18 @@ async def test_iam_route_test_exchange_rejects_non_owner() -> None:
         "success": False,
         "error": "CALLER_IDENTITY_FORBIDDEN",
     }
-    identity.exchange_caller_identity.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_rejects_production_environment() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.side_effect = CallerIdentityPermissionError()
-
     response = await get_iam_token(
-        _Request({CallerIdentityServiceProtocol: identity}),
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=_service(error="CALLER_IDENTITY_FORBIDDEN"),
     )
 
     assert response.status_code == 403
@@ -231,24 +101,18 @@ async def test_iam_route_test_exchange_rejects_production_environment() -> None:
         "success": False,
         "error": "CALLER_IDENTITY_FORBIDDEN",
     }
-    identity.get_iam_token_context.assert_called_once_with(
-        bot_id="bot-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        entity_id=None,
-        is_test_exchange=True,
-    )
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_requires_bot_id() -> None:
     response = await get_iam_token(
-        _Request({}),
+        _Request(),
         bot_id=None,
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=_service(error="CALLER_CREDENTIAL_REQUEST_INVALID"),
     )
 
     assert response.status_code == 400
@@ -260,15 +124,13 @@ async def test_iam_route_test_exchange_requires_bot_id() -> None:
 
 @pytest.mark.asyncio
 async def test_iam_route_rejects_ambiguous_bot_without_entity() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.side_effect = CallerIdentityAmbiguousError()
-    request = _Request({CallerIdentityServiceProtocol: identity})
-
     response = await get_iam_token(
-        request,
+        _Request(),
         bot_id="default",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
+        entity_id=None,
+        service=_service(error="CALLER_IDENTITY_AMBIGUOUS"),
     )
 
     assert response.status_code == 409
@@ -276,4 +138,3 @@ async def test_iam_route_rejects_ambiguous_bot_without_entity() -> None:
         "success": False,
         "error": "CALLER_IDENTITY_AMBIGUOUS",
     }
-    identity.exchange_caller_identity.assert_not_called()

--- a/src/backend/tests/community/contracts/gateway/schema_snapshots/api_response/service_backed_rule01_GET_api_bots_id_appcoding_bots.json
+++ b/src/backend/tests/community/contracts/gateway/schema_snapshots/api_response/service_backed_rule01_GET_api_bots_id_appcoding_bots.json
@@ -224,6 +224,9 @@
           },
           "caller_config_revision": {
             "type": "integer"
+          },
+          "members": {
+            "type": "array"
           }
         },
         "required": [
@@ -244,6 +247,7 @@
           "gmt_modified",
           "id",
           "is_delete",
+          "members",
           "modifier_id",
           "owner_id",
           "owner_name",

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_list_bot_members.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_list_bot_members.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``BotService._list_bot_members``.
+
+Covers the branches exercised when enriching appcoding-bots responses with a
+bot's member (collaborator) list:
+
+- ``owner_id`` missing -> ``[]`` (no repo call).
+- happy path: collaborators are serialized to ``{user_id, user_name}`` only.
+- repository failure -> degrades to ``[]`` without raising.
+
+The service is constructed with MagicMock collaborators (matching the existing
+``test_list_desktop_live_status`` construction contract); only the
+``collaborator_repo`` seam is driven.
+"""
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.bot_collaborator.models import (
+    CollaboratorRecord,
+    CollaboratorRole,
+)
+from agentclaw.community.core.bot_management.services.bot_service import BotService
+
+
+def _make_bot_service(collaborator_repo) -> BotService:
+    return BotService(
+        drm_reader=MagicMock(),
+        repository=MagicMock(),
+        allocation_config=MagicMock(),
+        device_binding_repo=MagicMock(),
+        skill_set_factory=MagicMock(),
+        cleanup_service=MagicMock(),
+        bcn_service=MagicMock(),
+        bot_publish_repo=MagicMock(),
+        passport_plugin=MagicMock(),
+        oss_record_repo=MagicMock(),
+        bot_publish_service_provider=lambda: MagicMock(),
+        device_service_provider=lambda: MagicMock(),
+        path_factory=MagicMock(),
+        template_service=MagicMock(),
+        workspace_hosting_service=MagicMock(),
+        collaborator_repo=collaborator_repo,
+        restart_lock_repo=MagicMock(),
+        teclaw_provision_service_provider=lambda: MagicMock(),
+        device_status_client=MagicMock(),
+        cron_auto_setup_service_provider=lambda: MagicMock(),
+    )
+
+
+def _record(user_id: str, user_name, role=CollaboratorRole.MEMBER) -> CollaboratorRecord:
+    return CollaboratorRecord(
+        bot_pk=1,
+        bot_id="app_bot_1",
+        owner_id="test_user",
+        user_id=user_id,
+        user_name=user_name,
+        role=role,
+        operator_id="test_user",
+    )
+
+
+class TestListBotMembers:
+    def test_missing_owner_returns_empty(self):
+        svc = _make_bot_service(collaborator_repo=MagicMock())
+        # A truthy-falsy owner_id (None / empty) short-circuits before any repo call.
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id=None) == []
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id="") == []
+        svc._collaborator_repo.list_by_bot.assert_not_called()
+
+    def test_maps_collaborators_to_member_dicts(self):
+        repo = MagicMock()
+        repo.list_by_bot.return_value = [
+            _record("u1", "Alice"),
+            _record("u2", None),
+        ]
+        svc = _make_bot_service(collaborator_repo=repo)
+
+        members = svc._list_bot_members(bot_id="app_bot_1", owner_id="test_user")
+
+        repo.list_by_bot.assert_called_once()
+        kwargs = repo.list_by_bot.call_args.kwargs
+        assert kwargs["bot_id"] == "app_bot_1"
+        assert kwargs["owner_id"] == "test_user"
+        # env is read via get_current_env() at call time.
+        assert "env" in kwargs
+
+        assert members == [
+            {"user_id": "u1", "user_name": "Alice"},
+            {"user_id": "u2", "user_name": None},
+        ]
+
+    def test_no_collaborators_returns_empty(self):
+        repo = MagicMock()
+        repo.list_by_bot.return_value = []
+        svc = _make_bot_service(collaborator_repo=repo)
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id="test_user") == []
+
+    def test_repository_failure_degrades_to_empty(self):
+        repo = MagicMock()
+        repo.list_by_bot.side_effect = RuntimeError("db down")
+        svc = _make_bot_service(collaborator_repo=repo)
+        # Enrichment must never break the coding-bots listing.
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id="test_user") == []

--- a/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
@@ -1,0 +1,219 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenContext,
+    CallerIdentityAmbiguousError,
+    CallerIdentityPermissionError,
+    CallerIdentityStage,
+    McpCallType,
+)
+from agentclaw.community.core.caller_identity.credential import (
+    CALLER_CREDENTIAL_REQUEST_INVALID,
+    CALLER_OUTBOUND_UPDATE_FAILED,
+    CallerCredentialError,
+)
+from agentclaw.community.core.caller_identity.iam_token_service import (
+    CallerIamTokenService,
+)
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+from agentclaw.community.api.caller_credential import UnavailableCallerTokenProvider
+from agentclaw.community.di.modules.caller_identity_module import CallerIdentityModule
+
+
+def _context(*, exchange: bool = True, owner_id: str | None = "owner-1") -> CallerIamTokenContext:
+    return CallerIamTokenContext(
+        bot_id="bot-1",
+        owner_id=owner_id,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        bot_call_type=McpCallType.CALLER,
+        should_exchange_caller_token=exchange,
+        binding_id=9,
+    )
+
+
+def _service(*, context: CallerIamTokenContext | None = None):
+    identity = MagicMock()
+    identity.get_iam_token_context.return_value = context or _context()
+    auth = MagicMock()
+    auth.resolve_user_from_request = AsyncMock(
+        return_value=SimpleNamespace(staffId="caller-1")
+    )
+    provider = MagicMock()
+    updater = MagicMock()
+    return (
+        CallerIamTokenService(
+            caller_identity=identity,
+            auth_plugin=auth,
+            token_provider=provider,
+            runtime_updater=updater,
+        ),
+        identity,
+        auth,
+        provider,
+        updater,
+    )
+
+
+def _request() -> AuthRequestContext:
+    return AuthRequestContext({}, {}, {}, "http://test/")
+
+
+@pytest.mark.asyncio
+async def test_service_installs_caller_token_without_returning_it() -> None:
+    identity = MagicMock()
+    identity.get_iam_token_context.return_value = CallerIamTokenContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        bot_call_type=McpCallType.CALLER,
+        should_exchange_caller_token=True,
+        binding_id=9,
+    )
+    auth = MagicMock()
+    auth.resolve_user_from_request = AsyncMock(
+        return_value=SimpleNamespace(staffId="caller-1")
+    )
+    service = CallerIamTokenService(
+        caller_identity=identity,
+        auth_plugin=auth,
+        token_provider=MagicMock(),
+        runtime_updater=MagicMock(),
+    )
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=AuthRequestContext({}, {}, {}, "http://test/"),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id="entity-1",
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    assert result.iam_token == "iam-token"
+    assert identity.exchange_caller_identity.call_args.kwargs["binding_id"] == 9
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("iam_token", "bot_id", "test_exchange", "expected_error"),
+    [
+        ("", "bot-1", False, "IAM_TOKEN cookie not found"),
+        ("iam-token", None, True, CALLER_CREDENTIAL_REQUEST_INVALID),
+        ("iam-token", None, False, None),
+    ],
+)
+async def test_service_returns_early_iam_outcomes(
+    iam_token: str,
+    bot_id: str | None,
+    test_exchange: bool,
+    expected_error: str | None,
+) -> None:
+    service, identity, *_ = _service()
+
+    result = await service.get_iam_token(
+        iam_token=iam_token,
+        auth_request=_request(),
+        bot_id=bot_id,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=test_exchange,
+    )
+
+    assert result.error == expected_error
+    if expected_error is None:
+        assert result.iam_token == "iam-token"
+    identity.get_iam_token_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (CallerIdentityAmbiguousError(), "CALLER_IDENTITY_AMBIGUOUS"),
+        (CallerIdentityPermissionError(), "CALLER_IDENTITY_FORBIDDEN"),
+        (RuntimeError("repository unavailable"), None),
+    ],
+)
+async def test_service_fails_closed_or_falls_back_for_context_errors(
+    exception: Exception,
+    expected_error: str | None,
+) -> None:
+    service, identity, *_ = _service()
+    identity.get_iam_token_context.side_effect = exception
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=_request(),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=False,
+    )
+
+    assert result.error == expected_error
+    assert result.iam_token == ("" if expected_error else "iam-token")
+
+
+@pytest.mark.asyncio
+async def test_service_skips_non_caller_and_rejects_missing_owner() -> None:
+    service, identity, *_ = _service(context=_context(exchange=False))
+
+    skipped = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=False,
+    )
+    assert skipped.error is None
+
+    identity.get_iam_token_context.return_value = _context(owner_id=None)
+    missing_owner = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=False,
+    )
+    assert missing_owner.error == CALLER_CREDENTIAL_REQUEST_INVALID
+
+
+@pytest.mark.asyncio
+async def test_service_maps_exchange_and_runtime_failures() -> None:
+    service, identity, *_ = _service()
+    identity.exchange_caller_identity.side_effect = CallerCredentialError("UPSTREAM")
+
+    credential_failure = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=True,
+    )
+    assert credential_failure.error == "UPSTREAM"
+    identity.authorize_iam_token_exchange.assert_called_once()
+
+    identity.exchange_caller_identity.side_effect = RuntimeError("BaaS unavailable")
+    runtime_failure = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=False,
+    )
+    assert runtime_failure.error == CALLER_OUTBOUND_UPDATE_FAILED
+
+
+def test_unavailable_provider_and_module_provider_fail_closed() -> None:
+    with pytest.raises(CallerCredentialError):
+        UnavailableCallerTokenProvider().exchange(
+            auth_context=MagicMock(), iam_token="iam", bot_id="bot",
+            owner_user_id="owner", task_metadata={},
+        )
+
+    service = CallerIdentityModule().caller_iam_token_service(
+        caller_identity=MagicMock(), auth_plugin=MagicMock(),
+        token_provider=MagicMock(), runtime_updater=MagicMock(),
+    )
+    assert isinstance(service, CallerIamTokenService)

--- a/src/backend/tests/community/core/caller_identity/test_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_service.py
@@ -242,11 +242,8 @@ def test_iam_context_does_not_reuse_draft_binding_outside_draft(
     assert context.binding_id is None
 
 
-def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> None:
+def test_exchange_caller_identity_installs_opaque_token_without_passport_lookup() -> None:
     service, _ = _service(bot=_bot(call_type="caller"))
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
     token_provider = MagicMock()
     caller_token = CallerToken(
         access_token="caller-token",
@@ -262,7 +259,6 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
         caller_user_id="caller-1",
         bot_id="bot-1",
         owner_user_id="owner-1",
-        passport=passport,
         token_provider=token_provider,
         runtime_updater=runtime_updater,
         stage="draft",
@@ -271,14 +267,18 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
         binding_id=9,
     )
 
-    token_provider.exchange.assert_called_once()
+    token_provider.exchange.assert_called_once_with(
+        auth_context=caller_identity_service.AuthContext(user_id="caller-1"),
+        iam_token="iam-token",
+        bot_id="bot-1",
+        owner_user_id="owner-1",
+        task_metadata=caller_identity_service.CALLER_CHAT_TASK,
+    )
     runtime_updater.update_caller_identity.assert_called_once_with(
         bot_id="bot-1",
         owner_user_id="owner-1",
         caller_user_id="caller-1",
         caller_token=caller_token,
-        agent_pass_token="agent-pass-token",
-        agent_code="agent-code",
         stage="draft",
         publish_id=None,
         entity_id="entity-1",
@@ -288,9 +288,6 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
 
 def test_exchange_caller_identity_propagates_test_exchange_to_runtime() -> None:
     service, _ = _service(bot=_bot(call_type="owner"))
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
     token_provider = MagicMock()
     caller_token = CallerToken(
         access_token="caller-token",
@@ -306,7 +303,6 @@ def test_exchange_caller_identity_propagates_test_exchange_to_runtime() -> None:
         caller_user_id="owner-1",
         bot_id="bot-1",
         owner_user_id="owner-1",
-        passport=passport,
         token_provider=token_provider,
         runtime_updater=runtime_updater,
         stage="draft",
@@ -325,9 +321,6 @@ def test_exchange_caller_identity_does_not_pass_draft_binding_outside_draft(
     stage: str,
 ) -> None:
     service, _ = _service(bot=_bot(call_type="caller"))
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
     token_provider = MagicMock()
     token_provider.exchange.return_value = CallerToken(
         access_token="caller-token",
@@ -342,7 +335,6 @@ def test_exchange_caller_identity_does_not_pass_draft_binding_outside_draft(
         caller_user_id="caller-1",
         bot_id="bot-1",
         owner_user_id="owner-1",
-        passport=passport,
         token_provider=token_provider,
         runtime_updater=runtime_updater,
         stage=stage,

--- a/src/backend/tests/community/core/service_bot/repository/test_publish_operation_repository.py
+++ b/src/backend/tests/community/core/service_bot/repository/test_publish_operation_repository.py
@@ -176,3 +176,36 @@ def test_transitions_on_missing_row_return_none(repo):
     assert repo.complete(123456) is None
     assert repo.fail(123456, "e") is None
     assert repo.abandon(123456, "r") is None
+
+
+def test_publish_operation_kind_deploy_partition():
+    """Every PublishOperationKind must be classified as either version-setting
+    (a deploy — its completed op marks which version is live on its bot) or
+    version-preserving (restart/scale/teardown — leaves the deployed version
+    unchanged). is_online_release_recorded's liveness scan filters on
+    ``sets_deployed_version``, so an unclassified new kind would be silently
+    mistreated; this partition assertion fails CI until the kind is classified in
+    models.py (`_KINDS_SET_DEPLOYED_VERSION` / `_KINDS_PRESERVE_DEPLOYED_VERSION`)."""
+    setting = PublishOperationKind.version_setting_kinds()
+    preserving = PublishOperationKind.version_preserving_kinds()
+
+    # Disjoint and exhaustive over all kinds (every kind in exactly one bucket).
+    assert setting.isdisjoint(preserving)
+    assert setting | preserving == set(PublishOperationKind)
+
+    # The property agrees with the sets for every kind.
+    for kind in PublishOperationKind:
+        assert kind.sets_deployed_version == (kind in setting)
+
+    # Pin the intended classification so a semantic change is a conscious edit.
+    assert setting == {
+        PublishOperationKind.FIRST_RELEASE,
+        PublishOperationKind.UPGRADE,
+        PublishOperationKind.ROLLBACK_DEPLOY,
+        PublishOperationKind.EVAL_PUBLISH,
+    }
+    assert preserving == {
+        PublishOperationKind.RESTART,
+        PublishOperationKind.SCALE,
+        PublishOperationKind.EVAL_TEARDOWN,
+    }

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_http_methods.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_http_methods.py
@@ -195,6 +195,23 @@ class TestBaasServiceHttpMethods:
         assert call.args[0] == "/api/v1/paas/devices/PAAS-1/outbound-rule"
         assert call.kwargs["json"] == {"header_operation_rules": []}
 
+    def test_append_caller_outbound_rule_uses_exact_append_path_and_body(self):
+        service, http = _make_service()
+        http.set_response("put", _resp({}))
+        rule = MagicMock()
+        rule.header_operation_rules = [MagicMock()]
+        service._outbound_rule_to_dict = MagicMock(
+            return_value={"header_operation_rules": [{"header_name": "x-caller-token"}]}
+        )
+
+        assert service.append_caller_outbound_rule("dev-1@tpl-1", rule) is True
+
+        call = http.calls_to("put")[0]
+        assert call.args[0] == "/api/v1/paas/devices/dev-1@tpl-1/outbound-rule?mode=append"
+        assert call.kwargs["json"] == {
+            "header_operation_rules": [{"header_name": "x-caller-token"}]
+        }
+
     def test_get_http_info_uses_http_client_port(self):
         """get_http_info 走 self._http.get 而非裸 httpx。
 

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -53,13 +53,10 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
             ]
         )
     )
-    service._build_outbound_operation_rule = MagicMock(
-        return_value=OutBoundOperationRule()
-    )
     service.list_devices_by_bot_uuid = MagicMock(
         return_value=[{"provider_device_id": "device-1@template-1"}]
     )
-    service.update_device_outbound_rule = MagicMock(return_value=True)
+    service.append_caller_outbound_rule = MagicMock(return_value=True)
     service._resolve_caller_binding_id = MagicMock(return_value=9)
 
     update_kwargs = {
@@ -72,8 +69,6 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
             expires_at=datetime.now(),
             fingerprint="ignored",
         ),
-        "agent_pass_token": "agent-pass-token",
-        "agent_code": "agent-code",
         "stage": "draft",
         "publish_id": None,
         "entity_id": "entity-1",
@@ -97,7 +92,7 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
     service._outbound_rule_provider.build_caller_rule.assert_called_with(
         caller_token="caller-token"
     )
-    paas_device_id, outbound_rule = service.update_device_outbound_rule.call_args.args
+    paas_device_id, outbound_rule = service.append_caller_outbound_rule.call_args.args
     assert paas_device_id == "device-1@template-1"
     assert outbound_rule.header_operation_rules[0].header_name == "x-caller-token"
     assert outbound_rule.header_operation_rules[0].action == "set"
@@ -120,8 +115,6 @@ def test_caller_identity_rejects_ambiguous_bot_without_entity_id() -> None:
                 expires_at=datetime.now(),
                 fingerprint="ignored",
             ),
-            agent_pass_token="agent-pass-token",
-            agent_code="agent-code",
             stage="draft",
             publish_id=None,
         )
@@ -157,13 +150,10 @@ def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
             ]
         )
     )
-    service._build_outbound_operation_rule = MagicMock(
-        return_value=OutBoundOperationRule()
-    )
     service.list_devices_by_bot_uuid = MagicMock(
         return_value=[{"provider_device_id": "device-1@template-1"}]
     )
-    service.update_device_outbound_rule = MagicMock(return_value=True)
+    service.append_caller_outbound_rule = MagicMock(return_value=True)
 
     service.update_caller_identity(
         bot_id="bot-1",
@@ -175,8 +165,6 @@ def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
             expires_at=datetime.now(),
             fingerprint="ignored",
         ),
-        agent_pass_token="agent-pass-token",
-        agent_code="agent-code",
         stage="draft",
         publish_id=None,
         entity_id="entity-1",
@@ -184,4 +172,4 @@ def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
         is_test_exchange=True,
     )
 
-    service.update_device_outbound_rule.assert_called_once()
+    service.append_caller_outbound_rule.assert_called_once()

--- a/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
@@ -371,15 +371,27 @@ async def test_upgrade_bot_not_found_abandons_and_falls_back():
 
 
 # ── retry / abandonment: ledger-driven decisions (#197 Task 10) ───────────────
+def _land_completed_op(svc, ledger, *, publish_id, kind, bot_uuid, baas_id):
+    """Open → record workflow → complete a ledger op landing ``baas_id`` on
+    ``bot_uuid`` (a completed BaaS deploy/lifecycle workflow)."""
+    op = svc._operation_runner.open_operation(
+        publish_id=publish_id, kind=kind, stage=PublishStage.ONLINE, bot_uuid=bot_uuid
+    )
+    ledger.record_workflow(op.id, baas_publish_id=baas_id, bot_uuid=bot_uuid)
+    ledger.complete(op.id)
+    return op
+
+
 def test_is_online_release_recorded_reads_ledger():
     ledger = _ledger()
     baas = FakeBaas()
     publish_service = Mock()
-    publish_service.get_publish_by_id.return_value = _record(PublishStatus.ONLINE_PUB.value)
+    rec = _record(PublishStatus.ONLINE_PUB.value)
+    publish_service.get_publish_by_id.return_value = rec
     svc = _flow(ledger=ledger, baas=baas, build_service=Mock(),
                 publish_service=publish_service)
 
-    # No op, no ext marker (record ext has no 'publish') → not recorded.
+    # No online release op for this publish → not recorded.
     assert svc.is_online_release_recorded(1) is False
 
     # An online op with only the workflow recorded (ID_RECORDED, binding/ext not
@@ -391,20 +403,76 @@ def test_is_online_release_recorded_reads_ledger():
     ledger.record_workflow(op.id, baas_publish_id=901, bot_uuid="BOT-x")
     assert svc.is_online_release_recorded(1) is False
 
-    # Only once the op COMPLETES (binding + ext done) is it "recorded".
+    # Once the op COMPLETES it is the latest deploy that landed on the bot → the
+    # live online release.
     ledger.complete(op.id)
     assert svc.is_online_release_recorded(1) is True
 
 
-def test_is_online_release_recorded_ext_fallback_for_pre_ledger():
+def test_is_online_release_recorded_false_for_rolled_back_completed_op():
+    """A COMPLETED online op is stale once a later deploy lands on the same bot.
+
+    Rollback demotes a SUCCESS record to DRAFT and re-deploys the previous version
+    onto the shared online bot (a ROLLBACK_DEPLOY op with a higher baas_publish_id).
+    The demoted record's prior COMPLETED online op is no longer the latest deploy on
+    the bot, so a re-publish of that record must run the release again — the stale op
+    must NOT gate it (otherwise the online leg is skipped and no BaaS workflow is
+    ever issued for the new lifecycle)."""
+    ledger = _ledger()
+    baas = FakeBaas()
+    publish_service = Mock()
+    rec = _record(PublishStatus.ONLINE_PUB.value)
+    publish_service.get_publish_by_id.return_value = rec
+    svc = _flow(ledger=ledger, baas=baas, build_service=Mock(),
+                publish_service=publish_service)
+
+    # This record's online upgrade completed and is the latest deploy on the bot.
+    _land_completed_op(svc, ledger, publish_id=1, kind="upgrade",
+                       bot_uuid="BOT-live", baas_id=901)
+    assert svc.is_online_release_recorded(1) is True
+
+    # Rollback re-deploys the previous version onto the SAME bot (higher baas id),
+    # on the target record (publish_id=2). The demoted record's op 901 is no longer
+    # the latest deploy → stale → not recorded → a re-publish runs the release.
+    _land_completed_op(svc, ledger, publish_id=2, kind="rollback_deploy",
+                       bot_uuid="BOT-live", baas_id=902)
+    assert svc.is_online_release_recorded(1) is False
+
+
+def test_is_online_release_recorded_true_after_restart_or_scale():
+    """A restart / scale lands on the same online bot (higher baas id) but does NOT
+    set the deployed version, so it must not make a live release look stale — else
+    retry() would misroute (re-run the release instead of restart) and the online
+    gate could re-issue a redundant deploy."""
+    ledger = _ledger()
+    publish_service = Mock()
+    rec = _record(PublishStatus.ONLINE_PUB.value)
+    publish_service.get_publish_by_id.return_value = rec
+    svc = _flow(ledger=ledger, baas=FakeBaas(), build_service=Mock(),
+                publish_service=publish_service)
+
+    _land_completed_op(svc, ledger, publish_id=1, kind="upgrade",
+                       bot_uuid="BOT-live", baas_id=901)
+    # A restart and a scale-up land afterwards on the same bot (version unchanged).
+    _land_completed_op(svc, ledger, publish_id=1, kind="restart",
+                       bot_uuid="BOT-live", baas_id=902)
+    _land_completed_op(svc, ledger, publish_id=1, kind="scale",
+                       bot_uuid="BOT-live", baas_id=903)
+    assert svc.is_online_release_recorded(1) is True
+
+
+def test_is_online_release_recorded_ignores_ext_marker():
+    """The answer is purely ledger-driven: an ext.publish.online marker with no
+    completed online release op in the ledger does NOT count as recorded. (The
+    ledger is the source of truth; a record with a live release always carries its
+    own COMPLETED first_release/upgrade op.)"""
     ledger = _ledger()
     svc = _flow(ledger=ledger, baas=FakeBaas(), build_service=Mock(),
                 publish_service=Mock())
-    # No ledger op, but a legacy ext.publish.online marker (pre-ledger record).
     rec = _record(PublishStatus.ONLINE_PUB.value)
     rec.ext = {"publish": {"online": 500}}
     svc._publish_service.get_publish_by_id = Mock(return_value=rec)
-    assert svc.is_online_release_recorded(2) is True
+    assert svc.is_online_release_recorded(2) is False
 
 
 def test_abandon_inflight_operations_marks_nonterminal():

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -3161,16 +3161,19 @@ async def test_retry_missing_source_status_raises():
 
 @pytest.mark.asyncio
 async def test_retry_from_online_pub_recorded_calls_restart():
-    # Online release already recorded (ext.publish.online) → a BaaS-wait failure →
-    # retry restarts the BaaS publish.
+    # Online release already recorded in the ledger — a COMPLETED online upgrade that
+    # is the latest deploy on the bot → a BaaS-wait failure → retry restarts the
+    # BaaS publish.
     record = _make_publish_record(
         status=PublishStatus.FAILED.value,
-        ext={
-            "source_status": PublishStatus.ONLINE_PUB.value,
-            "publish": {"online": 9},
-        },
+        ext={"source_status": PublishStatus.ONLINE_PUB.value},
     )
     svc, _ = _svc_with_record(record)
+    op = svc._operation_runner.open_operation(
+        publish_id=1, kind="upgrade", stage=PublishStage.ONLINE, bot_uuid="BOT-live"
+    )
+    svc._publish_operation_repo.record_workflow(op.id, baas_publish_id=9, bot_uuid="BOT-live")
+    svc._publish_operation_repo.complete(op.id)
     # #162 + durable restart: retry runs execute_restart inline then enqueues the poll.
     svc.execute_restart = AsyncMock(return_value={"success": True})
     result = await svc.retry(publish_id=1, operator="op")

--- a/src/backend/tests/community/endpoints/test_public_bots_appcoding_bots.py
+++ b/src/backend/tests/community/endpoints/test_public_bots_appcoding_bots.py
@@ -67,3 +67,89 @@ def _seed_appcoding_bot(world):
 )
 def list_public_coding_bots_ok():
     """Happy path: a coding bot linked to the architect bot (no auth required)."""
+
+
+# --- Regression: members (collaborators) are returned on each coding bot ---
+
+from agentclaw.community.core.bot_collaborator.repository.protocol import (  # noqa: E402
+    CollaboratorRepositoryProtocol,
+)
+
+MEMBER_USER_ID = "collab_001"
+MEMBER_USER_NAME = "Collab One"
+MEMBER_ROLE = "member"
+
+
+def _seed_appcoding_bot_with_member(world):
+    """Insert a coding bot, its template, and one collaborator (member)."""
+    bot = world.get(BotRepository).insert(
+        {
+            "bot_id": CODING_BOT_ID,
+            "bot_name": "App Coding Bot 1",
+            "owner_id": "test_user",
+            "owner_name": "test_user",
+            "creator_id": "test_user",
+            "entity_id": "test_user",
+            "entity_type": "staff",
+            "active_engine": "openclaw",
+            "bot_type": "personal",
+            "status": "ACTIVE",
+        }
+    )
+    world.get(TemplateRepository).insert(
+        {
+            "bot_id": CODING_BOT_ID,
+            "ext": {"architect_bot_id": ARCHITECT_BOT_ID, "template": "appcoding"},
+        }
+    )
+    # Seed a collaborator (member) linked via bot_pk (ac_bots.id).
+    world.get(CollaboratorRepositoryProtocol).insert(
+        {
+            "bot_pk": bot["id"],
+            "bot_id": CODING_BOT_ID,
+            "owner_id": "test_user",
+            "user_id": MEMBER_USER_ID,
+            "user_name": MEMBER_USER_NAME,
+            "role": MEMBER_ROLE,
+            "operator_id": "test_user",
+        }
+    )
+
+
+def _assert_members_returned(response, world):
+    """extra_assertion: each returned coding bot carries its member list.
+
+    Runner calls extra_assertions as ``assertion(response, world)``.
+    """
+    items = response.json().get("data", [])
+    coding = next(it for it in items if it.get("bot_id") == CODING_BOT_ID)
+    members = coding.get("members")
+    assert isinstance(members, list), "members should be a list"
+    assert len(members) == 1, f"expected 1 member, got {len(members)}"
+    m = members[0]
+    assert m["user_id"] == MEMBER_USER_ID
+    assert m["user_name"] == MEMBER_USER_NAME
+    # operator_id / role / timestamps are intentionally NOT exposed here.
+    for hidden in ("operator_id", "role", "gmt_create", "gmt_modified"):
+        assert hidden not in m, f"{hidden} should not be exposed"
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/public/bots/{bot_id}/appcoding-bots",
+    scenario="ok-with-members",
+    input=CaseInput(
+        path_params={"bot_id": ARCHITECT_BOT_ID},
+    ),
+    seed=_seed_appcoding_bot_with_member,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": [{"bot_id": CODING_BOT_ID}],
+        },
+    ),
+    extra_assertions=(_assert_members_returned,),
+)
+def list_public_coding_bots_with_members():
+    """Each coding bot now returns its `members` (collaborators) list."""

--- a/src/backend/tests/community/kernel/test_device_dto.py
+++ b/src/backend/tests/community/kernel/test_device_dto.py
@@ -50,6 +50,7 @@ def test_header_operation_rule_to_dict_full_shape() -> None:
         "header_name": "Authorization",
         "value": "tok",
         "placeholder": "${API-KEY}",
+        "separator": None,
     }
 
 
@@ -83,6 +84,7 @@ def test_outbound_rule_to_dict_nests_header_rules() -> None:
                 "header_name": "h1",
                 "value": "v1",
                 "placeholder": None,
+                "separator": None,
             },
             {
                 "domains": ["d2"],
@@ -90,6 +92,7 @@ def test_outbound_rule_to_dict_nests_header_rules() -> None:
                 "header_name": "h2",
                 "value": "v2",
                 "placeholder": "${P}",
+                "separator": None,
             },
         ]
     }


### PR DESCRIPTION

- Inject  config into HttpCallback via CoreServiceContainer
- Set  header on callback POST when origin is configured
- Log response body (status + text) after every callback request
- Add unit tests covering origin header presence/absence and response body logging on both success and failure paths