### PR TITLE
feat(backend): support caller identity switching

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -292,6 +292,7 @@ from agentclaw.community.core.errors import (  # noqa: E402
 )
 from agentclaw.community.core.caller_identity.contracts import (  # noqa: E402
     CallerCallTypeInvalidError,
+    CallerIdentityAmbiguousError,
     CallerIdentityNotFoundError,
     CallerIdentityPermissionError,
     CallerIdentityReadOnlyError,
@@ -309,6 +310,7 @@ _DOMAIN_ERROR_STATUS_MAP: dict[type[DomainError], int] = {
     Conflict:              409,
     InternalError:         500,
     CallerIdentityPermissionError: 403,
+    CallerIdentityAmbiguousError: 409,
     CallerIdentityNotFoundError: 404,
     CallerIdentityReadOnlyError: 409,
     CallerLockEpochError: 409,

--- a/src/backend/src/agentclaw/community/adapters/http/caller_identity/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/caller_identity/router.py
@@ -41,10 +41,11 @@ async def get_caller_context(
 ) -> CallerContextResponse:
     """Return exact draft or published Caller identity context."""
     logger.info(
-        "caller_context_get_started bot_id=%s stage=%s publish_id=%s",
+        "caller_context_get_started bot_id=%s stage=%s publish_id=%s entity_scoped=%s",
         bot_id,
         query.stage.value,
         query.publish_id,
+        query.entity_id is not None,
     )
     # COSEC: the actor is derived only from the authenticated request context;
     # query/path values cannot replace the current identity.
@@ -55,21 +56,24 @@ async def get_caller_context(
             actor_id=user.staffId,
             stage=query.stage,
             publish_id=query.publish_id,
+            entity_id=query.entity_id,
         )
     except DomainError:
         logger.warning(
-            "caller_context_get_failed bot_id=%s stage=%s publish_id=%s",
+            "caller_context_get_failed bot_id=%s stage=%s publish_id=%s entity_scoped=%s",
             bot_id,
             query.stage.value,
             query.publish_id,
+            query.entity_id is not None,
         )
         raise
     except Exception:
         logger.warning(
-            "caller_context_get_failed bot_id=%s stage=%s publish_id=%s",
+            "caller_context_get_failed bot_id=%s stage=%s publish_id=%s entity_scoped=%s",
             bot_id,
             query.stage.value,
             query.publish_id,
+            query.entity_id is not None,
         )
         # COSEC: replace untrusted exception details and suppress their context
         # before the production handler logs or serializes this failure.
@@ -84,10 +88,11 @@ async def get_caller_context(
     )
     logger.info(
         "caller_context_get_succeeded bot_id=%s stage=%s publish_id=%s "
-        "bot_call_type=%s",
+        "entity_scoped=%s bot_call_type=%s",
         bot_id,
         response.stage.value,
         response.publish_id,
+        query.entity_id is not None,
         response.bot_call_type.value,
     )
     return response
@@ -108,11 +113,12 @@ async def update_mcp_call_type(
     """Update one draft MCP identity using the current authenticated owner."""
     logger.info(
         "mcp_call_type_http_update_started bot_id=%s stage=draft "
-        "server_code=%s call_type=%s lock_epoch=%s",
+        "server_code=%s call_type=%s lock_epoch=%s entity_scoped=%s",
         bot_id,
         server_code,
         request.call_type.value,
         request.lock_epoch,
+        query.entity_id is not None,
     )
     # COSEC: user/owner/engine identity is absent from the strict body and the
     # actor is always supplied from the authenticated request context.
@@ -123,25 +129,28 @@ async def update_mcp_call_type(
             call_type=request.call_type,
             actor_id=user.staffId,
             lock_epoch=request.lock_epoch,
+            entity_id=query.entity_id,
         )
     except DomainError:
         logger.warning(
             "mcp_call_type_http_update_failed bot_id=%s stage=draft "
-            "server_code=%s call_type=%s lock_epoch=%s",
+            "server_code=%s call_type=%s lock_epoch=%s entity_scoped=%s",
             bot_id,
             server_code,
             request.call_type.value,
             request.lock_epoch,
+            query.entity_id is not None,
         )
         raise
     except Exception:
         logger.warning(
             "mcp_call_type_http_update_failed bot_id=%s stage=draft "
-            "server_code=%s call_type=%s lock_epoch=%s",
+            "server_code=%s call_type=%s lock_epoch=%s entity_scoped=%s",
             bot_id,
             server_code,
             request.call_type.value,
             request.lock_epoch,
+            query.entity_id is not None,
         )
         # COSEC: replace untrusted exception details and suppress their context
         # before the production handler logs or serializes this failure.
@@ -153,12 +162,13 @@ async def update_mcp_call_type(
     )
     logger.info(
         "mcp_call_type_http_update_succeeded bot_id=%s stage=draft "
-        "server_code=%s call_type=%s bot_call_type=%s lock_epoch=%s",
+        "server_code=%s call_type=%s bot_call_type=%s lock_epoch=%s entity_scoped=%s",
         bot_id,
         response.server_code,
         response.call_type.value,
         response.bot_call_type.value,
         request.lock_epoch,
+        query.entity_id is not None,
     )
     return response
 

--- a/src/backend/src/agentclaw/community/adapters/http/caller_identity/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/caller_identity/schemas.py
@@ -34,12 +34,12 @@ class CallerContextQuery(BaseModel):
 
 
 class UpdateMcpCallTypeRequest(BaseModel):
-    """Owner-controlled draft update with an exact opaque lock epoch."""
+    """Owner-controlled draft update with an optional collaboration lock epoch."""
 
     model_config = ConfigDict(extra="forbid")
 
     call_type: McpCallType
-    lock_epoch: Annotated[int, Field(gt=0, strict=True)]
+    lock_epoch: Annotated[int | None, Field(gt=0, strict=True)] = None
 
 
 class UpdateMcpCallTypeQuery(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/caller_identity/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/caller_identity/schemas.py
@@ -19,6 +19,7 @@ class CallerContextQuery(BaseModel):
 
     stage: CallerIdentityStage
     publish_id: Annotated[int | None, Field(gt=0)] = None
+    entity_id: str | None = None
 
     @model_validator(mode="after")
     def validate_stage_scope(self) -> Self:
@@ -42,9 +43,14 @@ class UpdateMcpCallTypeRequest(BaseModel):
 
 
 class UpdateMcpCallTypeQuery(BaseModel):
-    """Reject every query parameter on the authenticated draft update."""
+    """Compatibility query fields for the authenticated draft update."""
 
     model_config = ConfigDict(extra="forbid")
+
+    # Accepted only because gateway callers already append this opaque value.
+    # Authentication remains exclusively bound to ``get_current_user``.
+    ctoken: str | None = None
+    entity_id: str | None = None
 
 
 class CallerContextResponse(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
@@ -17,6 +17,9 @@ from agentclaw.community.api.caller_identity_service import (
     CallerIdentityServiceProtocol,
     CallerIdentityStage,
 )
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIdentityAmbiguousError,
+)
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.auth import AuthPlugin, AuthRequestContext
@@ -139,6 +142,7 @@ async def get_iam_token(
     bot_id: str | None = Query(default=None),
     stage: CallerIdentityStage = Query(default=CallerIdentityStage.DRAFT),
     publish_id: int | None = Query(default=None),
+    entity_id: str | None = Query(default=None),
 ) -> Response:
     headers = _cors_headers(request)
     iam_token = request.cookies.get("IAM_TOKEN") or ""
@@ -171,6 +175,18 @@ async def get_iam_token(
             bot_id=bot_id,
             stage=stage,
             publish_id=publish_id,
+            entity_id=entity_id,
+        )
+    except CallerIdentityAmbiguousError as exc:
+        logger.warning(
+            "caller_token_context_ambiguous bot_id=%s stage=%s",
+            bot_id,
+            stage.value,
+        )
+        return JSONResponse(
+            content={"success": False, "error": exc.detail},
+            status_code=409,
+            headers=headers,
         )
     except Exception:
         logger.warning(
@@ -227,6 +243,8 @@ async def get_iam_token(
             runtime_updater=updater,
             stage=stage.value,
             publish_id=publish_id,
+            entity_id=entity_id,
+            binding_id=token_context.binding_id,
         )
     except CallerCredentialError as exc:
         logger.warning(

--- a/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
@@ -19,12 +19,14 @@ from agentclaw.community.api.caller_identity_service import (
 )
 from agentclaw.community.core.caller_identity.contracts import (
     CallerIdentityAmbiguousError,
+    CallerIdentityPermissionError,
 )
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.auth import AuthPlugin, AuthRequestContext
 from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.plugin_api.token_exchange import TokenExchangePlugin
+from agentclaw.community.utils.env_utils import get_current_env
 
 router = APIRouter()
 logger = get_logger()
@@ -143,6 +145,7 @@ async def get_iam_token(
     stage: CallerIdentityStage = Query(default=CallerIdentityStage.DRAFT),
     publish_id: int | None = Query(default=None),
     entity_id: str | None = Query(default=None),
+    is_test_exchange: bool = False,
 ) -> Response:
     headers = _cors_headers(request)
     iam_token = request.cookies.get("IAM_TOKEN") or ""
@@ -150,6 +153,20 @@ async def get_iam_token(
         return JSONResponse(
             content={"success": False, "error": "IAM_TOKEN cookie not found"},
             status_code=400,
+            headers=headers,
+        )
+    if is_test_exchange and not bot_id:
+        logger.warning("caller_test_exchange_rejected reason=bot_id_missing")
+        return JSONResponse(
+            content={"success": False, "error": CALLER_CREDENTIAL_REQUEST_INVALID},
+            status_code=400,
+            headers=headers,
+        )
+    if is_test_exchange and get_current_env() == "prod":
+        logger.warning("caller_test_exchange_rejected reason=production_environment")
+        return JSONResponse(
+            content={"success": False, "error": CallerIdentityPermissionError().detail},
+            status_code=403,
             headers=headers,
         )
     if not bot_id:
@@ -176,12 +193,14 @@ async def get_iam_token(
             stage=stage,
             publish_id=publish_id,
             entity_id=entity_id,
+            is_test_exchange=is_test_exchange,
         )
     except CallerIdentityAmbiguousError as exc:
         logger.warning(
-            "caller_token_context_ambiguous bot_id=%s stage=%s",
+            "caller_token_context_ambiguous bot_id=%s stage=%s test_exchange=%s",
             bot_id,
             stage.value,
+            is_test_exchange,
         )
         return JSONResponse(
             content={"success": False, "error": exc.detail},
@@ -190,24 +209,29 @@ async def get_iam_token(
         )
     except Exception:
         logger.warning(
-            "caller_token_context_unavailable bot_id=%s stage=%s",
+            "caller_token_context_unavailable bot_id=%s stage=%s test_exchange=%s",
             bot_id,
             stage.value,
+            is_test_exchange,
         )
         return _success_iam_response(iam_token, headers)
     if not token_context.should_exchange_caller_token:
         logger.info(
-            "caller_token_exchange_skipped bot_id=%s stage=%s call_type=%s",
+            "caller_token_exchange_skipped bot_id=%s stage=%s call_type=%s "
+            "test_exchange=%s",
             bot_id,
             stage.value,
             token_context.bot_call_type.value,
+            is_test_exchange,
         )
         return _success_iam_response(iam_token, headers)
     if not token_context.owner_id:
         logger.warning(
-            "caller_token_exchange_failed bot_id=%s stage=%s reason=owner_missing",
+            "caller_token_exchange_failed bot_id=%s stage=%s reason=owner_missing "
+            "test_exchange=%s",
             bot_id,
             stage.value,
+            is_test_exchange,
         )
         return JSONResponse(
             content={"success": False, "error": CALLER_CREDENTIAL_REQUEST_INVALID},
@@ -217,6 +241,20 @@ async def get_iam_token(
 
     try:
         current_user = await _resolve_current_user(request)
+        if is_test_exchange and current_user.staffId != token_context.owner_id:
+            logger.warning(
+                "caller_test_exchange_rejected bot_id=%s stage=%s reason=not_owner",
+                bot_id,
+                stage.value,
+            )
+            return JSONResponse(
+                content={
+                    "success": False,
+                    "error": CallerIdentityPermissionError().detail,
+                },
+                status_code=403,
+                headers=headers,
+            )
         passport = _get_optional_dependency(
             request,
             PassportPlugin,
@@ -232,26 +270,32 @@ async def get_iam_token(
             CallerRuntimeUpdater,
             CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
         )
+        exchange_kwargs = {
+            "iam_token": iam_token,
+            "caller_user_id": current_user.staffId,
+            "bot_id": bot_id,
+            "owner_user_id": token_context.owner_id,
+            "passport": passport,
+            "token_provider": provider,
+            "runtime_updater": updater,
+            "stage": stage.value,
+            "publish_id": publish_id,
+            "entity_id": entity_id,
+            "binding_id": token_context.binding_id,
+        }
+        if is_test_exchange:
+            exchange_kwargs["is_test_exchange"] = True
         await asyncio.to_thread(
             caller_identity.exchange_caller_identity,
-            iam_token=iam_token,
-            caller_user_id=current_user.staffId,
-            bot_id=bot_id,
-            owner_user_id=token_context.owner_id,
-            passport=passport,
-            token_provider=provider,
-            runtime_updater=updater,
-            stage=stage.value,
-            publish_id=publish_id,
-            entity_id=entity_id,
-            binding_id=token_context.binding_id,
+            **exchange_kwargs,
         )
     except CallerCredentialError as exc:
         logger.warning(
-            "caller_token_exchange_failed bot_id=%s stage=%s code=%s",
+            "caller_token_exchange_failed bot_id=%s stage=%s code=%s test_exchange=%s",
             bot_id,
             stage.value,
             exc.code,
+            is_test_exchange,
         )
         return JSONResponse(
             content={"success": False, "error": exc.code},
@@ -260,9 +304,10 @@ async def get_iam_token(
         )
     except Exception:
         logger.warning(
-            "caller_runtime_update_failed bot_id=%s stage=%s",
+            "caller_runtime_update_failed bot_id=%s stage=%s test_exchange=%s",
             bot_id,
             stage.value,
+            is_test_exchange,
         )
         return JSONResponse(
             content={"success": False, "error": CALLER_OUTBOUND_UPDATE_FAILED},
@@ -271,9 +316,10 @@ async def get_iam_token(
         )
 
     logger.info(
-        "caller_token_exchange_succeeded bot_id=%s stage=%s",
+        "caller_token_exchange_succeeded bot_id=%s stage=%s test_exchange=%s",
         bot_id,
         stage.value,
+        is_test_exchange,
     )
     # COSEC: the Caller credential is written to BaaS only. Returning it to
     # the browser would turn a server-side runtime credential into an API secret.

--- a/src/backend/src/agentclaw/community/api/caller_credential.py
+++ b/src/backend/src/agentclaw/community/api/caller_credential.py
@@ -56,6 +56,8 @@ class CallerRuntimeUpdater(Protocol):
         agent_code: str,
         stage: str,
         publish_id: int | None,
+        entity_id: str | None = None,
+        binding_id: int | None = None,
     ) -> None:
         """Replace the device's complete outbound rule with Caller overlay."""
         ...

--- a/src/backend/src/agentclaw/community/api/caller_credential.py
+++ b/src/backend/src/agentclaw/community/api/caller_credential.py
@@ -58,6 +58,7 @@ class CallerRuntimeUpdater(Protocol):
         publish_id: int | None,
         entity_id: str | None = None,
         binding_id: int | None = None,
+        is_test_exchange: bool = False,
     ) -> None:
         """Replace the device's complete outbound rule with Caller overlay."""
         ...

--- a/src/backend/src/agentclaw/community/api/caller_identity_service.py
+++ b/src/backend/src/agentclaw/community/api/caller_identity_service.py
@@ -36,7 +36,7 @@ class CallerIdentityServiceProtocol(Protocol):
         server_code: str,
         call_type: McpCallType,
         actor_id: str,
-        lock_epoch: int,
+        lock_epoch: int | None = None,
         entity_id: str | None = None,
     ) -> McpCallTypeUpdateResult: ...
 
@@ -72,6 +72,7 @@ class CallerIdentityServiceProtocol(Protocol):
         stage: CallerIdentityStage,
         publish_id: int | None = None,
         entity_id: str | None = None,
+        is_test_exchange: bool = False,
     ) -> CallerIamTokenContext: ...
 
     def exchange_caller_identity(
@@ -88,6 +89,7 @@ class CallerIdentityServiceProtocol(Protocol):
         publish_id: int | None,
         entity_id: str | None = None,
         binding_id: int | None = None,
+        is_test_exchange: bool = False,
     ) -> None: ...
 
 

--- a/src/backend/src/agentclaw/community/api/caller_identity_service.py
+++ b/src/backend/src/agentclaw/community/api/caller_identity_service.py
@@ -13,6 +13,7 @@ from agentclaw.community.core.caller_identity.contracts import (
     CallerCallTypeInvalidError,
     CallerContext,
     CallerIamTokenContext,
+    CallerIdentityAmbiguousError,
     CallerIdentityNotFoundError,
     CallerIdentityPermissionError,
     CallerIdentityReadOnlyError,
@@ -36,6 +37,7 @@ class CallerIdentityServiceProtocol(Protocol):
         call_type: McpCallType,
         actor_id: str,
         lock_epoch: int,
+        entity_id: str | None = None,
     ) -> McpCallTypeUpdateResult: ...
 
     def get_context(
@@ -45,6 +47,7 @@ class CallerIdentityServiceProtocol(Protocol):
         actor_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> CallerContext: ...
 
     def get_bot_call_type(
@@ -52,6 +55,7 @@ class CallerIdentityServiceProtocol(Protocol):
         bot_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> McpCallType: ...
 
     def is_caller_bot(
@@ -59,6 +63,7 @@ class CallerIdentityServiceProtocol(Protocol):
         bot_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> bool: ...
 
     def get_iam_token_context(
@@ -66,6 +71,7 @@ class CallerIdentityServiceProtocol(Protocol):
         bot_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> CallerIamTokenContext: ...
 
     def exchange_caller_identity(
@@ -80,6 +86,8 @@ class CallerIdentityServiceProtocol(Protocol):
         runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,
         publish_id: int | None,
+        entity_id: str | None = None,
+        binding_id: int | None = None,
     ) -> None: ...
 
 
@@ -88,6 +96,7 @@ __all__ = [
     "CallerCallTypeInvalidError",
     "CallerContext",
     "CallerIamTokenContext",
+    "CallerIdentityAmbiguousError",
     "CallerIdentityNotFoundError",
     "CallerIdentityPermissionError",
     "CallerIdentityReadOnlyError",

--- a/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
@@ -8,6 +8,10 @@ from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 from agentclaw.community.core.bot_management.repository.models import BotRestartLockRecord
 
 
+class BotLookupAmbiguousError(RuntimeError):
+    """A caller-specific Bot lookup matched more than one live row."""
+
+
 @runtime_checkable
 class BotRepository(Protocol):
     """Protocol for bot repository implementations.
@@ -48,6 +52,16 @@ class BotRepository(Protocol):
         Used when reading bot metadata (like active_engine) without
         verifying ownership. For permission checks, use get_by_id_and_owner.
         """
+        ...
+
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Get one live Bot by exact bot and entity identifiers in this env."""
+        ...
+
+    def get_unique_by_id(self, bot_id: str) -> Optional[Dict[str, Any]]:
+        """Get one live Bot by id or raise when the caller scope is ambiguous."""
         ...
 
     def list_by_owner(

--- a/src/backend/src/agentclaw/community/core/caller_identity/contracts.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/contracts.py
@@ -28,6 +28,11 @@ class CallerIdentityNotFoundError(NotFound):
         super().__init__("BOT_NOT_FOUND")
 
 
+class CallerIdentityAmbiguousError(Conflict):
+    def __init__(self) -> None:
+        super().__init__("CALLER_IDENTITY_AMBIGUOUS")
+
+
 class CallerIdentityReadOnlyError(Conflict):
     def __init__(self) -> None:
         super().__init__("BOT_CONFIG_READ_ONLY")
@@ -82,6 +87,7 @@ class CallerIamTokenContext:
     publish_id: int | None
     bot_call_type: McpCallType
     should_exchange_caller_token: bool
+    binding_id: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,6 +105,7 @@ __all__ = [
     "CallerCallTypeInvalidError",
     "CallerContext",
     "CallerIamTokenContext",
+    "CallerIdentityAmbiguousError",
     "CallerIdentityNotFoundError",
     "CallerIdentityPermissionError",
     "CallerIdentityReadOnlyError",

--- a/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
@@ -57,6 +57,8 @@ class CallerRuntimeUpdaterProtocol(Protocol):
         agent_code: str,
         stage: str,
         publish_id: int | None,
+        entity_id: str | None = None,
+        binding_id: int | None = None,
     ) -> None: ...
 
 

--- a/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
@@ -59,6 +59,7 @@ class CallerRuntimeUpdaterProtocol(Protocol):
         publish_id: int | None,
         entity_id: str | None = None,
         binding_id: int | None = None,
+        is_test_exchange: bool = False,
     ) -> None: ...
 
 

--- a/src/backend/src/agentclaw/community/core/caller_identity/repository.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/repository.py
@@ -33,7 +33,7 @@ class CallerIdentityRepositoryProtocol(Protocol):
         effective_server_codes: set[str],
         lock_key: str,
         lock_holder_user_id: str,
-        lock_epoch: int,
+        lock_epoch: int | None,
     ) -> DraftCallTypeMutationResult: ...
 
     def compensate_draft_call_type(
@@ -48,7 +48,7 @@ class CallerIdentityRepositoryProtocol(Protocol):
         expected_revision: int,
         lock_key: str,
         lock_holder_user_id: str,
-        lock_epoch: int,
+        lock_epoch: int | None,
     ) -> DraftCallTypeCompensationResult: ...
 
     def list_draft_call_types(

--- a/src/backend/src/agentclaw/community/core/caller_identity/service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/service.py
@@ -85,11 +85,19 @@ class CallerIdentityService:
     ) -> McpCallTypeUpdateResult:
         """Update draft state, then synchronously refresh Agent Principal."""
         normalized_call_type = self._parse_call_type(call_type)
-        bot = (
-            self._bot_repository.get_by_id_and_entity(bot_id, entity_id)
-            if entity_id is not None
-            else self._bot_repository.get_by_id_and_owner(bot_id, actor_id)
-        )
+        if entity_id is not None:
+            bot = self._bot_repository.get_by_id_and_entity(bot_id, entity_id)
+        else:
+            try:
+                # COSEC: do not select an arbitrary duplicate Bot when callers
+                # omit entity_id; the mutation must fail closed.
+                bot = self._bot_repository.get_unique_by_id(bot_id)
+            except BotLookupAmbiguousError as exc:
+                logger.warning(
+                    "caller_mcp_call_type_update_rejected_ambiguous_bot bot_id=%s",
+                    bot_id,
+                )
+                raise CallerIdentityAmbiguousError from exc
         # COSEC: an entity-scoped lookup does not authorize the request; the
         # authenticated actor must still be the Bot owner.
         if bot is None or str(bot.get("owner_id") or "") != actor_id:

--- a/src/backend/src/agentclaw/community/core/caller_identity/service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/service.py
@@ -9,12 +9,16 @@ from agentclaw.community.core.bot_collaborator.repository.protocol import (
     BotCollabLockRepositoryProtocol,
     CollaboratorRepositoryProtocol,
 )
-from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotLookupAmbiguousError,
+    BotRepository,
+)
 from agentclaw.community.core.caller_identity.contracts import (
     CALLER_IDENTITY_CAPABILITY,
     CallerCallTypeInvalidError,
     CallerContext,
     CallerIamTokenContext,
+    CallerIdentityAmbiguousError,
     CallerIdentityNotFoundError,
     CallerIdentityPermissionError,
     CallerIdentityReadOnlyError,
@@ -77,10 +81,17 @@ class CallerIdentityService:
         call_type: McpCallType,
         actor_id: str,
         lock_epoch: int,
+        entity_id: str | None = None,
     ) -> McpCallTypeUpdateResult:
         """Update draft state, then synchronously refresh Agent Principal."""
         normalized_call_type = self._parse_call_type(call_type)
-        bot = self._bot_repository.get_by_id_and_owner(bot_id, actor_id)
+        bot = (
+            self._bot_repository.get_by_id_and_entity(bot_id, entity_id)
+            if entity_id is not None
+            else self._bot_repository.get_by_id_and_owner(bot_id, actor_id)
+        )
+        # COSEC: an entity-scoped lookup does not authorize the request; the
+        # authenticated actor must still be the Bot owner.
         if bot is None or str(bot.get("owner_id") or "") != actor_id:
             raise CallerIdentityPermissionError
         if bot.get("bot_type") != "service" or bot.get("status") != "ACTIVE":
@@ -176,10 +187,11 @@ class CallerIdentityService:
         actor_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> CallerContext:
         """Return draft MCP details and the Bot aggregate for an authorized user."""
         normalized_stage = CallerIdentityStage(stage)
-        bot, is_owner = self._authorize_read(bot_id, actor_id)
+        bot, is_owner = self._authorize_read(bot_id, actor_id, entity_id)
         mcp_call_types = dict(
             self._repository.list_draft_call_types(
                 int(bot["id"]),
@@ -204,46 +216,68 @@ class CallerIdentityService:
         bot_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> McpCallType:
         """Provide marketplace callers the aggregate without MCP enumeration."""
         del stage, publish_id
-        return self._bot_call_type(self._get_bot(bot_id))
+        return self._bot_call_type(self._get_bot(bot_id, entity_id))
 
     def is_caller_bot(
         self,
         bot_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> bool:
-        return self.get_bot_call_type(bot_id, stage, publish_id) is McpCallType.CALLER
+        return (
+            self.get_bot_call_type(bot_id, stage, publish_id, entity_id)
+            is McpCallType.CALLER
+        )
 
     def get_iam_token_context(
         self,
         bot_id: str,
         stage: CallerIdentityStage,
         publish_id: int | None = None,
+        entity_id: str | None = None,
     ) -> CallerIamTokenContext:
         """Use only ac_bots.call_type to decide the IAM Caller branch."""
-        bot = self._get_bot(bot_id)
+        bot = self._get_bot(bot_id, entity_id)
+        resolved_stage = CallerIdentityStage(stage)
         bot_call_type = self._bot_call_type(bot)
         should_exchange = (
             bot.get("bot_type") == "service"
             and bot.get("status") == "ACTIVE"
             and bot_call_type is McpCallType.CALLER
         )
+        binding_id = (
+            bot.get("binding_id")
+            if resolved_stage is CallerIdentityStage.DRAFT
+            else None
+        )
+        if (
+            not isinstance(binding_id, int)
+            or isinstance(binding_id, bool)
+            or binding_id <= 0
+        ):
+            binding_id = None
         logger.info(
-            "caller_iam_context_resolved bot_id=%s stage=%s caller=%s",
+            "caller_iam_context_resolved bot_id=%s stage=%s caller=%s entity_scoped=%s "
+            "draft_binding_available=%s",
             bot_id,
-            CallerIdentityStage(stage).value,
+            resolved_stage.value,
             should_exchange,
+            entity_id is not None,
+            binding_id is not None,
         )
         return CallerIamTokenContext(
             bot_id=bot_id,
             owner_id=str(bot.get("owner_id") or "") or None,
-            stage=CallerIdentityStage(stage),
+            stage=resolved_stage,
             publish_id=publish_id,
             bot_call_type=bot_call_type,
             should_exchange_caller_token=should_exchange,
+            binding_id=binding_id,
         )
 
     def exchange_caller_identity(
@@ -258,6 +292,8 @@ class CallerIdentityService:
         runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,
         publish_id: int | None,
+        entity_id: str | None = None,
+        binding_id: int | None = None,
     ) -> None:
         """Exchange and install the Caller credential for one chat request."""
         delegation_credential = passport.query_token(bot_id, owner_user_id) or ""
@@ -277,15 +313,26 @@ class CallerIdentityService:
             delegation_credential=delegation_credential,
             task_metadata=CALLER_CHAT_TASK,
         )
+        runtime_update_kwargs: dict[str, Any] = {
+            "bot_id": bot_id,
+            "owner_user_id": owner_user_id,
+            "caller_user_id": caller_user_id,
+            "caller_token": caller_token,
+            "agent_pass_token": delegation_credential,
+            "agent_code": agent_code,
+            "stage": stage,
+            "publish_id": publish_id,
+            "entity_id": entity_id,
+        }
+        if (
+            stage == CallerIdentityStage.DRAFT.value
+            and isinstance(binding_id, int)
+            and not isinstance(binding_id, bool)
+            and binding_id > 0
+        ):
+            runtime_update_kwargs["binding_id"] = binding_id
         runtime_updater.update_caller_identity(
-            bot_id=bot_id,
-            owner_user_id=owner_user_id,
-            caller_user_id=caller_user_id,
-            caller_token=caller_token,
-            agent_pass_token=delegation_credential,
-            agent_code=agent_code,
-            stage=stage,
-            publish_id=publish_id,
+            **runtime_update_kwargs,
         )
 
     def _compensate_after_sync_failure(
@@ -334,8 +381,9 @@ class CallerIdentityService:
         self,
         bot_id: str,
         actor_id: str,
+        entity_id: str | None,
     ) -> tuple[Mapping[str, Any], bool]:
-        bot = self._get_bot(bot_id)
+        bot = self._get_bot(bot_id, entity_id)
         is_owner = str(bot.get("owner_id") or "") == actor_id
         if is_owner:
             return bot, True
@@ -348,8 +396,20 @@ class CallerIdentityService:
             raise CallerIdentityPermissionError
         return bot, False
 
-    def _get_bot(self, bot_id: str) -> Mapping[str, Any]:
-        bot = self._bot_repository.get_by_id(bot_id)
+    def _get_bot(
+        self,
+        bot_id: str,
+        entity_id: str | None = None,
+    ) -> Mapping[str, Any]:
+        if entity_id is not None:
+            bot = self._bot_repository.get_by_id_and_entity(bot_id, entity_id)
+        else:
+            try:
+                # COSEC: do not select an arbitrary duplicate Bot when callers
+                # omit entity_id; the caller-specific lookup fails closed.
+                bot = self._bot_repository.get_unique_by_id(bot_id)
+            except BotLookupAmbiguousError as exc:
+                raise CallerIdentityAmbiguousError from exc
         if bot is None:
             raise CallerIdentityNotFoundError
         return bot

--- a/src/backend/src/agentclaw/community/core/caller_identity/service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/service.py
@@ -80,7 +80,7 @@ class CallerIdentityService:
         server_code: str,
         call_type: McpCallType,
         actor_id: str,
-        lock_epoch: int,
+        lock_epoch: int | None = None,
         entity_id: str | None = None,
     ) -> McpCallTypeUpdateResult:
         """Update draft state, then synchronously refresh Agent Principal."""
@@ -123,7 +123,15 @@ class CallerIdentityService:
 
         lock_key = f"{bot_id}:{actor_id}"
         lock = self._lock_repository.get_by_key(lock_key)
-        if lock is None or lock.holder_user_id != actor_id or lock.id != lock_epoch:
+        if lock_epoch is None:
+            if lock is not None:
+                logger.warning(
+                    "caller_mcp_call_type_update_rejected_missing_lock_epoch "
+                    "bot_id=%s",
+                    bot_id,
+                )
+                raise CallerLockEpochError
+        elif lock is None or lock.holder_user_id != actor_id or lock.id != lock_epoch:
             raise CallerLockEpochError
 
         try:
@@ -142,8 +150,6 @@ class CallerIdentityService:
             raise CallerLockEpochError from exc
         except CallerIdentityEngineChangedError as exc:
             raise CallerIdentityReadOnlyError from exc
-        except (TypeError, ValueError) as exc:
-            raise CallerCallTypeInvalidError from exc
 
         try:
             identity_modes = self._repository.list_draft_call_types(
@@ -176,11 +182,12 @@ class CallerIdentityService:
 
         logger.info(
             "caller_mcp_call_type_updated bot_id=%s server_code=%s call_type=%s "
-            "bot_call_type=%s",
+            "bot_call_type=%s lock_epoch_supplied=%s",
             bot_id,
             server_code,
             normalized_call_type.value,
             mutation.bot_call_type.value,
+            lock_epoch is not None,
         )
         return McpCallTypeUpdateResult(
             server_code=server_code,
@@ -215,7 +222,7 @@ class CallerIdentityService:
             editable=(
                 is_owner
                 and normalized_stage is CallerIdentityStage.DRAFT
-                and self._holds_lock(bot, actor_id)
+                and self._can_edit_draft(bot, actor_id)
             ),
         )
 
@@ -248,15 +255,26 @@ class CallerIdentityService:
         stage: CallerIdentityStage,
         publish_id: int | None = None,
         entity_id: str | None = None,
+        is_test_exchange: bool = False,
     ) -> CallerIamTokenContext:
-        """Use only ac_bots.call_type to decide the IAM Caller branch."""
+        """Resolve whether the IAM request should execute the Caller branch."""
         bot = self._get_bot(bot_id, entity_id)
         resolved_stage = CallerIdentityStage(stage)
-        bot_call_type = self._bot_call_type(bot)
+        # COSEC: temporary browser testing only bypasses the Bot type and
+        # aggregate call-type lookup/gates. Exact Bot resolution, ACTIVE state and
+        # the downstream IAM/Passport/runtime validations remain mandatory.
+        bot_call_type = (
+            McpCallType.OWNER if is_test_exchange else self._bot_call_type(bot)
+        )
         should_exchange = (
-            bot.get("bot_type") == "service"
-            and bot.get("status") == "ACTIVE"
-            and bot_call_type is McpCallType.CALLER
+            bot.get("status") == "ACTIVE"
+            and (
+                is_test_exchange
+                or (
+                    bot.get("bot_type") == "service"
+                    and bot_call_type is McpCallType.CALLER
+                )
+            )
         )
         binding_id = (
             bot.get("binding_id")
@@ -270,11 +288,12 @@ class CallerIdentityService:
         ):
             binding_id = None
         logger.info(
-            "caller_iam_context_resolved bot_id=%s stage=%s caller=%s entity_scoped=%s "
-            "draft_binding_available=%s",
+            "caller_iam_context_resolved bot_id=%s stage=%s caller=%s "
+            "test_exchange=%s entity_scoped=%s draft_binding_available=%s",
             bot_id,
             resolved_stage.value,
             should_exchange,
+            is_test_exchange,
             entity_id is not None,
             binding_id is not None,
         )
@@ -302,6 +321,7 @@ class CallerIdentityService:
         publish_id: int | None,
         entity_id: str | None = None,
         binding_id: int | None = None,
+        is_test_exchange: bool = False,
     ) -> None:
         """Exchange and install the Caller credential for one chat request."""
         delegation_credential = passport.query_token(bot_id, owner_user_id) or ""
@@ -339,6 +359,17 @@ class CallerIdentityService:
             and binding_id > 0
         ):
             runtime_update_kwargs["binding_id"] = binding_id
+        if is_test_exchange:
+            # The HTTP adapter restricts this temporary path to a non-production
+            # Bot owner. BaaS needs the marker only to accept a personal Bot for
+            # that controlled end-to-end test.
+            runtime_update_kwargs["is_test_exchange"] = True
+        logger.info(
+            "caller_runtime_update_requested bot_id=%s stage=%s test_exchange=%s",
+            bot_id,
+            stage,
+            is_test_exchange,
+        )
         runtime_updater.update_caller_identity(
             **runtime_update_kwargs,
         )
@@ -353,7 +384,7 @@ class CallerIdentityService:
         mutation: Any,
         effective_server_codes: set[str],
         actor_id: str,
-        lock_epoch: int,
+        lock_epoch: int | None,
     ) -> None:
         try:
             compensation = self._repository.compensate_draft_call_type(
@@ -425,6 +456,11 @@ class CallerIdentityService:
     def _holds_lock(self, bot: Mapping[str, Any], actor_id: str) -> bool:
         lock = self._lock_repository.get_by_key(f"{bot['bot_id']}:{bot['owner_id']}")
         return lock is not None and lock.holder_user_id == actor_id
+
+    def _can_edit_draft(self, bot: Mapping[str, Any], actor_id: str) -> bool:
+        """Permit an owner when no collaboration lock has been created yet."""
+        lock = self._lock_repository.get_by_key(f"{bot['bot_id']}:{bot['owner_id']}")
+        return lock is None or lock.holder_user_id == actor_id
 
     @staticmethod
     def _bot_call_type(bot: Mapping[str, Any]) -> McpCallType:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3157,6 +3157,8 @@ class BaasService:  # pragma: no cover
         agent_code: str,
         stage: str,
         publish_id: int | None,
+        entity_id: str | None = None,
+        binding_id: int | None = None,
     ) -> None:
         """Install one Caller-token overlay on the Bot's current BaaS device."""
         if (
@@ -3166,7 +3168,13 @@ class BaasService:  # pragma: no cover
         ):
             raise CallerCredentialError(CALLER_CREDENTIAL_REQUEST_INVALID)
 
-        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_user_id)
+        bot = (
+            self._bot_repo.get_by_id_and_entity(bot_id, entity_id)
+            if entity_id is not None
+            else self._bot_repo.get_by_id_and_owner(bot_id, owner_user_id)
+        )
+        # COSEC: an entity-scoped lookup is not authorization; require the
+        # resolved Bot owner to match the identity already resolved upstream.
         if (
             not bot
             or bot.get("bot_type") != "service"
@@ -3175,14 +3183,19 @@ class BaasService:  # pragma: no cover
         ):
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
 
-        binding_id = self._resolve_caller_binding_id(
-            bot=bot,
-            bot_id=bot_id,
-            owner_user_id=owner_user_id,
-            stage=stage,
-            publish_id=publish_id,
+        use_supplied_binding_id = self._is_valid_caller_binding_id(binding_id)
+        resolved_binding_id = (
+            binding_id
+            if use_supplied_binding_id
+            else self._resolve_caller_binding_id(
+                bot=bot,
+                bot_id=bot_id,
+                owner_user_id=owner_user_id,
+                stage=stage,
+                publish_id=publish_id,
+            )
         )
-        binding = self._device_binding_repo.get_by_id(binding_id)
+        binding = self._device_binding_repo.get_by_id(resolved_binding_id)
         if (
             binding is None
             or str(getattr(binding, "status", "")).upper() != "ACTIVE"
@@ -3219,27 +3232,44 @@ class BaasService:  # pragma: no cover
         )
 
         logger.info(
-            "caller_outbound_update_started bot_id=%s stage=%s rule_count=%s",
+            "caller_outbound_update_started bot_id=%s stage=%s rule_count=%s "
+            "entity_scoped=%s supplied_binding_id=%s",
             bot_id,
             stage,
             len(complete_rule.header_operation_rules),
+            entity_id is not None,
+            use_supplied_binding_id,
         )
         try:
             updated = self.update_device_outbound_rule(paas_device_id, complete_rule)
         except Exception as exc:
             logger.warning(
-                "caller_outbound_update_failed bot_id=%s stage=%s error_type=%s",
+                "caller_outbound_update_failed bot_id=%s stage=%s error_type=%s "
+                "entity_scoped=%s supplied_binding_id=%s",
                 bot_id,
                 stage,
                 type(exc).__name__,
+                entity_id is not None,
+                use_supplied_binding_id,
             )
             raise CallerCredentialError(CALLER_OUTBOUND_UPDATE_FAILED) from exc
         if not updated:
             raise CallerCredentialError(CALLER_OUTBOUND_UPDATE_FAILED)
         logger.info(
-            "caller_outbound_update_succeeded bot_id=%s stage=%s",
+            "caller_outbound_update_succeeded bot_id=%s stage=%s entity_scoped=%s "
+            "supplied_binding_id=%s",
             bot_id,
             stage,
+            entity_id is not None,
+            use_supplied_binding_id,
+        )
+
+    @staticmethod
+    def _is_valid_caller_binding_id(binding_id: object) -> bool:
+        return (
+            isinstance(binding_id, int)
+            and not isinstance(binding_id, bool)
+            and binding_id > 0
         )
 
     def _resolve_caller_binding_id(
@@ -3275,11 +3305,7 @@ class BaasService:  # pragma: no cover
             )
         else:
             raise CallerCredentialError(CALLER_CREDENTIAL_REQUEST_INVALID)
-        if (
-            not isinstance(binding_id, int)
-            or isinstance(binding_id, bool)
-            or binding_id <= 0
-        ):
+        if not self._is_valid_caller_binding_id(binding_id):
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
         return binding_id
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3160,6 +3160,7 @@ class BaasService:  # pragma: no cover
         publish_id: int | None,
         entity_id: str | None = None,
         binding_id: int | None = None,
+        is_test_exchange: bool = False,
     ) -> None:
         """Install one Caller-token overlay on the Bot's current BaaS device."""
         if (
@@ -3186,7 +3187,7 @@ class BaasService:  # pragma: no cover
         # resolved Bot owner to match the identity already resolved upstream.
         if (
             not bot
-            or bot.get("bot_type") != "service"
+            or (not is_test_exchange and bot.get("bot_type") != "service")
             or bot.get("status") != "ACTIVE"
             or str(bot.get("owner_id") or "") != owner_user_id
         ):
@@ -3242,35 +3243,38 @@ class BaasService:  # pragma: no cover
 
         logger.info(
             "caller_outbound_update_started bot_id=%s stage=%s rule_count=%s "
-            "entity_scoped=%s supplied_binding_id=%s",
+            "entity_scoped=%s supplied_binding_id=%s test_exchange=%s",
             bot_id,
             stage,
             len(complete_rule.header_operation_rules),
             entity_id is not None,
             use_supplied_binding_id,
+            is_test_exchange,
         )
         try:
             updated = self.update_device_outbound_rule(paas_device_id, complete_rule)
         except Exception as exc:
             logger.warning(
                 "caller_outbound_update_failed bot_id=%s stage=%s error_type=%s "
-                "entity_scoped=%s supplied_binding_id=%s",
+                "entity_scoped=%s supplied_binding_id=%s test_exchange=%s",
                 bot_id,
                 stage,
                 type(exc).__name__,
                 entity_id is not None,
                 use_supplied_binding_id,
+                is_test_exchange,
             )
             raise CallerCredentialError(CALLER_OUTBOUND_UPDATE_FAILED) from exc
         if not updated:
             raise CallerCredentialError(CALLER_OUTBOUND_UPDATE_FAILED)
         logger.info(
             "caller_outbound_update_succeeded bot_id=%s stage=%s entity_scoped=%s "
-            "supplied_binding_id=%s",
+            "supplied_binding_id=%s test_exchange=%s",
             bot_id,
             stage,
             entity_id is not None,
             use_supplied_binding_id,
+            is_test_exchange,
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -34,6 +34,7 @@ from agentclaw.community.core.caller_identity.credential import (
     CallerCredentialError,
     CallerToken,
 )
+from agentclaw.community.core.bot_management.repository.protocol import BotLookupAmbiguousError
 
 from agentclaw.community.plugin_api.http_client import HttpClient
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
@@ -3168,11 +3169,19 @@ class BaasService:  # pragma: no cover
         ):
             raise CallerCredentialError(CALLER_CREDENTIAL_REQUEST_INVALID)
 
-        bot = (
-            self._bot_repo.get_by_id_and_entity(bot_id, entity_id)
-            if entity_id is not None
-            else self._bot_repo.get_by_id_and_owner(bot_id, owner_user_id)
-        )
+        if entity_id is not None:
+            bot = self._bot_repo.get_by_id_and_entity(bot_id, entity_id)
+        else:
+            try:
+                # COSEC: do not select an arbitrary duplicate Bot when callers
+                # omit entity_id; the caller credential target must be unique.
+                bot = self._bot_repo.get_unique_by_id(bot_id)
+            except BotLookupAmbiguousError as exc:
+                logger.warning(
+                    "caller_identity_update_rejected_ambiguous_bot bot_id=%s",
+                    bot_id,
+                )
+                raise CallerCredentialError(CALLER_TARGET_AMBIGUOUS) from exc
         # COSEC: an entity-scoped lookup is not authorization; require the
         # resolved Bot owner to match the identity already resolved upstream.
         if (

--- a/src/backend/src/agentclaw/community/plugin_api/models.py
+++ b/src/backend/src/agentclaw/community/plugin_api/models.py
@@ -84,8 +84,6 @@ class BotModel(Base):
             "env": self.env,
             "bot_type": self.bot_type,
             "template_type": self.template_type,
-            "call_type": self.call_type,
-            "caller_config_revision": self.caller_config_revision,
         }
 
 

--- a/src/backend/src/agentclaw/community/plugin_api/models.py
+++ b/src/backend/src/agentclaw/community/plugin_api/models.py
@@ -84,6 +84,8 @@ class BotModel(Base):
             "env": self.env,
             "bot_type": self.bot_type,
             "template_type": self.template_type,
+            "call_type": self.call_type,
+            "caller_config_revision": self.caller_config_revision,
         }
 
 

--- a/src/backend/src/agentclaw/community/plugins/bot_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_repository.py
@@ -43,6 +43,9 @@ from typing import Any, Dict, List, Optional
 from injector import inject
 from sqlalchemy import func, or_
 
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotLookupAmbiguousError,
+)
 from agentclaw.community.core.workspace.constants import SUPPORTED_ENGINE_TYPES
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
@@ -215,6 +218,44 @@ class BotRepository:
                 .first()
             )
             return bot.to_dict() if bot else None
+
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Query one live Bot by exact bot and entity identifiers in this env."""
+        with self._db.orm_session() as db:
+            # COSEC: SQLAlchemy binds both identifiers; never interpolate request
+            # values into a raw SQL expression.
+            bot = (
+                db.query(self.Model)
+                .filter(
+                    self.Model.bot_id == bot_id,
+                    self.Model.entity_id == entity_id,
+                    self.Model.is_delete == 0,
+                    self._env(),
+                )
+                .first()
+            )
+            return bot.to_dict() if bot else None
+
+    def get_unique_by_id(self, bot_id: str) -> Optional[Dict[str, Any]]:
+        """Return one live Bot by id or fail closed when callers are ambiguous."""
+        with self._db.orm_session() as db:
+            # COSEC: SQLAlchemy binds the request-derived identifier; never
+            # interpolate it into a raw SQL expression.
+            bots = (
+                db.query(self.Model)
+                .filter(
+                    self.Model.bot_id == bot_id,
+                    self.Model.is_delete == 0,
+                    self._env(),
+                )
+                .limit(2)
+                .all()
+            )
+            if len(bots) > 1:
+                raise BotLookupAmbiguousError
+            return bots[0].to_dict() if bots else None
 
     def list_by_owner(
         self, owner_id: str, page: int = 1, page_size: int = 20

--- a/src/backend/src/agentclaw/community/plugins/bot_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_repository.py
@@ -135,6 +135,14 @@ class BotRepository:
     def _env(self):
         return self.Model.env == get_current_env()
 
+    @staticmethod
+    def _to_caller_identity_dict(bot: BotModel) -> Dict[str, Any]:
+        """Return the private Bot projection required by Caller services."""
+        result = bot.to_dict()
+        result["call_type"] = bot.call_type
+        result["caller_config_revision"] = bot.caller_config_revision
+        return result
+
     def get_by_id_and_owner(
         self, bot_id: str, owner_id: str
     ) -> Optional[Dict[str, Any]]:
@@ -236,7 +244,7 @@ class BotRepository:
                 )
                 .first()
             )
-            return bot.to_dict() if bot else None
+            return self._to_caller_identity_dict(bot) if bot else None
 
     def get_unique_by_id(self, bot_id: str) -> Optional[Dict[str, Any]]:
         """Return one live Bot by id or fail closed when callers are ambiguous."""
@@ -255,7 +263,7 @@ class BotRepository:
             )
             if len(bots) > 1:
                 raise BotLookupAmbiguousError
-            return bots[0].to_dict() if bots else None
+            return self._to_caller_identity_dict(bots[0]) if bots else None
 
     def list_by_owner(
         self, owner_id: str, page: int = 1, page_size: int = 20

--- a/src/backend/src/agentclaw/community/plugins/caller_identity_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/caller_identity_repository.py
@@ -44,26 +44,42 @@ class CallerIdentityRepository:
         effective_server_codes: set[str],
         lock_key: str,
         lock_holder_user_id: str,
-        lock_epoch: int,
+        lock_epoch: int | None,
     ) -> DraftCallTypeMutationResult:
         normalized_call_type = McpCallType.parse(call_type)
         env = get_current_env()
         with self._db.transactional_orm_session() as session:
-            # COSEC: verify the exact lock inside the write transaction so a
-            # released or stolen lock cannot authorize a stale mutation.
-            lock = (
-                session.query(BotCollabLockModel)
-                .filter(
-                    BotCollabLockModel.lock_key == lock_key,
-                    BotCollabLockModel.holder_user_id == lock_holder_user_id,
-                    BotCollabLockModel.id == lock_epoch,
-                    BotCollabLockModel.env == env,
+            if lock_epoch is not None:
+                # COSEC: verify the exact lock inside the write transaction so a
+                # released or stolen lock cannot authorize a stale mutation.
+                lock = (
+                    session.query(BotCollabLockModel)
+                    .filter(
+                        BotCollabLockModel.lock_key == lock_key,
+                        BotCollabLockModel.holder_user_id == lock_holder_user_id,
+                        BotCollabLockModel.id == lock_epoch,
+                        BotCollabLockModel.env == env,
+                    )
+                    .with_for_update()
+                    .one_or_none()
                 )
-                .with_for_update()
-                .one_or_none()
-            )
-            if lock is None:
-                raise CallerIdentityLockMismatchError
+                if lock is None:
+                    raise CallerIdentityLockMismatchError
+            else:
+                # COSEC: repeat the unlocked-path check in the write
+                # transaction. A lock created after the service check must not
+                # be bypassed by an omitted epoch.
+                lock = (
+                    session.query(BotCollabLockModel)
+                    .filter(
+                        BotCollabLockModel.lock_key == lock_key,
+                        BotCollabLockModel.env == env,
+                    )
+                    .with_for_update()
+                    .one_or_none()
+                )
+                if lock is not None:
+                    raise CallerIdentityLockMismatchError
             bot = (
                 session.query(BotModel)
                 .filter(BotModel.id == bot_pk, BotModel.env == env)
@@ -141,23 +157,38 @@ class CallerIdentityRepository:
         expected_revision: int,
         lock_key: str,
         lock_holder_user_id: str,
-        lock_epoch: int,
+        lock_epoch: int | None,
     ) -> DraftCallTypeCompensationResult:
         env = get_current_env()
         with self._db.transactional_orm_session() as session:
-            lock = (
-                session.query(BotCollabLockModel)
-                .filter(
-                    BotCollabLockModel.lock_key == lock_key,
-                    BotCollabLockModel.holder_user_id == lock_holder_user_id,
-                    BotCollabLockModel.id == lock_epoch,
-                    BotCollabLockModel.env == env,
+            if lock_epoch is not None:
+                lock = (
+                    session.query(BotCollabLockModel)
+                    .filter(
+                        BotCollabLockModel.lock_key == lock_key,
+                        BotCollabLockModel.holder_user_id == lock_holder_user_id,
+                        BotCollabLockModel.id == lock_epoch,
+                        BotCollabLockModel.env == env,
+                    )
+                    .with_for_update()
+                    .one_or_none()
                 )
-                .with_for_update()
-                .one_or_none()
-            )
-            if lock is None:
-                raise CallerIdentityLockMismatchError
+                if lock is None:
+                    raise CallerIdentityLockMismatchError
+            else:
+                # COSEC: do not roll back an unlocked mutation after another
+                # editor has established a collaboration lock.
+                lock = (
+                    session.query(BotCollabLockModel)
+                    .filter(
+                        BotCollabLockModel.lock_key == lock_key,
+                        BotCollabLockModel.env == env,
+                    )
+                    .with_for_update()
+                    .one_or_none()
+                )
+                if lock is not None:
+                    raise CallerIdentityLockMismatchError
             bot = (
                 session.query(BotModel)
                 .filter(BotModel.id == bot_pk, BotModel.env == env)

--- a/src/backend/tests/community/api/test_caller_iam_token.py
+++ b/src/backend/tests/community/api/test_caller_iam_token.py
@@ -18,6 +18,7 @@ from agentclaw.community.api.caller_identity_service import (
 )
 from agentclaw.community.core.caller_identity.contracts import (
     CallerIamTokenContext,
+    CallerIdentityAmbiguousError,
     McpCallType,
 )
 from agentclaw.community.core.caller_identity.credential import CallerToken
@@ -50,6 +51,7 @@ async def test_iam_route_delegates_caller_exchange_without_returning_token() -> 
         publish_id=None,
         bot_call_type=McpCallType.CALLER,
         should_exchange_caller_token=True,
+        binding_id=9,
     )
     auth = MagicMock()
     auth.resolve_user_from_request = AsyncMock(
@@ -87,12 +89,42 @@ async def test_iam_route_delegates_caller_exchange_without_returning_token() -> 
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
+        entity_id="entity-1",
     )
 
     assert response.status_code == 200
     assert json.loads(response.body) == {"success": True, "iam_token": "iam-token"}
+    identity.get_iam_token_context.assert_called_once_with(
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id="entity-1",
+    )
     identity.exchange_caller_identity.assert_called_once()
     exchange_kwargs = identity.exchange_caller_identity.call_args.kwargs
     assert exchange_kwargs["caller_user_id"] == "caller-1"
     assert exchange_kwargs["token_provider"] is token_provider
     assert exchange_kwargs["runtime_updater"] is runtime_updater
+    assert exchange_kwargs["entity_id"] == "entity-1"
+    assert exchange_kwargs["binding_id"] == 9
+
+
+@pytest.mark.asyncio
+async def test_iam_route_rejects_ambiguous_bot_without_entity() -> None:
+    identity = MagicMock()
+    identity.get_iam_token_context.side_effect = CallerIdentityAmbiguousError()
+    request = _Request({CallerIdentityServiceProtocol: identity})
+
+    response = await get_iam_token(
+        request,
+        bot_id="default",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+    )
+
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "success": False,
+        "error": "CALLER_IDENTITY_AMBIGUOUS",
+    }
+    identity.exchange_caller_identity.assert_not_called()

--- a/src/backend/tests/community/api/test_caller_iam_token.py
+++ b/src/backend/tests/community/api/test_caller_iam_token.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import json
 from datetime import datetime
 from types import SimpleNamespace
@@ -24,6 +25,11 @@ from agentclaw.community.core.caller_identity.contracts import (
 from agentclaw.community.core.caller_identity.credential import CallerToken
 from agentclaw.community.plugin_api.auth import AuthPlugin
 from agentclaw.community.plugin_api.passport import PassportPlugin
+
+
+token_exchange_router = importlib.import_module(
+    "agentclaw.community.adapters.http.token_exchange.router"
+)
 
 
 class _Request:
@@ -99,6 +105,7 @@ async def test_iam_route_delegates_caller_exchange_without_returning_token() -> 
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id="entity-1",
+        is_test_exchange=False,
     )
     identity.exchange_caller_identity.assert_called_once()
     exchange_kwargs = identity.exchange_caller_identity.call_args.kwargs
@@ -107,6 +114,154 @@ async def test_iam_route_delegates_caller_exchange_without_returning_token() -> 
     assert exchange_kwargs["runtime_updater"] is runtime_updater
     assert exchange_kwargs["entity_id"] == "entity-1"
     assert exchange_kwargs["binding_id"] == 9
+
+
+@pytest.mark.asyncio
+async def test_iam_route_test_exchange_forces_exchange_for_non_caller_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(token_exchange_router, "get_current_env", lambda: "pre")
+    identity = MagicMock()
+    identity.get_iam_token_context.return_value = CallerIamTokenContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        bot_call_type=McpCallType.OWNER,
+        should_exchange_caller_token=True,
+    )
+    auth = MagicMock()
+    auth.resolve_user_from_request = AsyncMock(
+        return_value=SimpleNamespace(
+            id="id-1",
+            staffId="owner-1",
+            operatorName="Caller",
+            nickName="Caller",
+            tenantId="tenant-1",
+        )
+    )
+    request = _Request(
+        {
+            CallerIdentityServiceProtocol: identity,
+            AuthPlugin: auth,
+            PassportPlugin: MagicMock(),
+            CallerTokenProvider: MagicMock(),
+            CallerRuntimeUpdater: MagicMock(),
+        }
+    )
+
+    response = await get_iam_token(
+        request,
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=True,
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {"success": True, "iam_token": "iam-token"}
+    identity.get_iam_token_context.assert_called_once_with(
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=True,
+    )
+    identity.exchange_caller_identity.assert_called_once()
+    assert (
+        identity.exchange_caller_identity.call_args.kwargs["is_test_exchange"]
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_iam_route_test_exchange_rejects_non_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(token_exchange_router, "get_current_env", lambda: "pre")
+    identity = MagicMock()
+    identity.get_iam_token_context.return_value = CallerIamTokenContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        bot_call_type=McpCallType.OWNER,
+        should_exchange_caller_token=True,
+    )
+    auth = MagicMock()
+    auth.resolve_user_from_request = AsyncMock(
+        return_value=SimpleNamespace(
+            id="id-1",
+            staffId="caller-1",
+            operatorName="Caller",
+            nickName="Caller",
+            tenantId="tenant-1",
+        )
+    )
+
+    response = await get_iam_token(
+        _Request(
+            {
+                CallerIdentityServiceProtocol: identity,
+                AuthPlugin: auth,
+            }
+        ),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=True,
+    )
+
+    assert response.status_code == 403
+    assert json.loads(response.body) == {
+        "success": False,
+        "error": "CALLER_IDENTITY_FORBIDDEN",
+    }
+    identity.exchange_caller_identity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_iam_route_test_exchange_rejects_production_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(token_exchange_router, "get_current_env", lambda: "prod")
+    identity = MagicMock()
+
+    response = await get_iam_token(
+        _Request({CallerIdentityServiceProtocol: identity}),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=True,
+    )
+
+    assert response.status_code == 403
+    assert json.loads(response.body) == {
+        "success": False,
+        "error": "CALLER_IDENTITY_FORBIDDEN",
+    }
+    identity.get_iam_token_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_iam_route_test_exchange_requires_bot_id() -> None:
+    response = await get_iam_token(
+        _Request({}),
+        bot_id=None,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=True,
+    )
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == {
+        "success": False,
+        "error": "CALLER_CREDENTIAL_REQUEST_INVALID",
+    }
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/caller_identity/test_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_service.py
@@ -8,6 +8,7 @@ import pytest
 
 from agentclaw.community.core.caller_identity.contracts import (
     CallerCallTypeInvalidError,
+    CallerIdentityAmbiguousError,
     CallerIdentityStage,
     CallerIdentityReadOnlyError,
     CallerLockEpochError,
@@ -22,6 +23,9 @@ from agentclaw.community.core.caller_identity.repository import (
     CallerIdentityLockMismatchError,
 )
 from agentclaw.community.core.caller_identity.service import CallerIdentityService
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotLookupAmbiguousError,
+)
 
 
 def _bot(*, call_type: str = "owner") -> dict[str, object]:
@@ -42,6 +46,7 @@ def _bot(*, call_type: str = "owner") -> dict[str, object]:
 def _service(*, bot: dict[str, object]):
     bot_repository = MagicMock()
     bot_repository.get_by_id.return_value = bot
+    bot_repository.get_unique_by_id.return_value = bot
     bot_repository.get_by_id_and_owner.return_value = bot
     collaborator_repository = MagicMock()
     lock_repository = MagicMock()
@@ -66,7 +71,9 @@ def _service(*, bot: dict[str, object]):
 
 
 def test_iam_context_reads_only_bot_aggregate_call_type() -> None:
-    service, deps = _service(bot=_bot(call_type="caller"))
+    bot = _bot(call_type="caller")
+    bot["binding_id"] = 9
+    service, deps = _service(bot=bot)
 
     context = service.get_iam_token_context(
         bot_id="bot-1",
@@ -75,8 +82,67 @@ def test_iam_context_reads_only_bot_aggregate_call_type() -> None:
 
     assert context.should_exchange_caller_token is True
     assert context.bot_call_type is McpCallType.CALLER
+    assert context.binding_id == 9
     deps.repository.list_draft_call_types.assert_not_called()
     deps.mcp_provider.collect_bot_active_mcps.assert_not_called()
+
+
+def test_iam_context_uses_exact_entity_scoped_bot_lookup() -> None:
+    service, deps = _service(bot=_bot(call_type="caller"))
+    deps.bot_repository.get_by_id_and_entity.return_value = _bot(call_type="caller")
+
+    context = service.get_iam_token_context(
+        bot_id="default",
+        stage=CallerIdentityStage.DRAFT,
+        entity_id="entity-1",
+    )
+
+    assert context.should_exchange_caller_token is True
+    deps.bot_repository.get_by_id_and_entity.assert_called_once_with(
+        "default", "entity-1"
+    )
+    deps.bot_repository.get_by_id.assert_not_called()
+
+
+def test_caller_reads_reject_ambiguous_bot_id_without_entity_id() -> None:
+    service, deps = _service(bot=_bot(call_type="caller"))
+    deps.bot_repository.get_unique_by_id.side_effect = BotLookupAmbiguousError
+
+    with pytest.raises(CallerIdentityAmbiguousError):
+        service.get_context(
+            bot_id="default",
+            actor_id="owner-1",
+            stage=CallerIdentityStage.DRAFT,
+        )
+    with pytest.raises(CallerIdentityAmbiguousError):
+        service.get_iam_token_context(
+            bot_id="default",
+            stage=CallerIdentityStage.DRAFT,
+        )
+    with pytest.raises(CallerIdentityAmbiguousError):
+        service.get_bot_call_type("default", CallerIdentityStage.DRAFT)
+
+    deps.bot_repository.get_by_id.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "stage",
+    [CallerIdentityStage.VERIFY, CallerIdentityStage.ONLINE],
+)
+def test_iam_context_does_not_reuse_draft_binding_outside_draft(
+    stage: CallerIdentityStage,
+) -> None:
+    bot = _bot(call_type="caller")
+    bot["binding_id"] = 9
+    service, _ = _service(bot=bot)
+
+    context = service.get_iam_token_context(
+        bot_id="bot-1",
+        stage=stage,
+        publish_id=1,
+    )
+
+    assert context.binding_id is None
 
 
 def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> None:
@@ -104,6 +170,8 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
         runtime_updater=runtime_updater,
         stage="draft",
         publish_id=None,
+        entity_id="entity-1",
+        binding_id=9,
     )
 
     token_provider.exchange.assert_called_once()
@@ -116,12 +184,49 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
         agent_code="agent-code",
         stage="draft",
         publish_id=None,
+        entity_id="entity-1",
+        binding_id=9,
     )
+
+
+@pytest.mark.parametrize("stage", ["verify", "online"])
+def test_exchange_caller_identity_does_not_pass_draft_binding_outside_draft(
+    stage: str,
+) -> None:
+    service, _ = _service(bot=_bot(call_type="caller"))
+    passport = MagicMock()
+    passport.query_token.return_value = "agent-pass-token"
+    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
+    token_provider = MagicMock()
+    token_provider.exchange.return_value = CallerToken(
+        access_token="caller-token",
+        subject_user_id="caller-1",
+        expires_at=datetime.now(),
+        fingerprint="fingerprint",
+    )
+    runtime_updater = MagicMock()
+
+    service.exchange_caller_identity(
+        iam_token="iam-token",
+        caller_user_id="caller-1",
+        bot_id="bot-1",
+        owner_user_id="owner-1",
+        passport=passport,
+        token_provider=token_provider,
+        runtime_updater=runtime_updater,
+        stage=stage,
+        publish_id=1,
+        entity_id="entity-1",
+        binding_id=9,
+    )
+
+    assert "binding_id" not in runtime_updater.update_caller_identity.call_args.kwargs
 
 
 @pytest.mark.asyncio
 async def test_mcp_update_syncs_complete_identity_manifest_to_agent_principal() -> None:
     service, deps = _service(bot=_bot())
+    deps.bot_repository.get_by_id_and_entity.return_value = _bot()
     deps.lock_repository.get_by_key.return_value = SimpleNamespace(
         holder_user_id="owner-1",
         id=7,
@@ -148,6 +253,7 @@ async def test_mcp_update_syncs_complete_identity_manifest_to_agent_principal() 
         call_type=McpCallType.CALLER,
         actor_id="owner-1",
         lock_epoch=7,
+        entity_id="entity-1",
     )
 
     assert result.bot_call_type is McpCallType.CALLER
@@ -162,6 +268,9 @@ async def test_mcp_update_syncs_complete_identity_manifest_to_agent_principal() 
             {"server_code": "documents", "name": "Documents"},
         ],
         identity_modes={"calendar": McpCallType.CALLER},
+    )
+    deps.bot_repository.get_by_id_and_entity.assert_called_once_with(
+        "bot-1", "entity-1"
     )
 
 

--- a/src/backend/tests/community/core/caller_identity/test_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_service.py
@@ -275,6 +275,24 @@ async def test_mcp_update_syncs_complete_identity_manifest_to_agent_principal() 
 
 
 @pytest.mark.asyncio
+async def test_mcp_update_rejects_ambiguous_bot_id_without_entity_id() -> None:
+    service, deps = _service(bot=_bot())
+    deps.bot_repository.get_unique_by_id.side_effect = BotLookupAmbiguousError
+
+    with pytest.raises(CallerIdentityAmbiguousError):
+        await service.update_mcp_call_type(
+            bot_id="default",
+            server_code="calendar",
+            call_type=McpCallType.CALLER,
+            actor_id="owner-1",
+            lock_epoch=7,
+        )
+
+    deps.bot_repository.get_by_id_and_owner.assert_not_called()
+    deps.mcp_provider.collect_bot_active_mcps.assert_not_called()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("active_mcps", "lock", "expected_error"),
     [

--- a/src/backend/tests/community/core/caller_identity/test_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_service.py
@@ -87,6 +87,49 @@ def test_iam_context_reads_only_bot_aggregate_call_type() -> None:
     deps.mcp_provider.collect_bot_active_mcps.assert_not_called()
 
 
+def test_iam_context_test_exchange_skips_bot_type_and_call_type() -> None:
+    bot = _bot(call_type="owner")
+    bot["bot_type"] = "personal"
+    bot["call_type"] = "invalid-for-test"
+    service, _ = _service(bot=bot)
+
+    context = service.get_iam_token_context(
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        is_test_exchange=True,
+    )
+
+    assert context.should_exchange_caller_token is True
+    assert context.bot_call_type is McpCallType.OWNER
+
+
+def test_iam_context_default_keeps_non_caller_bot_fast_path() -> None:
+    bot = _bot(call_type="owner")
+    bot["bot_type"] = "personal"
+    service, _ = _service(bot=bot)
+
+    context = service.get_iam_token_context(
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+    )
+
+    assert context.should_exchange_caller_token is False
+
+
+def test_iam_context_test_exchange_still_requires_active_bot() -> None:
+    bot = _bot(call_type="owner")
+    bot["status"] = "INACTIVE"
+    service, _ = _service(bot=bot)
+
+    context = service.get_iam_token_context(
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        is_test_exchange=True,
+    )
+
+    assert context.should_exchange_caller_token is False
+
+
 def test_iam_context_uses_exact_entity_scoped_bot_lookup() -> None:
     service, deps = _service(bot=_bot(call_type="caller"))
     deps.bot_repository.get_by_id_and_entity.return_value = _bot(call_type="caller")
@@ -189,6 +232,40 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
     )
 
 
+def test_exchange_caller_identity_propagates_test_exchange_to_runtime() -> None:
+    service, _ = _service(bot=_bot(call_type="owner"))
+    passport = MagicMock()
+    passport.query_token.return_value = "agent-pass-token"
+    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
+    token_provider = MagicMock()
+    caller_token = CallerToken(
+        access_token="caller-token",
+        subject_user_id="owner-1",
+        expires_at=datetime.now(),
+        fingerprint="fingerprint",
+    )
+    token_provider.exchange.return_value = caller_token
+    runtime_updater = MagicMock()
+
+    service.exchange_caller_identity(
+        iam_token="iam-token",
+        caller_user_id="owner-1",
+        bot_id="bot-1",
+        owner_user_id="owner-1",
+        passport=passport,
+        token_provider=token_provider,
+        runtime_updater=runtime_updater,
+        stage="draft",
+        publish_id=None,
+        is_test_exchange=True,
+    )
+
+    assert (
+        runtime_updater.update_caller_identity.call_args.kwargs["is_test_exchange"]
+        is True
+    )
+
+
 @pytest.mark.parametrize("stage", ["verify", "online"])
 def test_exchange_caller_identity_does_not_pass_draft_binding_outside_draft(
     stage: str,
@@ -275,6 +352,71 @@ async def test_mcp_update_syncs_complete_identity_manifest_to_agent_principal() 
 
 
 @pytest.mark.asyncio
+async def test_mcp_update_without_lock_epoch_allows_unlocked_owner() -> None:
+    service, deps = _service(bot=_bot())
+    deps.mcp_provider.collect_bot_active_mcps.return_value = [
+        {"server_code": "calendar"}
+    ]
+    deps.lock_repository.get_by_key.return_value = None
+    deps.repository.replace_draft_call_type.return_value = DraftCallTypeMutationResult(
+        previous_explicit_call_type=None,
+        bot_call_type=McpCallType.CALLER,
+        revision=1,
+    )
+    deps.repository.list_draft_call_types.return_value = {
+        "calendar": McpCallType.CALLER,
+    }
+    deps.mcp_sync_service.sync_mcp_identity_to_agent_principal.return_value = {
+        "success": True,
+    }
+
+    result = await service.update_mcp_call_type(
+        bot_id="bot-1",
+        server_code="calendar",
+        call_type=McpCallType.CALLER,
+        actor_id="owner-1",
+    )
+
+    assert result.bot_call_type is McpCallType.CALLER
+    assert deps.repository.replace_draft_call_type.call_args.kwargs["lock_epoch"] is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_update_without_lock_epoch_rejects_existing_lock() -> None:
+    service, deps = _service(bot=_bot())
+    deps.mcp_provider.collect_bot_active_mcps.return_value = [
+        {"server_code": "calendar"}
+    ]
+    deps.lock_repository.get_by_key.return_value = SimpleNamespace(
+        holder_user_id="owner-1",
+        id=7,
+    )
+
+    with pytest.raises(CallerLockEpochError):
+        await service.update_mcp_call_type(
+            bot_id="bot-1",
+            server_code="calendar",
+            call_type=McpCallType.CALLER,
+            actor_id="owner-1",
+        )
+
+    deps.repository.replace_draft_call_type.assert_not_called()
+
+
+def test_caller_context_is_editable_for_unlocked_owner() -> None:
+    service, deps = _service(bot=_bot())
+    deps.lock_repository.get_by_key.return_value = None
+
+    context = service.get_context(
+        bot_id="bot-1",
+        actor_id="owner-1",
+        stage=CallerIdentityStage.DRAFT,
+    )
+
+    assert context.editable is True
+
+
+@pytest.mark.asyncio
 async def test_mcp_update_rejects_ambiguous_bot_id_without_entity_id() -> None:
     service, deps = _service(bot=_bot())
     deps.bot_repository.get_unique_by_id.side_effect = BotLookupAmbiguousError
@@ -329,10 +471,11 @@ async def test_mcp_update_rejects_missing_mcp_and_stale_lock(
     [
         (CallerIdentityLockMismatchError(), CallerLockEpochError),
         (CallerIdentityEngineChangedError(), CallerIdentityReadOnlyError),
-        (ValueError("invalid call type"), CallerCallTypeInvalidError),
+        (TypeError("transactional session is unavailable"), TypeError),
+        (ValueError("persisted call type is corrupt"), ValueError),
     ],
 )
-async def test_mcp_update_maps_repository_concurrency_errors(
+async def test_mcp_update_only_maps_repository_domain_errors(
     repository_error: Exception,
     expected_error: type[Exception],
 ) -> None:
@@ -395,6 +538,39 @@ async def test_mcp_update_compensates_when_agent_principal_sync_fails() -> None:
         deps.repository.compensate_draft_call_type.call_args.kwargs["expected_revision"]
         == 3
     )
+
+
+@pytest.mark.asyncio
+async def test_mcp_update_without_epoch_stops_compensation_when_lock_appears() -> None:
+    service, deps = _service(bot=_bot())
+    deps.mcp_provider.collect_bot_active_mcps.return_value = [
+        {"server_code": "calendar"}
+    ]
+    deps.lock_repository.get_by_key.return_value = None
+    deps.repository.replace_draft_call_type.return_value = DraftCallTypeMutationResult(
+        previous_explicit_call_type=None,
+        bot_call_type=McpCallType.CALLER,
+        revision=3,
+    )
+    deps.repository.list_draft_call_types.return_value = {
+        "calendar": McpCallType.CALLER,
+    }
+    deps.mcp_sync_service.sync_mcp_identity_to_agent_principal.side_effect = (
+        RuntimeError("Agent Principal unavailable")
+    )
+    deps.repository.compensate_draft_call_type.side_effect = (
+        CallerIdentityLockMismatchError
+    )
+
+    with pytest.raises(CallerMcpSyncError):
+        await service.update_mcp_call_type(
+            bot_id="bot-1",
+            server_code="calendar",
+            call_type=McpCallType.CALLER,
+            actor_id="owner-1",
+        )
+
+    assert deps.repository.compensate_draft_call_type.call_args.kwargs["lock_epoch"] is None
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -4,7 +4,16 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from agentclaw.community.core.caller_identity.credential import CallerToken
+import pytest
+
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotLookupAmbiguousError,
+)
+from agentclaw.community.core.caller_identity.credential import (
+    CALLER_TARGET_AMBIGUOUS,
+    CallerCredentialError,
+    CallerToken,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.kernel.device_dto import (
     HeaderOperationRule,
@@ -93,3 +102,29 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
     assert outbound_rule.header_operation_rules[0].header_name == "x-caller-token"
     assert outbound_rule.header_operation_rules[0].action == "set"
     assert outbound_rule.header_operation_rules[0].value == "caller-token"
+
+
+def test_caller_identity_rejects_ambiguous_bot_without_entity_id() -> None:
+    service = _bare_baas_service()
+    service._bot_repo = MagicMock()
+    service._bot_repo.get_unique_by_id.side_effect = BotLookupAmbiguousError
+
+    with pytest.raises(CallerCredentialError) as exc_info:
+        service.update_caller_identity(
+            bot_id="default",
+            owner_user_id="owner-1",
+            caller_user_id="caller-1",
+            caller_token=CallerToken(
+                access_token="caller-token",
+                subject_user_id="caller-1",
+                expires_at=datetime.now(),
+                fingerprint="ignored",
+            ),
+            agent_pass_token="agent-pass-token",
+            agent_code="agent-code",
+            stage="draft",
+            publish_id=None,
+        )
+
+    assert exc_info.value.code == CALLER_TARGET_AMBIGUOUS
+    service._bot_repo.get_by_id_and_owner.assert_not_called()

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -128,3 +128,60 @@ def test_caller_identity_rejects_ambiguous_bot_without_entity_id() -> None:
 
     assert exc_info.value.code == CALLER_TARGET_AMBIGUOUS
     service._bot_repo.get_by_id_and_owner.assert_not_called()
+
+
+def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
+    service = _bare_baas_service()
+    service._bot_repo = MagicMock()
+    service._bot_repo.get_by_id_and_entity.return_value = {
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "bot_type": "personal",
+        "status": "ACTIVE",
+    }
+    service._device_binding_repo = MagicMock()
+    service._device_binding_repo.get_by_id.return_value = SimpleNamespace(
+        status="ACTIVE",
+        device_id="baas-bot-1",
+    )
+    service._outbound_rule_provider = MagicMock()
+    service._outbound_rule_provider.build_caller_rule.return_value = (
+        OutBoundOperationRule(
+            header_operation_rules=[
+                HeaderOperationRule(
+                    domains=["https://mcp.example"],
+                    action="set",
+                    header_name="x-caller-token",
+                    value="caller-token",
+                )
+            ]
+        )
+    )
+    service._build_outbound_operation_rule = MagicMock(
+        return_value=OutBoundOperationRule()
+    )
+    service.list_devices_by_bot_uuid = MagicMock(
+        return_value=[{"provider_device_id": "device-1@template-1"}]
+    )
+    service.update_device_outbound_rule = MagicMock(return_value=True)
+
+    service.update_caller_identity(
+        bot_id="bot-1",
+        owner_user_id="owner-1",
+        caller_user_id="owner-1",
+        caller_token=CallerToken(
+            access_token="caller-token",
+            subject_user_id="owner-1",
+            expires_at=datetime.now(),
+            fingerprint="ignored",
+        ),
+        agent_pass_token="agent-pass-token",
+        agent_code="agent-code",
+        stage="draft",
+        publish_id=None,
+        entity_id="entity-1",
+        binding_id=9,
+        is_test_exchange=True,
+    )
+
+    service.update_device_outbound_rule.assert_called_once()

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -16,10 +16,10 @@ def _bare_baas_service() -> BaasService:
     return object.__new__(BaasService)
 
 
-def test_caller_identity_sets_raw_token_on_the_resolved_paas_device() -> None:
+def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> None:
     service = _bare_baas_service()
     service._bot_repo = MagicMock()
-    service._bot_repo.get_by_id_and_owner.return_value = {
+    service._bot_repo.get_by_id_and_entity.return_value = {
         "bot_id": "bot-1",
         "owner_id": "owner-1",
         "bot_type": "service",
@@ -51,24 +51,41 @@ def test_caller_identity_sets_raw_token_on_the_resolved_paas_device() -> None:
         return_value=[{"provider_device_id": "device-1@template-1"}]
     )
     service.update_device_outbound_rule = MagicMock(return_value=True)
+    service._resolve_caller_binding_id = MagicMock(return_value=9)
 
-    service.update_caller_identity(
-        bot_id="bot-1",
-        owner_user_id="owner-1",
-        caller_user_id="caller-1",
-        caller_token=CallerToken(
+    update_kwargs = {
+        "bot_id": "bot-1",
+        "owner_user_id": "owner-1",
+        "caller_user_id": "caller-1",
+        "caller_token": CallerToken(
             access_token="caller-token",
             subject_user_id="caller-1",
             expires_at=datetime.now(),
             fingerprint="ignored",
         ),
-        agent_pass_token="agent-pass-token",
-        agent_code="agent-code",
-        stage="draft",
-        publish_id=None,
+        "agent_pass_token": "agent-pass-token",
+        "agent_code": "agent-code",
+        "stage": "draft",
+        "publish_id": None,
+        "entity_id": "entity-1",
+    }
+    service.update_caller_identity(**update_kwargs)
+
+    service._resolve_caller_binding_id.assert_called_once()
+    service._device_binding_repo.get_by_id.assert_called_once_with(9)
+    service._resolve_caller_binding_id.reset_mock()
+    service._device_binding_repo.get_by_id.reset_mock()
+
+    service.update_caller_identity(
+        **update_kwargs,
+        binding_id=11,
     )
 
-    service._outbound_rule_provider.build_caller_rule.assert_called_once_with(
+    service._resolve_caller_binding_id.assert_not_called()
+    service._device_binding_repo.get_by_id.assert_called_once_with(11)
+    assert service._bot_repo.get_by_id_and_entity.call_count == 2
+    service._bot_repo.get_by_id_and_owner.assert_not_called()
+    service._outbound_rule_provider.build_caller_rule.assert_called_with(
         caller_token="caller-token"
     )
     paas_device_id, outbound_rule = service.update_device_outbound_rule.call_args.args

--- a/src/backend/tests/community/endpoints/test_caller_identity_router.py
+++ b/src/backend/tests/community/endpoints/test_caller_identity_router.py
@@ -77,6 +77,24 @@ def _seed_mutable_caller_identity(world) -> None:
     )
 
 
+def _seed_ambiguous_default_bots(world) -> None:
+    _seed_owner(world)
+    make_bot(
+        world,
+        bot_id="default",
+        owner_id=_OWNER_ID,
+        bot_type="service",
+        status="ACTIVE",
+    )
+    make_bot(
+        world,
+        bot_id="default",
+        owner_id="other_default_owner",
+        bot_type="service",
+        status="ACTIVE",
+    )
+
+
 def _assert_mcp_call_type_updated(response, world) -> None:
     body = response.json()
     assert body["call_type"] == "caller", body
@@ -89,7 +107,7 @@ def _assert_mcp_call_type_updated(response, world) -> None:
     scenario="happy",
     input=CaseInput(
         path_params={"bot_id": _BOT_ID},
-        query_params={"stage": "draft"},
+        query_params={"stage": "draft", "entity_id": _OWNER_ID},
         headers={"x-user-id": _OWNER_ID},
     ),
     seed=_seed_editable_service_bot,
@@ -127,11 +145,34 @@ def get_caller_context_not_found():
 
 
 @endpoint_test(
+    method="GET",
+    path="/api/bots/{bot_id}/caller-context",
+    scenario="ambiguous_default_without_entity",
+    input=CaseInput(
+        path_params={"bot_id": "default"},
+        query_params={"stage": "draft"},
+        headers={"x-user-id": _OWNER_ID},
+    ),
+    seed=_seed_ambiguous_default_bots,
+    expect=ExpectError(
+        status=409,
+        json_contains={"detail": "CALLER_IDENTITY_AMBIGUOUS"},
+    ),
+)
+def get_caller_context_rejects_ambiguous_default_without_entity():
+    """Caller reads must not select an arbitrary default Bot."""
+
+
+@endpoint_test(
     method="PATCH",
     path="/api/bots/{bot_id}/mcps/{server_code}/call-type",
     scenario="happy",
     input=CaseInput(
         path_params={"bot_id": _BOT_ID, "server_code": _SERVER_CODE},
+        query_params={
+            "ctoken": "opaque-gateway-compatibility-value",
+            "entity_id": _OWNER_ID,
+        },
         headers={"x-user-id": _OWNER_ID},
         json_body={"call_type": "caller", "lock_epoch": 1},
     ),
@@ -148,6 +189,23 @@ def get_caller_context_not_found():
 )
 def update_mcp_call_type_happy():
     """The HTTP route maps an accepted Caller update to its response payload."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/api/bots/{bot_id}/mcps/{server_code}/call-type",
+    scenario="invalid_query",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID, "server_code": _SERVER_CODE},
+        query_params={"unexpected": "rejected"},
+        headers={"x-user-id": _OWNER_ID},
+        json_body={"call_type": "caller", "lock_epoch": 1},
+    ),
+    seed=_seed_mutable_caller_identity,
+    expect=ExpectError(status=422),
+)
+def update_mcp_call_type_rejects_unknown_query_parameter():
+    """Only documented compatibility query parameters are accepted."""
 
 
 @endpoint_test(

--- a/src/backend/tests/community/endpoints/test_caller_identity_router.py
+++ b/src/backend/tests/community/endpoints/test_caller_identity_router.py
@@ -34,7 +34,7 @@ def _seed_owner(world) -> None:
     make_staff_user(world, user_id=_OWNER_ID)
 
 
-def _seed_editable_service_bot(world) -> None:
+def _seed_service_bot(world, *, acquire_lock: bool) -> None:
     _seed_owner(world)
     make_bot(
         world,
@@ -43,15 +43,20 @@ def _seed_editable_service_bot(world) -> None:
         bot_type="service",
         status="ACTIVE",
     )
-    world.get(CollaboratorLockService).acquire_lock(
-        _BOT_ID,
-        _OWNER_ID,
-        _OWNER_ID,
-    )
+    if acquire_lock:
+        world.get(CollaboratorLockService).acquire_lock(
+            _BOT_ID,
+            _OWNER_ID,
+            _OWNER_ID,
+        )
 
 
-def _seed_mutable_caller_identity(world) -> None:
-    _seed_editable_service_bot(world)
+def _seed_editable_service_bot(world) -> None:
+    _seed_service_bot(world, acquire_lock=True)
+
+
+def _seed_mutable_caller_identity(world, *, acquire_lock: bool = True) -> None:
+    _seed_service_bot(world, acquire_lock=acquire_lock)
     bot = world.get(BotRepository).get_by_id(_BOT_ID)
     engine_type = str(bot["active_engine"])
     skill_set = world.get(SkillSetRepository).create(
@@ -75,6 +80,10 @@ def _seed_mutable_caller_identity(world) -> None:
         user_id=_OWNER_ID,
         env=get_current_env(),
     )
+
+
+def _seed_unlocked_mutable_caller_identity(world) -> None:
+    _seed_mutable_caller_identity(world, acquire_lock=False)
 
 
 def _seed_ambiguous_default_bots(world) -> None:
@@ -189,6 +198,31 @@ def get_caller_context_rejects_ambiguous_default_without_entity():
 )
 def update_mcp_call_type_happy():
     """The HTTP route maps an accepted Caller update to its response payload."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/api/bots/{bot_id}/mcps/{server_code}/call-type",
+    scenario="unlocked_owner_without_epoch",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID, "server_code": _SERVER_CODE},
+        query_params={"entity_id": _OWNER_ID},
+        headers={"x-user-id": _OWNER_ID},
+        json_body={"call_type": "caller"},
+    ),
+    seed=_seed_unlocked_mutable_caller_identity,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "server_code": _SERVER_CODE,
+            "call_type": "caller",
+            "bot_call_type": "caller",
+        },
+    ),
+    extra_assertions=(_assert_mcp_call_type_updated,),
+)
+def update_mcp_call_type_without_lock_epoch_for_unlocked_owner():
+    """A single owner may update Caller identity before a lock exists."""
 
 
 @endpoint_test(

--- a/src/backend/tests/community/plugins/test_bot_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_repository_unified.py
@@ -17,6 +17,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotLookupAmbiguousError,
+)
 from agentclaw.community.core.service_bot.repository.models import BotPublishModel
 from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.plugins.bot_repository import BotRepository
@@ -90,6 +93,8 @@ def test_insert_and_get(repo):
     assert rec["engine_types"]  # defaulted
     got = repo.get_by_id_and_owner("bot-1", "emp1")
     assert got["bot_name"] == "Bot One"
+    assert got["call_type"] == "owner"
+    assert got["caller_config_revision"] == 0
 
 
 def test_get_by_id_without_owner(repo):
@@ -125,6 +130,37 @@ def test_get_by_id_returns_none_for_deleted(repo):
     # get_by_id should return None for deleted bots
     got = repo.get_by_id("bot-1")
     assert got is None
+
+
+def test_get_by_id_and_entity_selects_the_correct_default_bot(repo):
+    first = repo.insert(
+        _data(bot_id="default", entity_id="entity-one", owner_id="owner-one")
+    )
+    second = repo.insert(
+        _data(bot_id="default", entity_id="entity-two", owner_id="owner-two")
+    )
+
+    selected = repo.get_by_id_and_entity("default", "entity-two")
+
+    assert selected is not None
+    assert selected["id"] == second["id"]
+    assert selected["owner_id"] == "owner-two"
+    assert selected["id"] != first["id"]
+
+
+def test_get_unique_by_id_rejects_duplicate_default_bots(repo):
+    repo.insert(_data(bot_id="default", entity_id="entity-one"))
+    repo.insert(_data(bot_id="default", entity_id="entity-two"))
+
+    with pytest.raises(BotLookupAmbiguousError):
+        repo.get_unique_by_id("default")
+
+
+def test_get_unique_by_id_preserves_single_and_missing_lookups(repo):
+    inserted = repo.insert(_data(bot_id="default", entity_id="entity-one"))
+
+    assert repo.get_unique_by_id("default")["id"] == inserted["id"]
+    assert repo.get_unique_by_id("missing") is None
 
 
 def test_insert_plain_not_upsert(repo):

--- a/src/backend/tests/community/plugins/test_bot_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_repository_unified.py
@@ -93,8 +93,8 @@ def test_insert_and_get(repo):
     assert rec["engine_types"]  # defaulted
     got = repo.get_by_id_and_owner("bot-1", "emp1")
     assert got["bot_name"] == "Bot One"
-    assert got["call_type"] == "owner"
-    assert got["caller_config_revision"] == 0
+    assert "call_type" not in got
+    assert "caller_config_revision" not in got
 
 
 def test_get_by_id_without_owner(repo):
@@ -146,6 +146,8 @@ def test_get_by_id_and_entity_selects_the_correct_default_bot(repo):
     assert selected["id"] == second["id"]
     assert selected["owner_id"] == "owner-two"
     assert selected["id"] != first["id"]
+    assert selected["call_type"] == "owner"
+    assert selected["caller_config_revision"] == 0
 
 
 def test_get_unique_by_id_rejects_duplicate_default_bots(repo):
@@ -159,7 +161,11 @@ def test_get_unique_by_id_rejects_duplicate_default_bots(repo):
 def test_get_unique_by_id_preserves_single_and_missing_lookups(repo):
     inserted = repo.insert(_data(bot_id="default", entity_id="entity-one"))
 
-    assert repo.get_unique_by_id("default")["id"] == inserted["id"]
+    selected = repo.get_unique_by_id("default")
+
+    assert selected["id"] == inserted["id"]
+    assert selected["call_type"] == "owner"
+    assert selected["caller_config_revision"] == 0
     assert repo.get_unique_by_id("missing") is None
 
 


### PR DESCRIPTION
Adds guarded Caller IAM exchange and runtime outbound updates, optional collaboration lock epochs, and legacy Owner compatibility. Verified: 39 targeted Caller tests and Ruff pass.