### PR TITLE
refactor(bot_run): unify timeout as float with single resolution point

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -66,6 +66,7 @@ user_config:
     queue_max: 0                     # 全局最大排队等待数（0=不限）
     acquire_timeout: 0               # acquire 等待槽位超时秒数（0=不限）
     task_timeout: 660.0              # 单任务最大执行秒数（0=不限，默认660=10分钟+1分钟缓冲）
+    default_timeout: 30.0            # 请求默认超时秒数（metadata 未指定 timeout 时使用）
 
   # BotRun 队列 Worker 配置
   bot_run_queue:

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -66,6 +66,7 @@ user_config:
     queue_max: 0                     # 全局最大排队等待数（0=不限）
     acquire_timeout: 0               # acquire 等待槽位超时秒数（0=不限）
     task_timeout: 660.0              # 单任务最大执行秒数（0=不限，默认660=10分钟+1分钟缓冲）
+    default_timeout: 30.0            # 请求默认超时秒数（metadata 未指定 timeout 时使用）
 
   teamclaw:
     base_url: "https://teamclaw.example.com"

--- a/src/baas/src/secbaas/community/bootstrap/_configs.py
+++ b/src/baas/src/secbaas/community/bootstrap/_configs.py
@@ -294,6 +294,11 @@ class BotRunnerConfig(ConfigSchema):
         ge=0,
         description="单个任务最大执行秒数，默认 660（10分钟+1分钟缓冲）；0=不限；超时自动取消并释放槽位",
     )
+    default_timeout: float = Field(
+        default=30.0,
+        gt=0,
+        description="请求默认超时秒数，metadata 未指定 timeout 时使用",
+    )
 
 
 class BcnUplinkConfigSchema(BaseModel):

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -611,6 +611,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
             task_message_dispatcher,
         ),
         system_config_service=system_config_service,
+        default_request_timeout=config.bot_service.request_timeout,
     )
 
     bcn_downlink_service = providers.Singleton(

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -611,7 +611,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
             task_message_dispatcher,
         ),
         system_config_service=system_config_service,
-        default_request_timeout=config.bot_service.request_timeout,
+        default_request_timeout=config.bot_runner.default_timeout,
     )
 
     bcn_downlink_service = providers.Singleton(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -271,7 +271,7 @@ class AsyncChatClient:
         message: str,
         session_key: str | None = None,
         wait_result: bool = True,
-        timeout: int | None = None,  # noqa: ASYNC109
+        timeout: float | None = None,  # noqa: ASYNC109
         auth_token: str | None = None,
         app_id: str | None = None,
         chat_metadata: dict[str, str] | None = None,
@@ -412,7 +412,7 @@ class AsyncChatClient:
         self,
         message: str,
         session_key: str | None = None,
-        timeout: int | None = None,  # noqa: ASYNC109
+        timeout: float | None = None,  # noqa: ASYNC109
         auth_token: str | None = None,
         app_id: str | None = None,
         chat_metadata: dict[str, str] | None = None,
@@ -576,7 +576,7 @@ class AsyncChatClient:
     @staticmethod
     async def _drain_stream_queue(
         queue: asyncio.Queue[StreamChunk],
-        timeout: int | None,
+        timeout: float | None,
     ) -> AsyncIterator[StreamChunk]:
         """从 stream_queue 消费 StreamChunk，遇到终止 chunk 后停止。
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -353,7 +353,7 @@ class BaasBotService(BotService):
         binding_info: BotBindingInfo,
         wait_result: bool = True,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
         chat_metadata: dict[str, str] | None = None,
     ) -> BotResponse:
         """Send a message and get response via ChatClient.
@@ -401,9 +401,7 @@ class BaasBotService(BotService):
                 message=message,
                 session_key=session_id,
                 wait_result=wait_result,
-                timeout=timeout
-                if timeout is not None
-                else self._config.request_timeout,
+                timeout=timeout,
                 auth_token=auth_token,
                 app_id=app_id,
                 chat_metadata=chat_metadata,
@@ -439,7 +437,7 @@ class BaasBotService(BotService):
         message: str,
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
     ) -> AsyncIterator[StreamChunk]:
         """流式发送消息，逐 chunk 产出 StreamChunk。
 
@@ -473,9 +471,7 @@ class BaasBotService(BotService):
             async for chunk in client.send_message_stream(
                 message=message,
                 session_key=session_id,
-                timeout=timeout
-                if timeout is not None
-                else self._config.request_timeout,
+                timeout=timeout,
                 auth_token=auth_token,
                 app_id=app_id,
             ):

--- a/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
@@ -195,7 +195,7 @@ class ClawBotService(BotService):
         binding_info: BotBindingInfo,
         wait_result: bool = True,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
         chat_metadata: dict[str, str] | None = None,
     ) -> BotResponse:
         """Send a message and get response via ChatClient.
@@ -239,9 +239,7 @@ class ClawBotService(BotService):
                 message=message,
                 session_key=session_id,
                 wait_result=wait_result,
-                timeout=timeout
-                if timeout is not None
-                else self._config.request_timeout,
+                timeout=timeout,
                 auth_token=auth_token,
                 app_id=app_id,
                 chat_metadata=chat_metadata,
@@ -263,7 +261,7 @@ class ClawBotService(BotService):
         message: str,
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
     ) -> AsyncIterator[StreamChunk]:
         """流式发送消息，逐 chunk 产出 StreamChunk。
 
@@ -290,9 +288,7 @@ class ClawBotService(BotService):
             async for chunk in client.send_message_stream(
                 message=message,
                 session_key=session_id,
-                timeout=timeout
-                if timeout is not None
-                else self._config.request_timeout,
+                timeout=timeout,
                 auth_token=auth_token,
                 app_id=app_id,
             ):

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -87,7 +87,7 @@ class BotService(Protocol):
         binding_info: BotBindingInfo,
         wait_result: bool = True,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
         chat_metadata: dict[str, str] | None = None,
     ) -> BotResponse:
         """发送消息并获取响应
@@ -110,7 +110,7 @@ class BotService(Protocol):
         message: str,
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
     ) -> AsyncIterator[StreamChunk]:
         """流式发送消息，返回 StreamChunk 迭代器。
 
@@ -225,7 +225,7 @@ class MessageDispatcher(Protocol):
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         wait_result: bool = True,
-        timeout: int | None = None,
+        timeout: float,
         bot_id: str = "",
         callback: Any = None,
         chat_metadata: dict[str, str] | None = None,
@@ -260,7 +260,7 @@ class MessageDispatcher(Protocol):
         message: str,
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
         bot_id: str = "",
     ) -> AsyncIterator[StreamChunk]:
         """流式消息发送分发，返回 StreamChunk 迭代器。

--- a/src/baas/src/secbaas/community/core/service/bot_run/_noop_message_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_noop_message_dispatcher.py
@@ -41,7 +41,7 @@ class NoopMessageDispatcher:
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         wait_result: bool = True,
-        timeout: int | None = None,
+        timeout: float,
         bot_id: str = "",
         callback: Any = None,
         chat_metadata: dict[str, str] | None = None,
@@ -61,7 +61,7 @@ class NoopMessageDispatcher:
         message: str,
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
         bot_id: str = "",
     ) -> AsyncIterator[StreamChunk]:
         logger.warning(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -89,12 +89,14 @@ class BotRunner:
         bot_service_plugin: BotServicePlugin,
         dispatchers: list[MessageDispatcher],
         system_config_service: SystemConfigManageService | None = None,
+        default_request_timeout: float = 30.0,
     ):
         self._bot_service_selector = bot_service_selector
         self._run_repository = run_repository
         self._bot_service_plugin = bot_service_plugin
         self._dispatchers = dispatchers
         self._system_config_service = system_config_service
+        self._default_request_timeout = default_request_timeout
         self._dispatcher_map: dict[str, MessageDispatcher] = {
             d.__class__.__name__: d for d in self._dispatchers
         }
@@ -224,7 +226,7 @@ class BotRunner:
         Returns:
             Tuple of (message_id, session_id)
         """
-        timeout: int | None = metadata.get("timeout")
+        timeout: float = float(metadata.get("timeout") or self._default_request_timeout)
 
         if message_id is None:
             message_id = str(uuid.uuid4())
@@ -323,7 +325,7 @@ class BotRunner:
         Returns:
             Tuple of (message_id, session_id, AsyncIterator[StreamChunk])
         """
-        timeout: int | None = metadata.get("timeout")
+        timeout: float = float(metadata.get("timeout") or self._default_request_timeout)
 
         if message_id is None:
             message_id = str(uuid.uuid4())

--- a/src/baas/src/secbaas/community/core/service/bot_run/_task_concurrency_pool.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_task_concurrency_pool.py
@@ -93,7 +93,7 @@ class TaskConcurrencySlot:
         return self._key
 
     async def run(
-        self, coro: Coroutine[Any, Any, _T], timeout: int | None = None
+        self, coro: Coroutine[Any, Any, _T], timeout: float | None = None
     ) -> _T:
         """在 slot 内执行协程，超时自动取消并释放 slot。
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_task_message_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_task_message_dispatcher.py
@@ -62,7 +62,7 @@ class TaskMessageDispatcher:
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         wait_result: bool = True,
-        timeout: int | None = None,
+        timeout: float,
         bot_id: str = "",
         callback: Any = None,
         chat_metadata: dict[str, str] | None = None,
@@ -96,7 +96,7 @@ class TaskMessageDispatcher:
         message: str,
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
-        timeout: int | None = None,
+        timeout: float,
         bot_id: str = "",
     ) -> AsyncIterator[StreamChunk]:
         """流式直传：直接 yield bot_service.send_message_stream 的 chunk。
@@ -195,7 +195,7 @@ class TaskMessageDispatcher:
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         wait_result: bool = True,
-        timeout: int | None = None,
+        timeout: float,
         bot_id: str = "",
         chat_metadata: dict[str, str] | None = None,
     ) -> None:
@@ -217,7 +217,7 @@ class TaskMessageDispatcher:
                     binding_info=binding_info,
                     wait_result=wait_result,
                     context=context,
-                    timeout=timeout,
+                    timeout=max(timeout - 0.2, 0.1),
                     chat_metadata=chat_metadata,
                 )
 

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -392,6 +392,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
+            timeout=30.0,
             )
             assert response.content == "response content"
             mock_pool.get.assert_awaited_once()
@@ -423,6 +424,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
+                timeout=30.0,
                 )
             mock_failed.assert_called_once_with("SESSION-xyz", err_msg="error msg")
 
@@ -450,6 +452,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
+                timeout=30.0,
                 )
             mock_failed.assert_called_once_with("SESSION-xyz", err_msg="ws closed")
 
@@ -476,6 +479,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
+            timeout=30.0,
             )
             assert response.content == "ok"
             mock_completed.assert_called_once_with(None, result={"content": "ok"})
@@ -502,6 +506,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
+            timeout=30.0,
             )
             mock_resolve.assert_called_once()
 
@@ -533,6 +538,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
+                timeout=30.0,
                 )
             mock_failed.assert_called_once()
 
@@ -1338,6 +1344,7 @@ class TestSendMessageExtended:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
+            timeout=30.0,
             )
             mock_client.send_message.assert_awaited_once_with(
                 message="hello",
@@ -1378,6 +1385,7 @@ class TestSendMessageExtended:
                 message="hello",
                 binding_info=binding,
                 context=context,
+            timeout=30.0,
             )
             mock_client.send_message.assert_awaited_once_with(
                 message="hello",
@@ -1412,6 +1420,7 @@ class TestSendMessageExtended:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
+                timeout=30.0,
                 )
             mock_failed.assert_called_once_with(
                 "SESSION-xyz", err_msg="DNS resolution failed"
@@ -1444,6 +1453,7 @@ class TestSendMessageExtended:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
+                timeout=30.0,
                 )
 
     @pytest.mark.asyncio
@@ -1469,6 +1479,7 @@ class TestSendMessageExtended:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
+            timeout=30.0,
             )
             mock_pool.get.assert_awaited_once_with(
                 conn_info.target,
@@ -2137,6 +2148,7 @@ class TestSendMessageWaitResult:
                 message="hello",
                 binding_info=binding,
                 wait_result=False,
+            timeout=30.0,
             )
             call_kwargs = mock_client.send_message.call_args[1]
             assert call_kwargs["wait_result"] is False

--- a/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
@@ -275,6 +275,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=baas_binding,
+            timeout=30.0,
             )
 
     @pytest.mark.asyncio
@@ -291,6 +292,7 @@ class TestSendMessage:
                 message="hello",
                 binding_info=arca_binding,
                 wait_result=True,
+            timeout=30.0,
             )
 
         assert isinstance(result, BotResponse)
@@ -330,6 +332,7 @@ class TestSendMessage:
                 message="hello",
                 binding_info=arca_binding,
                 context=ctx,
+            timeout=30.0,
             )
 
         assert result.content == "resp with auth"
@@ -359,6 +362,7 @@ class TestSendMessage:
                 message="ping",
                 binding_info=arca_binding,
                 wait_result=False,
+            timeout=30.0,
             )
 
         assert result.content == "fast resp"
@@ -388,6 +392,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="boom",
                     binding_info=arca_binding,
+                timeout=30.0,
                 )
 
         # No release needed — shared connection stays in pool
@@ -411,6 +416,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=arca_binding,
+                timeout=30.0,
                 )
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_noop_message_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_noop_message_dispatcher.py
@@ -42,6 +42,7 @@ class TestNoopMessageDispatcher:
             message="hello",
             binding_info=binding_info,
             context=context,
+            timeout=30.0,
         )
 
     @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
@@ -76,6 +76,7 @@ class TestTaskMessageDispatcherSend:
             message="hello",
             binding_info=arca_binding,
             context=context,
+            timeout=30.0,
         )
         await asyncio.sleep(0)
 
@@ -93,6 +94,7 @@ class TestTaskMessageDispatcherSend:
             message="hello",
             binding_info=arca_binding,
             context=context,
+            timeout=30.0,
         )
         await asyncio.sleep(0)
 
@@ -110,6 +112,7 @@ class TestTaskMessageDispatcherSend:
             message="hello",
             binding_info=arca_binding,
             context=context,
+            timeout=30.0,
         )
         await asyncio.sleep(0)
 
@@ -132,6 +135,7 @@ class TestTaskMessageDispatcherSend:
             message="hello",
             binding_info=arca_binding,
             context=context,
+            timeout=30.0,
         )
         await asyncio.sleep(0)
 
@@ -153,6 +157,7 @@ class TestTaskMessageDispatcherSend:
             binding_info=arca_binding,
             context=context,
             wait_result=False,
+            timeout=30.0,
         )
         await asyncio.sleep(0)
 
@@ -187,6 +192,7 @@ class TestTaskMessageDispatcherSend:
             binding_info=arca_binding,
             context=context,
             callback="bcn_uplink",
+            timeout=30.0,
         )
         await asyncio.sleep(0.1)
 
@@ -251,6 +257,7 @@ class TestTaskMessageDispatcherWithPool:
             binding_info=arca_binding,
             context=context,
             bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            timeout=30.0,
         )
         await asyncio.sleep(0.2)
         assert pool.active_count == 0
@@ -271,6 +278,78 @@ class TestTaskMessageDispatcherWithPool:
             binding_info=arca_binding,
             context=context,
             bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            timeout=30.0,
         )
         await asyncio.sleep(0.2)
+        assert pool.active_count == 0
+
+
+class TestTaskMessageDispatcherTimeout:
+    """Cover timeout reduction logic: bot_service gets timeout - 0.2 (floored at 0.1),
+    slot.run gets the original timeout."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_receives_reduced_timeout(
+        self, mock_bot_service, mock_run_repo, arca_binding, context
+    ):
+        dispatcher = TaskMessageDispatcher(
+            run_repository=mock_run_repo, task_pool=None
+        )
+        await dispatcher.dispatch_send(
+            bot_service=mock_bot_service,
+            run_id="run-001",
+            session_id="sess-001",
+            message="hello",
+            binding_info=arca_binding,
+            context=context,
+            timeout=30.0,
+        )
+        await asyncio.sleep(0)
+
+        call_kw = mock_bot_service.send_message.call_args.kwargs
+        assert call_kw["timeout"] == pytest.approx(29.8)
+
+    @pytest.mark.asyncio
+    async def test_small_timeout_floored_to_0_1(
+        self, mock_bot_service, mock_run_repo, arca_binding, context
+    ):
+        dispatcher = TaskMessageDispatcher(
+            run_repository=mock_run_repo, task_pool=None
+        )
+        await dispatcher.dispatch_send(
+            bot_service=mock_bot_service,
+            run_id="run-001",
+            session_id="sess-001",
+            message="hello",
+            binding_info=arca_binding,
+            context=context,
+            timeout=0.1,
+        )
+        await asyncio.sleep(0)
+
+        call_kw = mock_bot_service.send_message.call_args.kwargs
+        assert call_kw["timeout"] == pytest.approx(0.1)
+
+    @pytest.mark.asyncio
+    async def test_slot_run_receives_original_timeout(
+        self, mock_bot_service, mock_run_repo, arca_binding, context
+    ):
+        pool = TaskConcurrencyPool(softmax=1, per_key_max=0)
+        dispatcher = TaskMessageDispatcher(
+            run_repository=mock_run_repo, task_pool=pool
+        )
+        await dispatcher.dispatch_send(
+            bot_service=mock_bot_service,
+            run_id="run-001",
+            session_id="sess-001",
+            message="hello",
+            binding_info=arca_binding,
+            context=context,
+            bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            timeout=15.0,
+        )
+        await asyncio.sleep(0.2)
+
+        call_kw = mock_bot_service.send_message.call_args.kwargs
+        assert call_kw["timeout"] == pytest.approx(14.8)
         assert pool.active_count == 0


### PR DESCRIPTION
- Resolve timeout once at BotRunner entry: metadata['timeout'] or config.bot_service.request_timeout (default 30.0), guaranteed non-None
- Change timeout type from int|None to float across the entire call chain (Protocol, dispatcher, BotService, AsyncChatClient, TaskConcurrencyPool) to support sub-second precision (e.g. 0.2s)
- Remove per-layer request_timeout fallback in ClawBotService and BaasBotService — they now transparently pass through the resolved value
- Fix double wait_for: slot.run uses original timeout as outer guard, bot_service.send_message receives timeout - 0.2 (floored at 0.1) as inner timeout, giving DB write a 200ms margin before the outer guard fires
- Inject default_request_timeout into BotRunner via DI container
- Add unit tests covering timeout reduction, floor edge case, and pool-path passthrough