### PR TITLE
feat(bcs): add recoverable state machine judging

### DIFF
--- a/docs/bot-provider-integration.md
+++ b/docs/bot-provider-integration.md
@@ -148,6 +148,10 @@ Constraints:
 - `state` is fixed to `final`.
 - Send only one successful final event for the same `run_id`.
 - When retrying the same callback event, keep the same `X-BCN-Event-Id`.
+- An HTTP `2xx` means BCS has durably accepted the event. For a state-machine
+  node with a judge, BCS first enters `judging` and evaluates it in the
+  background; the response does not mean that the judge or the full run has
+  completed.
 
 ## Error responses
 

--- a/docs/bot-provider-integration.zh-CN.md
+++ b/docs/bot-provider-integration.zh-CN.md
@@ -126,6 +126,7 @@ X-BCN-Event-Id: <uuid>
 - `seq` 固定为 `1`。
 - `state` 固定为 `final`。
 - 同一个 `run_id` 只发送一次成功的 final。
+- HTTP `2xx` 表示 BCS 已可靠接收并持久化该事件。对于配置了 Judge 的状态机节点，BCS 会先进入 `judging` 并在后台完成判定；响应不表示 Judge 或整个状态机已经完成。
 - Provider 重试同一个回调事件时，应保持同一个 `X-BCN-Event-Id`。
 
 ## 错误响应

--- a/src/bcs/.config/nextest.toml
+++ b/src/bcs/.config/nextest.toml
@@ -53,6 +53,13 @@ slow-timeout = { period = "60s", terminate-after = 5 }
 filter = 'binary(integration_collab_reachability)'
 threads-required = "num-cpus"
 
+[[profile.default.overrides]]
+# This unit test exercises a real detached HTTP callback and initializes a fresh
+# reqwest client. Reserve the runner while it observes localhost delivery so CPU
+# saturation cannot turn scheduler latency into a false callback failure.
+filter = 'package(bcs-http) & test(=admin_invocation_terminal::tests::matching_bot_terminal_dispatches_callback_once)'
+threads-required = "num-cpus"
+
 # ────────────────────────────────────────────────────────────────
 # quick profile: fast tests only, for quick feedback during iteration.
 # Skips tests marked #[ignore = "slow"] and fails slow tests outright.
@@ -70,6 +77,10 @@ slow-timeout = { period = "10s", terminate-after = 1 }
 
 [[profile.quick.overrides]]
 filter = 'binary(integration_collab_reachability)'
+threads-required = "num-cpus"
+
+[[profile.quick.overrides]]
+filter = 'package(bcs-http) & test(=admin_invocation_terminal::tests::matching_bot_terminal_dispatches_callback_once)'
 threads-required = "num-cpus"
 
 # ────────────────────────────────────────────────────────────────
@@ -94,4 +105,8 @@ slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
 filter = 'binary(integration_collab_reachability)'
+threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
+filter = 'package(bcs-http) & test(=admin_invocation_terminal::tests::matching_bot_terminal_dispatches_callback_once)'
 threads-required = "num-cpus"

--- a/src/bcs/AGENTS.md
+++ b/src/bcs/AGENTS.md
@@ -8,9 +8,12 @@ Before changing BCS code, read `src/bcs/CLAUDE.md` and follow its module
 architecture, layering, testing, and coding rules. If this file and
 `CLAUDE.md` overlap, treat `CLAUDE.md` as the detailed local source of truth.
 
-## No Global Formatting
+## Never Run Rustfmt
 
-Do not run `cargo fmt`, `cargo fmt --all`, or any global formatter in BCS.
+Never run `rustfmt`, either directly or indirectly. This includes `cargo fmt`,
+`cargo fmt --all`, editor format-on-save, scripts, hooks, and any other command
+that invokes `rustfmt` in BCS. There are no exceptions to this rule.
+
 Keep whitespace and style edits limited to the lines that must change for the
 task. Avoid import reordering, line wrapping, or formatting churn in unrelated
 code.

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "bcs-session",
  "bcs-session-store",
  "bcs-test-support",
+ "futures",
  "serde_json",
  "serde_yaml",
  "tokio",

--- a/src/bcs/assets/panel/src/StateMachineRunView.tsx
+++ b/src/bcs/assets/panel/src/StateMachineRunView.tsx
@@ -30,6 +30,7 @@ export type StateMachineNodeStatus =
   | 'pending'
   | 'ready'
   | 'running'
+  | 'judging'
   | 'completed'
   | 'failed'
   | 'retry_scheduled'
@@ -178,6 +179,7 @@ const NODE_ACTIVE_STATUSES = new Set<string>([
   'pending',
   'ready',
   'running',
+  'judging',
   'retry_scheduled',
 ]);
 const NODE_TERMINAL_STATUSES = new Set<string>([
@@ -1443,6 +1445,16 @@ function getStatusTone(status?: string): StatusTone {
     };
   }
 
+  if (normalized === 'judging') {
+    return {
+      bg: '#faf5ff',
+      border: '#e9d5ff',
+      text: '#7e22ce',
+      stroke: '#9333ea',
+      fill: '#f3e8ff',
+    };
+  }
+
   if (normalized === 'ready') {
     return {
       bg: '#eef2ff',
@@ -1526,6 +1538,10 @@ function renderNodeStatusMarker(status: string | undefined) {
 
   if (normalized === 'running' || normalized === 'retry_scheduled') {
     return <path d="M -1.8 -3.2 L 4 0 L -1.8 3.2 Z" fill="#ffffff" />;
+  }
+
+  if (normalized === 'judging') {
+    return <path d="M 0 -3.8 L 3.8 0 L 0 3.8 L -3.8 0 Z" fill="#ffffff" />;
   }
 
   if (normalized === 'skipped') {
@@ -1641,6 +1657,7 @@ function getEdgeState(
     isCompletedStatus(targetStatus) ||
     isFailedStatus(targetStatus) ||
     normalizeStatus(targetStatus) === 'running' ||
+    normalizeStatus(targetStatus) === 'judging' ||
     normalizeStatus(targetStatus) === 'retry_scheduled' ||
     normalizeStatus(targetStatus) === 'ready'
   ) {
@@ -2280,12 +2297,16 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
           const runningNode = data.nodes.find(
             (node) => normalizeStatus(node.status) === 'running',
           );
+          const judgingNode = data.nodes.find(
+            (node) => normalizeStatus(node.status) === 'judging',
+          );
           const activeNode = data.nodes.find((node) =>
             isNodeActiveStatus(node.status),
           );
 
           return (
             runningNode?.node_id ||
+            judgingNode?.node_id ||
             activeNode?.node_id ||
             data.nodes[0]?.node_id ||
             null
@@ -2561,7 +2582,7 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
       !selectedNodeId ||
       !nodeDetailModalOpen ||
       nodeDetailLoading ||
-      normalizeStatus(selectedNodeStatus) !== 'running'
+      !['running', 'judging'].includes(normalizeStatus(selectedNodeStatus))
     ) {
       return undefined;
     }
@@ -3249,7 +3270,9 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
                             y={y}
                             vectorEffect="non-scaling-stroke"
                           />
-                          {normalizeStatus(node.status) === 'running' ? (
+                          {['running', 'judging'].includes(
+                            normalizeStatus(node.status),
+                          ) ? (
                             <rect
                               fill="none"
                               height={height}

--- a/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/admin_invocation_terminal.rs
@@ -173,6 +173,13 @@ mod tests {
     use super::*;
     use crate::state::{AdminInvocationCallback, AdminInvocationRun};
 
+    // Callback delivery initializes a fresh reqwest client (including native
+    // certificate roots) in a detached task. On a fully loaded nextest run,
+    // that startup can legitimately take longer than two seconds even though
+    // the localhost callback is dispatched correctly.
+    const CALLBACK_DELIVERY_TIMEOUT: Duration = Duration::from_secs(10);
+    const DUPLICATE_CALLBACK_OBSERVATION_WINDOW: Duration = Duration::from_secs(1);
+
     fn admin_run(callback_url: String) -> AdminInvocationRun {
         AdminInvocationRun {
             provider_id: "admin-provider".to_string(),
@@ -241,11 +248,11 @@ mod tests {
         };
 
         bot_terminal_observer_port_contract_tests(&observer, event.clone(), async {
-            let (mut socket, _) = timeout(Duration::from_secs(2), listener.accept())
+            let (mut socket, _) = timeout(CALLBACK_DELIVERY_TIMEOUT, listener.accept())
                 .await
                 .unwrap()
                 .unwrap();
-            let request = timeout(Duration::from_secs(2), read_http_request(&mut socket))
+            let request = timeout(CALLBACK_DELIVERY_TIMEOUT, read_http_request(&mut socket))
                 .await
                 .unwrap();
             socket
@@ -261,7 +268,7 @@ mod tests {
 
         observer.observe(event).await;
         assert!(
-            timeout(Duration::from_millis(100), listener.accept())
+            timeout(DUPLICATE_CALLBACK_OBSERVATION_WINDOW, listener.accept())
                 .await
                 .is_err()
         );

--- a/src/bcs/crates/bootstrap/bcs/src/lib.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/lib.rs
@@ -138,6 +138,7 @@ pub mod metrics;
 pub mod migrations;
 pub mod plugins;
 pub mod server;
+pub mod state_machine_judge_worker;
 pub mod state_machine_timeout_scanner;
 pub mod timeout_scanner;
 pub mod token_expiry_scanner;

--- a/src/bcs/crates/bootstrap/bcs/src/migrations.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/migrations.rs
@@ -517,6 +517,9 @@ const SQLITE_DDL_STATEMENTS: &[&str] = &[
         delivery_request_id TEXT DEFAULT NULL,
         bot_delivery_run_id TEXT DEFAULT NULL,
         artifact_text TEXT DEFAULT NULL,
+        judge_claim_token TEXT DEFAULT NULL,
+        judge_lease_until_ms INTEGER DEFAULT NULL,
+        judge_decision_json TEXT DEFAULT NULL,
         error_message TEXT DEFAULT NULL,
         started_at_ms INTEGER DEFAULT NULL,
         completed_at_ms INTEGER DEFAULT NULL,
@@ -526,6 +529,7 @@ const SQLITE_DDL_STATEMENTS: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_sm_nodes_run_status ON bcs_state_machine_node_runs(env, run_id, status)",
     "CREATE INDEX IF NOT EXISTS idx_sm_nodes_status_started ON bcs_state_machine_node_runs(env, status, started_at_ms)",
     "CREATE INDEX IF NOT EXISTS idx_sm_nodes_timeout_deadline ON bcs_state_machine_node_runs(env, status, timeout_deadline_ms)",
+    "CREATE INDEX IF NOT EXISTS idx_sm_nodes_judge_claim ON bcs_state_machine_node_runs(env, status, judge_lease_until_ms)",
     "CREATE INDEX IF NOT EXISTS idx_sm_nodes_assignee_status ON bcs_state_machine_node_runs(env, assignee_bot_id, status)",
     "CREATE INDEX IF NOT EXISTS idx_sm_nodes_delivery_request ON bcs_state_machine_node_runs(env, delivery_request_id)",
     "CREATE INDEX IF NOT EXISTS idx_sm_nodes_bot_delivery_run ON bcs_state_machine_node_runs(env, bot_delivery_run_id)",
@@ -684,6 +688,10 @@ const SQLITE_VERSIONED_MIGRATIONS: &[SqliteMigration] = &[
         version: 5,
         name: "add_session_collection_timestamp",
     },
+    SqliteMigration {
+        version: 6,
+        name: "add_state_machine_node_judging",
+    },
 ];
 
 pub fn sqlite_target_version() -> i64 {
@@ -784,6 +792,7 @@ pub async fn run_sqlite_bootstrap_tables(db: &dyn DbPlugin) -> DbResult<()> {
     }
     ensure_sqlite_message_owner_bot_id(db).await?;
     ensure_sqlite_session_collected_column(db).await?;
+    ensure_sqlite_state_machine_judge_columns(db).await?;
     Ok(())
 }
 
@@ -838,6 +847,35 @@ async fn ensure_sqlite_session_collected_column(db: &dyn DbPlugin) -> DbResult<(
          ON bcs_session_participants(env, group_id, bot_uuid, collected, collected_at)",
     ))
     .await?;
+    Ok(())
+}
+
+async fn ensure_sqlite_state_machine_judge_columns(db: &dyn DbPlugin) -> DbResult<()> {
+    if !table_exists(db, "bcs_state_machine_node_runs").await? {
+        return Ok(());
+    }
+    let columns = sqlite_table_columns(db, "bcs_state_machine_node_runs").await?;
+    if !columns.iter().any(|column| column == "judge_claim_token") {
+        db.execute(DbStatement::new(
+            "ALTER TABLE bcs_state_machine_node_runs ADD COLUMN judge_claim_token TEXT DEFAULT NULL",
+        ))
+        .await?;
+    }
+    if !columns
+        .iter()
+        .any(|column| column == "judge_lease_until_ms")
+    {
+        db.execute(DbStatement::new(
+            "ALTER TABLE bcs_state_machine_node_runs ADD COLUMN judge_lease_until_ms INTEGER DEFAULT NULL",
+        ))
+        .await?;
+    }
+    if !columns.iter().any(|column| column == "judge_decision_json") {
+        db.execute(DbStatement::new(
+            "ALTER TABLE bcs_state_machine_node_runs ADD COLUMN judge_decision_json TEXT DEFAULT NULL",
+        ))
+        .await?;
+    }
     Ok(())
 }
 
@@ -900,6 +938,10 @@ async fn apply_sqlite_migration_body(
         // collected_at column is added by ensure_sqlite_session_collected_column
         // in run_sqlite_bootstrap_tables; version 5 only records progress.
         5 => Ok(()),
+        // Judge claim, lease, and decision columns are added by the bootstrap
+        // repair pass before the version is recorded so fresh and legacy SQLite
+        // databases converge.
+        6 => ensure_sqlite_state_machine_judge_columns(db).await,
         _ => Ok(()),
     }
 }
@@ -1110,6 +1152,22 @@ mod tests {
 
         let columns = column_names(&db, "bcs_bots").await?;
         assert!(columns.iter().any(|column| column == "agent_code"));
+        let node_columns = column_names(&db, "bcs_state_machine_node_runs").await?;
+        assert!(
+            node_columns
+                .iter()
+                .any(|column| column == "judge_claim_token")
+        );
+        assert!(
+            node_columns
+                .iter()
+                .any(|column| column == "judge_lease_until_ms")
+        );
+        assert!(
+            node_columns
+                .iter()
+                .any(|column| column == "judge_decision_json")
+        );
         assert_eq!(
             migration_rows(&db).await?,
             vec![
@@ -1125,7 +1183,12 @@ mod tests {
                     5,
                     "add_session_collection_timestamp".to_string(),
                     "sqlite".to_string()
-                )
+                ),
+                (
+                    6,
+                    "add_state_machine_node_judging".to_string(),
+                    "sqlite".to_string()
+                ),
             ]
         );
         Ok(())
@@ -1137,7 +1200,7 @@ mod tests {
 
         let report = check_sqlite_migrations(&db).await?;
 
-        assert_eq!(report.pending_versions.len(), 5);
+        assert_eq!(report.pending_versions.len(), 6);
         assert_eq!(report.pending_versions[0].version, 1);
         assert_eq!(report.pending_versions[0].name, "init_schema");
         assert!(report.pending_versions[0].statements.is_empty());
@@ -1155,6 +1218,11 @@ mod tests {
         assert_eq!(
             report.pending_versions[4].name,
             "add_session_collection_timestamp"
+        );
+        assert_eq!(report.pending_versions[5].version, 6);
+        assert_eq!(
+            report.pending_versions[5].name,
+            "add_state_machine_node_judging"
         );
         Ok(())
     }
@@ -1181,9 +1249,37 @@ mod tests {
                     5,
                     "add_session_collection_timestamp".to_string(),
                     "sqlite".to_string()
-                )
+                ),
+                (
+                    6,
+                    "add_state_machine_node_judging".to_string(),
+                    "sqlite".to_string()
+                ),
             ]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sqlite_judge_column_repair_handles_missing_and_legacy_tables() -> DbResult<()> {
+        let db = LocalSqliteDbPlugin::new()?;
+
+        ensure_sqlite_state_machine_judge_columns(&db).await?;
+        db.execute(DbStatement::new(
+            "CREATE TABLE bcs_state_machine_node_runs (id INTEGER PRIMARY KEY)",
+        ))
+        .await?;
+
+        ensure_sqlite_state_machine_judge_columns(&db).await?;
+
+        let columns = column_names(&db, "bcs_state_machine_node_runs").await?;
+        assert!(columns.iter().any(|column| column == "judge_claim_token"));
+        assert!(
+            columns
+                .iter()
+                .any(|column| column == "judge_lease_until_ms")
+        );
+        assert!(columns.iter().any(|column| column == "judge_decision_json"));
         Ok(())
     }
 

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1126,6 +1126,12 @@ impl Default for BcsServerState {
             crate::state_machine_timeout_scanner::DEFAULT_BATCH_SIZE,
             crate::state_machine_timeout_scanner::DEFAULT_TIMEOUT_GRACE_MS,
         );
+        let _state_machine_judge_handle = crate::state_machine_judge_worker::spawn(
+            services.collaboration_runtime.clone(),
+            crate::state_machine_judge_worker::DEFAULT_SCAN_INTERVAL,
+            crate::state_machine_judge_worker::DEFAULT_BATCH_SIZE,
+            crate::state_machine_judge_worker::DEFAULT_LEASE_MS,
+        );
 
         // Start JWT token expiry scanner
         let _token_expiry_handle = crate::token_expiry_scanner::spawn(
@@ -2262,6 +2268,12 @@ impl BcsServer {
             crate::state_machine_timeout_scanner::DEFAULT_BATCH_SIZE,
             crate::state_machine_timeout_scanner::DEFAULT_TIMEOUT_GRACE_MS,
         );
+        let _state_machine_judge_handle = crate::state_machine_judge_worker::spawn(
+            services.collaboration_runtime.clone(),
+            crate::state_machine_judge_worker::DEFAULT_SCAN_INTERVAL,
+            crate::state_machine_judge_worker::DEFAULT_BATCH_SIZE,
+            crate::state_machine_judge_worker::DEFAULT_LEASE_MS,
+        );
 
         let (leader_election, lifecycle) = create_standalone_leader_lifecycle();
         register_late_lifecycles(&lifecycle, fuse_client.as_ref());
@@ -2799,6 +2811,12 @@ impl BcsServer {
             crate::state_machine_timeout_scanner::DEFAULT_SCAN_INTERVAL,
             crate::state_machine_timeout_scanner::DEFAULT_BATCH_SIZE,
             crate::state_machine_timeout_scanner::DEFAULT_TIMEOUT_GRACE_MS,
+        );
+        let _state_machine_judge_handle = crate::state_machine_judge_worker::spawn(
+            services.collaboration_runtime.clone(),
+            crate::state_machine_judge_worker::DEFAULT_SCAN_INTERVAL,
+            crate::state_machine_judge_worker::DEFAULT_BATCH_SIZE,
+            crate::state_machine_judge_worker::DEFAULT_LEASE_MS,
         );
 
         let auth_config = crate::auth_wiring::resolve_auth_config(

--- a/src/bcs/crates/bootstrap/bcs/src/state_machine_judge_worker.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/state_machine_judge_worker.rs
@@ -1,0 +1,80 @@
+//! Durable asynchronous state-machine judge worker.
+//!
+//! Bot callbacks only persist the `running -> judging` transition. This worker
+//! claims judging nodes with a renewable lease and performs the slow judge
+//! evaluation outside the callback request lifetime.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bcs_service_api::CollaborationRuntimeService;
+use tracing::{debug, info, warn};
+
+pub const DEFAULT_SCAN_INTERVAL: Duration = Duration::from_millis(500);
+pub const DEFAULT_BATCH_SIZE: usize = 4;
+pub const DEFAULT_LEASE_MS: u64 = 30_000;
+
+pub async fn scan_once(
+    runtime: &Arc<dyn CollaborationRuntimeService>,
+    batch_size: usize,
+    lease_ms: u64,
+) -> usize {
+    if batch_size == 0 {
+        return 0;
+    }
+    match runtime.process_pending_judges(batch_size, lease_ms).await {
+        Ok(processed) => processed,
+        Err(error) => {
+            warn!(
+                target: "state_machine_judge_worker",
+                event = "worker.scan_failed",
+                error = %error,
+            );
+            0
+        }
+    }
+}
+
+pub fn spawn(
+    runtime: Arc<dyn CollaborationRuntimeService>,
+    interval: Duration,
+    batch_size: usize,
+    lease_ms: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        info!(
+            target: "state_machine_judge_worker",
+            event = "worker.started",
+            interval_ms = interval.as_millis() as u64,
+            batch_size = batch_size,
+            lease_ms = lease_ms,
+        );
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            let processed = scan_once(&runtime, batch_size, lease_ms).await;
+            if processed > 0 {
+                debug!(
+                    target: "state_machine_judge_worker",
+                    event = "worker.tick",
+                    processed = processed,
+                );
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn scan_once_skips_zero_batch() {
+        let runtime = bcs_services_container::Services::builder()
+            .build_for_test()
+            .collaboration_runtime;
+
+        assert_eq!(scan_once(&runtime, 0, DEFAULT_LEASE_MS).await, 0);
+    }
+}

--- a/src/bcs/crates/contracts/bcs-domain/src/collaboration.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/collaboration.rs
@@ -450,6 +450,7 @@ pub enum StateMachineNodeStatus {
     Pending,
     Ready,
     Running,
+    Judging,
     Completed,
     Failed,
     RetryScheduled,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
@@ -324,4 +324,13 @@ pub trait CollaborationRuntimeService: Send + Sync {
         let _ = (limit, timeout_grace_ms);
         Ok(0)
     }
+
+    async fn process_pending_judges(
+        &self,
+        limit: usize,
+        lease_ms: u64,
+    ) -> Result<usize, CollaborationRuntimeError> {
+        let _ = (limit, lease_ms);
+        Ok(0)
+    }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/collaboration.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/collaboration.rs
@@ -133,6 +133,86 @@ pub trait StateMachineRunRepoPort: Send + Sync {
         Ok(true)
     }
 
+    async fn mark_node_judging(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        artifact_text: String,
+    ) -> ServiceResult<bool>;
+
+    async fn list_claimable_judging_node_runs(
+        &self,
+        now_ms: u64,
+        limit: usize,
+    ) -> ServiceResult<Vec<StateMachineNodeRun>> {
+        let _ = (now_ms, limit);
+        Ok(Vec::new())
+    }
+
+    async fn claim_judging_node(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        now_ms: u64,
+        lease_until_ms: u64,
+    ) -> ServiceResult<bool>;
+
+    async fn renew_judging_node_claim(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        lease_until_ms: u64,
+    ) -> ServiceResult<bool>;
+
+    async fn get_judging_node_decision(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+    ) -> ServiceResult<Option<String>>;
+
+    async fn persist_judging_node_decision(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        decision_json: String,
+        now_ms: u64,
+    ) -> ServiceResult<bool>;
+
+    async fn complete_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        completed_at: u64,
+    ) -> ServiceResult<bool>;
+
+    async fn fail_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        error: String,
+        completed_at: u64,
+    ) -> ServiceResult<bool>;
+
+    async fn finish_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+    ) -> ServiceResult<bool>;
+
     async fn complete_node_attempt(
         &self,
         run_id: &str,
@@ -192,7 +272,7 @@ pub trait StateMachineRunRepoPort: Send + Sync {
         run_id: &str,
     ) -> ServiceResult<Option<StateMachineDeliveryCorrelation>>;
 
-    async fn list_expired_running_node_runs(
+    async fn list_expired_active_node_runs(
         &self,
         now_ms: u64,
         timeout_grace_ms: u64,

--- a/src/bcs/crates/services/bcs-collaboration-runtime/Cargo.toml
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+futures = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -19,25 +19,23 @@ use bcs_protocol::{
 };
 use bcs_service_api::{
     BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort, BotDeliveryTarget,
-    BotRegistryCoreService,
-    CancelStateMachineRunCommand,
-    ChatEventState, CollaborationDefinitionRecord, CollaborationEventRepoPort,
-    CollaborationRuntimeError, CollaborationRuntimeService, ConfigureGroupRuntimeCommand,
-    ConfigureGroupRuntimeOutcome, CreateOrReactivateCommand, DefinitionYamlSource,
-    FrontendDeliveryCommand, FrontendDeliveryKind,
-    FrontendDeliveryPort, FrontendDeliveryTarget, GroupCoreService, GroupRuntimeBindingRepoPort,
-    GroupCollaborationDefinitionView, HandleBotTerminalEventCommand,
-    HandleBotTerminalEventOutcome, MAX_COLLABORATION_DEFINITION_YAML_BYTES,
-    MessageLogContent, MessageLogEventType, MessageLogMode, MessageLogStatus,
-    MESSAGE_LOG_SCHEMA_VERSION, MSG_LOG_TARGET, message_log_json,
-    NewSessionParams, PatchGroupCollaborationDefinitionCommand, RunFallbackDelivery,
+    BotRegistryCoreService, CancelStateMachineRunCommand, ChatEventState,
+    CollaborationDefinitionRecord, CollaborationEventRepoPort, CollaborationRuntimeError,
+    CollaborationRuntimeService, ConfigureGroupRuntimeCommand, ConfigureGroupRuntimeOutcome,
+    CreateOrReactivateCommand, DefinitionYamlSource, FrontendDeliveryCommand, FrontendDeliveryKind,
+    FrontendDeliveryPort, FrontendDeliveryTarget, GroupCollaborationDefinitionView,
+    GroupCoreService, GroupRuntimeBindingRepoPort, HandleBotTerminalEventCommand,
+    HandleBotTerminalEventOutcome, JudgeArtifact, JudgeDecision, JudgeEvaluatorPort, JudgeRequest,
+    MAX_COLLABORATION_DEFINITION_YAML_BYTES, MESSAGE_LOG_SCHEMA_VERSION, MSG_LOG_TARGET,
+    MessageLogContent, MessageLogEventType, MessageLogMode, MessageLogStatus, NewSessionParams,
+    PatchGroupCollaborationDefinitionCommand, RunFallbackDelivery, ServiceError,
     SessionHistoryResult, SessionKind, SessionManagementService, StartStateMachineRunCommand,
     StartStateMachineRunOutcome, StateMachineDefinitionRepoPort, StateMachineRunRepoPort,
-    JudgeArtifact, JudgeEvaluatorPort, JudgeRequest, ServiceError,
     StateMachineGraphDefinitionView, StateMachineGraphEdgeView, StateMachineGraphNodeView,
     StateMachineJudgeOutputView, StateMachineNodeRunView, StateMachineRunGraphView,
-    StateMachineRunView, UpgradeGroupCollaborationDefinitionCommand,
+    StateMachineRunView, UpgradeGroupCollaborationDefinitionCommand, message_log_json,
 };
+use futures::{StreamExt, stream};
 use serde_json::Value;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -49,7 +47,7 @@ const BCS_STATE_MACHINE_BOT_NAME: &str = "BCS State Machine";
 const DEFAULT_JUDGE_TIMEOUT_MS: u64 = 90_000;
 
 enum JudgeEvaluationResult {
-    Outcome(String),
+    Decision(JudgeDecision),
     Failed(String),
 }
 
@@ -540,7 +538,7 @@ impl CollaborationRuntime {
         }
     }
 
-    async fn publish_state_machine_bot_event(
+    fn publish_state_machine_bot_event(
         &self,
         run: &StateMachineRun,
         bot_id: &str,
@@ -549,7 +547,7 @@ impl CollaborationRuntime {
         event_payload: &Value,
         state: &ChatEventState,
     ) {
-        let Some(frontend_delivery) = self.frontend_delivery.as_ref() else {
+        let Some(frontend_delivery) = self.frontend_delivery.clone() else {
             return;
         };
         let frontend_event = workbench_event_name(event_type, state);
@@ -567,37 +565,54 @@ impl CollaborationRuntime {
             "group_id": run.group_id.clone(),
             "bot_uuid": bot_id,
         });
-        let fallback = BcsFrame::Event(EventFrame::new(
-            event_type.to_string(),
-            Some(payload),
-            None,
-        ));
-        if let Err(error) = frontend_delivery
-            .publish(FrontendDeliveryCommand {
-                target: FrontendDeliveryTarget::Session {
-                    session_id: run.session_id.clone(),
-                },
-                event_json: frame.to_string(),
-                delivery_kind: FrontendDeliveryKind::WorkbenchEvent,
-                run_fallback: Some(RunFallbackDelivery {
-                    run_id: delivery_run_id.to_string(),
-                    session_id: run.session_id.clone(),
-                    event_json: serde_json::to_string(&fallback)
-                        .unwrap_or_else(|_| frame.to_string()),
-                }),
-                exclude_conn_id: None,
-            })
+        let fallback =
+            BcsFrame::Event(EventFrame::new(event_type.to_string(), Some(payload), None));
+        let command = FrontendDeliveryCommand {
+            target: FrontendDeliveryTarget::Session {
+                session_id: run.session_id.clone(),
+            },
+            event_json: frame.to_string(),
+            delivery_kind: FrontendDeliveryKind::WorkbenchEvent,
+            run_fallback: Some(RunFallbackDelivery {
+                run_id: delivery_run_id.to_string(),
+                session_id: run.session_id.clone(),
+                event_json: serde_json::to_string(&fallback).unwrap_or_else(|_| frame.to_string()),
+            }),
+            exclude_conn_id: None,
+        };
+        let run_id = run.run_id.clone();
+        let session_id = run.session_id.clone();
+        let delivery_run_id = delivery_run_id.to_string();
+        let bot_id = bot_id.to_string();
+        tokio::spawn(async move {
+            match tokio::time::timeout(
+                Duration::from_millis(500),
+                frontend_delivery.publish(command),
+            )
             .await
-        {
-            warn!(
-                run_id = %run.run_id,
-                bot_delivery_run_id = %delivery_run_id,
-                session_id = %run.session_id,
-                bot_id = %bot_id,
-                error = %error,
-                "state_machine: failed to publish bot event to frontend"
-            );
-        }
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(error)) => {
+                    warn!(
+                        run_id = %run_id,
+                        bot_delivery_run_id = %delivery_run_id,
+                        session_id = %session_id,
+                        bot_id = %bot_id,
+                        error = %error,
+                        "state_machine: failed to publish bot event to frontend"
+                    );
+                }
+                Err(_) => {
+                    warn!(
+                        run_id = %run_id,
+                        bot_delivery_run_id = %delivery_run_id,
+                        session_id = %session_id,
+                        bot_id = %bot_id,
+                        "state_machine: timed out publishing bot event to frontend"
+                    );
+                }
+            }
+        });
     }
 
     async fn build_node_prompt(
@@ -1127,27 +1142,44 @@ impl CollaborationRuntime {
         node_id: &str,
         attempt: i32,
         artifact_text: &str,
+        timeout_deadline_ms: Option<u64>,
     ) -> Result<JudgeEvaluationResult, CollaborationRuntimeError> {
         let state_machine = match &compiled.definition.runtime {
             CollaborationRuntimeDefinition::StateMachine(state_machine) => state_machine,
-            _ => return Ok(JudgeEvaluationResult::Outcome("complete".to_string())),
+            _ => {
+                return Ok(JudgeEvaluationResult::Failed(
+                    "judge evaluation requires a state-machine definition".to_string(),
+                ));
+            }
         };
         let Some(node) = state_machine.nodes.get(node_id) else {
-            return Ok(JudgeEvaluationResult::Outcome("complete".to_string()));
+            return Ok(JudgeEvaluationResult::Failed(format!(
+                "judge node is missing from the state-machine definition: {node_id}"
+            )));
         };
         let Some(judge) = &node.judge else {
-            return Ok(JudgeEvaluationResult::Outcome("complete".to_string()));
+            return Ok(JudgeEvaluationResult::Failed(format!(
+                "judge configuration is missing for node: {node_id}"
+            )));
         };
         let upstream_outputs = self
             .judge_upstream_outputs(compiled, &run.run_id, node_id)
             .await?;
         let judge_type = judge.judge_type.clone().unwrap_or_else(|| "llm".to_string());
         let allowed_outcomes = judge.outcomes.clone();
-        let judge_timeout_ms = node
+        let configured_judge_timeout_ms = node
             .node_timeout_ms
             .or(state_machine.defaults.node_timeout_ms)
             .unwrap_or(DEFAULT_JUDGE_TIMEOUT_MS)
             .max(1);
+        let judge_timeout_ms = timeout_deadline_ms
+            .map(|deadline_ms| {
+                deadline_ms
+                    .saturating_sub(bcs_protocol::now_ms())
+                    .max(1)
+                    .min(configured_judge_timeout_ms)
+            })
+            .unwrap_or(configured_judge_timeout_ms);
         info!(
             run_id = %run.run_id,
             node_id = %node_id,
@@ -1261,18 +1293,6 @@ impl CollaborationRuntime {
             .await?;
             return Ok(JudgeEvaluationResult::Failed(failure));
         }
-        self.events
-            .append_event(
-                &run.run_id,
-                Some(node_id),
-                Some(attempt),
-                "state_machine.judge.completed",
-                serde_json::to_value(&decision).map_err(|error| {
-                    CollaborationRuntimeError::InvalidRequest(error.to_string())
-                })?,
-                bcs_protocol::now_ms(),
-            )
-            .await?;
         info!(
             run_id = %run.run_id,
             node_id = %node_id,
@@ -1282,7 +1302,7 @@ impl CollaborationRuntime {
             elapsed_ms = elapsed_ms,
             "state_machine: judge evaluation completed"
         );
-        Ok(JudgeEvaluationResult::Outcome(decision.outcome))
+        Ok(JudgeEvaluationResult::Decision(decision))
     }
 
     async fn append_judge_failure_event(
@@ -1343,6 +1363,332 @@ impl CollaborationRuntime {
             }
         }
         Ok(artifacts)
+    }
+
+    async fn process_judging_node(
+        &self,
+        node: StateMachineNodeRun,
+        lease_ms: u64,
+    ) -> Result<bool, CollaborationRuntimeError> {
+        let lease_ms = lease_ms.max(1_000);
+        let claim_token = Uuid::new_v4().to_string();
+        let claimed_at = bcs_protocol::now_ms();
+        if !self
+            .runs
+            .claim_judging_node(
+                &node.run_id,
+                &node.node_id,
+                node.attempt,
+                &claim_token,
+                claimed_at,
+                claimed_at.saturating_add(lease_ms),
+            )
+            .await?
+        {
+            return Ok(false);
+        }
+        self.events
+            .append_event(
+                &node.run_id,
+                Some(&node.node_id),
+                Some(node.attempt),
+                "state_machine.judge.claimed",
+                serde_json::json!({
+                    "run_id": node.run_id.clone(),
+                    "node_id": node.node_id.clone(),
+                    "attempt": node.attempt,
+                    "claim_token": claim_token.clone(),
+                    "lease_until_ms": claimed_at.saturating_add(lease_ms),
+                }),
+                claimed_at,
+            )
+            .await?;
+        let Some(run) = self.runs.get_run(&node.run_id).await? else {
+            return Ok(false);
+        };
+        if run.status != StateMachineRunStatus::Running {
+            return Ok(false);
+        }
+        let definition = self.load_run_definition(&run).await?;
+        let compiled = validate_definition(definition)?;
+        let group = self.groups.get(&run.group_id).await.ok_or_else(|| {
+            CollaborationRuntimeError::InvalidRequest(format!("group not found: {}", run.group_id))
+        })?;
+        let artifact_text = node.artifact_text.clone().ok_or_else(|| {
+            CollaborationRuntimeError::InvalidRequest(format!(
+                "judging node {}/{} has no artifact",
+                node.run_id, node.node_id
+            ))
+        })?;
+        let persisted_decision_json = self
+            .runs
+            .get_judging_node_decision(&node.run_id, &node.node_id, node.attempt)
+            .await?;
+        let needs_decision_persist = persisted_decision_json.is_none();
+        let evaluation = async {
+            if let Some(decision_json) = persisted_decision_json {
+                let decision =
+                    serde_json::from_str::<JudgeDecision>(&decision_json).map_err(|error| {
+                        CollaborationRuntimeError::InvalidRequest(format!(
+                            "invalid persisted judge decision for {}/{} attempt {}: {error}",
+                            node.run_id, node.node_id, node.attempt
+                        ))
+                    })?;
+                info!(
+                    run_id = %node.run_id,
+                    node_id = %node.node_id,
+                    attempt = node.attempt,
+                    outcome = %decision.outcome,
+                    "state_machine: resuming persisted judge decision"
+                );
+                Ok(JudgeEvaluationResult::Decision(decision))
+            } else if node.status != StateMachineNodeStatus::Judging {
+                Err(CollaborationRuntimeError::InvalidRequest(format!(
+                    "completed judging node {}/{} attempt {} has no persisted decision",
+                    node.run_id, node.node_id, node.attempt
+                )))
+            } else {
+                self.evaluate_node_outcome(
+                    &compiled,
+                    &run,
+                    &node.node_id,
+                    node.attempt,
+                    &artifact_text,
+                    node.timeout_deadline_ms,
+                )
+                .await
+            }
+        };
+        tokio::pin!(evaluation);
+        let renewal_interval = Duration::from_millis((lease_ms / 3).clamp(100, 30_000));
+        let mut renewal_ticker = tokio::time::interval(renewal_interval);
+        renewal_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        renewal_ticker.tick().await;
+        let evaluation = loop {
+            tokio::select! {
+                evaluation = &mut evaluation => break evaluation?,
+                _ = renewal_ticker.tick() => {
+                    let lease_until_ms = bcs_protocol::now_ms().saturating_add(lease_ms);
+                    if !self.runs
+                        .renew_judging_node_claim(
+                            &node.run_id,
+                            &node.node_id,
+                            node.attempt,
+                            &claim_token,
+                            lease_until_ms,
+                        )
+                        .await?
+                    {
+                        warn!(
+                            run_id = %node.run_id,
+                            node_id = %node.node_id,
+                            attempt = node.attempt,
+                            claim_token = %claim_token,
+                            "state_machine: judge claim was lost"
+                        );
+                        return Ok(false);
+                    }
+                }
+            }
+        };
+        match evaluation {
+            JudgeEvaluationResult::Decision(decision) => {
+                let decision_json = serde_json::to_string(&decision).map_err(|error| {
+                    CollaborationRuntimeError::InvalidRequest(error.to_string())
+                })?;
+                let decision_value = serde_json::to_value(&decision).map_err(|error| {
+                    CollaborationRuntimeError::InvalidRequest(error.to_string())
+                })?;
+                let outcome = decision.outcome.clone();
+                let completed_at = node.completed_at.unwrap_or_else(bcs_protocol::now_ms);
+                let continuation = async {
+                    if needs_decision_persist
+                        && !self
+                            .runs
+                            .persist_judging_node_decision(
+                                &node.run_id,
+                                &node.node_id,
+                                node.attempt,
+                                &claim_token,
+                                decision_json,
+                                bcs_protocol::now_ms(),
+                            )
+                            .await?
+                    {
+                        return Ok::<bool, CollaborationRuntimeError>(false);
+                    }
+                    let newly_completed = node.status == StateMachineNodeStatus::Judging;
+                    if newly_completed
+                        && !self
+                            .runs
+                            .complete_judging_node_attempt(
+                                &node.run_id,
+                                &node.node_id,
+                                node.attempt,
+                                &claim_token,
+                                completed_at,
+                            )
+                            .await?
+                    {
+                        return Ok::<bool, CollaborationRuntimeError>(false);
+                    }
+                    let decision_event_exists = self
+                        .judge_outputs_for_node(&node.run_id, &node.node_id)
+                        .await?
+                        .into_iter()
+                        .any(|output| {
+                            output.attempt == node.attempt && output.decision == decision
+                        });
+                    if !decision_event_exists {
+                        self.events
+                            .append_event(
+                                &run.run_id,
+                                Some(&node.node_id),
+                                Some(node.attempt),
+                                "state_machine.judge.completed",
+                                decision_value,
+                                bcs_protocol::now_ms(),
+                            )
+                            .await?;
+                    }
+                    if newly_completed {
+                        info!(
+                            run_id = %node.run_id,
+                            group_id = %run.group_id,
+                            session_id = %run.session_id,
+                            node_id = %node.node_id,
+                            attempt = node.attempt,
+                            outcome = %outcome,
+                            artifact_len = artifact_text.len(),
+                            "state_machine: judged node completed"
+                        );
+                        if let Some(delivery_request_id) = node.delivery_request_id.as_deref() {
+                            if let Some(correlation) = self
+                                .runs
+                                .lookup_delivery_correlation(delivery_request_id)
+                                .await?
+                            {
+                                log_state_machine_node_result(
+                                    &run,
+                                    &correlation,
+                                    MessageLogStatus::Completed,
+                                    Some(&outcome),
+                                    None,
+                                    Some(artifact_text.len()),
+                                );
+                            }
+                        }
+                    }
+                    self.skip_unselected_targets(
+                        &compiled,
+                        &run,
+                        &node.node_id,
+                        &outcome,
+                        completed_at,
+                    )
+                    .await?;
+                    self.dispatch_ready_targets(&compiled, &group, &run, &node.node_id, &outcome)
+                        .await?;
+                    self.complete_run_if_done(&compiled, &run).await?;
+                    if !self
+                        .runs
+                        .finish_judging_node_attempt(
+                            &node.run_id,
+                            &node.node_id,
+                            node.attempt,
+                            &claim_token,
+                        )
+                        .await?
+                    {
+                        return Ok(false);
+                    }
+                    Ok::<bool, CollaborationRuntimeError>(true)
+                };
+                tokio::pin!(continuation);
+                let continued = loop {
+                    tokio::select! {
+                        result = &mut continuation => break result,
+                        _ = renewal_ticker.tick() => {
+                            let lease_until_ms = bcs_protocol::now_ms().saturating_add(lease_ms);
+                            if !self.runs
+                                .renew_judging_node_claim(
+                                    &node.run_id,
+                                    &node.node_id,
+                                    node.attempt,
+                                    &claim_token,
+                                    lease_until_ms,
+                                )
+                                .await?
+                            {
+                                warn!(
+                                    run_id = %node.run_id,
+                                    node_id = %node.node_id,
+                                    attempt = node.attempt,
+                                    claim_token = %claim_token,
+                                    "state_machine: judge continuation claim was lost"
+                                );
+                                return Ok(false);
+                            }
+                        }
+                    }
+                }?;
+                if !continued {
+                    return Ok(false);
+                }
+            }
+            JudgeEvaluationResult::Failed(error) => {
+                let failed_at = bcs_protocol::now_ms();
+                if !self
+                    .runs
+                    .fail_judging_node_attempt(
+                        &node.run_id,
+                        &node.node_id,
+                        node.attempt,
+                        &claim_token,
+                        error.clone(),
+                        failed_at,
+                    )
+                    .await?
+                {
+                    return Ok(false);
+                }
+                warn!(
+                    run_id = %node.run_id,
+                    group_id = %run.group_id,
+                    session_id = %run.session_id,
+                    node_id = %node.node_id,
+                    attempt = node.attempt,
+                    error = %error,
+                    "state_machine: judged node failed"
+                );
+                if let Some(delivery_request_id) = node.delivery_request_id.as_deref() {
+                    if let Some(correlation) = self
+                        .runs
+                        .lookup_delivery_correlation(delivery_request_id)
+                        .await?
+                    {
+                        log_state_machine_node_result(
+                            &run,
+                            &correlation,
+                            MessageLogStatus::Failed,
+                            None,
+                            Some(&error),
+                            None,
+                        );
+                    }
+                }
+                self.fail_node_or_schedule_retry(
+                    &compiled,
+                    &group,
+                    &run,
+                    &node.node_id,
+                    node.attempt,
+                    error,
+                )
+                .await?;
+            }
+        }
+        Ok(true)
     }
 }
 
@@ -1624,6 +1970,27 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             .runs
             .get_node_run(&correlation.state_machine_run_id, &correlation.node_id)
             .await?;
+        let duplicate_judging_final = node.as_ref().is_some_and(|node| {
+            matches!(cmd.state, ChatEventState::Final)
+                && run.status == StateMachineRunStatus::Running
+                && node.status == StateMachineNodeStatus::Judging
+                && node.attempt == correlation.attempt
+                && node.delivery_request_id.as_deref()
+                    == Some(correlation.delivery_request_id.as_str())
+                && correlation.assignee_bot_id == cmd.bot_id
+        });
+        if duplicate_judging_final {
+            info!(
+                run_id = %correlation.state_machine_run_id,
+                node_id = %correlation.node_id,
+                attempt = correlation.attempt,
+                "state_machine: duplicate final event accepted while judging"
+            );
+            return Ok(HandleBotTerminalEventOutcome {
+                consumed: true,
+                view: self.run_view(&run.run_id).await?,
+            });
+        }
         let current_event = node.as_ref().is_some_and(|node| {
             run.status == StateMachineRunStatus::Running
                 && node.status == StateMachineNodeStatus::Running
@@ -1686,15 +2053,6 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             "state_machine: bot terminal event received"
         );
         log_state_machine_bot_event(&run, &correlation, &cmd, event_text_len);
-        self.publish_state_machine_bot_event(
-            &run,
-            &cmd.bot_id,
-            &cmd.run_id,
-            &cmd.event_type,
-            &cmd.event_payload,
-            &cmd.state,
-        )
-        .await;
         let definition = self.load_run_definition(&run).await?;
         let compiled = validate_definition(definition)?;
         let group = self
@@ -1715,109 +2073,93 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                     )
                 })?;
                 let artifact_len = text.len();
-                let evaluation = self
-                    .evaluate_node_outcome(
-                        &compiled,
-                        &run,
-                        &correlation.node_id,
-                        correlation.attempt,
-                        &text,
-                    )
-                    .await?;
-                match evaluation {
-                    JudgeEvaluationResult::Outcome(outcome) => {
-                        let completed_at = bcs_protocol::now_ms();
-                        if self
-                            .runs
-                            .complete_node_attempt(
+                if compiled_node_has_judge(&compiled, &correlation.node_id) {
+                    if self
+                        .runs
+                        .mark_node_judging(
+                            &correlation.state_machine_run_id,
+                            &correlation.node_id,
+                            correlation.attempt,
+                            text,
+                        )
+                        .await?
+                    {
+                        self.events
+                            .append_event(
                                 &correlation.state_machine_run_id,
-                                &correlation.node_id,
-                                correlation.attempt,
-                                text,
-                                completed_at,
-                            )
-                            .await?
-                        {
-                            info!(
-                                run_id = %correlation.state_machine_run_id,
-                                group_id = %run.group_id,
-                                session_id = %run.session_id,
-                                node_id = %correlation.node_id,
-                                attempt = correlation.attempt,
-                                outcome = %outcome,
-                                artifact_len = artifact_len,
-                                "state_machine: node completed"
-                            );
-                            log_state_machine_node_result(
-                                &run,
-                                &correlation,
-                                MessageLogStatus::Completed,
-                                Some(&outcome),
-                                None,
-                                Some(artifact_len),
-                            );
-                            self.skip_unselected_targets(
-                                &compiled,
-                                &run,
-                                &correlation.node_id,
-                                &outcome,
-                                completed_at,
+                                Some(&correlation.node_id),
+                                Some(correlation.attempt),
+                                "state_machine.judge.requested",
+                                serde_json::json!({
+                                    "run_id": correlation.state_machine_run_id.clone(),
+                                    "node_id": correlation.node_id.clone(),
+                                    "attempt": correlation.attempt,
+                                    "artifact_len": artifact_len,
+                                    "timeout_deadline_ms": node.as_ref().and_then(|node| node.timeout_deadline_ms),
+                                }),
+                                bcs_protocol::now_ms(),
                             )
                             .await?;
-                            self.dispatch_ready_targets(
-                                &compiled,
-                                &group,
-                                &run,
-                                &correlation.node_id,
-                                &outcome,
-                            )
-                            .await?;
-                            view = self.complete_run_if_done(&compiled, &run).await?;
-                        }
+                        info!(
+                            run_id = %correlation.state_machine_run_id,
+                            group_id = %run.group_id,
+                            session_id = %run.session_id,
+                            node_id = %correlation.node_id,
+                            attempt = correlation.attempt,
+                            artifact_len = artifact_len,
+                            "state_machine: node queued for judging"
+                        );
                     }
-                    JudgeEvaluationResult::Failed(error) => {
-                        let failed_at = bcs_protocol::now_ms();
-                        if self
-                            .runs
-                            .fail_node_attempt(
-                                &correlation.state_machine_run_id,
-                                &correlation.node_id,
-                                correlation.attempt,
-                                error.clone(),
-                                failed_at,
-                            )
-                            .await?
-                        {
-                            warn!(
-                                run_id = %correlation.state_machine_run_id,
-                                group_id = %run.group_id,
-                                session_id = %run.session_id,
-                                node_id = %correlation.node_id,
-                                attempt = correlation.attempt,
-                                error = %error,
-                                "state_machine: node failed"
-                            );
-                            log_state_machine_node_result(
-                                &run,
-                                &correlation,
-                                MessageLogStatus::Failed,
-                                None,
-                                Some(&error),
-                                None,
-                            );
-                            view = self
-                                .fail_node_or_schedule_retry(
-                                    &compiled,
-                                    &group,
-                                    &run,
-                                    &correlation.node_id,
-                                    correlation.attempt,
-                                    error,
-                                )
-                                .await?;
-                        } else {
-                            view = self.run_view(&run.run_id).await?;
-                        }
+                    view = self.run_view(&run.run_id).await?;
+                } else {
+                    let outcome = "complete";
+                    let completed_at = bcs_protocol::now_ms();
+                    if self
+                        .runs
+                        .complete_node_attempt(
+                            &correlation.state_machine_run_id,
+                            &correlation.node_id,
+                            correlation.attempt,
+                            text,
+                            completed_at,
+                        )
+                        .await?
+                    {
+                        info!(
+                            run_id = %correlation.state_machine_run_id,
+                            group_id = %run.group_id,
+                            session_id = %run.session_id,
+                            node_id = %correlation.node_id,
+                            attempt = correlation.attempt,
+                            outcome = %outcome,
+                            artifact_len = artifact_len,
+                            "state_machine: node completed"
+                        );
+                        log_state_machine_node_result(
+                            &run,
+                            &correlation,
+                            MessageLogStatus::Completed,
+                            Some(outcome),
+                            None,
+                            Some(artifact_len),
+                        );
+                        self.skip_unselected_targets(
+                            &compiled,
+                            &run,
+                            &correlation.node_id,
+                            outcome,
+                            completed_at,
+                        )
+                        .await?;
+                        self.dispatch_ready_targets(
+                            &compiled,
+                            &group,
+                            &run,
+                            &correlation.node_id,
+                            outcome,
+                        )
+                        .await?;
+                        view = self.complete_run_if_done(&compiled, &run).await?;
                     }
                 }
             }
@@ -1869,6 +2211,14 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 view = self.run_view(&run.run_id).await?;
             }
         }
+        self.publish_state_machine_bot_event(
+            &run,
+            &cmd.bot_id,
+            &cmd.run_id,
+            &cmd.event_type,
+            &cmd.event_payload,
+            &cmd.state,
+        );
         Ok(HandleBotTerminalEventOutcome {
             consumed: true,
             view,
@@ -1884,8 +2234,9 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             return Ok(0);
         }
         let now = bcs_protocol::now_ms();
-        let expired_nodes = self.runs
-            .list_expired_running_node_runs(now, timeout_grace_ms, limit)
+        let expired_nodes = self
+            .runs
+            .list_expired_active_node_runs(now, timeout_grace_ms, limit)
             .await?;
         let mut processed = 0usize;
         for node in expired_nodes {
@@ -1954,6 +2305,39 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 error,
             )
             .await?;
+        }
+        Ok(processed)
+    }
+
+    async fn process_pending_judges(
+        &self,
+        limit: usize,
+        lease_ms: u64,
+    ) -> Result<usize, CollaborationRuntimeError> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let candidates = self
+            .runs
+            .list_claimable_judging_node_runs(bcs_protocol::now_ms(), limit)
+            .await?;
+        let results = stream::iter(candidates)
+            .map(|node| self.process_judging_node(node, lease_ms))
+            .buffer_unordered(limit)
+            .collect::<Vec<_>>()
+            .await;
+        let mut processed = 0usize;
+        for result in results {
+            match result {
+                Ok(true) => processed += 1,
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "state_machine: failed to process pending judge"
+                    );
+                }
+            }
         }
         Ok(processed)
     }
@@ -3427,6 +3811,16 @@ fn compiled_node_max_attempts(compiled: &CompiledStateMachine, node_id: &str) ->
                 .max(1)
         }
         _ => 1,
+    }
+}
+
+fn compiled_node_has_judge(compiled: &CompiledStateMachine, node_id: &str) -> bool {
+    match &compiled.definition.runtime {
+        CollaborationRuntimeDefinition::StateMachine(state_machine) => state_machine
+            .nodes
+            .get(node_id)
+            .is_some_and(|node| node.judge.is_some()),
+        _ => false,
     }
 }
 

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -2,7 +2,10 @@ use std::{
     collections::BTreeMap,
     future::Future,
     io::{self, Write},
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -18,19 +21,19 @@ use bcs_group::GroupStore;
 use bcs_group_store::MemoryGroupRepo;
 use bcs_protocol::{BcsFrame, ChatSendParams};
 use bcs_service_api::{
-    BotDeliveryCommand, BotDeliveryPort, BotDeliveryResult, BotDeliveryTarget, ChatEventState,
-    CollaborationEventRepoPort, CollaborationRuntimeService, ConfigureGroupRuntimeCommand,
-    DefinitionYamlSource, FrontendDeliveryCommand,
-    FrontendDeliveryPort, FrontendDeliveryResult, FrontendDeliveryTarget, GroupCoreService,
-    CallbackChannelConfig, CallbackConfig, PatchGroupCollaborationDefinitionCommand,
-    ServiceResult, ServiceSpec, SessionManagementService, StartStateMachineRunCommand,
-    StateMachineDefinitionRepoPort,
-    JudgeDecision, JudgeEvaluatorPort, JudgeRequest, ServiceError
+    BotDeliveryCommand, BotDeliveryPort, BotDeliveryResult, BotDeliveryTarget,
+    CallbackChannelConfig, CallbackConfig, ChatEventState, CollaborationEventRepoPort,
+    CollaborationRuntimeService, ConfigureGroupRuntimeCommand, DefinitionYamlSource,
+    FrontendDeliveryCommand, FrontendDeliveryPort, FrontendDeliveryResult, FrontendDeliveryTarget,
+    GroupCoreService, JudgeDecision, JudgeEvaluatorPort, JudgeRequest,
+    PatchGroupCollaborationDefinitionCommand, ServiceError, ServiceResult, ServiceSpec,
+    SessionManagementService, StartStateMachineRunCommand, StateMachineDefinitionRepoPort,
+    StateMachineRunRepoPort,
 };
 use bcs_session::SessionManagementServiceImpl;
 use bcs_session_store::MemorySessionRepo;
 use serde_json::{Value, json};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 #[derive(Clone, Default)]
 struct SharedLogBuffer(Arc<std::sync::Mutex<Vec<u8>>>);
@@ -226,6 +229,7 @@ async fn single_node_run_completes_session_with_bot_final_text() {
         .await
         .expect("handle delta");
     assert!(delta.consumed);
+    wait_for_frontend_commands(&frontend_delivery, 2).await;
     let frontend_commands = frontend_delivery.commands.lock().await;
     assert_eq!(frontend_commands.len(), 2);
     let delta_event: Value =
@@ -281,6 +285,7 @@ async fn single_node_run_completes_session_with_bot_final_text() {
         .expect("handle final");
 
     assert!(handled.consumed);
+    wait_for_frontend_commands(&frontend_delivery, 3).await;
     let frontend_commands = frontend_delivery.commands.lock().await;
     assert_eq!(frontend_commands.len(), 3);
     assert!(matches!(
@@ -1118,6 +1123,353 @@ async fn complete_transitions_support_fan_out_and_implicit_all_join() {
 }
 
 #[tokio::test]
+async fn judged_node_final_is_acknowledged_before_judge_execution() {
+    let group = Arc::new(GroupStore::new());
+    group.upsert(test_group()).await.expect("seed group");
+    let sessions = test_sessions();
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let delivery = Arc::new(RecordingDelivery::default());
+    let judge = Arc::new(RecordingJudge::with_outcome("approved"));
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions,
+        delivery.clone(),
+        judge.clone(),
+    );
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: Some(judge_branch_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"question": "judge asynchronously"}),
+            caller_id: None,
+        })
+        .await
+        .expect("start run");
+    let review_run_id = delivery.commands.lock().await[0].run_id.clone();
+    let command = bcs_service_api::HandleBotTerminalEventCommand {
+        bot_id: "driver-bot".to_string(),
+        run_id: review_run_id,
+        event_type: "chat.event".to_string(),
+        event_payload: json!({
+            "state": "final",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "candidate final answer"}]
+            }
+        }),
+        state: ChatEventState::Final,
+        bcs_session_id: Some(started.view.run.session_id.clone()),
+    };
+
+    let handled = runtime
+        .handle_bot_terminal_event(command.clone())
+        .await
+        .expect("accept final");
+    let view = handled.view.expect("judging run view");
+    let review = view
+        .nodes
+        .iter()
+        .find(|node| node.node_id == "review")
+        .expect("review node");
+    assert_eq!(review.status, StateMachineNodeStatus::Judging);
+    assert_eq!(
+        review.artifact_text.as_deref(),
+        Some("candidate final answer")
+    );
+    assert!(judge.requests.lock().await.is_empty());
+
+    runtime
+        .handle_bot_terminal_event(command)
+        .await
+        .expect("accept duplicate final");
+    assert!(judge.requests.lock().await.is_empty());
+
+    assert_eq!(runtime.process_pending_judges(1, 30_000).await.unwrap(), 1);
+    assert_eq!(judge.requests.lock().await.len(), 1);
+    let view = runtime
+        .get_state_machine_run(&started.view.run.run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        view.nodes
+            .iter()
+            .find(|node| node.node_id == "review")
+            .unwrap()
+            .status,
+        StateMachineNodeStatus::Completed
+    );
+}
+
+#[tokio::test]
+async fn judged_node_final_does_not_wait_for_frontend_publication() {
+    let group = Arc::new(GroupStore::new());
+    group.upsert(test_group()).await.expect("seed group");
+    let sessions = test_sessions();
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let delivery = Arc::new(RecordingDelivery::default());
+    let frontend_delivery = Arc::new(BlockingFrontendDelivery::default());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions,
+        delivery.clone(),
+        Arc::new(RecordingJudge::with_outcome("approved")),
+    )
+    .with_frontend_delivery(frontend_delivery.clone());
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: Some(judge_branch_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"question": "judge asynchronously"}),
+            caller_id: None,
+        })
+        .await
+        .expect("start run");
+    let review_run_id = delivery.commands.lock().await[0].run_id.clone();
+    let handled = tokio::time::timeout(
+        Duration::from_secs(1),
+        runtime.handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
+            bot_id: "driver-bot".to_string(),
+            run_id: review_run_id,
+            event_type: "chat.event".to_string(),
+            event_payload: json!({
+                "state": "final",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "candidate final answer"}]
+                }
+            }),
+            state: ChatEventState::Final,
+            bcs_session_id: Some(started.view.run.session_id.clone()),
+        }),
+    )
+    .await
+    .expect("BaaS acknowledgement must not wait for frontend publication")
+    .expect("accept final");
+
+    let review = handled
+        .view
+        .expect("judging run view")
+        .nodes
+        .into_iter()
+        .find(|node| node.node_id == "review")
+        .expect("review node");
+    assert_eq!(review.status, StateMachineNodeStatus::Judging);
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        frontend_delivery.blocked_started.notified(),
+    )
+    .await
+    .expect("detached frontend publication should start");
+    frontend_delivery.release.notify_one();
+}
+
+#[tokio::test]
+async fn completed_judge_continuation_recovers_without_re_evaluating() {
+    let group = Arc::new(GroupStore::new());
+    group.upsert(test_group()).await.expect("seed group");
+    let sessions = test_sessions();
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let delivery = Arc::new(RecordingDelivery::default());
+    let judge = Arc::new(RecordingJudge::with_outcome("rejected"));
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        group,
+        sessions,
+        delivery.clone(),
+        judge.clone(),
+    );
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: Some(judge_branch_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"question": "recover judge continuation"}),
+            caller_id: None,
+        })
+        .await
+        .expect("start run");
+    let review_run_id = delivery.commands.lock().await[0].run_id.clone();
+    runtime
+        .handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
+            bot_id: "driver-bot".to_string(),
+            run_id: review_run_id,
+            event_type: "chat.event".to_string(),
+            event_payload: json!({
+                "state": "final",
+                "message": {
+                    "content": [{"type": "text", "text": "candidate"}]
+                }
+            }),
+            state: ChatEventState::Final,
+            bcs_session_id: Some(started.view.run.session_id.clone()),
+        })
+        .await
+        .expect("accept final");
+
+    let claimed_at = bcs_protocol::now_ms();
+    assert!(
+        store
+            .claim_judging_node(
+                &started.view.run.run_id,
+                "review",
+                0,
+                "crashed-worker",
+                claimed_at,
+                claimed_at.saturating_add(10),
+            )
+            .await
+            .unwrap()
+    );
+    let decision = JudgeDecision {
+        outcome: "approved".to_string(),
+        reason: "persisted before worker crash".to_string(),
+        confidence: 1.0,
+        checked_criteria: Vec::new(),
+        retry_instruction: String::new(),
+        raw_response: None,
+    };
+    assert!(
+        store
+            .persist_judging_node_decision(
+                &started.view.run.run_id,
+                "review",
+                0,
+                "crashed-worker",
+                serde_json::to_string(&decision).unwrap(),
+                claimed_at,
+            )
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .complete_judging_node_attempt(
+                &started.view.run.run_id,
+                "review",
+                0,
+                "crashed-worker",
+                claimed_at,
+            )
+            .await
+            .unwrap()
+    );
+
+    tokio::time::sleep(Duration::from_millis(15)).await;
+    assert_eq!(runtime.process_pending_judges(1, 1_000).await.unwrap(), 1);
+    assert!(judge.requests.lock().await.is_empty());
+    assert_eq!(delivery.commands.lock().await.len(), 2);
+    let view = runtime
+        .get_state_machine_run(&started.view.run.run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        view.nodes
+            .iter()
+            .find(|node| node.node_id == "review")
+            .unwrap()
+            .status,
+        StateMachineNodeStatus::Completed
+    );
+    assert_eq!(view.judge_outputs.len(), 1);
+    assert_eq!(view.judge_outputs[0].decision, decision);
+}
+
+#[tokio::test]
+async fn judging_node_is_failed_by_the_node_timeout_scanner() {
+    let group = Arc::new(GroupStore::new());
+    group.upsert(test_group()).await.expect("seed group");
+    let sessions = test_sessions();
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let delivery = Arc::new(RecordingDelivery::default());
+    let judge = Arc::new(RecordingJudge::with_outcome("approved"));
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions,
+        delivery.clone(),
+        judge.clone(),
+    );
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: Some(judge_timeout_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"question": "judge timeout scan"}),
+            caller_id: None,
+        })
+        .await
+        .expect("start run");
+    let review_run_id = delivery.commands.lock().await[0].run_id.clone();
+    runtime
+        .handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
+            bot_id: "driver-bot".to_string(),
+            run_id: review_run_id,
+            event_type: "chat.event".to_string(),
+            event_payload: json!({
+                "state": "final",
+                "message": {
+                    "content": [{"type": "text", "text": "candidate"}]
+                }
+            }),
+            state: ChatEventState::Final,
+            bcs_session_id: Some(started.view.run.session_id.clone()),
+        })
+        .await
+        .expect("accept final");
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    assert_eq!(
+        runtime.process_expired_node_timeouts(10, 0).await.unwrap(),
+        1
+    );
+    assert!(judge.requests.lock().await.is_empty());
+    let view = runtime
+        .get_state_machine_run(&started.view.run.run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(view.run.status, StateMachineRunStatus::Failed);
+    assert_eq!(
+        view.nodes
+            .iter()
+            .find(|node| node.node_id == "review")
+            .unwrap()
+            .status,
+        StateMachineNodeStatus::Failed
+    );
+}
+
+#[tokio::test]
 async fn judged_node_routes_selected_outcome_and_skips_unselected_branch() {
     let group = Arc::new(GroupStore::new());
     group.upsert(test_group()).await.expect("seed group");
@@ -1242,6 +1594,7 @@ async fn judged_node_publishes_bot_output_but_not_judge_message_to_workbench() {
     )
     .await;
 
+    wait_for_frontend_commands(&frontend_delivery, 2).await;
     let frontend_commands = frontend_delivery.commands.lock().await;
     assert_eq!(frontend_commands.len(), 2);
     let panel_event: Value =
@@ -1648,6 +2001,32 @@ impl FrontendDeliveryPort for RecordingFrontendDelivery {
     }
 }
 
+#[derive(Default)]
+struct BlockingFrontendDelivery {
+    calls: AtomicUsize,
+    blocked_started: Notify,
+    release: Notify,
+}
+
+#[async_trait]
+impl FrontendDeliveryPort for BlockingFrontendDelivery {
+    async fn publish(&self, cmd: FrontendDeliveryCommand) -> ServiceResult<FrontendDeliveryResult> {
+        let target = cmd.target;
+        if self.calls.fetch_add(1, Ordering::SeqCst) > 0 {
+            self.blocked_started.notify_one();
+            self.release.notified().await;
+        }
+        Ok(FrontendDeliveryResult {
+            target,
+            delivered: 1,
+        })
+    }
+
+    async fn unregister_run(&self, _run_id: &str) -> ServiceResult<()> {
+        Ok(())
+    }
+}
+
 fn chat_send_params(command: &BotDeliveryCommand) -> ChatSendParams {
     match &command.frame {
         BcsFrame::Request(request) => {
@@ -1767,7 +2146,11 @@ async fn complete_with_text(
     session_id: &str,
     text: &str,
 ) -> bcs_service_api::HandleBotTerminalEventOutcome {
-    runtime
+    let correlation = runtime
+        .lookup_delivery_correlation(delivery_run_id)
+        .await
+        .expect("lookup delivery correlation");
+    let mut outcome = runtime
         .handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
             bot_id: "driver-bot".to_string(),
             run_id: delivery_run_id.to_string(),
@@ -1785,7 +2168,31 @@ async fn complete_with_text(
             bcs_session_id: Some(session_id.to_string()),
         })
         .await
-        .expect("handle final")
+        .expect("handle final");
+    runtime
+        .process_pending_judges(4, 30_000)
+        .await
+        .expect("process pending judges");
+    if let Some(correlation) = correlation {
+        outcome.view = runtime
+            .get_state_machine_run(&correlation.state_machine_run_id)
+            .await
+            .expect("get state machine run after judge");
+    }
+    outcome
+}
+
+async fn wait_for_frontend_commands(
+    frontend_delivery: &Arc<RecordingFrontendDelivery>,
+    expected: usize,
+) {
+    for _ in 0..100 {
+        if frontend_delivery.commands.lock().await.len() >= expected {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    panic!("frontend command count did not reach {expected}");
 }
 
 async fn wait_for_callback_status(

--- a/src/bcs/crates/services/bcs-collaboration-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-collaboration-store/src/lib.rs
@@ -39,9 +39,24 @@ struct StoreInner {
     bindings: BTreeMap<String, GroupRuntimeBinding>,
     runs: BTreeMap<String, StateMachineRun>,
     nodes: BTreeMap<(String, String), StateMachineNodeRun>,
+    judge_claims: BTreeMap<(String, String), JudgeClaim>,
+    judge_decisions: BTreeMap<(String, String), JudgeDecisionRecord>,
     correlations: BTreeMap<String, StateMachineDeliveryCorrelation>,
     correlation_aliases: BTreeMap<String, String>,
     events: Vec<CollaborationEventRecord>,
+}
+
+#[derive(Debug, Clone)]
+struct JudgeClaim {
+    attempt: i32,
+    token: String,
+    lease_until_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+struct JudgeDecisionRecord {
+    attempt: i32,
+    decision_json: String,
 }
 
 #[derive(Debug, Clone)]
@@ -355,6 +370,12 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
         node.timeout_deadline_ms = node
             .node_timeout_ms
             .map(|timeout_ms| started_at.saturating_add(timeout_ms));
+        inner
+            .judge_claims
+            .remove(&(run_id.to_string(), node_id.to_string()));
+        inner
+            .judge_decisions
+            .remove(&(run_id.to_string(), node_id.to_string()));
         Ok(())
     }
 
@@ -389,6 +410,301 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
         node.timeout_deadline_ms = node
             .node_timeout_ms
             .map(|timeout_ms| started_at.saturating_add(timeout_ms));
+        inner
+            .judge_claims
+            .remove(&(run_id.to_string(), node_id.to_string()));
+        inner
+            .judge_decisions
+            .remove(&(run_id.to_string(), node_id.to_string()));
+        Ok(true)
+    }
+
+    async fn mark_node_judging(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        artifact_text: String,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        if !run_is_running(&inner, run_id)? {
+            return Ok(false);
+        }
+        let node = node_mut(&mut inner, run_id, node_id)?;
+        if node.status != StateMachineNodeStatus::Running || node.attempt != attempt {
+            return Ok(false);
+        }
+        node.status = StateMachineNodeStatus::Judging;
+        node.artifact_text = Some(artifact_text);
+        node.error = None;
+        node.completed_at = None;
+        inner
+            .judge_claims
+            .remove(&(run_id.to_string(), node_id.to_string()));
+        inner
+            .judge_decisions
+            .remove(&(run_id.to_string(), node_id.to_string()));
+        Ok(true)
+    }
+
+    async fn list_claimable_judging_node_runs(
+        &self,
+        now_ms: u64,
+        limit: usize,
+    ) -> ServiceResult<Vec<StateMachineNodeRun>> {
+        let inner = self.inner.read().await;
+        let mut nodes = inner
+            .nodes
+            .values()
+            .filter(|node| {
+                let key = (node.run_id.clone(), node.node_id.clone());
+                let claim = inner.judge_claims.get(&key);
+                (node.status == StateMachineNodeStatus::Judging
+                    || node.status == StateMachineNodeStatus::Completed && claim.is_some())
+                    && inner
+                        .judge_claims
+                        .get(&key)
+                        .is_none_or(|claim| claim.lease_until_ms <= now_ms)
+                    && inner
+                        .runs
+                        .get(&node.run_id)
+                        .is_some_and(|run| run.status == StateMachineRunStatus::Running)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        nodes.sort_by(|left, right| {
+            left.started_at
+                .cmp(&right.started_at)
+                .then_with(|| left.run_id.cmp(&right.run_id))
+                .then_with(|| left.node_id.cmp(&right.node_id))
+        });
+        nodes.truncate(limit);
+        Ok(nodes)
+    }
+
+    async fn claim_judging_node(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        now_ms: u64,
+        lease_until_ms: u64,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        if !run_is_running(&inner, run_id)? {
+            return Ok(false);
+        }
+        let key = (run_id.to_string(), node_id.to_string());
+        let node = inner.nodes.get(&key).ok_or_else(|| {
+            ServiceError::InternalError(format!("state machine node not found: {run_id}/{node_id}"))
+        })?;
+        if !matches!(
+            node.status,
+            StateMachineNodeStatus::Judging | StateMachineNodeStatus::Completed
+        ) || node.attempt != attempt
+        {
+            return Ok(false);
+        }
+        if inner
+            .judge_claims
+            .get(&key)
+            .is_some_and(|claim| claim.lease_until_ms > now_ms)
+        {
+            return Ok(false);
+        }
+        inner.judge_claims.insert(
+            key,
+            JudgeClaim {
+                attempt,
+                token: claim_token.to_string(),
+                lease_until_ms,
+            },
+        );
+        Ok(true)
+    }
+
+    async fn renew_judging_node_claim(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        lease_until_ms: u64,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        let key = (run_id.to_string(), node_id.to_string());
+        let node_matches = inner.nodes.get(&key).is_some_and(|node| {
+            matches!(
+                node.status,
+                StateMachineNodeStatus::Judging | StateMachineNodeStatus::Completed
+            ) && node.attempt == attempt
+        });
+        let Some(claim) = inner.judge_claims.get_mut(&key) else {
+            return Ok(false);
+        };
+        if !node_matches || claim.attempt != attempt || claim.token != claim_token {
+            return Ok(false);
+        }
+        claim.lease_until_ms = lease_until_ms;
+        Ok(true)
+    }
+
+    async fn get_judging_node_decision(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+    ) -> ServiceResult<Option<String>> {
+        let inner = self.inner.read().await;
+        let key = (run_id.to_string(), node_id.to_string());
+        let Some(node) = inner.nodes.get(&key) else {
+            return Err(ServiceError::InternalError(format!(
+                "state machine node not found: {run_id}/{node_id}"
+            )));
+        };
+        if node.attempt != attempt {
+            return Ok(None);
+        }
+        Ok(inner
+            .judge_decisions
+            .get(&key)
+            .filter(|decision| decision.attempt == attempt)
+            .map(|decision| decision.decision_json.clone()))
+    }
+
+    async fn persist_judging_node_decision(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        decision_json: String,
+        now_ms: u64,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        if !run_is_running(&inner, run_id)? {
+            return Ok(false);
+        }
+        let key = (run_id.to_string(), node_id.to_string());
+        let node_matches = inner.nodes.get(&key).is_some_and(|node| {
+            node.status == StateMachineNodeStatus::Judging && node.attempt == attempt
+        });
+        let claim_matches = inner.judge_claims.get(&key).is_some_and(|claim| {
+            claim.attempt == attempt && claim.token == claim_token && claim.lease_until_ms > now_ms
+        });
+        if !node_matches || !claim_matches || inner.judge_decisions.contains_key(&key) {
+            return Ok(false);
+        }
+        inner.judge_decisions.insert(
+            key,
+            JudgeDecisionRecord {
+                attempt,
+                decision_json,
+            },
+        );
+        Ok(true)
+    }
+
+    async fn complete_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        completed_at: u64,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        if !run_is_running(&inner, run_id)? {
+            return Ok(false);
+        }
+        let key = (run_id.to_string(), node_id.to_string());
+        let claim_matches = inner
+            .judge_claims
+            .get(&key)
+            .is_some_and(|claim| claim.attempt == attempt && claim.token == claim_token);
+        let decision_matches = inner
+            .judge_decisions
+            .get(&key)
+            .is_some_and(|decision| decision.attempt == attempt);
+        let Some(node) = inner.nodes.get_mut(&key) else {
+            return Err(ServiceError::InternalError(format!(
+                "state machine node not found: {run_id}/{node_id}"
+            )));
+        };
+        if !claim_matches
+            || !decision_matches
+            || node.status != StateMachineNodeStatus::Judging
+            || node.attempt != attempt
+        {
+            return Ok(false);
+        }
+        node.status = StateMachineNodeStatus::Completed;
+        node.error = None;
+        node.completed_at = Some(completed_at);
+        node.timeout_deadline_ms = None;
+        Ok(true)
+    }
+
+    async fn fail_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        error: String,
+        completed_at: u64,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        if !run_is_running(&inner, run_id)? {
+            return Ok(false);
+        }
+        let key = (run_id.to_string(), node_id.to_string());
+        let claim_matches = inner
+            .judge_claims
+            .get(&key)
+            .is_some_and(|claim| claim.attempt == attempt && claim.token == claim_token);
+        let Some(node) = inner.nodes.get_mut(&key) else {
+            return Err(ServiceError::InternalError(format!(
+                "state machine node not found: {run_id}/{node_id}"
+            )));
+        };
+        if !claim_matches
+            || node.status != StateMachineNodeStatus::Judging
+            || node.attempt != attempt
+        {
+            return Ok(false);
+        }
+        node.status = StateMachineNodeStatus::Failed;
+        node.error = Some(error);
+        node.completed_at = Some(completed_at);
+        node.timeout_deadline_ms = None;
+        inner.judge_claims.remove(&key);
+        inner.judge_decisions.remove(&key);
+        Ok(true)
+    }
+
+    async fn finish_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        let key = (run_id.to_string(), node_id.to_string());
+        let node_matches = inner.nodes.get(&key).is_some_and(|node| {
+            node.status == StateMachineNodeStatus::Completed && node.attempt == attempt
+        });
+        let claim_matches = inner
+            .judge_claims
+            .get(&key)
+            .is_some_and(|claim| claim.attempt == attempt && claim.token == claim_token);
+        if !node_matches || !claim_matches {
+            return Ok(false);
+        }
+        inner.judge_claims.remove(&key);
+        inner.judge_decisions.remove(&key);
         Ok(true)
     }
 
@@ -412,6 +728,7 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
         node.artifact_text = Some(artifact_text);
         node.error = None;
         node.completed_at = Some(completed_at);
+        node.timeout_deadline_ms = None;
         Ok(true)
     }
 
@@ -428,12 +745,23 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
             return Ok(false);
         }
         let node = node_mut(&mut inner, run_id, node_id)?;
-        if node.status != StateMachineNodeStatus::Running || node.attempt != attempt {
+        if !matches!(
+            node.status,
+            StateMachineNodeStatus::Running | StateMachineNodeStatus::Judging
+        ) || node.attempt != attempt
+        {
             return Ok(false);
         }
         node.status = StateMachineNodeStatus::Failed;
         node.error = Some(error);
         node.completed_at = Some(completed_at);
+        node.timeout_deadline_ms = None;
+        inner
+            .judge_claims
+            .remove(&(run_id.to_string(), node_id.to_string()));
+        inner
+            .judge_decisions
+            .remove(&(run_id.to_string(), node_id.to_string()));
         Ok(true)
     }
 
@@ -461,6 +789,12 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
         node.started_at = None;
         node.completed_at = None;
         node.timeout_deadline_ms = None;
+        inner
+            .judge_claims
+            .remove(&(run_id.to_string(), node_id.to_string()));
+        inner
+            .judge_decisions
+            .remove(&(run_id.to_string(), node_id.to_string()));
         Ok(true)
     }
 
@@ -556,7 +890,7 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
         Ok(inner.correlations.get(primary_key).cloned())
     }
 
-    async fn list_expired_running_node_runs(
+    async fn list_expired_active_node_runs(
         &self,
         now_ms: u64,
         timeout_grace_ms: u64,
@@ -567,10 +901,12 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
             .nodes
             .values()
             .filter(|node| {
-                node.status == StateMachineNodeStatus::Running
-                    && node.timeout_deadline_ms.is_some_and(|deadline| {
-                        deadline.saturating_add(timeout_grace_ms) <= now_ms
-                    })
+                matches!(
+                    node.status,
+                    StateMachineNodeStatus::Running | StateMachineNodeStatus::Judging
+                ) && node
+                    .timeout_deadline_ms
+                    .is_some_and(|deadline| deadline.saturating_add(timeout_grace_ms) <= now_ms)
                     && inner
                         .runs
                         .get(&node.run_id)
@@ -1375,6 +1711,8 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
             "UPDATE bcs_state_machine_node_runs \
              SET status = 'running', attempt = ?, delivery_request_id = ?, \
                  bot_delivery_run_id = NULL, artifact_text = NULL, \
+                 judge_claim_token = NULL, judge_lease_until_ms = NULL, \
+                 judge_decision_json = NULL, \
                  error_message = NULL, started_at_ms = ?, completed_at_ms = NULL, \
                  timeout_deadline_ms = CASE \
                    WHEN node_timeout_ms IS NULL THEN NULL \
@@ -1416,6 +1754,8 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                 "UPDATE bcs_state_machine_node_runs n \
                  SET n.status = 'running', n.delivery_request_id = ?, \
                      n.bot_delivery_run_id = NULL, n.artifact_text = NULL, \
+                     n.judge_claim_token = NULL, n.judge_lease_until_ms = NULL, \
+                     n.judge_decision_json = NULL, \
                      n.error_message = NULL, n.started_at_ms = ?, n.completed_at_ms = NULL, \
                      n.timeout_deadline_ms = CASE \
                        WHEN n.node_timeout_ms IS NULL THEN NULL \
@@ -1436,6 +1776,8 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                 "UPDATE bcs_state_machine_node_runs \
                  SET status = 'running', delivery_request_id = ?, \
                      bot_delivery_run_id = NULL, artifact_text = NULL, \
+                     judge_claim_token = NULL, judge_lease_until_ms = NULL, \
+                     judge_decision_json = NULL, \
                      error_message = NULL, started_at_ms = ?, completed_at_ms = NULL, \
                      timeout_deadline_ms = CASE \
                        WHEN node_timeout_ms IS NULL THEN NULL \
@@ -1472,18 +1814,18 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
         Ok(result.affected_rows > 0)
     }
 
-    async fn complete_node_attempt(
+    async fn mark_node_judging(
         &self,
         run_id: &str,
         node_id: &str,
         attempt: i32,
         artifact_text: String,
-        completed_at: u64,
     ) -> ServiceResult<bool> {
         let sql = format!(
             "UPDATE bcs_state_machine_node_runs \
-             SET status = 'completed', artifact_text = ?, error_message = NULL, \
-                 completed_at_ms = ?, timeout_deadline_ms = NULL, {} \
+             SET status = 'judging', artifact_text = ?, error_message = NULL, \
+                 completed_at_ms = NULL, judge_claim_token = NULL, \
+                 judge_lease_until_ms = NULL, judge_decision_json = NULL, {} \
              WHERE env = ? AND run_id = ? AND node_id = ? \
                AND attempt = ? AND status = 'running' \
                AND record_status = 'active' \
@@ -1500,6 +1842,367 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                 sql,
                 vec![
                     DbValue::from(artifact_text),
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!("state machine node mark judging: {error}"))
+            })?;
+        Ok(result.affected_rows > 0)
+    }
+
+    async fn list_claimable_judging_node_runs(
+        &self,
+        now_ms: u64,
+        limit: usize,
+    ) -> ServiceResult<Vec<StateMachineNodeRun>> {
+        let sql = "SELECT n.run_id, n.node_id, n.status, n.attempt, n.node_timeout_ms, \
+                    n.timeout_deadline_ms, n.max_attempts, n.assignee_bot_id, \
+                    n.delivery_request_id, n.bot_delivery_run_id, n.artifact_text, \
+                    n.error_message, n.started_at_ms, n.completed_at_ms \
+             FROM bcs_state_machine_node_runs n \
+             INNER JOIN bcs_state_machine_runs r \
+               ON r.env = n.env AND r.run_id = n.run_id \
+             WHERE n.env = ? \
+               AND (n.status = 'judging' OR \
+                    (n.status = 'completed' AND n.judge_claim_token IS NOT NULL)) \
+               AND (n.judge_lease_until_ms IS NULL OR n.judge_lease_until_ms <= ?) \
+               AND n.record_status = 'active' \
+               AND r.status = 'running' AND r.record_status = 'active' \
+             ORDER BY n.started_at_ms ASC, n.run_id ASC, n.node_id ASC \
+             LIMIT ?";
+        let rows = self
+            .db
+            .query(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(now_ms),
+                    DbValue::from(limit as u64),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!("claimable judging node list: {error}"))
+            })?;
+        rows.into_iter()
+            .map(row_to_state_machine_node_run)
+            .collect()
+    }
+
+    async fn claim_judging_node(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        now_ms: u64,
+        lease_until_ms: u64,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET judge_claim_token = ?, judge_lease_until_ms = ?, {} \
+             WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status IN ('judging', 'completed') \
+               AND (judge_lease_until_ms IS NULL OR judge_lease_until_ms <= ?) \
+               AND record_status = 'active' \
+               AND EXISTS ( \
+                 SELECT 1 FROM bcs_state_machine_runs r \
+                 WHERE r.env = bcs_state_machine_node_runs.env \
+                   AND r.run_id = bcs_state_machine_node_runs.run_id \
+                   AND r.status = 'running' AND r.record_status = 'active' \
+               )",
+            self.flavor.set_modified_now()
+        );
+        let result = self.db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(claim_token),
+                    DbValue::from(lease_until_ms),
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                    DbValue::from(now_ms),
+                ],
+            ))
+            .await
+            .map_err(|error| ServiceError::InternalError(format!("judging node claim: {error}")))?;
+        Ok(result.affected_rows > 0)
+    }
+
+    async fn renew_judging_node_claim(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        lease_until_ms: u64,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET judge_lease_until_ms = ?, {} \
+             WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status IN ('judging', 'completed') \
+               AND judge_claim_token = ? AND record_status = 'active'",
+            self.flavor.set_modified_now()
+        );
+        let result = self
+            .db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(lease_until_ms),
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                    DbValue::from(claim_token),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!("judging node claim renew: {error}"))
+            })?;
+        Ok(result.affected_rows > 0)
+    }
+
+    async fn get_judging_node_decision(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+    ) -> ServiceResult<Option<String>> {
+        let rows = self
+            .db
+            .query(DbStatement::with_params(
+                "SELECT judge_decision_json FROM bcs_state_machine_node_runs \
+                 WHERE env = ? AND run_id = ? AND node_id = ? AND attempt = ? \
+                   AND status IN ('judging', 'completed') AND record_status = 'active' \
+                 LIMIT 1",
+                vec![
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!("judging node decision get: {error}"))
+            })?;
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(None);
+        };
+        row.get_string("judge_decision_json").map_err(|error| {
+            ServiceError::InternalError(format!("judging node decision decode: {error}"))
+        })
+    }
+
+    async fn persist_judging_node_decision(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        decision_json: String,
+        now_ms: u64,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET judge_decision_json = ?, {} \
+             WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status = 'judging' \
+               AND judge_claim_token = ? AND judge_lease_until_ms > ? \
+               AND judge_decision_json IS NULL AND record_status = 'active' \
+               AND EXISTS ( \
+                 SELECT 1 FROM bcs_state_machine_runs r \
+                 WHERE r.env = bcs_state_machine_node_runs.env \
+                   AND r.run_id = bcs_state_machine_node_runs.run_id \
+                   AND r.status = 'running' AND r.record_status = 'active' \
+               )",
+            self.flavor.set_modified_now()
+        );
+        let result = self
+            .db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(decision_json),
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                    DbValue::from(claim_token),
+                    DbValue::from(now_ms),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!("judging node decision persist: {error}"))
+            })?;
+        Ok(result.affected_rows > 0)
+    }
+
+    async fn complete_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        completed_at: u64,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET status = 'completed', error_message = NULL, completed_at_ms = ?, \
+                 timeout_deadline_ms = NULL, {} \
+             WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status = 'judging' AND judge_claim_token = ? \
+               AND judge_decision_json IS NOT NULL \
+               AND record_status = 'active' \
+               AND EXISTS ( \
+                 SELECT 1 FROM bcs_state_machine_runs r \
+                 WHERE r.env = bcs_state_machine_node_runs.env \
+                   AND r.run_id = bcs_state_machine_node_runs.run_id \
+                   AND r.status = 'running' AND r.record_status = 'active' \
+               )",
+            self.flavor.set_modified_now()
+        );
+        let result = self
+            .db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(completed_at),
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                    DbValue::from(claim_token),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!("judging node complete: {error}"))
+            })?;
+        Ok(result.affected_rows > 0)
+    }
+
+    async fn fail_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+        error: String,
+        completed_at: u64,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET status = 'failed', error_message = ?, completed_at_ms = ?, \
+                 timeout_deadline_ms = NULL, judge_claim_token = NULL, \
+                 judge_lease_until_ms = NULL, judge_decision_json = NULL, {} \
+             WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status = 'judging' AND judge_claim_token = ? \
+               AND record_status = 'active' \
+               AND EXISTS ( \
+                 SELECT 1 FROM bcs_state_machine_runs r \
+                 WHERE r.env = bcs_state_machine_node_runs.env \
+                   AND r.run_id = bcs_state_machine_node_runs.run_id \
+                   AND r.status = 'running' AND r.record_status = 'active' \
+               )",
+            self.flavor.set_modified_now()
+        );
+        let result = self
+            .db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(error),
+                    DbValue::from(completed_at),
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                    DbValue::from(claim_token),
+                ],
+            ))
+            .await
+            .map_err(|error| ServiceError::InternalError(format!("judging node fail: {error}")))?;
+        Ok(result.affected_rows > 0)
+    }
+
+    async fn finish_judging_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        claim_token: &str,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET judge_claim_token = NULL, judge_lease_until_ms = NULL, \
+                 judge_decision_json = NULL, {} \
+                 WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status = 'completed' \
+               AND judge_claim_token = ? AND record_status = 'active'",
+            self.flavor.set_modified_now()
+        );
+        let result = self
+            .db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                    DbValue::from(claim_token),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!("judging node finish: {error}"))
+            })?;
+        Ok(result.affected_rows > 0)
+    }
+
+    async fn complete_node_attempt(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        artifact_text: String,
+        completed_at: u64,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET status = 'completed', artifact_text = ?, error_message = NULL, \
+                 completed_at_ms = ?, timeout_deadline_ms = NULL, \
+                 judge_claim_token = NULL, judge_lease_until_ms = NULL, \
+                 judge_decision_json = NULL, {} \
+             WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status = 'running' \
+               AND record_status = 'active' \
+               AND EXISTS ( \
+                 SELECT 1 FROM bcs_state_machine_runs r \
+                 WHERE r.env = bcs_state_machine_node_runs.env \
+                   AND r.run_id = bcs_state_machine_node_runs.run_id \
+                   AND r.status = 'running' AND r.record_status = 'active' \
+               )",
+            self.flavor.set_modified_now()
+        );
+        let result = self
+            .db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(artifact_text),
                     DbValue::from(completed_at),
                     DbValue::from(self.env.as_str()),
                     DbValue::from(run_id),
@@ -1508,7 +2211,9 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                 ],
             ))
             .await
-            .map_err(|error| ServiceError::InternalError(format!("state machine node complete: {error}")))?;
+            .map_err(|error| {
+                ServiceError::InternalError(format!("state machine node complete: {error}"))
+            })?;
         Ok(result.affected_rows > 0)
     }
 
@@ -1523,9 +2228,10 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
         let sql = format!(
             "UPDATE bcs_state_machine_node_runs \
              SET status = 'failed', error_message = ?, completed_at_ms = ?, \
-                 timeout_deadline_ms = NULL, {} \
+                 timeout_deadline_ms = NULL, judge_claim_token = NULL, \
+                 judge_lease_until_ms = NULL, judge_decision_json = NULL, {} \
              WHERE env = ? AND run_id = ? AND node_id = ? \
-               AND attempt = ? AND status = 'running' \
+               AND attempt = ? AND status IN ('running', 'judging') \
                AND record_status = 'active' \
                AND EXISTS ( \
                  SELECT 1 FROM bcs_state_machine_runs r \
@@ -1535,7 +2241,8 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                )",
             self.flavor.set_modified_now()
         );
-        let result = self.db
+        let result = self
+            .db
             .execute(DbStatement::with_params(
                 sql,
                 vec![
@@ -1548,7 +2255,9 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                 ],
             ))
             .await
-            .map_err(|error| ServiceError::InternalError(format!("state machine node fail: {error}")))?;
+            .map_err(|error| {
+                ServiceError::InternalError(format!("state machine node fail: {error}"))
+            })?;
         Ok(result.affected_rows > 0)
     }
 
@@ -1565,6 +2274,8 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                  delivery_request_id = NULL, bot_delivery_run_id = NULL, \
                  artifact_text = NULL, error_message = NULL, started_at_ms = NULL, \
                  completed_at_ms = NULL, timeout_deadline_ms = NULL, \
+                 judge_claim_token = NULL, judge_lease_until_ms = NULL, \
+                 judge_decision_json = NULL, \
                  {} \
              WHERE env = ? AND run_id = ? AND node_id = ? \
                AND attempt = ? AND status = 'failed' \
@@ -1809,7 +2520,7 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
         rows.into_iter().next().map(row_to_delivery_correlation).transpose()
     }
 
-    async fn list_expired_running_node_runs(
+    async fn list_expired_active_node_runs(
         &self,
         now_ms: u64,
         timeout_grace_ms: u64,
@@ -1822,7 +2533,7 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                    FROM bcs_state_machine_node_runs n \
                    INNER JOIN bcs_state_machine_runs r \
                      ON r.env = n.env AND r.run_id = n.run_id \
-                   WHERE n.env = ? AND n.status = 'running' \
+                   WHERE n.env = ? AND n.status IN ('running', 'judging') \
                      AND n.timeout_deadline_ms IS NOT NULL \
                      AND n.timeout_deadline_ms + ? <= ? \
                      AND n.record_status = 'active' \
@@ -2381,6 +3092,7 @@ fn node_status_to_str(status: StateMachineNodeStatus) -> &'static str {
         StateMachineNodeStatus::Pending => "pending",
         StateMachineNodeStatus::Ready => "ready",
         StateMachineNodeStatus::Running => "running",
+        StateMachineNodeStatus::Judging => "judging",
         StateMachineNodeStatus::Completed => "completed",
         StateMachineNodeStatus::Failed => "failed",
         StateMachineNodeStatus::RetryScheduled => "retry_scheduled",
@@ -2393,6 +3105,7 @@ fn parse_node_status(value: &str) -> ServiceResult<StateMachineNodeStatus> {
         "pending" => Ok(StateMachineNodeStatus::Pending),
         "ready" => Ok(StateMachineNodeStatus::Ready),
         "running" => Ok(StateMachineNodeStatus::Running),
+        "judging" => Ok(StateMachineNodeStatus::Judging),
         "completed" => Ok(StateMachineNodeStatus::Completed),
         "failed" => Ok(StateMachineNodeStatus::Failed),
         "retry_scheduled" => Ok(StateMachineNodeStatus::RetryScheduled),
@@ -2527,6 +3240,9 @@ mod tests {
                 delivery_request_id TEXT DEFAULT NULL,
                 bot_delivery_run_id TEXT DEFAULT NULL,
                 artifact_text TEXT DEFAULT NULL,
+                judge_claim_token TEXT DEFAULT NULL,
+                judge_lease_until_ms INTEGER DEFAULT NULL,
+                judge_decision_json TEXT DEFAULT NULL,
                 error_message TEXT DEFAULT NULL,
                 started_at_ms INTEGER DEFAULT NULL,
                 completed_at_ms INTEGER DEFAULT NULL,
@@ -2798,7 +3514,7 @@ runtime:
         store.create_run(run.clone(), vec![node]).await.unwrap();
 
         let expired = store
-            .list_expired_running_node_runs(700, 500, 10)
+            .list_expired_active_node_runs(700, 500, 10)
             .await
             .unwrap();
         assert_eq!(expired.len(), 1);
@@ -2825,9 +3541,182 @@ runtime:
             .await
             .unwrap());
         let expired_after_terminal = store
-            .list_expired_running_node_runs(900, 500, 10)
+            .list_expired_active_node_runs(900, 500, 10)
             .await
             .unwrap();
         assert!(expired_after_terminal.is_empty());
+    }
+
+    #[tokio::test]
+    async fn memory_store_claims_and_recovers_judging_nodes() {
+        let store = MemoryCollaborationStore::new();
+        let run = StateMachineRun {
+            run_id: "run-judge".to_string(),
+            definition_id: "def".to_string(),
+            definition_version: 1,
+            group_id: "group".to_string(),
+            group_version: 1,
+            session_id: "session".to_string(),
+            created_by: None,
+            status: StateMachineRunStatus::Running,
+            input: serde_json::Value::Null,
+            output: None,
+            error: None,
+            created_at: 1,
+            updated_at: 1,
+            completed_at: None,
+        };
+        let node = StateMachineNodeRun {
+            run_id: run.run_id.clone(),
+            node_id: "review".to_string(),
+            status: StateMachineNodeStatus::Running,
+            attempt: 0,
+            node_timeout_ms: Some(60_000),
+            timeout_deadline_ms: Some(60_000),
+            max_attempts: 1,
+            assignee_bot_id: "bot-a".to_string(),
+            delivery_request_id: Some("delivery-a".to_string()),
+            bot_delivery_run_id: None,
+            artifact_text: None,
+            error: None,
+            started_at: Some(0),
+            completed_at: None,
+        };
+        store.create_run(run, vec![node]).await.unwrap();
+
+        assert!(
+            store
+                .mark_node_judging("run-judge", "review", 0, "candidate artifact".to_string())
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            store
+                .list_claimable_judging_node_runs(100, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            store
+                .claim_judging_node("run-judge", "review", 0, "claim-a", 100, 1_000)
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .list_claimable_judging_node_runs(999, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            !store
+                .complete_judging_node_attempt("run-judge", "review", 0, "stale", 1_000)
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .claim_judging_node("run-judge", "review", 0, "claim-b", 1_000, 2_000)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .complete_judging_node_attempt("run-judge", "review", 0, "claim-a", 1_100)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .persist_judging_node_decision(
+                    "run-judge",
+                    "review",
+                    0,
+                    "claim-a",
+                    r#"{"outcome":"rejected"}"#.to_string(),
+                    1_100,
+                )
+                .await
+                .unwrap()
+        );
+        let decision_json = r#"{"outcome":"approved"}"#.to_string();
+        assert!(
+            store
+                .persist_judging_node_decision(
+                    "run-judge",
+                    "review",
+                    0,
+                    "claim-b",
+                    decision_json.clone(),
+                    1_100,
+                )
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            store
+                .get_judging_node_decision("run-judge", "review", 0)
+                .await
+                .unwrap(),
+            Some(decision_json)
+        );
+        assert!(
+            store
+                .complete_judging_node_attempt("run-judge", "review", 0, "claim-b", 1_200)
+                .await
+                .unwrap()
+        );
+
+        let node = store
+            .get_node_run("run-judge", "review")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(node.status, StateMachineNodeStatus::Completed);
+        assert_eq!(node.artifact_text.as_deref(), Some("candidate artifact"));
+        assert_eq!(node.timeout_deadline_ms, None);
+        assert!(
+            store
+                .list_claimable_judging_node_runs(1_999, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            store
+                .list_claimable_judging_node_runs(2_000, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            store
+                .claim_judging_node("run-judge", "review", 0, "claim-c", 2_000, 3_000)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .finish_judging_node_attempt("run-judge", "review", 0, "claim-b")
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .finish_judging_node_attempt("run-judge", "review", 0, "claim-c")
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .list_claimable_judging_node_runs(3_000, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/bcs/crates/services/bcs-collaboration-store/tests/mysql_store.rs
+++ b/src/bcs/crates/services/bcs-collaboration-store/tests/mysql_store.rs
@@ -374,6 +374,84 @@ async fn mysql_runtime_node_and_run_updates_use_cas_sql() {
 }
 
 #[tokio::test]
+async fn mysql_runtime_judging_claims_use_lease_protected_cas_sql() {
+    let node = test_node();
+    let db = Arc::new(RecordingDb {
+        runtime_node_rows: Mutex::new(vec![node_row(&node)]),
+        ..RecordingDb::default()
+    });
+    let store = MySqlCollaborationStore::new(db.clone(), "dev".to_string());
+
+    assert!(
+        store
+            .mark_node_judging("sm-run-1", "answer", 1, "candidate".to_string())
+            .await
+            .expect("mark judging")
+    );
+    let candidates = store
+        .list_claimable_judging_node_runs(1_000, 4)
+        .await
+        .expect("list judging nodes");
+    assert_eq!(candidates.len(), 1);
+    assert!(
+        store
+            .claim_judging_node("sm-run-1", "answer", 1, "claim-1", 1_000, 31_000)
+            .await
+            .expect("claim judging node")
+    );
+    assert!(
+        store
+            .renew_judging_node_claim("sm-run-1", "answer", 1, "claim-1", 41_000)
+            .await
+            .expect("renew judging claim")
+    );
+    assert!(
+        store
+            .persist_judging_node_decision(
+                "sm-run-1",
+                "answer",
+                1,
+                "claim-1",
+                r#"{"outcome":"approved"}"#.to_string(),
+                1_500,
+            )
+            .await
+            .expect("persist judging decision")
+    );
+    assert!(
+        store
+            .complete_judging_node_attempt("sm-run-1", "answer", 1, "claim-1", 2_000)
+            .await
+            .expect("complete judging node")
+    );
+    assert!(
+        store
+            .finish_judging_node_attempt("sm-run-1", "answer", 1, "claim-1")
+            .await
+            .expect("finish judging node")
+    );
+
+    let queries = db.queries.lock().await;
+    assert!(queries[0].sql().contains("n.status = 'judging'"));
+    assert!(queries[0].sql().contains("n.judge_lease_until_ms <= ?"));
+    let executes = db.executes.lock().await;
+    assert!(executes[0].sql().contains("SET status = 'judging'"));
+    assert!(executes[1].sql().contains("judge_claim_token = ?"));
+    assert!(executes[1].sql().contains("judge_lease_until_ms <= ?"));
+    assert!(executes[2].sql().contains("judge_claim_token = ?"));
+    assert!(executes[3].sql().contains("judge_decision_json = ?"));
+    assert!(executes[3].sql().contains("judge_lease_until_ms > ?"));
+    assert!(executes[4].sql().contains("status = 'completed'"));
+    assert!(
+        executes[4]
+            .sql()
+            .contains("judge_decision_json IS NOT NULL")
+    );
+    assert!(executes[5].sql().contains("judge_decision_json = NULL"));
+    assert!(executes[5].sql().contains("status = 'completed'"));
+}
+
+#[tokio::test]
 async fn mysql_runtime_delivery_correlation_and_events_are_persistent() {
     let correlation = test_correlation();
     let db = Arc::new(RecordingDb {

--- a/src/bcs/migrations/README.md
+++ b/src/bcs/migrations/README.md
@@ -9,6 +9,9 @@ The open-source v1 baseline starts from a single MySQL/OceanBase init schema:
 | 001 | `mysql/001_init_schema.sql` | Create the full BCS schema for a fresh MySQL/OceanBase database |
 | 002 | `mysql/002_add_owner_bot_id.sql` | Add message ownership metadata and its lookup index |
 | 003 | `mysql/003_add_organizations.sql` | Add organizations and organization membership tables |
+| 004 | `mysql/004_add_session_collection.sql` | Add session collection state |
+| 005 | `mysql/005_add_session_collection_timestamp.sql` | Add session collection timestamps |
+| 006 | `mysql/006_state_machine_node_judging.sql` | Add durable state-machine judge claim, lease, and fenced decision fields |
 
 The previous internal incremental SQL files were removed from the public
 migration path and replaced by the v1 baseline. New public migrations should be
@@ -76,12 +79,12 @@ The startup runner executes SQLite schema work in this order:
 Each migration is recorded only after all of its steps succeed. Re-running
 startup must be idempotent, and checksum mismatches fail startup.
 
-The current SQLite migrations are `001_init_schema`,
-`002_channel_binding_audit_timestamps`, and `003_add_organizations`. The
-version-3 body is a no-op because startup creates missing organization tables
+The current SQLite migration target is version 6. It includes the baseline,
+channel audit timestamps, organizations, session collection metadata, and the
+state-machine judge claim/lease/decision columns. Some version bodies are no-ops
+because the startup bootstrap or repair pass creates the corresponding shape
 before recording the version. Future schema changes should add later migration
-versions. Do not add pre-open-source local schema repairs to the baseline
-migration.
+versions. Do not add pre-open-source local schema repairs to the baseline migration.
 Pre-baseline local SQLite files are not a compatibility target; recreate them
 from the current bootstrap schema if needed.
 

--- a/src/bcs/migrations/mysql/006_state_machine_node_judging.sql
+++ b/src/bcs/migrations/mysql/006_state_machine_node_judging.sql
@@ -1,0 +1,9 @@
+-- Persist ownership of asynchronous state-machine judge work. The node status
+-- itself is stored in the existing `status` column as `judging`.
+ALTER TABLE `bcs_state_machine_node_runs`
+  ADD COLUMN `judge_claim_token` varchar(64) DEFAULT NULL,
+  ADD COLUMN `judge_lease_until_ms` bigint(20) unsigned DEFAULT NULL,
+  ADD COLUMN `judge_decision_json` mediumtext DEFAULT NULL;
+
+CREATE INDEX `idx_sm_nodes_judge_claim`
+  ON `bcs_state_machine_node_runs` (`env`, `status`, `judge_lease_until_ms`);


### PR DESCRIPTION
## Summary

Add a recoverable `judging` phase for state machine bot nodes so BaaS can receive the bot response immediately while judge evaluation continues asynchronously.

## Changes

- Add the `judging` node status and expose it in the admin panel.
- Run judge evaluation in a background worker after the bot returns its final output.
- Persist judge claim tokens, lease expiration, and decisions for safe recovery.
- Fence stale workers from writing judge results.
- Allow interrupted post-judge processing to resume without calling the LLM again.
- Publish frontend bot events asynchronously with a bounded timeout.
- Add MySQL and SQLite schema migrations and indexes.
- Preserve existing behavior for bots that do not use the BaaS judging flow.
- Update integration documentation and test configuration.

## Problem Fixed

Previously, a state machine node could remain `running` indefinitely after the LLM judge returned successfully. Failures or stale workers during post-judge processing could leave the node unclaimable, while frontend event publication could delay the transition into judge processing.

The new flow transitions the node to `judging`, returns control to BaaS immediately, and completes judge processing through a leased, recoverable background workflow.

## Database Changes

The migration adds:

- `judge_claim_token`
- `judge_lease_until_ms`
- `judge_decision_json`
- An index for locating claimable judging nodes