### PR TITLE
feat: add BCN distributed trace propagation

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1381,6 +1381,8 @@ dependencies = [
  "bcs-test-support",
  "chrono",
  "futures",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1389,6 +1391,8 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -333,6 +333,9 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "native-tls",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "regex",
  "reqwest",
  "secrecy",
@@ -352,6 +355,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "urlencoding",
  "uuid",
@@ -921,6 +925,9 @@ dependencies = [
  "bcs-user-directory-api",
  "futures",
  "hex",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
@@ -931,7 +938,9 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "urlencoding",
  "uuid",
@@ -1132,12 +1141,16 @@ dependencies = [
  "bcs-route-security",
  "bcs-service-api",
  "futures",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tower",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -3153,6 +3166,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3443,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3652,6 +3761,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4598,6 +4708,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +4842,25 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "rustversion",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -123,6 +123,13 @@ inventory = "0.3"
 tracing            = "0.1"
 tracing-appender   = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "local-time"] }
+tracing-opentelemetry = "=0.32.0"
+
+# Distributed tracing
+opentelemetry = { version = "=0.31.0", features = ["trace"] }
+opentelemetry-http = "=0.31.0"
+opentelemetry_sdk = { version = "=0.31.0", features = ["trace"] }
+opentelemetry-otlp = { version = "=0.31.0", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
 
 # Async
 async-trait = "0.1"

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -48,6 +48,15 @@ enabled = true
 mode = "pull"
 endpoint_path = "/metrics"
 
+[telemetry]
+enabled = true
+service_name = "bcn"
+# Complete OTLP traces endpoint; include /v1/traces.
+otlp_traces_endpoint = "http://otel-collector.example.com:4318/v1/traces"
+
+[telemetry.extra_headers]
+x-collector-route = "collector-local"
+
 [llm]
 type = "none"
 base_url = "https://api.openai.com/v1"

--- a/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
+++ b/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
@@ -32,6 +32,10 @@ thiserror       = { workspace = true }
 strum           = { workspace = true }
 tokio           = { workspace = true }
 tracing         = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tower-http      = { workspace = true, features = ["trace"] }
+opentelemetry   = { workspace = true }
+opentelemetry-http = { workspace = true }
 urlencoding     = { workspace = true }
 uuid            = { workspace = true }
 sha2            = { workspace = true }
@@ -54,3 +58,4 @@ bcs-user-directory-api = { workspace = true }
 tempfile = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 tracing-subscriber = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
@@ -1,0 +1,379 @@
+use axum::http::HeaderMap;
+use opentelemetry::{KeyValue, global};
+use opentelemetry::trace::Status;
+use opentelemetry_http::HeaderExtractor;
+use std::time::Duration;
+use tower_http::trace::{MakeSpan, OnResponse};
+use tracing::{Span, debug_span, info_span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+const TRUNCATION_MARKER: &str = "...[TRUNCATED]...";
+pub(crate) const SPAN_CONTENT_LIMIT_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusinessTraceOperation {
+    GatewayDispatch,
+    ProviderCallback,
+}
+
+impl BusinessTraceOperation {
+    pub fn span_name(self) -> &'static str {
+        match self {
+            Self::GatewayDispatch => "bcn.gateway.dispatch",
+            Self::ProviderCallback => "bcn.provider.callback",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ChatClientObservation {
+    pub detach: Option<bool>,
+    pub wait_timeout_ms: Option<u64>,
+}
+
+pub(crate) fn chat_client_observation(headers: &HeaderMap) -> ChatClientObservation {
+    ChatClientObservation {
+        detach: headers
+            .get("x-bcs-client-detach")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse().ok()),
+        wait_timeout_ms: headers
+            .get("x-bcs-client-wait-timeout-ms")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse().ok()),
+    }
+}
+
+pub fn classify_business_request(path: &str) -> Option<BusinessTraceOperation> {
+    let segments: Vec<_> = path.trim_matches('/').split('/').collect();
+    match segments.as_slice() {
+        ["bots", bot_id, "chat" | "chat-async"] if !bot_id.is_empty() => {
+            Some(BusinessTraceOperation::GatewayDispatch)
+        }
+        ["bot", "events"] | ["bot", "events", "coordination"] => {
+            Some(BusinessTraceOperation::ProviderCallback)
+        }
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BcnMakeSpan;
+
+impl<B> MakeSpan<B> for BcnMakeSpan {
+    fn make_span(&mut self, request: &axum::http::Request<B>) -> Span {
+        let method = request.method().as_str();
+        let path = request.uri().path();
+        let Some(operation) = classify_business_request(path) else {
+            return debug_span!(
+                target: "bcs_http_access",
+                "http.request",
+                http.request.method = %method,
+                url.path = %path,
+            );
+        };
+
+        let span = match operation {
+            BusinessTraceOperation::GatewayDispatch => info_span!(
+                target: "bcn_otel",
+                "bcn.gateway.dispatch",
+                otel.kind = "server",
+                http.request.method = %method,
+                url.path = %path,
+            ),
+            BusinessTraceOperation::ProviderCallback => info_span!(
+                target: "bcn_otel",
+                "bcn.provider.callback",
+                otel.kind = "server",
+                http.request.method = %method,
+                url.path = %path,
+            ),
+        };
+        let parent = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderExtractor(request.headers()))
+        });
+        let _ = span.set_parent(parent);
+        span
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BcnOnResponse;
+
+impl<B> OnResponse<B> for BcnOnResponse {
+    fn on_response(self, response: &axum::http::Response<B>, latency: Duration, span: &Span) {
+        let status = response.status().as_u16() as i64;
+        span.set_attribute("http.response.status_code", status);
+        span.set_attribute("http.server.request.duration_ms", latency.as_millis() as i64);
+        if response.status().is_server_error() {
+            span.set_status(Status::error(format!("HTTP {status}")));
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CapturedSpanContent {
+    pub content: String,
+    pub original_size_bytes: usize,
+    pub captured_size_bytes: usize,
+    pub truncated: bool,
+}
+
+pub(crate) fn truncate_span_content(input: &str, limit_bytes: usize) -> CapturedSpanContent {
+    let original_size_bytes = input.len();
+    if original_size_bytes <= limit_bytes {
+        return CapturedSpanContent {
+            content: input.to_string(),
+            original_size_bytes,
+            captured_size_bytes: original_size_bytes,
+            truncated: false,
+        };
+    }
+
+    if limit_bytes <= TRUNCATION_MARKER.len() {
+        let end = floor_char_boundary(input, limit_bytes);
+        let content = input[..end].to_string();
+        return CapturedSpanContent {
+            captured_size_bytes: content.len(),
+            content,
+            original_size_bytes,
+            truncated: true,
+        };
+    }
+
+    let available = limit_bytes - TRUNCATION_MARKER.len();
+    let requested_head = available.saturating_mul(3) / 4;
+    let head_end = floor_char_boundary(input, requested_head);
+    let requested_tail = available - head_end;
+    let tail_start = ceil_char_boundary(input, input.len().saturating_sub(requested_tail));
+    let content = format!(
+        "{}{}{}",
+        &input[..head_end],
+        TRUNCATION_MARKER,
+        &input[tail_start..]
+    );
+
+    CapturedSpanContent {
+        captured_size_bytes: content.len(),
+        content,
+        original_size_bytes,
+        truncated: true,
+    }
+}
+
+pub(crate) fn record_span_content(event_name: &'static str, content: &str) {
+    let captured = truncate_span_content(content, SPAN_CONTENT_LIMIT_BYTES);
+    Span::current().add_event(
+        event_name,
+        vec![
+            KeyValue::new("bcn.content", captured.content),
+            KeyValue::new(
+                "bcn.content.original_size_bytes",
+                captured.original_size_bytes as i64,
+            ),
+            KeyValue::new(
+                "bcn.content.captured_size_bytes",
+                captured.captured_size_bytes as i64,
+            ),
+            KeyValue::new(
+                "bcn.content.limit_bytes",
+                SPAN_CONTENT_LIMIT_BYTES as i64,
+            ),
+            KeyValue::new("bcn.content.truncated", captured.truncated),
+        ],
+    );
+}
+
+fn floor_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while index < value.len() && !value.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue};
+    use opentelemetry::{global, trace::TracerProvider as _};
+    use opentelemetry_sdk::{
+        propagation::TraceContextPropagator,
+        trace::{InMemorySpanExporterBuilder, SdkTracerProvider},
+    };
+    use tower_http::trace::{MakeSpan, OnResponse};
+    use tracing_subscriber::prelude::*;
+
+    #[test]
+    fn span_content_keeps_short_utf8_text() {
+        let captured = truncate_span_content("你好 BCN", 4096);
+
+        assert_eq!(captured.content, "你好 BCN");
+        assert_eq!(captured.original_size_bytes, 10);
+        assert_eq!(captured.captured_size_bytes, 10);
+        assert!(!captured.truncated);
+    }
+
+    #[test]
+    fn span_content_preserves_head_and_tail_within_byte_limit() {
+        let input = format!("{}END", "你".repeat(2000));
+        let captured = truncate_span_content(&input, 4096);
+
+        assert!(captured.truncated);
+        assert!(captured.content.contains("...[TRUNCATED]..."));
+        assert!(captured.content.ends_with("END"));
+        assert!(captured.captured_size_bytes <= 4096);
+        assert_eq!(captured.original_size_bytes, input.len());
+        assert!(std::str::from_utf8(captured.content.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn chat_client_observation_parses_detach_and_wait_timeout_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-bcs-client-detach", HeaderValue::from_static("true"));
+        headers.insert(
+            "x-bcs-client-wait-timeout-ms",
+            HeaderValue::from_static("60000"),
+        );
+
+        let observation = chat_client_observation(&headers);
+
+        assert_eq!(observation.detach, Some(true));
+        assert_eq!(observation.wait_timeout_ms, Some(60_000));
+    }
+
+    #[test]
+    fn business_trace_operation_classifies_chat_and_callback_routes() {
+        assert_eq!(
+            classify_business_request("/bots/bot-1/chat-async"),
+            Some(BusinessTraceOperation::GatewayDispatch)
+        );
+        assert_eq!(
+            classify_business_request("/bot/events"),
+            Some(BusinessTraceOperation::ProviderCallback)
+        );
+        assert_eq!(classify_business_request("/chat/runs/run-1"), None);
+    }
+
+    #[test]
+    fn gateway_request_span_uses_inbound_traceparent_as_remote_parent() {
+        assert_request_span_parent("/bots/bot-1/chat-async", "bcn.gateway.dispatch");
+    }
+
+    #[test]
+    fn provider_callback_span_uses_provider_traceparent_as_remote_parent() {
+        assert_request_span_parent("/bot/events", "bcn.provider.callback");
+    }
+
+    fn assert_request_span_parent(path: &str, expected_name: &str) {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let exporter = InMemorySpanExporterBuilder::new().build();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("bcn-gateway-test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let request = axum::http::Request::builder()
+                .method("POST")
+                .uri(path)
+                .header(
+                    "traceparent",
+                    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                )
+                .body(())
+                .unwrap();
+            let mut make_span = BcnMakeSpan::default();
+            drop(make_span.make_span(&request));
+        });
+
+        provider.force_flush().unwrap();
+        let spans = exporter.get_finished_spans().unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].name, expected_name);
+        assert_eq!(
+            spans[0].span_context.trace_id().to_string(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(
+            spans[0].parent_span_id.to_string(),
+            "b7ad6b7169203331"
+        );
+    }
+
+    #[test]
+    fn gateway_response_records_status_latency_and_server_error() {
+        let exporter = InMemorySpanExporterBuilder::new().build();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("bcn-gateway-test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!(target: "bcn_otel", "bcn.gateway.dispatch");
+            let response = axum::http::Response::builder()
+                .status(503)
+                .body(())
+                .unwrap();
+            BcnOnResponse.on_response(&response, Duration::from_millis(42), &span);
+            drop(span);
+        });
+
+        provider.force_flush().unwrap();
+        let spans = exporter.get_finished_spans().unwrap();
+        let attributes = &spans[0].attributes;
+        assert!(attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "http.response.status_code"
+                && attribute.value == opentelemetry::Value::I64(503)
+        }));
+        assert!(attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "http.server.request.duration_ms"
+                && attribute.value == opentelemetry::Value::I64(42)
+        }));
+        assert!(matches!(spans[0].status, Status::Error { .. }));
+    }
+
+    #[test]
+    fn content_event_records_truncated_body_and_sizes() {
+        let exporter = InMemorySpanExporterBuilder::new().build();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("bcn-content-test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!(target: "bcn_otel", "bcn.gateway.dispatch");
+            let _guard = span.enter();
+            record_span_content("bcn.chat.message", &"x".repeat(5000));
+        });
+
+        provider.force_flush().unwrap();
+        let spans = exporter.get_finished_spans().unwrap();
+        let event = &spans[0].events.events[0];
+        assert_eq!(event.name, "bcn.chat.message");
+        assert!(event.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "bcn.content.truncated"
+                && attribute.value == opentelemetry::Value::Bool(true)
+        }));
+        let captured = event
+            .attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == "bcn.content")
+            .unwrap();
+        assert!(matches!(&captured.value, opentelemetry::Value::String(value) if value.as_str().len() <= 4096));
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
@@ -1,6 +1,6 @@
 use axum::http::HeaderMap;
 use opentelemetry::{KeyValue, global};
-use opentelemetry::trace::Status;
+use opentelemetry::trace::{Status, TraceContextExt};
 use opentelemetry_http::HeaderExtractor;
 use std::time::Duration;
 use tower_http::trace::{MakeSpan, OnResponse};
@@ -13,14 +13,14 @@ pub(crate) const SPAN_CONTENT_LIMIT_BYTES: usize = 4096;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BusinessTraceOperation {
     GatewayDispatch,
-    ProviderCallback,
+    BotResponse,
 }
 
 impl BusinessTraceOperation {
     pub fn span_name(self) -> &'static str {
         match self {
             Self::GatewayDispatch => "bcn.gateway.dispatch",
-            Self::ProviderCallback => "bcn.provider.callback",
+            Self::BotResponse => "bcn.bot.response",
         }
     }
 }
@@ -50,9 +50,7 @@ pub fn classify_business_request(path: &str) -> Option<BusinessTraceOperation> {
         ["bots", bot_id, "chat" | "chat-async"] if !bot_id.is_empty() => {
             Some(BusinessTraceOperation::GatewayDispatch)
         }
-        ["bot", "events"] | ["bot", "events", "coordination"] => {
-            Some(BusinessTraceOperation::ProviderCallback)
-        }
+        ["bot", "events"] => Some(BusinessTraceOperation::BotResponse),
         _ => None,
     }
 }
@@ -64,6 +62,9 @@ impl<B> MakeSpan<B> for BcnMakeSpan {
     fn make_span(&mut self, request: &axum::http::Request<B>) -> Span {
         let method = request.method().as_str();
         let path = request.uri().path();
+        if path == "/bot/events/coordination" {
+            return Span::none();
+        }
         let Some(operation) = classify_business_request(path) else {
             return debug_span!(
                 target: "bcs_http_access",
@@ -73,7 +74,23 @@ impl<B> MakeSpan<B> for BcnMakeSpan {
             );
         };
 
+        let parent = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderExtractor(request.headers()))
+        });
+        if matches!(path, "/bot/events") || path.ends_with("/chat-async") {
+            if !parent.span().span_context().is_valid() {
+                return Span::none();
+            }
+        }
+
         let span = match operation {
+            BusinessTraceOperation::GatewayDispatch if path.ends_with("/chat-async") => info_span!(
+                target: "bcn_otel",
+                "bcn.gateway.dispatch",
+                otel.kind = "server",
+                http.request.method = %method,
+                http.route = "/bots/{id}/chat-async",
+            ),
             BusinessTraceOperation::GatewayDispatch => info_span!(
                 target: "bcn_otel",
                 "bcn.gateway.dispatch",
@@ -81,17 +98,14 @@ impl<B> MakeSpan<B> for BcnMakeSpan {
                 http.request.method = %method,
                 url.path = %path,
             ),
-            BusinessTraceOperation::ProviderCallback => info_span!(
+            BusinessTraceOperation::BotResponse => info_span!(
                 target: "bcn_otel",
-                "bcn.provider.callback",
+                "bcn.bot.response",
                 otel.kind = "server",
                 http.request.method = %method,
                 url.path = %path,
             ),
         };
-        let parent = global::get_text_map_propagator(|propagator| {
-            propagator.extract(&HeaderExtractor(request.headers()))
-        });
         let _ = span.set_parent(parent);
         span
     }
@@ -162,26 +176,43 @@ pub(crate) fn truncate_span_content(input: &str, limit_bytes: usize) -> Captured
 }
 
 pub(crate) fn record_span_content(event_name: &'static str, content: &str) {
+    record_span_content_inner(event_name, content, None);
+}
+
+pub(crate) fn record_span_content_with_untrusted(
+    event_name: &'static str,
+    content: &str,
+    untrusted: bool,
+) {
+    record_span_content_inner(event_name, content, Some(untrusted));
+}
+
+fn record_span_content_inner(
+    event_name: &'static str,
+    content: &str,
+    untrusted: Option<bool>,
+) {
     let captured = truncate_span_content(content, SPAN_CONTENT_LIMIT_BYTES);
-    Span::current().add_event(
-        event_name,
-        vec![
-            KeyValue::new("bcn.content", captured.content),
-            KeyValue::new(
-                "bcn.content.original_size_bytes",
-                captured.original_size_bytes as i64,
-            ),
-            KeyValue::new(
-                "bcn.content.captured_size_bytes",
-                captured.captured_size_bytes as i64,
-            ),
-            KeyValue::new(
-                "bcn.content.limit_bytes",
-                SPAN_CONTENT_LIMIT_BYTES as i64,
-            ),
-            KeyValue::new("bcn.content.truncated", captured.truncated),
-        ],
-    );
+    let mut attributes = vec![
+        KeyValue::new("bcn.content", captured.content),
+        KeyValue::new(
+            "bcn.content.original_size_bytes",
+            captured.original_size_bytes as i64,
+        ),
+        KeyValue::new(
+            "bcn.content.captured_size_bytes",
+            captured.captured_size_bytes as i64,
+        ),
+        KeyValue::new(
+            "bcn.content.limit_bytes",
+            SPAN_CONTENT_LIMIT_BYTES as i64,
+        ),
+        KeyValue::new("bcn.content.truncated", captured.truncated),
+    ];
+    if let Some(untrusted) = untrusted {
+        attributes.push(KeyValue::new("bcn.content.untrusted", untrusted));
+    }
+    Span::current().add_event(event_name, attributes);
 }
 
 fn floor_char_boundary(value: &str, mut index: usize) -> usize {
@@ -258,8 +289,9 @@ mod tests {
         );
         assert_eq!(
             classify_business_request("/bot/events"),
-            Some(BusinessTraceOperation::ProviderCallback)
+            Some(BusinessTraceOperation::BotResponse)
         );
+        assert_eq!(classify_business_request("/bot/events/coordination"), None);
         assert_eq!(classify_business_request("/chat/runs/run-1"), None);
     }
 
@@ -269,8 +301,33 @@ mod tests {
     }
 
     #[test]
-    fn provider_callback_span_uses_provider_traceparent_as_remote_parent() {
-        assert_request_span_parent("/bot/events", "bcn.provider.callback");
+    fn bot_response_span_uses_provider_traceparent_as_remote_parent() {
+        assert_request_span_parent("/bot/events", "bcn.bot.response");
+    }
+
+    #[test]
+    fn gated_routes_without_valid_traceparent_do_not_create_spans() {
+        assert_request_creates_no_span("/bots/bot-1/chat-async", None);
+        assert_request_creates_no_span("/bot/events", None);
+        assert_request_creates_no_span("/bots/bot-1/chat-async", Some("malformed"));
+        assert_request_creates_no_span("/bot/events", Some("malformed"));
+    }
+
+    #[test]
+    fn coordination_route_returns_disabled_span_even_with_traceparent() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let request = axum::http::Request::builder()
+            .method("POST")
+            .uri("/bot/events/coordination")
+            .header(
+                "traceparent",
+                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            )
+            .body(())
+            .unwrap();
+        let mut make_span = BcnMakeSpan::default();
+
+        assert!(make_span.make_span(&request).is_disabled());
     }
 
     fn assert_request_span_parent(path: &str, expected_name: &str) {
@@ -309,6 +366,33 @@ mod tests {
             spans[0].parent_span_id.to_string(),
             "b7ad6b7169203331"
         );
+    }
+
+    fn assert_request_creates_no_span(path: &str, traceparent: Option<&str>) {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let exporter = InMemorySpanExporterBuilder::new().build();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("bcn-gateway-test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::EnvFilter::new("bcn_otel=info"))
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let mut builder = axum::http::Request::builder().method("POST").uri(path);
+            if let Some(traceparent) = traceparent {
+                builder = builder.header("traceparent", traceparent);
+            }
+            let request = builder.body(()).unwrap();
+            let mut make_span = BcnMakeSpan::default();
+            let span = make_span.make_span(&request);
+            assert!(span.is_disabled());
+            drop(span);
+        });
+
+        provider.force_flush().unwrap();
+        assert!(exporter.get_finished_spans().unwrap().is_empty());
     }
 
     #[test]

--- a/src/bcs/crates/adapters/http/bcs-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/lib.rs
@@ -3,6 +3,7 @@
 mod chat_digest;
 pub mod admin_invocation_terminal;
 pub mod error;
+pub mod gateway_trace;
 pub mod headers;
 pub mod mapping;
 pub mod oauth;

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
@@ -15,12 +15,14 @@ use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::chat_digest::{ChatDigestRecord, log_chat_digest};
-use crate::gateway_trace::{chat_client_observation, record_span_content};
+use crate::gateway_trace::{
+    chat_client_observation, record_span_content, record_span_content_with_untrusted,
+};
 use crate::state::HttpAppState;
 
 use super::{bot_id_from_headers, container_header_matches};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ChatRequest {
     pub message: String,
     #[serde(default)]
@@ -124,7 +126,14 @@ pub async fn bot_chat(
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
     let effective_timeout_ms = effective_legacy_chat_timeout_ms(req.timeout_ms);
-    record_chat_dispatch_trace(&bot_uuid, &headers, &req, false, effective_timeout_ms);
+    record_chat_dispatch_trace(
+        &bot_uuid,
+        &headers,
+        &req,
+        false,
+        effective_timeout_ms,
+        None,
+    );
 
     let from_bot_id = match resolve_bot_caller(&state, &headers).await {
         Ok(from_bot_id) => from_bot_id,
@@ -287,11 +296,11 @@ pub async fn bot_chat_async(
         .timeout_ms
         .unwrap_or(state.async_chat_run_timeout_ms)
         .min(24 * 60 * 60 * 1_000);
-    record_chat_dispatch_trace(&bot_uuid, &headers, &req, true, timeout_ms);
-
     let from_bot_id = match resolve_bot_caller(&state, &headers).await {
         Ok(from_bot_id) => from_bot_id,
         Err(err) => {
+            Span::current().set_attribute("bcn.auth.result", "failed");
+            record_span_content_with_untrusted("bcn.chat.message", &req.message, true);
             log_bot_chat_digest(ChatDigestArgs {
                 endpoint: "bot_chat_async",
                 from_bot_id: None,
@@ -313,39 +322,48 @@ pub async fn bot_chat_async(
     let authenticated_staff_id = authenticated_staff_id(&state, &headers, &uri).await;
 
     let run_id = uuid::Uuid::new_v4().to_string();
-    Span::current().set_attribute("bcn.run.id", run_id.clone());
-    let session_key = resolve_session_key(
+    let trace_request = req.clone();
+    let session_key = match resolve_session_key(
         req.session_id.as_deref(),
         &run_id,
         client_identity.as_deref(),
         &from_bot_id,
-    )
-    .map_err(LegacyChatError::invalid_request)
-    .map_err(|err| {
-        log_bot_chat_digest(ChatDigestArgs {
-            endpoint: "bot_chat_async",
-            from_bot_id: Some(&from_bot_id),
-            target_bot_id: &bot_uuid,
-            run_id: Some(&run_id),
-            session_id: req.session_id.as_deref(),
-            client: client_identity.as_deref(),
-            async_mode: true,
-            timeout_ms: Some(timeout_ms),
-            message_len,
-            started,
-            success: false,
-            status_code: err.status,
-            error_kind: Some(err.error_kind),
-        });
-        err
-    })?;
+    ) {
+        Ok(session_key) => session_key,
+        Err(message) => {
+            let err = LegacyChatError::invalid_request(message);
+            record_authenticated_async_chat_trace(
+                &bot_uuid,
+                &headers,
+                &trace_request,
+                timeout_ms,
+                &run_id,
+            );
+            log_bot_chat_digest(ChatDigestArgs {
+                endpoint: "bot_chat_async",
+                from_bot_id: Some(&from_bot_id),
+                target_bot_id: &bot_uuid,
+                run_id: Some(&run_id),
+                session_id: req.session_id.as_deref(),
+                client: client_identity.as_deref(),
+                async_mode: true,
+                timeout_ms: Some(timeout_ms),
+                message_len,
+                started,
+                success: false,
+                status_code: err.status,
+                error_kind: Some(err.error_kind),
+            });
+            return Err(err);
+        }
+    };
     let run_channel_from = req.from.clone();
     let organization_code = normalize_optional_string(req.organization_code);
     let chat_from_actor_id = Some(req.from.unwrap_or_else(|| "user".to_string()));
     let tags = normalize_tags(req.tags);
     let caller_wait_mode = normalize_optional_string(req.caller_wait_mode);
     let digest_client = client_identity.clone();
-    let accepted = state
+    let accepted_result = state
         .services
         .a2a_chat_runs
         .start_async_chat(AsyncA2aChatCommand {
@@ -366,9 +384,39 @@ pub async fn bot_chat_async(
             caller_wait_mode,
             organization_code,
         })
-        .await
-        .map_err(map_service_error)
-        .map_err(|err| {
+        .await;
+    let accepted = match accepted_result {
+        Ok(accepted) => {
+            record_authenticated_async_chat_trace(
+                &bot_uuid,
+                &headers,
+                &trace_request,
+                timeout_ms,
+                &run_id,
+            );
+            accepted
+        }
+        Err(service_error) => {
+            if matches!(
+                service_error,
+                ServiceError::Unauthorized(_) | ServiceError::Forbidden(_)
+            ) {
+                Span::current().set_attribute("bcn.auth.result", "failed");
+                record_span_content_with_untrusted(
+                    "bcn.chat.message",
+                    &trace_request.message,
+                    true,
+                );
+            } else {
+                record_authenticated_async_chat_trace(
+                    &bot_uuid,
+                    &headers,
+                    &trace_request,
+                    timeout_ms,
+                    &run_id,
+                );
+            }
+            let err = map_service_error(service_error);
             log_bot_chat_digest(ChatDigestArgs {
                 endpoint: "bot_chat_async",
                 from_bot_id: Some(&from_bot_id),
@@ -384,8 +432,9 @@ pub async fn bot_chat_async(
                 status_code: err.status,
                 error_kind: Some(err.error_kind),
             });
-            err
-        })?;
+            return Err(err);
+        }
+    };
     Span::current().set_attribute("bcn.delivery.accepted", true);
 
     log_bot_chat_digest(ChatDigestArgs {
@@ -416,12 +465,32 @@ pub async fn bot_chat_async(
     ))
 }
 
+fn record_authenticated_async_chat_trace(
+    target_bot_id: &str,
+    headers: &HeaderMap,
+    request: &ChatRequest,
+    timeout_ms: u64,
+    run_id: &str,
+) {
+    Span::current().set_attribute("bcn.auth.result", "success");
+    Span::current().set_attribute("bcn.run.id", run_id.to_string());
+    record_chat_dispatch_trace(
+        target_bot_id,
+        headers,
+        request,
+        true,
+        timeout_ms,
+        Some(false),
+    );
+}
+
 fn record_chat_dispatch_trace(
     target_bot_id: &str,
     headers: &HeaderMap,
     request: &ChatRequest,
     async_mode: bool,
     effective_timeout_ms: u64,
+    content_untrusted: Option<bool>,
 ) {
     let span = Span::current();
     span.set_attribute("bcn.operation", "chat.dispatch");
@@ -453,7 +522,11 @@ fn record_chat_dispatch_trace(
     if let Some(wait_timeout_ms) = client.wait_timeout_ms {
         span.set_attribute("bcn.client.wait_timeout_ms", wait_timeout_ms as i64);
     }
-    record_span_content("bcn.chat.message", &request.message);
+    if let Some(untrusted) = content_untrusted {
+        record_span_content_with_untrusted("bcn.chat.message", &request.message, untrusted);
+    } else {
+        record_span_content("bcn.chat.message", &request.message);
+    }
 }
 
 fn effective_legacy_chat_timeout_ms(timeout_ms: Option<u64>) -> u64 {

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
@@ -11,8 +11,11 @@ use bcs_service_api::{
 use serde::Deserialize;
 use serde_json::Value;
 use std::time::Instant;
+use tracing::Span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::chat_digest::{ChatDigestRecord, log_chat_digest};
+use crate::gateway_trace::{chat_client_observation, record_span_content};
 use crate::state::HttpAppState;
 
 use super::{bot_id_from_headers, container_header_matches};
@@ -121,6 +124,7 @@ pub async fn bot_chat(
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
     let effective_timeout_ms = effective_legacy_chat_timeout_ms(req.timeout_ms);
+    record_chat_dispatch_trace(&bot_uuid, &headers, &req, false, effective_timeout_ms);
 
     let from_bot_id = match resolve_bot_caller(&state, &headers).await {
         Ok(from_bot_id) => from_bot_id,
@@ -166,6 +170,7 @@ pub async fn bot_chat(
     }
 
     let run_id = uuid::Uuid::new_v4().to_string();
+    Span::current().set_attribute("bcn.run.id", run_id.clone());
     let session_key = resolve_session_key(
         req.session_id.as_deref(),
         &run_id,
@@ -237,6 +242,7 @@ pub async fn bot_chat(
             });
             err
         })?;
+    Span::current().set_attribute("bcn.delivery.accepted", outcome.delivered);
 
     log_bot_chat_digest(ChatDigestArgs {
         endpoint: "bot_chat",
@@ -281,6 +287,7 @@ pub async fn bot_chat_async(
         .timeout_ms
         .unwrap_or(state.async_chat_run_timeout_ms)
         .min(24 * 60 * 60 * 1_000);
+    record_chat_dispatch_trace(&bot_uuid, &headers, &req, true, timeout_ms);
 
     let from_bot_id = match resolve_bot_caller(&state, &headers).await {
         Ok(from_bot_id) => from_bot_id,
@@ -306,6 +313,7 @@ pub async fn bot_chat_async(
     let authenticated_staff_id = authenticated_staff_id(&state, &headers, &uri).await;
 
     let run_id = uuid::Uuid::new_v4().to_string();
+    Span::current().set_attribute("bcn.run.id", run_id.clone());
     let session_key = resolve_session_key(
         req.session_id.as_deref(),
         &run_id,
@@ -378,6 +386,7 @@ pub async fn bot_chat_async(
             });
             err
         })?;
+    Span::current().set_attribute("bcn.delivery.accepted", true);
 
     log_bot_chat_digest(ChatDigestArgs {
         endpoint: "bot_chat_async",
@@ -405,6 +414,46 @@ pub async fn bot_chat_async(
             "expires_at_ms": accepted.expires_at_ms,
         })),
     ))
+}
+
+fn record_chat_dispatch_trace(
+    target_bot_id: &str,
+    headers: &HeaderMap,
+    request: &ChatRequest,
+    async_mode: bool,
+    effective_timeout_ms: u64,
+) {
+    let span = Span::current();
+    span.set_attribute("bcn.operation", "chat.dispatch");
+    span.set_attribute("bcn.target.bot_id", target_bot_id.to_string());
+    span.set_attribute("bcn.chat.async", async_mode);
+    span.set_attribute("bcn.chat.timeout_ms", effective_timeout_ms as i64);
+    span.set_attribute("bcn.chat.message_size_bytes", request.message.len() as i64);
+    span.set_attribute("bcn.chat.tags_count", request.tags.len() as i64);
+    span.set_attribute(
+        "bcn.chat.response_mode",
+        format!("{:?}", request.response_mode),
+    );
+    if let Some(value) = request.from.as_deref() {
+        span.set_attribute("bcn.chat.from", value.to_string());
+    }
+    if let Some(value) = request.session_id.as_deref() {
+        span.set_attribute("bcn.chat.session_id", value.to_string());
+    }
+    if let Some(value) = request.caller_wait_mode.as_deref() {
+        span.set_attribute("bcn.chat.caller_wait_mode", value.to_string());
+    }
+    if let Some(value) = request.organization_code.as_deref() {
+        span.set_attribute("bcn.chat.organization_code", value.to_string());
+    }
+    let client = chat_client_observation(headers);
+    if let Some(detach) = client.detach {
+        span.set_attribute("bcn.client.detach", detach);
+    }
+    if let Some(wait_timeout_ms) = client.wait_timeout_ms {
+        span.set_attribute("bcn.client.wait_timeout_ms", wait_timeout_ms as i64);
+    }
+    record_span_content("bcn.chat.message", &request.message);
 }
 
 fn effective_legacy_chat_timeout_ms(timeout_ms: Option<u64>) -> u64 {

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -17,8 +17,10 @@ use bcs_service_api::{
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
-use tracing::{info, warn};
+use tracing::{Span, info, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::gateway_trace::record_span_content;
 use crate::state::HttpAppState;
 
 const BOT_EVENT_REQUEST_BODY_LIMIT: usize = 2 * 1024 * 1024;
@@ -205,6 +207,12 @@ pub async fn post_bot_event(
     headers: HeaderMap,
     LoggedBotEventRequest(req): LoggedBotEventRequest,
 ) -> Result<Json<Value>, BotEventRouteError> {
+    let callback_content = serde_json::to_string(&json!({
+        "message": &req.message.text,
+        "payload": &req.payload,
+    }))
+    .expect("serializing JSON callback content cannot fail");
+    record_span_content("bcn.provider.callback.content", &callback_content);
     let provider_id = header_required(&headers, BCN_PROVIDER_ID_HEADER)?;
     // Derive state: prefer the explicit `state` field (1.0); fall back to
     // extracting from `payload.state` for chat events (2.0 callback-streaming);
@@ -243,6 +251,17 @@ pub async fn post_bot_event(
         message_text = %req.message.text,
         "provider callback: received bot event"
     );
+    let span = Span::current();
+    span.set_attribute("bcn.operation", "provider.callback");
+    span.set_attribute("bcn.provider.id", provider_id.clone());
+    span.set_attribute("bcn.run.id", req.run_id.clone());
+    span.set_attribute("bcn.callback.state", format!("{effective_state:?}"));
+    if let Some(seq) = req.seq {
+        span.set_attribute("bcn.callback.seq", seq as i64);
+    }
+    if let Some(event) = req.event.as_deref() {
+        span.set_attribute("bcn.callback.event", event.to_string());
+    }
     let credential = credential_from_headers(&state, &headers, &provider_id).await?;
 
     let outcome = match state
@@ -275,6 +294,11 @@ pub async fn post_bot_event(
         failed_count = %outcome.failed_count,
         "provider callback: bot event processed"
     );
+    span.set_attribute(
+        "bcn.callback.delivered_count",
+        outcome.delivered_count as i64,
+    );
+    span.set_attribute("bcn.callback.failed_count", outcome.failed_count as i64);
 
     Ok(Json(json!({
         "ok": true,
@@ -288,6 +312,12 @@ pub async fn post_coordination_event(
     headers: HeaderMap,
     Json(req): Json<ProviderCoordinationEventRequest>,
 ) -> Result<Json<Value>, BotEventRouteError> {
+    let callback_content = serde_json::to_string(&json!({
+        "result_text": &req.result_text,
+        "intent": &req.intent,
+    }))
+    .expect("serializing JSON callback content cannot fail");
+    record_span_content("bcn.provider.callback.content", &callback_content);
     let provider_id = header_required(&headers, BCN_PROVIDER_ID_HEADER)?;
     let credential = credential_from_headers(&state, &headers, &provider_id).await?;
     info!(
@@ -299,7 +329,18 @@ pub async fn post_coordination_event(
         mcp_server = ?req.mcp_server,
         "provider callback: received coordination event"
     );
-
+    let span = Span::current();
+    span.set_attribute("bcn.operation", "provider.callback");
+    span.set_attribute("bcn.provider.id", provider_id.clone());
+    span.set_attribute("bcn.run.id", req.run_id.clone());
+    span.set_attribute("bcn.callback.tool_call_id", req.tool_call_id.clone());
+    span.set_attribute("bcn.callback.kind", format!("{:?}", req.kind));
+    if let Some(tool_name) = req.tool_name.as_deref() {
+        span.set_attribute("bcn.callback.tool_name", tool_name.to_string());
+    }
+    if let Some(mcp_server) = req.mcp_server.as_deref() {
+        span.set_attribute("bcn.callback.mcp_server", mcp_server.to_string());
+    }
     let outcome = state
         .services
         .provider_bot_events
@@ -320,6 +361,8 @@ pub async fn post_coordination_event(
         })
         .await
         .map_err(bot_event_error)?;
+    span.set_attribute("bcn.callback.processed", outcome.processed);
+    span.set_attribute("bcn.callback.duplicate", outcome.duplicate);
 
     Ok(Json(json!({
         "ok": true,

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 use tracing::{Span, info, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::gateway_trace::record_span_content;
+use crate::gateway_trace::record_span_content_with_untrusted;
 use crate::state::HttpAppState;
 
 const BOT_EVENT_REQUEST_BODY_LIMIT: usize = 2 * 1024 * 1024;
@@ -212,8 +212,13 @@ pub async fn post_bot_event(
         "payload": &req.payload,
     }))
     .expect("serializing JSON callback content cannot fail");
-    record_span_content("bcn.provider.callback.content", &callback_content);
-    let provider_id = header_required(&headers, BCN_PROVIDER_ID_HEADER)?;
+    let provider_id = match header_required(&headers, BCN_PROVIDER_ID_HEADER) {
+        Ok(provider_id) => provider_id,
+        Err(error) => {
+            record_bot_response_auth_failure(&callback_content);
+            return Err(error);
+        }
+    };
     // Derive state: prefer the explicit `state` field (1.0); fall back to
     // extracting from `payload.state` for chat events (2.0 callback-streaming);
     // for agent events default to Delta (non-terminal, goes through pipeline).
@@ -237,6 +242,12 @@ pub async fn post_bot_event(
         // agent events (tool/thinking/lifecycle) — non-terminal pipeline.
         ChatEventState::Delta
     } else {
+        Span::current().set_attribute("bcn.auth.result", "unverified");
+        record_span_content_with_untrusted(
+            "bcn.bot.response.content",
+            &callback_content,
+            true,
+        );
         return Err(BotEventRouteError::bad_request(
             "state is required when event/payload are absent (1.0 contract)",
         ));
@@ -251,18 +262,13 @@ pub async fn post_bot_event(
         message_text = %req.message.text,
         "provider callback: received bot event"
     );
-    let span = Span::current();
-    span.set_attribute("bcn.operation", "provider.callback");
-    span.set_attribute("bcn.provider.id", provider_id.clone());
-    span.set_attribute("bcn.run.id", req.run_id.clone());
-    span.set_attribute("bcn.callback.state", format!("{effective_state:?}"));
-    if let Some(seq) = req.seq {
-        span.set_attribute("bcn.callback.seq", seq as i64);
-    }
-    if let Some(event) = req.event.as_deref() {
-        span.set_attribute("bcn.callback.event", event.to_string());
-    }
-    let credential = credential_from_headers(&state, &headers, &provider_id).await?;
+    let credential = match credential_from_headers(&state, &headers, &provider_id).await {
+        Ok(credential) => credential,
+        Err(error) => {
+            record_bot_response_auth_failure(&callback_content);
+            return Err(error);
+        }
+    };
 
     let outcome = match state
         .services
@@ -270,11 +276,11 @@ pub async fn post_bot_event(
         .submit_event(ProviderBotEventCommand {
             provider_id: provider_id.clone(),
             credential,
-            run_id: req.run_id,
-            state: effective_state,
-            message_text: req.message.text,
-            event: req.event,
-            payload: req.payload,
+            run_id: req.run_id.clone(),
+            state: effective_state.clone(),
+            message_text: req.message.text.clone(),
+            event: req.event.clone(),
+            payload: req.payload.clone(),
         })
         .await
     {
@@ -285,7 +291,11 @@ pub async fn post_bot_event(
                 error = %error,
                 "provider callback: bot event rejected"
             );
-            return Err(bot_event_error(error));
+            let route_error = bot_event_error(error);
+            if matches!(route_error.status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+                record_bot_response_auth_failure(&callback_content);
+            }
+            return Err(route_error);
         }
     };
     info!(
@@ -294,11 +304,24 @@ pub async fn post_bot_event(
         failed_count = %outcome.failed_count,
         "provider callback: bot event processed"
     );
+    let span = Span::current();
+    span.set_attribute("bcn.auth.result", "success");
+    span.set_attribute("bcn.operation", "bot.response");
+    span.set_attribute("bcn.provider.id", provider_id.clone());
+    span.set_attribute("bcn.run.id", req.run_id.clone());
+    span.set_attribute("bcn.callback.state", format!("{effective_state:?}"));
+    if let Some(seq) = req.seq {
+        span.set_attribute("bcn.callback.seq", seq as i64);
+    }
+    if let Some(event) = req.event.as_deref() {
+        span.set_attribute("bcn.callback.event", event.to_string());
+    }
     span.set_attribute(
         "bcn.callback.delivered_count",
         outcome.delivered_count as i64,
     );
     span.set_attribute("bcn.callback.failed_count", outcome.failed_count as i64);
+    record_span_content_with_untrusted("bcn.bot.response.content", &callback_content, false);
 
     Ok(Json(json!({
         "ok": true,
@@ -312,12 +335,6 @@ pub async fn post_coordination_event(
     headers: HeaderMap,
     Json(req): Json<ProviderCoordinationEventRequest>,
 ) -> Result<Json<Value>, BotEventRouteError> {
-    let callback_content = serde_json::to_string(&json!({
-        "result_text": &req.result_text,
-        "intent": &req.intent,
-    }))
-    .expect("serializing JSON callback content cannot fail");
-    record_span_content("bcn.provider.callback.content", &callback_content);
     let provider_id = header_required(&headers, BCN_PROVIDER_ID_HEADER)?;
     let credential = credential_from_headers(&state, &headers, &provider_id).await?;
     info!(
@@ -329,18 +346,6 @@ pub async fn post_coordination_event(
         mcp_server = ?req.mcp_server,
         "provider callback: received coordination event"
     );
-    let span = Span::current();
-    span.set_attribute("bcn.operation", "provider.callback");
-    span.set_attribute("bcn.provider.id", provider_id.clone());
-    span.set_attribute("bcn.run.id", req.run_id.clone());
-    span.set_attribute("bcn.callback.tool_call_id", req.tool_call_id.clone());
-    span.set_attribute("bcn.callback.kind", format!("{:?}", req.kind));
-    if let Some(tool_name) = req.tool_name.as_deref() {
-        span.set_attribute("bcn.callback.tool_name", tool_name.to_string());
-    }
-    if let Some(mcp_server) = req.mcp_server.as_deref() {
-        span.set_attribute("bcn.callback.mcp_server", mcp_server.to_string());
-    }
     let outcome = state
         .services
         .provider_bot_events
@@ -361,14 +366,16 @@ pub async fn post_coordination_event(
         })
         .await
         .map_err(bot_event_error)?;
-    span.set_attribute("bcn.callback.processed", outcome.processed);
-    span.set_attribute("bcn.callback.duplicate", outcome.duplicate);
-
     Ok(Json(json!({
         "ok": true,
         "processed": outcome.processed,
         "duplicate": outcome.duplicate,
     })))
+}
+
+fn record_bot_response_auth_failure(callback_content: &str) {
+    Span::current().set_attribute("bcn.auth.result", "failed");
+    record_span_content_with_untrusted("bcn.bot.response.content", callback_content, true);
 }
 
 fn header_required(headers: &HeaderMap, name: &'static str) -> Result<String, BotEventRouteError> {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
@@ -6,6 +6,7 @@ use bcs_auth_api::{AuthPluginChain, AuthPrincipal};
 use bcs_auth_local::StaticAuthPlugin;
 use bcs_bot::BotCore;
 use bcs_http::{
+    gateway_trace::{BcnMakeSpan, BcnOnResponse},
     router::build_router,
     state::{ChatRunEventPort, ChainUserIdentityPort, HttpAppState},
 };
@@ -25,6 +26,9 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tower::ServiceExt;
+use tower_http::trace::TraceLayer;
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::prelude::*;
 
 #[derive(Default)]
 struct RecordingA2aChat {
@@ -37,6 +41,8 @@ struct RecordingA2aChat {
     blocking_content: Mutex<String>,
     blocking_failure: Mutex<Option<String>>,
     blocking_returns_error: Mutex<bool>,
+    async_unauthorized: Mutex<bool>,
+    async_forbidden: Mutex<bool>,
 }
 
 #[derive(Clone, Default)]
@@ -245,6 +251,12 @@ impl A2aChatRunService for RecordingA2aChat {
         &self,
         cmd: AsyncA2aChatCommand,
     ) -> ServiceResult<AsyncA2aChatAccepted> {
+        if *self.async_unauthorized.lock().await {
+            return Err(ServiceError::Unauthorized("owner mismatch".to_string()));
+        }
+        if *self.async_forbidden.lock().await {
+            return Err(ServiceError::Forbidden("access denied".to_string()));
+        }
         if let Some(bot_id) = self.not_connected_bot_id.lock().await.clone() {
             return Err(ServiceError::BotNotConnected(bot_id));
         }
@@ -620,6 +632,245 @@ async fn bot_chat_async_returns_accepted_and_preserves_cli_session_fallback() {
     assert_eq!(commands[0].caller_wait_mode.as_deref(), Some("detached"));
     assert_eq!(commands[0].organization_code, None);
     assert_eq!(a2a.run_channel_froms.lock().await.as_slice(), &[None]);
+}
+
+#[tokio::test]
+async fn bot_chat_async_marks_unauthorized_content_untrusted_without_business_attributes() {
+    let (app, _, _) = build_chat_app().await;
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+    let message = "unauthorized-sensitive-content";
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/bots/target-bot/chat-async")
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .header("authorization", "Bearer invalid-token")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::json!({ "message": message }).to_string()))
+                .unwrap(),
+        ).await.unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let span = spans.iter().find(|span| span.name == "bcn.gateway.dispatch").unwrap();
+    assert_span_string_attribute(span, "bcn.auth.result", "failed");
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.target.bot_id"));
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "url.path"));
+    assert_span_string_attribute(span, "http.route", "/bots/{id}/chat-async");
+    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
+    assert_event_bool_attribute(event, "bcn.content.untrusted", true);
+    assert_event_contains(event, message);
+}
+
+#[tokio::test]
+async fn bot_chat_async_marks_authenticated_content_trusted() {
+    let (app, _, _) = build_chat_app().await;
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/bots/target-bot/chat-async")
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .header("authorization", "Bearer caller-token")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"message":"trusted-content"}"#))
+                .unwrap(),
+        ).await.unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::ACCEPTED);
+    let span = spans.iter().find(|span| span.name == "bcn.gateway.dispatch").unwrap();
+    assert_span_string_attribute(span, "bcn.auth.result", "success");
+    assert_span_string_attribute(span, "bcn.target.bot_id", "target-bot");
+    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
+    assert_event_bool_attribute(event, "bcn.content.untrusted", false);
+    assert_event_contains(event, "trusted-content");
+}
+
+#[tokio::test]
+async fn bot_chat_async_marks_service_authorization_failure_untrusted() {
+    let (app, a2a, _) = build_chat_app().await;
+    *a2a.async_unauthorized.lock().await = true;
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/bots/unverified-target/chat-async")
+                    .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                    .header("authorization", "Bearer caller-token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"message":"authorization-failure-content"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let span = spans.iter().find(|span| span.name == "bcn.gateway.dispatch").unwrap();
+    assert_span_string_attribute(span, "bcn.auth.result", "failed");
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.target.bot_id"));
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
+    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
+    assert_event_bool_attribute(event, "bcn.content.untrusted", true);
+    assert_event_contains(event, "authorization-failure-content");
+}
+
+#[tokio::test]
+async fn bot_chat_async_marks_service_forbidden_failure_untrusted() {
+    let (app, a2a, _) = build_chat_app().await;
+    *a2a.async_forbidden.lock().await = true;
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/bots/unverified-target/chat-async")
+                    .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                    .header("authorization", "Bearer caller-token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"message":"forbidden-content"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let span = spans.iter().find(|span| span.name == "bcn.gateway.dispatch").unwrap();
+    assert_span_string_attribute(span, "bcn.auth.result", "failed");
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.target.bot_id"));
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
+    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
+    assert_event_bool_attribute(event, "bcn.content.untrusted", true);
+    assert_event_contains(event, "forbidden-content");
+}
+
+#[tokio::test]
+async fn bot_chat_async_records_trusted_content_after_auth_when_session_is_invalid() {
+    let (app, _, _) = build_chat_app().await;
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/bots/target-bot/chat-async")
+                    .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                    .header("authorization", "Bearer caller-token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"message":"invalid-session-content","session_id":" "}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let span = spans.iter().find(|span| span.name == "bcn.gateway.dispatch").unwrap();
+    assert_span_string_attribute(span, "bcn.auth.result", "success");
+    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
+    assert_event_bool_attribute(event, "bcn.content.untrusted", false);
+    assert_event_contains(event, "invalid-session-content");
+}
+
+async fn capture_otel_spans<F, T>(future: F) -> (T, Vec<opentelemetry_sdk::trace::SpanData>)
+where
+    F: Future<Output = T>,
+{
+    opentelemetry::global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+    let exporter = opentelemetry_sdk::trace::InMemorySpanExporterBuilder::new().build();
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "bot-chat-contract");
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::new("bcn_otel=info"))
+        .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+    let output = future.with_subscriber(subscriber).await;
+    provider.force_flush().unwrap();
+    (output, exporter.get_finished_spans().unwrap())
+}
+
+fn assert_span_string_attribute(
+    span: &opentelemetry_sdk::trace::SpanData,
+    key: &str,
+    expected: &str,
+) {
+    assert!(span.attributes.iter().any(|attr| {
+        attr.key.as_str() == key
+            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str() == expected)
+    }));
+}
+
+fn assert_event_bool_attribute(
+    event: &opentelemetry::trace::Event,
+    key: &str,
+    expected: bool,
+) {
+    assert!(event.attributes.iter().any(|attr| {
+        attr.key.as_str() == key && attr.value == opentelemetry::Value::Bool(expected)
+    }));
+}
+
+fn assert_event_contains(event: &opentelemetry::trace::Event, expected: &str) {
+    assert!(event.attributes.iter().any(|attr| {
+        attr.key.as_str() == "bcn.content"
+            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains(expected))
+    }));
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
@@ -13,6 +13,7 @@ use axum::{
 use bcs_bot::{BotCore, ProviderBotEvents, ProviderCore, ProviderManagement};
 use bcs_bot_store::{MemoryBotRepo, MemoryProviderStore};
 use bcs_http::{
+    gateway_trace::{BcnMakeSpan, BcnOnResponse},
     router::build_router,
     state::{BotRuntimeTokenResolverPort, HttpAppState},
 };
@@ -32,6 +33,9 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 use tokio::sync::{Mutex, RwLock};
 use tower::ServiceExt;
+use tower_http::trace::TraceLayer;
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::prelude::*;
 
 #[derive(Clone, Default)]
 struct SharedLogBuffer(Arc<std::sync::Mutex<Vec<u8>>>);
@@ -77,6 +81,55 @@ where
     future.await;
     drop(guard);
     String::from_utf8(buffer.0.lock().unwrap().clone()).unwrap()
+}
+
+async fn capture_otel_spans<F, T>(future: F) -> (T, Vec<opentelemetry_sdk::trace::SpanData>)
+where
+    F: Future<Output = T>,
+{
+    opentelemetry::global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+    let exporter = opentelemetry_sdk::trace::InMemorySpanExporterBuilder::new().build();
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "bot-events-contract");
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::new("bcn_otel=info"))
+        .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+    let output = future.with_subscriber(subscriber).await;
+    provider.force_flush().unwrap();
+    (output, exporter.get_finished_spans().unwrap())
+}
+
+fn assert_otel_span_string_attribute(
+    span: &opentelemetry_sdk::trace::SpanData,
+    key: &str,
+    expected: &str,
+) {
+    assert!(span.attributes.iter().any(|attr| {
+        attr.key.as_str() == key
+            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str() == expected)
+    }));
+}
+
+fn assert_otel_event_bool_attribute(
+    event: &opentelemetry::trace::Event,
+    key: &str,
+    expected: bool,
+) {
+    assert!(event.attributes.iter().any(|attr| {
+        attr.key.as_str() == key && attr.value == opentelemetry::Value::Bool(expected)
+    }));
+}
+
+fn assert_otel_event_contains(event: &opentelemetry::trace::Event, expected: &str) {
+    assert!(event.attributes.iter().any(|attr| {
+        attr.key.as_str() == "bcn.content"
+            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains(expected))
+    }));
 }
 
 struct TestApp {
@@ -1575,6 +1628,192 @@ async fn bot_events_rejects_provider_admin_token_for_static_bearer_provider() {
     let body = response_json(response).await;
     assert_eq!(body["error"], "auth_mode_mismatch");
     assert!(message_flow.events.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn bot_events_marks_auth_failure_content_untrusted_without_business_attributes() {
+    let resolver = Arc::new(StaticAgentpassResolver::default());
+    let TestApp {
+        app,
+        provider_core,
+        provider_bot_core,
+        run_context,
+        ..
+    } = test_app(resolver.clone());
+    let registered = register_provider_bot_with_admin_token(
+        provider_core.as_ref(),
+        provider_bot_core.as_ref(),
+        ProviderAuthMode::StaticBearer,
+        "reviewer-v2",
+    )
+    .await;
+    resolver
+        .insert_provider_admin(&registered.admin_token, &registered.provider_id)
+        .await;
+    run_context
+        .put_context(BotRunContext {
+            run_id: "run-untrusted".to_string(),
+            bot_id: registered.bot_uuid,
+            group_id: "group-1".to_string(),
+            bcs_session_id: None,
+            deadline_ms: bcs_protocol::now_ms() + 60_000,
+            terminal: false,
+        })
+        .await;
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+    let provider_id = registered.provider_id;
+    let admin_token = registered.admin_token;
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/bot/events")
+                    .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                    .header("content-type", "application/json")
+                    .header("X-BCN-Provider-Id", provider_id)
+                    .header("X-BCN-Provider-Bot-Ref", "reviewer-v2")
+                    .header("authorization", format!("Bearer {admin_token}"))
+                    .body(Body::from(json!({
+                        "run_id": "run-untrusted",
+                        "state": "final",
+                        "message": { "text": "untrusted-callback-content" }
+                    }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let span = spans.iter().find(|span| span.name == "bcn.bot.response").unwrap();
+    assert_otel_span_string_attribute(span, "bcn.auth.result", "failed");
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.provider.id"));
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
+    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
+    assert_otel_event_bool_attribute(event, "bcn.content.untrusted", true);
+    assert_otel_event_contains(event, "untrusted-callback-content");
+}
+
+#[tokio::test]
+async fn bot_events_marks_success_content_trusted_with_business_attributes() {
+    let TestApp {
+        app,
+        provider_core,
+        provider_bot_core,
+        run_context,
+        ..
+    } = test_app(Arc::new(StaticAgentpassResolver::default()));
+    let registered = register_provider_bot(
+        provider_core.as_ref(),
+        provider_bot_core.as_ref(),
+        ProviderAuthMode::StaticBearer,
+        "reviewer-v2",
+    )
+    .await;
+    let token = registered.bot_runtime_token.unwrap();
+    run_context
+        .put_context(BotRunContext {
+            run_id: "run-trusted".to_string(),
+            bot_id: registered.bot_uuid,
+            group_id: "group-1".to_string(),
+            bcs_session_id: None,
+            deadline_ms: bcs_protocol::now_ms() + 60_000,
+            terminal: false,
+        })
+        .await;
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+    let provider_id = registered.provider_id;
+    let request_provider_id = provider_id.clone();
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/bot/events")
+                    .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                    .header("content-type", "application/json")
+                    .header("X-BCN-Provider-Id", request_provider_id.as_str())
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::from(json!({
+                        "run_id": "run-trusted",
+                        "state": "final",
+                        "message": { "text": "trusted-callback-content" }
+                    }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let span = spans.iter().find(|span| span.name == "bcn.bot.response").unwrap();
+    assert_otel_span_string_attribute(span, "bcn.auth.result", "success");
+    assert_otel_span_string_attribute(span, "bcn.provider.id", &provider_id);
+    assert_otel_span_string_attribute(span, "bcn.run.id", "run-trusted");
+    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
+    assert_otel_event_bool_attribute(event, "bcn.content.untrusted", false);
+    assert_otel_event_contains(event, "trusted-callback-content");
+}
+
+#[tokio::test]
+async fn bot_events_records_untrusted_content_when_auth_cannot_follow_invalid_shape() {
+    let TestApp { app, .. } = test_app(Arc::new(StaticAgentpassResolver::default()));
+    let app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(BcnMakeSpan)
+            .on_response(BcnOnResponse),
+    );
+
+    let (status, spans) = capture_otel_spans(async move {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/bot/events")
+                    .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                    .header("content-type", "application/json")
+                    .header("X-BCN-Provider-Id", "unverified-provider")
+                    .header("authorization", "Bearer unverified-token")
+                    .body(Body::from(json!({
+                        "run_id": "unverified-run",
+                        "message": { "text": "invalid-shape-content" }
+                    }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        drop(response);
+        status
+    })
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let span = spans.iter().find(|span| span.name == "bcn.bot.response").unwrap();
+    assert_otel_span_string_attribute(span, "bcn.auth.result", "unverified");
+    assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.provider.id"));
+    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
+    assert_otel_event_bool_attribute(event, "bcn.content.untrusted", true);
+    assert_otel_event_contains(event, "invalid-shape-content");
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-provider-http/Cargo.toml
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/Cargo.toml
@@ -22,9 +22,13 @@ serde           = { workspace = true }
 serde_json      = { workspace = true }
 tokio           = { workspace = true }
 tracing         = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+opentelemetry   = { workspace = true }
+opentelemetry-http = { workspace = true }
 uuid            = { workspace = true }
 
 [dev-dependencies]
 axum               = { workspace = true }
 tower              = { workspace = true, features = ["util"] }
 tracing-subscriber = { workspace = true }
+opentelemetry_sdk  = { workspace = true, features = ["testing"] }

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -17,9 +17,12 @@ use bcs_service_api::{
     BotRunContext, BotRunContextPort, ChatEventState, GroupHistoryBotRequestPort, MessageFlowService,
     ProviderTransportPreference, ServiceError, ServiceResult,
 };
+use opentelemetry::global;
+use opentelemetry_http::HeaderInjector;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tracing::{info, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 mod sse;
 
@@ -735,6 +738,12 @@ async fn send_provider_request(
     if protocol_version == "2.0" {
         request = request.header(BCN_TRANSPORT_HEADER, transport);
     }
+    let context = tracing::Span::current().context();
+    let mut trace_headers = reqwest::header::HeaderMap::new();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&context, &mut HeaderInjector(&mut trace_headers));
+    });
+    request = request.headers(trace_headers);
     let response = request
         .json(body)
         .send()

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -25,13 +25,16 @@ use bcs_service_api::{
 };
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, RwLock};
+use tracing::Instrument;
 use tracing::field::{Field, Visit};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::{Layer, layer::Context, prelude::*};
 
 type CapturedState = Arc<Mutex<Option<CapturedRequest>>>;
 
 #[derive(Debug, Clone)]
 struct CapturedRequest {
+    traceparent: Option<String>,
     authorization: Option<String>,
     accept: Option<String>,
     transport: Option<String>,
@@ -40,6 +43,63 @@ struct CapturedRequest {
     timestamp: Option<String>,
     legacy_protocol_version: Option<String>,
     body: Value,
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn provider_delivery_injects_current_gateway_span_context() {
+    use opentelemetry::{global, trace::{TraceContextExt as _, TracerProvider as _}};
+    use opentelemetry_sdk::{
+        propagation::TraceContextPropagator,
+        trace::{InMemorySpanExporterBuilder, SdkTracerProvider},
+    };
+
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    let exporter = InMemorySpanExporterBuilder::new().build();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter)
+        .build();
+    let tracer = provider.tracer("bcn-provider-transport-test");
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_opentelemetry::layer().with_tracer(tracer));
+    let dispatch = tracing::Dispatch::new(subscriber);
+    let _dispatch_guard = tracing::dispatcher::set_default(&dispatch);
+
+    let captured: CapturedState = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/webhook", post(capture_ack))
+        .with_state(captured.clone());
+    let (webhook_url, server) = spawn_server(app).await;
+    let span = tracing::info_span!(target: "bcn_otel", "bcn.gateway.dispatch");
+    let span_context = span.context();
+    let expected_trace_id = span_context.span().span_context().trace_id().to_string();
+    let expected_parent_span_id = span_context.span().span_context().span_id().to_string();
+
+    HttpProviderTransport::allowing_private_networks_for_tests()
+        .deliver(BotDeliveryCommand {
+            target: provider_target(webhook_url),
+            run_id: "run-traced".to_string(),
+            frame: BcsFrame::Request(RequestFrame::new(
+                "run-traced",
+                "chat.send",
+                Some(json!({
+                    "session_key": "group:trace",
+                    "message": { "text": "hello" }
+                })),
+            )),
+            delivery_kind: BotDeliveryKind::Send,
+            provider_transport: Default::default(),
+        })
+        .instrument(span)
+        .await
+        .unwrap();
+
+    let request = captured.lock().await.clone().unwrap();
+    let traceparent = request.traceparent.expect("traceparent header");
+    let fields: Vec<_> = traceparent.split('-').collect();
+    assert_eq!(fields[0], "00");
+    assert_eq!(fields[1], expected_trace_id);
+    assert_eq!(fields[2], expected_parent_span_id);
+    server.abort();
 }
 
 #[derive(Debug, Clone)]
@@ -814,6 +874,10 @@ async fn capture_sse() -> Response {
 }
 
 async fn capture(captured: CapturedState, headers: HeaderMap, body: Value) {
+    let traceparent = headers
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     let authorization = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
@@ -843,6 +907,7 @@ async fn capture(captured: CapturedState, headers: HeaderMap, body: Value) {
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
     *captured.lock().await = Some(CapturedRequest {
+        traceparent,
         authorization,
         accept,
         transport,

--- a/src/bcs/crates/adapters/ws/bcs-ws/Cargo.toml
+++ b/src/bcs/crates/adapters/ws/bcs-ws/Cargo.toml
@@ -15,6 +15,8 @@ axum        = { workspace = true }
 tokio       = { workspace = true }
 tokio-util  = { workspace = true }
 tracing     = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
 async-trait = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
@@ -35,3 +37,5 @@ tokio-test  = "0.4"
 tokio-tungstenite = "0.26"
 bcs-session = { workspace = true }
 bcs-test-support = { workspace = true }
+tracing-subscriber = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
@@ -23,10 +23,13 @@ use bcs_service_api::{
     SystemMessageService, TaskCompleteCommand, TaskDispatchCommand,
     TaskMessageCommand, TaskRunAliasRegistration,
 };
+use opentelemetry::{Context, KeyValue};
+use opentelemetry::trace::TraceContextExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::{Mutex, mpsc};
-use tracing::{debug, info, warn};
+use tracing::{Instrument, Span, debug, info, info_span, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::bot::BotConnectionRegistry;
 use crate::shared::RunChannelManager;
@@ -36,6 +39,8 @@ pub type Result<T> = std::result::Result<T, BotWsDispatchError>;
 const BOT_DELIVERY_IS_PROVIDER_CODE: &str = "bot_delivery_is_provider";
 const BOT_DELIVERY_IS_PROVIDER_MESSAGE: &str =
     "Bot delivery is configured for HttpProvider; WebSocket uplink is no longer accepted for this bot";
+const BOT_RESPONSE_CONTENT_LIMIT_BYTES: usize = 4096;
+const TRUNCATION_MARKER: &str = "...[TRUNCATED]...";
 
 fn unwrap_outbound_group_id(
     wire_group_id: &str,
@@ -869,20 +874,115 @@ async fn handle_event_frame(
         return Ok(());
     }
 
-    handle_default_group_event(
-        state,
-        &bot_id,
-        &run_id,
-        &real_group_id,
-        bcs_session_id.as_deref(),
-        event,
-        &event_payload,
-        &event_state,
-        is_final,
-    )
-    .await?;
+    let trace_parent = if event.event == "chat.event" {
+        state.run_channels.trace_parent(&run_id).await
+    } else {
+        None
+    };
+    if let Some(trace_parent) = trace_parent {
+        let span = info_span!(
+            target: "bcn_otel",
+            "bcn.bot.response",
+            otel.kind = "consumer",
+        );
+        let _ = span.set_parent(Context::new().with_remote_span_context(trace_parent));
+        async {
+            handle_default_group_event(
+                state,
+                &bot_id,
+                &run_id,
+                &real_group_id,
+                bcs_session_id.as_deref(),
+                event,
+                &event_payload,
+                &event_state,
+                is_final,
+            )
+            .await?;
+            record_ws_bot_response_trace(&bot_id, &run_id, &event_state, &event_payload);
+            Ok::<(), BotWsDispatchError>(())
+        }
+        .instrument(span)
+        .await?;
+    } else {
+        handle_default_group_event(
+            state,
+            &bot_id,
+            &run_id,
+            &real_group_id,
+            bcs_session_id.as_deref(),
+            event,
+            &event_payload,
+            &event_state,
+            is_final,
+        )
+        .await?;
+    }
 
     Ok(())
+}
+
+fn record_ws_bot_response_trace(
+    bot_id: &str,
+    run_id: &str,
+    event_state: &ChatEventState,
+    event_payload: &Value,
+) {
+    let span = Span::current();
+    span.set_attribute("bcn.operation", "bot.response");
+    span.set_attribute("bcn.bot.id", bot_id.to_string());
+    span.set_attribute("bcn.run.id", run_id.to_string());
+    span.set_attribute("bcn.callback.state", format!("{event_state:?}"));
+    let content = serde_json::to_string(event_payload)
+        .expect("serializing parsed WebSocket bot event payload cannot fail");
+    let (captured, truncated) = truncate_bot_response_content(&content);
+    span.add_event(
+        "bcn.bot.response.content",
+        vec![
+            KeyValue::new("bcn.content", captured.clone()),
+            KeyValue::new("bcn.content.original_size_bytes", content.len() as i64),
+            KeyValue::new("bcn.content.captured_size_bytes", captured.len() as i64),
+            KeyValue::new("bcn.content.limit_bytes", BOT_RESPONSE_CONTENT_LIMIT_BYTES as i64),
+            KeyValue::new("bcn.content.truncated", truncated),
+            KeyValue::new("bcn.content.untrusted", false),
+        ],
+    );
+}
+
+fn truncate_bot_response_content(content: &str) -> (String, bool) {
+    if content.len() <= BOT_RESPONSE_CONTENT_LIMIT_BYTES {
+        return (content.to_string(), false);
+    }
+    let available = BOT_RESPONSE_CONTENT_LIMIT_BYTES - TRUNCATION_MARKER.len();
+    let requested_head = available.saturating_mul(3) / 4;
+    let head_end = floor_char_boundary(content, requested_head);
+    let requested_tail = available - head_end;
+    let tail_start = ceil_char_boundary(content, content.len().saturating_sub(requested_tail));
+    (
+        format!(
+            "{}{}{}",
+            &content[..head_end],
+            TRUNCATION_MARKER,
+            &content[tail_start..]
+        ),
+        true,
+    )
+}
+
+fn floor_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while index < value.len() && !value.is_char_boundary(index) {
+        index += 1;
+    }
+    index
 }
 
 // ---------------------------------------------------------------------------
@@ -1847,6 +1947,20 @@ mod tests {
 
         assert_eq!(group_id, "group-1");
         assert_eq!(session_id.as_deref(), Some("group-1:abcdef12"));
+    }
+
+    #[test]
+    fn bot_response_truncation_is_utf8_safe_and_preserves_head_and_tail() {
+        let content = format!("START{}END", "你".repeat(2000));
+
+        let (captured, truncated) = truncate_bot_response_content(&content);
+
+        assert!(truncated);
+        assert!(captured.starts_with("START"));
+        assert!(captured.ends_with("END"));
+        assert!(captured.contains(TRUNCATION_MARKER));
+        assert!(captured.len() <= BOT_RESPONSE_CONTENT_LIMIT_BYTES);
+        assert!(std::str::from_utf8(captured.as_bytes()).is_ok());
     }
 
     #[test]

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
+use opentelemetry::trace::SpanContext;
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, info, warn};
 
@@ -12,6 +13,7 @@ pub struct ClientChannel {
     pub registered_at: Instant,
     pub source: Option<String>,
     pub user_id: Option<String>,
+    pub trace_parent: Option<SpanContext>,
 }
 
 #[derive(Debug, Default)]
@@ -35,11 +37,26 @@ impl RunChannelManager {
         source: Option<String>,
         user_id: Option<String>,
     ) {
+        self.register_with_trace_parent(run_id, bcs_group_id, tx, source, user_id, None)
+            .await;
+    }
+
+    pub async fn register_with_trace_parent(
+        &self,
+        run_id: String,
+        bcs_group_id: String,
+        tx: mpsc::Sender<String>,
+        source: Option<String>,
+        user_id: Option<String>,
+        trace_parent: Option<SpanContext>,
+    ) {
+        let trace_parent = trace_parent.filter(SpanContext::is_valid);
         let channel = ClientChannel {
             tx,
             registered_at: Instant::now(),
             source,
             user_id,
+            trace_parent,
         };
 
         self.channels.write().await.insert(run_id.clone(), channel);
@@ -207,6 +224,15 @@ impl RunChannelManager {
         self.channels.read().await.contains_key(&resolved_run_id)
     }
 
+    pub async fn trace_parent(&self, run_id: &str) -> Option<SpanContext> {
+        let resolved_run_id = self.resolve_run_id(run_id).await;
+        self.channels
+            .read()
+            .await
+            .get(&resolved_run_id)
+            .and_then(|channel| channel.trace_parent.clone())
+    }
+
     pub async fn register_alias(&self, alias_run_id: String, source_run_id: String) -> bool {
         if alias_run_id == source_run_id {
             return self.is_registered(&source_run_id).await;
@@ -317,6 +343,17 @@ impl RunChannelManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState};
+
+    fn test_span_context() -> SpanContext {
+        SpanContext::new(
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+            SpanId::from_hex("b7ad6b7169203331").unwrap(),
+            TraceFlags::SAMPLED,
+            false,
+            TraceState::default(),
+        )
+    }
 
     #[tokio::test]
     async fn register_and_send_event() {
@@ -393,5 +430,52 @@ mod tests {
         assert!(!manager.is_registered("outer-run").await);
         assert!(!manager.is_registered("sub-run").await);
         assert!(manager.get_session_runs("grp-001:abcdef12").await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn trace_parent_lookup_resolves_alias_and_cleans_up_with_channel() {
+        let manager = RunChannelManager::new();
+        let (tx, _rx) = mpsc::channel(16);
+        let trace_parent = test_span_context();
+
+        manager
+            .register_with_trace_parent(
+                "outer-run".to_string(),
+                "grp-001".to_string(),
+                tx,
+                Some("http-chat-async".to_string()),
+                None,
+                Some(trace_parent.clone()),
+            )
+            .await;
+        assert!(
+            manager
+                .register_alias("inner-run".to_string(), "outer-run".to_string())
+                .await
+        );
+
+        assert_eq!(manager.trace_parent("inner-run").await, Some(trace_parent));
+        manager.unregister("inner-run").await;
+        assert_eq!(manager.trace_parent("outer-run").await, None);
+        assert_eq!(manager.trace_parent("inner-run").await, None);
+    }
+
+    #[tokio::test]
+    async fn invalid_trace_parent_is_not_retained() {
+        let manager = RunChannelManager::new();
+        let (tx, _rx) = mpsc::channel(1);
+
+        manager
+            .register_with_trace_parent(
+                "run-invalid".to_string(),
+                "group-1".to_string(),
+                tx,
+                Some("http-chat-async".to_string()),
+                None,
+                Some(SpanContext::empty_context()),
+            )
+            .await;
+
+        assert_eq!(manager.trace_parent("run-invalid").await, None);
     }
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -27,7 +28,10 @@ use bcs_session::NoopSessionManagementService;
 use bcs_test_support::NoopBotRunContextPort;
 use bcs_ws::bot::{BotConnectionRegistry, BotDispatchState, dispatch_frame};
 use bcs_ws::shared::RunChannelManager;
+use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState};
 use tokio::sync::{Mutex, mpsc};
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::prelude::*;
 
 #[derive(Default)]
 struct RecordingMessageFlow {
@@ -1352,6 +1356,138 @@ async fn bot_chat_event_frame_is_forwarded_to_message_flow() {
         events[0].bcs_session_id.as_deref(),
         Some("group-1:00000000")
     );
+}
+
+#[tokio::test]
+async fn traced_chat_event_creates_bot_response_child_span_after_message_flow_accepts() {
+    let state = new_state();
+    let (tx, _rx) = mpsc::channel(8);
+    let (client_tx, _client_rx) = mpsc::channel(8);
+    let mut registered_bot_id = Some("bot-compat:staff".to_string());
+    let trace_parent = SpanContext::new(
+        TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+        SpanId::from_hex("b7ad6b7169203331").unwrap(),
+        TraceFlags::SAMPLED,
+        false,
+        TraceState::default(),
+    );
+    state
+        .dispatch_state
+        .run_channels
+        .register_with_trace_parent(
+            "run-traced".to_string(),
+            "group-1:abcdef12".to_string(),
+            client_tx,
+            Some("http-chat-async".to_string()),
+            None,
+            Some(trace_parent),
+        )
+        .await;
+    assert!(
+        state
+            .dispatch_state
+            .run_channels
+            .trace_parent("run-traced")
+            .await
+            .is_some()
+    );
+    let event = BcsFrame::Event(EventFrame::new(
+        "chat.event",
+        Some(serde_json::json!({
+            "run_id": "run-traced",
+            "bcs_group_id": "group-1",
+            "state": WireChatEventState::Delta,
+            "message": {
+                "role": "assistant",
+                "content": [{ "type": "text", "text": "ws-response-content" }],
+                "timestamp": 123
+            }
+        })),
+        Some(1),
+    ));
+    let text = serde_json::to_string(&event).unwrap();
+
+    let (result, spans) = capture_otel_spans(async move {
+        dispatch_frame(
+            &state.dispatch_state,
+            &text,
+            &tx,
+            &mut registered_bot_id,
+        )
+        .await
+    })
+    .await;
+
+    result.unwrap();
+    let span = spans
+        .iter()
+        .find(|span| span.name == "bcn.bot.response")
+        .unwrap_or_else(|| panic!("expected bot response span, got {spans:#?}"));
+    assert_eq!(span.span_context.trace_id().to_string(), "0af7651916cd43dd8448eb211c80319c");
+    assert_eq!(span.parent_span_id.to_string(), "b7ad6b7169203331");
+    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
+    assert!(event.attributes.iter().any(|attr| {
+        attr.key.as_str() == "bcn.content.untrusted"
+            && attr.value == opentelemetry::Value::Bool(false)
+    }));
+    assert!(event.attributes.iter().any(|attr| {
+        attr.key.as_str() == "bcn.content"
+            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains("ws-response-content"))
+    }));
+}
+
+#[tokio::test]
+async fn chat_event_without_trace_mapping_does_not_create_response_span() {
+    let state = new_state();
+    let (tx, _rx) = mpsc::channel(8);
+    let mut registered_bot_id = Some("bot-compat:staff".to_string());
+    let event = BcsFrame::Event(EventFrame::new(
+        "chat.event",
+        Some(serde_json::json!({
+            "run_id": "run-untraced",
+            "bcs_group_id": "group-1",
+            "state": WireChatEventState::Delta,
+            "message": {
+                "role": "assistant",
+                "content": [{ "type": "text", "text": "untraced-ws-response" }],
+                "timestamp": 123
+            }
+        })),
+        Some(1),
+    ));
+    let text = serde_json::to_string(&event).unwrap();
+
+    let (result, spans) = capture_otel_spans(async move {
+        dispatch_frame(
+            &state.dispatch_state,
+            &text,
+            &tx,
+            &mut registered_bot_id,
+        )
+        .await
+    })
+    .await;
+
+    result.unwrap();
+    assert!(spans.is_empty());
+}
+
+async fn capture_otel_spans<F, T>(future: F) -> (T, Vec<opentelemetry_sdk::trace::SpanData>)
+where
+    F: Future<Output = T>,
+{
+    let exporter = opentelemetry_sdk::trace::InMemorySpanExporterBuilder::new().build();
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "ws-response-contract");
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::new("bcn_otel=info"))
+        .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+    let output = future.with_subscriber(subscriber).await;
+    provider.force_flush().unwrap();
+    (output, exporter.get_finished_spans().unwrap())
 }
 
 #[tokio::test]

--- a/src/bcs/crates/bootstrap/bcs/Cargo.toml
+++ b/src/bcs/crates/bootstrap/bcs/Cargo.toml
@@ -40,6 +40,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-appender    = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 
 # Async
 async-trait = { workspace = true }

--- a/src/bcs/crates/bootstrap/bcs/Cargo.toml
+++ b/src/bcs/crates/bootstrap/bcs/Cargo.toml
@@ -176,3 +176,4 @@ bcs-cli = { workspace = true }
 bcs-services-container = { workspace = true, features = ["test-support"] }
 serial_test = "3"
 bcs-jwt = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -56,6 +56,67 @@ pub struct CorsConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct TelemetryConfig {
+    #[serde(default = "default_telemetry_enabled")]
+    pub enabled: bool,
+
+    #[serde(default = "default_telemetry_service_name")]
+    pub service_name: String,
+
+    #[serde(default)]
+    pub otlp_traces_endpoint: Option<String>,
+
+    #[serde(default)]
+    pub extra_headers: BTreeMap<String, String>,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_telemetry_enabled(),
+            service_name: default_telemetry_service_name(),
+            otlp_traces_endpoint: None,
+            extra_headers: BTreeMap::new(),
+        }
+    }
+}
+
+impl TelemetryConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.service_name.trim().is_empty() {
+            return Err("telemetry.service_name must not be empty".to_string());
+        }
+        if let Some(endpoint) = self.otlp_traces_endpoint.as_deref() {
+            let endpoint = reqwest::Url::parse(endpoint)
+                .map_err(|error| format!("telemetry.otlp_traces_endpoint is invalid: {error}"))?;
+            if !matches!(endpoint.scheme(), "http" | "https") {
+                return Err(
+                    "telemetry.otlp_traces_endpoint must use http or https".to_string(),
+                );
+            }
+        }
+        for (name, value) in &self.extra_headers {
+            axum::http::HeaderName::try_from(name.as_str()).map_err(|_| {
+                format!("telemetry.extra_headers contains invalid header name '{name}'")
+            })?;
+            axum::http::HeaderValue::try_from(value.as_str()).map_err(|_| {
+                format!("telemetry.extra_headers contains an invalid value for '{name}'")
+            })?;
+        }
+        Ok(())
+    }
+}
+
+fn default_telemetry_enabled() -> bool {
+    true
+}
+
+fn default_telemetry_service_name() -> String {
+    "bcn".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CollaborationConfig {
     #[serde(default)]
     pub templates: CollaborationTemplatesConfig,
@@ -257,6 +318,10 @@ pub struct BcsConfig {
     /// Logging configuration.
     #[serde(default)]
     pub logging: LoggingConfig,
+
+    /// OpenTelemetry trace export configuration.
+    #[serde(default)]
+    pub telemetry: TelemetryConfig,
 
     /// bcsfuse integration configuration.
     /// When enabled, fusion is delegated to bcsfuse (Python service) via HTTP.
@@ -610,6 +675,7 @@ impl Default for BcsConfig {
             manifest: ManifestConfig::default(),
             onboard_binding_enabled: false,
             logging: LoggingConfig::default(),
+            telemetry: TelemetryConfig::default(),
             bcsfuse: BcsFuseConfig::default(),
             auth_sdk: AuthSdkConfig::default(),
             user_directory: UserDirectoryConfig::default(),
@@ -1010,6 +1076,10 @@ impl BcsConfig {
 }
 
 fn validate_loaded_config(config: &BcsConfig) -> Result<(), Box<dyn std::error::Error>> {
+    config.telemetry.validate().map_err(|e| {
+        Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+            as Box<dyn std::error::Error>
+    })?;
     config.validate_metrics().map_err(|e| {
         Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
             as Box<dyn std::error::Error>
@@ -1140,6 +1210,66 @@ mod tests {
                 "http://localhost:8000".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_telemetry_config_defaults_without_section() {
+        let config: BcsConfig = toml::from_str(r#"bots_base_dir = "/bots""#).unwrap();
+
+        assert!(config.telemetry.enabled);
+        assert_eq!(config.telemetry.service_name, "bcn");
+        assert_eq!(config.telemetry.otlp_traces_endpoint, None);
+        assert!(config.telemetry.extra_headers.is_empty());
+    }
+
+    #[test]
+    fn test_telemetry_config_parses_endpoint_and_extra_headers() {
+        let config: BcsConfig = toml::from_str(
+            r#"
+bots_base_dir = "/bots"
+
+[telemetry]
+enabled = true
+service_name = "bcn-prod"
+otlp_traces_endpoint = "https://collector.example.com/v1/traces"
+
+[telemetry.extra_headers]
+x-collector-route = "collector-local"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.telemetry.service_name, "bcn-prod");
+        assert_eq!(
+            config.telemetry.otlp_traces_endpoint.as_deref(),
+            Some("https://collector.example.com/v1/traces")
+        );
+        assert_eq!(
+            config
+                .telemetry
+                .extra_headers
+                .get("x-collector-route")
+                .map(String::as_str),
+            Some("collector-local")
+        );
+    }
+
+    #[test]
+    fn test_telemetry_config_validation_rejects_invalid_endpoint_and_headers() {
+        let invalid_endpoint = TelemetryConfig {
+            otlp_traces_endpoint: Some("not-an-http-endpoint".to_string()),
+            ..TelemetryConfig::default()
+        };
+        assert!(invalid_endpoint.validate().is_err());
+
+        let invalid_header = TelemetryConfig {
+            extra_headers: BTreeMap::from([(
+                "invalid header".to_string(),
+                "value".to_string(),
+            )]),
+            ..TelemetryConfig::default()
+        };
+        assert!(invalid_header.validate().is_err());
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/config_loader.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config_loader.rs
@@ -157,7 +157,12 @@ fn is_sensitive_config_key(key: &str) -> bool {
     let lower = key.to_ascii_lowercase();
     matches!(
         lower.as_str(),
-        "password" | "api_key" | "auth_token" | "client_secret" | "gateway_client_secret"
+        "password"
+            | "api_key"
+            | "auth_token"
+            | "client_secret"
+            | "gateway_client_secret"
+            | "extra_headers"
     ) || lower.ends_with("_password")
         || lower.ends_with("_api_key")
         || lower.ends_with("_secret")
@@ -540,6 +545,28 @@ mod tests {
             "<redacted>"
         );
         assert_eq!(source["cache"]["redis"]["connection"]["password"], "redis-pass");
+    }
+
+    #[test]
+    fn test_redact_telemetry_extra_headers_as_a_sensitive_container() {
+        let source = serde_json::json!({
+            "telemetry": {
+                "otlp_traces_endpoint": "https://collector.example.com/v1/traces",
+                "extra_headers": {
+                    "x-collector-route": "collector-local",
+                    "authorization": "Bearer secret"
+                }
+            }
+        });
+
+        let redacted = redact_sensitive_values(&source);
+
+        assert_eq!(
+            redacted["telemetry"]["otlp_traces_endpoint"],
+            "https://collector.example.com/v1/traces"
+        );
+        assert_eq!(redacted["telemetry"]["extra_headers"], "<redacted>");
+        assert!(source["telemetry"]["extra_headers"].is_object());
     }
 
     // =========================================================================

--- a/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
@@ -14,7 +14,9 @@ use bcs_service_api::{ChatRunCleanupPort, ChatRunEventPort, SecretService};
 use bcs_services_container::Services;
 use bcs_ws::bot::BotConnectionRegistry;
 use bcs_ws::shared::RunChannelManager;
+use opentelemetry::trace::TraceContextExt;
 use tokio::sync::mpsc;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::server::BcsServerState;
 
@@ -237,8 +239,26 @@ impl ChatRunEventPort for BootstrapRunChannelPort {
         source: Option<String>,
         from: Option<String>,
     ) {
+        let current_span = tracing::Span::current();
+        let is_gateway_dispatch = current_span.metadata().is_some_and(|metadata| {
+            metadata.target() == "bcn_otel" && metadata.name() == "bcn.gateway.dispatch"
+        });
+        let trace_parent = if source.as_deref() == Some("http-chat-async") && is_gateway_dispatch {
+            let context = current_span.context();
+            let span_context = context.span().span_context().clone();
+            span_context.is_valid().then_some(span_context)
+        } else {
+            None
+        };
         self.run_channels
-            .register(run_id, session_key, sender, source, from)
+            .register_with_trace_parent(
+                run_id,
+                session_key,
+                sender,
+                source,
+                from,
+                trace_parent,
+            )
             .await;
     }
 
@@ -336,6 +356,8 @@ mod tests {
     use bcs_ws::web::WorkbenchConnectionRegistry;
     use std::collections::HashMap;
     use tokio::sync::Mutex;
+    use tracing::{Instrument, info_span, instrument::WithSubscriber};
+    use tracing_subscriber::prelude::*;
 
     #[test]
     fn health_version_uses_runtime_override_when_set() {
@@ -348,6 +370,59 @@ mod tests {
         assert!(version.contains("avernet main/def"));
         assert!(version.contains("2026-07-10"));
         assert!(!version.contains("build "));
+    }
+
+    #[tokio::test]
+    async fn async_chat_run_registration_captures_current_trace_context() {
+        let exporter = opentelemetry_sdk::trace::InMemorySpanExporterBuilder::new().build();
+        let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_simple_exporter(exporter)
+            .build();
+        let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "run-channel-test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::EnvFilter::new("bcn_otel=info"))
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let run_channels = Arc::new(RunChannelManager::new());
+        let port = BootstrapRunChannelPort {
+            run_channels: run_channels.clone(),
+        };
+        let (tx, _rx) = mpsc::channel(1);
+        let (unrelated_tx, _unrelated_rx) = mpsc::channel(1);
+
+        async move {
+            let span = info_span!(target: "bcn_otel", "bcn.gateway.dispatch");
+            async {
+                port.register(
+                    "run-traced".to_string(),
+                    "group-1".to_string(),
+                    tx,
+                    Some("http-chat-async".to_string()),
+                    None,
+                )
+                .await;
+            }
+            .instrument(span)
+            .await;
+
+            let unrelated = info_span!(target: "bcn_otel", "unrelated.span");
+            async {
+                port.register(
+                    "run-unrelated".to_string(),
+                    "group-1".to_string(),
+                    unrelated_tx,
+                    Some("http-chat-async".to_string()),
+                    None,
+                )
+                .await;
+            }
+            .instrument(unrelated)
+            .await;
+        }
+        .with_subscriber(subscriber)
+        .await;
+
+        assert!(run_channels.trace_parent("run-traced").await.is_some());
+        assert!(run_channels.trace_parent("run-unrelated").await.is_none());
     }
 
     struct NoopGroupMetricsSnapshotPort;

--- a/src/bcs/crates/bootstrap/bcs/src/lib.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/lib.rs
@@ -139,6 +139,7 @@ pub mod migrations;
 pub mod plugins;
 pub mod server;
 pub mod state_machine_timeout_scanner;
+mod telemetry;
 pub mod timeout_scanner;
 pub mod token_expiry_scanner;
 
@@ -156,7 +157,7 @@ pub use config::{
     AuthSdkConfig, BcsConfig, CacheConfig, DatabaseConfig, DatabaseType, DingTalkAccountConfig,
     InviteConfig, LlmConfig, LlmProviderType, LoggingConfig, MessageHistoryConfig, MetricsConfig,
     MetricsMode, MistConfig, RedisCacheConfig, SecurityGatewayProviderConfig,
-    StructuredOutputMode, UserDirectoryConfig, UserDirectoryProviderConfig,
+    StructuredOutputMode, TelemetryConfig, UserDirectoryConfig, UserDirectoryProviderConfig,
 };
 pub use error::{BcsError, Result};
 pub use plugins::{CachePluginKind, DbPluginKind, InfrastructurePlugins};
@@ -182,7 +183,8 @@ pub async fn run_from_env_with_config_dir(config_dir: Option<&std::path::PathBuf
         .validate_api_keys()
         .map_err(BcsError::InvalidConfig)?;
 
-    logging::init(&config.logging);
+    let telemetry = telemetry::Telemetry::init(&config.telemetry);
+    logging::init(&config.logging, telemetry.tracer());
     logging::spawn_cleanup_task(config.logging.outputs.clone());
 
     tracing::info!(

--- a/src/bcs/crates/bootstrap/bcs/src/logging.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/logging.rs
@@ -8,6 +8,7 @@
 //! - Automatic cleanup of old log files (`max_keep_days`)
 
 use crate::config::{LogOutputConfig, LogOutputFormat, LoggingConfig};
+use opentelemetry_sdk::trace::SdkTracer;
 use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
 use std::io::{IsTerminal, Write};
@@ -190,24 +191,11 @@ impl<'a> MakeWriter<'a> for RotatingFileWriter {
 
 /// Initialize the tracing subscriber based on `LoggingConfig`.
 ///
-/// Two code paths:
-/// - Console-only (no file outputs): uses `tracing_subscriber::fmt()` directly.
-/// - Console + file outputs: uses registry with per-layer filters.
-pub fn init(config: &LoggingConfig) {
+/// Console, file, and BCN OpenTelemetry output use independent layer filters.
+pub fn init(config: &LoggingConfig, tracer: SdkTracer) {
     let timer = LocalTime::new(format_description!(
         "[year]-[month]-[day] [hour]:[minute]:[second]"
     ));
-
-    if config.outputs.is_empty() {
-        if config.console {
-            tracing_subscriber::fmt()
-                .with_timer(timer)
-                .with_ansi(console_ansi_enabled())
-                .with_env_filter(build_env_filter(config))
-                .init();
-        }
-        return;
-    }
 
     let file_layers: Vec<Box<dyn Layer<_> + Send + Sync>> = config
         .outputs
@@ -262,9 +250,14 @@ pub fn init(config: &LoggingConfig) {
         None
     };
 
+    let otel_layer = tracing_opentelemetry::layer()
+        .with_tracer(tracer)
+        .with_filter(Targets::new().with_target("bcn_otel", LevelFilter::TRACE));
+
     tracing_subscriber::registry()
         .with(console_layer)
         .with(file_layers)
+        .with(otel_layer)
         .init();
 }
 

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -2993,7 +2993,11 @@ impl BcsServer {
                         .unwrap()
                 },
             ))
-            .layer(TraceLayer::new_for_http())
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(bcs_http::gateway_trace::BcnMakeSpan)
+                    .on_response(bcs_http::gateway_trace::BcnOnResponse),
+            )
             .layer(
                 CorsLayer::new()
                     .allow_origin(AllowOrigin::predicate(move |origin, _| {

--- a/src/bcs/crates/bootstrap/bcs/src/telemetry.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/telemetry.rs
@@ -1,0 +1,307 @@
+use crate::config::TelemetryConfig;
+use opentelemetry::{global, trace::TracerProvider as _};
+use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::{
+    Resource,
+    propagation::TraceContextPropagator,
+    trace::{Sampler, SdkTracer, SdkTracerProvider},
+};
+use std::collections::HashMap;
+
+const DEFAULT_SERVICE_NAME: &str = "bcn";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EndpointSource {
+    Environment,
+    Config(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedTelemetryConfig {
+    service_name: String,
+    endpoint: Option<EndpointSource>,
+    extra_headers: HashMap<String, String>,
+    export_enabled: bool,
+}
+
+impl ResolvedTelemetryConfig {
+    fn from_values(
+        file: &TelemetryConfig,
+        service_name: Option<&str>,
+        traces_endpoint: Option<&str>,
+        general_endpoint: Option<&str>,
+        sdk_disabled: Option<&str>,
+    ) -> Self {
+        let service_name = service_name
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                let value = file.service_name.trim();
+                (!value.is_empty()).then_some(value)
+            })
+            .unwrap_or(DEFAULT_SERVICE_NAME)
+            .to_string();
+        let environment_endpoint = traces_endpoint
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                general_endpoint
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+            .map(|_| EndpointSource::Environment);
+        let endpoint = environment_endpoint.or_else(|| {
+            file.otlp_traces_endpoint
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| EndpointSource::Config(value.to_string()))
+        });
+        let sdk_disabled = sdk_disabled.is_some_and(|value| value.eq_ignore_ascii_case("true"));
+        let export_enabled = file.enabled && !sdk_disabled && endpoint.is_some();
+
+        Self {
+            service_name,
+            endpoint,
+            extra_headers: file
+                .extra_headers
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect(),
+            export_enabled,
+        }
+    }
+
+    fn from_env(file: &TelemetryConfig) -> Self {
+        let service_name = std::env::var("OTEL_SERVICE_NAME").ok();
+        let traces_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").ok();
+        let general_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+        let sdk_disabled = std::env::var("OTEL_SDK_DISABLED").ok();
+        Self::from_values(
+            file,
+            service_name.as_deref(),
+            traces_endpoint.as_deref(),
+            general_endpoint.as_deref(),
+            sdk_disabled.as_deref(),
+        )
+    }
+}
+
+fn build_span_exporter(
+    config: &ResolvedTelemetryConfig,
+) -> Result<SpanExporter, opentelemetry_otlp::ExporterBuildError> {
+    let builder = SpanExporter::builder()
+        .with_http()
+        .with_headers(config.extra_headers.clone());
+    match config.endpoint.as_ref() {
+        Some(EndpointSource::Config(endpoint)) => {
+            builder.with_endpoint(endpoint.clone()).build()
+        }
+        Some(EndpointSource::Environment) | None => builder.build(),
+    }
+}
+
+pub struct Telemetry {
+    provider: SdkTracerProvider,
+    tracer: SdkTracer,
+}
+
+impl Telemetry {
+    pub fn init(file_config: &TelemetryConfig) -> Self {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let config = ResolvedTelemetryConfig::from_env(file_config);
+        let resource = Resource::builder_empty()
+            .with_service_name(config.service_name.clone())
+            .build();
+        let builder = SdkTracerProvider::builder()
+            .with_sampler(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
+            .with_resource(resource);
+
+        let provider = if config.export_enabled {
+            match build_span_exporter(&config) {
+                Ok(exporter) => builder.with_batch_exporter(exporter).build(),
+                Err(error) => {
+                    eprintln!(
+                        "[telemetry] WARNING: failed to initialize OTLP trace exporter: {error}. Trace export disabled."
+                    );
+                    builder.build()
+                }
+            }
+        } else {
+            builder.build()
+        };
+        let tracer = provider.tracer("bcn");
+        global::set_tracer_provider(provider.clone());
+
+        Self { provider, tracer }
+    }
+
+    pub fn tracer(&self) -> SdkTracer {
+        self.tracer.clone()
+    }
+}
+
+impl Drop for Telemetry {
+    fn drop(&mut self) {
+        if let Err(error) = self.provider.shutdown() {
+            eprintln!("[telemetry] WARNING: failed to shut down trace provider: {error}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{Span as _, Tracer as _};
+    use std::collections::BTreeMap;
+    use std::io::{Read, Write};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn environment_values_override_file_telemetry_config() {
+        let file = crate::config::TelemetryConfig {
+            service_name: "bcn-file".to_string(),
+            otlp_traces_endpoint: Some("http://file-collector/v1/traces".to_string()),
+            ..crate::config::TelemetryConfig::default()
+        };
+        let config = ResolvedTelemetryConfig::from_values(
+            &file,
+            Some("bcn-test"),
+            Some("http://collector/traces"),
+            Some("http://collector"),
+            None,
+        );
+
+        assert_eq!(config.service_name, "bcn-test");
+        assert_eq!(config.endpoint, Some(EndpointSource::Environment));
+        assert!(config.export_enabled);
+    }
+
+    #[test]
+    fn file_telemetry_values_are_used_without_environment_overrides() {
+        let file = crate::config::TelemetryConfig {
+            service_name: "bcn-file".to_string(),
+            otlp_traces_endpoint: Some("http://file-collector/v1/traces".to_string()),
+            extra_headers: BTreeMap::from([(
+                "x-collector-route".to_string(),
+                "collector-local".to_string(),
+            )]),
+            ..crate::config::TelemetryConfig::default()
+        };
+        let config = ResolvedTelemetryConfig::from_values(&file, None, None, None, None);
+
+        assert_eq!(config.service_name, "bcn-file");
+        assert_eq!(
+            config.endpoint,
+            Some(EndpointSource::Config(
+                "http://file-collector/v1/traces".to_string()
+            ))
+        );
+        assert_eq!(
+            config.extra_headers.get("x-collector-route"),
+            Some(&"collector-local".to_string())
+        );
+        assert!(config.export_enabled);
+    }
+
+    #[test]
+    fn blank_traces_endpoint_falls_back_to_general_environment_endpoint() {
+        let file = crate::config::TelemetryConfig::default();
+        let config = ResolvedTelemetryConfig::from_values(
+            &file,
+            None,
+            Some("  "),
+            Some("http://general-collector:4318"),
+            None,
+        );
+
+        assert_eq!(config.endpoint, Some(EndpointSource::Environment));
+        assert!(config.export_enabled);
+    }
+
+    #[test]
+    fn file_or_sdk_disabled_prevents_export() {
+        let file_disabled = crate::config::TelemetryConfig {
+            enabled: false,
+            otlp_traces_endpoint: Some("http://file-collector/v1/traces".to_string()),
+            ..crate::config::TelemetryConfig::default()
+        };
+        let config = ResolvedTelemetryConfig::from_values(
+            &file_disabled,
+            None,
+            Some("http://env-collector/v1/traces"),
+            None,
+            None,
+        );
+        assert!(!config.export_enabled);
+
+        let file_enabled = crate::config::TelemetryConfig {
+            otlp_traces_endpoint: Some("http://file-collector/v1/traces".to_string()),
+            ..crate::config::TelemetryConfig::default()
+        };
+        let config = ResolvedTelemetryConfig::from_values(
+            &file_enabled,
+            None,
+            None,
+            None,
+            Some("TRUE"),
+        );
+        assert!(!config.export_enabled);
+    }
+
+    #[test]
+    fn configured_extra_headers_are_sent_to_otlp_endpoint() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 2048];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let size = stream.read(&mut buffer).unwrap();
+                if size == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..size]);
+            }
+            request_tx
+                .send(String::from_utf8_lossy(&request).into_owned())
+                .unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n")
+                .unwrap();
+        });
+
+        let file = crate::config::TelemetryConfig {
+            otlp_traces_endpoint: Some(format!("http://{address}/v1/traces")),
+            extra_headers: BTreeMap::from([(
+                "x-bcn-config-header-test".to_string(),
+                "configured".to_string(),
+            )]),
+            ..crate::config::TelemetryConfig::default()
+        };
+        let config = ResolvedTelemetryConfig::from_values(&file, None, None, None, None);
+        let exporter = build_span_exporter(&config).unwrap();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("bcn-header-test");
+        let mut span = tracer.start("header-test");
+        span.end();
+        provider.force_flush().unwrap();
+
+        let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("x-bcn-config-header-test: configured\r\n")
+        );
+        provider.shutdown().unwrap();
+        server.join().unwrap();
+    }
+}

--- a/src/bcs/crates/bootstrap/bcs/tests/e2e_ws_messaging.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/e2e_ws_messaging.rs
@@ -85,6 +85,7 @@ fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
         api_keys: vec![],
         metrics: Default::default(),
         invite: Default::default(),
+        ..BcsConfig::default()
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/helpers/mod.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/helpers/mod.rs
@@ -81,6 +81,7 @@ pub fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
             group_link_url: None,
             session_link_url: None,
         },
+        ..BcsConfig::default()
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_bcsfuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_bcsfuse.rs
@@ -70,6 +70,7 @@ fn create_test_config_bcsfuse_enabled(bots_dir: &PathBuf) -> BcsConfig {
         api_keys: vec![],
         metrics: Default::default(),
         invite: Default::default(),
+        ..BcsConfig::default()
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
@@ -78,6 +78,7 @@ fn create_config_bcsfuse_enabled(bots_dir: &PathBuf) -> BcsConfig {
         api_keys: vec![],
         metrics: Default::default(),
         invite: Default::default(),
+        ..BcsConfig::default()
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_onboarding.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_onboarding.rs
@@ -90,6 +90,7 @@ fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
         api_keys: vec![],
         metrics: Default::default(),
         invite: Default::default(),
+        ..BcsConfig::default()
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_ownership.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_ownership.rs
@@ -88,6 +88,7 @@ fn create_test_config(bots_dir: &PathBuf) -> BcsConfig {
         api_keys: vec![],
         metrics: Default::default(),
         invite: Default::default(),
+        ..BcsConfig::default()
     }
 }
 

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -177,12 +177,10 @@ impl BcsClient {
         self.client_identity = Some(identity.into());
     }
 
-    /// Configure the W3C Trace Context propagated only on business dispatch
-    /// requests. Polling and management requests intentionally omit it.
+    /// Configure the opaque Trace Context propagated only on business dispatch
+    /// requests. The gateway owns W3C validation; polling and management
+    /// requests intentionally omit it.
     pub fn set_traceparent(&mut self, value: &str) -> Result<()> {
-        if !valid_w3c_traceparent(value) {
-            return Err(anyhow!("invalid W3C TRACEPARENT value"));
-        }
         let header = HeaderValue::from_str(value).context("invalid TRACEPARENT header value")?;
         self.traceparent = Some(header);
         Ok(())
@@ -2652,36 +2650,6 @@ impl BcsClient {
     }
 }
 
-fn valid_w3c_traceparent(value: &str) -> bool {
-    let mut fields = value.split('-');
-    let (Some(version), Some(trace_id), Some(parent_id), Some(flags)) = (
-        fields.next(),
-        fields.next(),
-        fields.next(),
-        fields.next(),
-    ) else {
-        return false;
-    };
-    if fields.next().is_some()
-        || version != "00"
-        || trace_id.len() != 32
-        || parent_id.len() != 16
-        || flags.len() != 2
-    {
-        return false;
-    }
-    let lowercase_hex = |field: &str| {
-        field
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    };
-    lowercase_hex(trace_id)
-        && lowercase_hex(parent_id)
-        && lowercase_hex(flags)
-        && trace_id.bytes().any(|byte| byte != b'0')
-        && parent_id.bytes().any(|byte| byte != b'0')
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2899,17 +2867,40 @@ mod tests {
     }
 
     #[test]
-    fn test_set_traceparent_rejects_invalid_w3c_values() {
-        let invalid_values = [
+    fn test_set_traceparent_forwards_http_safe_values_without_w3c_semantic_validation() {
+        let values = [
             "not-a-traceparent",
-            "00-00000000000000000000000000000000-b7ad6b7169203331-01",
-            "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01",
-            "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-09",
+            "02-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-09-extension",
         ];
 
-        for value in invalid_values {
+        for value in values {
             let mut client = BcsClient::new("http://localhost:21000");
-            assert!(client.set_traceparent(value).is_err(), "accepted {value}");
+            client.set_traceparent(value).unwrap();
+            let request = client
+                .add_chat_dispatch_headers(
+                    client.http_client.post("http://localhost:21000/bots/bot-1/chat-async"),
+                    true,
+                    1_800_000,
+                )
+                .build()
+                .unwrap();
+
+            assert_eq!(
+                request
+                    .headers()
+                    .get("traceparent")
+                    .and_then(|header| header.to_str().ok()),
+                Some(value)
+            );
+        }
+    }
+
+    #[test]
+    fn test_set_traceparent_rejects_unsafe_http_header_values() {
+        for value in ["bad\ntraceparent", "bad\r\ntraceparent: injected"] {
+            let mut client = BcsClient::new("http://localhost:21000");
+            assert!(client.set_traceparent(value).is_err(), "accepted {value:?}");
         }
     }
 

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
+use reqwest::header::HeaderValue;
 use serde::Deserialize;
 use tracing::{debug, info, warn};
 
@@ -54,6 +55,9 @@ pub struct BcsClient {
     /// as `X-BCS-Service-Key` for external caller attribution and replaces bot
     /// bearer / X-BCS-Bot-Token on the wire.
     service_key: Option<String>,
+    /// W3C Trace Context inherited from the Bash tool process. The CLI is a
+    /// transparent carrier and never creates its own span.
+    traceparent: Option<HeaderValue>,
 }
 
 impl BcsClient {
@@ -70,6 +74,7 @@ impl BcsClient {
             oauth_headers: None,
             client_identity: None,
             service_key: None,
+            traceparent: None,
         }
     }
 
@@ -86,6 +91,7 @@ impl BcsClient {
             oauth_headers: None,
             client_identity: None,
             service_key: None,
+            traceparent: None,
         }
     }
 
@@ -106,6 +112,7 @@ impl BcsClient {
             oauth_headers: None,
             client_identity: None,
             service_key: None,
+            traceparent: None,
         }
     }
 
@@ -126,6 +133,7 @@ impl BcsClient {
             oauth_headers: Some(oauth_headers),
             client_identity: None,
             service_key: None,
+            traceparent: None,
         }
     }
 
@@ -145,6 +153,7 @@ impl BcsClient {
             oauth_headers: None,
             client_identity: None,
             service_key: Some(raw_key.into()),
+            traceparent: None,
         }
     }
 
@@ -166,6 +175,17 @@ impl BcsClient {
     /// Set the client identity for X-BCS-Client header (e.g., "bcs-cli/0.3.0").
     pub fn set_client_identity(&mut self, identity: impl Into<String>) {
         self.client_identity = Some(identity.into());
+    }
+
+    /// Configure the W3C Trace Context propagated only on business dispatch
+    /// requests. Polling and management requests intentionally omit it.
+    pub fn set_traceparent(&mut self, value: &str) -> Result<()> {
+        if !valid_w3c_traceparent(value) {
+            return Err(anyhow!("invalid W3C TRACEPARENT value"));
+        }
+        let header = HeaderValue::from_str(value).context("invalid TRACEPARENT header value")?;
+        self.traceparent = Some(header);
+        Ok(())
     }
 
     /// Get the current token.
@@ -290,6 +310,25 @@ impl BcsClient {
     fn add_chat_headers(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         self.add_auth(builder)
             .header(BCS_CHAT_VERSION_HEADER, BCS_CHAT_VERSION)
+    }
+
+    fn add_chat_dispatch_headers(
+        &self,
+        builder: reqwest::RequestBuilder,
+        detach: bool,
+        client_wait_timeout_ms: u64,
+    ) -> reqwest::RequestBuilder {
+        let builder = self
+            .add_chat_headers(builder)
+            .header("X-BCS-Client-Detach", detach.to_string())
+            .header(
+                "X-BCS-Client-Wait-Timeout-Ms",
+                client_wait_timeout_ms.to_string(),
+            );
+        match &self.traceparent {
+            Some(traceparent) => builder.header("traceparent", traceparent.clone()),
+            None => builder,
+        }
     }
 
     // ========================================================================
@@ -992,11 +1031,14 @@ impl BcsClient {
         payload: &serde_json::Value,
         timeout_ms: Option<u64>,
     ) -> reqwest::RequestBuilder {
-        self.add_chat_headers(
+        let client_wait_timeout_ms = Self::chat_request_timeout(timeout_ms).as_millis() as u64;
+        self.add_chat_dispatch_headers(
             self.http_client
                 .post(url)
                 .json(payload)
                 .timeout(Self::chat_request_timeout(timeout_ms)),
+            false,
+            client_wait_timeout_ms,
         )
     }
 
@@ -1089,6 +1131,8 @@ impl BcsClient {
         tags: &[String],
         response_mode: Option<&str>,
         organization_code: Option<&str>,
+        client_wait_timeout_ms: u64,
+        detach: bool,
     ) -> Result<ChatRunSubmitResponse> {
         let url = format!("{}/bots/{}/chat-async", self.base_url, bot_id);
         let payload = Self::chat_async_payload(
@@ -1101,11 +1145,13 @@ impl BcsClient {
         );
 
         let response = self
-            .add_chat_headers(
+            .add_chat_dispatch_headers(
                 self.http_client
                     .post(&url)
                     .json(&payload)
                     .timeout(Duration::from_secs(10)),
+                detach,
+                client_wait_timeout_ms,
             )
             .send()
             .await
@@ -1241,7 +1287,8 @@ impl BcsClient {
         poll_wait_ms: Option<u64>,
         organization_code: Option<&str>,
     ) -> Result<serde_json::Value> {
-        let overall_timeout = Duration::from_millis(overall_timeout_ms.unwrap_or(30 * 60 * 1_000));
+        let client_wait_timeout_ms = overall_timeout_ms.unwrap_or(30 * 60 * 1_000);
+        let overall_timeout = Duration::from_millis(client_wait_timeout_ms);
         let poll_wait_ms = poll_wait_ms.unwrap_or(15_000);
 
         let submit = self
@@ -1253,6 +1300,8 @@ impl BcsClient {
                 tags,
                 response_mode,
                 organization_code,
+                client_wait_timeout_ms,
+                false,
             )
             .await?;
         let run_id = submit.run_id.clone();
@@ -1328,7 +1377,8 @@ impl BcsClient {
         poll_wait_ms: Option<u64>,
         organization_code: Option<&str>,
     ) -> Result<serde_json::Value> {
-        let overall_timeout = Duration::from_millis(overall_timeout_ms.unwrap_or(30 * 60 * 1_000));
+        let client_wait_timeout_ms = overall_timeout_ms.unwrap_or(30 * 60 * 1_000);
+        let overall_timeout = Duration::from_millis(client_wait_timeout_ms);
         let poll_wait_ms = poll_wait_ms.unwrap_or(15_000);
 
         let submit = self
@@ -1340,6 +1390,8 @@ impl BcsClient {
                 tags,
                 response_mode,
                 organization_code,
+                client_wait_timeout_ms,
+                true,
             )
             .await?;
         let run_id = submit.run_id.clone();
@@ -2600,6 +2652,36 @@ impl BcsClient {
     }
 }
 
+fn valid_w3c_traceparent(value: &str) -> bool {
+    let mut fields = value.split('-');
+    let (Some(version), Some(trace_id), Some(parent_id), Some(flags)) = (
+        fields.next(),
+        fields.next(),
+        fields.next(),
+        fields.next(),
+    ) else {
+        return false;
+    };
+    if fields.next().is_some()
+        || version != "00"
+        || trace_id.len() != 32
+        || parent_id.len() != 16
+        || flags.len() != 2
+    {
+        return false;
+    }
+    let lowercase_hex = |field: &str| {
+        field
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    };
+    lowercase_hex(trace_id)
+        && lowercase_hex(parent_id)
+        && lowercase_hex(flags)
+        && trace_id.bytes().any(|byte| byte != b'0')
+        && parent_id.bytes().any(|byte| byte != b'0')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2753,6 +2835,82 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some(BCS_CHAT_VERSION)
         );
+    }
+
+    #[test]
+    fn test_chat_dispatch_headers_include_configured_traceparent() {
+        let mut client = BcsClient::new("http://localhost:21000");
+        client
+            .set_traceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+            .unwrap();
+
+        let request = client
+            .add_chat_dispatch_headers(
+                client.http_client.post("http://localhost:21000/bots/bot-1/chat-async"),
+                true,
+                1_800_000,
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request
+                .headers()
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok()),
+            Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("x-bcs-client-detach")
+                .and_then(|value| value.to_str().ok()),
+            Some("true")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("x-bcs-client-wait-timeout-ms")
+                .and_then(|value| value.to_str().ok()),
+            Some("1800000")
+        );
+    }
+
+    #[test]
+    fn test_status_poll_headers_omit_trace_and_wait_controls() {
+        let mut client = BcsClient::new("http://localhost:21000");
+        client
+            .set_traceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+            .unwrap();
+
+        let request = client
+            .add_chat_headers(client.http_client.get("http://localhost:21000/chat/runs/run-1"))
+            .build()
+            .unwrap();
+
+        assert!(request.headers().get("traceparent").is_none());
+        assert!(request.headers().get("x-bcs-client-detach").is_none());
+        assert!(
+            request
+                .headers()
+                .get("x-bcs-client-wait-timeout-ms")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_set_traceparent_rejects_invalid_w3c_values() {
+        let invalid_values = [
+            "not-a-traceparent",
+            "00-00000000000000000000000000000000-b7ad6b7169203331-01",
+            "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01",
+            "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        ];
+
+        for value in invalid_values {
+            let mut client = BcsClient::new("http://localhost:21000");
+            assert!(client.set_traceparent(value).is_err(), "accepted {value}");
+        }
     }
 
     #[test]
@@ -3010,7 +3168,10 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = BcsClient::new(server.uri());
+        let mut client = BcsClient::new(server.uri());
+        client
+            .set_traceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+            .unwrap();
         let error = client
             .chat_polling(
                 "bot-target",
@@ -3033,6 +3194,27 @@ mod tests {
             .iter()
             .find(|request| request.url.path() == "/bots/bot-target/chat-async")
             .expect("chat submit request");
+        assert_eq!(
+            submit
+                .headers
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok()),
+            Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+        );
+        assert_eq!(
+            submit
+                .headers
+                .get("x-bcs-client-detach")
+                .and_then(|value| value.to_str().ok()),
+            Some("false")
+        );
+        assert_eq!(
+            submit
+                .headers
+                .get("x-bcs-client-wait-timeout-ms")
+                .and_then(|value| value.to_str().ok()),
+            Some("20")
+        );
         let payload: serde_json::Value = serde_json::from_slice(&submit.body).unwrap();
         assert!(payload.get("timeout_ms").is_none());
         assert!(payload.get("caller_wait_mode").is_none());
@@ -3154,6 +3336,13 @@ mod tests {
         assert_eq!(
             request.timeout().copied(),
             Some(Duration::from_millis(17_345))
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("x-bcs-client-wait-timeout-ms")
+                .and_then(|value| value.to_str().ok()),
+            Some("17345")
         );
     }
 }

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -57,7 +57,7 @@ use clap::ArgAction;
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::{Level, debug, info};
+use tracing::{Level, debug, info, warn};
 use tracing_subscriber::FmtSubscriber;
 
 use bcs_cli::BcsClient;
@@ -1876,6 +1876,11 @@ async fn main() -> Result<()> {
             BcsClient::with_token(bcs_url, token)
         };
         client.set_client_identity(format!("bcs-cli/{}", env!("CARGO_PKG_VERSION")));
+        if let Ok(traceparent) = std::env::var("TRACEPARENT") {
+            if let Err(error) = client.set_traceparent(traceparent.trim()) {
+                warn!(error = %error, "Ignoring invalid TRACEPARENT from tool environment");
+            }
+        }
         client
     }
 


### PR DESCRIPTION
## Summary

- Propagate cchooks-provided W3C `TRACEPARENT` from `bcs-cli chat` to the BCN gateway and continue the trace toward providers.
- Add gateway dispatch and provider callback spans with HTTP metadata, chat parameters, and UTF-8-safe message/callback capture capped at 4 KiB with truncation metadata.
- Add optional BCN server OTLP trace export configuration, including endpoint and extra request headers, while remaining safe when telemetry is not configured.

## Configuration

- Support `telemetry.otlp_traces_endpoint` and `[telemetry.extra_headers]` in the BCN config file.
- Preserve OpenTelemetry environment-variable support, including `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, and `OTEL_EXPORTER_OTLP_HEADERS`.

## Validation

- Not run, per request (`git push --no-verify`).
