### PR TITLE
feat(paas): add optional mode param to update_outbound_operation_rule

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/paas_service/paas_facade_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/paas_service/paas_facade_router.py
@@ -44,6 +44,7 @@ from secbaas.community.api.device_manage import (
     DeviceNotFoundException,
     ErrorCode,
     OutBoundOperationRule,
+    OutBoundOperationRuleUpdatedMode,
     PaasServiceFacade,
     SigmaCreationResult,
     SigmaDeviceConfig,
@@ -666,6 +667,10 @@ async def update_outbound_operation_rule(
         Path(description="设备ID，格式：device_id@template_id"),
     ],
     outbound_operation_rule: OutBoundOperationRule,
+    mode: Annotated[
+        OutBoundOperationRuleUpdatedMode | None,
+        Query(description="更新模式：replace(默认) 或 append。不传时默认 replace"),
+    ] = None,
     facade: PaasServiceFacade = Depends(
         Provide[ApplicationContainer.services.paas_facade]
     ),
@@ -695,6 +700,7 @@ async def update_outbound_operation_rule(
         await facade.update_outbound_operation_rule(
             paas_device_id=paas_device_id,
             outbound_operation_rule=outbound_operation_rule,
+            mode=mode,
         )
         logger.info("Outbound operation rule updated successfully: %s", paas_device_id)
         return ApiResponse(

--- a/src/baas/src/secbaas/community/api/device_manage/_protocols.py
+++ b/src/baas/src/secbaas/community/api/device_manage/_protocols.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
         SigmaDeviceConfig,
         TeClawDeviceConfig,
     )
-    from ._outbound_rule import OutBoundOperationRule
+    from ._outbound_rule import OutBoundOperationRule, OutBoundOperationRuleUpdatedMode
 
 
 @runtime_checkable
@@ -189,6 +189,7 @@ class LocalPaasService(Protocol):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule for a device."""
         ...
@@ -302,6 +303,7 @@ class PaasServiceFacade(Protocol):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule for a device."""
         ...

--- a/src/baas/src/secbaas/community/api/paas/_protocols.py
+++ b/src/baas/src/secbaas/community/api/paas/_protocols.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         DeviceInfo,
         LocalPaasService,
         OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
     )
     from secbaas.community.api.health_check.bot import TTLInfo
 
@@ -78,6 +79,7 @@ class PaasService(Protocol):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule for a device."""
         ...

--- a/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
@@ -645,12 +645,14 @@ class ArcaPaasService(PaasService):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule for Arca sandbox.
 
         Args:
             paas_device_id: Arca sandbox_id to update.
             outbound_operation_rule: New outbound operation rule to apply.
+            mode: Update mode (REPLACE or APPEND). Defaults to REPLACE if not provided.
 
         Returns:
             True if successful.
@@ -663,12 +665,14 @@ class ArcaPaasService(PaasService):
             self._update_outbound_operation_rule_sync,
             paas_device_id,
             outbound_operation_rule,
+            mode,
         )
 
     def _update_outbound_operation_rule_sync(
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Synchronous implementation of update_outbound_operation_rule for use in to_thread()."""
         try:
@@ -676,9 +680,13 @@ class ArcaPaasService(PaasService):
                 f"Updating outbound operation rule for sandbox: {paas_device_id}"
             )
             sandbox = self._arca_sandbox_plugin.connect_sync_sandbox(paas_device_id)
+            update_mode = OutBoundOperationRuleUpdatedMode.REPLACE
+            if mode and mode == OutBoundOperationRuleUpdatedMode.APPEND:
+                update_mode = OutBoundOperationRuleUpdatedMode.APPEND
+
             result = sandbox.update_outbound_rule(
                 rule=outbound_operation_rule,
-                updated_mode=OutBoundOperationRuleUpdatedMode.REPLACE,
+                updated_mode=update_mode,
             )
             self._logger.info(
                 f"Outbound operation rule updated successfully: {paas_device_id}, result={result}"

--- a/src/baas/src/secbaas/community/core/service/paas/_facade.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_facade.py
@@ -55,7 +55,10 @@ from secbaas.community.logger import get_logger
 from ._factory import PaasServiceFactory
 
 if TYPE_CHECKING:
-    from secbaas.community.api.device_manage import OutBoundOperationRule
+    from secbaas.community.api.device_manage import (
+        OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
+    )
     from secbaas.community.api.health_check.bot import TTLInfo
     from secbaas.community.api.template_manage import DeviceTemplateManageService
     from secbaas.community.core.repository.device import DeviceRepository
@@ -1199,6 +1202,7 @@ class PaasServiceFacade(PaasServiceFacadeProtocol):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule for a device.
 
@@ -1256,7 +1260,7 @@ class PaasServiceFacade(PaasServiceFacadeProtocol):
 
             # Update outbound operation rule using raw_paas_device_id (without @template_id suffix)
             result = await service.update_outbound_operation_rule(
-                raw_paas_device_id, outbound_operation_rule
+                raw_paas_device_id, outbound_operation_rule, mode=mode
             )
 
             self._logger.info(

--- a/src/baas/src/secbaas/community/core/service/paas/_k8s_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_k8s_paas_service.py
@@ -36,7 +36,10 @@ from secbaas.community.spi.sandbox.k8s import K8sSandboxPlugin
 from ._paas_service import PaasService
 
 if TYPE_CHECKING:
-    from secbaas.community.api.device_manage import OutBoundOperationRule
+    from secbaas.community.api.device_manage import (
+        OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
+    )
     from secbaas.community.api.health_check.bot import TTLInfo
 
 _SANDBOX_ID_ORDINAL = re.compile(r"^(.+)-(\d+)$")
@@ -781,6 +784,7 @@ class K8sPaasService(PaasService):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update the outbound proxy rules ConfigMap for a K8s StatefulSet.
 

--- a/src/baas/src/secbaas/community/core/service/paas/_local_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_local_paas_service.py
@@ -84,7 +84,10 @@ def _normalize_message(raw_message: str | list | Any) -> str:
 
 
 if TYPE_CHECKING:
-    from secbaas.community.api.device_manage import OutBoundOperationRule
+    from secbaas.community.api.device_manage import (
+        OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
+    )
 
     # Phase 34: DeviceRecord forward reference for _process_publish_callback_for_device
     from secbaas.community.core.repository.device import DeviceRecord
@@ -1481,6 +1484,7 @@ class LocalPaasService(PaasService, LocalPaasServiceProtocol):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule for a local device.
 

--- a/src/baas/src/secbaas/community/core/service/paas/_mock_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_mock_paas_service.py
@@ -32,7 +32,10 @@ from secbaas.community.api.tenant_manage import TenantType
 from ._paas_service import PaasService
 
 if TYPE_CHECKING:
-    from secbaas.community.api.device_manage import OutBoundOperationRule
+    from secbaas.community.api.device_manage import (
+        OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
+    )
 
 
 def _is_mock_failure(env_var: str) -> bool:
@@ -178,6 +181,7 @@ class MockPaasService(PaasService):
         self,
         paas_device_id: str,
         outbound_operation_rule: "OutBoundOperationRule",
+        mode: "OutBoundOperationRuleUpdatedMode | None" = None,
     ) -> bool:
         """Mock update outbound operation rule.
 

--- a/src/baas/src/secbaas/community/core/service/paas/_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_paas_service.py
@@ -27,7 +27,11 @@ from secbaas.community.api.tenant_manage import TenantType
 
 if TYPE_CHECKING:
     from secbaas.community.api.bot_runtime import HttpConnectionInfo
-    from secbaas.community.api.device_manage import DeviceInfo, OutBoundOperationRule
+    from secbaas.community.api.device_manage import (
+        DeviceInfo,
+        OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
+    )
     from secbaas.community.api.health_check.bot import TTLInfo
 
 
@@ -174,6 +178,7 @@ class PaasService(PaasServiceProtocol, ABC):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule for a device.
 

--- a/src/baas/src/secbaas/community/core/service/paas/_poolab_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_poolab_paas_service.py
@@ -14,6 +14,7 @@ from secbaas.community.api.device_manage import (
     CommandResult,
     DeviceCreateConfig,
     OutBoundOperationRule,
+    OutBoundOperationRuleUpdatedMode,
     PoolabCreateConfig,
     PoolabCreationResult,
     PoolabCredentials,
@@ -86,6 +87,7 @@ class PoolabPaasService(PaasService):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         raise NotImplementedError(
             "Poolab platform does not support outbound operation rules"

--- a/src/baas/src/secbaas/community/core/service/paas/_sigma_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_sigma_paas_service.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING, Any
 from secbaas.community.api.device_manage import CommandResult, DeviceCreateConfig
 
 if TYPE_CHECKING:
-    from secbaas.community.api.device_manage import DeviceInfo, OutBoundOperationRule
+    from secbaas.community.api.device_manage import (
+        DeviceInfo,
+        OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
+    )
 
 from secbaas.community.api.bot_runtime import HttpConnectionInfo, WsConnectionInfo
 from secbaas.community.api.device_manage import (
@@ -213,6 +217,7 @@ class SigmaPaasService(PaasService):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """STUB: Update outbound operation rule for Sigma device.
 

--- a/src/baas/src/secbaas/community/core/service/paas/_standalone_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_standalone_paas_service.py
@@ -497,6 +497,7 @@ class StandalonePaasService(PaasService):
         self,
         paas_device_id: str,
         outbound_operation_rule: Any,
+        mode: Any = None,
     ) -> bool:
         """Not supported: Docker platform does not support outbound operation rules.
 

--- a/src/baas/src/secbaas/community/core/service/paas/_teclaw_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_teclaw_paas_service.py
@@ -25,7 +25,10 @@ from secbaas.community.spi.bot.teclaw import TeClawBotPlugin
 from ._paas_service import PaasService
 
 if TYPE_CHECKING:
-    from secbaas.community.api.device_manage import OutBoundOperationRule
+    from secbaas.community.api.device_manage import (
+        OutBoundOperationRule,
+        OutBoundOperationRuleUpdatedMode,
+    )
     from secbaas.community.api.health_check.bot import TTLInfo
 
 
@@ -243,6 +246,7 @@ class TeClawPaasService(PaasService):
         self,
         paas_device_id: str,
         outbound_operation_rule: OutBoundOperationRule,
+        mode: OutBoundOperationRuleUpdatedMode | None = None,
     ) -> bool:
         """Update outbound operation rule via plugin.update_outbound_rule.
 

--- a/src/baas/tests/architecture/test_no_bootstrap_get_container_in_all.py
+++ b/src/baas/tests/architecture/test_no_bootstrap_get_container_in_all.py
@@ -29,8 +29,8 @@ _KNOWN_DEBT: dict[str, list[tuple[str, int]]] = {
         ("core/utils/callback_utils.py", 31),
         ("core/repository/file_transfer_ticket/_factory.py", 7),
         ("core/repository/ws_relay_session/_factory.py", 11),
-        ("core/service/paas/_local_paas_service.py", 1010),
-        ("core/service/paas/_local_paas_service.py", 2217),
+        ("core/service/paas/_local_paas_service.py", 1013),
+        ("core/service/paas/_local_paas_service.py", 2221),
     ],
     "plugins": [
         ("plugins/sandbox/utils/arca_utils.py", 92),

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -392,7 +392,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             assert response.content == "response content"
             mock_pool.get.assert_awaited_once()
@@ -424,7 +424,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once_with("SESSION-xyz", err_msg="error msg")
 
@@ -452,7 +452,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once_with("SESSION-xyz", err_msg="ws closed")
 
@@ -479,7 +479,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             assert response.content == "ok"
             mock_completed.assert_called_once_with(None, result={"content": "ok"})
@@ -506,7 +506,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_resolve.assert_called_once()
 
@@ -538,7 +538,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once()
 
@@ -1344,7 +1344,7 @@ class TestSendMessageExtended:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_client.send_message.assert_awaited_once_with(
                 message="hello",
@@ -1385,7 +1385,7 @@ class TestSendMessageExtended:
                 message="hello",
                 binding_info=binding,
                 context=context,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_client.send_message.assert_awaited_once_with(
                 message="hello",
@@ -1420,7 +1420,7 @@ class TestSendMessageExtended:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once_with(
                 "SESSION-xyz", err_msg="DNS resolution failed"
@@ -1453,7 +1453,7 @@ class TestSendMessageExtended:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
 
     @pytest.mark.asyncio
@@ -1479,7 +1479,7 @@ class TestSendMessageExtended:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_pool.get.assert_awaited_once_with(
                 conn_info.target,
@@ -2148,7 +2148,7 @@ class TestSendMessageWaitResult:
                 message="hello",
                 binding_info=binding,
                 wait_result=False,
-            timeout=30.0,
+                timeout=30.0,
             )
             call_kwargs = mock_client.send_message.call_args[1]
             assert call_kwargs["wait_result"] is False

--- a/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
@@ -275,7 +275,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=baas_binding,
-            timeout=30.0,
+                timeout=30.0,
             )
 
     @pytest.mark.asyncio
@@ -292,7 +292,7 @@ class TestSendMessage:
                 message="hello",
                 binding_info=arca_binding,
                 wait_result=True,
-            timeout=30.0,
+                timeout=30.0,
             )
 
         assert isinstance(result, BotResponse)
@@ -332,7 +332,7 @@ class TestSendMessage:
                 message="hello",
                 binding_info=arca_binding,
                 context=ctx,
-            timeout=30.0,
+                timeout=30.0,
             )
 
         assert result.content == "resp with auth"
@@ -362,7 +362,7 @@ class TestSendMessage:
                 message="ping",
                 binding_info=arca_binding,
                 wait_result=False,
-            timeout=30.0,
+                timeout=30.0,
             )
 
         assert result.content == "fast resp"
@@ -392,7 +392,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="boom",
                     binding_info=arca_binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
 
         # No release needed — shared connection stays in pool
@@ -416,7 +416,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=arca_binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
@@ -292,9 +292,7 @@ class TestTaskMessageDispatcherTimeout:
     async def test_send_message_receives_reduced_timeout(
         self, mock_bot_service, mock_run_repo, arca_binding, context
     ):
-        dispatcher = TaskMessageDispatcher(
-            run_repository=mock_run_repo, task_pool=None
-        )
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=None)
         await dispatcher.dispatch_send(
             bot_service=mock_bot_service,
             run_id="run-001",
@@ -313,9 +311,7 @@ class TestTaskMessageDispatcherTimeout:
     async def test_small_timeout_floored_to_0_1(
         self, mock_bot_service, mock_run_repo, arca_binding, context
     ):
-        dispatcher = TaskMessageDispatcher(
-            run_repository=mock_run_repo, task_pool=None
-        )
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=None)
         await dispatcher.dispatch_send(
             bot_service=mock_bot_service,
             run_id="run-001",
@@ -335,9 +331,7 @@ class TestTaskMessageDispatcherTimeout:
         self, mock_bot_service, mock_run_repo, arca_binding, context
     ):
         pool = TaskConcurrencyPool(softmax=1, per_key_max=0)
-        dispatcher = TaskMessageDispatcher(
-            run_repository=mock_run_repo, task_pool=pool
-        )
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=pool)
         await dispatcher.dispatch_send(
             bot_service=mock_bot_service,
             run_id="run-001",

--- a/src/baas/tests/unit/core/service/paas/test_arca_paas_service_coverage.py
+++ b/src/baas/tests/unit/core/service/paas/test_arca_paas_service_coverage.py
@@ -1022,6 +1022,21 @@ class TestUpdateOutboundOperationRule:
             service._update_outbound_operation_rule_sync("dev-001", rule)
         assert exc_info.value.code == ErrorCode.DEVICE_UNAVAILABLE
 
+    def test_update_outbound_sync_append_mode(self, service, mock_sandbox):
+        """APPEND mode is forwarded to sandbox.update_outbound_rule."""
+        mock_sandbox.update_outbound_rule.return_value = True
+
+        rule = OutBoundOperationRule()
+        result = service._update_outbound_operation_rule_sync(
+            "dev-001", rule, mode=OutBoundOperationRuleUpdatedMode.APPEND
+        )
+
+        assert result is True
+        mock_sandbox.update_outbound_rule.assert_called_once_with(
+            rule=rule,
+            updated_mode=OutBoundOperationRuleUpdatedMode.APPEND,
+        )
+
     @pytest.mark.asyncio
     async def test_update_outbound_async(self, service, mock_sandbox):
         """Test the async update_outbound_operation_rule wrapper."""

--- a/src/baas/tests/unit/core/service/paas/test_facade.py
+++ b/src/baas/tests/unit/core/service/paas/test_facade.py
@@ -1274,7 +1274,7 @@ class TestUpdateOutboundOperationRule:
             template_id=42
         )
         mock_service.update_outbound_operation_rule.assert_called_once_with(
-            "sandbox-abc123", rule
+            "sandbox-abc123", rule, mode=None
         )
 
     @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/service/paas/test_facade_coverage.py
+++ b/src/baas/tests/unit/core/service/paas/test_facade_coverage.py
@@ -1136,7 +1136,9 @@ class TestUpdateOutboundOperationRule:
 
         result = await f.update_outbound_operation_rule("dev@42", rule)
         assert result is True
-        mock_svc.update_outbound_operation_rule.assert_awaited_once_with("dev", rule, mode=None)
+        mock_svc.update_outbound_operation_rule.assert_awaited_once_with(
+            "dev", rule, mode=None
+        )
 
     @pytest.mark.asyncio
     async def test_update_rule_template_not_found(self):

--- a/src/baas/tests/unit/core/service/paas/test_facade_coverage.py
+++ b/src/baas/tests/unit/core/service/paas/test_facade_coverage.py
@@ -1136,7 +1136,7 @@ class TestUpdateOutboundOperationRule:
 
         result = await f.update_outbound_operation_rule("dev@42", rule)
         assert result is True
-        mock_svc.update_outbound_operation_rule.assert_awaited_once_with("dev", rule)
+        mock_svc.update_outbound_operation_rule.assert_awaited_once_with("dev", rule, mode=None)
 
     @pytest.mark.asyncio
     async def test_update_rule_template_not_found(self):


### PR DESCRIPTION
Propagate the mode query param from the router down through facade, ABC, protocols, and all service implementations to the ArcaPaasService sandbox.update_outbound_rule call. Defaults to REPLACE when not provided.

- Router: add mode query param (OutBoundOperationRuleUpdatedMode | None)
- Facade/ABC/Protocol: add mode param to signature and pass through
- All impls (arca/teclaw/k8s/local/mock/sigma/poolab/standalone): add mode param
- ArcaPaasService: use APPEND when mode is explicitly set, otherwise REPLACE
- Update test_facade and test_facade_coverage assertions for new param