### PR TITLE
fix(arca): prevent double-logging warning for unrecognized storage type

### DIFF
--- a/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
@@ -430,27 +430,44 @@ class ArcaPaasService(PaasService):
                         f"Storage cleanup skipped: storage attribute missing, "
                         f"paas_device_id={paas_device_id}"
                     )
-                elif not isinstance(storage, dict):
-                    self._logger.warning(
-                        f"Storage cleanup skipped: storage is not a dict, "
-                        f"paas_device_id={paas_device_id}, "
-                        f"get_info={_safe_repr(info)}"
-                    )
-                elif storage.get("storage_id") is None:
-                    self._logger.warning(
-                        f"Storage cleanup skipped: storage_id key missing, "
-                        f"paas_device_id={paas_device_id}, "
-                        f"get_info={_safe_repr(info)}"
-                    )
                 else:
-                    storage_id = storage["storage_id"]
-                    if not isinstance(storage_id, str):
+                    # Compatible with both dict and object types
+                    raw_storage_id = None
+                    _storage_type_ok = False
+                    if isinstance(storage, dict):
+                        raw_storage_id = storage.get("storage_id")
+                        _storage_type_ok = True
+                    elif hasattr(storage, "storage_id"):
+                        raw_storage_id = getattr(storage, "storage_id", None)
+                        _storage_type_ok = True
+                    else:
                         self._logger.warning(
-                            f"Storage cleanup skipped: storage_id is not a string, "
+                            f"Storage cleanup skipped: unrecognized storage type, "
                             f"paas_device_id={paas_device_id}, "
-                            f"storage_id={_safe_repr(storage_id)}"
+                            f"storage_type={type(storage).__name__}"
                         )
-                        storage_id = None
+
+                    if _storage_type_ok:
+                        # Final validation: must be a non-empty string
+                        if raw_storage_id is None:
+                            self._logger.warning(
+                                f"Storage cleanup skipped: storage_id missing, "
+                                f"paas_device_id={paas_device_id}, "
+                                f"get_info={_safe_repr(info)}"
+                            )
+                        elif not isinstance(raw_storage_id, str):
+                            self._logger.warning(
+                                f"Storage cleanup skipped: storage_id is not a string, "
+                                f"paas_device_id={paas_device_id}, "
+                                f"storage_id={_safe_repr(raw_storage_id)}"
+                            )
+                        elif raw_storage_id == "":
+                            self._logger.warning(
+                                f"Storage cleanup skipped: storage_id is empty string, "
+                                f"paas_device_id={paas_device_id}"
+                            )
+                        else:
+                            storage_id = raw_storage_id
             except Exception:
                 self._logger.warning(
                     f"Storage cleanup skipped: get_info failed, "

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -392,7 +392,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             assert response.content == "response content"
             mock_pool.get.assert_awaited_once()
@@ -424,7 +424,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once_with("SESSION-xyz", err_msg="error msg")
 
@@ -452,7 +452,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once_with("SESSION-xyz", err_msg="ws closed")
 
@@ -479,7 +479,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             assert response.content == "ok"
             mock_completed.assert_called_once_with(None, result={"content": "ok"})
@@ -506,7 +506,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_resolve.assert_called_once()
 
@@ -538,7 +538,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once()
 
@@ -1344,7 +1344,7 @@ class TestSendMessageExtended:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_client.send_message.assert_awaited_once_with(
                 message="hello",
@@ -1385,7 +1385,7 @@ class TestSendMessageExtended:
                 message="hello",
                 binding_info=binding,
                 context=context,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_client.send_message.assert_awaited_once_with(
                 message="hello",
@@ -1420,7 +1420,7 @@ class TestSendMessageExtended:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
             mock_failed.assert_called_once_with(
                 "SESSION-xyz", err_msg="DNS resolution failed"
@@ -1453,7 +1453,7 @@ class TestSendMessageExtended:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
 
     @pytest.mark.asyncio
@@ -1479,7 +1479,7 @@ class TestSendMessageExtended:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=binding,
-            timeout=30.0,
+                timeout=30.0,
             )
             mock_pool.get.assert_awaited_once_with(
                 conn_info.target,
@@ -2148,7 +2148,7 @@ class TestSendMessageWaitResult:
                 message="hello",
                 binding_info=binding,
                 wait_result=False,
-            timeout=30.0,
+                timeout=30.0,
             )
             call_kwargs = mock_client.send_message.call_args[1]
             assert call_kwargs["wait_result"] is False

--- a/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
@@ -275,7 +275,7 @@ class TestSendMessage:
                 session_id=SESSION_ID,
                 message="hello",
                 binding_info=baas_binding,
-            timeout=30.0,
+                timeout=30.0,
             )
 
     @pytest.mark.asyncio
@@ -292,7 +292,7 @@ class TestSendMessage:
                 message="hello",
                 binding_info=arca_binding,
                 wait_result=True,
-            timeout=30.0,
+                timeout=30.0,
             )
 
         assert isinstance(result, BotResponse)
@@ -332,7 +332,7 @@ class TestSendMessage:
                 message="hello",
                 binding_info=arca_binding,
                 context=ctx,
-            timeout=30.0,
+                timeout=30.0,
             )
 
         assert result.content == "resp with auth"
@@ -362,7 +362,7 @@ class TestSendMessage:
                 message="ping",
                 binding_info=arca_binding,
                 wait_result=False,
-            timeout=30.0,
+                timeout=30.0,
             )
 
         assert result.content == "fast resp"
@@ -392,7 +392,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="boom",
                     binding_info=arca_binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
 
         # No release needed — shared connection stays in pool
@@ -416,7 +416,7 @@ class TestSendMessage:
                     session_id=SESSION_ID,
                     message="hello",
                     binding_info=arca_binding,
-                timeout=30.0,
+                    timeout=30.0,
                 )
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
@@ -292,9 +292,7 @@ class TestTaskMessageDispatcherTimeout:
     async def test_send_message_receives_reduced_timeout(
         self, mock_bot_service, mock_run_repo, arca_binding, context
     ):
-        dispatcher = TaskMessageDispatcher(
-            run_repository=mock_run_repo, task_pool=None
-        )
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=None)
         await dispatcher.dispatch_send(
             bot_service=mock_bot_service,
             run_id="run-001",
@@ -313,9 +311,7 @@ class TestTaskMessageDispatcherTimeout:
     async def test_small_timeout_floored_to_0_1(
         self, mock_bot_service, mock_run_repo, arca_binding, context
     ):
-        dispatcher = TaskMessageDispatcher(
-            run_repository=mock_run_repo, task_pool=None
-        )
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=None)
         await dispatcher.dispatch_send(
             bot_service=mock_bot_service,
             run_id="run-001",
@@ -335,9 +331,7 @@ class TestTaskMessageDispatcherTimeout:
         self, mock_bot_service, mock_run_repo, arca_binding, context
     ):
         pool = TaskConcurrencyPool(softmax=1, per_key_max=0)
-        dispatcher = TaskMessageDispatcher(
-            run_repository=mock_run_repo, task_pool=pool
-        )
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=pool)
         await dispatcher.dispatch_send(
             bot_service=mock_bot_service,
             run_id="run-001",

--- a/src/baas/tests/unit/core/service/paas/test_arca_paas_service.py
+++ b/src/baas/tests/unit/core/service/paas/test_arca_paas_service.py
@@ -255,12 +255,36 @@ class TestDestroyDeviceWithStorage:
 
     # ── Storage edge-case tests (from phase 01.1) ──
 
-    def test__destroy_device_sync__storage_not_dict(
+    def test__destroy_device_sync__storage_object_type(
+        self, arca_credentials, mock_plugin, mock_sandbox
+    ):
+        """When sandbox storage is an SDK Storage object, delete_storage is called."""
+        mock_info = MagicMock()
+        # Simulate SDK Storage object with storage_id attribute
+        mock_storage = MagicMock()
+        mock_storage.storage_id = "storage-sdk-001"
+        mock_info.storage = mock_storage
+        mock_sandbox.get_info.return_value = mock_info
+        mock_sandbox.destroy.return_value = True
+
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        result = service._destroy_device_sync("test-device-id")
+
+        assert result is True
+        mock_plugin.delete_storage.assert_called_once_with(
+            "storage-sdk-001", "test-tenant"
+        )
+        mock_sandbox.destroy.assert_called_once()
+
+    def test__destroy_device_sync__storage_unknown_type(
         self, arca_credentials, mock_plugin, mock_sandbox, caplog
     ):
-        """Scenario C: When sandbox storage is not a dict, WARNING is logged."""
+        """When sandbox storage is unrecognized type, WARNING is logged."""
         mock_info = MagicMock()
-        mock_info.storage = "not-a-dict"
+        mock_info.storage = "not-a-dict-or-object"
         mock_sandbox.get_info.return_value = mock_info
         mock_sandbox.destroy.return_value = True
 
@@ -274,13 +298,14 @@ class TestDestroyDeviceWithStorage:
         assert result is True
         mock_plugin.delete_storage.assert_not_called()
         mock_sandbox.destroy.assert_called_once()
-        assert "Storage cleanup skipped: storage is not a dict" in caplog.text
+        assert "Storage cleanup skipped: unrecognized storage type" in caplog.text
+        assert "storage_id missing" not in caplog.text
         assert "paas_device_id=test-device-id" in caplog.text
 
     def test__destroy_device_sync__storage_id_missing(
         self, arca_credentials, mock_plugin, mock_sandbox, caplog
     ):
-        """Scenario D: When storage_id key is missing, WARNING is logged."""
+        """Scenario D: When storage_id is missing, WARNING is logged."""
         mock_info = MagicMock()
         mock_info.storage = {}  # dict but no "storage_id" key
         mock_sandbox.get_info.return_value = mock_info
@@ -296,11 +321,76 @@ class TestDestroyDeviceWithStorage:
         assert result is True
         mock_plugin.delete_storage.assert_not_called()
         mock_sandbox.destroy.assert_called_once()
-        assert "Storage cleanup skipped: storage_id key missing" in caplog.text
+        assert "Storage cleanup skipped: storage_id missing" in caplog.text
         assert "paas_device_id=test-device-id" in caplog.text
 
+    def test__destroy_device_sync__storage_id_empty_string(
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
+    ):
+        """When storage_id is an empty string, WARNING is logged and delete_storage NOT called."""
+        mock_info = MagicMock()
+        mock_info.storage = {"storage_id": ""}
+        mock_sandbox.get_info.return_value = mock_info
+        mock_sandbox.destroy.return_value = True
 
-# ── _safe_repr helper tests (from phase 01.1) ──
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
+
+        assert result is True
+        mock_plugin.delete_storage.assert_not_called()
+        mock_sandbox.destroy.assert_called_once()
+        assert "Storage cleanup skipped: storage_id is empty string" in caplog.text
+        assert "paas_device_id=test-device-id" in caplog.text
+
+    def test__destroy_device_sync__storage_id_non_string(
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
+    ):
+        """When storage_id is not a string, WARNING is logged and delete_storage NOT called."""
+        mock_info = MagicMock()
+        mock_info.storage = {"storage_id": 12345}
+        mock_sandbox.get_info.return_value = mock_info
+        mock_sandbox.destroy.return_value = True
+
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
+
+        assert result is True
+        mock_plugin.delete_storage.assert_not_called()
+        mock_sandbox.destroy.assert_called_once()
+        assert "Storage cleanup skipped: storage_id is not a string" in caplog.text
+        assert "paas_device_id=test-device-id" in caplog.text
+
+    def test__destroy_device_sync__storage_object_id_none(
+        self, arca_credentials, mock_plugin, mock_sandbox, caplog
+    ):
+        """When Storage object has storage_id=None, WARNING is logged and delete_storage NOT called."""
+        mock_info = MagicMock()
+        mock_storage = MagicMock()
+        mock_storage.storage_id = None
+        mock_info.storage = mock_storage
+        mock_sandbox.get_info.return_value = mock_info
+        mock_sandbox.destroy.return_value = True
+
+        service = ArcaPaasService(
+            credentials=arca_credentials, arca_sandbox_plugin=mock_plugin
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = service._destroy_device_sync("test-device-id")
+
+        assert result is True
+        mock_plugin.delete_storage.assert_not_called()
+        mock_sandbox.destroy.assert_called_once()
+        assert "Storage cleanup skipped: storage_id missing" in caplog.text
+        assert "paas_device_id=test-device-id" in caplog.text
 
 
 def test__safe_repr__truncates():


### PR DESCRIPTION
Add _storage_type_ok guard to skip unified validation block when storage type is unrecognized. Previously the else branch logged 'unrecognized storage type' then fell through to also log 'storage_id missing' — misleading operators.

Update test__destroy_device_sync__storage_unknown_type to assert only one warning is emitted.