### PR TITLE
feat(aicoding): architect-rebind supports source/target architect

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/architect_rebind_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/architect_rebind_router.py
@@ -1,10 +1,6 @@
-"""AICoding one-click architect-bot rebind route.
+"""One-click rebind of application-coding bots between domain architect bots.
 
-``PUT /api/bots/{architect_bot_id}/architect-rebind`` is an aicoding-creation
-specific endpoint (it binds ``applicationCoding`` bots to a domain architect
-bot), so it lives under the aicoding HTTP package instead of the generic
-bot-management router. The path is kept under ``/api/bots`` because it
-operates on bot resources; only the owning code moves.
+``PUT /api/bots/{architect_bot_id}/architect-rebind``
 """
 from __future__ import annotations
 
@@ -30,7 +26,7 @@ router = APIRouter(prefix="/api/bots", tags=["aicoding"])
 
 
 class ApiResponse(BaseModel):
-    """Unified API response envelope for the rebind route."""
+    """Unified API response envelope."""
 
     success: bool
     message: str = "OK"
@@ -39,9 +35,18 @@ class ApiResponse(BaseModel):
 
 
 class RebindArchitectRequest(BaseModel):
-    """请求模型：一键换绑架构师 bot（把一批应用 coding bot 绑定到指定架构师 bot）。"""
+    """换绑请求：从源架构师 bot 把一批应用 coding bot 换绑到目标架构师 bot。"""
 
+    target_architect_bot_id: str
     coding_bot_ids: List[str]
+
+    @field_validator("target_architect_bot_id")
+    @classmethod
+    def _target_non_empty(cls, value: str) -> str:
+        cleaned = value.strip() if isinstance(value, str) else ""
+        if not cleaned:
+            raise ValueError("target_architect_bot_id 不能为空")
+        return cleaned
 
     @field_validator("coding_bot_ids")
     @classmethod
@@ -59,15 +64,11 @@ async def rebind_architect_bot(
     ctx: RequestContext = Depends(get_request_context),
     _architect_rebind_service: ArchitectRebindServiceProtocol = Injected(ArchitectRebindServiceProtocol),
 ) -> ApiResponse:
-    """一键换绑架构师 bot（支持批量）：把应用 coding bot 绑定到指定架构师 bot。
+    """把应用 coding bot 从源架构师 bot 换绑到目标架构师 bot。
 
-    PUT /api/bots/{architect_bot_id}/architect-rebind
-    Body: {"coding_bot_ids": ["app_coding_bot_id_1", ...]}
-
-    - {architect_bot_id} 须为 domain architect bot (ext.is_domain_bot == true)
-    - coding_bot_ids 为 applicationCoding bot 列表，自动去重保序
-    - 仅允许架构师 bot 的 owner 调用，非 owner -> 403
-    - 落库 ac_templates.ext.architect_bot_id；单条失败不影响其余
+    - 路径 ``{architect_bot_id}`` = 源架构师 bot（须 domain，操作者须为其 owner）
+    - body ``target_architect_bot_id`` = 目标架构师 bot（须 domain，不校验 owner）
+    - body ``coding_bot_ids`` = applicationCoding bot 列表
     """
     try:
         operator_id = ctx.user_id
@@ -80,8 +81,9 @@ async def rebind_architect_bot(
             )
         result = await asyncio.to_thread(
             _architect_rebind_service.rebind_architect_bot_batch,
+            source_architect_bot_id=architect_bot_id,
+            target_architect_bot_id=payload.target_architect_bot_id,
             coding_bot_ids=payload.coding_bot_ids,
-            architect_bot_id=architect_bot_id,
             operator_id=operator_id,
         )
         return ApiResponse(success=True, data=result)

--- a/src/backend/src/agentclaw/community/core/aicoding/services/architect_rebind_service.py
+++ b/src/backend/src/agentclaw/community/core/aicoding/services/architect_rebind_service.py
@@ -1,15 +1,4 @@
-"""Architect-bot rebind service (aicoding-creation specific).
-
-Moved out of the generic ``BotService`` because one-click rebind of
-application-coding bots onto a domain architect bot is an aicoding-creation
-concern, not general bot lifecycle. The ownership/behaviour contract is
-unchanged from the original ``BotService`` implementation:
-
-- owner boundary lives on the **architect** side (owner-scoped 403);
-- per-coding-bot helper only validates existence + ``template_type``;
-- batch flow returns a per-item ``error_code`` map, single failure does not
-  abort the rest, and success items never leak the template/token ciphertext.
-"""
+"""Rebind application-coding bots from one domain architect bot to another."""
 from __future__ import annotations
 
 import json
@@ -41,6 +30,23 @@ class ArchitectRebindService:
         self._repository = repository
         self._template_service = template_service
 
+    def _get_architect_domain_by_id_or_raise(self, architect_bot_id: str) -> Dict[str, Any]:
+        """校验并返回 domain architect bot（仅校验存在性 + is_domain_bot，不校验 owner）。"""
+        architect = self._repository.get_by_id(architect_bot_id)
+        if not architect:
+            raise BotNotFoundError(f"架构师 Bot 不存在: {architect_bot_id}")
+        arch_ext = architect.get("ext") or {}
+        if isinstance(arch_ext, str):
+            try:
+                arch_ext = json.loads(arch_ext)
+            except (ValueError, TypeError):
+                arch_ext = {}
+        if not (isinstance(arch_ext, dict) and arch_ext.get("is_domain_bot") is True):
+            raise BotServiceError(
+                f"目标 Bot 不是架构师 Bot (is_domain_bot != true): {architect_bot_id}"
+            )
+        return architect
+
     def _get_architect_domain_or_raise(self, architect_bot_id: str, operator_id: str) -> Dict[str, Any]:
         """校验并返回 domain architect bot（owner-scoped，不存在/非本人所有 -> 403）。"""
         architect = self._repository.get_by_id_and_owner(architect_bot_id, operator_id)
@@ -59,22 +65,9 @@ class ArchitectRebindService:
         return architect
 
     def _rebind_coding_bot_to_architect(
-        self, coding_bot_id: str, architect_bot_id: str, operator_id: str,
+        self, coding_bot_id: str, target_architect_bot_id: str, operator_id: str,
     ) -> Dict[str, Any]:
-        """换绑单个应用 coding bot 的核心逻辑（owner/架构师校验由调用方负责）。
-
-        Args:
-            coding_bot_id: template_type == "applicationCoding" 的 bot_id
-            architect_bot_id: 目标架构师 bot（调用方已校验为 domain + owner）
-            operator_id: 工号，仅用于审计日志
-
-        Returns:
-            {bot_id, architect_bot_id, previous_architect_bot_id, changed, template}
-
-        Raises:
-            BotNotFoundError: coding bot 不存在
-            BotServiceError: 非 applicationCoding 或模板缺失
-        """
+        """把单个 applicationCoding bot 的 architect_bot_id 改写为目标架构师。"""
         coding_bot = self._repository.get_by_id(coding_bot_id)
         if not coding_bot:
             raise BotNotFoundError(f"应用 Coding Bot 不存在: {coding_bot_id}")
@@ -90,79 +83,65 @@ class ArchitectRebindService:
         if not isinstance(ext, dict):
             ext = {}
         previous_architect_bot_id = ext.get("architect_bot_id")
-        if previous_architect_bot_id == architect_bot_id:
+        if previous_architect_bot_id == target_architect_bot_id:
             logger.info(
                 "[architect_rebind_service.rebind_architect_bot] no-op, coding bot %s already bound to %s",
-                coding_bot_id, architect_bot_id,
+                coding_bot_id, target_architect_bot_id,
             )
             return {
                 "bot_id": coding_bot_id,
-                "architect_bot_id": architect_bot_id,
+                "architect_bot_id": target_architect_bot_id,
                 "previous_architect_bot_id": previous_architect_bot_id,
                 "changed": False,
             }
 
         new_ext = dict(ext)
-        new_ext["architect_bot_id"] = architect_bot_id
+        new_ext["architect_bot_id"] = target_architect_bot_id
         updated_template = self._template_service.update_template(
             coding_bot_id, new_ext, template_type="applicationCoding",
         )
         logger.info(
             "[architect_rebind_service.rebind_architect_bot] coding bot %s rebind %s -> %s by %s",
-            coding_bot_id, previous_architect_bot_id, architect_bot_id, operator_id,
+            coding_bot_id, previous_architect_bot_id, target_architect_bot_id, operator_id,
         )
         return {
             "bot_id": coding_bot_id,
-            "architect_bot_id": architect_bot_id,
+            "architect_bot_id": target_architect_bot_id,
             "previous_architect_bot_id": previous_architect_bot_id,
             "changed": True,
             "template": updated_template,
         }
 
     def rebind_architect_bot(
-        self, coding_bot_id: str, architect_bot_id: str, operator_id: str,
+        self,
+        coding_bot_id: str,
+        source_architect_bot_id: str,
+        target_architect_bot_id: str,
+        operator_id: str,
     ) -> Dict[str, Any]:
-        """把单个应用 coding bot 绑定到指定架构师 bot。
-
-        Args:
-            coding_bot_id: applicationCoding bot 的 bot_id
-            architect_bot_id: domain 架构师 bot 的 bot_id
-            operator_id: 工号
-
-        Returns:
-            {bot_id, architect_bot_id, previous_architect_bot_id, changed, template}
-
-        Raises:
-            BotPermissionError: 架构师 bot 不存在或非本人所有
-            BotNotFoundError: coding bot 不存在
-            BotServiceError: bot 类型不符或模板缺失
-        """
-        if not coding_bot_id or not architect_bot_id:
-            raise BotServiceError("coding_bot_id 与 architect_bot_id 不能为空")
-        if coding_bot_id == architect_bot_id:
-            raise BotServiceError("coding_bot_id 与 architect_bot_id 不能相同")
-        self._get_architect_domain_or_raise(architect_bot_id, operator_id)
-        return self._rebind_coding_bot_to_architect(coding_bot_id, architect_bot_id, operator_id)
+        """换绑单个应用 coding bot：源架构师 owner 校验 -> 绑定到目标架构师。"""
+        if not coding_bot_id or not source_architect_bot_id or not target_architect_bot_id:
+            raise BotServiceError("coding_bot_id / source_architect_bot_id / target_architect_bot_id 不能为空")
+        if source_architect_bot_id == target_architect_bot_id:
+            raise BotServiceError("源架构师与目标架构师不能相同")
+        if coding_bot_id in (source_architect_bot_id, target_architect_bot_id):
+            raise BotServiceError("coding_bot_id 不能与架构师 id 相同")
+        self._get_architect_domain_or_raise(source_architect_bot_id, operator_id)
+        self._get_architect_domain_by_id_or_raise(target_architect_bot_id)
+        return self._rebind_coding_bot_to_architect(coding_bot_id, target_architect_bot_id, operator_id)
 
     def rebind_architect_bot_batch(
-        self, coding_bot_ids: List[str], architect_bot_id: str, operator_id: str,
+        self,
+        coding_bot_ids: List[str],
+        source_architect_bot_id: str,
+        target_architect_bot_id: str,
+        operator_id: str,
     ) -> Dict[str, Any]:
-        """把多个应用 coding bot 批量绑定到同一架构师 bot（去重保序，单条失败不影响其余）。
-
-        Args:
-            coding_bot_ids: applicationCoding bot 的 bot_id 列表
-            architect_bot_id: domain 架构师 bot 的 bot_id
-            operator_id: 工号
-
-        Returns:
-            {architect_bot_id, results[], total, succeeded, failed}；result 不含 token。
-
-        Raises:
-            BotPermissionError: 架构师 bot 不存在或非本人所有（整批拒绝）
-            BotServiceError: 架构师非 domain 或参数非法（整批拒绝）
-        """
-        if not architect_bot_id:
-            raise BotServiceError("architect_bot_id 不能为空")
+        """批量换绑：去重保序，单条失败不影响其余。"""
+        if not source_architect_bot_id or not target_architect_bot_id:
+            raise BotServiceError("source_architect_bot_id / target_architect_bot_id 不能为空")
+        if source_architect_bot_id == target_architect_bot_id:
+            raise BotServiceError("源架构师与目标架构师不能相同")
         if not coding_bot_ids:
             raise BotServiceError("coding_bot_ids 不能为空")
 
@@ -174,23 +153,24 @@ class ArchitectRebindService:
                 uniq_ids.append(bid)
         if not uniq_ids:
             raise BotServiceError("coding_bot_ids 不能为空")
-        if architect_bot_id in seen:
-            raise BotServiceError("coding_bot_id 不能与 architect_bot_id 相同")
+        if source_architect_bot_id in seen or target_architect_bot_id in seen:
+            raise BotServiceError("coding_bot_id 不能与架构师 id 相同")
 
-        self._get_architect_domain_or_raise(architect_bot_id, operator_id)
+        self._get_architect_domain_or_raise(source_architect_bot_id, operator_id)
+        self._get_architect_domain_by_id_or_raise(target_architect_bot_id)
 
         results = []
         succeeded = 0
         failed = 0
         for coding_bot_id in uniq_ids:
             try:
-                one = self._rebind_coding_bot_to_architect(coding_bot_id, architect_bot_id, operator_id)
+                one = self._rebind_coding_bot_to_architect(coding_bot_id, target_architect_bot_id, operator_id)
                 results.append({
                     "bot_id": coding_bot_id,
                     "success": True,
                     "changed": one.get("changed"),
                     "previous_architect_bot_id": one.get("previous_architect_bot_id"),
-                    "architect_bot_id": architect_bot_id,
+                    "architect_bot_id": target_architect_bot_id,
                 })
                 succeeded += 1
             except BotNotFoundError as e:
@@ -223,11 +203,13 @@ class ArchitectRebindService:
                 })
 
         logger.info(
-            "[architect_rebind_service.rebind_architect_bot_batch] architect=%s total=%d succeeded=%d failed=%d by %s",
-            architect_bot_id, len(uniq_ids), succeeded, failed, operator_id,
+            "[architect_rebind_service.rebind_architect_bot_batch] source=%s target=%s total=%d succeeded=%d failed=%d by %s",
+            source_architect_bot_id, target_architect_bot_id,
+            len(uniq_ids), succeeded, failed, operator_id,
         )
         return {
-            "architect_bot_id": architect_bot_id,
+            "source_architect_bot_id": source_architect_bot_id,
+            "target_architect_bot_id": target_architect_bot_id,
             "results": results,
             "total": len(uniq_ids),
             "succeeded": succeeded,

--- a/src/backend/tests/community/api/aicoding/test_architect_rebind_router.py
+++ b/src/backend/tests/community/api/aicoding/test_architect_rebind_router.py
@@ -71,10 +71,11 @@ class TestRebindArchitectBot:
     def test_success(self, client):
         tc, svc = client
         svc.rebind_architect_bot_batch.return_value = {
-            "architect_bot_id": "arch1",
+            "source_architect_bot_id": "arch1",
+            "target_architect_bot_id": "arch2",
             "results": [
                 {"bot_id": "c1", "success": True, "changed": True,
-                 "previous_architect_bot_id": "old", "architect_bot_id": "arch1"},
+                 "previous_architect_bot_id": "old", "architect_bot_id": "arch2"},
             ],
             "total": 1,
             "succeeded": 1,
@@ -82,14 +83,15 @@ class TestRebindArchitectBot:
         }
         resp = tc.put(
             "/api/bots/arch1/architect-rebind",
-            json={"coding_bot_ids": ["c1", "c2", "c1"]},
+            json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["c1", "c2", "c1"]},
         )
         assert resp.status_code == 200
         data = resp.json()
         assert data["success"] is True
         assert data["data"]["total"] == 1
         kwargs = svc.rebind_architect_bot_batch.call_args.kwargs
-        assert kwargs["architect_bot_id"] == "arch1"
+        assert kwargs["source_architect_bot_id"] == "arch1"
+        assert kwargs["target_architect_bot_id"] == "arch2"
         assert kwargs["coding_bot_ids"] == ["c1", "c2", "c1"]
         assert kwargs["operator_id"] == "test_user"
 
@@ -98,7 +100,7 @@ class TestRebindArchitectBot:
         tc.app.dependency_overrides[get_request_context] = lambda: _make_ctx(user_id="anonymous")
         resp = tc.put(
             "/api/bots/arch1/architect-rebind",
-            json={"coding_bot_ids": ["c1"]},
+            json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["c1"]},
         )
         body = resp.json()
         assert body["success"] is False
@@ -110,7 +112,7 @@ class TestRebindArchitectBot:
         # RebindArchitectRequest validator rejects empty/all-blank list -> 422
         resp = tc.put(
             "/api/bots/arch1/architect-rebind",
-            json={"coding_bot_ids": ["  ", ""]},
+            json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["  ", ""]},
         )
         assert resp.status_code == 422
         svc.rebind_architect_bot_batch.assert_not_called()
@@ -118,12 +120,13 @@ class TestRebindArchitectBot:
     def test_coding_bot_ids_are_stripped_of_whitespace(self, client):
         tc, svc = client
         svc.rebind_architect_bot_batch.return_value = {
-            "architect_bot_id": "arch1", "results": [], "total": 0,
+            "source_architect_bot_id": "arch1",
+            "target_architect_bot_id": "arch2", "results": [], "total": 0,
             "succeeded": 0, "failed": 0,
         }
         resp = tc.put(
             "/api/bots/arch1/architect-rebind",
-            json={"coding_bot_ids": ["  c1  ", "c2", "   "]},
+            json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["  c1  ", "c2", "   "]},
         )
         assert resp.status_code == 200
         kwargs = svc.rebind_architect_bot_batch.call_args.kwargs
@@ -132,7 +135,7 @@ class TestRebindArchitectBot:
     def test_bot_not_found(self, client):
         tc, svc = client
         svc.rebind_architect_bot_batch.side_effect = BotNotFoundError("nope")
-        resp = tc.put("/api/bots/arch1/architect-rebind", json={"coding_bot_ids": ["c1"]})
+        resp = tc.put("/api/bots/arch1/architect-rebind", json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["c1"]})
         data = resp.json()
         assert data["success"] is False
         assert data["error_code"] == 404
@@ -140,7 +143,7 @@ class TestRebindArchitectBot:
     def test_permission_error(self, client):
         tc, svc = client
         svc.rebind_architect_bot_batch.side_effect = BotPermissionError("forbidden")
-        resp = tc.put("/api/bots/arch1/architect-rebind", json={"coding_bot_ids": ["c1"]})
+        resp = tc.put("/api/bots/arch1/architect-rebind", json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["c1"]})
         data = resp.json()
         assert data["success"] is False
         assert data["error_code"] == 403
@@ -148,7 +151,7 @@ class TestRebindArchitectBot:
     def test_service_error(self, client):
         tc, svc = client
         svc.rebind_architect_bot_batch.side_effect = BotServiceError("bad")
-        resp = tc.put("/api/bots/arch1/architect-rebind", json={"coding_bot_ids": ["c1"]})
+        resp = tc.put("/api/bots/arch1/architect-rebind", json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["c1"]})
         data = resp.json()
         assert data["success"] is False
         assert data["error_code"] == 400
@@ -156,7 +159,26 @@ class TestRebindArchitectBot:
     def test_unexpected_exception(self, client):
         tc, svc = client
         svc.rebind_architect_bot_batch.side_effect = ValueError("boom")
-        resp = tc.put("/api/bots/arch1/architect-rebind", json={"coding_bot_ids": ["c1"]})
+        resp = tc.put("/api/bots/arch1/architect-rebind", json={"target_architect_bot_id": "arch2", "coding_bot_ids": ["c1"]})
         data = resp.json()
         assert data["success"] is False
         assert data["error_code"] == 500
+
+    def test_missing_target_architect_bot_id_rejected_by_request_model(self, client):
+        tc, svc = client
+        # RebindArchitectRequest requires target_architect_bot_id -> 422
+        resp = tc.put(
+            "/api/bots/arch1/architect-rebind",
+            json={"coding_bot_ids": ["c1"]},
+        )
+        assert resp.status_code == 422
+        svc.rebind_architect_bot_batch.assert_not_called()
+
+    def test_blank_target_architect_bot_id_rejected_by_request_model(self, client):
+        tc, svc = client
+        resp = tc.put(
+            "/api/bots/arch1/architect-rebind",
+            json={"target_architect_bot_id": "   ", "coding_bot_ids": ["c1"]},
+        )
+        assert resp.status_code == 422
+        svc.rebind_architect_bot_batch.assert_not_called()

--- a/src/backend/tests/community/core/aicoding/services/test_architect_rebind_service.py
+++ b/src/backend/tests/community/core/aicoding/services/test_architect_rebind_service.py
@@ -30,6 +30,7 @@ from agentclaw.community.core.aicoding.services.architect_rebind_service import 
 
 ARCH_ID = "arch1"
 OPERATOR = "u001"
+TARGET_ID = "arch2"
 
 
 def _make_service() -> ArchitectRebindService:
@@ -114,6 +115,32 @@ class TestGetArchitectDomainOrRaise:
             svc._get_architect_domain_or_raise(ARCH_ID, OPERATOR)
 
 
+
+# ===========================================================================
+# _get_architect_domain_by_id_or_raise (target side, not owner-scoped)
+# ===========================================================================
+class TestGetArchitectDomainByIdOrRaise:
+    def test_not_found_raises_bot_not_found(self):
+        svc = _make_service()
+        svc._repository.get_by_id.return_value = None
+        with pytest.raises(BotNotFoundError):
+            svc._get_architect_domain_by_id_or_raise(TARGET_ID)
+        # not owner-scoped: never calls get_by_id_and_owner
+        svc._repository.get_by_id_and_owner.assert_not_called()
+
+    def test_not_a_domain_bot_raises_service_error(self):
+        svc = _make_service()
+        svc._repository.get_by_id.return_value = _architect_bot(TARGET_ID, is_domain=False)
+        with pytest.raises(BotServiceError):
+            svc._get_architect_domain_by_id_or_raise(TARGET_ID)
+
+    def test_success_returns_architect_without_owner_check(self):
+        svc = _make_service()
+        arch = _architect_bot(TARGET_ID)  # owner_id would be OPERATOR but irrelevant
+        svc._repository.get_by_id.return_value = arch
+        assert svc._get_architect_domain_by_id_or_raise(TARGET_ID) is arch
+        svc._repository.get_by_id_and_owner.assert_not_called()
+
 # ===========================================================================
 # _rebind_coding_bot_to_architect
 # ===========================================================================
@@ -186,103 +213,151 @@ class TestRebindCodingBotToArchitect:
 # rebind_architect_bot (single)
 # ===========================================================================
 class TestRebindArchitectBot:
+    def _setup_source_target(self, svc):
+        # SOURCE architect is owned by operator; TARGET architect exists as domain.
+        svc._repository.get_by_id_and_owner.return_value = _architect_bot(ARCH_ID)
+        svc._repository.get_by_id.return_value = _architect_bot(TARGET_ID)
+
     def test_empty_args_raises_service_error(self):
         svc = _make_service()
         with pytest.raises(BotServiceError):
-            svc.rebind_architect_bot("", ARCH_ID, OPERATOR)
+            svc.rebind_architect_bot("", ARCH_ID, TARGET_ID, OPERATOR)
         with pytest.raises(BotServiceError):
-            svc.rebind_architect_bot("c1", "", OPERATOR)
+            svc.rebind_architect_bot("c1", "", TARGET_ID, OPERATOR)
+        with pytest.raises(BotServiceError):
+            svc.rebind_architect_bot("c1", ARCH_ID, "", OPERATOR)
+
+    def test_source_equals_target_raises(self):
+        svc = _make_service()
+        with pytest.raises(BotServiceError):
+            svc.rebind_architect_bot("c1", ARCH_ID, ARCH_ID, OPERATOR)
 
     def test_coding_equals_architect_raises(self):
         svc = _make_service()
         with pytest.raises(BotServiceError):
-            svc.rebind_architect_bot(ARCH_ID, ARCH_ID, OPERATOR)
+            svc.rebind_architect_bot(ARCH_ID, ARCH_ID, TARGET_ID, OPERATOR)
+        with pytest.raises(BotServiceError):
+            svc.rebind_architect_bot(TARGET_ID, ARCH_ID, TARGET_ID, OPERATOR)
 
-    def test_architect_not_owned_raises_permission(self):
+    def test_source_not_owned_raises_permission(self):
         svc = _make_service()
         svc._repository.get_by_id_and_owner.return_value = None
         with pytest.raises(BotPermissionError):
-            svc.rebind_architect_bot("c1", ARCH_ID, OPERATOR)
-        # must not reach the coding-bot lookup
+            svc.rebind_architect_bot("c1", ARCH_ID, TARGET_ID, OPERATOR)
+        # must not reach target / coding-bot lookup
         svc._repository.get_by_id.assert_not_called()
+
+    def test_target_not_found_raises_bot_not_found(self):
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _architect_bot(ARCH_ID)
+        svc._repository.get_by_id.return_value = None
+        with pytest.raises(BotNotFoundError):
+            svc.rebind_architect_bot("c1", ARCH_ID, TARGET_ID, OPERATOR)
+        svc._template_service.get_template.assert_not_called()
 
     def test_success_returns_change(self):
         svc = _make_service()
-        svc._repository.get_by_id_and_owner.return_value = _architect_bot()
-        svc._repository.get_by_id.return_value = _coding_bot()
+        self._setup_source_target(svc)
+        # _rebind path uses repository.get_by_id for coding-bot too; make coding distinct.
+        coding = {TARGET_ID: _architect_bot(TARGET_ID), "c1": _coding_bot("c1")}
+        svc._repository.get_by_id.side_effect = lambda bid: coding[bid]
         svc._template_service.get_template.return_value = _template(ext={"architect_bot_id": "old"})
         svc._template_service.update_template.return_value = {
-            "bot_id": "c1", "ext": {"architect_bot_id": ARCH_ID}
+            "bot_id": "c1", "ext": {"architect_bot_id": TARGET_ID}
         }
-        result = svc.rebind_architect_bot("c1", ARCH_ID, OPERATOR)
+        result = svc.rebind_architect_bot("c1", ARCH_ID, TARGET_ID, OPERATOR)
         assert result["changed"] is True
-        # architect owner check: owner-scoped exactly once
+        assert result["architect_bot_id"] == TARGET_ID
+        # source owner check exactly once
         assert svc._repository.get_by_id_and_owner.call_count == 1
-        # coding-bot existence: plain get_by_id (NOT owner-scoped) exactly once
-        svc._repository.get_by_id.assert_called_once_with("c1")
-
 
 # ===========================================================================
 # rebind_architect_bot_batch
 # ===========================================================================
 class TestRebindArchitectBotBatch:
-    def test_empty_architect_raises(self):
+    def test_empty_args_raises_service_error(self):
         svc = _make_service()
         with pytest.raises(BotServiceError):
-            svc.rebind_architect_bot_batch(["c1"], "", OPERATOR)
+            svc.rebind_architect_bot_batch(["c1"], "", TARGET_ID, OPERATOR)
+        with pytest.raises(BotServiceError):
+            svc.rebind_architect_bot_batch(["c1"], ARCH_ID, "", OPERATOR)
 
     def test_empty_coding_ids_raises(self):
         svc = _make_service()
         with pytest.raises(BotServiceError):
-            svc.rebind_architect_bot_batch([], ARCH_ID, OPERATOR)
+            svc.rebind_architect_bot_batch([], ARCH_ID, TARGET_ID, OPERATOR)
 
     def test_all_blank_coding_ids_raises(self):
         svc = _make_service()
         with pytest.raises(BotServiceError):
-            svc.rebind_architect_bot_batch(["", ""], ARCH_ID, OPERATOR)
+            svc.rebind_architect_bot_batch(["", ""], ARCH_ID, TARGET_ID, OPERATOR)
 
-    def test_architect_in_coding_ids_raises_before_lookup(self):
+    def test_source_in_coding_ids_raises_before_lookup(self):
         svc = _make_service()
         with pytest.raises(BotServiceError):
-            svc.rebind_architect_bot_batch(["c1", ARCH_ID], ARCH_ID, OPERATOR)
+            svc.rebind_architect_bot_batch(["c1", ARCH_ID], ARCH_ID, TARGET_ID, OPERATOR)
         svc._repository.get_by_id_and_owner.assert_not_called()
 
-    def test_architect_check_called_once_for_n_items(self):
+    def test_target_in_coding_ids_raises_before_lookup(self):
         svc = _make_service()
-        svc._repository.get_by_id_and_owner.return_value = _architect_bot()
-        svc._repository.get_by_id.return_value = _coding_bot()
+        with pytest.raises(BotServiceError):
+            svc.rebind_architect_bot_batch(["c1", TARGET_ID], ARCH_ID, TARGET_ID, OPERATOR)
+        svc._repository.get_by_id_and_owner.assert_not_called()
+
+    def test_source_equals_target_raises(self):
+        svc = _make_service()
+        with pytest.raises(BotServiceError):
+            svc.rebind_architect_bot_batch(["c1"], ARCH_ID, ARCH_ID, OPERATOR)
+
+    def test_source_target_checks_each_called_once_for_n_items(self):
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _architect_bot(ARCH_ID)
+        # get_by_id used for BOTH target check (once) and per-coding-bot existence; first call = target
+        coding = {TARGET_ID: _architect_bot(TARGET_ID), "c1": _coding_bot("c1")}
+        svc._repository.get_by_id.side_effect = lambda bid: coding[bid]
         svc._template_service.get_template.return_value = _template(ext={"architect_bot_id": "old"})
         svc._template_service.update_template.return_value = {"bot_id": "x"}
-        svc.rebind_architect_bot_batch(["c1", "c2", "c3"], ARCH_ID, OPERATOR)
+        svc.rebind_architect_bot_batch(["c1"], ARCH_ID, TARGET_ID, OPERATOR)
+        # source owner check once
         assert svc._repository.get_by_id_and_owner.call_count == 1
 
     def test_dedup_preserves_order(self):
         svc = _make_service()
-        svc._repository.get_by_id_and_owner.return_value = _architect_bot()
+        svc._repository.get_by_id_and_owner.return_value = _architect_bot(ARCH_ID)
+        svc._repository.get_by_id.return_value = _architect_bot(TARGET_ID)
         svc._rebind_coding_bot_to_architect = MagicMock(
             return_value={"changed": True, "previous_architect_bot_id": "old"}
         )
-        result = svc.rebind_architect_bot_batch(["b", "a", "b", "c", "a"], ARCH_ID, OPERATOR)
+        result = svc.rebind_architect_bot_batch(["b", "a", "b", "c", "a"], ARCH_ID, TARGET_ID, OPERATOR)
         called = [c.args[0] for c in svc._rebind_coding_bot_to_architect.call_args_list]
         assert called == ["b", "a", "c"]
         assert result["total"] == 3
         assert result["succeeded"] == 3
 
-    def test_architect_not_owned_whole_batch_rejected(self):
+    def test_source_not_owned_whole_batch_rejected(self):
         svc = _make_service()
         svc._repository.get_by_id_and_owner.return_value = None
         with pytest.raises(BotPermissionError):
-            svc.rebind_architect_bot_batch(["c1"], ARCH_ID, OPERATOR)
+            svc.rebind_architect_bot_batch(["c1"], ARCH_ID, TARGET_ID, OPERATOR)
+
+    def test_target_not_found_whole_batch_rejected(self):
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _architect_bot(ARCH_ID)
+        svc._repository.get_by_id.return_value = None
+        with pytest.raises(BotNotFoundError):
+            svc.rebind_architect_bot_batch(["c1"], ARCH_ID, TARGET_ID, OPERATOR)
 
     def test_mixed_results_per_item(self):
         svc = _make_service()
-        svc._repository.get_by_id_and_owner.return_value = _architect_bot()
+        svc._repository.get_by_id_and_owner.return_value = _architect_bot(ARCH_ID)
+        # First get_by_id call = target (arch2 exists); subsequent = coding bots.
         coding = {
-            "c1": _coding_bot("c1"),                         # success -> changed True
-            "c2": None,                                       # not_found
-            "c3": _coding_bot("c3", template_type="other"),   # invalid (non-appcoding)
-            "c4": _coding_bot("c4"),                          # forbidden (update raises BotPermissionError)
-            "c5": _coding_bot("c5"),                          # error   (update raises ValueError)
+            TARGET_ID: _architect_bot(TARGET_ID),
+            "c1": _coding_bot("c1"),
+            "c2": None,
+            "c3": _coding_bot("c3", template_type="other"),
+            "c4": _coding_bot("c4"),
+            "c5": _coding_bot("c5"),
         }
         svc._repository.get_by_id.side_effect = lambda bid: coding[bid]
         templates = {
@@ -291,7 +366,7 @@ class TestRebindArchitectBotBatch:
             "c5": _template("c5", ext={"architect_bot_id": "old"}),
         }
         svc._template_service.get_template.side_effect = lambda bid: templates[bid]
-        updated = {"bot_id": "x", "ext": {"architect_bot_id": ARCH_ID}}
+        updated = {"bot_id": "x", "ext": {"architect_bot_id": TARGET_ID}}
 
         def _update(bid, ext, template_type=None):
             if bid == "c1":
@@ -305,7 +380,7 @@ class TestRebindArchitectBotBatch:
         svc._template_service.update_template.side_effect = _update
 
         result = svc.rebind_architect_bot_batch(
-            ["c1", "c2", "c3", "c4", "c5"], ARCH_ID, OPERATOR
+            ["c1", "c2", "c3", "c4", "c5"], ARCH_ID, TARGET_ID, OPERATOR
         )
 
         assert result["total"] == 5
@@ -317,14 +392,13 @@ class TestRebindArchitectBotBatch:
             "success": True,
             "changed": True,
             "previous_architect_bot_id": "old",
-            "architect_bot_id": ARCH_ID,
+            "architect_bot_id": TARGET_ID,
         }
         assert by_id["c2"]["success"] is False and by_id["c2"]["error_code"] == "not_found"
         assert by_id["c3"]["success"] is False and by_id["c3"]["error_code"] == "invalid"
         assert by_id["c4"]["success"] is False and by_id["c4"]["error_code"] == "forbidden"
         assert by_id["c5"]["success"] is False and by_id["c5"]["error_code"] == "error"
-        # success item must never leak template / token ciphertext
         assert "template" not in by_id["c1"]
         assert "token" not in by_id["c1"]
-        # architect owner-scoped check happened exactly once for the whole batch
+        # source owner-scoped check happened exactly once for the whole batch
         assert svc._repository.get_by_id_and_owner.call_count == 1

--- a/src/backend/tests/community/endpoints/test_bot_architect_rebind.py
+++ b/src/backend/tests/community/endpoints/test_bot_architect_rebind.py
@@ -24,6 +24,7 @@ from tests.community.framework import (
 ARCHITECT_BOT_ID = "arch_bot_rebind_arch"
 CODING_BOT_ID = "app_bot_rebind_app"
 OTHER_ARCHITECT_BOT_ID = "other_arch"
+TARGET_ARCHITECT_BOT_ID = "target_arch"
 
 
 def _seed_architect_and_coding_bot(world):
@@ -38,6 +39,23 @@ def _seed_architect_and_coding_bot(world):
             "owner_name": "test_user",
             "creator_id": "test_user",
             "entity_id": "test_user",
+            "entity_type": "staff",
+            "active_engine": "openclaw",
+            "bot_type": "personal",
+            "status": "ACTIVE",
+            "ext": {"is_domain_bot": True},
+        }
+    )
+    # Target domain architect bot (may be owned by someone else; rebind
+    # only requires the *source* architect to be owned by the caller).
+    bot_repo.insert(
+        {
+            "bot_id": TARGET_ARCHITECT_BOT_ID,
+            "bot_name": "Target Architect Bot (rebind)",
+            "owner_id": "other_user",
+            "owner_name": "other_user",
+            "creator_id": "other_user",
+            "entity_id": "other_user",
             "entity_type": "staff",
             "active_engine": "openclaw",
             "bot_type": "personal",
@@ -80,7 +98,7 @@ def _seed_architect_and_coding_bot(world):
     input=CaseInput(
         path_params={"architect_bot_id": ARCHITECT_BOT_ID},
         headers={"x-user-id": "test_user"},
-        json_body={"coding_bot_ids": [CODING_BOT_ID]},
+        json_body={"target_architect_bot_id": TARGET_ARCHITECT_BOT_ID, "coding_bot_ids": [CODING_BOT_ID]},
     ),
     seed=_seed_architect_and_coding_bot,
     expect=ExpectSuccess(
@@ -88,7 +106,8 @@ def _seed_architect_and_coding_bot(world):
         json_contains={
             "success": True,
             "data": {
-                "architect_bot_id": ARCHITECT_BOT_ID,
+                "source_architect_bot_id": ARCHITECT_BOT_ID,
+                "target_architect_bot_id": TARGET_ARCHITECT_BOT_ID,
                 "total": 1,
                 "succeeded": 1,
                 "failed": 0,
@@ -107,7 +126,7 @@ def rebind_architect_bot_ok():
     input=CaseInput(
         path_params={"architect_bot_id": ARCHITECT_BOT_ID},
         headers={"x-user-id": "anonymous"},
-        json_body={"coding_bot_ids": [CODING_BOT_ID]},
+        json_body={"target_architect_bot_id": TARGET_ARCHITECT_BOT_ID, "coding_bot_ids": [CODING_BOT_ID]},
     ),
     seed=_seed_architect_and_coding_bot,
     expect=ExpectError(


### PR DESCRIPTION
## Summary

Rework the architect-rebind endpoint into a source/target model so an operator
can hand off application-coding bots from one domain architect bot to a domain
architect bot owned by someone else.

## Contract

`PUT /api/bots/{architect_bot_id}/architect-rebind`

| Field | Meaning | Auth |
| --- | --- | --- |
| Path `{architect_bot_id}` | Source architect bot (the one the operator acts from) | Must be `domain` AND owned by the operator; otherwise 403 |
| Body `target_architect_bot_id` | Target architect bot (rebind destination) | Must be `domain`; ownership is NOT checked |
| Body `coding_bot_ids` | Application-coding bots to rebind | Each validated as `applicationCoding` |

On success, `ac_templates.ext.architect_bot_id` is rewritten to the target.

## Auth change vs. previous behavior

- Before: the operator had to own the **target** architect bot, so rebind into
  someone else's architect was rejected with 403.
- After: the operator must own the **source** architect bot; apps can be rebound
  onto an architect owned by another user.

| Scenario | Before | After |
| --- | --- | --- |
| Owner of source A rebinds into B (owned by someone else) | 403 | allowed |
| Non-owner of A tries to move A's apps | allowed (only B ownership checked) | 403 |
| A and B owned by the same user | allowed | allowed |

## Changes

- `architect_rebind_router.py`: `RebindArchitectRequest` gains
  `target_architect_bot_id` (non-empty validator).
- `architect_rebind_service.py`: new
  `_get_architect_domain_by_id_or_raise` (target side: existence +
  `is_domain_bot` only, not owner-scoped); `rebind_architect_bot(_batch)`
  signatures now take `source_architect_bot_id` + `target_architect_bot_id`;
  the source is owner-checked (whole batch rejected on failure), the target is
  existence-checked; the response now includes `source_architect_bot_id` and
  `target_architect_bot_id`.
- Tests: router / service / endpoint cases updated to the new contract, covering
  source-not-owner (whole batch 403), target-not-found (whole batch 404), and an
  end-to-end happy path where the target architect is owned by `other_user`.

## Test results

- 43 unit/router tests pass
- 2 endpoint cases pass (`ok_rebind_coding_bot`, `anonymous_user`)
