### PR TITLE
feat(bcs-cli): support manager-worker group creation

### DIFF
--- a/src/bcs/CLAUDE.md
+++ b/src/bcs/CLAUDE.md
@@ -499,7 +499,10 @@ bcs-cli request-group-help --gap-type skill --description "需要数据库死锁
 bcs-cli confirm-group-help --url http://localhost:21000/groups/<token>/confirm
 
 # Create a group directly
-bcs-cli create-group --driver zhangsan --participants "zhangsan:driver,lisi:consultant"
+bcs-cli create-group --driver zhangsan --participants "lisi,wangwu"
+
+# Create a manager-worker group; participants are assigned the worker role
+bcs-cli create-group --manager zhangsan --participants "lisi,wangwu"
 
 # Fuse contexts
 bcs-cli fuse --group <group_id> --question "如何协调？" --participants bot1,bot2

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/group.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/group.md
@@ -100,12 +100,13 @@ bcs confirm-group-help --url "http://xxx/proposals/xxx/confirm"
 跳过提案流程，直接创建一个群组。**推荐在 agent 已知参与者的场景下使用**（如 agent 自己建群自己确认）。
 
 ```bash
-bcs create-group --driver "<driver_bot_id>" --participants "<bot1,bot2>" [--topic "<群组主题>"] [--context "<协作背景>"]
+bcs create-group (--driver "<driver_bot_id>" | --manager "<manager_bot_id>") --participants "<bot1,bot2>" [--topic "<群组主题>"] [--context "<协作背景>"]
 ```
 
 **参数：**
 
-- `--driver "BotID"`: 指定 driver Bot（**必需**）
+- `--driver "BotID"`: 创建普通 chat 群，并指定 driver Bot（与 `--manager` 二选一）
+- `--manager "BotID"`: 创建 manager-worker 群，并指定唯一 manager Bot（与 `--driver` 二选一）
 - `--participants "Bot1,Bot2"`: 参与者列表（**必需**）
 - `--topic "主题"`: 群组主题，设置群组 label 为 "Group: {topic}"（可选）
 - `--context "背景"`: 协作背景描述（可选）
@@ -119,6 +120,9 @@ bcs create-group --driver "bot-001" --participants "bot-sec,bot-dba" --topic "�
 
 # 带上下文
 bcs create-group --driver "bot-001" --participants "bot-dba,bot-pm" --topic "数据库死锁排查" --context "用户反馈系统卡顿，疑似死锁"
+
+# manager-worker 群；participants 自动作为 worker，manager 无需重复出现在列表中
+bcs create-group --manager "bot-manager" --participants "bot-worker-1,bot-worker-2" --topic "并行实现任务"
 ```
 
 **返回示例：**

--- a/src/bcs/crates/tools/bcs-cli/bcs-http-skills/SKILL.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-http-skills/SKILL.md
@@ -51,6 +51,12 @@ bcs-cli --url "$BCS_API_BASE_URL" create-group \
   --participants "bot-dba,bot-security" \
   --topic "Incident analysis"
 
+# Create a manager-worker group; all participants are assigned the worker role
+bcs-cli --url "$BCS_API_BASE_URL" create-group \
+  --manager "bot-manager" \
+  --participants "bot-worker-1,bot-worker-2" \
+  --topic "Parallel implementation"
+
 # Send a direct message to a bot
 bcs-cli --url "$BCS_API_BASE_URL" chat \
   --bot-uuid "bot-dba" \

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -1523,6 +1523,25 @@ impl BcsClient {
         context: Option<&str>,
         topic: Option<&str>,
     ) -> Result<CreateGroupResponse> {
+        self.create_group_with_strategy_and_context(
+            driver_bot,
+            participants,
+            context,
+            topic,
+            None,
+        )
+        .await
+    }
+
+    /// Create a group with optional context, topic, and group strategy.
+    pub async fn create_group_with_strategy_and_context(
+        &self,
+        driver_bot: &str,
+        participants: Vec<ParticipantInfo>,
+        context: Option<&str>,
+        topic: Option<&str>,
+        group_strategy: Option<&str>,
+    ) -> Result<CreateGroupResponse> {
         let url = format!("{}/groups", self.base_url);
 
         let payload = CreateGroupRequest {
@@ -1538,7 +1557,7 @@ impl BcsClient {
             topic: topic.map(|s| s.to_string()),
             group_kind: None,
             service_spec: None,
-            group_strategy: None,
+            group_strategy: group_strategy.map(str::to_string),
             originator: None,
             collaboration_definition_yaml: None,
             auto_start_on_service_invocation: None,

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -972,9 +972,13 @@ enum Commands {
         #[arg(short, long, hide = true)]
         id: Option<String>,
 
-        /// Driver bot ID
-        #[arg(long)]
-        driver: String,
+        /// Driver bot ID for a regular chat group (required unless --manager is used)
+        #[arg(long, required_unless_present = "manager", conflicts_with = "manager")]
+        driver: Option<String>,
+
+        /// Manager bot ID for a manager-worker group (required unless --driver is used)
+        #[arg(long, required_unless_present = "driver", conflicts_with = "driver")]
+        manager: Option<String>,
 
         /// Participants (comma-separated bot UUIDs, e.g. "bot1,20260412_abc:100005")
         #[arg(short, long)]
@@ -2528,6 +2532,7 @@ async fn main() -> Result<()> {
             token,
             id: _,
             driver,
+            manager,
             participants,
             context,
             topic,
@@ -2540,16 +2545,42 @@ async fn main() -> Result<()> {
                 oauth_headers.as_ref(),
             );
 
+            let (driver, group_strategy) = match (driver, manager) {
+                (Some(driver), None) => (driver, None),
+                (None, Some(manager)) => (manager, Some("manager_worker")),
+                _ => return Err(anyhow!("Exactly one of --driver or --manager is required")),
+            };
+
             // Format: bot_uuid (may contain colons, e.g. "20260412_347nf7bz:100005")
-            // Comma-separated for multiple participants.
-            // Consistent with request-group-help which also passes bot_uuid as-is.
-            let participants: Vec<bcs_protocol::ParticipantInfo> = participants
+            // Comma-separated for multiple participants. In manager-worker groups,
+            // the manager role is derived from --manager and every other participant
+            // is a worker, so role suffixes do not conflict with bot UUID syntax.
+            let mut participants: Vec<bcs_protocol::ParticipantInfo> = participants
                 .split(',')
                 .map(|p| bcs_protocol::ParticipantInfo {
                     bot_uuid: p.trim().to_string(),
-                    role: None,
+                    role: group_strategy.map(|_| {
+                        if p.trim() == driver {
+                            "manager".to_string()
+                        } else {
+                            "worker".to_string()
+                        }
+                    }),
                 })
                 .collect();
+            if group_strategy.is_some()
+                && !participants
+                    .iter()
+                    .any(|participant| participant.bot_uuid == driver)
+            {
+                participants.insert(
+                    0,
+                    bcs_protocol::ParticipantInfo {
+                        bot_uuid: driver.clone(),
+                        role: Some("manager".to_string()),
+                    },
+                );
+            }
 
             debug_request!(
                 debug,
@@ -2557,16 +2588,18 @@ async fn main() -> Result<()> {
                 "/groups",
                 json!({
                     "driver_bot": &driver,
-                    "participants": &participants
+                    "participants": &participants,
+                    "group_strategy": group_strategy
                 })
             );
 
             let result = client
-                .create_group_with_context(
+                .create_group_with_strategy_and_context(
                     &driver,
                     participants,
                     context.as_deref(),
                     topic.as_deref(),
+                    group_strategy,
                 )
                 .await?;
 
@@ -3985,6 +4018,67 @@ mod tests {
 
         let error = decode_group_continuation(&encoded).unwrap_err();
         assert!(error.to_string().contains("Unsupported list-groups continuation token version"));
+    }
+
+    #[test]
+    fn test_create_group_accepts_manager_instead_of_driver() {
+        let cli = Cli::try_parse_from([
+            "bcs-cli",
+            "create-group",
+            "--manager",
+            "manager-bot",
+            "--participants",
+            "worker-1,worker-2",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::CreateGroup {
+                driver,
+                manager,
+                participants,
+                ..
+            } => {
+                assert!(driver.is_none());
+                assert_eq!(manager.as_deref(), Some("manager-bot"));
+                assert_eq!(participants, "worker-1,worker-2");
+            }
+            _ => panic!("expected create-group command"),
+        }
+    }
+
+    #[test]
+    fn test_create_group_rejects_driver_and_manager_together() {
+        let error = match Cli::try_parse_from([
+            "bcs-cli",
+            "create-group",
+            "--driver",
+            "driver-bot",
+            "--manager",
+            "manager-bot",
+            "--participants",
+            "worker-1",
+        ]) {
+            Ok(_) => panic!("expected --driver and --manager to conflict"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn test_create_group_requires_driver_or_manager() {
+        let error = match Cli::try_parse_from([
+            "bcs-cli",
+            "create-group",
+            "--participants",
+            "worker-1",
+        ]) {
+            Ok(_) => panic!("expected create-group to require a lead bot"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/src/bcs/crates/tools/bcs-cli/tests/create_group_tests.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/create_group_tests.rs
@@ -1,0 +1,111 @@
+#[allow(dead_code)]
+#[path = "e2e/common/mod.rs"]
+mod common;
+
+use common::{TestContext, assert_success};
+use wiremock::{
+    matchers::{bearer_token, method, path},
+    Mock, ResponseTemplate,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_group_with_manager_sends_manager_worker_roles() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    Mock::given(method("POST"))
+        .and(path("/groups"))
+        .and(bearer_token(&ctx.session.token))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "manager-worker-group",
+            "driver_bot": "manager-bot",
+            "participants": ["manager-bot", "worker-1", "worker-2"]
+        })))
+        .expect(1)
+        .mount(&ctx.mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/groups/manager-worker-group/sessions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": []
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("create-group")
+        .arg("--manager")
+        .arg("manager-bot")
+        .arg("--participants")
+        .arg("worker-1,worker-2")
+        .output()
+        .expect("Failed to execute create-group");
+
+    assert_success(&output);
+    let requests = ctx.mock_server.received_requests().await.unwrap();
+    let request = requests
+        .iter()
+        .find(|request| request.method.as_str() == "POST" && request.url.path() == "/groups")
+        .expect("create-group request");
+    let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+    assert_eq!(body["driver_bot"], "manager-bot");
+    assert_eq!(body["group_strategy"], "manager_worker");
+    assert_eq!(
+        body["participants"],
+        serde_json::json!([
+            {"bot_uuid": "manager-bot", "role": "manager"},
+            {"bot_uuid": "worker-1", "role": "worker"},
+            {"bot_uuid": "worker-2", "role": "worker"}
+        ])
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_group_with_driver_preserves_chat_request() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    Mock::given(method("POST"))
+        .and(path("/groups"))
+        .and(bearer_token(&ctx.session.token))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chat-group",
+            "driver_bot": "driver-bot",
+            "participants": ["driver-bot", "participant-1"]
+        })))
+        .expect(1)
+        .mount(&ctx.mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/groups/chat-group/sessions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": []
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("create-group")
+        .arg("--driver")
+        .arg("driver-bot")
+        .arg("--participants")
+        .arg("participant-1")
+        .output()
+        .expect("Failed to execute create-group");
+
+    assert_success(&output);
+    let requests = ctx.mock_server.received_requests().await.unwrap();
+    let request = requests
+        .iter()
+        .find(|request| request.method.as_str() == "POST" && request.url.path() == "/groups")
+        .expect("create-group request");
+    let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+    assert_eq!(body["driver_bot"], "driver-bot");
+    assert!(body.get("group_strategy").is_none());
+    assert_eq!(
+        body["participants"],
+        serde_json::json!([
+            {"bot_uuid": "participant-1", "role": null}
+        ])
+    );
+}


### PR DESCRIPTION
## Summary

- add `--manager` as the `create-group` entry point for manager-worker groups
- map the manager to `driver_bot`, set `group_strategy=manager_worker`, and assign all other participants the worker role
- preserve the existing `--driver` chat-group behavior and make the two lead options mutually exclusive
- document the new command shape and add request-body compatibility coverage

## User impact

Users can now create a manager-worker group and its initial group session directly with:

```bash
bcs-cli create-group --manager "manager-bot" --participants "worker-1,worker-2"
```

The manager does not need to be repeated in `--participants`.

## Validation

- `cargo test -p bcs-cli --bin bcs-cli` — 79 passed
- `cargo test -p bcs-cli --test create_group_tests` — 2 passed
- BCS HTTP Skill validation passed
- `git diff --check` passed
- pre-push gate skipped with `--no-verify` per request

## Known unrelated test issue

A full `cargo test -p bcs-cli` run is currently blocked by `client::tests::test_chat_polling_timeout_leaves_server_run_active`, which fails because the expected `local polling timeout` error text is absent. This PR does not change the chat polling path.