### PR TITLE
fix(harness): stop softening LLM-disabled scans into a high health_score

### DIFF
--- a/src/backend/src/agentclaw/community/core/harness/services/content_scanner.py
+++ b/src/backend/src/agentclaw/community/core/harness/services/content_scanner.py
@@ -277,13 +277,24 @@ class ContentScanner:
         if file_avg_scores:
             return int(sum(file_avg_scores) / len(file_avg_scores))
 
-        # Fallback: penalty-based scoring
+        # Fallback: penalty-based scoring. LLM01 ("LLM 服务未启用") is not a
+        # content defect — it means the diagnostic never ran, so it neither
+        # adds penalty nor softens the score. Without this skip, an all-LLM01
+        # scan (LLM down) gets softened to a misleadingly high score
+        # (e.g. 6 INFO findings → 100 - 6*2 = 88). When *every* finding is
+        # LLM01, no real diagnosis ran → report 0 instead of a dressed-up 88.
         penalty = 0
+        real_findings = False
         for f in findings:
+            if f.rule_id == "LLM01":
+                continue
+            real_findings = True
             if f.severity == Severity.CRITICAL:
                 penalty += 20
             elif f.severity == Severity.WARNING:
                 penalty += 10
             elif f.severity == Severity.INFO:
                 penalty += 2
+        if not real_findings:
+            return 0
         return max(0, 100 - penalty)

--- a/src/backend/tests/community/core/harness/services/test_content_scanner.py
+++ b/src/backend/tests/community/core/harness/services/test_content_scanner.py
@@ -400,6 +400,45 @@ class TestScoring:
         ]
         assert ContentScanner._compute_score(findings) == 80  # 100 - 20
 
+    def test_llm_disabled_findings_not_scored_as_content(self):
+        """LLM01 (LLM disabled) is not a content defect — it must not be
+        softened into a high score via the INFO penalty branch.
+
+        Reproduces the prod case where LLM service was down: 6 LLM01 INFO
+        findings (AGENTS×3 / TOOLS×2 / SOUL×1) were scored as
+        100 - 6*2 = 88, misreporting a non-scanned bot as healthy. With the
+        fix, an all-LLM-disabled scan reports 0 (no real diagnosis ran), and
+        real content findings alongside LLM01 are penalised as before.
+        """
+        file_types = ["AGENTS.md", "TOOLS.md", "SOUL.md"]
+        llm_disabled = (
+            [Finding(rule_id="LLM01", rule_name="LLM 服务未启用",
+                     severity=Severity.INFO, file_type="AGENTS.md",
+                     message="m", score=0) for _ in range(3)]
+            + [Finding(rule_id="LLM01", rule_name="LLM 服务未启用",
+                       severity=Severity.INFO, file_type="TOOLS.md",
+                       message="m", score=0) for _ in range(2)]
+            + [Finding(rule_id="LLM01", rule_name="LLM 服务未启用",
+                       severity=Severity.INFO, file_type="SOUL.md",
+                       message="m", score=0)]
+        )
+        # All LLM01, no real diagnosis ran → 0, not 88
+        assert ContentScanner._compute_score(llm_disabled, file_types=file_types) == 0
+
+    def test_llm_disabled_ignored_when_real_findings_present(self):
+        """Real content findings are still penalised even if LLM01 findings
+        are mixed in — LLM01 neither adds penalty nor softens the score."""
+        findings = [
+            Finding(rule_id="LLM01", rule_name="LLM 服务未启用",
+                    severity=Severity.INFO, file_type="AGENTS.md",
+                    message="m", score=0),
+            Finding(rule_id="D-SAFETY-001", rule_name="test",
+                    severity=Severity.CRITICAL, file_type="SAFETY.md",
+                    message="m", score=0),
+        ]
+        # Only the CRITICAL counts: 100 - 20 = 80 (LLM01 skipped, not +2)
+        assert ContentScanner._compute_score(findings) == 80
+
 
 class TestSummarize:
     """Test the findings summary — summarized by file-type-level result (pass/warning/fail/error)."""


### PR DESCRIPTION
When LLM service is down, every diagnostic is skipped and only LLM01 ("LLM 服务未启用", INFO) findings are produced. The penalty fallback in _compute_score counted these as content defects: 6×INFO = -12 → score 88, misreporting an un-scanned bot as healthy.

LLM01 is not a content defect — it means the diagnostic never ran. Skip it in the penalty branch; when *all* findings are LLM01 (no real diagnosis ran), return 0 instead of a dressed-up 88. Real content findings mixed with LLM01 are penalised exactly as before (LLM01 neither adds penalty nor softens the score).

No None introduced, so _compute_grade's >= comparisons are unaffected; schema/DB/frontend contract unchanged.

Tests:
- test_llm_disabled_findings_not_scored_as_content: 6 LLM01 → 0 (was 88)
- test_llm_disabled_ignored_when_real_findings_present: LLM01 + CRITICAL → 80