### PR TITLE
feat(bcs): add dedicated common error log

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -106,6 +106,15 @@ targets = ["*", "!bcs_chat_digest", "!bcs_sse_detail"]
 max_keep_days = 7
 
 [[logging.outputs]]
+name = "common-error"
+path = "/var/log/bcs"
+file = "common-error.log"
+level = "error"
+rotation = "daily"
+targets = ["*"]
+max_keep_days = 7
+
+[[logging.outputs]]
 name = "messages"
 path = "/var/log/bcs"
 file = "bcs-messages.log"

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -80,6 +80,15 @@ default_level = "debug"
 console = true
 
 [[logging.outputs]]
+name = "common-error"
+path = "./logs"
+file = "common-error.log"
+level = "error"
+rotation = "daily"
+targets = ["*"]
+max_keep_days = 7
+
+[[logging.outputs]]
 name = "messages"
 path = "./logs"
 file = "bcs-messages.log"

--- a/src/bcs/crates/bootstrap/bcs/src/config_loader.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config_loader.rs
@@ -654,6 +654,26 @@ mod tests {
     }
 
     #[test]
+    fn test_real_local_config_routes_all_errors_to_common_error_file() {
+        let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../configs/bcs-config-local.toml");
+        let content = std::fs::read_to_string(config_path).unwrap();
+        let config: crate::config::BcsConfig = toml::from_str(&content).unwrap();
+
+        let common_error = config
+            .logging
+            .outputs
+            .iter()
+            .find(|output| output.name == "common-error")
+            .expect("local config should include common-error output");
+
+        assert_eq!(common_error.path, "./logs");
+        assert_eq!(common_error.file, "common-error.log");
+        assert_eq!(common_error.level, "error");
+        assert_eq!(common_error.targets, vec!["*"]);
+    }
+
+    #[test]
     fn test_real_base_config_accepts_dingtalk_lab_json_override() {
         let source_config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../configs");
         let dir = tempfile::tempdir().unwrap();

--- a/src/bcs/crates/bootstrap/bcs/src/logging.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/logging.rs
@@ -400,6 +400,64 @@ mod tests {
     }
 
     #[test]
+    fn error_is_written_to_main_and_common_error_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+        let main_output = LogOutputConfig {
+            name: "main".to_string(),
+            path: path.clone(),
+            file: "bcs.log".to_string(),
+            level: "info".to_string(),
+            rotation: "daily".to_string(),
+            format: LogOutputFormat::Text,
+            targets: vec!["*".to_string()],
+            max_keep_days: 7,
+        };
+        let common_error_output = LogOutputConfig {
+            name: "common-error".to_string(),
+            path,
+            file: "common-error.log".to_string(),
+            level: "error".to_string(),
+            rotation: "daily".to_string(),
+            format: LogOutputFormat::Text,
+            targets: vec!["*".to_string()],
+            max_keep_days: 7,
+        };
+
+        let subscriber = tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(RotatingFileWriter::new(dir.path(), &main_output.file))
+                    .with_ansi(false)
+                    .with_filter(build_output_targets_filter(&main_output)),
+            )
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(RotatingFileWriter::new(
+                        dir.path(),
+                        &common_error_output.file,
+                    ))
+                    .with_ansi(false)
+                    .with_filter(build_output_targets_filter(&common_error_output)),
+            );
+
+        let dispatch = tracing::Dispatch::new(subscriber);
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::warn!(target: "bcs_http::routes", "warning stays in main only");
+            tracing::error!(target: "bcs_http::routes", "error is duplicated");
+        });
+
+        let main = std::fs::read_to_string(dir.path().join("bcs.log")).unwrap();
+        let common_error =
+            std::fs::read_to_string(dir.path().join("common-error.log")).unwrap();
+
+        assert!(main.contains("warning stays in main only"));
+        assert!(main.contains("error is duplicated"));
+        assert!(!common_error.contains("warning stays in main only"));
+        assert!(common_error.contains("error is duplicated"));
+    }
+
+    #[test]
     fn json_output_flattens_message_log_fields() {
         let dir = tempfile::tempdir().unwrap();
         let output = LogOutputConfig {

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -634,6 +634,16 @@ fn default_true() -> bool {
 fn default_log_outputs() -> Vec<LogOutputConfig> {
     vec![
         LogOutputConfig {
+            name: "common-error".to_string(),
+            path: "./logs".to_string(),
+            file: "common-error.log".to_string(),
+            level: "error".to_string(),
+            rotation: "daily".to_string(),
+            format: LogOutputFormat::Text,
+            targets: vec!["*".to_string()],
+            max_keep_days: 7,
+        },
+        LogOutputConfig {
             name: "messages".to_string(),
             path: "./logs".to_string(),
             file: "bcs-messages.log".to_string(),
@@ -1108,6 +1118,23 @@ mod tests {
         assert_eq!(messages.format, LogOutputFormat::Json);
         assert_eq!(messages.targets, vec!["bcs_message"]);
         assert_eq!(messages.max_keep_days, 7);
+    }
+
+    #[test]
+    fn default_logging_outputs_include_common_error_file() {
+        let logging = LoggingConfig::default();
+
+        let common_error = logging
+            .outputs
+            .iter()
+            .find(|output| output.name == "common-error")
+            .expect("common error log output should be configured by default");
+
+        assert_eq!(common_error.file, "common-error.log");
+        assert_eq!(common_error.level, "error");
+        assert_eq!(common_error.format, LogOutputFormat::Text);
+        assert_eq!(common_error.targets, vec!["*"]);
+        assert_eq!(common_error.max_keep_days, 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a `common-error.log` output that captures `ERROR` events from all tracing targets
- keep existing `bcs.log` error recording unchanged
- configure the deployment and local templates, plus the default logging contract
- add routing and configuration tests for the dedicated error output

## Why

BCS currently records errors together with general logs. A dedicated error file makes incident investigation easier while preserving the existing `bcs.log` behavior.

## Validation

- `cargo test -p bcs-config-api`
- `cargo test -p bcs error_is_written_to_main_and_common_error_outputs`
- `cargo test -p bcs test_real_local_config_routes_all_errors_to_common_error_file`
- `git diff --check`