### PR TITLE
fix(baas): remove dead socket.gethostbyname(gethostname()) causing startup crash

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/internal/internal_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/internal/internal_router.py
@@ -16,8 +16,6 @@ forward → race fallthrough → MACHINE_NOT_CONNECTED), shared with
 ``LocalPaasService._route_command`` to keep the two paths from drifting.
 """
 
-import socket
-
 from dependency_injector.wiring import inject
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
@@ -27,18 +25,6 @@ from secbaas.community.bootstrap import ApplicationContainer, Provide
 from secbaas.community.logger import get_logger
 
 logger = get_logger("router")
-
-# Lazy-initialized server IP to avoid blocking DNS lookup at import time
-_SERVER_IP: str | None = None
-
-
-def _get_server_ip() -> str:
-    """Get server IP address, lazily cached to avoid blocking at import."""
-    global _SERVER_IP
-    if _SERVER_IP is None:
-        _SERVER_IP = socket.gethostbyname(socket.gethostname())
-    return _SERVER_IP
-
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 

--- a/src/baas/src/secbaas/community/core/service/paas/desktop/_connection_manager.py
+++ b/src/baas/src/secbaas/community/core/service/paas/desktop/_connection_manager.py
@@ -13,7 +13,6 @@ Per D-CPL01~05: Connection pool limits with hard rejection at 10,000.
 from __future__ import annotations
 
 import asyncio
-import socket
 import time
 import uuid
 from datetime import datetime
@@ -27,9 +26,6 @@ from secbaas.community.logger import get_logger
 
 from ._utils import get_instance_id
 from .worker_router import UDSConfig
-
-# WR-01 Fix: Cache server IP at module level to avoid blocking DNS lookup
-_SERVER_IP = socket.gethostbyname(socket.gethostname())
 
 logger = get_logger("core-service")
 


### PR DESCRIPTION
Fixes #83

## Problem
Module-level `socket.gethostbyname(socket.gethostname())` in `_connection_manager.py` crashes the BaaS import chain at startup on machines where the hostname has no DNS or /etc/hosts entry (`gaierror [Errno 8] nodename nor servname provided, or not known`).

## Root Cause
Two sites contained dead code with this pattern:

1. `core/service/paas/desktop/_connection_manager.py:32` — `_SERVER_IP` defined at module level but **never referenced anywhere in the file**
2. `adapters/web/routers/internal/internal_router.py:35-40` — `_get_server_ip()` function and `_SERVER_IP` global defined but **never called anywhere in the codebase**

## Fix
Removed the dead code and the unused `import socket` from both files. No functional change — the variables and functions were never consumed.