### PR TITLE
fix: move heartbeat after converter to prevent idle timeout starvation

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
@@ -54,7 +54,13 @@ from secbaas.community.api.bcn import (
     ChatSendInput,
 )
 from secbaas.community.api.bot_runtime import BotBindingNotFoundError
-from secbaas.community.api.sse import SseConverterFactory, SseEvent, StreamChunk
+from secbaas.community.api.sse import (
+    SseConverterFactory,
+    SseEvent,
+    StreamChunk,
+    convert_chunks_to_sse,
+    with_sse_heartbeat,
+)
 from secbaas.community.bootstrap import ApplicationContainer
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.secret import SecretStorePlugin
@@ -277,20 +283,14 @@ async def _dispatch_chat_send_stream(
 
     converter = converter_factory.create("default")
 
-    async def _stream() -> AsyncIterator[str]:
-        try:
-            async for chunk in chunk_iter:
-                event = converter.convert(chunk, run_id=req.id)
-                if event is None:
-                    continue
-                sse = event.to_sse()
-                yield sse
-        except Exception as e:
-            logger.exception("[chat.send.stream] Unexpected error: run_id=%s", req.id)
-            yield _build_sse_error(req.id, "INTERNAL_ERROR", str(e), False)
+    def on_error(e: Exception) -> str:
+        logger.exception("[chat.send.stream] Unexpected error: run_id=%s", req.id)
+        return _build_sse_error(req.id, "INTERNAL_ERROR", str(e), False)
 
     return StreamingResponse(
-        _stream(),
+        with_sse_heartbeat(
+            convert_chunks_to_sse(chunk_iter, converter, req.id, on_error=on_error)
+        ),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
@@ -5,7 +5,6 @@
 
 import json
 import time
-from collections.abc import AsyncIterator
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -37,7 +36,12 @@ from secbaas.community.api.bot_runtime import (
     TooManyRequestsError,
 )
 from secbaas.community.api.open_api import OpenAPICode, get_code_message
-from secbaas.community.api.sse import SseConverterFactory, SseEvent
+from secbaas.community.api.sse import (
+    SseConverterFactory,
+    SseEvent,
+    convert_chunks_to_sse,
+    with_sse_heartbeat,
+)
 from secbaas.community.bootstrap import ApplicationContainer
 from secbaas.community.logger import get_logger
 
@@ -271,35 +275,36 @@ async def deliver_message_stream(
 
     converter = converter_factory.create("default")
 
-    async def _sse_generator() -> AsyncIterator[str]:
-        # 先发送一个 ready 事件，携带 message_id 和 session_id
-        yield SseEvent(
-            event="ready",
+    ready_sse = SseEvent(
+        event="ready",
+        data=json.dumps(
+            {"message_id": message_id, "session_id": session_id},
+            ensure_ascii=False,
+        ),
+    ).to_sse()
+
+    def on_error(e: Exception) -> str:
+        logger.exception(
+            "deliver_message_stream chunk error: message_id=%s", message_id
+        )
+        return SseEvent(
+            event="error",
             data=json.dumps(
-                {"message_id": message_id, "session_id": session_id},
+                {"message_id": message_id, "error": str(e)},
                 ensure_ascii=False,
             ),
         ).to_sse()
 
-        try:
-            async for chunk in chunk_iter:
-                event = converter.convert(chunk, run_id=message_id)
-                if event is not None:
-                    yield event.to_sse()
-        except Exception as e:
-            logger.exception(
-                "deliver_message_stream chunk error: message_id=%s", message_id
-            )
-            yield SseEvent(
-                event="error",
-                data=json.dumps(
-                    {"message_id": message_id, "error": str(e)},
-                    ensure_ascii=False,
-                ),
-            ).to_sse()
-
     return StreamingResponse(
-        _sse_generator(),
+        with_sse_heartbeat(
+            convert_chunks_to_sse(
+                chunk_iter,
+                converter,
+                message_id,
+                prefix=[ready_sse],
+                on_error=on_error,
+            )
+        ),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/src/baas/src/secbaas/community/api/sse/__init__.py
+++ b/src/baas/src/secbaas/community/api/sse/__init__.py
@@ -3,12 +3,20 @@
 定义 StreamChunk、SseEvent 模型及 StreamConverter 插件协议。
 """
 
+from ._heartbeat import (
+    HEARTBEAT_SSE,
+    convert_chunks_to_sse,
+    with_sse_heartbeat,
+)
 from ._models import SseEvent, StreamChunk
 from ._protocol import SseConverterFactory, StreamConverter
 
 __all__ = [
+    "HEARTBEAT_SSE",
     "SseEvent",
     "StreamChunk",
     "StreamConverter",
     "SseConverterFactory",
+    "convert_chunks_to_sse",
+    "with_sse_heartbeat",
 ]

--- a/src/baas/src/secbaas/community/api/sse/_heartbeat.py
+++ b/src/baas/src/secbaas/community/api/sse/_heartbeat.py
@@ -1,0 +1,101 @@
+"""SSE heartbeat wrapper and chunk-to-SSE conversion helper.
+
+Wraps a serialized SSE string stream so that when no bytes are yielded
+for ``interval`` seconds, a ``": heartbeat\\n\\n"`` comment frame is emitted.
+This prevents downstream idle timeouts even when the upstream is active
+but the converter filters out all chunks (e.g. high-frequency tool
+update/progress events).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
+
+from ._models import StreamChunk
+from ._protocol import StreamConverter
+
+HEARTBEAT_SSE = ": heartbeat\n\n"
+
+
+@dataclass
+class _End:
+    """Sentinel marking stream completion."""
+
+
+async def convert_chunks_to_sse(
+    chunk_iter: AsyncIterator[StreamChunk],
+    converter: StreamConverter,
+    run_id: str,
+    *,
+    prefix: list[str] | None = None,
+    on_error: Callable[[Exception], str] | None = None,
+) -> AsyncIterator[str]:
+    """Convert StreamChunks to SSE strings via a converter.
+
+    Yields optional *prefix* SSE strings first (e.g. a ready event),
+    then converts each chunk. Chunks that convert to None are skipped.
+    On exception, calls *on_error* if provided; otherwise re-raises.
+    """
+    if prefix:
+        for sse in prefix:
+            yield sse
+    try:
+        async for chunk in chunk_iter:
+            event = converter.convert(chunk, run_id=run_id)
+            if event is None:
+                continue
+            yield event.to_sse()
+    except Exception as e:
+        if on_error is not None:
+            yield on_error(e)
+        else:
+            raise
+
+
+async def with_sse_heartbeat(
+    sse_iter: AsyncIterator[str],
+    *,
+    interval: float = 30.0,
+) -> AsyncIterator[str]:
+    """Wrap an SSE string stream, injecting heartbeat when idle.
+
+    Uses a producer-consumer pattern: a background task drains *sse_iter*
+    into a queue; the main loop reads from the queue with a timeout. On
+    timeout it yields :data:`HEARTBEAT_SSE`. Cancelling the queue.get()
+    timeout does **not** cancel the original generator.
+    """
+    queue: asyncio.Queue[str | _End | Exception] = asyncio.Queue()
+    end = _End()
+
+    async def producer() -> None:
+        try:
+            async for sse in sse_iter:
+                await queue.put(sse)
+        except Exception as e:
+            await queue.put(e)
+        finally:
+            await queue.put(end)
+
+    producer_task = asyncio.create_task(producer())
+    try:
+        while True:
+            try:
+                item: str | _End | Exception = await asyncio.wait_for(
+                    queue.get(), timeout=interval
+                )
+            except TimeoutError:
+                yield HEARTBEAT_SSE
+                continue
+            if item is end:
+                return
+            if isinstance(item, Exception):
+                raise item
+            yield item
+    finally:
+        producer_task.cancel()
+        try:
+            await producer_task
+        except (asyncio.CancelledError, Exception):
+            pass

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -378,7 +378,7 @@ class BotRunner:
             bot_id=bot_id,
         )
 
-        return message_id, actual_session_id, _with_heartbeat(stream_iter)
+        return message_id, actual_session_id, stream_iter
 
     async def get_messages(
         self,
@@ -717,59 +717,3 @@ class BotRunner:
                 return None
             raise
         return binding_data_to_info(data)
-
-
-async def _with_heartbeat(
-    stream: AsyncIterator[StreamChunk],
-) -> AsyncIterator[StreamChunk]:
-    """包装流式迭代器，每 30s 插入一个 heartbeat chunk。
-
-    使用 producer-consumer 模式：后台 task 从原始 stream 取数据放入 Queue，
-    主循环从 Queue 取并设超时。这样超时只 cancel queue.get()，不会 kill
-    原始 async generator（直接 wait_for(stream.__anext__) 会在超时时 cancel
-    生成器，导致后续数据全部丢失）。
-    """
-    queue: asyncio.Queue[StreamChunk | _StreamEnd | Exception] = asyncio.Queue()
-    end = _StreamEnd()
-
-    async def producer() -> None:
-        try:
-            async for chunk in stream:
-                await queue.put(chunk)
-        except Exception as e:
-            await queue.put(e)
-        finally:
-            await queue.put(end)
-
-    producer_task = asyncio.create_task(producer())
-    try:
-        while True:
-            try:
-                item: StreamChunk | _StreamEnd | Exception = await asyncio.wait_for(
-                    queue.get(), timeout=30.0
-                )
-            except TimeoutError:
-                yield StreamChunk(type="heartbeat")
-                continue
-            if item is end:
-                return
-            if isinstance(item, Exception):
-                raise item
-            if isinstance(item, StreamChunk):
-                yield item
-            else:
-                logger.warning(
-                    "[heartbeat] Unexpected item type from queue: %s",
-                    type(item).__name__,
-                )
-    finally:
-        producer_task.cancel()
-        try:
-            await producer_task
-        except (asyncio.CancelledError, Exception):
-            pass
-
-
-@dataclass
-class _StreamEnd:
-    """哨兵对象，标记 stream 结束。"""

--- a/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
@@ -79,3 +79,32 @@ async def test_stream_dispatch_skips_dropped_converter_events():
         "state": "delta",
         "deltaText": "hello",
     }
+
+
+@pytest.mark.asyncio
+async def test_stream_dispatch_error_yields_error_sse():
+    """When chunk_iter raises, on_error produces an error SSE event."""
+
+    class _ErrorStreamService:
+        async def handle_chat_send_stream(self, _input):
+            async def _chunks():
+                yield StreamChunk(type="delta", content="hi")
+                raise RuntimeError("chunk boom")
+
+            return _chunks()
+
+    response = await _dispatch_chat_send_stream(
+        _chat_send_request(),
+        _ErrorStreamService(),
+        _ConverterFactory(),
+    )
+
+    items = []
+    async for item in response.body_iterator:
+        items.append(item)
+
+    # delta + error
+    assert len(items) == 2
+    assert items[0].startswith("id: 1\nevent: chat\n")
+    assert "error" in items[1]
+    assert "INTERNAL_ERROR" in items[1]

--- a/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
@@ -5,6 +5,7 @@ NOT TestClient. Covers deliver_message and get_message_result
 endpoints plus _normalize_bot_id helper.
 """
 
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -659,6 +660,51 @@ class TestDeliverMessageStream:
         call_kwargs = mock_runner.deliver_message_stream.call_args.kwargs
         assert call_kwargs["metadata"]["stream"] == "true"
         assert call_kwargs["metadata"]["timeout"] == "30"
+
+    @pytest.mark.asyncio
+    async def test_chunk_error_yields_error_sse(self):
+        """When chunk_iter raises, on_error produces an error SSE event."""
+
+        async def failing_chunks():
+            yield StreamChunk(type="delta", content="hi")
+            raise RuntimeError("chunk boom")
+
+        api_key = _make_api_key_record(app_type="system")
+        ctx = _make_context()
+        req = _make_stream_message_request()
+
+        mock_runner = AsyncMock()
+        mock_runner.deliver_message_stream = AsyncMock(
+            return_value=("msg-e1", "sess-e1", failing_chunks())
+        )
+
+        with patch(
+            "secbaas.community.adapters.web.routers.open_api.message_router.validate_policy",
+            return_value="bot-1:entity-1",
+        ):
+            result = await deliver_message_stream(
+                request=req,
+                api_key_record=api_key,
+                context=ctx,
+                bot_runner=mock_runner,
+                converter_factory=_make_converter_factory(),
+            )
+
+        items = []
+        async for item in result.body_iterator:
+            items.append(item)
+
+        # ready + delta + error
+        assert len(items) == 3
+        assert items[0].startswith("event: ready\n")
+        assert "event: chat\n" in items[1]
+        assert items[2].startswith("event: error\n")
+        data_line = next(
+            line for line in items[2].splitlines() if line.startswith("data: ")
+        )
+        data = json.loads(data_line.removeprefix("data: "))
+        assert data["message_id"] == "msg-e1"
+        assert "chunk boom" in data["error"]
 
 
 # ── get_message_result ──────────────────────────────────────

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -28,7 +28,7 @@ from secbaas.community.api.bot_runtime import (
     TooManyRequestsError,
 )
 from secbaas.community.api.device_manage import ErrorCode, PaasError
-from secbaas.community.api.sse import StreamChunk
+from secbaas.community.api.sse import SseEvent, StreamChunk
 from secbaas.community.core.service.bot_run import (
     BotBindingNotFoundError,
     BotRunner,
@@ -1642,76 +1642,275 @@ class TestSelectDispatcherConfig:
         assert result is task_d
 
 
-# ==================== Tests: _with_heartbeat ====================
+# ==================== Tests: with_sse_heartbeat ====================
 
 
-class TestWithHeartbeat:
-    """Cover _with_heartbeat: normal yield, timeout heartbeat, StopAsyncIteration."""
+class TestWithSseHeartbeat:
+    """Cover with_sse_heartbeat: normal yield, timeout heartbeat, empty stream."""
 
     @pytest.mark.asyncio
-    async def test_yields_chunks(self):
-        from secbaas.community.core.service.bot_run._runner import _with_heartbeat
+    async def test_yields_sse(self):
+        from secbaas.community.api.sse import with_sse_heartbeat
 
         async def source():
-            yield StreamChunk(type="delta", content="a")
-            yield StreamChunk(type="final", content="done")
+            yield "event: delta\ndata: a\n\n"
+            yield "event: final\ndata: done\n\n"
 
-        chunks = []
-        async for chunk in _with_heartbeat(source()):
-            chunks.append(chunk)
+        results = []
+        async for sse in with_sse_heartbeat(source()):
+            results.append(sse)
 
-        assert len(chunks) == 2
-        assert chunks[0].type == "delta"
-        assert chunks[1].type == "final"
+        assert len(results) == 2
+        assert results[0] == "event: delta\ndata: a\n\n"
+        assert results[1] == "event: final\ndata: done\n\n"
 
     @pytest.mark.asyncio
     async def test_inserts_heartbeat_on_timeout(self):
-        from secbaas.community.core.service.bot_run._runner import _with_heartbeat
+        from secbaas.community.api.sse import HEARTBEAT_SSE, with_sse_heartbeat
 
         async def slow_source():
-            yield StreamChunk(type="delta", content="first")
+            yield "event: delta\ndata: first\n\n"
             await asyncio.sleep(0.15)
-            yield StreamChunk(type="final", content="late")
+            yield "event: final\ndata: late\n\n"
 
         original_wait_for = asyncio.wait_for
 
         with patch(
-            "secbaas.community.core.service.bot_run._runner.asyncio.wait_for",
+            "secbaas.community.api.sse._heartbeat.asyncio.wait_for",
             lambda coro, timeout: original_wait_for(coro, 0.1),
         ):
-            chunks = []
-            async for chunk in _with_heartbeat(slow_source()):
-                chunks.append(chunk)
+            results = []
+            async for sse in with_sse_heartbeat(slow_source()):
+                results.append(sse)
 
-        assert len(chunks) == 3
-        assert chunks[0].type == "delta"
-        assert chunks[1].type == "heartbeat"
-        assert chunks[2].type == "final"
+        assert len(results) == 3
+        assert results[0] == "event: delta\ndata: first\n\n"
+        assert results[1] == HEARTBEAT_SSE
+        assert results[2] == "event: final\ndata: late\n\n"
 
     @pytest.mark.asyncio
     async def test_empty_stream(self):
-        from secbaas.community.core.service.bot_run._runner import _with_heartbeat
+        from secbaas.community.api.sse import with_sse_heartbeat
 
         async def empty():
             return
             yield  # make it an async generator
 
-        chunks = []
-        async for chunk in _with_heartbeat(empty()):
-            chunks.append(chunk)
+        results = []
+        async for sse in with_sse_heartbeat(empty()):
+            results.append(sse)
 
-        assert chunks == []
+        assert results == []
 
     @pytest.mark.asyncio
-    async def test_single_chunk(self):
-        from secbaas.community.core.service.bot_run._runner import _with_heartbeat
+    async def test_single_sse(self):
+        from secbaas.community.api.sse import with_sse_heartbeat
 
         async def single():
-            yield StreamChunk(type="final", content="only")
+            yield "event: final\ndata: only\n\n"
 
-        chunks = []
-        async for chunk in _with_heartbeat(single()):
-            chunks.append(chunk)
+        results = []
+        async for sse in with_sse_heartbeat(single()):
+            results.append(sse)
 
-        assert len(chunks) == 1
-        assert chunks[0].content == "only"
+        assert len(results) == 1
+        assert results[0] == "event: final\ndata: only\n\n"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_when_all_filtered(self):
+        """Upstream yields nothing useful for >interval; heartbeat should fire."""
+        from secbaas.community.api.sse import HEARTBEAT_SSE, with_sse_heartbeat
+
+        async def silent_source():
+            await asyncio.sleep(0.15)
+            return
+            yield  # make it an async generator
+
+        original_wait_for = asyncio.wait_for
+
+        with patch(
+            "secbaas.community.api.sse._heartbeat.asyncio.wait_for",
+            lambda coro, timeout: original_wait_for(coro, 0.1),
+        ):
+            results = []
+            async for sse in with_sse_heartbeat(silent_source()):
+                results.append(sse)
+
+        assert results == [HEARTBEAT_SSE]
+
+    @pytest.mark.asyncio
+    async def test_propagates_upstream_exception(self):
+        """Exceptions from the upstream SSE iterator are re-raised."""
+        from secbaas.community.api.sse import with_sse_heartbeat
+
+        async def failing_source():
+            yield "event: delta\ndata: a\n\n"
+            raise RuntimeError("upstream boom")
+
+        with pytest.raises(RuntimeError, match="upstream boom"):
+            async for _sse in with_sse_heartbeat(failing_source()):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_cancels_producer_on_early_exit(self):
+        """If the consumer stops early, the producer task is cancelled cleanly."""
+        from secbaas.community.api.sse import with_sse_heartbeat
+
+        async def endless_source():
+            yield "event: delta\ndata: a\n\n"
+            await asyncio.sleep(100)
+
+        gen = with_sse_heartbeat(endless_source())
+        # Read one item then abandon the generator
+        async for sse in gen:
+            assert sse == "event: delta\ndata: a\n\n"
+            break
+
+        # Generator cleanup runs __anext__ → triggers finally block
+        await gen.aclose()
+
+
+# ==================== Tests: convert_chunks_to_sse ====================
+
+
+class TestConvertChunksToSse:
+    """Cover convert_chunks_to_sse: prefix, conversion, None filtering, errors."""
+
+    @pytest.mark.asyncio
+    async def test_converts_chunks(self):
+        from secbaas.community.api.sse import convert_chunks_to_sse
+
+        converter = _DummyConverter()
+        converter._results = [
+            SseEvent(event="delta", data='{"a":1}'),
+            SseEvent(event="final", data='{"b":2}'),
+        ]
+
+        async def chunks():
+            yield StreamChunk(type="delta", content="a")
+            yield StreamChunk(type="final", content="b")
+
+        results = []
+        async for sse in convert_chunks_to_sse(chunks(), converter, "run-1"):
+            results.append(sse)
+
+        assert len(results) == 2
+        assert results[0] == 'event: delta\ndata: {"a":1}\n\n'
+        assert results[1] == 'event: final\ndata: {"b":2}\n\n'
+
+    @pytest.mark.asyncio
+    async def test_skips_none_events(self):
+        from secbaas.community.api.sse import convert_chunks_to_sse
+
+        converter = _DummyConverter()
+        converter._results = [
+            None,
+            SseEvent(event="delta", data='{"ok":true}'),
+            None,
+        ]
+
+        async def chunks():
+            yield StreamChunk(type="agent")
+            yield StreamChunk(type="delta", content="hi")
+            yield StreamChunk(type="agent")
+
+        results = []
+        async for sse in convert_chunks_to_sse(chunks(), converter, "r1"):
+            results.append(sse)
+
+        assert len(results) == 1
+        assert results[0] == 'event: delta\ndata: {"ok":true}\n\n'
+
+    @pytest.mark.asyncio
+    async def test_prefix_yields_first(self):
+        from secbaas.community.api.sse import convert_chunks_to_sse
+
+        converter = _DummyConverter()
+        converter._results = [SseEvent(event="delta", data='{"x":1}')]
+
+        ready = 'event: ready\ndata: {"mid":"m1"}\n\n'
+
+        async def chunks():
+            yield StreamChunk(type="delta", content="x")
+
+        results = []
+        async for sse in convert_chunks_to_sse(
+            chunks(), converter, "r1", prefix=[ready]
+        ):
+            results.append(sse)
+
+        assert results == [ready, 'event: delta\ndata: {"x":1}\n\n']
+
+    @pytest.mark.asyncio
+    async def test_on_error_callback(self):
+        from secbaas.community.api.sse import convert_chunks_to_sse
+
+        converter = _DummyConverter()
+        converter._results = [SseEvent(event="delta", data='{"a":1}')]
+
+        async def chunks():
+            yield StreamChunk(type="delta", content="a")
+            raise RuntimeError("convert boom")
+
+        captured: list[Exception] = []
+
+        def on_error(e: Exception) -> str:
+            captured.append(e)
+            return 'event: error\ndata: {"msg":"boom"}\n\n'
+
+        results = []
+        async for sse in convert_chunks_to_sse(chunks(), converter, "r1", on_error=on_error):
+            results.append(sse)
+
+        assert len(results) == 2
+        assert results[0] == 'event: delta\ndata: {"a":1}\n\n'
+        assert results[1] == 'event: error\ndata: {"msg":"boom"}\n\n'
+        assert len(captured) == 1
+        assert isinstance(captured[0], RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_re_raise_without_on_error(self):
+        from secbaas.community.api.sse import convert_chunks_to_sse
+
+        converter = _DummyConverter()
+        converter._results = [SseEvent(event="delta", data='{"a":1}')]
+
+        async def chunks():
+            yield StreamChunk(type="delta", content="a")
+            raise RuntimeError("no handler")
+
+        with pytest.raises(RuntimeError, match="no handler"):
+            async for _sse in convert_chunks_to_sse(chunks(), converter, "r1"):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_empty_chunk_iter(self):
+        from secbaas.community.api.sse import convert_chunks_to_sse
+
+        converter = _DummyConverter()
+        converter._results = []
+
+        async def empty():
+            return
+            yield  # async generator
+
+        results = []
+        async for _sse in convert_chunks_to_sse(empty(), converter, "r1"):
+            results.append(_sse)
+
+        assert results == []
+
+
+class _DummyConverter:
+    """Minimal StreamConverter stub for testing convert_chunks_to_sse."""
+
+    _idx = 0
+
+    @staticmethod
+    def name() -> str:
+        return "dummy"
+
+    def convert(self, chunk, *, run_id: str):
+        result = self._results[self._idx]
+        self._idx += 1
+        return result


### PR DESCRIPTION
The heartbeat timer was placed before the SSE converter, timing out based on upstream chunk arrival. When upstream sends high-frequency tool update/progress events that the converter filters to None, the timer keeps getting reset (chunks arrive), but no SSE bytes are written downstream. This starves the heartbeat and the BCS socket goes silent for 120s, triggering an idle timeout.

Move heartbeat logic to after the converter, so it fires based on actual SSE byte output intervals. Extract a reusable with_sse_heartbeat() wrapper in api/sse and apply it in both bcn_router and message_router. Remove the old _with_heartbeat from _runner, which returned StreamChunk(type=heartbeat) before conversion.

Changes:
- Add api/sse/_heartbeat.py with with_sse_heartbeat() + HEARTBEAT_SSE
- Remove _with_heartbeat and _StreamEnd from _runner.py
- Wrap _convert_stream() with with_sse_heartbeat in bcn_router
- Wrap _convert_stream() with with_sse_heartbeat in message_router
- Replace TestWithHeartbeat with TestWithSseHeartbeat (7 tests, 100% cov)