### PR TITLE
fix(service_bot): detect stale online release via the bot's ledger timeline

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/repository/models.py
@@ -275,6 +275,36 @@ class PublishOperationKind(StrEnum):
         """
         return _KIND_BAAS_PUBLISH_TYPES[self]
 
+    @property
+    def sets_deployed_version(self) -> bool:
+        """Whether a *successful* op of this kind sets/replaces which application
+        version is running on its target bot.
+
+        ``True`` for the deploy kinds (first release, upgrade, rollback re-deploy,
+        eval publish); ``False`` for the lifecycle kinds that leave the deployed
+        version unchanged (restart, scale, eval teardown). This is the fence for
+        the online-release liveness scan: a record's completed online release is
+        still the *live* deployment on the shared online bot only while no later
+        ``sets_deployed_version`` op has landed on that bot — a newer upgrade or a
+        rollback re-deploy supersedes it, but a restart / scale does not.
+
+        Every kind is partitioned into exactly one of
+        ``_KINDS_SET_DEPLOYED_VERSION`` / ``_KINDS_PRESERVE_DEPLOYED_VERSION``;
+        ``test_publish_operation_kind_deploy_partition`` asserts the partition, so a
+        newly added kind fails CI until it is classified here.
+        """
+        return self in _KINDS_SET_DEPLOYED_VERSION
+
+    @classmethod
+    def version_setting_kinds(cls) -> frozenset["PublishOperationKind"]:
+        """Kinds whose successful op sets/replaces the deployed version (deploys)."""
+        return _KINDS_SET_DEPLOYED_VERSION
+
+    @classmethod
+    def version_preserving_kinds(cls) -> frozenset["PublishOperationKind"]:
+        """Kinds that leave the deployed version unchanged (restart/scale/teardown)."""
+        return _KINDS_PRESERVE_DEPLOYED_VERSION
+
 
 # The BaaS publish_type(s) each kind's workflow can carry — the adopt-by-query
 # type fence, co-located with the kind it describes (exposed via
@@ -288,6 +318,24 @@ _KIND_BAAS_PUBLISH_TYPES: Dict[PublishOperationKind, frozenset[str]] = {
     PublishOperationKind.EVAL_PUBLISH: frozenset({"CREATE"}),
     PublishOperationKind.EVAL_TEARDOWN: frozenset({"DESTROY", "STOP"}),
 }
+
+# Deploy vs lifecycle partition of every kind (exposed via
+# ``PublishOperationKind.sets_deployed_version``). A deploy kind's completed op
+# marks which version is live on its bot; a lifecycle kind leaves it unchanged.
+# The two sets MUST partition every ``PublishOperationKind`` (asserted by
+# ``test_publish_operation_kind_deploy_partition``): a new kind must be classified
+# into exactly one, or the liveness scan silently mistreats it.
+_KINDS_SET_DEPLOYED_VERSION: frozenset[PublishOperationKind] = frozenset({
+    PublishOperationKind.FIRST_RELEASE,
+    PublishOperationKind.UPGRADE,
+    PublishOperationKind.ROLLBACK_DEPLOY,
+    PublishOperationKind.EVAL_PUBLISH,
+})
+_KINDS_PRESERVE_DEPLOYED_VERSION: frozenset[PublishOperationKind] = frozenset({
+    PublishOperationKind.RESTART,
+    PublishOperationKind.SCALE,
+    PublishOperationKind.EVAL_TEARDOWN,
+})
 
 
 class PublishOperationState(StrEnum):

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
     BotPublishRecord,
     PublishOperationKind,
+    PublishOperationRecord,
     PublishOperationState,
 )
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
@@ -864,35 +865,90 @@ class PublishFlowService(
         return self._publish_service.get_publish_by_id(publish_id)
 
     def is_online_release_recorded(self, publish_id: int) -> bool:
-        """True once this record's online release is fully recorded — i.e. the
-        binding + ``ext.publish.online`` were written, not merely the BaaS
-        workflow id.
+        """True when this record's online release is the *live* deployment on its
+        bot — i.e. the latest version-setting op that has landed on the shared
+        online bot belongs to this publish.
 
-        This is the crash-resume guard for the online leg, which runs *within*
-        ONLINE_PUB with no status transition to guard it, so the threshold must
-        be the *completed* release, not just the created workflow. Both consumers
-        need this threshold:
+        Purely ledger-driven (#197): the ledger is the source of truth for what is
+        deployed. The question is answered from the bot's op timeline alone, in two
+        steps:
 
-        * the online_release task gate (``tasks.py``) skips re-running the release
-          only when it is fully done; at ``ID_RECORDED``-but-not-complete a re-run
-          MUST re-enter (the runner then resumes: reuses the in-flight op + binding
-          and finishes the ext write) — gating on the mere workflow id would strand
-          the record with an orphaned bot (binding/ext never written).
-        * ``retry`` chooses BaaS-restart only for a completed release (a BaaS-side
-          failure); a partial release re-runs the release work instead.
+        1. This record's own online release op (first-release / upgrade) must be
+           ``COMPLETED`` — a completed BaaS deploy that landed a binding + ext.
+           Anything short of that (no op, or an ``ID_RECORDED`` deploy still
+           mid-flight) is *not* recorded: the online_release gate must re-enter so
+           the runner resumes the same op (no second bot), and ``retry`` must re-run
+           the release work rather than restart.
+        2. That completed release must still be the latest deploy on the bot. A
+           ``COMPLETED`` op genuinely completed and is never rewritten; what makes it
+           stale is a *later* version-setting op landing on the same bot. Rollback
+           demotes this record to DRAFT and re-deploys the previous version onto the
+           bot (a ``ROLLBACK_DEPLOY`` with a higher, globally-monotonic
+           ``baas_publish_id``), so the demoted record's release is no longer the
+           latest deploy and a re-publish must run again. A restart / scale lands on
+           the bot too but does not set the version (``sets_deployed_version``), so
+           it never supersedes a release.
 
-        Ledger-driven (#197): the latest online-stage release op (first-release or
-        upgrade) is ``COMPLETED``. The ``ext.publish.online`` marker (written in the
-        release's ext step, one step before ``complete_operation``) is a transitional
-        fallback — it covers both the tiny record-ext→complete window and any record
-        that predates the ledger during rollout."""
+        Consumers: the online_release gate (``tasks.py``) skips the release only
+        when it is the live deployment; ``retry`` chooses BaaS-restart only for a
+        completed, still-live release (a BaaS-side wait failure) and otherwise
+        re-runs the release work."""
+        release_op = self._completed_online_release_op(publish_id)
+        if release_op is None or not release_op.bot_uuid:
+            return False
+
+        return not self._online_release_superseded(release_op)
+
+    def _completed_online_release_op(
+        self, publish_id: int
+    ) -> PublishOperationRecord | None:
+        """This record's completed online release op (first-release or upgrade),
+        or ``None`` if it has no completed online deploy yet.
+
+        Reads the latest attempt of each release kind and keeps the COMPLETED one.
+        An ``UPGRADE`` that hit ``BOT_NOT_FOUND`` is ABANDONED and a
+        ``FIRST_RELEASE`` fallback completes, so both kinds can coexist for one
+        publish; only the completed one is the record's real release. A still
+        in-flight (``ID_RECORDED``) or absent op yields ``None`` — the caller
+        treats that as not-yet-recorded (re-enter / re-run rather than skip)."""
+        completed = []
         for kind in (PublishOperationKind.FIRST_RELEASE, PublishOperationKind.UPGRADE):
             op = self._publish_operation_repo.get_latest_by_kind(
                 publish_id, kind, PublishStage.ONLINE.value
             )
-            if op is not None and op.state == PublishOperationState.COMPLETED.value:
+            if (
+                op is not None
+                and op.state == PublishOperationState.COMPLETED.value
+                and op.baas_publish_id is not None
+            ):
+                completed.append(op)
+        if not completed:
+            return None
+        return max(completed, key=lambda o: o.baas_publish_id)
+
+    def _online_release_superseded(self, release_op: PublishOperationRecord) -> bool:
+        """True if a later version-setting deploy has landed on the same online bot
+        — i.e. ``release_op`` is no longer the live deployment.
+
+        Scans the shared bot's ledger timeline for a ``sets_deployed_version`` op
+        (a newer upgrade, or a rollback re-deploy of another version) whose workflow
+        landed after this release (higher, globally-monotonic ``baas_publish_id``).
+        A landed op is one that reached ``ID_RECORDED``/``COMPLETED`` (a workflow was
+        issued); ``FAILED``/``ABANDONED`` deploys never took, so they do not
+        supersede. Restart / scale are skipped — they do not set the version."""
+        landed = {
+            PublishOperationState.ID_RECORDED.value,
+            PublishOperationState.COMPLETED.value,
+        }
+        for op in self._publish_operation_repo.list_by_bot(
+            release_op.bot_uuid, release_op.env
+        ):
+            if (
+                op.baas_publish_id is not None
+                and op.baas_publish_id > release_op.baas_publish_id
+                and op.state in landed
+                and PublishOperationKind(op.operation_kind).sets_deployed_version
+            ):
                 return True
-        record = self.get_publish_record(publish_id)
-        ext = (record.ext or {}) if record else {}
-        return bool(ext.get("publish", {}).get(PublishStage.ONLINE.value))
+        return False
 

--- a/src/backend/tests/community/core/service_bot/repository/test_publish_operation_repository.py
+++ b/src/backend/tests/community/core/service_bot/repository/test_publish_operation_repository.py
@@ -176,3 +176,36 @@ def test_transitions_on_missing_row_return_none(repo):
     assert repo.complete(123456) is None
     assert repo.fail(123456, "e") is None
     assert repo.abandon(123456, "r") is None
+
+
+def test_publish_operation_kind_deploy_partition():
+    """Every PublishOperationKind must be classified as either version-setting
+    (a deploy — its completed op marks which version is live on its bot) or
+    version-preserving (restart/scale/teardown — leaves the deployed version
+    unchanged). is_online_release_recorded's liveness scan filters on
+    ``sets_deployed_version``, so an unclassified new kind would be silently
+    mistreated; this partition assertion fails CI until the kind is classified in
+    models.py (`_KINDS_SET_DEPLOYED_VERSION` / `_KINDS_PRESERVE_DEPLOYED_VERSION`)."""
+    setting = PublishOperationKind.version_setting_kinds()
+    preserving = PublishOperationKind.version_preserving_kinds()
+
+    # Disjoint and exhaustive over all kinds (every kind in exactly one bucket).
+    assert setting.isdisjoint(preserving)
+    assert setting | preserving == set(PublishOperationKind)
+
+    # The property agrees with the sets for every kind.
+    for kind in PublishOperationKind:
+        assert kind.sets_deployed_version == (kind in setting)
+
+    # Pin the intended classification so a semantic change is a conscious edit.
+    assert setting == {
+        PublishOperationKind.FIRST_RELEASE,
+        PublishOperationKind.UPGRADE,
+        PublishOperationKind.ROLLBACK_DEPLOY,
+        PublishOperationKind.EVAL_PUBLISH,
+    }
+    assert preserving == {
+        PublishOperationKind.RESTART,
+        PublishOperationKind.SCALE,
+        PublishOperationKind.EVAL_TEARDOWN,
+    }

--- a/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
@@ -371,15 +371,27 @@ async def test_upgrade_bot_not_found_abandons_and_falls_back():
 
 
 # ── retry / abandonment: ledger-driven decisions (#197 Task 10) ───────────────
+def _land_completed_op(svc, ledger, *, publish_id, kind, bot_uuid, baas_id):
+    """Open → record workflow → complete a ledger op landing ``baas_id`` on
+    ``bot_uuid`` (a completed BaaS deploy/lifecycle workflow)."""
+    op = svc._operation_runner.open_operation(
+        publish_id=publish_id, kind=kind, stage=PublishStage.ONLINE, bot_uuid=bot_uuid
+    )
+    ledger.record_workflow(op.id, baas_publish_id=baas_id, bot_uuid=bot_uuid)
+    ledger.complete(op.id)
+    return op
+
+
 def test_is_online_release_recorded_reads_ledger():
     ledger = _ledger()
     baas = FakeBaas()
     publish_service = Mock()
-    publish_service.get_publish_by_id.return_value = _record(PublishStatus.ONLINE_PUB.value)
+    rec = _record(PublishStatus.ONLINE_PUB.value)
+    publish_service.get_publish_by_id.return_value = rec
     svc = _flow(ledger=ledger, baas=baas, build_service=Mock(),
                 publish_service=publish_service)
 
-    # No op, no ext marker (record ext has no 'publish') → not recorded.
+    # No online release op for this publish → not recorded.
     assert svc.is_online_release_recorded(1) is False
 
     # An online op with only the workflow recorded (ID_RECORDED, binding/ext not
@@ -391,20 +403,76 @@ def test_is_online_release_recorded_reads_ledger():
     ledger.record_workflow(op.id, baas_publish_id=901, bot_uuid="BOT-x")
     assert svc.is_online_release_recorded(1) is False
 
-    # Only once the op COMPLETES (binding + ext done) is it "recorded".
+    # Once the op COMPLETES it is the latest deploy that landed on the bot → the
+    # live online release.
     ledger.complete(op.id)
     assert svc.is_online_release_recorded(1) is True
 
 
-def test_is_online_release_recorded_ext_fallback_for_pre_ledger():
+def test_is_online_release_recorded_false_for_rolled_back_completed_op():
+    """A COMPLETED online op is stale once a later deploy lands on the same bot.
+
+    Rollback demotes a SUCCESS record to DRAFT and re-deploys the previous version
+    onto the shared online bot (a ROLLBACK_DEPLOY op with a higher baas_publish_id).
+    The demoted record's prior COMPLETED online op is no longer the latest deploy on
+    the bot, so a re-publish of that record must run the release again — the stale op
+    must NOT gate it (otherwise the online leg is skipped and no BaaS workflow is
+    ever issued for the new lifecycle)."""
+    ledger = _ledger()
+    baas = FakeBaas()
+    publish_service = Mock()
+    rec = _record(PublishStatus.ONLINE_PUB.value)
+    publish_service.get_publish_by_id.return_value = rec
+    svc = _flow(ledger=ledger, baas=baas, build_service=Mock(),
+                publish_service=publish_service)
+
+    # This record's online upgrade completed and is the latest deploy on the bot.
+    _land_completed_op(svc, ledger, publish_id=1, kind="upgrade",
+                       bot_uuid="BOT-live", baas_id=901)
+    assert svc.is_online_release_recorded(1) is True
+
+    # Rollback re-deploys the previous version onto the SAME bot (higher baas id),
+    # on the target record (publish_id=2). The demoted record's op 901 is no longer
+    # the latest deploy → stale → not recorded → a re-publish runs the release.
+    _land_completed_op(svc, ledger, publish_id=2, kind="rollback_deploy",
+                       bot_uuid="BOT-live", baas_id=902)
+    assert svc.is_online_release_recorded(1) is False
+
+
+def test_is_online_release_recorded_true_after_restart_or_scale():
+    """A restart / scale lands on the same online bot (higher baas id) but does NOT
+    set the deployed version, so it must not make a live release look stale — else
+    retry() would misroute (re-run the release instead of restart) and the online
+    gate could re-issue a redundant deploy."""
+    ledger = _ledger()
+    publish_service = Mock()
+    rec = _record(PublishStatus.ONLINE_PUB.value)
+    publish_service.get_publish_by_id.return_value = rec
+    svc = _flow(ledger=ledger, baas=FakeBaas(), build_service=Mock(),
+                publish_service=publish_service)
+
+    _land_completed_op(svc, ledger, publish_id=1, kind="upgrade",
+                       bot_uuid="BOT-live", baas_id=901)
+    # A restart and a scale-up land afterwards on the same bot (version unchanged).
+    _land_completed_op(svc, ledger, publish_id=1, kind="restart",
+                       bot_uuid="BOT-live", baas_id=902)
+    _land_completed_op(svc, ledger, publish_id=1, kind="scale",
+                       bot_uuid="BOT-live", baas_id=903)
+    assert svc.is_online_release_recorded(1) is True
+
+
+def test_is_online_release_recorded_ignores_ext_marker():
+    """The answer is purely ledger-driven: an ext.publish.online marker with no
+    completed online release op in the ledger does NOT count as recorded. (The
+    ledger is the source of truth; a record with a live release always carries its
+    own COMPLETED first_release/upgrade op.)"""
     ledger = _ledger()
     svc = _flow(ledger=ledger, baas=FakeBaas(), build_service=Mock(),
                 publish_service=Mock())
-    # No ledger op, but a legacy ext.publish.online marker (pre-ledger record).
     rec = _record(PublishStatus.ONLINE_PUB.value)
     rec.ext = {"publish": {"online": 500}}
     svc._publish_service.get_publish_by_id = Mock(return_value=rec)
-    assert svc.is_online_release_recorded(2) is True
+    assert svc.is_online_release_recorded(2) is False
 
 
 def test_abandon_inflight_operations_marks_nonterminal():

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -3161,16 +3161,19 @@ async def test_retry_missing_source_status_raises():
 
 @pytest.mark.asyncio
 async def test_retry_from_online_pub_recorded_calls_restart():
-    # Online release already recorded (ext.publish.online) → a BaaS-wait failure →
-    # retry restarts the BaaS publish.
+    # Online release already recorded in the ledger — a COMPLETED online upgrade that
+    # is the latest deploy on the bot → a BaaS-wait failure → retry restarts the
+    # BaaS publish.
     record = _make_publish_record(
         status=PublishStatus.FAILED.value,
-        ext={
-            "source_status": PublishStatus.ONLINE_PUB.value,
-            "publish": {"online": 9},
-        },
+        ext={"source_status": PublishStatus.ONLINE_PUB.value},
     )
     svc, _ = _svc_with_record(record)
+    op = svc._operation_runner.open_operation(
+        publish_id=1, kind="upgrade", stage=PublishStage.ONLINE, bot_uuid="BOT-live"
+    )
+    svc._publish_operation_repo.record_workflow(op.id, baas_publish_id=9, bot_uuid="BOT-live")
+    svc._publish_operation_repo.complete(op.id)
     # #162 + durable restart: retry runs execute_restart inline then enqueues the poll.
     svc.execute_restart = AsyncMock(return_value={"success": True})
     result = await svc.retry(publish_id=1, operator="op")


### PR DESCRIPTION
## Problem

When a live (`SUCCESS`) publish record is rolled back, it is demoted to `DRAFT` and its `ext.publish.online` / `ext.binding.online` pointers are cleared, but the prior lifecycle's `COMPLETED` online-release op is left **untouched** in the `ac_publish_operation` ledger.

Re-promoting that same record `draft → verify → online` then reached the online-release gate in `publish_flow/tasks.py`:

```python
if status == PublishStatus.ONLINE_PUB and not self._flow.is_online_release_recorded(publish_id):
    release_result = await self._flow.execute_release_phase(...)
```

Since #197, `is_online_release_recorded` reported that stale `COMPLETED` op as "recorded", so `execute_release_phase` was **skipped**. No BaaS workflow was ever issued and the progress poll stranded the record:

```
[PublishFlowService.advance_publish_progress] No baas_publish_id found for stage=online, publish_id=5984
```

Verify worked because that leg is guarded by the `BUILT → VALIDATE_PUB` status transition, not this gate.

## Root cause

`is_online_release_recorded` conflated "the op completed" with "the release is still live". A `COMPLETED` op genuinely completed and is never rewritten — what makes it *stale* is a **later** operation changing what the shared online bot deploys.

The online bot is **shared across versions** (`_execute_upgrade_release` resolves `bot_uuid` from the previous record's online binding). Rollback re-deploys the previous version onto that same bot via a `ROLLBACK_DEPLOY` op (a real `UPDATE`, with a higher, globally-monotonic `baas_publish_id`). So after rollback the demoted record's online release is simply no longer the latest deploy on the bot.

## Fix

Answer the question **purely from the ledger's own bot timeline** — the ledger is the single source of truth for what is deployed. A record's online release is "recorded" iff:

1. its own online release op (`first_release` / `upgrade`) is `COMPLETED` (a landed BaaS deploy), **and**
2. that op is still the **latest version-setting op on the bot** — i.e. the latest deploy on the bot belongs to this publish.

A newer upgrade or a rollback re-deploy supersedes it; a `RESTART` / `SCALE` on the same bot does **not** (they land on the bot too, but preserve the deployed version). `is_online_release_recorded` now finds the record's completed release op, then scans `list_by_bot(bot_uuid, env)` for a later `sets_deployed_version` op — if one exists, the release is stale and must run again.

`PublishOperationKind.sets_deployed_version` classifies every kind as a deploy (`first_release` / `upgrade` / `rollback_deploy` / `eval_publish`) or lifecycle-only (`restart` / `scale` / `eval_teardown`).

The method **no longer reads `ext.publish.online` at all** — a record with a live online release always carries its own `COMPLETED` release op, so the former ext fallback (for pre-ledger records) is dropped and the ledger is authoritative.

## Exhaustiveness guard

`test_publish_operation_kind_deploy_partition` asserts the deploy/lifecycle sets are disjoint and cover **every** `PublishOperationKind`, so a newly added kind fails CI until it is classified — the liveness scan can never silently mistreat an unclassified kind.

## Tests

- Rolled-back release becomes stale once a `rollback_deploy` lands on the bot (the #5984 scenario).
- `restart`/`scale` after a release do **not** make it stale.
- No completed ledger op (even with a legacy `ext.publish.online`) → not recorded.
- `retry` from `ONLINE_PUB` uses the ledger to decide restart-vs-rerun.
- Kind partition is exhaustive and matches the property.
- Full `tests/community/core/service_bot/` suite green (637 passed).

## Notes

- Behavioral change: the `ext.publish.online` fallback (a #197 transitional path for pre-ledger records) is intentionally removed so the ledger is the sole source of truth. By this release the ledger has been authoritative for all online releases, and an actively-publishing/retrying record always has its own current-lifecycle op.
- Targeted at `REL20260723`.