### PR TITLE
feat(ci): add changed-line coverage gate to local test runs

### DIFF
--- a/src/baas/scripts/ci_test.sh
+++ b/src/baas/scripts/ci_test.sh
@@ -22,6 +22,13 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+    echo "auto-detected base: $base (merge-base of HEAD and origin/dev)"
+  fi
+fi
+
 if [[ ! -d "$baas_dir" ]]; then
   echo "baas CI failed: community package not found: $baas_dir" >&2
   exit 1

--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -41,6 +41,13 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+    echo "auto-detected base: $base (merge-base of HEAD and origin/dev)"
+  fi
+fi
+
 cd "$backend_dir"
 mkdir -p "$report_dir"
 

--- a/src/engine/scripts/ci_test.sh
+++ b/src/engine/scripts/ci_test.sh
@@ -21,6 +21,13 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+    echo "auto-detected base: $base (merge-base of HEAD and origin/dev)"
+  fi
+fi
+
 cd "$engine_dir"
 if [[ -z "$python_bin" ]]; then
   echo "engine CI failed: neither python nor python3 found" >&2

--- a/src/gateway/scripts/ci_test.sh
+++ b/src/gateway/scripts/ci_test.sh
@@ -21,6 +21,13 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+    echo "auto-detected base: $base (merge-base of HEAD and origin/dev)"
+  fi
+fi
+
 if [[ ! -d "$gateway_dir" ]]; then
   echo "gateway CI failed: community package not found: $gateway_dir" >&2
   exit 1
@@ -56,9 +63,17 @@ if [[ "$gateway_ci_status" -ne 0 ]]; then
 fi
 
 echo "--- unit coverage report ---"
+check_args=(
+  "$repo_root/scripts/ci/report_check.py"
+  --junit "$unit_report"
+  --coverage "$coverage_report"
+  --source-root "$gateway_dir/src"
+  --min-case-pass-rate 100
+  --min-line-coverage "$line_coverage_min"
+)
 if [[ -n "$base" ]]; then
-  echo "diff coverage check not yet configured (base=$base head=$head)"
+  check_args+=(--base "$base" --head "$head" --min-change-line-coverage 80)
 fi
-echo "Coverage report: file://$report_dir/html/index.html"
+"$python_bin" "${check_args[@]}"
 echo "--- end unit coverage report ---"
 echo "gateway CI gate passed"


### PR DESCRIPTION
## Summary

Dima: 2026072100117626864

When `--base` is not explicitly passed to `ci_test.sh`, automatically detect `origin/dev` merge-base as the base ref. This enables the `--min-change-line-coverage` gate in `report_check.py` for local runs, making local test behavior consistent with GitHub CI.

For gateway, replace the `diff coverage check not yet configured` placeholder with an actual `report_check.py` invocation using `--min-change-line-coverage 80`.

## Changes

- `src/backend/scripts/ci_test.sh`: auto-base inference → enables `--min-change-line-coverage 80`
- `src/engine/scripts/ci_test.sh`: auto-base inference → enables `--min-change-line-coverage 90`
- `src/baas/scripts/ci_test.sh`: auto-base inference → enables `--min-change-line-coverage 90`
- `src/gateway/scripts/ci_test.sh`: auto-base inference + replace placeholder with `report_check.py` gate (80%)

## Backward Compatibility

- When `origin/dev` doesn't exist, auto-base gracefully falls back to empty base → same as current behavior
- When `--base` is explicitly passed (CI, pre-push), auto-base is skipped → no behavior change

## Testing

- All 4 scripts pass `bash -n` syntax check
- No internal/corp leakage in changes

## Cross-repo Handoff

Avernet-first change. After merge: mirror sync → OCB update `ocb-public` gitlink + corp verification.

## Review

3 reviewers (correctness, security, quality) — all passed with zero P0/P1 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)