### PR TITLE
Add distributed tracing for BCN async chat flows

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
@@ -175,44 +175,51 @@ pub(crate) fn truncate_span_content(input: &str, limit_bytes: usize) -> Captured
     }
 }
 
-pub(crate) fn record_span_content(event_name: &'static str, content: &str) {
-    record_span_content_inner(event_name, content, None);
+pub(crate) fn record_span_content_event(event_name: &'static str, content: &str) {
+    let captured = truncate_span_content(content, SPAN_CONTENT_LIMIT_BYTES);
+    Span::current().add_event(
+        event_name,
+        vec![
+            KeyValue::new("bcn.content", captured.content),
+            KeyValue::new(
+                "bcn.content.original_size_bytes",
+                captured.original_size_bytes as i64,
+            ),
+            KeyValue::new(
+                "bcn.content.captured_size_bytes",
+                captured.captured_size_bytes as i64,
+            ),
+            KeyValue::new(
+                "bcn.content.limit_bytes",
+                SPAN_CONTENT_LIMIT_BYTES as i64,
+            ),
+            KeyValue::new("bcn.content.truncated", captured.truncated),
+        ],
+    );
 }
 
-pub(crate) fn record_span_content_with_untrusted(
-    event_name: &'static str,
+pub(crate) fn record_span_content_attributes(
+    content_attribute_name: &'static str,
     content: &str,
     untrusted: bool,
 ) {
-    record_span_content_inner(event_name, content, Some(untrusted));
-}
-
-fn record_span_content_inner(
-    event_name: &'static str,
-    content: &str,
-    untrusted: Option<bool>,
-) {
     let captured = truncate_span_content(content, SPAN_CONTENT_LIMIT_BYTES);
-    let mut attributes = vec![
-        KeyValue::new("bcn.content", captured.content),
-        KeyValue::new(
-            "bcn.content.original_size_bytes",
-            captured.original_size_bytes as i64,
-        ),
-        KeyValue::new(
-            "bcn.content.captured_size_bytes",
-            captured.captured_size_bytes as i64,
-        ),
-        KeyValue::new(
-            "bcn.content.limit_bytes",
-            SPAN_CONTENT_LIMIT_BYTES as i64,
-        ),
-        KeyValue::new("bcn.content.truncated", captured.truncated),
-    ];
-    if let Some(untrusted) = untrusted {
-        attributes.push(KeyValue::new("bcn.content.untrusted", untrusted));
-    }
-    Span::current().add_event(event_name, attributes);
+    let span = Span::current();
+    span.set_attribute(content_attribute_name, captured.content);
+    span.set_attribute(
+        "bcn.content.original_size_bytes",
+        captured.original_size_bytes as i64,
+    );
+    span.set_attribute(
+        "bcn.content.captured_size_bytes",
+        captured.captured_size_bytes as i64,
+    );
+    span.set_attribute(
+        "bcn.content.limit_bytes",
+        SPAN_CONTENT_LIMIT_BYTES as i64,
+    );
+    span.set_attribute("bcn.content.truncated", captured.truncated);
+    span.set_attribute("bcn.content.untrusted", untrusted);
 }
 
 fn floor_char_boundary(value: &str, mut index: usize) -> usize {
@@ -430,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    fn content_event_records_truncated_body_and_sizes() {
+    fn content_attributes_record_truncated_body_and_sizes_without_events() {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = SdkTracerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -442,22 +449,48 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             let span = info_span!(target: "bcn_otel", "bcn.gateway.dispatch");
             let _guard = span.enter();
-            record_span_content("bcn.chat.message", &"x".repeat(5000));
+            record_span_content_attributes(
+                "gen_ai.input.messages",
+                &"x".repeat(5000),
+                false,
+            );
         });
 
         provider.force_flush().unwrap();
         let spans = exporter.get_finished_spans().unwrap();
-        let event = &spans[0].events.events[0];
-        assert_eq!(event.name, "bcn.chat.message");
-        assert!(event.attributes.iter().any(|attribute| {
+        assert!(spans[0].events.events.is_empty());
+        assert!(spans[0].attributes.iter().all(|attribute| {
+            attribute.key.as_str() != "bcn.content"
+        }));
+        assert!(spans[0].attributes.iter().any(|attribute| {
             attribute.key.as_str() == "bcn.content.truncated"
                 && attribute.value == opentelemetry::Value::Bool(true)
         }));
-        let captured = event
+        assert!(spans[0].attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "bcn.content.original_size_bytes"
+                && attribute.value == opentelemetry::Value::I64(5000)
+        }));
+        assert!(spans[0].attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "bcn.content.limit_bytes"
+                && attribute.value == opentelemetry::Value::I64(4096)
+        }));
+        assert!(spans[0].attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "bcn.content.untrusted"
+                && attribute.value == opentelemetry::Value::Bool(false)
+        }));
+        let captured = spans[0]
             .attributes
             .iter()
-            .find(|attribute| attribute.key.as_str() == "bcn.content")
+            .find(|attribute| attribute.key.as_str() == "gen_ai.input.messages")
             .unwrap();
-        assert!(matches!(&captured.value, opentelemetry::Value::String(value) if value.as_str().len() <= 4096));
+        let captured_size = match &captured.value {
+            opentelemetry::Value::String(value) => value.as_str().len(),
+            other => panic!("unexpected captured content value: {other:?}"),
+        };
+        assert!(captured_size <= 4096);
+        assert!(spans[0].attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "bcn.content.captured_size_bytes"
+                && attribute.value == opentelemetry::Value::I64(captured_size as i64)
+        }));
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
@@ -16,7 +16,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::chat_digest::{ChatDigestRecord, log_chat_digest};
 use crate::gateway_trace::{
-    chat_client_observation, record_span_content, record_span_content_with_untrusted,
+    chat_client_observation, record_span_content_attributes, record_span_content_event,
 };
 use crate::state::HttpAppState;
 
@@ -300,7 +300,7 @@ pub async fn bot_chat_async(
         Ok(from_bot_id) => from_bot_id,
         Err(err) => {
             Span::current().set_attribute("bcn.auth.result", "failed");
-            record_span_content_with_untrusted("bcn.chat.message", &req.message, true);
+            record_span_content_attributes("gen_ai.input.messages", &req.message, true);
             log_bot_chat_digest(ChatDigestArgs {
                 endpoint: "bot_chat_async",
                 from_bot_id: None,
@@ -402,8 +402,8 @@ pub async fn bot_chat_async(
                 ServiceError::Unauthorized(_) | ServiceError::Forbidden(_)
             ) {
                 Span::current().set_attribute("bcn.auth.result", "failed");
-                record_span_content_with_untrusted(
-                    "bcn.chat.message",
+                record_span_content_attributes(
+                    "gen_ai.input.messages",
                     &trace_request.message,
                     true,
                 );
@@ -523,9 +523,13 @@ fn record_chat_dispatch_trace(
         span.set_attribute("bcn.client.wait_timeout_ms", wait_timeout_ms as i64);
     }
     if let Some(untrusted) = content_untrusted {
-        record_span_content_with_untrusted("bcn.chat.message", &request.message, untrusted);
+        record_span_content_attributes(
+            "gen_ai.input.messages",
+            &request.message,
+            untrusted,
+        );
     } else {
-        record_span_content("bcn.chat.message", &request.message);
+        record_span_content_event("bcn.chat.message", &request.message);
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 use tracing::{Span, info, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::gateway_trace::record_span_content_with_untrusted;
+use crate::gateway_trace::record_span_content_attributes;
 use crate::state::HttpAppState;
 
 const BOT_EVENT_REQUEST_BODY_LIMIT: usize = 2 * 1024 * 1024;
@@ -243,8 +243,8 @@ pub async fn post_bot_event(
         ChatEventState::Delta
     } else {
         Span::current().set_attribute("bcn.auth.result", "unverified");
-        record_span_content_with_untrusted(
-            "bcn.bot.response.content",
+        record_span_content_attributes(
+            "gen_ai.output.messages",
             &callback_content,
             true,
         );
@@ -321,7 +321,7 @@ pub async fn post_bot_event(
         outcome.delivered_count as i64,
     );
     span.set_attribute("bcn.callback.failed_count", outcome.failed_count as i64);
-    record_span_content_with_untrusted("bcn.bot.response.content", &callback_content, false);
+    record_span_content_attributes("gen_ai.output.messages", &callback_content, false);
 
     Ok(Json(json!({
         "ok": true,
@@ -375,7 +375,7 @@ pub async fn post_coordination_event(
 
 fn record_bot_response_auth_failure(callback_content: &str) {
     Span::current().set_attribute("bcn.auth.result", "failed");
-    record_span_content_with_untrusted("bcn.bot.response.content", callback_content, true);
+    record_span_content_attributes("gen_ai.output.messages", callback_content, true);
 }
 
 fn header_required(headers: &HeaderMap, name: &'static str) -> Result<String, BotEventRouteError> {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
@@ -667,9 +667,9 @@ async fn bot_chat_async_marks_unauthorized_content_untrusted_without_business_at
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.target.bot_id"));
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "url.path"));
     assert_span_string_attribute(span, "http.route", "/bots/{id}/chat-async");
-    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
-    assert_event_bool_attribute(event, "bcn.content.untrusted", true);
-    assert_event_contains(event, message);
+    assert!(span.events.events.is_empty());
+    assert_span_bool_attribute(span, "bcn.content.untrusted", true);
+    assert_span_attribute_contains(span, "gen_ai.input.messages", message);
 }
 
 #[tokio::test]
@@ -702,9 +702,9 @@ async fn bot_chat_async_marks_authenticated_content_trusted() {
     let span = spans.iter().find(|span| span.name == "bcn.gateway.dispatch").unwrap();
     assert_span_string_attribute(span, "bcn.auth.result", "success");
     assert_span_string_attribute(span, "bcn.target.bot_id", "target-bot");
-    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
-    assert_event_bool_attribute(event, "bcn.content.untrusted", false);
-    assert_event_contains(event, "trusted-content");
+    assert!(span.events.events.is_empty());
+    assert_span_bool_attribute(span, "bcn.content.untrusted", false);
+    assert_span_attribute_contains(span, "gen_ai.input.messages", "trusted-content");
 }
 
 #[tokio::test]
@@ -742,9 +742,13 @@ async fn bot_chat_async_marks_service_authorization_failure_untrusted() {
     assert_span_string_attribute(span, "bcn.auth.result", "failed");
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.target.bot_id"));
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
-    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
-    assert_event_bool_attribute(event, "bcn.content.untrusted", true);
-    assert_event_contains(event, "authorization-failure-content");
+    assert!(span.events.events.is_empty());
+    assert_span_bool_attribute(span, "bcn.content.untrusted", true);
+    assert_span_attribute_contains(
+        span,
+        "gen_ai.input.messages",
+        "authorization-failure-content",
+    );
 }
 
 #[tokio::test]
@@ -782,9 +786,9 @@ async fn bot_chat_async_marks_service_forbidden_failure_untrusted() {
     assert_span_string_attribute(span, "bcn.auth.result", "failed");
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.target.bot_id"));
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
-    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
-    assert_event_bool_attribute(event, "bcn.content.untrusted", true);
-    assert_event_contains(event, "forbidden-content");
+    assert!(span.events.events.is_empty());
+    assert_span_bool_attribute(span, "bcn.content.untrusted", true);
+    assert_span_attribute_contains(span, "gen_ai.input.messages", "forbidden-content");
 }
 
 #[tokio::test]
@@ -819,9 +823,9 @@ async fn bot_chat_async_records_trusted_content_after_auth_when_session_is_inval
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let span = spans.iter().find(|span| span.name == "bcn.gateway.dispatch").unwrap();
     assert_span_string_attribute(span, "bcn.auth.result", "success");
-    let event = span.events.events.iter().find(|event| event.name == "bcn.chat.message").unwrap();
-    assert_event_bool_attribute(event, "bcn.content.untrusted", false);
-    assert_event_contains(event, "invalid-session-content");
+    assert!(span.events.events.is_empty());
+    assert_span_bool_attribute(span, "bcn.content.untrusted", false);
+    assert_span_attribute_contains(span, "gen_ai.input.messages", "invalid-session-content");
 }
 
 async fn capture_otel_spans<F, T>(future: F) -> (T, Vec<opentelemetry_sdk::trace::SpanData>)
@@ -856,19 +860,23 @@ fn assert_span_string_attribute(
     }));
 }
 
-fn assert_event_bool_attribute(
-    event: &opentelemetry::trace::Event,
+fn assert_span_bool_attribute(
+    span: &opentelemetry_sdk::trace::SpanData,
     key: &str,
     expected: bool,
 ) {
-    assert!(event.attributes.iter().any(|attr| {
+    assert!(span.attributes.iter().any(|attr| {
         attr.key.as_str() == key && attr.value == opentelemetry::Value::Bool(expected)
     }));
 }
 
-fn assert_event_contains(event: &opentelemetry::trace::Event, expected: &str) {
-    assert!(event.attributes.iter().any(|attr| {
-        attr.key.as_str() == "bcn.content"
+fn assert_span_attribute_contains(
+    span: &opentelemetry_sdk::trace::SpanData,
+    key: &str,
+    expected: &str,
+) {
+    assert!(span.attributes.iter().any(|attr| {
+        attr.key.as_str() == key
             && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains(expected))
     }));
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
@@ -121,19 +121,23 @@ fn assert_otel_span_string_attribute(
     }));
 }
 
-fn assert_otel_event_bool_attribute(
-    event: &opentelemetry::trace::Event,
+fn assert_otel_span_bool_attribute(
+    span: &opentelemetry_sdk::trace::SpanData,
     key: &str,
     expected: bool,
 ) {
-    assert!(event.attributes.iter().any(|attr| {
+    assert!(span.attributes.iter().any(|attr| {
         attr.key.as_str() == key && attr.value == opentelemetry::Value::Bool(expected)
     }));
 }
 
-fn assert_otel_event_contains(event: &opentelemetry::trace::Event, expected: &str) {
-    assert!(event.attributes.iter().any(|attr| {
-        attr.key.as_str() == "bcn.content"
+fn assert_otel_span_attribute_contains(
+    span: &opentelemetry_sdk::trace::SpanData,
+    key: &str,
+    expected: &str,
+) {
+    assert!(span.attributes.iter().any(|attr| {
+        attr.key.as_str() == key
             && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains(expected))
     }));
 }
@@ -2078,9 +2082,13 @@ async fn bot_events_marks_auth_failure_content_untrusted_without_business_attrib
     assert_otel_span_string_attribute(span, "bcn.auth.result", "failed");
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.provider.id"));
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
-    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
-    assert_otel_event_bool_attribute(event, "bcn.content.untrusted", true);
-    assert_otel_event_contains(event, "untrusted-callback-content");
+    assert!(span.events.events.is_empty());
+    assert_otel_span_bool_attribute(span, "bcn.content.untrusted", true);
+    assert_otel_span_attribute_contains(
+        span,
+        "gen_ai.output.messages",
+        "untrusted-callback-content",
+    );
 }
 
 #[tokio::test]
@@ -2148,9 +2156,13 @@ async fn bot_events_marks_success_content_trusted_with_business_attributes() {
     assert_otel_span_string_attribute(span, "bcn.auth.result", "success");
     assert_otel_span_string_attribute(span, "bcn.provider.id", &provider_id);
     assert_otel_span_string_attribute(span, "bcn.run.id", "run-trusted");
-    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
-    assert_otel_event_bool_attribute(event, "bcn.content.untrusted", false);
-    assert_otel_event_contains(event, "trusted-callback-content");
+    assert!(span.events.events.is_empty());
+    assert_otel_span_bool_attribute(span, "bcn.content.untrusted", false);
+    assert_otel_span_attribute_contains(
+        span,
+        "gen_ai.output.messages",
+        "trusted-callback-content",
+    );
 }
 
 #[tokio::test]
@@ -2190,9 +2202,13 @@ async fn bot_events_records_untrusted_content_when_auth_cannot_follow_invalid_sh
     let span = spans.iter().find(|span| span.name == "bcn.bot.response").unwrap();
     assert_otel_span_string_attribute(span, "bcn.auth.result", "unverified");
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.provider.id"));
-    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
-    assert_otel_event_bool_attribute(event, "bcn.content.untrusted", true);
-    assert_otel_event_contains(event, "invalid-shape-content");
+    assert!(span.events.events.is_empty());
+    assert_otel_span_bool_attribute(span, "bcn.content.untrusted", true);
+    assert_otel_span_attribute_contains(
+        span,
+        "gen_ai.output.messages",
+        "invalid-shape-content",
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
@@ -23,7 +23,7 @@ use bcs_service_api::{
     SystemMessageService, TaskCompleteCommand, TaskDispatchCommand,
     TaskMessageCommand, TaskRunAliasRegistration,
 };
-use opentelemetry::{Context, KeyValue};
+use opentelemetry::Context;
 use opentelemetry::trace::TraceContextExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -854,6 +854,14 @@ async fn handle_event_frame(
             event_state,
             ChatEventState::Final | ChatEventState::Aborted | ChatEventState::Error
         ) || matches!(event.event.as_str(), "agent") && is_final;
+        info!(
+            bot_id = %bot_id,
+            run_id = %run_id,
+            event_type = %event.event,
+            response_span_created = false,
+            response_span_skip_reason = "collaboration_runtime",
+            "Bot response tracing skipped"
+        );
         state
             .collaboration_runtime
             .handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
@@ -880,6 +888,15 @@ async fn handle_event_frame(
         None
     };
     if let Some(trace_parent) = trace_parent {
+        info!(
+            bot_id = %bot_id,
+            run_id = %run_id,
+            event_type = %event.event,
+            parent_trace_id = %trace_parent.trace_id(),
+            parent_span_id = %trace_parent.span_id(),
+            response_span_created = true,
+            "Creating traced Bot response span"
+        );
         let span = info_span!(
             target: "bcn_otel",
             "bcn.bot.response",
@@ -905,6 +922,16 @@ async fn handle_event_frame(
         .instrument(span)
         .await?;
     } else {
+        if event.event == "chat.event" {
+            info!(
+                bot_id = %bot_id,
+                run_id = %run_id,
+                event_type = %event.event,
+                response_span_created = false,
+                response_span_skip_reason = "missing_run_trace_context",
+                "Bot response tracing skipped"
+            );
+        }
         handle_default_group_event(
             state,
             &bot_id,
@@ -936,16 +963,23 @@ fn record_ws_bot_response_trace(
     let content = serde_json::to_string(event_payload)
         .expect("serializing parsed WebSocket bot event payload cannot fail");
     let (captured, truncated) = truncate_bot_response_content(&content);
-    span.add_event(
-        "bcn.bot.response.content",
-        vec![
-            KeyValue::new("bcn.content", captured.clone()),
-            KeyValue::new("bcn.content.original_size_bytes", content.len() as i64),
-            KeyValue::new("bcn.content.captured_size_bytes", captured.len() as i64),
-            KeyValue::new("bcn.content.limit_bytes", BOT_RESPONSE_CONTENT_LIMIT_BYTES as i64),
-            KeyValue::new("bcn.content.truncated", truncated),
-            KeyValue::new("bcn.content.untrusted", false),
-        ],
+    span.set_attribute("gen_ai.output.messages", captured.clone());
+    span.set_attribute("bcn.content.original_size_bytes", content.len() as i64);
+    span.set_attribute("bcn.content.captured_size_bytes", captured.len() as i64);
+    span.set_attribute(
+        "bcn.content.limit_bytes",
+        BOT_RESPONSE_CONTENT_LIMIT_BYTES as i64,
+    );
+    span.set_attribute("bcn.content.truncated", truncated);
+    span.set_attribute("bcn.content.untrusted", false);
+    info!(
+        bot_id = %bot_id,
+        run_id = %run_id,
+        response_state = ?event_state,
+        content_original_size_bytes = content.len(),
+        content_captured_size_bytes = captured.len(),
+        content_truncated = truncated,
+        "Bot response trace attributes recorded"
     );
 }
 
@@ -1093,11 +1127,14 @@ async fn handle_master_slave_response(
                 }
                 TaskRunAliasRegistration::Rejected => false,
             };
+            let trace_context_linked = run_channel_alias_registered
+                && state.run_channels.trace_parent(sub_run_id).await.is_some();
             info!(
                 task_id = %run_id,
                 sub_bot_run_id = %sub_run_id,
                 task_alias_registration = ?task_alias_registration,
                 run_channel_alias_registered = run_channel_alias_registered,
+                trace_context_linked = trace_context_linked,
                 "master_slave: registered sub bot run_id alias"
             );
             log_master_slave_bot_accept(

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/shared/run_channels.rs
@@ -226,11 +226,18 @@ impl RunChannelManager {
 
     pub async fn trace_parent(&self, run_id: &str) -> Option<SpanContext> {
         let resolved_run_id = self.resolve_run_id(run_id).await;
-        self.channels
+        let trace_parent = self.channels
             .read()
             .await
             .get(&resolved_run_id)
-            .and_then(|channel| channel.trace_parent.clone())
+            .and_then(|channel| channel.trace_parent.clone());
+        debug!(
+            run_id = %run_id,
+            resolved_run_id = %resolved_run_id,
+            trace_parent_found = trace_parent.is_some(),
+            "Run channel trace context lookup"
+        );
+        trace_parent
     }
 
     pub async fn register_alias(&self, alias_run_id: String, source_run_id: String) -> bool {

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
@@ -1425,14 +1425,88 @@ async fn traced_chat_event_creates_bot_response_child_span_after_message_flow_ac
         .unwrap_or_else(|| panic!("expected bot response span, got {spans:#?}"));
     assert_eq!(span.span_context.trace_id().to_string(), "0af7651916cd43dd8448eb211c80319c");
     assert_eq!(span.parent_span_id.to_string(), "b7ad6b7169203331");
-    let event = span.events.events.iter().find(|event| event.name == "bcn.bot.response.content").unwrap();
-    assert!(event.attributes.iter().any(|attr| {
+    assert!(span.events.events.is_empty());
+    assert!(span.attributes.iter().any(|attr| {
         attr.key.as_str() == "bcn.content.untrusted"
             && attr.value == opentelemetry::Value::Bool(false)
     }));
-    assert!(event.attributes.iter().any(|attr| {
-        attr.key.as_str() == "bcn.content"
+    assert!(span.attributes.iter().any(|attr| {
+        attr.key.as_str() == "gen_ai.output.messages"
             && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains("ws-response-content"))
+    }));
+}
+
+#[tokio::test]
+async fn traced_plugin_run_alias_creates_bot_response_child_span() {
+    let state = new_state();
+    let (tx, _rx) = mpsc::channel(8);
+    let (client_tx, _client_rx) = mpsc::channel(8);
+    let mut registered_bot_id = Some("bot-compat:staff".to_string());
+    let trace_parent = SpanContext::new(
+        TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+        SpanId::from_hex("b7ad6b7169203331").unwrap(),
+        TraceFlags::SAMPLED,
+        false,
+        TraceState::default(),
+    );
+    state
+        .dispatch_state
+        .run_channels
+        .register_with_trace_parent(
+            "gateway-run".to_string(),
+            "group-1:abcdef12".to_string(),
+            client_tx,
+            Some("http-chat-async".to_string()),
+            None,
+            Some(trace_parent),
+        )
+        .await;
+
+    let event = BcsFrame::Event(EventFrame::new(
+        "chat.event",
+        Some(serde_json::json!({
+            "run_id": "plugin-run",
+            "bcs_group_id": "group-1",
+            "state": WireChatEventState::Final,
+            "message": {
+                "role": "assistant",
+                "content": [{ "type": "text", "text": "plugin-ws-response" }],
+                "timestamp": 123
+            }
+        })),
+        Some(1),
+    ));
+    let event_text = serde_json::to_string(&event).unwrap();
+
+    let (result, spans) = capture_otel_spans(async move {
+        dispatch_frame(
+            &state.dispatch_state,
+            r#"{"type":"res","id":"gateway-run","ok":true,"payload":{"run_id":"plugin-run"}}"#,
+            &tx,
+            &mut registered_bot_id,
+        )
+        .await?;
+        dispatch_frame(
+            &state.dispatch_state,
+            &event_text,
+            &tx,
+            &mut registered_bot_id,
+        )
+        .await
+    })
+    .await;
+
+    result.unwrap();
+    let span = spans
+        .iter()
+        .find(|span| span.name == "bcn.bot.response")
+        .unwrap_or_else(|| panic!("expected aliased bot response span, got {spans:#?}"));
+    assert_eq!(span.span_context.trace_id().to_string(), "0af7651916cd43dd8448eb211c80319c");
+    assert_eq!(span.parent_span_id.to_string(), "b7ad6b7169203331");
+    assert!(span.events.events.is_empty());
+    assert!(span.attributes.iter().any(|attr| {
+        attr.key.as_str() == "gen_ai.output.messages"
+            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains("plugin-ws-response"))
     }));
 }
 

--- a/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
@@ -243,13 +243,37 @@ impl ChatRunEventPort for BootstrapRunChannelPort {
         let is_gateway_dispatch = current_span.metadata().is_some_and(|metadata| {
             metadata.target() == "bcn_otel" && metadata.name() == "bcn.gateway.dispatch"
         });
-        let trace_parent = if source.as_deref() == Some("http-chat-async") && is_gateway_dispatch {
+        let (trace_parent, trace_context_status) = if source.as_deref() != Some("http-chat-async") {
+            (None, "source_not_http_chat_async")
+        } else if !is_gateway_dispatch {
+            (None, "gateway_span_not_current")
+        } else {
             let context = current_span.context();
             let span_context = context.span().span_context().clone();
-            span_context.is_valid().then_some(span_context)
-        } else {
-            None
+            if span_context.is_valid() {
+                (Some(span_context), "attached")
+            } else {
+                (None, "current_span_context_invalid")
+            }
         };
+        let trace_id = trace_parent
+            .as_ref()
+            .map(|context| context.trace_id().to_string())
+            .unwrap_or_default();
+        let parent_span_id = trace_parent
+            .as_ref()
+            .map(|context| context.span_id().to_string())
+            .unwrap_or_default();
+        tracing::info!(
+            run_id = %run_id,
+            session_key = %session_key,
+            source = ?source,
+            is_gateway_dispatch,
+            trace_context_status,
+            trace_id = %trace_id,
+            parent_span_id = %parent_span_id,
+            "Chat run trace context registration evaluated"
+        );
         self.run_channels
             .register_with_trace_parent(
                 run_id,


### PR DESCRIPTION
## Summary

- Add optional BCN server telemetry configuration for an OTLP endpoint and extra exporter headers, while keeping telemetry disabled when it is not configured.
- Forward `TRACEPARENT` from `bcs-cli chat` to the BCN gateway and propagate the active trace context to HTTP providers.
- Create trace-linked `bcn.gateway.dispatch` and `bcn.bot.response` spans for asynchronous chat dispatches, provider callbacks, and WebSocket bot responses.
- Record truncated message bodies as `gen_ai.input.messages` and `gen_ai.output.messages` span attributes, together with byte-size, truncation, and trust metadata, without creating message span events.
- Preserve trace correlation when a WebSocket plugin acknowledges a request with a different run ID, and add structured diagnostics for trace-context registration, alias linkage, response-span creation, and skipped-span reasons.
- Keep `/bot/events/coordination` untraced and avoid creating async chat or bot response spans when no valid upstream trace context is available.

## Test strategy

- `cargo test -p bcs-http --lib --test bot_chat_contract --test bot_events_contract`
- `cargo test -p bcs-ws --lib --test frame_compat`
- `cargo test -p bcs --lib`
- `cargo test -p bcs --no-run`
