### PR TITLE
fix(bcs): expose async judge progress and cover provider timeout

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -155,7 +155,7 @@ jobs:
         #   singlebox --standalone --with-bcs-coverage start bcs_bots
         #     -> builds the instrumented bcs in target/cov-e2e/llvm-cov-target,
         #        starts BCS + 5 OpenClaw bots (BCN plugin built by setup_bcn_plugin)
-        #   e2e.sh                      -> 12 user-story cases
+        #   e2e.sh                      -> 13 user-story cases
         #   SIGTERM bcs                 -> flush profraw
         #   singlebox stop bcs_bots     -> tear down
         #   cargo llvm-cov report + endpoint coverage report

--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -25,6 +25,7 @@ acceptance_targets=()
 explicit_acceptance_targets=()
 coverage_modules=()
 reporter_command=()
+source "$repo_root/src/bcs/scripts/e2e-test/mock_services.sh"
 
 if [[ -n "${SINGLEBOX_COVERAGE_MODULE:-}" ]]; then
   requested_modules+=("$SINGLEBOX_COVERAGE_MODULE")
@@ -202,8 +203,10 @@ run_real_singlebox() {
       STANDALONE_OPENCLAW_ROOT="$coverage_standalone_root" \
       STANDALONE_RUNTIME_DIR="$coverage_standalone_runtime" \
       bash "$repo_root/scripts/singlebox.sh" --standalone stop all || true
+    bcs_e2e_mock_stop || true
   }
   trap cleanup_real_singlebox EXIT
+  bcs_e2e_mock_start "$coverage_root/mock-services"
   env OCB_SKIP_GIT_HOOKS=1 SINGLEBOX_MODEL_CONFIG_MODE="$model_config_mode" \
     STANDALONE_OPENCLAW_ROOT="$coverage_standalone_root" \
     STANDALONE_RUNTIME_DIR="$coverage_standalone_runtime" \

--- a/scripts/modules/bcs.sh
+++ b/scripts/modules/bcs.sh
@@ -135,6 +135,15 @@ prepare_bcs_runtime_config() {
         escaped_mock_user_name="$(toml_sed_replacement "$bcs_mock_user_name")"
         sed_args+=("-e" "s|^mock_user_name = \".*\"$|mock_user_name = \"${escaped_mock_user_name}\"|")
     fi
+    if [ -n "${BCS_E2E_MOCK_BASE_URL:-}" ]; then
+        local escaped_e2e_judge_url
+        escaped_e2e_judge_url="$(toml_sed_replacement "${BCS_E2E_MOCK_BASE_URL}/v1")"
+        sed_args+=(
+            "-e" "/^\[llm\]/,/^\[/{s|^type = \".*\"$|type = \"openai_compatible\"|;s|^base_url = \".*\"$|base_url = \"${escaped_e2e_judge_url}\"|;s|^api_key_env = \".*\"$|api_key_env = \"BCS_E2E_JUDGE_API_KEY\"|;s|^model = \".*\"$|model = \"e2e-judge\"|;s|^timeout_ms = [0-9][0-9]*$|timeout_ms = 30000|;}"
+            "-e" "/^\[security.outbound_url\]/,/^\[/{s|^block_private_networks = .*|block_private_networks = false|;s|^allow_loopback = .*|allow_loopback = true|;}"
+        )
+        log_info "Enabling local Provider/Judge mock for BCS E2E"
+    fi
 
     local config_file tmp_file
     for config_file in "$base_config" "$local_config"; do

--- a/scripts/test_singlebox_coverage_gate.sh
+++ b/scripts/test_singlebox_coverage_gate.sh
@@ -22,7 +22,7 @@ make_fake_repo() {
     "${tmp}/src/backend/src/agentclaw/community/core/cron" \
     "${tmp}/src/backend/src/agentclaw/community/plugin_api" \
     "${tmp}/src/baas" \
-    "${tmp}/src/bcs/scripts"
+    "${tmp}/src/bcs/scripts/e2e-test"
   cp "$SCRIPT" "${tmp}/scripts/ci/singlebox_coverage.sh"
   cp "$REPORTER" "${tmp}/scripts/ci/singlebox_coverage_report.py"
   cp "$MANIFEST_CHECKER" "${tmp}/scripts/ci/singlebox_coverage_manifest_check.py"
@@ -64,6 +64,15 @@ modules:
       router_min_percent: 100
 YAML
   chmod +x "${tmp}/scripts/ci/singlebox_coverage.sh"
+  cat > "${tmp}/src/bcs/scripts/e2e-test/mock_services.sh" <<'SH'
+#!/usr/bin/env bash
+bcs_e2e_mock_start() {
+  BCS_E2E_MOCK_BASE_URL="http://127.0.0.1:39090"
+  BCS_E2E_JUDGE_API_KEY="local-e2e-key"
+  export BCS_E2E_MOCK_BASE_URL BCS_E2E_JUDGE_API_KEY
+}
+bcs_e2e_mock_stop() { :; }
+SH
   cat > "${tmp}/scripts/singlebox.sh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -74,6 +83,10 @@ esac
 if [ "${SINGLEBOX_MODEL_CONFIG_MODE:-}" != "${SINGLEBOX_EXPECTED_MODEL_CONFIG_MODE:-mock}" ]; then
   echo "singlebox coverage model config mode mismatch" >&2
   exit 12
+fi
+if [ "${BCS_E2E_MOCK_BASE_URL:-}" != "http://127.0.0.1:39090" ]; then
+  echo "singlebox coverage should expose the Provider/Judge mock to BCS" >&2
+  exit 16
 fi
 case "${STANDALONE_OPENCLAW_ROOT:-}" in
   "${PWD}/scripts/.dependencies/coverage/singlebox/standalone-openclaw") ;;

--- a/src/bcs/assets/panel/src/StateMachineRunView.tsx
+++ b/src/bcs/assets/panel/src/StateMachineRunView.tsx
@@ -35,6 +35,10 @@ export type StateMachineNodeStatus =
   | 'retry_scheduled'
   | 'skipped';
 
+export type StateMachineNodeSubStatus =
+  | 'awaiting_response'
+  | 'judging';
+
 export interface StateMachineRun {
   run_id: string;
   definition_id: string;
@@ -76,6 +80,7 @@ export interface StateMachineNode {
   assignee_bot_id?: string;
   started_at?: number;
   completed_at?: number;
+  sub_status?: StateMachineNodeSubStatus;
 }
 
 export interface StateMachineNodeDetailNode {
@@ -103,6 +108,7 @@ export interface StateMachineJudgeOutput {
 
 export interface StateMachineNodeDetailResponse {
   node: StateMachineNodeDetailNode;
+  sub_status?: StateMachineNodeSubStatus;
   judge_outputs?: StateMachineJudgeOutput[];
 }
 
@@ -1430,10 +1436,51 @@ function normalizeStatus(status?: string) {
   return (status || 'unknown').toLowerCase();
 }
 
+function getStatusLabel(status?: string) {
+  const normalized = normalizeStatus(status);
+
+  if (normalized === 'judging') {
+    return 'Judging response';
+  }
+
+  if (normalized === 'awaiting_response') {
+    return 'Awaiting bot response';
+  }
+
+  if (normalized === 'retry_scheduled') {
+    return 'Retry scheduled';
+  }
+
+  return normalized;
+}
+
+function getNodeDisplayStatus(
+  status?: string,
+  subStatus?: StateMachineNodeSubStatus,
+) {
+  return normalizeStatus(status) === 'running' && subStatus
+    ? subStatus
+    : status;
+}
+
 function getStatusTone(status?: string): StatusTone {
   const normalized = normalizeStatus(status);
 
-  if (normalized === 'running' || normalized === 'retry_scheduled') {
+  if (normalized === 'judging') {
+    return {
+      bg: '#f5f3ff',
+      border: '#ddd6fe',
+      text: '#6d28d9',
+      stroke: '#7c3aed',
+      fill: '#ede9fe',
+    };
+  }
+
+  if (
+    normalized === 'running' ||
+    normalized === 'awaiting_response' ||
+    normalized === 'retry_scheduled'
+  ) {
     return {
       bg: '#eff6ff',
       border: '#bfdbfe',
@@ -1503,6 +1550,15 @@ function getStatusTone(status?: string): StatusTone {
 function renderNodeStatusMarker(status: string | undefined) {
   const normalized = normalizeStatus(status);
 
+  if (normalized === 'judging') {
+    return (
+      <>
+        <path d="M -3.2 -3.2 H 3.2 M -3.2 3.2 H 3.2" fill="none" />
+        <path d="M -2.6 -2.8 C -2.6 -0.9, 2.6 0.9, 2.6 2.8 M 2.6 -2.8 C 2.6 -0.9, -2.6 0.9, -2.6 2.8" fill="none" />
+      </>
+    );
+  }
+
   if (
     normalized === 'completed' ||
     normalized === 'success' ||
@@ -1524,7 +1580,11 @@ function renderNodeStatusMarker(status: string | undefined) {
     );
   }
 
-  if (normalized === 'running' || normalized === 'retry_scheduled') {
+  if (
+    normalized === 'running' ||
+    normalized === 'awaiting_response' ||
+    normalized === 'retry_scheduled'
+  ) {
     return <path d="M -1.8 -3.2 L 4 0 L -1.8 3.2 Z" fill="#ffffff" />;
   }
 
@@ -2531,6 +2591,12 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
   const headerTitle = graph ? runQuery || runLabel : runId;
   const selectedNodeStatus =
     selectedRuntimeNode?.status || selectedNode?.status || undefined;
+  const selectedNodeSubStatus =
+    selectedNodeDetail?.sub_status || selectedNode?.sub_status;
+  const selectedNodeDisplayStatus = getNodeDisplayStatus(
+    selectedNodeStatus,
+    selectedNodeSubStatus,
+  );
   const selectedNodeAttempt =
     selectedRuntimeNode?.attempt ?? selectedNode?.attempt;
   const selectedNodeAttemptText = formatNodeAttempt(
@@ -2548,7 +2614,7 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
       selectedNode.assignee_bot_id ||
       stringifyValue(selectedNode.assignee)
     : '-';
-  const selectedNodeStatusTone = getStatusTone(selectedNodeStatus);
+  const selectedNodeStatusTone = getStatusTone(selectedNodeDisplayStatus);
   const selectedNodeDurationParts = formatDurationParts(
     selectedNodeStarted,
     selectedNodeCompleted,
@@ -2655,7 +2721,7 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
             <NodeSummaryStatus>
               <NodeStatusSummaryPill $tone={selectedNodeStatusTone}>
                 <NodeStatusDot $tone={selectedNodeStatusTone} />
-                {selectedNodeStatus || 'unknown'}
+                {getStatusLabel(selectedNodeDisplayStatus)}
               </NodeStatusSummaryPill>
             </NodeSummaryStatus>
           </NodeTagRow>
@@ -2734,6 +2800,12 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
         {selectedRuntimeNode?.error ? (
           <InlineNotice $danger>
             <strong>Node error:</strong> {selectedRuntimeNode.error}
+          </InlineNotice>
+        ) : null}
+
+        {selectedNodeSubStatus === 'judging' ? (
+          <InlineNotice>
+            Bot response received. Judging is in progress.
           </InlineNotice>
         ) : null}
 
@@ -2989,7 +3061,7 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
           <Actions>
             {graph?.run.status ? (
               <StatusPill $tone={getStatusTone(graph.run.status)}>
-                {graph.run.status}
+                {getStatusLabel(graph.run.status)}
               </StatusPill>
             ) : null}
             <IconButton
@@ -3184,7 +3256,11 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
 
                     {layout.nodes.map((layoutNode) => {
                       const { node, x, y, width, height } = layoutNode;
-                      const tone = getStatusTone(node.status);
+                      const displayStatus = getNodeDisplayStatus(
+                        node.status,
+                        node.sub_status,
+                      );
+                      const tone = getStatusTone(displayStatus);
                       const selected = node.node_id === selectedNodeId;
                       const nodePhase = isNodeActiveStatus(node.status)
                         ? 'active'
@@ -3296,7 +3372,7 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
                             strokeWidth="1.8"
                             transform={`translate(${x + width - 1} ${y + 1})`}
                           >
-                            <title>{node.status || 'unknown'}</title>
+                            <title>{getStatusLabel(displayStatus)}</title>
                             <circle
                               cx="0"
                               cy="0"
@@ -3305,7 +3381,7 @@ const StateMachineRunView: React.FC<StateMachineRunViewProps> = (props) => {
                               stroke="#ffffff"
                               strokeWidth="1.5"
                             />
-                            {renderNodeStatusMarker(node.status)}
+                            {renderNodeStatusMarker(displayStatus)}
                           </g>
                           <foreignObject
                             height="18"

--- a/src/bcs/assets/panel/src/index.ts
+++ b/src/bcs/assets/panel/src/index.ts
@@ -7,6 +7,7 @@ export type {
   StateMachineNodeDetailNode,
   StateMachineNodeDetailResponse,
   StateMachineNodeStatus,
+  StateMachineNodeSubStatus,
   StateMachineRun,
   StateMachineRunGraph,
   StateMachineRunStatus,

--- a/src/bcs/crates/bootstrap/bcs/tests/helpers/mod.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/helpers/mod.rs
@@ -92,11 +92,16 @@ static INIT_AUTH_MOCK: std::sync::Once = std::sync::Once::new();
 pub async fn start_test_server(
     bots_dir: &PathBuf,
 ) -> (SocketAddr, tokio::task::JoinHandle<Result<(), bcs::BcsError>>) {
+    start_test_server_with_config(create_test_config(bots_dir)).await
+}
+
+pub async fn start_test_server_with_config(
+    config: BcsConfig,
+) -> (SocketAddr, tokio::task::JoinHandle<Result<(), bcs::BcsError>>) {
     INIT_AUTH_MOCK.call_once(|| {
         // SAFETY: runs exactly once before any server starts handling requests.
         unsafe { std::env::set_var("BCS_AUTH_MOCK", "1") };
     });
-    let config = create_test_config(bots_dir);
     let server = BcsServer::new_allowing_private_outbound_for_tests(config);
     server
         .run_on_random_port()

--- a/src/bcs/crates/bootstrap/bcs/tests/provider_downlink_integration.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/provider_downlink_integration.rs
@@ -8,10 +8,15 @@ use axum::{
     http::{HeaderMap, header},
     routing::post,
 };
+use bcs::LlmProviderType;
 use bcs_domain::SystemMessageEvent;
-use helpers::{MockBot, create_temp_bots_dir, start_test_server, start_test_server_with_state};
+use helpers::{
+    MockBot, create_temp_bots_dir, create_test_config, start_test_server,
+    start_test_server_with_config, start_test_server_with_state,
+};
+use secrecy::Secret;
 use serde_json::{Value, json};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 
 #[tokio::test]
 async fn provider_bot_registers_and_is_routable_without_ws_connection() {
@@ -464,6 +469,169 @@ async fn state_machine_dispatches_provider_bot_and_accepts_final_callback() {
     assert_eq!(view["nodes"][0]["artifact_text"], "state-machine provider final");
 }
 
+#[tokio::test]
+async fn provider_callback_timeout_does_not_cancel_slow_state_machine_judge() {
+    let provider = start_provider_webhook().await;
+    let judge = start_blocking_judge().await;
+    let bots_dir = create_temp_bots_dir();
+    let mut config = create_test_config(&bots_dir.path().to_path_buf());
+    config.llm.provider_type = LlmProviderType::OpenAiCompatible;
+    config.llm.base_url = judge.url();
+    config.llm.api_key_env = None;
+    config.llm.api_key = Some(Secret::new("test-judge-key".to_string()));
+    config.llm.timeout_ms = 5_000;
+    let (bcs_addr, _bcs_server) = start_test_server_with_config(config).await;
+    let client = reqwest::Client::new();
+    let mut driver = MockBot::connect(bcs_addr).await;
+    driver.register("Driver", &["drive"], bcs_addr).await;
+    let registered = register_provider_bot(
+        &client,
+        bcs_addr,
+        provider.url(),
+        "provider-slow-judge",
+        "slow-judge-worker",
+    )
+    .await;
+    let group_id = create_judged_state_machine_group(
+        &client,
+        bcs_addr,
+        &driver.token,
+        &driver.bot_id,
+        &registered.bot_uuid,
+    )
+    .await;
+    provider.capture.clear().await;
+
+    let response = client
+        .post(format!(
+            "http://{}/groups/{}/state-machine-runs",
+            bcs_addr, group_id
+        ))
+        .json(&json!({
+            "input": { "question": "verify async provider callback judging" }
+        }))
+        .send()
+        .await
+        .expect("start judged state-machine run");
+    let status = response.status();
+    let body_text = response.text().await.expect("judged state-machine run body");
+    assert!(
+        status.is_success(),
+        "start judged state-machine run failed: {status} {body_text}"
+    );
+    let run: Value = serde_json::from_str(&body_text).expect("judged run response");
+    let state_machine_run_id = run["run"]["run_id"]
+        .as_str()
+        .expect("state-machine run id")
+        .to_string();
+
+    let review_send = provider.capture.wait_for_method("chat.send").await;
+    let review_provider_run_id = review_send.body["id"]
+        .as_str()
+        .expect("review provider run id")
+        .to_string();
+    let graph = wait_for_node_sub_status(
+        &client,
+        bcs_addr,
+        &state_machine_run_id,
+        "review",
+        "awaiting_response",
+    )
+    .await;
+    let review = graph["nodes"]
+        .as_array()
+        .expect("graph nodes")
+        .iter()
+        .find(|node| node["node_id"] == "review")
+        .expect("review graph node");
+    assert_eq!(review["status"], "running");
+
+    let callback_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(1))
+        .build()
+        .expect("callback client");
+    let callback_response = callback_client
+        .post(format!("http://{}/bot/events", bcs_addr))
+        .header("X-BCN-Provider-Id", registered.provider_id.as_str())
+        .header(
+            "Authorization",
+            format!("Bearer {}", registered.bot_runtime_token),
+        )
+        .json(&json!({
+            "run_id": review_provider_run_id,
+            "state": "final",
+            "message": { "text": "candidate awaiting slow judge" }
+        }))
+        .send()
+        .await
+        .expect("provider callback must return before the slow judge completes");
+    assert_eq!(callback_response.status().as_u16(), 200);
+
+    judge.control.wait_for_start().await;
+    let graph = wait_for_node_sub_status(
+        &client,
+        bcs_addr,
+        &state_machine_run_id,
+        "review",
+        "judging",
+    )
+    .await;
+    let review = graph["nodes"]
+        .as_array()
+        .expect("graph nodes")
+        .iter()
+        .find(|node| node["node_id"] == "review")
+        .expect("review graph node");
+    assert_eq!(review["status"], "running");
+    assert_eq!(review["sub_status"], "judging");
+
+    let response = client
+        .get(format!(
+            "http://{}/state-machine-runs/{}/nodes/review",
+            bcs_addr, state_machine_run_id
+        ))
+        .send()
+        .await
+        .expect("get review node detail");
+    let detail: Value = response.json().await.expect("review node detail");
+    assert_eq!(detail["sub_status"], "judging");
+    assert_eq!(detail["node"]["artifact_text"], "candidate awaiting slow judge");
+
+    provider.capture.clear().await;
+    judge.control.release();
+    let publish_send = provider.capture.wait_for_method("chat.send").await;
+    let publish_provider_run_id = publish_send.body["id"]
+        .as_str()
+        .expect("publish provider run id")
+        .to_string();
+    let response = client
+        .post(format!("http://{}/bot/events", bcs_addr))
+        .header("X-BCN-Provider-Id", registered.provider_id.as_str())
+        .header(
+            "Authorization",
+            format!("Bearer {}", registered.bot_runtime_token),
+        )
+        .json(&json!({
+            "run_id": publish_provider_run_id,
+            "state": "final",
+            "message": { "text": "published after slow judge" }
+        }))
+        .send()
+        .await
+        .expect("publish provider callback");
+    assert_eq!(response.status().as_u16(), 200);
+
+    let view = wait_for_state_machine_run_status(
+        &client,
+        bcs_addr,
+        &state_machine_run_id,
+        "completed",
+    )
+    .await;
+    assert_eq!(view["run"]["output"], "published after slow judge");
+    assert_eq!(view["judge_outputs"][0]["decision"]["outcome"], "approved");
+}
+
 #[derive(Clone, Default)]
 struct ProviderCapture {
     requests: Arc<Mutex<Vec<CapturedProviderRequest>>>,
@@ -509,6 +677,91 @@ struct ProviderServer {
     capture: ProviderCapture,
     addr: SocketAddr,
     _handle: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone)]
+struct BlockingJudgeControl {
+    started: Arc<Semaphore>,
+    release: Arc<Semaphore>,
+}
+
+impl Default for BlockingJudgeControl {
+    fn default() -> Self {
+        Self {
+            started: Arc::new(Semaphore::new(0)),
+            release: Arc::new(Semaphore::new(0)),
+        }
+    }
+}
+
+impl BlockingJudgeControl {
+    async fn wait_for_start(&self) {
+        tokio::time::timeout(Duration::from_secs(2), self.started.acquire())
+            .await
+            .expect("slow judge should start")
+            .expect("slow judge start semaphore should remain open")
+            .forget();
+    }
+
+    fn release(&self) {
+        self.release.add_permits(1);
+    }
+}
+
+struct BlockingJudgeServer {
+    control: BlockingJudgeControl,
+    addr: SocketAddr,
+    _handle: tokio::task::JoinHandle<()>,
+}
+
+impl BlockingJudgeServer {
+    fn url(&self) -> String {
+        format!("http://{}/v1", self.addr)
+    }
+}
+
+async fn start_blocking_judge() -> BlockingJudgeServer {
+    let control = BlockingJudgeControl::default();
+    let app = Router::new()
+        .route("/v1/chat/completions", post(blocking_judge_handler))
+        .with_state(control.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind slow judge");
+    let addr = listener.local_addr().expect("slow judge addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    BlockingJudgeServer {
+        control,
+        addr,
+        _handle: handle,
+    }
+}
+
+async fn blocking_judge_handler(
+    State(control): State<BlockingJudgeControl>,
+    Json(_body): Json<Value>,
+) -> Json<Value> {
+    control.started.add_permits(1);
+    control
+        .release
+        .acquire()
+        .await
+        .expect("slow judge release semaphore should remain open")
+        .forget();
+    let decision = json!({
+        "outcome": "approved",
+        "reason": "candidate satisfies the test criteria",
+        "confidence": 0.99,
+        "checked_criteria": [],
+        "retry_instruction": ""
+    });
+    Json(json!({
+        "choices": [{
+            "message": { "content": decision.to_string() }
+        }]
+    }))
 }
 
 impl ProviderServer {
@@ -815,6 +1068,80 @@ runtime:
     group["id"].as_str().expect("state-machine group id").to_string()
 }
 
+async fn create_judged_state_machine_group(
+    client: &reqwest::Client,
+    bcs_addr: SocketAddr,
+    token: &str,
+    driver_bot: &str,
+    provider_bot: &str,
+) -> String {
+    let definition_yaml = r#"
+api_version: bcs.collaboration/v1
+name: Provider Slow Judge State Machine
+participants:
+  worker:
+    required: true
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      review:
+        kind: bot_task
+        display_name: Review
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: Produce a candidate response.
+        judge:
+          type: llm
+          criteria:
+            - The candidate is suitable for publishing.
+          outcomes: [approved]
+        transitions:
+          approved:
+            targets: [publish]
+      publish:
+        kind: bot_task
+        display_name: Publish
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: Publish the approved response.
+        final_output: true
+"#;
+    let response = client
+        .post(format!("http://{}/groups", bcs_addr))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&json!({
+            "driver_bot": driver_bot,
+            "group_strategy": "state_machine",
+            "participant_bindings": {
+                "worker": {
+                    "source": "manual",
+                    "bot_ids": [provider_bot]
+                }
+            },
+            "participants": [
+                { "bot_uuid": driver_bot },
+                { "bot_uuid": provider_bot }
+            ],
+            "collaboration_definition_yaml": definition_yaml
+        }))
+        .send()
+        .await
+        .expect("create judged state-machine group");
+    let status = response.status();
+    let body_text = response.text().await.expect("judged state-machine group body");
+    assert!(
+        status.is_success(),
+        "create judged state-machine group failed: {status} {body_text}"
+    );
+    let group: Value = serde_json::from_str(&body_text).expect("judged group response");
+    group["id"].as_str().expect("judged group id").to_string()
+}
+
 async fn send_group_message(
     client: &reqwest::Client,
     bcs_addr: SocketAddr,
@@ -882,5 +1209,38 @@ async fn wait_for_state_machine_run_status(
     }
     panic!(
         "state-machine run {run_id} did not reach {expected_status}; last view: {last_view:#?}"
+    );
+}
+
+async fn wait_for_node_sub_status(
+    client: &reqwest::Client,
+    bcs_addr: SocketAddr,
+    run_id: &str,
+    node_id: &str,
+    expected_sub_status: &str,
+) -> Value {
+    let mut last_graph = None;
+    for _ in 0..100 {
+        let response = client
+            .get(format!(
+                "http://{}/state-machine-runs/{}/graph",
+                bcs_addr, run_id
+            ))
+            .send()
+            .await
+            .expect("get state-machine graph");
+        let graph: Value = response.json().await.expect("state-machine graph");
+        let reached = graph["nodes"]
+            .as_array()
+            .and_then(|nodes| nodes.iter().find(|node| node["node_id"] == node_id))
+            .is_some_and(|node| node["sub_status"] == expected_sub_status);
+        if reached {
+            return graph;
+        }
+        last_graph = Some(graph);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!(
+        "state-machine node {run_id}/{node_id} did not enter sub_status={expected_sub_status}; last graph: {last_graph:#?}"
     );
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
@@ -127,9 +127,21 @@ pub struct StateMachineJudgeOutputView {
     pub decision: JudgeDecision,
 }
 
+/// More specific presentation state while a node's durable status is
+/// `running`. New runtime phases can be added without widening the durable
+/// state-machine status model.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StateMachineNodeSubStatus {
+    AwaitingResponse,
+    Judging,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateMachineNodeRunView {
     pub node: StateMachineNodeRun,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_status: Option<StateMachineNodeSubStatus>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub judge_outputs: Vec<StateMachineJudgeOutputView>,
 }
@@ -172,6 +184,8 @@ pub struct StateMachineGraphNodeView {
     pub started_at: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_status: Option<StateMachineNodeSubStatus>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -57,7 +57,8 @@ pub use application::collaboration_runtime::{
     PatchGroupCollaborationDefinitionCommand,
     StartStateMachineRunCommand, StartStateMachineRunOutcome, StateMachineGraphDefinitionView,
     StateMachineGraphEdgeView, StateMachineGraphNodeView, StateMachineRunGraphView,
-    StateMachineJudgeOutputView, StateMachineNodeRunView, StateMachineRunView,
+    StateMachineJudgeOutputView, StateMachineNodeRunView, StateMachineNodeSubStatus,
+    StateMachineRunView,
     UpgradeGroupCollaborationDefinitionCommand,
 };
 pub use application::collaboration_template::{

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/collaboration.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/collaboration.rs
@@ -142,6 +142,16 @@ pub trait StateMachineRunRepoPort: Send + Sync {
         completed_at: u64,
     ) -> ServiceResult<bool>;
 
+    /// Persist the bot artifact while the node remains running so callers can
+    /// distinguish bot execution from the subsequent Judge evaluation.
+    async fn record_node_artifact_if_running(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        artifact_text: String,
+    ) -> ServiceResult<bool>;
+
     async fn fail_node_attempt(
         &self,
         run_id: &str,

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -35,8 +35,8 @@ use bcs_service_api::{
     StartStateMachineRunOutcome, StateMachineDefinitionRepoPort, StateMachineRunRepoPort,
     JudgeArtifact, JudgeEvaluatorPort, JudgeRequest, ServiceError,
     StateMachineGraphDefinitionView, StateMachineGraphEdgeView, StateMachineGraphNodeView,
-    StateMachineJudgeOutputView, StateMachineNodeRunView, StateMachineRunGraphView,
-    StateMachineRunView, UpgradeGroupCollaborationDefinitionCommand,
+    StateMachineJudgeOutputView, StateMachineNodeRunView, StateMachineNodeSubStatus,
+    StateMachineRunGraphView, StateMachineRunView, UpgradeGroupCollaborationDefinitionCommand,
 };
 use serde_json::Value;
 use tracing::{info, warn};
@@ -1472,8 +1472,10 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             return Ok(None);
         };
         let judge_outputs = self.judge_outputs_for_node(run_id, node_id).await?;
+        let sub_status = node_sub_status(&node);
         Ok(Some(StateMachineNodeRunView {
             node,
+            sub_status,
             judge_outputs,
         }))
     }
@@ -1715,6 +1717,22 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                     )
                 })?;
                 let artifact_len = text.len();
+                if node_uses_judge(&compiled, &correlation.node_id)
+                    && !self
+                        .runs
+                        .record_node_artifact_if_running(
+                            &correlation.state_machine_run_id,
+                            &correlation.node_id,
+                            correlation.attempt,
+                            text.clone(),
+                        )
+                        .await?
+                {
+                    return Ok(HandleBotTerminalEventOutcome {
+                        consumed: true,
+                        view: self.run_view(&run.run_id).await?,
+                    });
+                }
                 let evaluation = self
                     .evaluate_node_outcome(
                         &compiled,
@@ -2830,6 +2848,7 @@ fn run_graph_view(
                 assignee_bot_id: run_node.map(|node| node.assignee_bot_id.clone()),
                 started_at: run_node.and_then(|node| node.started_at),
                 completed_at: run_node.and_then(|node| node.completed_at),
+                sub_status: run_node.and_then(node_sub_status),
             }
         })
         .collect();
@@ -2858,6 +2877,27 @@ fn run_graph_view(
         },
         nodes,
         edges,
+    })
+}
+
+fn node_uses_judge(compiled: &CompiledStateMachine, node_id: &str) -> bool {
+    match &compiled.definition.runtime {
+        CollaborationRuntimeDefinition::StateMachine(state_machine) => state_machine
+            .nodes
+            .get(node_id)
+            .is_some_and(|node| node.judge.is_some()),
+        _ => false,
+    }
+}
+
+fn node_sub_status(node: &StateMachineNodeRun) -> Option<StateMachineNodeSubStatus> {
+    if node.status != StateMachineNodeStatus::Running {
+        return None;
+    }
+    Some(if node.artifact_text.is_some() {
+        StateMachineNodeSubStatus::Judging
+    } else {
+        StateMachineNodeSubStatus::AwaitingResponse
     })
 }
 

--- a/src/bcs/crates/services/bcs-collaboration-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-collaboration-store/src/lib.rs
@@ -415,6 +415,26 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
         Ok(true)
     }
 
+    async fn record_node_artifact_if_running(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        artifact_text: String,
+    ) -> ServiceResult<bool> {
+        let mut inner = self.inner.write().await;
+        if !run_is_running(&inner, run_id)? {
+            return Ok(false);
+        }
+        let node = node_mut(&mut inner, run_id, node_id)?;
+        if node.status != StateMachineNodeStatus::Running || node.attempt != attempt {
+            return Ok(false);
+        }
+        node.artifact_text = Some(artifact_text);
+        node.error = None;
+        Ok(true)
+    }
+
     async fn fail_node_attempt(
         &self,
         run_id: &str,
@@ -1512,6 +1532,47 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
         Ok(result.affected_rows > 0)
     }
 
+    async fn record_node_artifact_if_running(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        attempt: i32,
+        artifact_text: String,
+    ) -> ServiceResult<bool> {
+        let sql = format!(
+            "UPDATE bcs_state_machine_node_runs \
+             SET artifact_text = ?, error_message = NULL, {} \
+             WHERE env = ? AND run_id = ? AND node_id = ? \
+               AND attempt = ? AND status = 'running' \
+               AND record_status = 'active' \
+               AND EXISTS ( \
+                 SELECT 1 FROM bcs_state_machine_runs r \
+                 WHERE r.env = bcs_state_machine_node_runs.env \
+                   AND r.run_id = bcs_state_machine_node_runs.run_id \
+                   AND r.status = 'running' AND r.record_status = 'active' \
+               )",
+            self.flavor.set_modified_now()
+        );
+        let result = self.db
+            .execute(DbStatement::with_params(
+                sql,
+                vec![
+                    DbValue::from(artifact_text),
+                    DbValue::from(self.env.as_str()),
+                    DbValue::from(run_id),
+                    DbValue::from(node_id),
+                    DbValue::from(attempt),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!(
+                    "state machine node record artifact: {error}"
+                ))
+            })?;
+        Ok(result.affected_rows > 0)
+    }
+
     async fn fail_node_attempt(
         &self,
         run_id: &str,
@@ -2596,6 +2657,22 @@ mod tests {
         assert_eq!(node.delivery_request_id.as_deref(), Some("delivery-1"));
         assert_eq!(node.started_at, Some(2_000));
         assert_eq!(node.timeout_deadline_ms, Some(122_000));
+
+        let recorded = store
+            .record_node_artifact_if_running(
+                "run-sqlite-cas",
+                "answer",
+                0,
+                "candidate".to_string(),
+            )
+            .await?;
+        assert!(recorded);
+        let node = store
+            .get_node_run("run-sqlite-cas", "answer")
+            .await?
+            .expect("node exists");
+        assert_eq!(node.status, StateMachineNodeStatus::Running);
+        assert_eq!(node.artifact_text.as_deref(), Some("candidate"));
 
         Ok(())
     }

--- a/src/bcs/crates/services/bcs-collaboration-store/tests/mysql_store.rs
+++ b/src/bcs/crates/services/bcs-collaboration-store/tests/mysql_store.rs
@@ -324,6 +324,15 @@ async fn mysql_runtime_node_and_run_updates_use_cas_sql() {
         )
         .await
         .expect("mark running");
+    let artifact_recorded = store
+        .record_node_artifact_if_running(
+            "sm-run-1",
+            "answer",
+            1,
+            "candidate".to_string(),
+        )
+        .await
+        .expect("record node artifact");
     let completed = store
         .complete_node_attempt(
             "sm-run-1",
@@ -354,23 +363,28 @@ async fn mysql_runtime_node_and_run_updates_use_cas_sql() {
         .await
         .expect("skip node");
 
+    assert!(artifact_recorded);
     assert!(completed);
     assert!(updated);
     assert!(retry_scheduled);
     assert!(skipped);
     let executes = db.executes.lock().await;
-    assert_eq!(executes.len(), 5);
+    assert_eq!(executes.len(), 6);
     assert!(executes[0].sql().contains("timeout_deadline_ms = CASE"));
     assert_eq!(executes[0].params()[0], DbValue::from(1));
     assert_eq!(executes[0].params()[1], DbValue::from("delivery-1"));
+    assert!(executes[1].sql().contains("SET artifact_text = ?"));
     assert!(executes[1].sql().contains("AND attempt = ? AND status = 'running'"));
-    assert_eq!(executes[1].params()[5], DbValue::from(1));
-    assert!(executes[2].sql().contains("status NOT IN ('completed', 'failed', 'aborted')"));
-    assert!(executes[3].sql().contains("AND attempt = ? AND status = 'failed'"));
-    assert_eq!(executes[3].params()[4], DbValue::from(1));
-    assert!(executes[4].sql().contains("SET status = 'skipped'"));
-    assert!(executes[4].sql().contains("AND status = 'pending'"));
-    assert_eq!(executes[4].params()[0], DbValue::from(2_200_u64));
+    assert_eq!(executes[1].params()[0], DbValue::from("candidate"));
+    assert_eq!(executes[1].params()[4], DbValue::from(1));
+    assert!(executes[2].sql().contains("AND attempt = ? AND status = 'running'"));
+    assert_eq!(executes[2].params()[5], DbValue::from(1));
+    assert!(executes[3].sql().contains("status NOT IN ('completed', 'failed', 'aborted')"));
+    assert!(executes[4].sql().contains("AND attempt = ? AND status = 'failed'"));
+    assert_eq!(executes[4].params()[4], DbValue::from(1));
+    assert!(executes[5].sql().contains("SET status = 'skipped'"));
+    assert!(executes[5].sql().contains("AND status = 'pending'"));
+    assert_eq!(executes[5].params()[0], DbValue::from(2_200_u64));
 }
 
 #[tokio::test]
@@ -445,7 +459,7 @@ async fn mysql_runtime_delivery_correlation_and_events_are_persistent() {
 #[tokio::test]
 async fn mysql_runtime_cas_failures_return_false() {
     let db = Arc::new(RecordingDb {
-        execute_affected_rows: Mutex::new(VecDeque::from([0, 0, 0, 0])),
+        execute_affected_rows: Mutex::new(VecDeque::from([0, 0, 0, 0, 0])),
         ..RecordingDb::default()
     });
     let store = MySqlCollaborationStore::new(db, "dev".to_string());
@@ -460,6 +474,15 @@ async fn mysql_runtime_cas_failures_return_false() {
         )
         .await
         .expect("complete node");
+    let artifact_recorded = store
+        .record_node_artifact_if_running(
+            "sm-run-1",
+            "answer",
+            1,
+            "candidate".to_string(),
+        )
+        .await
+        .expect("record node artifact");
     let failed = store
         .fail_node_attempt(
             "sm-run-1",
@@ -487,6 +510,7 @@ async fn mysql_runtime_cas_failures_return_false() {
         .expect("update run");
 
     assert!(!completed);
+    assert!(!artifact_recorded);
     assert!(!failed);
     assert!(!retry_scheduled);
     assert!(!run_updated);

--- a/src/bcs/scripts/e2e-test/http_provider_judge_mock.py
+++ b/src/bcs/scripts/e2e-test/http_provider_judge_mock.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Local HTTP Provider and blocking Judge used by the BCS E2E coverage suite."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+class MockState:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.provider_requests: list[dict[str, Any]] = []
+        self.judge_started = threading.Event()
+        self.judge_release = threading.Event()
+
+    def reset(self) -> None:
+        with self.lock:
+            self.provider_requests.clear()
+        self.judge_started.clear()
+        self.judge_release.clear()
+
+
+STATE = MockState()
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "BcsE2eHttpMock/1.0"
+
+    def log_message(self, format: str, *args: Any) -> None:
+        print(format % args, flush=True)
+
+    def read_json(self) -> Any:
+        length = int(self.headers.get("content-length", "0"))
+        payload = self.rfile.read(length) if length else b"{}"
+        return json.loads(payload)
+
+    def send_json(self, status: int, payload: Any) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        if self.path == "/health":
+            self.send_json(200, {"ok": True})
+            return
+        if self.path == "/control/provider/requests":
+            with STATE.lock:
+                requests = list(STATE.provider_requests)
+            self.send_json(200, {"requests": requests})
+            return
+        if self.path == "/control/judge/status":
+            self.send_json(
+                200,
+                {
+                    "started": STATE.judge_started.is_set(),
+                    "released": STATE.judge_release.is_set(),
+                },
+            )
+            return
+        self.send_json(404, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        if self.path == "/control/reset":
+            STATE.reset()
+            self.send_json(200, {"ok": True})
+            return
+        if self.path == "/control/provider/clear":
+            with STATE.lock:
+                STATE.provider_requests.clear()
+            self.send_json(200, {"ok": True})
+            return
+        if self.path == "/control/judge/release":
+            STATE.judge_release.set()
+            self.send_json(200, {"ok": True})
+            return
+        if self.path == "/provider/webhook":
+            body = self.read_json()
+            with STATE.lock:
+                STATE.provider_requests.append(
+                    {
+                        "authorization": self.headers.get("authorization"),
+                        "body": body,
+                    }
+                )
+            self.send_json(200, {"ok": True})
+            return
+        if self.path == "/v1/chat/completions":
+            self.read_json()
+            STATE.judge_started.set()
+            if not STATE.judge_release.wait(timeout=30):
+                self.send_json(504, {"error": "judge_release_timeout"})
+                return
+            decision = {
+                "outcome": "approved",
+                "reason": "candidate satisfies the E2E criteria",
+                "confidence": 0.99,
+                "checked_criteria": [],
+                "retry_instruction": "",
+            }
+            self.send_json(
+                200,
+                {
+                    "choices": [
+                        {"message": {"content": json.dumps(decision)}}
+                    ]
+                },
+            )
+            return
+        self.send_json(404, {"error": "not_found"})
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--ready-file", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    host, port = server.server_address[:2]
+    ready_file = Path(args.ready_file)
+    ready_file.parent.mkdir(parents=True, exist_ok=True)
+    ready_file.write_text(f"http://{host}:{port}\n", encoding="utf-8")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bcs/scripts/e2e-test/mock_services.sh
+++ b/src/bcs/scripts/e2e-test/mock_services.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Lifecycle helper for the local Provider/Judge mock used by coverage E2E.
+
+BCS_E2E_MOCK_OWNED="${BCS_E2E_MOCK_OWNED:-0}"
+BCS_E2E_MOCK_PID="${BCS_E2E_MOCK_PID:-}"
+BCS_E2E_MOCK_SERVICES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bcs_e2e_mock_start() {
+    local runtime_dir="$1"
+    if [[ -n "${BCS_E2E_MOCK_BASE_URL:-}" ]]; then
+        if curl --noproxy '*' -fsS "${BCS_E2E_MOCK_BASE_URL}/health" >/dev/null 2>&1; then
+            BCS_E2E_MOCK_OWNED=0
+            export BCS_E2E_MOCK_OWNED
+            return 0
+        fi
+        echo "BCS E2E mock is not healthy at ${BCS_E2E_MOCK_BASE_URL}" >&2
+        return 1
+    fi
+
+    local ready_file log_file
+    ready_file="${runtime_dir}/ready"
+    log_file="${runtime_dir}/mock.log"
+    mkdir -p "$runtime_dir"
+    rm -f "$ready_file" "$log_file"
+    python3 "${BCS_E2E_MOCK_SERVICES_DIR}/http_provider_judge_mock.py" \
+        --ready-file "$ready_file" >"$log_file" 2>&1 &
+    BCS_E2E_MOCK_PID=$!
+    BCS_E2E_MOCK_OWNED=1
+
+    local attempt
+    for attempt in $(seq 1 100); do
+        if [[ -s "$ready_file" ]]; then
+            BCS_E2E_MOCK_BASE_URL="$(tr -d '\r\n' < "$ready_file")"
+            if curl --noproxy '*' -fsS "${BCS_E2E_MOCK_BASE_URL}/health" >/dev/null 2>&1; then
+                export BCS_E2E_MOCK_BASE_URL BCS_E2E_MOCK_PID BCS_E2E_MOCK_OWNED
+                export BCS_E2E_JUDGE_API_KEY="local-e2e-key"
+                echo "BCS E2E Provider/Judge mock: ${BCS_E2E_MOCK_BASE_URL}"
+                return 0
+            fi
+        fi
+        if ! kill -0 "$BCS_E2E_MOCK_PID" 2>/dev/null; then
+            break
+        fi
+        sleep 0.05
+    done
+
+    echo "BCS E2E Provider/Judge mock failed to start; log: ${log_file}" >&2
+    tail -n 80 "$log_file" >&2 || true
+    bcs_e2e_mock_stop
+    return 1
+}
+
+bcs_e2e_mock_stop() {
+    if [[ "${BCS_E2E_MOCK_OWNED:-0}" != "1" || -z "${BCS_E2E_MOCK_PID:-}" ]]; then
+        return 0
+    fi
+    kill "$BCS_E2E_MOCK_PID" 2>/dev/null || true
+    wait "$BCS_E2E_MOCK_PID" 2>/dev/null || true
+    BCS_E2E_MOCK_OWNED=0
+    BCS_E2E_MOCK_PID=""
+    export BCS_E2E_MOCK_OWNED BCS_E2E_MOCK_PID
+}

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -21,6 +21,9 @@ E2E_TESTS_STORIES=(
     "story_cli_operator_runs_sessions_and_services"
     "story_cli_operator_validates_channel_management"
 )
+if [[ -n "${BCS_E2E_MOCK_BASE_URL:-}" ]]; then
+    E2E_TESTS_STORIES+=("story_provider_callback_survives_slow_judge")
+fi
 
 require_status() {
     local desc="$1" expected="$2"
@@ -52,6 +55,103 @@ except Exception:
 
 urlencode() {
     python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$1"
+}
+
+wait_for_mock_provider_method() {
+    local method="$1" payload request
+    for _ in $(seq 1 100); do
+        payload=$(curl --noproxy '*' -fsS \
+            "${BCS_E2E_MOCK_BASE_URL}/control/provider/requests" 2>/dev/null || true)
+        request=$(printf '%s' "$payload" | python3 -c '
+import json,sys
+try:
+    target=sys.argv[1]
+    requests=json.load(sys.stdin).get("requests", [])
+    match=next((item for item in requests if item.get("body", {}).get("method") == target), None)
+    print(json.dumps(match, separators=(",", ":")) if match else "")
+except Exception:
+    print("")
+' "$method")
+        if [[ -n "$request" ]]; then
+            printf '%s\n' "$request"
+            return 0
+        fi
+        sleep 0.05
+    done
+    return 1
+}
+
+wait_for_mock_judge_start() {
+    local payload started
+    for _ in $(seq 1 100); do
+        payload=$(curl --noproxy '*' -fsS \
+            "${BCS_E2E_MOCK_BASE_URL}/control/judge/status" 2>/dev/null || true)
+        started=$(json_path "$payload" "started")
+        [[ "$started" == "True" || "$started" == "true" ]] && return 0
+        sleep 0.05
+    done
+    return 1
+}
+
+state_machine_graph_node_field() {
+    local graph="$1" node_id="$2" field="$3"
+    printf '%s' "$graph" | python3 -c '
+import json,sys
+try:
+    data=json.load(sys.stdin)
+    node=next(item for item in data.get("nodes", []) if item.get("node_id") == sys.argv[1])
+    value=node.get(sys.argv[2])
+    print("" if value is None else value)
+except Exception:
+    print("")
+' "$node_id" "$field"
+}
+
+wait_for_graph_node_sub_status() {
+    local run_id="$1" node_id="$2" expected="$3" graph actual
+    for _ in $(seq 1 100); do
+        graph=$(curl --noproxy '*' -fsS \
+            -H "X-Mock-User-Id: $BCS_MOCK_USER_ID" \
+            -H "X-Mock-Nick-Name: $BCS_MOCK_USER_NICK_NAME" \
+            "${BCS_API_BASE_URL}/state-machine-runs/${run_id}/graph" 2>/dev/null || true)
+        actual=$(state_machine_graph_node_field "$graph" "$node_id" "sub_status")
+        if [[ "$actual" == "$expected" ]]; then
+            printf '%s\n' "$graph"
+            return 0
+        fi
+        sleep 0.05
+    done
+    return 1
+}
+
+wait_for_state_machine_status() {
+    local run_id="$1" expected="$2" view actual
+    for _ in $(seq 1 100); do
+        view=$(curl --noproxy '*' -fsS \
+            -H "X-Mock-User-Id: $BCS_MOCK_USER_ID" \
+            -H "X-Mock-Nick-Name: $BCS_MOCK_USER_NICK_NAME" \
+            "${BCS_API_BASE_URL}/state-machine-runs/${run_id}" 2>/dev/null || true)
+        actual=$(json_path "$view" "run.status")
+        if [[ "$actual" == "$expected" ]]; then
+            printf '%s\n' "$view"
+            return 0
+        fi
+        sleep 0.05
+    done
+    return 1
+}
+
+provider_callback_with_timeout() {
+    local provider_id="$1" runtime_token="$2" body="$3"
+    local curl_args=(--noproxy '*' -s -o "$_RESPONSE_FILE" -D "$_RESPONSE_HEADERS_FILE"
+        -w '%{http_code}' --max-time 1 -X POST
+        -H "X-BCN-Provider-Id: ${provider_id}"
+        -H "Authorization: Bearer ${runtime_token}"
+        -H "Content-Type: application/json"
+        -d "$body")
+    HTTP_STATUS=$(curl "${curl_args[@]}" "${BCS_API_BASE_URL}/bot/events" 2>/dev/null) || HTTP_STATUS="000"
+    RESPONSE=$(cat "$_RESPONSE_FILE")
+    RESPONSE_HEADERS=$(cat "$_RESPONSE_HEADERS_FILE")
 }
 
 # User story: A signed-in user opens Avernet and prepares an owned agent for use.
@@ -609,6 +709,212 @@ print(json.dumps({
 
     api_delete "/groups/${group_id}?bot_id=${BOT_CEO_UUID}"
     require_status "structured collaboration fixture is cleaned up" "200" || return
+}
+
+# Coverage-only user story: a Provider-backed state-machine node returns while
+# its Judge is intentionally blocked. The callback must return before the
+# caller's timeout, expose both running sub-statuses, and resume after release.
+story_provider_callback_survives_slow_judge() {
+    info "Story: an HTTP Provider callback survives a slow state-machine Judge"
+
+    local control_status
+    control_status=$(curl --noproxy '*' -s -o /dev/null -w '%{http_code}' \
+        -X POST "${BCS_E2E_MOCK_BASE_URL}/control/reset" 2>/dev/null) || control_status="000"
+    assert_eq "Provider/Judge mock resets before the story" "$control_status" "200"
+    [[ "$control_status" == "200" ]] || return
+
+    api_post "/providers" \
+        "{\"name\":\"Slow Judge E2E Provider\",\"webhook_url\":\"${BCS_E2E_MOCK_BASE_URL}/provider/webhook\",\"auth\":{\"mode\":\"static_bearer\"},\"protocol_version\":\"2.0\",\"coordination\":{\"mode\":\"native_tool\"}}"
+    require_status "operator registers the local HTTP Provider" "200" || return
+    local provider_id admin_token bcs_token
+    provider_id=$(json_path "$RESPONSE" "provider_id")
+    admin_token=$(json_path "$RESPONSE" "provider_admin_token")
+    bcs_token=$(json_path "$RESPONSE" "bcs_to_provider_token")
+    assert_not_empty "local Provider receives an id" "$provider_id"
+    assert_not_empty "local Provider receives an admin token" "$admin_token"
+    [[ -n "$provider_id" && -n "$admin_token" ]] || return
+
+    local provider_bot_ref="slow-judge-worker-$$-$(date +%s)"
+    api_request_headers POST "/providers/${provider_id}/bots" \
+        "{\"name\":\"Slow Judge Worker\",\"summary\":\"Returns before Judge completion\",\"owners\":[\"${BCS_MOCK_USER_ID}\"],\"provider_bot_ref\":\"${provider_bot_ref}\",\"domains\":[\"release\"],\"skills\":[\"review\"],\"scopes\":[\"local\"]}" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "operator publishes the slow-Judge Provider bot" "200" || return
+    local provider_bot_uuid runtime_token
+    provider_bot_uuid=$(json_path "$RESPONSE" "bot_uuid")
+    runtime_token=$(json_path "$RESPONSE" "bot_runtime_token")
+    assert_not_empty "slow-Judge Provider bot receives a BCS id" "$provider_bot_uuid"
+    assert_not_empty "slow-Judge Provider bot receives a runtime token" "$runtime_token"
+    [[ -n "$provider_bot_uuid" && -n "$runtime_token" ]] || return
+
+    # Group membership enforces the same trust boundary for Provider-backed
+    # bots as it does for native bots. Make the fixture explicitly public and
+    # establish its relationship with the driver before creating the group.
+    api_put "/bots/${provider_bot_uuid}/visibility" '{"visibility":"public"}'
+    require_status "operator makes the slow-Judge Provider bot discoverable" "200" || return
+    api_post "/friends/request" \
+        "{\"from_bot\":\"${BOT_CEO_UUID}\",\"to_bot\":\"${provider_bot_uuid}\"}"
+    if [[ "$HTTP_STATUS" == "200" || "$HTTP_STATUS" == "201" ]]; then
+        pass "driver befriends the slow-Judge Provider bot"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "driver befriends the slow-Judge Provider bot (expected 200/201, actual=${HTTP_STATUS})"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    [[ "$HTTP_STATUS" == "200" || "$HTTP_STATUS" == "201" ]] || return
+    api_get "/bots/${BOT_CEO_UUID}/friends"
+    require_status "driver reads friends after Provider trust setup" "200" || return
+    assert_contains "driver trust list contains the slow-Judge Provider bot" \
+        "$RESPONSE" "$provider_bot_uuid"
+
+    local definition_yaml create_body
+    definition_yaml="name: HTTP Provider Slow Judge E2E
+participants:
+  worker:
+    required: true
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      review:
+        kind: bot_task
+        display_name: Review
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: Produce a candidate response.
+        judge:
+          type: llm
+          criteria:
+            - The candidate is suitable for publishing.
+          outcomes: [approved]
+        transitions:
+          approved:
+            targets: [publish]
+      publish:
+        kind: bot_task
+        display_name: Publish
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: Publish the approved response.
+        final_output: true"
+    create_body=$(python3 -c '
+import json,sys
+print(json.dumps({
+  "driver_bot": sys.argv[1],
+  "label": "HTTP Provider slow Judge E2E",
+  "group_strategy": "state_machine",
+  "participant_bindings": {
+    "worker": {"source": "manual", "bot_ids": [sys.argv[2]]}
+  },
+  "participants": [
+    {"bot_uuid": sys.argv[1]},
+    {"bot_uuid": sys.argv[2]}
+  ],
+  "collaboration_definition_yaml": sys.argv[3]
+}, ensure_ascii=False))
+' "$BOT_CEO_UUID" "$provider_bot_uuid" "$definition_yaml")
+    api_post "/groups" "$create_body"
+    require_status "user creates a judged Provider state-machine group" "200" || return
+    local group_id
+    group_id=$(json_path "$RESPONSE" "id")
+    assert_not_empty "judged Provider group receives an id" "$group_id"
+    [[ -n "$group_id" ]] || return
+
+    curl --noproxy '*' -fsS -X POST \
+        "${BCS_E2E_MOCK_BASE_URL}/control/provider/clear" >/dev/null || return
+    api_post "/groups/${group_id}/state-machine-runs" \
+        '{"input":{"question":"verify asynchronous callback judging"}}'
+    require_status "user starts the judged Provider workflow" "202" || return
+    local run_id
+    run_id=$(json_path "$RESPONSE" "run.run_id")
+    assert_not_empty "judged Provider workflow returns a run id" "$run_id"
+    [[ -n "$run_id" ]] || return
+
+    local review_request review_provider_run_id graph
+    review_request=$(wait_for_mock_provider_method "chat.send" || true)
+    assert_not_empty "HTTP Provider receives the review task" "$review_request"
+    [[ -n "$review_request" ]] || return
+    review_provider_run_id=$(json_path "$review_request" "body.id")
+    assert_not_empty "review task carries a Provider run id" "$review_provider_run_id"
+    assert_json_eq "Provider delivery uses its callback credential" "$review_request" \
+        "authorization" "Bearer ${bcs_token}"
+    [[ -n "$review_provider_run_id" ]] || return
+
+    graph=$(wait_for_graph_node_sub_status \
+        "$run_id" "review" "awaiting_response" || true)
+    assert_not_empty "running node exposes awaiting_response" "$graph"
+    [[ -n "$graph" ]] || return
+    assert_eq "review node remains durably running before its reply" \
+        "$(state_machine_graph_node_field "$graph" "review" "status")" "running"
+
+    curl --noproxy '*' -fsS -X POST \
+        "${BCS_E2E_MOCK_BASE_URL}/control/provider/clear" >/dev/null || return
+    provider_callback_with_timeout "$provider_id" "$runtime_token" \
+        "{\"run_id\":\"${review_provider_run_id}\",\"state\":\"final\",\"message\":{\"text\":\"candidate awaiting slow judge\"}}"
+    if ! require_status "Provider final callback returns before its one-second timeout" "200"; then
+        curl --noproxy '*' -fsS -X POST \
+            "${BCS_E2E_MOCK_BASE_URL}/control/judge/release" >/dev/null || true
+        return
+    fi
+
+    if wait_for_mock_judge_start; then
+        pass "slow Judge receives the candidate after callback acceptance"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        fail "slow Judge did not receive the candidate"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        TESTS_TOTAL=$((TESTS_TOTAL + 1))
+        return
+    fi
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+
+    graph=$(wait_for_graph_node_sub_status "$run_id" "review" "judging" || true)
+    assert_not_empty "running node exposes judging while Judge is blocked" "$graph"
+    [[ -n "$graph" ]] || return
+    assert_eq "review node remains durably running during judging" \
+        "$(state_machine_graph_node_field "$graph" "review" "status")" "running"
+
+    api_get "/state-machine-runs/${run_id}/nodes/review"
+    require_status "user reads the node while Judge is blocked" "200" || return
+    assert_json_eq "node detail exposes judging" "$RESPONSE" \
+        "sub_status" "judging"
+    assert_json_eq "node detail persists the returned Provider artifact" "$RESPONSE" \
+        "node.artifact_text" "candidate awaiting slow judge"
+
+    curl --noproxy '*' -fsS -X POST \
+        "${BCS_E2E_MOCK_BASE_URL}/control/judge/release" >/dev/null || return
+    local publish_request publish_provider_run_id
+    publish_request=$(wait_for_mock_provider_method "chat.send" || true)
+    assert_not_empty "HTTP Provider receives the publish task after Judge release" "$publish_request"
+    [[ -n "$publish_request" ]] || return
+    publish_provider_run_id=$(json_path "$publish_request" "body.id")
+    assert_not_empty "publish task carries a Provider run id" "$publish_provider_run_id"
+    [[ -n "$publish_provider_run_id" ]] || return
+
+    api_request_headers POST "/bot/events" \
+        "{\"run_id\":\"${publish_provider_run_id}\",\"state\":\"final\",\"message\":{\"text\":\"published after slow judge\"}}" \
+        "X-BCN-Provider-Id: ${provider_id}" \
+        "Authorization: Bearer ${runtime_token}"
+    require_status "publish callback is accepted" "200" || return
+
+    local completed_view
+    completed_view=$(wait_for_state_machine_status "$run_id" "completed" || true)
+    assert_not_empty "Provider workflow completes after Judge release" "$completed_view"
+    [[ -n "$completed_view" ]] || return
+    assert_json_eq "completed workflow keeps the published output" "$completed_view" \
+        "run.output" "published after slow judge"
+    assert_json_eq "completed workflow records the approved Judge outcome" "$completed_view" \
+        "judge_outputs.0.decision.outcome" "approved"
+
+    api_delete "/groups/${group_id}?bot_id=${BOT_CEO_UUID}"
+    require_status "slow-Judge Provider group is cleaned up" "200" || return
+    api_request_headers DELETE "/providers/${provider_id}/bots/${provider_bot_ref}" "" \
+        "Authorization: Bearer ${admin_token}"
+    require_status "slow-Judge Provider bot is retired" "200" || return
 }
 
 # User story: A provider operator publishes, governs, and retires a provider-backed agent.

--- a/src/bcs/scripts/e2e_coverage.sh
+++ b/src/bcs/scripts/e2e_coverage.sh
@@ -39,6 +39,7 @@ bcs_port="${BCS_PORT:-21000}"
 compat_min="${BCS_E2E_COVERAGE_MIN:-0}"
 line_min="${BCS_E2E_LINE_MIN:-$compat_min}"
 method_min="${BCS_E2E_METHOD_MIN:-$compat_min}"
+source "$bcs_dir/scripts/e2e-test/mock_services.sh"
 
 skip_start=0
 no_stop=0
@@ -87,8 +88,12 @@ cleanup_bcs() {
   pids=$(lsof -tiTCP:"$bcs_port" -sTCP:LISTEN 2>/dev/null || true)
   [[ -n "$pids" ]] && echo "$pids" | xargs kill -TERM 2>/dev/null || true
 }
+cleanup_e2e() {
+  cleanup_bcs
+  bcs_e2e_mock_stop
+}
 if [[ "$no_stop" -eq 0 ]]; then
-  trap cleanup_bcs EXIT
+  trap cleanup_e2e EXIT
 fi
 
 # The 5 bot ports, matching the BOT1..BOT5_PORT defaults in scripts/modules/bcs.sh.
@@ -137,6 +142,7 @@ preflight_reclaim_ports() {
 #    no frontend (e2e needs none).
 if [[ "$skip_start" -eq 0 ]]; then
   preflight_reclaim_ports
+  bcs_e2e_mock_start "$cov_dir/mock-services"
   # Export LLVM_PROFILE_FILE BEFORE singlebox starts the instrumented bcs server
   # (and bcs-cli). prepare_bcs_coverage_bin sets it too, but only inside
   # singlebox's process; the bcs server it launches inherits this one. Without
@@ -163,6 +169,8 @@ if [[ "$skip_start" -eq 0 ]]; then
   # bot-onboarding setup requests nor a stale log from a prior run.
   bcs_log="$repo_root/scripts/.dependencies/logs/bcs.log"
   "$repo_root/scripts/singlebox.sh" --standalone --with-bcs-coverage start bcs_bots
+elif [[ -n "${BCS_E2E_MOCK_BASE_URL:-}" ]]; then
+  bcs_e2e_mock_start "$cov_dir/mock-services"
 fi
 
 # Re-export the instrumented binary paths for the e2e.sh child process.


### PR DESCRIPTION
Persist provider artifacts before asynchronous judging and derive extensible running-node sub-statuses for the API and panel.

Exercise the callback-cancellation regression with a local HTTP Provider and blocking Judge in the instrumented singlebox E2E coverage suite.