### PR TITLE
feat: include bot members in appcoding-bots endpoints

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -558,6 +558,48 @@ class BotService:
             )
             return None
 
+    def _list_bot_members(
+        self, bot_id: str, owner_id: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        """List a bot's members (collaborators) for the appcoding-bots response.
+
+        Reads the ``ac_bot_collaborator`` table (added admin/member
+        collaborators) scoped to the current env. The bot owner is intentionally
+        not synthesized as a member here: owner identity lives on the bot record
+        itself (``owner_id`` / ``owner_name``); callers wanting the full roster
+        should combine that with this list.
+
+        Returns an empty list when there are no collaborators, when ``owner_id``
+        is missing, or when the lookup itself fails — member enrichment must
+        never break the coding-bots listing.
+
+        Args:
+            bot_id: Bot ID of the coding bot.
+            owner_id: Bot owner's work number (filters the collaborator index).
+
+        Returns:
+            A list of member dicts with ``user_id`` and ``user_name`` only
+            (operator_id / role / timestamps are not exposed on this public
+            surface).
+        """
+        if not owner_id:
+            return []
+        try:
+            env = get_current_env()
+            collaborators = self._collaborator_repo.list_by_bot(
+                bot_id=bot_id, owner_id=owner_id, env=env,
+            )
+            return [
+                {"user_id": c.user_id, "user_name": c.user_name}
+                for c in collaborators
+            ]
+        except Exception as e:
+            logger.warning(
+                "[bot_service._list_bot_members] Failed: bot_id=%s, owner_id=%s, error=%s",
+                bot_id, owner_id, e,
+            )
+            return []
+
     def _try_acquire_restart_lock(
         self, env: str, entity_id: str, bot_id: str, holder_user_id: str
     ) -> Optional[BotRestartLockRecord]:
@@ -1662,6 +1704,16 @@ class BotService:
                     ext = template_ext_map.get(bot_id)
                     if ext is not None:
                         bot["template_config"] = ext
+                    # Attach bot member (collaborator) information. The owner
+                    # is intentionally NOT included here: it lives on the bot
+                    # record itself (owner_id / owner_name); only added admin/
+                    # member collaborators are returned. Failure is non-fatal:
+                    # an empty list is attached so enrichment never breaks the
+                    # coding-bots list.
+                    bot["members"] = self._list_bot_members(
+                        bot_id=bot_id,
+                        owner_id=bot.get("owner_id"),
+                    )
                     coding_bots.append(bot)
             except Exception as e:
                 logger.warning(

--- a/src/backend/tests/community/contracts/gateway/schema_snapshots/api_response/service_backed_rule01_GET_api_bots_id_appcoding_bots.json
+++ b/src/backend/tests/community/contracts/gateway/schema_snapshots/api_response/service_backed_rule01_GET_api_bots_id_appcoding_bots.json
@@ -224,6 +224,9 @@
           },
           "caller_config_revision": {
             "type": "integer"
+          },
+          "members": {
+            "type": "array"
           }
         },
         "required": [
@@ -244,6 +247,7 @@
           "gmt_modified",
           "id",
           "is_delete",
+          "members",
           "modifier_id",
           "owner_id",
           "owner_name",

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_list_bot_members.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_list_bot_members.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``BotService._list_bot_members``.
+
+Covers the branches exercised when enriching appcoding-bots responses with a
+bot's member (collaborator) list:
+
+- ``owner_id`` missing -> ``[]`` (no repo call).
+- happy path: collaborators are serialized to ``{user_id, user_name}`` only.
+- repository failure -> degrades to ``[]`` without raising.
+
+The service is constructed with MagicMock collaborators (matching the existing
+``test_list_desktop_live_status`` construction contract); only the
+``collaborator_repo`` seam is driven.
+"""
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.bot_collaborator.models import (
+    CollaboratorRecord,
+    CollaboratorRole,
+)
+from agentclaw.community.core.bot_management.services.bot_service import BotService
+
+
+def _make_bot_service(collaborator_repo) -> BotService:
+    return BotService(
+        drm_reader=MagicMock(),
+        repository=MagicMock(),
+        allocation_config=MagicMock(),
+        device_binding_repo=MagicMock(),
+        skill_set_factory=MagicMock(),
+        cleanup_service=MagicMock(),
+        bcn_service=MagicMock(),
+        bot_publish_repo=MagicMock(),
+        passport_plugin=MagicMock(),
+        oss_record_repo=MagicMock(),
+        bot_publish_service_provider=lambda: MagicMock(),
+        device_service_provider=lambda: MagicMock(),
+        path_factory=MagicMock(),
+        template_service=MagicMock(),
+        workspace_hosting_service=MagicMock(),
+        collaborator_repo=collaborator_repo,
+        restart_lock_repo=MagicMock(),
+        teclaw_provision_service_provider=lambda: MagicMock(),
+        device_status_client=MagicMock(),
+        cron_auto_setup_service_provider=lambda: MagicMock(),
+    )
+
+
+def _record(user_id: str, user_name, role=CollaboratorRole.MEMBER) -> CollaboratorRecord:
+    return CollaboratorRecord(
+        bot_pk=1,
+        bot_id="app_bot_1",
+        owner_id="test_user",
+        user_id=user_id,
+        user_name=user_name,
+        role=role,
+        operator_id="test_user",
+    )
+
+
+class TestListBotMembers:
+    def test_missing_owner_returns_empty(self):
+        svc = _make_bot_service(collaborator_repo=MagicMock())
+        # A truthy-falsy owner_id (None / empty) short-circuits before any repo call.
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id=None) == []
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id="") == []
+        svc._collaborator_repo.list_by_bot.assert_not_called()
+
+    def test_maps_collaborators_to_member_dicts(self):
+        repo = MagicMock()
+        repo.list_by_bot.return_value = [
+            _record("u1", "Alice"),
+            _record("u2", None),
+        ]
+        svc = _make_bot_service(collaborator_repo=repo)
+
+        members = svc._list_bot_members(bot_id="app_bot_1", owner_id="test_user")
+
+        repo.list_by_bot.assert_called_once()
+        kwargs = repo.list_by_bot.call_args.kwargs
+        assert kwargs["bot_id"] == "app_bot_1"
+        assert kwargs["owner_id"] == "test_user"
+        # env is read via get_current_env() at call time.
+        assert "env" in kwargs
+
+        assert members == [
+            {"user_id": "u1", "user_name": "Alice"},
+            {"user_id": "u2", "user_name": None},
+        ]
+
+    def test_no_collaborators_returns_empty(self):
+        repo = MagicMock()
+        repo.list_by_bot.return_value = []
+        svc = _make_bot_service(collaborator_repo=repo)
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id="test_user") == []
+
+    def test_repository_failure_degrades_to_empty(self):
+        repo = MagicMock()
+        repo.list_by_bot.side_effect = RuntimeError("db down")
+        svc = _make_bot_service(collaborator_repo=repo)
+        # Enrichment must never break the coding-bots listing.
+        assert svc._list_bot_members(bot_id="app_bot_1", owner_id="test_user") == []

--- a/src/backend/tests/community/endpoints/test_public_bots_appcoding_bots.py
+++ b/src/backend/tests/community/endpoints/test_public_bots_appcoding_bots.py
@@ -67,3 +67,89 @@ def _seed_appcoding_bot(world):
 )
 def list_public_coding_bots_ok():
     """Happy path: a coding bot linked to the architect bot (no auth required)."""
+
+
+# --- Regression: members (collaborators) are returned on each coding bot ---
+
+from agentclaw.community.core.bot_collaborator.repository.protocol import (  # noqa: E402
+    CollaboratorRepositoryProtocol,
+)
+
+MEMBER_USER_ID = "collab_001"
+MEMBER_USER_NAME = "Collab One"
+MEMBER_ROLE = "member"
+
+
+def _seed_appcoding_bot_with_member(world):
+    """Insert a coding bot, its template, and one collaborator (member)."""
+    bot = world.get(BotRepository).insert(
+        {
+            "bot_id": CODING_BOT_ID,
+            "bot_name": "App Coding Bot 1",
+            "owner_id": "test_user",
+            "owner_name": "test_user",
+            "creator_id": "test_user",
+            "entity_id": "test_user",
+            "entity_type": "staff",
+            "active_engine": "openclaw",
+            "bot_type": "personal",
+            "status": "ACTIVE",
+        }
+    )
+    world.get(TemplateRepository).insert(
+        {
+            "bot_id": CODING_BOT_ID,
+            "ext": {"architect_bot_id": ARCHITECT_BOT_ID, "template": "appcoding"},
+        }
+    )
+    # Seed a collaborator (member) linked via bot_pk (ac_bots.id).
+    world.get(CollaboratorRepositoryProtocol).insert(
+        {
+            "bot_pk": bot["id"],
+            "bot_id": CODING_BOT_ID,
+            "owner_id": "test_user",
+            "user_id": MEMBER_USER_ID,
+            "user_name": MEMBER_USER_NAME,
+            "role": MEMBER_ROLE,
+            "operator_id": "test_user",
+        }
+    )
+
+
+def _assert_members_returned(response, world):
+    """extra_assertion: each returned coding bot carries its member list.
+
+    Runner calls extra_assertions as ``assertion(response, world)``.
+    """
+    items = response.json().get("data", [])
+    coding = next(it for it in items if it.get("bot_id") == CODING_BOT_ID)
+    members = coding.get("members")
+    assert isinstance(members, list), "members should be a list"
+    assert len(members) == 1, f"expected 1 member, got {len(members)}"
+    m = members[0]
+    assert m["user_id"] == MEMBER_USER_ID
+    assert m["user_name"] == MEMBER_USER_NAME
+    # operator_id / role / timestamps are intentionally NOT exposed here.
+    for hidden in ("operator_id", "role", "gmt_create", "gmt_modified"):
+        assert hidden not in m, f"{hidden} should not be exposed"
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/public/bots/{bot_id}/appcoding-bots",
+    scenario="ok-with-members",
+    input=CaseInput(
+        path_params={"bot_id": ARCHITECT_BOT_ID},
+    ),
+    seed=_seed_appcoding_bot_with_member,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": [{"bot_id": CODING_BOT_ID}],
+        },
+    ),
+    extra_assertions=(_assert_members_returned,),
+)
+def list_public_coding_bots_with_members():
+    """Each coding bot now returns its `members` (collaborators) list."""


### PR DESCRIPTION
## Summary

The `GET /api/public/bots/{bot_id}/appcoding-bots` (and the authed twin `GET /api/bots/{bot_id}/appcoding-bots`) endpoints now return each coding bot's member information.

## Changes

- `core/bot_management/services/bot_service.py`
  - `list_coding_bots_by_architect`: attach a `members` field to every returned coding bot record (shared by both the public no-auth and the management endpoints).
  - New private helper `BotService._list_bot_members(bot_id, owner_id)` queries `ac_bot_collaborator` via the already-injected `self._collaborator_repo.list_by_bot(...)`.
- `tests/community/endpoints/test_public_bots_appcoding_bots.py`
  - New regression case `ok-with-members`: seeds one collaborator and asserts the response carries `members` with only `user_id` / `user_name`.

## `members` field shape

Each element exposes only non-sensitive member identity — `operator_id`, `role`, and timestamps are intentionally NOT exposed on this surface, and existing sensitive-field scrubbing (`iam_token` / `token` / `device_id` / `binding_id`) is unaffected.

```json
{
  "success": true,
  "data": [
    {
      "bot_id": "app_bot_1",
      "owner_id": "test_user",
      "template_config": { "architect_bot_id": "arch_001" },
      "members": [
        { "user_id": "collab_001", "user_name": "Collab One" }
      ]
    }
  ]
}
```

## Safety

- Member enrichment degrades gracefully: a missing `owner_id` or a repository failure yields `members: []` and never breaks the coding-bots listing.
- `list_by_bot` is env-scoped (current env), matching the existing collaborator query access pattern (`_query_admin_worknos`).

## Tests

- New case `ok-with-members`: **passed**.
- appcoding-bots endpoints + router unit tests (public no-auth + management): **14 passed**, no regressions.
- Broader run (endpoints dir + bot_public + bot_management/test_router): **814 passed**.

generated with Codex