### PR TITLE
feat(bcs): list groups for authenticated actor

### DIFF
--- a/src/bcs/CLAUDE.md
+++ b/src/bcs/CLAUDE.md
@@ -180,6 +180,9 @@ Bots have a `created_by` field set during onboard when a user identity is availa
 ### Unprotected Endpoints (read-only)
 - `GET /bots`, `GET /bots/{id}`, `GET /bots/discover`
 
+### Authenticated Endpoints (read-only)
+- `GET /groups/my` lists formal group memberships for the authenticated human or bot; session-only memberships are excluded
+
 ### Database Migration
 ```sql
 ALTER TABLE bcs_bots ADD COLUMN created_by VARCHAR(256) DEFAULT NULL;
@@ -375,6 +378,7 @@ export BOT_DATA_DIR=/path/to/bot/data
 | `/groups/{token}/confirm` | POST | Confirm proposal and create group |
 | `/groups` | POST | Create group directly |
 | `/groups` | GET | List all groups |
+| `/groups/my` | GET | List formal groups for the authenticated human or bot |
 | `/groups/{id}` | GET | Get group details |
 | `/groups/{id}` | DELETE | Delete group |
 | `/groups/{id}/members` | POST | Add member to group |

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -647,7 +647,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "base64 0.22.1",
  "bcs-config",
  "bcs-config-api",
  "bcs-protocol",

--- a/src/bcs/crates/adapters/http/bcs-http/src/router.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/router.rs
@@ -176,6 +176,7 @@ fn build_api_routes() -> Router<HttpAppState> {
             post(routes::friends::reject_friend_request),
         )
         .route("/groups", get(routes::groups::list_groups).post(routes::groups::create_group))
+        .route("/groups/my", get(routes::groups::list_my_groups))
         .route(
             "/groups/{id}",
             get(routes::groups::get_group).delete(routes::groups::delete_group),

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -522,6 +522,47 @@ pub async fn list_bot_groups(
     Path(bot_uuid): Path<String>,
     Query(query): Query<ListBotGroupsQuery>,
 ) -> Result<Json<Value>, HttpAdapterError> {
+    let page = list_actor_groups(&state, &bot_uuid, query).await?;
+
+    Ok(Json(serde_json::json!({
+        "bot_uuid": bot_uuid,
+        "items": page.items,
+        "total": page.total,
+        "offset": page.offset,
+        "limit": page.limit,
+    })))
+}
+
+pub async fn list_my_groups(
+    State(state): State<HttpAppState>,
+    headers: HeaderMap,
+    uri: Uri,
+    Query(query): Query<ListBotGroupsQuery>,
+) -> Result<Json<Value>, HttpAdapterError> {
+    let actor_id = resolve_actor_caller(&state, &headers, &uri).await?;
+    let page = list_actor_groups(&state, &actor_id, query).await?;
+
+    Ok(Json(serde_json::json!({
+        "actor_id": actor_id,
+        "items": page.items,
+        "total": page.total,
+        "offset": page.offset,
+        "limit": page.limit,
+    })))
+}
+
+struct ActorGroupListPage {
+    items: Vec<Value>,
+    total: u64,
+    offset: u64,
+    limit: u64,
+}
+
+async fn list_actor_groups(
+    state: &HttpAppState,
+    actor_id: &str,
+    query: ListBotGroupsQuery,
+) -> Result<ActorGroupListPage, HttpAdapterError> {
     let offset = query.offset.unwrap_or(0);
     let limit = query.limit.unwrap_or(10);
     let kind_filter = group_kind_filter(query.group_kind);
@@ -530,7 +571,7 @@ pub async fn list_bot_groups(
         .services
         .group_query
         .list_bot_groups(BotGroupListCommand {
-            bot_id: bot_uuid.clone(),
+            bot_id: actor_id.to_string(),
             group_kind: kind_filter,
             q: query.q.clone(),
             offset,
@@ -546,13 +587,12 @@ pub async fn list_bot_groups(
             .map(bot_group_list_entry_to_legacy_json)
             .collect();
 
-        return Ok(Json(serde_json::json!({
-            "bot_uuid": bot_uuid,
-            "items": items,
-            "total": result.total,
-            "offset": result.offset,
-            "limit": result.limit,
-        })));
+        return Ok(ActorGroupListPage {
+            items,
+            total: result.total,
+            offset: result.offset,
+            limit: result.limit,
+        });
     }
 
     // Union: include groups where the actor is only a session participant
@@ -567,7 +607,7 @@ pub async fn list_bot_groups(
     if let Ok(session_group_ids) = state
         .services
         .session_management
-        .list_group_ids_by_session_participant(&bot_uuid)
+        .list_group_ids_by_session_participant(actor_id)
         .await
     {
         for gid in session_group_ids {
@@ -619,13 +659,12 @@ pub async fn list_bot_groups(
             .map(bot_group_list_entry_to_legacy_json)
             .collect();
 
-        return Ok(Json(serde_json::json!({
-            "bot_uuid": bot_uuid,
-            "items": items,
-            "total": result.total,
-            "offset": result.offset,
-            "limit": result.limit,
-        })));
+        return Ok(ActorGroupListPage {
+            items,
+            total: result.total,
+            offset: result.offset,
+            limit: result.limit,
+        });
     }
 
     let session_extra_len = session_extra.len() as u64;
@@ -642,13 +681,12 @@ pub async fn list_bot_groups(
         .map(bot_group_list_entry_to_legacy_json)
         .collect();
 
-    Ok(Json(serde_json::json!({
-        "bot_uuid": bot_uuid,
-        "items": items,
-        "total": total,
-        "offset": offset,
-        "limit": limit,
-    })))
+    Ok(ActorGroupListPage {
+        items,
+        total,
+        offset,
+        limit,
+    })
 }
 
 fn group_detail_matches_bot_group_query(group: &GroupDetailResult, q: Option<&str>) -> bool {

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -81,6 +81,32 @@ fn default_include_session_groups() -> bool {
     true
 }
 
+fn formal_only_group_query(mut query: ListBotGroupsQuery) -> ListBotGroupsQuery {
+    query.include_session_groups = false;
+    query
+}
+
+#[cfg(test)]
+mod list_my_groups_query_tests {
+    use super::{GroupKindFilter, ListBotGroupsQuery, formal_only_group_query};
+
+    #[test]
+    fn my_groups_forces_session_only_groups_off() {
+        let query = formal_only_group_query(ListBotGroupsQuery {
+            offset: Some(4),
+            limit: Some(5),
+            group_kind: GroupKindFilter::default(),
+            q: Some("topic".to_string()),
+            include_session_groups: true,
+        });
+
+        assert!(!query.include_session_groups);
+        assert_eq!(query.offset, Some(4));
+        assert_eq!(query.limit, Some(5));
+        assert_eq!(query.q.as_deref(), Some("topic"));
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct DeleteSessionQuery {
     pub bot_id: String,
@@ -540,7 +566,7 @@ pub async fn list_my_groups(
     Query(query): Query<ListBotGroupsQuery>,
 ) -> Result<Json<Value>, HttpAdapterError> {
     let actor_id = resolve_actor_caller(&state, &headers, &uri).await?;
-    let page = list_actor_groups(&state, &actor_id, query).await?;
+    let page = list_actor_groups(&state, &actor_id, formal_only_group_query(query)).await?;
 
     Ok(Json(serde_json::json!({
         "actor_id": actor_id,
@@ -1608,7 +1634,9 @@ async fn resolve_actor_caller(
     uri: &Uri,
 ) -> Result<String, HttpAdapterError> {
     if let Ok(bot_id) = authenticated_bot_from_headers(state, headers).await {
-        return Ok(bot_id);
+        if !bot_id.trim().is_empty() {
+            return Ok(bot_id);
+        }
     }
     extract_human_actor_id(state, headers, uri)
         .await

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -1330,7 +1330,7 @@ async fn my_groups_resolves_bot_principal_and_preserves_query() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/groups/my?group_kind=normal&offset=4&limit=5&q=05&include_session_groups=false")
+                .uri("/groups/my?group_kind=normal&offset=4&limit=5&q=05&include_session_groups=true")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1382,6 +1382,28 @@ async fn my_groups_resolves_human_identity() {
     let calls = query.bot_group_calls.lock().await;
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].bot_id, "human_alice");
+}
+
+#[tokio::test]
+async fn my_groups_rejects_empty_bot_actor_identity() {
+    let query = Arc::new(RecordingGroupQuery::default());
+    let services = Services::builder().group_query(query).build_for_test();
+    let app = build_router(HttpAppState::new(services).with_auth_chain(
+        static_bot_auth_chain(""),
+        AuthConfig::default(),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/groups/my")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -2,7 +2,7 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use bcs_auth_api::{AuthPluginChain, AuthPrincipal};
+use bcs_auth_api::{AuthConfig, AuthPluginChain, AuthPrincipal};
 use bcs_auth_local::StaticAuthPlugin;
 use bcs_bot::BotCore;
 use bcs_group::GroupStore;
@@ -38,6 +38,14 @@ fn static_auth_chain(staff_no: &str, nick_name: &str) -> Arc<AuthPluginChain> {
     let principal = AuthPrincipal {
         user_id: Some(staff_no.to_string()),
         user_name: Some(nick_name.to_string()),
+        ..Default::default()
+    };
+    Arc::new(AuthPluginChain::new(vec![Box::new(StaticAuthPlugin::with_principal(principal))]))
+}
+
+fn static_bot_auth_chain(bot_uuid: &str) -> Arc<AuthPluginChain> {
+    let principal = AuthPrincipal {
+        bot_uuid: Some(bot_uuid.to_string()),
         ..Default::default()
     };
     Arc::new(AuthPluginChain::new(vec![Box::new(StaticAuthPlugin::with_principal(principal))]))
@@ -1306,6 +1314,104 @@ async fn group_query_routes_delegate_to_group_query_service() {
     let workspace_calls = query.workspace_calls.lock().await;
     assert_eq!(workspace_calls.len(), 1);
     assert_eq!(workspace_calls[0].group_id, "group-1");
+}
+
+#[tokio::test]
+async fn my_groups_resolves_bot_principal_and_preserves_query() {
+    let query = Arc::new(RecordingGroupQuery::default());
+    let services = Services::builder()
+        .group_query(query.clone())
+        .build_for_test();
+    let app = build_router(HttpAppState::new(services).with_auth_chain(
+        static_bot_auth_chain("bot-current"),
+        AuthConfig::default(),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/groups/my?group_kind=normal&offset=4&limit=5&q=05&include_session_groups=false")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["actor_id"], "bot-current");
+    assert!(json.get("bot_uuid").is_none());
+    assert_eq!(json["items"][0]["group_id"], "bot-group-1");
+
+    let calls = query.bot_group_calls.lock().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].bot_id, "bot-current");
+    assert_eq!(calls[0].group_kind, Some(Default::default()));
+    assert_eq!(calls[0].q.as_deref(), Some("05"));
+    assert_eq!(calls[0].offset, 4);
+    assert_eq!(calls[0].limit, 5);
+}
+
+#[tokio::test]
+async fn my_groups_resolves_human_identity() {
+    let query = Arc::new(RecordingGroupQuery::default());
+    let services = Services::builder()
+        .group_query(query.clone())
+        .build_for_test();
+    let chain = static_auth_chain("alice", "Alice");
+    let app = build_router(HttpAppState::new(services).with_user_identity(Arc::new(
+        ChainUserIdentityPort::new(chain),
+    )));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/groups/my?include_session_groups=false")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["actor_id"], "human_alice");
+
+    let calls = query.bot_group_calls.lock().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].bot_id, "human_alice");
+}
+
+#[tokio::test]
+async fn my_groups_rejects_anonymous_without_shadowing_group_detail() {
+    let query = Arc::new(RecordingGroupQuery::default());
+    let services = Services::builder().group_query(query).build_for_test();
+    let app = build_router(HttpAppState::new(services));
+
+    let my_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/groups/my?include_session_groups=false")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(my_response.status(), StatusCode::UNAUTHORIZED);
+
+    let detail_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/groups/group-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(detail_response.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/tools/bcs-cli/Cargo.toml
+++ b/src/bcs/crates/tools/bcs-cli/Cargo.toml
@@ -22,7 +22,6 @@ anyhow    = { workspace = true }
 dirs = { workspace = true }
 
 # Serialization
-base64     = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/group.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/group.md
@@ -10,7 +10,7 @@
 | `confirm-group-help` | `--url`                 | 确认群聊提案                 |
 | `create-group`       | `--topic`               | 直接创建群组                 |
 | `get-group`          | `--group`               | 获取群组信息                 |
-| `list-groups`        | `[--mine]`              | 列出所有群组，或当前 Bot 所在群组 |
+| `list-groups`        | 无                      | 列出当前认证用户或 Bot 正式参与的群组 |
 | `add-member`         | `--group`, `--bot-uuid` | 添加成员到已有群组           |
 | `group-status`       | `--group`, `--status`   | 更新群组状态（仅协调者）     |
 | `terminate-group`    | `--group`               | 终止群组会话（仅 driver）    |
@@ -172,36 +172,57 @@ bcs get-group --group "grp-001"
 
 ## list-groups - 列出群组
 
-默认列出所有群组：
+列出当前认证主体正式参与的群组，不包含仅通过 session 参与的群组。服务端根据
+认证信息识别主体：Bot token 对应 Bot UUID，用户身份对应
+`human_<staff_no>`；CLI 不需要从本地 session 读取 Bot UUID。
 
 ```bash
 bcs list-groups
 ```
 
-使用 `--mine` 仅列出当前 Bot 参与的群组。当前 Bot 从
-`$BOT_DATA_DIR/.bcs/session.json` 的 `bot_uuid` 读取：
+默认从 offset `0` 开始，每批返回最多 20 个群组。可以直接指定 offset
+和批大小，或使用 `--all` 从指定 offset 起获取所有剩余结果：
 
 ```bash
-bcs list-groups --mine
+bcs list-groups --offset 20 --batch-size 10
+bcs list-groups --offset 20 --all
+```
+
+当后面还有结果时，结构化输出会包含 `next_offset` 和可直接执行的
+`next_command`：
+
+```json
+{
+  "items": [
+    {"group_id": "grp-021"},
+    {"group_id": "grp-022"}
+  ],
+  "offset": 20,
+  "returned": 2,
+  "total": 42,
+  "has_more": true,
+  "next_offset": 22,
+  "next_command": "bcs-cli list-groups --offset 22 --batch-size 2"
+}
 ```
 
 **返回示例：**
 
 ```json
-[
-  {
-    "group_id": "grp-001",
-    "topic": "数据库死锁排查",
-    "status": "active",
-    "participants_count": 3
-  },
-  {
-    "group_id": "grp-002",
-    "topic": "安全事件处理",
-    "status": "completed",
-    "participants_count": 4
-  }
-]
+{
+  "items": [
+    {
+      "group_id": "grp-001",
+      "topic": "数据库死锁排查",
+      "status": "active",
+      "participants_count": 3
+    }
+  ],
+  "offset": 0,
+  "returned": 1,
+  "total": 1,
+  "has_more": false
+}
 ```
 
 ---
@@ -430,7 +451,7 @@ bcs request-group-help --topic "数据库死锁排查" --participants "bot-dba-u
 | `confirm-group-help` | `group_id`, `driver_bot`, `participants`, `chat_url`       |
 | `create-group`       | `id`, `driver_bot`, `participants`, `chat_url`             |
 | `get-group`          | `group_id`, `topic`, `status`, `driver_bot`, `originator`, `participants`, `created_at` |
-| `list-groups`        | 群组列表：`group_id`, `topic`, `status`, `participants_count` |
+| `list-groups`        | `items`, `offset`, `returned`, `total`, `has_more`, 可选 `next_offset`/`next_command` |
 | `add-member`         | 添加确认                                                   |
 | `group-status`       | `updated`, `group_id`, `status`, `reason`, `changed_by`    |
 | `terminate-group`    | 终止确认                                                   |

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -1728,7 +1728,6 @@ impl BcsClient {
         &self,
         offset: u64,
         limit: u64,
-        include_session_groups: bool,
     ) -> Result<CurrentActorGroupListPage> {
         let url = format!("{}/groups/my", self.base_url);
 
@@ -1736,10 +1735,6 @@ impl BcsClient {
             .add_auth(self.http_client.get(&url).query(&[
                 ("offset", offset.to_string()),
                 ("limit", limit.to_string()),
-                (
-                    "include_session_groups",
-                    include_session_groups.to_string(),
-                ),
             ]))
             .send()
             .await

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -36,6 +36,15 @@ pub struct BotGroupListPage {
     pub limit: u64,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct CurrentActorGroupListPage {
+    pub actor_id: String,
+    pub items: Vec<serde_json::Value>,
+    pub total: u64,
+    pub offset: u64,
+    pub limit: u64,
+}
+
 /// Client for interacting with the Bot Coordination Service.
 #[derive(Debug, Clone)]
 pub struct BcsClient {
@@ -1712,6 +1721,44 @@ impl BcsClient {
         }
 
         response.json().await.context("Invalid bot groups response")
+    }
+
+    /// List groups that include the authenticated human or bot actor.
+    pub async fn list_my_groups(
+        &self,
+        offset: u64,
+        limit: u64,
+        include_session_groups: bool,
+    ) -> Result<CurrentActorGroupListPage> {
+        let url = format!("{}/groups/my", self.base_url);
+
+        let response = self
+            .add_auth(self.http_client.get(&url).query(&[
+                ("offset", offset.to_string()),
+                ("limit", limit.to_string()),
+                (
+                    "include_session_groups",
+                    include_session_groups.to_string(),
+                ),
+            ]))
+            .send()
+            .await
+            .context("Failed to list current actor groups")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "List current actor groups failed ({}): {}",
+                status,
+                body
+            ));
+        }
+
+        response
+            .json()
+            .await
+            .context("Invalid current actor groups response")
     }
 
     /// Add a member to a group.

--- a/src/bcs/crates/tools/bcs-cli/src/lib.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/lib.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::FmtSubscriber;
 
 mod client;
 
-pub use client::{BcsClient, BotGroupListPage};
+pub use client::{BcsClient, BotGroupListPage, CurrentActorGroupListPage};
 
 /// Get current environment from `AGENTCLAW_ENV` or `env` variable.
 /// Priority: `AGENTCLAW_ENV` > `env` > `SERVER_ENV` chain > "dev" (default)

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -51,7 +51,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 #[cfg(debug_assertions)]
 use clap::ArgAction;
 use clap::{Parser, Subcommand};
@@ -66,47 +65,18 @@ use bcs_protocol::{BCS_PROTOCOL_VERSION, BotConnectParams};
 // disable agentpass, agentpass token should be auto injected into the http headers
 const AUTH_VIA_AGENT_PASS: bool = false;
 const DEFAULT_GROUP_BATCH_SIZE: u64 = 20;
-const GROUP_CONTINUATION_VERSION: u8 = 1;
-
-#[derive(Debug, Serialize, Deserialize)]
-struct GroupContinuation {
-    version: u8,
-    bot_uuid: String,
-    next_offset: u64,
-    batch_size: u64,
-}
 
 #[derive(Debug, Serialize)]
 struct GroupListOutput {
     items: Vec<serde_json::Value>,
+    offset: u64,
     returned: u64,
     total: u64,
     has_more: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    continuation: Option<String>,
+    next_offset: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     next_command: Option<String>,
-}
-
-fn encode_group_continuation(token: &GroupContinuation) -> Result<String> {
-    let bytes = serde_json::to_vec(token)
-        .map_err(|error| anyhow!("Failed to encode list-groups continuation token: {error}"))?;
-    Ok(URL_SAFE_NO_PAD.encode(bytes))
-}
-
-fn decode_group_continuation(encoded: &str) -> Result<GroupContinuation> {
-    let bytes = URL_SAFE_NO_PAD
-        .decode(encoded)
-        .map_err(|_| anyhow!("Invalid list-groups continuation token"))?;
-    let token: GroupContinuation = serde_json::from_slice(&bytes)
-        .map_err(|_| anyhow!("Invalid list-groups continuation token"))?;
-    if token.version != GROUP_CONTINUATION_VERSION {
-        return Err(anyhow!(
-            "Unsupported list-groups continuation token version: {}",
-            token.version
-        ));
-    }
-    Ok(token)
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -1027,22 +997,22 @@ enum Commands {
         focus: Option<String>,
     },
 
-    /// List groups the current bot formally participates in
+    /// List groups the authenticated human or bot formally participates in
     ListGroups {
         /// Authentication token (auto-discovered if not provided)
         #[arg(short, long)]
         token: Option<String>,
 
         /// Maximum number of groups to return in this batch
-        #[arg(long)]
-        batch_size: Option<u64>,
+        #[arg(long, default_value_t = DEFAULT_GROUP_BATCH_SIZE)]
+        batch_size: u64,
 
-        /// Continue from a token returned by a previous list-groups call
-        #[arg(long = "continue", value_name = "TOKEN")]
-        continuation: Option<String>,
+        /// Start listing at this zero-based group offset
+        #[arg(long, default_value_t = 0)]
+        offset: u64,
 
         /// Fetch all groups by following every batch
-        #[arg(long, conflicts_with = "continuation")]
+        #[arg(long)]
         all: bool,
     },
 
@@ -2741,7 +2711,7 @@ async fn main() -> Result<()> {
         Commands::ListGroups {
             token,
             batch_size,
-            continuation,
+            offset: start_offset,
             all,
         } => {
             let token = get_token(token.as_deref())?;
@@ -2752,52 +2722,41 @@ async fn main() -> Result<()> {
                 oauth_headers.as_ref(),
             );
 
-            let bot_uuid = resolve_my_bot_uuid()?;
-            let continuation = continuation
-                .as_deref()
-                .map(decode_group_continuation)
-                .transpose()?;
-            if let Some(continuation) = continuation.as_ref() {
-                if continuation.bot_uuid != bot_uuid {
-                    return Err(anyhow!(
-                        "Continuation token belongs to bot {}, but the current session bot is {}",
-                        continuation.bot_uuid,
-                        bot_uuid
-                    ));
-                }
-            }
-            let start_offset = continuation
-                .as_ref()
-                .map(|token| token.next_offset)
-                .unwrap_or(0);
-            let batch_size = batch_size
-                .or_else(|| continuation.as_ref().map(|token| token.batch_size))
-                .unwrap_or(DEFAULT_GROUP_BATCH_SIZE);
             if batch_size == 0 {
                 return Err(anyhow!("Batch size must be greater than 0"));
             }
             let mut offset = start_offset;
             let mut groups = Vec::new();
+            let mut actor_id = None;
             let (next_offset, total) = loop {
                 debug_request!(
                     debug,
                     "GET",
-                    &format!("/bots/{}/groups", &bot_uuid),
+                    "/groups/my",
                     json!({
                         "offset": offset,
                         "limit": batch_size,
                         "include_session_groups": false,
                     })
                 );
-                let page = client
-                    .list_bot_groups(&bot_uuid, offset, batch_size, false)
-                    .await?;
+                let page = client.list_my_groups(offset, batch_size, false).await?;
                 if page.offset != offset {
                     return Err(anyhow!(
-                        "Invalid bot groups pagination response: requested offset={}, received offset={}",
+                        "Invalid current actor groups pagination response: requested offset={}, received offset={}",
                         offset,
                         page.offset
                     ));
+                }
+                if let Some(current_actor_id) = actor_id.as_deref() {
+                    if current_actor_id != page.actor_id {
+                        return Err(anyhow!(
+                            "Current actor changed during pagination: expected {}, received {}",
+                            current_actor_id,
+                            page.actor_id
+                        ));
+                    }
+                } else {
+                    actor_id = Some(page.actor_id.clone());
                 }
                 let page_groups = page.items;
                 let total = page.total;
@@ -2809,27 +2768,29 @@ async fn main() -> Result<()> {
                 }
                 offset = next_offset;
             };
+            let actor_id = actor_id.ok_or_else(|| {
+                anyhow!("Current actor groups response did not identify the authenticated actor")
+            })?;
             let returned = groups.len() as u64;
             let has_more = !all && returned > 0 && next_offset < total;
-            let continuation = if has_more {
-                Some(encode_group_continuation(&GroupContinuation {
-                    version: GROUP_CONTINUATION_VERSION,
-                    bot_uuid: bot_uuid.clone(),
-                    next_offset,
-                    batch_size,
-                })?)
+            let next_offset = if has_more {
+                Some(next_offset)
             } else {
                 None
             };
-            let next_command = continuation
-                .as_ref()
-                .map(|token| format!("bcs-cli list-groups --continue {token}"));
+            let next_command = next_offset.map(|next_offset| {
+                format!(
+                    "bcs-cli list-groups --offset {} --batch-size {}",
+                    next_offset, batch_size
+                )
+            });
             let output = GroupListOutput {
                 items: groups,
+                offset: start_offset,
                 returned,
                 total,
                 has_more,
-                continuation,
+                next_offset,
                 next_command,
             };
 
@@ -2838,7 +2799,7 @@ async fn main() -> Result<()> {
             if structured_mode {
                 println!("{}", serde_json::to_string(&output)?);
             } else {
-                println!("Groups for current bot {} ({}/{}):", bot_uuid, returned, total);
+                println!("Groups for current actor {} ({}/{}):", actor_id, returned, total);
                 for group in &output.items {
                     let id = group
                         .get("id")
@@ -4009,20 +3970,6 @@ mod tests {
         let mut file = std::fs::File::create(session_file).unwrap();
         file.write_all(serde_json::to_string_pretty(&value).unwrap().as_bytes())
             .unwrap();
-    }
-
-    #[test]
-    fn group_continuation_rejects_unsupported_version() {
-        let encoded = encode_group_continuation(&GroupContinuation {
-            version: GROUP_CONTINUATION_VERSION + 1,
-            bot_uuid: "bot-1".to_string(),
-            next_offset: 20,
-            batch_size: 20,
-        })
-        .unwrap();
-
-        let error = decode_group_continuation(&encoded).unwrap_err();
-        assert!(error.to_string().contains("Unsupported list-groups continuation token version"));
     }
 
     #[test]

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -2736,15 +2736,19 @@ async fn main() -> Result<()> {
                     json!({
                         "offset": offset,
                         "limit": batch_size,
-                        "include_session_groups": false,
                     })
                 );
-                let page = client.list_my_groups(offset, batch_size, false).await?;
+                let page = client.list_my_groups(offset, batch_size).await?;
                 if page.offset != offset {
                     return Err(anyhow!(
                         "Invalid current actor groups pagination response: requested offset={}, received offset={}",
                         offset,
                         page.offset
+                    ));
+                }
+                if page.actor_id.trim().is_empty() {
+                    return Err(anyhow!(
+                        "Current actor groups response did not identify the authenticated actor"
                     ));
                 }
                 if let Some(current_actor_id) = actor_id.as_deref() {
@@ -2761,6 +2765,13 @@ async fn main() -> Result<()> {
                 let page_groups = page.items;
                 let total = page.total;
                 let page_returned = page_groups.len() as u64;
+                if page_returned == 0 && offset < total {
+                    return Err(anyhow!(
+                        "Current actor groups pagination made no progress at offset {} while total is {}",
+                        offset,
+                        total
+                    ));
+                }
                 groups.extend(page_groups);
                 let next_offset = offset.saturating_add(page_returned);
                 if !all || page_returned == 0 || next_offset >= total {

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
@@ -2,7 +2,7 @@
 
 use crate::common::{assert_failure, assert_output_contains, assert_success, TestContext};
 use wiremock::{
-    matchers::{bearer_token, method, path, query_param},
+    matchers::{bearer_token, method, path, query_param, query_param_is_missing},
     Mock, ResponseTemplate,
 };
 
@@ -24,7 +24,7 @@ async fn list_groups_uses_authenticated_actor_without_local_bot_uuid() {
         .and(bearer_token(&ctx.session.token))
         .and(query_param("offset", "0"))
         .and(query_param("limit", "20"))
-        .and(query_param("include_session_groups", "false"))
+        .and(query_param_is_missing("include_session_groups"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "actor_id": "bot-current",
             "items": [{
@@ -66,7 +66,7 @@ async fn list_groups_uses_offset_and_returns_readable_next_command() {
         .and(path("/groups/my"))
         .and(query_param("offset", "2"))
         .and(query_param("limit", "2"))
-        .and(query_param("include_session_groups", "false"))
+        .and(query_param_is_missing("include_session_groups"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "actor_id": "bot-current",
             "items": [
@@ -190,6 +190,57 @@ async fn list_groups_rejects_mismatched_page_offset() {
 }
 
 #[tokio::test]
+async fn list_groups_rejects_zero_progress_page_with_records_remaining() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    Mock::given(method("GET"))
+        .and(path("/groups/my"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "actor_id": "bot-current",
+            "items": [],
+            "total": 2,
+            "offset": 0,
+            "limit": 20
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("list-groups")
+        .arg("--all")
+        .output()
+        .expect("Failed to execute list-groups");
+
+    assert_failure(&output, None);
+    assert_output_contains(&output, "pagination made no progress");
+}
+
+#[tokio::test]
+async fn list_groups_rejects_empty_actor_id() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    Mock::given(method("GET"))
+        .and(path("/groups/my"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "actor_id": "",
+            "items": [],
+            "total": 0,
+            "offset": 0,
+            "limit": 20
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("list-groups")
+        .output()
+        .expect("Failed to execute list-groups");
+
+    assert_failure(&output, None);
+    assert_output_contains(&output, "did not identify the authenticated actor");
+}
+
+#[tokio::test]
 async fn list_groups_human_output_includes_readable_next_command() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
     Mock::given(method("GET"))
@@ -255,7 +306,7 @@ async fn list_groups_all_collects_remaining_pages_from_offset() {
         .and(path("/groups/my"))
         .and(query_param("offset", "1"))
         .and(query_param("limit", "2"))
-        .and(query_param("include_session_groups", "false"))
+        .and(query_param_is_missing("include_session_groups"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "actor_id": "bot-current",
             "items": [{"group_id": "group-2"}, {"group_id": "group-3"}],
@@ -270,7 +321,7 @@ async fn list_groups_all_collects_remaining_pages_from_offset() {
         .and(path("/groups/my"))
         .and(query_param("offset", "3"))
         .and(query_param("limit", "2"))
-        .and(query_param("include_session_groups", "false"))
+        .and(query_param_is_missing("include_session_groups"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "actor_id": "bot-current",
             "items": [{"group_id": "group-4"}],
@@ -301,4 +352,50 @@ async fn list_groups_all_collects_remaining_pages_from_offset() {
     assert_eq!(json["has_more"], false);
     assert!(json.get("next_offset").is_none());
     assert!(json.get("next_command").is_none());
+}
+
+#[tokio::test]
+async fn list_groups_all_rejects_actor_change_between_pages() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    Mock::given(method("GET"))
+        .and(path("/groups/my"))
+        .and(query_param("offset", "0"))
+        .and(query_param("limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "actor_id": "bot-first",
+            "items": [{"group_id": "group-1"}],
+            "total": 2,
+            "offset": 0,
+            "limit": 1
+        })))
+        .expect(1)
+        .mount(&ctx.mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/groups/my"))
+        .and(query_param("offset", "1"))
+        .and(query_param("limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "actor_id": "bot-second",
+            "items": [{"group_id": "group-2"}],
+            "total": 2,
+            "offset": 1,
+            "limit": 1
+        })))
+        .expect(1)
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("list-groups")
+        .arg("--all")
+        .arg("--batch-size")
+        .arg("1")
+        .output()
+        .expect("Failed to execute list-groups");
+
+    assert_failure(&output, None);
+    assert_output_contains(&output, "current actor changed during pagination");
 }

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/groups_test.rs
@@ -7,18 +7,26 @@ use wiremock::{
 };
 
 #[tokio::test]
-async fn list_groups_uses_current_bot_and_excludes_session_only_groups() {
+async fn list_groups_uses_authenticated_actor_without_local_bot_uuid() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
+    std::fs::write(
+        ctx.session_path(),
+        serde_json::to_vec(&serde_json::json!({
+            "token": ctx.session.token,
+            "bcs_url": ctx.session.bcs_url,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
 
     Mock::given(method("GET"))
-        .and(path(bot_groups_path))
+        .and(path("/groups/my"))
         .and(bearer_token(&ctx.session.token))
         .and(query_param("offset", "0"))
         .and(query_param("limit", "20"))
         .and(query_param("include_session_groups", "false"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "bot_uuid": ctx.session.bot_uuid,
+            "actor_id": "bot-current",
             "items": [{
                 "group_id": "group-for-current-bot",
                 "coordinator_bot": "current-bot",
@@ -43,85 +51,53 @@ async fn list_groups_uses_current_bot_and_excludes_session_only_groups() {
     assert_success(&output);
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["items"][0]["group_id"], "group-for-current-bot");
+    assert_eq!(json["offset"], 0);
     assert_eq!(json["returned"], 1);
     assert_eq!(json["total"], 1);
     assert_eq!(json["has_more"], false);
-    assert!(json.get("continuation").is_none());
+    assert!(json.get("next_offset").is_none());
     assert!(json.get("next_command").is_none());
 }
 
 #[tokio::test]
-async fn list_groups_continues_from_returned_token() {
+async fn list_groups_uses_offset_and_returns_readable_next_command() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
-
     Mock::given(method("GET"))
-        .and(path(bot_groups_path.clone()))
-        .and(query_param("offset", "0"))
+        .and(path("/groups/my"))
+        .and(query_param("offset", "2"))
         .and(query_param("limit", "2"))
         .and(query_param("include_session_groups", "false"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "bot_uuid": ctx.session.bot_uuid,
+            "actor_id": "bot-current",
             "items": [
-                {"group_id": "group-1"},
-                {"group_id": "group-2"}
+                {"group_id": "group-3"},
+                {"group_id": "group-4"}
             ],
-            "total": 3,
-            "offset": 0,
+            "total": 5,
+            "offset": 2,
             "limit": 2
         })))
-        .expect(1)
         .mount(&ctx.mock_server)
         .await;
 
-    let first = ctx
+    let output = ctx
         .cmd()
         .arg("list-groups")
+        .arg("--offset")
+        .arg("2")
         .arg("--batch-size")
         .arg("2")
         .output()
-        .expect("Failed to execute first page");
-    assert_success(&first);
-    let first_json: serde_json::Value = serde_json::from_slice(&first.stdout).unwrap();
-    assert_eq!(first_json["returned"], 2);
-    assert_eq!(first_json["has_more"], true);
-    let continuation = first_json["continuation"].as_str().unwrap();
-    assert!(first_json["next_command"]
-        .as_str()
-        .unwrap()
-        .contains(continuation));
+        .expect("Failed to execute offset page");
 
-    Mock::given(method("GET"))
-        .and(path(bot_groups_path))
-        .and(query_param("offset", "2"))
-        .and(query_param("limit", "1"))
-        .and(query_param("include_session_groups", "false"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "bot_uuid": ctx.session.bot_uuid,
-            "items": [{"group_id": "group-3"}],
-            "total": 3,
-            "offset": 2,
-            "limit": 1
-        })))
-        .expect(1)
-        .mount(&ctx.mock_server)
-        .await;
-
-    let second = ctx
-        .cmd()
-        .arg("list-groups")
-        .arg("--continue")
-        .arg(continuation)
-        .arg("--batch-size")
-        .arg("1")
-        .output()
-        .expect("Failed to execute continuation page");
-    assert_success(&second);
-    let second_json: serde_json::Value = serde_json::from_slice(&second.stdout).unwrap();
-    assert_eq!(second_json["items"][0]["group_id"], "group-3");
-    assert_eq!(second_json["returned"], 1);
-    assert_eq!(second_json["has_more"], false);
-    assert!(second_json.get("continuation").is_none());
+    assert_success(&output);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["offset"], 2);
+    assert_eq!(json["next_offset"], 4);
+    assert_eq!(
+        json["next_command"],
+        "bcs-cli list-groups --offset 4 --batch-size 2"
+    );
 }
 
 #[tokio::test]
@@ -140,26 +116,10 @@ async fn list_groups_rejects_zero_batch_size() {
 }
 
 #[tokio::test]
-async fn list_groups_rejects_invalid_continuation() {
-    let ctx = TestContext::new().await.expect("Failed to create test context");
-    let output = ctx
-        .cmd()
-        .arg("list-groups")
-        .arg("--continue")
-        .arg("not-a-token")
-        .output()
-        .expect("Failed to execute list-groups");
-
-    assert_failure(&output, None);
-    assert_output_contains(&output, "invalid list-groups continuation token");
-}
-
-#[tokio::test]
 async fn list_groups_rejects_malformed_page_envelope() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
     Mock::given(method("GET"))
-        .and(path(bot_groups_path))
+        .and(path("/groups/my"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "items": []
         })))
@@ -172,18 +132,18 @@ async fn list_groups_rejects_malformed_page_envelope() {
         .output()
         .expect("Failed to execute list-groups");
     assert_failure(&output, None);
-    assert_output_contains(&output, "invalid bot groups response");
+    assert_output_contains(&output, "invalid current actor groups response");
 }
 
 #[tokio::test]
 async fn list_groups_accepts_server_capped_limit() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
     Mock::given(method("GET"))
-        .and(path(bot_groups_path))
+        .and(path("/groups/my"))
         .and(query_param("offset", "0"))
         .and(query_param("limit", "20"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "actor_id": "bot-current",
             "items": [{"group_id": "group-1"}],
             "total": 2,
             "offset": 0,
@@ -201,16 +161,16 @@ async fn list_groups_accepts_server_capped_limit() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["returned"], 1);
     assert_eq!(json["has_more"], true);
-    assert!(json["continuation"].is_string());
+    assert_eq!(json["next_offset"], 1);
 }
 
 #[tokio::test]
 async fn list_groups_rejects_mismatched_page_offset() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
     Mock::given(method("GET"))
-        .and(path(bot_groups_path))
+        .and(path("/groups/my"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "actor_id": "bot-current",
             "items": [],
             "total": 0,
             "offset": 1,
@@ -230,12 +190,12 @@ async fn list_groups_rejects_mismatched_page_offset() {
 }
 
 #[tokio::test]
-async fn list_groups_human_output_includes_next_command() {
+async fn list_groups_human_output_includes_readable_next_command() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
     Mock::given(method("GET"))
-        .and(path(bot_groups_path))
+        .and(path("/groups/my"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "actor_id": "bot-current",
             "items": [{"group_id": "group-1"}],
             "total": 2,
             "offset": 0,
@@ -252,62 +212,25 @@ async fn list_groups_human_output_includes_next_command() {
         .expect("Failed to execute human list-groups");
     assert_success(&output);
     assert_output_contains(&output, "Has more: true");
-    assert_output_contains(&output, "Next: bcs-cli list-groups --continue");
+    assert_output_contains(
+        &output,
+        "Next: bcs-cli list-groups --offset 1 --batch-size 20",
+    );
 }
 
 #[tokio::test]
-async fn list_groups_rejects_continuation_for_another_bot() {
-    let first_ctx = TestContext::new().await.expect("Failed to create first context");
-    let first_path = format!("/bots/{}/groups", first_ctx.session.bot_uuid);
-    Mock::given(method("GET"))
-        .and(path(first_path))
-        .and(query_param("offset", "0"))
-        .and(query_param("limit", "1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "items": [{"group_id": "group-1"}],
-            "total": 2,
-            "offset": 0,
-            "limit": 1
-        })))
-        .mount(&first_ctx.mock_server)
-        .await;
-    let first = first_ctx
-        .cmd()
-        .arg("list-groups")
-        .arg("--batch-size")
-        .arg("1")
-        .output()
-        .expect("Failed to create continuation token");
-    assert_success(&first);
-    let first_json: serde_json::Value = serde_json::from_slice(&first.stdout).unwrap();
-    let continuation = first_json["continuation"].as_str().unwrap();
-
-    let second_ctx = TestContext::new().await.expect("Failed to create second context");
-    let second = second_ctx
-        .cmd()
-        .arg("list-groups")
-        .arg("--continue")
-        .arg(continuation)
-        .output()
-        .expect("Failed to execute mismatched continuation");
-    assert_failure(&second, None);
-    assert_output_contains(&second, "continuation token belongs to bot");
-}
-
-#[tokio::test]
-async fn list_groups_rejects_all_with_continuation() {
+async fn list_groups_rejects_removed_continue_flag() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
     let output = ctx
         .cmd()
         .arg("list-groups")
-        .arg("--all")
         .arg("--continue")
-        .arg("token")
+        .arg("20")
         .output()
-        .expect("Failed to execute conflicting list-groups options");
+        .expect("Failed to execute list-groups");
 
     assert_failure(&output, Some(2));
-    assert_output_contains(&output, "--all' cannot be used with '--continue");
+    assert_output_contains(&output, "unexpected argument '--continue'");
 }
 
 #[tokio::test]
@@ -325,33 +248,34 @@ async fn list_groups_rejects_removed_mine_flag() {
 }
 
 #[tokio::test]
-async fn list_groups_all_collects_every_batch() {
+async fn list_groups_all_collects_remaining_pages_from_offset() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let bot_groups_path = format!("/bots/{}/groups", ctx.session.bot_uuid);
 
     Mock::given(method("GET"))
-        .and(path(bot_groups_path.clone()))
-        .and(query_param("offset", "0"))
+        .and(path("/groups/my"))
+        .and(query_param("offset", "1"))
         .and(query_param("limit", "2"))
         .and(query_param("include_session_groups", "false"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "items": [{"group_id": "group-1"}, {"group_id": "group-2"}],
-            "total": 3,
-            "offset": 0,
+            "actor_id": "bot-current",
+            "items": [{"group_id": "group-2"}, {"group_id": "group-3"}],
+            "total": 4,
+            "offset": 1,
             "limit": 2
         })))
         .expect(1)
         .mount(&ctx.mock_server)
         .await;
     Mock::given(method("GET"))
-        .and(path(bot_groups_path))
-        .and(query_param("offset", "2"))
+        .and(path("/groups/my"))
+        .and(query_param("offset", "3"))
         .and(query_param("limit", "2"))
         .and(query_param("include_session_groups", "false"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "items": [{"group_id": "group-3"}],
-            "total": 3,
-            "offset": 2,
+            "actor_id": "bot-current",
+            "items": [{"group_id": "group-4"}],
+            "total": 4,
+            "offset": 3,
             "limit": 2
         })))
         .expect(1)
@@ -362,6 +286,8 @@ async fn list_groups_all_collects_every_batch() {
         .cmd()
         .arg("list-groups")
         .arg("--all")
+        .arg("--offset")
+        .arg("1")
         .arg("--batch-size")
         .arg("2")
         .output()
@@ -369,9 +295,10 @@ async fn list_groups_all_collects_every_batch() {
     assert_success(&output);
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["items"].as_array().unwrap().len(), 3);
+    assert_eq!(json["offset"], 1);
     assert_eq!(json["returned"], 3);
-    assert_eq!(json["total"], 3);
+    assert_eq!(json["total"], 4);
     assert_eq!(json["has_more"], false);
-    assert!(json.get("continuation").is_none());
+    assert!(json.get("next_offset").is_none());
     assert!(json.get("next_command").is_none());
 }


### PR DESCRIPTION
## Summary

- add `GET /groups/my` to list formal groups for the authenticated human or bot while preserving `GET /bots/{id}/groups`
- update `bcs-cli list-groups` to call `/groups/my` without requiring a local bot UUID
- replace the unreleased opaque continuation token with `--offset`, `next_offset`, and a readable `next_command`
- reject inconsistent zero-progress pages and empty or changing actor identities

## Why

Bots may not know their own UUID, so requiring it in the request path makes current-actor group discovery unnecessarily difficult. The server already has enough authentication context to resolve both bot and human callers.

## Impact

- authenticated bot tokens resolve to the bot actor
- authenticated human identities resolve to the human actor
- `/groups/my` always excludes session-only memberships, even if `include_session_groups=true` is supplied
- anonymous `/groups/my` requests return `401`
- `--continue` and `--mine` are removed without compatibility handling because they have not been released
- `--offset` defaults to `0`, `--batch-size` defaults to `20`, and `--all` continues from the requested offset

## Checks

- `cargo test --package bcs-http --test groups_contract`
- `cargo test --package bcs-http --lib list_my_groups_query_tests::my_groups_forces_session_only_groups_off`
- `cargo test --package bcs-cli -- --test-threads=1`
- `cargo check --package bcs-http --all-targets`
- `cargo check --package bcs-cli --all-targets`
- `git diff --check`

Singlebox coverage was not run locally.
