### PR TITLE
fix(bcs): emit schema-compliant GenAI telemetry

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "bcs-services-container",
  "bcs-session",
  "bcs-session-store",
+ "bcs-telemetry",
  "bcs-test-support",
  "bcs-user-directory-api",
  "futures",
@@ -1328,6 +1329,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs-telemetry"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "bcs-test-support"
 version = "0.1.0"
 dependencies = [
@@ -1378,6 +1386,7 @@ dependencies = [
  "bcs-route-security",
  "bcs-service-api",
  "bcs-session",
+ "bcs-telemetry",
  "bcs-test-support",
  "chrono",
  "futures",

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -76,6 +76,7 @@ members = [
     "crates/tools/bcs-admin",
     "crates/tools/bcs-cli",
     # auxiliary
+    "crates/auxiliary/bcs-telemetry",
     "crates/auxiliary/ding-logger",
     # test-support
     "crates/test-support/bcs-test-support",
@@ -226,6 +227,7 @@ bcs-friend-store = { path = "crates/services/bcs-friend-store" }
 bcs-relation   = { path = "crates/services/bcs-relation" }
 bcs-relation-store = { path = "crates/services/bcs-relation-store" }
 bcs-secret         = { path = "crates/services/bcs-secret" }
+bcs-telemetry      = { path = "crates/auxiliary/bcs-telemetry" }
 ding-logger    = { path = "crates/auxiliary/ding-logger" }
 bcs-service-api  = { path = "crates/service-api/bcs-service-api" }
 bcs-services-container = { path = "crates/service-api/bcs-services-container" }

--- a/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
+++ b/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
@@ -22,6 +22,7 @@ bcs-auth-api    = { workspace = true }
 bcs-jwt         = { workspace = true }
 bcs-services-container = { workspace = true }
 bcs-protocol    = { workspace = true }
+bcs-telemetry   = { workspace = true }
 axum            = { workspace = true }
 async-trait     = { workspace = true }
 base64          = { workspace = true }

--- a/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/gateway_trace.rs
@@ -1,4 +1,7 @@
 use axum::http::HeaderMap;
+use bcs_telemetry::{
+    CapturedGenAiMessages, capture_gen_ai_input_messages, capture_gen_ai_output_messages,
+};
 use opentelemetry::{KeyValue, global};
 use opentelemetry::trace::{Status, TraceContextExt};
 use opentelemetry_http::HeaderExtractor;
@@ -198,14 +201,52 @@ pub(crate) fn record_span_content_event(event_name: &'static str, content: &str)
     );
 }
 
-pub(crate) fn record_span_content_attributes(
-    content_attribute_name: &'static str,
+pub(crate) fn record_gen_ai_input_message(content: &str, untrusted: bool) {
+    let captured = capture_gen_ai_input_messages(content, SPAN_CONTENT_LIMIT_BYTES);
+    record_gen_ai_messages("gen_ai.input.messages", captured, untrusted);
+}
+
+pub(crate) fn record_gen_ai_output_message(
+    content: &str,
+    finish_reason: &str,
+    untrusted: bool,
+) {
+    let captured =
+        capture_gen_ai_output_messages(content, finish_reason, SPAN_CONTENT_LIMIT_BYTES);
+    record_gen_ai_messages("gen_ai.output.messages", captured, untrusted);
+}
+
+pub(crate) fn record_span_content_attribute(
+    attribute_name: &'static str,
     content: &str,
     untrusted: bool,
 ) {
     let captured = truncate_span_content(content, SPAN_CONTENT_LIMIT_BYTES);
     let span = Span::current();
-    span.set_attribute(content_attribute_name, captured.content);
+    span.set_attribute(attribute_name, captured.content);
+    span.set_attribute(
+        "bcn.content.original_size_bytes",
+        captured.original_size_bytes as i64,
+    );
+    span.set_attribute(
+        "bcn.content.captured_size_bytes",
+        captured.captured_size_bytes as i64,
+    );
+    span.set_attribute(
+        "bcn.content.limit_bytes",
+        SPAN_CONTENT_LIMIT_BYTES as i64,
+    );
+    span.set_attribute("bcn.content.truncated", captured.truncated);
+    span.set_attribute("bcn.content.untrusted", untrusted);
+}
+
+fn record_gen_ai_messages(
+    attribute_name: &'static str,
+    captured: CapturedGenAiMessages,
+    untrusted: bool,
+) {
+    let span = Span::current();
+    span.set_attribute(attribute_name, captured.value);
     span.set_attribute(
         "bcn.content.original_size_bytes",
         captured.original_size_bytes as i64,
@@ -449,11 +490,7 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             let span = info_span!(target: "bcn_otel", "bcn.gateway.dispatch");
             let _guard = span.enter();
-            record_span_content_attributes(
-                "gen_ai.input.messages",
-                &"x".repeat(5000),
-                false,
-            );
+            record_gen_ai_input_message(&"x".repeat(5000), false);
         });
 
         provider.force_flush().unwrap();
@@ -490,7 +527,7 @@ mod tests {
         assert!(captured_size <= 4096);
         assert!(spans[0].attributes.iter().any(|attribute| {
             attribute.key.as_str() == "bcn.content.captured_size_bytes"
-                && attribute.value == opentelemetry::Value::I64(captured_size as i64)
+                && matches!(attribute.value, opentelemetry::Value::I64(size) if size < 4096)
         }));
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
@@ -16,7 +16,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::chat_digest::{ChatDigestRecord, log_chat_digest};
 use crate::gateway_trace::{
-    chat_client_observation, record_span_content_attributes, record_span_content_event,
+    chat_client_observation, record_gen_ai_input_message, record_span_content_event,
 };
 use crate::state::HttpAppState;
 
@@ -300,7 +300,7 @@ pub async fn bot_chat_async(
         Ok(from_bot_id) => from_bot_id,
         Err(err) => {
             Span::current().set_attribute("bcn.auth.result", "failed");
-            record_span_content_attributes("gen_ai.input.messages", &req.message, true);
+            record_gen_ai_input_message(&req.message, true);
             log_bot_chat_digest(ChatDigestArgs {
                 endpoint: "bot_chat_async",
                 from_bot_id: None,
@@ -402,11 +402,7 @@ pub async fn bot_chat_async(
                 ServiceError::Unauthorized(_) | ServiceError::Forbidden(_)
             ) {
                 Span::current().set_attribute("bcn.auth.result", "failed");
-                record_span_content_attributes(
-                    "gen_ai.input.messages",
-                    &trace_request.message,
-                    true,
-                );
+                record_gen_ai_input_message(&trace_request.message, true);
             } else {
                 record_authenticated_async_chat_trace(
                     &bot_uuid,
@@ -523,11 +519,7 @@ fn record_chat_dispatch_trace(
         span.set_attribute("bcn.client.wait_timeout_ms", wait_timeout_ms as i64);
     }
     if let Some(untrusted) = content_untrusted {
-        record_span_content_attributes(
-            "gen_ai.input.messages",
-            &request.message,
-            untrusted,
-        );
+        record_gen_ai_input_message(&request.message, untrusted);
     } else {
         record_span_content_event("bcn.chat.message", &request.message);
     }

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_events.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 use tracing::{Span, info, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::gateway_trace::record_span_content_attributes;
+use crate::gateway_trace::{record_gen_ai_output_message, record_span_content_attribute};
 use crate::state::HttpAppState;
 
 const BOT_EVENT_REQUEST_BODY_LIMIT: usize = 2 * 1024 * 1024;
@@ -207,15 +207,15 @@ pub async fn post_bot_event(
     headers: HeaderMap,
     LoggedBotEventRequest(req): LoggedBotEventRequest,
 ) -> Result<Json<Value>, BotEventRouteError> {
-    let callback_content = serde_json::to_string(&json!({
-        "message": &req.message.text,
-        "payload": &req.payload,
-    }))
-    .expect("serializing JSON callback content cannot fail");
+    let callback_content = bot_event_trace_content(&req);
+    let requested_finish_reason = requested_finish_reason(&req);
     let provider_id = match header_required(&headers, BCN_PROVIDER_ID_HEADER) {
         Ok(provider_id) => provider_id,
         Err(error) => {
-            record_bot_response_auth_failure(&callback_content);
+            record_bot_response_auth_failure(
+                &callback_content,
+                requested_finish_reason,
+            );
             return Err(error);
         }
     };
@@ -243,11 +243,7 @@ pub async fn post_bot_event(
         ChatEventState::Delta
     } else {
         Span::current().set_attribute("bcn.auth.result", "unverified");
-        record_span_content_attributes(
-            "gen_ai.output.messages",
-            &callback_content,
-            true,
-        );
+        record_gen_ai_output_message(&callback_content, "unknown", true);
         return Err(BotEventRouteError::bad_request(
             "state is required when event/payload are absent (1.0 contract)",
         ));
@@ -265,7 +261,10 @@ pub async fn post_bot_event(
     let credential = match credential_from_headers(&state, &headers, &provider_id).await {
         Ok(credential) => credential,
         Err(error) => {
-            record_bot_response_auth_failure(&callback_content);
+            record_bot_response_auth_failure(
+                &callback_content,
+                finish_reason(&effective_state),
+            );
             return Err(error);
         }
     };
@@ -293,7 +292,10 @@ pub async fn post_bot_event(
             );
             let route_error = bot_event_error(error);
             if matches!(route_error.status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
-                record_bot_response_auth_failure(&callback_content);
+                record_bot_response_auth_failure(
+                    &callback_content,
+                    finish_reason(&effective_state),
+                );
             }
             return Err(route_error);
         }
@@ -321,7 +323,11 @@ pub async fn post_bot_event(
         outcome.delivered_count as i64,
     );
     span.set_attribute("bcn.callback.failed_count", outcome.failed_count as i64);
-    record_span_content_attributes("gen_ai.output.messages", &callback_content, false);
+    record_bot_response_content(
+        &callback_content,
+        finish_reason(&effective_state),
+        false,
+    );
 
     Ok(Json(json!({
         "ok": true,
@@ -373,9 +379,79 @@ pub async fn post_coordination_event(
     })))
 }
 
-fn record_bot_response_auth_failure(callback_content: &str) {
+fn record_bot_response_auth_failure(
+    callback_content: &str,
+    finish_reason: Option<&str>,
+) {
     Span::current().set_attribute("bcn.auth.result", "failed");
-    record_span_content_attributes("gen_ai.output.messages", callback_content, true);
+    record_bot_response_content(callback_content, finish_reason, true);
+}
+
+fn record_bot_response_content(
+    content: &str,
+    finish_reason: Option<&str>,
+    untrusted: bool,
+) {
+    if let Some(finish_reason) = finish_reason {
+        record_gen_ai_output_message(content, finish_reason, untrusted);
+    } else {
+        record_span_content_attribute("bcn.bot.response.chunk", content, untrusted);
+    }
+}
+
+fn finish_reason(state: &ChatEventState) -> Option<&'static str> {
+    match state {
+        ChatEventState::Final => Some("stop"),
+        ChatEventState::Error => Some("error"),
+        ChatEventState::Aborted => Some("aborted"),
+        ChatEventState::Delta
+        | ChatEventState::ToolCallStart
+        | ChatEventState::ToolCallEnd => None,
+    }
+}
+
+fn requested_finish_reason(req: &BotEventRequest) -> Option<&'static str> {
+    if let Some(state) = req.state.as_ref() {
+        return finish_reason(state);
+    }
+    match req
+        .payload
+        .as_ref()
+        .and_then(|payload| payload.get("state"))
+        .and_then(Value::as_str)
+    {
+        Some("final") => Some("stop"),
+        Some("error") => Some("error"),
+        Some("aborted") => Some("aborted"),
+        Some("delta") => None,
+        _ if req.event.is_some() => None,
+        _ => Some("unknown"),
+    }
+}
+
+fn bot_event_trace_content(req: &BotEventRequest) -> String {
+    if !req.message.text.is_empty() {
+        return req.message.text.clone();
+    }
+    let Some(payload) = req.payload.as_ref() else {
+        return String::new();
+    };
+    if let Some(content) = payload.pointer("/message/content").and_then(Value::as_str) {
+        return content.to_string();
+    }
+    let content = payload
+        .pointer("/message/content")
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .collect::<String>()
+        });
+    match content {
+        Some(content) if !content.is_empty() => content,
+        _ => payload.to_string(),
+    }
 }
 
 fn header_required(headers: &HeaderMap, name: &'static str) -> Result<String, BotEventRouteError> {
@@ -456,5 +532,35 @@ fn bot_event_error(error: ProviderBotEventError) -> BotEventRouteError {
         ProviderBotEventError::Internal(message) => {
             BotEventRouteError::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_content_preserves_agent_payload_when_message_text_is_absent() {
+        let request = BotEventRequest {
+            run_id: "run-1".to_string(),
+            seq: Some(1),
+            state: None,
+            message: BotEventMessage::default(),
+            event: Some("agent".to_string()),
+            payload: Some(json!({
+                "type": "tool_result",
+                "tool_name": "search",
+                "result": "found"
+            })),
+        };
+
+        let content = bot_event_trace_content(&request);
+        let Ok(payload): Result<Value, _> = serde_json::from_str(&content) else {
+            panic!("expected preserved payload JSON");
+        };
+
+        assert_eq!(payload["type"], "tool_result");
+        assert_eq!(payload["tool_name"], "search");
+        assert_eq!(payload["result"], "found");
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
@@ -669,7 +669,7 @@ async fn bot_chat_async_marks_unauthorized_content_untrusted_without_business_at
     assert_span_string_attribute(span, "http.route", "/bots/{id}/chat-async");
     assert!(span.events.events.is_empty());
     assert_span_bool_attribute(span, "bcn.content.untrusted", true);
-    assert_span_attribute_contains(span, "gen_ai.input.messages", message);
+    assert_gen_ai_input_message(span, message);
 }
 
 #[tokio::test]
@@ -704,7 +704,7 @@ async fn bot_chat_async_marks_authenticated_content_trusted() {
     assert_span_string_attribute(span, "bcn.target.bot_id", "target-bot");
     assert!(span.events.events.is_empty());
     assert_span_bool_attribute(span, "bcn.content.untrusted", false);
-    assert_span_attribute_contains(span, "gen_ai.input.messages", "trusted-content");
+    assert_gen_ai_input_message(span, "trusted-content");
 }
 
 #[tokio::test]
@@ -744,11 +744,7 @@ async fn bot_chat_async_marks_service_authorization_failure_untrusted() {
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
     assert!(span.events.events.is_empty());
     assert_span_bool_attribute(span, "bcn.content.untrusted", true);
-    assert_span_attribute_contains(
-        span,
-        "gen_ai.input.messages",
-        "authorization-failure-content",
-    );
+    assert_gen_ai_input_message(span, "authorization-failure-content");
 }
 
 #[tokio::test]
@@ -788,7 +784,7 @@ async fn bot_chat_async_marks_service_forbidden_failure_untrusted() {
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
     assert!(span.events.events.is_empty());
     assert_span_bool_attribute(span, "bcn.content.untrusted", true);
-    assert_span_attribute_contains(span, "gen_ai.input.messages", "forbidden-content");
+    assert_gen_ai_input_message(span, "forbidden-content");
 }
 
 #[tokio::test]
@@ -825,7 +821,7 @@ async fn bot_chat_async_records_trusted_content_after_auth_when_session_is_inval
     assert_span_string_attribute(span, "bcn.auth.result", "success");
     assert!(span.events.events.is_empty());
     assert_span_bool_attribute(span, "bcn.content.untrusted", false);
-    assert_span_attribute_contains(span, "gen_ai.input.messages", "invalid-session-content");
+    assert_gen_ai_input_message(span, "invalid-session-content");
 }
 
 async fn capture_otel_spans<F, T>(future: F) -> (T, Vec<opentelemetry_sdk::trace::SpanData>)
@@ -870,15 +866,25 @@ fn assert_span_bool_attribute(
     }));
 }
 
-fn assert_span_attribute_contains(
-    span: &opentelemetry_sdk::trace::SpanData,
-    key: &str,
-    expected: &str,
-) {
-    assert!(span.attributes.iter().any(|attr| {
-        attr.key.as_str() == key
-            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains(expected))
-    }));
+fn assert_gen_ai_input_message(span: &opentelemetry_sdk::trace::SpanData, expected: &str) {
+    let value = span
+        .attributes
+        .iter()
+        .find_map(|attr| match &attr.value {
+            opentelemetry::Value::String(value)
+                if attr.key.as_str() == "gen_ai.input.messages" =>
+            {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .expect("gen_ai.input.messages string attribute");
+    let messages: Value = serde_json::from_str(value).expect("schema-compliant input messages JSON");
+    assert_eq!(messages.as_array().map(Vec::len), Some(1));
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[0]["parts"].as_array().map(Vec::len), Some(1));
+    assert_eq!(messages[0]["parts"][0]["type"], "text");
+    assert_eq!(messages[0]["parts"][0]["content"], expected);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
@@ -131,15 +131,30 @@ fn assert_otel_span_bool_attribute(
     }));
 }
 
-fn assert_otel_span_attribute_contains(
+fn assert_gen_ai_output_message(
     span: &opentelemetry_sdk::trace::SpanData,
-    key: &str,
-    expected: &str,
+    expected_content: &str,
+    expected_finish_reason: &str,
 ) {
-    assert!(span.attributes.iter().any(|attr| {
-        attr.key.as_str() == key
-            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains(expected))
-    }));
+    let value = span
+        .attributes
+        .iter()
+        .find_map(|attr| match &attr.value {
+            opentelemetry::Value::String(value)
+                if attr.key.as_str() == "gen_ai.output.messages" =>
+            {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .expect("gen_ai.output.messages string attribute");
+    let messages: Value = serde_json::from_str(value).expect("schema-compliant output messages JSON");
+    assert_eq!(messages.as_array().map(Vec::len), Some(1));
+    assert_eq!(messages[0]["role"], "assistant");
+    assert_eq!(messages[0]["parts"].as_array().map(Vec::len), Some(1));
+    assert_eq!(messages[0]["parts"][0]["type"], "text");
+    assert_eq!(messages[0]["parts"][0]["content"], expected_content);
+    assert_eq!(messages[0]["finish_reason"], expected_finish_reason);
 }
 
 struct TestApp {
@@ -2084,11 +2099,7 @@ async fn bot_events_marks_auth_failure_content_untrusted_without_business_attrib
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.run.id"));
     assert!(span.events.events.is_empty());
     assert_otel_span_bool_attribute(span, "bcn.content.untrusted", true);
-    assert_otel_span_attribute_contains(
-        span,
-        "gen_ai.output.messages",
-        "untrusted-callback-content",
-    );
+    assert_gen_ai_output_message(span, "untrusted-callback-content", "stop");
 }
 
 #[tokio::test]
@@ -2158,11 +2169,7 @@ async fn bot_events_marks_success_content_trusted_with_business_attributes() {
     assert_otel_span_string_attribute(span, "bcn.run.id", "run-trusted");
     assert!(span.events.events.is_empty());
     assert_otel_span_bool_attribute(span, "bcn.content.untrusted", false);
-    assert_otel_span_attribute_contains(
-        span,
-        "gen_ai.output.messages",
-        "trusted-callback-content",
-    );
+    assert_gen_ai_output_message(span, "trusted-callback-content", "stop");
 }
 
 #[tokio::test]
@@ -2204,11 +2211,7 @@ async fn bot_events_records_untrusted_content_when_auth_cannot_follow_invalid_sh
     assert!(!span.attributes.iter().any(|attr| attr.key.as_str() == "bcn.provider.id"));
     assert!(span.events.events.is_empty());
     assert_otel_span_bool_attribute(span, "bcn.content.untrusted", true);
-    assert_otel_span_attribute_contains(
-        span,
-        "gen_ai.output.messages",
-        "invalid-shape-content",
-    );
+    assert_gen_ai_output_message(span, "invalid-shape-content", "unknown");
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/ws/bcs-ws/Cargo.toml
+++ b/src/bcs/crates/adapters/ws/bcs-ws/Cargo.toml
@@ -29,6 +29,7 @@ chrono      = { workspace = true }
 bcs-domain      = { workspace = true }
 bcs-service-api = { workspace = true }
 bcs-protocol    = { workspace = true }
+bcs-telemetry   = { workspace = true }
 bcs-callback    = { workspace = true }
 bcs-route-security = { workspace = true }
 

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
@@ -960,12 +960,41 @@ fn record_ws_bot_response_trace(
     span.set_attribute("bcn.bot.id", bot_id.to_string());
     span.set_attribute("bcn.run.id", run_id.to_string());
     span.set_attribute("bcn.callback.state", format!("{event_state:?}"));
-    let content = serde_json::to_string(event_payload)
-        .expect("serializing parsed WebSocket bot event payload cannot fail");
-    let (captured, truncated) = truncate_bot_response_content(&content);
-    span.set_attribute("gen_ai.output.messages", captured.clone());
-    span.set_attribute("bcn.content.original_size_bytes", content.len() as i64);
-    span.set_attribute("bcn.content.captured_size_bytes", captured.len() as i64);
+    let content = bot_response_text(event_payload);
+    let (attribute_name, captured, original_size_bytes, captured_size_bytes, truncated) =
+        if let Some(finish_reason) = bot_response_finish_reason(event_state) {
+            let captured = bcs_telemetry::capture_gen_ai_output_messages(
+                &content,
+                finish_reason,
+                BOT_RESPONSE_CONTENT_LIMIT_BYTES,
+            );
+            (
+                "gen_ai.output.messages",
+                captured.value,
+                captured.original_size_bytes,
+                captured.captured_size_bytes,
+                captured.truncated,
+            )
+        } else {
+            let (captured, truncated) = truncate_bot_response_content(&content);
+            let captured_size_bytes = captured.len();
+            (
+                "bcn.bot.response.chunk",
+                captured,
+                content.len(),
+                captured_size_bytes,
+                truncated,
+            )
+        };
+    span.set_attribute(attribute_name, captured);
+    span.set_attribute(
+        "bcn.content.original_size_bytes",
+        original_size_bytes as i64,
+    );
+    span.set_attribute(
+        "bcn.content.captured_size_bytes",
+        captured_size_bytes as i64,
+    );
     span.set_attribute(
         "bcn.content.limit_bytes",
         BOT_RESPONSE_CONTENT_LIMIT_BYTES as i64,
@@ -976,11 +1005,44 @@ fn record_ws_bot_response_trace(
         bot_id = %bot_id,
         run_id = %run_id,
         response_state = ?event_state,
-        content_original_size_bytes = content.len(),
-        content_captured_size_bytes = captured.len(),
+        content_original_size_bytes = original_size_bytes,
+        content_captured_size_bytes = captured_size_bytes,
         content_truncated = truncated,
         "Bot response trace attributes recorded"
     );
+}
+
+fn bot_response_finish_reason(event_state: &ChatEventState) -> Option<&'static str> {
+    match event_state {
+        ChatEventState::Final => Some("stop"),
+        ChatEventState::Error => Some("error"),
+        ChatEventState::Aborted => Some("aborted"),
+        ChatEventState::Delta
+        | ChatEventState::ToolCallStart
+        | ChatEventState::ToolCallEnd => None,
+    }
+}
+
+fn bot_response_text(event_payload: &Value) -> String {
+    if let Some(content) = event_payload
+        .pointer("/message/content")
+        .and_then(Value::as_str)
+    {
+        return content.to_string();
+    }
+    let content = event_payload
+        .pointer("/message/content")
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .collect::<String>()
+        });
+    match content {
+        Some(content) if !content.is_empty() => content,
+        _ => event_payload.to_string(),
+    }
 }
 
 fn truncate_bot_response_content(content: &str) -> (String, bool) {
@@ -1949,6 +2011,9 @@ async fn handle_task_complete(
 mod tests {
     use bcs_protocol::RouteSelectorWire;
     use bcs_service_api::{Group, Participant, ParticipantRole};
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider, SpanData};
+    use tracing_subscriber::prelude::*;
 
     use super::*;
 
@@ -1998,6 +2063,116 @@ mod tests {
         assert!(captured.contains(TRUNCATION_MARKER));
         assert!(captured.len() <= BOT_RESPONSE_CONTENT_LIMIT_BYTES);
         assert!(std::str::from_utf8(captured.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn terminal_bot_response_records_schema_compliant_output_messages() {
+        let span = capture_bot_response_span(
+            ChatEventState::Final,
+            serde_json::json!({
+                "state": "final",
+                "message": {
+                    "content": [{ "type": "text", "text": "bot \"answer\"" }]
+                }
+            }),
+        );
+
+        let Some(value) = span
+            .attributes
+            .iter()
+            .find_map(|attribute| match &attribute.value {
+                opentelemetry::Value::String(value)
+                    if attribute.key.as_str() == "gen_ai.output.messages" =>
+                {
+                    Some(value.as_str())
+                }
+                _ => None,
+            })
+        else {
+            panic!("expected gen_ai.output.messages string attribute");
+        };
+        let Ok(messages): std::result::Result<Value, _> = serde_json::from_str(value) else {
+            panic!("expected schema-compliant output messages JSON");
+        };
+        assert_eq!(messages.as_array().map(Vec::len), Some(1));
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["parts"].as_array().map(Vec::len), Some(1));
+        assert_eq!(messages[0]["parts"][0]["type"], "text");
+        assert_eq!(messages[0]["parts"][0]["content"], "bot \"answer\"");
+        assert_eq!(messages[0]["finish_reason"], "stop");
+    }
+
+    #[test]
+    fn delta_bot_response_records_bcn_chunk_instead_of_complete_output() {
+        let span = capture_bot_response_span(
+            ChatEventState::Delta,
+            serde_json::json!({
+                "state": "delta",
+                "message": {
+                    "content": [{ "type": "text", "text": "partial response" }]
+                }
+            }),
+        );
+
+        assert!(span.attributes.iter().all(|attribute| {
+            attribute.key.as_str() != "gen_ai.output.messages"
+        }));
+        assert!(span.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "bcn.bot.response.chunk"
+                && matches!(&attribute.value, opentelemetry::Value::String(value) if value.as_str() == "partial response")
+        }));
+    }
+
+    #[test]
+    fn terminal_bot_response_preserves_non_text_payload_as_text_content() {
+        let payload = serde_json::json!({
+            "state": "final",
+            "message": {
+                "content": [{ "type": "image", "url": "https://example.invalid/image.png" }]
+            }
+        });
+        let span = capture_bot_response_span(ChatEventState::Final, payload.clone());
+
+        let Some(value) = span
+            .attributes
+            .iter()
+            .find_map(|attribute| match &attribute.value {
+                opentelemetry::Value::String(value)
+                    if attribute.key.as_str() == "gen_ai.output.messages" =>
+                {
+                    Some(value.as_str())
+                }
+                _ => None,
+            })
+        else {
+            panic!("expected gen_ai.output.messages string attribute");
+        };
+        let Ok(messages): std::result::Result<Value, _> = serde_json::from_str(value) else {
+            panic!("expected schema-compliant output messages JSON");
+        };
+        assert_eq!(messages[0]["parts"][0]["content"], payload.to_string());
+    }
+
+    fn capture_bot_response_span(event_state: ChatEventState, event_payload: Value) -> SpanData {
+        let exporter = InMemorySpanExporterBuilder::new().build();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("bcn-ws-response-test");
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(target: "bcn_otel", "bcn.bot.response");
+            let _guard = span.enter();
+            record_ws_bot_response_trace("bot-1", "run-1", &event_state, &event_payload);
+        });
+
+        assert!(provider.force_flush().is_ok());
+        let Ok(mut spans) = exporter.get_finished_spans() else {
+            panic!("expected exported bot response span");
+        };
+        spans.remove(0)
     }
 
     #[test]

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/frame_compat.rs
@@ -1430,9 +1430,12 @@ async fn traced_chat_event_creates_bot_response_child_span_after_message_flow_ac
         attr.key.as_str() == "bcn.content.untrusted"
             && attr.value == opentelemetry::Value::Bool(false)
     }));
+    assert!(span.attributes.iter().all(|attr| {
+        attr.key.as_str() != "gen_ai.output.messages"
+    }));
     assert!(span.attributes.iter().any(|attr| {
-        attr.key.as_str() == "gen_ai.output.messages"
-            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains("ws-response-content"))
+        attr.key.as_str() == "bcn.bot.response.chunk"
+            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str() == "ws-response-content")
     }));
 }
 
@@ -1504,10 +1507,7 @@ async fn traced_plugin_run_alias_creates_bot_response_child_span() {
     assert_eq!(span.span_context.trace_id().to_string(), "0af7651916cd43dd8448eb211c80319c");
     assert_eq!(span.parent_span_id.to_string(), "b7ad6b7169203331");
     assert!(span.events.events.is_empty());
-    assert!(span.attributes.iter().any(|attr| {
-        attr.key.as_str() == "gen_ai.output.messages"
-            && matches!(&attr.value, opentelemetry::Value::String(value) if value.as_str().contains("plugin-ws-response"))
-    }));
+    assert_gen_ai_output_message(span, "plugin-ws-response", "stop");
 }
 
 #[tokio::test]
@@ -1562,6 +1562,36 @@ where
     let output = future.with_subscriber(subscriber).await;
     provider.force_flush().unwrap();
     (output, exporter.get_finished_spans().unwrap())
+}
+
+fn assert_gen_ai_output_message(
+    span: &opentelemetry_sdk::trace::SpanData,
+    expected_content: &str,
+    expected_finish_reason: &str,
+) {
+    let Some(value) = span
+        .attributes
+        .iter()
+        .find_map(|attribute| match &attribute.value {
+            opentelemetry::Value::String(value)
+                if attribute.key.as_str() == "gen_ai.output.messages" =>
+            {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+    else {
+        panic!("expected gen_ai.output.messages string attribute");
+    };
+    let Ok(messages): Result<serde_json::Value, _> = serde_json::from_str(value) else {
+        panic!("expected schema-compliant output messages JSON");
+    };
+    assert_eq!(messages.as_array().map(Vec::len), Some(1));
+    assert_eq!(messages[0]["role"], "assistant");
+    assert_eq!(messages[0]["parts"].as_array().map(Vec::len), Some(1));
+    assert_eq!(messages[0]["parts"][0]["type"], "text");
+    assert_eq!(messages[0]["parts"][0]["content"], expected_content);
+    assert_eq!(messages[0]["finish_reason"], expected_finish_reason);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/auxiliary/bcs-telemetry/Cargo.toml
+++ b/src/bcs/crates/auxiliary/bcs-telemetry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name        = "bcs-telemetry"
+description = "OpenTelemetry semantic attribute helpers for BCS adapters"
+edition     = { workspace = true }
+license     = { workspace = true }
+repository  = { workspace = true }
+rust-version = { workspace = true }
+version     = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+serde_json = { workspace = true }

--- a/src/bcs/crates/auxiliary/bcs-telemetry/src/lib.rs
+++ b/src/bcs/crates/auxiliary/bcs-telemetry/src/lib.rs
@@ -1,0 +1,134 @@
+//! Pure OpenTelemetry semantic attribute encoders shared by delivery adapters.
+//!
+//! This crate owns no tracing pipeline or BCS business behavior. It only converts
+//! adapter-provided text into bounded, schema-compliant GenAI message JSON.
+
+use serde_json::{Value, json};
+
+const TRUNCATION_MARKER: &str = "...[TRUNCATED]...";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapturedGenAiMessages {
+    /// JSON string stored in the GenAI span attribute.
+    pub value: String,
+    /// Original unencoded text size.
+    pub original_size_bytes: usize,
+    /// Captured unencoded text size, including the truncation marker when present.
+    pub captured_size_bytes: usize,
+    /// Whether the text content was truncated before JSON serialization.
+    pub truncated: bool,
+}
+
+/// Encode one user text message using the `gen_ai.input.messages` schema.
+pub fn capture_gen_ai_input_messages(
+    content: &str,
+    limit_bytes: usize,
+) -> CapturedGenAiMessages {
+    capture_gen_ai_messages(content, None, limit_bytes)
+}
+
+/// Encode one assistant text message using the `gen_ai.output.messages` schema.
+pub fn capture_gen_ai_output_messages(
+    content: &str,
+    finish_reason: &str,
+    limit_bytes: usize,
+) -> CapturedGenAiMessages {
+    capture_gen_ai_messages(content, Some(finish_reason), limit_bytes)
+}
+
+fn capture_gen_ai_messages(
+    content: &str,
+    finish_reason: Option<&str>,
+    limit_bytes: usize,
+) -> CapturedGenAiMessages {
+    let original = serialize_messages(content, finish_reason);
+    if original.len() <= limit_bytes {
+        return CapturedGenAiMessages {
+            value: original,
+            original_size_bytes: content.len(),
+            captured_size_bytes: content.len(),
+            truncated: false,
+        };
+    }
+
+    let empty_size = serialize_messages("", finish_reason).len();
+    let content_budget = limit_bytes
+        .saturating_sub(empty_size)
+        .saturating_sub(TRUNCATION_MARKER.len());
+    let head_budget = content_budget.saturating_mul(3) / 4;
+    let head_end = take_head_within_json_budget(content, head_budget);
+    let head_size = escaped_json_len(&content[..head_end]);
+    let tail_budget = content_budget.saturating_sub(head_size);
+    let tail_start = take_tail_within_json_budget(content, head_end, tail_budget);
+    let captured_content = format!(
+        "{}{}{}",
+        &content[..head_end],
+        TRUNCATION_MARKER,
+        &content[tail_start..]
+    );
+    let value = serialize_messages(&captured_content, finish_reason);
+
+    CapturedGenAiMessages {
+        value,
+        original_size_bytes: content.len(),
+        captured_size_bytes: captured_content.len(),
+        truncated: true,
+    }
+}
+
+fn serialize_messages(content: &str, finish_reason: Option<&str>) -> String {
+    let mut message = json!({
+        "role": if finish_reason.is_some() { "assistant" } else { "user" },
+        "parts": [{
+            "type": "text",
+            "content": content,
+        }],
+    });
+    if let Some(finish_reason) = finish_reason {
+        message["finish_reason"] = Value::String(finish_reason.to_string());
+    }
+    Value::Array(vec![message]).to_string()
+}
+
+fn take_head_within_json_budget(content: &str, budget: usize) -> usize {
+    let mut size: usize = 0;
+    let mut end = 0;
+    for (index, character) in content.char_indices() {
+        let character_size = escaped_json_char_len(character);
+        if size.saturating_add(character_size) > budget {
+            break;
+        }
+        size += character_size;
+        end = index + character.len_utf8();
+    }
+    end
+}
+
+fn take_tail_within_json_budget(content: &str, head_end: usize, budget: usize) -> usize {
+    let mut size: usize = 0;
+    let mut start = content.len();
+    for (index, character) in content.char_indices().rev() {
+        if index < head_end {
+            break;
+        }
+        let character_size = escaped_json_char_len(character);
+        if size.saturating_add(character_size) > budget {
+            break;
+        }
+        size += character_size;
+        start = index;
+    }
+    start
+}
+
+fn escaped_json_len(content: &str) -> usize {
+    content.chars().map(escaped_json_char_len).sum()
+}
+
+fn escaped_json_char_len(character: char) -> usize {
+    match character {
+        '\"' | '\\' | '\u{0008}' | '\u{000c}' | '\n' | '\r' | '\t' => 2,
+        '\u{0000}'..='\u{001f}' => 6,
+        _ => character.len_utf8(),
+    }
+}

--- a/src/bcs/crates/auxiliary/bcs-telemetry/tests/gen_ai_messages.rs
+++ b/src/bcs/crates/auxiliary/bcs-telemetry/tests/gen_ai_messages.rs
@@ -1,0 +1,55 @@
+use bcs_telemetry::{capture_gen_ai_input_messages, capture_gen_ai_output_messages};
+use serde_json::Value;
+
+const LIMIT_BYTES: usize = 4096;
+
+#[test]
+fn input_messages_are_schema_compliant_json() {
+    let captured = capture_gen_ai_input_messages("你好 \"BCN\"", LIMIT_BYTES);
+
+    let Ok(messages): Result<Value, _> = serde_json::from_str(&captured.value) else {
+        panic!("input messages must be valid JSON");
+    };
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[0]["parts"][0]["type"], "text");
+    assert_eq!(messages[0]["parts"][0]["content"], "你好 \"BCN\"");
+    assert_eq!(messages.as_array().map(Vec::len), Some(1));
+    assert!(!captured.truncated);
+}
+
+#[test]
+fn output_messages_are_schema_compliant_json() {
+    let captured = capture_gen_ai_output_messages("response text", "stop", LIMIT_BYTES);
+
+    let Ok(messages): Result<Value, _> = serde_json::from_str(&captured.value) else {
+        panic!("output messages must be valid JSON");
+    };
+    assert_eq!(messages[0]["role"], "assistant");
+    assert_eq!(messages[0]["parts"][0]["type"], "text");
+    assert_eq!(messages[0]["parts"][0]["content"], "response text");
+    assert_eq!(messages[0]["finish_reason"], "stop");
+    assert_eq!(messages.as_array().map(Vec::len), Some(1));
+    assert!(!captured.truncated);
+}
+
+#[test]
+fn truncation_preserves_valid_json_and_truncates_only_content() {
+    let content = format!("START{}\\\"\nEND", "你".repeat(3000));
+
+    let captured = capture_gen_ai_output_messages(&content, "error", LIMIT_BYTES);
+
+    assert!(captured.truncated);
+    assert!(captured.value.len() <= LIMIT_BYTES);
+    assert_eq!(captured.original_size_bytes, content.len());
+    let Ok(messages): Result<Value, _> = serde_json::from_str(&captured.value) else {
+        panic!("truncated output messages must be valid JSON");
+    };
+    let Some(text) = messages[0]["parts"][0]["content"].as_str() else {
+        panic!("output message must contain text content");
+    };
+    assert!(text.starts_with("START"));
+    assert!(text.ends_with("\\\"\nEND"));
+    assert!(text.contains("...[TRUNCATED]..."));
+    assert_eq!(messages[0]["finish_reason"], "error");
+    assert_eq!(captured.captured_size_bytes, text.len());
+}


### PR DESCRIPTION
## Summary

- encode `gen_ai.input.messages` and `gen_ai.output.messages` as schema-compliant JSON message arrays
- truncate individual text content fields before serialization so captured attributes remain valid JSON within the 4 KiB limit
- keep streaming response chunks in the BCN-namespaced `bcn.bot.response.chunk` attribute while recording terminal responses with standard finish reasons
- preserve callback and WebSocket payload content, including non-text payloads, and strengthen contract tests to parse and validate the exported schema

## Test strategy

- `cargo test -p bcs-telemetry -p bcs-http -p bcs-ws`
- validate input/output roles, text parts, finish reasons, UTF-8-safe truncation, JSON escaping, and the 4 KiB serialized limit
- cover authenticated and rejected HTTP requests, provider callbacks, WebSocket terminal responses, and streaming chunks
