### PR TITLE
fix: avoid reusing incomplete singlebox bot sessions

### DIFF
--- a/scripts/test_bcn_plugin_source.sh
+++ b/scripts/test_bcn_plugin_source.sh
@@ -226,6 +226,59 @@ test_stack_script_has_npm_branch() {
   assert_contains "$src" '[ "$BCN_PLUGIN_SOURCE" != "npm" ]'
 }
 
+test_session_bot_uuid_requires_usable_session() {
+  local tmp; tmp="$(mktemp -d)"
+  local funcs="${tmp}/stack-session-functions.sh"
+  local profile_root="${tmp}/profiles"
+  local session_file="${profile_root}/.openclaw-ceo/.bcs/session.json"
+
+  awk '
+    /^profile_dir_for\(\)/ {emit=1}
+    /^workspace_dir_for\(\)/ {emit=0}
+    emit {print}
+  ' "${PROJECT_ROOT}/src/bcs/scripts/start_bcs_bots.sh" > "$funcs"
+  mkdir -p "$(dirname "$session_file")"
+
+  cat > "$session_file" <<JSON
+{"bot_uuid":"default:545716","token":"saved-token","bcs_url":"ws://127.0.0.1:21000/ws/bot"}
+JSON
+  local bot_uuid
+  bot_uuid="$(
+    OPENCLAW_PROFILE_ROOT="$profile_root"
+    OPENCLAW_PROFILE_PREFIX=".openclaw-"
+    BCS_URL="ws://127.0.0.1:21000/ws/bot"
+    . "$funcs"
+    session_bot_uuid_for ceo
+  )"
+  assert_eq "$bot_uuid" "default:545716" "usable session should preserve bot identity"
+
+  cat > "$session_file" <<JSON
+{"bot_uuid":"default:545716","token":"","bcs_url":"ws://127.0.0.1:21000/ws/bot"}
+JSON
+  bot_uuid="$(
+    OPENCLAW_PROFILE_ROOT="$profile_root"
+    OPENCLAW_PROFILE_PREFIX=".openclaw-"
+    BCS_URL="ws://127.0.0.1:21000/ws/bot"
+    . "$funcs"
+    session_bot_uuid_for ceo
+  )"
+  assert_eq "$bot_uuid" "" "session without token must not pin bot identity"
+
+  cat > "$session_file" <<JSON
+{"bot_uuid":"default:545716","token":"saved-token","bcs_url":"ws://127.0.0.1:29999/ws/bot"}
+JSON
+  bot_uuid="$(
+    OPENCLAW_PROFILE_ROOT="$profile_root"
+    OPENCLAW_PROFILE_PREFIX=".openclaw-"
+    BCS_URL="ws://127.0.0.1:21000/ws/bot"
+    . "$funcs"
+    session_bot_uuid_for ceo
+  )"
+  assert_eq "$bot_uuid" "" "session for a different BCS URL must not pin bot identity"
+
+  rm -rf "$tmp"
+}
+
 test_stack_config_allows_plugin_path_refresh() {
   local tmp; tmp="$(mktemp -d)"
   local funcs="${tmp}/stack-match-functions.sh"
@@ -373,6 +426,7 @@ test_load_dir_source_mode
 test_load_dir_npm_mode
 test_stack_script_forwards_mode
 test_stack_script_has_npm_branch
+test_session_bot_uuid_requires_usable_session
 test_stack_config_allows_plugin_path_refresh
 test_dynamic_config_refreshes_plugin_path
 

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
@@ -482,6 +482,10 @@ export class BcsWsClient {
       }
       const content = fs.readFileSync(sessionPath, 'utf-8');
       const session = JSON.parse(content) as SessionInfo;
+      if (typeof session.token !== 'string' || !session.token.trim()) {
+        this._log?.warn?.('Ignoring saved BCS session without reconnect token');
+        return null;
+      }
       // Verify URL matches
       if (session.bcs_url !== this._account.bcsUrl) {
         this._log?.warn?.(

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { once } from 'node:events';
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import { createServer, type AddressInfo, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -236,6 +236,98 @@ describe('BcsWsClient security behavior', () => {
       await client.connect(null);
       assert.equal(bcs.connectParams?.bot_id, 'default:mock-user');
       assert.equal(bcs.connectParams?.token, undefined);
+    } finally {
+      await client.disconnect();
+      await bcs.close();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not reuse an incomplete saved session to pin bot identity', async () => {
+    const bcs = await startBcsStub();
+    const dataDir = await mkdtemp(join(tmpdir(), 'bcn-incomplete-session-'));
+    const logs: string[] = [];
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: `ws://127.0.0.1:${bcs.port}/ws/bot`,
+      botId: 'Bot 1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60_000,
+      reconnectIntervalMs: 5_000,
+      connectionTimeoutMs: 10_000,
+    };
+    await mkdir(join(dataDir, '.bcs'), { recursive: true });
+    await writeFile(
+      join(dataDir, '.bcs', 'session.json'),
+      JSON.stringify({
+        bot_uuid: 'default:545716',
+        token: '',
+        bcs_url: account.bcsUrl,
+      }),
+    );
+    const client = new BcsWsClient({
+      account,
+      dataDir,
+      log: {
+        info: () => undefined,
+        warn: (...args: unknown[]) => logs.push(args.join(' ')),
+        error: () => undefined,
+      },
+    });
+
+    try {
+      await client.connect(null);
+      assert.equal(bcs.connectParams?.bot_id, undefined);
+      assert.equal(bcs.connectParams?.token, undefined);
+      assert.equal(logs.some(line => line.includes('Ignoring saved BCS session without reconnect token')), true);
+    } finally {
+      await client.disconnect();
+      await bcs.close();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reconnects with a saved token when the bot identity is not assigned yet', async () => {
+    const bcs = await startBcsStub();
+    const dataDir = await mkdtemp(join(tmpdir(), 'bcn-pending-session-'));
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: `ws://127.0.0.1:${bcs.port}/ws/bot`,
+      botId: 'Bot 1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60_000,
+      reconnectIntervalMs: 5_000,
+      connectionTimeoutMs: 10_000,
+    };
+    await mkdir(join(dataDir, '.bcs'), { recursive: true });
+    await writeFile(
+      join(dataDir, '.bcs', 'session.json'),
+      JSON.stringify({
+        bot_uuid: null,
+        token: 'pending-token',
+        bcs_url: account.bcsUrl,
+      }),
+    );
+    const client = new BcsWsClient({ account, dataDir });
+
+    try {
+      await client.connect(null);
+      assert.equal(bcs.connectParams?.bot_id, undefined);
+      assert.equal(bcs.connectParams?.token, 'pending-token');
     } finally {
       await client.disconnect();
       await bcs.close();

--- a/src/bcs/scripts/start_bcs_bots.sh
+++ b/src/bcs/scripts/start_bcs_bots.sh
@@ -92,7 +92,14 @@ session_bot_uuid_for() {
     [ -f "$session_file" ] || return 0
     command -v jq >/dev/null 2>&1 || return 0
 
-    jq -r 'if (.bot_uuid | type) == "string" then .bot_uuid else empty end' "$session_file" 2>/dev/null | head -n 1
+    jq -r --arg bcs_url "$BCS_URL" '
+      if ((.bot_uuid | type) == "string")
+        and ((.bot_uuid | length) > 0)
+        and ((.token | type) == "string")
+        and ((.token | length) > 0)
+        and (.bcs_url == $bcs_url)
+      then .bot_uuid else empty end
+    ' "$session_file" 2>/dev/null | head -n 1
 }
 
 workspace_dir_for() {


### PR DESCRIPTION
## Summary

- Only reuse a persisted BCS bot identity in singlebox when the session has a non-empty token and matches the active BCS URL.
- Ignore persisted plugin sessions without a reconnect token, while preserving token-only sessions whose bot UUID is not assigned yet.
- Add regressions for incomplete and stale session files.

## Root cause

A stale or incomplete `.bcs/session.json` could supply only `bot_uuid`. The launcher wrote it as `channels.bcs.botId`, then every fresh bot attempted `bot.connect` with that same ID and no token, causing a BCS registration conflict.

## Validation

- `bash scripts/test_bcn_plugin_source.sh`
- BCN plugin lint, tests (52 passed), and build
- Real `bash scripts/ci/singlebox_coverage.sh`
  - Backend acceptance: 40 passed
  - BCS E2E: 454 passed, 0 failed
  - BCS coverage: line 42.76%, method 38.47%, router/CLI 100%
- CI artifact verification passed

> Note: the repository pre-push Rust nextest gate times out in existing WebSocket/human-regression integration tests under default parallel execution. The real singlebox coverage flow above passed; this PR does not modify Rust test code.