### PR TITLE
fix(bcs-cli): select compiled URL by runtime environment

### DIFF
--- a/src/bcs/crates/tools/bcs-cli/CONTEXT.md
+++ b/src/bcs/crates/tools/bcs-cli/CONTEXT.md
@@ -28,6 +28,13 @@
 ## Configuration
 
 - CLI args, optional config files, and tokens are read at tool entrypoints only.
+- BCS API URL precedence is `--url`, `BCS_API_BASE_URL`, `MOLTIS_BCS_URL`,
+  `$BOT_DATA_DIR/.bcs/session.json`, a runtime-selected compiled distribution
+  default, then the local default.
+- Distributions may compile both `BCS_CLI_DEFAULT_PRE_URL` and
+  `BCS_CLI_DEFAULT_PROD_URL` into one binary. The CLI selects pre for
+  `pre`/`prepub` and production for every other runtime environment. Public
+  builds omit both values and retain the local default.
 - This crate must not choose server-side concrete implementations.
 
 ## Runtime ownership

--- a/src/bcs/crates/tools/bcs-cli/build.rs
+++ b/src/bcs/crates/tools/bcs-cli/build.rs
@@ -4,6 +4,8 @@ fn main() {
     println!("cargo:rustc-env=GIT_COMMIT_HASH={hash}");
     println!("cargo:rustc-env=BUILD_DATE={date}");
     println!("cargo:rerun-if-changed=../../../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=BCS_CLI_DEFAULT_PRE_URL");
+    println!("cargo:rerun-if-env-changed=BCS_CLI_DEFAULT_PROD_URL");
 }
 
 fn git_commit_hash() -> String {

--- a/src/bcs/crates/tools/bcs-cli/src/lib.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/lib.rs
@@ -15,6 +15,9 @@ mod client;
 
 pub use client::{BcsClient, BotGroupListPage};
 
+const COMPILED_PRE_BCS_URL: Option<&str> = option_env!("BCS_CLI_DEFAULT_PRE_URL");
+const COMPILED_PROD_BCS_URL: Option<&str> = option_env!("BCS_CLI_DEFAULT_PROD_URL");
+
 /// Get current environment from `AGENTCLAW_ENV` or `env` variable.
 /// Priority: `AGENTCLAW_ENV` > `env` > `SERVER_ENV` chain > "dev" (default)
 pub fn get_current_env() -> String {
@@ -135,7 +138,51 @@ fn resolve_session_bcs_url() -> Result<Option<String>> {
     normalize_url_from_source(raw_url.to_string(), "$BOT_DATA_DIR/.bcs/session.json").map(Some)
 }
 
-fn resolve_bcs_url(args: &GlobalArgs) -> Result<String> {
+fn resolve_distribution_default_url_for_env(
+    runtime_env: &str,
+    pre_url: Option<&str>,
+    prod_url: Option<&str>,
+) -> Result<Option<String>> {
+    let (pre_url, prod_url) = match (pre_url, prod_url) {
+        (None, None) => return Ok(None),
+        (Some(pre_url), Some(prod_url)) => (pre_url, prod_url),
+        _ => {
+            return Err(anyhow!(
+                "BCS_CLI_DEFAULT_PRE_URL and BCS_CLI_DEFAULT_PROD_URL must both be configured"
+            ));
+        }
+    };
+
+    let is_pre = matches!(
+        runtime_env.to_ascii_lowercase().as_str(),
+        "pre" | "prepub"
+    );
+    let (url, source) = if is_pre {
+        (pre_url, "compiled default (pre-release)")
+    } else {
+        (prod_url, "compiled default (production)")
+    };
+
+    normalize_url_from_source(url.to_string(), source).map(Some)
+}
+
+/// Resolve the distribution-specific URL compiled into this CLI build.
+///
+/// Public builds omit both compile-time values and return `None`. Internal
+/// builds provide both values and select one using the runtime environment.
+pub fn resolve_compiled_distribution_default_url() -> Result<Option<String>> {
+    resolve_distribution_default_url_for_env(
+        &get_current_env(),
+        COMPILED_PRE_BCS_URL,
+        COMPILED_PROD_BCS_URL,
+    )
+}
+
+fn resolve_bcs_url_with_distribution_defaults(
+    args: &GlobalArgs,
+    pre_url: Option<&str>,
+    prod_url: Option<&str>,
+) -> Result<String> {
     if let Some(url) = args.url.as_ref() {
         return normalize_url_from_source(url.clone(), "--url");
     }
@@ -148,12 +195,26 @@ fn resolve_bcs_url(args: &GlobalArgs) -> Result<String> {
         return Ok(url);
     }
 
+    if let Some(url) =
+        resolve_distribution_default_url_for_env(&get_current_env(), pre_url, prod_url)?
+    {
+        return Ok(url);
+    }
+
     let default_url = "http://127.0.0.1:21000";
     info!(
         "No BCS URL configured, defaulting to local BCS: {}",
         default_url
     );
     normalize_url_from_source(default_url.to_string(), "default (local)")
+}
+
+fn resolve_bcs_url(args: &GlobalArgs) -> Result<String> {
+    resolve_bcs_url_with_distribution_defaults(
+        args,
+        COMPILED_PRE_BCS_URL,
+        COMPILED_PROD_BCS_URL,
+    )
 }
 
 /// Discover authentication token from various sources.
@@ -342,7 +403,7 @@ pub fn init(args: &GlobalArgs) -> Result<RuntimeConfig> {
     // Get current environment (defaults to "dev")
     let env = get_current_env();
 
-    // Determine BCS URL: CLI arg > env var > session.json > default
+    // Determine BCS URL: CLI arg > env var > session.json > compiled default > local
     let bcs_url = resolve_bcs_url(args)?;
 
     // Determine cookie: CLI arg > env var
@@ -471,6 +532,196 @@ mod tests {
     }
 
     #[test]
+    fn test_distribution_default_selects_pre_for_pre_and_prepub() {
+        let pre_url = Some("https://pre.example.com/");
+        let prod_url = Some("https://prod.example.com/");
+
+        assert_eq!(
+            resolve_distribution_default_url_for_env("pre", pre_url, prod_url).unwrap(),
+            Some("https://pre.example.com".to_string())
+        );
+        assert_eq!(
+            resolve_distribution_default_url_for_env("PREPUB", pre_url, prod_url).unwrap(),
+            Some("https://pre.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_distribution_default_selects_prod_for_other_or_missing_env() {
+        let pre_url = Some("https://pre.example.com");
+        let prod_url = Some("https://prod.example.com");
+
+        for runtime_env in ["prod", "gray", "dev", "local", ""] {
+            assert_eq!(
+                resolve_distribution_default_url_for_env(runtime_env, pre_url, prod_url).unwrap(),
+                Some("https://prod.example.com".to_string())
+            );
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_runtime_environment_priority_matches_legacy_cli() {
+        let keys = [
+            "AGENTCLAW_ENV",
+            "env",
+            "SERVER_ENV",
+            "REAL_SERVER_ENV",
+            "ALIPAY_APP_ENV",
+        ];
+        let originals: Vec<_> = keys
+            .iter()
+            .map(|key| std::env::var(key).ok())
+            .collect();
+
+        safe_set_var("AGENTCLAW_ENV", "prod");
+        safe_set_var("env", "prepub");
+        safe_set_var("SERVER_ENV", "pre");
+        assert_eq!(get_current_env(), "prod");
+
+        safe_remove_var("AGENTCLAW_ENV");
+        assert_eq!(get_current_env(), "prepub");
+
+        safe_remove_var("env");
+        safe_set_var("SERVER_ENV", "prepub");
+        assert_eq!(get_current_env(), "pre");
+
+        for (key, original) in keys.into_iter().zip(originals) {
+            if let Some(value) = original {
+                safe_set_var(key, value);
+            } else {
+                safe_remove_var(key);
+            }
+        }
+    }
+
+    #[test]
+    fn test_distribution_default_is_absent_for_public_build() {
+        assert_eq!(
+            resolve_distribution_default_url_for_env("pre", None, None).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_distribution_default_rejects_partial_compiled_configuration() {
+        let pre_only = resolve_distribution_default_url_for_env(
+            "pre",
+            Some("https://pre.example.com"),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        let prod_only = resolve_distribution_default_url_for_env(
+            "prod",
+            None,
+            Some("https://prod.example.com"),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(pre_only.contains("must both be configured"));
+        assert!(prod_only.contains("must both be configured"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_compiled_distribution_defaults_match_build_mode() {
+        let requested_pre_url = std::env::var("BCS_CLI_DEFAULT_PRE_URL").ok();
+        let requested_prod_url = std::env::var("BCS_CLI_DEFAULT_PROD_URL").ok();
+        match (requested_pre_url.as_deref(), requested_prod_url.as_deref()) {
+            (None, None) => {
+                assert_eq!(COMPILED_PRE_BCS_URL, None);
+                assert_eq!(COMPILED_PROD_BCS_URL, None);
+            }
+            (Some(pre_url), Some(prod_url)) => {
+                assert_eq!(COMPILED_PRE_BCS_URL, Some(pre_url));
+                assert_eq!(COMPILED_PROD_BCS_URL, Some(prod_url));
+            }
+            _ => panic!("build environment must provide both compiled BCS defaults"),
+        }
+
+        let original_agentclaw_env = std::env::var("AGENTCLAW_ENV").ok();
+        safe_set_var("AGENTCLAW_ENV", "pre");
+        let pre_result = resolve_compiled_distribution_default_url();
+
+        safe_set_var("AGENTCLAW_ENV", "prod");
+        let prod_result = resolve_compiled_distribution_default_url();
+
+        if let Some(value) = original_agentclaw_env {
+            safe_set_var("AGENTCLAW_ENV", value);
+        } else {
+            safe_remove_var("AGENTCLAW_ENV");
+        }
+
+        match (COMPILED_PRE_BCS_URL, COMPILED_PROD_BCS_URL) {
+            (None, None) => {
+                assert_eq!(pre_result.unwrap(), None);
+                assert_eq!(prod_result.unwrap(), None);
+            }
+            (Some(pre_url), Some(prod_url)) => {
+                assert_eq!(pre_result.unwrap(), normalize_bcs_api_url(pre_url));
+                assert_eq!(prod_result.unwrap(), normalize_bcs_api_url(prod_url));
+            }
+            _ => panic!("compiled BCS defaults must both be configured"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_session_url_overrides_distribution_default() {
+        let temp_dir = TempDir::new().unwrap();
+        write_session_file(
+            &temp_dir,
+            serde_json::json!({
+                "bot_uuid": null,
+                "token": "session-token",
+                "api_base_url": "https://session.example.com"
+            }),
+        );
+
+        let original_data_dir = std::env::var("BOT_DATA_DIR").ok();
+        let original_url = std::env::var("MOLTIS_BCS_URL").ok();
+        let original_base_url = std::env::var("BCS_API_BASE_URL").ok();
+
+        safe_set_var("BOT_DATA_DIR", temp_dir.path());
+        safe_remove_var("MOLTIS_BCS_URL");
+        safe_remove_var("BCS_API_BASE_URL");
+
+        let args = GlobalArgs {
+            url: None,
+            cookie: None,
+            log_level: "info".to_string(),
+            json: false,
+            debug: false,
+        };
+        let resolved = resolve_bcs_url_with_distribution_defaults(
+            &args,
+            Some("https://pre.example.com"),
+            Some("https://prod.example.com"),
+        )
+        .unwrap();
+
+        if let Some(value) = original_data_dir {
+            safe_set_var("BOT_DATA_DIR", value);
+        } else {
+            safe_remove_var("BOT_DATA_DIR");
+        }
+        if let Some(value) = original_url {
+            safe_set_var("MOLTIS_BCS_URL", value);
+        } else {
+            safe_remove_var("MOLTIS_BCS_URL");
+        }
+        if let Some(value) = original_base_url {
+            safe_set_var("BCS_API_BASE_URL", value);
+        } else {
+            safe_remove_var("BCS_API_BASE_URL");
+        }
+
+        assert_eq!(resolved, "https://session.example.com");
+    }
+
+    #[test]
     #[serial]
     fn test_resolve_bcs_url_defaults_to_local() {
         let original_data_dir = std::env::var("BOT_DATA_DIR").ok();
@@ -488,7 +739,7 @@ mod tests {
             json: false,
             debug: false,
         };
-        let result = resolve_bcs_url(&args);
+        let result = resolve_bcs_url_with_distribution_defaults(&args, None, None);
 
         if let Some(value) = original_data_dir {
             safe_set_var("BOT_DATA_DIR", value);

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -9,17 +9,19 @@
 //! # Configuration
 //!
 //! BCS CLI can be configured via:
-//! 1. Command-line arguments (highest priority)
-//! 2. Environment variables: MOLTIS_BCS_URL, BCS_COOKIE
-//! 3. Session file: $BOT_DATA_DIR/.bcs/session.json
-//! 4. Default local URL (lowest priority)
+//! 1. `--url` (highest priority)
+//! 2. `BCS_API_BASE_URL`
+//! 3. `MOLTIS_BCS_URL`
+//! 4. Session file: `$BOT_DATA_DIR/.bcs/session.json`
+//! 5. Runtime-selected compiled distribution default
+//! 6. Default local URL (lowest priority)
 //!
 //! # Environment-Based Configuration
 //!
-//! Set `env` environment variable to switch between environments:
-//! - `env=dev` (default) - development environment
-//! - `env=pre` - pre-production environment
-//! - `env=prod` - production environment
+//! Distribution builds may compile both pre and production defaults into one
+//! binary. Runtime environment priority is `AGENTCLAW_ENV`, `env`, then the
+//! server environment chain. `pre`/`prepub` selects pre; every other value
+//! selects production. Public builds omit both compiled defaults.
 //!
 //! # Token Discovery
 //!
@@ -330,6 +332,10 @@ fn resolve_bcs_url(cli: &Cli) -> Result<String> {
     }
 
     if let Some(url) = resolve_session_bcs_url()? {
+        return Ok(url);
+    }
+
+    if let Some(url) = bcs_cli::resolve_compiled_distribution_default_url()? {
         return Ok(url);
     }
 
@@ -1702,7 +1708,7 @@ async fn main() -> Result<()> {
     // Get current environment (defaults to "dev")
     let env = get_current_env();
 
-    // Determine BCS URL: CLI arg > env var > session.json > default
+    // Determine BCS URL: CLI arg > env var > session.json > compiled default > local
     // Note: bcs_url resolution is deferred for commands that don't need it (e.g., --web mode).
     let bcs_url = resolve_bcs_url(&cli).unwrap_or_default();
 
@@ -4428,7 +4434,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_resolve_bcs_url_defaults_to_local() {
+    fn test_resolve_bcs_url_uses_distribution_default_or_local() {
         let original_data_dir = std::env::var("BOT_DATA_DIR").ok();
         let original_url = std::env::var("MOLTIS_BCS_URL").ok();
         let original_base_url = std::env::var("BCS_API_BASE_URL").ok();
@@ -4450,6 +4456,9 @@ mod tests {
             command: Commands::Health,
         };
         let result = resolve_bcs_url(&cli);
+        let expected = bcs_cli::resolve_compiled_distribution_default_url()
+            .unwrap()
+            .unwrap_or_else(|| "http://127.0.0.1:21000".to_string());
 
         if let Some(value) = original_data_dir {
             safe_set_var("BOT_DATA_DIR", value);
@@ -4473,12 +4482,12 @@ mod tests {
         }
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "http://127.0.0.1:21000");
+        assert_eq!(result.unwrap(), expected);
     }
 
     #[test]
     #[serial]
-    fn test_resolve_bcs_url_defaults_to_local_when_agentclaw_env_pre() {
+    fn test_resolve_bcs_url_uses_pre_distribution_default_or_local() {
         let original_data_dir = std::env::var("BOT_DATA_DIR").ok();
         let original_url = std::env::var("MOLTIS_BCS_URL").ok();
         let original_base_url = std::env::var("BCS_API_BASE_URL").ok();
@@ -4500,6 +4509,9 @@ mod tests {
             command: Commands::Health,
         };
         let result = resolve_bcs_url(&cli);
+        let expected = bcs_cli::resolve_compiled_distribution_default_url()
+            .unwrap()
+            .unwrap_or_else(|| "http://127.0.0.1:21000".to_string());
 
         if let Some(value) = original_data_dir {
             safe_set_var("BOT_DATA_DIR", value);
@@ -4523,7 +4535,7 @@ mod tests {
         }
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "http://127.0.0.1:21000");
+        assert_eq!(result.unwrap(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Allow distributions to compile pre-release and production BCS defaults into one `bcs-cli` binary.
- Select the compiled default at runtime using the existing environment resolution chain.
- Preserve URL precedence: explicit CLI URL, environment URL, session URL, compiled distribution default, then localhost.
- Keep public builds backward compatible when no compiled defaults are provided.
- Add tests for public and distribution build modes, environment priority, URL selection, and override precedence.

## Why

After internal packaging moved away from the previous BCS source layout, the CLI lost its environment-aware default URL behavior. Some Provider-integrated bots cannot guarantee that `BCS_API_BASE_URL` is present at runtime, so the CLI could incorrectly fall back to `127.0.0.1:21000`.

The fix lets a distribution build one artifact containing both defaults while still choosing pre-release or production only when the binary runs.

## User impact

- `pre` and `prepub` environments select the pre-release compiled default.
- Other or missing runtime environments select the production compiled default.
- Explicit URL environment variables and session configuration continue to override compiled defaults.
- Unconfigured public builds continue to use the local default.

## Validation

- `cargo test --package bcs-cli` in public build mode: 146 passed, 1 existing ignored.
- `cargo test --package bcs-cli` with both compiled defaults: 146 passed, 1 existing ignored.
- `cargo check --package bcs-cli --all-targets` passed.
- `git diff --check` passed.
