### PR TITLE
feat(expert-chat): add caller identity exchange on container startup

### DIFF
--- a/src/baas/packages/community/src/secbaas/adapters/web/routers/bot_service/file_transfer_router.py
+++ b/src/baas/packages/community/src/secbaas/adapters/web/routers/bot_service/file_transfer_router.py
@@ -83,6 +83,7 @@ async def get_upload_url(
             device_affinity=device_affinity,
             file_size=request.file_size,
             part_size=request.part_size,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -180,6 +181,7 @@ async def get_download_url(
             device_path=request.device_path,
             expire_seconds=request.expire_seconds,
             device_affinity=device_affinity,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -532,7 +534,6 @@ async def get_transfer_status(
 
     Returns the transfer's status along with conditional fields:
     - download_url when status == DONE
-    - upload_url when status == CREATED
     - error_message when status == FAILED
     """
     logger.info(
@@ -544,9 +545,15 @@ async def get_transfer_status(
         result = await dispatcher.dispatch_get_transfer_status(
             transfer_id=transfer_id,
             tenant=tenant,
+            bot_uuid=bot_uuid,
         )
         return ApiResponse(data=result)
 
+    except BotNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "BOT_NOT_FOUND", "message": str(e), "bot_uuid": bot_uuid},
+        )
     except TransferNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/baas/packages/community/src/secbaas/api/bot_runtime/__init__.py
+++ b/src/baas/packages/community/src/secbaas/api/bot_runtime/__init__.py
@@ -1,0 +1,7 @@
+"""Bot runtime API — public exports for packages tree."""
+
+from ._exceptions import TransferStateConflictError
+
+__all__ = [
+    "TransferStateConflictError",
+]

--- a/src/baas/packages/community/src/secbaas/api/bot_runtime/_exceptions.py
+++ b/src/baas/packages/community/src/secbaas/api/bot_runtime/_exceptions.py
@@ -1,0 +1,38 @@
+"""API-layer exceptions for file transfer operations.
+
+Defines the BotServiceError base and TransferStateConflictError for the
+packages tree (secbaas.* import convention).  These classes exist so the
+repo-layer TransferStateConflictError can inherit from the API-layer
+definition via diamond inheritance — otherwise dispatcher except clauses
+catching the API class cannot handle repo-originated instances.
+"""
+
+
+class BotServiceError(Exception):
+    """Base exception for bot service errors.
+
+    All bot service API exceptions inherit from this class.
+    """
+
+    error_code: str = "BOT_SERVICE_ERROR"
+    http_status: int = 400
+
+    def __init__(self, message: str = "") -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class TransferStateConflictError(BotServiceError):
+    """Raised when an invalid state transition is attempted on a file transfer.
+
+    This is the API-layer definition imported by adapters (routers).
+    The repo-layer equivalent inherits from this class so that except
+    clauses catching the API class also handle repo-originated instances.
+    """
+
+    error_code: str = "TRANSFER_STATE_CONFLICT"
+    http_status: int = 409
+
+    def __init__(self, message: str = "") -> None:
+        self.message = message
+        super().__init__(message)

--- a/src/baas/packages/community/src/secbaas/api/bot_runtime/_file_transfer_models.py
+++ b/src/baas/packages/community/src/secbaas/api/bot_runtime/_file_transfer_models.py
@@ -51,6 +51,11 @@ class GetUploadUrlRequest(BaseModel):
         ge=1048576,
         description="Custom part size in bytes for multipart, defaults to 10MB if file_size >= threshold.",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this upload",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -109,6 +114,11 @@ class GetDownloadUrlRequest(BaseModel):
         le=86400,
         description="Pre-signed URL validity duration in seconds (60–86400, default 3600)",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this download",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -132,7 +142,6 @@ class GetTransferStatusResponse(BaseModel):
 
     Maps from TicketRecord.  Conditional fields:
     - download_url: only present when status == DONE
-    - upload_url: only present when status == CREATED (resume support)
     - expires_at: intentionally null for transfer queries; OSS presigned URLs
       embed their own expiry via the Expires query parameter
     - error_message: only present when status == FAILED
@@ -144,11 +153,14 @@ class GetTransferStatusResponse(BaseModel):
     filename: str
     device_path: str | None
     download_url: str | None = None
-    upload_url: str | None = None
-    expires_at: str | None = None
+    expires_at: str | None = Field(
+        default=None,
+        description="Intentionally null for transfer queries; OSS presigned URLs embed their own expiry via the Expires query parameter. Only populated in direct upload/download URL generation responses.",
+    )
     error_message: str | None = None
     created_at: str
     updated_at: str
+    operator: str
 
     model_config = {"from_attributes": True}
 

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_model.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_model.py
@@ -34,9 +34,9 @@ class FileTransferTicketModel(Base):
     fileservice_staging_path = Column(String(1024), nullable=False)
     error_message = Column(Text, nullable=True)
     download_url = Column(String(2048), nullable=True)
-    upload_url = Column(String(2048), nullable=True)
     multipart_session_id = Column(String(256), nullable=True)
     env = Column(String(16), nullable=False)
+    operator = Column(String(256), nullable=False, server_default="unknown")
 
     __table_args__ = (
         UniqueConstraint("transfer_id", "env", name="uk_ft_transfer_id_env"),
@@ -59,7 +59,7 @@ class FileTransferTicketModel(Base):
             fileservice_staging_path=self.fileservice_staging_path,
             error_message=self.error_message,
             download_url=self.download_url,
-            upload_url=self.upload_url,
             multipart_session_id=self.multipart_session_id,
             env=self.env,
+            operator=self.operator,
         )

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_repository.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_orm_repository.py
@@ -71,6 +71,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         log.info(
             "create_ticket: transfer_id=%s, direction=%s, multipart_session_id=%s",
@@ -92,6 +93,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
             error_message=error_message,
             multipart_session_id=multipart_session_id,
             env=env,
+            operator=operator,
         )
         self._session.add(row)
         self._session.flush()
@@ -235,13 +237,13 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
+        download_url_preview = (download_url[:200]) if download_url else None
         log.info(
-            "update_urls: transfer_id=%s, download_url=%s, upload_url=%s",
+            "update_urls: transfer_id=%s, download_url=%s, download_url_preview=%s",
             transfer_id,
             bool(download_url),
-            bool(upload_url),
+            download_url_preview,
         )
         from sqlalchemy import func
 
@@ -249,11 +251,11 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         update_kwargs: dict = {"gmt_modified": func.now()}
         if download_url is not None:
             update_kwargs["download_url"] = download_url
-        if upload_url is not None:
-            update_kwargs["upload_url"] = upload_url
-
-        if "download_url" not in update_kwargs and "upload_url" not in update_kwargs:
-            return  # no-op: both None
+        else:
+            log.debug(
+                "update_urls: transfer_id=%s, download_url is None, no-op", transfer_id
+            )
+            return  # no-op
 
         result = (
             self._session.query(FileTransferTicketModel)

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_protocol.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_protocol.py
@@ -2,6 +2,9 @@
 
 from typing import Protocol, runtime_checkable
 
+from secbaas.api.bot_runtime import (
+    TransferStateConflictError as ApiTransferStateConflictError,
+)
 from secbaas.api.bot_runtime._file_transfer_models import (
     TransferNotFoundError as ApiTransferNotFoundError,
 )
@@ -27,16 +30,29 @@ class TransferNotFoundError(FileTransferRepositoryError, ApiTransferNotFoundErro
     """
 
     def __init__(self, transfer_id: str) -> None:
+        message = f"Transfer ticket {transfer_id} not found"
+        self.message = message  # Set explicitly — cooperative MRO stops at RuntimeError
         super().__init__(
-            f"Transfer ticket {transfer_id} not found",
+            message,
             error_code="FILE_TRANSFER_NOT_FOUND",
         )
 
 
-class TransferStateConflictError(FileTransferRepositoryError):
-    """Raised when an invalid state transition is attempted."""
+class TransferStateConflictError(
+    FileTransferRepositoryError, ApiTransferStateConflictError
+):
+    """Raised when an invalid state transition is attempted on a file transfer.
+
+    Inherits from both FileTransferRepositoryError (repo-layer base) and
+    the API-layer TransferStateConflictError so that except clauses catching
+    the API class also handle repo-originated instances (e.g. from
+    update_status in race conditions).
+    """
 
     def __init__(self, message: str) -> None:
+        self.message = (
+            message  # Set explicitly — BotServiceError.__init__ unreachable via MRO
+        )
         super().__init__(message, error_code="FILE_TRANSFER_STATE_CONFLICT")
 
 
@@ -62,6 +78,7 @@ class TicketRepository(Protocol):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         """Insert a new transfer ticket record. Returns the new record ID."""
         ...
@@ -83,7 +100,8 @@ class TicketRepository(Protocol):
         Uses a CAS (Compare-And-Swap) SQL UPDATE: only modifies the row if
         its current status is one of the allowed source states for new_status.
         Same-state transitions are idempotent.
-        Raises DeviceCreationError on invalid transition or not found.
+        Raises TransferStateConflictError on invalid state transition.
+        Raises TransferNotFoundError if no ticket with the given transfer_id exists.
         """
         ...
 
@@ -116,10 +134,9 @@ class TicketRepository(Protocol):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
-        """Update download_url and/or upload_url on a ticket.
+        """Update download_url on a ticket.
 
-        Updates only the fields that are not None. Both None is a no-op.
+        Returns early (no-op) when download_url is None.
         """
         ...

--- a/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_record.py
+++ b/src/baas/packages/community/src/secbaas/core/repository/file_transfer_ticket/_record.py
@@ -11,11 +11,11 @@ class TicketRecord:
     Columns per DDL schema (17 fields):
     id, gmt_create, gmt_modified, transfer_id, tenant, paas_device_id,
     direction, status, staging_subdir, filename, device_path,
-    fileservice_staging_path, error_message, download_url, upload_url,
-    multipart_session_id, env
+    fileservice_staging_path, error_message, download_url,
+    multipart_session_id, env, operator
 
     Nullable fields: staging_subdir, device_path, error_message, download_url,
-    upload_url, multipart_session_id.
+    multipart_session_id.
     """
 
     id: int
@@ -32,6 +32,6 @@ class TicketRecord:
     fileservice_staging_path: str
     error_message: str | None
     download_url: str | None
-    upload_url: str | None
     multipart_session_id: str | None
     env: str
+    operator: str

--- a/src/baas/packages/community/src/secbaas/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
+++ b/src/baas/packages/community/src/secbaas/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from secbaas.api.bot_runtime import (
     BotFileTransferDispatcher,
+    BotNotFoundError,
     CancelUploadResponse,
     CompleteUploadResponse,
     GetDownloadUrlResponse,
@@ -81,6 +82,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_affinity: str | None = None,
         file_size: int = 0,
         part_size: int | None = None,
+        operator: str | None = None,
     ) -> GetUploadUrlResponse:
         """Orchestrate upload URL generation (v1.5: D-01/D-02/D-05 flow).
 
@@ -103,6 +105,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             tenant,
             file_size,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         # D-05: Retention mode — device_path is None, skip device resolution
         if device_path is not None:
@@ -208,6 +213,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 fileservice_staging_path=staging_path,
                 error_message=None,
                 multipart_session_id=multipart_session.session_id,
+                operator=operator,
             )
 
             logger.info(
@@ -250,6 +256,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 device_path=device_path,
                 fileservice_staging_path=staging_path,
                 error_message=None,
+                operator=operator,
             )
 
             logger.info(
@@ -270,6 +277,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_path: str,
         expire_seconds: int = 3600,
         device_affinity: str | None = None,
+        operator: str | None = None,
     ) -> GetDownloadUrlResponse:
         """Orchestrate download URL request (D-10 flow).
 
@@ -288,6 +296,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path,
             tenant,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         _, _, paas_device_id = await self._resolve_bot_device(
             bot_uuid=bot_uuid,
@@ -342,6 +353,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path=device_path,
             fileservice_staging_path=staging_path,
             error_message=None,
+            operator=operator,
         )
 
         logger.info("Ticket created: transfer_id=%s, direction=DOWNLOAD", transfer_id)
@@ -371,12 +383,23 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         self,
         transfer_id: str,
         tenant: str | None = None,
+        bot_uuid: str | None = None,
     ) -> GetTransferStatusResponse:
         """Query a transfer ticket by transfer_id (D-12 query flow).
 
         Maps TicketRecord fields to GetTransferStatusResponse with
         conditional URL/error fields based on ticket status.
+
+        When bot_uuid is provided, validates that the bot exists and belongs
+        to the specified tenant before returning the transfer status.
         """
+        # Validate bot ownership when bot_uuid is provided
+        if bot_uuid is not None and tenant is not None:
+            env = get_current_env()
+            bots = self._bot_repo.list_by_bot_uuid(bot_uuid, tenant, env)
+            if not bots:
+                raise BotNotFoundError(bot_uuid)
+
         record = self._ticket_repo.get_by_transfer_id(
             transfer_id,
             tenant=tenant,
@@ -386,7 +409,6 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
 
         # Conditional fields per status
         download_url = record.download_url if record.status == "DONE" else None
-        upload_url = record.upload_url if record.status == "CREATED" else None
         # OSS presigned URLs embed their own expiry — expires_at is null for transfer queries
         expires_at: str | None = None
 
@@ -399,11 +421,11 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             filename=record.filename,
             device_path=record.device_path,
             download_url=download_url,
-            upload_url=upload_url,
             expires_at=expires_at,
             error_message=error_message,
             created_at=record.gmt_create.isoformat(),
             updated_at=record.gmt_modified.isoformat(),
+            operator=record.operator,
         )
 
     # ------------------------------------------------------------------

--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/file_transfer_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/file_transfer_router.py
@@ -84,6 +84,7 @@ async def get_upload_url(
             device_affinity=device_affinity,
             file_size=request.file_size,
             part_size=request.part_size,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -181,6 +182,7 @@ async def get_download_url(
             device_path=request.device_path,
             expire_seconds=request.expire_seconds,
             device_affinity=device_affinity,
+            operator=request.operator,
         )
         return ApiResponse(data=result)
 
@@ -533,7 +535,6 @@ async def get_transfer_status(
 
     Returns the transfer's status along with conditional fields:
     - download_url when status == DONE
-    - upload_url when status == CREATED
     - error_message when status == FAILED
     """
     logger.info(

--- a/src/baas/src/secbaas/community/api/bot_runtime/_file_transfer_models.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_file_transfer_models.py
@@ -51,6 +51,11 @@ class GetUploadUrlRequest(BaseModel):
         ge=1048576,
         description="Custom part size in bytes for multipart, defaults to 10MB if file_size >= threshold.",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this upload",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -109,6 +114,11 @@ class GetDownloadUrlRequest(BaseModel):
         le=86400,
         description="Pre-signed URL validity duration in seconds (60–86400, default 3600)",
     )
+    operator: str = Field(
+        default="unknown",
+        max_length=256,
+        description="Identifier of the user or system initiating this download",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -132,7 +142,6 @@ class GetTransferStatusResponse(BaseModel):
 
     Maps from TicketRecord.  Conditional fields:
     - download_url: only present when status == DONE
-    - upload_url: only present when status == CREATED (resume support)
     - expires_at: intentionally null for transfer queries; OSS presigned URLs
       embed their own expiry via the Expires query parameter
     - error_message: only present when status == FAILED
@@ -144,11 +153,14 @@ class GetTransferStatusResponse(BaseModel):
     filename: str
     device_path: str | None
     download_url: str | None = None
-    upload_url: str | None = None
-    expires_at: str | None = None
+    expires_at: str | None = Field(
+        default=None,
+        description="Intentionally null for transfer queries; OSS presigned URLs embed their own expiry via the Expires query parameter. Only populated in direct upload/download URL generation responses.",
+    )
     error_message: str | None = None
     created_at: str
     updated_at: str
+    operator: str
 
     model_config = {"from_attributes": True}
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
@@ -136,6 +136,7 @@ class BotFileTransferDispatcher(Protocol):
         device_affinity: str | None = None,
         file_size: int = 0,
         part_size: int | None = None,
+        operator: str | None = None,
     ) -> GetUploadUrlResponse: ...
 
     async def dispatch_get_download_url(
@@ -145,6 +146,7 @@ class BotFileTransferDispatcher(Protocol):
         device_path: str,
         expire_seconds: int = 3600,
         device_affinity: str | None = None,
+        operator: str | None = None,
     ) -> GetDownloadUrlResponse: ...
 
     async def dispatch_get_transfer_status(

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_model.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_model.py
@@ -35,9 +35,9 @@ class FileTransferTicketModel(Base):
     fileservice_staging_path = Column(String(1024), nullable=False)
     error_message = Column(Text, nullable=True)
     download_url = Column(String(2048), nullable=True)
-    upload_url = Column(String(2048), nullable=True)
     multipart_session_id = Column(String(256), nullable=True)
     env = Column(String(16), nullable=False)
+    operator = Column(String(256), nullable=False, server_default="unknown")
 
     __table_args__ = (
         UniqueConstraint("transfer_id", "env", name="uk_ft_transfer_id_env"),
@@ -60,7 +60,7 @@ class FileTransferTicketModel(Base):
             fileservice_staging_path=self.fileservice_staging_path,
             error_message=self.error_message,
             download_url=self.download_url,
-            upload_url=self.upload_url,
             multipart_session_id=self.multipart_session_id,
             env=self.env,
+            operator=self.operator,
         )

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_repository.py
@@ -71,6 +71,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         log.info(
             "create_ticket: transfer_id=%s, direction=%s, multipart_session_id=%s",
@@ -92,6 +93,7 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
             error_message=error_message,
             multipart_session_id=multipart_session_id,
             env=env,
+            operator=operator,
         )
         self._session.add(row)
         self._session.flush()
@@ -235,13 +237,13 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
+        download_url_preview = (download_url[:200]) if download_url else None
         log.info(
-            "update_urls: transfer_id=%s, download_url=%s, upload_url=%s",
+            "update_urls: transfer_id=%s, download_url=%s, download_url_preview=%s",
             transfer_id,
             bool(download_url),
-            bool(upload_url),
+            download_url_preview,
         )
         from sqlalchemy import func
 
@@ -249,11 +251,11 @@ class OrmTicketRepository(OrmConnectionMixin, TicketRepository):
         update_kwargs: dict = {"gmt_modified": func.now()}
         if download_url is not None:
             update_kwargs["download_url"] = download_url
-        if upload_url is not None:
-            update_kwargs["upload_url"] = upload_url
-
-        if "download_url" not in update_kwargs and "upload_url" not in update_kwargs:
-            return  # no-op: both None
+        else:
+            log.debug(
+                "update_urls: transfer_id=%s, download_url is None, no-op", transfer_id
+            )
+            return  # no-op
 
         result = (
             self._session.query(FileTransferTicketModel)

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_protocol.py
@@ -30,8 +30,10 @@ class TransferNotFoundError(FileTransferRepositoryError, ApiTransferNotFoundErro
     """
 
     def __init__(self, transfer_id: str) -> None:
+        message = f"Transfer ticket {transfer_id} not found"
+        self.message = message  # Set explicitly — cooperative MRO stops at RuntimeError
         super().__init__(
-            f"Transfer ticket {transfer_id} not found",
+            message,
             error_code="FILE_TRANSFER_NOT_FOUND",
         )
 
@@ -47,6 +49,9 @@ class TransferStateConflictError(
     """
 
     def __init__(self, message: str) -> None:
+        self.message = (
+            message  # Set explicitly — BotServiceError.__init__ unreachable via MRO
+        )
         super().__init__(message, error_code="FILE_TRANSFER_STATE_CONFLICT")
 
 
@@ -72,6 +77,7 @@ class TicketRepository(Protocol):
         fileservice_staging_path: str,
         error_message: str | None,
         multipart_session_id: str | None = None,
+        operator: str = "unknown",
     ) -> int:
         """Insert a new transfer ticket record. Returns the new record ID."""
         ...
@@ -93,7 +99,8 @@ class TicketRepository(Protocol):
         Uses a CAS (Compare-And-Swap) SQL UPDATE: only modifies the row if
         its current status is one of the allowed source states for new_status.
         Same-state transitions are idempotent.
-        Raises DeviceCreationError on invalid transition or not found.
+        Raises TransferStateConflictError on invalid state transition.
+        Raises TransferNotFoundError if no ticket with the given transfer_id exists.
         """
         ...
 
@@ -126,10 +133,9 @@ class TicketRepository(Protocol):
         transfer_id: str,
         *,
         download_url: str | None = None,
-        upload_url: str | None = None,
     ) -> None:
-        """Update download_url and/or upload_url on a ticket.
+        """Update download_url on a ticket.
 
-        Updates only the fields that are not None. Both None is a no-op.
+        Returns early (no-op) when download_url is None.
         """
         ...

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_record.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_record.py
@@ -11,11 +11,11 @@ class TicketRecord:
     Columns per DDL schema (17 fields):
     id, gmt_create, gmt_modified, transfer_id, tenant, paas_device_id,
     direction, status, staging_subdir, filename, device_path,
-    fileservice_staging_path, error_message, download_url, upload_url,
-    multipart_session_id, env
+    fileservice_staging_path, error_message, download_url,
+    multipart_session_id, env, operator
 
     Nullable fields: staging_subdir, device_path, error_message, download_url,
-    upload_url, multipart_session_id.
+    multipart_session_id.
     """
 
     id: int
@@ -32,6 +32,6 @@ class TicketRecord:
     fileservice_staging_path: str
     error_message: str | None
     download_url: str | None
-    upload_url: str | None
     multipart_session_id: str | None
     env: str
+    operator: str

--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_file_transfer_dispatcher.py
@@ -82,6 +82,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_affinity: str | None = None,
         file_size: int = 0,
         part_size: int | None = None,
+        operator: str | None = None,
     ) -> GetUploadUrlResponse:
         """Orchestrate upload URL generation (v1.5: D-01/D-02/D-05 flow).
 
@@ -104,6 +105,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             tenant,
             file_size,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         # D-05: Retention mode — device_path is None, skip device resolution
         if device_path is not None:
@@ -209,6 +213,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 fileservice_staging_path=staging_path,
                 error_message=None,
                 multipart_session_id=multipart_session.session_id,
+                operator=operator,
             )
 
             logger.info(
@@ -251,6 +256,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
                 device_path=device_path,
                 fileservice_staging_path=staging_path,
                 error_message=None,
+                operator=operator,
             )
 
             logger.info(
@@ -271,6 +277,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
         device_path: str,
         expire_seconds: int = 3600,
         device_affinity: str | None = None,
+        operator: str | None = None,
     ) -> GetDownloadUrlResponse:
         """Orchestrate download URL request (D-10 flow).
 
@@ -289,6 +296,9 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path,
             tenant,
         )
+        # D-04: Normalize empty/None operator to "unknown" before any DB write
+        if not operator or not operator.strip():
+            operator = "unknown"
 
         _, _, paas_device_id = await self._resolve_bot_device(
             bot_uuid=bot_uuid,
@@ -343,6 +353,7 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             device_path=device_path,
             fileservice_staging_path=staging_path,
             error_message=None,
+            operator=operator,
         )
 
         logger.info("Ticket created: transfer_id=%s, direction=DOWNLOAD", transfer_id)
@@ -398,7 +409,6 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
 
         # Conditional fields per status
         download_url = record.download_url if record.status == "DONE" else None
-        upload_url = record.upload_url if record.status == "CREATED" else None
         # OSS presigned URLs embed their own expiry — expires_at is null for transfer queries
         expires_at: str | None = None
 
@@ -411,11 +421,11 @@ class DefaultBotFileTransferDispatcher(BotBaseDispatcher, BotFileTransferDispatc
             filename=record.filename,
             device_path=record.device_path,
             download_url=download_url,
-            upload_url=upload_url,
             expires_at=expires_at,
             error_message=error_message,
             created_at=record.gmt_create.isoformat(),
             updated_at=record.gmt_modified.isoformat(),
+            operator=record.operator,
         )
 
     # ------------------------------------------------------------------

--- a/src/baas/tests/e2e/mock_paas_failure/test_hook_execution_failure.py
+++ b/src/baas/tests/e2e/mock_paas_failure/test_hook_execution_failure.py
@@ -17,6 +17,7 @@ Requires:
   (just restart-mock-failure-hook)
 """
 
+import asyncio
 import uuid
 
 import pytest
@@ -115,6 +116,19 @@ class TestDestroyHookFailure:
         )
         await activate_bot(api, bot)
 
+        # Ensure bot is in terminal state before destroy to avoid 409
+        # (CREATE publish must reach SUCCESS/FAILED before a new DESTROY
+        # publish can be created; PublishConflictError otherwise).
+        for _ in range(10):
+            resp = await api.client.get(
+                api.bot_url(bot["bot_uuid"]), params=api.params()
+            )
+            if resp.status_code == 200:
+                status = resp.json()["data"]["status"]
+                if status in ("ACTIVE", "FAILED"):
+                    break
+            await asyncio.sleep(0.2)
+
         # Destroy the bot
         resp = await api.client.post(
             api.bot_url(bot["bot_uuid"]) + "/destroy",
@@ -153,6 +167,19 @@ class TestRestartHookFailure:
         bot = await create_and_activate_bot(
             api, f"restart-hook-fail-{unique_id}", device_count=1
         )
+
+        # Ensure bot is in terminal state before restart to avoid 409
+        # (CREATE publish must reach SUCCESS/FAILED before a new RESTART
+        # publish can be created; PublishConflictError otherwise).
+        for _ in range(10):
+            resp = await api.client.get(
+                api.bot_url(bot["bot_uuid"]), params=api.params()
+            )
+            if resp.status_code == 200:
+                status = resp.json()["data"]["status"]
+                if status in ("ACTIVE", "FAILED"):
+                    break
+            await asyncio.sleep(0.2)
 
         # Restart the bot
         resp = await api.client.post(

--- a/src/baas/tests/unit/adapters/web/routers/bot_service/test_file_transfer_router.py
+++ b/src/baas/tests/unit/adapters/web/routers/bot_service/test_file_transfer_router.py
@@ -658,6 +658,7 @@ async def test_get_transfer_status_success(mock_dispatcher):
         download_url="https://oss.example.com/dl",
         created_at="2025-01-01T00:00:00",
         updated_at="2025-01-01T00:00:00",
+        operator="unknown",
     )
     resp = await _get("/api/v1/bots/t1/bot-001/files/transfers/tf-001")
 

--- a/src/baas/tests/unit/adapters/web/routers/bot_service/test_transfer_query_router.py
+++ b/src/baas/tests/unit/adapters/web/routers/bot_service/test_transfer_query_router.py
@@ -46,10 +46,10 @@ async def test_get_transfer_status_success(mock_dispatcher):
             filename="data.csv",
             device_path="/home/data.csv",
             download_url="https://oss.example.com/dl?token=abc",
-            upload_url=None,
             expires_at="2099-01-01T00:00:00",
             created_at="2025-01-01T00:00:00",
             updated_at="2025-01-01T00:01:00",
+            operator="unknown",
         )
     )
 

--- a/src/baas/tests/unit/core/repository/file_transfer_ticket/test_orm_ticket_repository.py
+++ b/src/baas/tests/unit/core/repository/file_transfer_ticket/test_orm_ticket_repository.py
@@ -1,0 +1,408 @@
+"""
+OrmTicketRepository unit tests.
+
+Uses pytest + MagicMock ORM session pattern matching existing
+test_orm_bot_repository.py tests.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from secbaas.community.core.repository.file_transfer_ticket import (
+    OrmTicketRepository,
+    TicketRecord,
+    TransferNotFoundError,
+    TransferStateConflictError,
+)
+
+# ==================== Fixtures ====================
+
+
+@pytest.fixture
+def mock_session():
+    """Mock SQLAlchemy ORM session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_database(mock_session):
+    """Mock database that yields a mock ORM session via @with_orm_session."""
+    database = MagicMock()
+    database.orm_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    database.orm_session.return_value.__exit__ = MagicMock(return_value=False)
+    return database
+
+
+@pytest.fixture(autouse=True)
+def _patch_model():
+    """Patch FileTransferTicketModel so constructor returns a mock with .id=42 pre-set."""
+    with patch(
+        "secbaas.community.core.repository.file_transfer_ticket._orm_repository.FileTransferTicketModel",
+        autospec=False,
+    ) as mock_cls:
+
+        def _make_model(**kwargs):
+            model = MagicMock()
+            model.id = 42
+            for k, v in kwargs.items():
+                setattr(model, k, v)
+            return model
+
+        mock_cls.side_effect = _make_model
+        yield mock_cls
+
+
+@pytest.fixture
+def repo(mock_database):
+    """Create an OrmTicketRepository instance with mock database."""
+    return OrmTicketRepository(mock_database)
+
+
+# ==================== TestCreateTicket ====================
+
+
+class TestCreateTicket:
+    def test_create_returns_id(self, repo, mock_session):
+        result = repo.create_ticket(
+            transfer_id="tf-001",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
+            error_message=None,
+            operator="test-user",
+        )
+
+        assert result is not None
+        mock_session.add.assert_called_once()
+        mock_session.flush.assert_called_once()
+
+    def test_create_model_fields(self, repo, mock_session):
+        repo.create_ticket(
+            transfer_id="tf-001",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir="my-subdir",
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
+            error_message=None,
+            multipart_session_id="upload-123",
+            operator="test-user",
+        )
+
+        mock_session.add.assert_called_once()
+        model = mock_session.add.call_args[0][0]
+        assert model.transfer_id == "tf-001"
+        assert model.tenant == "t1"
+        assert model.paas_device_id == "sandbox@42"
+        assert model.direction == "UPLOAD"
+        assert model.status == "CREATED"
+        assert model.staging_subdir == "my-subdir"
+        assert model.filename == "data.csv"
+        assert model.device_path == "/home/data.csv"
+        assert model.fileservice_staging_path == "file-transfers/t1/tf-001/data.csv"
+        assert model.error_message is None
+        assert model.multipart_session_id == "upload-123"
+        assert model.operator == "test-user"
+
+    def test_create_default_operator(self, repo, mock_session):
+        """When operator is not provided, defaults to 'unknown'."""
+        repo.create_ticket(
+            transfer_id="tf-002",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="DOWNLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-002/data.csv",
+            error_message=None,
+            operator="unknown",
+        )
+
+        model = mock_session.add.call_args[0][0]
+        assert model.operator == "unknown"
+
+    def test_create_nullable_fields(self, repo, mock_session):
+        """Verify nullable fields can be passed as None."""
+        repo.create_ticket(
+            transfer_id="tf-003",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path=None,
+            fileservice_staging_path="file-transfers/t1/tf-003/data.csv",
+            error_message=None,
+            multipart_session_id=None,
+            operator="unknown",
+        )
+
+        model = mock_session.add.call_args[0][0]
+        assert model.staging_subdir is None
+        assert model.device_path is None
+        assert model.multipart_session_id is None
+        assert model.error_message is None
+
+
+# ==================== TestGetByTransferId ====================
+
+
+class TestGetByTransferId:
+    def test_found(self, repo, mock_session):
+        now = datetime.now()
+        record = TicketRecord(
+            id=5,
+            gmt_create=now,
+            gmt_modified=now,
+            transfer_id="tf-xyz",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-xyz/data.csv",
+            error_message=None,
+            download_url=None,
+            multipart_session_id=None,
+            env="test",
+            operator="unknown",
+        )
+        model = MagicMock()
+        model.to_record.return_value = record
+        mock_session.query.return_value.filter.return_value.first.return_value = model
+
+        result = repo.get_by_transfer_id("tf-xyz")
+
+        assert result is not None
+        assert result.id == 5
+        assert result.transfer_id == "tf-xyz"
+        mock_session.query.assert_called_once()
+
+    def test_not_found(self, repo, mock_session):
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        result = repo.get_by_transfer_id("nonexistent")
+
+        assert result is None
+
+    def test_with_tenant_filter(self, repo, mock_session):
+        """Verify that when tenant is passed, the filter chain includes tenant condition."""
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        repo.get_by_transfer_id("tf-xyz", tenant="t1")
+
+        assert mock_session.query.return_value.filter.call_count >= 1
+
+
+# ==================== TestUpdateStatus ====================
+
+
+class TestUpdateStatus:
+    def test_valid_transition(self, repo, mock_session):
+        """CAS update returns 1 — valid transition succeeds."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        # Should not raise
+        repo.update_status("tf-001", "UPLOADING")
+
+    def test_invalid_transition(self, repo, mock_session):
+        """CAS update returns 0, fallback query finds ticket with conflicting status."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 0
+        # Fallback first() returns a model with status=DONE (terminal)
+        fallback_row = MagicMock()
+        fallback_row.status = "DONE"
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            fallback_row
+        )
+
+        with pytest.raises(TransferStateConflictError):
+            repo.update_status("tf-001", "UPLOADING")
+
+    def test_not_found(self, repo, mock_session):
+        """CAS update returns 0, fallback query returns None → TransferNotFoundError."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 0
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(TransferNotFoundError, match="not found"):
+            repo.update_status("nonexistent", "DONE")
+
+    def test_same_state_idempotent(self, repo, mock_session):
+        """Same-state transition is idempotent (CREATED→CREATED allowed)."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        # Should not raise
+        repo.update_status("tf-001", "CREATED")
+
+    def test_with_error_message(self, repo, mock_session):
+        """Verify error_message is passed through to update_kwargs."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        repo.update_status("tf-001", "FAILED", error_message="timeout")
+
+        call_kwargs = (
+            mock_session.query.return_value.filter.return_value.update.call_args
+        )
+        update_dict = call_kwargs[0][0]
+        assert update_dict["error_message"] == "timeout"
+        assert update_dict["status"] == "FAILED"
+
+
+# ==================== TestUpdateUrls ====================
+
+
+class TestUpdateUrls:
+    def test_update_download_url(self, repo, mock_session):
+        """Setting download_url triggers an UPDATE query."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        repo.update_urls("tf-001", download_url="https://oss.example.com/dl")
+
+        call_kwargs = (
+            mock_session.query.return_value.filter.return_value.update.call_args
+        )
+        update_dict = call_kwargs[0][0]
+        assert update_dict["download_url"] == "https://oss.example.com/dl"
+
+    def test_noop_when_none(self, repo, mock_session):
+        """When download_url is None, the method returns early — no query."""
+        repo.update_urls("tf-001")
+
+        # session.query should NOT be called (early return guard)
+        mock_session.query.assert_not_called()
+
+    def test_not_found(self, repo, mock_session):
+        """update() returns 0 — TransferNotFoundError is raised."""
+        mock_session.query.return_value.filter.return_value.update.return_value = 0
+
+        with pytest.raises(TransferNotFoundError):
+            repo.update_urls("tf-001", download_url="https://oss.example.com/dl")
+
+
+# ==================== TestListPendingUploads ====================
+
+
+class TestListPendingUploads:
+    def test_returns_tickets(self, repo, mock_session):
+        now = datetime.now()
+
+        def _make_record(transfer_id, status):
+            return TicketRecord(
+                id=1,
+                gmt_create=now,
+                gmt_modified=now,
+                transfer_id=transfer_id,
+                tenant="t1",
+                paas_device_id="sandbox@42",
+                direction="UPLOAD",
+                status=status,
+                staging_subdir=None,
+                filename="data.csv",
+                device_path="/home/data.csv",
+                fileservice_staging_path=f"file-transfers/t1/{transfer_id}/data.csv",
+                error_message=None,
+                download_url=None,
+                multipart_session_id=None,
+                env="test",
+                operator="unknown",
+            )
+
+        model1 = MagicMock()
+        model1.to_record.return_value = _make_record("tf-001", "UPLOADING")
+        model2 = MagicMock()
+        model2.to_record.return_value = _make_record("tf-002", "UPLOADING")
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [
+            model1,
+            model2,
+        ]
+
+        result = repo.list_pending_uploads(["CREATED", "UPLOADING"], 10)
+
+        assert len(result) == 2
+        assert result[0].transfer_id == "tf-001"
+        assert result[1].transfer_id == "tf-002"
+
+    def test_empty_result(self, repo, mock_session):
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+
+        result = repo.list_pending_uploads(["CREATED"], 10)
+
+        assert result == []
+
+    def test_respects_limit(self, repo, mock_session):
+        """Verify the limit argument is passed to the query chain."""
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+
+        repo.list_pending_uploads(["CREATED"], 5)
+
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.assert_called_once_with(
+            5
+        )
+
+
+# ==================== TestGetByFileserviceStagingPath ====================
+
+
+class TestGetByFileserviceStagingPath:
+    def test_found(self, repo, mock_session):
+        now = datetime.now()
+        record = TicketRecord(
+            id=5,
+            gmt_create=now,
+            gmt_modified=now,
+            transfer_id="tf-xyz",
+            tenant="t1",
+            paas_device_id="sandbox@42",
+            direction="UPLOAD",
+            status="CREATED",
+            staging_subdir=None,
+            filename="data.csv",
+            device_path="/home/data.csv",
+            fileservice_staging_path="file-transfers/t1/tf-xyz/data.csv",
+            error_message=None,
+            download_url=None,
+            multipart_session_id=None,
+            env="test",
+            operator="unknown",
+        )
+        model = MagicMock()
+        model.to_record.return_value = record
+        mock_session.query.return_value.filter.return_value.first.return_value = model
+
+        result = repo.get_by_fileservice_staging_path(
+            "file-transfers/t1/tf-xyz/data.csv"
+        )
+
+        assert result is not None
+        assert result.transfer_id == "tf-xyz"
+
+    def test_not_found(self, repo, mock_session):
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        result = repo.get_by_fileservice_staging_path("nonexistent/path")
+
+        assert result is None
+
+    def test_with_tenant_filter(self, repo, mock_session):
+        """Verify that when tenant is passed, the filter chain includes tenant condition."""
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        repo.get_by_fileservice_staging_path(
+            "file-transfers/t1/tf-xyz/data.csv", tenant="t1"
+        )
+
+        assert mock_session.query.return_value.filter.call_count >= 1

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_dispatcher.py
@@ -48,9 +48,9 @@ def _make_ticket(**overrides):
         fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
         error_message=None,
         download_url=None,
-        upload_url=None,
         multipart_session_id=None,
         env="test",
+        operator="unknown",
     )
     defaults.update(overrides)
     return TicketRecord(**defaults)
@@ -303,13 +303,10 @@ class TestDispatchGetTransferStatus:
 
     @pytest.mark.asyncio
     async def test_status_created(self, dispatcher, ticket_repo):
-        ticket = _make_ticket(
-            status="CREATED", upload_url="https://oss.example.com/put"
-        )
+        ticket = _make_ticket(status="CREATED")
         ticket_repo.get_by_transfer_id.return_value = ticket
         result = await dispatcher.dispatch_get_transfer_status("tf-001", tenant="t1")
         assert result.status == "CREATED"
-        assert result.upload_url == "https://oss.example.com/put"
 
     @pytest.mark.asyncio
     async def test_status_failed(self, dispatcher, ticket_repo):

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_operator.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_file_transfer_operator.py
@@ -1,0 +1,281 @@
+"""Unit tests for operator field — normalization, passthrough, and status response."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from secbaas.community.api.bot_runtime import (
+    GetDownloadUrlRequest,
+    GetUploadUrlRequest,
+)
+from secbaas.community.core.repository.file_transfer_ticket import TicketRecord
+from secbaas.community.core.service.bot_runtime.dispatcher._file_transfer_dispatcher import (
+    DefaultBotFileTransferDispatcher,
+)
+from secbaas.community.spi.file_transfer import (
+    MultipartSession,
+    ObjectListing,
+    PartInfo,
+)
+
+
+def _make_ticket(**overrides):
+    now = datetime.now()
+    defaults = dict(
+        id=1,
+        gmt_create=now,
+        gmt_modified=now,
+        transfer_id="tf-001",
+        tenant="test-tenant",
+        paas_device_id="sandbox@42",
+        direction="UPLOAD",
+        status="CREATED",
+        staging_subdir=None,
+        filename="data.csv",
+        device_path="/home/data.csv",
+        fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
+        error_message=None,
+        download_url=None,
+        multipart_session_id=None,
+        env="test",
+        operator="unknown",
+    )
+    defaults.update(overrides)
+    return TicketRecord(**defaults)
+
+
+@pytest.fixture
+def bot_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def device_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def paas_facade():
+    facade = MagicMock()
+    facade.push_file = AsyncMock()
+    return facade
+
+
+@pytest.fixture
+def file_backend():
+    backend = MagicMock()
+    backend.generate_upload_url.return_value = "https://oss.example.com/put?token=abc"
+    backend.generate_download_url.return_value = "https://oss.example.com/get?token=abc"
+    backend.check_object_exists.return_value = True
+    backend.build_staging_path.return_value = "file-transfers/t1/tf-001/data.csv"
+    backend.build_staging_prefix.return_value = "file-transfers/t1/"
+    backend.list_objects.return_value = ObjectListing(
+        items=[], truncated=False, next_marker=None
+    )
+    backend.initiate_multipart_upload.return_value = MultipartSession(
+        session_id="mp-session-1",
+        part_count=2,
+        parts=[
+            PartInfo(part_number=1, upload_url="https://oss.example.com/part1"),
+            PartInfo(part_number=2, upload_url="https://oss.example.com/part2"),
+        ],
+    )
+    backend.list_parts.return_value = [
+        PartInfo(part_number=1, upload_url="", etag="etag-1"),
+    ]
+    return backend
+
+
+@pytest.fixture
+def ticket_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def dispatcher(bot_repo, device_repo, paas_facade, file_backend, ticket_repo):
+    return DefaultBotFileTransferDispatcher(
+        bot_repo=bot_repo,
+        device_repo=device_repo,
+        paas_facade=paas_facade,
+        file_transfer_backend=file_backend,
+        ticket_repo=ticket_repo,
+    )
+
+
+def _setup_resolve_bot_device(dispatcher, bot_repo, device_repo):
+    mock_bot = MagicMock()
+    mock_bot.id = 1
+    mock_bot.bot_uuid = "bot-001"
+    mock_bot.tenant = "test-tenant"
+    bot_repo.get_by_bot_uuid.return_value = mock_bot
+    mock_device = MagicMock()
+    mock_device.id = 1
+    mock_device.device_uuid = "dev-001"
+    mock_device.provider_device_id = "sandbox@42"
+    mock_device.status = "ACTIVE"
+    device_repo.list_by_bot_id.return_value = [mock_device]
+
+
+# ── Test 1: operator=None normalizes to "unknown" (D-04) ─────────────
+
+
+class TestOperatorNoneNormalization:
+    @pytest.mark.asyncio
+    async def test_upload_operator_none(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator=None in dispatch_get_upload_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator=None,
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_download_operator_none(
+        self, dispatcher, bot_repo, device_repo, ticket_repo, paas_facade
+    ):
+        """operator=None in dispatch_get_download_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_download_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            operator=None,
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+
+# ── Test 2: operator="" normalizes to "unknown" (D-04) ───────────────
+
+
+class TestOperatorEmptyStringNormalization:
+    @pytest.mark.asyncio
+    async def test_upload_operator_empty_string(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator="" in dispatch_get_upload_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator="",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_download_operator_empty_string(
+        self, dispatcher, bot_repo, device_repo, ticket_repo, paas_facade
+    ):
+        """operator="" in dispatch_get_download_url → create_ticket called with 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_download_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            operator="",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+
+# ── Test 3: operator="   " normalizes to "unknown" (D-04) ────────────
+
+
+class TestOperatorWhitespaceNormalization:
+    @pytest.mark.asyncio
+    async def test_upload_operator_whitespace_only(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator="   " in dispatch_get_upload_url → .strip() → 'unknown'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator="   ",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "unknown"
+
+
+# ── Test 4: operator="user123" passes through unchanged ───────────────
+
+
+class TestOperatorPassthrough:
+    @pytest.mark.asyncio
+    async def test_upload_operator_passthrough(
+        self, dispatcher, bot_repo, device_repo, ticket_repo
+    ):
+        """operator='user123' in upload → create_ticket called with 'user123'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_upload_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            filename="data.csv",
+            file_size=100,
+            operator="user123",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "user123"
+
+    @pytest.mark.asyncio
+    async def test_download_operator_passthrough(
+        self, dispatcher, bot_repo, device_repo, ticket_repo, paas_facade
+    ):
+        """operator='bob' in download → create_ticket called with 'bob'."""
+        _setup_resolve_bot_device(dispatcher, bot_repo, device_repo)
+        await dispatcher.dispatch_get_download_url(
+            bot_uuid="bot-001",
+            tenant="t1",
+            device_path="/home/data.csv",
+            operator="bob",
+        )
+        assert ticket_repo.create_ticket.call_args.kwargs["operator"] == "bob"
+
+
+# ── Test 5: GetTransferStatusResponse includes operator field (D-05) ──
+
+
+class TestTransferStatusOperator:
+    @pytest.mark.asyncio
+    async def test_status_response_includes_operator(self, dispatcher, ticket_repo):
+        """dispatch_get_transfer_status returns operator from TicketRecord."""
+        ticket = _make_ticket(status="DONE", operator="alice")
+        ticket_repo.get_by_transfer_id.return_value = ticket
+        result = await dispatcher.dispatch_get_transfer_status("tf-001", tenant="t1")
+        assert result.operator == "alice"
+
+
+# ── Test 6: Pydantic model default value (D-03) ──────────────────────
+
+
+class TestPydanticModelDefaults:
+    def test_upload_request_default_operator(self):
+        """GetUploadUrlRequest without operator → defaults to 'unknown'."""
+        req = GetUploadUrlRequest(device_path="/home/data.csv")
+        assert req.operator == "unknown"
+
+    def test_download_request_default_operator(self):
+        """GetDownloadUrlRequest without operator → defaults to 'unknown'."""
+        req = GetDownloadUrlRequest(device_path="/home/data.csv")
+        assert req.operator == "unknown"
+
+    def test_upload_request_explicit_operator(self):
+        """GetUploadUrlRequest with explicit operator → preserves value."""
+        req = GetUploadUrlRequest(device_path="/home/data.csv", operator="mybot")
+        assert req.operator == "mybot"
+
+    def test_download_request_explicit_operator(self):
+        """GetDownloadUrlRequest with explicit operator → preserves value."""
+        req = GetDownloadUrlRequest(device_path="/home/data.csv", operator="mybot")
+        assert req.operator == "mybot"

--- a/src/baas/tests/unit/core/service/scheduler/test_file_transfer_poller.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_file_transfer_poller.py
@@ -50,7 +50,6 @@ def _make_ticket(**overrides):
         fileservice_staging_path="file-transfers/t1/tf-001/data.csv",
         error_message=None,
         download_url=None,
-        upload_url=None,
         multipart_session_id=None,
         env="test",
     )

--- a/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/token_exchange/router.py
@@ -1,34 +1,22 @@
-import asyncio
-from typing import Any
+"""Token exchange HTTP boundary; Caller policy lives in application services."""
 
 from fastapi import APIRouter, Query, Request, Response
 from fastapi.responses import JSONResponse
 
-from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
 from agentclaw.community.api.caller_credential import (
     CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
     CALLER_CREDENTIAL_REQUEST_INVALID,
-    CALLER_OUTBOUND_UPDATE_FAILED,
-    CallerCredentialError,
-    CallerRuntimeUpdater,
-    CallerTokenProvider,
 )
-from agentclaw.community.api.caller_identity_service import (
-    CallerIdentityServiceProtocol,
-    CallerIdentityStage,
-)
-from agentclaw.community.core.caller_identity.contracts import (
-    CallerIdentityAmbiguousError,
-    CallerIdentityPermissionError,
-)
+from agentclaw.community.api.caller_identity_service import CallerIdentityStage
 from agentclaw.community.di import Injected
-from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.auth import AuthPlugin, AuthRequestContext
-from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.plugin_api.auth import AuthRequestContext
 from agentclaw.community.plugin_api.token_exchange import TokenExchangePlugin
 
+
 router = APIRouter()
-logger = get_logger()
 
 
 def _cors_headers(request: Request) -> dict[str, str]:
@@ -39,59 +27,24 @@ def _cors_headers(request: Request) -> dict[str, str]:
     }
 
 
-def _success_iam_response(iam_token: str, headers: dict[str, str]) -> Response:
-    return JSONResponse(
-        content={"success": True, "iam_token": iam_token},
-        headers=headers,
-    )
-
-
-def _request_injector(request: Request):
-    return getattr(getattr(request, "app", None), "state", None).injector
-
-
-def _get_optional_dependency(
-    request: Request,
-    dependency: Any,
-    error_code: str,
-):
-    try:
-        return _request_injector(request).get(dependency)
-    except Exception as exc:
-        logger.warning("caller_token_dependency_unavailable code=%s", error_code)
-        raise CallerCredentialError(error_code) from exc
-
-
-def _build_auth_context(request: Request) -> AuthRequestContext:
+def _auth_request(request: Request) -> AuthRequestContext:
     return AuthRequestContext(
         cookies=dict(request.cookies),
-        headers={k: v for k, v in request.headers.items()},
+        headers=dict(request.headers),
         query_params=dict(request.query_params),
         base_url=str(request.base_url),
     )
 
 
-async def _resolve_current_user(request: Request):
-    auth_plugin = _get_optional_dependency(
-        request,
-        AuthPlugin,
-        CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-    )
-    identity = await auth_plugin.resolve_user_from_request(_build_auth_context(request))
-    return AuthenticatedUser(
-        id=identity.id,
-        staffId=identity.staffId,
-        operatorName=identity.operatorName,
-        nickName=identity.nickName,
-        tenantId=identity.tenantId,
-    )
-
-
-def _caller_error_status(code: str) -> int:
-    if code == CALLER_CREDENTIAL_REQUEST_INVALID:
+def _caller_error_status(error: str) -> int:
+    if error == CALLER_CREDENTIAL_REQUEST_INVALID or error == "IAM_TOKEN cookie not found":
         return 400
-    if code == CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE:
+    if error == CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE:
         return 503
+    if error == "CALLER_IDENTITY_AMBIGUOUS":
+        return 409
+    if error == "CALLER_IDENTITY_FORBIDDEN":
+        return 403
     return 502
 
 
@@ -114,13 +67,10 @@ async def token_exchange(
     request: Request,
     plugin: TokenExchangePlugin = Injected(TokenExchangePlugin),
 ) -> Response:
-    headers = _cors_headers(request)
-    # Plugin owns the per-runtime policy: Local returns a mock; Prod
-    # reads IAM_TOKEN and calls Buservice. Missing cookie / upstream
-    # failures raise DomainError subclasses mapped to 400/500 by the
-    # global handler in api/app.py.
-    content = await plugin.exchange_from_request(request)
-    return JSONResponse(content=content, headers=headers)
+    return JSONResponse(
+        content=await plugin.exchange_from_request(request),
+        headers=_cors_headers(request),
+    )
 
 
 @router.options("/api/v1/token/iam")
@@ -145,190 +95,24 @@ async def get_iam_token(
     publish_id: int | None = Query(default=None),
     entity_id: str | None = Query(default=None),
     is_test_exchange: bool = False,
+    service: CallerIamTokenServiceProtocol = Injected(CallerIamTokenServiceProtocol),
 ) -> Response:
-    headers = _cors_headers(request)
-    iam_token = request.cookies.get("IAM_TOKEN") or ""
-    if not iam_token:
-        return JSONResponse(
-            content={"success": False, "error": "IAM_TOKEN cookie not found"},
-            status_code=400,
-            headers=headers,
-        )
-    if is_test_exchange and not bot_id:
-        logger.warning("caller_test_exchange_rejected reason=bot_id_missing")
-        return JSONResponse(
-            content={"success": False, "error": CALLER_CREDENTIAL_REQUEST_INVALID},
-            status_code=400,
-            headers=headers,
-        )
-    if not bot_id:
-        return _success_iam_response(iam_token, headers)
-
-    try:
-        caller_identity = _get_optional_dependency(
-            request,
-            CallerIdentityServiceProtocol,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-    except CallerCredentialError:
-        logger.warning(
-            "caller_token_context_unavailable bot_id=%s stage=%s "
-            "reason=identity_service_missing",
-            bot_id,
-            stage.value,
-        )
-        return _success_iam_response(iam_token, headers)
-    try:
-        token_context = await asyncio.to_thread(
-            caller_identity.get_iam_token_context,
-            bot_id=bot_id,
-            stage=stage,
-            publish_id=publish_id,
-            entity_id=entity_id,
-            is_test_exchange=is_test_exchange,
-        )
-    except CallerIdentityAmbiguousError as exc:
-        logger.warning(
-            "caller_token_context_ambiguous bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.detail},
-            status_code=409,
-            headers=headers,
-        )
-    except CallerIdentityPermissionError as exc:
-        logger.warning(
-            "caller_token_context_forbidden bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.detail},
-            status_code=403,
-            headers=headers,
-        )
-    except Exception:
-        logger.warning(
-            "caller_token_context_unavailable bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return _success_iam_response(iam_token, headers)
-    if not token_context.should_exchange_caller_token:
-        logger.info(
-            "caller_token_exchange_skipped bot_id=%s stage=%s call_type=%s "
-            "test_exchange=%s",
-            bot_id,
-            stage.value,
-            token_context.bot_call_type.value,
-            is_test_exchange,
-        )
-        return _success_iam_response(iam_token, headers)
-    if not token_context.owner_id:
-        logger.warning(
-            "caller_token_exchange_failed bot_id=%s stage=%s reason=owner_missing "
-            "test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": CALLER_CREDENTIAL_REQUEST_INVALID},
-            status_code=400,
-            headers=headers,
-        )
-
-    try:
-        current_user = await _resolve_current_user(request)
-        if is_test_exchange:
-            caller_identity.authorize_iam_token_exchange(
-                caller_user_id=current_user.staffId,
-                owner_user_id=token_context.owner_id,
-                is_test_exchange=True,
-            )
-        passport = _get_optional_dependency(
-            request,
-            PassportPlugin,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-        provider = _get_optional_dependency(
-            request,
-            CallerTokenProvider,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-        updater = _get_optional_dependency(
-            request,
-            CallerRuntimeUpdater,
-            CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE,
-        )
-        exchange_kwargs = {
-            "iam_token": iam_token,
-            "caller_user_id": current_user.staffId,
-            "bot_id": bot_id,
-            "owner_user_id": token_context.owner_id,
-            "passport": passport,
-            "token_provider": provider,
-            "runtime_updater": updater,
-            "stage": stage.value,
-            "publish_id": publish_id,
-            "entity_id": entity_id,
-            "binding_id": token_context.binding_id,
-        }
-        if is_test_exchange:
-            exchange_kwargs["is_test_exchange"] = True
-        await asyncio.to_thread(
-            caller_identity.exchange_caller_identity,
-            **exchange_kwargs,
-        )
-    except CallerCredentialError as exc:
-        logger.warning(
-            "caller_token_exchange_failed bot_id=%s stage=%s code=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            exc.code,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.code},
-            status_code=_caller_error_status(exc.code),
-            headers=headers,
-        )
-    except CallerIdentityPermissionError as exc:
-        logger.warning(
-            "caller_token_exchange_forbidden bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": exc.detail},
-            status_code=403,
-            headers=headers,
-        )
-    except Exception:
-        logger.warning(
-            "caller_runtime_update_failed bot_id=%s stage=%s test_exchange=%s",
-            bot_id,
-            stage.value,
-            is_test_exchange,
-        )
-        return JSONResponse(
-            content={"success": False, "error": CALLER_OUTBOUND_UPDATE_FAILED},
-            status_code=502,
-            headers=headers,
-        )
-
-    logger.info(
-        "caller_token_exchange_succeeded bot_id=%s stage=%s test_exchange=%s",
-        bot_id,
-        stage.value,
-        is_test_exchange,
+    result = await service.get_iam_token(
+        iam_token=request.cookies.get("IAM_TOKEN") or "",
+        auth_request=_auth_request(request),
+        bot_id=bot_id,
+        stage=stage,
+        publish_id=publish_id,
+        entity_id=entity_id,
+        is_test_exchange=is_test_exchange,
     )
-    # COSEC: the Caller credential is written to BaaS only. Returning it to
-    # the browser would turn a server-side runtime credential into an API secret.
-    return _success_iam_response(iam_token, headers)
+    content = {"success": result.error is None}
+    if result.error is None:
+        content["iam_token"] = result.iam_token
+    else:
+        content["error"] = result.error
+    return JSONResponse(
+        content=content,
+        status_code=200 if result.error is None else _caller_error_status(result.error),
+        headers=_cors_headers(request),
+    )

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -66,6 +66,7 @@ internal_dependencies:
   - agentclaw.community.core.service_bot.services.baas_service  # BotWsConnectionInfoResponse / HttpConnectionInfo — typed in baas_service.py (BaasService is a plain core service)
   - agentclaw.community.core.service_bot.types       # PublishStage enum — typed in baas_service.py
   - agentclaw.community.kernel.device_dto            # OutBoundOperationRule — typed in baas_service.py Protocol (B6)
+  - agentclaw.community.plugin_api.auth              # AuthRequestContext — typed in caller_iam_token_service.py
   - agentclaw.community.plugin_api.passport          # PassportPlugin — typed in caller_identity_service.py
 ```
 

--- a/src/backend/src/agentclaw/community/api/caller_credential.py
+++ b/src/backend/src/agentclaw/community/api/caller_credential.py
@@ -34,11 +34,28 @@ class CallerTokenProvider(Protocol):
         *,
         auth_context: AuthContext,
         iam_token: str,
-        delegation_credential: str,
+        bot_id: str,
+        owner_user_id: str,
         task_metadata: Mapping[str, str],
     ) -> CallerToken:
         """Issue one non-retried Caller execution credential."""
         ...
+
+
+class UnavailableCallerTokenProvider:
+    """Stable non-Corp binding that fails closed without Injector errors."""
+
+    def exchange(
+        self,
+        *,
+        auth_context: AuthContext,
+        iam_token: str,
+        bot_id: str,
+        owner_user_id: str,
+        task_metadata: Mapping[str, str],
+    ) -> CallerToken:
+        del auth_context, iam_token, bot_id, owner_user_id, task_metadata
+        raise CallerCredentialError(CALLER_CREDENTIAL_PROVIDER_UNAVAILABLE)
 
 
 @runtime_checkable
@@ -52,15 +69,13 @@ class CallerRuntimeUpdater(Protocol):
         owner_user_id: str,
         caller_user_id: str,
         caller_token: CallerToken,
-        agent_pass_token: str,
-        agent_code: str,
         stage: str,
         publish_id: int | None,
         entity_id: str | None = None,
         binding_id: int | None = None,
         is_test_exchange: bool = False,
     ) -> None:
-        """Replace the device's complete outbound rule with Caller overlay."""
+        """Append the Caller overlay to the exact runtime device."""
         ...
 
 
@@ -78,4 +93,5 @@ __all__ = [
     "CallerRuntimeUpdater",
     "CallerToken",
     "CallerTokenProvider",
+    "UnavailableCallerTokenProvider",
 ]

--- a/src/backend/src/agentclaw/community/api/caller_iam_token_service.py
+++ b/src/backend/src/agentclaw/community/api/caller_iam_token_service.py
@@ -1,0 +1,26 @@
+"""Application boundary for IAM-token Caller identity updates."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenOutcome,
+    CallerIdentityStage,
+)
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+
+
+@runtime_checkable
+class CallerIamTokenServiceProtocol(Protocol):
+    async def get_iam_token(
+        self,
+        *,
+        iam_token: str,
+        auth_request: AuthRequestContext,
+        bot_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        is_test_exchange: bool,
+    ) -> CallerIamTokenOutcome: ...

--- a/src/backend/src/agentclaw/community/api/caller_identity_service.py
+++ b/src/backend/src/agentclaw/community/api/caller_identity_service.py
@@ -24,7 +24,6 @@ from agentclaw.community.core.caller_identity.contracts import (
     McpCallType,
     McpCallTypeUpdateResult,
 )
-from agentclaw.community.plugin_api.passport import PassportPlugin
 
 
 @runtime_checkable
@@ -90,7 +89,6 @@ class CallerIdentityServiceProtocol(Protocol):
         caller_user_id: str,
         bot_id: str,
         owner_user_id: str,
-        passport: PassportPlugin,
         token_provider: CallerTokenProviderProtocol,
         runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,

--- a/src/backend/src/agentclaw/community/core/caller_identity/contracts.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/contracts.py
@@ -90,6 +90,14 @@ class CallerIamTokenContext:
     binding_id: int | None = None
 
 
+@dataclass(frozen=True)
+class CallerIamTokenOutcome:
+    """HTTP-neutral result of optional Caller identity installation."""
+
+    iam_token: str
+    error: str | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class CallerContext:
     capability: str

--- a/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
@@ -1,0 +1,113 @@
+"""Core application service for optional Caller identity installation."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agentclaw.community.core.caller_identity.credential import (
+    CALLER_CREDENTIAL_REQUEST_INVALID,
+    CALLER_OUTBOUND_UPDATE_FAILED,
+    CallerCredentialError,
+)
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIdentityAmbiguousError,
+    CallerIamTokenOutcome,
+    CallerIdentityPermissionError,
+    CallerIdentityStage,
+)
+from agentclaw.community.core.caller_identity.protocols import (
+    CallerIdentityTokenExchangeProtocol,
+    CallerRuntimeUpdaterProtocol,
+    CallerTokenProviderProtocol,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.auth import AuthPlugin, AuthRequestContext
+
+
+logger = get_logger()
+
+
+class CallerIamTokenService:
+    """Keep Caller exchange policy out of the HTTP router."""
+
+    def __init__(
+        self,
+        *,
+        caller_identity: CallerIdentityTokenExchangeProtocol,
+        auth_plugin: AuthPlugin,
+        token_provider: CallerTokenProviderProtocol,
+        runtime_updater: CallerRuntimeUpdaterProtocol,
+    ) -> None:
+        self._caller_identity = caller_identity
+        self._auth_plugin = auth_plugin
+        self._token_provider = token_provider
+        self._runtime_updater = runtime_updater
+
+    async def get_iam_token(
+        self,
+        *,
+        iam_token: str,
+        auth_request: AuthRequestContext,
+        bot_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        is_test_exchange: bool,
+    ) -> CallerIamTokenOutcome:
+        if not iam_token:
+            return CallerIamTokenOutcome(iam_token="", error="IAM_TOKEN cookie not found")
+        if is_test_exchange and not bot_id:
+            return CallerIamTokenOutcome(iam_token="", error=CALLER_CREDENTIAL_REQUEST_INVALID)
+        if not bot_id:
+            return CallerIamTokenOutcome(iam_token=iam_token)
+        try:
+            context = await asyncio.to_thread(
+                self._caller_identity.get_iam_token_context,
+                bot_id=bot_id,
+                stage=stage,
+                publish_id=publish_id,
+                entity_id=entity_id,
+                is_test_exchange=is_test_exchange,
+            )
+        except CallerIdentityAmbiguousError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.detail)
+        except CallerIdentityPermissionError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.detail)
+        except Exception:
+            logger.warning("caller_token_context_unavailable bot_id=%s stage=%s", bot_id, stage.value)
+            return CallerIamTokenOutcome(iam_token=iam_token)
+        if not context.should_exchange_caller_token:
+            return CallerIamTokenOutcome(iam_token=iam_token)
+        if not context.owner_id:
+            return CallerIamTokenOutcome(iam_token="", error=CALLER_CREDENTIAL_REQUEST_INVALID)
+        try:
+            identity = await self._auth_plugin.resolve_user_from_request(auth_request)
+            if is_test_exchange:
+                self._caller_identity.authorize_iam_token_exchange(
+                    caller_user_id=identity.staffId,
+                    owner_user_id=context.owner_id,
+                    is_test_exchange=True,
+                )
+            await asyncio.to_thread(
+                self._caller_identity.exchange_caller_identity,
+                iam_token=iam_token,
+                caller_user_id=identity.staffId,
+                bot_id=bot_id,
+                owner_user_id=context.owner_id,
+                token_provider=self._token_provider,
+                runtime_updater=self._runtime_updater,
+                stage=stage.value,
+                publish_id=publish_id,
+                entity_id=entity_id,
+                binding_id=context.binding_id,
+                is_test_exchange=is_test_exchange,
+            )
+        except CallerCredentialError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.code)
+        except CallerIdentityPermissionError as exc:
+            return CallerIamTokenOutcome(iam_token="", error=exc.detail)
+        except Exception:
+            logger.warning("caller_runtime_update_failed bot_id=%s stage=%s", bot_id, stage.value)
+            return CallerIamTokenOutcome(iam_token="", error=CALLER_OUTBOUND_UPDATE_FAILED)
+        logger.info("caller_token_exchange_succeeded bot_id=%s stage=%s", bot_id, stage.value)
+        return CallerIamTokenOutcome(iam_token=iam_token)

--- a/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
-from agentclaw.community.core.caller_identity.credential import (
-    AuthContext,
-    CallerToken,
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenContext,
+    CallerIdentityStage,
 )
+from agentclaw.community.core.caller_identity.credential import AuthContext, CallerToken
 
 
 @runtime_checkable
@@ -37,7 +38,8 @@ class CallerTokenProviderProtocol(Protocol):
         *,
         auth_context: AuthContext,
         iam_token: str,
-        delegation_credential: str,
+        bot_id: str,
+        owner_user_id: str,
         task_metadata: Mapping[str, str],
     ) -> CallerToken: ...
 
@@ -53,8 +55,44 @@ class CallerRuntimeUpdaterProtocol(Protocol):
         owner_user_id: str,
         caller_user_id: str,
         caller_token: CallerToken,
-        agent_pass_token: str,
-        agent_code: str,
+        stage: str,
+        publish_id: int | None,
+        entity_id: str | None = None,
+        binding_id: int | None = None,
+        is_test_exchange: bool = False,
+    ) -> None: ...
+
+
+@runtime_checkable
+class CallerIdentityTokenExchangeProtocol(Protocol):
+    """Core port for the Caller IAM-token exchange use case."""
+
+    def get_iam_token_context(
+        self,
+        bot_id: str,
+        stage: CallerIdentityStage,
+        publish_id: int | None = None,
+        entity_id: str | None = None,
+        is_test_exchange: bool = False,
+    ) -> CallerIamTokenContext: ...
+
+    def authorize_iam_token_exchange(
+        self,
+        *,
+        caller_user_id: str,
+        owner_user_id: str,
+        is_test_exchange: bool,
+    ) -> None: ...
+
+    def exchange_caller_identity(
+        self,
+        *,
+        iam_token: str,
+        caller_user_id: str,
+        bot_id: str,
+        owner_user_id: str,
+        token_provider: CallerTokenProviderProtocol,
+        runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,
         publish_id: int | None,
         entity_id: str | None = None,
@@ -65,6 +103,7 @@ class CallerRuntimeUpdaterProtocol(Protocol):
 
 __all__ = [
     "CallerMcpSyncProtocol",
+    "CallerIdentityTokenExchangeProtocol",
     "CallerRuntimeUpdaterProtocol",
     "CallerTokenProviderProtocol",
 ]

--- a/src/backend/src/agentclaw/community/core/caller_identity/service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/service.py
@@ -31,9 +31,7 @@ from agentclaw.community.core.caller_identity.contracts import (
 )
 from agentclaw.community.core.caller_identity.credential import (
     CALLER_CHAT_TASK,
-    CALLER_CREDENTIAL_REQUEST_INVALID,
     AuthContext,
-    CallerCredentialError,
 )
 from agentclaw.community.core.caller_identity.protocols import (
     CallerMcpSyncProtocol,
@@ -47,7 +45,6 @@ from agentclaw.community.core.caller_identity.repository import (
 )
 from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -335,7 +332,6 @@ class CallerIdentityService:
         caller_user_id: str,
         bot_id: str,
         owner_user_id: str,
-        passport: PassportPlugin,
         token_provider: CallerTokenProviderProtocol,
         runtime_updater: CallerRuntimeUpdaterProtocol,
         stage: str,
@@ -345,21 +341,11 @@ class CallerIdentityService:
         is_test_exchange: bool = False,
     ) -> None:
         """Exchange and install the Caller credential for one chat request."""
-        delegation_credential = passport.query_token(bot_id, owner_user_id) or ""
-        if not delegation_credential:
-            raise CallerCredentialError(CALLER_CREDENTIAL_REQUEST_INVALID)
-
-        passport_detail = passport.query_agent_passport(bot_id, owner_user_id)
-        agent_code_value = (
-            passport_detail.get("agent_code")
-            if isinstance(passport_detail, Mapping)
-            else None
-        )
-        agent_code = agent_code_value if isinstance(agent_code_value, str) else ""
         caller_token = token_provider.exchange(
             auth_context=AuthContext(user_id=caller_user_id),
             iam_token=iam_token,
-            delegation_credential=delegation_credential,
+            bot_id=bot_id,
+            owner_user_id=owner_user_id,
             task_metadata=CALLER_CHAT_TASK,
         )
         runtime_update_kwargs: dict[str, Any] = {
@@ -367,8 +353,6 @@ class CallerIdentityService:
             "owner_user_id": owner_user_id,
             "caller_user_id": caller_user_id,
             "caller_token": caller_token,
-            "agent_pass_token": delegation_credential,
-            "agent_code": agent_code,
             "stage": stage,
             "publish_id": publish_id,
             "entity_id": entity_id,

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -27,12 +27,19 @@ stands alone and is wired into the DI graph for callers to inject.
 """
 from __future__ import annotations
 
+import asyncio
 import traceback
 from typing import Any, Dict, Optional
 
 from injector import inject
 
+from agentclaw.community.api.caller_credential import (
+    CallerRuntimeUpdater,
+    CallerTokenProvider,
+)
+from agentclaw.community.api.caller_identity_service import CallerIdentityServiceProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.caller_identity.contracts import CallerIdentityStage
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
 from agentclaw.community.core.expert_chat.errors import (
@@ -63,7 +70,10 @@ class ExpertChatInstanceService:
     ``ExpertChatInstanceRepository`` (ledger), ``BaasService`` (container
     lifecycle), ``BotPublishRepositoryProtocol`` (success publish order /
     migration_path reverse-lookup), ``BotRepository`` (bot info lookup),
-    ``DeviceBindingRepository`` (device binding for caller containers).
+    ``DeviceBindingRepository`` (device binding for caller containers),
+    ``CallerIdentityServiceProtocol`` (caller identity exchange),
+    ``CallerTokenProvider`` (token exchange), ``CallerRuntimeUpdater``
+    (runtime identity update).
     """
 
     @inject
@@ -75,6 +85,9 @@ class ExpertChatInstanceService:
         bot_repo: BotRepository,
         binding_repo: DeviceBindingRepository,
         bot_build_service: BotBuildService,
+        caller_identity: CallerIdentityServiceProtocol,
+        token_provider: CallerTokenProvider,
+        runtime_updater: CallerRuntimeUpdater,
     ) -> None:
         self._instance_repo = instance_repo
         self._baas = baas_service
@@ -82,6 +95,9 @@ class ExpertChatInstanceService:
         self._bot_repo = bot_repo
         self._binding_repo = binding_repo
         self._bot_build_service = bot_build_service
+        self._caller_identity = caller_identity
+        self._token_provider = token_provider
+        self._runtime_updater = runtime_updater
 
     # ------------------------------------------------------------------
     # Public entry
@@ -243,6 +259,23 @@ class ExpertChatInstanceService:
                         "[ExpertChatInstance] Updated binding status: binding_id=%s status=%s",
                         binding_id, binding_status,
                     )
+
+                # Exchange caller identity when container is successfully pulled
+                if status == "SUCCESS":
+                    if iam_token:
+                        await self._exchange_caller_identity(
+                            iam_token=iam_token,
+                            user_id=user_id,
+                            bot_id=bot_id,
+                            owner_id=owner_id,
+                            publish_id=service_bot_publish_id,
+                            binding_id=binding_id,
+                        )
+                    else:
+                        logger.warning(
+                            "[ExpertChatInstance] Skip caller identity exchange: no iam_token provided bot=%s owner=%s user=%s",
+                            bot_id, owner_id, user_id,
+                        )
 
                 ext = dict(ext)
                 ext["baas_publish"] = progress
@@ -540,3 +573,55 @@ class ExpertChatInstanceService:
             "tenant": ws_info.tenant,
             "bot_uuid": ws_info.bot_uuid,
         }
+
+    # ------------------------------------------------------------------
+    # Caller identity exchange
+    # ------------------------------------------------------------------
+    async def _exchange_caller_identity(
+        self,
+        *,
+        iam_token: str,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        publish_id: int,
+        binding_id: Optional[int] = None,
+    ) -> None:
+        """Exchange and install Caller credential for the container.
+
+        Called after the container is successfully pulled (status == "SUCCESS").
+        Failures are logged but do not interrupt the container startup flow.
+
+        Args:
+            iam_token: IAM token for authentication.
+            user_id: The caller's user ID.
+            bot_id: The bot ID.
+            owner_id: The bot owner's ID.
+            publish_id: The service bot publish record ID.
+            binding_id: The device binding ID (optional).
+        """
+        try:
+            await asyncio.to_thread(
+                self._caller_identity.exchange_caller_identity,
+                iam_token=iam_token,
+                caller_user_id=user_id,
+                bot_id=bot_id,
+                owner_user_id=owner_id,
+                token_provider=self._token_provider,
+                runtime_updater=self._runtime_updater,
+                stage=CallerIdentityStage.ONLINE.value,
+                publish_id=publish_id,
+                entity_id=owner_id,
+                binding_id=binding_id,
+                is_test_exchange=False,
+            )
+            logger.info(
+                "[ExpertChatInstance] Caller identity exchange succeeded: bot=%s owner=%s user=%s",
+                bot_id, owner_id, user_id,
+            )
+        except Exception as e:
+            # Log error but do not interrupt container startup
+            logger.error(
+                "[ExpertChatInstance] Caller identity exchange failed: bot=%s owner=%s user=%s error=%s",
+                bot_id, owner_id, user_id, e,
+            )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3147,6 +3147,45 @@ class BaasService:  # pragma: no cover
                 f"BaaS API error: {e.response.status_code} - {e.response.text}"
             )
 
+    def append_caller_outbound_rule(
+        self,
+        paas_device_id: str,
+        caller_rule: OutBoundOperationRule,
+    ) -> bool:
+        """Append one validated Caller overlay without replacing base rules."""
+        payload = self._outbound_rule_to_dict(caller_rule)
+        logger.info(
+            "caller_outbound_append_started rule_count=%s",
+            len(caller_rule.header_operation_rules),
+        )
+        try:
+            response = self._http.put(
+                f"/api/v1/paas/devices/{paas_device_id}/outbound-rule?mode=append",
+                json=payload,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            response_data = response.json()
+            if response_data.get("code") != 0:
+                logger.warning("caller_outbound_append_rejected")
+                raise BaasServiceError("BaaS Caller outbound append rejected")
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "caller_outbound_append_http_failed status_code=%s",
+                exc.response.status_code,
+            )
+            raise BaasServiceError("BaaS Caller outbound append failed") from exc
+        except BaasServiceError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "caller_outbound_append_failed error_type=%s",
+                type(exc).__name__,
+            )
+            raise BaasServiceError("BaaS Caller outbound append failed") from exc
+        logger.info("caller_outbound_append_succeeded")
+        return True
+
     def update_caller_identity(
         self,
         *,
@@ -3154,8 +3193,6 @@ class BaasService:  # pragma: no cover
         owner_user_id: str,
         caller_user_id: str,
         caller_token: CallerToken,
-        agent_pass_token: str,
-        agent_code: str,
         stage: str,
         publish_id: int | None,
         entity_id: str | None = None,
@@ -3166,7 +3203,6 @@ class BaasService:  # pragma: no cover
         if (
             not caller_token.access_token
             or caller_token.subject_user_id != caller_user_id
-            or not agent_pass_token
         ):
             raise CallerCredentialError(CALLER_CREDENTIAL_REQUEST_INVALID)
 
@@ -3222,37 +3258,24 @@ class BaasService:  # pragma: no cover
         if not self._is_valid_paas_device_id(paas_device_id):
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
 
-        base_rule = self._build_outbound_operation_rule(
-            bot_id=bot_id,
-            owner_id=owner_user_id,
-            agent_pass_token=agent_pass_token,
-            agent_code=agent_code,
-        )
         caller_rule = self._outbound_rule_provider.build_caller_rule(
             caller_token=caller_token.access_token,
         )
         if not self._is_valid_caller_rule(caller_rule, caller_token.access_token):
             raise CallerCredentialError(CALLER_OUTBOUND_INVALID)
         assert caller_rule is not None
-        complete_rule = OutBoundOperationRule(
-            header_operation_rules=(
-                base_rule.header_operation_rules
-                + caller_rule.header_operation_rules
-            )
-        )
-
         logger.info(
             "caller_outbound_update_started bot_id=%s stage=%s rule_count=%s "
             "entity_scoped=%s supplied_binding_id=%s test_exchange=%s",
             bot_id,
             stage,
-            len(complete_rule.header_operation_rules),
+            len(caller_rule.header_operation_rules),
             entity_id is not None,
             use_supplied_binding_id,
             is_test_exchange,
         )
         try:
-            updated = self.update_device_outbound_rule(paas_device_id, complete_rule)
+            updated = self.append_caller_outbound_rule(paas_device_id, caller_rule)
         except Exception as exc:
             logger.warning(
                 "caller_outbound_update_failed bot_id=%s stage=%s error_type=%s "

--- a/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
@@ -7,7 +7,14 @@ from injector import Binder, Module, inject, provider, singleton
 from agentclaw.community.api.caller_identity_service import (
     CallerIdentityServiceProtocol,
 )
-from agentclaw.community.api.caller_credential import CallerRuntimeUpdater
+from agentclaw.community.api.caller_credential import (
+    CallerRuntimeUpdater,
+    CallerTokenProvider,
+    UnavailableCallerTokenProvider,
+)
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
 from agentclaw.community.api.mcp_sync_service import MCPSyncServiceProtocol
 from agentclaw.community.core.bot_collaborator.repository.protocol import (
     BotCollabLockRepositoryProtocol,
@@ -18,11 +25,15 @@ from agentclaw.community.core.caller_identity.repository import (
     CallerIdentityRepositoryProtocol,
 )
 from agentclaw.community.core.caller_identity.service import CallerIdentityService
+from agentclaw.community.core.caller_identity.iam_token_service import (
+    CallerIamTokenService,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.plugins.caller_identity_repository import (
     CallerIdentityRepository,
 )
+from agentclaw.community.plugin_api.auth import AuthPlugin
 
 
 class CallerIdentityModule(Module):
@@ -32,6 +43,11 @@ class CallerIdentityModule(Module):
         binder.bind(
             CallerIdentityRepositoryProtocol,
             to=CallerIdentityRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            CallerTokenProvider,
+            to=UnavailableCallerTokenProvider,
             scope=singleton,
         )
 
@@ -75,3 +91,20 @@ class CallerIdentityModule(Module):
     ) -> CallerRuntimeUpdater:
         """Use the existing BaaS singleton for the Caller outbound PUT."""
         return baas_service
+
+    @singleton
+    @provider
+    @inject
+    def caller_iam_token_service(
+        self,
+        caller_identity: CallerIdentityServiceProtocol,
+        auth_plugin: AuthPlugin,
+        token_provider: CallerTokenProvider,
+        runtime_updater: CallerRuntimeUpdater,
+    ) -> CallerIamTokenServiceProtocol:
+        return CallerIamTokenService(
+            caller_identity=caller_identity,
+            auth_plugin=auth_plugin,
+            token_provider=token_provider,
+            runtime_updater=runtime_updater,
+        )

--- a/src/backend/src/agentclaw/community/kernel/device_dto.py
+++ b/src/backend/src/agentclaw/community/kernel/device_dto.py
@@ -98,6 +98,7 @@ class HeaderOperationRule:
     header_name: str
     value: str
     placeholder: str | None = None
+    separator: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -106,6 +107,7 @@ class HeaderOperationRule:
             "header_name": self.header_name,
             "value": self.value,
             "placeholder": self.placeholder,
+            "separator": self.separator,
         }
 
 

--- a/src/backend/tests/community/api/test_caller_iam_token.py
+++ b/src/backend/tests/community/api/test_caller_iam_token.py
@@ -1,207 +1,80 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from agentclaw.community.adapters.http.token_exchange.router import get_iam_token
-from agentclaw.community.api.caller_credential import (
-    CallerRuntimeUpdater,
-    CallerTokenProvider,
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
 )
-from agentclaw.community.api.caller_identity_service import (
-    CallerIdentityServiceProtocol,
-    CallerIdentityStage,
-)
-from agentclaw.community.core.caller_identity.contracts import (
-    CallerIamTokenContext,
-    CallerIdentityAmbiguousError,
-    CallerIdentityPermissionError,
-    McpCallType,
-)
-from agentclaw.community.core.caller_identity.credential import CallerToken
-from agentclaw.community.plugin_api.auth import AuthPlugin
-from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.api.caller_identity_service import CallerIdentityStage
+from agentclaw.community.core.caller_identity.contracts import CallerIamTokenOutcome
 
 
 class _Request:
-    def __init__(self, dependencies: dict[object, object]) -> None:
-        self.cookies = {"IAM_TOKEN": "iam-token"}
-        self.headers: dict[str, str] = {}
-        self.query_params: dict[str, str] = {}
-        self.base_url = "http://test/"
-        self.app = SimpleNamespace(
-            state=SimpleNamespace(
-                injector=SimpleNamespace(
-                    get=lambda dependency: dependencies[dependency]
-                )
-            )
-        )
+    cookies = {"IAM_TOKEN": "iam-token"}
+    headers: dict[str, str] = {}
+    query_params: dict[str, str] = {}
+    base_url = "http://test/"
+
+
+def _service(*, iam_token: str = "iam-token", error: str | None = None) -> MagicMock:
+    service = MagicMock(spec=CallerIamTokenServiceProtocol)
+    service.get_iam_token = AsyncMock(
+        return_value=CallerIamTokenOutcome(iam_token=iam_token, error=error)
+    )
+    return service
 
 
 @pytest.mark.asyncio
 async def test_iam_route_delegates_caller_exchange_without_returning_token() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.return_value = CallerIamTokenContext(
-        bot_id="bot-1",
-        owner_id="owner-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        bot_call_type=McpCallType.CALLER,
-        should_exchange_caller_token=True,
-        binding_id=9,
-    )
-    auth = MagicMock()
-    auth.resolve_user_from_request = AsyncMock(
-        return_value=SimpleNamespace(
-            id="id-1",
-            staffId="caller-1",
-            operatorName="Caller",
-            nickName="Caller",
-            tenantId="tenant-1",
-        )
-    )
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
-    token_provider = MagicMock()
-    token_provider.exchange.return_value = CallerToken(
-        access_token="caller-token",
-        subject_user_id="caller-1",
-        expires_at=datetime.now(),
-        fingerprint="ignored",
-    )
-    runtime_updater = MagicMock()
-    request = _Request(
-        {
-            CallerIdentityServiceProtocol: identity,
-            AuthPlugin: auth,
-            PassportPlugin: passport,
-            CallerTokenProvider: token_provider,
-            CallerRuntimeUpdater: runtime_updater,
-        }
-    )
+    service = _service()
 
     response = await get_iam_token(
-        request,
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id="entity-1",
+        service=service,
     )
 
     assert response.status_code == 200
     assert json.loads(response.body) == {"success": True, "iam_token": "iam-token"}
-    identity.get_iam_token_context.assert_called_once_with(
-        bot_id="bot-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        entity_id="entity-1",
-        is_test_exchange=False,
-    )
-    identity.exchange_caller_identity.assert_called_once()
-    exchange_kwargs = identity.exchange_caller_identity.call_args.kwargs
-    assert exchange_kwargs["caller_user_id"] == "caller-1"
-    assert exchange_kwargs["token_provider"] is token_provider
-    assert exchange_kwargs["runtime_updater"] is runtime_updater
-    assert exchange_kwargs["entity_id"] == "entity-1"
-    assert exchange_kwargs["binding_id"] == 9
+    assert service.get_iam_token.call_args.kwargs["bot_id"] == "bot-1"
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_forces_exchange_for_non_caller_context() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.return_value = CallerIamTokenContext(
-        bot_id="bot-1",
-        owner_id="owner-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        bot_call_type=McpCallType.OWNER,
-        should_exchange_caller_token=True,
-    )
-    auth = MagicMock()
-    auth.resolve_user_from_request = AsyncMock(
-        return_value=SimpleNamespace(
-            id="id-1",
-            staffId="owner-1",
-            operatorName="Caller",
-            nickName="Caller",
-            tenantId="tenant-1",
-        )
-    )
-    request = _Request(
-        {
-            CallerIdentityServiceProtocol: identity,
-            AuthPlugin: auth,
-            PassportPlugin: MagicMock(),
-            CallerTokenProvider: MagicMock(),
-            CallerRuntimeUpdater: MagicMock(),
-        }
-    )
+    service = _service()
 
     response = await get_iam_token(
-        request,
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=service,
     )
 
     assert response.status_code == 200
     assert json.loads(response.body) == {"success": True, "iam_token": "iam-token"}
-    identity.get_iam_token_context.assert_called_once_with(
-        bot_id="bot-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        entity_id=None,
-        is_test_exchange=True,
-    )
-    identity.exchange_caller_identity.assert_called_once()
-    assert (
-        identity.exchange_caller_identity.call_args.kwargs["is_test_exchange"]
-        is True
-    )
+    assert service.get_iam_token.call_args.kwargs["is_test_exchange"] is True
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_rejects_non_owner() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.return_value = CallerIamTokenContext(
-        bot_id="bot-1",
-        owner_id="owner-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        bot_call_type=McpCallType.OWNER,
-        should_exchange_caller_token=True,
-    )
-    auth = MagicMock()
-    auth.resolve_user_from_request = AsyncMock(
-        return_value=SimpleNamespace(
-            id="id-1",
-            staffId="caller-1",
-            operatorName="Caller",
-            nickName="Caller",
-            tenantId="tenant-1",
-        )
-    )
-    identity.authorize_iam_token_exchange.side_effect = CallerIdentityPermissionError()
-
     response = await get_iam_token(
-        _Request(
-            {
-                CallerIdentityServiceProtocol: identity,
-                AuthPlugin: auth,
-            }
-        ),
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=_service(error="CALLER_IDENTITY_FORBIDDEN"),
     )
 
     assert response.status_code == 403
@@ -209,21 +82,18 @@ async def test_iam_route_test_exchange_rejects_non_owner() -> None:
         "success": False,
         "error": "CALLER_IDENTITY_FORBIDDEN",
     }
-    identity.exchange_caller_identity.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_rejects_production_environment() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.side_effect = CallerIdentityPermissionError()
-
     response = await get_iam_token(
-        _Request({CallerIdentityServiceProtocol: identity}),
+        _Request(),
         bot_id="bot-1",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=_service(error="CALLER_IDENTITY_FORBIDDEN"),
     )
 
     assert response.status_code == 403
@@ -231,24 +101,18 @@ async def test_iam_route_test_exchange_rejects_production_environment() -> None:
         "success": False,
         "error": "CALLER_IDENTITY_FORBIDDEN",
     }
-    identity.get_iam_token_context.assert_called_once_with(
-        bot_id="bot-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        entity_id=None,
-        is_test_exchange=True,
-    )
 
 
 @pytest.mark.asyncio
 async def test_iam_route_test_exchange_requires_bot_id() -> None:
     response = await get_iam_token(
-        _Request({}),
+        _Request(),
         bot_id=None,
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
         entity_id=None,
         is_test_exchange=True,
+        service=_service(error="CALLER_CREDENTIAL_REQUEST_INVALID"),
     )
 
     assert response.status_code == 400
@@ -260,15 +124,13 @@ async def test_iam_route_test_exchange_requires_bot_id() -> None:
 
 @pytest.mark.asyncio
 async def test_iam_route_rejects_ambiguous_bot_without_entity() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.side_effect = CallerIdentityAmbiguousError()
-    request = _Request({CallerIdentityServiceProtocol: identity})
-
     response = await get_iam_token(
-        request,
+        _Request(),
         bot_id="default",
         stage=CallerIdentityStage.DRAFT,
         publish_id=None,
+        entity_id=None,
+        service=_service(error="CALLER_IDENTITY_AMBIGUOUS"),
     )
 
     assert response.status_code == 409
@@ -276,4 +138,3 @@ async def test_iam_route_rejects_ambiguous_bot_without_entity() -> None:
         "success": False,
         "error": "CALLER_IDENTITY_AMBIGUOUS",
     }
-    identity.exchange_caller_identity.assert_not_called()

--- a/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
@@ -1,0 +1,219 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenContext,
+    CallerIdentityAmbiguousError,
+    CallerIdentityPermissionError,
+    CallerIdentityStage,
+    McpCallType,
+)
+from agentclaw.community.core.caller_identity.credential import (
+    CALLER_CREDENTIAL_REQUEST_INVALID,
+    CALLER_OUTBOUND_UPDATE_FAILED,
+    CallerCredentialError,
+)
+from agentclaw.community.core.caller_identity.iam_token_service import (
+    CallerIamTokenService,
+)
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+from agentclaw.community.api.caller_credential import UnavailableCallerTokenProvider
+from agentclaw.community.di.modules.caller_identity_module import CallerIdentityModule
+
+
+def _context(*, exchange: bool = True, owner_id: str | None = "owner-1") -> CallerIamTokenContext:
+    return CallerIamTokenContext(
+        bot_id="bot-1",
+        owner_id=owner_id,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        bot_call_type=McpCallType.CALLER,
+        should_exchange_caller_token=exchange,
+        binding_id=9,
+    )
+
+
+def _service(*, context: CallerIamTokenContext | None = None):
+    identity = MagicMock()
+    identity.get_iam_token_context.return_value = context or _context()
+    auth = MagicMock()
+    auth.resolve_user_from_request = AsyncMock(
+        return_value=SimpleNamespace(staffId="caller-1")
+    )
+    provider = MagicMock()
+    updater = MagicMock()
+    return (
+        CallerIamTokenService(
+            caller_identity=identity,
+            auth_plugin=auth,
+            token_provider=provider,
+            runtime_updater=updater,
+        ),
+        identity,
+        auth,
+        provider,
+        updater,
+    )
+
+
+def _request() -> AuthRequestContext:
+    return AuthRequestContext({}, {}, {}, "http://test/")
+
+
+@pytest.mark.asyncio
+async def test_service_installs_caller_token_without_returning_it() -> None:
+    identity = MagicMock()
+    identity.get_iam_token_context.return_value = CallerIamTokenContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        bot_call_type=McpCallType.CALLER,
+        should_exchange_caller_token=True,
+        binding_id=9,
+    )
+    auth = MagicMock()
+    auth.resolve_user_from_request = AsyncMock(
+        return_value=SimpleNamespace(staffId="caller-1")
+    )
+    service = CallerIamTokenService(
+        caller_identity=identity,
+        auth_plugin=auth,
+        token_provider=MagicMock(),
+        runtime_updater=MagicMock(),
+    )
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=AuthRequestContext({}, {}, {}, "http://test/"),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id="entity-1",
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    assert result.iam_token == "iam-token"
+    assert identity.exchange_caller_identity.call_args.kwargs["binding_id"] == 9
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("iam_token", "bot_id", "test_exchange", "expected_error"),
+    [
+        ("", "bot-1", False, "IAM_TOKEN cookie not found"),
+        ("iam-token", None, True, CALLER_CREDENTIAL_REQUEST_INVALID),
+        ("iam-token", None, False, None),
+    ],
+)
+async def test_service_returns_early_iam_outcomes(
+    iam_token: str,
+    bot_id: str | None,
+    test_exchange: bool,
+    expected_error: str | None,
+) -> None:
+    service, identity, *_ = _service()
+
+    result = await service.get_iam_token(
+        iam_token=iam_token,
+        auth_request=_request(),
+        bot_id=bot_id,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=test_exchange,
+    )
+
+    assert result.error == expected_error
+    if expected_error is None:
+        assert result.iam_token == "iam-token"
+    identity.get_iam_token_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (CallerIdentityAmbiguousError(), "CALLER_IDENTITY_AMBIGUOUS"),
+        (CallerIdentityPermissionError(), "CALLER_IDENTITY_FORBIDDEN"),
+        (RuntimeError("repository unavailable"), None),
+    ],
+)
+async def test_service_fails_closed_or_falls_back_for_context_errors(
+    exception: Exception,
+    expected_error: str | None,
+) -> None:
+    service, identity, *_ = _service()
+    identity.get_iam_token_context.side_effect = exception
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=_request(),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=False,
+    )
+
+    assert result.error == expected_error
+    assert result.iam_token == ("" if expected_error else "iam-token")
+
+
+@pytest.mark.asyncio
+async def test_service_skips_non_caller_and_rejects_missing_owner() -> None:
+    service, identity, *_ = _service(context=_context(exchange=False))
+
+    skipped = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=False,
+    )
+    assert skipped.error is None
+
+    identity.get_iam_token_context.return_value = _context(owner_id=None)
+    missing_owner = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=False,
+    )
+    assert missing_owner.error == CALLER_CREDENTIAL_REQUEST_INVALID
+
+
+@pytest.mark.asyncio
+async def test_service_maps_exchange_and_runtime_failures() -> None:
+    service, identity, *_ = _service()
+    identity.exchange_caller_identity.side_effect = CallerCredentialError("UPSTREAM")
+
+    credential_failure = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=True,
+    )
+    assert credential_failure.error == "UPSTREAM"
+    identity.authorize_iam_token_exchange.assert_called_once()
+
+    identity.exchange_caller_identity.side_effect = RuntimeError("BaaS unavailable")
+    runtime_failure = await service.get_iam_token(
+        iam_token="iam-token", auth_request=_request(), bot_id="bot-1",
+        stage=CallerIdentityStage.DRAFT, publish_id=None, entity_id=None,
+        is_test_exchange=False,
+    )
+    assert runtime_failure.error == CALLER_OUTBOUND_UPDATE_FAILED
+
+
+def test_unavailable_provider_and_module_provider_fail_closed() -> None:
+    with pytest.raises(CallerCredentialError):
+        UnavailableCallerTokenProvider().exchange(
+            auth_context=MagicMock(), iam_token="iam", bot_id="bot",
+            owner_user_id="owner", task_metadata={},
+        )
+
+    service = CallerIdentityModule().caller_iam_token_service(
+        caller_identity=MagicMock(), auth_plugin=MagicMock(),
+        token_provider=MagicMock(), runtime_updater=MagicMock(),
+    )
+    assert isinstance(service, CallerIamTokenService)

--- a/src/backend/tests/community/core/caller_identity/test_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_service.py
@@ -242,11 +242,8 @@ def test_iam_context_does_not_reuse_draft_binding_outside_draft(
     assert context.binding_id is None
 
 
-def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> None:
+def test_exchange_caller_identity_installs_opaque_token_without_passport_lookup() -> None:
     service, _ = _service(bot=_bot(call_type="caller"))
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
     token_provider = MagicMock()
     caller_token = CallerToken(
         access_token="caller-token",
@@ -262,7 +259,6 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
         caller_user_id="caller-1",
         bot_id="bot-1",
         owner_user_id="owner-1",
-        passport=passport,
         token_provider=token_provider,
         runtime_updater=runtime_updater,
         stage="draft",
@@ -271,14 +267,18 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
         binding_id=9,
     )
 
-    token_provider.exchange.assert_called_once()
+    token_provider.exchange.assert_called_once_with(
+        auth_context=caller_identity_service.AuthContext(user_id="caller-1"),
+        iam_token="iam-token",
+        bot_id="bot-1",
+        owner_user_id="owner-1",
+        task_metadata=caller_identity_service.CALLER_CHAT_TASK,
+    )
     runtime_updater.update_caller_identity.assert_called_once_with(
         bot_id="bot-1",
         owner_user_id="owner-1",
         caller_user_id="caller-1",
         caller_token=caller_token,
-        agent_pass_token="agent-pass-token",
-        agent_code="agent-code",
         stage="draft",
         publish_id=None,
         entity_id="entity-1",
@@ -288,9 +288,6 @@ def test_exchange_caller_identity_uses_passport_and_installs_opaque_token() -> N
 
 def test_exchange_caller_identity_propagates_test_exchange_to_runtime() -> None:
     service, _ = _service(bot=_bot(call_type="owner"))
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
     token_provider = MagicMock()
     caller_token = CallerToken(
         access_token="caller-token",
@@ -306,7 +303,6 @@ def test_exchange_caller_identity_propagates_test_exchange_to_runtime() -> None:
         caller_user_id="owner-1",
         bot_id="bot-1",
         owner_user_id="owner-1",
-        passport=passport,
         token_provider=token_provider,
         runtime_updater=runtime_updater,
         stage="draft",
@@ -325,9 +321,6 @@ def test_exchange_caller_identity_does_not_pass_draft_binding_outside_draft(
     stage: str,
 ) -> None:
     service, _ = _service(bot=_bot(call_type="caller"))
-    passport = MagicMock()
-    passport.query_token.return_value = "agent-pass-token"
-    passport.query_agent_passport.return_value = {"agent_code": "agent-code"}
     token_provider = MagicMock()
     token_provider.exchange.return_value = CallerToken(
         access_token="caller-token",
@@ -342,7 +335,6 @@ def test_exchange_caller_identity_does_not_pass_draft_binding_outside_draft(
         caller_user_id="caller-1",
         bot_id="bot-1",
         owner_user_id="owner-1",
-        passport=passport,
         token_provider=token_provider,
         runtime_updater=runtime_updater,
         stage=stage,

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -73,6 +73,9 @@ def _make_service(
     bot_repo=None,
     binding_repo=None,
     bot_build_service=None,
+    caller_identity=None,
+    token_provider=None,
+    runtime_updater=None,
 ):
     """Construct ExpertChatInstanceService with mocks."""
     instance_repo = instance_repo or MagicMock()
@@ -81,6 +84,9 @@ def _make_service(
     bot_repo = bot_repo or MagicMock()
     binding_repo = binding_repo or MagicMock()
     bot_build_service = bot_build_service or MagicMock()
+    caller_identity = caller_identity or MagicMock()
+    token_provider = token_provider or MagicMock()
+    runtime_updater = runtime_updater or MagicMock()
 
     svc = ExpertChatInstanceService(
         instance_repo=instance_repo,
@@ -89,8 +95,11 @@ def _make_service(
         bot_repo=bot_repo,
         binding_repo=binding_repo,
         bot_build_service=bot_build_service,
+        caller_identity=caller_identity,
+        token_provider=token_provider,
+        runtime_updater=runtime_updater,
     )
-    return svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service
+    return svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater
 
 
 def _wire_publish(publish_repo, record=None):
@@ -130,7 +139,7 @@ class TestResolveBuildArtifact:
 
     def test_no_success_publish_raises_not_published(self):
         """Lines 267, 271: No success publish record raises BotNotPublishedError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         publish_repo.get_by_publish_bot_id = MagicMock(return_value=None)
 
         with pytest.raises(BotNotPublishedError) as exc_info:
@@ -141,7 +150,7 @@ class TestResolveBuildArtifact:
 
     def test_success_returns_record_and_migration_path(self):
         """Successful resolution returns (record, migration_path)."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         record = MockPublishRecord(
             id=456,
             version=2,
@@ -156,7 +165,7 @@ class TestResolveBuildArtifact:
 
     def test_publish_record_ext_none_returns_none_migration_path(self):
         """Line 275: When publish_record.ext is None, migration_path should be None."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         record = MockPublishRecord(id=789, version=1, ext=None)
         # Override __post_init__ effect
         record.ext = None
@@ -169,7 +178,7 @@ class TestResolveBuildArtifact:
 
     def test_publish_record_version_none_uses_default(self):
         """Line 103: When publish_record.version is None, default to 1."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         record = MockPublishRecord(id=999, version=None, ext={"migration_path": "/nas/path"})
         # Ensure version is None
         record.version = None
@@ -187,7 +196,7 @@ class TestCreateContainer:
     @pytest.mark.asyncio
     async def test_bot_not_found_raises_connection_error(self):
         """Bot not found raises ConnectionError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         bot_repo.get_by_id_and_owner = MagicMock(return_value=None)
 
         with pytest.raises(ConnectionError) as exc_info:
@@ -199,7 +208,7 @@ class TestCreateContainer:
     @pytest.mark.asyncio
     async def test_generic_exception_wrapped_as_connection_error(self):
         """Generic exceptions wrapped as ConnectionError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         _wire_bot_repo(bot_repo)
         bot_build_service.release_async = AsyncMock(side_effect=RuntimeError("network error"))
 
@@ -212,7 +221,7 @@ class TestCreateContainer:
     @pytest.mark.asyncio
     async def test_no_bot_uuid_in_result_raises_connection_error(self):
         """No bot_uuid in release_async result raises ConnectionError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         _wire_bot_repo(bot_repo)
         bot_build_service.release_async = AsyncMock(return_value={"publish_id": 999})  # No bot_uuid
 
@@ -225,7 +234,7 @@ class TestCreateContainer:
     @pytest.mark.asyncio
     async def test_success_returns_bot_uuid_and_publish_id(self):
         """Successful create returns bot_uuid and publish_id."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         _wire_bot_repo(bot_repo)
         _wire_binding_repo(binding_repo)
         bot_build_service.release_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 888})
@@ -250,7 +259,7 @@ class TestCreateContainer:
     @pytest.mark.asyncio
     async def test_release_async_called_with_correct_params(self):
         """release_async is called with expected parameters."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         bot_info = {
             "bot_id": BOT_ID,
             "owner_id": OWNER_ID,
@@ -279,7 +288,7 @@ class TestUpgradeContainer:
     @pytest.mark.asyncio
     async def test_bot_not_found_raises_connection_error(self):
         """Bot not found raises ConnectionError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         bot_repo.get_by_id_and_owner = MagicMock(return_value=None)
 
         with pytest.raises(ConnectionError) as exc_info:
@@ -290,7 +299,7 @@ class TestUpgradeContainer:
     @pytest.mark.asyncio
     async def test_success_returns_bot_uuid_and_publish_id(self):
         """Successful upgrade returns bot_uuid and publish_id."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         _wire_bot_repo(bot_repo)
         bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
 
@@ -303,7 +312,7 @@ class TestUpgradeContainer:
     @pytest.mark.asyncio
     async def test_generic_exception_wrapped_as_connection_error(self):
         """Generic exceptions wrapped as ConnectionError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         _wire_bot_repo(bot_repo)
         bot_build_service.upgrade_async = AsyncMock(side_effect=RuntimeError("upgrade failed"))
 
@@ -316,7 +325,7 @@ class TestUpgradeContainer:
     @pytest.mark.asyncio
     async def test_upgrade_async_called_with_correct_params(self):
         """upgrade_async is called with expected parameters."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         bot_info = {
             "bot_id": BOT_ID,
             "owner_id": OWNER_ID,
@@ -344,7 +353,7 @@ class TestBuildConnection:
 
     def test_baas_service_error_wrapped_as_connection_error(self):
         """BaasServiceError wrapped as ConnectionError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         baas.get_ws_info_by_bot_uuid = MagicMock(side_effect=BaasServiceError("ws error"))
 
         with pytest.raises(ConnectionError) as exc_info:
@@ -355,7 +364,7 @@ class TestBuildConnection:
 
     def test_generic_exception_wrapped_as_connection_error(self):
         """Generic exceptions wrapped as ConnectionError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         baas.get_ws_info_by_bot_uuid = MagicMock(side_effect=RuntimeError("timeout"))
 
         with pytest.raises(ConnectionError) as exc_info:
@@ -365,7 +374,7 @@ class TestBuildConnection:
 
     def test_success_returns_connection_dict(self):
         """Successful build returns connection dict."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         ws_info = _make_ws_info()
         baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
 
@@ -385,7 +394,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_no_success_publish_raises_not_published(self):
         """No success publish record raises BotNotPublishedError."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         instance_repo.get_instance = MagicMock(return_value=None)
         instance_repo.upsert_instance = MagicMock(
             return_value={"id": 1, "status": "init", "ext": None}
@@ -398,7 +407,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_success_instance_returns_immediately(self):
         """Instance already success with matching version returns immediately."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -423,7 +432,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_success_instance_with_old_version_upgrades(self):
         """Success instance with old version triggers upgrade."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -449,7 +458,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_new_instance_creates_container(self):
         """New instance triggers create_container."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         instance_repo.upsert_instance = MagicMock(
             return_value={"id": 1, "status": "init", "ext": None}
         )
@@ -488,7 +497,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_instance_not_ready_returns_need_poll(self):
         """Instance not ready returns need_poll=True."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -512,7 +521,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_init_status_with_baas_publish_id_skips_upgrade(self):
         """When status is 'init' and baas_publish_id exists, should skip upgrade and poll progress."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -543,7 +552,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_init_status_without_baas_publish_id_calls_upgrade(self):
         """When status is 'init' but no baas_publish_id, should call upgrade."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -569,7 +578,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_non_init_status_calls_upgrade(self):
         """When status is not 'init' (e.g., 'failed'), should call upgrade."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -598,7 +607,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_success_instance_without_bot_uuid_creates_container(self):
         """Success instance without bot_uuid triggers create."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": None,  # No bot_uuid
             "service_bot_publish_id": 123,
@@ -630,7 +639,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_success_instance_version_none_uses_zero(self):
         """ext.get('version') defaults to 0 when None."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "version": None,  # No version
@@ -660,7 +669,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_baas_publish_failed_sets_status_to_failed(self):
         """FAILED status from baas_publish sets instance status to 'failed'."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         instance_repo.upsert_instance = MagicMock(
             return_value={"id": 1, "status": "init", "ext": None}
         )
@@ -694,7 +703,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_create_without_publish_id_skips_poll(self):
         """When baas_publish_id is None, skip polling."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         instance_repo.upsert_instance = MagicMock(
             return_value={"id": 1, "status": "init", "ext": None}
         )
@@ -725,7 +734,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_upgrade_adds_bot_uuid_to_ext_if_missing(self):
         """Upgrade preserves bot_uuid in ext when upgrading."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -766,7 +775,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_force_upgrade_bypasses_version_check(self):
         """force_upgrade=True bypasses the version check fast path."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -797,7 +806,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_upgrade_updates_version_in_ext(self):
         """Upgrade container updates version in ext to new version."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -834,7 +843,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_force_upgrade_false_uses_fast_path(self):
         """force_upgrade=False uses the version check fast path when version is current."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -859,7 +868,7 @@ class TestGetCallerConnection:
     @pytest.mark.asyncio
     async def test_force_upgrade_creates_when_no_bot_uuid(self):
         """force_upgrade=True with no bot_uuid triggers create, not upgrade."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": None,  # No bot_uuid
             "service_bot_publish_id": 123,
@@ -898,7 +907,7 @@ class TestGetCallerConnectionExceptionHandling:
     @pytest.mark.asyncio
     async def test_exception_records_traceback_in_ext(self):
         """Exception during get_caller_connection records traceback in instance ext."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         instance_repo.get_instance = MagicMock(return_value=None)
         instance_repo.upsert_instance = MagicMock(
             return_value={"id": 1, "status": "init", "ext": None}
@@ -925,7 +934,7 @@ class TestGetCallerConnectionExceptionHandling:
     @pytest.mark.asyncio
     async def test_exception_update_failure_does_not_affect_main_flow(self):
         """If update_instance fails when recording error, exception still propagates."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         instance_repo.get_instance = MagicMock(return_value=None)
         instance_repo.upsert_instance = MagicMock(
             return_value={"id": 1, "status": "init", "ext": None}
@@ -943,7 +952,7 @@ class TestGetCallerConnectionExceptionHandling:
     @pytest.mark.asyncio
     async def test_exception_in_upgrade_records_traceback(self):
         """Exception during upgrade records traceback in instance ext."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "version": 1,
@@ -971,7 +980,7 @@ class TestGetCallerConnectionExceptionHandling:
     @pytest.mark.asyncio
     async def test_build_connection_exception_records_traceback(self):
         """Exception during _build_connection records traceback in instance ext."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "version": 2,
@@ -1000,7 +1009,7 @@ class TestGetCallerConnectionExceptionHandling:
     @pytest.mark.asyncio
     async def test_exception_preserves_existing_ext(self):
         """Exception handling preserves existing ext data and adds error info."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "version": 1,
@@ -1035,7 +1044,7 @@ class TestGetCallerConnectionEdgeCases:
     @pytest.mark.asyncio
     async def test_create_container_success_returns_connection(self):
         """Full happy path: create container and return connection."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
 
         call_count = [0]
         def mock_get_instance(*args, **kwargs):
@@ -1067,7 +1076,7 @@ class TestGetCallerConnectionEdgeCases:
     @pytest.mark.asyncio
     async def test_publish_record_version_none_uses_default_one(self):
         """When publish_record.version is None, defaults to 1 for comparison."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "version": 2,
@@ -1095,7 +1104,7 @@ class TestRepositoryUpdateInstanceWithStatusOnly:
     @pytest.mark.asyncio
     async def test_publish_status_success_sets_instance_status(self):
         """SUCCESS status from baas_publish sets instance status to 'success'."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
 
         call_count = [0]
         def mock_get_instance(*args, **kwargs):
@@ -1132,7 +1141,7 @@ class TestRepositoryUpdateInstanceWithStatusOnly:
     @pytest.mark.asyncio
     async def test_publish_status_failed_sets_instance_status(self):
         """FAILED status from baas_publish sets instance status to 'failed'."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
 
         call_count = [0]
         def mock_get_instance(*args, **kwargs):
@@ -1169,7 +1178,7 @@ class TestRepositoryUpdateInstanceWithStatusOnly:
     @pytest.mark.asyncio
     async def test_publish_status_running_sets_instance_status_to_init(self):
         """RUNNING status sets instance status to 'init' (not original status)."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
 
         call_count = [0]
         def mock_get_instance(*args, **kwargs):
@@ -1213,7 +1222,7 @@ class TestGetCallerConnectionIamToken:
     @pytest.mark.asyncio
     async def test_iam_token_param_accepted_without_error(self):
         """Passing iam_token does not raise any error."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -1237,7 +1246,7 @@ class TestGetCallerConnectionIamToken:
     @pytest.mark.asyncio
     async def test_iam_token_none_works_same_as_default(self):
         """Passing iam_token=None works the same as not passing it."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -1262,7 +1271,7 @@ class TestGetCallerConnectionIamToken:
     @pytest.mark.asyncio
     async def test_iam_token_with_force_upgrade_accepted(self):
         """iam_token works correctly with force_upgrade parameter."""
-        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service = _make_service()
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
         existing_ext = {
             "bot_uuid": BOT_UUID,
             "service_bot_publish_id": 123,
@@ -1286,3 +1295,270 @@ class TestGetCallerConnectionIamToken:
 
         assert result["need_poll"] is False
         bot_build_service.upgrade_async.assert_called_once()
+
+
+class TestCallerIdentityExchange:
+    """Tests for caller identity exchange when container is successfully pulled."""
+
+    @pytest.mark.asyncio
+    async def test_exchange_called_when_status_success_and_iam_token_provided(self):
+        """When status is SUCCESS and iam_token is provided, exchange_caller_identity is called."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        # Setup mocks
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 123,
+            "version": 1,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "success", "ext": existing_ext}
+        )
+        _wire_publish(publish_repo, MockPublishRecord(version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "SUCCESS"})
+        ws_info = _make_ws_info()
+        baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        # Call with iam_token
+        result = await svc.get_caller_connection(
+            USER_ID, BOT_ID, OWNER_ID, iam_token="test-iam-token"
+        )
+
+        # Verify exchange_caller_identity was called
+        caller_identity.exchange_caller_identity.assert_called_once()
+        call_kwargs = caller_identity.exchange_caller_identity.call_args[1]
+        assert call_kwargs["iam_token"] == "test-iam-token"
+        assert call_kwargs["caller_user_id"] == USER_ID
+        assert call_kwargs["bot_id"] == BOT_ID
+        assert call_kwargs["owner_user_id"] == OWNER_ID
+        assert call_kwargs["stage"] == "online"
+        assert call_kwargs["entity_id"] == OWNER_ID
+        assert call_kwargs["is_test_exchange"] is False
+
+    @pytest.mark.asyncio
+    async def test_exchange_not_called_when_no_iam_token(self):
+        """When iam_token is None, exchange_caller_identity is not called and warning is logged."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 123,
+            "version": 1,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "success", "ext": existing_ext}
+        )
+        _wire_publish(publish_repo, MockPublishRecord(version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "SUCCESS"})
+        ws_info = _make_ws_info()
+        baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        # Call without iam_token
+        with patch("agentclaw.community.core.expert_chat.services.expert_chat_instance_service.logger") as mock_logger:
+            result = await svc.get_caller_connection(USER_ID, BOT_ID, OWNER_ID)
+
+        # Verify exchange_caller_identity was NOT called
+        caller_identity.exchange_caller_identity.assert_not_called()
+        # Verify warning was logged
+        mock_logger.warning.assert_called()
+        warning_call = mock_logger.warning.call_args
+        assert "Skip caller identity exchange" in str(warning_call)
+
+    @pytest.mark.asyncio
+    async def test_exchange_not_called_when_status_not_success(self):
+        """When status is not SUCCESS, exchange_caller_identity is not called."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 123,
+            "version": 1,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "init", "ext": existing_ext}
+        )
+        _wire_publish(publish_repo, MockPublishRecord(version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "RUNNING"})
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        # Call with iam_token but status is RUNNING
+        result = await svc.get_caller_connection(
+            USER_ID, BOT_ID, OWNER_ID, iam_token="test-iam-token"
+        )
+
+        # Verify exchange_caller_identity was NOT called
+        caller_identity.exchange_caller_identity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exchange_failure_does_not_interrupt_container_startup(self):
+        """When exchange_caller_identity fails, container startup continues normally."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 123,
+            "version": 1,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "success", "ext": existing_ext}
+        )
+        _wire_publish(publish_repo, MockPublishRecord(version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "SUCCESS"})
+        ws_info = _make_ws_info()
+        baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        # Make exchange_caller_identity raise an exception
+        caller_identity.exchange_caller_identity = MagicMock(side_effect=RuntimeError("exchange failed"))
+
+        # Call with iam_token
+        result = await svc.get_caller_connection(
+            USER_ID, BOT_ID, OWNER_ID, iam_token="test-iam-token"
+        )
+
+        # Verify the method still returns successfully despite the exchange failure
+        assert result["need_poll"] is False
+        assert result["connection"]["bot_uuid"] == BOT_UUID
+        # Verify exchange_caller_identity was called
+        caller_identity.exchange_caller_identity.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exchange_with_binding_id_passed(self):
+        """binding_id is passed to exchange_caller_identity when available."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 123,
+            "version": 1,
+            "binding_id": BINDING_ID,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "init", "ext": existing_ext}
+        )
+        _wire_publish(publish_repo, MockPublishRecord(version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "SUCCESS"})
+        ws_info = _make_ws_info()
+        baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        # Call with iam_token
+        result = await svc.get_caller_connection(
+            USER_ID, BOT_ID, OWNER_ID, iam_token="test-iam-token"
+        )
+
+        # Verify binding_id was passed
+        caller_identity.exchange_caller_identity.assert_called_once()
+        call_kwargs = caller_identity.exchange_caller_identity.call_args[1]
+        assert call_kwargs["binding_id"] == BINDING_ID
+
+    @pytest.mark.asyncio
+    async def test_exchange_publish_id_from_service_bot_publish_record(self):
+        """publish_id comes from service_bot_publish_id (publish_record.id)."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        SERVICE_BOT_PUBLISH_ID = 456  # This should be passed as publish_id
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 789,  # Old value
+            "version": 1,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "success", "ext": existing_ext}
+        )
+        # Create publish record with specific ID
+        _wire_publish(publish_repo, MockPublishRecord(id=SERVICE_BOT_PUBLISH_ID, version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "SUCCESS"})
+        ws_info = _make_ws_info()
+        baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        # Call with iam_token
+        result = await svc.get_caller_connection(
+            USER_ID, BOT_ID, OWNER_ID, iam_token="test-iam-token"
+        )
+
+        # Verify publish_id is from publish_record.id
+        caller_identity.exchange_caller_identity.assert_called_once()
+        call_kwargs = caller_identity.exchange_caller_identity.call_args[1]
+        assert call_kwargs["publish_id"] == SERVICE_BOT_PUBLISH_ID
+
+    @pytest.mark.asyncio
+    async def test_exchange_success_logs_info(self):
+        """Successful exchange logs info message."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 123,
+            "version": 1,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "success", "ext": existing_ext}
+        )
+        _wire_publish(publish_repo, MockPublishRecord(version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "SUCCESS"})
+        ws_info = _make_ws_info()
+        baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        with patch("agentclaw.community.core.expert_chat.services.expert_chat_instance_service.logger") as mock_logger:
+            result = await svc.get_caller_connection(
+                USER_ID, BOT_ID, OWNER_ID, iam_token="test-iam-token"
+            )
+
+        # Verify success log
+        mock_logger.info.assert_called()
+        info_calls = [str(call) for call in mock_logger.info.call_args_list]
+        assert any("Caller identity exchange succeeded" in call for call in info_calls)
+
+    @pytest.mark.asyncio
+    async def test_exchange_failure_logs_error(self):
+        """Exchange failure logs error message."""
+        svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater = _make_service()
+
+        existing_ext = {
+            "bot_uuid": BOT_UUID,
+            "service_bot_publish_id": 123,
+            "version": 1,
+        }
+        instance_repo.get_instance = MagicMock(
+            return_value={"id": 1, "status": "success", "ext": existing_ext}
+        )
+        _wire_publish(publish_repo, MockPublishRecord(version=2))
+        _wire_bot_repo(bot_repo)
+        bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
+        baas.get_publish_progress = MagicMock(return_value={"status": "SUCCESS"})
+        ws_info = _make_ws_info()
+        baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
+        instance_repo.update_instance = MagicMock(return_value=True)
+
+        # Make exchange_caller_identity raise an exception
+        caller_identity.exchange_caller_identity = MagicMock(side_effect=RuntimeError("exchange failed"))
+
+        with patch("agentclaw.community.core.expert_chat.services.expert_chat_instance_service.logger") as mock_logger:
+            result = await svc.get_caller_connection(
+                USER_ID, BOT_ID, OWNER_ID, iam_token="test-iam-token"
+            )
+
+        # Verify error log
+        mock_logger.error.assert_called()
+        error_call = str(mock_logger.error.call_args)
+        assert "Caller identity exchange failed" in error_call
+        assert "exchange failed" in error_call

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_http_methods.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_http_methods.py
@@ -195,6 +195,23 @@ class TestBaasServiceHttpMethods:
         assert call.args[0] == "/api/v1/paas/devices/PAAS-1/outbound-rule"
         assert call.kwargs["json"] == {"header_operation_rules": []}
 
+    def test_append_caller_outbound_rule_uses_exact_append_path_and_body(self):
+        service, http = _make_service()
+        http.set_response("put", _resp({}))
+        rule = MagicMock()
+        rule.header_operation_rules = [MagicMock()]
+        service._outbound_rule_to_dict = MagicMock(
+            return_value={"header_operation_rules": [{"header_name": "x-caller-token"}]}
+        )
+
+        assert service.append_caller_outbound_rule("dev-1@tpl-1", rule) is True
+
+        call = http.calls_to("put")[0]
+        assert call.args[0] == "/api/v1/paas/devices/dev-1@tpl-1/outbound-rule?mode=append"
+        assert call.kwargs["json"] == {
+            "header_operation_rules": [{"header_name": "x-caller-token"}]
+        }
+
     def test_get_http_info_uses_http_client_port(self):
         """get_http_info 走 self._http.get 而非裸 httpx。
 

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -53,13 +53,10 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
             ]
         )
     )
-    service._build_outbound_operation_rule = MagicMock(
-        return_value=OutBoundOperationRule()
-    )
     service.list_devices_by_bot_uuid = MagicMock(
         return_value=[{"provider_device_id": "device-1@template-1"}]
     )
-    service.update_device_outbound_rule = MagicMock(return_value=True)
+    service.append_caller_outbound_rule = MagicMock(return_value=True)
     service._resolve_caller_binding_id = MagicMock(return_value=9)
 
     update_kwargs = {
@@ -72,8 +69,6 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
             expires_at=datetime.now(),
             fingerprint="ignored",
         ),
-        "agent_pass_token": "agent-pass-token",
-        "agent_code": "agent-code",
         "stage": "draft",
         "publish_id": None,
         "entity_id": "entity-1",
@@ -97,7 +92,7 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
     service._outbound_rule_provider.build_caller_rule.assert_called_with(
         caller_token="caller-token"
     )
-    paas_device_id, outbound_rule = service.update_device_outbound_rule.call_args.args
+    paas_device_id, outbound_rule = service.append_caller_outbound_rule.call_args.args
     assert paas_device_id == "device-1@template-1"
     assert outbound_rule.header_operation_rules[0].header_name == "x-caller-token"
     assert outbound_rule.header_operation_rules[0].action == "set"
@@ -120,8 +115,6 @@ def test_caller_identity_rejects_ambiguous_bot_without_entity_id() -> None:
                 expires_at=datetime.now(),
                 fingerprint="ignored",
             ),
-            agent_pass_token="agent-pass-token",
-            agent_code="agent-code",
             stage="draft",
             publish_id=None,
         )
@@ -157,13 +150,10 @@ def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
             ]
         )
     )
-    service._build_outbound_operation_rule = MagicMock(
-        return_value=OutBoundOperationRule()
-    )
     service.list_devices_by_bot_uuid = MagicMock(
         return_value=[{"provider_device_id": "device-1@template-1"}]
     )
-    service.update_device_outbound_rule = MagicMock(return_value=True)
+    service.append_caller_outbound_rule = MagicMock(return_value=True)
 
     service.update_caller_identity(
         bot_id="bot-1",
@@ -175,8 +165,6 @@ def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
             expires_at=datetime.now(),
             fingerprint="ignored",
         ),
-        agent_pass_token="agent-pass-token",
-        agent_code="agent-code",
         stage="draft",
         publish_id=None,
         entity_id="entity-1",
@@ -184,4 +172,4 @@ def test_caller_identity_test_exchange_allows_active_personal_bot() -> None:
         is_test_exchange=True,
     )
 
-    service.update_device_outbound_rule.assert_called_once()
+    service.append_caller_outbound_rule.assert_called_once()

--- a/src/backend/tests/community/kernel/test_device_dto.py
+++ b/src/backend/tests/community/kernel/test_device_dto.py
@@ -50,6 +50,7 @@ def test_header_operation_rule_to_dict_full_shape() -> None:
         "header_name": "Authorization",
         "value": "tok",
         "placeholder": "${API-KEY}",
+        "separator": None,
     }
 
 
@@ -83,6 +84,7 @@ def test_outbound_rule_to_dict_nests_header_rules() -> None:
                 "header_name": "h1",
                 "value": "v1",
                 "placeholder": None,
+                "separator": None,
             },
             {
                 "domains": ["d2"],
@@ -90,6 +92,7 @@ def test_outbound_rule_to_dict_nests_header_rules() -> None:
                 "header_name": "h2",
                 "value": "v2",
                 "placeholder": "${P}",
+                "separator": None,
             },
         ]
     }


### PR DESCRIPTION
When BaaS container is successfully pulled (status == "SUCCESS"), call
  CallerIdentityService.exchange_caller_identity to update the container's
  caller identity credentials.

  Changes:
  - Add 3 dependencies to ExpertChatInstanceService:
    - CallerIdentityServiceProtocol
    - CallerTokenProvider
    - CallerRuntimeUpdater
  - Add private method _exchange_caller_identity() for async identity exchange
  - Log warning when iam_token is not provided
  - Exchange failures don't interrupt container startup flow
  - Add 8 unit tests covering all new behaviors