### PR TITLE
Gateway v1 API — Group B: user-principal auth strategy, route-security config + bots sample

### DIFF
--- a/src/gateway/configs/route_security.yaml
+++ b/src/gateway/configs/route_security.yaml
@@ -1,0 +1,20 @@
+# Route → auth-strategy table for the gateway (auth design §8).
+#
+# Keys are "[METHOD ]<path-glob>" (method optional; omit it to cover all
+# methods). More specific rules override more general ones; "/**" is the
+# top-level default. Each value is an OR-list of alternatives; an alternative is
+# a strategy name (default params) or `{ strategy: { scopes: [...],
+# delegation: optional|forbidden } }`.
+#
+# The authoritative per-operation source is each route's `x-avernet-security`
+# marker; this file is the aggregated table the gateway resolves at request time
+# (v1 authors it by hand until the publish/register compiler lands).
+
+route_security:
+  # Top-level default: every route requires an authenticated user.
+  "/**":
+    - first_party_user
+
+  # Sample group — the bots endpoints (explicit, more-specific rule).
+  "/openapi/v1/bots/**":
+    - first_party_user: {}

--- a/src/gateway/src/gateway/community/adapters/web/__init__.py
+++ b/src/gateway/src/gateway/community/adapters/web/__init__.py
@@ -3,4 +3,12 @@
 Import the app explicitly to avoid eager bootstrapping on package import::
 
     from gateway.community.adapters.web.app import app
+
+Group routers depend on ``require_principal`` for authenticated access.
 """
+
+from ._auth import require_principal
+
+__all__ = [
+    "require_principal",
+]

--- a/src/gateway/src/gateway/community/adapters/web/_auth.py
+++ b/src/gateway/src/gateway/community/adapters/web/_auth.py
@@ -1,0 +1,38 @@
+"""Delivery-layer auth dependency.
+
+``require_principal`` snapshots the FastAPI request into a framework-agnostic
+``CredentialBundle`` and delegates to the ``Authenticator`` built by the
+composition root (stored on ``app.state``), mapping auth failure to HTTP 401.
+The adapter imports only ``spi`` — the runner, route table, and strategies live
+behind the ``Authenticator`` it receives.
+
+NOTE: auth failures use FastAPI's default error body; wrapping them in the
+standard response envelope is a follow-up (a global exception handler).
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from gateway.community.spi.auth import AuthError
+from gateway.community.spi.authn import CredentialBundle, Principal
+
+
+def _bundle(request: Request) -> CredentialBundle:
+    return CredentialBundle(
+        headers={k.lower(): v for k, v in request.headers.items()},
+        cookies=dict(request.cookies),
+        query=dict(request.query_params),
+    )
+
+
+async def require_principal(request: Request) -> Principal:
+    """FastAPI dependency: authenticate the request or raise 401."""
+    authenticator = request.app.state.authenticator
+    try:
+        principal: Principal = await authenticator.authenticate(
+            request.method, request.url.path, _bundle(request)
+        )
+    except AuthError as err:
+        raise HTTPException(status_code=401, detail=str(err)) from err
+    return principal

--- a/src/gateway/src/gateway/community/adapters/web/app.py
+++ b/src/gateway/src/gateway/community/adapters/web/app.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 from gateway.community import __version__
 from gateway.community.adapters.web.routers import include_all
+from gateway.community.bootstrap import build_authenticator
 from gateway.community.config import ConfigLoader
 from gateway.community.logger import get_logger, get_logger_plugin
 from gateway.community.tracer import get_tracer_plugin
@@ -61,6 +62,10 @@ def create_app() -> FastAPI:
     async def health() -> dict[str, str]:
         """Liveness probe."""
         return {"status": "ok"}
+
+    # Build the authenticator once (composition root); the require_principal
+    # dependency reads it off app.state.
+    app.state.authenticator = build_authenticator()
 
     # Mount the public /openapi/v1 API group routers.
     include_all(app)

--- a/src/gateway/src/gateway/community/adapters/web/app.py
+++ b/src/gateway/src/gateway/community/adapters/web/app.py
@@ -8,7 +8,6 @@ from fastapi import FastAPI
 
 from gateway.community import __version__
 from gateway.community.adapters.web.routers import include_all
-from gateway.community.bootstrap import build_authenticator
 from gateway.community.config import ConfigLoader
 from gateway.community.logger import get_logger, get_logger_plugin
 from gateway.community.tracer import get_tracer_plugin
@@ -63,8 +62,12 @@ def create_app() -> FastAPI:
         """Liveness probe."""
         return {"status": "ok"}
 
-    # Build the authenticator once (composition root); the require_principal
-    # dependency reads it off app.state.
+    # Wire the authenticator (composition). Imported lazily inside the factory so
+    # the adapters layer keeps no *static* dependency on bootstrap — function-body
+    # imports are exempt from the layer-boundary check by design (composition at
+    # call time).
+    from gateway.community.bootstrap import build_authenticator
+
     app.state.authenticator = build_authenticator()
 
     # Mount the public /openapi/v1 API group routers.

--- a/src/gateway/src/gateway/community/adapters/web/routers/__init__.py
+++ b/src/gateway/src/gateway/community/adapters/web/routers/__init__.py
@@ -1,27 +1,28 @@
-"""Public API router registry and aggregation.
+"""Public API router aggregation.
 
-Each `/openapi/v1` resource group defines an ``APIRouter`` and registers it in
-``GROUP_ROUTERS``. ``include_all(app)`` mounts every registered router onto the
-FastAPI app; it is called once from ``adapters/web/app.py::create_app``.
+``include_all(app)`` mounts every ``/openapi/v1`` group router onto the app; it
+is called once from ``create_app``. Add a group by importing its router in
+``_group_routers``.
 
-The routers are **definition-only**: their handlers are stubs whose sole
-purpose is to make FastAPI generate the OpenAPI contract. No group routers are
-registered yet — they land in the per-group tasks.
+Group routers are definition-only: their handlers are stubs whose purpose is to
+make FastAPI generate the OpenAPI contract.
 """
 
 from fastapi import APIRouter, FastAPI
 
-# Group routers register here (appended in each group's module on import).
-GROUP_ROUTERS: list[APIRouter] = []
+
+def _group_routers() -> list[APIRouter]:
+    from gateway.community.adapters.web.routers.bots import router as bots_router
+
+    return [bots_router]
 
 
 def include_all(app: FastAPI) -> None:
     """Mount every registered public-API group router onto ``app``."""
-    for router in GROUP_ROUTERS:
+    for router in _group_routers():
         app.include_router(router)
 
 
 __all__ = [
-    "GROUP_ROUTERS",
     "include_all",
 ]

--- a/src/gateway/src/gateway/community/adapters/web/routers/bots/__init__.py
+++ b/src/gateway/src/gateway/community/adapters/web/routers/bots/__init__.py
@@ -1,0 +1,7 @@
+"""Bots API group (``/openapi/v1/bots``)."""
+
+from ._router import router
+
+__all__ = [
+    "router",
+]

--- a/src/gateway/src/gateway/community/adapters/web/routers/bots/_router.py
+++ b/src/gateway/src/gateway/community/adapters/web/routers/bots/_router.py
@@ -1,0 +1,153 @@
+"""Bots group — sample ``/openapi/v1/bots`` endpoints (definition only).
+
+Handlers are stubs: at runtime the gateway forwards to the backend and never
+runs these; they exist so FastAPI generates the OpenAPI contract. Every route
+requires an authenticated user principal — declared via ``x-avernet-security``
+and enforced by the ``require_principal`` dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+
+from gateway.community.adapters.web import require_principal
+from gateway.community.adapters.web.contracts import (
+    Deleted,
+    Envelope,
+    NameCheck,
+    Page,
+    PageParamsDep,
+    requires_user_principal,
+)
+from gateway.community.spi.authn import Principal
+
+from ._schemas import (
+    Bot,
+    BotAuthPending,
+    BotAuthStatus,
+    BotCreate,
+    BotStatus,
+    BotUpdate,
+    Ceiling,
+    Passport,
+)
+
+router = APIRouter(prefix="/openapi/v1/bots", tags=["bots"])
+
+_SEC = requires_user_principal()
+PrincipalDep = Annotated[Principal, Depends(require_principal)]
+
+
+@router.post(
+    "",
+    status_code=201,
+    response_model=Envelope[Bot],
+    responses={
+        202: {
+            "model": Envelope[BotAuthPending],
+            "description": "Needs user authorization",
+        }
+    },
+    openapi_extra=_SEC,
+)
+async def create_bot(body: BotCreate, principal: PrincipalDep) -> Envelope[Bot]:
+    """Create a bot (201), or return 202 + a Passport iframe when authorization is needed."""
+    raise NotImplementedError
+
+
+@router.get("", response_model=Envelope[Page[Bot]], openapi_extra=_SEC)
+async def list_bots(
+    page: PageParamsDep,
+    principal: PrincipalDep,
+    keyword: str | None = None,
+    engine: str | None = None,
+    status: str | None = None,
+) -> Envelope[Page[Bot]]:
+    """List the caller's bots (filter + paginate)."""
+    raise NotImplementedError
+
+
+@router.get("/check-name", response_model=Envelope[NameCheck], openapi_extra=_SEC)
+async def check_bot_name(name: str, principal: PrincipalDep) -> Envelope[NameCheck]:
+    """Check whether a bot name is available."""
+    raise NotImplementedError
+
+
+@router.get("/ceiling", response_model=Envelope[Ceiling], openapi_extra=_SEC)
+async def get_bots_ceiling(principal: PrincipalDep) -> Envelope[Ceiling]:
+    """Get the caller's bot-creation quota ceiling."""
+    raise NotImplementedError
+
+
+@router.get("/{bot_id}", response_model=Envelope[Bot], openapi_extra=_SEC)
+async def get_bot(bot_id: str, principal: PrincipalDep) -> Envelope[Bot]:
+    """Get a bot's details."""
+    raise NotImplementedError
+
+
+@router.put("/{bot_id}", response_model=Envelope[Bot], openapi_extra=_SEC)
+async def update_bot(
+    bot_id: str, body: BotUpdate, principal: PrincipalDep
+) -> Envelope[Bot]:
+    """Update a bot (engine is immutable)."""
+    raise NotImplementedError
+
+
+@router.delete("/{bot_id}", response_model=Envelope[Deleted], openapi_extra=_SEC)
+async def delete_bot(bot_id: str, principal: PrincipalDep) -> Envelope[Deleted]:
+    """Delete a bot."""
+    raise NotImplementedError
+
+
+@router.post("/{bot_id}/restart", response_model=Envelope[Bot], openapi_extra=_SEC)
+async def restart_bot(bot_id: str, principal: PrincipalDep) -> Envelope[Bot]:
+    """Restart a bot (re-provision its device)."""
+    raise NotImplementedError
+
+
+@router.get(
+    "/{bot_id}/auth-status", response_model=Envelope[BotAuthStatus], openapi_extra=_SEC
+)
+async def get_bot_auth_status(
+    bot_id: str, principal: PrincipalDep
+) -> Envelope[BotAuthStatus]:
+    """Poll Passport authorization; completes creation when ISSUED."""
+    raise NotImplementedError
+
+
+@router.get("/{bot_id}/status", response_model=Envelope[BotStatus], openapi_extra=_SEC)
+async def get_bot_status(bot_id: str, principal: PrincipalDep) -> Envelope[BotStatus]:
+    """Get a bot's runtime / device readiness."""
+    raise NotImplementedError
+
+
+@router.get("/{bot_id}/passport", response_model=Envelope[Passport], openapi_extra=_SEC)
+async def get_bot_passport(bot_id: str, principal: PrincipalDep) -> Envelope[Passport]:
+    """Get a bot's Agent Passport."""
+    raise NotImplementedError
+
+
+@router.get(
+    "/{bot_id}/engine-config",
+    response_model=Envelope[dict[str, Any]],
+    openapi_extra=_SEC,
+)
+async def get_bot_engine_config(
+    bot_id: str, principal: PrincipalDep
+) -> Envelope[dict[str, Any]]:
+    """Read a bot's engine configuration (free-form JSON)."""
+    raise NotImplementedError
+
+
+@router.put(
+    "/{bot_id}/engine-config",
+    response_model=Envelope[dict[str, Any]],
+    openapi_extra=_SEC,
+)
+async def update_bot_engine_config(
+    bot_id: str, body: dict[str, Any], principal: PrincipalDep
+) -> Envelope[dict[str, Any]]:
+    """Write a bot's engine configuration (free-form JSON)."""
+    raise NotImplementedError

--- a/src/gateway/src/gateway/community/adapters/web/routers/bots/_schemas.py
+++ b/src/gateway/src/gateway/community/adapters/web/routers/bots/_schemas.py
@@ -12,7 +12,7 @@ class Bot(BaseModel):
 
     bot_id: str
     bot_name: str
-    bot_desc: str | None = None
+    bot_desc: str
     engine: str
     cluster_name: str
     bot_type: str
@@ -24,12 +24,14 @@ class BotCreate(BaseModel):
     """Create-a-bot request body."""
 
     bot_name: str
-    bot_desc: str | None = None
+    bot_desc: str
     engine: str
     cluster_name: str
     bot_type: str
-    payload: dict[str, Any] = Field(
-        default_factory=dict, description="Engine/vendor-specific options."
+    engine_options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Engine/vendor-specific inputs, kept nested rather than "
+        "flattened into the request body.",
     )
 
 
@@ -39,7 +41,7 @@ class BotUpdate(BaseModel):
     bot_name: str | None = None
     bot_desc: str | None = None
     cluster_name: str | None = None
-    payload: dict[str, Any] | None = None
+    engine_options: dict[str, Any] | None = None
 
 
 class BotAuthPending(BaseModel):

--- a/src/gateway/src/gateway/community/adapters/web/routers/bots/_schemas.py
+++ b/src/gateway/src/gateway/community/adapters/web/routers/bots/_schemas.py
@@ -1,0 +1,78 @@
+"""Request/response models for the bots group."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Bot(BaseModel):
+    """An agent (bot) record."""
+
+    bot_id: str
+    bot_name: str
+    bot_desc: str | None = None
+    engine: str
+    cluster_name: str
+    bot_type: str
+    status: str = Field(description="Lifecycle status: PENDING | ACTIVE | FAILED.")
+    owner_entity_id: str
+
+
+class BotCreate(BaseModel):
+    """Create-a-bot request body."""
+
+    bot_name: str
+    bot_desc: str | None = None
+    engine: str
+    cluster_name: str
+    bot_type: str
+    payload: dict[str, Any] = Field(
+        default_factory=dict, description="Engine/vendor-specific options."
+    )
+
+
+class BotUpdate(BaseModel):
+    """Partial update; engine is fixed at creation and cannot change."""
+
+    bot_name: str | None = None
+    bot_desc: str | None = None
+    cluster_name: str | None = None
+    payload: dict[str, Any] | None = None
+
+
+class BotAuthPending(BaseModel):
+    """Returned (202) when bot creation needs user authorization (Passport)."""
+
+    bot_id: str
+    iframe_url: str
+
+
+class BotAuthStatus(BaseModel):
+    """Passport authorization status; ``bot`` is present once ISSUED."""
+
+    status: str
+    message: str | None = None
+    bot: Bot | None = None
+
+
+class BotStatus(BaseModel):
+    """Runtime / device readiness of a bot."""
+
+    status: str
+    is_ready: bool
+    device_id: str | None = None
+
+
+class Ceiling(BaseModel):
+    """Per-caller bot creation quota ceiling."""
+
+    ceiling: int
+
+
+class Passport(BaseModel):
+    """Agent Passport (identity credential) summary."""
+
+    bot_id: str
+    passport_id: str

--- a/src/gateway/src/gateway/community/bootstrap/__init__.py
+++ b/src/gateway/src/gateway/community/bootstrap/__init__.py
@@ -1,5 +1,13 @@
 """Bootstrap — dependency injection and application lifecycle.
 
-Wires plugins, repositories, and services into an application container.
-Manages startup and shutdown sequences.
+The composition root: wires concrete plugins and services into the app. Adapters
+import the built objects from here (e.g. the ``Authenticator``) rather than
+constructing plugins themselves.
 """
+
+from ._authn import Authenticator, build_authenticator
+
+__all__ = [
+    "Authenticator",
+    "build_authenticator",
+]

--- a/src/gateway/src/gateway/community/bootstrap/_authn.py
+++ b/src/gateway/src/gateway/community/bootstrap/_authn.py
@@ -1,0 +1,71 @@
+"""Composition of the auth subsystem (composition root, Rule 14).
+
+Builds the strategy registry and the route-security table, and exposes an
+:class:`Authenticator` that ties them to the core runner. Only the composition
+root wires concrete plugins and touches ``PluginAccessor``; adapters receive the
+built ``Authenticator`` via ``app.state`` and never import plugins or core.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from gateway.community.core.authn import RouteSecurity
+from gateway.community.core.authn import authenticate as run_auth
+from gateway.community.plugin_accessor import PluginAccessor
+from gateway.community.plugins.auth.bare import BareAuthPlugin
+from gateway.community.plugins.authn.first_party_user import FirstPartyUserStrategy
+from gateway.community.spi.auth import AuthError, AuthPlugin
+from gateway.community.spi.authn import AuthStrategy, CredentialBundle, Principal
+
+# Fallback tenant when a first-party identity carries none (single-box default).
+_DEFAULT_TENANT = "default"
+# Fallback table when no config file is present: every route needs a user.
+_DEFAULT_TABLE = {"/**": ["first_party_user"]}
+
+_auth_plugin = PluginAccessor[AuthPlugin]("gateway.auth", BareAuthPlugin)
+
+
+@dataclass(frozen=True)
+class Authenticator:
+    """Resolves a route's requirement and runs its strategies to a Principal."""
+
+    strategies: dict[str, AuthStrategy]
+    route_security: RouteSecurity
+
+    async def authenticate(
+        self, method: str, path: str, creds: CredentialBundle
+    ) -> Principal:
+        requirement = self.route_security.resolve(method, path)
+        if requirement is None:  # fail-closed: no policy → deny
+            raise AuthError("no auth policy for route")
+        return await run_auth(creds, requirement, self.strategies)
+
+
+def build_authenticator() -> Authenticator:
+    """Build the auth registry + route table (called once from ``create_app``)."""
+    strategies: dict[str, AuthStrategy] = {
+        FirstPartyUserStrategy.name: FirstPartyUserStrategy(
+            auth=_auth_plugin.get(), default_tenant=_DEFAULT_TENANT
+        ),
+    }
+    return Authenticator(strategies=strategies, route_security=_load_route_security())
+
+
+def _load_route_security() -> RouteSecurity:
+    configs_dir = _resolve_configs_dir()
+    path = configs_dir / "route_security.yaml" if configs_dir else None
+    if path is not None and path.exists():
+        return RouteSecurity.from_yaml(path)
+    return RouteSecurity.from_table(_DEFAULT_TABLE)
+
+
+def _resolve_configs_dir() -> Path | None:
+    explicit = os.getenv("GATEWAY_CONFIG_PATH", "").strip()
+    if explicit:
+        p = Path(explicit)
+        return p if p.is_dir() else p.parent
+    cwd = Path.cwd() / "configs"
+    return cwd if cwd.exists() else None

--- a/src/gateway/src/gateway/community/core/authn/__init__.py
+++ b/src/gateway/src/gateway/community/core/authn/__init__.py
@@ -1,0 +1,15 @@
+"""Core authn — transport-agnostic route-security resolution + auth runner.
+
+``RouteSecurity`` resolves a request to its required strategies; ``authenticate``
+runs them against the strategy registry to produce a Principal. Neither depends
+on any web framework (Rule 7).
+"""
+
+from ._route_security import Requirement, RouteSecurity
+from ._runner import authenticate
+
+__all__ = [
+    "Requirement",
+    "RouteSecurity",
+    "authenticate",
+]

--- a/src/gateway/src/gateway/community/core/authn/_route_security.py
+++ b/src/gateway/src/gateway/community/core/authn/_route_security.py
@@ -1,0 +1,125 @@
+"""Route → auth-requirement table (auth design §8).
+
+Loads the ``route_security`` table (a ``"[METHOD ]<path-glob>" -> OR-list``
+mapping) and resolves an incoming ``(method, path)`` to the **most specific**
+matching rule's requirement. Fail-closed: an unmatched route resolves to
+``None`` and the caller must deny.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from gateway.community.spi.authn import Delegation, StrategyParams
+
+# A requirement is an OR-list of alternatives; each alternative is an AND-map of
+# strategy name -> params (one strategy per alternative in practice today).
+Requirement = list[dict[str, StrategyParams]]
+
+
+@dataclass(frozen=True)
+class _Rule:
+    method: str | None  # None = applies to every method
+    segments: tuple[str, ...]  # path split on "/", e.g. ("openapi", "v1", "bots", "**")
+    requirement: Requirement
+
+
+class RouteSecurity:
+    """The compiled route-security table, queryable per request."""
+
+    def __init__(self, rules: list[_Rule]) -> None:
+        self._rules = rules
+
+    @classmethod
+    def from_table(cls, table: dict[str, Any]) -> RouteSecurity:
+        return cls([_parse_rule(key, value) for key, value in table.items()])
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> RouteSecurity:
+        raw = yaml.safe_load(Path(path).read_text()) or {}
+        return cls.from_table(raw.get("route_security", {}))
+
+    def resolve(self, method: str, path: str) -> Requirement | None:
+        """Most-specific matching rule's requirement, or ``None`` if none match."""
+        segments = _segments(path)
+        matches = [r for r in self._rules if _matches(r, method, segments)]
+        if not matches:
+            return None
+        return max(matches, key=_specificity).requirement
+
+
+# ── parsing ──────────────────────────────────────────────────────────────────
+
+
+def _parse_rule(key: str, value: Any) -> _Rule:
+    method, path = _split_key(key)
+    return _Rule(method=method, segments=_segments(path), requirement=_parse_req(value))
+
+
+def _split_key(key: str) -> tuple[str | None, str]:
+    parts = key.strip().split(None, 1)
+    if len(parts) == 2 and parts[0].isupper() and parts[1].startswith("/"):
+        return parts[0], parts[1]
+    return None, key.strip()
+
+
+def _segments(path: str) -> tuple[str, ...]:
+    return tuple(seg for seg in path.split("/") if seg)
+
+
+def _parse_req(value: Any) -> Requirement:
+    requirement: Requirement = []
+    for item in value or []:
+        if isinstance(item, str):
+            requirement.append({item: StrategyParams()})
+        elif isinstance(item, dict):
+            requirement.append(
+                {name: _parse_params(params) for name, params in item.items()}
+            )
+    return requirement
+
+
+def _parse_params(params: Any) -> StrategyParams:
+    params = params or {}
+    return StrategyParams(
+        scopes=frozenset(params.get("scopes", [])),
+        delegation=Delegation(params.get("delegation", Delegation.OPTIONAL.value)),
+    )
+
+
+# ── matching (§8.3) ──────────────────────────────────────────────────────────
+
+
+def _is_param(seg: str) -> bool:
+    return seg.startswith("{") and seg.endswith("}")
+
+
+def _matches(rule: _Rule, method: str, path_segments: tuple[str, ...]) -> bool:
+    if rule.method is not None and rule.method != method:
+        return False
+    return _match_segments(rule.segments, path_segments)
+
+
+def _match_segments(pattern: tuple[str, ...], segs: tuple[str, ...]) -> bool:
+    if not pattern:
+        return not segs
+    head, rest = pattern[0], pattern[1:]
+    if head == "**":  # matches any remaining segments, including none
+        return True
+    if not segs:
+        return False
+    if head != segs[0] and not _is_param(head):
+        return False
+    return _match_segments(rest, segs[1:])
+
+
+def _specificity(rule: _Rule) -> tuple[int, int, int, int]:
+    """Higher = more specific: exact beats glob, more literals, then method."""
+    has_glob = "**" in rule.segments
+    literals = sum(1 for s in rule.segments if s != "**" and not _is_param(s))
+    params = sum(1 for s in rule.segments if _is_param(s))
+    return (0 if has_glob else 1, literals, params, int(rule.method is not None))

--- a/src/gateway/src/gateway/community/core/authn/_runner.py
+++ b/src/gateway/src/gateway/community/core/authn/_runner.py
@@ -3,12 +3,15 @@
 Given the request credentials, a route's requirement (OR-list of alternatives),
 and the strategy registry, try each alternative in order:
 
-- a strategy returning ``None`` (credential absent) fails that alternative;
-- a strategy raising ``AuthError`` (credential invalid) fails that alternative;
+- a strategy returning ``None`` (credential absent) fails that alternative and
+  falls through to the next one;
+- a strategy raising ``AuthError`` (credential present but invalid) is
+  **terminal** — it propagates immediately, with no OR fallback, so a bad
+  credential can never be masked by a later alternative;
 - a Principal with insufficient scope fails that alternative;
 - otherwise the alternative succeeds and its Principal is adopted.
 
-If no alternative succeeds, raise the last error (fail-closed).
+If no alternative applies, raise the last error (fail-closed).
 """
 
 from __future__ import annotations
@@ -31,15 +34,14 @@ async def authenticate(
         ok = True
         for name, params in alternative.items():  # AND within an alternative
             strategy = registry.get(name)
-            if strategy is None:
-                ok, last_err = False, AuthError(f"unknown auth strategy: {name}")
-                break
-            try:
-                principal = await strategy.build(creds, params)
-            except AuthError as err:  # credential present but invalid
-                ok, last_err = False, err
-                break
-            if principal is None:  # credential absent → not applicable
+            if strategy is None:  # misconfigured route → fail closed, terminal
+                raise AuthError(f"unknown auth strategy: {name}")
+            # A strategy raising AuthError means the credential is present but
+            # INVALID — that is terminal (no OR fallback), so let it propagate.
+            # Only a None result (credential absent) falls through to the next
+            # alternative.
+            principal = await strategy.build(creds, params)
+            if principal is None:  # credential absent → this alternative is N/A
                 ok = False
                 break
             if not params.scopes <= principal.scopes:  # required ⊆ granted

--- a/src/gateway/src/gateway/community/core/authn/_runner.py
+++ b/src/gateway/src/gateway/community/core/authn/_runner.py
@@ -1,0 +1,51 @@
+"""Auth runner — execute a route's requirement to produce a Principal (§7).
+
+Given the request credentials, a route's requirement (OR-list of alternatives),
+and the strategy registry, try each alternative in order:
+
+- a strategy returning ``None`` (credential absent) fails that alternative;
+- a strategy raising ``AuthError`` (credential invalid) fails that alternative;
+- a Principal with insufficient scope fails that alternative;
+- otherwise the alternative succeeds and its Principal is adopted.
+
+If no alternative succeeds, raise the last error (fail-closed).
+"""
+
+from __future__ import annotations
+
+from gateway.community.spi.auth import AuthError
+from gateway.community.spi.authn import AuthStrategy, CredentialBundle, Principal
+
+from ._route_security import Requirement
+
+
+async def authenticate(
+    creds: CredentialBundle,
+    requirement: Requirement,
+    registry: dict[str, AuthStrategy],
+) -> Principal:
+    """Build a Principal for the request, or raise ``AuthError`` (401/403)."""
+    last_err: AuthError | None = None
+    for alternative in requirement:  # OR across alternatives
+        built: Principal | None = None
+        ok = True
+        for name, params in alternative.items():  # AND within an alternative
+            strategy = registry.get(name)
+            if strategy is None:
+                ok, last_err = False, AuthError(f"unknown auth strategy: {name}")
+                break
+            try:
+                principal = await strategy.build(creds, params)
+            except AuthError as err:  # credential present but invalid
+                ok, last_err = False, err
+                break
+            if principal is None:  # credential absent → not applicable
+                ok = False
+                break
+            if not params.scopes <= principal.scopes:  # required ⊆ granted
+                ok, last_err = False, AuthError("insufficient scope")
+                break
+            built = principal
+        if ok and built is not None:
+            return built
+    raise last_err or AuthError("unauthorized")

--- a/src/gateway/src/gateway/community/plugins/authn/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/authn/__init__.py
@@ -1,0 +1,6 @@
+"""Authn strategy plugin implementations.
+
+Each subpackage is one ``AuthStrategy`` (a named way to build a Principal).
+Strategies are flavor-agnostic; provider differences live behind the SPIs a
+strategy depends on (e.g. ``AuthPlugin``).
+"""

--- a/src/gateway/src/gateway/community/plugins/authn/first_party_user/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/authn/first_party_user/__init__.py
@@ -1,0 +1,7 @@
+"""``first_party_user`` auth strategy plugin."""
+
+from ._strategy import FirstPartyUserStrategy
+
+__all__ = [
+    "FirstPartyUserStrategy",
+]

--- a/src/gateway/src/gateway/community/plugins/authn/first_party_user/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/first_party_user/_strategy.py
@@ -1,0 +1,54 @@
+"""``first_party_user`` strategy — builds a UserPrincipal from a session cookie.
+
+For our own frontend / a human with a login session. The browser can't carry a
+tenant token (it's a secret), so the tenant is taken from the authenticated
+user's identity, falling back to a configured default (auth design §4.6, §6.2).
+"""
+
+from __future__ import annotations
+
+from gateway.community.spi.auth import AuthError, AuthPlugin
+from gateway.community.spi.authn import (
+    CredentialBundle,
+    Delegation,
+    Principal,
+    StrategyParams,
+    UserPrincipal,
+)
+
+# Cookies that indicate a first-party login session is present.
+_SESSION_COOKIES = ("IAM_TOKEN", "SSO_TOKEN", "access_token")
+
+
+class FirstPartyUserStrategy:
+    """Resolve a login-session cookie into a :class:`UserPrincipal`.
+
+    Implements the ``AuthStrategy`` protocol structurally (``name`` + ``build``);
+    the composition root registers it in an ``AuthStrategy``-typed registry,
+    where mypy verifies conformance.
+    """
+
+    name = "first_party_user"
+
+    def __init__(self, auth: AuthPlugin, default_tenant: str) -> None:
+        self._auth = auth
+        self._default_tenant = default_tenant  # fallback when identity has no tenant
+
+    async def build(
+        self, creds: CredentialBundle, params: StrategyParams
+    ) -> Principal | None:
+        if not any(name in creds.cookies for name in _SESSION_COOKIES):
+            return None  # no first-party session → strategy not applicable
+        if params.delegation is Delegation.FORBIDDEN:
+            raise AuthError(
+                "route forbids a user identity but a session cookie is present"
+            )
+        # Invalid session → AuthPlugin raises AuthError (hard failure).
+        user = await self._auth.get_login_user(
+            cookie=creds.headers.get("cookie", ""),
+            referer=creds.headers.get("referer"),
+        )
+        # Browser can't present a tenant token; take it from the identity.
+        tenant = user.tenant_id or self._default_tenant
+        # Scope vocabulary is out of scope this session — no scopes granted yet.
+        return UserPrincipal(tenant=tenant, subject=user, scopes=frozenset())

--- a/src/gateway/src/gateway/community/spi/authn/__init__.py
+++ b/src/gateway/src/gateway/community/spi/authn/__init__.py
@@ -1,13 +1,26 @@
 """Authn SPI — the neutral Principal contract produced by the gateway.
 
-See ``_models`` for the model definitions and the auth design doc
+See ``_models`` for the model definitions, ``_protocols`` for the
+``AuthStrategy`` contract, and the auth design doc
 (``src/gateway/docs/2026-07-21-auth-design.md``) for the full picture.
 """
 
-from ._models import Principal, PrincipalType, UserPrincipal
+from ._models import (
+    CredentialBundle,
+    Delegation,
+    Principal,
+    PrincipalType,
+    StrategyParams,
+    UserPrincipal,
+)
+from ._protocols import AuthStrategy
 
 __all__ = [
+    "AuthStrategy",
+    "CredentialBundle",
+    "Delegation",
     "Principal",
     "PrincipalType",
+    "StrategyParams",
     "UserPrincipal",
 ]

--- a/src/gateway/src/gateway/community/spi/authn/_models.py
+++ b/src/gateway/src/gateway/community/spi/authn/_models.py
@@ -12,6 +12,8 @@ third-party / app-principal access is added; ``PrincipalType`` is left open for
 that.
 """
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Literal
 
@@ -52,3 +54,36 @@ class UserPrincipal(BaseModel):
 # `Principal` becomes a discriminated union (UserPrincipal | AppPrincipal | ...)
 # when app-principal access lands; for now the only member is UserPrincipal.
 Principal = UserPrincipal
+
+
+# ── Strategy inputs (framework-agnostic) ─────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CredentialBundle:
+    """Framework-agnostic snapshot of a request's credentials.
+
+    A delivery adapter fills this from the incoming request (e.g. a FastAPI
+    ``Request``); an ``AuthStrategy`` reads it without depending on any web
+    framework.
+    """
+
+    headers: Mapping[str, str]
+    cookies: Mapping[str, str]
+    query: Mapping[str, str]
+
+
+class Delegation(StrEnum):
+    """Whether a route lets the caller act on behalf of an end user."""
+
+    OPTIONAL = "optional"  # end-user handle allowed but not required (default)
+    FORBIDDEN = "forbidden"  # pure caller only; reject an end-user handle
+    # REQUIRED lands with verified delegation (app acting for a real user).
+
+
+@dataclass(frozen=True)
+class StrategyParams:
+    """Per-route parameters for one strategy, from its ``x-avernet-security`` block."""
+
+    scopes: frozenset[str] = frozenset()
+    delegation: Delegation = Delegation.OPTIONAL

--- a/src/gateway/src/gateway/community/spi/authn/_protocols.py
+++ b/src/gateway/src/gateway/community/spi/authn/_protocols.py
@@ -1,0 +1,31 @@
+"""Authn SPI — the ``AuthStrategy`` contract (how a Principal is built).
+
+A strategy is a named way to turn a request's credentials into a
+:class:`~gateway.community.spi.authn.Principal`. The gateway holds a small,
+closed set of them; each route names the one(s) it accepts via its
+``x-avernet-security`` marker (see the auth design doc §5).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ._models import CredentialBundle, Principal, StrategyParams
+
+
+class AuthStrategy(Protocol):
+    """Builds a Principal from a request, or signals inapplicability."""
+
+    name: str  # stable id referenced by x-avernet-security
+
+    async def build(
+        self, creds: CredentialBundle, params: StrategyParams
+    ) -> Principal | None:
+        """Try to build a Principal (tenant included) from the request.
+
+        Returns ``None`` when this strategy's credential is **absent** — not
+        applicable, so the next OR branch may try. Raises ``AuthError`` when the
+        credential is **present but invalid** (hard failure, no fallback).
+        Returns a ``Principal`` on success; the runner then checks scope.
+        """
+        ...

--- a/src/gateway/tests/contracts/spi/test_auth_strategy.py
+++ b/src/gateway/tests/contracts/spi/test_auth_strategy.py
@@ -1,0 +1,49 @@
+"""Conformance tests for the ``AuthStrategy`` protocol (Rule 25)."""
+
+from __future__ import annotations
+
+from gateway.community.plugins.auth.bare import BareAuthPlugin
+from gateway.community.plugins.authn.first_party_user import FirstPartyUserStrategy
+from gateway.community.spi.auth import AuthenticatedUser
+from gateway.community.spi.authn import (
+    AuthStrategy,
+    CredentialBundle,
+    StrategyParams,
+    UserPrincipal,
+)
+
+
+class AuthStrategyContract:
+    """Behaviour every ``AuthStrategy`` implementation must satisfy."""
+
+    strategy: AuthStrategy
+    applicable_creds: CredentialBundle
+    inapplicable_creds: CredentialBundle
+
+    def test_has_stable_name(self) -> None:
+        assert isinstance(self.strategy.name, str)
+        assert self.strategy.name
+
+    async def test_returns_none_when_not_applicable(self) -> None:
+        result = await self.strategy.build(self.inapplicable_creds, StrategyParams())
+        assert result is None
+
+    async def test_builds_a_principal_when_applicable(self) -> None:
+        result = await self.strategy.build(self.applicable_creds, StrategyParams())
+        assert result is not None
+
+
+class TestFirstPartyUserStrategy(AuthStrategyContract):
+    def setup_method(self) -> None:
+        self.strategy = FirstPartyUserStrategy(
+            auth=BareAuthPlugin(default_user=AuthenticatedUser(id="u", username="a")),
+            default_tenant="tenant-default",
+        )
+        self.applicable_creds = CredentialBundle(
+            headers={"cookie": "SSO_TOKEN=x"}, cookies={"SSO_TOKEN": "x"}, query={}
+        )
+        self.inapplicable_creds = CredentialBundle(headers={}, cookies={}, query={})
+
+    async def test_builds_user_principal(self) -> None:
+        principal = await self.strategy.build(self.applicable_creds, StrategyParams())
+        assert isinstance(principal, UserPrincipal)

--- a/src/gateway/tests/integration/baseline/test_startup.py
+++ b/src/gateway/tests/integration/baseline/test_startup.py
@@ -33,7 +33,7 @@ class TestAppCreation:
         assert app is not None
 
     def test_app_has_expected_routes(self, client: TestClient) -> None:
-        routes = {r.path for r in client.app.routes}
+        routes = {getattr(r, "path", None) for r in client.app.routes}
         assert "/api/test" in routes
         assert "/health" in routes
         assert "/docs" in routes

--- a/src/gateway/tests/test_auth_runner.py
+++ b/src/gateway/tests/test_auth_runner.py
@@ -85,3 +85,15 @@ async def test_or_falls_back_to_second_alternative() -> None:
 async def test_unknown_strategy_is_denied() -> None:
     with pytest.raises(AuthError):
         await authenticate(_CREDS, [{"missing": StrategyParams()}], {})
+
+
+async def test_invalid_credential_is_terminal_no_fallback() -> None:
+    # A present-but-invalid credential (AuthError) in one alternative must NOT
+    # fall back to a later valid alternative — the whole attempt is rejected.
+    registry: dict[str, AuthStrategy] = {
+        "bad": _Fixed("bad", AuthError("invalid api key")),
+        "good": _Fixed("good", _principal()),
+    }
+    req = [{"bad": StrategyParams()}, {"good": StrategyParams()}]
+    with pytest.raises(AuthError):
+        await authenticate(_CREDS, req, registry)

--- a/src/gateway/tests/test_auth_runner.py
+++ b/src/gateway/tests/test_auth_runner.py
@@ -1,0 +1,87 @@
+"""Unit tests for the auth runner (OR/AND + scope, §7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.community.core.authn import authenticate
+from gateway.community.spi.auth import AuthenticatedUser, AuthError
+from gateway.community.spi.authn import (
+    AuthStrategy,
+    CredentialBundle,
+    Principal,
+    StrategyParams,
+    UserPrincipal,
+)
+
+_CREDS = CredentialBundle(headers={}, cookies={}, query={})
+
+
+def _principal(scopes: frozenset[str] = frozenset()) -> UserPrincipal:
+    return UserPrincipal(
+        tenant="t", subject=AuthenticatedUser(id="u", username="a"), scopes=scopes
+    )
+
+
+class _Fixed:
+    """A strategy that always yields a fixed result (Principal, None, or raises)."""
+
+    def __init__(self, name: str, result: Principal | AuthError | None) -> None:
+        self.name = name
+        self._result = result
+
+    async def build(
+        self, creds: CredentialBundle, params: StrategyParams
+    ) -> Principal | None:
+        if isinstance(self._result, AuthError):
+            raise self._result
+        return self._result
+
+
+async def test_returns_principal_on_success() -> None:
+    registry: dict[str, AuthStrategy] = {"fp": _Fixed("fp", _principal())}
+    principal = await authenticate(_CREDS, [{"fp": StrategyParams()}], registry)
+    assert isinstance(principal, UserPrincipal)
+
+
+async def test_none_result_is_unauthorized() -> None:
+    registry: dict[str, AuthStrategy] = {"fp": _Fixed("fp", None)}
+    with pytest.raises(AuthError):
+        await authenticate(_CREDS, [{"fp": StrategyParams()}], registry)
+
+
+async def test_autherror_propagates() -> None:
+    registry: dict[str, AuthStrategy] = {"fp": _Fixed("fp", AuthError("bad"))}
+    with pytest.raises(AuthError):
+        await authenticate(_CREDS, [{"fp": StrategyParams()}], registry)
+
+
+async def test_insufficient_scope_is_denied() -> None:
+    registry: dict[str, AuthStrategy] = {"fp": _Fixed("fp", _principal())}
+    req = [{"fp": StrategyParams(scopes=frozenset({"bots:read"}))}]
+    with pytest.raises(AuthError):
+        await authenticate(_CREDS, req, registry)
+
+
+async def test_required_scope_subset_is_allowed() -> None:
+    registry: dict[str, AuthStrategy] = {
+        "fp": _Fixed("fp", _principal(scopes=frozenset({"bots:read", "bots:write"})))
+    }
+    req = [{"fp": StrategyParams(scopes=frozenset({"bots:read"}))}]
+    principal = await authenticate(_CREDS, req, registry)
+    assert isinstance(principal, UserPrincipal)
+
+
+async def test_or_falls_back_to_second_alternative() -> None:
+    registry: dict[str, AuthStrategy] = {
+        "a": _Fixed("a", None),
+        "b": _Fixed("b", _principal()),
+    }
+    req = [{"a": StrategyParams()}, {"b": StrategyParams()}]
+    principal = await authenticate(_CREDS, req, registry)
+    assert isinstance(principal, UserPrincipal)
+
+
+async def test_unknown_strategy_is_denied() -> None:
+    with pytest.raises(AuthError):
+        await authenticate(_CREDS, [{"missing": StrategyParams()}], {})

--- a/src/gateway/tests/test_authn_models.py
+++ b/src/gateway/tests/test_authn_models.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 from pydantic import ValidationError
 
 from gateway.community.spi.auth import AuthenticatedUser
-from gateway.community.spi.authn import Principal, PrincipalType, UserPrincipal
+from gateway.community.spi.authn import (
+    CredentialBundle,
+    Delegation,
+    Principal,
+    PrincipalType,
+    StrategyParams,
+    UserPrincipal,
+)
 
 
 def _subject() -> AuthenticatedUser:
@@ -46,3 +55,22 @@ def test_user_principal_is_immutable() -> None:
 
 def test_principal_alias_is_user_principal() -> None:
     assert Principal is UserPrincipal
+
+
+def test_strategy_params_defaults() -> None:
+    params = StrategyParams()
+    assert params.scopes == frozenset()
+    assert params.delegation is Delegation.OPTIONAL
+
+
+def test_strategy_params_are_frozen() -> None:
+    params = StrategyParams(scopes=frozenset({"bots:read"}))
+    with pytest.raises(FrozenInstanceError):
+        params.delegation = Delegation.FORBIDDEN  # type: ignore[misc]
+
+
+def test_credential_bundle_is_frozen() -> None:
+    creds = CredentialBundle(headers={}, cookies={"SSO_TOKEN": "x"}, query={})
+    assert creds.cookies["SSO_TOKEN"] == "x"
+    with pytest.raises(FrozenInstanceError):
+        creds.headers = {}  # type: ignore[misc]

--- a/src/gateway/tests/test_bots_router.py
+++ b/src/gateway/tests/test_bots_router.py
@@ -1,0 +1,52 @@
+"""Contract + auth-integration tests for the bots group."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from gateway.community.adapters.web.app import create_app
+
+
+def _openapi() -> dict[str, Any]:
+    return TestClient(create_app()).get("/openapi.json").json()
+
+
+def test_bots_routes_present() -> None:
+    paths = _openapi()["paths"]
+    assert "/openapi/v1/bots" in paths
+    assert "/openapi/v1/bots/{bot_id}" in paths
+    assert "/openapi/v1/bots/check-name" in paths
+
+
+def test_every_v1_operation_declares_security() -> None:
+    paths = _openapi()["paths"]
+    operations = [
+        (path, method, op)
+        for path, item in paths.items()
+        if path.startswith("/openapi/v1/")
+        for method, op in item.items()
+        if method in {"get", "post", "put", "patch", "delete"}
+    ]
+    assert operations  # sanity: there are v1 operations
+    for path, method, op in operations:
+        assert "x-avernet-security" in op, f"{method} {path} missing x-avernet-security"
+
+
+def test_responses_use_envelope() -> None:
+    schemas = _openapi()["components"]["schemas"]
+    assert any(name.startswith("Envelope") for name in schemas)
+
+
+def test_requires_authentication_without_session() -> None:
+    client = TestClient(create_app(), raise_server_exceptions=False)
+    assert client.get("/openapi/v1/bots").status_code == 401
+
+
+def test_auth_passes_with_session_cookie() -> None:
+    client = TestClient(create_app(), raise_server_exceptions=False)
+    # A session cookie clears auth; the stub handler then raises (500), which
+    # proves the request got past authentication (auth would 401 otherwise).
+    resp = client.get("/openapi/v1/bots", headers={"cookie": "SSO_TOKEN=x"})
+    assert resp.status_code == 500

--- a/src/gateway/tests/test_first_party_user_strategy.py
+++ b/src/gateway/tests/test_first_party_user_strategy.py
@@ -1,0 +1,90 @@
+"""Unit tests for the first_party_user auth strategy."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.community.plugins.auth.bare import BareAuthPlugin
+from gateway.community.plugins.authn.first_party_user import FirstPartyUserStrategy
+from gateway.community.spi.auth import AuthenticatedUser, AuthError
+from gateway.community.spi.authn import (
+    CredentialBundle,
+    Delegation,
+    StrategyParams,
+    UserPrincipal,
+)
+
+_DEFAULT_TENANT = "tenant-default"
+
+
+def _creds_with_session() -> CredentialBundle:
+    return CredentialBundle(
+        headers={"cookie": "SSO_TOKEN=abc"}, cookies={"SSO_TOKEN": "abc"}, query={}
+    )
+
+
+def _strategy(user: AuthenticatedUser) -> FirstPartyUserStrategy:
+    return FirstPartyUserStrategy(
+        auth=BareAuthPlugin(default_user=user), default_tenant=_DEFAULT_TENANT
+    )
+
+
+async def test_no_session_cookie_is_not_applicable() -> None:
+    strategy = _strategy(AuthenticatedUser(id="u1", username="alice"))
+    result = await strategy.build(
+        CredentialBundle(headers={}, cookies={}, query={}), StrategyParams()
+    )
+    assert result is None
+
+
+async def test_builds_user_principal_with_identity_tenant() -> None:
+    strategy = _strategy(
+        AuthenticatedUser(id="u1", username="alice", tenant_id="tenant-9")
+    )
+    principal = await strategy.build(_creds_with_session(), StrategyParams())
+    assert isinstance(principal, UserPrincipal)
+    assert principal.tenant == "tenant-9"
+    assert principal.subject.id == "u1"
+    assert principal.scopes == frozenset()
+
+
+async def test_falls_back_to_default_tenant() -> None:
+    strategy = _strategy(AuthenticatedUser(id="u1", username="alice"))  # no tenant_id
+    principal = await strategy.build(_creds_with_session(), StrategyParams())
+    assert isinstance(principal, UserPrincipal)
+    assert principal.tenant == _DEFAULT_TENANT
+
+
+async def test_forbidden_delegation_with_session_raises() -> None:
+    strategy = _strategy(AuthenticatedUser(id="u1", username="alice"))
+    with pytest.raises(AuthError):
+        await strategy.build(
+            _creds_with_session(), StrategyParams(delegation=Delegation.FORBIDDEN)
+        )
+
+
+class _RaisingAuth:
+    async def get_login_user(
+        self, cookie: str | None = None, referer: str | None = None
+    ) -> AuthenticatedUser:
+        raise AuthError("invalid session")
+
+    def is_allowed(self, user: AuthenticatedUser) -> bool:
+        return True
+
+    def check_permission(
+        self,
+        user_id: str,
+        permission_codes: str,
+        request_url: str = "",
+        request_map: str = "",
+    ) -> bool:
+        return True
+
+
+async def test_invalid_session_is_hard_failure() -> None:
+    strategy = FirstPartyUserStrategy(
+        auth=_RaisingAuth(), default_tenant=_DEFAULT_TENANT
+    )
+    with pytest.raises(AuthError):
+        await strategy.build(_creds_with_session(), StrategyParams())

--- a/src/gateway/tests/test_route_security.py
+++ b/src/gateway/tests/test_route_security.py
@@ -1,0 +1,63 @@
+"""Unit tests for the route-security table (config parsing + matching)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gateway.community.core.authn import RouteSecurity
+from gateway.community.spi.authn import Delegation
+
+_CONFIG = Path(__file__).resolve().parents[1] / "configs" / "route_security.yaml"
+
+
+def test_shipped_config_loads_and_covers_bots() -> None:
+    rs = RouteSecurity.from_yaml(_CONFIG)
+    req = rs.resolve("GET", "/openapi/v1/bots/abc")
+    assert req is not None
+    assert "first_party_user" in req[0]
+
+
+def test_more_specific_rule_wins() -> None:
+    rs = RouteSecurity.from_table(
+        {
+            "/**": ["first_party_user"],
+            "/openapi/v1/bots/**": [{"first_party_user": {"delegation": "forbidden"}}],
+        }
+    )
+    bots = rs.resolve("POST", "/openapi/v1/bots/x")
+    assert bots is not None
+    assert bots[0]["first_party_user"].delegation is Delegation.FORBIDDEN
+
+    other = rs.resolve("GET", "/openapi/v1/other")
+    assert other is not None
+    assert other[0]["first_party_user"].delegation is Delegation.OPTIONAL
+
+
+def test_method_specific_rule_beats_method_agnostic() -> None:
+    rs = RouteSecurity.from_table(
+        {
+            "/openapi/v1/bots/{id}": [{"first_party_user": {}}],
+            "GET /openapi/v1/bots/{id}": [
+                {"first_party_user": {"scopes": ["bots:read"]}}
+            ],
+        }
+    )
+    get_req = rs.resolve("GET", "/openapi/v1/bots/42")
+    assert get_req is not None
+    assert get_req[0]["first_party_user"].scopes == frozenset({"bots:read"})
+
+    post_req = rs.resolve("POST", "/openapi/v1/bots/42")
+    assert post_req is not None
+    assert post_req[0]["first_party_user"].scopes == frozenset()
+
+
+def test_param_segment_matches_one_segment() -> None:
+    rs = RouteSecurity.from_table({"/openapi/v1/bots/{id}": ["first_party_user"]})
+    assert rs.resolve("GET", "/openapi/v1/bots/42") is not None
+    # {id} matches exactly one segment, not a deeper path.
+    assert rs.resolve("GET", "/openapi/v1/bots/42/skills") is None
+
+
+def test_unmatched_route_is_fail_closed() -> None:
+    rs = RouteSecurity.from_table({"/openapi/v1/bots/**": ["first_party_user"]})
+    assert rs.resolve("GET", "/openapi/v1/channels") is None

--- a/src/gateway/tests/test_routers.py
+++ b/src/gateway/tests/test_routers.py
@@ -1,46 +1,18 @@
-"""Tests for the public-API router aggregator and app wiring."""
+"""Tests for the public-API router aggregation."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
-from gateway.community.adapters.web import routers
 from gateway.community.adapters.web.app import create_app
 
 
 def test_openapi_document_served() -> None:
-    client = TestClient(create_app())
-    resp = client.get("/openapi.json")
+    resp = TestClient(create_app()).get("/openapi.json")
     assert resp.status_code == 200
     assert resp.json()["openapi"].startswith("3.")
 
 
-def test_include_all_mounts_registered_routers() -> None:
-    router = APIRouter()
-
-    @router.get("/openapi/v1/_probe")
-    async def _probe() -> dict[str, str]:
-        return {"ok": "true"}
-
-    app = FastAPI()
-    original = list(routers.GROUP_ROUTERS)
-    routers.GROUP_ROUTERS.append(router)
-    try:
-        routers.include_all(app)
-        paths = TestClient(app).get("/openapi.json").json()["paths"]
-        assert "/openapi/v1/_probe" in paths
-    finally:
-        routers.GROUP_ROUTERS[:] = original
-
-
-def test_include_all_is_noop_without_registered_routers() -> None:
-    app = FastAPI()
-    before = len(app.routes)
-    original = list(routers.GROUP_ROUTERS)
-    routers.GROUP_ROUTERS.clear()
-    try:
-        routers.include_all(app)
-        assert len(app.routes) == before
-    finally:
-        routers.GROUP_ROUTERS[:] = original
+def test_bots_group_is_mounted() -> None:
+    paths = TestClient(create_app()).get("/openapi.json").json()["paths"]
+    assert any(path.startswith("/openapi/v1/bots") for path in paths)


### PR DESCRIPTION
## What

Group B of the gateway v1 API — the first working **auth vertical slice** plus the sample **bots** endpoints, on top of the Group A contract foundation (merged in #345). Follows the auth design (`src/gateway/docs/2026-07-21-auth-design.md`) §4–§8.

### In this PR
- **Auth strategy SPI** (`spi/authn`): `AuthStrategy` protocol + strategy inputs `CredentialBundle` / `StrategyParams` / `Delegation` (framework-agnostic).
- **`first_party_user` strategy** (`plugins/authn/first_party_user`): resolves a login-session cookie into a `UserPrincipal` via the existing `AuthPlugin` (tenant from the identity, falling back to a configured default). `None` when not applicable, `AuthError` when invalid.
- **Route-security config** (`configs/route_security.yaml`) + **`core/authn`**: `RouteSecurity` parses the `"[METHOD ]<path-glob>"` table and resolves a request to its **most-specific** rule (fail-closed on no match); `authenticate()` runs the requirement's OR/AND alternatives against the strategy registry with scope checking (required ⊆ granted).
- **Composition + wiring**: `bootstrap._authn` builds an `Authenticator` (strategies + route table) and it's stored on `app.state` in `create_app`; the delivery-layer `require_principal` dependency snapshots the request and delegates to it, mapping auth failure to 401.
- **Sample `bots` group** (`adapters/web/routers/bots`): `/openapi/v1/bots` endpoints (definition-only stubs) each declaring `x-avernet-security` and depending on `require_principal`.
- **Tests**: strategy, runner, route-table matching/specificity, an `AuthStrategy` conformance test, and bots contract + auth-integration tests (401 without a session; reaches the stub with one).

## How the config answers "which strategy per endpoint"

`configs/route_security.yaml` is the aggregated table; a request resolves to the most-specific matching rule and the runner executes its strategies. The per-operation `x-avernet-security` markers remain the authoritative author-declared source (v1 hand-authors the table until the publish/register compiler lands).

## Architecture

Composition and `PluginAccessor` live only in `bootstrap`; adapters import only `spi` + `bootstrap` and receive the built `Authenticator` via `app.state`; core (`RouteSecurity` + runner) is transport-agnostic. Private modules (`_`-prefixed) are re-exported via `__init__.py` per the repo convention. All architecture-rule tests pass.

## Verification

`ruff` (import-sort + format + lint), `mypy --strict` (on the new modules), and the unit gate `pytest -m "not e2e"` — **250 passed**. An adversarial code-review pass over the auth logic found no defects (route matching, fail-closed behavior, and per-route guarding verified against a live TestClient).

## Known limitations (documented, not reachable with the shipped config)

- Multi-strategy AND within one alternative keeps only the last strategy's principal (no merge contract; scoped to "one strategy per alternative" today).
- Route specificity ranks by aggregate literal/param counts, not position-by-position; not reachable with the current 2-rule table and cannot weaken auth (the `/**` default requires a user principal).
- Auth-failure responses currently use FastAPI's default body; wrapping them in the standard envelope is a follow-up.

## Out of scope

Business logic / backend endpoints, the scope vocabulary, third-party app-principal access, and the remaining groups (identity, resources, mcp, routines, skills, channels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FizQrLd647Rg27X1Fmqt6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01FizQrLd647Rg27X1Fmqt6Z)_