### PR TITLE
feat(bcs): auto-join humans for session chat

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -1449,7 +1449,7 @@ pub async fn session_chat(
     Json(body): Json<SessionChatRequest>,
 ) -> impl IntoResponse {
     // 1. Look up session
-    let sess = match state.services.session_management.get(&sid).await {
+    let mut sess = match state.services.session_management.get(&sid).await {
         Ok(Some(s)) => s,
         Ok(None) => {
             return (
@@ -1484,23 +1484,63 @@ pub async fn session_chat(
 
     // 4. Caller must be a session participant
     let caller_id = match &caller {
-        GroupChatCaller::Bot { bot_uuid } => bot_uuid.as_str(),
-        GroupChatCaller::Human(h) => h.actor_id.as_str(),
+        GroupChatCaller::Bot { bot_uuid } => bot_uuid.clone(),
+        GroupChatCaller::Human(h) => h.actor_id.clone(),
     };
-    let is_participant = sess.participants.iter().any(|p| p.bot_uuid == caller_id);
+    let is_participant = sess
+        .participants
+        .iter()
+        .any(|p| p.bot_uuid == caller_id);
     if !is_participant {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": "caller is not a session participant"})),
-        )
-            .into_response();
+        // COSEC: only the authenticated Human may self-enroll. Bot callers
+        // remain fail-closed so a valid Bot token cannot expand membership.
+        let GroupChatCaller::Human(human) = &caller else {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "caller is not a session participant"})),
+            )
+                .into_response();
+        };
+        let mut participant = bcs_service_api::Participant::human(
+            &human.actor_id,
+            bcs_service_api::ParticipantRole::Observer,
+        );
+        participant.mode = Some(bcs_service_api::ParticipantMode::Present);
+        participant.bot_name = human
+            .nick_name
+            .clone()
+            .or_else(|| Some(human.staff_no.clone()));
+        sess = match state
+            .services
+            .session_management
+            .add_participant(&sid, participant.clone())
+            .await
+        {
+            Ok(updated) => updated,
+            Err(error) => return session_error_to_response(&error),
+        };
+        let event = SystemMessageEvent::BotJoined {
+            group_id: sess.group_id.clone(),
+            actor: participant.into(),
+        };
+        let _ = state
+            .services
+            .system_message
+            .notify(&sess.group_id, event, &sid, &sess.participants)
+            .await;
     }
 
     // 5. Route via MessageFlowService with session_id pinned from path
+    // COSEC: Human messages are always bound to the authenticated actor, even
+    // when the request supplies `from`; Bot callers retain legacy validation.
+    let requested_sender_id = match &caller {
+        GroupChatCaller::Human(human) => Some(human.actor_id.clone()),
+        GroupChatCaller::Bot { .. } => body.from,
+    };
     let cmd = GroupChatCommand {
         caller: group_chat_caller_context(&caller),
         group_id: sess.group_id.clone(),
-        requested_sender_id: body.from,
+        requested_sender_id,
         message: body.message,
         session_id: Some(sid.clone()),
     };

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -703,7 +703,11 @@ async fn build_group_app_with_identity(
 ) {
     let temp_dir = TempDir::new().unwrap();
     let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
-    for (bot_id, name) in [("owner-bot", "Owner"), ("target-bot", "Target")] {
+    for (bot_id, name) in [
+        ("owner-bot", "Owner"),
+        ("target-bot", "Target"),
+        ("intruder-bot", "Intruder"),
+    ] {
         registry
             .register(
                 bot_id.to_string(),
@@ -716,6 +720,12 @@ async fn build_group_app_with_identity(
             .await
             .unwrap();
     }
+    registry
+        .store_token_mapping(
+            "intruder-token".to_string(),
+            "intruder-bot".to_string(),
+        )
+        .await;
     registry
         .save_created_by("owner-bot", "123", true)
         .await
@@ -932,6 +942,65 @@ async fn session_chat_auto_joins_authenticated_human_and_binds_sender_identity()
     assert_eq!(participant["role"], "observer");
     assert_eq!(participant["actor_kind"], "human");
     assert_eq!(participant["mode"], "present");
+}
+
+#[tokio::test]
+async fn session_chat_does_not_auto_join_authenticated_bot() {
+    let (
+        app,
+        _group_store,
+        _routing,
+        _bot_delivery,
+        _frontend_delivery,
+        _bot_request,
+        message_flow,
+        _group_message_history,
+    ) = build_group_app().await;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions/group-1:abcdef12/chat")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer intruder-token")
+                .body(Body::from(
+                    serde_json::json!({
+                        "message": "should be rejected",
+                        "from": "intruder-bot"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"], "caller is not a session participant");
+    assert!(message_flow.group_chats.lock().await.is_empty());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/group-1:abcdef12")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["participants"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|participant| participant["bot_uuid"] != "intruder-bot"));
 }
 
 async fn post_session_chat_with_flow_error(error: ServiceError) -> (StatusCode, Value) {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -242,7 +242,15 @@ impl BotRequestPort for RecordingBotRequest {
 }
 
 struct StaticSessionManagement {
-    session: Session,
+    session: Mutex<Session>,
+}
+
+impl StaticSessionManagement {
+    fn new(session: Session) -> Self {
+        Self {
+            session: Mutex::new(session),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -255,7 +263,8 @@ impl SessionManagementService for StaticSessionManagement {
     }
 
     async fn get(&self, session_id: &str) -> Result<Option<Session>, SessionUseCaseError> {
-        Ok((self.session.id == session_id).then(|| self.session.clone()))
+        let session = self.session.lock().await;
+        Ok((session.id == session_id).then(|| session.clone()))
     }
 
     async fn belongs_to_group(
@@ -263,7 +272,8 @@ impl SessionManagementService for StaticSessionManagement {
         session_id: &str,
         group_id: &str,
     ) -> Result<bool, SessionUseCaseError> {
-        Ok(self.session.id == session_id && self.session.group_id == group_id)
+        let session = self.session.lock().await;
+        Ok(session.id == session_id && session.group_id == group_id)
     }
 
     async fn list_by_group(
@@ -309,10 +319,21 @@ impl SessionManagementService for StaticSessionManagement {
 
     async fn add_participant(
         &self,
-        _session_id: &str,
-        _participant: Participant,
+        session_id: &str,
+        participant: Participant,
     ) -> Result<Session, SessionUseCaseError> {
-        unimplemented!("not needed by this test")
+        let mut session = self.session.lock().await;
+        if session.id != session_id {
+            return Err(SessionUseCaseError::NotFound(session_id.to_string()));
+        }
+        if !session
+            .participants
+            .iter()
+            .any(|existing| existing.bot_uuid == participant.bot_uuid)
+        {
+            session.participants.push(participant);
+        }
+        Ok(session.clone())
     }
 
     async fn remove_participant(
@@ -744,8 +765,7 @@ async fn build_group_app_with_identity(
         .bot_delivery(bot_delivery.clone())
         .frontend_delivery(frontend_delivery.clone())
         .message_flow(message_flow.clone())
-        .session_management(Arc::new(StaticSessionManagement {
-            session: test_session(
+        .session_management(Arc::new(StaticSessionManagement::new(test_session(
                 "group-1:abcdef12",
                 "group-1",
                 vec![
@@ -753,8 +773,7 @@ async fn build_group_app_with_identity(
                     Participant::bot("target-bot", ParticipantRole::Consultant),
                     Participant::human("human_123", ParticipantRole::Observer),
                 ],
-            ),
-        }))
+            ))))
         .group_query(group_use_cases)
         .group_message_history(group_message_history.clone())
         .build_for_test();
@@ -841,6 +860,78 @@ async fn session_messages_uses_history_service() {
         CallerContext::Human(human)
             if human.actor_id == "human_123" && human.staff_no == "123"
     ));
+}
+
+#[tokio::test]
+async fn session_chat_auto_joins_authenticated_human_and_binds_sender_identity() {
+    let chain = static_auth_chain("456", "Alice");
+    let (
+        app,
+        _group_store,
+        _routing,
+        _bot_delivery,
+        _frontend_delivery,
+        _bot_request,
+        message_flow,
+        _group_message_history,
+    ) = build_group_app_with_identity(Arc::new(ChainUserIdentityPort::new(chain))).await;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions/group-1:abcdef12/chat")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "message": "hello as Alice",
+                        "from": "owner-bot"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let group_chats = message_flow.group_chats.lock().await;
+    assert_eq!(group_chats.len(), 1);
+    assert_eq!(
+        group_chats[0].requested_sender_id.as_deref(),
+        Some("human_456")
+    );
+    assert!(matches!(
+        &group_chats[0].caller,
+        CallerContext::Human(human)
+            if human.actor_id == "human_456" && human.staff_no == "456"
+    ));
+    drop(group_chats);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/group-1:abcdef12")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let participant = json["participants"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|participant| participant["bot_uuid"] == "human_456")
+        .expect("authenticated Human should be added to the session");
+    assert_eq!(participant["bot_name"], "Alice");
+    assert_eq!(participant["role"], "observer");
+    assert_eq!(participant["actor_kind"], "human");
+    assert_eq!(participant["mode"], "present");
 }
 
 async fn post_session_chat_with_flow_error(error: ServiceError) -> (StatusCode, Value) {
@@ -956,7 +1047,7 @@ async fn state_machine_session_messages_use_runtime_history() {
     });
     let mut services = Services::noop();
     services.group = group_store;
-    services.session_management = Arc::new(StaticSessionManagement { session });
+    services.session_management = Arc::new(StaticSessionManagement::new(session));
     services.group_message_history = group_message_history.clone();
     services.collaboration_runtime = collaboration_runtime.clone();
     let app = build_router(HttpAppState::new(services));

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -409,6 +409,39 @@ pub(crate) async fn manager_worker_self_owner(
     None
 }
 
+async fn apply_session_participant_scope(
+    flow: &BcsMessageFlow,
+    group: &mut Group,
+    session_id: Option<&str>,
+) -> ServiceResult<()> {
+    let (Some(session_id), Some(session_mgmt)) = (session_id, flow.session_management.as_ref())
+    else {
+        return Ok(());
+    };
+    let session = session_mgmt
+        .get(session_id)
+        .await
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .ok_or_else(|| ServiceError::SessionNotFound(session_id.to_string()))?;
+    if session.group_id != group.id {
+        return Err(ServiceError::InvalidOperation {
+            message: format!(
+                "session '{}' does not belong to group '{}'",
+                session_id, group.id
+            ),
+            request_id: None,
+        });
+    }
+    if session.participants.is_empty() {
+        return Err(ServiceError::InvalidOperation {
+            message: format!("session '{}' has no participants", session_id),
+            request_id: None,
+        });
+    }
+    group.participants = session.participants;
+    Ok(())
+}
+
 pub async fn handle_web_send(
     flow: &BcsMessageFlow,
     cmd: WebSendCommand,
@@ -440,38 +473,8 @@ pub async fn handle_web_send(
     }
 
     flow.group.reset_message_count(&cmd.group_id).await?;
+    apply_session_participant_scope(flow, &mut group, cmd.session_id.as_deref()).await?;
     backfill_bot_names(flow.registry.as_ref(), &mut group).await;
-    if let Some(ref bcs_session_id) = cmd.session_id {
-        if let Some(ref session_mgmt) = flow.session_management {
-            match session_mgmt.get(bcs_session_id).await {
-                Ok(Some(sess)) => {
-                    if sess.group_id != cmd.group_id {
-                        return Err(ServiceError::InvalidOperation {
-                            message: format!(
-                                "session '{}' does not belong to group '{}'",
-                                bcs_session_id, cmd.group_id
-                            ),
-                            request_id: None,
-                        });
-                    }
-                    if sess.participants.is_empty() {
-                        return Err(ServiceError::InvalidOperation {
-                            message: format!("session '{}' has no participants", bcs_session_id),
-                            request_id: None,
-                        });
-                    }
-                    group.participants = sess.participants;
-                    backfill_bot_names(flow.registry.as_ref(), &mut group).await;
-                }
-                Ok(None) => {
-                    return Err(ServiceError::SessionNotFound(bcs_session_id.clone()));
-                }
-                Err(error) => {
-                    return Err(ServiceError::InternalError(error.to_string()));
-                }
-            }
-        }
-    }
 
     let overlay = build_route_overlay(flow, &group).await;
     let decision = if group.group_kind == GroupKind::Dm {
@@ -864,12 +867,13 @@ pub async fn handle_group_chat(
     flow: &BcsMessageFlow,
     cmd: GroupChatCommand,
 ) -> ServiceResult<GroupChatOutcome> {
-    let group = flow
+    let mut group = flow
         .group
         .get(&cmd.group_id)
         .await
         .ok_or_else(|| ServiceError::GroupNotFound(cmd.group_id.clone()))?;
 
+    apply_session_participant_scope(flow, &mut group, cmd.session_id.as_deref()).await?;
     verify_group_chat_caller_access(flow, &group, &cmd.caller).await?;
     let sender_id = resolve_group_chat_sender(&cmd)?;
     verify_group_chat_sender(flow, &group, &sender_id, &cmd.caller).await?;

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -2418,6 +2418,83 @@ async fn group_chat_rejects_bot_that_is_not_a_session_participant() {
 }
 
 #[tokio::test]
+async fn group_chat_rejects_session_from_another_group() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let session_id = "other-group:mismatched";
+    let session = test_session(
+        session_id,
+        "other-group",
+        vec![Participant::bot(
+            "bot-driver",
+            ParticipantRole::Driver,
+        )],
+    );
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_session_management(Arc::new(StaticSessionManagement::new(session)));
+
+    let error = flow
+        .handle_group_chat(GroupChatCommand {
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: "bot-driver".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            requested_sender_id: Some("bot-driver".to_string()),
+            message: "should not be delivered".to_string(),
+            session_id: Some(session_id.to_string()),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ServiceError::InvalidOperation { message, .. }
+            if message == "session 'other-group:mismatched' does not belong to group 'group-1'"
+    ));
+    assert!(support.bot_delivery.frames().await.is_empty());
+}
+
+#[tokio::test]
+async fn group_chat_rejects_session_without_participants() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let session_id = "group-1:empty";
+    let session = test_session(session_id, "group-1", Vec::new());
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_session_management(Arc::new(StaticSessionManagement::new(session)));
+
+    let error = flow
+        .handle_group_chat(GroupChatCommand {
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: "bot-driver".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            requested_sender_id: Some("bot-driver".to_string()),
+            message: "should not be delivered".to_string(),
+            session_id: Some(session_id.to_string()),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ServiceError::InvalidOperation { message, .. }
+            if message == "session 'group-1:empty' has no participants"
+    ));
+    assert!(support.bot_delivery.frames().await.is_empty());
+}
+
+#[tokio::test]
 async fn group_chat_treats_requested_sender_id_literally_without_trimming() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     support

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -1,7 +1,7 @@
 use bcs_message_flow::{BcsGroupMessageHistory, BcsMessageFlow, MemoryBotRunContextStore};
 use bcs_protocol::BcsFrame;
 use bcs_service_api::{
-    ActorKind, BotDeliveryKind, BotDeliveryTarget, BotEventCommand, BotRegistryCoreService,
+    ActorKind, BotActor, BotDeliveryKind, BotDeliveryTarget, BotEventCommand, BotRegistryCoreService,
     BotRunContextPort,
     CallerContext, ChatAbortCommand, ChatEventState, GroupCallbackCommand, GroupChatCommand, GroupHistoryBotRequestPort,
     FrontendDeliveryTarget, Group, GroupHistoryCommand, GroupKind, GroupMessage, GroupMessageHistoryService, GroupMessageType,
@@ -2326,6 +2326,95 @@ async fn group_chat_validates_sender_and_returns_legacy_delivery_projection() {
             .iter()
             .any(|frame| matches!(frame, BcsFrame::Request(req) if req.method == "chat.send"))
     );
+}
+
+#[tokio::test]
+async fn group_chat_uses_session_participants_for_human_sender_validation() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let session_id = "group-1:human-chat";
+    let session = test_session(
+        session_id,
+        "group-1",
+        vec![
+            Participant::bot("bot-driver", ParticipantRole::Driver),
+            Participant::human("human_2", ParticipantRole::Observer),
+        ],
+    );
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_session_management(Arc::new(StaticSessionManagement::new(session)));
+
+    let outcome = flow
+        .handle_group_chat(GroupChatCommand {
+            caller: CallerContext::Human(HumanActor {
+                actor_id: "human_2".to_string(),
+                staff_no: "2".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            requested_sender_id: Some("human_2".to_string()),
+            message: "hello from the session Human".to_string(),
+            session_id: Some(session_id.to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.delivered_count, 1);
+    let frames = support.bot_delivery.frames().await;
+    let send_frame = frames
+        .iter()
+        .find(|frame| matches!(frame, BcsFrame::Request(req) if req.method == "chat.send"))
+        .expect("chat.send frame");
+    let BcsFrame::Request(req) = send_frame else {
+        panic!("expected request frame");
+    };
+    let params = req.params.as_ref().expect("params");
+    assert_eq!(params["channel"]["actor_id"], "human_2");
+    assert_eq!(params["session_context"]["from_bot_id"], "human_2");
+}
+
+#[tokio::test]
+async fn group_chat_rejects_bot_that_is_not_a_session_participant() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let session_id = "group-1:driver-only";
+    let session = test_session(
+        session_id,
+        "group-1",
+        vec![Participant::bot(
+            "bot-driver",
+            ParticipantRole::Driver,
+        )],
+    );
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_session_management(Arc::new(StaticSessionManagement::new(session)));
+
+    let error = flow
+        .handle_group_chat(GroupChatCommand {
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: "bot-observer".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            requested_sender_id: Some("bot-observer".to_string()),
+            message: "should not be delivered".to_string(),
+            session_id: Some(session_id.to_string()),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(error, ServiceError::Unauthorized(message) if message.contains("not a participant"))
+    );
+    assert!(support.bot_delivery.frames().await.is_empty());
 }
 
 #[tokio::test]

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/session.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/session.md
@@ -249,6 +249,11 @@ bcs session chat --session "<session_id>" --message "<消息内容>"
 
 与 Group 级 chat（`/groups/{id}/chat`）的区别：Session chat 将 session_id 锁定在路径上，消息只在该 Session 的参与者间路由。
 
+认证 Human 尚未加入目标 Session 时，服务端会先以
+`Observer + Present` 加入，再以该 Human 的 `actor_id` 发送消息。
+请求体中的 `from` 不会覆盖 Human 身份；Bot 调用者仍必须已经是
+Session 参与者。
+
 **示例：**
 
 ```bash


### PR DESCRIPTION
## Summary

- Automatically add an authenticated Human caller to a running Session as `Observer + Present` before handling `POST /sessions/{session_id}/chat` when they are not already a participant.
- Bind Human messages to the authenticated caller's `actor_id`, so the request `from` field cannot override the sender identity; Bot callers remain fail-closed and must already be Session participants.
- Validate and route Session chat against Session participants rather than the parent Group participant list, and document the updated contract.

## Why

The endpoint previously rejected authenticated Human callers who were not already Session participants. Even after adding a Human to the Session, the message flow still validated the sender against the parent Group, preventing a Session-only Human from sending under their own identity.

## Validation

- `cargo test -p bcs-message-flow`
- `cargo test -p bcs-http`
- `cargo check -p bcs-http -p bcs-message-flow --all-targets`
- `git diff --check origin/dev...HEAD`