### PR TITLE
fix(bcs): reject invalid explicit bot credentials

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -1633,11 +1633,18 @@ async fn resolve_actor_caller(
     headers: &HeaderMap,
     uri: &Uri,
 ) -> Result<String, HttpAdapterError> {
-    if let Ok(bot_id) = authenticated_bot_from_headers(state, headers).await {
-        if !bot_id.trim().is_empty() {
-            return Ok(bot_id);
+    let explicit_bot_token = headers.contains_key("X-BCS-Bot-Token");
+    match authenticated_bot_from_headers(state, headers).await {
+        Ok(bot_id) if !bot_id.trim().is_empty() => return Ok(bot_id),
+        Ok(_) if explicit_bot_token => {
+            return Err(HttpAdapterError::Unauthorized(
+                "valid bot token is required".to_string(),
+            ));
         }
+        Err(error) if explicit_bot_token => return Err(error),
+        _ => {}
     }
+
     extract_human_actor_id(state, headers, uri)
         .await
         .ok_or_else(|| HttpAdapterError::Unauthorized("valid bot token or human cookie is required".to_string()))

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -1451,15 +1451,19 @@ async fn my_groups_rejects_explicit_bot_token_when_container_validation_fails() 
 async fn my_groups_rejects_empty_bot_actor_identity() {
     let query = Arc::new(RecordingGroupQuery::default());
     let services = Services::builder().group_query(query).build_for_test();
-    let app = build_router(HttpAppState::new(services).with_auth_chain(
-        static_bot_auth_chain(""),
-        AuthConfig::default(),
-    ));
+    let chain = static_auth_chain("alice", "Alice");
+    let app = build_router(
+        HttpAppState::new(services)
+            .with_auth_chain(static_bot_auth_chain(""), AuthConfig::default())
+            .with_user_identity(Arc::new(ChainUserIdentityPort::new(chain))),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/groups/my")
+                .header("authorization", "Bearer human-oauth-token")
+                .header("X-BCS-Bot-Token", "valid-bot-token")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -1322,15 +1322,19 @@ async fn my_groups_resolves_bot_principal_and_preserves_query() {
     let services = Services::builder()
         .group_query(query.clone())
         .build_for_test();
-    let app = build_router(HttpAppState::new(services).with_auth_chain(
-        static_bot_auth_chain("bot-current"),
-        AuthConfig::default(),
-    ));
+    let chain = static_auth_chain("alice", "Alice");
+    let app = build_router(
+        HttpAppState::new(services)
+            .with_auth_chain(static_bot_auth_chain("bot-current"), AuthConfig::default())
+            .with_user_identity(Arc::new(ChainUserIdentityPort::new(chain))),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/groups/my?group_kind=normal&offset=4&limit=5&q=05&include_session_groups=true")
+                .header("authorization", "Bearer human-oauth-token")
+                .header("X-BCS-Bot-Token", "valid-bot-token")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1368,6 +1372,7 @@ async fn my_groups_resolves_human_identity() {
         .oneshot(
             Request::builder()
                 .uri("/groups/my?include_session_groups=false")
+                .header("authorization", "Bearer human-oauth-token")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1382,6 +1387,64 @@ async fn my_groups_resolves_human_identity() {
     let calls = query.bot_group_calls.lock().await;
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].bot_id, "human_alice");
+}
+
+#[tokio::test]
+async fn my_groups_rejects_explicit_invalid_bot_token_instead_of_falling_back_to_human() {
+    let query = Arc::new(RecordingGroupQuery::default());
+    let services = Services::builder()
+        .group_query(query.clone())
+        .build_for_test();
+    let chain = static_auth_chain("alice", "Alice");
+    let app = build_router(HttpAppState::new(services).with_user_identity(Arc::new(
+        ChainUserIdentityPort::new(chain),
+    )));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/groups/my")
+                .header("authorization", "Bearer human-oauth-token")
+                .header("X-BCS-Bot-Token", "stale-bot-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(query.bot_group_calls.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn my_groups_rejects_explicit_bot_token_when_container_validation_fails() {
+    let query = Arc::new(RecordingGroupQuery::default());
+    let services = Services::builder()
+        .group_query(query.clone())
+        .build_for_test();
+    let chain = static_auth_chain("alice", "Alice");
+    let app = build_router(
+        HttpAppState::new(services)
+            .with_auth_chain(static_bot_auth_chain("bot-current"), AuthConfig::default())
+            .with_user_identity(Arc::new(ChainUserIdentityPort::new(chain)))
+            .with_strict_container_validation(true),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/groups/my")
+                .header("authorization", "Bearer human-oauth-token")
+                .header("X-BCS-Bot-Token", "valid-bot-token")
+                .header("x-agentclaw-bolt-id", "different-container")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(query.bot_group_calls.lock().await.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Treat the presence of `X-BCS-Bot-Token` as an explicit request to authenticate as a bot.
- Return bot authentication and container-validation errors instead of silently falling back to the human OAuth identity.
- Preserve human OAuth fallback when no explicit bot-token header is supplied, and keep valid bot credentials higher priority when both identities are available.
- Add regression coverage for stale bot tokens, container mismatches, mixed bot/human credentials, and human-only OAuth requests.

## Root cause

`resolve_actor_caller` discarded every error from bot authentication. In office/OAuth mode, the CLI can send both a human OAuth `Authorization` header and `X-BCS-Bot-Token`; an invalid explicit bot credential therefore selected the human actor and returned the wrong actor's groups.

## Impact

`GET /groups/my` now fails closed when an explicit bot credential is invalid, while requests that only carry a valid human OAuth identity continue to resolve as `human_<staff_no>`.

## Contract impact

- No endpoint or response-schema change.
- No service or plugin API change.
- This corrects authentication precedence for the existing endpoint.

## Verification

- `cargo test -p bcs-http`
- `git diff --check`