### PR TITLE
feat(backend)botchat统一接口+开放api

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_chat/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_chat/router.py
@@ -33,6 +33,18 @@ async def list_sessions(
         ),
     ),
     query: str | None = Query(default=None, description="Fuzzy search on session name and user input"),
+    biz_scene: str | None = Query(default=None, description="Business scene"),
+    biz_task_id: str | None = Query(default=None, description="Business task ID"),
+    group_id: str | None = Query(default=None, description="BCS group ID"),
+    match_mode: str = Query(default="exact", pattern="^(exact|contains)$"),
+    include_output_match: bool = Query(
+        default=False, description="Include trace output in keyword matching"
+    ),
+    time_scope: str = Query(
+        default="default",
+        pattern="^(default|all)$",
+        description="Use 'all' only for an exact identifier lookup",
+    ),
     from_date: datetime | None = Query(default=None, description="Start time (ISO 8601)"),
     to_date: datetime | None = Query(default=None, description="End time (ISO 8601)"),
     page: int = Query(default=1, ge=1, description="Page number"),
@@ -58,9 +70,17 @@ async def list_sessions(
             session_id=session_id,
             session_key=session_key,
             query=query,
+            biz_scene=biz_scene,
+            biz_task_id=biz_task_id,
+            group_id=group_id,
+            match_mode=match_mode,
+            include_output_match=include_output_match,
+            time_scope=time_scope,
             log_source=log_source,
         )
         return ApiResponse(success=True, message="ok", data=result)
+    except ValueError as e:
+        return ApiResponse(success=False, message=str(e), error_code=4000)
     except LangfuseAPIError as e:
         return ApiResponse(success=False, message=str(e), error_code=5999)
     except Exception as e:

--- a/src/backend/src/agentclaw/community/api/bot_chat_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_chat_service.py
@@ -1,9 +1,14 @@
 """Service API Protocol for bot-chat session listing + health."""
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from datetime import datetime
+from typing import Protocol, runtime_checkable
 
-from agentclaw.community.core.bot_chat.schemas import ConversationDetail, HealthCheckData
+from agentclaw.community.core.bot_chat.schemas import (
+    ConversationDetail,
+    HealthCheckData,
+    SessionListResponse,
+)
 
 
 @runtime_checkable
@@ -13,8 +18,8 @@ class BotChatServiceProtocol(Protocol):
     async def list_sessions(
         self,
         owner_id: str,
-        from_date: Any | None = None,
-        to_date: Any | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
         page: int = 1,
         limit: int = 20,
         bot_id: str | None = None,
@@ -22,8 +27,14 @@ class BotChatServiceProtocol(Protocol):
         session_id: str | None = None,
         session_key: str | None = None,
         query: str | None = None,
+        biz_scene: str | None = None,
+        biz_task_id: str | None = None,
+        group_id: str | None = None,
+        match_mode: str = "exact",
+        include_output_match: bool = False,
+        time_scope: str = "default",
         log_source: str | None = None,
-    ) -> Any: ...
+    ) -> SessionListResponse: ...
 
     async def get_session(
         self,

--- a/src/backend/src/agentclaw/community/core/bot_chat/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_chat/README.md
@@ -23,3 +23,27 @@ internal_dependencies:
 ### Change impact
 
 Local to the bot-chat flow. Changes here affect the single-user chat path; group chat lives separately.
+
+## Query contract
+
+`GET /api/v1/bot-chats` keeps exact matching and the existing 72-hour default
+window for backward compatibility. Optional product-query capabilities are:
+
+- `biz_scene` and `biz_task_id`: merge direct trace fields with relations
+  recorded by `POST /api/bot-chat/log-relations`;
+- `group_id`: resolve all BCS sessions for the group and normalize missing
+  `agent:main:` prefixes before querying traces;
+- `match_mode=contains`: fuzzy ID/business matching, limited to a 90-day range;
+- `include_output_match=true`: include trace output in keyword matching;
+- `time_scope=all`: allowed only for an exact identifier lookup.
+
+List and detail responses may include `bot_id`, `bot_name`, `group_id`, and
+`session_kind`. These are optional display fields; `session_kind` is not a
+filter. A missing/deleted Bot leaves `bot_name` null so clients can fall back
+to `bot_id`. Observation responses preserve raw metadata for detail rendering.
+
+Task relations with an explicit `user_id` are isolated to that user; legacy
+relations without identity remain readable for backward compatibility. ORM
+index declarations create indexes for new local databases only. Existing
+deployments must apply equivalent DDL through their normal database migration
+process.

--- a/src/backend/src/agentclaw/community/core/bot_chat/models.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/models.py
@@ -91,6 +91,10 @@ class AcOtelLogTrace(Base):
         Index("idx_ac_otel_log_trace_bot", "bot_id"),
         Index("idx_ac_otel_log_trace_session_id", "session_id"),
         Index("idx_ac_otel_log_trace_session_key", "session_key"),
+        Index("idx_ac_otel_log_trace_task", "biz_scene", "biz_task_id", "start_time_ms"),
+        Index("idx_ac_otel_log_trace_task_only", "biz_task_id", "start_time_ms"),
+        Index("idx_ac_otel_log_trace_session", "session_id", "start_time_ms"),
+        Index("idx_ac_otel_log_trace_session_key_time", "session_key", "start_time_ms"),
     )
 
 
@@ -164,3 +168,18 @@ class AcOtelLogBizRef(Base):
         Index("idx_ac_otel_log_biz_ref_user", "user_id"),
         Index("idx_ac_otel_log_biz_ref_bot", "bot_id"),
     )
+
+
+class BcsGroupSession(Base):
+    """Read model for resolving a BCS group to its runtime sessions."""
+
+    __tablename__ = "bcs_group_sessions"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    gmt_create = Column(DateTime, server_default=func.now())
+    session_id = Column(String(64), nullable=False)
+    group_id = Column(String(64), nullable=False)
+    env = Column(String(32), nullable=False, default="prod")
+    status = Column(String(16), nullable=False, default="running")
+    session_kind = Column(String(32), nullable=False, default="chat")

--- a/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
@@ -1,0 +1,175 @@
+"""SQL query construction and display-label enrichment for bot-chat reads."""
+
+from typing import Any
+
+from sqlalchemy import and_, or_
+
+from agentclaw.community.core.bot_chat.models import (
+    AcOtelLogBizRef,
+    AcOtelLogTrace,
+    BcsGroupSession,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.models import BotModel
+from agentclaw.community.utils.env_utils import get_current_env
+
+logger = get_logger()
+
+_GROUP_SESSION_KEY_PREFIX = "agent:main:"
+
+
+def match_column(column: Any, value: str, match_mode: str) -> Any:
+    """Build exact or substring matching for a SQLAlchemy column."""
+    return column.like(f"%{value}%") if match_mode == "contains" else column == value
+
+
+def load_task_refs(
+    session: Any,
+    biz_scene: str | None,
+    biz_task_id: str | None,
+    match_mode: str,
+    owner_id: str,
+    bot_id: str | None,
+) -> dict[str, set[str]]:
+    """Load task references visible to the current user/Bot scope."""
+    if not biz_scene and not biz_task_id:
+        return {}
+    query = session.query(AcOtelLogBizRef)
+    if biz_scene:
+        query = query.filter(
+            match_column(AcOtelLogBizRef.biz_scene, biz_scene, match_mode)
+        )
+    if biz_task_id:
+        query = query.filter(
+            match_column(AcOtelLogBizRef.biz_task_id, biz_task_id, match_mode)
+        )
+    query = query.filter(
+        or_(
+            AcOtelLogBizRef.user_id == owner_id,
+            AcOtelLogBizRef.user_id.is_(None),
+        )
+    )
+    if bot_id:
+        relation_bot_ids = [bot_id]
+        if bot_id == "default":
+            relation_bot_ids.append(f"{owner_id}_default")
+        query = query.filter(
+            or_(
+                AcOtelLogBizRef.bot_id.in_(relation_bot_ids),
+                AcOtelLogBizRef.bot_id.is_(None),
+            )
+        )
+
+    refs: dict[str, set[str]] = {}
+    for row in query.all():
+        refs.setdefault(row.ref_type, set()).add(row.ref_value)
+    return refs
+
+
+def task_trace_condition(
+    refs: dict[str, set[str]],
+    biz_scene: str | None,
+    biz_task_id: str | None,
+    match_mode: str,
+) -> Any:
+    """Combine direct task fields with relation-derived trace identifiers."""
+    direct = []
+    if biz_scene:
+        direct.append(match_column(AcOtelLogTrace.biz_scene, biz_scene, match_mode))
+    if biz_task_id:
+        direct.append(
+            match_column(AcOtelLogTrace.biz_task_id, biz_task_id, match_mode)
+        )
+    candidates = [and_(*direct)]
+    if refs.get("trace_id"):
+        candidates.append(AcOtelLogTrace.trace_id.in_(refs["trace_id"]))
+    if refs.get("session_id"):
+        candidates.append(AcOtelLogTrace.session_id.in_(refs["session_id"]))
+    if refs.get("session_key"):
+        candidates.append(AcOtelLogTrace.session_key.in_(refs["session_key"]))
+    return or_(*candidates)
+
+
+def list_group_sessions(
+    session: Any, group_id: str
+) -> dict[str, str | None]:
+    """Resolve every BCS session in a group to its normalized log session key."""
+    rows = (
+        session.query(BcsGroupSession)
+        .filter(
+            BcsGroupSession.env == get_current_env(),
+            BcsGroupSession.group_id == group_id,
+            BcsGroupSession.session_id.isnot(None),
+        )
+        .order_by(BcsGroupSession.gmt_create.desc(), BcsGroupSession.id.desc())
+        .all()
+    )
+    result: dict[str, str | None] = {}
+    for row in rows:
+        value = row.session_id.strip()
+        if not value:
+            continue
+        session_key = (
+            value
+            if value.startswith("agent:")
+            else f"{_GROUP_SESSION_KEY_PREFIX}{value}"
+        )
+        result.setdefault(session_key, row.session_kind)
+    return result
+
+
+def load_bot_names(session: Any, bot_ids: set[str]) -> dict[str, str]:
+    """Batch-load active Bot names, degrading to an empty map on read failure."""
+    if not bot_ids:
+        return {}
+    try:
+        rows = (
+            session.query(BotModel)
+            .filter(
+                BotModel.bot_id.in_(bot_ids),
+                BotModel.is_delete == 0,
+                BotModel.env == get_current_env(),
+            )
+            .order_by(BotModel.id.desc())
+            .all()
+        )
+    except Exception as exc:
+        logger.warning(
+            "Bot name enrichment failed; returning null labels: error_type=%s",
+            type(exc).__name__,
+        )
+        return {}
+
+    result: dict[str, str] = {}
+    for row in rows:
+        row_bot_id = getattr(row, "bot_id", None)
+        bot_name = getattr(row, "bot_name", None)
+        if row_bot_id and row_bot_id not in result and bot_name:
+            result[row_bot_id] = bot_name
+    return result
+
+
+def enrich_trace_labels(session: Any, row: Any) -> Any:
+    """Attach optional Bot and group labels to a detached trace row."""
+    if row.bot_id:
+        row.bot_name = load_bot_names(session, {row.bot_id}).get(row.bot_id)
+    session_key = row.session_key
+    if not session_key:
+        return row
+
+    candidates = {session_key}
+    if session_key.startswith(_GROUP_SESSION_KEY_PREFIX):
+        candidates.add(session_key[len(_GROUP_SESSION_KEY_PREFIX):])
+    group_session = (
+        session.query(BcsGroupSession)
+        .filter(
+            BcsGroupSession.env == get_current_env(),
+            BcsGroupSession.session_id.in_(candidates),
+        )
+        .order_by(BcsGroupSession.gmt_create.desc(), BcsGroupSession.id.desc())
+        .first()
+    )
+    if group_session and getattr(group_session, "group_id", None):
+        row.group_id = group_session.group_id
+        row.session_kind = getattr(group_session, "session_kind", None)
+    return row

--- a/src/backend/src/agentclaw/community/core/bot_chat/repository.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/repository.py
@@ -7,7 +7,7 @@ from hashlib import sha256
 from types import SimpleNamespace
 from typing import Any
 
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, or_
 
 from agentclaw.community.core.bot_chat.models import (
     AwLangfuseObservation,
@@ -15,6 +15,7 @@ from agentclaw.community.core.bot_chat.models import (
     AcOtelLogBizRef,
     AcOtelLogObservation,
     AcOtelLogTrace,
+    BcsGroupSession,
 )
 from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
 from agentclaw.community.core.bot_chat.schemas import (
@@ -28,6 +29,9 @@ from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.utils.env_utils import get_current_env
 
 logger = get_logger()
+
+_GROUP_SESSION_KEY_PREFIX = "agent:main:"
+_OUTPUT_PREVIEW_LENGTH = 500
 
 
 def _extract_user_input(trace_input: Any) -> str | None:
@@ -69,6 +73,16 @@ def _extract_user_input(trace_input: Any) -> str | None:
     if isinstance(trace_input, dict):
         return trace_input.get("content", str(trace_input))
     return str(trace_input)
+
+
+def _output_preview(trace_output: Any) -> str | None:
+    if trace_output is None:
+        return None
+    if isinstance(trace_output, str):
+        value = trace_output
+    else:
+        value = json.dumps(trace_output, ensure_ascii=False)
+    return value[:_OUTPUT_PREVIEW_LENGTH]
 
 
 def _decimal_for_column_or_none(value: Any, column: Any) -> Decimal | None:
@@ -113,6 +127,16 @@ class BotChatDbRepository:
             return value
         return json.dumps(value, ensure_ascii=False)
 
+    def _metadata_bot_id(self, metadata_json: str | None) -> str | None:
+        metadata = self._safe_json_loads(metadata_json, {})
+        if not isinstance(metadata, dict):
+            return None
+        attributes = metadata.get("attributes") or {}
+        if not isinstance(attributes, dict):
+            return None
+        value = attributes.get("identity.bot_id")
+        return str(value) if value else None
+
     def _ref_digest(self, ref_value: str) -> str:
         return f"sha256:{sha256(ref_value.encode('utf-8')).hexdigest()}"
 
@@ -134,10 +158,14 @@ class BotChatDbRepository:
             latency=row.latency,
             total_cost=row.total_cost,
             observations=row.observations,
-            bot_id=row.bot_id,
+            bot_id=row.bot_id or self._metadata_bot_id(row.trace_metadata),
             device_id=row.device_id,
             real_session_id=row.real_session_id,
             usage_total_tokens=None,
+            bot_name=None,
+            group_id=None,
+            session_kind=None,
+            match_sources=[],
         )
 
     def _detach_ocb_trace_row(self, row: Any) -> Any:
@@ -157,9 +185,13 @@ class BotChatDbRepository:
             latency=row.latency_ms,
             total_cost=row.total_cost,
             observations=None,
-            bot_id=row.bot_id,
+            bot_id=row.bot_id or self._metadata_bot_id(row.metadata_json),
             device_id=None,
             usage_total_tokens=row.usage_total_tokens,
+            bot_name=None,
+            group_id=None,
+            session_kind=None,
+            match_sources=[],
         )
 
     def _fill_ocb_trace_usage_from_observations(self, session: Any, row: AcOtelLogTrace) -> None:
@@ -207,6 +239,7 @@ class BotChatDbRepository:
         from datetime import datetime
 
         input_data = self._safe_json_loads(row.input, None)
+        output_data = self._safe_json_loads(row.output, row.output)
         metadata_raw = self._safe_json_loads(row.trace_metadata, {})
         attributes = dict(metadata_raw.get("attributes") or {}) if isinstance(metadata_raw, dict) else {}
         biz_task_id = (
@@ -239,8 +272,14 @@ class BotChatDbRepository:
             biz_scene=biz_scene,
             session_id=session_id,
             session_key=session_key,
+            bot_id=getattr(row, "bot_id", None),
+            bot_name=getattr(row, "bot_name", None),
+            group_id=getattr(row, "group_id", None),
+            session_kind=getattr(row, "session_kind", None),
             name=row.name or "未命名会话",
             input=_extract_user_input(input_data),
+            output_preview=_output_preview(output_data),
+            match_sources=list(getattr(row, "match_sources", None) or []),
             status="SUCCESS",
             timestamp=timestamp,
             user_id=row.user_id,
@@ -287,6 +326,10 @@ class BotChatDbRepository:
             biz_scene=biz_scene,
             session_id=session_id,
             session_key=session_key,
+            bot_id=getattr(row, "bot_id", None),
+            bot_name=getattr(row, "bot_name", None),
+            group_id=getattr(row, "group_id", None),
+            session_kind=getattr(row, "session_kind", None),
             name=row.name or "未命名会话",
             input=input_data,
             output=output_data,
@@ -332,6 +375,7 @@ class BotChatDbRepository:
             total_tokens=int(getattr(row, "usage_total_tokens", None) or 0),
             input=input_value,
             output=output,
+            metadata=metadata if isinstance(metadata, dict) else None,
             model_name=getattr(row, "model", None) or attributes.get("gen_ai.response.model") or attributes.get("gen_ai.request.model"),
             parent_observation_id=getattr(row, "parent_observation_id", None),
             children=[],
@@ -397,6 +441,162 @@ class BotChatDbRepository:
         """Check if user_id is either owner or collaborator of bot_id."""
         return self.is_bot_owner(user_id, bot_id) or self.is_bot_collaborator(user_id, bot_id)
 
+    @staticmethod
+    def _match(column: Any, value: str, match_mode: str) -> Any:
+        return column.like(f"%{value}%") if match_mode == "contains" else column == value
+
+    def _load_task_refs(
+        self,
+        session: Any,
+        biz_scene: str | None,
+        biz_task_id: str | None,
+        match_mode: str,
+        owner_id: str,
+        bot_id: str | None,
+    ) -> dict[str, set[str]]:
+        if not biz_scene and not biz_task_id:
+            return {}
+        query = session.query(AcOtelLogBizRef)
+        if biz_scene:
+            query = query.filter(self._match(AcOtelLogBizRef.biz_scene, biz_scene, match_mode))
+        if biz_task_id:
+            query = query.filter(self._match(AcOtelLogBizRef.biz_task_id, biz_task_id, match_mode))
+        query = query.filter(
+            or_(
+                AcOtelLogBizRef.user_id == owner_id,
+                AcOtelLogBizRef.user_id.is_(None),
+            )
+        )
+        if bot_id:
+            relation_bot_ids = [bot_id]
+            if bot_id == "default":
+                relation_bot_ids.append(f"{owner_id}_default")
+            query = query.filter(
+                or_(
+                    AcOtelLogBizRef.bot_id.in_(relation_bot_ids),
+                    AcOtelLogBizRef.bot_id.is_(None),
+                )
+            )
+        refs: dict[str, set[str]] = {}
+        for row in query.all():
+            refs.setdefault(row.ref_type, set()).add(row.ref_value)
+        return refs
+
+    def _task_trace_condition(
+        self,
+        refs: dict[str, set[str]],
+        biz_scene: str | None,
+        biz_task_id: str | None,
+        match_mode: str,
+    ) -> Any:
+        direct = []
+        if biz_scene:
+            direct.append(self._match(AcOtelLogTrace.biz_scene, biz_scene, match_mode))
+        if biz_task_id:
+            direct.append(self._match(AcOtelLogTrace.biz_task_id, biz_task_id, match_mode))
+        candidates = [and_(*direct)]
+        if refs.get("trace_id"):
+            candidates.append(AcOtelLogTrace.trace_id.in_(refs["trace_id"]))
+        if refs.get("session_id"):
+            candidates.append(AcOtelLogTrace.session_id.in_(refs["session_id"]))
+        if refs.get("session_key"):
+            candidates.append(AcOtelLogTrace.session_key.in_(refs["session_key"]))
+        return or_(*candidates)
+
+    def _list_group_sessions(
+        self, session: Any, group_id: str
+    ) -> dict[str, str | None]:
+        rows = (
+            session.query(BcsGroupSession)
+            .filter(
+                BcsGroupSession.env == get_current_env(),
+                BcsGroupSession.group_id == group_id,
+                BcsGroupSession.session_id.isnot(None),
+            )
+            .order_by(BcsGroupSession.gmt_create.desc(), BcsGroupSession.id.desc())
+            .all()
+        )
+        result: dict[str, str | None] = {}
+        for row in rows:
+            value = row.session_id.strip()
+            if not value:
+                continue
+            session_key = value if value.startswith("agent:") else f"{_GROUP_SESSION_KEY_PREFIX}{value}"
+            result.setdefault(session_key, row.session_kind)
+        return result
+
+    def _load_bot_names(self, session: Any, bot_ids: set[str]) -> dict[str, str]:
+        if not bot_ids:
+            return {}
+        try:
+            rows = (
+                session.query(BotModel)
+                .filter(
+                    BotModel.bot_id.in_(bot_ids),
+                    BotModel.is_delete == 0,
+                    BotModel.env == get_current_env(),
+                )
+                .order_by(BotModel.id.desc())
+                .all()
+            )
+        except Exception as exc:
+            logger.warning(
+                "Bot name enrichment failed; returning null labels: error_type=%s",
+                type(exc).__name__,
+            )
+            return {}
+        result: dict[str, str] = {}
+        for row in rows:
+            bot_id = getattr(row, "bot_id", None)
+            bot_name = getattr(row, "bot_name", None)
+            if bot_id and bot_id not in result and bot_name:
+                result[bot_id] = bot_name
+        return result
+
+    def _enrich_trace_labels(self, session: Any, row: Any) -> Any:
+        if row.bot_id:
+            row.bot_name = self._load_bot_names(session, {row.bot_id}).get(row.bot_id)
+        session_key = row.session_key
+        if session_key:
+            candidates = {session_key}
+            if session_key.startswith(_GROUP_SESSION_KEY_PREFIX):
+                candidates.add(session_key[len(_GROUP_SESSION_KEY_PREFIX):])
+            group_session = (
+                session.query(BcsGroupSession)
+                .filter(
+                    BcsGroupSession.env == get_current_env(),
+                    BcsGroupSession.session_id.in_(candidates),
+                )
+                .order_by(BcsGroupSession.gmt_create.desc(), BcsGroupSession.id.desc())
+                .first()
+            )
+            if group_session and getattr(group_session, "group_id", None):
+                row.group_id = group_session.group_id
+                row.session_kind = getattr(group_session, "session_kind", None)
+        return row
+
+    def get_bot_name(self, bot_id: str | None) -> str | None:
+        if not bot_id:
+            return None
+        with self._db.orm_session() as session:
+            return self._load_bot_names(session, {bot_id}).get(bot_id)
+
+    def get_group_labels(
+        self, session_key: str | None
+    ) -> tuple[str | None, str | None]:
+        if not session_key:
+            return None, None
+        probe = SimpleNamespace(
+            bot_id=None,
+            bot_name=None,
+            session_key=session_key,
+            group_id=None,
+            session_kind=None,
+        )
+        with self._db.orm_session() as session:
+            enriched = self._enrich_trace_labels(session, probe)
+        return enriched.group_id, enriched.session_kind
+
     def list_traces(
         self,
         owner_id: str,
@@ -409,6 +609,11 @@ class BotChatDbRepository:
         session_id: str | None = None,
         session_key: str | None = None,
         query: str | None = None,
+        biz_scene: str | None = None,
+        biz_task_id: str | None = None,
+        group_id: str | None = None,
+        match_mode: str = "exact",
+        include_output_match: bool = False,
     ) -> tuple[list[ConversationSession], int]:
         """List traces from DB with pagination."""
         with self._db.orm_session() as session:
@@ -432,24 +637,52 @@ class BotChatDbRepository:
                 conditions.append(AwLangfuseTrace.bot_id == bot_id)
 
             if trace_id:
-                conditions.append(AwLangfuseTrace.trace_id == trace_id)
+                conditions.append(self._match(AwLangfuseTrace.trace_id, trace_id, match_mode))
 
             # session_key maps to DB session_id
             if session_key:
-                conditions.append(AwLangfuseTrace.session_id == session_key)
+                conditions.append(self._match(AwLangfuseTrace.session_id, session_key, match_mode))
 
             # session_id maps to DB real_session_id
             if session_id:
-                conditions.append(AwLangfuseTrace.real_session_id == session_id)
+                conditions.append(self._match(AwLangfuseTrace.real_session_id, session_id, match_mode))
+
+            task_refs = self._load_task_refs(
+                session,
+                biz_scene,
+                biz_task_id,
+                match_mode,
+                owner_id,
+                bot_id,
+            )
+            if biz_scene or biz_task_id:
+                ref_conditions = []
+                if task_refs.get("trace_id"):
+                    ref_conditions.append(AwLangfuseTrace.trace_id.in_(task_refs["trace_id"]))
+                if task_refs.get("session_id"):
+                    ref_conditions.append(AwLangfuseTrace.real_session_id.in_(task_refs["session_id"]))
+                if task_refs.get("session_key"):
+                    ref_conditions.append(AwLangfuseTrace.session_id.in_(task_refs["session_key"]))
+                if not ref_conditions:
+                    return [], 0
+                conditions.append(or_(*ref_conditions))
+
+            group_sessions: dict[str, str | None] = {}
+            if group_id:
+                group_sessions = self._list_group_sessions(session, group_id)
+                if not group_sessions:
+                    return [], 0
+                conditions.append(AwLangfuseTrace.session_id.in_(group_sessions))
 
             if query:
                 like_pattern = f"%{query}%"
-                conditions.append(
-                    and_(
-                        AwLangfuseTrace.name.like(like_pattern)
-                        | AwLangfuseTrace.input.like(like_pattern)
-                    )
-                )
+                text_conditions = [
+                    AwLangfuseTrace.name.like(like_pattern),
+                    AwLangfuseTrace.input.like(like_pattern),
+                ]
+                if include_output_match:
+                    text_conditions.append(AwLangfuseTrace.output.like(like_pattern))
+                conditions.append(or_(*text_conditions))
 
             where_clause = and_(*conditions)
 
@@ -471,10 +704,18 @@ class BotChatDbRepository:
                 .all()
             )
 
-            sessions = [
-                self._row_to_session(row)
-                for row in rows
-            ]
+            detached = [self._detach_trace_row(row) for row in rows]
+            bot_names = self._load_bot_names(
+                session, {row.bot_id for row in detached if row.bot_id}
+            )
+            for row in detached:
+                row.bot_name = bot_names.get(row.bot_id)
+                if group_id:
+                    row.group_id = group_id
+                    row.session_kind = group_sessions.get(row.session_key)
+                if biz_scene or biz_task_id:
+                    row.match_sources = ["biz_ref"]
+            sessions = [self._row_to_session(row) for row in detached]
             return sessions, total
 
     def list_ocb_traces(
@@ -489,6 +730,11 @@ class BotChatDbRepository:
         session_id: str | None = None,
         session_key: str | None = None,
         query: str | None = None,
+        biz_scene: str | None = None,
+        biz_task_id: str | None = None,
+        group_id: str | None = None,
+        match_mode: str = "exact",
+        include_output_match: bool = False,
     ) -> tuple[list[ConversationSession], int]:
         with self._db.orm_session() as session:
             conditions = [
@@ -503,14 +749,40 @@ class BotChatDbRepository:
             else:
                 conditions.append(AcOtelLogTrace.bot_id == bot_id)
             if trace_id:
-                conditions.append(AcOtelLogTrace.trace_id == trace_id)
+                conditions.append(self._match(AcOtelLogTrace.trace_id, trace_id, match_mode))
             if session_key:
-                conditions.append(AcOtelLogTrace.session_key == session_key)
+                conditions.append(self._match(AcOtelLogTrace.session_key, session_key, match_mode))
             if session_id:
-                conditions.append(AcOtelLogTrace.session_id == session_id)
+                conditions.append(self._match(AcOtelLogTrace.session_id, session_id, match_mode))
+            task_refs = self._load_task_refs(
+                session,
+                biz_scene,
+                biz_task_id,
+                match_mode,
+                owner_id,
+                bot_id,
+            )
+            if biz_scene or biz_task_id:
+                conditions.append(
+                    self._task_trace_condition(
+                        task_refs, biz_scene, biz_task_id, match_mode
+                    )
+                )
+            group_sessions: dict[str, str | None] = {}
+            if group_id:
+                group_sessions = self._list_group_sessions(session, group_id)
+                if not group_sessions:
+                    return [], 0
+                conditions.append(AcOtelLogTrace.session_key.in_(group_sessions))
             if query:
                 like_pattern = f"%{query}%"
-                conditions.append(AcOtelLogTrace.name.like(like_pattern) | AcOtelLogTrace.input.like(like_pattern))
+                text_conditions = [
+                    AcOtelLogTrace.name.like(like_pattern),
+                    AcOtelLogTrace.input.like(like_pattern),
+                ]
+                if include_output_match:
+                    text_conditions.append(AcOtelLogTrace.output.like(like_pattern))
+                conditions.append(or_(*text_conditions))
 
             where_clause = and_(*conditions)
             total = session.query(func.count(AcOtelLogTrace.id)).filter(where_clause).scalar() or 0
@@ -526,6 +798,38 @@ class BotChatDbRepository:
                 self._detach_ocb_trace_row(row)
                 for row in rows
             ]
+            bot_names = self._load_bot_names(
+                session,
+                {row.bot_id for row in detached if row.bot_id},
+            )
+            ref_trace_ids = task_refs.get("trace_id", set())
+            ref_session_ids = task_refs.get("session_id", set())
+            ref_session_keys = task_refs.get("session_key", set())
+            for row in detached:
+                row.bot_name = bot_names.get(row.bot_id)
+                if group_id:
+                    row.group_id = group_id
+                    row.session_kind = group_sessions.get(row.session_key)
+                sources = []
+                direct_scene = not biz_scene or (
+                    biz_scene in (row.biz_scene or "")
+                    if match_mode == "contains"
+                    else row.biz_scene == biz_scene
+                )
+                direct_task = not biz_task_id or (
+                    biz_task_id in (row.biz_task_id or "")
+                    if match_mode == "contains"
+                    else row.biz_task_id == biz_task_id
+                )
+                if (biz_scene or biz_task_id) and direct_scene and direct_task:
+                    sources.append("direct")
+                if (
+                    row.trace_id in ref_trace_ids
+                    or row.session_id in ref_session_ids
+                    or row.session_key in ref_session_keys
+                ):
+                    sources.append("biz_ref")
+                row.match_sources = sources
             sessions = [
                 self._row_to_session(row)
                 for row in detached
@@ -540,12 +844,20 @@ class BotChatDbRepository:
                 .filter(AwLangfuseTrace.trace_id == trace_id)
                 .first()
             )
-            return self._detach_trace_row(row) if row is not None else None
+            return (
+                self._enrich_trace_labels(session, self._detach_trace_row(row))
+                if row is not None
+                else None
+            )
 
     def get_ocb_trace(self, trace_id: str) -> Any | None:
         with self._db.orm_session() as session:
             row = session.query(AcOtelLogTrace).filter(AcOtelLogTrace.trace_id == trace_id).first()
-            return self._detach_ocb_trace_row(row) if row is not None else None
+            return (
+                self._enrich_trace_labels(session, self._detach_ocb_trace_row(row))
+                if row is not None
+                else None
+            )
 
     def list_ocb_observations(self, trace_id: str) -> list[ConversationObservation]:
         with self._db.orm_session() as session:

--- a/src/backend/src/agentclaw/community/core/bot_chat/repository.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/repository.py
@@ -15,22 +15,25 @@ from agentclaw.community.core.bot_chat.models import (
     AcOtelLogBizRef,
     AcOtelLogObservation,
     AcOtelLogTrace,
-    BcsGroupSession,
 )
 from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
+from agentclaw.community.core.bot_chat.query_support import (
+    enrich_trace_labels,
+    list_group_sessions,
+    load_bot_names,
+    load_task_refs,
+    match_column,
+    task_trace_condition,
+)
 from agentclaw.community.core.bot_chat.schemas import (
     ConversationObservation,
     ConversationDetail,
     ConversationSession,
     SessionMetadata,
 )
-from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.utils.env_utils import get_current_env
 
-logger = get_logger()
-
-_GROUP_SESSION_KEY_PREFIX = "agent:main:"
 _OUTPUT_PREVIEW_LENGTH = 500
 
 
@@ -441,145 +444,11 @@ class BotChatDbRepository:
         """Check if user_id is either owner or collaborator of bot_id."""
         return self.is_bot_owner(user_id, bot_id) or self.is_bot_collaborator(user_id, bot_id)
 
-    @staticmethod
-    def _match(column: Any, value: str, match_mode: str) -> Any:
-        return column.like(f"%{value}%") if match_mode == "contains" else column == value
-
-    def _load_task_refs(
-        self,
-        session: Any,
-        biz_scene: str | None,
-        biz_task_id: str | None,
-        match_mode: str,
-        owner_id: str,
-        bot_id: str | None,
-    ) -> dict[str, set[str]]:
-        if not biz_scene and not biz_task_id:
-            return {}
-        query = session.query(AcOtelLogBizRef)
-        if biz_scene:
-            query = query.filter(self._match(AcOtelLogBizRef.biz_scene, biz_scene, match_mode))
-        if biz_task_id:
-            query = query.filter(self._match(AcOtelLogBizRef.biz_task_id, biz_task_id, match_mode))
-        query = query.filter(
-            or_(
-                AcOtelLogBizRef.user_id == owner_id,
-                AcOtelLogBizRef.user_id.is_(None),
-            )
-        )
-        if bot_id:
-            relation_bot_ids = [bot_id]
-            if bot_id == "default":
-                relation_bot_ids.append(f"{owner_id}_default")
-            query = query.filter(
-                or_(
-                    AcOtelLogBizRef.bot_id.in_(relation_bot_ids),
-                    AcOtelLogBizRef.bot_id.is_(None),
-                )
-            )
-        refs: dict[str, set[str]] = {}
-        for row in query.all():
-            refs.setdefault(row.ref_type, set()).add(row.ref_value)
-        return refs
-
-    def _task_trace_condition(
-        self,
-        refs: dict[str, set[str]],
-        biz_scene: str | None,
-        biz_task_id: str | None,
-        match_mode: str,
-    ) -> Any:
-        direct = []
-        if biz_scene:
-            direct.append(self._match(AcOtelLogTrace.biz_scene, biz_scene, match_mode))
-        if biz_task_id:
-            direct.append(self._match(AcOtelLogTrace.biz_task_id, biz_task_id, match_mode))
-        candidates = [and_(*direct)]
-        if refs.get("trace_id"):
-            candidates.append(AcOtelLogTrace.trace_id.in_(refs["trace_id"]))
-        if refs.get("session_id"):
-            candidates.append(AcOtelLogTrace.session_id.in_(refs["session_id"]))
-        if refs.get("session_key"):
-            candidates.append(AcOtelLogTrace.session_key.in_(refs["session_key"]))
-        return or_(*candidates)
-
-    def _list_group_sessions(
-        self, session: Any, group_id: str
-    ) -> dict[str, str | None]:
-        rows = (
-            session.query(BcsGroupSession)
-            .filter(
-                BcsGroupSession.env == get_current_env(),
-                BcsGroupSession.group_id == group_id,
-                BcsGroupSession.session_id.isnot(None),
-            )
-            .order_by(BcsGroupSession.gmt_create.desc(), BcsGroupSession.id.desc())
-            .all()
-        )
-        result: dict[str, str | None] = {}
-        for row in rows:
-            value = row.session_id.strip()
-            if not value:
-                continue
-            session_key = value if value.startswith("agent:") else f"{_GROUP_SESSION_KEY_PREFIX}{value}"
-            result.setdefault(session_key, row.session_kind)
-        return result
-
-    def _load_bot_names(self, session: Any, bot_ids: set[str]) -> dict[str, str]:
-        if not bot_ids:
-            return {}
-        try:
-            rows = (
-                session.query(BotModel)
-                .filter(
-                    BotModel.bot_id.in_(bot_ids),
-                    BotModel.is_delete == 0,
-                    BotModel.env == get_current_env(),
-                )
-                .order_by(BotModel.id.desc())
-                .all()
-            )
-        except Exception as exc:
-            logger.warning(
-                "Bot name enrichment failed; returning null labels: error_type=%s",
-                type(exc).__name__,
-            )
-            return {}
-        result: dict[str, str] = {}
-        for row in rows:
-            bot_id = getattr(row, "bot_id", None)
-            bot_name = getattr(row, "bot_name", None)
-            if bot_id and bot_id not in result and bot_name:
-                result[bot_id] = bot_name
-        return result
-
-    def _enrich_trace_labels(self, session: Any, row: Any) -> Any:
-        if row.bot_id:
-            row.bot_name = self._load_bot_names(session, {row.bot_id}).get(row.bot_id)
-        session_key = row.session_key
-        if session_key:
-            candidates = {session_key}
-            if session_key.startswith(_GROUP_SESSION_KEY_PREFIX):
-                candidates.add(session_key[len(_GROUP_SESSION_KEY_PREFIX):])
-            group_session = (
-                session.query(BcsGroupSession)
-                .filter(
-                    BcsGroupSession.env == get_current_env(),
-                    BcsGroupSession.session_id.in_(candidates),
-                )
-                .order_by(BcsGroupSession.gmt_create.desc(), BcsGroupSession.id.desc())
-                .first()
-            )
-            if group_session and getattr(group_session, "group_id", None):
-                row.group_id = group_session.group_id
-                row.session_kind = getattr(group_session, "session_kind", None)
-        return row
-
     def get_bot_name(self, bot_id: str | None) -> str | None:
         if not bot_id:
             return None
         with self._db.orm_session() as session:
-            return self._load_bot_names(session, {bot_id}).get(bot_id)
+            return load_bot_names(session, {bot_id}).get(bot_id)
 
     def get_group_labels(
         self, session_key: str | None
@@ -594,7 +463,7 @@ class BotChatDbRepository:
             session_kind=None,
         )
         with self._db.orm_session() as session:
-            enriched = self._enrich_trace_labels(session, probe)
+            enriched = enrich_trace_labels(session, probe)
         return enriched.group_id, enriched.session_kind
 
     def list_traces(
@@ -637,17 +506,17 @@ class BotChatDbRepository:
                 conditions.append(AwLangfuseTrace.bot_id == bot_id)
 
             if trace_id:
-                conditions.append(self._match(AwLangfuseTrace.trace_id, trace_id, match_mode))
+                conditions.append(match_column(AwLangfuseTrace.trace_id, trace_id, match_mode))
 
             # session_key maps to DB session_id
             if session_key:
-                conditions.append(self._match(AwLangfuseTrace.session_id, session_key, match_mode))
+                conditions.append(match_column(AwLangfuseTrace.session_id, session_key, match_mode))
 
             # session_id maps to DB real_session_id
             if session_id:
-                conditions.append(self._match(AwLangfuseTrace.real_session_id, session_id, match_mode))
+                conditions.append(match_column(AwLangfuseTrace.real_session_id, session_id, match_mode))
 
-            task_refs = self._load_task_refs(
+            task_refs = load_task_refs(
                 session,
                 biz_scene,
                 biz_task_id,
@@ -669,7 +538,7 @@ class BotChatDbRepository:
 
             group_sessions: dict[str, str | None] = {}
             if group_id:
-                group_sessions = self._list_group_sessions(session, group_id)
+                group_sessions = list_group_sessions(session, group_id)
                 if not group_sessions:
                     return [], 0
                 conditions.append(AwLangfuseTrace.session_id.in_(group_sessions))
@@ -705,7 +574,7 @@ class BotChatDbRepository:
             )
 
             detached = [self._detach_trace_row(row) for row in rows]
-            bot_names = self._load_bot_names(
+            bot_names = load_bot_names(
                 session, {row.bot_id for row in detached if row.bot_id}
             )
             for row in detached:
@@ -749,12 +618,12 @@ class BotChatDbRepository:
             else:
                 conditions.append(AcOtelLogTrace.bot_id == bot_id)
             if trace_id:
-                conditions.append(self._match(AcOtelLogTrace.trace_id, trace_id, match_mode))
+                conditions.append(match_column(AcOtelLogTrace.trace_id, trace_id, match_mode))
             if session_key:
-                conditions.append(self._match(AcOtelLogTrace.session_key, session_key, match_mode))
+                conditions.append(match_column(AcOtelLogTrace.session_key, session_key, match_mode))
             if session_id:
-                conditions.append(self._match(AcOtelLogTrace.session_id, session_id, match_mode))
-            task_refs = self._load_task_refs(
+                conditions.append(match_column(AcOtelLogTrace.session_id, session_id, match_mode))
+            task_refs = load_task_refs(
                 session,
                 biz_scene,
                 biz_task_id,
@@ -764,13 +633,13 @@ class BotChatDbRepository:
             )
             if biz_scene or biz_task_id:
                 conditions.append(
-                    self._task_trace_condition(
+                    task_trace_condition(
                         task_refs, biz_scene, biz_task_id, match_mode
                     )
                 )
             group_sessions: dict[str, str | None] = {}
             if group_id:
-                group_sessions = self._list_group_sessions(session, group_id)
+                group_sessions = list_group_sessions(session, group_id)
                 if not group_sessions:
                     return [], 0
                 conditions.append(AcOtelLogTrace.session_key.in_(group_sessions))
@@ -798,7 +667,7 @@ class BotChatDbRepository:
                 self._detach_ocb_trace_row(row)
                 for row in rows
             ]
-            bot_names = self._load_bot_names(
+            bot_names = load_bot_names(
                 session,
                 {row.bot_id for row in detached if row.bot_id},
             )
@@ -845,7 +714,7 @@ class BotChatDbRepository:
                 .first()
             )
             return (
-                self._enrich_trace_labels(session, self._detach_trace_row(row))
+                enrich_trace_labels(session, self._detach_trace_row(row))
                 if row is not None
                 else None
             )
@@ -854,7 +723,7 @@ class BotChatDbRepository:
         with self._db.orm_session() as session:
             row = session.query(AcOtelLogTrace).filter(AcOtelLogTrace.trace_id == trace_id).first()
             return (
-                self._enrich_trace_labels(session, self._detach_ocb_trace_row(row))
+                enrich_trace_labels(session, self._detach_ocb_trace_row(row))
                 if row is not None
                 else None
             )

--- a/src/backend/src/agentclaw/community/core/bot_chat/schemas.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/schemas.py
@@ -20,8 +20,23 @@ class ConversationSession(BaseModel):
     biz_scene: str | None = Field(default=None, description="Business scene")
     session_id: str | None = Field(default=None, description="Canonical session ID")
     session_key: str | None = Field(default=None, description="Engine session key")
+    bot_id: str | None = Field(default=None, description="Bot ID")
+    bot_name: str | None = Field(default=None, description="Bot display name")
+    group_id: str | None = Field(default=None, description="BCS group ID")
+    session_kind: str | None = Field(default=None, description="Optional group-session label")
     name: str = Field(default="", description="Session / trace name")
     input: str | None = Field(default=None, description="Last user message extracted from trace input")
+    output_preview: str | None = Field(default=None, description="Short trace output preview")
+    search_output: str | None = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description="Full output retained internally for client-side filtering",
+    )
+    match_sources: list[str] = Field(
+        default_factory=list,
+        description="Sources that matched the business task, such as direct or biz_ref",
+    )
     status: str = Field(default="SUCCESS", description="SUCCESS or FAILED")
     timestamp: str = Field(..., description="ISO 8601 timestamp")
     user_id: str | None = Field(default=None, description="Langfuse userId (owner_id)")
@@ -44,6 +59,7 @@ class ConversationObservation(BaseModel):
     total_tokens: int = Field(default=0)
     input: Any = Field(default=None)
     output: Any = Field(default=None)
+    metadata: dict[str, Any] | None = Field(default=None, description="Raw observation metadata")
     model_name: str | None = Field(default=None, description="Model name from metadata.attributes['gen_ai.request.model']")
     parent_observation_id: str | None = Field(default=None)
     children: list["ConversationObservation"] = Field(default_factory=list)
@@ -57,6 +73,10 @@ class ConversationDetail(BaseModel):
     biz_scene: str | None = Field(default=None)
     session_id: str | None = Field(default=None)
     session_key: str | None = Field(default=None)
+    bot_id: str | None = Field(default=None)
+    bot_name: str | None = Field(default=None)
+    group_id: str | None = Field(default=None)
+    session_kind: str | None = Field(default=None)
     name: str = Field(default="")
     input: Any = Field(default=None)
     output: Any = Field(default=None)

--- a/src/backend/src/agentclaw/community/core/bot_chat/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/service.py
@@ -31,6 +31,8 @@ _DEFAULT_PAGE_SIZE = 20
 _MAX_PAGE_SIZE = 100
 # 对外列表接口默认回看时间窗口；调用方不传 from_date/to_date 时查最近 72 小时。
 _DEFAULT_TIME_RANGE_HOURS = 72
+# Fuzzy searches are bounded even when callers provide an explicit range.
+_MAX_FUZZY_TIME_RANGE_DAYS = 90
 # metadata 精确查询走多页扫描时的内部批大小；与对外返回 limit 解耦。
 _SCAN_PAGE_SIZE = 100
 # metadata 精确查询走多页扫描时默认最多扫描页数；默认最多扫描 100 * 10 条 trace。
@@ -54,6 +56,13 @@ def _build_auth_header(public_key: str, secret_key: str) -> str:
 
     credentials = f"{public_key}:{secret_key}"
     return f"Basic {base64.b64encode(credentials.encode()).decode()}"
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Treat timezone-free API values as UTC and normalize aware values."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _extract_user_input(trace_input: Any) -> str | None:
@@ -115,8 +124,24 @@ def _map_trace_to_session(trace: dict[str, Any]) -> ConversationSession:
             or attributes.get("agentic.biz_scene")
             or attributes.get("identity.biz_scene")
         ),
+        session_id=attributes.get("gen_ai.session.id"),
+        session_key=(
+            attributes.get("session_id")
+            or attributes.get("gen_ai.conversation.id")
+        ),
+        bot_id=attributes.get("identity.bot_id"),
         name=trace.get("name") or "未命名会话",
         input=_extract_user_input(trace.get("input")),
+        output_preview=(
+            str(trace.get("output"))[:500]
+            if trace.get("output") is not None
+            else None
+        ),
+        search_output=(
+            str(trace.get("output"))
+            if trace.get("output") is not None
+            else None
+        ),
         status="FAILED" if trace.get("success") is False else "SUCCESS",
         timestamp=trace.get("timestamp", ""),
         user_id=trace.get("userId"),
@@ -152,6 +177,7 @@ def _map_observation(obs: dict[str, Any]) -> ConversationObservation:
         total_tokens=int(usage.get("totalTokens") or 0),
         input=obs.get("input"),
         output=obs.get("output"),
+        metadata=metadata_raw if isinstance(metadata_raw, dict) else None,
         model_name=attributes.get("gen_ai.request.model"),
         parent_observation_id=obs.get("parentObservationId"),
         children=[],
@@ -195,14 +221,23 @@ def _apply_client_side_filters(
     session_id: str | None,
     session_key: str | None,
     query: str | None = None,
+    biz_scene: str | None = None,
+    biz_task_id: str | None = None,
+    match_mode: str = "exact",
+    include_output_match: bool = False,
 ) -> list[ConversationSession]:
     """Apply client-side filters that Langfuse API doesn't support natively."""
     result = sessions
+    def matches(actual: str | None, expected: str) -> bool:
+        if actual is None:
+            return False
+        return expected in actual if match_mode == "contains" else actual == expected
+
     if trace_id:
         result = [
             s
             for s in result
-            if s.id == trace_id
+            if matches(s.id, trace_id)
         ]
     if bot_id:
         result = [
@@ -219,7 +254,16 @@ def _apply_client_side_filters(
             for s in result
             if (
                 s.metadata
-                and _matches_session_key(s.metadata.attributes, session_key)
+                and (
+                    (
+                        session_key
+                        in str(s.metadata.attributes.get("session_id") or "")
+                        or session_key
+                        in str(s.metadata.attributes.get("gen_ai.conversation.id") or "")
+                    )
+                    if match_mode == "contains"
+                    else _matches_session_key(s.metadata.attributes, session_key)
+                )
             )
         ]
     if session_id:
@@ -228,9 +272,15 @@ def _apply_client_side_filters(
             for s in result
             if (
                 s.metadata
-                and s.metadata.attributes.get("gen_ai.session.id") == session_id
+                and matches(
+                    s.metadata.attributes.get("gen_ai.session.id"), session_id
+                )
             )
         ]
+    if biz_scene:
+        result = [s for s in result if matches(s.biz_scene, biz_scene)]
+    if biz_task_id:
+        result = [s for s in result if matches(s.biz_task_id, biz_task_id)]
     if query:
         q = query.lower()
         result = [
@@ -244,6 +294,11 @@ def _apply_client_side_filters(
                 or (
                     s.input is not None
                     and q in s.input.lower()
+                )
+                or (
+                    include_output_match
+                    and s.search_output is not None
+                    and q in s.search_output.lower()
                 )
             )
         ]
@@ -319,19 +374,62 @@ class BotChatService:
         session_id: str | None = None,
         session_key: str | None = None,
         query: str | None = None,
+        biz_scene: str | None = None,
+        biz_task_id: str | None = None,
+        group_id: str | None = None,
+        match_mode: str = "exact",
+        include_output_match: bool = False,
+        time_scope: str = "default",
         log_source: str | None = None,
     ) -> SessionListResponse:
         """List conversation sessions for a given owner."""
         limit = min(max(1, limit), _MAX_PAGE_SIZE)
         page = max(1, page)
 
+        if match_mode not in {"exact", "contains"}:
+            raise ValueError("match_mode must be 'exact' or 'contains'")
+        if time_scope not in {"default", "all"}:
+            raise ValueError("time_scope must be 'default' or 'all'")
+
+        exact_identifiers = (
+            trace_id,
+            session_id,
+            session_key,
+            biz_task_id,
+            group_id,
+        )
+        if time_scope == "all" and (
+            match_mode != "exact" or not any(exact_identifiers)
+        ):
+            raise ValueError(
+                "time_scope=all requires match_mode=exact and an exact identifier"
+            )
+
         now = datetime.now(timezone.utc)
-        if from_date is None:
-            from_date = now - timedelta(hours=_DEFAULT_TIME_RANGE_HOURS)
-        if to_date is None:
-            to_date = now
+        if from_date is not None:
+            from_date = _as_utc(from_date)
+        if to_date is not None:
+            to_date = _as_utc(to_date)
+        if time_scope == "all":
+            from_date = from_date or datetime(1970, 1, 1, tzinfo=timezone.utc)
+            to_date = to_date or now
+        else:
+            if from_date is None:
+                from_date = now - timedelta(hours=_DEFAULT_TIME_RANGE_HOURS)
+            if to_date is None:
+                to_date = now
+        if from_date > to_date:
+            raise ValueError("from_date must not be later than to_date")
+        if (
+            match_mode == "contains"
+            and to_date - from_date > timedelta(days=_MAX_FUZZY_TIME_RANGE_DAYS)
+        ):
+            raise ValueError("contains queries support a maximum time range of 90 days")
 
         effective_source = self._get_log_source(log_source)
+        # Task relations and group-session mappings are stored in the DB.
+        if group_id or biz_scene or biz_task_id:
+            effective_source = "db"
 
         if effective_source == "langfuse":
             return await self._list_sessions_langfuse(
@@ -345,6 +443,8 @@ class BotChatService:
                 session_id=session_id,
                 session_key=session_key,
                 query=query,
+                match_mode=match_mode,
+                include_output_match=include_output_match,
             )
 
         # Default DB mode: for non-default bot, check access (owner or collaborator).
@@ -374,6 +474,11 @@ class BotChatService:
             session_id=session_id,
             session_key=session_key,
             query=query,
+            biz_scene=biz_scene,
+            biz_task_id=biz_task_id,
+            group_id=group_id,
+            match_mode=match_mode,
+            include_output_match=include_output_match,
         )
 
     async def _list_sessions_db(
@@ -388,6 +493,11 @@ class BotChatService:
         session_id: str | None,
         session_key: str | None,
         query: str | None,
+        biz_scene: str | None,
+        biz_task_id: str | None,
+        group_id: str | None,
+        match_mode: str,
+        include_output_match: bool,
     ) -> SessionListResponse:
         """List sessions using one DB source per request.
 
@@ -411,6 +521,11 @@ class BotChatService:
             session_id=session_id,
             session_key=session_key,
             query=query,
+            biz_scene=biz_scene,
+            biz_task_id=biz_task_id,
+            group_id=group_id,
+            match_mode=match_mode,
+            include_output_match=include_output_match,
         )
 
         if total == 0:
@@ -425,6 +540,11 @@ class BotChatService:
                 session_id=session_id,
                 session_key=session_key,
                 query=query,
+                biz_scene=biz_scene,
+                biz_task_id=biz_task_id,
+                group_id=group_id,
+                match_mode=match_mode,
+                include_output_match=include_output_match,
             )
 
         has_more = page * limit < total
@@ -449,9 +569,18 @@ class BotChatService:
         session_id: str | None,
         session_key: str | None,
         query: str | None,
+        match_mode: str,
+        include_output_match: bool,
     ) -> SessionListResponse:
         """List sessions using Langfuse source with legacy scan logic."""
-        requires_exhaustive_scan = bool(bot_id or session_id or session_key)
+        requires_exhaustive_scan = bool(
+            bot_id
+            or trace_id
+            or session_id
+            or session_key
+            or query
+            or match_mode == "contains"
+        )
 
         if requires_exhaustive_scan:
             return await self._list_sessions_with_exhaustive_scan(
@@ -465,6 +594,8 @@ class BotChatService:
                 session_id=session_id,
                 session_key=session_key,
                 query=query,
+                match_mode=match_mode,
+                include_output_match=include_output_match,
             )
 
         traces, total = await self._fetch_traces_from_langfuse(
@@ -479,7 +610,16 @@ class BotChatService:
             _map_trace_to_session(t)
             for t in traces
         ]
-        sessions = _apply_client_side_filters(sessions, bot_id, trace_id, session_id, session_key, query)
+        sessions = _apply_client_side_filters(
+            sessions,
+            bot_id,
+            trace_id,
+            session_id,
+            session_key,
+            query,
+            match_mode=match_mode,
+            include_output_match=include_output_match,
+        )
 
         filtered_total = len(sessions)
         has_more = (page * limit) < total
@@ -577,6 +717,8 @@ class BotChatService:
         session_id: str | None,
         session_key: str | None,
         query: str | None,
+        match_mode: str = "exact",
+        include_output_match: bool = False,
     ) -> SessionListResponse:
         """List sessions with exhaustive multi-page scan for exact metadata matching.
 
@@ -602,7 +744,16 @@ class BotChatService:
                 _map_trace_to_session(t)
                 for t in traces
             ]
-            filtered = _apply_client_side_filters(sessions, bot_id, trace_id, session_id, session_key, query)
+            filtered = _apply_client_side_filters(
+                sessions,
+                bot_id,
+                trace_id,
+                session_id,
+                session_key,
+                query,
+                match_mode=match_mode,
+                include_output_match=include_output_match,
+            )
             matched_sessions.extend(filtered)
             scanned_count += len(sessions)
 
@@ -717,9 +868,32 @@ class BotChatService:
         metadata_raw = trace_data.get("metadata") or {}
         attributes = (metadata_raw.get("attributes") or {}) if isinstance(metadata_raw, dict) else {}
         usage = trace_data.get("usage") or {}
+        session_id = attributes.get("gen_ai.session.id")
+        session_key = (
+            attributes.get("session_id")
+            or attributes.get("gen_ai.conversation.id")
+        )
+        bot_id = attributes.get("identity.bot_id")
+        group_id, session_kind = self._db_repo.get_group_labels(session_key)
 
         return ConversationDetail(
             id=trace_data.get("id", ""),
+            biz_task_id=(
+                trace_data.get("biz_task_id")
+                or attributes.get("agentic.biz_task_id")
+                or attributes.get("identity.biz_task_id")
+            ),
+            biz_scene=(
+                trace_data.get("biz_scene")
+                or attributes.get("agentic.biz_scene")
+                or attributes.get("identity.biz_scene")
+            ),
+            session_id=session_id,
+            session_key=session_key,
+            bot_id=bot_id,
+            bot_name=self._db_repo.get_bot_name(bot_id),
+            group_id=group_id,
+            session_kind=session_kind,
             name=trace_data.get("name") or "未命名会话",
             input=trace_data.get("input"),
             output=trace_data.get("output"),

--- a/src/backend/tests/community/acceptance/bot_chat/test_otel_roundtrip_lifecycle.py
+++ b/src/backend/tests/community/acceptance/bot_chat/test_otel_roundtrip_lifecycle.py
@@ -50,7 +50,7 @@ def _otlp_payload(trace_id: str, start_ns: int) -> dict:
                                     ),
                                     _attr(
                                         "gen_ai.output.messages",
-                                        '{"role":"assistant","content":"hello"}',
+                                        '{"role":"assistant","content":"output-only-marker"}',
                                     ),
                                 ],
                             },
@@ -121,7 +121,15 @@ def test_bot_chat_otel_ingest_query_and_relation_roundtrip(live_backend):
                 {
                     "ref_type": "trace_id",
                     "ref_value": trace_id,
-                }
+                },
+                {
+                    "ref_type": "session_id",
+                    "ref_value": "session-live",
+                },
+                {
+                    "ref_type": "session_key",
+                    "ref_value": "session-key-live",
+                },
             ],
         }
         first_relation = client.post(
@@ -130,9 +138,9 @@ def test_bot_chat_otel_ingest_query_and_relation_roundtrip(live_backend):
         )
         assert first_relation.status_code == 200, first_relation.text
         assert first_relation.json()["data"] == {
-            "inserted": 1,
+            "inserted": 3,
             "updated": 0,
-            "total": 1,
+            "total": 3,
         }
 
         second_relation = client.post(
@@ -142,6 +150,127 @@ def test_bot_chat_otel_ingest_query_and_relation_roundtrip(live_backend):
         assert second_relation.status_code == 200, second_relation.text
         assert second_relation.json()["data"] == {
             "inserted": 0,
-            "updated": 1,
-            "total": 1,
+            "updated": 3,
+            "total": 3,
         }
+
+        task_queries = [
+            {
+                "biz_scene": "singlebox-coverage",
+                "biz_task_id": trace_id,
+            },
+            {
+                "biz_task_id": trace_id,
+            },
+            {
+                "biz_scene": "singlebox-coverage",
+            },
+            {
+                "biz_scene": "singlebox-cover",
+                "biz_task_id": trace_id[:12],
+                "match_mode": "contains",
+            },
+        ]
+        for params in task_queries:
+            task_result = client.get("/api/v1/bot-chats", params=params)
+            assert task_result.status_code == 200, task_result.text
+            task_body = task_result.json()
+            assert task_body["success"] is True
+            assert task_body["data"]["total"] == 1
+            assert task_body["data"]["sessions"][0]["id"] == trace_id
+            assert task_body["data"]["sessions"][0]["match_sources"]
+
+        output_result = client.get(
+            "/api/v1/bot-chats",
+            params={
+                "query": "output-only-marker",
+                "include_output_match": "true",
+            },
+        )
+        assert output_result.status_code == 200, output_result.text
+        output_body = output_result.json()
+        assert output_body["success"] is True
+        assert output_body["data"]["total"] == 1
+        assert output_body["data"]["sessions"][0]["id"] == trace_id
+
+        identifier_queries = [
+            {
+                "session_id": "session-live",
+                "match_mode": "exact",
+            },
+            {
+                "session_key": "key-live",
+                "match_mode": "contains",
+            },
+            {
+                "bot_id": "default",
+                "trace_id": trace_id,
+            },
+        ]
+        for params in identifier_queries:
+            identifier_result = client.get("/api/v1/bot-chats", params=params)
+            assert identifier_result.status_code == 200, identifier_result.text
+            identifier_body = identifier_result.json()
+            assert identifier_body["success"] is True
+            assert identifier_body["data"]["total"] == 1
+
+        empty_group = client.get(
+            "/api/v1/bot-chats",
+            params={"group_id": "missing-group-fixture"},
+        )
+        assert empty_group.status_code == 200, empty_group.text
+        assert empty_group.json()["data"]["total"] == 0
+
+        historical_result = client.get(
+            "/api/v1/bot-chats",
+            params={
+                "trace_id": trace_id,
+                "time_scope": "all",
+            },
+        )
+        assert historical_result.status_code == 200, historical_result.text
+        assert historical_result.json()["data"]["total"] == 1
+
+        invalid_unbounded = client.get(
+            "/api/v1/bot-chats",
+            params={"time_scope": "all"},
+        )
+        assert invalid_unbounded.status_code == 200, invalid_unbounded.text
+        assert invalid_unbounded.json()["error_code"] == 4000
+
+        invalid_fuzzy_range = client.get(
+            "/api/v1/bot-chats",
+            params={
+                "query": "marker",
+                "match_mode": "contains",
+                "from_date": "2025-01-01T00:00:00",
+                "to_date": "2025-04-02T00:00:01",
+            },
+        )
+        assert invalid_fuzzy_range.status_code == 200, invalid_fuzzy_range.text
+        assert invalid_fuzzy_range.json()["error_code"] == 4000
+
+        isolated_relation = client.post(
+            "/api/bot-chat/log-relations",
+            json={
+                "biz_scene": "isolated-scene",
+                "biz_task_id": f"isolated-{trace_id}",
+                "user_id": "different-user-fixture",
+                "refs": [
+                    {
+                        "ref_type": "trace_id",
+                        "ref_value": trace_id,
+                    }
+                ],
+            },
+        )
+        assert isolated_relation.status_code == 200, isolated_relation.text
+        isolated_query = client.get(
+            "/api/v1/bot-chats",
+            params={
+                "biz_scene": "isolated-scene",
+                "biz_task_id": f"isolated-{trace_id}",
+            },
+        )
+        assert isolated_query.status_code == 200, isolated_query.text
+        assert isolated_query.json()["data"]["total"] == 0

--- a/src/backend/tests/community/api/bot_chat/test_bot_chat_router.py
+++ b/src/backend/tests/community/api/bot_chat/test_bot_chat_router.py
@@ -1,8 +1,7 @@
 """API integration tests for bot_chat router."""
 
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
 from agentclaw.community.core.bot_chat.schemas import (
     ConversationSession,
@@ -56,6 +55,50 @@ def sample_sessions():
 # ---------------------------------------------------------------------------
 
 class TestListSessions:
+
+    @pytest.mark.asyncio
+    async def test_product_query_parameters_are_forwarded(self, mock_service, mock_user):
+        from agentclaw.community.adapters.http.bot_chat.router import list_sessions
+
+        mock_service.list_sessions = AsyncMock(
+            return_value=SessionListResponse(
+                sessions=[],
+                total=0,
+                page=1,
+                limit=20,
+                has_more=False,
+            )
+        )
+
+        await list_sessions(
+            service=mock_service,
+            user=mock_user,
+            owner_id=None,
+            bot_id=None,
+            trace_id=None,
+            session_id=None,
+            session_key=None,
+            query="fixture",
+            biz_scene="scene_fixture",
+            biz_task_id="task_fixture",
+            group_id="group_fixture",
+            match_mode="contains",
+            include_output_match=True,
+            time_scope="default",
+            from_date=None,
+            to_date=None,
+            page=1,
+            limit=20,
+            log_source=None,
+        )
+
+        kwargs = mock_service.list_sessions.call_args.kwargs
+        assert kwargs["biz_scene"] == "scene_fixture"
+        assert kwargs["biz_task_id"] == "task_fixture"
+        assert kwargs["group_id"] == "group_fixture"
+        assert kwargs["match_mode"] == "contains"
+        assert kwargs["include_output_match"] is True
+        assert kwargs["time_scope"] == "default"
 
     @pytest.mark.asyncio
     async def test_list_sessions_success(self, mock_service, mock_user, sample_sessions):

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
@@ -1,0 +1,548 @@
+"""Product-query coverage using only local, synthetic records."""
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.bot_chat.models import (
+    AcOtelLogTrace,
+    AwLangfuseTrace,
+    BcsGroupSession,
+)
+from agentclaw.community.core.bot_chat.repository import BotChatDbRepository
+from agentclaw.community.core.bot_chat.service import (
+    BotChatService,
+    _apply_client_side_filters,
+    _map_observation,
+    _map_trace_to_session,
+)
+from agentclaw.community.core.bot_chat.schemas import ConversationSession
+from agentclaw.community.di.config import BotChatConfig
+from agentclaw.community.plugin_api.models import Base, BotModel
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class _LocalDb:
+    def __init__(self) -> None:
+        self._engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self._engine)
+        self._factory = sessionmaker(bind=self._engine)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+def _write_trace(
+    repo: BotChatDbRepository,
+    *,
+    trace_id: str,
+    session_id: str,
+    session_key: str,
+    biz_scene: str | None = None,
+    biz_task_id: str | None = None,
+    output: str = "synthetic output",
+) -> None:
+    repo.upsert_ocb_trace(
+        {
+            "trace_id": trace_id,
+            "session_id": session_id,
+            "session_key": session_key,
+            "biz_scene": biz_scene,
+            "biz_task_id": biz_task_id,
+            "user_id": "user_fixture",
+            "bot_id": "bot_fixture",
+            "name": "Synthetic trace",
+            "input": "synthetic input",
+            "output": output,
+            "start_time_ms": 1_000,
+            "usage": {},
+        }
+    )
+
+
+def test_task_query_merges_direct_and_relation_matches_without_duplicates():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    _write_trace(
+        repo,
+        trace_id="trace_direct",
+        session_id="session_direct",
+        session_key="agent:main:session_direct",
+        biz_scene="scene_fixture",
+        biz_task_id="task_fixture",
+    )
+    _write_trace(
+        repo,
+        trace_id="trace_relation",
+        session_id="session_relation",
+        session_key="agent:main:session_relation",
+    )
+    repo.upsert_biz_refs(
+        {
+            "biz_scene": "scene_fixture",
+            "biz_task_id": "task_fixture",
+            "refs": [
+                {"ref_type": "trace_id", "ref_value": "trace_relation"},
+                {"ref_type": "trace_id", "ref_value": "trace_direct"},
+            ],
+        }
+    )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        biz_scene="scene_fixture",
+        biz_task_id="task_fixture",
+    )
+
+    assert total == 2
+    assert {row.id for row in rows} == {"trace_direct", "trace_relation"}
+    sources = {row.id: row.match_sources for row in rows}
+    assert sources["trace_direct"] == ["direct", "biz_ref"]
+    assert sources["trace_relation"] == ["biz_ref"]
+
+    by_task, task_total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        biz_task_id="task_fixture",
+    )
+    by_scene, scene_total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        biz_scene="scene_fixture",
+    )
+    contains, contains_total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        biz_scene="scene_fix",
+        biz_task_id="task_fix",
+        match_mode="contains",
+    )
+
+    assert task_total == scene_total == contains_total == 2
+    assert {row.id for row in by_task} == {"trace_direct", "trace_relation"}
+    assert {row.id for row in by_scene} == {"trace_direct", "trace_relation"}
+    assert {row.id for row in contains} == {"trace_direct", "trace_relation"}
+
+
+def test_task_relations_are_isolated_by_user_when_identity_is_present():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    _write_trace(
+        repo,
+        trace_id="trace_current_user",
+        session_id="session_current_user",
+        session_key="agent:main:session_current_user",
+    )
+    repo.upsert_biz_refs(
+        {
+            "biz_scene": "scene_fixture",
+            "biz_task_id": "task_fixture",
+            "user_id": "different_user_fixture",
+            "refs": [
+                {"ref_type": "trace_id", "ref_value": "trace_current_user"},
+            ],
+        }
+    )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        biz_scene="scene_fixture",
+        biz_task_id="task_fixture",
+    )
+
+    assert rows == []
+    assert total == 0
+
+
+def test_group_query_normalizes_session_key_and_returns_optional_labels():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    session_fragment = "group_fixture:session_fixture"
+    _write_trace(
+        repo,
+        trace_id="trace_group",
+        session_id="session_fixture",
+        session_key=f"agent:main:{session_fragment}",
+        output="result available only in output",
+    )
+    with db.orm_session() as session:
+        session.add(
+            BcsGroupSession(
+                session_id=session_fragment,
+                group_id="group_fixture",
+                env=get_current_env(),
+                session_kind="chat",
+            )
+        )
+        session.add(
+            BotModel(
+                bot_id="bot_fixture",
+                bot_name="Fixture Bot",
+                entity_id="user_fixture",
+                entity_type="staff",
+                creator_id="user_fixture",
+                owner_id="user_fixture",
+                env=get_current_env(),
+            )
+        )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        group_id="group_fixture",
+        query="available only",
+        include_output_match=True,
+    )
+
+    assert total == 1
+    assert rows[0].group_id == "group_fixture"
+    assert rows[0].session_kind == "chat"
+    assert rows[0].bot_id == "bot_fixture"
+    assert rows[0].bot_name == "Fixture Bot"
+    assert rows[0].output_preview == "result available only in output"
+
+    detail_row = repo.get_ocb_trace("trace_group")
+    assert detail_row.group_id == "group_fixture"
+    assert detail_row.session_kind == "chat"
+    assert detail_row.bot_name == "Fixture Bot"
+
+
+def test_group_query_supports_multiple_sessions_and_existing_agent_prefix():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    fragment = "group_fixture:session_one"
+    prefixed = "agent:custom:group_fixture:session_two"
+    _write_trace(
+        repo,
+        trace_id="trace_group_one",
+        session_id="session_one",
+        session_key=f"agent:main:{fragment}",
+    )
+    _write_trace(
+        repo,
+        trace_id="trace_group_two",
+        session_id="session_two",
+        session_key=prefixed,
+    )
+    with db.orm_session() as session:
+        session.add_all(
+            [
+                BcsGroupSession(
+                    session_id=fragment,
+                    group_id="group_fixture",
+                    env=get_current_env(),
+                    session_kind="chat",
+                ),
+                BcsGroupSession(
+                    session_id=prefixed,
+                    group_id="group_fixture",
+                    env=get_current_env(),
+                    session_kind="service_invocation",
+                ),
+            ]
+        )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        group_id="group_fixture",
+    )
+
+    assert total == 2
+    assert {row.id for row in rows} == {"trace_group_one", "trace_group_two"}
+    assert {row.session_kind for row in rows} == {"chat", "service_invocation"}
+
+
+def test_group_query_supports_legacy_trace_storage():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    fragment = "group_fixture:legacy_session"
+    full_session_key = f"agent:main:{fragment}"
+    with db.orm_session() as session:
+        session.add(
+            BcsGroupSession(
+                session_id=fragment,
+                group_id="group_fixture",
+                env=get_current_env(),
+                session_kind="chat",
+            )
+        )
+        session.add(
+            AwLangfuseTrace(
+                trace_id="trace_legacy_fixture",
+                gmt_trace=1_000,
+                session_id=full_session_key,
+                real_session_id="legacy_session_fixture",
+                user_id="user_fixture",
+                bot_id="default",
+                name="Synthetic legacy trace",
+            )
+        )
+
+    rows, total = repo.list_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        group_id="group_fixture",
+    )
+
+    assert total == 1
+    assert rows[0].id == "trace_legacy_fixture"
+    assert rows[0].group_id == "group_fixture"
+
+
+def test_bot_id_falls_back_to_metadata_and_missing_bot_name_stays_null():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    with db.orm_session() as session:
+        session.add(
+            AcOtelLogTrace(
+                trace_id="trace_metadata_bot",
+                user_id="user_fixture",
+                bot_id=None,
+                name="Synthetic trace",
+                metadata_json='{"attributes":{"identity.bot_id":"deleted_bot_fixture"}}',
+                start_time_ms=1_000,
+            )
+        )
+        session.add(
+            BotModel(
+                bot_id="deleted_bot_fixture",
+                bot_name="Deleted Fixture Bot",
+                entity_id="user_fixture",
+                entity_type="staff",
+                creator_id="user_fixture",
+                owner_id="user_fixture",
+                env=get_current_env(),
+                is_delete=1,
+            )
+        )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+    )
+
+    assert total == 1
+    assert rows[0].bot_id == "deleted_bot_fixture"
+    assert rows[0].bot_name is None
+
+
+@pytest.mark.asyncio
+async def test_contains_query_accepts_90_days_and_rejects_longer_ranges():
+    service = BotChatService(
+        MagicMock(),
+        BotChatConfig(
+            langfuse_base_url="",
+            langfuse_public_key="",
+            langfuse_secret_key="",
+        ),
+    )
+    service._db_repo = MagicMock()
+    service._db_repo.list_ocb_traces.return_value = ([], 0)
+    service._db_repo.list_traces.return_value = ([], 0)
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    await service.list_sessions(
+        owner_id="user_fixture",
+        from_date=start,
+        to_date=start + timedelta(days=90),
+        match_mode="contains",
+        query="x",
+    )
+
+    with pytest.raises(ValueError, match="maximum time range of 90 days"):
+        await service.list_sessions(
+            owner_id="user_fixture",
+            from_date=start,
+            to_date=start + timedelta(days=90, seconds=1),
+            match_mode="contains",
+            query="x",
+        )
+
+
+@pytest.mark.asyncio
+async def test_unbounded_time_scope_requires_exact_identifier():
+    service = BotChatService(
+        MagicMock(),
+        BotChatConfig(
+            langfuse_base_url="",
+            langfuse_public_key="",
+            langfuse_secret_key="",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires match_mode=exact"):
+        await service.list_sessions(
+            owner_id="user_fixture",
+            time_scope="all",
+        )
+
+
+def test_observation_keeps_raw_metadata_for_detail_rendering():
+    observation = _map_observation(
+        {
+            "id": "observation_fixture",
+            "type": "SPAN",
+            "metadata": {
+                "attributes": {"fixture.attribute": "fixture-value"},
+                "custom": {"safe": True},
+            },
+        }
+    )
+
+    assert observation.metadata == {
+        "attributes": {"fixture.attribute": "fixture-value"},
+        "custom": {"safe": True},
+    }
+
+
+def test_langfuse_output_filter_uses_full_output_but_does_not_serialize_it():
+    full_output = ("a" * 600) + "needle_after_preview"
+    session = _map_trace_to_session(
+        {
+            "id": "trace_fixture",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "output": full_output,
+        }
+    )
+
+    matched = _apply_client_side_filters(
+        [session],
+        bot_id=None,
+        trace_id=None,
+        session_id=None,
+        session_key=None,
+        query="needle_after_preview",
+        include_output_match=True,
+    )
+
+    assert matched == [session]
+    assert len(session.output_preview or "") == 500
+    assert "search_output" not in session.model_dump()
+
+
+@pytest.mark.asyncio
+async def test_langfuse_filter_scans_later_pages_before_paginating():
+    service = BotChatService(
+        MagicMock(),
+        BotChatConfig(
+            langfuse_base_url="https://langfuse.example.com",
+            langfuse_public_key="fixture-public",
+            langfuse_secret_key="fixture-secret",
+        ),
+    )
+    service._fetch_traces_from_langfuse = AsyncMock(
+        side_effect=[
+            (
+                [
+                    {
+                        "id": "trace_page_one",
+                        "timestamp": "2026-01-02T00:00:00Z",
+                        "output": "not a match",
+                    }
+                ],
+                2,
+            ),
+            (
+                [
+                    {
+                        "id": "trace_page_two",
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "output": ("x" * 600) + "later_page_needle",
+                    }
+                ],
+                2,
+            ),
+        ]
+    )
+
+    result = await service._list_sessions_langfuse(
+        owner_id="user_fixture",
+        from_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        to_date=datetime(2026, 1, 3, tzinfo=timezone.utc),
+        page=1,
+        limit=20,
+        bot_id=None,
+        trace_id=None,
+        session_id=None,
+        session_key=None,
+        query="later_page_needle",
+        match_mode="exact",
+        include_output_match=True,
+    )
+
+    assert result.total == 1
+    assert [row.id for row in result.sessions] == ["trace_page_two"]
+    assert service._fetch_traces_from_langfuse.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_time_scope_all_accepts_old_exact_trace_and_naive_dates():
+    service = BotChatService(
+        MagicMock(),
+        BotChatConfig(
+            langfuse_base_url="",
+            langfuse_public_key="",
+            langfuse_secret_key="",
+        ),
+    )
+    old_session = ConversationSession(
+        id="trace_old_fixture",
+        timestamp="2020-01-01T00:00:00Z",
+    )
+    service._db_repo = MagicMock()
+    service._db_repo.list_ocb_traces.return_value = ([old_session], 1)
+
+    result = await service.list_sessions(
+        owner_id="user_fixture",
+        trace_id="trace_old_fixture",
+        from_date=datetime(2020, 1, 1),
+        to_date=datetime(2020, 1, 2),
+        time_scope="all",
+    )
+
+    assert result.total == 1
+    kwargs = service._db_repo.list_ocb_traces.call_args.kwargs
+    assert kwargs["from_ms"] == 1_577_836_800_000

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 
 from agentclaw.community.core.bot_chat.service import (
     BotChatService,
@@ -1679,6 +1679,8 @@ class TestBotChatServiceGetSession:
 
         service._db_repo = MagicMock()
         service._db_repo.has_bot_access.return_value = True
+        service._db_repo.get_group_labels.return_value = (None, None)
+        service._db_repo.get_bot_name.return_value = "bot-a"
 
         mock_aiohttp_session = AsyncMock()
         mock_aiohttp_session.get = mock_get
@@ -1722,6 +1724,8 @@ class TestBotChatServiceGetSession:
 
         service._db_repo = MagicMock()
         service._db_repo.has_bot_access.return_value = True
+        service._db_repo.get_group_labels.return_value = (None, None)
+        service._db_repo.get_bot_name.return_value = "bot-a"
 
         mock_aiohttp_session = AsyncMock()
         mock_aiohttp_session.get = mock_get


### PR DESCRIPTION
本次不新增后端公开 API，修改 2 个现有 API，复用 2 个现有 API。

   API                                 类型    本次调整
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   GET /api/v1/bot-chats               修改    增加 Task、群聊、模糊匹配、Output 搜索和历史数据查询能力
  ──────────────────────────────────  ──────  ──────────────────────────────────────────────────────────
   GET /api/v1/bot-chats/{trace_id}    修改    增加 Bot、群聊标签及 Observation Metadata
  ──────────────────────────────────  ──────  ──────────────────────────────────────────────────────────
   POST /api/bot-chat/log-relations    复用    保持现状，用于写入 Task 与 Trace/Session 的关联关系
  ──────────────────────────────────  ──────  ──────────────────────────────────────────────────────────
   GET /api/v1/bot-chats/health        复用    保持现状，不修改

  ### 1. GET /api/v1/bot-chats

  原有参数全部保留：

  owner_id
  bot_id
  trace_id
  session_id
  session_key
  query
  from_date
  to_date
  page
  limit
  log_source

  新增可选参数：

   参数                    类型/默认值                    说明
  ━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   biz_scene               string                         业务场景
  ──────────────────────  ─────────────────────────────  ────────────────────────────────────────────────
   biz_task_id             string                         业务任务 ID
  ──────────────────────  ─────────────────────────────  ────────────────────────────────────────────────
   group_id                string                         BCS 群 ID
  ──────────────────────  ─────────────────────────────  ────────────────────────────────────────────────
   match_mode              exact，contains；默认 exact    控制 Trace、Session、Task 等字段的匹配方式
  ──────────────────────  ─────────────────────────────  ────────────────────────────────────────────────
   include_output_match    boolean=false                  query 是否同时搜索完整 Output
  ──────────────────────  ─────────────────────────────  ────────────────────────────────────────────────
   time_scope              default，all；默认 default     all 用于精确查询历史数据，不受默认 72 小时限制

  新增可选响应字段：

   字段              说明
  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   bot_id            Trace 对应的 Bot ID；结构化字段为空时从 Metadata 回退
  ────────────────  ───────────────────────────────────────────────────────
   bot_name          Bot 名称；Bot 不存在、已删除或查询失败时为 null
  ────────────────  ───────────────────────────────────────────────────────
   group_id          Trace 所属群 ID
  ────────────────  ───────────────────────────────────────────────────────
   session_kind      群 Session 的可选展示标签，不参与过滤
  ────────────────  ───────────────────────────────────────────────────────
   output_preview    Output 前 500 字符，仅用于列表展示
  ────────────────  ───────────────────────────────────────────────────────
   match_sources     Task 命中来源，如 direct、biz_ref

  主要查询规则：

  - biz_scene + biz_task_id：查询指定场景内的任务。
  - 仅 biz_task_id：跨场景查询任务。
  - 仅 biz_scene：查询场景下的 Trace。
  - Task 查询同时匹配 Trace 直存字段和 log-relations 关系。
  - Task 结果按 Trace 去重并分页。
  - group_id 会查询群内全部 BCS Session。
  - BCS Session ID 未带 agent: 时自动补充 agent:main:。
  - include_output_match=true 时搜索完整 Output，不受 500 字符 Preview 限制。
  - match_mode=contains 不限制关键词长度，但时间跨度最多 90 天。
  - time_scope=all 只能配合 exact 和至少一个精确标识使用。

  示例：

  GET /api/v1/bot-chats?biz_scene=scene_fixture&biz_task_id=task_fixture&page=1&limit=20

  GET /api/v1/bot-chats?group_id=group_fixture&match_mode=exact&page=1&limit=100

  GET /api/v1/bot-chats?query=approval&include_output_match=true&match_mode=contains

  GET /api/v1/bot-chats?session_key=agent:main:session_fixture&match_mode=exact&time_scope=all

  ### 2. GET /api/v1/bot-chats/{trace_id}

  请求参数不变。

  新增可选响应字段：

   字段                       说明
  ━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   bot_id                     当前 Trace 的 Bot ID
  ─────────────────────────  ──────────────────────────────
   bot_name                   Bot 名称，无法获取时为 null
  ─────────────────────────  ──────────────────────────────
   group_id                   根据 Session Key 反查的群 ID
  ─────────────────────────  ──────────────────────────────
   session_kind               群 Session 展示标签
  ─────────────────────────  ──────────────────────────────
   observations[].metadata    Observation 原始 Metadata

  原有内容保持不变：

  - Trace Input/Output
  - Trace 基本信息
  - Observation 父子树结构
  - Observation Input/Output
  - Token、Cost、Latency 等统计数据

  ### 3. POST /api/bot-chat/log-relations

  接口不修改、不新增替代接口。

  继续使用：

  POST /api/bot-chat/log-relations

  示例：

  {
    "biz_scene": "scene_fixture",
    "biz_task_id": "task_fixture",
    "user_id": "user_fixture",
    "bot_id": "bot_fixture",
    "refs": [
      {
        "ref_type": "trace_id",
        "ref_value": "trace_fixture"
      },
      {
        "ref_type": "session_id",
        "ref_value": "session_fixture"
      },
      {
        "ref_type": "session_key",
        "ref_value": "agent:main:session_fixture"
      }
    ]
  }

  本次查询时会按已记录的 user_id、bot_id 进行关系隔离；历史上没有身份信息的关系记录仍保持兼容。

  ## 兼容性说明

  - 原有请求参数、默认精确匹配和默认 72 小时时间范围不变。
  - 原有响应字段、类型和含义不变。
  - 新响应字段属于加法兼容，均为可选字段。
  - 原分页协议不变，单页最大仍为 100 条。
  - 不新增 Task、Session、群聊或关联 Trace 专用后端 API。
  - /tclog/embed/session 和 /tclog/embed/task 是后续前端兼容路由，不属于本次后端 API