### PR TITLE
fix(bcs-cli): restore discover JSON output

### DIFF
--- a/src/bcs/crates/contracts/bcs-protocol/src/http/bots.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/bots.rs
@@ -163,7 +163,7 @@ pub struct DiscoverBotsResponse {
 }
 
 /// Extended response from bot discovery with visibility and friendship info.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DiscoverBotsExtendedResponse {
     pub bots: Vec<DiscoverBotEntry>,
     pub count: usize,

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -118,6 +118,46 @@ fn emit_structured_result(result: &StructuredResult) {
     );
 }
 
+fn render_discover_result(
+    result: &bcs_protocol::DiscoverBotsExtendedResponse,
+    json_output: bool,
+) -> Result<String> {
+    if json_output {
+        return Ok(serde_json::to_string_pretty(result)?);
+    }
+
+    let mut lines = vec![format!("Discovered {} bots:", result.count)];
+    for bot in &result.bots {
+        let name = bot.capabilities.name.as_deref().unwrap_or("unnamed");
+        let vis = &bot.visibility;
+        let friend_tag = match bot.is_friend {
+            Some(true) => " ★friend",
+            Some(false) | None => "",
+        };
+        let provider_tag = bot
+            .provider_info
+            .as_ref()
+            .map(|provider| {
+                format!(
+                    " provider={}/{}",
+                    provider.provider_name, provider.provider_id
+                )
+            })
+            .unwrap_or_default();
+        let agent_code_tag = bot
+            .agent_code
+            .as_ref()
+            .map(|agent_code| format!(" agent_code={agent_code}"))
+            .unwrap_or_default();
+        lines.push(format!(
+            "  - {} ({}) [{}]{}{}{}",
+            bot.bot_uuid, name, vis, friend_tag, provider_tag, agent_code_tag
+        ));
+    }
+
+    Ok(lines.join("\n"))
+}
+
 fn classify_auth_error_message(msg: &str) -> &'static str {
     if msg.contains("timed out locally") {
         "auth_timeout"
@@ -891,6 +931,10 @@ enum Commands {
         /// Organization member role filter. Requires --organization-code.
         #[arg(long)]
         role: Option<String>,
+
+        /// Output discover results in human-readable text instead of JSON
+        #[arg(long)]
+        no_json: bool,
     },
 
     /// Update bot status
@@ -2293,6 +2337,7 @@ async fn main() -> Result<()> {
             collaborate_bot,
             organization_code,
             role,
+            no_json,
         } => {
             let token = get_token(token.as_deref())?;
             let client = create_client(
@@ -2333,35 +2378,10 @@ async fn main() -> Result<()> {
                 })
             );
 
-            println!("Discovered {} bots:", result.count);
-            for bot in &result.bots {
-                let name = bot.capabilities.name.as_deref().unwrap_or("unnamed");
-                let vis = &bot.visibility;
-                let friend_tag = match bot.is_friend {
-                    Some(true) => " ★friend",
-                    Some(false) => "",
-                    None => "",
-                };
-                let provider_tag = bot
-                    .provider_info
-                    .as_ref()
-                    .map(|provider| {
-                        format!(
-                            " provider={}/{}",
-                            provider.provider_name, provider.provider_id
-                        )
-                    })
-                    .unwrap_or_default();
-                let agent_code_tag = bot
-                    .agent_code
-                    .as_ref()
-                    .map(|agent_code| format!(" agent_code={agent_code}"))
-                    .unwrap_or_default();
-                println!(
-                    "  - {} ({}) [{}]{}{}{}",
-                    bot.bot_uuid, name, vis, friend_tag, provider_tag, agent_code_tag
-                );
-            }
+            println!(
+                "{}",
+                render_discover_result(&result, structured_mode && !no_json)?
+            );
         }
 
         Commands::UpdateStatus {

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/discover_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/discover_test.rs
@@ -1,0 +1,69 @@
+//! E2E tests for `bcs-cli discover`.
+
+use crate::common::{assert_success, TestContext};
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
+
+async fn mount_discover_response(ctx: &TestContext) {
+    Mock::given(method("GET"))
+        .and(path("/bots/discover"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "count": 1,
+            "bots": [{
+                "bot_uuid": "bot-1",
+                "capabilities": {
+                    "name": "Helper",
+                    "summary": "A test helper"
+                },
+                "visibility": "public",
+                "is_friend": true,
+                "agent_code": "agent-code-1",
+                "provider_info": {
+                    "provider_id": "provider-1",
+                    "provider_name": "Provider One"
+                }
+            }]
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+}
+
+#[tokio::test]
+async fn discover_defaults_to_json_output() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    mount_discover_response(&ctx).await;
+
+    let output = ctx
+        .cmd()
+        .arg("discover")
+        .output()
+        .expect("Failed to execute discover");
+
+    assert_success(&output);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["count"], 1);
+    assert_eq!(value["bots"][0]["bot_uuid"], "bot-1");
+    assert_eq!(value["bots"][0]["provider_info"]["provider_id"], "provider-1");
+}
+
+#[tokio::test]
+async fn discover_no_json_preserves_human_output() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    mount_discover_response(&ctx).await;
+
+    let output = ctx
+        .cmd()
+        .arg("discover")
+        .arg("--no-json")
+        .output()
+        .expect("Failed to execute discover --no-json");
+
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Discovered 1 bots:"));
+    assert!(stdout.contains("bot-1 (Helper) [public]"));
+    assert!(stdout.contains("provider=Provider One/provider-1"));
+    assert!(serde_json::from_str::<serde_json::Value>(&stdout).is_err());
+}

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/main.rs
@@ -1,6 +1,7 @@
 //! E2E test suite for bcs-cli
 
 mod common;
+mod discover_test;
 mod smoke_test;
 mod list_test;
 mod groups_test;


### PR DESCRIPTION
## Summary

- Restore JSON output as the default for `bcs-cli discover`.
- Restore `bcs-cli discover --no-json` for human-readable interactive output.
- Make `DiscoverBotsExtendedResponse` serializable and add end-to-end coverage using the real CLI process.

## Background

The JSON renderer, command-local `--no-json` option, and their tests were present in `ERV10158366-20260705` but were omitted during the initial `ocb-public` import. The current discover handler therefore printed human-readable text unconditionally, despite the CLI still defaulting to structured output.

## Compatibility

This change does not modify the discover HTTP request or response schema. It only changes how the CLI renders the response it already receives, so old CLI/new server and new CLI/old server combinations remain compatible.

## Test Plan

- `cargo test --package bcs-cli`: 148 passed, 1 existing ignored.
- `cargo check --package bcs-cli --all-targets`: passed.
- Added E2E coverage for default JSON output and `discover --no-json` text output.
