### PR TITLE
fix(resources): address legacy uploads in workspace namespace

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/resources/router.py
@@ -70,6 +70,7 @@ from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_management.services.engine_resolver import resolve_engine_for_bot
 from agentclaw.community.core.devices.services import device_info as device_info_lookup
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
+from agentclaw.community.core.config_compose.teclaw_paths import WORKSPACE_NS
 
 logger = logging.getLogger(__name__)
 
@@ -639,7 +640,18 @@ async def upload_files_legacy(
     eid, ebid, eeng, eetype = _get_path_params(ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo)
     legacy_svc = get_legacy_resource_service(resource_repo, bot_repo, path_factory=path_factory, entity_id=eid, bot_id=ebid, engine_type=eeng, entity_type=eetype)
     ctx_dev = resolver.resolve_for_bot(ebid, ctx.user_id)
-    device_fs = device_fs_dispatcher.dispatch(ctx_dev)
+    # This compatibility endpoint still persists resource metadata through the
+    # legacy service, but file bytes must use the same logical workspace address
+    # as /files/upload.  A generic dispatcher leaves a root upload as a host path;
+    # ARCA then normalizes it to //filename and the container rejects it.
+    device_fs = device_fs_dispatcher.dispatch_addressed(
+        ctx_dev,
+        namespace=WORKSPACE_NS,
+        entity_type=eetype,
+        entity_id=eid,
+        bot_id=ebid,
+        engine_type=eeng,
+    )
 
     results, errors = [], []
     for file in files:
@@ -651,6 +663,7 @@ async def upload_files_legacy(
                 user_id=ctx.user_id,
                 created_by=ctx.user_id,
                 device_fs=device_fs,
+                device_path_prefix=f"{WORKSPACE_NS}/data",
             )
             results.append(resource)
         except ValueError as e:

--- a/src/backend/src/agentclaw/community/core/resources/services/file_service.py
+++ b/src/backend/src/agentclaw/community/core/resources/services/file_service.py
@@ -382,6 +382,7 @@ class FileService:
         target_dir: str = "",
         preserve_structure: bool = False,
         device_fs: "DeviceFileSystem",
+        device_path_prefix: str | None = None,
     ) -> Dict:
         """Upload a single file to specified directory.
 
@@ -447,7 +448,12 @@ class FileService:
         # disk and we report its real stat; for a remote (Arca) write the
         # path is not on local disk, so we fall back to the byte count and
         # current time — matching the prior per-branch behavior.
-        await device_fs.write_file(str(file_path), data)
+        device_path = (
+            f"{device_path_prefix}/{rel_path}"
+            if device_path_prefix
+            else str(file_path)
+        )
+        await device_fs.write_file(device_path, data)
         try:
             stat = file_path.stat()
             size = stat.st_size

--- a/src/backend/src/agentclaw/community/core/resources/services/resource_service.py
+++ b/src/backend/src/agentclaw/community/core/resources/services/resource_service.py
@@ -308,6 +308,7 @@ class ResourceService:
         user_id: Optional[str] = None,
         created_by: Optional[str] = None,
         device_fs: "DeviceFileSystem",
+        device_path_prefix: str | None = None,
     ) -> Resource:
         """Upload a file and create resource record.
 
@@ -337,6 +338,7 @@ class ResourceService:
             filename=filename,
             target_dir=target_dir,
             device_fs=device_fs,
+            device_path_prefix=device_path_prefix,
         )
         logger.info(f"[ResourceService.upload_file] File saved: {file_info['path']}")
 

--- a/src/backend/tests/community/adapters/http/test_http_adapters_use_resolver.py
+++ b/src/backend/tests/community/adapters/http/test_http_adapters_use_resolver.py
@@ -453,6 +453,7 @@ def _resources_router_app(mock_ctx, tmp_path):
     device_fs.list_dir = AsyncMock(return_value=[])
     dispatcher = MagicMock()
     dispatcher.dispatch.return_value = device_fs
+    dispatcher.dispatch_addressed.return_value = device_fs
 
     bot_repo = MagicMock()
     # Force non-arca / non-baas (local) so we hit the device_fs branch.
@@ -543,10 +544,10 @@ class TestResourcesRouterUsesResolver:
             dispatcher.dispatch.assert_called_once()
             assert dispatcher.dispatch.call_args[0][0] is resolver.resolve_for_bot.return_value
 
-    def test_upload_files_legacy_endpoint_uses_resolver(
+    def test_upload_files_legacy_endpoint_addresses_workspace_data_namespace(
         self, mock_request_ctx, tmp_path
     ):
-        """resources/router.py:631 — upload_files_legacy 走 resolver+dispatch。"""
+        """The legacy upload must not send a root-relative host path to ARCA."""
         with _resources_router_app(mock_request_ctx, tmp_path) as (
             client,
             resolver,
@@ -567,7 +568,17 @@ class TestResourcesRouterUsesResolver:
                 },
             )
             resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
-            dispatcher.dispatch.assert_called_once()
+            dispatcher.dispatch_addressed.assert_called_once_with(
+                resolver.resolve_for_bot.return_value,
+                namespace="workspace",
+                entity_type="staff",
+                entity_id="user-1",
+                bot_id="bot-1",
+                engine_type="openclaw",
+            )
+            device_fs.write_file.assert_awaited_once_with(
+                "workspace/data/test.txt", b"hello"
+            )
 
 
 # ── resources/file_router.py ─────────────────────────────────────────


### PR DESCRIPTION
## 修复内容

修复兼容接口 `POST /api/resources/file` 在资源根目录上传时将文件路径交给通用 dispatcher 的问题。该路径在 ARCA 侧会被规范化为 `//<filename>`，最终尝试写入容器根目录并返回 403。

现在旧接口与 `/files/upload` 一致：按 `workspace` 命名空间分发，并将旧资源目录显式映射为 `workspace/data/<relative-path>`。资源元数据的旧有持久化流程保持不变。

## 验证

- `uv run pytest tests/community/adapters/http/test_http_adapters_use_resolver.py::TestResourcesRouterUsesResolver::test_upload_files_legacy_endpoint_addresses_workspace_data_namespace tests/community/core/resources/test_resource_service.py -q`（32 passed）
- 后端全量 CI：8,654 tests，0 failures / 0 errors。
- 本地 singlebox 覆盖率门禁未完成：隔离环境 `npm install` 长时间无活跃网络连接而卡住，已停止；本次改动未涉及 singlebox。