### PR TITLE
[Skills Pool P3] OpenClaw 暗准备 Pool 并支持运行时探测

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -13,12 +13,15 @@ provides:
   - "MarketSyncService"
   - "GitSyncService"
   - "SkillAuthService"
+  - "CurrentRuntimeLayoutProbeService"
 consumes:
   - "BotRepository"
   - "Events"
   - "core/mcp services"
   - "CachePlugin"
   - "DeviceAccessor"
+  - "DeviceContextResolver"
+  - "DeviceAdapterTransport"
   - "MCPCenterPlugin"
   - "ObjectStoragePlugin"
   - "SecretResolver"
@@ -38,6 +41,7 @@ internal_dependencies:
   - agentclaw.community.kernel
   - agentclaw.community.log
   - agentclaw.community.plugin_api.cache
+  - agentclaw.community.plugin_api.device_adapter_transport
   - agentclaw.community.plugin_api.devices
   - agentclaw.community.plugin_api.mcp_center
   - agentclaw.community.plugin_api.object_storage

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -1,0 +1,287 @@
+"""Current-runtime orchestration for the Skills Pool layout probe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal
+
+from injector import inject
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from agentclaw.community.core.devices.services.device_context_resolver import (
+    DeviceContextResolver,
+)
+from agentclaw.community.core.devices.services.device_context import (
+    DeviceNotBoundError,
+    UnknownProviderError,
+)
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
+    DeviceAdapterTransport,
+)
+
+
+LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+
+
+class RuntimeLayoutProbeStatus(str, Enum):
+    READY = "READY"
+    NOT_CAPABLE = "NOT_CAPABLE"
+    TRANSIENT_ERROR = "TRANSIENT_ERROR"
+    INVALID = "INVALID"
+
+
+@dataclass(frozen=True)
+class OpenClawPoolLayout:
+    pool_root: Path
+    marker: Path
+
+    @classmethod
+    def for_home(cls, home: str | Path = "/home/admin") -> "OpenClawPoolLayout":
+        pool_root = Path(home) / ".openclaw" / "workspace" / "skills-pool"
+        return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
+
+
+@dataclass(frozen=True)
+class RuntimeLayoutProbeResult:
+    status: RuntimeLayoutProbeStatus
+    engine: str
+    layout_contract_version: str
+    preparation_id: str | None
+    evidence: dict[str, Any]
+
+
+class _RuntimeLayoutProbeData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: RuntimeLayoutProbeStatus
+    engine: str
+    layout_contract_version: str
+    preparation_id: str | None
+    evidence: dict[str, Any]
+
+
+class _RuntimeLayoutProbeEnvelope(BaseModel):
+    success: Literal[True]
+    data: _RuntimeLayoutProbeData
+
+
+class CurrentRuntimeLayoutProbeService:
+    """Resolve the Bot's active binding and ask that adapter to inspect itself."""
+
+    @inject
+    def __init__(
+        self,
+        *,
+        resolver: DeviceContextResolver,
+        adapter_transport: DeviceAdapterTransport,
+    ) -> None:
+        self._resolver = resolver
+        self._transport = adapter_transport
+
+    async def probe_bot(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+        layout: OpenClawPoolLayout | None = None,
+    ) -> RuntimeLayoutProbeResult:
+        layout = layout or OpenClawPoolLayout.for_home()
+        if engine == "teclaw":
+            return self._not_capable(
+                engine,
+                "engine_has_no_filesystem_pool_layout",
+            )
+        if engine != "openclaw":
+            return self._not_capable(engine, "engine_pool_probe_not_implemented")
+
+        try:
+            context = self._resolver.resolve_for_bot(bot_id, user_id)
+            response = await self._transport.invoke(
+                context.conn_info,
+                "POST",
+                "/api/skills/layout/probe",
+                body={
+                    "engine": engine,
+                    "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                },
+                timeout=10.0,
+            )
+        except DeviceNotBoundError:
+            return self._not_capable(engine, "current_runtime_not_bound")
+        except UnknownProviderError as error:
+            return self._invalid_control_plane(
+                engine,
+                layout,
+                "current_runtime_provider_invalid",
+                error,
+            )
+        except DeviceAdapterEndpointNotFoundError:
+            return await self._confirm_runtime_without_probe_endpoint(
+                conn_info=context.conn_info,
+                engine=engine,
+                layout=layout,
+            )
+        except DeviceAdapterHTTPStatusError as error:
+            return self._classify_http_status_error(
+                engine=engine,
+                layout=layout,
+                error=error,
+            )
+        except Exception as error:
+            return self._transient(engine, layout, error)
+
+        return self._parse_response(response, engine=engine, layout=layout)
+
+    async def _confirm_runtime_without_probe_endpoint(
+        self,
+        *,
+        conn_info: dict[str, Any],
+        engine: str,
+        layout: OpenClawPoolLayout,
+    ) -> RuntimeLayoutProbeResult:
+        """Treat 404 as old-image capability only after adapter liveness succeeds."""
+        try:
+            await self._transport.invoke(
+                conn_info,
+                "GET",
+                "/health",
+                timeout=5.0,
+            )
+        except DeviceAdapterHTTPStatusError as error:
+            return self._classify_http_status_error(
+                engine=engine,
+                layout=layout,
+                error=error,
+            )
+        except Exception as error:
+            return self._transient(engine, layout, error)
+        return self._not_capable(
+            engine,
+            "runtime_layout_probe_endpoint_absent",
+        )
+
+    @staticmethod
+    def _classify_http_status_error(
+        *,
+        engine: str,
+        layout: OpenClawPoolLayout,
+        error: DeviceAdapterHTTPStatusError,
+    ) -> RuntimeLayoutProbeResult:
+        if error.status_code >= 500 or error.status_code in {408, 425, 429}:
+            return CurrentRuntimeLayoutProbeService._transient(
+                engine,
+                layout,
+                error,
+            )
+        return CurrentRuntimeLayoutProbeService._invalid_control_plane(
+            engine,
+            layout,
+            "runtime_probe_rejected",
+            error,
+        )
+
+    @staticmethod
+    def _parse_response(
+        response: dict[str, Any],
+        *,
+        engine: str,
+        layout: OpenClawPoolLayout,
+    ) -> RuntimeLayoutProbeResult:
+        try:
+            envelope = _RuntimeLayoutProbeEnvelope.model_validate(response)
+        except ValidationError:
+            return CurrentRuntimeLayoutProbeService._invalid_response(engine, layout)
+        data = envelope.data
+        if (
+            data.engine != engine
+            or data.layout_contract_version != LAYOUT_CONTRACT_VERSION
+            or (
+                data.status is RuntimeLayoutProbeStatus.READY
+                and not isinstance(data.preparation_id, str)
+            )
+        ):
+            return CurrentRuntimeLayoutProbeService._invalid_response(engine, layout)
+        return RuntimeLayoutProbeResult(
+            status=data.status,
+            engine=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=data.preparation_id,
+            evidence=data.evidence,
+        )
+
+    @staticmethod
+    def _invalid_control_plane(
+        engine: str,
+        layout: OpenClawPoolLayout,
+        reason: str,
+        error: Exception,
+    ) -> RuntimeLayoutProbeResult:
+        return RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.INVALID,
+            engine=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=None,
+            evidence={
+                "reason": reason,
+                "marker": str(layout.marker),
+                "error_type": type(error).__name__,
+            },
+        )
+
+    @staticmethod
+    def _not_capable(engine: str, reason: str) -> RuntimeLayoutProbeResult:
+        return RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+            engine=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=None,
+            evidence={"reason": reason},
+        )
+
+    @staticmethod
+    def _invalid_response(
+        engine: str, layout: OpenClawPoolLayout
+    ) -> RuntimeLayoutProbeResult:
+        return RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.INVALID,
+            engine=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=None,
+            evidence={
+                "reason": "invalid_runtime_probe_response",
+                "marker": str(layout.marker),
+            },
+        )
+
+    @staticmethod
+    def _transient(
+        engine: str,
+        layout: OpenClawPoolLayout,
+        error: Exception,
+    ) -> RuntimeLayoutProbeResult:
+        return RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
+            engine=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=None,
+            evidence={
+                "reason": "runtime_probe_failed",
+                "marker": str(layout.marker),
+                "error_type": type(error).__name__,
+                "error": str(error),
+            },
+        )
+
+
+__all__ = [
+    "CurrentRuntimeLayoutProbeService",
+    "LAYOUT_CONTRACT_VERSION",
+    "OpenClawPoolLayout",
+    "RuntimeLayoutProbeResult",
+    "RuntimeLayoutProbeStatus",
+]

--- a/src/backend/src/agentclaw/community/plugin_api/device_adapter_transport.py
+++ b/src/backend/src/agentclaw/community/plugin_api/device_adapter_transport.py
@@ -27,6 +27,20 @@ class DeviceAdapterTimeoutError(TimeoutError):
     """The adapter transport exceeded its request deadline."""
 
 
+class DeviceAdapterEndpointNotFoundError(ValueError):
+    """The current runtime does not expose the requested adapter endpoint."""
+
+
+class DeviceAdapterHTTPStatusError(ValueError):
+    """The adapter returned a non-success HTTP status other than 404."""
+
+    def __init__(self, status_code: int, response_text: str) -> None:
+        self.status_code = status_code
+        super().__init__(
+            f"Adapter returned HTTP {status_code}: {response_text}"
+        )
+
+
 @runtime_checkable
 class DeviceAdapterTransport(Plugin, Protocol):
     """Forward an HTTP request to a bot's engine adapter."""
@@ -59,6 +73,8 @@ class DeviceAdapterTransport(Plugin, Protocol):
             ``{"success": bool, "data": ...}``).
 
         Raises:
+            DeviceAdapterEndpointNotFoundError: The runtime has no such endpoint.
+            DeviceAdapterHTTPStatusError: The runtime returned another HTTP error.
             DeviceAdapterTimeoutError: When an explicit ``timeout`` is exceeded.
             ValueError: On transport/HTTP failure (prod impl), so callers
                 can surface a uniform error envelope.

--- a/src/backend/src/agentclaw/community/plugins/local/device_adapter_transport.py
+++ b/src/backend/src/agentclaw/community/plugins/local/device_adapter_transport.py
@@ -107,6 +107,22 @@ class InMemoryDeviceAdapterTransport(MockSeam, DeviceAdapterTransport):
         *,
         timeout: float | None = None,
     ) -> dict[str, Any]:
+        if path == "/api/skills/layout/probe":
+            contract_version = (body or {}).get(
+                "layout_contract_version", "skills-pool-p3-v1"
+            )
+            return {
+                "success": True,
+                "data": {
+                    "status": "NOT_CAPABLE",
+                    "engine": (body or {}).get("engine", "openclaw"),
+                    "layout_contract_version": contract_version,
+                    "preparation_id": None,
+                    "evidence": {
+                        "reason": "local_simulator_has_no_persistent_pool_layout"
+                    },
+                },
+            }
         store = self._store(conn_info)
         # Segments after ``/api/cron``: [] | [status] | [running] |
         # [task_id] | [task_id, run|runs]

--- a/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    CurrentRuntimeLayoutProbeService,
+    OpenClawPoolLayout,
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.devices.services.device_context import (
+    DeviceNotBoundError,
+    UnknownProviderError,
+)
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
+)
+
+
+def _service(
+    *,
+    response: dict | None = None,
+    transport_error: Exception | None = None,
+    resolver_error: Exception | None = None,
+):
+    context = Mock(conn_info={"url": "http://current-runtime"})
+    resolver = Mock()
+    if resolver_error is not None:
+        resolver.resolve_for_bot.side_effect = resolver_error
+    else:
+        resolver.resolve_for_bot.return_value = context
+    transport = Mock()
+    if transport_error is not None:
+        transport.invoke = AsyncMock(side_effect=transport_error)
+    else:
+        transport.invoke = AsyncMock(
+            return_value=response
+            or {
+                "success": True,
+                "data": {
+                    "status": "READY",
+                    "engine": "openclaw",
+                    "layout_contract_version": "skills-pool-p3-v1",
+                    "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+                    "evidence": {
+                        "checks": {
+                            "pool_repo_mounted": True,
+                            "legacy_repo_bridge_valid": True,
+                        }
+                    },
+                },
+            }
+        )
+    service = CurrentRuntimeLayoutProbeService(
+        resolver=resolver,
+        adapter_transport=transport,
+    )
+    return service, resolver, transport, context
+
+
+@pytest.mark.asyncio
+async def test_ready_is_taken_from_current_runtime_inspection():
+    service, resolver, transport, context = _service()
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.READY
+    assert result.preparation_id == "2a958f59-8cf4-4413-a267-7d56d3382f23"
+    resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
+    transport.invoke.assert_awaited_once_with(
+        context.conn_info,
+        "POST",
+        "/api/skills/layout/probe",
+        body={
+            "engine": "openclaw",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+        timeout=10.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_without_marker_is_not_capable():
+    service, *_ = _service(
+        response={
+            "success": True,
+            "data": {
+                "status": "NOT_CAPABLE",
+                "engine": "openclaw",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": None,
+                "evidence": {"reason": "pool_ready_marker_absent"},
+            },
+        }
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.NOT_CAPABLE
+    assert result.evidence["reason"] == "pool_ready_marker_absent"
+
+
+@pytest.mark.asyncio
+async def test_runtime_invalid_result_stays_invalid():
+    response = {
+        "success": True,
+        "data": {
+            "status": "INVALID",
+            "engine": "openclaw",
+            "layout_contract_version": "skills-pool-p3-v1",
+            "preparation_id": "prep-1",
+            "evidence": {"reason": "legacy_repo_bridge_invalid"},
+        },
+    }
+    service, *_ = _service(response=response)
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.INVALID
+    assert result.evidence["reason"] == "legacy_repo_bridge_invalid"
+
+
+@pytest.mark.asyncio
+async def test_unreachable_runtime_is_transient():
+    service, *_ = _service(transport_error=TimeoutError("unreachable"))
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
+    assert result.evidence["reason"] == "runtime_probe_failed"
+
+
+@pytest.mark.asyncio
+async def test_bot_without_current_binding_is_not_capable():
+    service, *_ = _service(
+        resolver_error=DeviceNotBoundError("no active binding")
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.NOT_CAPABLE
+    assert result.evidence["reason"] == "current_runtime_not_bound"
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_is_invalid_instead_of_retried():
+    service, *_ = _service(
+        resolver_error=UnknownProviderError("broken provider")
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.INVALID
+    assert result.evidence["reason"] == "current_runtime_provider_invalid"
+
+
+@pytest.mark.asyncio
+async def test_marker_from_newer_nas_but_old_endpoint_is_not_capable():
+    service, _, transport, context = _service()
+    transport.invoke = AsyncMock(
+        side_effect=[
+            DeviceAdapterEndpointNotFoundError("old image"),
+            {"status": "ok"},
+        ]
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.NOT_CAPABLE
+    assert result.evidence["reason"] == "runtime_layout_probe_endpoint_absent"
+    assert transport.invoke.await_args_list[1].args == (
+        context.conn_info,
+        "GET",
+        "/health",
+    )
+    assert transport.invoke.await_args_list[1].kwargs == {"timeout": 5.0}
+
+
+@pytest.mark.asyncio
+async def test_proxy_target_404_is_transient_when_liveness_also_fails():
+    service, _, transport, _ = _service()
+    transport.invoke = AsyncMock(
+        side_effect=DeviceAdapterEndpointNotFoundError("proxy target missing")
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
+    assert result.evidence["reason"] == "runtime_probe_failed"
+    assert transport.invoke.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_probe_404_then_health_401_is_invalid():
+    service, _, transport, _ = _service()
+    transport.invoke = AsyncMock(
+        side_effect=[
+            DeviceAdapterEndpointNotFoundError("probe endpoint absent"),
+            DeviceAdapterHTTPStatusError(401, "unauthorized"),
+        ]
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.INVALID
+    assert result.evidence["reason"] == "runtime_probe_rejected"
+
+
+@pytest.mark.asyncio
+async def test_permanent_http_rejection_is_invalid():
+    service, *_ = _service(
+        transport_error=DeviceAdapterHTTPStatusError(401, "unauthorized")
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.INVALID
+    assert result.evidence["reason"] == "runtime_probe_rejected"
+
+
+@pytest.mark.asyncio
+async def test_runtime_http_500_is_transient():
+    service, *_ = _service(
+        transport_error=DeviceAdapterHTTPStatusError(500, "unavailable")
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
+
+
+@pytest.mark.asyncio
+async def test_malformed_runtime_response_is_invalid():
+    service, *_ = _service(response={"success": True, "data": {"status": "READY"}})
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.INVALID
+    assert result.evidence["reason"] == "invalid_runtime_probe_response"
+
+
+@pytest.mark.asyncio
+async def test_teclaw_is_noop_without_resolving_runtime():
+    service, resolver, transport, _ = _service(
+        transport_error=AssertionError("must not touch runtime")
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="teclaw",
+        layout=OpenClawPoolLayout.for_home("/not-used"),
+    )
+
+    assert result == RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        engine="teclaw",
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id=None,
+        evidence={"reason": "engine_has_no_filesystem_pool_layout"},
+    )
+    resolver.resolve_for_bot.assert_not_called()
+    transport.invoke.assert_not_awaited()
+
+
+def test_real_engine_response_schema_is_accepted(monkeypatch):
+    engine_source = Path(__file__).resolve().parents[5] / "engine" / "src"
+    monkeypatch.syspath_prepend(str(engine_source))
+    from engine.community.api.skills.schemas import (
+        RuntimeLayoutProbeApiResponse,
+        RuntimeLayoutProbeResponse,
+    )
+
+    engine_response = RuntimeLayoutProbeApiResponse(
+        success=True,
+        data=RuntimeLayoutProbeResponse(
+            status="READY",
+            engine="openclaw",
+            layout_contract_version="skills-pool-p3-v1",
+            preparation_id="2a958f59-8cf4-4413-a267-7d56d3382f23",
+            evidence={"checks": {"pool_repo_mounted": True}},
+        ),
+        message="运行时 Skills Pool 布局探测完成",
+    )
+
+    result = CurrentRuntimeLayoutProbeService._parse_response(
+        engine_response.model_dump(mode="json"),
+        engine="openclaw",
+        layout=OpenClawPoolLayout.for_home(),
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.READY
+    assert result.preparation_id == "2a958f59-8cf4-4413-a267-7d56d3382f23"

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -17,6 +17,9 @@ from engine.community.api.skills.schemas import (
     BindPathRequest,
     CenterEnsureRequestSchema,
     CleanSymlinkRequest,
+    RuntimeLayoutProbeApiResponse,
+    RuntimeLayoutProbeRequest,
+    RuntimeLayoutProbeResponse,
     SyncSymlinkRequest,
 )
 from engine.community.core.engine.capability import Capability
@@ -29,6 +32,7 @@ from engine.community.core.skills.models import (
     SyncBindPathsRequest,
     SyncSymlinksRequest,
 )
+from engine.community.core.skills.layout_probe import inspect_runtime_layout
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 log = logging.getLogger("api-skills")
@@ -37,6 +41,22 @@ log = logging.getLogger("api-skills")
 def _skills_plugin():
     from engine.community.manager import EngineManager
     return EngineManager.get_instance().skills
+
+
+@router.post("/layout/probe", response_model=RuntimeLayoutProbeApiResponse)
+def probe_runtime_skills_layout(
+    body: RuntimeLayoutProbeRequest,
+) -> RuntimeLayoutProbeApiResponse:
+    """Inspect local facts in FastAPI's worker pool, outside the event loop."""
+    result = inspect_runtime_layout(
+        engine=body.engine,
+        expected_contract_version=body.layout_contract_version,
+    )
+    return RuntimeLayoutProbeApiResponse(
+        success=True,
+        data=RuntimeLayoutProbeResponse.model_validate(result.to_data()),
+        message="运行时 Skills Pool 布局探测完成",
+    )
 
 
 @router.post("/symlink", response_model=ApiResponse)

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -1,9 +1,11 @@
 """Skills router HTTP schemas."""
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel
+
+from engine.community.api.response import ApiResponse
 
 
 class SymlinkItem(BaseModel):
@@ -49,6 +51,23 @@ class CenterEnsureResponseSchema(BaseModel):
     failed: list[CenterEnsureFailureSchema]
 
 
+class RuntimeLayoutProbeRequest(BaseModel):
+    engine: str
+    layout_contract_version: str
+
+
+class RuntimeLayoutProbeResponse(BaseModel):
+    status: Literal["READY", "NOT_CAPABLE", "TRANSIENT_ERROR", "INVALID"]
+    engine: str
+    layout_contract_version: str
+    preparation_id: str | None
+    evidence: dict[str, Any]
+
+
+class RuntimeLayoutProbeApiResponse(ApiResponse):
+    data: RuntimeLayoutProbeResponse
+
+
 __all__ = [
     "SymlinkItem",
     "SyncSymlinkRequest",
@@ -59,4 +78,7 @@ __all__ = [
     "CenterEnsureRequestSchema",
     "CenterEnsureFailureSchema",
     "CenterEnsureResponseSchema",
+    "RuntimeLayoutProbeRequest",
+    "RuntimeLayoutProbeResponse",
+    "RuntimeLayoutProbeApiResponse",
 ]

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -21,6 +21,10 @@ from engine.community.core.skills.models import (
     CleanSymlinksResult,
     SyncSymlinksResult,
 )
+from engine.community.core.skills.layout_probe import (
+    RuntimeLayoutInspection,
+    RuntimeLayoutInspectionStatus,
+)
 from engine.community.manager import EngineManager
 
 
@@ -215,3 +219,31 @@ def test_ensure_center_skills_route_success(rich_manager, client):
         {"skill_uuid": "u2", "version": "2.0.0", "reason": "missing"}
     ]
     assert len(captured["items"]) == 2
+
+
+def test_runtime_layout_probe_has_no_engine_capability_dependency(client, monkeypatch):
+    import importlib
+
+    router_module = importlib.import_module("engine.community.api.skills.router")
+    monkeypatch.setattr(
+        router_module,
+        "inspect_runtime_layout",
+        lambda **_kwargs: RuntimeLayoutInspection(
+            status=RuntimeLayoutInspectionStatus.READY,
+            engine="openclaw",
+            layout_contract_version="skills-pool-p3-v1",
+            preparation_id="prep-1",
+            evidence={"checks": {"pool_repo_mounted": True}},
+        ),
+    )
+
+    response = client.post(
+        "/api/skills/layout/probe",
+        json={
+            "engine": "openclaw",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["status"] == "READY"

--- a/src/engine/src/engine/community/core/skills/layout_probe.py
+++ b/src/engine/src/engine/community/core/skills/layout_probe.py
@@ -1,0 +1,519 @@
+"""In-runtime validation for the persistent OpenClaw Skills Pool layout."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+from uuid import UUID
+
+
+LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+
+
+class RuntimeLayoutInspectionStatus(str, Enum):
+    READY = "READY"
+    NOT_CAPABLE = "NOT_CAPABLE"
+    TRANSIENT_ERROR = "TRANSIENT_ERROR"
+    INVALID = "INVALID"
+
+
+@dataclass(frozen=True)
+class RuntimeLayoutInspection:
+    status: RuntimeLayoutInspectionStatus
+    engine: str
+    layout_contract_version: str
+    preparation_id: str | None
+    evidence: dict[str, Any]
+
+    def to_data(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "engine": self.engine,
+            "layout_contract_version": self.layout_contract_version,
+            "preparation_id": self.preparation_id,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True)
+class _OpenClawLayout:
+    legacy_root: Path
+    legacy_local: Path
+    legacy_repo: Path
+    pool_root: Path
+    pool_local: Path
+    pool_repo: Path
+    marker: Path
+
+    @classmethod
+    def for_home(cls, home: Path) -> "_OpenClawLayout":
+        workspace = home / ".openclaw" / "workspace"
+        legacy_root = workspace / "skills"
+        pool_root = workspace / "skills-pool"
+        return cls(
+            legacy_root=legacy_root,
+            legacy_local=legacy_root / "skills-local",
+            legacy_repo=legacy_root / "skills-repo",
+            pool_root=pool_root,
+            pool_local=pool_root / "skills-local",
+            pool_repo=pool_root / "skills-repo",
+            marker=pool_root / ".pool-ready",
+        )
+
+
+def _not_capable(
+    engine: str, contract_version: str, reason: str
+) -> RuntimeLayoutInspection:
+    return RuntimeLayoutInspection(
+        status=RuntimeLayoutInspectionStatus.NOT_CAPABLE,
+        engine=engine,
+        layout_contract_version=contract_version,
+        preparation_id=None,
+        evidence={"reason": reason},
+    )
+
+
+def _invalid(
+    *,
+    engine: str,
+    contract_version: str,
+    layout: _OpenClawLayout,
+    reason: str,
+    preparation_id: str | None = None,
+    checks: dict[str, bool] | None = None,
+) -> RuntimeLayoutInspection:
+    evidence: dict[str, Any] = {
+        "reason": reason,
+        "marker": str(layout.marker),
+    }
+    if checks is not None:
+        evidence["checks"] = checks
+    return RuntimeLayoutInspection(
+        status=RuntimeLayoutInspectionStatus.INVALID,
+        engine=engine,
+        layout_contract_version=contract_version,
+        preparation_id=preparation_id,
+        evidence=evidence,
+    )
+
+
+def _transient(
+    *,
+    engine: str,
+    contract_version: str,
+    layout: _OpenClawLayout,
+    reason: str,
+    error: OSError,
+    preparation_id: str | None = None,
+) -> RuntimeLayoutInspection:
+    return RuntimeLayoutInspection(
+        status=RuntimeLayoutInspectionStatus.TRANSIENT_ERROR,
+        engine=engine,
+        layout_contract_version=contract_version,
+        preparation_id=preparation_id,
+        evidence={
+            "reason": reason,
+            "marker": str(layout.marker),
+            "error_type": type(error).__name__,
+            "errno": error.errno,
+        },
+    )
+
+
+def _valid_uuid(value: object) -> bool:
+    try:
+        UUID(str(value))
+    except (ValueError, TypeError, AttributeError):
+        return False
+    return True
+
+
+def _valid_timestamp(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None
+
+
+def _lexical_symlink_target(path: Path) -> Path:
+    target = path.readlink()
+    if not target.is_absolute():
+        target = path.parent / target
+    return Path(os.path.abspath(target))
+
+
+def _marker_contract_valid(
+    marker: dict[str, Any],
+    *,
+    layout: _OpenClawLayout,
+    expected_contract_version: str,
+) -> bool:
+    summary = marker.get("validation_summary")
+    if not isinstance(summary, dict):
+        return False
+    bridge = summary.get("legacy_repo_bridge")
+    pool_local = summary.get("pool_local")
+    pool_repo = summary.get("pool_repo")
+    managed = summary.get("managed_active_entries")
+    return (
+        marker.get("engine") == "openclaw"
+        and marker.get("layout_contract_version") == expected_contract_version
+        and _valid_uuid(marker.get("preparation_id"))
+        and _valid_timestamp(marker.get("prepared_at"))
+        and marker.get("pool_local_root") == str(layout.pool_local)
+        and marker.get("pool_repo_root") == str(layout.pool_repo)
+        and summary.get("all_valid") is True
+        and isinstance(pool_local, dict)
+        and pool_local.get("path") == str(layout.pool_local)
+        and pool_local.get("valid") is True
+        and isinstance(pool_repo, dict)
+        and pool_repo.get("path") == str(layout.pool_repo)
+        and pool_repo.get("readable_mount") is True
+        and pool_repo.get("valid") is True
+        and isinstance(bridge, dict)
+        and bridge.get("path") == str(layout.legacy_repo)
+        and bridge.get("target") == str(layout.pool_repo)
+        and bridge.get("valid") is True
+        and isinstance(managed, list)
+    )
+
+
+def _managed_entry_record(
+    entry: Path, layout: _OpenClawLayout
+) -> dict[str, Any] | None:
+    try:
+        entry_stat = entry.lstat()
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISLNK(entry_stat.st_mode):
+        return None
+    target = _lexical_symlink_target(entry)
+    try:
+        relative = target.relative_to(layout.legacy_local)
+        source = "local"
+        pool_target = layout.pool_local / relative
+    except ValueError:
+        try:
+            relative = target.relative_to(layout.legacy_repo)
+            source = "repo"
+            pool_target = layout.pool_repo / relative
+        except ValueError:
+            return None
+    try:
+        entry.stat()
+        valid = True
+    except (FileNotFoundError, NotADirectoryError):
+        valid = False
+    return {
+        "path": str(entry),
+        "source": source,
+        "legacy_target": str(target),
+        "pool_target": str(pool_target),
+        # The marker is a structural capability proof, not a content checksum.
+        # Skills created after preparation are copied by the final-sync task.
+        "valid": valid,
+    }
+
+
+def _managed_entries_valid(marker: dict[str, Any], layout: _OpenClawLayout) -> bool:
+    entries = layout.legacy_root.iterdir()
+    for entry in entries:
+        if entry in (layout.legacy_local, layout.legacy_repo):
+            continue
+        record = _managed_entry_record(entry, layout)
+        if record is not None:
+            if record["valid"] is not True:
+                return False
+
+    declared = marker["validation_summary"]["managed_active_entries"]
+    if any(
+        not isinstance(record, dict)
+        or record.get("source") not in {"local", "repo"}
+        or not isinstance(record.get("path"), str)
+        or not isinstance(record.get("legacy_target"), str)
+        or not isinstance(record.get("pool_target"), str)
+        or record.get("valid") is not True
+        for record in declared
+    ):
+        return False
+    return True
+
+
+def inspect_runtime_layout(
+    *,
+    engine: str,
+    expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
+    home: Path = Path("/home/admin"),
+    repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
+) -> RuntimeLayoutInspection:
+    """Inspect local runtime facts; this function never mutates the filesystem."""
+    if engine == "teclaw":
+        return _not_capable(
+            engine,
+            expected_contract_version,
+            "engine_has_no_filesystem_pool_layout",
+        )
+    if engine != "openclaw":
+        return _not_capable(
+            engine,
+            expected_contract_version,
+            "engine_pool_probe_not_implemented",
+        )
+
+    layout = _OpenClawLayout.for_home(home)
+    try:
+        marker_stat = layout.marker.stat()
+    except (FileNotFoundError, NotADirectoryError):
+        result = _not_capable(
+            engine,
+            expected_contract_version,
+            "pool_ready_marker_absent",
+        )
+        return RuntimeLayoutInspection(
+            status=result.status,
+            engine=result.engine,
+            layout_contract_version=result.layout_contract_version,
+            preparation_id=None,
+            evidence={**result.evidence, "marker": str(layout.marker)},
+        )
+    except PermissionError:
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="marker_unreadable",
+        )
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="marker_temporarily_unreadable",
+            error=error,
+        )
+    if not stat.S_ISREG(marker_stat.st_mode):
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="marker_not_regular_file",
+        )
+    try:
+        marker = json.loads(layout.marker.read_bytes())
+    except PermissionError:
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="marker_unreadable",
+        )
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="marker_temporarily_unreadable",
+            error=error,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="invalid_marker_json",
+        )
+    if not isinstance(marker, dict) or not _marker_contract_valid(
+        marker,
+        layout=layout,
+        expected_contract_version=expected_contract_version,
+    ):
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="marker_contract_mismatch",
+            preparation_id=(
+                str(marker.get("preparation_id"))
+                if isinstance(marker, dict) and marker.get("preparation_id")
+                else None
+            ),
+        )
+
+    preparation_id = str(marker["preparation_id"])
+    try:
+        pool_local_stat = layout.pool_local.lstat()
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        pool_local_stat = None
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="pool_local_temporarily_unavailable",
+            error=error,
+            preparation_id=preparation_id,
+        )
+    if (
+        pool_local_stat is None
+        or stat.S_ISLNK(pool_local_stat.st_mode)
+        or not stat.S_ISDIR(pool_local_stat.st_mode)
+    ):
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="pool_local_invalid",
+            preparation_id=preparation_id,
+        )
+    try:
+        pool_repo_stat = layout.pool_repo.stat()
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        pool_repo_stat = None
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="pool_repo_temporarily_unavailable",
+            error=error,
+            preparation_id=preparation_id,
+        )
+    try:
+        pool_repo_mounted = repo_is_mounted(layout.pool_repo)
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="pool_repo_temporarily_unavailable",
+            error=error,
+            preparation_id=preparation_id,
+        )
+    if (
+        pool_repo_stat is None
+        or not stat.S_ISDIR(pool_repo_stat.st_mode)
+        or not pool_repo_mounted
+    ):
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="pool_repo_not_mounted",
+            preparation_id=preparation_id,
+        )
+    try:
+        with os.scandir(layout.pool_repo):
+            pass
+    except PermissionError:
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="pool_repo_unreadable",
+            preparation_id=preparation_id,
+        )
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="pool_repo_temporarily_unavailable",
+            error=error,
+            preparation_id=preparation_id,
+        )
+    try:
+        legacy_repo_stat = layout.legacy_repo.lstat()
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        legacy_repo_stat = None
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="legacy_repo_bridge_temporarily_unavailable",
+            error=error,
+            preparation_id=preparation_id,
+        )
+    legacy_repo_target = None
+    if legacy_repo_stat is not None and stat.S_ISLNK(legacy_repo_stat.st_mode):
+        try:
+            legacy_repo_target = _lexical_symlink_target(layout.legacy_repo)
+        except OSError as error:
+            return _transient(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="legacy_repo_bridge_temporarily_unavailable",
+                error=error,
+                preparation_id=preparation_id,
+            )
+    if (
+        legacy_repo_stat is None
+        or not stat.S_ISLNK(legacy_repo_stat.st_mode)
+        or legacy_repo_target != layout.pool_repo
+    ):
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="legacy_repo_bridge_invalid",
+            preparation_id=preparation_id,
+        )
+    try:
+        managed_entries_valid = _managed_entries_valid(marker, layout)
+    except PermissionError:
+        managed_entries_valid = False
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="managed_active_entries_temporarily_unavailable",
+            error=error,
+            preparation_id=preparation_id,
+        )
+    if not managed_entries_valid:
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="managed_active_entry_invalid",
+            preparation_id=preparation_id,
+        )
+
+    checks = {
+        "marker_valid": True,
+        "pool_local_valid": True,
+        "pool_repo_mounted": True,
+        "pool_repo_readable": True,
+        "legacy_repo_bridge_valid": True,
+        "managed_active_entries_valid": True,
+    }
+    return RuntimeLayoutInspection(
+        status=RuntimeLayoutInspectionStatus.READY,
+        engine=engine,
+        layout_contract_version=expected_contract_version,
+        preparation_id=preparation_id,
+        evidence={
+            "marker": str(layout.marker),
+            "prepared_at": marker["prepared_at"],
+            "checks": checks,
+        },
+    )
+
+
+__all__ = [
+    "LAYOUT_CONTRACT_VERSION",
+    "RuntimeLayoutInspection",
+    "RuntimeLayoutInspectionStatus",
+    "inspect_runtime_layout",
+]

--- a/src/engine/src/engine/community/core/skills/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/core/skills/tests/test_layout_probe.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import errno
 import json
+import os
 from pathlib import Path
+
+import pytest
 
 from engine.community.core.skills.layout_probe import (
     LAYOUT_CONTRACT_VERSION,
@@ -80,13 +83,9 @@ def test_absent_marker_is_not_capable(tmp_path):
 
 def test_marker_nas_io_error_is_transient(tmp_path, monkeypatch):
     home, _, _, pool_repo = _ready_home(tmp_path)
-    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
-    original_read_bytes = Path.read_bytes
 
-    def fail_marker_read(path):
-        if path == marker_path:
-            raise OSError(errno.ESTALE, "stale NAS handle")
-        return original_read_bytes(path)
+    def fail_marker_read(_path):
+        raise OSError(errno.ESTALE, "stale NAS handle")
 
     monkeypatch.setattr(Path, "read_bytes", fail_marker_read)
 
@@ -103,13 +102,9 @@ def test_marker_nas_io_error_is_transient(tmp_path, monkeypatch):
 
 def test_marker_stat_nas_io_error_is_transient(tmp_path, monkeypatch):
     home, _, _, pool_repo = _ready_home(tmp_path)
-    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
-    original_stat = Path.stat
 
-    def fail_marker_stat(path, *args, **kwargs):
-        if path == marker_path:
-            raise OSError(errno.ESTALE, "stale NAS handle")
-        return original_stat(path, *args, **kwargs)
+    def fail_marker_stat(_path, *_args, **_kwargs):
+        raise OSError(errno.ESTALE, "stale NAS handle")
 
     monkeypatch.setattr(Path, "stat", fail_marker_stat)
 
@@ -320,3 +315,125 @@ def test_teclaw_is_noop_without_touching_home(tmp_path):
 
     assert result.status is RuntimeLayoutInspectionStatus.NOT_CAPABLE
     assert result.evidence["reason"] == "engine_has_no_filesystem_pool_layout"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("preparation_id", "not-a-uuid"),
+        ("prepared_at", None),
+        ("prepared_at", "not-a-timestamp"),
+    ],
+)
+def test_marker_contract_rejects_invalid_identity_or_timestamp(
+    tmp_path, field, value
+):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
+    marker = json.loads(marker_path.read_text())
+    marker[field] = value
+    marker_path.write_text(json.dumps(marker))
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "marker_contract_mismatch"
+
+
+def test_marker_contract_rejects_non_dict_validation_summary(tmp_path):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
+    marker = json.loads(marker_path.read_text())
+    marker["validation_summary"] = []
+    marker_path.write_text(json.dumps(marker))
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "marker_contract_mismatch"
+
+
+def test_relative_repo_bridge_target_is_accepted(tmp_path):
+    home, legacy_root, _, pool_repo = _ready_home(tmp_path)
+    bridge = legacy_root / "skills-repo"
+    bridge.unlink()
+    bridge.symlink_to(
+        os.path.relpath(pool_repo, start=bridge.parent),
+        target_is_directory=True,
+    )
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_repo_and_external_active_entries_preserve_ready_status(tmp_path):
+    home, legacy_root, _, pool_repo = _ready_home(tmp_path)
+    (pool_repo / "repo-skill").mkdir()
+    repo_active = legacy_root / "repo-skill"
+    repo_active.symlink_to(
+        legacy_root / "skills-repo" / "repo-skill",
+        target_is_directory=True,
+    )
+    external_skill = tmp_path / "external-skill"
+    external_skill.mkdir()
+    (legacy_root / "external-skill").symlink_to(
+        external_skill,
+        target_is_directory=True,
+    )
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_invalid_declared_managed_entry_is_rejected(tmp_path):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
+    marker = json.loads(marker_path.read_text())
+    marker["validation_summary"]["managed_active_entries"] = [
+        {"source": "unknown"}
+    ]
+    marker_path.write_text(json.dumps(marker))
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "managed_active_entry_invalid"
+
+
+def test_other_engine_is_not_capable_without_touching_home(tmp_path):
+    result = inspect_runtime_layout(
+        engine="claude_code",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=tmp_path / "missing",
+        repo_is_mounted=lambda _path: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.NOT_CAPABLE
+    assert result.evidence["reason"] == "engine_pool_probe_not_implemented"

--- a/src/engine/src/engine/community/core/skills/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/core/skills/tests/test_layout_probe.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import errno
+import json
+from pathlib import Path
+
+from engine.community.core.skills.layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+    RuntimeLayoutInspectionStatus,
+    inspect_runtime_layout,
+)
+
+
+def _ready_home(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    home = tmp_path / "home" / "admin"
+    legacy_root = home / ".openclaw" / "workspace" / "skills"
+    pool_root = home / ".openclaw" / "workspace" / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+    legacy_repo = legacy_root / "skills-repo"
+    pool_local.mkdir(parents=True)
+    pool_repo.mkdir()
+    legacy_root.mkdir(parents=True, exist_ok=True)
+    legacy_repo.symlink_to(pool_repo, target_is_directory=True)
+    marker = {
+        "engine": "openclaw",
+        "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+        "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+        "prepared_at": "2026-07-23T06:00:00Z",
+        "pool_local_root": str(pool_local),
+        "pool_repo_root": str(pool_repo),
+        "validation_summary": {
+            "all_valid": True,
+            "pool_local": {"path": str(pool_local), "valid": True},
+            "pool_repo": {
+                "path": str(pool_repo),
+                "readable_mount": True,
+                "valid": True,
+            },
+            "legacy_repo_bridge": {
+                "path": str(legacy_repo),
+                "target": str(pool_repo),
+                "valid": True,
+            },
+            "managed_active_entries": [],
+            "external_active_entry_count": 0,
+        },
+    }
+    (pool_root / ".pool-ready").write_text(json.dumps(marker))
+    return home, legacy_root, pool_local, pool_repo
+
+
+def test_ready_requires_real_bridge_mount_and_readable_repo(tmp_path):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+    assert result.preparation_id == "2a958f59-8cf4-4413-a267-7d56d3382f23"
+    assert result.evidence["checks"]["pool_repo_mounted"] is True
+    assert result.evidence["checks"]["legacy_repo_bridge_valid"] is True
+
+
+def test_absent_marker_is_not_capable(tmp_path):
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=tmp_path,
+        repo_is_mounted=lambda _path: False,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.NOT_CAPABLE
+    assert result.evidence["reason"] == "pool_ready_marker_absent"
+
+
+def test_marker_nas_io_error_is_transient(tmp_path, monkeypatch):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
+    original_read_bytes = Path.read_bytes
+
+    def fail_marker_read(path):
+        if path == marker_path:
+            raise OSError(errno.ESTALE, "stale NAS handle")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fail_marker_read)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.TRANSIENT_ERROR
+    assert result.evidence["reason"] == "marker_temporarily_unreadable"
+
+
+def test_marker_stat_nas_io_error_is_transient(tmp_path, monkeypatch):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
+    original_stat = Path.stat
+
+    def fail_marker_stat(path, *args, **kwargs):
+        if path == marker_path:
+            raise OSError(errno.ESTALE, "stale NAS handle")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fail_marker_stat)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.TRANSIENT_ERROR
+    assert result.evidence["reason"] == "marker_temporarily_unreadable"
+
+
+def test_readable_directory_without_mount_is_invalid(tmp_path):
+    home, _, _, _ = _ready_home(tmp_path)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda _path: False,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "pool_repo_not_mounted"
+
+
+def test_repo_mount_io_error_is_transient(tmp_path):
+    home, _, _, _ = _ready_home(tmp_path)
+
+    def fail_mount_probe(_path):
+        raise OSError(errno.EIO, "OSSFS temporarily unavailable")
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=fail_mount_probe,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.TRANSIENT_ERROR
+    assert result.evidence["reason"] == "pool_repo_temporarily_unavailable"
+
+
+def test_bridge_replaced_by_directory_is_invalid(tmp_path):
+    home, legacy_root, _, pool_repo = _ready_home(tmp_path)
+    bridge = legacy_root / "skills-repo"
+    bridge.unlink()
+    bridge.mkdir()
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "legacy_repo_bridge_invalid"
+
+
+def test_managed_active_entry_drift_is_invalid(tmp_path):
+    home, legacy_root, pool_local, pool_repo = _ready_home(tmp_path)
+    pool_skill = pool_local / "handmade"
+    pool_skill.mkdir()
+    legacy_local = legacy_root / "skills-local"
+    legacy_local.mkdir()
+    legacy_skill = legacy_local / "handmade"
+    legacy_skill.mkdir()
+    active = legacy_root / "handmade"
+    active.symlink_to(legacy_skill, target_is_directory=True)
+
+    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
+    marker = json.loads(marker_path.read_text())
+    marker["validation_summary"]["managed_active_entries"] = [
+        {
+            "path": str(active),
+            "source": "local",
+            "legacy_target": str(legacy_skill),
+            "pool_target": str(pool_skill),
+            "valid": True,
+        }
+    ]
+    marker_path.write_text(json.dumps(marker))
+    active.unlink()
+    active.symlink_to(legacy_local / "missing", target_is_directory=True)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "managed_active_entry_invalid"
+
+
+def test_managed_active_entry_nas_io_error_is_transient(tmp_path, monkeypatch):
+    home, legacy_root, _, pool_repo = _ready_home(tmp_path)
+    legacy_local = legacy_root / "skills-local"
+    legacy_skill = legacy_local / "handmade"
+    legacy_skill.mkdir(parents=True)
+    active = legacy_root / "handmade"
+    active.symlink_to(legacy_skill, target_is_directory=True)
+    original_lstat = Path.lstat
+
+    def fail_active_lstat(path):
+        if path == active:
+            raise OSError(errno.ESTALE, "stale NAS handle")
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", fail_active_lstat)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.TRANSIENT_ERROR
+    assert (
+        result.evidence["reason"]
+        == "managed_active_entries_temporarily_unavailable"
+    )
+
+
+def test_deactivating_prepared_managed_entry_does_not_invalidate_marker(tmp_path):
+    home, legacy_root, pool_local, pool_repo = _ready_home(tmp_path)
+    pool_skill = pool_local / "handmade"
+    pool_skill.mkdir()
+    legacy_local = legacy_root / "skills-local"
+    legacy_local.mkdir()
+    legacy_skill = legacy_local / "handmade"
+    legacy_skill.mkdir()
+    active = legacy_root / "handmade"
+    active.symlink_to(legacy_skill, target_is_directory=True)
+    marker_path = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-ready"
+    marker = json.loads(marker_path.read_text())
+    marker["validation_summary"]["managed_active_entries"] = [
+        {
+            "path": str(active),
+            "source": "local",
+            "legacy_target": str(legacy_skill),
+            "pool_target": str(pool_skill),
+            "valid": True,
+        }
+    ]
+    marker_path.write_text(json.dumps(marker))
+    active.unlink()
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_new_managed_entry_can_wait_for_final_sync(tmp_path):
+    home, legacy_root, _, pool_repo = _ready_home(tmp_path)
+    legacy_local = legacy_root / "skills-local"
+    legacy_local.mkdir()
+    legacy_skill = legacy_local / "created-after-preparation"
+    legacy_skill.mkdir()
+    active = legacy_root / "created-after-preparation"
+    active.symlink_to(legacy_skill, target_is_directory=True)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_pool_local_symlink_is_not_a_canonical_directory(tmp_path):
+    home, _, pool_local, pool_repo = _ready_home(tmp_path)
+    external = tmp_path / "external-local"
+    external.mkdir()
+    pool_local.rmdir()
+    pool_local.symlink_to(external, target_is_directory=True)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "pool_local_invalid"
+
+
+def test_teclaw_is_noop_without_touching_home(tmp_path):
+    result = inspect_runtime_layout(
+        engine="teclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=tmp_path / "missing",
+        repo_is_mounted=lambda _path: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.NOT_CAPABLE
+    assert result.evidence["reason"] == "engine_has_no_filesystem_pool_layout"


### PR DESCRIPTION
## 变更说明

- 新增 Engine 侧只读 Current Runtime Layout Probe，校验 marker、Pool local/repo、Legacy repo bridge 与受管 active entry
- 新增 Backend 四态编排：READY / NOT_CAPABLE / TRANSIENT_ERROR / INVALID，并基于当前 binding 调用运行实例
- 对旧镜像的 probe 404 增加 /health 存活确认，避免把代理目标缺失误判为 NOT_CAPABLE
- 增加版本化强类型响应契约，以及真实 Engine schema 输出到 Backend parser 的跨边界测试
- Teclaw 明确保持 no-op；本 PR 不执行 Pool 激活、mapping 或 DB locator 切换

## 兼容性

- 新 Backend 兼容新旧镜像：旧镜像无 endpoint 时在确认 adapter 存活后返回 NOT_CAPABLE
- NAS/OSSFS 的 EIO/ESTALE/超时归为 TRANSIENT_ERROR；结构损坏归为 INVALID
- marker 只证明结构能力，不冻结日常 skill 内容；准备后新增 local skill 留给后续 final-sync

## 验证

- Backend community: 8601 passed
- Engine community: 1894 passed, 5 skipped
- Backend architecture + focused: 117 passed
- OCB image preparation: 10 passed
- OCB production transport: 27 passed
- Ruff / bash -n / git diff --check: passed
- Spec 与工程标准双轴复核：零剩余 actionable finding

Fixes #368