### PR TITLE
fix(ci): auto-infer base ref in ci_test.sh for changed-line-coverage gate

### DIFF
--- a/src/baas/scripts/ci_test.sh
+++ b/src/baas/scripts/ci_test.sh
@@ -22,6 +22,14 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  # Auto-infer base ref so that local `just test` / bare `ci_test.sh` also
+  # enforces the changed-line-coverage gate, matching GitHub CI behavior.
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+  fi
+fi
+
 if [[ ! -d "$baas_dir" ]]; then
   echo "baas CI failed: community package not found: $baas_dir" >&2
   exit 1

--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -41,6 +41,14 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  # Auto-infer base ref so that local `just test` / bare `ci_test.sh` also
+  # enforces the changed-line-coverage gate, matching GitHub CI behavior.
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+  fi
+fi
+
 cd "$backend_dir"
 mkdir -p "$report_dir"
 

--- a/src/engine/scripts/ci_test.sh
+++ b/src/engine/scripts/ci_test.sh
@@ -21,6 +21,14 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  # Auto-infer base ref so that local `just test` / bare `ci_test.sh` also
+  # enforces the changed-line-coverage gate, matching GitHub CI behavior.
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+  fi
+fi
+
 cd "$engine_dir"
 if [[ -z "$python_bin" ]]; then
   echo "engine CI failed: neither python nor python3 found" >&2

--- a/src/gateway/scripts/ci_test.sh
+++ b/src/gateway/scripts/ci_test.sh
@@ -21,6 +21,14 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$base" ]]; then
+  # Auto-infer base ref so that local `just test` / bare `ci_test.sh` also
+  # enforces the changed-line-coverage gate, matching GitHub CI behavior.
+  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+    base="$(git merge-base "$head" origin/dev)"
+  fi
+fi
+
 if [[ ! -d "$gateway_dir" ]]; then
   echo "gateway CI failed: community package not found: $gateway_dir" >&2
   exit 1


### PR DESCRIPTION
## Problem

When `ci_test.sh` is run without `--base` (e.g. via `just test` or bare invocation), the changed-line-coverage gate is skipped. GitHub CI always passes `--base` and enforces the gate, causing local tests to pass while CI fails on coverage, wasting developer time.

## Solution

Add auto-inference of the base ref using `git merge-base HEAD origin/dev` when `--base` is not explicitly provided, so the changed-line-coverage gate also runs locally. Falls back gracefully when `origin/dev` is not available.

## Changed Files

- `src/backend/scripts/ci_test.sh` — +8 lines: base auto-inference block
- `src/baas/scripts/ci_test.sh` — +8 lines: base auto-inference block
- `src/engine/scripts/ci_test.sh` — +8 lines: base auto-inference block
- `src/gateway/scripts/ci_test.sh` — +8 lines: base auto-inference block

## Verification

- `bash -n` syntax check passes for all 4 scripts
- Logic matches existing `scripts/ci/pre_push.sh` pattern
- No credential or internal reference leaks
- Graceful degradation when `origin/dev` is not available

## Review

Three independent reviews (correctness, security, quality) — all passed with no blocking findings.

## Cross-repo

OCB syncs via mirror/gitlink after this PR is merged. No separate OCB PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)