### PR TITLE
fix(engine): sort favorite sessions by favorited time

### DIFF
--- a/src/engine/src/engine/community/api/session_favorites/router.py
+++ b/src/engine/src/engine/community/api/session_favorites/router.py
@@ -42,8 +42,8 @@ async def list_session_favorites(
     warning = check_capability(Capability.SESSION_LIST)
     try:
         repository = get_session_favorite_repository()
-        favorite_session_ids = set(
-            await asyncio.to_thread(repository.list_session_ids, resolved_user_id)
+        favorite_session_ids = await asyncio.to_thread(
+            repository.list_session_ids, resolved_user_id
         )
         if not favorite_session_ids:
             return ApiResponse(success=True, data=[], warning=warning)
@@ -57,9 +57,15 @@ async def list_session_favorites(
                 offset=0,
             )
         )
+        # Engines own their session ordering, so restore the SQLite favorite
+        # order before applying favorite-list pagination.
+        favorite_rank = {
+            session_id: index for index, session_id in enumerate(favorite_session_ids)
+        }
         favorite_sessions = [
-            session for session in sessions if session.id in favorite_session_ids
+            session for session in sessions if session.id in favorite_rank
         ]
+        favorite_sessions.sort(key=lambda session: favorite_rank[session.id])
         paged_sessions = favorite_sessions[offset:offset + limit]
         return ApiResponse(
             success=True,

--- a/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
+++ b/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
@@ -55,7 +55,7 @@ def test_list_returns_full_session_data_for_current_users_favorites(
     repository,
     session_api,
 ):
-    repository.list_session_ids.return_value = ["session-1", "session-3"]
+    repository.list_session_ids.return_value = ["session-3", "session-1"]
     session_api.list = AsyncMock(return_value=[
         _make_session("session-1"),
         _make_session("session-2"),
@@ -71,8 +71,8 @@ def test_list_returns_full_session_data_for_current_users_favorites(
     body = response.json()
     assert body["success"] is True
     assert body["data"] == [{
-        "id": "session-3",
-        "title": "Title for session-3",
+        "id": "session-1",
+        "title": "Title for session-1",
         "user_id": "user-a",
         "agent_id": "main",
         "model": None,

--- a/src/engine/src/engine/community/core/session_favorite/repository.py
+++ b/src/engine/src/engine/community/core/session_favorite/repository.py
@@ -25,6 +25,7 @@ class SessionFavoriteRepository:
         self._initialized = False
 
     def list_session_ids(self, user_id: str) -> list[str]:
+        """Return session IDs with the most recently favorited session first."""
         self._ensure_initialized()
         with self._connect() as connection:
             # 以下为安全注释COSEC：使用参数化查询防止 SQL 注入，禁止字符串拼接
@@ -33,7 +34,7 @@ class SessionFavoriteRepository:
                 SELECT session_id
                 FROM session_favorites
                 WHERE user_id = ?
-                ORDER BY created_at ASC
+                ORDER BY created_at DESC, rowid DESC
                 """,
                 (user_id,),
             ).fetchall()

--- a/src/engine/src/engine/community/core/session_favorite/tests/test_repository.py
+++ b/src/engine/src/engine/community/core/session_favorite/tests/test_repository.py
@@ -15,7 +15,7 @@ def test_add_list_and_remove_are_scoped_to_user(tmp_path):
     repository.add("user-a", "session-2")
     repository.add("user-b", "session-1")
 
-    assert repository.list_session_ids("user-a") == ["session-1", "session-2"]
+    assert repository.list_session_ids("user-a") == ["session-2", "session-1"]
     assert repository.list_session_ids("user-b") == ["session-1"]
 
     assert repository.remove("user-a", "session-1") is True


### PR DESCRIPTION
## Summary

- return favorite session IDs in reverse favorited-time order with deterministic ordering for favorites created in the same second
- restore the SQLite favorite order after engine session enrichment and before applying pagination
- keep the `/api/sessions` ordering and the session-favorites response schema unchanged

## Testing

- `PYTHONPATH=src uv run --with pytest --with pytest-asyncio python -m pytest src/engine/community/api/tests/test_session_router.py src/engine/community/core/session_favorite/tests/test_repository.py src/engine/community/api/session_favorites/tests/test_router.py -q` (`68 passed`)
- changed executable lines: `100%` covered; affected modules: `98%` combined coverage
- `uv run --with ruff ruff check ...`
- `git diff --check origin/REL20260723`