### PR TITLE
log(baas): surface gateway redirect Location on ws-info HTTP errors

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -1853,9 +1853,22 @@ class BaasService:  # pragma: no cover
             # only floods the alarm/ticket pipeline. Whether a failure is truly
             # alarm-worthy is the caller's call, made where the business context
             # is known.
+            #
+            # The BaaS app only ever answers this endpoint with JSON
+            # (200/404/503/500); a 3xx status here is injected by the fronting
+            # gateway (Spanner) before the request reaches BaaS. Its ``Location``
+            # says where the request is being redirected (login/SSO host vs a
+            # moved route), and bot_uuid/tenant/device_affinity let us cluster
+            # intermittent redirects by bot/tenant/target device — the data
+            # needed to tell a partial-instance/routing fault apart from a
+            # blanket auth requirement.
+            location = e.response.headers.get("location")
             logger.warning(
                 f"[BaasService.get_ws_info_by_bot_uuid] "
-                f"HTTP error: {e.response.status_code} - {e.response.text}"
+                f"HTTP error: {e.response.status_code} - "
+                f"bot_uuid={bot_uuid}, tenant={effective_tenant}, "
+                f"device_affinity={device_affinity}, location={location!r} - "
+                f"{e.response.text}"
             )
             raise BaasServiceError(
                 f"BaaS API error: {e.response.status_code} - {e.response.text}"

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_ws_info_logging.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_ws_info_logging.py
@@ -24,9 +24,14 @@ from agentclaw.community.core.service_bot.services.baas_service import (
 )
 
 
-def _make_service_raising(status_code: int, body: str) -> BaasService:
+def _make_service_raising(
+    status_code: int, body: str, headers: dict[str, str] | None = None
+) -> BaasService:
     """BaasService whose injected http_client.get(...).raise_for_status() raises
     an httpx.HTTPStatusError — the path get_ws_info classifies as an HTTP error.
+
+    ``headers`` seeds the raising response's headers (e.g. a gateway ``Location``
+    on a 3xx redirect) so tests can assert what the warning log surfaces.
     """
     binding = MagicMock()
     binding.device_id = "BOT-xyz"
@@ -34,7 +39,9 @@ def _make_service_raising(status_code: int, body: str) -> BaasService:
     binding_repo.get_by_id.return_value = binding
 
     request = httpx.Request("GET", "http://baas.test/api/v1/bots/BOT-xyz/ws-info")
-    response = httpx.Response(status_code, request=request, text=body)
+    response = httpx.Response(
+        status_code, request=request, text=body, headers=headers or {}
+    )
     err = httpx.HTTPStatusError(f"{status_code}", request=request, response=response)
     http_resp = MagicMock()
     http_resp.raise_for_status.side_effect = err
@@ -105,3 +112,28 @@ class TestGetWsInfoErrorLogging:
         service = _make_service_raising(500, "boom")
         with pytest.raises(BaasServiceError):
             service.get_ws_info(bind_id=1)
+
+    def test_302_redirect_logs_location_and_correlation_fields(self):
+        """A gateway 302 (Spanner) must surface the redirect ``Location`` plus
+        bot_uuid/tenant/device_affinity in the WARNING log, so intermittent
+        redirects can be clustered and the redirect target inspected.
+        """
+        body = (
+            '<html><head><title>302 Found</title></head>'
+            '<body><h1>302 Found</h1><hr/>Powered by Spanner</body></html>'
+        )
+        location = "https://login.example.com/sso?back=/api/v1/bots"
+        service = _make_service_raising(302, body, headers={"Location": location})
+        with patch(
+            "agentclaw.community.core.service_bot.services.baas_service.logger"
+        ) as spy:
+            with pytest.raises(BaasServiceError):
+                service.get_ws_info(bind_id=1, device_affinity="500207")
+
+        warnings = _ws_info_logged_calls(spy, "warning")
+        assert warnings, "302 should log at WARNING"
+        assert not _ws_info_logged_calls(spy, "error"), "302 must NOT log at ERROR"
+        logged = str(warnings[0].args[0])
+        assert location in logged, "redirect Location must be in the warning log"
+        assert "bot_uuid=BOT-xyz" in logged
+        assert "device_affinity=500207" in logged


### PR DESCRIPTION
## Why

Production `ws-info` lookups are intermittently failing with `302 Found` responses whose body is a generic `Powered by Spanner` HTML page:

```
[BaasService.get_ws_info_by_bot_uuid] HTTP error: 302 - <!DOCTYPE HTML ...> ... Powered by Spanner ...
```

The BaaS `ws-info` endpoint (`src/baas/.../bot_service/wss_router.py`) only ever answers with JSON (`200/404/503/500`) and requires **no** auth header — so a `3xx` here is injected by the **Spanner gateway in front of secbaas**, before the request reaches BaaS. Because the failures are intermittent (most `ws-info` calls succeed), the cause is not a blanket auth requirement — it's a *conditional* redirect (a partial-instance/routing fault, a deploy window, or route-specific redirect).

The current warning log gives no way to investigate this: it drops the `Location` header (where the redirect points) and carries no correlation fields (which bot/tenant/device the failing call was for).

## What

Enrich the `httpx.HTTPStatusError` warning in `get_ws_info_by_bot_uuid` to log:

- the redirect **`Location`** header — reveals whether Spanner is bouncing to a login/SSO host vs a moved route;
- **`bot_uuid`**, **`tenant`**, **`device_affinity`** — let intermittent redirects be clustered by bot / tenant / target device.

Together this is enough to distinguish a partial routing/instance fault from an auth (SSO) redirect on the next occurrence.

The raised `BaasServiceError` message is **unchanged**, so downstream error handling and callers are untouched. This is a log-only change.

## Testing

`tests/community/core/service_bot/services/test_baas_service_ws_info_logging.py`:

- Existing 404/503 WARNING-not-ERROR contract tests still pass.
- Added `test_302_redirect_logs_location_and_correlation_fields`: a `302` with a `Location` header must surface that `Location` plus `bot_uuid`/`device_affinity` in the warning log, and still log at WARNING (not ERROR).

```
4 passed in 0.07s
```

## Notes

This is a diagnostic aid, not a fix — it makes the next production occurrence self-explaining so we can confirm the root cause (gateway routing vs SSO). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0151iGxqFZoPczDxGqXC8vPD)_