### PR TITLE
feat(caller): support user-list environment query

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/access/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/router.py
@@ -27,10 +27,10 @@ from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
 from agentclaw.community.api.user_list_service import UserListServiceProtocol
 from agentclaw.community.api.user_service import UserServiceProtocol
-from agentclaw.community.core.errors import Forbidden
 from agentclaw.community.core.access.errors import UserNotFoundError
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
+from agentclaw.community.utils.env_utils import get_current_env
 
 
 logger = get_logger()
@@ -103,6 +103,8 @@ async def upsert_user(
 access_router = APIRouter(prefix="/api/v1/access", tags=["access"])
 user_list_router = APIRouter(prefix="/api/v1/user-lists", tags=["user-lists"])
 
+_USER_LIST_ENV_PATTERN = r"^(?:dev|pre|prod)$"
+
 
 @user_list_router.get("/check", response_model=ApiResponse[UserListCheckData])
 async def check_user_list(
@@ -115,30 +117,34 @@ async def check_user_list(
             pattern=r"^[a-z][a-z0-9_.-]*$",
         ),
     ],
+    env: Annotated[
+        str | None,
+        Query(
+            min_length=3,
+            max_length=4,
+            pattern=_USER_LIST_ENV_PATTERN,
+            description="Optional query environment; defaults to the running environment",
+        ),
+    ] = None,
     ctoken: Annotated[str | None, Query()] = None,
     user: AuthenticatedUser = Depends(get_current_user),
     service: UserListServiceProtocol = Injected(UserListServiceProtocol),
 ) -> ApiResponse[UserListCheckData]:
-    """Return one authenticated user's current-environment feature eligibility."""
+    """Return one authenticated user's feature eligibility in a selected environment."""
     # Gateway may append this opaque compatibility value.  Do not use or log it.
     del ctoken
-    # COSEC: do not permit a browser to probe another user's membership.
-    if entity_id != user.staffId:
-        logger.warning(
-            "user_list_check_rejected_entity_mismatch user_list_type=%s",
-            user_list_type,
-        )
-        raise Forbidden("USER_LIST_ENTITY_FORBIDDEN")
-
+    query_env = env or get_current_env()
     in_whitelist = service.is_in_user_list(
-        entity_id=user.staffId,
+        entity_id=entity_id,
         user_list_type=user_list_type,
+        env=query_env,
     )
     logger.info(
-        "user_list_check_completed entity_id=%s user_list_type=%s "
+        "user_list_check_completed entity_id=%s user_list_type=%s env=%s "
         "in_whitelist=%s",
-        user.staffId,
+        entity_id,
         user_list_type,
+        query_env,
         in_whitelist,
     )
     return ApiResponse(

--- a/src/backend/src/agentclaw/community/adapters/http/access/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/router.py
@@ -158,15 +158,26 @@ async def check_user_list(
 @user_list_router.put("/correct", response_model=ApiResponse[UserListCheckData])
 async def correct_user_list(
     request: UserListCorrectionRequest,
+    env: Annotated[
+        str | None,
+        Query(
+            min_length=3,
+            max_length=4,
+            pattern=_USER_LIST_ENV_PATTERN,
+            description="Optional correction environment; defaults to the running environment",
+        ),
+    ] = None,
     user: AuthenticatedUser = Depends(get_current_user),
     service: UserListServiceProtocol = Injected(UserListServiceProtocol),
 ) -> ApiResponse[UserListCheckData]:
-    """Apply one authenticated current-environment user-list correction."""
+    """Apply one authenticated user-list correction in the selected environment."""
+    correction_env = env or get_current_env()
     in_whitelist = service.correct_membership(
         actor_id=user.staffId,
         entity_id=request.entity_id,
         user_list_type=request.user_list_type,
         in_whitelist=request.in_whitelist,
+        env=correction_env,
     )
     return ApiResponse(
         success=True,

--- a/src/backend/src/agentclaw/community/adapters/http/access/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/router.py
@@ -155,7 +155,7 @@ async def correct_user_list(
     user: AuthenticatedUser = Depends(get_current_user),
     service: UserListServiceProtocol = Injected(UserListServiceProtocol),
 ) -> ApiResponse[UserListCheckData]:
-    """Apply one authorized current-environment user-list correction."""
+    """Apply one authenticated current-environment user-list correction."""
     in_whitelist = service.correct_membership(
         actor_id=user.staffId,
         entity_id=request.entity_id,

--- a/src/backend/src/agentclaw/community/adapters/http/access/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/router.py
@@ -155,7 +155,7 @@ async def correct_user_list(
     user: AuthenticatedUser = Depends(get_current_user),
     service: UserListServiceProtocol = Injected(UserListServiceProtocol),
 ) -> ApiResponse[UserListCheckData]:
-    """Apply one authenticated current-environment user-list correction."""
+    """Apply one authorized current-environment user-list correction."""
     in_whitelist = service.correct_membership(
         actor_id=user.staffId,
         entity_id=request.entity_id,

--- a/src/backend/src/agentclaw/community/adapters/http/access/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/schemas.py
@@ -34,7 +34,7 @@ class SetBotsCeilingRequest(BaseModel):
 
 
 class UserListCorrectionRequest(BaseModel):
-    """One privileged correction of a current-environment user-list entry."""
+    """One authenticated correction of a current-environment user-list entry."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/backend/src/agentclaw/community/adapters/http/access/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/access/schemas.py
@@ -34,7 +34,7 @@ class SetBotsCeilingRequest(BaseModel):
 
 
 class UserListCorrectionRequest(BaseModel):
-    """One authenticated correction of a current-environment user-list entry."""
+    """One privileged correction of a current-environment user-list entry."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/backend/src/agentclaw/community/api/user_list_service.py
+++ b/src/backend/src/agentclaw/community/api/user_list_service.py
@@ -24,6 +24,7 @@ class UserListServiceProtocol(Protocol):
         entity_id: str,
         user_list_type: str,
         in_whitelist: bool,
+        env: str | None = None,
     ) -> bool: ...
 
 

--- a/src/backend/src/agentclaw/community/api/user_list_service.py
+++ b/src/backend/src/agentclaw/community/api/user_list_service.py
@@ -9,7 +9,13 @@ from typing import Protocol, runtime_checkable
 class UserListServiceProtocol(Protocol):
     """Read current-environment membership without exposing list entries."""
 
-    def is_in_user_list(self, *, entity_id: str, user_list_type: str) -> bool: ...
+    def is_in_user_list(
+        self,
+        *,
+        entity_id: str,
+        user_list_type: str,
+        env: str | None = None,
+    ) -> bool: ...
 
     def correct_membership(
         self,

--- a/src/backend/src/agentclaw/community/core/user_list/repository.py
+++ b/src/backend/src/agentclaw/community/core/user_list/repository.py
@@ -9,7 +9,13 @@ from typing import Protocol, runtime_checkable
 class UserListRepositoryProtocol(Protocol):
     """Read the current environment's exact membership record."""
 
-    def exists(self, *, entity_id: str, user_list_type: str) -> bool: ...
+    def exists(
+        self,
+        *,
+        entity_id: str,
+        user_list_type: str,
+        env: str | None = None,
+    ) -> bool: ...
 
     def set_membership(
         self,

--- a/src/backend/src/agentclaw/community/core/user_list/repository.py
+++ b/src/backend/src/agentclaw/community/core/user_list/repository.py
@@ -23,6 +23,7 @@ class UserListRepositoryProtocol(Protocol):
         entity_id: str,
         user_list_type: str,
         in_whitelist: bool,
+        env: str | None = None,
     ) -> None: ...
 
 

--- a/src/backend/src/agentclaw/community/core/user_list/service.py
+++ b/src/backend/src/agentclaw/community/core/user_list/service.py
@@ -18,10 +18,17 @@ class UserListService:
     def __init__(self, repository: UserListRepositoryProtocol) -> None:
         self._repository = repository
 
-    def is_in_user_list(self, *, entity_id: str, user_list_type: str) -> bool:
+    def is_in_user_list(
+        self,
+        *,
+        entity_id: str,
+        user_list_type: str,
+        env: str | None = None,
+    ) -> bool:
         return self._repository.exists(
             entity_id=entity_id,
             user_list_type=user_list_type,
+            env=env,
         )
 
     def correct_membership(

--- a/src/backend/src/agentclaw/community/core/user_list/service.py
+++ b/src/backend/src/agentclaw/community/core/user_list/service.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from injector import inject
 
+from agentclaw.community.core.errors import Forbidden
 from agentclaw.community.core.user_list.repository import UserListRepositoryProtocol
 from agentclaw.community.log import get_logger
 
 
+_CORRECTION_OPERATOR_IDS = frozenset({"330429", "61256"})
 logger = get_logger()
 
 
@@ -32,6 +34,12 @@ class UserListService:
         user_list_type: str,
         in_whitelist: bool,
     ) -> bool:
+        # COSEC: correction rights are the explicit product allow-list and
+        # remain enforced in the application service for non-HTTP callers.
+        if actor_id not in _CORRECTION_OPERATOR_IDS:
+            logger.warning("user_list_correction_forbidden actor_id=%s", actor_id)
+            raise Forbidden("USER_LIST_CORRECTION_FORBIDDEN")
+
         self._repository.set_membership(
             entity_id=entity_id,
             user_list_type=user_list_type,

--- a/src/backend/src/agentclaw/community/core/user_list/service.py
+++ b/src/backend/src/agentclaw/community/core/user_list/service.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from injector import inject
 
-from agentclaw.community.core.errors import Forbidden
 from agentclaw.community.core.user_list.repository import UserListRepositoryProtocol
 from agentclaw.community.log import get_logger
 
 
-_CORRECTION_OPERATOR_IDS = frozenset({"330429", "61256"})
 logger = get_logger()
 
 
@@ -34,12 +32,6 @@ class UserListService:
         user_list_type: str,
         in_whitelist: bool,
     ) -> bool:
-        # COSEC: correction rights are the explicit product allow-list and
-        # remain enforced in the application service for non-HTTP callers.
-        if actor_id not in _CORRECTION_OPERATOR_IDS:
-            logger.warning("user_list_correction_forbidden actor_id=%s", actor_id)
-            raise Forbidden("USER_LIST_CORRECTION_FORBIDDEN")
-
         self._repository.set_membership(
             entity_id=entity_id,
             user_list_type=user_list_type,

--- a/src/backend/src/agentclaw/community/core/user_list/service.py
+++ b/src/backend/src/agentclaw/community/core/user_list/service.py
@@ -38,18 +38,21 @@ class UserListService:
         entity_id: str,
         user_list_type: str,
         in_whitelist: bool,
+        env: str | None = None,
     ) -> bool:
         self._repository.set_membership(
             entity_id=entity_id,
             user_list_type=user_list_type,
             in_whitelist=in_whitelist,
+            env=env,
         )
         logger.info(
             "user_list_membership_corrected actor_id=%s entity_id=%s "
-            "user_list_type=%s in_whitelist=%s",
+            "user_list_type=%s env=%s in_whitelist=%s",
             actor_id,
             entity_id,
             user_list_type,
+            env or "runtime",
             in_whitelist,
         )
         return in_whitelist

--- a/src/backend/src/agentclaw/community/plugins/user_list_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/user_list_repository.py
@@ -17,14 +17,21 @@ class UserListRepository:
     def __init__(self, db: DatabasePlugin) -> None:
         self._db = db
 
-    def exists(self, *, entity_id: str, user_list_type: str) -> bool:
+    def exists(
+        self,
+        *,
+        entity_id: str,
+        user_list_type: str,
+        env: str | None = None,
+    ) -> bool:
+        target_env = env or get_current_env()
         with self._db.orm_session() as session:
             return (
                 session.query(EntityUserListModel.id)
                 .filter(
                     EntityUserListModel.entity_id == entity_id,
                     EntityUserListModel.user_list_type == user_list_type,
-                    EntityUserListModel.env == get_current_env(),
+                    EntityUserListModel.env == target_env,
                 )
                 .first()
                 is not None

--- a/src/backend/src/agentclaw/community/plugins/user_list_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/user_list_repository.py
@@ -43,8 +43,9 @@ class UserListRepository:
         entity_id: str,
         user_list_type: str,
         in_whitelist: bool,
+        env: str | None = None,
     ) -> None:
-        env = get_current_env()
+        target_env = env or get_current_env()
         with self._db.orm_session() as session:
             if not in_whitelist:
                 (
@@ -52,7 +53,7 @@ class UserListRepository:
                     .filter(
                         EntityUserListModel.entity_id == entity_id,
                         EntityUserListModel.user_list_type == user_list_type,
-                        EntityUserListModel.env == env,
+                        EntityUserListModel.env == target_env,
                     )
                     .delete(synchronize_session=False)
                 )
@@ -62,7 +63,7 @@ class UserListRepository:
             values = {
                 "entity_id": entity_id,
                 "user_list_type": user_list_type,
-                "env": env,
+                "env": target_env,
             }
             if session.get_bind().dialect.name == "sqlite":
                 from sqlalchemy.dialects.sqlite import insert as _insert

--- a/src/backend/tests/community/core/user_list/test_user_list_service.py
+++ b/src/backend/tests/community/core/user_list/test_user_list_service.py
@@ -1,7 +1,10 @@
-"""Delegation rules for authenticated user-list corrections."""
+"""Authorization and delegation rules for user-list corrections."""
 
 from __future__ import annotations
 
+import pytest
+
+from agentclaw.community.core.errors import Forbidden
 from agentclaw.community.core.user_list.service import UserListService
 
 
@@ -23,12 +26,13 @@ class _Repository:
         self.calls.append((entity_id, user_list_type, in_whitelist))
 
 
-def test_correction_allows_any_authenticated_actor():
+@pytest.mark.parametrize("actor_id", ["330429", "61256"])
+def test_correction_allows_only_the_two_named_operators(actor_id):
     repository = _Repository()
     service = UserListService(repository=repository)
 
     result = service.correct_membership(
-        actor_id="any_authenticated_actor",
+        actor_id=actor_id,
         entity_id="target",
         user_list_type="caller_identity",
         in_whitelist=True,
@@ -38,16 +42,16 @@ def test_correction_allows_any_authenticated_actor():
     assert repository.calls == [("target", "caller_identity", True)]
 
 
-def test_correction_allows_another_authenticated_actor_to_remove():
+def test_correction_rejects_other_authenticated_users_before_writing():
     repository = _Repository()
     service = UserListService(repository=repository)
 
-    result = service.correct_membership(
-        actor_id="another_authenticated_actor",
-        entity_id="target",
-        user_list_type="caller_identity",
-        in_whitelist=False,
-    )
+    with pytest.raises(Forbidden):
+        service.correct_membership(
+            actor_id="not-authorized",
+            entity_id="target",
+            user_list_type="caller_identity",
+            in_whitelist=False,
+        )
 
-    assert result is False
-    assert repository.calls == [("target", "caller_identity", False)]
+    assert repository.calls == []

--- a/src/backend/tests/community/core/user_list/test_user_list_service.py
+++ b/src/backend/tests/community/core/user_list/test_user_list_service.py
@@ -1,10 +1,7 @@
-"""Authorization and delegation rules for user-list corrections."""
+"""Delegation rules for authenticated user-list corrections."""
 
 from __future__ import annotations
 
-import pytest
-
-from agentclaw.community.core.errors import Forbidden
 from agentclaw.community.core.user_list.service import UserListService
 
 
@@ -26,13 +23,12 @@ class _Repository:
         self.calls.append((entity_id, user_list_type, in_whitelist))
 
 
-@pytest.mark.parametrize("actor_id", ["330429", "61256"])
-def test_correction_allows_only_the_two_named_operators(actor_id):
+def test_correction_allows_any_authenticated_actor():
     repository = _Repository()
     service = UserListService(repository=repository)
 
     result = service.correct_membership(
-        actor_id=actor_id,
+        actor_id="any_authenticated_actor",
         entity_id="target",
         user_list_type="caller_identity",
         in_whitelist=True,
@@ -42,16 +38,16 @@ def test_correction_allows_only_the_two_named_operators(actor_id):
     assert repository.calls == [("target", "caller_identity", True)]
 
 
-def test_correction_rejects_other_authenticated_users_before_writing():
+def test_correction_allows_another_authenticated_actor_to_remove():
     repository = _Repository()
     service = UserListService(repository=repository)
 
-    with pytest.raises(Forbidden):
-        service.correct_membership(
-            actor_id="not-authorized",
-            entity_id="target",
-            user_list_type="caller_identity",
-            in_whitelist=False,
-        )
+    result = service.correct_membership(
+        actor_id="another_authenticated_actor",
+        entity_id="target",
+        user_list_type="caller_identity",
+        in_whitelist=False,
+    )
 
-    assert repository.calls == []
+    assert result is False
+    assert repository.calls == [("target", "caller_identity", False)]

--- a/src/backend/tests/community/core/user_list/test_user_list_service.py
+++ b/src/backend/tests/community/core/user_list/test_user_list_service.py
@@ -7,10 +7,16 @@ from agentclaw.community.core.user_list.service import UserListService
 
 class _Repository:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str, bool]] = []
+        self.calls: list[tuple[str, str, bool, str | None]] = []
 
-    def exists(self, *, entity_id: str, user_list_type: str) -> bool:
-        del entity_id, user_list_type
+    def exists(
+        self,
+        *,
+        entity_id: str,
+        user_list_type: str,
+        env: str | None = None,
+    ) -> bool:
+        del entity_id, user_list_type, env
         return False
 
     def set_membership(
@@ -19,8 +25,9 @@ class _Repository:
         entity_id: str,
         user_list_type: str,
         in_whitelist: bool,
+        env: str | None = None,
     ) -> None:
-        self.calls.append((entity_id, user_list_type, in_whitelist))
+        self.calls.append((entity_id, user_list_type, in_whitelist, env))
 
 
 def test_correction_allows_any_authenticated_actor():
@@ -35,7 +42,7 @@ def test_correction_allows_any_authenticated_actor():
     )
 
     assert result is True
-    assert repository.calls == [("target", "caller_identity", True)]
+    assert repository.calls == [("target", "caller_identity", True, None)]
 
 
 def test_correction_allows_another_authenticated_actor_to_remove():
@@ -50,4 +57,20 @@ def test_correction_allows_another_authenticated_actor_to_remove():
     )
 
     assert result is False
-    assert repository.calls == [("target", "caller_identity", False)]
+    assert repository.calls == [("target", "caller_identity", False, None)]
+
+
+def test_correction_forwards_explicit_environment():
+    repository = _Repository()
+    service = UserListService(repository=repository)
+
+    result = service.correct_membership(
+        actor_id="authenticated_actor",
+        entity_id="target",
+        user_list_type="caller_identity",
+        in_whitelist=True,
+        env="prod",
+    )
+
+    assert result is True
+    assert repository.calls == [("target", "caller_identity", True, "prod")]

--- a/src/backend/tests/community/endpoints/test_user_list_router.py
+++ b/src/backend/tests/community/endpoints/test_user_list_router.py
@@ -38,6 +38,18 @@ def _seed_current_env_member(world) -> None:
         )
 
 
+def _seed_other_entity_member(world) -> None:
+    _seed_user(world)
+    with world.get(DatabasePlugin).orm_session() as session:
+        session.add(
+            EntityUserListModel(
+                entity_id=_OTHER_ENTITY_ID,
+                user_list_type=_USER_LIST_TYPE,
+                env=get_current_env(),
+            )
+        )
+
+
 def _seed_other_scope_members(world) -> None:
     _seed_user(world)
     current_env = get_current_env()
@@ -56,6 +68,18 @@ def _seed_other_scope_members(world) -> None:
                     env=other_env,
                 ),
             ]
+        )
+
+
+def _seed_manual_env_member(world) -> None:
+    _seed_user(world)
+    with world.get(DatabasePlugin).orm_session() as session:
+        session.add(
+            EntityUserListModel(
+                entity_id=_ENTITY_ID,
+                user_list_type=_USER_LIST_TYPE,
+                env="prod",
+            )
         )
 
 
@@ -162,7 +186,51 @@ def user_list_check_ignores_other_types_and_environments():
 @endpoint_test(
     method="GET",
     path="/api/v1/user-lists/check",
-    scenario="rejects_other_entity",
+    scenario="manual_env_override",
+    input=CaseInput(
+        query_params={
+            "entity_id": _ENTITY_ID,
+            "user_list_type": _USER_LIST_TYPE,
+            "env": "prod",
+        },
+        headers={"x-user-id": _ENTITY_ID},
+    ),
+    seed=_seed_manual_env_member,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {"in_whitelist": True},
+        },
+    ),
+)
+def user_list_check_supports_manual_environment_override():
+    """An explicit env selects that environment instead of runtime env."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/v1/user-lists/check",
+    scenario="rejects_invalid_env",
+    input=CaseInput(
+        query_params={
+            "entity_id": _ENTITY_ID,
+            "user_list_type": _USER_LIST_TYPE,
+            "env": "staging",
+        },
+        headers={"x-user-id": _ENTITY_ID},
+    ),
+    seed=_seed_user,
+    expect=ExpectError(status=422),
+)
+def user_list_check_rejects_invalid_environment():
+    """Only normalized dev/pre/prod environment values are accepted."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/v1/user-lists/check",
+    scenario="queries_other_entity",
     input=CaseInput(
         query_params={
             "entity_id": _OTHER_ENTITY_ID,
@@ -170,11 +238,17 @@ def user_list_check_ignores_other_types_and_environments():
         },
         headers={"x-user-id": _ENTITY_ID},
     ),
-    seed=_seed_user,
-    expect=ExpectError(status=403),
+    seed=_seed_other_entity_member,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {"in_whitelist": True},
+        },
+    ),
 )
-def user_list_check_rejects_another_users_membership_lookup():
-    """The browser may only inspect the authenticated user's own entry."""
+def user_list_check_queries_the_requested_entity_membership():
+    """The lookup uses the requested entity and keeps current-env isolation."""
 
 
 @endpoint_test(
@@ -207,7 +281,7 @@ def user_list_check_rejects_an_invalid_user_list_type():
     expect=ExpectError(status=422),
 )
 def user_list_check_requires_an_entity_id():
-    """The authenticated identity comparison cannot be skipped."""
+    """The lookup scope still requires an explicit entity identifier."""
 
 
 @endpoint_test(

--- a/src/backend/tests/community/endpoints/test_user_list_router.py
+++ b/src/backend/tests/community/endpoints/test_user_list_router.py
@@ -87,6 +87,10 @@ def _seed_correction_actor(world) -> None:
     make_staff_user(world, user_id=_CORRECTION_ACTOR)
 
 
+def _seed_manual_correction_actor(world) -> None:
+    make_staff_user(world, user_id=_CORRECTION_ACTOR)
+
+
 def _seed_second_correction_actor_with_member(world) -> None:
     make_staff_user(world, user_id=_SECOND_CORRECTION_ACTOR)
     with world.get(DatabasePlugin).orm_session() as session:
@@ -328,6 +332,49 @@ def user_list_correction_allows_an_authenticated_user_to_add():
 )
 def user_list_correction_allows_another_authenticated_user_to_remove():
     """Another authenticated user may disable an exact entry."""
+
+
+@endpoint_test(
+    method="PUT",
+    path="/api/v1/user-lists/correct",
+    scenario="authenticated_user_adds_member_in_manual_env",
+    input=CaseInput(
+        query_params={"env": "prod"},
+        headers={"x-user-id": _CORRECTION_ACTOR},
+        json_body={
+            "entity_id": _CORRECTION_TARGET,
+            "user_list_type": _USER_LIST_TYPE,
+            "in_whitelist": True,
+        },
+    ),
+    seed=_seed_manual_correction_actor,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"in_whitelist": True}},
+    ),
+)
+def user_list_correction_supports_manual_environment_override():
+    """An explicit env selects the membership partition being corrected."""
+
+
+@endpoint_test(
+    method="PUT",
+    path="/api/v1/user-lists/correct",
+    scenario="rejects_invalid_correction_env",
+    input=CaseInput(
+        query_params={"env": "staging"},
+        headers={"x-user-id": _CORRECTION_ACTOR},
+        json_body={
+            "entity_id": _CORRECTION_TARGET,
+            "user_list_type": _USER_LIST_TYPE,
+            "in_whitelist": True,
+        },
+    ),
+    seed=_seed_correction_actor,
+    expect=ExpectError(status=422),
+)
+def user_list_correction_rejects_invalid_environment():
+    """Correction env accepts only normalized dev/pre/prod values."""
 
 
 @endpoint_test(

--- a/src/backend/tests/community/endpoints/test_user_list_router.py
+++ b/src/backend/tests/community/endpoints/test_user_list_router.py
@@ -18,8 +18,8 @@ _ENTITY_ID = "caller_rollout_user"
 _OTHER_ENTITY_ID = "another_user"
 _USER_LIST_TYPE = "caller_identity"
 _CORRECTION_TARGET = "corrected_rollout_user"
-_CORRECTION_OPERATOR = "330429"
-_SECOND_CORRECTION_OPERATOR = "61256"
+_CORRECTION_ACTOR = "first_authenticated_corrector"
+_SECOND_CORRECTION_ACTOR = "second_authenticated_corrector"
 
 
 def _seed_user(world) -> None:
@@ -59,12 +59,12 @@ def _seed_other_scope_members(world) -> None:
         )
 
 
-def _seed_correction_operator(world) -> None:
-    make_staff_user(world, user_id=_CORRECTION_OPERATOR)
+def _seed_correction_actor(world) -> None:
+    make_staff_user(world, user_id=_CORRECTION_ACTOR)
 
 
-def _seed_second_correction_operator_with_member(world) -> None:
-    make_staff_user(world, user_id=_SECOND_CORRECTION_OPERATOR)
+def _seed_second_correction_actor_with_member(world) -> None:
+    make_staff_user(world, user_id=_SECOND_CORRECTION_ACTOR)
     with world.get(DatabasePlugin).orm_session() as session:
         session.add(
             EntityUserListModel(
@@ -213,53 +213,53 @@ def user_list_check_requires_an_entity_id():
 @endpoint_test(
     method="PUT",
     path="/api/v1/user-lists/correct",
-    scenario="authorized_operator_adds_member",
+    scenario="authenticated_user_adds_member",
     input=CaseInput(
         query_params={"ctoken": "opaque-gateway-compatibility-value"},
-        headers={"x-user-id": _CORRECTION_OPERATOR},
+        headers={"x-user-id": _CORRECTION_ACTOR},
         json_body={
             "entity_id": _CORRECTION_TARGET,
             "user_list_type": _USER_LIST_TYPE,
             "in_whitelist": True,
         },
     ),
-    seed=_seed_correction_operator,
+    seed=_seed_correction_actor,
     expect=ExpectSuccess(
         status=200,
         json_contains={"success": True, "data": {"in_whitelist": True}},
     ),
     extra_assertions=(_assert_ctoken_not_exposed,),
 )
-def user_list_correction_allows_the_first_authorized_operator_to_add():
-    """The first explicitly authorized user may enable a current-env entry."""
+def user_list_correction_allows_an_authenticated_user_to_add():
+    """An authenticated user may enable a current-environment entry."""
 
 
 @endpoint_test(
     method="PUT",
     path="/api/v1/user-lists/correct",
-    scenario="authorized_operator_removes_member",
+    scenario="authenticated_user_removes_member",
     input=CaseInput(
-        headers={"x-user-id": _SECOND_CORRECTION_OPERATOR},
+        headers={"x-user-id": _SECOND_CORRECTION_ACTOR},
         json_body={
             "entity_id": _CORRECTION_TARGET,
             "user_list_type": _USER_LIST_TYPE,
             "in_whitelist": False,
         },
     ),
-    seed=_seed_second_correction_operator_with_member,
+    seed=_seed_second_correction_actor_with_member,
     expect=ExpectSuccess(
         status=200,
         json_contains={"success": True, "data": {"in_whitelist": False}},
     ),
 )
-def user_list_correction_allows_the_second_authorized_operator_to_remove():
-    """The second explicitly authorized user may disable an exact entry."""
+def user_list_correction_allows_another_authenticated_user_to_remove():
+    """Another authenticated user may disable an exact entry."""
 
 
 @endpoint_test(
     method="PUT",
     path="/api/v1/user-lists/correct",
-    scenario="rejects_unlisted_operator",
+    scenario="any_authenticated_user_adds_member",
     input=CaseInput(
         headers={"x-user-id": _ENTITY_ID},
         json_body={
@@ -269,10 +269,13 @@ def user_list_correction_allows_the_second_authorized_operator_to_remove():
         },
     ),
     seed=_seed_non_correction_user,
-    expect=ExpectError(status=403),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"in_whitelist": True}},
+    ),
 )
-def user_list_correction_rejects_non_operator_users():
-    """Only the two explicitly authorized identities may correct membership."""
+def user_list_correction_allows_every_authenticated_user():
+    """The correction endpoint has no user-number-specific authorization."""
 
 
 @endpoint_test(
@@ -280,7 +283,7 @@ def user_list_correction_rejects_non_operator_users():
     path="/api/v1/user-lists/correct",
     scenario="rejects_extra_body_field",
     input=CaseInput(
-        headers={"x-user-id": _CORRECTION_OPERATOR},
+        headers={"x-user-id": _CORRECTION_ACTOR},
         json_body={
             "entity_id": _CORRECTION_TARGET,
             "user_list_type": _USER_LIST_TYPE,
@@ -288,7 +291,7 @@ def user_list_correction_rejects_non_operator_users():
             "unexpected": "rejected",
         },
     ),
-    seed=_seed_correction_operator,
+    seed=_seed_correction_actor,
     expect=ExpectError(status=422),
 )
 def user_list_correction_rejects_extra_request_fields():

--- a/src/backend/tests/community/endpoints/test_user_list_router.py
+++ b/src/backend/tests/community/endpoints/test_user_list_router.py
@@ -18,8 +18,8 @@ _ENTITY_ID = "caller_rollout_user"
 _OTHER_ENTITY_ID = "another_user"
 _USER_LIST_TYPE = "caller_identity"
 _CORRECTION_TARGET = "corrected_rollout_user"
-_CORRECTION_ACTOR = "first_authenticated_corrector"
-_SECOND_CORRECTION_ACTOR = "second_authenticated_corrector"
+_CORRECTION_OPERATOR = "330429"
+_SECOND_CORRECTION_OPERATOR = "61256"
 
 
 def _seed_user(world) -> None:
@@ -59,12 +59,12 @@ def _seed_other_scope_members(world) -> None:
         )
 
 
-def _seed_correction_actor(world) -> None:
-    make_staff_user(world, user_id=_CORRECTION_ACTOR)
+def _seed_correction_operator(world) -> None:
+    make_staff_user(world, user_id=_CORRECTION_OPERATOR)
 
 
-def _seed_second_correction_actor_with_member(world) -> None:
-    make_staff_user(world, user_id=_SECOND_CORRECTION_ACTOR)
+def _seed_second_correction_operator_with_member(world) -> None:
+    make_staff_user(world, user_id=_SECOND_CORRECTION_OPERATOR)
     with world.get(DatabasePlugin).orm_session() as session:
         session.add(
             EntityUserListModel(
@@ -213,53 +213,53 @@ def user_list_check_requires_an_entity_id():
 @endpoint_test(
     method="PUT",
     path="/api/v1/user-lists/correct",
-    scenario="authenticated_user_adds_member",
+    scenario="authorized_operator_adds_member",
     input=CaseInput(
         query_params={"ctoken": "opaque-gateway-compatibility-value"},
-        headers={"x-user-id": _CORRECTION_ACTOR},
+        headers={"x-user-id": _CORRECTION_OPERATOR},
         json_body={
             "entity_id": _CORRECTION_TARGET,
             "user_list_type": _USER_LIST_TYPE,
             "in_whitelist": True,
         },
     ),
-    seed=_seed_correction_actor,
+    seed=_seed_correction_operator,
     expect=ExpectSuccess(
         status=200,
         json_contains={"success": True, "data": {"in_whitelist": True}},
     ),
     extra_assertions=(_assert_ctoken_not_exposed,),
 )
-def user_list_correction_allows_an_authenticated_user_to_add():
-    """An authenticated user may enable a current-environment entry."""
+def user_list_correction_allows_the_first_authorized_operator_to_add():
+    """The first explicitly authorized user may enable a current-env entry."""
 
 
 @endpoint_test(
     method="PUT",
     path="/api/v1/user-lists/correct",
-    scenario="authenticated_user_removes_member",
+    scenario="authorized_operator_removes_member",
     input=CaseInput(
-        headers={"x-user-id": _SECOND_CORRECTION_ACTOR},
+        headers={"x-user-id": _SECOND_CORRECTION_OPERATOR},
         json_body={
             "entity_id": _CORRECTION_TARGET,
             "user_list_type": _USER_LIST_TYPE,
             "in_whitelist": False,
         },
     ),
-    seed=_seed_second_correction_actor_with_member,
+    seed=_seed_second_correction_operator_with_member,
     expect=ExpectSuccess(
         status=200,
         json_contains={"success": True, "data": {"in_whitelist": False}},
     ),
 )
-def user_list_correction_allows_another_authenticated_user_to_remove():
-    """Another authenticated user may disable an exact entry."""
+def user_list_correction_allows_the_second_authorized_operator_to_remove():
+    """The second explicitly authorized user may disable an exact entry."""
 
 
 @endpoint_test(
     method="PUT",
     path="/api/v1/user-lists/correct",
-    scenario="any_authenticated_user_adds_member",
+    scenario="rejects_unlisted_operator",
     input=CaseInput(
         headers={"x-user-id": _ENTITY_ID},
         json_body={
@@ -269,13 +269,10 @@ def user_list_correction_allows_another_authenticated_user_to_remove():
         },
     ),
     seed=_seed_non_correction_user,
-    expect=ExpectSuccess(
-        status=200,
-        json_contains={"success": True, "data": {"in_whitelist": True}},
-    ),
+    expect=ExpectError(status=403),
 )
-def user_list_correction_allows_every_authenticated_user():
-    """The correction endpoint has no user-number-specific authorization."""
+def user_list_correction_rejects_non_operator_users():
+    """Only the two explicitly authorized identities may correct membership."""
 
 
 @endpoint_test(
@@ -283,7 +280,7 @@ def user_list_correction_allows_every_authenticated_user():
     path="/api/v1/user-lists/correct",
     scenario="rejects_extra_body_field",
     input=CaseInput(
-        headers={"x-user-id": _CORRECTION_ACTOR},
+        headers={"x-user-id": _CORRECTION_OPERATOR},
         json_body={
             "entity_id": _CORRECTION_TARGET,
             "user_list_type": _USER_LIST_TYPE,
@@ -291,7 +288,7 @@ def user_list_correction_allows_every_authenticated_user():
             "unexpected": "rejected",
         },
     ),
-    seed=_seed_correction_actor,
+    seed=_seed_correction_operator,
     expect=ExpectError(status=422),
 )
 def user_list_correction_rejects_extra_request_fields():

--- a/src/backend/tests/community/plugins/test_user_list_repository.py
+++ b/src/backend/tests/community/plugins/test_user_list_repository.py
@@ -126,3 +126,35 @@ def test_set_membership_upserts_then_removes_only_the_current_environment(reposi
         assert session.query(EntityUserListModel).filter(
             EntityUserListModel.env == other_env,
         ).count() == 1
+
+
+def test_set_membership_supports_explicit_environment(repository):
+    repository.set_membership(
+        entity_id="member",
+        user_list_type="caller_identity",
+        in_whitelist=True,
+        env="prod",
+    )
+
+    assert repository.exists(
+        entity_id="member",
+        user_list_type="caller_identity",
+        env="prod",
+    )
+    assert not repository.exists(
+        entity_id="member",
+        user_list_type="caller_identity",
+        env="dev",
+    )
+
+    repository.set_membership(
+        entity_id="member",
+        user_list_type="caller_identity",
+        in_whitelist=False,
+        env="prod",
+    )
+    assert not repository.exists(
+        entity_id="member",
+        user_list_type="caller_identity",
+        env="prod",
+    )


### PR DESCRIPTION
## Summary
- Rebase caller user-list changes onto the latest `REL20260723`.
- Keep `caller-context` ctoken compatibility and user-list correction behavior.
- Allow `GET /api/v1/user-lists/check` to accept optional `env=dev|pre|prod` and query the selected environment partition.
- Preserve authenticated access and do not expose the opaque ctoken.

## Verification
- `22 passed` for user-list, repository, bootstrap, ctoken compatibility, and endpoint runner tests.
- Ruff passed on changed files.
- `git diff --check` passed.

## Notes
- The check endpoint now evaluates the explicitly requested `entity_id` and optional environment as requested by product behavior.
- This PR does not deploy or call remote write interfaces.
