### PR TITLE
[Skills Pool P3] 打通 OpenClaw 已登记技能的 Pool 激活闭环

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
@@ -35,6 +35,16 @@ class SkillRepository(Protocol):
                     env: str | None = None) -> list[dict]:
         ...
 
+    def get_bot_local_by_name(
+        self,
+        *,
+        bot_id: str,
+        name: str,
+        user_id: str | None = None,
+    ) -> dict | None:
+        """精确查询 Bot 自有的同名 local 技能，不包含全局行。"""
+        ...
+
     def create(self, skill_data: dict) -> dict:
         ...
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -665,7 +665,7 @@ class SkillService:
                         link_name = self.get_link_name(relative_path)
                     else:
                         skill_id = skill_path[8:]
-                        link_name = skill_id
+                        link_name = Path(skill_id).name
                     results["success"].append({
                         "id": skill_id,
                         "link_name": link_name,
@@ -1795,7 +1795,24 @@ class SkillService:
 
         # ===== 通过 DeviceFileSystem 写入文件（自动适配 local/arca/teclaw） =====
         device_fs = self._device_fs_factory(bolt_id, user_id)
-        skill_dir = self.local_dir / skill_name
+        # POOL_ACTIVE 后 DB locator 已经是 Pool canonical 绝对路径。重传同名
+        # 本地技能时必须继续使用该 locator；否则会写到 Legacy bridge 后又以
+        # Legacy locator 新建一条重复记录。
+        existing_skill = self._skill_repo.get_bot_local_by_name(
+            bot_id=bolt_id or "default",
+            name=skill_name,
+            user_id=user_id,
+        )
+        existing_locator = (
+            str(existing_skill["git_path"])[len("local://") :]
+            if existing_skill is not None
+            else ""
+        )
+        skill_dir = (
+            Path(existing_locator)
+            if existing_locator.startswith("/")
+            else self.local_dir / skill_name
+        )
         skill_dir_str = str(skill_dir)
         # The DB ``git_path`` keeps ``skill_dir_str`` (logical for teclaw, host for
         # arca); the device-fs delete/write use the adapter-expanded engine path
@@ -1822,8 +1839,6 @@ class SkillService:
 
             # Check if skill with same path already exists (区分 Bot)
             skill_path = f"local://{skill_dir_str}"
-            existing_skill = self.get_skill_by_path(skill_path, bolt_id=bolt_id, user_id=user_id)
-
             if existing_skill:
                 # Update existing skill metadata using repository
                 update_data = {

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -750,11 +750,13 @@ class SkillSetService:
                 git_path = skill['git_path']
                 if git_path.startswith("git://"):
                     rel_path = git_path[6:]
+                    link_name = self.skill_service.get_link_name(rel_path)
                 elif git_path.startswith("local://"):
                     rel_path = git_path[8:]
+                    link_name = rel_path.rstrip('/').split('/')[-1]
                 else:
                     rel_path = git_path
-                link_name = self.skill_service.get_link_name(rel_path)
+                    link_name = self.skill_service.get_link_name(rel_path)
                 try:
                     await self.skill_service.deactivate_skill(
                         link_name, bolt_id=self.bot_id, user_id=user_id
@@ -1228,10 +1230,11 @@ class SkillSetService:
                 if path_part.startswith('/'):
                     # 绝对路径格式: /aidesktop/.../skills-local/skill-name
                     skill_name = path_part.rstrip('/').split('/')[-1]
+                    source = path_part.rstrip('/')
                 else:
                     # 相对名称格式: skill-name
                     skill_name = path_part.split('/')[-1] if '/' in path_part else path_part
-                source = str(skills_local_dir / skill_name)
+                    source = str(skills_local_dir / skill_name)
                 target = str(base_skills_dir / skill_name)
                 symlinks.append(SynlinkMappingInfo(source=source, target=target))
 
@@ -2472,7 +2475,7 @@ class SkillSetActivator(_DeviceSyncMixin):
         if is_default:
             result.success = True
             result.message = f"默认技能集 '{skill_set_name}' 已启用"
-            logger.info(f"[SkillSetActivator.activate] Default skill set always enabled (ac_user_default_skill_set dropped)")
+            logger.info("[SkillSetActivator.activate] Default skill set always enabled (ac_user_default_skill_set dropped)")
             return result
         else:
             # 3. 普通能力集：检查 is_active 状态
@@ -2584,7 +2587,7 @@ class SkillSetActivator(_DeviceSyncMixin):
         if is_default:
             result.success = False
             result.message = f"默认技能集 '{skill_set_name}' 无法禁用，所有默认技能集保持启用状态"
-            logger.info(f"[SkillSetActivator.deactivate] Default skill set cannot be disabled (ac_user_default_skill_set dropped)")
+            logger.info("[SkillSetActivator.deactivate] Default skill set cannot be disabled (ac_user_default_skill_set dropped)")
             return result
         else:
             # 3. 普通能力集：检查 is_active 状态

--- a/src/backend/src/agentclaw/community/core/skill_center/utils/skill_metadata_writer.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/utils/skill_metadata_writer.py
@@ -100,7 +100,7 @@ class SkillSetMetadataWriter:
                 return Path(rel_path).name
             elif git_path.startswith("local://"):
                 # local://skill-name -> skill-name
-                return git_path[8:]  # Remove "local://"
+                return Path(git_path[8:]).name  # Remove "local://"
             else:
                 # Fallback: treat as path and get basename
                 return Path(git_path).name

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -1,8 +1,9 @@
 # skills_pool
 
-Skills Pool 控制面的 Bot 级布局状态与首次迁移认领边界。本模块只建立
-durable state、rollout gate 和 CAS/lease；不负责容器目录准备、运行时
-probe、mapping、locator 切换或完整 Engine Layout Descriptor。
+Skills Pool 控制面的 Bot 级布局状态、首次迁移认领和激活编排边界。
+容器目录暗准备由镜像负责；本模块通过当前 runtime adapter 完成 probe、
+OpenClaw 原子数据面切换与 Pool mapping，并在最后事务性提交 locator 和
+`POOL_ACTIVE`。完整多引擎 Engine Layout Descriptor 仍不在本期范围内。
 
 ## 核心语义
 
@@ -17,6 +18,12 @@ probe、mapping、locator 切换或完整 Engine Layout Descriptor。
   `ac_bot_publish` DRAFT 记录证明。认领入口不接受调用方自报运行形态，
   ONLINE 服务与 Teclaw 不产生认领。
 - lease 的认领、接管和续租都由数据库时钟与 generation fencing 保护。
+- 激活只处理已经认领且由当前 worker 持有 lease 的 OpenClaw Bot；每次执行
+  都重新读取 Bot 和当前 provider binding，并重新 probe marker。
+- 容器内以系统原生原子 exchange 将 Legacy local 切成指向 Pool canonical
+  local 的永久单向 bridge；不支持原子 exchange 时保持 Legacy。
+- 数据面切换后先全量发布并验证 Pool mapping，再在一个 CAS 事务中更新该
+  Bot 全部 local locator 和 `POOL_ACTIVE`。mapping 或事务失败只前滚重试。
 
 ## Context Boundary
 
@@ -26,16 +33,27 @@ provides:
   - "SkillsPoolLayoutRepositoryProtocol"
   - "SkillsPoolRolloutGate"
   - "SkillsPoolMigrationClaimService"
+  - "SkillsPoolReconcileService"
   - "BotSkillLayoutState and migration enums"
 consumes:
   - "BotRepository"
   - "BotPublishRepositoryProtocol"
   - "CommonConfigService and CommonWhiteListService"
   - "DatabasePlugin (through plugins/skills_pool_layout_repository.py)"
+  - "SkillsPoolRuntimeProtocol"
+  - "SkillsPoolSkillRepositoryProtocol"
 internal_dependencies:
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.common_config
+  - agentclaw.community.core.skill_center
   - agentclaw.community.core.service_bot
   - agentclaw.community.core.base
   - agentclaw.community.plugin_api.database
+  - agentclaw.community.core.skills_pool.ports
 ```
+
+### Change impact
+
+状态机或激活顺序变化会同时影响迁移 Worker、Bot locator 事务和运行时
+mapping/bridge 实现；端口变化还必须同步 Backend runtime、skill
+repository 实现及相应测试。

--- a/src/backend/src/agentclaw/community/core/skills_pool/__init__.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/__init__.py
@@ -11,6 +11,11 @@ from agentclaw.community.core.skills_pool.rollout_gate import (
     RolloutDecisionReason,
     SkillsPoolRolloutGate,
 )
+from agentclaw.community.core.skills_pool.reconcile_service import (
+    SkillsPoolReconcileOutcome,
+    SkillsPoolReconcileResult,
+    SkillsPoolReconcileService,
+)
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
@@ -31,5 +36,8 @@ __all__ = [
     "SkillLayout",
     "SkillLayoutPhase",
     "SkillsPoolMigrationClaimService",
+    "SkillsPoolReconcileOutcome",
+    "SkillsPoolReconcileResult",
+    "SkillsPoolReconcileService",
     "SkillsPoolRolloutGate",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -1,0 +1,46 @@
+"""Skills Pool 激活闭环使用的领域值对象。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class OpenClawPoolPaths:
+    """OpenClaw P3 的容器视角路径契约。"""
+
+    active: str = "/home/admin/.openclaw/workspace/skills"
+    legacy_local: str = "/home/admin/.openclaw/workspace/skills/skills-local"
+    pool_local: str = (
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+    )
+    pool_repo: str = (
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredSkillAsset:
+    """Backend 中属于一个 Bot 的技能来源记录。"""
+
+    skill_id: int
+    name: str
+    git_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class PoolSkillMapping:
+    """显式以目标 Pool layout 构造的运行时 mapping。"""
+
+    source: str
+    target: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"source": self.source, "target": self.target}
+
+
+__all__ = [
+    "OpenClawPoolPaths",
+    "PoolSkillMapping",
+    "RegisteredSkillAsset",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/ports.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/ports.py
@@ -1,0 +1,83 @@
+"""Skills Pool 领域服务依赖的运行时与资产仓储端口。"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeResult,
+)
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+)
+
+
+@runtime_checkable
+class SkillsPoolSkillRepositoryProtocol(Protocol):
+    """激活所需的 Bot 级 Skill 资产视图。"""
+
+    def list_bot_local_assets(
+        self, *, env: str, bot_id: str
+    ) -> list[RegisteredSkillAsset]:
+        ...
+
+    def list_bot_active_assets(
+        self,
+        *,
+        env: str,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ) -> list[RegisteredSkillAsset]:
+        ...
+
+
+@runtime_checkable
+class SkillsPoolRuntimeProtocol(Protocol):
+    """当前运行环境上的探测、切换和 mapping 边界。"""
+
+    async def probe(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ) -> RuntimeLayoutProbeResult:
+        ...
+
+    async def cutover(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        migration_generation: str,
+        preparation_id: str,
+        registered_local_names: list[str],
+        mappings: list[PoolSkillMapping],
+    ) -> dict[str, object]:
+        ...
+
+    async def publish_mappings(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        mappings: list[PoolSkillMapping],
+    ) -> bool:
+        ...
+
+    async def verify_mappings(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        mappings: list[PoolSkillMapping],
+    ) -> bool:
+        ...
+
+
+__all__ = [
+    "SkillsPoolRuntimeProtocol",
+    "SkillsPoolSkillRepositoryProtocol",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -1,0 +1,325 @@
+"""已认领 Bot 的 Skills Pool 激活闭环。
+
+本模块只编排控制面步骤；最终同步和原子 bridge 由当前运行时完成，数据库
+仓储负责 locator 与 ``POOL_ACTIVE`` 的同事务提交。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import PurePosixPath
+
+from injector import inject
+
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotRepository,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skills_pool.models import (
+    OpenClawPoolPaths,
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+)
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayout,
+)
+from agentclaw.community.core.skills_pool.ports import (
+    SkillsPoolRuntimeProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
+
+
+class SkillsPoolReconcileOutcome(StrEnum):
+    POOL_ACTIVE = "pool_active"
+    ALREADY_ACTIVE = "already_active"
+    NOT_CLAIMED = "not_claimed"
+    LEASE_NOT_HELD = "lease_not_held"
+    BOT_NOT_FOUND = "bot_not_found"
+    BOT_CHANGED = "bot_changed"
+    NOT_CAPABLE = "not_capable"
+    TRANSIENT_ERROR = "transient_error"
+    INVALID = "invalid"
+    STATE_RACE_LOST = "state_race_lost"
+    CUTOVER_FAILED = "cutover_failed"
+    MAPPING_FAILED = "mapping_failed"
+    MAPPING_VERIFY_FAILED = "mapping_verify_failed"
+    DATABASE_COMMIT_FAILED = "database_commit_failed"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillsPoolReconcileResult:
+    outcome: SkillsPoolReconcileOutcome
+    preparation_id: str | None = None
+    evidence: dict[str, object] | None = None
+
+
+class SkillsPoolReconcileService:
+    """将一个已认领的 OpenClaw Bot 前滚到 ``POOL_ACTIVE``。"""
+
+    @inject
+    def __init__(
+        self,
+        *,
+        bot_repository: BotRepository,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        skill_repository: SkillsPoolSkillRepositoryProtocol,
+        runtime: SkillsPoolRuntimeProtocol,
+    ) -> None:
+        self._bots = bot_repository
+        self._layouts = layout_repository
+        self._skills = skill_repository
+        self._runtime = runtime
+        self._paths = OpenClawPoolPaths()
+
+    async def reconcile(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        lease_owner: str,
+    ) -> SkillsPoolReconcileResult:
+        state = self._layouts.get(scope)
+        if state.active_layout is SkillLayout.POOL:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
+                preparation_id=state.preparation_id,
+            )
+        if (
+            not state.persisted
+            or state.target_layout is not SkillLayout.POOL
+            or state.migration_generation is None
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.NOT_CLAIMED
+            )
+        if state.lease_owner != lease_owner:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.LEASE_NOT_HELD
+            )
+
+        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
+        if bot is None:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.BOT_NOT_FOUND
+            )
+        if (
+            bot.get("env") != scope.env
+            or bot.get("active_engine") != "openclaw"
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.BOT_CHANGED
+            )
+
+        owner_id = bot.get("owner_id")
+        if not isinstance(owner_id, (str, int)) or isinstance(owner_id, bool):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.BOT_CHANGED
+            )
+        user_id = str(owner_id)
+        generation = state.migration_generation
+        if not self._layouts.holds_lease(
+            scope=scope,
+            migration_generation=generation,
+            lease_owner=lease_owner,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.LEASE_NOT_HELD
+            )
+
+        probe = await self._runtime.probe(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            engine="openclaw",
+        )
+        if probe.status is not RuntimeLayoutProbeStatus.READY:
+            return SkillsPoolReconcileResult(
+                self._probe_outcome(probe.status),
+                evidence=probe.evidence,
+            )
+        if (
+            probe.preparation_id is None
+            or probe.layout_contract_version != state.layout_contract_version
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.INVALID,
+                evidence=probe.evidence,
+            )
+
+        local_assets = self._skills.list_bot_local_assets(
+            env=scope.env,
+            bot_id=scope.bot_id,
+        )
+        active_assets = self._skills.list_bot_active_assets(
+            env=scope.env,
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            engine="openclaw",
+        )
+        try:
+            local_names = [self._local_name(asset) for asset in local_assets]
+            mappings = self._build_pool_mappings(active_assets)
+        except ValueError as error:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.INVALID,
+                evidence={"reason": str(error)},
+            )
+
+        if not state.data_plane_cutover_committed:
+            recorded = self._layouts.record_ready_probe(
+                scope=scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                preparation_id=probe.preparation_id,
+                evidence=probe.evidence,
+            )
+            if not recorded:
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                )
+            if not self._layouts.begin_cutover(
+                scope=scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                preparation_id=probe.preparation_id,
+            ):
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                )
+
+            cutover = await self._runtime.cutover(
+                bot_id=scope.bot_id,
+                user_id=user_id,
+                migration_generation=generation,
+                preparation_id=probe.preparation_id,
+                registered_local_names=local_names,
+                mappings=mappings,
+            )
+            if cutover.get("committed") is not True:
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                    preparation_id=probe.preparation_id,
+                    evidence=cutover,
+                )
+            if not self._layouts.record_cutover_committed(
+                scope=scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                preparation_id=probe.preparation_id,
+                evidence=cutover,
+            ):
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                    preparation_id=probe.preparation_id,
+                )
+
+        if not self._layouts.holds_lease(
+            scope=scope,
+            migration_generation=generation,
+            lease_owner=lease_owner,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.LEASE_NOT_HELD,
+                preparation_id=probe.preparation_id,
+            )
+        if not await self._runtime.publish_mappings(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            mappings=mappings,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.MAPPING_FAILED,
+                preparation_id=probe.preparation_id,
+            )
+        if not await self._runtime.verify_mappings(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            mappings=mappings,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+                preparation_id=probe.preparation_id,
+            )
+
+        local_locators = {
+            asset.skill_id: f"local://{self._paths.pool_local}/{name}"
+            for asset, name in zip(local_assets, local_names, strict=True)
+        }
+        if not self._layouts.commit_pool_active(
+            scope=scope,
+            migration_generation=generation,
+            lease_owner=lease_owner,
+            preparation_id=probe.preparation_id,
+            local_locators=local_locators,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.DATABASE_COMMIT_FAILED,
+                preparation_id=probe.preparation_id,
+            )
+        return SkillsPoolReconcileResult(
+            SkillsPoolReconcileOutcome.POOL_ACTIVE,
+            preparation_id=probe.preparation_id,
+        )
+
+    @staticmethod
+    def _probe_outcome(
+        status: RuntimeLayoutProbeStatus,
+    ) -> SkillsPoolReconcileOutcome:
+        return {
+            RuntimeLayoutProbeStatus.NOT_CAPABLE: (
+                SkillsPoolReconcileOutcome.NOT_CAPABLE
+            ),
+            RuntimeLayoutProbeStatus.TRANSIENT_ERROR: (
+                SkillsPoolReconcileOutcome.TRANSIENT_ERROR
+            ),
+            RuntimeLayoutProbeStatus.INVALID: SkillsPoolReconcileOutcome.INVALID,
+        }.get(status, SkillsPoolReconcileOutcome.INVALID)
+
+    @staticmethod
+    def _source_tail(git_path: str, prefix: str) -> PurePosixPath:
+        raw = git_path[len(prefix) :]
+        path = PurePosixPath(raw)
+        if not raw or path.name in {"", ".", ".."}:
+            raise ValueError(f"invalid skill locator: {git_path}")
+        return path
+
+    def _local_name(self, asset: RegisteredSkillAsset) -> str:
+        if not asset.git_path.startswith("local://"):
+            raise ValueError(f"skill {asset.skill_id} is not local")
+        return self._source_tail(asset.git_path, "local://").name
+
+    def _build_pool_mappings(
+        self,
+        assets: list[RegisteredSkillAsset],
+    ) -> list[PoolSkillMapping]:
+        mappings: list[PoolSkillMapping] = []
+        targets: dict[str, str] = {}
+        for asset in assets:
+            if asset.git_path.startswith("local://"):
+                relative = PurePosixPath(self._local_name(asset))
+                source = PurePosixPath(self._paths.pool_local) / relative
+            elif asset.git_path.startswith("git://"):
+                relative = self._source_tail(asset.git_path, "git://")
+                source = PurePosixPath(self._paths.pool_repo) / relative
+            else:
+                continue
+            target = str(PurePosixPath(self._paths.active) / relative.name)
+            if targets.get(target) == str(source):
+                continue
+            if target in targets:
+                raise ValueError(f"duplicate managed target: {target}")
+            targets[target] = str(source)
+            mappings.append(PoolSkillMapping(source=str(source), target=target))
+        return mappings
+
+
+__all__ = [
+    "SkillsPoolReconcileOutcome",
+    "SkillsPoolReconcileResult",
+    "SkillsPoolReconcileService",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -53,3 +53,60 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
     ) -> bool:
         """在 lease 缺失或过期时，以 CAS 竞争成为新持有者。"""
         ...
+
+    def holds_lease(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+    ) -> bool:
+        """用数据库时钟确认当前 worker 仍持有未过期 lease。"""
+        ...
+
+    def record_ready_probe(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """以 generation/lease CAS 记录当前运行时已具备 Pool 能力。"""
+        ...
+
+    def record_cutover_committed(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录不可逆的数据面切换已经完成。"""
+        ...
+
+    def begin_cutover(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+    ) -> bool:
+        """在运行时原子切换前持久化 pre-cutover 阶段。"""
+        ...
+
+    def commit_pool_active(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        local_locators: dict[int, str],
+    ) -> bool:
+        """在一个事务中更新该 Bot 全部 local locator 并提交 Pool Active。"""
+        ...

--- a/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
@@ -11,6 +11,15 @@ from agentclaw.community.core.skills_pool.repository.protocol import (
 from agentclaw.community.core.skills_pool.rollout_gate import (
     SkillsPoolRolloutGate,
 )
+from agentclaw.community.core.skills_pool.reconcile_service import (
+    SkillsPoolReconcileService,
+)
+from agentclaw.community.core.skills_pool.ports import (
+    SkillsPoolRuntimeProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.plugins.skill_repository import SkillRepository
+from agentclaw.community.plugins.skills_pool_runtime import OpenClawSkillsPoolRuntime
 from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
 )
@@ -33,5 +42,20 @@ class SkillsPoolModule(Module):
         binder.bind(
             SkillsPoolMigrationClaimService,
             to=SkillsPoolMigrationClaimService,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolSkillRepositoryProtocol,
+            to=SkillRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolRuntimeProtocol,
+            to=OpenClawSkillsPoolRuntime,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolReconcileService,
+            to=SkillsPoolReconcileService,
             scope=singleton,
         )

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -335,6 +335,116 @@ class SkillRepository:
             query = query.order_by(self.Skill.gmt_created.desc())
             return [_skill_to_dict(s) for s in query.all()]
 
+    def get_bot_local_by_name(
+        self,
+        *,
+        bot_id: str,
+        name: str,
+        user_id: str | None = None,
+    ) -> dict | None:
+        """精确命中 Bot-owned local 行，禁止回退到 ``bolt_id IS NULL``。"""
+
+        with self._db.orm_session() as db:
+            query = db.query(self.Skill).filter(
+                self.Skill.env == get_current_env(),
+                self.Skill.bolt_id == bot_id,
+                self.Skill.name == name,
+                self.Skill.git_path.like("local://%"),
+            )
+            if user_id is not None:
+                query = query.filter(
+                    self.Skill.user_id == _normalize_user_id(user_id)
+                )
+            row = query.order_by(self.Skill.gmt_created.desc()).first()
+            return _skill_to_dict(row) if row is not None else None
+
+    def list_bot_local_assets(
+        self,
+        *,
+        env: str,
+        bot_id: str,
+    ):
+        """列出精确 Bot 范围内的全部 local 来源行，不包含全局记录。"""
+
+        from agentclaw.community.core.skills_pool.models import (
+            RegisteredSkillAsset,
+        )
+
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(self.Skill)
+                .filter(
+                    self.Skill.env == env,
+                    self.Skill.bolt_id == bot_id,
+                    self.Skill.git_path.like("local://%"),
+                )
+                .order_by(self.Skill.id)
+                .all()
+            )
+            return [
+                RegisteredSkillAsset(
+                    skill_id=row.id,
+                    name=row.name,
+                    git_path=row.git_path,
+                )
+                for row in rows
+            ]
+
+    def list_bot_active_assets(
+        self,
+        *,
+        env: str,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ):
+        """返回普通 active sets 与该引擎默认 set 的完整、去重来源。"""
+
+        from agentclaw.community.core.skills_pool.models import (
+            RegisteredSkillAsset,
+        )
+
+        skill_sets = SkillSetRepository(self._db)
+        active_sets = skill_sets.get_all_active_skill_sets_for_env(
+            user_id=user_id,
+            bolt_id=bot_id,
+            engine_type=engine,
+            env=env,
+        )
+        seen: set[str] = set()
+        assets: list[RegisteredSkillAsset] = []
+        for skill_set in active_sets:
+            rows = skill_sets.get_skills_in_set_for_env(
+                str(skill_set["id"]),
+                env=env,
+            )
+            if skill_set.get("is_default"):
+                excluded = set(
+                    skill_sets.get_excluded_skills(
+                        user_id=user_id,
+                        bot_id=bot_id,
+                        skill_set_id=int(skill_set["id"]),
+                    )
+                )
+                rows = [
+                    row
+                    for row in rows
+                    if int(row.get("id", 0)) not in excluded
+                ]
+            for row in rows:
+                git_path = str(row.get("git_path") or "")
+                if not git_path or git_path in seen:
+                    continue
+                seen.add(git_path)
+                assets.append(
+                    RegisteredSkillAsset(
+                        skill_id=int(row["id"]),
+                        name=str(row["name"]),
+                        git_path=git_path,
+                    )
+                )
+        return assets
+
     def create(self, skill_data: dict) -> dict:
         with self._db.orm_session() as db:
             tags = skill_data.get("tags")
@@ -1022,9 +1132,19 @@ class SkillSetRepository:
             return rowcount > 0
 
     def get_skills_in_set(self, skill_set_id: str) -> list[dict]:
+        return self.get_skills_in_set_for_env(
+            skill_set_id,
+            env=get_current_env(),
+        )
+
+    def get_skills_in_set_for_env(
+        self,
+        skill_set_id: str,
+        *,
+        env: str,
+    ) -> list[dict]:
         from agentclaw.community.core.models import Skill
 
-        env = get_current_env()
         with self._db.orm_session() as db:
             # non-center: join by skill_id
             non_center = (

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -13,6 +13,7 @@ from sqlalchemy.sql.elements import ColumnElement
 from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
 )
+from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
@@ -197,3 +198,238 @@ class SkillsPoolLayoutRepository:
                 )
             )
         return affected == 1
+
+    def holds_lease(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+    ) -> bool:
+        """用数据库时钟检查 generation/lease，阻止过期 worker 写运行时。"""
+
+        with self._database.transactional_orm_session() as session:
+            return (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .first()
+                is not None
+            )
+
+    def record_ready_probe(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """仅当前 lease holder 可把已认领状态推进为 ``POOL_READY``。"""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_PREPARING.value,
+                            SkillLayoutPhase.POOL_READY.value,
+                            SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.POOL_READY.value
+                        ),
+                        BotSkillLayoutStateModel.preparation_id: preparation_id,
+                        BotSkillLayoutStateModel.last_probe_result: "READY",
+                        BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def record_cutover_committed(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """持久化不可逆边界，后续重试只能继续前滚。"""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
+                        ),
+                        BotSkillLayoutStateModel.data_plane_cutover_committed: 1,
+                        BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def begin_cutover(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+    ) -> bool:
+        """以 CAS 标记下一步将进入不可逆的数据面边界。"""
+
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.POOL_READY.value,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value
+                        )
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def commit_pool_active(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        local_locators: dict[int, str],
+    ) -> bool:
+        """原子提交精确 Bot 范围内的全部 local locator 和布局状态。"""
+
+        pool_prefix = (
+            "local:///home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/"
+        )
+        if any(
+            not isinstance(skill_id, int)
+            or not locator.startswith(pool_prefix)
+            for skill_id, locator in local_locators.items()
+        ):
+            return False
+
+        with self._database.transactional_orm_session() as session:
+            local_rows = (
+                session.query(Skill)
+                .filter(
+                    Skill.env == scope.env,
+                    Skill.bolt_id == scope.bot_id,
+                    Skill.git_path.like("local://%"),
+                )
+                .with_for_update()
+                .all()
+            )
+            if {row.id for row in local_rows} != set(local_locators):
+                return False
+
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.active_layout: (
+                            SkillLayout.POOL.value
+                        ),
+                        BotSkillLayoutStateModel.target_layout: None,
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.POOL_ACTIVE.value
+                        ),
+                        BotSkillLayoutStateModel.pool_activated_at: func.now(),
+                        BotSkillLayoutStateModel.lease_owner: None,
+                        BotSkillLayoutStateModel.lease_expires_at: None,
+                        BotSkillLayoutStateModel.last_failure_code: None,
+                        BotSkillLayoutStateModel.last_failure_stage: None,
+                        BotSkillLayoutStateModel.last_failure_retryable: None,
+                        BotSkillLayoutStateModel.last_failure_at: None,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            if affected != 1:
+                return False
+            for row in local_rows:
+                row.git_path = local_locators[row.id]
+        return True

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
@@ -1,0 +1,160 @@
+"""通过当前 Bot binding 调用容器内 Skills Pool 激活端点。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from injector import inject
+
+from agentclaw.community.core.devices.services.device_context_resolver import (
+    DeviceContextResolver,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    CurrentRuntimeLayoutProbeService,
+    RuntimeLayoutProbeResult,
+)
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterTransport,
+)
+
+logger = get_logger()
+
+
+class OpenClawSkillsPoolRuntime:
+    """ARCA/BaaS 共用的 adapter transport 实现。"""
+
+    @inject
+    def __init__(
+        self,
+        *,
+        resolver: DeviceContextResolver,
+        adapter_transport: DeviceAdapterTransport,
+        probe_service: CurrentRuntimeLayoutProbeService,
+    ) -> None:
+        self._resolver = resolver
+        self._transport = adapter_transport
+        self._probe = probe_service
+
+    async def probe(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ) -> RuntimeLayoutProbeResult:
+        return await self._probe.probe_bot(
+            bot_id=bot_id,
+            user_id=user_id,
+            engine=engine,
+        )
+
+    async def cutover(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        migration_generation: str,
+        preparation_id: str,
+        registered_local_names: list[str],
+        mappings: list[PoolSkillMapping],
+    ) -> dict[str, object]:
+        try:
+            response = await self._invoke(
+                bot_id=bot_id,
+                user_id=user_id,
+                path="/api/skills/layout/activate",
+                body={
+                    "migration_generation": migration_generation,
+                    "preparation_id": preparation_id,
+                    "registered_local_names": registered_local_names,
+                    "mappings": [mapping.to_dict() for mapping in mappings],
+                },
+            )
+        except Exception as error:
+            logger.exception(
+                "[skills_pool.runtime] cutover failed bot_id=%s generation=%s",
+                bot_id,
+                migration_generation,
+            )
+            return {
+                "committed": False,
+                "reason": "runtime_cutover_request_failed",
+                "error_type": type(error).__name__,
+            }
+        data = response.get("data")
+        if not isinstance(data, dict):
+            return {"committed": False, "reason": "runtime_cutover_response_invalid"}
+        return dict(data)
+
+    async def publish_mappings(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        mappings: list[PoolSkillMapping],
+    ) -> bool:
+        try:
+            response = await self._invoke(
+                bot_id=bot_id,
+                user_id=user_id,
+                path="/api/skills/layout/mappings/publish",
+                body={"mappings": [mapping.to_dict() for mapping in mappings]},
+            )
+        except Exception:
+            logger.exception(
+                "[skills_pool.runtime] mapping publish failed bot_id=%s",
+                bot_id,
+            )
+            return False
+        return response.get("success") is True
+
+    async def verify_mappings(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        mappings: list[PoolSkillMapping],
+    ) -> bool:
+        try:
+            response = await self._invoke(
+                bot_id=bot_id,
+                user_id=user_id,
+                path="/api/skills/layout/mappings/verify",
+                body={"mappings": [mapping.to_dict() for mapping in mappings]},
+            )
+        except Exception:
+            logger.exception(
+                "[skills_pool.runtime] mapping verify failed bot_id=%s",
+                bot_id,
+            )
+            return False
+        data = response.get("data")
+        return (
+            response.get("success") is True
+            and isinstance(data, dict)
+            and data.get("valid") is True
+        )
+
+    async def _invoke(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        path: str,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        context = self._resolver.resolve_for_bot(bot_id, user_id)
+        return await self._transport.invoke(
+            context.conn_info,
+            "POST",
+            path,
+            body=body,
+            timeout=30.0,
+        )
+
+
+__all__ = ["OpenClawSkillsPoolRuntime"]

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -25,6 +25,7 @@ description: a test skill
 def _service(local_dir: Path, adapter, fake_fs) -> SkillService:
     repo = MagicMock()
     repo.list_skills.return_value = []  # get_skill_by_path -> None -> create path
+    repo.get_bot_local_by_name.return_value = None
     svc = SkillService(
         skill_repo=repo,
         skill_repo_sync=MagicMock(get_local_skills_root=MagicMock(return_value=None)),

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -578,6 +578,37 @@ class TestRemoveSkillFromDefaultSet:
         )
 
     @pytest.mark.asyncio
+    async def test_default_set_deactivates_pool_local_by_entry_name(self):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = {
+            "id": "1",
+            "is_default": True,
+            "bolt_id": "default",
+        }
+        mock_skill_repo = MagicMock()
+        mock_skill_repo.get_by_id.return_value = {
+            "id": "42",
+            "git_path": (
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/my-skill"
+            ),
+        }
+        mock_skill_svc = MagicMock()
+        mock_skill_svc.deactivate_skill = AsyncMock(return_value=True)
+        svc = self._make_svc(
+            mock_repo,
+            skill_repo=mock_skill_repo,
+            skill_service=mock_skill_svc,
+        )
+
+        assert await svc.remove_skill_from_set("1", "42", user_id="user1")
+        mock_skill_svc.deactivate_skill.assert_called_once_with(
+            "my-skill",
+            bolt_id="default",
+            user_id="user1",
+        )
+
+    @pytest.mark.asyncio
     async def test_default_set_deactivate_failure_rollback(self):
         """Default set: deactivate_skill failure rolls back exclusion."""
         mock_repo = MagicMock()

--- a/src/backend/tests/community/core/skill_center/test_skill_metadata_writer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_metadata_writer.py
@@ -1,6 +1,6 @@
 """Tests for agentclaw.community.core.skill_center.utils.skill_metadata_writer."""
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +124,16 @@ class TestGetSkillDirName:
         writer = _make_writer(tmp_path)
         assert writer._get_skill_dir_name("local://my-local-skill") == "my-local-skill"
 
+    def test_pool_local_path_uses_basename(self, tmp_path):
+        writer = _make_writer(tmp_path)
+        assert (
+            writer._get_skill_dir_name(
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/my-local-skill"
+            )
+            == "my-local-skill"
+        )
+
     def test_bare_path_fallback(self, tmp_path):
         writer = _make_writer(tmp_path)
         assert writer._get_skill_dir_name("some/path/skill-name") == "skill-name"
@@ -153,6 +163,16 @@ class TestGetSkillAbsolutePath:
         result = writer._get_skill_absolute_path("local://my-local")
         expected = str(tmp_path / "skills-local" / "my-local")
         assert result == expected
+
+    def test_pool_local_absolute_path_is_not_prefixed_again(self, tmp_path):
+        writer = _make_writer(tmp_path)
+        locator_path = (
+            "/home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/my-local"
+        )
+        assert writer._get_skill_absolute_path(f"local://{locator_path}") == (
+            locator_path
+        )
 
     def test_bare_path_falls_back_to_repo_dir(self, tmp_path):
         writer = _make_writer(tmp_path)

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -21,6 +21,7 @@ from agentclaw.community.core.skills_pool.types import (
 from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
 )
+from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
 )
@@ -231,6 +232,16 @@ def test_lease_is_fenced_by_generation_and_current_owner() -> None:
         lease_owner="worker-2",
         lease_seconds=120,
     )
+    assert repository.holds_lease(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+    )
+    assert not repository.holds_lease(
+        scope=scope,
+        migration_generation="generation-stale",
+        lease_owner="worker-1",
+    )
 
 
 def test_expired_lease_competition_has_one_new_owner(tmp_path: Path) -> None:
@@ -253,6 +264,11 @@ def test_expired_lease_competition_has_one_new_owner(tmp_path: Path) -> None:
                 )
             }
         )
+    assert not repository.holds_lease(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-original",
+    )
 
     barrier = Barrier(2)
 
@@ -271,3 +287,187 @@ def test_expired_lease_competition_has_one_new_owner(tmp_path: Path) -> None:
     assert results.count(True) == 1
     winner = ["worker-2", "worker-3"][results.index(True)]
     assert repository.get(scope).lease_owner == winner
+
+
+def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    assert repository.record_cutover_committed(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"bridge": "valid"},
+    )
+    with database.transactional_orm_session() as session:
+        session.add_all(
+            [
+                Skill(
+                    id=1,
+                    name="local-a",
+                    git_path="local:///legacy/local-a",
+                    bolt_id="bot-1",
+                    env="pre",
+                ),
+                Skill(
+                    id=2,
+                    name="local-b",
+                    git_path="local://local-b",
+                    bolt_id="bot-1",
+                    env="pre",
+                ),
+                Skill(
+                    id=3,
+                    name="repo",
+                    git_path="git://business/repo",
+                    bolt_id="bot-1",
+                    env="pre",
+                ),
+                Skill(
+                    id=4,
+                    name="other-bot",
+                    git_path="local:///legacy/other-bot",
+                    bolt_id="bot-2",
+                    env="pre",
+                ),
+                Skill(
+                    id=5,
+                    name="other-env",
+                    git_path="local:///legacy/other-env",
+                    bolt_id="bot-1",
+                    env="prod",
+                ),
+            ]
+        )
+
+    committed = repository.commit_pool_active(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        local_locators={
+            1: (
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/local-a"
+            ),
+            2: (
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/local-b"
+            ),
+        },
+    )
+
+    assert committed
+    state = repository.get(scope)
+    assert state.active_layout is SkillLayout.POOL
+    assert state.target_layout is None
+    assert state.phase is SkillLayoutPhase.POOL_ACTIVE
+    assert state.pool_activated_at is not None
+    assert state.lease_owner is None
+    with database.transactional_orm_session() as session:
+        paths = {
+            row.id: row.git_path
+            for row in session.query(Skill).order_by(Skill.id).all()
+        }
+    assert paths == {
+        1: (
+            "local:///home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/local-a"
+        ),
+        2: (
+            "local:///home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/local-b"
+        ),
+        3: "git://business/repo",
+        4: "local:///legacy/other-bot",
+        5: "local:///legacy/other-env",
+    }
+
+
+def test_pool_active_commit_rejects_partial_or_stale_local_locator_set() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    assert repository.record_cutover_committed(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={},
+    )
+    with database.transactional_orm_session() as session:
+        session.add_all(
+            [
+                Skill(
+                    id=1,
+                    name="local-a",
+                    git_path="local:///legacy/local-a",
+                    bolt_id="bot-1",
+                    env="pre",
+                ),
+                Skill(
+                    id=2,
+                    name="local-b",
+                    git_path="local:///legacy/local-b",
+                    bolt_id="bot-1",
+                    env="pre",
+                ),
+            ]
+        )
+
+    assert not repository.commit_pool_active(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        local_locators={
+            1: (
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/local-a"
+            )
+        },
+    )
+    assert repository.get(scope).active_layout is SkillLayout.LEGACY

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -1,0 +1,332 @@
+"""OpenClaw Skills Pool 已登记技能激活闭环测试。"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skills_pool.models import (
+    OpenClawPoolPaths,
+    RegisteredSkillAsset,
+)
+from agentclaw.community.core.skills_pool.reconcile_service import (
+    SkillsPoolReconcileOutcome,
+    SkillsPoolReconcileService,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+GENERATION = "generation-1"
+PREPARATION_ID = "5ab2890d-ea0f-43f5-bfae-458457f3e54e"
+
+
+def claimed_state(**changes: object) -> BotSkillLayoutState:
+    state = BotSkillLayoutState(
+        scope=SCOPE,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=SkillLayout.POOL,
+        phase=SkillLayoutPhase.POOL_PREPARING,
+        migration_generation=GENERATION,
+        persisted=True,
+        layout_contract_version="skills-pool-p3-v1",
+        lease_owner="worker-1",
+    )
+    return replace(state, **changes)
+
+
+class FakeBotRepository:
+    def __init__(self) -> None:
+        self.bot: dict[str, object] | None = {
+            "bot_id": SCOPE.bot_id,
+            "entity_id": SCOPE.entity_id,
+            "owner_id": "owner-1",
+            "env": SCOPE.env,
+            "active_engine": "openclaw",
+        }
+
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> dict[str, object] | None:
+        return self.bot
+
+
+class FakeLayoutRepository:
+    def __init__(self, state: BotSkillLayoutState | None = None) -> None:
+        self.state = state or claimed_state()
+        self.events: list[str] = []
+        self.committed_locators: dict[int, str] | None = None
+        self.lease_valid = True
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
+
+    def record_ready_probe(self, **kwargs: object) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("ready")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.POOL_READY,
+            preparation_id=str(kwargs["preparation_id"]),
+            last_probe_result="READY",
+        )
+        return True
+
+    def holds_lease(self, **kwargs: object) -> bool:
+        return self.lease_valid and self._owns(kwargs)
+
+    def record_cutover_committed(self, **kwargs: object) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("cutover")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            data_plane_cutover_committed=True,
+        )
+        return True
+
+    def begin_cutover(self, **kwargs: object) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("begin")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+        )
+        return True
+
+    def commit_pool_active(
+        self,
+        *,
+        local_locators: dict[int, str],
+        **kwargs: object,
+    ) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("database")
+        self.committed_locators = local_locators
+        self.state = replace(
+            self.state,
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            lease_owner=None,
+        )
+        return True
+
+    def _owns(self, values: dict[str, object]) -> bool:
+        return (
+            values["scope"] == SCOPE
+            and values["migration_generation"] == GENERATION
+            and values["lease_owner"] == "worker-1"
+        )
+
+
+class FakeSkillRepository:
+    def __init__(self) -> None:
+        self.registered = [
+            RegisteredSkillAsset(
+                skill_id=11,
+                name="local-a",
+                git_path="local:///legacy/skills-local/local-a",
+            ),
+            RegisteredSkillAsset(
+                skill_id=12,
+                name="local-b",
+                git_path="local://local-b",
+            ),
+        ]
+        self.active = [
+            *self.registered,
+            RegisteredSkillAsset(
+                skill_id=21,
+                name="repo-skill",
+                git_path="git://business/repo-skill",
+            ),
+        ]
+
+    def list_bot_local_assets(
+        self, *, env: str, bot_id: str
+    ) -> list[RegisteredSkillAsset]:
+        assert (env, bot_id) == (SCOPE.env, SCOPE.bot_id)
+        return self.registered
+
+    def list_bot_active_assets(
+        self,
+        *,
+        env: str,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ) -> list[RegisteredSkillAsset]:
+        assert (env, bot_id) == (SCOPE.env, SCOPE.bot_id)
+        assert (user_id, engine) == ("owner-1", "openclaw")
+        return self.active
+
+
+class FakeRuntime:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.publish_success = True
+        self.probe_result = RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.READY,
+            engine="openclaw",
+            layout_contract_version="skills-pool-p3-v1",
+            preparation_id=PREPARATION_ID,
+            evidence={"marker": "valid"},
+        )
+
+    async def probe(self, **kwargs: object) -> RuntimeLayoutProbeResult:
+        self.events.append("probe")
+        return self.probe_result
+
+    async def cutover(self, **kwargs: object) -> dict[str, object]:
+        self.events.append("cutover")
+        assert kwargs["registered_local_names"] == ["local-a", "local-b"]
+        mappings = kwargs["mappings"]
+        assert [mapping.source for mapping in mappings] == [
+            f"{OpenClawPoolPaths().pool_local}/local-a",
+            f"{OpenClawPoolPaths().pool_local}/local-b",
+            f"{OpenClawPoolPaths().pool_repo}/business/repo-skill",
+        ]
+        return {"committed": True, "bridge": "valid"}
+
+    async def publish_mappings(self, **kwargs: object) -> bool:
+        self.events.append("mapping")
+        return self.publish_success
+
+    async def verify_mappings(self, **kwargs: object) -> bool:
+        self.events.append("verify")
+        return True
+
+
+def build_service(
+    layouts: FakeLayoutRepository,
+    runtime: FakeRuntime,
+) -> SkillsPoolReconcileService:
+    return SkillsPoolReconcileService(
+        bot_repository=FakeBotRepository(),
+        layout_repository=layouts,
+        skill_repository=FakeSkillRepository(),
+        runtime=runtime,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ready_claimed_bot_completes_pool_activation() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["ready", "begin", "cutover", "database"]
+    assert layouts.committed_locators == {
+        11: (
+            "local:///home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/local-a"
+        ),
+        12: (
+            "local:///home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/local-b"
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_mapping_failure_after_cutover_does_not_commit_database() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.publish_success = False
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.active_layout is SkillLayout.LEGACY
+    assert layouts.committed_locators is None
+    assert runtime.events == ["probe", "cutover", "mapping"]
+
+    runtime.publish_success = True
+    runtime.events.clear()
+    layouts.events.clear()
+    retried = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "mapping", "verify"]
+    assert layouts.events == ["database"]
+
+
+@pytest.mark.asyncio
+async def test_non_ready_runtime_keeps_legacy_without_data_plane_changes() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        preparation_id=None,
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.NOT_CAPABLE
+    assert runtime.events == ["probe"]
+    assert layouts.events == []
+    assert layouts.state.active_layout is SkillLayout.LEGACY
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_or_lease_cannot_continue_activation() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(lease_owner="another-worker"),
+    )
+    runtime = FakeRuntime()
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.LEASE_NOT_HELD
+    assert runtime.events == []
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_cannot_probe_or_publish_mappings() -> None:
+    layouts = FakeLayoutRepository()
+    layouts.lease_valid = False
+    runtime = FakeRuntime()
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.LEASE_NOT_HELD
+    assert runtime.events == []

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -1,0 +1,108 @@
+"""Skills Pool 当前运行时 transport contract。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+)
+from agentclaw.community.plugins.skills_pool_runtime import OpenClawSkillsPoolRuntime
+
+
+class FakeResolver:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def resolve_for_bot(self, bot_id: str, user_id: str):
+        self.calls.append((bot_id, user_id))
+        return SimpleNamespace(conn_info={"binding": len(self.calls)})
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def invoke(
+        self,
+        conn_info,
+        method,
+        path,
+        *,
+        body,
+        timeout,
+    ):
+        self.calls.append(
+            {
+                "conn_info": conn_info,
+                "method": method,
+                "path": path,
+                "body": body,
+                "timeout": timeout,
+            }
+        )
+        if path.endswith("/activate"):
+            return {"success": True, "data": {"committed": True}}
+        if path.endswith("/publish"):
+            return {"success": True, "data": {"published": True}}
+        return {"success": True, "data": {"valid": True}}
+
+
+class FakeProbe:
+    async def probe_bot(self, **kwargs):
+        return kwargs
+
+
+@pytest.mark.asyncio
+async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None:
+    resolver = FakeResolver()
+    transport = FakeTransport()
+    runtime = OpenClawSkillsPoolRuntime(
+        resolver=resolver,
+        adapter_transport=transport,
+        probe_service=FakeProbe(),
+    )
+    mappings = [
+        PoolSkillMapping(
+            source=(
+                "/home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/a"
+            ),
+            target="/home/admin/.openclaw/workspace/skills/a",
+        )
+    ]
+
+    cutover = await runtime.cutover(
+        bot_id="bot-1",
+        user_id="owner-1",
+        migration_generation="generation-1",
+        preparation_id="preparation-1",
+        registered_local_names=["a"],
+        mappings=mappings,
+    )
+    published = await runtime.publish_mappings(
+        bot_id="bot-1",
+        user_id="owner-1",
+        mappings=mappings,
+    )
+    verified = await runtime.verify_mappings(
+        bot_id="bot-1",
+        user_id="owner-1",
+        mappings=mappings,
+    )
+
+    assert cutover["committed"] is True
+    assert published
+    assert verified
+    assert resolver.calls == [
+        ("bot-1", "owner-1"),
+        ("bot-1", "owner-1"),
+        ("bot-1", "owner-1"),
+    ]
+    assert [call["path"] for call in transport.calls] == [
+        "/api/skills/layout/activate",
+        "/api/skills/layout/mappings/publish",
+        "/api/skills/layout/mappings/verify",
+    ]

--- a/src/backend/tests/community/di/test_skills_pool_wiring.py
+++ b/src/backend/tests/community/di/test_skills_pool_wiring.py
@@ -9,10 +9,19 @@ from agentclaw.community.core.skills_pool.repository.protocol import (
 from agentclaw.community.core.skills_pool.rollout_gate import (
     SkillsPoolRolloutGate,
 )
+from agentclaw.community.core.skills_pool.reconcile_service import (
+    SkillsPoolReconcileService,
+)
+from agentclaw.community.core.skills_pool.ports import (
+    SkillsPoolRuntimeProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.plugins.skills_pool_runtime import OpenClawSkillsPoolRuntime
 from agentclaw.community.di import DeployProfile, build_injector
 from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
 )
+from agentclaw.community.plugins.skill_repository import SkillRepository
 
 
 def test_skills_pool_control_plane_bindings_resolve() -> None:
@@ -29,4 +38,16 @@ def test_skills_pool_control_plane_bindings_resolve() -> None:
     assert isinstance(
         injector.get(SkillsPoolMigrationClaimService),
         SkillsPoolMigrationClaimService,
+    )
+    assert isinstance(
+        injector.get(SkillsPoolSkillRepositoryProtocol),
+        SkillRepository,
+    )
+    assert isinstance(
+        injector.get(SkillsPoolRuntimeProtocol),
+        OpenClawSkillsPoolRuntime,
+    )
+    assert isinstance(
+        injector.get(SkillsPoolReconcileService),
+        SkillsPoolReconcileService,
     )

--- a/src/backend/tests/community/plugins/test_skill_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_skill_repository_unified.py
@@ -151,6 +151,39 @@ def test_skill_list_and_published_center(skills):
     assert [c["name"] for c in centers] == ["c"]
 
 
+def test_get_bot_local_by_name_never_falls_back_to_global(skills):
+    skills.create(
+        {
+            "name": "same",
+            "git_path": "local:///global/same",
+            "bolt_id": None,
+            "user_id": "owner",
+        }
+    )
+    bot_owned = skills.create(
+        {
+            "name": "same",
+            "git_path": "local:///bot/same",
+            "bolt_id": "bot-x",
+            "user_id": "owner",
+        }
+    )
+
+    assert skills.get_bot_local_by_name(
+        bot_id="bot-x",
+        name="same",
+        user_id="owner",
+    )["id"] == bot_owned["id"]
+    assert (
+        skills.get_bot_local_by_name(
+            bot_id="bot-y",
+            name="same",
+            user_id="owner",
+        )
+        is None
+    )
+
+
 def test_skill_update_risk_and_mcp(skills):
     sid = skills.create({"name": "r"})["id"]
     assert skills.update_risk_tags(sid, ["high"])["risk_tags"] == [
@@ -185,6 +218,104 @@ def test_delete_by_bot_id(skills):
     skills.create({"name": "b2", "bolt_id": "bot-x"})
     assert skills.delete_by_bot_id("bot-x") == 2
     assert skills.list_skills(bolt_id="bot-x") == []
+
+
+def test_skills_pool_asset_views_are_exactly_bot_scoped(skills, sets):
+    local = skills.create(
+        {
+            "name": "local-a",
+            "git_path": "local:///legacy/local-a",
+            "bolt_id": "bot-x",
+        }
+    )
+    repo = skills.create(
+        {
+            "name": "repo-a",
+            "git_path": "git://business/repo-a",
+            "bolt_id": "bot-x",
+        }
+    )
+    skills.create(
+        {
+            "name": "other-local",
+            "git_path": "local:///legacy/other-local",
+            "bolt_id": "bot-y",
+        }
+    )
+    skill_set = sets.create(
+        {
+            "name": "active",
+            "bolt_id": "bot-x",
+            "user_id": "owner-x",
+            "engine_type": "openclaw",
+            "is_active": True,
+        }
+    )
+    sets.add_skill_to_set(skill_set["id"], local["id"])
+    sets.add_skill_to_set(skill_set["id"], repo["id"])
+
+    local_assets = skills.list_bot_local_assets(
+        env=local["env"],
+        bot_id="bot-x",
+    )
+    active_assets = skills.list_bot_active_assets(
+        env=local["env"],
+        bot_id="bot-x",
+        user_id="owner-x",
+        engine="openclaw",
+    )
+
+    assert [(asset.skill_id, asset.name) for asset in local_assets] == [
+        (int(local["id"]), "local-a")
+    ]
+    assert {asset.git_path for asset in active_assets} == {
+        "local:///legacy/local-a",
+        "git://business/repo-a",
+    }
+
+
+def test_skills_pool_active_assets_include_default_set_and_exclusions(
+    skills, sets
+):
+    default_enabled = skills.create(
+        {
+            "name": "default-enabled",
+            "git_path": "git://defaults/enabled",
+        }
+    )
+    default_excluded = skills.create(
+        {
+            "name": "default-excluded",
+            "git_path": "git://defaults/excluded",
+        }
+    )
+    default_set = sets.create(
+        {
+            "name": "OpenClaw defaults",
+            "is_default": True,
+            "is_active": True,
+            "engine_type": "openclaw",
+        }
+    )
+    sets.add_skill_to_set(default_set["id"], default_enabled["id"])
+    sets.add_skill_to_set(default_set["id"], default_excluded["id"])
+    sets.add_default_skill_exclusion(
+        user_id="owner-x",
+        bot_id="bot-x",
+        skill_set_id=int(default_set["id"]),
+        skill_id=int(default_excluded["id"]),
+    )
+
+    assets = skills.list_bot_active_assets(
+        env=default_enabled["env"],
+        bot_id="bot-x",
+        user_id="owner-x",
+        engine="openclaw",
+    )
+
+    assert [asset.git_path for asset in assets] == [
+        "git://defaults/enabled"
+    ]
 
 
 # ── SkillSetRepository ──────────────────────────────────────────────

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -37,6 +37,7 @@ class TestSkillServiceAsyncRouting:
         if mock_repo is None:
             mock_repo = MagicMock()
             mock_repo.list_skills.return_value = []
+            mock_repo.get_bot_local_by_name.return_value = None
             mock_repo.create.side_effect = lambda data: {"id": "1", **data}
             mock_repo.get_by_name_global.return_value = None
 
@@ -68,6 +69,82 @@ class TestSkillServiceAsyncRouting:
         # Verify DeviceFileSystemPlugin was used for file operations
         mock_device_fs.delete_tree.assert_called_once()
         mock_device_fs.write_file.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reupload_uses_existing_pool_locator_without_duplicate(
+        self, tmp_path
+    ):
+        pool_path = (
+            "/home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/test-skill"
+        )
+        existing = {
+            "id": "41",
+            "name": "test-skill",
+            "user_id": "user1",
+            "git_path": f"local://{pool_path}",
+        }
+        repo = MagicMock()
+        repo.get_bot_local_by_name.return_value = existing
+        repo.update.return_value = existing
+        service, device_fs, _ = self._service(tmp_path, mock_repo=repo)
+
+        result = await service.upload_skill(
+            [
+                {
+                    "filename": "SKILL.md",
+                    "content": (
+                        b"---\nname: test-skill\ndescription: test\n"
+                        b"---\n# Test"
+                    ),
+                    "relative_path": "SKILL.md",
+                }
+            ],
+            user_id="user1",
+            bolt_id="bot1",
+        )
+
+        assert result == existing
+        device_fs.delete_tree.assert_awaited_once_with(pool_path)
+        device_fs.write_file.assert_awaited_once_with(
+            f"{pool_path}/SKILL.md",
+            b"---\nname: test-skill\ndescription: test\n---\n# Test",
+        )
+        repo.update.assert_called_once()
+        repo.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_does_not_overwrite_global_local_skill(
+        self, tmp_path
+    ):
+        repo = MagicMock()
+        repo.get_bot_local_by_name.return_value = None
+        repo.create.side_effect = lambda data: {"id": "52", **data}
+        service, _, _ = self._service(tmp_path, mock_repo=repo)
+
+        result = await service.upload_skill(
+            [
+                {
+                    "filename": "SKILL.md",
+                    "content": (
+                        b"---\nname: shared-name\ndescription: bot copy\n"
+                        b"---\n# Bot copy"
+                    ),
+                    "relative_path": "SKILL.md",
+                }
+            ],
+            user_id="user1",
+            bolt_id="bot1",
+        )
+
+        assert result["id"] == "52"
+        repo.get_bot_local_by_name.assert_called_once_with(
+            bot_id="bot1",
+            name="shared-name",
+            user_id="user1",
+        )
+        repo.update.assert_not_called()
+        repo.create.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_upload_wraps_device_write_failure(self, tmp_path):

--- a/src/backend/tests/community/services/test_skill_set_service.py
+++ b/src/backend/tests/community/services/test_skill_set_service.py
@@ -57,6 +57,32 @@ class TestGetSymlinkMappings:
         assert symlinks[0].source.endswith("/skills-local/cct-zbb-instraction-query")
         assert symlinks[0].target.endswith("/skills/cct-zbb-instraction-query")
 
+    def test_pool_locator_is_used_as_mapping_source_without_legacy_rewrite(
+        self, skill_set_service, mock_skill_set_repo
+    ):
+        pool_source = (
+            "/home/admin/.openclaw/workspace/"
+            "skills-pool/skills-local/handmade"
+        )
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = [
+            {"id": "1", "name": "Pool", "is_default": False}
+        ]
+        mock_skill_set_repo.get_skills_in_set.return_value = [
+            {
+                "id": "1",
+                "name": "handmade",
+                "git_path": f"local://{pool_source}",
+            }
+        ]
+
+        mappings = skill_set_service.get_symlink_mappings(
+            user_id="100015",
+            bolt_id="default",
+        )
+
+        assert mappings[0].source == pool_source
+        assert mappings[0].target.endswith("/openclaw/workspace/skills/handmade")
+
     def test_local_path_with_relative_name(self, skill_set_service, mock_skill_set_repo, mock_skill_repo):
         """测试 local:// 相对名称格式 - 使用新接口的绝对路径软链"""
         mock_skill_set_repo.get_all_active_skill_sets.return_value = [

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -17,6 +17,8 @@ from engine.community.api.skills.schemas import (
     BindPathRequest,
     CenterEnsureRequestSchema,
     CleanSymlinkRequest,
+    PoolLayoutActivateRequest,
+    PoolMappingVerifyRequest,
     RuntimeLayoutProbeApiResponse,
     RuntimeLayoutProbeRequest,
     RuntimeLayoutProbeResponse,
@@ -28,11 +30,12 @@ from engine.community.core.skills.models import (
     CenterEnsureItem,
     CenterEnsureRequest,
     CleanSymlinksRequest,
+    PoolLayoutActivateRequest as PoolLayoutActivateCommand,
+    PoolLayoutProbeRequest as PoolLayoutProbeCommand,
     SymlinkItem,
     SyncBindPathsRequest,
     SyncSymlinksRequest,
 )
-from engine.community.core.skills.layout_probe import inspect_runtime_layout
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 log = logging.getLogger("api-skills")
@@ -44,18 +47,102 @@ def _skills_plugin():
 
 
 @router.post("/layout/probe", response_model=RuntimeLayoutProbeApiResponse)
-def probe_runtime_skills_layout(
+async def probe_runtime_skills_layout(
     body: RuntimeLayoutProbeRequest,
 ) -> RuntimeLayoutProbeApiResponse:
-    """Inspect local facts in FastAPI's worker pool, outside the event loop."""
-    result = inspect_runtime_layout(
-        engine=body.engine,
-        expected_contract_version=body.layout_contract_version,
-    )
+    """通过 Skills Service API 核验当前运行时事实。"""
+    plugin = _skills_plugin()
+    try:
+        result = await plugin.probe_pool_layout(
+            PoolLayoutProbeCommand(
+                engine=body.engine,
+                layout_contract_version=body.layout_contract_version,
+            )
+        )
+    except CapabilityNotSupportedError as error:
+        raise HTTPException(status_code=501, detail=str(error)) from error
     return RuntimeLayoutProbeApiResponse(
         success=True,
         data=RuntimeLayoutProbeResponse.model_validate(result.to_data()),
         message="运行时 Skills Pool 布局探测完成",
+    )
+
+
+@router.post("/layout/activate", response_model=ApiResponse)
+async def activate_runtime_skills_layout(
+    body: PoolLayoutActivateRequest,
+) -> ApiResponse:
+    """在当前容器的持久化文件系统上提交 OpenClaw Pool 数据面。"""
+
+    plugin = _skills_plugin()
+    try:
+        result = await plugin.activate_pool_layout(
+            PoolLayoutActivateCommand(
+                migration_generation=body.migration_generation,
+                preparation_id=body.preparation_id,
+                registered_local_names=body.registered_local_names,
+                mappings=[
+                    SymlinkItem(source=item.source, target=item.target)
+                    for item in body.mappings
+                ],
+            )
+        )
+    except CapabilityNotSupportedError as error:
+        raise HTTPException(status_code=501, detail=str(error)) from error
+    return ApiResponse(
+        success=result.committed,
+        data=result.to_data(),
+        message=(
+            "Skills Pool 数据面已提交"
+            if result.committed
+            else "Skills Pool 数据面未提交"
+        ),
+    )
+
+
+@router.post("/layout/mappings/verify", response_model=ApiResponse)
+async def verify_runtime_skill_mappings(
+    body: PoolMappingVerifyRequest,
+) -> ApiResponse:
+    """验证当前受管入口与 Pool source 一致。"""
+
+    plugin = _skills_plugin()
+    try:
+        result = await plugin.verify_pool_mappings(
+            [
+                SymlinkItem(source=item.source, target=item.target)
+                for item in body.mappings
+            ],
+        )
+    except CapabilityNotSupportedError as error:
+        raise HTTPException(status_code=501, detail=str(error)) from error
+    return ApiResponse(
+        success=result.valid,
+        data=result.to_data(),
+        message="Skill mapping 验证完成",
+    )
+
+
+@router.post("/layout/mappings/publish", response_model=ApiResponse)
+async def publish_runtime_skill_mappings(
+    body: PoolMappingVerifyRequest,
+) -> ApiResponse:
+    """全量发布 Pool 受管 mapping，保留结构桥和外部入口。"""
+
+    plugin = _skills_plugin()
+    try:
+        result = await plugin.publish_pool_mappings(
+            [
+                SymlinkItem(source=item.source, target=item.target)
+                for item in body.mappings
+            ],
+        )
+    except CapabilityNotSupportedError as error:
+        raise HTTPException(status_code=501, detail=str(error)) from error
+    return ApiResponse(
+        success=result.published,
+        data=result.to_data(),
+        message="Skill mapping 发布完成",
     )
 
 

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -68,6 +68,17 @@ class RuntimeLayoutProbeApiResponse(ApiResponse):
     data: RuntimeLayoutProbeResponse
 
 
+class PoolLayoutActivateRequest(BaseModel):
+    migration_generation: str
+    preparation_id: str
+    registered_local_names: list[str]
+    mappings: list[SymlinkItem]
+
+
+class PoolMappingVerifyRequest(BaseModel):
+    mappings: list[SymlinkItem]
+
+
 __all__ = [
     "SymlinkItem",
     "SyncSymlinkRequest",
@@ -81,4 +92,6 @@ __all__ = [
     "RuntimeLayoutProbeRequest",
     "RuntimeLayoutProbeResponse",
     "RuntimeLayoutProbeApiResponse",
+    "PoolLayoutActivateRequest",
+    "PoolMappingVerifyRequest",
 ]

--- a/src/engine/src/engine/community/api/tests/test_skills_bindpath.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_bindpath.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from engine.community.api.skills import router
@@ -130,6 +129,40 @@ class TestBindPathSymlink:
 
         assert resp.status_code == 200
         assert extra_link.is_symlink()  # 仍然存在
+
+    def test_clean_target_dir_preserves_layout_bridges(
+        self, client: TestClient, tmp_path: Path
+    ):
+        """全量 mapping 清理不能删除 skills-local / skills-repo 结构桥。"""
+        source = tmp_path / "pool" / "skill-a"
+        source.mkdir(parents=True)
+        link_dir = tmp_path / "skills"
+        pool_local = tmp_path / "pool" / "skills-local"
+        pool_repo = tmp_path / "pool" / "skills-repo"
+        pool_local.mkdir()
+        pool_repo.mkdir()
+        link_dir.mkdir()
+        local_bridge = link_dir / "skills-local"
+        repo_bridge = link_dir / "skills-repo"
+        local_bridge.symlink_to(pool_local, target_is_directory=True)
+        repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+
+        response = client.post(
+            "/api/skills/symlink/bindpath",
+            json={
+                "symlinks": [
+                    {
+                        "source": str(source),
+                        "target": str(link_dir / "skill-a"),
+                    }
+                ],
+                "clean_target_dir": True,
+            },
+        )
+
+        assert response.status_code == 200
+        assert local_bridge.is_symlink()
+        assert repo_bridge.is_symlink()
 
     def test_target_occupied_by_real_file(self, client: TestClient, tmp_path: Path):
         """target 被真实文件占用时应返回 409"""

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -17,13 +17,17 @@ from engine.community.api.skills.router import router as skills_router
 from engine.community.core.engine.base import BaseEngine
 from engine.community.core.engine.capability import Capability, EngineCapabilities
 from engine.community.core.engine.registry import EngineRegistry
+from engine.community.core.engine.exceptions import (
+    CapabilityNotSupportedError,
+)
 from engine.community.core.skills.models import (
     CleanSymlinksResult,
+    PoolLayoutActivationResult,
+    PoolLayoutProbeResult,
+    PoolLayoutProbeStatus,
+    PoolMappingPublishResult,
+    PoolMappingVerificationResult,
     SyncSymlinksResult,
-)
-from engine.community.core.skills.layout_probe import (
-    RuntimeLayoutInspection,
-    RuntimeLayoutInspectionStatus,
 )
 from engine.community.manager import EngineManager
 
@@ -221,21 +225,20 @@ def test_ensure_center_skills_route_success(rich_manager, client):
     assert len(captured["items"]) == 2
 
 
-def test_runtime_layout_probe_has_no_engine_capability_dependency(client, monkeypatch):
-    import importlib
-
-    router_module = importlib.import_module("engine.community.api.skills.router")
-    monkeypatch.setattr(
-        router_module,
-        "inspect_runtime_layout",
-        lambda **_kwargs: RuntimeLayoutInspection(
-            status=RuntimeLayoutInspectionStatus.READY,
+def test_runtime_layout_probe_has_no_engine_capability_dependency(
+    client, rich_manager
+):
+    plugin = MagicMock()
+    plugin.probe_pool_layout = AsyncMock(
+        return_value=PoolLayoutProbeResult(
+            status=PoolLayoutProbeStatus.READY,
             engine="openclaw",
             layout_contract_version="skills-pool-p3-v1",
             preparation_id="prep-1",
             evidence={"checks": {"pool_repo_mounted": True}},
-        ),
+        )
     )
+    rich_manager._active_engine._skills = plugin
 
     response = client.post(
         "/api/skills/layout/probe",
@@ -247,3 +250,114 @@ def test_runtime_layout_probe_has_no_engine_capability_dependency(client, monkey
 
     assert response.status_code == 200
     assert response.json()["data"]["status"] == "READY"
+    plugin.probe_pool_layout.assert_awaited_once()
+
+
+def test_pool_activation_and_mapping_routes_are_capability_independent(
+    client, rich_manager
+):
+    plugin = MagicMock()
+    plugin.activate_pool_layout = AsyncMock(
+        return_value=PoolLayoutActivationResult(
+            committed=True,
+            status="COMMITTED",
+            evidence={"bridge": "valid"},
+        ),
+    )
+    plugin.publish_pool_mappings = AsyncMock(
+        return_value=PoolMappingPublishResult(
+            published=True,
+            evidence={"total": 1},
+        ),
+    )
+    plugin.verify_pool_mappings = AsyncMock(
+        return_value=PoolMappingVerificationResult(
+            valid=True,
+            evidence={"checked": 1},
+        ),
+    )
+    rich_manager._active_engine._skills = plugin
+    mappings = [{"source": "/pool/a", "target": "/skills/a"}]
+
+    activation = client.post(
+        "/api/skills/layout/activate",
+        json={
+            "migration_generation": "generation-1",
+            "preparation_id": "preparation-1",
+            "registered_local_names": ["a"],
+            "mappings": mappings,
+        },
+    )
+    published = client.post(
+        "/api/skills/layout/mappings/publish",
+        json={"mappings": mappings},
+    )
+    verified = client.post(
+        "/api/skills/layout/mappings/verify",
+        json={"mappings": mappings},
+    )
+
+    assert activation.json()["data"]["committed"] is True
+    assert published.json()["data"]["published"] is True
+    assert verified.json()["data"]["valid"] is True
+    plugin.activate_pool_layout.assert_awaited_once()
+    plugin.publish_pool_mappings.assert_awaited_once()
+    plugin.verify_pool_mappings.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        (
+            "probe_pool_layout",
+            "/api/skills/layout/probe",
+            {
+                "engine": "claude_code",
+                "layout_contract_version": "skills-pool-p3-v1",
+            },
+        ),
+        (
+            "activate_pool_layout",
+            "/api/skills/layout/activate",
+            {
+                "migration_generation": "generation-1",
+                "preparation_id": "preparation-1",
+                "registered_local_names": [],
+                "mappings": [],
+            },
+        ),
+        (
+            "publish_pool_mappings",
+            "/api/skills/layout/mappings/publish",
+            {"mappings": []},
+        ),
+        (
+            "verify_pool_mappings",
+            "/api/skills/layout/mappings/verify",
+            {"mappings": []},
+        ),
+    ],
+)
+def test_pool_routes_map_unsupported_engine_to_501(
+    client,
+    rich_manager,
+    method: str,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    plugin = MagicMock()
+    setattr(
+        plugin,
+        method,
+        AsyncMock(
+            side_effect=CapabilityNotSupportedError(
+                "claude_code",
+                Capability.SKILLS_SYNC_BINDPATHS,
+            )
+        ),
+    )
+    rich_manager._active_engine._skills = plugin
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 501

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -33,7 +33,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from engine.community.core.engine.capability import Capability
 from engine.community.core.engine.context import AuthContext
+from engine.community.core.engine.exceptions import CapabilityNotSupportedError
 from engine.community.core.skills.models import (
     CenterEnsureFailure,
     CenterEnsureItem,
@@ -41,6 +43,12 @@ from engine.community.core.skills.models import (
     CenterEnsureResult,
     CleanSymlinksRequest,
     CleanSymlinksResult,
+    PoolLayoutActivateRequest,
+    PoolLayoutActivationResult,
+    PoolLayoutProbeRequest,
+    PoolLayoutProbeResult,
+    PoolMappingPublishResult,
+    PoolMappingVerificationResult,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
@@ -50,6 +58,7 @@ from engine.community.core.skills.models import (
     SyncBindPathsRequest,
     SyncSymlinksRequest,
     SyncSymlinksResult,
+    SymlinkItem,
 )
 from engine.community.core.skills.protocol import SkillsService
 from engine.community.plugin_api.claude_code.skills import ClaudeCodeSkillsPort
@@ -303,6 +312,42 @@ class ClaudeCodeSkillsAdapter(SkillsService):
             for d in raw.get("failed", []) if isinstance(d, dict)
         ]
         return CenterEnsureResult(ok=ok, failed=failed)
+
+    async def activate_pool_layout(
+        self,
+        request: PoolLayoutActivateRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutActivationResult:
+        raise CapabilityNotSupportedError(
+            "claude_code", Capability.SKILLS_SYNC_BINDPATHS
+        )
+
+    async def probe_pool_layout(
+        self,
+        request: PoolLayoutProbeRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutProbeResult:
+        raise CapabilityNotSupportedError(
+            "claude_code", Capability.SKILLS_SYNC_BINDPATHS
+        )
+
+    async def publish_pool_mappings(
+        self,
+        mappings: list[SymlinkItem],
+        auth: AuthContext | None = None,
+    ) -> PoolMappingPublishResult:
+        raise CapabilityNotSupportedError(
+            "claude_code", Capability.SKILLS_SYNC_BINDPATHS
+        )
+
+    async def verify_pool_mappings(
+        self,
+        mappings: list[SymlinkItem],
+        auth: AuthContext | None = None,
+    ) -> PoolMappingVerificationResult:
+        raise CapabilityNotSupportedError(
+            "claude_code", Capability.SKILLS_SYNC_BINDPATHS
+        )
 
 
 __all__ = ["ClaudeCodeSkillsAdapter"]

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -31,6 +31,13 @@ from engine.community.core.skills.models import (
     CenterEnsureResult,
     CleanSymlinksRequest,
     CleanSymlinksResult,
+    PoolLayoutActivateRequest,
+    PoolLayoutActivationResult,
+    PoolLayoutProbeRequest,
+    PoolLayoutProbeResult,
+    PoolLayoutProbeStatus,
+    PoolMappingPublishResult,
+    PoolMappingVerificationResult,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
@@ -38,6 +45,7 @@ from engine.community.core.skills.models import (
     SyncBindPathsRequest,
     SyncSymlinksRequest,
     SyncSymlinksResult,
+    SymlinkItem,
 )
 from engine.community.core.skills.protocol import SkillsService
 from engine.community.plugin_api.openclaw.skills import OpenClawSkillsPort
@@ -130,6 +138,87 @@ class OpenClawSkillsAdapter(SkillsService):
         return CleanSymlinksResult(
             directories_scanned=raw["directories_scanned"],
             removed=raw.get("removed", []),
+        )
+
+    async def activate_pool_layout(
+        self,
+        request: PoolLayoutActivateRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutActivationResult:
+        raw = await self._port.activate_pool_layout(
+            {
+                "migration_generation": request.migration_generation,
+                "preparation_id": request.preparation_id,
+                "registered_local_names": request.registered_local_names,
+                "mappings": [
+                    {"source": item.source, "target": item.target}
+                    for item in request.mappings
+                ],
+            }
+        )
+        return PoolLayoutActivationResult(
+            committed=raw.get("committed") is True,
+            status=str(raw.get("status", "")),
+            evidence=dict(raw.get("evidence") or {}),
+        )
+
+    async def probe_pool_layout(
+        self,
+        request: PoolLayoutProbeRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutProbeResult:
+        raw = await self._port.probe_pool_layout(
+            {
+                "engine": request.engine,
+                "layout_contract_version": request.layout_contract_version,
+            }
+        )
+        return PoolLayoutProbeResult(
+            status=PoolLayoutProbeStatus(str(raw["status"])),
+            engine=str(raw["engine"]),
+            layout_contract_version=str(raw["layout_contract_version"]),
+            preparation_id=(
+                str(raw["preparation_id"])
+                if raw.get("preparation_id") is not None
+                else None
+            ),
+            evidence=dict(raw.get("evidence") or {}),
+        )
+
+    async def publish_pool_mappings(
+        self,
+        mappings: list[SymlinkItem],
+        auth: AuthContext | None = None,
+    ) -> PoolMappingPublishResult:
+        raw = await self._port.publish_pool_mappings(
+            {
+                "mappings": [
+                    {"source": item.source, "target": item.target}
+                    for item in mappings
+                ]
+            }
+        )
+        return PoolMappingPublishResult(
+            published=raw.get("published") is True,
+            evidence=dict(raw.get("evidence") or {}),
+        )
+
+    async def verify_pool_mappings(
+        self,
+        mappings: list[SymlinkItem],
+        auth: AuthContext | None = None,
+    ) -> PoolMappingVerificationResult:
+        raw = await self._port.verify_pool_mappings(
+            {
+                "mappings": [
+                    {"source": item.source, "target": item.target}
+                    for item in mappings
+                ]
+            }
+        )
+        return PoolMappingVerificationResult(
+            valid=raw.get("valid") is True,
+            evidence=dict(raw.get("evidence") or {}),
         )
 
     # ── Per-skill ops (not exposed by OpenClaw) ───────────────────────────────

--- a/src/engine/src/engine/community/core/skills/models.py
+++ b/src/engine/src/engine/community/core/skills/models.py
@@ -6,7 +6,7 @@ See src/engine/docs/heterogeneous-engine-architecture.md §7.2.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any
 
 
@@ -174,6 +174,89 @@ class CenterEnsureResult:
     failed: list[CenterEnsureFailure] = field(default_factory=list)
 
 
+@dataclass
+class PoolLayoutActivateRequest:
+    """提交 OpenClaw Pool 数据面所需的稳定 Service API 请求。"""
+
+    migration_generation: str
+    preparation_id: str
+    registered_local_names: list[str] = field(default_factory=list)
+    mappings: list[SymlinkItem] = field(default_factory=list)
+
+
+@dataclass
+class PoolLayoutProbeRequest:
+    """运行时 Pool layout 核验请求。"""
+
+    engine: str
+    layout_contract_version: str
+
+
+class PoolLayoutProbeStatus(StrEnum):
+    READY = "READY"
+    NOT_CAPABLE = "NOT_CAPABLE"
+    TRANSIENT_ERROR = "TRANSIENT_ERROR"
+    INVALID = "INVALID"
+
+
+@dataclass
+class PoolLayoutProbeResult:
+    """运行时 Pool layout 核验结果。"""
+
+    status: PoolLayoutProbeStatus
+    engine: str
+    layout_contract_version: str
+    preparation_id: str | None
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_data(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "engine": self.engine,
+            "layout_contract_version": self.layout_contract_version,
+            "preparation_id": self.preparation_id,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass
+class PoolLayoutActivationResult:
+    """Pool 数据面切换结果。"""
+
+    committed: bool
+    status: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_data(self) -> dict[str, Any]:
+        return {
+            "committed": self.committed,
+            "status": self.status,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass
+class PoolMappingPublishResult:
+    """Pool mapping 全量发布结果。"""
+
+    published: bool
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_data(self) -> dict[str, Any]:
+        return {"published": self.published, "evidence": self.evidence}
+
+
+@dataclass
+class PoolMappingVerificationResult:
+    """Pool mapping 当前状态验证结果。"""
+
+    valid: bool
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_data(self) -> dict[str, Any]:
+        return {"valid": self.valid, "evidence": self.evidence}
+
+
 __all__ = [
     "CenterEnsureFailure",
     "CenterEnsureItem",
@@ -181,6 +264,13 @@ __all__ = [
     "CenterEnsureResult",
     "CleanSymlinksRequest",
     "CleanSymlinksResult",
+    "PoolLayoutActivateRequest",
+    "PoolLayoutActivationResult",
+    "PoolLayoutProbeRequest",
+    "PoolLayoutProbeResult",
+    "PoolLayoutProbeStatus",
+    "PoolMappingPublishResult",
+    "PoolMappingVerificationResult",
     "Skill",
     "SkillConfig",
     "SkillExecutionRequest",

--- a/src/engine/src/engine/community/core/skills/protocol.py
+++ b/src/engine/src/engine/community/core/skills/protocol.py
@@ -29,6 +29,12 @@ from engine.community.core.skills.models import (
     CenterEnsureResult,
     CleanSymlinksRequest,
     CleanSymlinksResult,
+    PoolLayoutActivateRequest,
+    PoolLayoutActivationResult,
+    PoolLayoutProbeRequest,
+    PoolLayoutProbeResult,
+    PoolMappingPublishResult,
+    PoolMappingVerificationResult,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
@@ -36,6 +42,7 @@ from engine.community.core.skills.models import (
     SyncBindPathsRequest,
     SyncSymlinksRequest,
     SyncSymlinksResult,
+    SymlinkItem,
 )
 
 
@@ -158,6 +165,38 @@ class SkillsService(Protocol):
         returned in `failed` with a human-readable reason; individual failures
         do not abort the batch.
         """
+        ...
+
+    async def activate_pool_layout(
+        self,
+        request: PoolLayoutActivateRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutActivationResult:
+        """最终同步已登记 local 并原子提交 Legacy→Pool bridge。"""
+        ...
+
+    async def probe_pool_layout(
+        self,
+        request: PoolLayoutProbeRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutProbeResult:
+        """核验当前运行时的 Pool layout 能力与事实。"""
+        ...
+
+    async def publish_pool_mappings(
+        self,
+        mappings: list[SymlinkItem],
+        auth: AuthContext | None = None,
+    ) -> PoolMappingPublishResult:
+        """发布目标 Pool layout 的完整受管 mapping。"""
+        ...
+
+    async def verify_pool_mappings(
+        self,
+        mappings: list[SymlinkItem],
+        auth: AuthContext | None = None,
+    ) -> PoolMappingVerificationResult:
+        """验证当前受管入口精确指向请求中的 Pool source。"""
         ...
 
 

--- a/src/engine/src/engine/community/plugin_api/openclaw/skills.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/skills.py
@@ -85,5 +85,29 @@ class OpenClawSkillsPort(Protocol):
         """
         ...
 
+    async def activate_pool_layout(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """最终同步已登记 local 并原子提交永久兼容 bridge。"""
+        ...
+
+    async def probe_pool_layout(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """核验当前 OpenClaw Pool layout。"""
+        ...
+
+    async def publish_pool_mappings(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """发布目标 Pool layout 的完整受管 mapping。"""
+        ...
+
+    async def verify_pool_mappings(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """验证受管入口精确解析到目标 Pool source。"""
+        ...
+
 
 __all__ = ["OpenClawSkillsPort"]

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -4,6 +4,7 @@ Also contains _SkillsEnsureError (relocated from engines/openclaw/skills.py).
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -11,6 +12,13 @@ from typing import Any
 
 from engine.community.plugin_api.workspace_root import workspace_root
 from engine.community.plugins.openclaw._file import _convert_path
+from engine.community.plugins.openclaw.layout_activation import (
+    SkillMapping,
+    activate_openclaw_pool,
+    publish_pool_mappings,
+    verify_skill_mappings,
+)
+from engine.community.plugins.openclaw.layout_probe import inspect_runtime_layout
 
 log = logging.getLogger("openclaw-port")
 
@@ -35,6 +43,55 @@ class _SkillsPortMixin:
     _DEFAULT_SKILLS_CENTER_LOCAL_ROOT = str(
         workspace_root() / "skills" / "skills-center"
     )
+
+    @staticmethod
+    def _pool_mappings(params: dict[str, Any]) -> list[SkillMapping]:
+        return [
+            SkillMapping(source=item["source"], target=item["target"])
+            for item in params.get("mappings", [])
+        ]
+
+    async def activate_pool_layout(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        result = await asyncio.to_thread(
+            activate_openclaw_pool,
+            migration_generation=params["migration_generation"],
+            preparation_id=params["preparation_id"],
+            registered_local_names=list(
+                params.get("registered_local_names", [])
+            ),
+            mappings=self._pool_mappings(params),
+        )
+        return result.to_data()
+
+    async def probe_pool_layout(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        result = await asyncio.to_thread(
+            inspect_runtime_layout,
+            engine=params["engine"],
+            expected_contract_version=params["layout_contract_version"],
+        )
+        return result.to_data()
+
+    async def publish_pool_mappings(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        result = await asyncio.to_thread(
+            publish_pool_mappings,
+            mappings=self._pool_mappings(params),
+        )
+        return result.to_data()
+
+    async def verify_pool_mappings(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        result = await asyncio.to_thread(
+            verify_skill_mappings,
+            mappings=self._pool_mappings(params),
+        )
+        return result.to_data()
 
     def _skills_resolve_base_dir(self) -> Path:
         """Resolve SKILLS_LINK_BASE_DIR from env, or default.
@@ -366,11 +423,14 @@ class _SkillsPortMixin:
 
         if clean_target_dir:
             target_dirs = {t.parent for t in desired}
+            reserved_layout_bridges = {"skills-local", "skills-repo"}
             for d in target_dirs:
                 if not d.is_dir():
                     continue
                 for entry in d.iterdir():
                     if not entry.is_symlink():
+                        continue
+                    if entry.name in reserved_layout_bridges:
                         continue
                     if entry not in desired:
                         entry.unlink()

--- a/src/engine/src/engine/community/plugins/openclaw/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/layout_activation.py
@@ -1,0 +1,538 @@
+"""OpenClaw Skills Pool 的运行时最终同步与原子 local bridge 切换。"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import re
+import sys
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Callable
+
+from engine.community.plugins.openclaw.layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+    RuntimeLayoutInspectionStatus,
+    inspect_runtime_layout,
+)
+from engine.community.plugins.openclaw.layout_sync import (
+    load_baseline_manifest,
+    merge_post_cutover_changes,
+    mirror_registered_local,
+    write_baseline_manifest,
+)
+
+
+class PoolActivationStatus(StrEnum):
+    COMMITTED = "COMMITTED"
+    ALREADY_COMMITTED = "ALREADY_COMMITTED"
+    INVALID = "INVALID"
+    TRANSIENT_ERROR = "TRANSIENT_ERROR"
+    POST_CUTOVER_SYNC_PENDING = "POST_CUTOVER_SYNC_PENDING"
+    NOT_ATOMIC = "NOT_ATOMIC"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillMapping:
+    source: str
+    target: str
+
+
+@dataclass(frozen=True, slots=True)
+class PoolActivationResult:
+    status: PoolActivationStatus
+    evidence: dict[str, object]
+
+    @property
+    def committed(self) -> bool:
+        return self.status in {
+            PoolActivationStatus.COMMITTED,
+            PoolActivationStatus.ALREADY_COMMITTED,
+        }
+
+    def to_data(self) -> dict[str, object]:
+        return {
+            "committed": self.committed,
+            "status": self.status.value,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MappingVerificationResult:
+    valid: bool
+    evidence: dict[str, object]
+
+    def to_data(self) -> dict[str, object]:
+        return {"valid": self.valid, "evidence": self.evidence}
+
+
+@dataclass(frozen=True, slots=True)
+class MappingPublishResult:
+    published: bool
+    evidence: dict[str, object]
+
+    def to_data(self) -> dict[str, object]:
+        return {"published": self.published, "evidence": self.evidence}
+
+
+@dataclass(frozen=True, slots=True)
+class _Layout:
+    legacy_root: Path
+    legacy_local: Path
+    pool_root: Path
+    pool_local: Path
+    pool_repo: Path
+
+    @classmethod
+    def for_home(cls, home: Path) -> "_Layout":
+        workspace = home / ".openclaw" / "workspace"
+        legacy_root = workspace / "skills"
+        pool_root = workspace / "skills-pool"
+        return cls(
+            legacy_root=legacy_root,
+            legacy_local=legacy_root / "skills-local",
+            pool_root=pool_root,
+            pool_local=pool_root / "skills-local",
+            pool_repo=pool_root / "skills-repo",
+        )
+
+
+def _lexical_target(link: Path) -> Path:
+    target = link.readlink()
+    if not target.is_absolute():
+        target = link.parent / target
+    return Path(os.path.abspath(target))
+
+
+def atomic_exchange_paths(left: Path, right: Path) -> bool:
+    """原子交换同一文件系统上的两个目录项。
+
+    Linux 使用 ``renameat2(RENAME_EXCHANGE)``，macOS 测试环境使用
+    ``renamex_np(RENAME_SWAP)``。不支持时返回 ``False``，调用方不得降级成
+    两次普通 rename。
+    """
+
+    if left.parent.stat().st_dev != right.parent.stat().st_dev:
+        return False
+    libc = ctypes.CDLL(None, use_errno=True)
+    left_raw = os.fsencode(left)
+    right_raw = os.fsencode(right)
+
+    if sys.platform.startswith("linux") and hasattr(libc, "renameat2"):
+        renameat2 = libc.renameat2
+        renameat2.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        renameat2.restype = ctypes.c_int
+        result = renameat2(-100, left_raw, -100, right_raw, 2)
+    elif sys.platform == "darwin" and hasattr(libc, "renamex_np"):
+        renamex_np = libc.renamex_np
+        renamex_np.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        renamex_np.restype = ctypes.c_int
+        result = renamex_np(left_raw, right_raw, 0x00000002)
+    else:
+        return False
+
+    if result == 0:
+        return True
+    current_errno = ctypes.get_errno()
+    if current_errno in {
+        errno.ENOSYS,
+        errno.ENOTSUP,
+        getattr(errno, "EOPNOTSUPP", errno.ENOTSUP),
+        errno.EXDEV,
+    }:
+        return False
+    raise OSError(current_errno, os.strerror(current_errno))
+
+
+def _invalid(reason: str, **evidence: object) -> PoolActivationResult:
+    return PoolActivationResult(
+        PoolActivationStatus.INVALID,
+        {"reason": reason, **evidence},
+    )
+
+
+def activate_openclaw_pool(
+    *,
+    migration_generation: str,
+    preparation_id: str,
+    registered_local_names: list[str],
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+    repo_is_mounted: Callable[[Path], bool] | None = None,
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    before_post_sync: Callable[[], None] | None = None,
+) -> PoolActivationResult:
+    """同步已登记 local，校验 mapping source，并原子提交 Legacy→Pool bridge。"""
+
+    home_path = Path(home)
+    layout = _Layout.for_home(home_path)
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", migration_generation):
+        return _invalid("migration_generation_invalid")
+
+    inspection = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home_path,
+        repo_is_mounted=repo_is_mounted,
+    )
+    if (
+        inspection.status is not RuntimeLayoutInspectionStatus.READY
+        or inspection.preparation_id != preparation_id
+    ):
+        return _invalid(
+            "runtime_layout_not_ready",
+            probe_status=inspection.status.value,
+            preparation_id=inspection.preparation_id,
+        )
+
+    temporary = layout.legacy_root / (
+        f".skills-local.pool-cutover-{migration_generation}"
+    )
+    quarantine = (
+        layout.pool_root
+        / ".migration-quarantine"
+        / migration_generation
+        / "skills-local"
+    )
+    baseline_path = layout.pool_root / (
+        f".cutover-baseline-{migration_generation}.json"
+    )
+    normalized_names: list[str] = []
+    for name in registered_local_names:
+        path = Path(name)
+        if (
+            not name
+            or path.is_absolute()
+            or len(path.parts) != 1
+            or name in {".", ".."}
+        ):
+            return _invalid("registered_local_name_invalid", name=name)
+        if name not in normalized_names:
+            normalized_names.append(name)
+    try:
+        if layout.legacy_local.is_symlink():
+            if _lexical_target(layout.legacy_local) != Path(
+                os.path.abspath(layout.pool_local)
+            ):
+                return _invalid("legacy_local_bridge_invalid")
+            cleanup_pending = False
+            post_sync: dict[str, object] = {}
+            if temporary.is_dir() and not temporary.is_symlink():
+                for name in normalized_names:
+                    source = temporary / name
+                    if not source.is_dir() or source.is_symlink():
+                        return _invalid(
+                            "registered_local_source_invalid",
+                            source=str(source),
+                        )
+                try:
+                    baseline = load_baseline_manifest(baseline_path)
+                    post_sync = merge_post_cutover_changes(
+                        source_root=temporary,
+                        pool_local=layout.pool_local,
+                        registered_local_names=normalized_names,
+                        baseline=baseline,
+                    )
+                except (OSError, ValueError) as error:
+                    return PoolActivationResult(
+                        PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                        {
+                            "reason": "post_cutover_sync_failed",
+                            "error_type": type(error).__name__,
+                            "errno": error.errno,
+                        },
+                    )
+                quarantine.parent.mkdir(parents=True, exist_ok=True)
+                if quarantine.exists() or quarantine.is_symlink():
+                    cleanup_pending = True
+                else:
+                    temporary.rename(quarantine)
+                baseline_path.unlink(missing_ok=True)
+            return PoolActivationResult(
+                PoolActivationStatus.ALREADY_COMMITTED,
+                {
+                    "bridge": str(layout.legacy_local),
+                    "target": str(layout.pool_local),
+                    "quarantine": str(quarantine),
+                    "quarantine_cleanup_pending": cleanup_pending,
+                    "post_sync": post_sync,
+                },
+            )
+        if not layout.legacy_local.is_dir():
+            return _invalid("legacy_local_not_directory")
+
+        for name in normalized_names:
+            source = layout.legacy_local / name
+            if not source.is_dir() or source.is_symlink():
+                return _invalid("registered_local_source_invalid", source=str(source))
+
+        mirror_registered_local(
+            source_root=layout.legacy_local,
+            pool_local=layout.pool_local,
+            registered_local_names=normalized_names,
+            staging_root=layout.pool_root
+            / f".final-sync-{migration_generation}",
+        )
+        baseline = write_baseline_manifest(
+            pool_local=layout.pool_local,
+            registered_local_names=normalized_names,
+            manifest_path=baseline_path,
+        )
+
+        targets: set[Path] = set()
+        for mapping in mappings:
+            source = Path(mapping.source)
+            target = Path(mapping.target)
+            if (
+                not source.is_absolute()
+                or not target.is_absolute()
+                or target.parent != layout.legacy_root
+                or target in targets
+                or not (
+                    source.is_relative_to(layout.pool_local)
+                    or source.is_relative_to(layout.pool_repo)
+                )
+                or not source.exists()
+            ):
+                return _invalid(
+                    "mapping_source_invalid",
+                    source=str(source),
+                    target=str(target),
+                )
+            targets.add(target)
+
+        if temporary.exists() or temporary.is_symlink():
+            return _invalid("cutover_temporary_path_occupied", path=str(temporary))
+        temporary.symlink_to(layout.pool_local, target_is_directory=True)
+        if not exchange_paths(layout.legacy_local, temporary):
+            temporary.unlink(missing_ok=True)
+            return PoolActivationResult(
+                PoolActivationStatus.NOT_ATOMIC,
+                {"reason": "atomic_exchange_unavailable"},
+            )
+
+        if (
+            not layout.legacy_local.is_symlink()
+            or _lexical_target(layout.legacy_local)
+            != Path(os.path.abspath(layout.pool_local))
+        ):
+            return _invalid("cutover_result_ambiguous")
+
+        if before_post_sync is not None:
+            before_post_sync()
+        try:
+            post_sync = merge_post_cutover_changes(
+                source_root=temporary,
+                pool_local=layout.pool_local,
+                registered_local_names=normalized_names,
+                baseline=baseline,
+            )
+        except (OSError, ValueError) as error:
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "post_cutover_sync_failed",
+                    "error_type": type(error).__name__,
+                    "errno": error.errno,
+                },
+            )
+
+        quarantine.parent.mkdir(parents=True, exist_ok=True)
+        cleanup_pending = False
+        if quarantine.exists() or quarantine.is_symlink():
+            cleanup_pending = True
+        else:
+            temporary.rename(quarantine)
+        baseline_path.unlink(missing_ok=True)
+        return PoolActivationResult(
+            PoolActivationStatus.COMMITTED,
+            {
+                "bridge": str(layout.legacy_local),
+                "target": str(layout.pool_local),
+                "quarantine": str(quarantine),
+                "quarantine_cleanup_pending": cleanup_pending,
+                "registered_local_count": len(normalized_names),
+                "mapping_source_count": len(mappings),
+                "post_sync": post_sync,
+            },
+        )
+    except OSError as error:
+        committed = (
+            layout.legacy_local.is_symlink()
+            and _lexical_target(layout.legacy_local)
+            == Path(os.path.abspath(layout.pool_local))
+        )
+        return PoolActivationResult(
+            (
+                PoolActivationStatus.COMMITTED
+                if committed
+                else PoolActivationStatus.TRANSIENT_ERROR
+            ),
+            {
+                "reason": (
+                    "post_cutover_cleanup_failed"
+                    if committed
+                    else "filesystem_operation_failed"
+                ),
+                "error_type": type(error).__name__,
+                "errno": error.errno,
+            },
+        )
+
+
+def verify_skill_mappings(
+    *,
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+) -> MappingVerificationResult:
+    """验证受管激活入口精确解析到请求中的 Pool source。"""
+
+    layout = _Layout.for_home(Path(home))
+    seen: set[Path] = set()
+    failures: list[dict[str, str]] = []
+    for mapping in mappings:
+        source = Path(mapping.source)
+        target = Path(mapping.target)
+        reason = ""
+        if (
+            not source.is_absolute()
+            or not (
+                source.is_relative_to(layout.pool_local)
+                or source.is_relative_to(layout.pool_repo)
+            )
+        ):
+            reason = "source_outside_pool"
+        elif not source.exists():
+            reason = "source_missing"
+        elif target.parent != layout.legacy_root or target in seen:
+            reason = "target_invalid"
+        elif not target.is_symlink():
+            reason = "target_not_symlink"
+        elif _lexical_target(target) != Path(os.path.abspath(source)):
+            reason = "target_mismatch"
+        seen.add(target)
+        if reason:
+            failures.append(
+                {"source": str(source), "target": str(target), "reason": reason}
+            )
+    return MappingVerificationResult(
+        valid=not failures,
+        evidence={"checked": len(mappings), "failures": failures},
+    )
+
+
+def publish_pool_mappings(
+    *,
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+) -> MappingPublishResult:
+    """对齐已登记 Pool mapping，同时保留尚未分类的既有入口。
+
+    #369 只掌握 Backend 已登记技能，不能把未出现在请求中的入口等同为
+    stale；完整文件系统枚举与受管/外部分类由后续 #370 承接。
+    """
+
+    layout = _Layout.for_home(Path(home))
+    desired: dict[Path, Path] = {}
+    failures: list[dict[str, str]] = []
+    for mapping in mappings:
+        source = Path(mapping.source)
+        target = Path(mapping.target)
+        reason = ""
+        if (
+            not source.is_absolute()
+            or not (
+                source.is_relative_to(layout.pool_local)
+                or source.is_relative_to(layout.pool_repo)
+            )
+            or not source.exists()
+        ):
+            reason = "source_invalid"
+        elif (
+            not target.is_absolute()
+            or target.parent != layout.legacy_root
+            or target.name in {"skills-local", "skills-repo"}
+            or target in desired
+        ):
+            reason = "target_invalid"
+        if reason:
+            failures.append(
+                {"source": str(source), "target": str(target), "reason": reason}
+            )
+        else:
+            desired[target] = source
+    if failures:
+        return MappingPublishResult(
+            published=False,
+            evidence={"reason": "mapping_invalid", "failures": failures},
+        )
+
+    created: list[str] = []
+    updated: list[str] = []
+    kept: list[str] = []
+    removed: list[str] = []
+    try:
+        for target, source in desired.items():
+            if target.is_symlink():
+                if _lexical_target(target) == Path(os.path.abspath(source)):
+                    kept.append(str(target))
+                    continue
+                target.unlink()
+                updated.append(str(target))
+            elif target.exists():
+                return MappingPublishResult(
+                    published=False,
+                    evidence={
+                        "reason": "managed_target_occupied",
+                        "target": str(target),
+                    },
+                )
+            target.symlink_to(source, target_is_directory=True)
+            if str(target) not in updated:
+                created.append(str(target))
+
+    except OSError as error:
+        return MappingPublishResult(
+            published=False,
+            evidence={
+                "reason": "mapping_publish_io_error",
+                "error_type": type(error).__name__,
+                "errno": error.errno,
+            },
+        )
+    return MappingPublishResult(
+        published=True,
+        evidence={
+            "total": len(desired),
+            "created": created,
+            "updated": updated,
+            "kept": kept,
+            "removed": removed,
+        },
+    )
+
+
+__all__ = [
+    "MappingVerificationResult",
+    "MappingPublishResult",
+    "PoolActivationResult",
+    "PoolActivationStatus",
+    "SkillMapping",
+    "activate_openclaw_pool",
+    "atomic_exchange_paths",
+    "publish_pool_mappings",
+    "verify_skill_mappings",
+]

--- a/src/engine/src/engine/community/plugins/openclaw/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/layout_probe.py
@@ -1,4 +1,4 @@
-"""In-runtime validation for the persistent OpenClaw Skills Pool layout."""
+"""OpenClaw 插件对持久化 Skills Pool layout 的运行时核验。"""
 
 from __future__ import annotations
 

--- a/src/engine/src/engine/community/plugins/openclaw/layout_sync.py
+++ b/src/engine/src/engine/community/plugins/openclaw/layout_sync.py
@@ -1,0 +1,240 @@
+"""Skills Pool cutover 前后 local 数据同步原语。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+from pathlib import Path
+from uuid import uuid4
+
+Fingerprint = tuple[str, str]
+Manifest = dict[str, Fingerprint]
+
+
+def mirror_registered_local(
+    *,
+    source_root: Path,
+    pool_local: Path,
+    registered_local_names: list[str],
+    staging_root: Path,
+) -> None:
+    """交换前把 registered local 精确镜像到 Pool。"""
+
+    _remove_path(staging_root)
+    staging_root.mkdir()
+    for name in registered_local_names:
+        staging = staging_root / name
+        shutil.copytree(
+            source_root / name,
+            staging,
+            symlinks=True,
+            copy_function=shutil.copy2,
+        )
+        destination = pool_local / name
+        _remove_path(destination)
+        staging.rename(destination)
+    staging_root.rmdir()
+
+
+def write_baseline_manifest(
+    *,
+    pool_local: Path,
+    registered_local_names: list[str],
+    manifest_path: Path,
+) -> Manifest:
+    """持久化交换前 Pool 快照，供交换后或失败重试执行三方合并。"""
+
+    manifest = snapshot_registered(
+        pool_local,
+        registered_local_names,
+    )
+    temporary = manifest_path.with_name(
+        f".{manifest_path.name}.{uuid4().hex}.tmp"
+    )
+    temporary.write_text(
+        json.dumps({key: list(value) for key, value in manifest.items()}),
+        encoding="utf-8",
+    )
+    os.replace(temporary, manifest_path)
+    return manifest
+
+
+def load_baseline_manifest(manifest_path: Path) -> Manifest:
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("cutover baseline must be an object")
+    manifest: Manifest = {}
+    for key, value in raw.items():
+        if (
+            not isinstance(key, str)
+            or not isinstance(value, list)
+            or len(value) != 2
+            or not all(isinstance(item, str) for item in value)
+        ):
+            raise ValueError("cutover baseline entry is invalid")
+        manifest[key] = (value[0], value[1])
+    return manifest
+
+
+def merge_post_cutover_changes(
+    *,
+    source_root: Path,
+    pool_local: Path,
+    registered_local_names: list[str],
+    baseline: Manifest,
+) -> dict[str, object]:
+    """三方合并交换窗口内的 Legacy 变化，保留交换后的 Pool 新写入。
+
+    ``baseline`` 是首次 final sync 后的 Pool；``source_root`` 是原子交换
+    后换出的 Legacy 快照；``pool_local`` 是交换后继续承接新写入的目标。
+    交换后 Pool 是唯一写入权威源：已有或已删除的目标绝不再被 Legacy
+    修改/删除。只对 baseline 中不存在、且 Pool 当前仍不存在的新路径执行
+    原子 no-clobber 创建；其余 Legacy delta 留在 quarantine 供审计。
+    """
+
+    source = snapshot_registered(source_root, registered_local_names)
+    changed = {
+        key
+        for key in set(baseline) | set(source)
+        if source.get(key) != baseline.get(key)
+    }
+    applied: list[str] = []
+    conflicts: list[str] = sorted(
+        key for key in changed if key not in source
+    )
+
+    upserts = sorted(
+        (key for key in changed if key in source),
+        key=lambda key: (key.count("/"), key),
+    )
+    for key in upserts:
+        source_path = source_root / key
+        target = pool_local / key
+        desired = source[key]
+        observed = _fingerprint(target)
+        if observed == desired:
+            continue
+        if baseline.get(key) is not None or observed is not None:
+            conflicts.append(key)
+            continue
+        if not _create_if_absent(
+            source=source_path,
+            target=target,
+            desired=desired,
+        ):
+            conflicts.append(key)
+            continue
+        applied.append(key)
+
+    return {
+        "applied": applied,
+        "conflicts_preserved_in_pool": conflicts,
+    }
+
+
+def snapshot_registered(
+    root: Path,
+    registered_local_names: list[str],
+) -> Manifest:
+    manifest: Manifest = {}
+    for name in registered_local_names:
+        skill_root = root / name
+        root_fingerprint = _fingerprint(skill_root)
+        if root_fingerprint is None:
+            continue
+        manifest[name] = root_fingerprint
+        if root_fingerprint[0] != "dir":
+            continue
+        for current_root, directory_names, file_names in os.walk(
+            skill_root,
+            followlinks=False,
+        ):
+            current_path = Path(current_root)
+            for entry_name in [*directory_names, *file_names]:
+                entry = current_path / entry_name
+                fingerprint = _fingerprint(entry)
+                if fingerprint is not None:
+                    manifest[entry.relative_to(root).as_posix()] = fingerprint
+    return manifest
+
+
+def _fingerprint(path: Path) -> Fingerprint | None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        return None
+    if stat.S_ISDIR(mode):
+        return ("dir", "")
+    if stat.S_ISLNK(mode):
+        return ("symlink", os.readlink(path))
+    if stat.S_ISREG(mode):
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return ("file", digest.hexdigest())
+    raise OSError(f"unsupported filesystem entry: {path}")
+
+
+def _create_if_absent(
+    *,
+    source: Path,
+    target: Path,
+    desired: Fingerprint,
+) -> bool:
+    if _fingerprint(target) is not None:
+        return False
+    if not target.parent.is_dir() or target.parent.is_symlink():
+        return False
+    kind = desired[0]
+    if kind == "dir":
+        try:
+            target.mkdir()
+        except (FileExistsError, FileNotFoundError, NotADirectoryError):
+            return False
+        return _fingerprint(target) == desired
+
+    temporary = target.with_name(f".{target.name}.{uuid4().hex}.pool-sync")
+    try:
+        if kind == "file":
+            shutil.copy2(source, temporary)
+        elif kind == "symlink":
+            temporary.symlink_to(os.readlink(source))
+        else:
+            raise OSError(f"unsupported manifest kind: {kind}")
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+
+    if _fingerprint(target) is not None:
+        _remove_path(temporary)
+        return False
+    try:
+        if kind == "file":
+            os.link(temporary, target)
+            temporary.unlink()
+        else:
+            target.symlink_to(os.readlink(temporary))
+            temporary.unlink()
+    except (FileExistsError, FileNotFoundError, NotADirectoryError):
+        _remove_path(temporary)
+        return False
+    return _fingerprint(target) == desired
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or (path.exists() and not path.is_dir()):
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+__all__ = [
+    "load_baseline_manifest",
+    "merge_post_cutover_changes",
+    "mirror_registered_local",
+    "snapshot_registered",
+    "write_baseline_manifest",
+]

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1,0 +1,745 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from engine.community.core.adapters.openclaw.skills import OpenClawSkillsAdapter
+from engine.community.core.skills.models import (
+    PoolLayoutActivateRequest,
+    PoolLayoutProbeRequest,
+    SymlinkItem,
+)
+from engine.community.plugins.openclaw.layout_activation import (
+    MappingPublishResult,
+    MappingVerificationResult,
+    PoolActivationResult,
+    PoolActivationStatus,
+    SkillMapping,
+    activate_openclaw_pool,
+    atomic_exchange_paths,
+    publish_pool_mappings,
+    verify_skill_mappings,
+)
+from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
+from engine.community.plugins.openclaw.layout_probe import LAYOUT_CONTRACT_VERSION
+from engine.community.plugins.openclaw.layout_probe import (
+    RuntimeLayoutInspection,
+    RuntimeLayoutInspectionStatus,
+)
+from engine.community.plugins.openclaw.layout_sync import (
+    write_baseline_manifest,
+)
+
+
+PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
+
+
+def _prepared_home(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    home = tmp_path / "home" / "admin"
+    workspace = home / ".openclaw" / "workspace"
+    legacy_root = workspace / "skills"
+    legacy_local = legacy_root / "skills-local"
+    pool_root = workspace / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+    legacy_repo = legacy_root / "skills-repo"
+
+    (legacy_local / "handmade").mkdir(parents=True)
+    (legacy_local / "handmade" / "SKILL.md").write_text("latest")
+    (pool_local / "handmade").mkdir(parents=True)
+    (pool_local / "handmade" / "SKILL.md").write_text("prepared-old")
+    (pool_local / "handmade" / "stale.txt").write_text("delete-me")
+    (pool_repo / "business" / "repo-skill").mkdir(parents=True)
+    (pool_repo / "business" / "repo-skill" / "SKILL.md").write_text("repo")
+    legacy_repo.symlink_to(pool_repo, target_is_directory=True)
+
+    marker = {
+        "engine": "openclaw",
+        "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+        "preparation_id": PREPARATION_ID,
+        "prepared_at": "2026-07-23T06:00:00Z",
+        "pool_local_root": str(pool_local),
+        "pool_repo_root": str(pool_repo),
+        "validation_summary": {
+            "all_valid": True,
+            "pool_local": {"path": str(pool_local), "valid": True},
+            "pool_repo": {
+                "path": str(pool_repo),
+                "readable_mount": True,
+                "valid": True,
+            },
+            "legacy_repo_bridge": {
+                "path": str(legacy_repo),
+                "target": str(pool_repo),
+                "valid": True,
+            },
+            "managed_active_entries": [],
+            "external_active_entry_count": 0,
+        },
+    }
+    (pool_root / ".pool-ready").write_text(json.dumps(marker))
+    return home, legacy_local, pool_local, pool_repo
+
+
+def test_registered_local_cutover_syncs_latest_content_and_atomically_bridges(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    mappings = [
+        SkillMapping(
+            source=str(pool_local / "handmade"),
+            target=str(legacy_local.parent / "handmade"),
+        ),
+        SkillMapping(
+            source=str(pool_repo / "business" / "repo-skill"),
+            target=str(legacy_local.parent / "repo-skill"),
+        ),
+    ]
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert legacy_local.is_symlink()
+    assert legacy_local.resolve() == pool_local.resolve()
+    assert (legacy_local / "handmade" / "SKILL.md").read_text() == "latest"
+    assert not (legacy_local / "handmade" / "stale.txt").exists()
+    quarantine = (
+        pool_local.parent
+        / ".migration-quarantine"
+        / "generation-1"
+        / "skills-local"
+    )
+    assert (quarantine / "handmade" / "SKILL.md").read_text() == "latest"
+
+    external_source = tmp_path / "external"
+    external_source.mkdir()
+    external_entry = legacy_local.parent / "external"
+    external_entry.symlink_to(external_source, target_is_directory=True)
+    unclassified_entry = legacy_local.parent / "unclassified"
+    unclassified_entry.symlink_to(
+        pool_local / "handmade", target_is_directory=True
+    )
+    published = publish_pool_mappings(mappings=mappings, home=home)
+    assert published.published
+    assert external_entry.is_symlink()
+    assert unclassified_entry.is_symlink()
+    assert legacy_local.is_symlink()
+    assert (legacy_local.parent / "skills-repo").is_symlink()
+    verification = verify_skill_mappings(mappings=mappings, home=home)
+    assert verification.valid
+    assert (legacy_local.parent / "handmade" / "SKILL.md").read_text() == "latest"
+    assert (legacy_local.parent / "repo-skill" / "SKILL.md").read_text() == "repo"
+
+    repeated = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert repeated.status is PoolActivationStatus.ALREADY_COMMITTED
+
+
+def test_cutover_rejects_missing_pool_mapping_source_before_bridge(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "missing"),
+                target=str(legacy_local.parent / "missing"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == "mapping_source_invalid"
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+
+
+def test_final_sync_materializes_skill_created_after_preparation(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    late_legacy = legacy_local / "late-skill"
+    late_legacy.mkdir()
+    (late_legacy / "SKILL.md").write_text("late")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade", "late-skill"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "late-skill"),
+                target=str(legacy_local.parent / "late-skill"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.committed
+    assert (pool_local / "late-skill" / "SKILL.md").read_text() == "late"
+
+
+def test_post_exchange_sync_captures_write_after_initial_copy(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def write_then_exchange(left: Path, right: Path) -> bool:
+        (left / "handmade" / "created-during-cutover.txt").write_text(
+            "must-survive"
+        )
+        return atomic_exchange_paths(left, right)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=write_then_exchange,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert (
+        pool_local / "handmade" / "created-during-cutover.txt"
+    ).read_text() == "must-survive"
+
+
+def test_post_exchange_sync_preserves_new_pool_write_on_same_file(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def update_legacy_then_exchange(left: Path, right: Path) -> bool:
+        (left / "handmade" / "SKILL.md").write_text("pre-exchange")
+        return atomic_exchange_paths(left, right)
+
+    def update_pool_after_exchange() -> None:
+        (legacy_local / "handmade" / "SKILL.md").write_text("post-exchange")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=update_legacy_then_exchange,
+        before_post_sync=update_pool_after_exchange,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == "post-exchange"
+    assert result.evidence["post_sync"]["conflicts_preserved_in_pool"] == [
+        "handmade/SKILL.md"
+    ]
+
+
+def test_post_exchange_new_file_uses_atomic_no_clobber(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import os
+
+    from engine.community.plugins.openclaw import layout_sync
+
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def add_legacy_file_then_exchange(left: Path, right: Path) -> bool:
+        (left / "handmade" / "raced.txt").write_text("legacy-window")
+        return atomic_exchange_paths(left, right)
+
+    real_link = os.link
+
+    def race_link(source: Path, target: Path) -> None:
+        if Path(target).name == "raced.txt":
+            Path(target).write_text("pool-after-exchange")
+        real_link(source, target)
+
+    monkeypatch.setattr(layout_sync.os, "link", race_link)
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=add_legacy_file_then_exchange,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert (legacy_local / "handmade" / "raced.txt").read_text() == (
+        "pool-after-exchange"
+    )
+    assert result.evidence["post_sync"]["conflicts_preserved_in_pool"] == [
+        "handmade/raced.txt"
+    ]
+
+
+def test_post_exchange_pool_parent_deletion_is_not_resurrected(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def add_child_then_exchange(left: Path, right: Path) -> bool:
+        (left / "handmade" / "late-child.txt").write_text("legacy-window")
+        return atomic_exchange_paths(left, right)
+
+    def delete_pool_parent() -> None:
+        shutil.rmtree(legacy_local / "handmade")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=add_child_then_exchange,
+        before_post_sync=delete_pool_parent,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert not (pool_local / "handmade").exists()
+    assert result.evidence["post_sync"][
+        "conflicts_preserved_in_pool"
+    ] == ["handmade/late-child.txt"]
+
+
+def test_post_exchange_deleted_parent_does_not_stall_new_subdirectory(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def add_subtree_then_exchange(left: Path, right: Path) -> bool:
+        new_dir = left / "handmade" / "late-directory"
+        new_dir.mkdir()
+        (new_dir / "child.txt").write_text("legacy-window")
+        return atomic_exchange_paths(left, right)
+
+    def delete_pool_parent() -> None:
+        shutil.rmtree(legacy_local / "handmade")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=add_subtree_then_exchange,
+        before_post_sync=delete_pool_parent,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert not (pool_local / "handmade").exists()
+    assert set(
+        result.evidence["post_sync"]["conflicts_preserved_in_pool"]
+    ) == {
+        "handmade/late-directory",
+        "handmade/late-directory/child.txt",
+    }
+
+
+def test_retry_after_exchange_finishes_quarantine_move(tmp_path: Path) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    write_baseline_manifest(
+        pool_local=pool_local,
+        registered_local_names=["handmade"],
+        manifest_path=pool_local.parent
+        / ".cutover-baseline-generation-1.json",
+    )
+    temporary = legacy_local.parent / ".skills-local.pool-cutover-generation-1"
+    legacy_local.rename(temporary)
+    legacy_local.symlink_to(pool_local, target_is_directory=True)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    quarantine = (
+        pool_local.parent
+        / ".migration-quarantine"
+        / "generation-1"
+        / "skills-local"
+    )
+    assert result.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert quarantine.is_dir()
+    assert not temporary.exists()
+
+
+def test_cutover_stays_legacy_when_atomic_exchange_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(legacy_local.parent / "handmade"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=lambda _left, _right: False,
+    )
+
+    assert result.status is PoolActivationStatus.NOT_ATOMIC
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+
+
+@pytest.mark.parametrize(
+    ("generation", "preparation_id", "names", "reason"),
+    [
+        ("bad generation", PREPARATION_ID, ["handmade"], "migration_generation_invalid"),
+        ("generation-1", "stale-preparation", ["handmade"], "runtime_layout_not_ready"),
+        ("generation-1", PREPARATION_ID, ["../escape"], "registered_local_name_invalid"),
+        ("generation-1", PREPARATION_ID, ["missing"], "registered_local_source_invalid"),
+    ],
+)
+def test_cutover_rejects_invalid_inputs(
+    tmp_path: Path,
+    generation: str,
+    preparation_id: str,
+    names: list[str],
+    reason: str,
+) -> None:
+    home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
+
+    result = activate_openclaw_pool(
+        migration_generation=generation,
+        preparation_id=preparation_id,
+        registered_local_names=names,
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == reason
+    assert legacy_local.is_dir()
+
+
+def test_cutover_rejects_non_directory_legacy_local(tmp_path: Path) -> None:
+    home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
+    shutil.rmtree(legacy_local)
+    legacy_local.write_text("occupied")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.evidence["reason"] == "legacy_local_not_directory"
+
+
+def test_cutover_cleans_stale_staging_and_replaces_pool_symlink(
+    tmp_path: Path,
+) -> None:
+    home, _legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    staging = pool_local.parent / ".final-sync-generation-1"
+    staging.symlink_to(tmp_path / "unused", target_is_directory=True)
+    shutil.rmtree(pool_local / "handmade")
+    (pool_local / "handmade").symlink_to(
+        tmp_path / "old", target_is_directory=True
+    )
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade", "handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.committed
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
+
+
+def test_cutover_rejects_occupied_temporary_and_ambiguous_exchange(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
+    temporary = legacy_local.parent / ".skills-local.pool-cutover-generation-1"
+    temporary.write_text("occupied")
+
+    occupied = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert occupied.evidence["reason"] == "cutover_temporary_path_occupied"
+
+    temporary.unlink()
+    ambiguous = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=lambda _left, _right: True,
+    )
+    assert ambiguous.evidence["reason"] == "cutover_result_ambiguous"
+
+
+def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
+    home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def fail_exchange(_left: Path, _right: Path) -> bool:
+        raise OSError(5, "io")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=fail_exchange,
+    )
+
+    assert result.status is PoolActivationStatus.TRANSIENT_ERROR
+    assert result.evidence["reason"] == "filesystem_operation_failed"
+    assert legacy_local.is_dir()
+
+
+def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:
+    home, legacy_local, pool_local, _pool_repo = _prepared_home(tmp_path)
+    valid_source = pool_local / "handmade"
+    mismatch_source = pool_local / "other"
+    mismatch_source.mkdir()
+    mismatch = legacy_local.parent / "mismatch"
+    mismatch.symlink_to(valid_source, target_is_directory=True)
+    duplicate = legacy_local.parent / "duplicate"
+    duplicate.symlink_to(valid_source, target_is_directory=True)
+    not_link = legacy_local.parent / "not-link"
+    not_link.mkdir()
+
+    result = verify_skill_mappings(
+        home=home,
+        mappings=[
+            SkillMapping("relative", str(legacy_local.parent / "outside")),
+            SkillMapping(
+                str(pool_local / "missing"),
+                str(legacy_local.parent / "missing"),
+            ),
+            SkillMapping(str(valid_source), str(tmp_path / "wrong-parent")),
+            SkillMapping(str(valid_source), str(not_link)),
+            SkillMapping(str(mismatch_source), str(mismatch)),
+            SkillMapping(str(valid_source), str(duplicate)),
+            SkillMapping(str(valid_source), str(duplicate)),
+        ],
+    )
+
+    assert not result.valid
+    assert {
+        failure["reason"] for failure in result.evidence["failures"]
+    } == {
+        "source_outside_pool",
+        "source_missing",
+        "target_invalid",
+        "target_not_symlink",
+        "target_mismatch",
+    }
+
+
+def test_mapping_publisher_validates_updates_and_occupied_targets(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, _pool_repo = _prepared_home(tmp_path)
+    source = pool_local / "handmade"
+    target = legacy_local.parent / "handmade"
+
+    invalid = publish_pool_mappings(
+        home=home,
+        mappings=[
+            SkillMapping("relative", str(target)),
+            SkillMapping(str(source), str(legacy_local)),
+        ],
+    )
+    assert not invalid.published
+    assert invalid.evidence["reason"] == "mapping_invalid"
+
+    target.symlink_to(tmp_path / "old", target_is_directory=True)
+    updated = publish_pool_mappings(
+        home=home,
+        mappings=[SkillMapping(str(source), str(target))],
+    )
+    assert updated.published
+    assert updated.evidence["updated"] == [str(target)]
+
+    kept = publish_pool_mappings(
+        home=home,
+        mappings=[SkillMapping(str(source), str(target))],
+    )
+    assert kept.published
+    assert kept.evidence["kept"] == [str(target)]
+
+    target.unlink()
+    target.mkdir()
+    occupied = publish_pool_mappings(
+        home=home,
+        mappings=[SkillMapping(str(source), str(target))],
+    )
+    assert not occupied.published
+    assert occupied.evidence["reason"] == "managed_target_occupied"
+
+
+@pytest.mark.asyncio
+async def test_openclaw_service_api_translates_pool_port_contract() -> None:
+    port = MagicMock()
+    port.activate_pool_layout = AsyncMock(
+        return_value={"committed": True, "status": "COMMITTED"}
+    )
+    port.probe_pool_layout = AsyncMock(
+        return_value={
+            "status": "READY",
+            "engine": "openclaw",
+            "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+            "preparation_id": PREPARATION_ID,
+            "evidence": {},
+        }
+    )
+    port.publish_pool_mappings = AsyncMock(
+        return_value={"published": True, "total": 1}
+    )
+    port.verify_pool_mappings = AsyncMock(
+        return_value={"valid": True, "checked": 1}
+    )
+    service = OpenClawSkillsAdapter(port)
+    mapping = SymlinkItem(source="/pool/a", target="/skills/a")
+
+    activated = await service.activate_pool_layout(
+        PoolLayoutActivateRequest(
+            migration_generation="generation-1",
+            preparation_id=PREPARATION_ID,
+            registered_local_names=["a"],
+            mappings=[mapping],
+        )
+    )
+    probed = await service.probe_pool_layout(
+        PoolLayoutProbeRequest(
+            engine="openclaw",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        )
+    )
+    published = await service.publish_pool_mappings([mapping])
+    verified = await service.verify_pool_mappings([mapping])
+
+    assert activated.committed
+    assert probed.status.value == "READY"
+    assert published.published
+    assert verified.valid
+    port.activate_pool_layout.assert_awaited_once_with(
+        {
+            "migration_generation": "generation-1",
+            "preparation_id": PREPARATION_ID,
+            "registered_local_names": ["a"],
+            "mappings": [{"source": "/pool/a", "target": "/skills/a"}],
+        }
+    )
+    port.probe_pool_layout.assert_awaited_once_with(
+        {
+            "engine": "openclaw",
+            "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_openclaw_port_runs_pool_filesystem_operations_off_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import _skills
+
+    monkeypatch.setattr(
+        _skills,
+        "activate_openclaw_pool",
+        lambda **_kwargs: PoolActivationResult(
+            PoolActivationStatus.COMMITTED, {"bridge": "valid"}
+        ),
+    )
+    monkeypatch.setattr(
+        _skills,
+        "inspect_runtime_layout",
+        lambda **_kwargs: RuntimeLayoutInspection(
+            status=RuntimeLayoutInspectionStatus.READY,
+            engine="openclaw",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=PREPARATION_ID,
+            evidence={},
+        ),
+    )
+    monkeypatch.setattr(
+        _skills,
+        "publish_pool_mappings",
+        lambda **_kwargs: MappingPublishResult(True, {"total": 1}),
+    )
+    monkeypatch.setattr(
+        _skills,
+        "verify_skill_mappings",
+        lambda **_kwargs: MappingVerificationResult(True, {"checked": 1}),
+    )
+    port = OpenClawPluginImpl()
+    params = {
+        "migration_generation": "generation-1",
+        "preparation_id": PREPARATION_ID,
+        "registered_local_names": ["a"],
+        "mappings": [{"source": "/pool/a", "target": "/skills/a"}],
+    }
+
+    assert (await port.activate_pool_layout(params))["committed"] is True
+    assert (
+        await port.probe_pool_layout(
+            {
+                "engine": "openclaw",
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+            }
+        )
+    )["status"] == "READY"
+    assert (await port.publish_pool_mappings(params))["published"] is True
+    assert (await port.verify_pool_mappings(params))["valid"] is True

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from engine.community.core.skills.layout_probe import (
+from engine.community.plugins.openclaw.layout_probe import (
     LAYOUT_CONTRACT_VERSION,
     RuntimeLayoutInspectionStatus,
     inspect_runtime_layout,


### PR DESCRIPTION
## Summary

- 新增 Bot 级 Skills Pool reconcile 服务，以 claim、runtime READY probe、lease/migration generation CAS 串联迁移
- 对 OpenClaw 执行已登记 local skills 最终同步、legacy local 原子桥切换、managed active mapping 发布与校验
- mapping 校验成功后，在同一 CAS 事务内提交 local locator 并切换 `POOL_ACTIVE`
- 补齐 `POOL_ACTIVE` 下技能读取、删除、上传、去重及 metadata 的新 locator 兼容
- Engine 侧新增强类型 probe/activate/mapping API；非 OpenClaw 引擎明确返回 501

## Scope boundaries

- 本 PR 仅覆盖 #369 已登记技能的 OpenClaw 激活闭环
- 未登记 local、外部软链与冲突归类留给 #370
- 生产生命周期唤醒与持久化调度留给 #371

## Verification

- 重放到最新 `dev` 前：Backend 目标测试 89 passed；Engine 完整门禁 1922 passed，change coverage 94.93%
- 重放到最新 `dev` 后：`git diff --check` 通过；完整本地门禁按要求停止，最终结果由 GitHub CI 判定

Closes #369