### PR TITLE
fix(bcs): exclude requester from discovery

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
@@ -107,7 +107,7 @@ async fn discover_with_fuse_unreachable_degrades_to_registry_only() {
     bot2.send_heartbeat().await;
 
     // Discover with q — fuse recommend will fail (unreachable), should degrade
-    let client = bot1.http_client(addr);
+    let client = bot2.http_client(addr);
     let result = client.discover_bots(Some("architecture")).await;
 
     assert!(result.is_ok(), "Discover should succeed even when fuse is unreachable: {:?}", result.err());
@@ -132,7 +132,7 @@ async fn discover_without_fuse_returns_registry_results() {
     bot2.register("DBABot", &["database"], addr).await;
     bot2.send_heartbeat().await;
 
-    let client = bot1.http_client(addr);
+    let client = bot2.http_client(addr);
     let result = client.discover_bots(Some("architecture")).await;
 
     assert!(result.is_ok(), "Discover should succeed: {:?}", result.err());
@@ -167,7 +167,7 @@ async fn discover_by_name_returns_matching_bots() {
     let url = format!("http://{}/bots/discover?name=arch", addr);
     let response: serde_json::Value = reqwest::Client::new()
         .get(&url)
-        .header("Authorization", format!("Bearer {}", bot1.token.as_str()))
+        .header("Authorization", format!("Bearer {}", bot2.token.as_str()))
         .send()
         .await
         .expect("Failed to call discover")
@@ -202,11 +202,15 @@ async fn discover_by_name_does_not_trigger_fuse() {
     bot1.register("TestBot", &["testing"], addr).await;
     bot1.send_heartbeat().await;
 
+    let mut bot2 = MockBot::connect(addr).await;
+    bot2.register("ObserverBot", &["observation"], addr).await;
+    bot2.send_heartbeat().await;
+
     // name search should NOT call fuse recommend — should succeed even with fuse unreachable
     let url = format!("http://{}/bots/discover?name=test", addr);
     let response = reqwest::Client::new()
         .get(&url)
-        .header("Authorization", format!("Bearer {}", bot1.token.as_str()))
+        .header("Authorization", format!("Bearer {}", bot2.token.as_str()))
         .send()
         .await
         .expect("Failed to call discover");

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
@@ -92,6 +92,7 @@ pub struct BotDiscoveryCommand {
     pub scopes: Option<String>,
     pub visibility: Option<String>,
     pub collaborate_bot: Option<String>,
+    /// Authenticated bot requester. When present, discovery excludes this bot.
     pub requester_bot_id: Option<String>,
     pub organization_code: Option<String>,
     pub role: Option<String>,

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -388,6 +388,9 @@ impl BotDiscoveryService for Bot {
 
         let entries = bots
             .into_iter()
+            .filter(|candidate| {
+                command.requester_bot_id.as_deref() != Some(candidate.bot.bot_uuid.as_str())
+            })
             .filter(|candidate| matches_discovery_selector(&candidate.bot, &command))
             .filter_map(|candidate| discover_entry(candidate, &command, friend_uuids.as_ref()))
             .collect::<Vec<_>>();
@@ -821,6 +824,9 @@ impl Bot {
         let mut entries = Vec::new();
         for bot in bots {
             if bot.actor_kind != ActorKind::Bot || bot.capabilities.name.is_none() {
+                continue;
+            }
+            if bot.bot_uuid.as_str() == requester {
                 continue;
             }
             if !matches_discovery_selector(&bot, &command) {

--- a/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
@@ -770,6 +770,7 @@ async fn discover_bots_applies_visibility_and_friend_matrix() {
         .discover_bots(BotDiscoveryCommand {
             q: Some("planner".to_string()),
             collaborate_bot: Some("driver".to_string()),
+            requester_bot_id: Some("driver".to_string()),
             ..Default::default()
         })
         .await
@@ -780,7 +781,7 @@ async fn discover_bots_applies_visibility_and_friend_matrix() {
         .iter()
         .map(|entry| (entry.bot_uuid.as_str(), entry.is_friend))
         .collect::<Vec<_>>();
-    assert!(ids.contains(&("driver", Some(false))));
+    assert!(!ids.iter().any(|(id, _)| *id == "driver"));
     assert!(ids.contains(&("protected-friend", Some(true))));
     assert!(!ids.iter().any(|(id, _)| *id == "protected-stranger"));
     assert!(!ids.iter().any(|(id, _)| *id == "private-planner"));
@@ -858,7 +859,7 @@ async fn organization_scoped_discovery_filters_effective_members_and_attaches_me
     let fixture = RegistryFixture::new();
     let registry: Arc<dyn BotRegistryCoreService> = fixture.registry.clone();
     let organization = Arc::new(StaticOrganizationCoreService::with_members(vec![
-        org_member("bot-a", "planner"),
+        org_member("bot-a", "traffic_analyst"),
         org_member("bot-b", "traffic_analyst"),
         org_member("bot-c", "traffic_analyst"),
         org_member("bot-d", "traffic_analyst"),
@@ -870,7 +871,7 @@ async fn organization_scoped_discovery_filters_effective_members_and_attaches_me
     .with_bot_core(fixture.registry.clone())
     .with_organization(organization);
 
-    register_bot(&fixture.registry, "bot-a", caps(Some("Requester"), Some("planner"), "public"), None).await;
+    register_bot(&fixture.registry, "bot-a", caps(Some("Requester"), Some("traffic"), "public"), None).await;
     register_bot(&fixture.registry, "bot-b", caps(Some("Traffic Public"), Some("traffic"), "protected"), None).await;
     register_bot(&fixture.registry, "bot-c", caps(Some("Traffic Private"), Some("traffic"), "private"), None).await;
     register_bot(&fixture.registry, "bot-d", caps(Some("Traffic Friend"), Some("traffic"), "private"), None).await;


### PR DESCRIPTION
## Summary

- exclude the authenticated requester bot from normal discovery results
- exclude the requester from organization-scoped discovery results
- document the `requester_bot_id` contract and add regression coverage

## Why

`bcs-cli discover` authenticates with a bot token, and the HTTP adapter already forwards the corresponding `requester_bot_id`. The application discovery service did not use that identity to filter candidates, so a bot could discover itself.

## Impact

Bot-authenticated discovery no longer returns the caller itself. Human and service callers without a requester bot identity retain the existing behavior.

## Checks

- `cargo test -p bcs-bot` — 96 passed
- `cargo test -p bcs-http --test discover_contract` — 6 passed
- branch was rebased onto `origin/dev`; push used `--no-verify` as requested
