### PR TITLE
fix(baas): preserve configured engine venv symlink

### DIFF
--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -1105,7 +1105,9 @@ class LocalProcessManager:
         """
         configured = os.environ.get("LOCAL_ENGINE_PYTHON")
         if configured:
-            candidate = Path(configured).expanduser().resolve()
+            candidate = Path(configured).expanduser()
+            if not candidate.is_absolute():
+                candidate = Path.cwd() / candidate
             if candidate.is_file() and os.access(candidate, os.X_OK):
                 return str(candidate)
             raise DeviceAllocateError(

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
@@ -1299,6 +1299,25 @@ class TestResolveEnginePython:
 
         assert result == str(configured_python)
 
+    def test_resolve_engine_python_preserves_configured_venv_symlink(
+        self, monkeypatch, tmp_path
+    ):
+        """Configured virtualenv interpreter keeps its symlink path."""
+        engine_src_dir = tmp_path / "engine" / "src"
+        engine_src_dir.mkdir(parents=True)
+        base_python = tmp_path / "uv" / "python"
+        base_python.parent.mkdir(parents=True)
+        base_python.touch()
+        base_python.chmod(base_python.stat().st_mode | stat.S_IXUSR)
+        venv_python = tmp_path / "runtime" / "bin" / "python"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.symlink_to(base_python)
+        monkeypatch.setenv("LOCAL_ENGINE_PYTHON", str(venv_python))
+
+        result = pm.LocalProcessManager._resolve_engine_python(engine_src_dir)
+
+        assert result == str(venv_python)
+
     def test_resolve_engine_python_rejects_missing_configured_override(
         self, monkeypatch, tmp_path
     ):


### PR DESCRIPTION
## Summary

- Preserve the configured engine interpreter symlink when BaaS starts a local adapter.
- Add a regression test for virtualenv interpreter symlinks.

## Root cause

`Path.resolve()` converted `LOCAL_ENGINE_PYTHON` from the engine virtualenv entry point to its uv-managed base interpreter. The base interpreter does not include `uvicorn`, so the adapter never listened on port 20010 and BaaS publish failed.

## Impact

Singlebox BaaS now starts per-Bot adapters with the configured engine virtualenv and its installed dependencies. No public contract or configuration schema changes.

## Validation

- `DEPLOY_ENV=test ../../../src/baas/.venv/bin/python -m pytest tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py tests/unit/plugins/sandbox/arca/test_process_manager_env.py -q`
- `../../../src/baas/.venv/bin/python -m ruff check src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py`
