### PR TITLE
feat: migrate complete OpenClaw filesystem truth (#370)

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -22,8 +22,19 @@ OpenClaw 原子数据面切换与 Pool mapping，并在最后事务性提交 loc
   都重新读取 Bot 和当前 provider binding，并重新 probe marker。
 - 容器内以系统原生原子 exchange 将 Legacy local 切成指向 Pool canonical
   local 的永久单向 bridge；不支持原子 exchange 时保持 Legacy。
+- 激活前同时核对已登记 local，并从文件系统枚举未登记 local、受管 active
+  entry 与外部 entry；完整 local 内容进入 Pool，但不会为未登记内容创建
+  数据库记录，外部 entry 保持原目标。
+- 已登记源缺失/不可读或受管入口冲突时，在数据面切换前阻断并持久化失败码、
+  阶段和独立证据；普通 probe 重试不会覆盖这份失败证据。
 - 数据面切换后先全量发布并验证 Pool mapping，再在一个 CAS 事务中更新该
   Bot 全部 local locator 和 `POOL_ACTIVE`。mapping 或事务失败只前滚重试。
+- 本模块当前只持久化尚未跨过 bridge 的结构性失败；bridge 已提交后的
+  `POST_CUTOVER_SYNC_PENDING`、mapping 与数据库提交失败的分阶段恢复和
+  审计持久化由 #376 的完整前滚恢复状态机承接，避免在 #370 重复定义状态。
+- local 后置合并采用 best-effort 原子 exchange：一般的切换前修改、切换后
+  Pool 修改和新增路径竞争均可收敛；无写栅栏时，跨 exchange 的已打开文件
+  描述符或连续同文件写入仍存在极窄竞态，作为 #370 的显式接受限制。
 
 ## Context Boundary
 
@@ -34,6 +45,8 @@ provides:
   - "SkillsPoolRolloutGate"
   - "SkillsPoolMigrationClaimService"
   - "SkillsPoolReconcileService"
+  - "PoolCutoverStatus"
+  - "PoolCutoverResult"
   - "BotSkillLayoutState and migration enums"
 consumes:
   - "BotRepository"

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,8 +40,40 @@ class PoolSkillMapping:
         return {"source": self.source, "target": self.target}
 
 
+class PoolCutoverStatus(StrEnum):
+    """Backend 与 Engine 激活端点之间的稳定状态契约。"""
+
+    COMMITTED = "COMMITTED"
+    ALREADY_COMMITTED = "ALREADY_COMMITTED"
+    ACTIVE_ENTRY_CONFLICT = "ACTIVE_ENTRY_CONFLICT"
+    DATA_INCONSISTENT = "DATA_INCONSISTENT"
+    INVALID = "INVALID"
+    TRANSIENT_ERROR = "TRANSIENT_ERROR"
+    POST_CUTOVER_SYNC_PENDING = "POST_CUTOVER_SYNC_PENDING"
+    NOT_ATOMIC = "NOT_ATOMIC"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True, slots=True)
+class PoolCutoverResult:
+    """Engine 激活响应在 Backend 领域层的类型化表示。"""
+
+    committed: bool
+    status: PoolCutoverStatus
+    evidence: dict[str, object]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "committed": self.committed,
+            "status": self.status.value,
+            "evidence": self.evidence,
+        }
+
+
 __all__ = [
     "OpenClawPoolPaths",
+    "PoolCutoverResult",
+    "PoolCutoverStatus",
     "PoolSkillMapping",
     "RegisteredSkillAsset",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/ports.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/ports.py
@@ -8,6 +8,7 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
     RuntimeLayoutProbeResult,
 )
 from agentclaw.community.core.skills_pool.models import (
+    PoolCutoverResult,
     PoolSkillMapping,
     RegisteredSkillAsset,
 )
@@ -55,7 +56,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         preparation_id: str,
         registered_local_names: list[str],
         mappings: list[PoolSkillMapping],
-    ) -> dict[str, object]:
+    ) -> PoolCutoverResult:
         ...
 
     async def publish_mappings(

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -20,6 +20,7 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
 )
 from agentclaw.community.core.skills_pool.models import (
     OpenClawPoolPaths,
+    PoolCutoverStatus,
     PoolSkillMapping,
     RegisteredSkillAsset,
 )
@@ -47,6 +48,8 @@ class SkillsPoolReconcileOutcome(StrEnum):
     TRANSIENT_ERROR = "transient_error"
     INVALID = "invalid"
     STATE_RACE_LOST = "state_race_lost"
+    DATA_INCONSISTENT = "data_inconsistent"
+    ACTIVE_ENTRY_CONFLICT = "active_entry_conflict"
     CUTOVER_FAILED = "cutover_failed"
     MAPPING_FAILED = "mapping_failed"
     MAPPING_VERIFY_FAILED = "mapping_verify_failed"
@@ -200,18 +203,43 @@ class SkillsPoolReconcileService:
                 registered_local_names=local_names,
                 mappings=mappings,
             )
-            if cutover.get("committed") is not True:
+            if not cutover.committed:
+                failure_profile = self._cutover_failure_profile(
+                    cutover.status
+                )
+                if failure_profile is not None:
+                    outcome, stage, retryable = failure_profile
+                    cutover_evidence = cutover.to_dict()
+                    recorded = self._layouts.record_pre_cutover_failure(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code=cutover.status.value,
+                        failure_stage=stage,
+                        retryable=retryable,
+                        evidence=cutover_evidence,
+                    )
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            preparation_id=probe.preparation_id,
+                        )
+                    return SkillsPoolReconcileResult(
+                        outcome,
+                        preparation_id=probe.preparation_id,
+                        evidence=cutover_evidence,
+                    )
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.CUTOVER_FAILED,
                     preparation_id=probe.preparation_id,
-                    evidence=cutover,
+                    evidence=cutover.to_dict(),
                 )
             if not self._layouts.record_cutover_committed(
                 scope=scope,
                 migration_generation=generation,
                 lease_owner=lease_owner,
                 preparation_id=probe.preparation_id,
-                evidence=cutover,
+                evidence=cutover.to_dict(),
             ):
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.STATE_RACE_LOST,
@@ -279,6 +307,38 @@ class SkillsPoolReconcileService:
             ),
             RuntimeLayoutProbeStatus.INVALID: SkillsPoolReconcileOutcome.INVALID,
         }.get(status, SkillsPoolReconcileOutcome.INVALID)
+
+    @staticmethod
+    def _cutover_failure_profile(
+        status: PoolCutoverStatus,
+    ) -> tuple[SkillsPoolReconcileOutcome, str, bool] | None:
+        return {
+            PoolCutoverStatus.DATA_INCONSISTENT: (
+                SkillsPoolReconcileOutcome.DATA_INCONSISTENT,
+                "pre_cutover_validation",
+                False,
+            ),
+            PoolCutoverStatus.ACTIVE_ENTRY_CONFLICT: (
+                SkillsPoolReconcileOutcome.ACTIVE_ENTRY_CONFLICT,
+                "pre_cutover_validation",
+                False,
+            ),
+            PoolCutoverStatus.NOT_ATOMIC: (
+                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                "atomic_cutover",
+                False,
+            ),
+            PoolCutoverStatus.INVALID: (
+                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                "pre_cutover_validation",
+                False,
+            ),
+            PoolCutoverStatus.TRANSIENT_ERROR: (
+                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                "pre_cutover_filesystem",
+                True,
+            ),
+        }.get(status)
 
     @staticmethod
     def _source_tail(git_path: str, prefix: str) -> PurePosixPath:

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
@@ -64,6 +64,7 @@ class BotSkillLayoutStateModel(Base):
     last_failure_code = Column(String(64), nullable=True)
     last_failure_stage = Column(String(64), nullable=True)
     last_failure_retryable = Column(SmallInteger, nullable=True)
+    last_failure_evidence = Column(Text, nullable=True)
     last_failure_at = Column(DateTime, nullable=True)
     pool_activated_at = Column(DateTime, nullable=True)
     lease_owner = Column(String(128), nullable=True)
@@ -123,6 +124,11 @@ class BotSkillLayoutStateModel(Base):
             last_failure_retryable=(
                 bool(self.last_failure_retryable)
                 if self.last_failure_retryable is not None
+                else None
+            ),
+            last_failure_evidence=(
+                json.loads(self.last_failure_evidence)
+                if self.last_failure_evidence
                 else None
             ),
             last_failure_at=self.last_failure_at,

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -99,6 +99,20 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """在运行时原子切换前持久化 pre-cutover 阶段。"""
         ...
 
+    def record_pre_cutover_failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> bool:
+        """持久化尚未跨越数据面边界的结构化失败及审计证据。"""
+        ...
+
     def commit_pool_active(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skills_pool/types.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/types.py
@@ -65,6 +65,7 @@ class BotSkillLayoutState:
     last_failure_code: str | None = None
     last_failure_stage: str | None = None
     last_failure_retryable: bool | None = None
+    last_failure_evidence: dict[str, object] | None = None
     last_failure_at: datetime | None = None
     pool_activated_at: datetime | None = None
     lease_owner: str | None = None

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -355,6 +355,60 @@ class SkillsPoolLayoutRepository:
             )
         return affected == 1
 
+    def record_pre_cutover_failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录结构化阻塞原因，但不跨越或回退数据面切换边界。"""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_READY.value,
+                            SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.last_failure_code: failure_code,
+                        BotSkillLayoutStateModel.last_failure_stage: (
+                            failure_stage
+                        ),
+                        BotSkillLayoutStateModel.last_failure_retryable: int(
+                            retryable
+                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
+                        BotSkillLayoutStateModel.last_failure_at: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
     def commit_pool_active(
         self,
         *,
@@ -423,6 +477,7 @@ class SkillsPoolLayoutRepository:
                         BotSkillLayoutStateModel.last_failure_code: None,
                         BotSkillLayoutStateModel.last_failure_stage: None,
                         BotSkillLayoutStateModel.last_failure_retryable: None,
+                        BotSkillLayoutStateModel.last_failure_evidence: None,
                         BotSkillLayoutStateModel.last_failure_at: None,
                     },
                     synchronize_session=False,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
@@ -14,6 +14,8 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
     RuntimeLayoutProbeResult,
 )
 from agentclaw.community.core.skills_pool.models import (
+    PoolCutoverResult,
+    PoolCutoverStatus,
     PoolSkillMapping,
 )
 from agentclaw.community.log import get_logger
@@ -61,7 +63,7 @@ class OpenClawSkillsPoolRuntime:
         preparation_id: str,
         registered_local_names: list[str],
         mappings: list[PoolSkillMapping],
-    ) -> dict[str, object]:
+    ) -> PoolCutoverResult:
         try:
             response = await self._invoke(
                 bot_id=bot_id,
@@ -80,15 +82,42 @@ class OpenClawSkillsPoolRuntime:
                 bot_id,
                 migration_generation,
             )
-            return {
-                "committed": False,
-                "reason": "runtime_cutover_request_failed",
-                "error_type": type(error).__name__,
-            }
+            return PoolCutoverResult(
+                committed=False,
+                status=PoolCutoverStatus.TRANSIENT_ERROR,
+                evidence={
+                    "reason": "runtime_cutover_request_failed",
+                    "error_type": type(error).__name__,
+                },
+            )
         data = response.get("data")
         if not isinstance(data, dict):
-            return {"committed": False, "reason": "runtime_cutover_response_invalid"}
-        return dict(data)
+            return PoolCutoverResult(
+                committed=False,
+                status=PoolCutoverStatus.INVALID,
+                evidence={"reason": "runtime_cutover_response_invalid"},
+            )
+        raw_status = str(data.get("status", ""))
+        try:
+            status = PoolCutoverStatus(raw_status)
+        except ValueError:
+            status = PoolCutoverStatus.UNKNOWN
+        evidence = dict(data.get("evidence") or {})
+        if status is PoolCutoverStatus.UNKNOWN:
+            evidence["raw_status"] = raw_status
+        committed = (
+            data.get("committed") is True
+            and status
+            in {
+                PoolCutoverStatus.COMMITTED,
+                PoolCutoverStatus.ALREADY_COMMITTED,
+            }
+        )
+        return PoolCutoverResult(
+            committed=committed,
+            status=status,
+            evidence=evidence,
+        )
 
     async def publish_mappings(
         self,

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -21,6 +21,9 @@ from agentclaw.community.core.skills_pool.types import (
 from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
 )
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
 from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
@@ -73,6 +76,12 @@ def rollout_evidence() -> RolloutEvidence:
         engine_type="openclaw",
         decision_reason="exact_bot_match",
     )
+
+
+def test_layout_repository_satisfies_public_protocol_shape() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+
+    assert isinstance(repository, SkillsPoolLayoutRepositoryProtocol)
 
 
 def test_missing_layout_state_reads_as_legacy_without_persisting() -> None:
@@ -287,6 +296,74 @@ def test_expired_lease_competition_has_one_new_owner(tmp_path: Path) -> None:
     assert results.count(True) == 1
     winner = ["worker-2", "worker-3"][results.index(True)]
     assert repository.get(scope).lease_owner == winner
+
+
+def test_pre_cutover_failure_evidence_survives_an_ordinary_retry() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    failure_evidence = {
+        "status": "DATA_INCONSISTENT",
+        "evidence": {
+            "reason": "registered_local_source_missing",
+            "registered_name": "handmade",
+        },
+    }
+
+    assert repository.record_pre_cutover_failure(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        failure_code="DATA_INCONSISTENT",
+        failure_stage="pre_cutover_validation",
+        retryable=False,
+        evidence=failure_evidence,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "still-valid"},
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_READY
+    assert state.last_probe_evidence == {"marker": "still-valid"}
+    assert state.last_failure_code == "DATA_INCONSISTENT"
+    assert state.last_failure_stage == "pre_cutover_validation"
+    assert state.last_failure_retryable is False
+    assert state.last_failure_evidence == failure_evidence
+    assert state.last_failure_at is not None
+    assert not repository.record_pre_cutover_failure(
+        scope=scope,
+        migration_generation="stale-generation",
+        lease_owner="worker-1",
+        failure_code="ACTIVE_ENTRY_CONFLICT",
+        failure_stage="pre_cutover_validation",
+        retryable=False,
+        evidence={},
+    )
 
 
 def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -12,6 +12,8 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
 )
 from agentclaw.community.core.skills_pool.models import (
     OpenClawPoolPaths,
+    PoolCutoverResult,
+    PoolCutoverStatus,
     RegisteredSkillAsset,
 )
 from agentclaw.community.core.skills_pool.reconcile_service import (
@@ -108,6 +110,19 @@ class FakeLayoutRepository:
         )
         return True
 
+    def record_pre_cutover_failure(self, **kwargs: object) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("failure")
+        self.state = replace(
+            self.state,
+            last_failure_code=str(kwargs["failure_code"]),
+            last_failure_stage=str(kwargs["failure_stage"]),
+            last_failure_retryable=bool(kwargs["retryable"]),
+            last_failure_evidence=dict(kwargs["evidence"]),
+        )
+        return True
+
     def commit_pool_active(
         self,
         *,
@@ -181,6 +196,17 @@ class FakeRuntime:
     def __init__(self) -> None:
         self.events: list[str] = []
         self.publish_success = True
+        self.cutover_result = PoolCutoverResult(
+            committed=True,
+            status=PoolCutoverStatus.COMMITTED,
+            evidence={
+                "local_inventory": {
+                    "registered": 2,
+                    "unregistered": 1,
+                    "total": 3,
+                }
+            },
+        )
         self.probe_result = RuntimeLayoutProbeResult(
             status=RuntimeLayoutProbeStatus.READY,
             engine="openclaw",
@@ -193,7 +219,7 @@ class FakeRuntime:
         self.events.append("probe")
         return self.probe_result
 
-    async def cutover(self, **kwargs: object) -> dict[str, object]:
+    async def cutover(self, **kwargs: object) -> PoolCutoverResult:
         self.events.append("cutover")
         assert kwargs["registered_local_names"] == ["local-a", "local-b"]
         mappings = kwargs["mappings"]
@@ -202,7 +228,7 @@ class FakeRuntime:
             f"{OpenClawPoolPaths().pool_local}/local-b",
             f"{OpenClawPoolPaths().pool_repo}/business/repo-skill",
         ]
-        return {"committed": True, "bridge": "valid"}
+        return self.cutover_result
 
     async def publish_mappings(self, **kwargs: object) -> bool:
         self.events.append("mapping")
@@ -278,6 +304,77 @@ async def test_mapping_failure_after_cutover_does_not_commit_database() -> None:
     assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "mapping", "verify"]
     assert layouts.events == ["database"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("runtime_status", "expected_outcome"),
+    [
+        (
+            "DATA_INCONSISTENT",
+            SkillsPoolReconcileOutcome.DATA_INCONSISTENT,
+        ),
+        (
+            "ACTIVE_ENTRY_CONFLICT",
+            SkillsPoolReconcileOutcome.ACTIVE_ENTRY_CONFLICT,
+        ),
+    ],
+)
+async def test_structural_cutover_failure_is_persisted_without_data_plane_change(
+    runtime_status: str,
+    expected_outcome: SkillsPoolReconcileOutcome,
+) -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus(runtime_status),
+        evidence={
+            "reason": "unsafe_filesystem_truth",
+            "affected": ["handmade"],
+        },
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is expected_outcome
+    assert layouts.events == ["ready", "begin", "failure"]
+    assert layouts.state.active_layout is SkillLayout.LEGACY
+    assert layouts.state.data_plane_cutover_committed is False
+    assert layouts.state.last_failure_code == runtime_status
+    assert layouts.state.last_failure_stage == "pre_cutover_validation"
+    assert layouts.state.last_failure_retryable is False
+    assert layouts.state.last_failure_evidence == runtime.cutover_result.to_dict()
+    assert runtime.events == ["probe", "cutover"]
+    assert layouts.committed_locators is None
+
+
+@pytest.mark.asyncio
+async def test_non_atomic_cutover_is_persisted_and_keeps_legacy() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.NOT_ATOMIC,
+        evidence={"reason": "atomic_exchange_unavailable"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert layouts.events == ["ready", "begin", "failure"]
+    assert layouts.state.active_layout is SkillLayout.LEGACY
+    assert layouts.state.last_failure_code == "NOT_ATOMIC"
+    assert layouts.state.last_failure_stage == "atomic_cutover"
+    assert layouts.state.last_failure_retryable is False
+    assert layouts.state.last_failure_evidence == runtime.cutover_result.to_dict()
+    assert runtime.events == ["probe", "cutover"]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from agentclaw.community.core.skills_pool.models import (
+    PoolCutoverStatus,
     PoolSkillMapping,
 )
 from agentclaw.community.plugins.skills_pool_runtime import OpenClawSkillsPoolRuntime
@@ -44,7 +45,14 @@ class FakeTransport:
             }
         )
         if path.endswith("/activate"):
-            return {"success": True, "data": {"committed": True}}
+            return {
+                "success": True,
+                "data": {
+                    "committed": True,
+                    "status": "COMMITTED",
+                    "evidence": {},
+                },
+            }
         if path.endswith("/publish"):
             return {"success": True, "data": {"published": True}}
         return {"success": True, "data": {"valid": True}}
@@ -53,6 +61,24 @@ class FakeTransport:
 class FakeProbe:
     async def probe_bot(self, **kwargs):
         return kwargs
+
+
+class FutureStatusTransport(FakeTransport):
+    async def invoke(self, conn_info, method, path, *, body, timeout):
+        response = await super().invoke(
+            conn_info,
+            method,
+            path,
+            body=body,
+            timeout=timeout,
+        )
+        if path.endswith("/activate"):
+            response["data"] = {
+                "committed": True,
+                "status": "FUTURE_STATUS",
+                "evidence": {"source": "newer-engine"},
+            }
+        return response
 
 
 @pytest.mark.asyncio
@@ -93,7 +119,8 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
         mappings=mappings,
     )
 
-    assert cutover["committed"] is True
+    assert cutover.committed
+    assert cutover.status is PoolCutoverStatus.COMMITTED
     assert published
     assert verified
     assert resolver.calls == [
@@ -106,3 +133,28 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
         "/api/skills/layout/mappings/publish",
         "/api/skills/layout/mappings/verify",
     ]
+
+
+@pytest.mark.asyncio
+async def test_pool_runtime_fails_closed_for_unknown_engine_status() -> None:
+    runtime = OpenClawSkillsPoolRuntime(
+        resolver=FakeResolver(),
+        adapter_transport=FutureStatusTransport(),
+        probe_service=FakeProbe(),
+    )
+
+    result = await runtime.cutover(
+        bot_id="bot-1",
+        user_id="owner-1",
+        migration_generation="generation-1",
+        preparation_id="preparation-1",
+        registered_local_names=[],
+        mappings=[],
+    )
+
+    assert result.status is PoolCutoverStatus.UNKNOWN
+    assert not result.committed
+    assert result.evidence == {
+        "source": "newer-engine",
+        "raw_status": "FUTURE_STATUS",
+    }

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -17,7 +17,9 @@ from engine.community.api.skills.schemas import (
     BindPathRequest,
     CenterEnsureRequestSchema,
     CleanSymlinkRequest,
+    PoolLayoutActivateApiResponse,
     PoolLayoutActivateRequest,
+    PoolLayoutActivateResponse,
     PoolMappingVerifyRequest,
     RuntimeLayoutProbeApiResponse,
     RuntimeLayoutProbeRequest,
@@ -68,10 +70,13 @@ async def probe_runtime_skills_layout(
     )
 
 
-@router.post("/layout/activate", response_model=ApiResponse)
+@router.post(
+    "/layout/activate",
+    response_model=PoolLayoutActivateApiResponse,
+)
 async def activate_runtime_skills_layout(
     body: PoolLayoutActivateRequest,
-) -> ApiResponse:
+) -> PoolLayoutActivateApiResponse:
     """在当前容器的持久化文件系统上提交 OpenClaw Pool 数据面。"""
 
     plugin = _skills_plugin()
@@ -89,9 +94,9 @@ async def activate_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
-    return ApiResponse(
+    return PoolLayoutActivateApiResponse(
         success=result.committed,
-        data=result.to_data(),
+        data=PoolLayoutActivateResponse.model_validate(result.to_data()),
         message=(
             "Skills Pool 数据面已提交"
             if result.committed

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -75,6 +75,26 @@ class PoolLayoutActivateRequest(BaseModel):
     mappings: list[SymlinkItem]
 
 
+class PoolLayoutActivateResponse(BaseModel):
+    committed: bool
+    status: Literal[
+        "COMMITTED",
+        "ALREADY_COMMITTED",
+        "ACTIVE_ENTRY_CONFLICT",
+        "DATA_INCONSISTENT",
+        "INVALID",
+        "TRANSIENT_ERROR",
+        "POST_CUTOVER_SYNC_PENDING",
+        "NOT_ATOMIC",
+        "UNKNOWN",
+    ]
+    evidence: dict[str, Any]
+
+
+class PoolLayoutActivateApiResponse(ApiResponse):
+    data: PoolLayoutActivateResponse
+
+
 class PoolMappingVerifyRequest(BaseModel):
     mappings: list[SymlinkItem]
 
@@ -93,5 +113,7 @@ __all__ = [
     "RuntimeLayoutProbeResponse",
     "RuntimeLayoutProbeApiResponse",
     "PoolLayoutActivateRequest",
+    "PoolLayoutActivateResponse",
+    "PoolLayoutActivateApiResponse",
     "PoolMappingVerifyRequest",
 ]

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -23,6 +23,7 @@ from engine.community.core.engine.exceptions import (
 from engine.community.core.skills.models import (
     CleanSymlinksResult,
     PoolLayoutActivationResult,
+    PoolLayoutActivationStatus,
     PoolLayoutProbeResult,
     PoolLayoutProbeStatus,
     PoolMappingPublishResult,
@@ -260,7 +261,7 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
     plugin.activate_pool_layout = AsyncMock(
         return_value=PoolLayoutActivationResult(
             committed=True,
-            status="COMMITTED",
+            status=PoolLayoutActivationStatus.COMMITTED,
             evidence={"bridge": "valid"},
         ),
     )

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -33,6 +33,7 @@ from engine.community.core.skills.models import (
     CleanSymlinksResult,
     PoolLayoutActivateRequest,
     PoolLayoutActivationResult,
+    PoolLayoutActivationStatus,
     PoolLayoutProbeRequest,
     PoolLayoutProbeResult,
     PoolLayoutProbeStatus,
@@ -156,10 +157,26 @@ class OpenClawSkillsAdapter(SkillsService):
                 ],
             }
         )
+        raw_status = str(raw.get("status", ""))
+        try:
+            status = PoolLayoutActivationStatus(raw_status)
+        except ValueError:
+            status = PoolLayoutActivationStatus.UNKNOWN
+        evidence = dict(raw.get("evidence") or {})
+        if status is PoolLayoutActivationStatus.UNKNOWN:
+            evidence["raw_status"] = raw_status
+        committed = (
+            raw.get("committed") is True
+            and status
+            in {
+                PoolLayoutActivationStatus.COMMITTED,
+                PoolLayoutActivationStatus.ALREADY_COMMITTED,
+            }
+        )
         return PoolLayoutActivationResult(
-            committed=raw.get("committed") is True,
-            status=str(raw.get("status", "")),
-            evidence=dict(raw.get("evidence") or {}),
+            committed=committed,
+            status=status,
+            evidence=evidence,
         )
 
     async def probe_pool_layout(

--- a/src/engine/src/engine/community/core/skills/models.py
+++ b/src/engine/src/engine/community/core/skills/models.py
@@ -176,7 +176,11 @@ class CenterEnsureResult:
 
 @dataclass
 class PoolLayoutActivateRequest:
-    """提交 OpenClaw Pool 数据面所需的稳定 Service API 请求。"""
+    """提交 OpenClaw Pool 数据面所需的稳定 Service API 请求。
+
+    ``registered_local_names`` 用于核对数据库登记事实；运行时还会枚举并
+    迁移 Legacy local 和 active 入口中的完整文件系统事实。
+    """
 
     migration_generation: str
     preparation_id: str
@@ -224,15 +228,29 @@ class PoolLayoutActivationResult:
     """Pool 数据面切换结果。"""
 
     committed: bool
-    status: str
+    status: "PoolLayoutActivationStatus"
     evidence: dict[str, Any] = field(default_factory=dict)
 
     def to_data(self) -> dict[str, Any]:
         return {
             "committed": self.committed,
-            "status": self.status,
+            "status": self.status.value,
             "evidence": self.evidence,
         }
+
+
+class PoolLayoutActivationStatus(StrEnum):
+    """跨 Service/Plugin/HTTP 边界稳定传输的切换状态。"""
+
+    COMMITTED = "COMMITTED"
+    ALREADY_COMMITTED = "ALREADY_COMMITTED"
+    ACTIVE_ENTRY_CONFLICT = "ACTIVE_ENTRY_CONFLICT"
+    DATA_INCONSISTENT = "DATA_INCONSISTENT"
+    INVALID = "INVALID"
+    TRANSIENT_ERROR = "TRANSIENT_ERROR"
+    POST_CUTOVER_SYNC_PENDING = "POST_CUTOVER_SYNC_PENDING"
+    NOT_ATOMIC = "NOT_ATOMIC"
+    UNKNOWN = "UNKNOWN"
 
 
 @dataclass
@@ -266,6 +284,7 @@ __all__ = [
     "CleanSymlinksResult",
     "PoolLayoutActivateRequest",
     "PoolLayoutActivationResult",
+    "PoolLayoutActivationStatus",
     "PoolLayoutProbeRequest",
     "PoolLayoutProbeResult",
     "PoolLayoutProbeStatus",

--- a/src/engine/src/engine/community/core/skills/protocol.py
+++ b/src/engine/src/engine/community/core/skills/protocol.py
@@ -172,7 +172,7 @@ class SkillsService(Protocol):
         request: PoolLayoutActivateRequest,
         auth: AuthContext | None = None,
     ) -> PoolLayoutActivationResult:
-        """最终同步已登记 local 并原子提交 Legacy→Pool bridge。"""
+        """核对登记事实、同步完整 local 并原子提交 Legacy→Pool bridge。"""
         ...
 
     async def probe_pool_layout(

--- a/src/engine/src/engine/community/plugin_api/openclaw/skills.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/skills.py
@@ -14,7 +14,24 @@ raises ``CapabilityNotSupportedError`` directly for each.
 """
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol, TypedDict
+
+
+class PoolLayoutActivationPortResult(TypedDict):
+    """Plugin API 返回的版本化 Pool 激活结果。"""
+
+    committed: bool
+    status: Literal[
+        "COMMITTED",
+        "ALREADY_COMMITTED",
+        "ACTIVE_ENTRY_CONFLICT",
+        "DATA_INCONSISTENT",
+        "INVALID",
+        "TRANSIENT_ERROR",
+        "POST_CUTOVER_SYNC_PENDING",
+        "NOT_ATOMIC",
+    ]
+    evidence: dict[str, Any]
 
 
 class OpenClawSkillsPort(Protocol):
@@ -87,8 +104,8 @@ class OpenClawSkillsPort(Protocol):
 
     async def activate_pool_layout(
         self, params: dict[str, Any]
-    ) -> dict[str, Any]:
-        """最终同步已登记 local 并原子提交永久兼容 bridge。"""
+    ) -> PoolLayoutActivationPortResult:
+        """核对登记事实、同步完整 local 并原子提交永久兼容 bridge。"""
         ...
 
     async def probe_pool_layout(
@@ -110,4 +127,4 @@ class OpenClawSkillsPort(Protocol):
         ...
 
 
-__all__ = ["OpenClawSkillsPort"]
+__all__ = ["OpenClawSkillsPort", "PoolLayoutActivationPortResult"]

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -10,6 +10,9 @@ import os
 from pathlib import Path
 from typing import Any
 
+from engine.community.plugin_api.openclaw.skills import (
+    PoolLayoutActivationPortResult,
+)
 from engine.community.plugin_api.workspace_root import workspace_root
 from engine.community.plugins.openclaw._file import _convert_path
 from engine.community.plugins.openclaw.layout_activation import (
@@ -53,7 +56,7 @@ class _SkillsPortMixin:
 
     async def activate_pool_layout(
         self, params: dict[str, Any]
-    ) -> dict[str, Any]:
+    ) -> PoolLayoutActivationPortResult:
         result = await asyncio.to_thread(
             activate_openclaw_pool,
             migration_generation=params["migration_generation"],
@@ -63,7 +66,7 @@ class _SkillsPortMixin:
             ),
             mappings=self._pool_mappings(params),
         )
-        return result.to_data()
+        return PoolLayoutActivationPortResult(**result.to_data())
 
     async def probe_pool_layout(
         self, params: dict[str, Any]

--- a/src/engine/src/engine/community/plugins/openclaw/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/layout_activation.py
@@ -1,26 +1,27 @@
-"""OpenClaw Skills Pool 的运行时最终同步与原子 local bridge 切换。"""
+"""OpenClaw Skills Pool 的完整文件系统收敛与原子 local bridge 切换。"""
 
 from __future__ import annotations
 
-import ctypes
-import errno
 import os
 import re
-import sys
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import Callable
 
+from engine.community.plugins.openclaw.layout_atomic import (
+    atomic_exchange_paths,
+)
 from engine.community.plugins.openclaw.layout_probe import (
     LAYOUT_CONTRACT_VERSION,
     RuntimeLayoutInspectionStatus,
     inspect_runtime_layout,
 )
 from engine.community.plugins.openclaw.layout_sync import (
+    Manifest,
     load_baseline_manifest,
     merge_post_cutover_changes,
-    mirror_registered_local,
+    mirror_local_tree,
     write_baseline_manifest,
 )
 
@@ -28,6 +29,8 @@ from engine.community.plugins.openclaw.layout_sync import (
 class PoolActivationStatus(StrEnum):
     COMMITTED = "COMMITTED"
     ALREADY_COMMITTED = "ALREADY_COMMITTED"
+    ACTIVE_ENTRY_CONFLICT = "ACTIVE_ENTRY_CONFLICT"
+    DATA_INCONSISTENT = "DATA_INCONSISTENT"
     INVALID = "INVALID"
     TRANSIENT_ERROR = "TRANSIENT_ERROR"
     POST_CUTOVER_SYNC_PENDING = "POST_CUTOVER_SYNC_PENDING"
@@ -85,6 +88,7 @@ class _Layout:
     pool_root: Path
     pool_local: Path
     pool_repo: Path
+    legacy_repo: Path
 
     @classmethod
     def for_home(cls, home: Path) -> "_Layout":
@@ -97,7 +101,23 @@ class _Layout:
             pool_root=pool_root,
             pool_local=pool_root / "skills-local",
             pool_repo=pool_root / "skills-repo",
+            legacy_repo=legacy_root / "skills-repo",
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _MappingPlan:
+    managed: dict[Path, Path]
+    external: tuple[Path, ...]
+    failures: tuple[dict[str, str], ...]
+    conflicts: tuple[dict[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _PostCutoverFinalization:
+    post_sync: dict[str, object]
+    cleanup_pending: bool
+    failure: PoolActivationResult | None = None
 
 
 def _lexical_target(link: Path) -> Path:
@@ -107,60 +127,244 @@ def _lexical_target(link: Path) -> Path:
     return Path(os.path.abspath(target))
 
 
-def atomic_exchange_paths(left: Path, right: Path) -> bool:
-    """原子交换同一文件系统上的两个目录项。
+def _canonical_pool_source(layout: _Layout, source: Path) -> Path | None:
+    source = Path(os.path.abspath(source))
+    for root, pool_root in (
+        (layout.legacy_local, layout.pool_local),
+        (layout.pool_local, layout.pool_local),
+        (layout.legacy_repo, layout.pool_repo),
+        (layout.pool_repo, layout.pool_repo),
+    ):
+        normalized_root = Path(os.path.abspath(root))
+        if source.is_relative_to(normalized_root):
+            return pool_root / source.relative_to(normalized_root)
+    return None
 
-    Linux 使用 ``renameat2(RENAME_EXCHANGE)``，macOS 测试环境使用
-    ``renamex_np(RENAME_SWAP)``。不支持时返回 ``False``，调用方不得降级成
-    两次普通 rename。
-    """
 
-    if left.parent.stat().st_dev != right.parent.stat().st_dev:
-        return False
-    libc = ctypes.CDLL(None, use_errno=True)
-    left_raw = os.fsencode(left)
-    right_raw = os.fsencode(right)
+def _pool_source_failure(layout: _Layout, source: Path) -> str | None:
+    """证明 source 是 canonical Pool root 内真实、可读的技能目录。"""
 
-    if sys.platform.startswith("linux") and hasattr(libc, "renameat2"):
-        renameat2 = libc.renameat2
-        renameat2.argtypes = [
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        ]
-        renameat2.restype = ctypes.c_int
-        result = renameat2(-100, left_raw, -100, right_raw, 2)
-    elif sys.platform == "darwin" and hasattr(libc, "renamex_np"):
-        renamex_np = libc.renamex_np
-        renamex_np.argtypes = [
-            ctypes.c_char_p,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        ]
-        renamex_np.restype = ctypes.c_int
-        result = renamex_np(left_raw, right_raw, 0x00000002)
-    else:
-        return False
+    normalized = Path(os.path.abspath(source))
+    containing_root: Path | None = None
+    for root in (layout.pool_local, layout.pool_repo):
+        normalized_root = Path(os.path.abspath(root))
+        if normalized.is_relative_to(normalized_root):
+            containing_root = normalized_root
+            break
+    if containing_root is None:
+        return "source_outside_pool"
+    if not normalized.exists():
+        return "source_missing"
+    try:
+        if not normalized.resolve(strict=True).is_relative_to(
+            containing_root.resolve(strict=True)
+        ):
+            return "source_escapes_pool"
+    except OSError:
+        return "source_unreadable"
+    if not normalized.is_dir():
+        return "source_not_directory"
+    unreadable = _first_unreadable_path(normalized)
+    if unreadable is not None:
+        return "source_unreadable"
+    return None
 
-    if result == 0:
-        return True
-    current_errno = ctypes.get_errno()
-    if current_errno in {
-        errno.ENOSYS,
-        errno.ENOTSUP,
-        getattr(errno, "EOPNOTSUPP", errno.ENOTSUP),
-        errno.EXDEV,
-    }:
-        return False
-    raise OSError(current_errno, os.strerror(current_errno))
+
+def _active_entry_inventory(
+    layout: _Layout,
+) -> tuple[dict[Path, Path], tuple[Path, ...], tuple[Path, ...]]:
+    managed: dict[Path, Path] = {}
+    external: list[Path] = []
+    occupied: list[Path] = []
+    reserved = {layout.legacy_local, layout.legacy_repo}
+    for entry in sorted(layout.legacy_root.iterdir(), key=lambda path: path.name):
+        if entry in reserved or entry.name.startswith(
+            ".skills-local.pool-cutover-"
+        ):
+            continue
+        if not entry.is_symlink():
+            occupied.append(entry)
+            continue
+        canonical = _canonical_pool_source(layout, _lexical_target(entry))
+        if canonical is None:
+            external.append(entry)
+        else:
+            managed[entry] = canonical
+    return managed, tuple(external), tuple(occupied)
+
+
+def _mapping_plan(
+    *,
+    layout: _Layout,
+    mappings: list[SkillMapping],
+) -> _MappingPlan:
+    desired: dict[Path, Path] = {}
+    failures: list[dict[str, str]] = []
+    conflicts: list[dict[str, str]] = []
+    for mapping in mappings:
+        source_input = Path(mapping.source)
+        source = Path(os.path.abspath(source_input))
+        target = Path(mapping.target)
+        reason = ""
+        if not source_input.is_absolute():
+            reason = "source_outside_pool"
+        else:
+            reason = _pool_source_failure(layout, source) or ""
+        if not reason and (
+            not target.is_absolute()
+            or target.parent != layout.legacy_root
+            or target in {layout.legacy_local, layout.legacy_repo}
+        ):
+            reason = "target_invalid"
+        elif (
+            not reason
+            and target in desired
+            and desired[target] != source
+        ):
+            conflicts.append(
+                {
+                    "target": str(target),
+                    "requested_source": str(source),
+                    "existing_source": str(desired[target]),
+                }
+            )
+            continue
+        if reason:
+            failures.append(
+                {"source": str(source), "target": str(target), "reason": reason}
+            )
+        else:
+            desired[target] = source
+
+    discovered, external, occupied = _active_entry_inventory(layout)
+    for target, source in discovered.items():
+        reason = _pool_source_failure(layout, source)
+        if reason:
+            failures.append(
+                {
+                    "source": str(source),
+                    "target": str(target),
+                    "reason": f"managed_{reason}",
+                }
+            )
+            continue
+        if target in desired and desired[target] != source:
+            conflicts.append(
+                {
+                    "target": str(target),
+                    "requested_source": str(desired[target]),
+                    "existing_source": str(source),
+                }
+            )
+        desired[target] = source
+    for target in occupied:
+        if target in desired:
+            conflicts.append(
+                {
+                    "target": str(target),
+                    "requested_source": str(desired[target]),
+                    "existing_source": "<occupied-non-symlink>",
+                }
+            )
+    for target in external:
+        desired.pop(target, None)
+    return _MappingPlan(
+        managed=desired,
+        external=external,
+        failures=tuple(failures),
+        conflicts=tuple(conflicts),
+    )
 
 
 def _invalid(reason: str, **evidence: object) -> PoolActivationResult:
     return PoolActivationResult(
         PoolActivationStatus.INVALID,
         {"reason": reason, **evidence},
+    )
+
+
+def _data_inconsistent(
+    reason: str, **evidence: object
+) -> PoolActivationResult:
+    return PoolActivationResult(
+        PoolActivationStatus.DATA_INCONSISTENT,
+        {"reason": reason, **evidence},
+    )
+
+
+def _active_entry_conflict(
+    conflicts: tuple[dict[str, str], ...],
+) -> PoolActivationResult:
+    return PoolActivationResult(
+        PoolActivationStatus.ACTIVE_ENTRY_CONFLICT,
+        {
+            "reason": "managed_active_entry_conflict",
+            "conflicts": list(conflicts),
+        },
+    )
+
+
+def _first_unreadable_path(root: Path) -> Path | None:
+    for current_root, directory_names, file_names in os.walk(
+        root,
+        followlinks=False,
+    ):
+        current = Path(current_root)
+        if not os.access(current, os.R_OK | os.X_OK):
+            return current
+        for name in [*directory_names, *file_names]:
+            entry = current / name
+            if entry.is_symlink():
+                continue
+            required = os.R_OK | os.X_OK if entry.is_dir() else os.R_OK
+            if not os.access(entry, required):
+                return entry
+    return None
+
+
+def _finalize_post_cutover(
+    *,
+    temporary: Path,
+    pool_local: Path,
+    quarantine: Path,
+    baseline_path: Path,
+    baseline: Manifest | None = None,
+) -> _PostCutoverFinalization:
+    """完成交换后的三方合并与审计快照归档；首次执行与重试共用。"""
+
+    try:
+        effective_baseline = (
+            baseline
+            if baseline is not None
+            else load_baseline_manifest(baseline_path)
+        )
+        post_sync = merge_post_cutover_changes(
+            source_root=temporary,
+            pool_local=pool_local,
+            baseline=effective_baseline,
+        )
+    except (OSError, ValueError) as error:
+        return _PostCutoverFinalization(
+            post_sync={},
+            cleanup_pending=False,
+            failure=PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "post_cutover_sync_failed",
+                    "error_type": type(error).__name__,
+                    "errno": getattr(error, "errno", None),
+                },
+            ),
+        )
+
+    quarantine.parent.mkdir(parents=True, exist_ok=True)
+    cleanup_pending = quarantine.exists() or quarantine.is_symlink()
+    if not cleanup_pending:
+        temporary.rename(quarantine)
+    baseline_path.unlink(missing_ok=True)
+    return _PostCutoverFinalization(
+        post_sync=post_sync,
+        cleanup_pending=cleanup_pending,
     )
 
 
@@ -175,7 +379,7 @@ def activate_openclaw_pool(
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
-    """同步已登记 local，校验 mapping source，并原子提交 Legacy→Pool bridge。"""
+    """校验登记事实、同步完整 local，并原子提交 Legacy→Pool bridge。"""
 
     home_path = Path(home)
     layout = _Layout.for_home(home_path)
@@ -228,8 +432,7 @@ def activate_openclaw_pool(
                 os.path.abspath(layout.pool_local)
             ):
                 return _invalid("legacy_local_bridge_invalid")
-            cleanup_pending = False
-            post_sync: dict[str, object] = {}
+            finalization = _PostCutoverFinalization({}, False)
             if temporary.is_dir() and not temporary.is_symlink():
                 for name in normalized_names:
                     source = temporary / name
@@ -238,37 +441,24 @@ def activate_openclaw_pool(
                             "registered_local_source_invalid",
                             source=str(source),
                         )
-                try:
-                    baseline = load_baseline_manifest(baseline_path)
-                    post_sync = merge_post_cutover_changes(
-                        source_root=temporary,
-                        pool_local=layout.pool_local,
-                        registered_local_names=normalized_names,
-                        baseline=baseline,
-                    )
-                except (OSError, ValueError) as error:
-                    return PoolActivationResult(
-                        PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
-                        {
-                            "reason": "post_cutover_sync_failed",
-                            "error_type": type(error).__name__,
-                            "errno": error.errno,
-                        },
-                    )
-                quarantine.parent.mkdir(parents=True, exist_ok=True)
-                if quarantine.exists() or quarantine.is_symlink():
-                    cleanup_pending = True
-                else:
-                    temporary.rename(quarantine)
-                baseline_path.unlink(missing_ok=True)
+                finalization = _finalize_post_cutover(
+                    temporary=temporary,
+                    pool_local=layout.pool_local,
+                    quarantine=quarantine,
+                    baseline_path=baseline_path,
+                )
+                if finalization.failure is not None:
+                    return finalization.failure
             return PoolActivationResult(
                 PoolActivationStatus.ALREADY_COMMITTED,
                 {
                     "bridge": str(layout.legacy_local),
                     "target": str(layout.pool_local),
                     "quarantine": str(quarantine),
-                    "quarantine_cleanup_pending": cleanup_pending,
-                    "post_sync": post_sync,
+                    "quarantine_cleanup_pending": (
+                        finalization.cleanup_pending
+                    ),
+                    "post_sync": finalization.post_sync,
                 },
             )
         if not layout.legacy_local.is_dir():
@@ -276,43 +466,55 @@ def activate_openclaw_pool(
 
         for name in normalized_names:
             source = layout.legacy_local / name
+            if not source.exists():
+                return _data_inconsistent(
+                    "registered_local_source_missing",
+                    registered_name=name,
+                    source=str(source),
+                )
             if not source.is_dir() or source.is_symlink():
-                return _invalid("registered_local_source_invalid", source=str(source))
+                return _data_inconsistent(
+                    "registered_local_source_invalid",
+                    registered_name=name,
+                    source=str(source),
+                )
+            unreadable = _first_unreadable_path(source)
+            if unreadable is not None:
+                return _data_inconsistent(
+                    "registered_local_source_unreadable",
+                    registered_name=name,
+                    source=str(source),
+                    unreadable_path=str(unreadable),
+                )
 
-        mirror_registered_local(
+        local_names = mirror_local_tree(
             source_root=layout.legacy_local,
             pool_local=layout.pool_local,
-            registered_local_names=normalized_names,
             staging_root=layout.pool_root
             / f".final-sync-{migration_generation}",
         )
         baseline = write_baseline_manifest(
             pool_local=layout.pool_local,
-            registered_local_names=normalized_names,
+            local_names=local_names,
             manifest_path=baseline_path,
         )
 
-        targets: set[Path] = set()
-        for mapping in mappings:
-            source = Path(mapping.source)
-            target = Path(mapping.target)
-            if (
-                not source.is_absolute()
-                or not target.is_absolute()
-                or target.parent != layout.legacy_root
-                or target in targets
-                or not (
-                    source.is_relative_to(layout.pool_local)
-                    or source.is_relative_to(layout.pool_repo)
-                )
-                or not source.exists()
+        mapping_plan = _mapping_plan(layout=layout, mappings=mappings)
+        if mapping_plan.conflicts:
+            return _active_entry_conflict(mapping_plan.conflicts)
+        if mapping_plan.failures:
+            if any(
+                failure["reason"].startswith("managed_")
+                for failure in mapping_plan.failures
             ):
-                return _invalid(
-                    "mapping_source_invalid",
-                    source=str(source),
-                    target=str(target),
+                return _data_inconsistent(
+                    "managed_active_source_invalid",
+                    failures=list(mapping_plan.failures),
                 )
-            targets.add(target)
+            return _invalid(
+                "mapping_source_invalid",
+                failures=list(mapping_plan.failures),
+            )
 
         if temporary.exists() or temporary.is_symlink():
             return _invalid("cutover_temporary_path_occupied", path=str(temporary))
@@ -333,40 +535,36 @@ def activate_openclaw_pool(
 
         if before_post_sync is not None:
             before_post_sync()
-        try:
-            post_sync = merge_post_cutover_changes(
-                source_root=temporary,
-                pool_local=layout.pool_local,
-                registered_local_names=normalized_names,
-                baseline=baseline,
-            )
-        except (OSError, ValueError) as error:
-            return PoolActivationResult(
-                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
-                {
-                    "reason": "post_cutover_sync_failed",
-                    "error_type": type(error).__name__,
-                    "errno": error.errno,
-                },
-            )
-
-        quarantine.parent.mkdir(parents=True, exist_ok=True)
-        cleanup_pending = False
-        if quarantine.exists() or quarantine.is_symlink():
-            cleanup_pending = True
-        else:
-            temporary.rename(quarantine)
-        baseline_path.unlink(missing_ok=True)
+        finalization = _finalize_post_cutover(
+            temporary=temporary,
+            pool_local=layout.pool_local,
+            quarantine=quarantine,
+            baseline_path=baseline_path,
+            baseline=baseline,
+        )
+        if finalization.failure is not None:
+            return finalization.failure
         return PoolActivationResult(
             PoolActivationStatus.COMMITTED,
             {
                 "bridge": str(layout.legacy_local),
                 "target": str(layout.pool_local),
                 "quarantine": str(quarantine),
-                "quarantine_cleanup_pending": cleanup_pending,
+                "quarantine_cleanup_pending": finalization.cleanup_pending,
                 "registered_local_count": len(normalized_names),
+                "local_inventory": {
+                    "registered": len(normalized_names),
+                    "unregistered": len(
+                        set(local_names) - set(normalized_names)
+                    ),
+                    "total": len(local_names),
+                },
                 "mapping_source_count": len(mappings),
-                "post_sync": post_sync,
+                "active_inventory": {
+                    "managed": len(mapping_plan.managed),
+                    "external": len(mapping_plan.external),
+                },
+                "post_sync": finalization.post_sync,
             },
         )
     except OSError as error:
@@ -401,36 +599,29 @@ def verify_skill_mappings(
     """验证受管激活入口精确解析到请求中的 Pool source。"""
 
     layout = _Layout.for_home(Path(home))
-    seen: set[Path] = set()
+    plan = _mapping_plan(layout=layout, mappings=mappings)
     failures: list[dict[str, str]] = []
-    for mapping in mappings:
-        source = Path(mapping.source)
-        target = Path(mapping.target)
+    failures.extend(plan.failures)
+    for conflict in plan.conflicts:
+        failures.append({**conflict, "reason": "managed_source_conflict"})
+    for target, source in plan.managed.items():
         reason = ""
-        if (
-            not source.is_absolute()
-            or not (
-                source.is_relative_to(layout.pool_local)
-                or source.is_relative_to(layout.pool_repo)
-            )
-        ):
-            reason = "source_outside_pool"
-        elif not source.exists():
-            reason = "source_missing"
-        elif target.parent != layout.legacy_root or target in seen:
-            reason = "target_invalid"
-        elif not target.is_symlink():
+        if not target.is_symlink():
             reason = "target_not_symlink"
         elif _lexical_target(target) != Path(os.path.abspath(source)):
             reason = "target_mismatch"
-        seen.add(target)
         if reason:
             failures.append(
                 {"source": str(source), "target": str(target), "reason": reason}
             )
     return MappingVerificationResult(
         valid=not failures,
-        evidence={"checked": len(mappings), "failures": failures},
+        evidence={
+            "checked": len(mappings),
+            "managed_checked": len(plan.managed),
+            "external_ignored": len(plan.external),
+            "failures": failures,
+        },
     )
 
 
@@ -439,45 +630,25 @@ def publish_pool_mappings(
     mappings: list[SkillMapping],
     home: str | Path = "/home/admin",
 ) -> MappingPublishResult:
-    """对齐已登记 Pool mapping，同时保留尚未分类的既有入口。
-
-    #369 只掌握 Backend 已登记技能，不能把未出现在请求中的入口等同为
-    stale；完整文件系统枚举与受管/外部分类由后续 #370 承接。
-    """
+    """按文件系统事实对齐全部受管 Pool mapping，并保留外部入口。"""
 
     layout = _Layout.for_home(Path(home))
-    desired: dict[Path, Path] = {}
-    failures: list[dict[str, str]] = []
-    for mapping in mappings:
-        source = Path(mapping.source)
-        target = Path(mapping.target)
-        reason = ""
-        if (
-            not source.is_absolute()
-            or not (
-                source.is_relative_to(layout.pool_local)
-                or source.is_relative_to(layout.pool_repo)
-            )
-            or not source.exists()
-        ):
-            reason = "source_invalid"
-        elif (
-            not target.is_absolute()
-            or target.parent != layout.legacy_root
-            or target.name in {"skills-local", "skills-repo"}
-            or target in desired
-        ):
-            reason = "target_invalid"
-        if reason:
-            failures.append(
-                {"source": str(source), "target": str(target), "reason": reason}
-            )
-        else:
-            desired[target] = source
-    if failures:
+    plan = _mapping_plan(layout=layout, mappings=mappings)
+    if plan.conflicts:
         return MappingPublishResult(
             published=False,
-            evidence={"reason": "mapping_invalid", "failures": failures},
+            evidence={
+                "reason": "managed_active_entry_conflict",
+                "conflicts": list(plan.conflicts),
+            },
+        )
+    if plan.failures:
+        return MappingPublishResult(
+            published=False,
+            evidence={
+                "reason": "mapping_invalid",
+                "failures": list(plan.failures),
+            },
         )
 
     created: list[str] = []
@@ -485,7 +656,7 @@ def publish_pool_mappings(
     kept: list[str] = []
     removed: list[str] = []
     try:
-        for target, source in desired.items():
+        for target, source in plan.managed.items():
             if target.is_symlink():
                 if _lexical_target(target) == Path(os.path.abspath(source)):
                     kept.append(str(target))
@@ -516,11 +687,12 @@ def publish_pool_mappings(
     return MappingPublishResult(
         published=True,
         evidence={
-            "total": len(desired),
+            "total": len(plan.managed),
             "created": created,
             "updated": updated,
             "kept": kept,
             "removed": removed,
+            "external_ignored": [str(path) for path in plan.external],
         },
     )
 

--- a/src/engine/src/engine/community/plugins/openclaw/layout_atomic.py
+++ b/src/engine/src/engine/community/plugins/openclaw/layout_atomic.py
@@ -1,0 +1,57 @@
+"""Skills Pool 同文件系统路径原子交换原语。"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import sys
+from pathlib import Path
+
+
+def atomic_exchange_paths(left: Path, right: Path) -> bool:
+    """以系统原生单次操作交换两个目录项，不支持时返回 ``False``。"""
+
+    if left.parent.stat().st_dev != right.parent.stat().st_dev:
+        return False
+    libc = ctypes.CDLL(None, use_errno=True)
+    left_raw = os.fsencode(left)
+    right_raw = os.fsencode(right)
+
+    if sys.platform.startswith("linux") and hasattr(libc, "renameat2"):
+        renameat2 = libc.renameat2
+        renameat2.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        renameat2.restype = ctypes.c_int
+        result = renameat2(-100, left_raw, -100, right_raw, 2)
+    elif sys.platform == "darwin" and hasattr(libc, "renamex_np"):
+        renamex_np = libc.renamex_np
+        renamex_np.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        renamex_np.restype = ctypes.c_int
+        result = renamex_np(left_raw, right_raw, 0x00000002)
+    else:
+        return False
+
+    if result == 0:
+        return True
+    current_errno = ctypes.get_errno()
+    if current_errno in {
+        errno.ENOSYS,
+        errno.ENOTSUP,
+        getattr(errno, "EOPNOTSUPP", errno.ENOTSUP),
+        errno.EXDEV,
+    }:
+        return False
+    raise OSError(current_errno, os.strerror(current_errno))
+
+
+__all__ = ["atomic_exchange_paths"]

--- a/src/engine/src/engine/community/plugins/openclaw/layout_sync.py
+++ b/src/engine/src/engine/community/plugins/openclaw/layout_sync.py
@@ -10,47 +10,45 @@ import stat
 from pathlib import Path
 from uuid import uuid4
 
+from engine.community.plugins.openclaw.layout_atomic import (
+    atomic_exchange_paths,
+)
+
 Fingerprint = tuple[str, str]
 Manifest = dict[str, Fingerprint]
 
 
-def mirror_registered_local(
+def mirror_local_tree(
     *,
     source_root: Path,
     pool_local: Path,
-    registered_local_names: list[str],
     staging_root: Path,
-) -> None:
-    """交换前把 registered local 精确镜像到 Pool。"""
+) -> list[str]:
+    """交换前把 Legacy local 的完整文件系统真相精确镜像到 Pool。"""
 
     _remove_path(staging_root)
     staging_root.mkdir()
-    for name in registered_local_names:
-        staging = staging_root / name
-        shutil.copytree(
-            source_root / name,
-            staging,
-            symlinks=True,
-            copy_function=shutil.copy2,
-        )
-        destination = pool_local / name
+    source_entries = sorted(source_root.iterdir(), key=lambda path: path.name)
+    for source in source_entries:
+        _copy_entry(source, staging_root / source.name)
+
+    for destination in list(pool_local.iterdir()):
         _remove_path(destination)
-        staging.rename(destination)
+    for staged in list(staging_root.iterdir()):
+        staged.rename(pool_local / staged.name)
     staging_root.rmdir()
+    return [entry.name for entry in source_entries]
 
 
 def write_baseline_manifest(
     *,
     pool_local: Path,
-    registered_local_names: list[str],
+    local_names: list[str],
     manifest_path: Path,
 ) -> Manifest:
     """持久化交换前 Pool 快照，供交换后或失败重试执行三方合并。"""
 
-    manifest = snapshot_registered(
-        pool_local,
-        registered_local_names,
-    )
+    manifest = snapshot_local(pool_local, local_names=local_names)
     temporary = manifest_path.with_name(
         f".{manifest_path.name}.{uuid4().hex}.tmp"
     )
@@ -83,19 +81,23 @@ def merge_post_cutover_changes(
     *,
     source_root: Path,
     pool_local: Path,
-    registered_local_names: list[str],
     baseline: Manifest,
 ) -> dict[str, object]:
     """三方合并交换窗口内的 Legacy 变化，保留交换后的 Pool 新写入。
 
     ``baseline`` 是首次 final sync 后的 Pool；``source_root`` 是原子交换
     后换出的 Legacy 快照；``pool_local`` 是交换后继续承接新写入的目标。
-    交换后 Pool 是唯一写入权威源：已有或已删除的目标绝不再被 Legacy
-    修改/删除。只对 baseline 中不存在、且 Pool 当前仍不存在的新路径执行
-    原子 no-clobber 创建；其余 Legacy delta 留在 quarantine 供审计。
+    交换后 Pool 是唯一写入权威源：新路径使用原子 no-clobber 创建；已有
+    路径使用原子 exchange 检查交换瞬间换出的实际版本，Pool 已变化时立即
+    回滚并保留 Pool。删除和无法安全收敛的 delta 留在 quarantine 供审计。
+
+    这是本期明确接受的 best-effort 边界：没有写栅栏时，跨 exchange 持有
+    的已打开文件描述符，或连续命中回滚后再次交换窗口的同文件写入，仍可能
+    落到随后清理的临时 inode。完整消除此竞态需要所有 writer 遵守共享的
+    quiesce/lock 协议，不属于 #370。
     """
 
-    source = snapshot_registered(source_root, registered_local_names)
+    source = snapshot_local(source_root)
     changed = {
         key
         for key in set(baseline) | set(source)
@@ -117,7 +119,22 @@ def merge_post_cutover_changes(
         observed = _fingerprint(target)
         if observed == desired:
             continue
-        if baseline.get(key) is not None or observed is not None:
+        baseline_fingerprint = baseline.get(key)
+        if baseline_fingerprint is not None:
+            if (
+                observed == baseline_fingerprint
+                and _replace_if_unchanged(
+                    source=source_path,
+                    target=target,
+                    expected=baseline_fingerprint,
+                    desired=desired,
+                )
+            ):
+                applied.append(key)
+            else:
+                conflicts.append(key)
+            continue
+        if observed is not None:
             conflicts.append(key)
             continue
         if not _create_if_absent(
@@ -135,12 +152,17 @@ def merge_post_cutover_changes(
     }
 
 
-def snapshot_registered(
+def snapshot_local(
     root: Path,
-    registered_local_names: list[str],
+    local_names: list[str] | None = None,
 ) -> Manifest:
     manifest: Manifest = {}
-    for name in registered_local_names:
+    names = (
+        local_names
+        if local_names is not None
+        else sorted(entry.name for entry in root.iterdir())
+    )
+    for name in names:
         skill_root = root / name
         root_fingerprint = _fingerprint(skill_root)
         if root_fingerprint is None:
@@ -159,6 +181,20 @@ def snapshot_registered(
                 if fingerprint is not None:
                     manifest[entry.relative_to(root).as_posix()] = fingerprint
     return manifest
+
+
+def _copy_entry(source: Path, destination: Path) -> None:
+    if source.is_symlink():
+        destination.symlink_to(os.readlink(source))
+    elif source.is_dir():
+        shutil.copytree(
+            source,
+            destination,
+            symlinks=True,
+            copy_function=shutil.copy2,
+        )
+    else:
+        shutil.copy2(source, destination, follow_symlinks=False)
 
 
 def _fingerprint(path: Path) -> Fingerprint | None:
@@ -224,6 +260,52 @@ def _create_if_absent(
     return _fingerprint(target) == desired
 
 
+def _replace_if_unchanged(
+    *,
+    source: Path,
+    target: Path,
+    expected: Fingerprint,
+    desired: Fingerprint,
+) -> bool:
+    """以 exchange 瞬间换出的对象判断 Pool 是否仍为 baseline。
+
+    先交换再检查，避免 check-then-replace 的 TOCTOU。若换出的 Pool 已变化，
+    立即原子换回；若回滚窗口内 canonical path 又收到写入，则该更晚写入
+    随临时项再次换回 canonical。调用方接受无协作写锁时跨 inode 写入仍有
+    极窄残余竞态；此处不声称提供文件内容 CAS。
+    """
+
+    if desired == expected:
+        return True
+    temporary = target.with_name(f".{target.name}.{uuid4().hex}.pool-sync")
+    try:
+        if desired[0] == "file":
+            shutil.copy2(source, temporary)
+        elif desired[0] == "symlink":
+            temporary.symlink_to(os.readlink(source))
+        elif desired[0] == "dir":
+            temporary.mkdir()
+        else:
+            return False
+        if not atomic_exchange_paths(temporary, target):
+            raise OSError("atomic file exchange unavailable")
+        displaced = _fingerprint(temporary)
+        if displaced == expected:
+            return _fingerprint(target) == desired
+
+        if not atomic_exchange_paths(temporary, target):
+            raise OSError("failed to restore concurrently changed Pool file")
+        candidate_after_rollback = _fingerprint(temporary)
+        if candidate_after_rollback != desired:
+            if not atomic_exchange_paths(temporary, target):
+                raise OSError("failed to restore newer Pool file")
+        return _fingerprint(target) == desired
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+    finally:
+        _remove_path(temporary)
+
+
 def _remove_path(path: Path) -> None:
     if path.is_symlink() or (path.exists() and not path.is_dir()):
         path.unlink()
@@ -234,7 +316,7 @@ def _remove_path(path: Path) -> None:
 __all__ = [
     "load_baseline_manifest",
     "merge_post_cutover_changes",
-    "mirror_registered_local",
-    "snapshot_registered",
+    "mirror_local_tree",
+    "snapshot_local",
     "write_baseline_manifest",
 ]

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -177,6 +177,59 @@ def test_cutover_rejects_missing_pool_mapping_source_before_bridge(
     assert not legacy_local.is_symlink()
 
 
+def test_registered_local_missing_is_structured_data_inconsistency(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    prepared_content = (pool_local / "handmade" / "SKILL.md").read_text()
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["missing"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.DATA_INCONSISTENT
+    assert result.evidence == {
+        "reason": "registered_local_source_missing",
+        "registered_name": "missing",
+        "source": str(legacy_local / "missing"),
+    }
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == prepared_content
+
+
+def test_registered_local_unreadable_is_structured_data_inconsistency(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    skill_file = legacy_local / "handmade" / "SKILL.md"
+    prepared_content = (pool_local / "handmade" / "SKILL.md").read_text()
+    skill_file.chmod(0)
+    try:
+        result = activate_openclaw_pool(
+            migration_generation="generation-1",
+            preparation_id=PREPARATION_ID,
+            registered_local_names=["handmade"],
+            mappings=[],
+            home=home,
+            repo_is_mounted=lambda path: path == pool_repo,
+        )
+    finally:
+        skill_file.chmod(0o600)
+
+    assert result.status is PoolActivationStatus.DATA_INCONSISTENT
+    assert result.evidence["reason"] == "registered_local_source_unreadable"
+    assert result.evidence["registered_name"] == "handmade"
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == prepared_content
+
+
 def test_final_sync_materializes_skill_created_after_preparation(
     tmp_path: Path,
 ) -> None:
@@ -201,6 +254,230 @@ def test_final_sync_materializes_skill_created_after_preparation(
 
     assert result.committed
     assert (pool_local / "late-skill" / "SKILL.md").read_text() == "late"
+
+
+def test_unregistered_local_and_managed_entry_follow_filesystem_truth(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    unregistered = legacy_local / "agent-created"
+    unregistered.mkdir()
+    (unregistered / "SKILL.md").write_text("filesystem-only")
+    active_entry = legacy_local.parent / "agent-created"
+    active_entry.symlink_to(unregistered, target_is_directory=True)
+
+    activated = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    published = publish_pool_mappings(mappings=[], home=home)
+    verified = verify_skill_mappings(mappings=[], home=home)
+
+    assert activated.status is PoolActivationStatus.COMMITTED
+    assert (
+        pool_local / "agent-created" / "SKILL.md"
+    ).read_text() == "filesystem-only"
+    assert activated.evidence["local_inventory"] == {
+        "registered": 1,
+        "unregistered": 1,
+        "total": 2,
+    }
+    assert activated.evidence["active_inventory"] == {
+        "managed": 1,
+        "external": 0,
+    }
+    assert published.published
+    assert active_entry.is_symlink()
+    assert active_entry.readlink() == pool_local / "agent-created"
+    assert verified.valid
+    assert verified.evidence["managed_checked"] == 1
+
+
+def test_external_active_entry_is_ignored_and_never_rewritten(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    external_source = tmp_path / "external-skill"
+    external_source.mkdir()
+    (external_source / "SKILL.md").write_text("external")
+    external_entry = legacy_local.parent / "external-skill"
+    external_entry.symlink_to(external_source, target_is_directory=True)
+    requested = SkillMapping(
+        source=str(pool_local / "handmade"),
+        target=str(external_entry),
+    )
+
+    activated = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[requested],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    published = publish_pool_mappings(mappings=[requested], home=home)
+    verified = verify_skill_mappings(mappings=[requested], home=home)
+
+    assert activated.status is PoolActivationStatus.COMMITTED
+    assert activated.evidence["active_inventory"] == {
+        "managed": 0,
+        "external": 1,
+    }
+    assert published.published
+    assert published.evidence["external_ignored"] == [str(external_entry)]
+    assert verified.valid
+    assert verified.evidence["external_ignored"] == 1
+    assert external_entry.readlink() == external_source
+
+
+def test_competing_managed_sources_block_before_atomic_cutover(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    other = legacy_local / "other"
+    other.mkdir()
+    (other / "SKILL.md").write_text("other")
+    active_entry = legacy_local.parent / "shared-name"
+    active_entry.symlink_to(other, target_is_directory=True)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(active_entry),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ACTIVE_ENTRY_CONFLICT
+    assert result.evidence == {
+        "reason": "managed_active_entry_conflict",
+        "conflicts": [
+            {
+                "target": str(active_entry),
+                "requested_source": str(pool_local / "handmade"),
+                "existing_source": str(pool_local / "other"),
+            }
+        ],
+    }
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert active_entry.readlink() == other
+
+
+def test_occupied_managed_target_blocks_before_atomic_cutover(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    occupied = legacy_local.parent / "handmade"
+    occupied.mkdir()
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(occupied),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ACTIVE_ENTRY_CONFLICT
+    assert result.evidence == {
+        "reason": "managed_active_entry_conflict",
+        "conflicts": [
+            {
+                "target": str(occupied),
+                "requested_source": str(pool_local / "handmade"),
+                "existing_source": "<occupied-non-symlink>",
+            }
+        ],
+    }
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert occupied.is_dir()
+
+
+def test_broken_managed_active_source_blocks_as_data_inconsistent(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    active_entry = legacy_local.parent / "missing-managed"
+    active_entry.symlink_to(
+        pool_local / "missing-managed",
+        target_is_directory=True,
+    )
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.DATA_INCONSISTENT
+    assert result.evidence["reason"] == "managed_active_source_invalid"
+    assert result.evidence["failures"] == [
+        {
+            "source": str(pool_local / "missing-managed"),
+            "target": str(active_entry),
+            "reason": "managed_source_missing",
+        }
+    ]
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+
+
+@pytest.mark.parametrize("source_kind", ["traversal", "symlink_escape"])
+def test_mapping_source_cannot_escape_canonical_pool_root(
+    tmp_path: Path,
+    source_kind: str,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    external = pool_local.parent.parent / "external"
+    external.mkdir()
+    if source_kind == "traversal":
+        source = pool_local / ".." / ".." / "external"
+        expected_reason = "source_outside_pool"
+    else:
+        source = pool_repo / "escape"
+        source.symlink_to(external, target_is_directory=True)
+        expected_reason = "source_escapes_pool"
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(source),
+                target=str(legacy_local.parent / "escape"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == "mapping_source_invalid"
+    assert result.evidence["failures"][0]["reason"] == expected_reason
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
 
 
 def test_post_exchange_sync_captures_write_after_initial_copy(
@@ -228,6 +505,63 @@ def test_post_exchange_sync_captures_write_after_initial_copy(
     assert (
         pool_local / "handmade" / "created-during-cutover.txt"
     ).read_text() == "must-survive"
+
+
+def test_post_exchange_sync_captures_new_unregistered_skill_root(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def create_skill_then_exchange(left: Path, right: Path) -> bool:
+        late_skill = left / "created-during-cutover"
+        late_skill.mkdir()
+        (late_skill / "SKILL.md").write_text("must-survive")
+        return atomic_exchange_paths(left, right)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=create_skill_then_exchange,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert (
+        pool_local / "created-during-cutover" / "SKILL.md"
+    ).read_text() == "must-survive"
+    assert result.evidence["post_sync"]["applied"] == [
+        "created-during-cutover",
+        "created-during-cutover/SKILL.md",
+    ]
+
+
+def test_post_exchange_sync_captures_existing_file_update_before_exchange(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def update_then_exchange(left: Path, right: Path) -> bool:
+        (left / "handmade" / "SKILL.md").write_text("updated-before-exchange")
+        return atomic_exchange_paths(left, right)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=update_then_exchange,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
+        "updated-before-exchange"
+    )
+    assert result.evidence["post_sync"]["applied"] == ["handmade/SKILL.md"]
 
 
 def test_post_exchange_sync_preserves_new_pool_write_on_same_file(
@@ -258,6 +592,52 @@ def test_post_exchange_sync_preserves_new_pool_write_on_same_file(
     assert result.evidence["post_sync"]["conflicts_preserved_in_pool"] == [
         "handmade/SKILL.md"
     ]
+
+
+def test_atomic_file_exchange_preserves_write_at_replacement_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import layout_sync
+
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def update_then_exchange(left: Path, right: Path) -> bool:
+        (left / "handmade" / "SKILL.md").write_text("legacy-window")
+        return atomic_exchange_paths(left, right)
+
+    real_exchange = layout_sync.atomic_exchange_paths
+    exchange_count = 0
+
+    def write_pool_at_exchange(left: Path, right: Path) -> bool:
+        nonlocal exchange_count
+        if exchange_count == 0:
+            right.write_text("pool-at-exchange")
+        exchange_count += 1
+        return real_exchange(left, right)
+
+    monkeypatch.setattr(
+        layout_sync,
+        "atomic_exchange_paths",
+        write_pool_at_exchange,
+    )
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=update_then_exchange,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
+        "pool-at-exchange"
+    )
+    assert result.evidence["post_sync"][
+        "conflicts_preserved_in_pool"
+    ] == ["handmade/SKILL.md"]
 
 
 def test_post_exchange_new_file_uses_atomic_no_clobber(
@@ -370,7 +750,7 @@ def test_retry_after_exchange_finishes_quarantine_move(tmp_path: Path) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
     write_baseline_manifest(
         pool_local=pool_local,
-        registered_local_names=["handmade"],
+        local_names=["handmade"],
         manifest_path=pool_local.parent
         / ".cutover-baseline-generation-1.json",
     )
@@ -429,7 +809,6 @@ def test_cutover_stays_legacy_when_atomic_exchange_is_unavailable(
         ("bad generation", PREPARATION_ID, ["handmade"], "migration_generation_invalid"),
         ("generation-1", "stale-preparation", ["handmade"], "runtime_layout_not_ready"),
         ("generation-1", PREPARATION_ID, ["../escape"], "registered_local_name_invalid"),
-        ("generation-1", PREPARATION_ID, ["missing"], "registered_local_source_invalid"),
     ],
 )
 def test_cutover_rejects_invalid_inputs(
@@ -583,7 +962,7 @@ def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:
         "source_missing",
         "target_invalid",
         "target_not_symlink",
-        "target_mismatch",
+        "managed_source_conflict",
     }
 
 
@@ -610,6 +989,19 @@ def test_mapping_publisher_validates_updates_and_occupied_targets(
         mappings=[SkillMapping(str(source), str(target))],
     )
     assert updated.published
+    assert updated.evidence["external_ignored"] == [str(target)]
+    assert target.readlink() == tmp_path / "old"
+
+    target.unlink()
+    target.symlink_to(
+        legacy_local / "handmade",
+        target_is_directory=True,
+    )
+    updated = publish_pool_mappings(
+        home=home,
+        mappings=[SkillMapping(str(source), str(target))],
+    )
+    assert updated.published
     assert updated.evidence["updated"] == [str(target)]
 
     kept = publish_pool_mappings(
@@ -626,7 +1018,7 @@ def test_mapping_publisher_validates_updates_and_occupied_targets(
         mappings=[SkillMapping(str(source), str(target))],
     )
     assert not occupied.published
-    assert occupied.evidence["reason"] == "managed_target_occupied"
+    assert occupied.evidence["reason"] == "managed_active_entry_conflict"
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -1,0 +1,78 @@
+"""OpenClaw Skills Pool Service API ↔ Plugin API 契约。"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from engine.community.core.adapters.openclaw.skills import OpenClawSkillsAdapter
+from engine.community.core.skills.models import (
+    PoolLayoutActivateRequest,
+    PoolLayoutActivationStatus,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_status",
+    [
+        "COMMITTED",
+        "ALREADY_COMMITTED",
+        "ACTIVE_ENTRY_CONFLICT",
+        "DATA_INCONSISTENT",
+        "INVALID",
+        "TRANSIENT_ERROR",
+        "POST_CUTOVER_SYNC_PENDING",
+        "NOT_ATOMIC",
+    ],
+)
+async def test_activation_status_contract_accepts_every_known_value(
+    raw_status: str,
+) -> None:
+    port = MagicMock()
+    port.activate_pool_layout = AsyncMock(
+        return_value={
+            "committed": raw_status in {"COMMITTED", "ALREADY_COMMITTED"},
+            "status": raw_status,
+            "evidence": {"source": "plugin"},
+        }
+    )
+
+    result = await OpenClawSkillsAdapter(port).activate_pool_layout(
+        PoolLayoutActivateRequest(
+            migration_generation="generation-1",
+            preparation_id="preparation-1",
+        )
+    )
+
+    assert result.status is PoolLayoutActivationStatus(raw_status)
+    assert result.to_data()["status"] == raw_status
+    port.activate_pool_layout.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unknown_activation_status_fails_closed_and_preserves_evidence() -> None:
+    port = MagicMock()
+    port.activate_pool_layout = AsyncMock(
+        return_value={
+            "committed": True,
+            "status": "FUTURE_STATUS",
+            "evidence": {"source": "newer-plugin"},
+        }
+    )
+
+    result = await OpenClawSkillsAdapter(port).activate_pool_layout(
+        PoolLayoutActivateRequest(
+            migration_generation="generation-1",
+            preparation_id="preparation-1",
+        )
+    )
+
+    assert result.status is PoolLayoutActivationStatus.UNKNOWN
+    assert not result.committed
+    assert result.evidence == {
+        "source": "newer-plugin",
+        "raw_status": "FUTURE_STATUS",
+    }
+    port.activate_pool_layout.assert_awaited_once()


### PR DESCRIPTION
## Summary

- migrate registered and unregistered OpenClaw local skills from the complete filesystem truth
- preserve external active entries, reject managed conflicts/data inconsistency, and validate canonical Pool sources
- use native atomic exchange plus best-effort post-cutover three-way reconciliation; Pool wins observed conflicts and Legacy is retained in quarantine
- type the Engine/Backend activation status contract and persist queryable pre-cutover failure evidence

## Accepted boundary

No write fence is introduced in #370. Cross-exchange open file descriptors or continuous writes to the same existing file retain an explicitly accepted narrow race. The implementation does not claim filesystem content CAS; this boundary is documented in the module contract.

## Structural analysis

- Contract changed: yes — OpenClaw Pool activation Plugin API and Backend runtime result are now explicit typed status contracts
- Consumers: Engine Service adapter, HTTP response schema, Backend Skills Pool runtime/reconciler
- Compatibility: unknown future status values fail closed as `UNKNOWN`; existing Legacy bots remain unchanged
- Migration/deprecation: dependency #399 / #369 is merged; this branch is rebased directly onto current `dev`
- Waiver: none

## Verification

- Engine community suite: `1950 passed, 5 skipped`
- Backend Skills Pool + architecture suites: `146 passed`
- Backend community suite: `8657 passed`
- Post-rebase focused Engine suite: `56 passed`
- Ruff on all changed Python files: passed
- `git diff --check`: passed
- Spec review: passed under the accepted best-effort boundary
- Engineering standards review: passed under the accepted best-effort boundary

Closes #370