### PR TITLE
test(gateway): add ci coverage check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 # fallback above.
 /.github/ @carolynli @xianmuyq @dxwinux @archer910517-ctrl @yuyiming
 /docs/arch/ @carolynli @xianmuyq @dxwinux @archer910517-ctrl @yuyiming
+/scripts/ @carolynli @vzvince @FreddieSun @totalfrank @pfmiles @cassiuscai @xxxxpenny @phoenixliu
 /src/bcs/ @carolynli @vzvince @questchaos @RaymondHX
 /src/frontend/ @zoii @ClaaaaaaaaaireR @greenishzyy
 /src/bcsfuse/ @archer910517-ctrl @wienyang

--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -146,6 +146,11 @@ if matches_any '^src/bcs/'; then
   fi
 fi
 
+if matches_any '^src/gateway/'; then
+  # Gateway CI: ruff lint + pytest + coverage + diff coverage (>=90%).
+  run_required "$repo_root/src/gateway/scripts/ci_test.sh" --base "$base" --head "$head"
+fi
+
 if matches_any '^src/frontend/'; then
   # Frontend 也通过模块自己的 ci_test.sh 作为统一入口。
   run_required "$repo_root/src/frontend/scripts/ci_test.sh" --base "$base" --head "$head"

--- a/scripts/ci/report_check.py
+++ b/scripts/ci/report_check.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 import argparse
 import os
 import subprocess
+import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
+
+RED = "\033[0;31m"
+NC = "\033[0m"
 
 
 def parse_junit(path: Path) -> tuple[int, int, int]:
@@ -161,6 +165,11 @@ def check_change_coverage(
         f"change line coverage: {rate:.2f}% ({covered}/{total}, required >= {minimum:.2f}%)"
     )
     if rate + 1e-9 < minimum:
+        print(
+            f"{RED}FAILED: changed-line coverage {rate:.2f}% "
+            f"is below minimum {minimum:.2f}%{NC}",
+            file=sys.stderr,
+        )
         print("uncovered changed executable lines:")
         for filename, lines in uncovered_by_file.items():
             print(f"  {filename}: {','.join(str(line) for line in lines)}")
@@ -186,6 +195,11 @@ def main() -> int:
         f"case pass rate: {case_rate:.2f}% ({passed}/{tests}, required >= {args.min_case_pass_rate:.2f}%)"
     )
     if case_rate + 1e-9 < args.min_case_pass_rate:
+        print(
+            f"{RED}FAILED: case pass rate {case_rate:.2f}% "
+            f"is below minimum {args.min_case_pass_rate:.2f}%{NC}",
+            file=sys.stderr,
+        )
         return 1
 
     line_rate, hits = parse_coverage(args.coverage)
@@ -194,6 +208,11 @@ def main() -> int:
             f"line coverage: {line_rate:.2f}% (required >= {args.min_line_coverage:.2f}%)"
         )
         if line_rate + 1e-9 < args.min_line_coverage:
+            print(
+                f"{RED}FAILED: line coverage {line_rate:.2f}% "
+                f"is below minimum {args.min_line_coverage:.2f}%{NC}",
+                file=sys.stderr,
+            )
             return 1
 
     if args.min_change_line_coverage is not None and args.base:

--- a/src/gateway/scripts/ci_test.sh
+++ b/src/gateway/scripts/ci_test.sh
@@ -8,7 +8,7 @@ gateway_dir="${GATEWAY_COMMUNITY_DIR:-$gateway_root}"
 report_dir="$gateway_dir/pytest_report"
 unit_report="$report_dir/TEST-unit.xml"
 coverage_report="$report_dir/TEST-cov.xml"
-line_coverage_min="${GATEWAY_CI_LINE_COVERAGE_MIN:-80}"
+line_coverage_min="${GATEWAY_CI_LINE_COVERAGE_MIN:-90}"
 python_bin="$(command -v python || command -v python3 || true)"
 base=""
 head="HEAD"
@@ -56,9 +56,18 @@ if [[ "$gateway_ci_status" -ne 0 ]]; then
 fi
 
 echo "--- unit coverage report ---"
+check_args=(
+  "$repo_root/scripts/ci/report_check.py"
+  --junit "$unit_report"
+  --coverage "$coverage_report"
+  --source-root "$gateway_dir/src/gateway"
+  --min-case-pass-rate 100
+  --min-line-coverage "$line_coverage_min"
+)
 if [[ -n "$base" ]]; then
-  echo "diff coverage check not yet configured (base=$base head=$head)"
+  check_args+=(--base "$base" --head "$head" --min-change-line-coverage 90)
 fi
+"$python_bin" "${check_args[@]}"
 echo "Coverage report: file://$report_dir/html/index.html"
 echo "--- end unit coverage report ---"
 echo "gateway CI gate passed"


### PR DESCRIPTION
## Summary
Add CI coverage checks for the Gateway module in the pre-push hook and refine report output.

## Changes

### Commit `b3c77bc` — test(gateway): add ci coverage check
- **`scripts/ci/pre_push.sh`**: Hook Gateway CI (`src/gateway/scripts/ci_test.sh`) when `src/gateway/` files change
- **`src/gateway/scripts/ci_test.sh`**:
  - Raise minimum line coverage threshold from 80% → 90%
  - Wire up `report_check.py` for diff coverage (≥90% changed-line coverage)
  - Enforce 100% test case pass rate

### Commit `2ddb680` — test(gateway): update script CODEOWNERS, refine report_check.py
- **`.github/CODEOWNERS`**: Add owners for `/scripts/`
- **`scripts/ci/report_check.py`**: Print red `FAILED:` messages to stderr when coverage/pass-rate thresholds are not met, improving CI log readability