### PR TITLE
fix(baas): convert aicoding command output

### DIFF
--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -167,10 +167,11 @@ def _transform_agent(payload: dict[str, Any], engine: str) -> dict[str, Any] | N
         return _transform_tool(data, engine)
 
     if stream == "command_output":
-        # Only claude_code relies on command_output for the tool result. Other
-        # engines (e.g. openclaw) ALSO emit a `tool`/`phase:result` frame for
-        # the same toolCallId, so consuming command_output there would persist a
-        # duplicate, name-less tool_result. Ignore it for non-claude engines.
+        # Claude-format engines rely on command_output for the tool result.
+        # Other engines (e.g. openclaw) ALSO emit a `tool`/`phase:result` frame
+        # for the same toolCallId, so consuming command_output there would
+        # persist a duplicate, name-less tool_result. Ignore it for other
+        # engines.
         if not _is_claude_engine(engine):
             return None
         return _transform_command_output(data)
@@ -207,7 +208,11 @@ def _transform_tool(data: dict[str, Any], engine: str) -> dict[str, Any] | None:
 
 
 def _is_claude_engine(engine: str) -> bool:
-    return engine.replace("-", "_").lower() in {"claude", "claude_code"}
+    return engine.replace("-", "_").lower() in {
+        "aicoding",
+        "claude",
+        "claude_code",
+    }
 
 
 def _is_claude_tool(data: dict[str, Any], engine: str) -> bool:

--- a/src/baas/tests/unit/core/service/sse/test_bcn_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_bcn_converter.py
@@ -207,6 +207,41 @@ def test_command_output_end_converts_to_tool_result():
     }
 
 
+def test_aicoding_command_output_end_converts_to_tool_result():
+    converter = DefaultStreamConverter()
+    event = converter.convert(
+        StreamChunk(
+            type="agent",
+            engine_type="aicoding",
+            metadata={
+                "engine_frame": {
+                    "stream": "command_output",
+                    "data": {
+                        "phase": "end",
+                        "toolCallId": "tool-aicoding",
+                        "output": "received",
+                        "exitCode": 0,
+                    },
+                }
+            },
+        ),
+        run_id="run-1",
+    )
+
+    assert event is not None
+    assert event.event == "agent"
+    assert _data(event) == {
+        "runId": "run-1",
+        "seq": 1,
+        "stream": "tool",
+        "phase": "result",
+        "toolCallId": "tool-aicoding",
+        "result": {"content": [{"type": "text", "text": "received"}]},
+        "isError": False,
+        "exitCode": 0,
+    }
+
+
 def test_command_output_non_end_phase_is_dropped():
     converter = DefaultStreamConverter()
     event = converter.convert(


### PR DESCRIPTION
## Summary

- Treat `aicoding` as a Claude-format engine when converting `command_output` events.
- Convert AICoding `command_output` events with `phase=end` into BCN `tool` / `phase=result` events.
- Add regression coverage while preserving the existing filtering behavior for engines such as OpenClaw that emit a separate tool result.

## Root cause

AICoding reports Bash completion through `stream=command_output`, but the BaaS converter only accepted that stream for `claude` and `claude_code`. The event was therefore dropped before BCS could receive the tool result and dispatch the task.

## Impact

BCS can now receive AICoding Bash completion results and process coordination echoes that depend on the tool result event.

## Checks

- Not run for the final commit, per request.
