### PR TITLE
fix(baas): preserve configured engine venv symlink

### DIFF
--- a/scripts/test_bcn_plugin_source.sh
+++ b/scripts/test_bcn_plugin_source.sh
@@ -226,6 +226,59 @@ test_stack_script_has_npm_branch() {
   assert_contains "$src" '[ "$BCN_PLUGIN_SOURCE" != "npm" ]'
 }
 
+test_session_bot_uuid_requires_usable_session() {
+  local tmp; tmp="$(mktemp -d)"
+  local funcs="${tmp}/stack-session-functions.sh"
+  local profile_root="${tmp}/profiles"
+  local session_file="${profile_root}/.openclaw-ceo/.bcs/session.json"
+
+  awk '
+    /^profile_dir_for\(\)/ {emit=1}
+    /^workspace_dir_for\(\)/ {emit=0}
+    emit {print}
+  ' "${PROJECT_ROOT}/src/bcs/scripts/start_bcs_bots.sh" > "$funcs"
+  mkdir -p "$(dirname "$session_file")"
+
+  cat > "$session_file" <<JSON
+{"bot_uuid":"default:545716","token":"saved-token","bcs_url":"ws://127.0.0.1:21000/ws/bot"}
+JSON
+  local bot_uuid
+  bot_uuid="$(
+    OPENCLAW_PROFILE_ROOT="$profile_root"
+    OPENCLAW_PROFILE_PREFIX=".openclaw-"
+    BCS_URL="ws://127.0.0.1:21000/ws/bot"
+    . "$funcs"
+    session_bot_uuid_for ceo
+  )"
+  assert_eq "$bot_uuid" "default:545716" "usable session should preserve bot identity"
+
+  cat > "$session_file" <<JSON
+{"bot_uuid":"default:545716","token":"","bcs_url":"ws://127.0.0.1:21000/ws/bot"}
+JSON
+  bot_uuid="$(
+    OPENCLAW_PROFILE_ROOT="$profile_root"
+    OPENCLAW_PROFILE_PREFIX=".openclaw-"
+    BCS_URL="ws://127.0.0.1:21000/ws/bot"
+    . "$funcs"
+    session_bot_uuid_for ceo
+  )"
+  assert_eq "$bot_uuid" "" "session without token must not pin bot identity"
+
+  cat > "$session_file" <<JSON
+{"bot_uuid":"default:545716","token":"saved-token","bcs_url":"ws://127.0.0.1:29999/ws/bot"}
+JSON
+  bot_uuid="$(
+    OPENCLAW_PROFILE_ROOT="$profile_root"
+    OPENCLAW_PROFILE_PREFIX=".openclaw-"
+    BCS_URL="ws://127.0.0.1:21000/ws/bot"
+    . "$funcs"
+    session_bot_uuid_for ceo
+  )"
+  assert_eq "$bot_uuid" "" "session for a different BCS URL must not pin bot identity"
+
+  rm -rf "$tmp"
+}
+
 test_stack_config_allows_plugin_path_refresh() {
   local tmp; tmp="$(mktemp -d)"
   local funcs="${tmp}/stack-match-functions.sh"
@@ -373,6 +426,7 @@ test_load_dir_source_mode
 test_load_dir_npm_mode
 test_stack_script_forwards_mode
 test_stack_script_has_npm_branch
+test_session_bot_uuid_requires_usable_session
 test_stack_config_allows_plugin_path_refresh
 test_dynamic_config_refreshes_plugin_path
 

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -1105,7 +1105,9 @@ class LocalProcessManager:
         """
         configured = os.environ.get("LOCAL_ENGINE_PYTHON")
         if configured:
-            candidate = Path(configured).expanduser().resolve()
+            candidate = Path(configured).expanduser()
+            if not candidate.is_absolute():
+                candidate = Path.cwd() / candidate
             if candidate.is_file() and os.access(candidate, os.X_OK):
                 return str(candidate)
             raise DeviceAllocateError(

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py
@@ -1299,6 +1299,25 @@ class TestResolveEnginePython:
 
         assert result == str(configured_python)
 
+    def test_resolve_engine_python_preserves_configured_venv_symlink(
+        self, monkeypatch, tmp_path
+    ):
+        """Configured virtualenv interpreter keeps its symlink path."""
+        engine_src_dir = tmp_path / "engine" / "src"
+        engine_src_dir.mkdir(parents=True)
+        base_python = tmp_path / "uv" / "python"
+        base_python.parent.mkdir(parents=True)
+        base_python.touch()
+        base_python.chmod(base_python.stat().st_mode | stat.S_IXUSR)
+        venv_python = tmp_path / "runtime" / "bin" / "python"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.symlink_to(base_python)
+        monkeypatch.setenv("LOCAL_ENGINE_PYTHON", str(venv_python))
+
+        result = pm.LocalProcessManager._resolve_engine_python(engine_src_dir)
+
+        assert result == str(venv_python)
+
     def test_resolve_engine_python_rejects_missing_configured_override(
         self, monkeypatch, tmp_path
     ):

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/bcs-ws-client.ts
@@ -482,6 +482,10 @@ export class BcsWsClient {
       }
       const content = fs.readFileSync(sessionPath, 'utf-8');
       const session = JSON.parse(content) as SessionInfo;
+      if (typeof session.token !== 'string' || !session.token.trim()) {
+        this._log?.warn?.('Ignoring saved BCS session without reconnect token');
+        return null;
+      }
       // Verify URL matches
       if (session.bcs_url !== this._account.bcsUrl) {
         this._log?.warn?.(

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/bcs-ws-client.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { once } from 'node:events';
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import { createServer, type AddressInfo, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -236,6 +236,98 @@ describe('BcsWsClient security behavior', () => {
       await client.connect(null);
       assert.equal(bcs.connectParams?.bot_id, 'default:mock-user');
       assert.equal(bcs.connectParams?.token, undefined);
+    } finally {
+      await client.disconnect();
+      await bcs.close();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not reuse an incomplete saved session to pin bot identity', async () => {
+    const bcs = await startBcsStub();
+    const dataDir = await mkdtemp(join(tmpdir(), 'bcn-incomplete-session-'));
+    const logs: string[] = [];
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: `ws://127.0.0.1:${bcs.port}/ws/bot`,
+      botId: 'Bot 1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60_000,
+      reconnectIntervalMs: 5_000,
+      connectionTimeoutMs: 10_000,
+    };
+    await mkdir(join(dataDir, '.bcs'), { recursive: true });
+    await writeFile(
+      join(dataDir, '.bcs', 'session.json'),
+      JSON.stringify({
+        bot_uuid: 'default:545716',
+        token: '',
+        bcs_url: account.bcsUrl,
+      }),
+    );
+    const client = new BcsWsClient({
+      account,
+      dataDir,
+      log: {
+        info: () => undefined,
+        warn: (...args: unknown[]) => logs.push(args.join(' ')),
+        error: () => undefined,
+      },
+    });
+
+    try {
+      await client.connect(null);
+      assert.equal(bcs.connectParams?.bot_id, undefined);
+      assert.equal(bcs.connectParams?.token, undefined);
+      assert.equal(logs.some(line => line.includes('Ignoring saved BCS session without reconnect token')), true);
+    } finally {
+      await client.disconnect();
+      await bcs.close();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reconnects with a saved token when the bot identity is not assigned yet', async () => {
+    const bcs = await startBcsStub();
+    const dataDir = await mkdtemp(join(tmpdir(), 'bcn-pending-session-'));
+    const account: ResolvedBcsAccount = {
+      accountId: 'default',
+      enabled: true,
+      bcsUrl: `ws://127.0.0.1:${bcs.port}/ws/bot`,
+      botId: 'Bot 1',
+      botName: 'Bot 1',
+      capabilities: {
+        summary: 'test bot',
+        domains: [],
+        skills: [],
+        scopes: [],
+      },
+      heartbeatIntervalMs: 60_000,
+      reconnectIntervalMs: 5_000,
+      connectionTimeoutMs: 10_000,
+    };
+    await mkdir(join(dataDir, '.bcs'), { recursive: true });
+    await writeFile(
+      join(dataDir, '.bcs', 'session.json'),
+      JSON.stringify({
+        bot_uuid: null,
+        token: 'pending-token',
+        bcs_url: account.bcsUrl,
+      }),
+    );
+    const client = new BcsWsClient({ account, dataDir });
+
+    try {
+      await client.connect(null);
+      assert.equal(bcs.connectParams?.bot_id, undefined);
+      assert.equal(bcs.connectParams?.token, 'pending-token');
     } finally {
       await client.disconnect();
       await bcs.close();

--- a/src/bcs/scripts/start_bcs_bots.sh
+++ b/src/bcs/scripts/start_bcs_bots.sh
@@ -92,7 +92,14 @@ session_bot_uuid_for() {
     [ -f "$session_file" ] || return 0
     command -v jq >/dev/null 2>&1 || return 0
 
-    jq -r 'if (.bot_uuid | type) == "string" then .bot_uuid else empty end' "$session_file" 2>/dev/null | head -n 1
+    jq -r --arg bcs_url "$BCS_URL" '
+      if ((.bot_uuid | type) == "string")
+        and ((.bot_uuid | length) > 0)
+        and ((.token | type) == "string")
+        and ((.token | length) > 0)
+        and (.bcs_url == $bcs_url)
+      then .bot_uuid else empty end
+    ' "$session_file" 2>/dev/null | head -n 1
 }
 
 workspace_dir_for() {


### PR DESCRIPTION
## Summary

Backport the complete singlebox BaaS/BCN startup fix set to `REL20260723`.

## Changes

- Preserve `LOCAL_ENGINE_PYTHON` virtualenv symlinks so BaaS adapters run with the interpreter that provides `uvicorn`.
- Ignore incomplete saved BCN sessions without a reconnect token, so a stale session cannot pin multiple local bots to one prior identity.

## Root causes

- Resolving the configured virtualenv interpreter followed its symlink to the uv-managed base interpreter, which lacks `uvicorn`; BaaS publish therefore failed before the adapter listened on port 20010.
- A partial `.bcs/session.json` could be reused without a reconnect token and retain an obsolete Bot identity, causing conflicts when the local five-Bot stack started.

## Validation

- `DEPLOY_ENV=test ../../../src/baas/.venv/bin/python -m pytest tests/unit/plugins/sandbox/arca/test_process_manager_coverage.py tests/unit/plugins/sandbox/arca/test_process_manager_env.py -q` — 112 passed, 3 skipped.
- `npx egg-bin test test/bcs-ws-client.test.ts --grep 'incomplete saved session|pending session'` — passed.
- Ruff check for the BaaS changes passed.
