### PR TITLE
feat(caller): route runtime updates by device provider

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3270,7 +3270,9 @@ class BaasService:  # pragma: no cover
         ):
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
 
-        devices = self.list_devices_by_bot_uuid(str(binding.device_id), timeout=3.0)
+        baas_lookup_id, lookup_source = self._caller_baas_lookup_id(binding)
+        logger.info("caller_baas_device_lookup_source=%s", lookup_source)
+        devices = self.list_devices_by_bot_uuid(baas_lookup_id, timeout=3.0)
         if not devices:
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
         if len(devices) != 1:
@@ -3328,6 +3330,16 @@ class BaasService:  # pragma: no cover
             and not isinstance(binding_id, bool)
             and binding_id > 0
         )
+
+    @staticmethod
+    def _caller_baas_lookup_id(binding: Any) -> tuple[str, str]:
+        """Resolve the BaaS bot UUID from the binding without guessing."""
+        device_props = getattr(binding, "device_props", None)
+        if isinstance(device_props, dict):
+            bot_uuid = device_props.get("bot_uuid")
+            if isinstance(bot_uuid, str) and bot_uuid.strip():
+                return bot_uuid.strip(), "device_props.bot_uuid"
+        return str(binding.device_id), "binding.device_id"
 
     def _resolve_caller_binding_id(
         self,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3270,9 +3270,7 @@ class BaasService:  # pragma: no cover
         ):
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
 
-        baas_lookup_id, lookup_source = self._caller_baas_lookup_id(binding)
-        logger.info("caller_baas_device_lookup_source=%s", lookup_source)
-        devices = self.list_devices_by_bot_uuid(baas_lookup_id, timeout=3.0)
+        devices = self.list_devices_by_bot_uuid(str(binding.device_id), timeout=3.0)
         if not devices:
             raise CallerCredentialError(CALLER_TARGET_NOT_FOUND)
         if len(devices) != 1:
@@ -3330,16 +3328,6 @@ class BaasService:  # pragma: no cover
             and not isinstance(binding_id, bool)
             and binding_id > 0
         )
-
-    @staticmethod
-    def _caller_baas_lookup_id(binding: Any) -> tuple[str, str]:
-        """Resolve the BaaS bot UUID from the binding without guessing."""
-        device_props = getattr(binding, "device_props", None)
-        if isinstance(device_props, dict):
-            bot_uuid = device_props.get("bot_uuid")
-            if isinstance(bot_uuid, str) and bot_uuid.strip():
-                return bot_uuid.strip(), "device_props.bot_uuid"
-        return str(binding.device_id), "binding.device_id"
 
     def _resolve_caller_binding_id(
         self,

--- a/src/backend/src/agentclaw/community/plugin_api/sandbox_runtime.py
+++ b/src/backend/src/agentclaw/community/plugin_api/sandbox_runtime.py
@@ -86,9 +86,19 @@ class SandboxRuntimeClient(Plugin, Protocol):
         ...
 
     def update_outbound_rule(
-        self, *, sandbox_id: str, rule: "OutBoundOperationRule", tenant_idx: int
+        self,
+        *,
+        sandbox_id: str,
+        rule: "OutBoundOperationRule",
+        tenant_idx: int,
+        mode: str = "replace",
     ) -> bool:
-        """Replace the live outbound-header rule on ``sandbox_id``."""
+        """Update the live outbound-header rule on ``sandbox_id``.
+
+        ``mode`` is ``replace`` by default. Provider-aware runtime overlays may
+        request ``append`` so a Caller rule does not erase existing managed
+        headers.
+        """
         ...
 
     def build_proxy_connection(

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -99,6 +99,60 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
     assert outbound_rule.header_operation_rules[0].value == "caller-token"
 
 
+def test_caller_identity_prefers_baas_bot_uuid_from_binding_props() -> None:
+    service = _bare_baas_service()
+    service._bot_repo = MagicMock()
+    service._bot_repo.get_by_id_and_entity.return_value = {
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "bot_type": "service",
+        "status": "ACTIVE",
+    }
+    service._device_binding_repo = MagicMock()
+    service._device_binding_repo.get_by_id.return_value = SimpleNamespace(
+        status="ACTIVE",
+        device_id="teamclaw-device-1",
+        device_props={"bot_uuid": "baas-bot-1"},
+    )
+    service._outbound_rule_provider = MagicMock()
+    service._outbound_rule_provider.build_caller_rule.return_value = (
+        OutBoundOperationRule(
+            header_operation_rules=[
+                HeaderOperationRule(
+                    domains=["https://mcp.example"],
+                    action="set",
+                    header_name="x-caller-token",
+                    value="caller-token",
+                )
+            ]
+        )
+    )
+    service.list_devices_by_bot_uuid = MagicMock(
+        return_value=[{"provider_device_id": "device-1@template-1"}]
+    )
+    service.append_caller_outbound_rule = MagicMock(return_value=True)
+
+    service.update_caller_identity(
+        bot_id="bot-1",
+        owner_user_id="owner-1",
+        caller_user_id="caller-1",
+        caller_token=CallerToken(
+            access_token="caller-token",
+            subject_user_id="caller-1",
+            expires_at=datetime.now(),
+            fingerprint="ignored",
+        ),
+        stage="draft",
+        publish_id=None,
+        entity_id="entity-1",
+        binding_id=9,
+    )
+
+    service.list_devices_by_bot_uuid.assert_called_once_with(
+        "baas-bot-1", timeout=3.0
+    )
+
+
 def test_caller_identity_rejects_ambiguous_bot_without_entity_id() -> None:
     service = _bare_baas_service()
     service._bot_repo = MagicMock()

--- a/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
+++ b/src/backend/tests/community/core/service_bot/services/test_caller_identity_outbound.py
@@ -98,61 +98,6 @@ def test_caller_identity_uses_supplied_binding_or_falls_back_to_resolution() -> 
     assert outbound_rule.header_operation_rules[0].action == "set"
     assert outbound_rule.header_operation_rules[0].value == "caller-token"
 
-
-def test_caller_identity_prefers_baas_bot_uuid_from_binding_props() -> None:
-    service = _bare_baas_service()
-    service._bot_repo = MagicMock()
-    service._bot_repo.get_by_id_and_entity.return_value = {
-        "bot_id": "bot-1",
-        "owner_id": "owner-1",
-        "bot_type": "service",
-        "status": "ACTIVE",
-    }
-    service._device_binding_repo = MagicMock()
-    service._device_binding_repo.get_by_id.return_value = SimpleNamespace(
-        status="ACTIVE",
-        device_id="teamclaw-device-1",
-        device_props={"bot_uuid": "baas-bot-1"},
-    )
-    service._outbound_rule_provider = MagicMock()
-    service._outbound_rule_provider.build_caller_rule.return_value = (
-        OutBoundOperationRule(
-            header_operation_rules=[
-                HeaderOperationRule(
-                    domains=["https://mcp.example"],
-                    action="set",
-                    header_name="x-caller-token",
-                    value="caller-token",
-                )
-            ]
-        )
-    )
-    service.list_devices_by_bot_uuid = MagicMock(
-        return_value=[{"provider_device_id": "device-1@template-1"}]
-    )
-    service.append_caller_outbound_rule = MagicMock(return_value=True)
-
-    service.update_caller_identity(
-        bot_id="bot-1",
-        owner_user_id="owner-1",
-        caller_user_id="caller-1",
-        caller_token=CallerToken(
-            access_token="caller-token",
-            subject_user_id="caller-1",
-            expires_at=datetime.now(),
-            fingerprint="ignored",
-        ),
-        stage="draft",
-        publish_id=None,
-        entity_id="entity-1",
-        binding_id=9,
-    )
-
-    service.list_devices_by_bot_uuid.assert_called_once_with(
-        "baas-bot-1", timeout=3.0
-    )
-
-
 def test_caller_identity_rejects_ambiguous_bot_without_entity_id() -> None:
     service = _bare_baas_service()
     service._bot_repo = MagicMock()


### PR DESCRIPTION
## Summary\n- Route Caller runtime updates by exact device binding provider.\n- Use ARCA sandbox_id with append-only outbound rules.\n- Keep BaaS/Teclaw compatibility through bot_uuid fallback.\n\n## Validation\n- Community Caller/BaaS focused tests: 21 passed\n- OCB corp focused tests: 22 passed\n- Focused Ruff and diff checks passed\n\nNo deployment was performed.