### PR TITLE
feat: wire skills pool lifecycle reconciliation

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -7,8 +7,16 @@ from typing import Any, Callable, Optional
 from agentclaw.community.core.bot_management.engines import resolve_provisioning
 from agentclaw.community.core.bot_management.utils import clear_baas_publish_failure_ext
 from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.events.bus import get_event_bus
+from agentclaw.community.core.events.types import BaasPublishCompletedEvent
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
-from agentclaw.community.core.task_queue.types import Complete, Fail, Reschedule, Retry, TaskOutcome
+from agentclaw.community.core.task_queue.types import (
+    Complete,
+    Fail,
+    Reschedule,
+    Retry,
+    TaskOutcome,
+)
 from agentclaw.community.kernel.lifecycle import LifecycleBase
 from agentclaw.community.log import get_logger
 
@@ -21,6 +29,27 @@ _CREATE_INIT_DEADLINE_SECONDS = 86400
 _PUBLISH_PROGRESS_TRANSIENT_ERROR = "get_publish_progress transient error"
 
 logger = get_logger()
+
+
+def _publish_baas_completed(
+    *,
+    binding_id: int,
+    bot_id: str,
+    owner_id: str,
+    publish_id: int,
+    publish_kind: str,
+) -> None:
+    """Publish an identity-only wake-up after the guarded BaaS success path."""
+
+    get_event_bus().publish(
+        BaasPublishCompletedEvent(
+            binding_id=binding_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            publish_id=publish_id,
+            publish_kind=publish_kind,
+        )
+    )
 
 
 def build_create_publish_poll_payload(
@@ -233,11 +262,22 @@ class BaasCreateInitTaskHandler:
             return Fail(f"invalid payload: {exc}")
 
         binding = self._binding_repository.get_by_id(binding_id)
-        if _binding_is_terminal(binding):
+        if binding is None:
             return Complete()
         if getattr(binding, "device_provider", None) != "baas":
             return Complete()
         if not _payload_publish_id_matches(binding, publish_id, "publish_id"):
+            return Complete()
+        if getattr(binding, "status", None) == DeviceBindingStatus.ACTIVE.value:
+            _publish_baas_completed(
+                binding_id=binding_id,
+                bot_id=payload["bot_id"],
+                owner_id=payload["owner_id"],
+                publish_id=publish_id,
+                publish_kind="create",
+            )
+            return Complete()
+        if getattr(binding, "status", None) == DeviceBindingStatus.FAILED.value:
             return Complete()
         success, message = self._baas_device_service.run_create_init_once(
             binding_id=binding_id,
@@ -249,6 +289,14 @@ class BaasCreateInitTaskHandler:
             self._baas_device_service._mark_service_start_failed(
                 binding_id=binding_id,
                 error=message,
+            )
+        else:
+            _publish_baas_completed(
+                binding_id=binding_id,
+                bot_id=payload["bot_id"],
+                owner_id=payload["owner_id"],
+                publish_id=publish_id,
+                publish_kind="create",
             )
         return Complete()
 
@@ -283,6 +331,24 @@ class BaasRestartPublishPollHandler:
         binding_id, bot_id, owner_id, publish_id, started_at_epoch_s, bot_uuid = parsed
 
         binding = self._binding_repository.get_by_id(binding_id)
+        if (
+            binding is not None
+            and getattr(binding, "status", None) == DeviceBindingStatus.ACTIVE.value
+            and getattr(binding, "device_provider", None) == "baas"
+            and _payload_publish_id_matches(
+                binding,
+                publish_id,
+                "restart_publish_id",
+            )
+        ):
+            _publish_baas_completed(
+                binding_id=binding_id,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                publish_id=publish_id,
+                publish_kind="restart",
+            )
+            return Complete()
         preflight = self._preflight(binding=binding, publish_id=publish_id)
         if preflight is not None:
             return preflight
@@ -367,9 +433,11 @@ class BaasRestartPublishPollHandler:
     ) -> TaskOutcome:
         if status == DeviceBindingStatus.ACTIVE.value:
             codefuse_token = self._read_codefuse_token(bot_id=bot_id, bot=bot)
-            write_err = self._baas_device_service.refresh_codefuse_token_on_publish_success(
-                bot_uuid=bot_uuid,
-                codefuse_token=codefuse_token,
+            write_err = (
+                self._baas_device_service.refresh_codefuse_token_on_publish_success(
+                    bot_uuid=bot_uuid,
+                    codefuse_token=codefuse_token,
+                )
             )
             if write_err is not None:
                 logger.warning(
@@ -392,6 +460,13 @@ class BaasRestartPublishPollHandler:
                 binding_id=binding_id,
                 status=DeviceBindingStatus.ACTIVE.value,
                 publish_id=publish_id,
+            )
+            _publish_baas_completed(
+                binding_id=binding_id,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                publish_id=publish_id,
+                publish_kind="restart",
             )
             return Complete()
         if status == DeviceBindingStatus.FAILED.value:
@@ -432,29 +507,19 @@ class BaasRestartPublishPollHandler:
         publish_id: int,
         failure_message: str | None = None,
     ) -> None:
-        try:
-            update_data = self._build_bot_update(
-                bot_id=bot_id,
-                owner_id=owner_id,
-                status=status,
-                publish_id=publish_id,
-                failure_message=failure_message,
-            )
-            if self._bot_repository is not None:
-                self._bot_repository.update_by_owner(bot_id, owner_id, update_data)
-            self._binding_repository.update_status(
-                binding_id=binding_id,
-                status=status,
-            )
-        except Exception as exc:
-            logger.warning(
-                "[BaasRestartPublishPollHandler] failed to persist "
-                "status=%s for bot_id=%s binding_id=%s: %s",
-                status,
-                bot_id,
-                binding_id,
-                exc,
-            )
+        update_data = self._build_bot_update(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            status=status,
+            publish_id=publish_id,
+            failure_message=failure_message,
+        )
+        if self._bot_repository is not None:
+            self._bot_repository.update_by_owner(bot_id, owner_id, update_data)
+        self._binding_repository.update_status(
+            binding_id=binding_id,
+            status=status,
+        )
 
     def _build_bot_update(
         self,
@@ -537,7 +602,6 @@ class BaasRestartPublishPollHandler:
             return None
         ctx = replace(base_ctx, template_config=template_config)
         return strategy.extract_runtime_token(ctx)
-
 
 
 class BaasPublishTaskLifecycle(LifecycleBase):

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -1059,6 +1059,24 @@ class DeviceService:
             f"is_first_active={prev_status == DeviceBindingStatus.PENDING.value}"
         )
 
+        if record.status == DeviceBindingStatus.PENDING.value:
+            # Required durable consumers run before the ACTIVE commit.  If
+            # enqueue fails, the exception propagates and the binding remains
+            # PENDING, so the runtime retry redelivers this one-shot signal.
+            from agentclaw.community.core.events.bus import get_event_bus
+            from agentclaw.community.core.events.types import DeviceAliveEvent
+
+            get_event_bus().publish(
+                DeviceAliveEvent(
+                    device_id=device_id,
+                    binding_id=record.id,
+                    entity_id=record.entity_id,
+                    entity_type=record.entity_type,
+                    device_provider=record.device_provider,
+                    sandbox_id=(record.device_props or {}).get("sandbox_id"),
+                )
+            )
+
         self._repo.update_status_and_alive_at(binding_id=record.id, status=new_status)
 
         # If status changed from PENDING to ACTIVE, sync bot status and trigger callbacks

--- a/src/backend/src/agentclaw/community/core/events/README.md
+++ b/src/backend/src/agentclaw/community/core/events/README.md
@@ -8,6 +8,7 @@ Event bus + canonical event types — pub/sub primitive for cross-domain notific
 purpose: "Event bus + canonical event types — pub/sub primitive for cross-domain notifications."
 provides:
   - "EventBus"
+  - "Required event delivery for durable hand-off boundaries"
   - "Canonical event type dataclasses"
 consumes:
   []
@@ -17,4 +18,8 @@ internal_dependencies:
 
 ### Change impact
 
-Event type changes break subscribers silently — the bus does not fail on schema drift. Treat event shapes as a public contract.
+Event type changes break subscribers silently, so treat event shapes as a public
+contract. Ordinary subscribers remain best-effort and cannot block siblings.
+Handlers registered with `required=True` are reserved for durable hand-off
+boundaries: all siblings still run, then `publish()` raises
+`RequiredEventDeliveryError` so the producer's retry mechanism can redeliver.

--- a/src/backend/src/agentclaw/community/core/events/bus.py
+++ b/src/backend/src/agentclaw/community/core/events/bus.py
@@ -6,6 +6,7 @@ Design choices:
 - Handlers registered by concrete event type — no inheritance walking.
 - Module-level singleton via get_event_bus(); reset_event_bus() for tests.
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -19,16 +20,34 @@ logger = get_logger()
 EventHandler = Callable[[Any], None]
 
 
+class RequiredEventDeliveryError(RuntimeError):
+    """A required event handler failed.
+
+    Required handlers are used only at durable hand-off boundaries.  The
+    publisher must surface this error so its own retry mechanism can redeliver
+    the lifecycle signal.
+    """
+
+
 class EventBus:
     """In-process synchronous event bus."""
 
     def __init__(self) -> None:
         self._handlers: dict[Type[Any], list[EventHandler]] = defaultdict(list)
+        self._required_handlers: set[tuple[Type[Any], EventHandler]] = set()
         self._lock = RLock()
 
-    def subscribe(self, event_type: Type[Any], handler: EventHandler) -> None:
+    def subscribe(
+        self,
+        event_type: Type[Any],
+        handler: EventHandler,
+        *,
+        required: bool = False,
+    ) -> None:
         with self._lock:
             self._handlers[event_type].append(handler)
+            if required:
+                self._required_handlers.add((event_type, handler))
         logger.info(
             "[EventBus.subscribe] event_type=%s handler=%s total=%d",
             event_type.__name__,
@@ -40,11 +59,17 @@ class EventBus:
         event_type = type(event)
         with self._lock:
             handlers = list(self._handlers.get(event_type, ()))
+            required_handlers = {
+                handler
+                for registered_type, handler in self._required_handlers
+                if registered_type is event_type
+            }
         logger.info(
             "[EventBus.publish] event_type=%s handlers=%d",
             event_type.__name__,
             len(handlers),
         )
+        required_failure: Exception | None = None
         for handler in handlers:
             handler_name = getattr(handler, "__name__", repr(handler))
             try:
@@ -55,10 +80,18 @@ class EventBus:
                     event_type.__name__,
                     handler_name,
                 )
+                if handler in required_handlers and required_failure is None:
+                    required_failure = RequiredEventDeliveryError(
+                        f"required handler failed for {event_type.__name__}: "
+                        f"{handler_name}"
+                    )
+        if required_failure is not None:
+            raise required_failure
 
     def clear(self) -> None:
         with self._lock:
             self._handlers.clear()
+            self._required_handlers.clear()
 
 
 _bus: EventBus | None = None

--- a/src/backend/src/agentclaw/community/core/events/types.py
+++ b/src/backend/src/agentclaw/community/core/events/types.py
@@ -1,4 +1,5 @@
 """Event payload types for the in-process event bus."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -19,9 +20,42 @@ class DeviceActivatedEvent:
         device_provider: "arca" | "daas" | "local".
         sandbox_id: Sandbox id from device_props, or None for non-sandbox devices.
     """
+
     device_id: str
     binding_id: int
     entity_id: str
     entity_type: str
     device_provider: str
     sandbox_id: str | None = None
+
+
+@dataclass(frozen=True)
+class DeviceAliveEvent:
+    """A validated PENDING device reported alive before its ACTIVE commit.
+
+    Required durable consumers may reject a failed hand-off.  In that case
+    the caller keeps the binding PENDING, so the runtime's retry redelivers the
+    event without inserting work for every later ACTIVE heartbeat.
+    """
+
+    device_id: str
+    binding_id: int
+    entity_id: str
+    entity_type: str
+    device_provider: str
+    sandbox_id: str | None = None
+
+
+@dataclass(frozen=True)
+class BaasPublishCompletedEvent:
+    """A current BaaS create/restart publish reached its successful terminal state.
+
+    This is only a lifecycle wake-up. Consumers must re-read the current Bot
+    and binding before making any business decision.
+    """
+
+    binding_id: int
+    bot_id: str
+    owner_id: str
+    publish_id: int
+    publish_kind: str

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -18,8 +18,22 @@ OpenClaw 原子数据面切换与 Pool mapping，并在最后事务性提交 loc
   `ac_bot_publish` DRAFT 记录证明。认领入口不接受调用方自报运行形态，
   ONLINE 服务与 Teclaw 不产生认领。
 - lease 的认领、接管和续租都由数据库时钟与 generation fencing 保护。
-- 激活只处理已经认领且由当前 worker 持有 lease 的 OpenClaw Bot；每次执行
-  都重新读取 Bot 和当前 provider binding，并重新 probe marker。
+- ARCA 存活和 BaaS 发布完成事件只做当前 binding 的基础身份校验并写入
+  `skills_pool.reconcile` 持久化任务；事件处理器不读取 marker、不推送
+  mapping，也不提交 locator。
+- 这两个持久化交接是 required delivery：ARCA 在提交 ACTIVE 前入队，失败
+  时保持 PENDING 并由下一次存活回调重投；BaaS 则由发布任务退避重试。
+  ACTIVE 心跳不重复插入任务。
+- 持久化任务以 `(env, entity_id, bot_id)` 为唯一 Bot 身份。事件中的
+  sandbox、device 或 publish 标识只作为审计证据；每次执行都会重新读取
+  当前 Bot，并由 runtime adapter 重新解析当前 provider binding。
+- 未认领 Bot 每次唤醒都重新经过 rollout gate；一旦 generation 已持久化，
+  后续任务只续租或接管同一 generation，不再因白名单移除而停止。
+- `NOT_CAPABLE` 正常完成并保持 Legacy，暂时性错误交给任务队列指数退避，
+  无效结构持久化失败证据并阻断；重复任务通过 generation/lease 收敛。
+- 激活只处理当前仍可编辑、已经认领且由当前 worker 持有 lease 的
+  OpenClaw Bot；每次执行都重新读取 Bot 和当前 provider binding，并重新
+  probe marker。
 - 容器内以系统原生原子 exchange 将 Legacy local 切成指向 Pool canonical
   local 的永久单向 bridge；不支持原子 exchange 时保持 Legacy。
 - 激活前同时核对已登记 local，并从文件系统枚举未登记 local、受管 active
@@ -45,6 +59,8 @@ provides:
   - "SkillsPoolRolloutGate"
   - "SkillsPoolMigrationClaimService"
   - "SkillsPoolReconcileService"
+  - "SkillsPoolReconcileTaskHandler"
+  - "SkillsPoolReconcileWakeupListener"
   - "PoolCutoverStatus"
   - "PoolCutoverResult"
   - "BotSkillLayoutState and migration enums"
@@ -55,12 +71,19 @@ consumes:
   - "DatabasePlugin (through plugins/skills_pool_layout_repository.py)"
   - "SkillsPoolRuntimeProtocol"
   - "SkillsPoolSkillRepositoryProtocol"
+  - "DeviceBindingRepository"
+  - "TaskQueueService and HandlerRegistry"
 internal_dependencies:
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.common_config
+  - agentclaw.community.core.devices
+  - agentclaw.community.core.events
   - agentclaw.community.core.skill_center
   - agentclaw.community.core.service_bot
+  - agentclaw.community.core.task_queue
   - agentclaw.community.core.base
+  - agentclaw.community.kernel.lifecycle
+  - agentclaw.community.log
   - agentclaw.community.plugin_api.database
   - agentclaw.community.core.skills_pool.ports
 ```

--- a/src/backend/src/agentclaw/community/core/skills_pool/__init__.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/__init__.py
@@ -16,6 +16,11 @@ from agentclaw.community.core.skills_pool.reconcile_service import (
     SkillsPoolReconcileResult,
     SkillsPoolReconcileService,
 )
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SKILLS_POOL_RECONCILE_TASK,
+    SkillsPoolReconcileTaskHandler,
+    SkillsPoolReconcileWakeupListener,
+)
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
@@ -36,8 +41,11 @@ __all__ = [
     "SkillLayout",
     "SkillLayoutPhase",
     "SkillsPoolMigrationClaimService",
+    "SKILLS_POOL_RECONCILE_TASK",
     "SkillsPoolReconcileOutcome",
     "SkillsPoolReconcileResult",
     "SkillsPoolReconcileService",
+    "SkillsPoolReconcileTaskHandler",
+    "SkillsPoolReconcileWakeupListener",
     "SkillsPoolRolloutGate",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/claim_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/claim_service.py
@@ -43,6 +43,7 @@ class MigrationClaimOutcome(StrEnum):
     INVALID_BOT_RECORD = "invalid_bot_record"
     ENVIRONMENT_MISMATCH = "environment_mismatch"
     RUNTIME_NOT_EDITABLE = "runtime_not_editable"
+    TRANSIENT_ERROR = "transient_error"
     CLAIM_RACE_LOST = "claim_race_lost"
 
 
@@ -97,7 +98,7 @@ class SkillsPoolMigrationClaimService:
                 publish_bot_id=scope.bot_id,
                 env=scope.env,
             )
-        except Exception:
+        except Exception as error:
             logger.exception(
                 "[skills_pool.claim] service draft lookup failed "
                 "env=%s entity_id=%s bot_id=%s",
@@ -105,7 +106,7 @@ class SkillsPoolMigrationClaimService:
                 scope.entity_id,
                 scope.bot_id,
             )
-            return None
+            raise _RuntimeFormLookupError from error
         if draft is None:
             return None
         if (
@@ -129,7 +130,7 @@ class SkillsPoolMigrationClaimService:
         """首次命中 gate 时提交 generation；已认领状态不再重读白名单。"""
 
         current = self._layout_repository.get(scope)
-        if self._has_pool_migration(current):
+        if current.active_layout is SkillLayout.POOL:
             return MigrationClaimResult(
                 outcome=MigrationClaimOutcome.ALREADY_CLAIMED,
                 state=current,
@@ -151,10 +152,21 @@ class SkillsPoolMigrationClaimService:
                 state=current,
             )
 
-        runtime_form = self._resolve_runtime_form(bot=bot, scope=scope)
+        try:
+            runtime_form = self._resolve_runtime_form(bot=bot, scope=scope)
+        except _RuntimeFormLookupError:
+            return MigrationClaimResult(
+                outcome=MigrationClaimOutcome.TRANSIENT_ERROR,
+                state=current,
+            )
         if runtime_form is None:
             return MigrationClaimResult(
                 outcome=MigrationClaimOutcome.RUNTIME_NOT_EDITABLE,
+                state=current,
+            )
+        if self._has_pool_migration(current):
+            return MigrationClaimResult(
+                outcome=MigrationClaimOutcome.ALREADY_CLAIMED,
                 state=current,
             )
 
@@ -212,3 +224,7 @@ class SkillsPoolMigrationClaimService:
             state=raced,
             rollout_decision=decision,
         )
+
+
+class _RuntimeFormLookupError(RuntimeError):
+    """Current service-draft facts could not be read temporarily."""

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -61,6 +61,7 @@ class SkillsPoolReconcileResult:
     outcome: SkillsPoolReconcileOutcome
     preparation_id: str | None = None
     evidence: dict[str, object] | None = None
+    retryable: bool | None = None
 
 
 class SkillsPoolReconcileService:
@@ -98,32 +99,19 @@ class SkillsPoolReconcileService:
             or state.target_layout is not SkillLayout.POOL
             or state.migration_generation is None
         ):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.NOT_CLAIMED
-            )
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.NOT_CLAIMED)
         if state.lease_owner != lease_owner:
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.LEASE_NOT_HELD
-            )
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.LEASE_NOT_HELD)
 
         bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
         if bot is None:
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.BOT_NOT_FOUND
-            )
-        if (
-            bot.get("env") != scope.env
-            or bot.get("active_engine") != "openclaw"
-        ):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.BOT_CHANGED
-            )
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_NOT_FOUND)
+        if bot.get("env") != scope.env or bot.get("active_engine") != "openclaw":
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
 
         owner_id = bot.get("owner_id")
         if not isinstance(owner_id, (str, int)) or isinstance(owner_id, bool):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.BOT_CHANGED
-            )
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         user_id = str(owner_id)
         generation = state.migration_generation
         if not self._layouts.holds_lease(
@@ -131,9 +119,7 @@ class SkillsPoolReconcileService:
             migration_generation=generation,
             lease_owner=lease_owner,
         ):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.LEASE_NOT_HELD
-            )
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.LEASE_NOT_HELD)
 
         probe = await self._runtime.probe(
             bot_id=scope.bot_id,
@@ -141,17 +127,50 @@ class SkillsPoolReconcileService:
             engine="openclaw",
         )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
+            if (
+                probe.status is RuntimeLayoutProbeStatus.INVALID
+                and not state.data_plane_cutover_committed
+            ):
+                recorded = self._layouts.record_pre_cutover_failure(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    failure_code="INVALID",
+                    failure_stage="runtime_probe",
+                    retryable=False,
+                    evidence=probe.evidence,
+                )
+                if not recorded:
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                    )
             return SkillsPoolReconcileResult(
                 self._probe_outcome(probe.status),
                 evidence=probe.evidence,
+                retryable=(probe.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR),
             )
         if (
             probe.preparation_id is None
             or probe.layout_contract_version != state.layout_contract_version
         ):
+            if not state.data_plane_cutover_committed:
+                recorded = self._layouts.record_pre_cutover_failure(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    failure_code="INVALID",
+                    failure_stage="runtime_probe",
+                    retryable=False,
+                    evidence=probe.evidence,
+                )
+                if not recorded:
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                    )
             return SkillsPoolReconcileResult(
                 SkillsPoolReconcileOutcome.INVALID,
                 evidence=probe.evidence,
+                retryable=False,
             )
 
         local_assets = self._skills.list_bot_local_assets(
@@ -204,9 +223,7 @@ class SkillsPoolReconcileService:
                 mappings=mappings,
             )
             if not cutover.committed:
-                failure_profile = self._cutover_failure_profile(
-                    cutover.status
-                )
+                failure_profile = self._cutover_failure_profile(cutover.status)
                 if failure_profile is not None:
                     outcome, stage, retryable = failure_profile
                     cutover_evidence = cutover.to_dict()
@@ -228,6 +245,7 @@ class SkillsPoolReconcileService:
                         outcome,
                         preparation_id=probe.preparation_id,
                         evidence=cutover_evidence,
+                        retryable=retryable,
                     )
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.CUTOVER_FAILED,

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
@@ -1,0 +1,382 @@
+"""Durable Skills Pool reconciliation task and lifecycle wake-up adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotRepository,
+)
+from agentclaw.community.core.devices.repository.protocol import (
+    DeviceBindingRepository,
+)
+from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
+from agentclaw.community.core.events.types import (
+    BaasPublishCompletedEvent,
+    DeviceAliveEvent,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+)
+from agentclaw.community.core.skills_pool.claim_service import (
+    MigrationClaimOutcome,
+    SkillsPoolMigrationClaimService,
+)
+from agentclaw.community.core.skills_pool.reconcile_service import (
+    SkillsPoolReconcileOutcome,
+    SkillsPoolReconcileResult,
+    SkillsPoolReconcileService,
+)
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+)
+from agentclaw.community.core.task_queue.services.registry import (
+    HandlerRegistry,
+)
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
+from agentclaw.community.core.task_queue.types import (
+    Complete,
+    Fail,
+    Reschedule,
+    Retry,
+    TaskOutcome,
+)
+from agentclaw.community.kernel.lifecycle import LifecycleBase
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+SKILLS_POOL_RECONCILE_TASK = "skills_pool.reconcile"
+SKILLS_POOL_RECONCILE_DEADLINE_SECONDS = 24 * 60 * 60
+SKILLS_POOL_LEASE_SECONDS = 300
+SKILLS_POOL_LEASE_BUSY_DELAY_SECONDS = 5.0
+
+
+def build_skills_pool_reconcile_payload(
+    *,
+    scope: BotSkillLayoutScope,
+    source: str,
+    signal_identity: dict[str, object],
+    wakeup_id: str | None = None,
+) -> dict[str, object]:
+    """Build the persisted work identity.
+
+    ``scope`` is the only durable Bot identity. Provider-specific values are
+    retained solely as audit evidence and are never forwarded to the runtime.
+    """
+
+    return {
+        "scope": {
+            "env": scope.env,
+            "entity_id": scope.entity_id,
+            "bot_id": scope.bot_id,
+        },
+        "source": source,
+        "signal_identity": dict(signal_identity),
+        "wakeup_id": wakeup_id or uuid4().hex,
+    }
+
+
+class SkillsPoolReconcileTaskHandler:
+    """Claim or resume one Bot migration and converge it under generation/lease."""
+
+    def __init__(
+        self,
+        *,
+        claim_service: SkillsPoolMigrationClaimService,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        reconcile_service: SkillsPoolReconcileService,
+        lease_seconds: int = SKILLS_POOL_LEASE_SECONDS,
+    ) -> None:
+        self._claims = claim_service
+        self._layouts = layout_repository
+        self._reconcile = reconcile_service
+        self._lease_seconds = lease_seconds
+
+    @property
+    def task_type(self) -> str:
+        return SKILLS_POOL_RECONCILE_TASK
+
+    def handle(self, payload: dict | None) -> TaskOutcome:
+        try:
+            scope, wakeup_id = self._parse_payload(payload)
+        except ValueError as error:
+            return Fail(f"invalid payload: {error}")
+
+        lease_owner = f"skills-pool:{wakeup_id}"
+        claim = self._claims.claim(
+            scope=scope,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            lease_owner=lease_owner,
+            lease_seconds=self._lease_seconds,
+        )
+
+        if claim.outcome in {
+            MigrationClaimOutcome.INELIGIBLE,
+            MigrationClaimOutcome.BOT_NOT_FOUND,
+            MigrationClaimOutcome.INVALID_BOT_RECORD,
+            MigrationClaimOutcome.ENVIRONMENT_MISMATCH,
+            MigrationClaimOutcome.RUNTIME_NOT_EDITABLE,
+        }:
+            return Complete()
+        if claim.outcome is MigrationClaimOutcome.TRANSIENT_ERROR:
+            return Retry("skills pool current runtime form lookup failed")
+        if claim.outcome is MigrationClaimOutcome.CLAIM_RACE_LOST:
+            return Retry("skills pool migration claim race lost")
+        if claim.state is None:
+            return Retry("skills pool migration claim returned no state")
+
+        lease_outcome = self._ensure_lease(
+            state=claim.state,
+            lease_owner=lease_owner,
+            newly_claimed=claim.outcome is MigrationClaimOutcome.CLAIMED,
+        )
+        if lease_outcome is not None:
+            return lease_outcome
+
+        result = asyncio.run(
+            self._reconcile.reconcile(
+                scope=scope,
+                lease_owner=lease_owner,
+            )
+        )
+        return self._task_outcome(result)
+
+    def _ensure_lease(
+        self,
+        *,
+        state: BotSkillLayoutState,
+        lease_owner: str,
+        newly_claimed: bool,
+    ) -> TaskOutcome | None:
+        if state.active_layout is SkillLayout.POOL:
+            return Complete()
+        if newly_claimed:
+            return None
+        generation = state.migration_generation
+        if generation is None:
+            return Fail("claimed skills pool state has no migration generation")
+
+        acquired = False
+        if state.lease_owner == lease_owner:
+            acquired = self._layouts.renew_lease(
+                scope=state.scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                lease_seconds=self._lease_seconds,
+            )
+        if not acquired:
+            acquired = self._layouts.try_acquire_lease(
+                scope=state.scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                lease_seconds=self._lease_seconds,
+            )
+        if acquired:
+            return None
+        return Reschedule(SKILLS_POOL_LEASE_BUSY_DELAY_SECONDS)
+
+    @staticmethod
+    def _task_outcome(result: SkillsPoolReconcileResult) -> TaskOutcome:
+        outcome = result.outcome
+        if outcome in {
+            SkillsPoolReconcileOutcome.POOL_ACTIVE,
+            SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
+            SkillsPoolReconcileOutcome.NOT_CAPABLE,
+            SkillsPoolReconcileOutcome.BOT_NOT_FOUND,
+            SkillsPoolReconcileOutcome.BOT_CHANGED,
+        }:
+            return Complete()
+        if outcome is SkillsPoolReconcileOutcome.LEASE_NOT_HELD:
+            return Reschedule(SKILLS_POOL_LEASE_BUSY_DELAY_SECONDS)
+        if outcome in {
+            SkillsPoolReconcileOutcome.NOT_CLAIMED,
+            SkillsPoolReconcileOutcome.TRANSIENT_ERROR,
+            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+            SkillsPoolReconcileOutcome.MAPPING_FAILED,
+            SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+            SkillsPoolReconcileOutcome.DATABASE_COMMIT_FAILED,
+        }:
+            return Retry(f"skills pool reconciliation {outcome.value}")
+        if (
+            outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+            and result.retryable is True
+        ):
+            return Retry(f"skills pool reconciliation {outcome.value}")
+
+        logger.error(
+            "[skills_pool.reconcile] migration blocked outcome=%s evidence=%s",
+            outcome.value,
+            result.evidence,
+        )
+        return Fail(f"skills pool reconciliation blocked: {outcome.value}")
+
+    @staticmethod
+    def _parse_payload(
+        payload: dict | None,
+    ) -> tuple[BotSkillLayoutScope, str]:
+        if not isinstance(payload, dict):
+            raise ValueError("payload must be an object")
+        raw_scope = payload.get("scope")
+        if not isinstance(raw_scope, dict):
+            raise ValueError("scope must be an object")
+        values: dict[str, str] = {}
+        for key in ("env", "entity_id", "bot_id"):
+            value = raw_scope.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"scope.{key} must be a non-empty string")
+            values[key] = value
+        wakeup_id = payload.get("wakeup_id")
+        if not isinstance(wakeup_id, str) or not wakeup_id.strip():
+            raise ValueError("wakeup_id must be a non-empty string")
+        source = payload.get("source")
+        if not isinstance(source, str) or not source.strip():
+            raise ValueError("source must be a non-empty string")
+        if not isinstance(payload.get("signal_identity"), dict):
+            raise ValueError("signal_identity must be an object")
+        return BotSkillLayoutScope(**values), wakeup_id
+
+
+class SkillsPoolReconcileWakeupListener(LifecycleBase):
+    """Validate cheap provider identity and enqueue durable Bot reconciliation."""
+
+    def __init__(
+        self,
+        *,
+        binding_repository: DeviceBindingRepository,
+        bot_repository: BotRepository,
+        task_queue_service: TaskQueueService,
+        registry: HandlerRegistry | None = None,
+        task_handler: SkillsPoolReconcileTaskHandler | None = None,
+    ) -> None:
+        self._bindings = binding_repository
+        self._bots = bot_repository
+        self._queue = task_queue_service
+        self._registry = registry
+        self._task_handler = task_handler
+
+    async def bootstrap(self) -> None:
+        if self._registry is not None and self._task_handler is not None:
+            self._registry.register(self._task_handler)
+        from agentclaw.community.core.events.bus import get_event_bus
+
+        bus = get_event_bus()
+        for event_type in (DeviceAliveEvent, BaasPublishCompletedEvent):
+            existing = bus._handlers.get(event_type, [])  # type: ignore[attr-defined]
+            if self.handle not in existing:
+                bus.subscribe(event_type, self.handle, required=True)
+
+    def handle(
+        self,
+        event: DeviceAliveEvent | BaasPublishCompletedEvent,
+    ) -> None:
+        if isinstance(event, DeviceAliveEvent):
+            self._handle_device_alive(event)
+            return
+        if isinstance(event, BaasPublishCompletedEvent):
+            self._handle_baas_publish_completed(event)
+
+    def _handle_device_alive(self, event: DeviceAliveEvent) -> None:
+        # BaaS has a publish-id signal below. Avoid turning its generic ACTIVE
+        # event into a second identity path.
+        if event.device_provider != "arca":
+            return
+        binding = self._bindings.get_by_id(event.binding_id)
+        if binding is None or binding.device_provider != "arca":
+            return
+        if (
+            binding.device_id != event.device_id
+            or binding.entity_id != event.entity_id
+            or binding.entity_type != event.entity_type
+        ):
+            return
+        current_sandbox = (binding.device_props or {}).get("sandbox_id")
+        if event.sandbox_id is not None and current_sandbox != event.sandbox_id:
+            return
+        self._enqueue(
+            binding=binding,
+            source="arca_device_alive",
+            signal_identity={
+                "binding_id": event.binding_id,
+                "device_id": event.device_id,
+                "sandbox_id": event.sandbox_id,
+            },
+        )
+
+    def _handle_baas_publish_completed(
+        self,
+        event: BaasPublishCompletedEvent,
+    ) -> None:
+        binding = self._bindings.get_by_id(event.binding_id)
+        if binding is None or binding.device_provider != "baas":
+            return
+        prop_key = (
+            "restart_publish_id" if event.publish_kind == "restart" else "publish_id"
+        )
+        current_publish_id = (binding.device_props or {}).get(prop_key)
+        if current_publish_id is None or str(current_publish_id) != str(
+            event.publish_id
+        ):
+            return
+        bot = self._bots.get_by_binding_id(event.binding_id)
+        if (
+            bot is None
+            or bot.get("bot_id") != event.bot_id
+            or str(bot.get("owner_id")) != event.owner_id
+        ):
+            return
+        self._enqueue(
+            binding=binding,
+            bot=bot,
+            source="baas_publish_completed",
+            signal_identity={
+                "binding_id": event.binding_id,
+                "publish_id": event.publish_id,
+                "publish_kind": event.publish_kind,
+            },
+        )
+
+    def _enqueue(
+        self,
+        *,
+        binding: DeviceBindingRecord,
+        source: str,
+        signal_identity: dict[str, object],
+        bot: dict[str, object] | None = None,
+    ) -> None:
+        current_bot = bot or self._bots.get_by_binding_id(binding.id)
+        if current_bot is None:
+            return
+        bot_id = current_bot.get("bot_id")
+        if not isinstance(bot_id, str) or not bot_id:
+            return
+        payload = build_skills_pool_reconcile_payload(
+            scope=BotSkillLayoutScope(
+                env=binding.env,
+                entity_id=binding.entity_id,
+                bot_id=bot_id,
+            ),
+            source=source,
+            signal_identity=signal_identity,
+        )
+        self._queue.enqueue(
+            SKILLS_POOL_RECONCILE_TASK,
+            payload,
+            deadline_seconds=SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
+        )
+
+
+__all__ = [
+    "SKILLS_POOL_RECONCILE_TASK",
+    "SkillsPoolReconcileTaskHandler",
+    "SkillsPoolReconcileWakeupListener",
+    "build_skills_pool_reconcile_payload",
+]

--- a/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
@@ -1,7 +1,11 @@
 """Skills Pool 控制面状态、灰度门禁与认领服务装配。"""
 
-from injector import Binder, Module, singleton
+from injector import Binder, Module, inject, provider, singleton
 
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.devices.repository.protocol import (
+    DeviceBindingRepository,
+)
 from agentclaw.community.core.skills_pool.claim_service import (
     SkillsPoolMigrationClaimService,
 )
@@ -14,11 +18,19 @@ from agentclaw.community.core.skills_pool.rollout_gate import (
 from agentclaw.community.core.skills_pool.reconcile_service import (
     SkillsPoolReconcileService,
 )
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SkillsPoolReconcileTaskHandler,
+    SkillsPoolReconcileWakeupListener,
+)
 from agentclaw.community.core.skills_pool.ports import (
     SkillsPoolRuntimeProtocol,
     SkillsPoolSkillRepositoryProtocol,
 )
 from agentclaw.community.plugins.skill_repository import SkillRepository
+from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
 from agentclaw.community.plugins.skills_pool_runtime import OpenClawSkillsPoolRuntime
 from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
@@ -58,4 +70,38 @@ class SkillsPoolModule(Module):
             SkillsPoolReconcileService,
             to=SkillsPoolReconcileService,
             scope=singleton,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def reconcile_task_handler(
+        self,
+        claim_service: SkillsPoolMigrationClaimService,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        reconcile_service: SkillsPoolReconcileService,
+    ) -> SkillsPoolReconcileTaskHandler:
+        return SkillsPoolReconcileTaskHandler(
+            claim_service=claim_service,
+            layout_repository=layout_repository,
+            reconcile_service=reconcile_service,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def reconcile_wakeup_listener(
+        self,
+        binding_repository: DeviceBindingRepository,
+        bot_repository: BotRepository,
+        task_queue_service: TaskQueueService,
+        registry: HandlerRegistry,
+        task_handler: SkillsPoolReconcileTaskHandler,
+    ) -> SkillsPoolReconcileWakeupListener:
+        return SkillsPoolReconcileWakeupListener(
+            binding_repository=binding_repository,
+            bot_repository=bot_repository,
+            task_queue_service=task_queue_service,
+            registry=registry,
+            task_handler=task_handler,
         )

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -181,7 +181,8 @@ class SkillsPoolLayoutRepository:
                     *self._scope_filter(scope),
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
-                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
                     or_(
                         BotSkillLayoutStateModel.lease_expires_at.is_(None),
                         BotSkillLayoutStateModel.lease_expires_at <= func.now(),
@@ -213,8 +214,7 @@ class SkillsPoolLayoutRepository:
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
                     BotSkillLayoutStateModel.lease_owner == lease_owner,
@@ -380,6 +380,7 @@ class SkillsPoolLayoutRepository:
                     == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
+                            SkillLayoutPhase.POOL_PREPARING.value,
                             SkillLayoutPhase.POOL_READY.value,
                             SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
                         )

--- a/src/backend/tests/community/architecture/test_lifecycle_discovery.py
+++ b/src/backend/tests/community/architecture/test_lifecycle_discovery.py
@@ -40,6 +40,7 @@ _EXPECTED_PARTICIPANTS: frozenset[str] = frozenset({
     "DesktopBotLifecycle",       # Phase 2: recover PENDING desktop bots
     "BaasPublishTaskLifecycle",  # Phase 2: register durable BaaS publish handlers
     "TeclawPublishTaskLifecycle",  # Phase 2: register durable Teclaw publish handler
+    "SkillsPoolReconcileWakeupListener",  # Phase 1/2: durable reconciliation
 })
 
 

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -1,10 +1,14 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agentclaw.community.core.bot_management.token_vault import TokenVault
 from agentclaw.community.core.devices.models import AllocatedDevice, DeviceBindingStatus
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
-from agentclaw.community.core.devices.services.baas_device_service import BaasDeviceService
+from agentclaw.community.core.devices.services.baas_device_service import (
+    BaasDeviceService,
+)
 from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
     BAAS_CREATE_INIT_TASK,
     BAAS_CREATE_PUBLISH_POLL_TASK,
@@ -17,6 +21,8 @@ from agentclaw.community.core.devices.services.baas_publish_task_handlers import
     build_create_publish_poll_payload,
     build_restart_publish_poll_payload,
 )
+from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+from agentclaw.community.core.events.types import BaasPublishCompletedEvent
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.types import Complete, Fail, Reschedule, Retry
 
@@ -613,7 +619,9 @@ def test_restart_poll_reschedules_when_pending():
         "template_type": "applicationCoding",
         "ext": {},
     }
-    baas_device_service.poll_publish_once.return_value = DeviceBindingStatus.PENDING.value
+    baas_device_service.poll_publish_once.return_value = (
+        DeviceBindingStatus.PENDING.value
+    )
 
     outcome = handler.handle(
         {
@@ -666,7 +674,9 @@ def test_restart_poll_marks_active_and_clears_old_baas_failure_ext_on_success():
         },
     }
     template_service.get_template_config.return_value = {"token": encrypted_token}
-    baas_device_service.poll_publish_once.return_value = DeviceBindingStatus.ACTIVE.value
+    baas_device_service.poll_publish_once.return_value = (
+        DeviceBindingStatus.ACTIVE.value
+    )
     baas_device_service.refresh_codefuse_token_on_publish_success.return_value = None
 
     outcome = handler.handle(
@@ -723,7 +733,9 @@ def test_restart_poll_marks_failed_with_current_publish_id_on_failure():
         "ext": {"keep": "value"},
     }
     bot_repository.get_by_id_and_owner.return_value = {"ext": {"keep": "value"}}
-    baas_device_service.poll_publish_once.return_value = DeviceBindingStatus.FAILED.value
+    baas_device_service.poll_publish_once.return_value = (
+        DeviceBindingStatus.FAILED.value
+    )
 
     outcome = handler.handle(
         {
@@ -958,11 +970,14 @@ def test_create_init_reads_codefuse_token_from_template_service_and_writes_conta
     service._sync_bot_config_when_device_active = MagicMock()
     service._sync_mcps_when_device_active = MagicMock()
 
-    with patch(
-        "agentclaw.community.core.devices.services.baas_device_service.time.sleep",
-    ), patch(
-        "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas",
-    ) as writer:
+    with (
+        patch(
+            "agentclaw.community.core.devices.services.baas_device_service.time.sleep",
+        ),
+        patch(
+            "agentclaw.community.core.devices.services.baas_codefuse_writer.write_codefuse_token_baas",
+        ) as writer,
+    ):
         ok, message = service.run_create_init_once(
             binding_id=42,
             bot_id="bot-001",
@@ -1015,7 +1030,9 @@ def test_create_init_marks_failed_when_init_fails():
     )
     repo.get_by_id.return_value = binding
     baas_device_service = _make_baas_device_service(repo=repo)
-    baas_device_service.run_create_init_once = MagicMock(return_value=(False, "init boom"))
+    baas_device_service.run_create_init_once = MagicMock(
+        return_value=(False, "init boom")
+    )
     handler = BaasCreateInitTaskHandler(
         binding_repository=repo,
         baas_device_service=baas_device_service,
@@ -1296,7 +1313,9 @@ def test_restart_poll_retries_on_transient_status_and_direct_unexpected_status()
         status=DeviceBindingStatus.PENDING.value,
         device_props={"restart_publish_id": 1001},
     )
-    bot_repository.get_by_binding_id.return_value = {"status": DeviceBindingStatus.PENDING.value}
+    bot_repository.get_by_binding_id.return_value = {
+        "status": DeviceBindingStatus.PENDING.value
+    }
     payload = {
         "binding_id": 42,
         "bot_id": "bot-001",
@@ -1406,3 +1425,234 @@ def test_baas_publish_task_lifecycle_registers_all_handlers():
         registry.get(BAAS_RESTART_PUBLISH_POLL_TASK),
         BaasRestartPublishPollHandler,
     )
+
+
+def test_create_init_success_publishes_baas_reconciliation_wakeup():
+    reset_event_bus()
+    received: list[BaasPublishCompletedEvent] = []
+    get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    try:
+        repo = MagicMock()
+        repo.get_by_id.return_value = _make_binding(
+            status=DeviceBindingStatus.PENDING.value,
+            device_props={"publish_id": 1001},
+        )
+        baas_device_service = MagicMock()
+        baas_device_service.run_create_init_once.return_value = (True, "ok")
+        handler = BaasCreateInitTaskHandler(
+            binding_repository=repo,
+            baas_device_service=baas_device_service,
+        )
+
+        outcome = handler.handle(
+            build_create_init_payload(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1001,
+            )
+        )
+
+        assert outcome == Complete()
+        assert received == [
+            BaasPublishCompletedEvent(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1001,
+                publish_kind="create",
+            )
+        ]
+    finally:
+        reset_event_bus()
+
+
+def test_create_init_replay_after_active_reemits_reconciliation_wakeup():
+    reset_event_bus()
+    received: list[BaasPublishCompletedEvent] = []
+    get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    try:
+        repo = MagicMock()
+        repo.get_by_id.return_value = _make_binding(
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_props={"publish_id": 1001},
+        )
+        baas_device_service = MagicMock()
+        handler = BaasCreateInitTaskHandler(
+            binding_repository=repo,
+            baas_device_service=baas_device_service,
+        )
+
+        outcome = handler.handle(
+            build_create_init_payload(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1001,
+            )
+        )
+
+        assert outcome == Complete()
+        baas_device_service.run_create_init_once.assert_not_called()
+        assert received == [
+            BaasPublishCompletedEvent(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1001,
+                publish_kind="create",
+            )
+        ]
+    finally:
+        reset_event_bus()
+
+
+def test_restart_success_publishes_baas_reconciliation_wakeup():
+    reset_event_bus()
+    received: list[BaasPublishCompletedEvent] = []
+    get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    try:
+        repo = MagicMock()
+        repo.get_by_id.return_value = _make_binding(
+            status=DeviceBindingStatus.PENDING.value,
+            device_props={"restart_publish_id": 1002},
+        )
+        bot_repository = MagicMock()
+        bot_repository.get_by_binding_id.return_value = {
+            "bot_id": "bot-001",
+            "owner_id": "owner-001",
+            "active_engine": "openclaw",
+            "bot_type": "personal",
+        }
+        bot_repository.get_by_id_and_owner.return_value = {
+            "ext": {},
+        }
+        baas_device_service = MagicMock()
+        baas_device_service.poll_publish_once.return_value = (
+            DeviceBindingStatus.ACTIVE.value
+        )
+        baas_device_service.refresh_codefuse_token_on_publish_success.return_value = (
+            None
+        )
+        handler, _ = _make_restart_handler(
+            repo=repo,
+            bot_repository=bot_repository,
+            baas_device_service=baas_device_service,
+        )
+
+        outcome = handler.handle(
+            build_restart_publish_poll_payload(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1002,
+                started_at_epoch_s=190.0,
+                bot_uuid="baas-bot-1",
+            )
+        )
+
+        assert outcome == Complete()
+        assert received == [
+            BaasPublishCompletedEvent(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1002,
+                publish_kind="restart",
+            )
+        ]
+    finally:
+        reset_event_bus()
+
+
+def test_restart_persist_failure_does_not_publish_completion() -> None:
+    reset_event_bus()
+    received: list[BaasPublishCompletedEvent] = []
+    get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    try:
+        repo = MagicMock()
+        repo.get_by_id.return_value = _make_binding(
+            status=DeviceBindingStatus.PENDING.value,
+            device_props={"restart_publish_id": 1002},
+        )
+        repo.update_status.side_effect = RuntimeError("database unavailable")
+        bot_repository = MagicMock()
+        bot_repository.get_by_binding_id.return_value = {
+            "bot_id": "bot-001",
+            "owner_id": "owner-001",
+            "active_engine": "openclaw",
+            "bot_type": "personal",
+        }
+        bot_repository.get_by_id_and_owner.return_value = {"ext": {}}
+        baas_device_service = MagicMock()
+        baas_device_service.poll_publish_once.return_value = (
+            DeviceBindingStatus.ACTIVE.value
+        )
+        baas_device_service.refresh_codefuse_token_on_publish_success.return_value = (
+            None
+        )
+        handler, _ = _make_restart_handler(
+            repo=repo,
+            bot_repository=bot_repository,
+            baas_device_service=baas_device_service,
+        )
+
+        with pytest.raises(RuntimeError, match="database unavailable"):
+            handler.handle(
+                build_restart_publish_poll_payload(
+                    binding_id=42,
+                    bot_id="bot-001",
+                    owner_id="owner-001",
+                    publish_id=1002,
+                    started_at_epoch_s=190.0,
+                    bot_uuid="baas-bot-1",
+                )
+            )
+
+        assert received == []
+    finally:
+        reset_event_bus()
+
+
+def test_restart_replay_after_active_reemits_reconciliation_wakeup():
+    reset_event_bus()
+    received: list[BaasPublishCompletedEvent] = []
+    get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    try:
+        repo = MagicMock()
+        repo.get_by_id.return_value = _make_binding(
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_props={"restart_publish_id": 1002},
+        )
+        bot_repository = MagicMock()
+        baas_device_service = MagicMock()
+        handler, _ = _make_restart_handler(
+            repo=repo,
+            bot_repository=bot_repository,
+            baas_device_service=baas_device_service,
+        )
+
+        outcome = handler.handle(
+            build_restart_publish_poll_payload(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1002,
+                started_at_epoch_s=190.0,
+                bot_uuid="baas-bot-1",
+            )
+        )
+
+        assert outcome == Complete()
+        baas_device_service.poll_publish_once.assert_not_called()
+        assert received == [
+            BaasPublishCompletedEvent(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1002,
+                publish_kind="restart",
+            )
+        ]
+    finally:
+        reset_event_bus()

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -46,7 +46,9 @@ def _make_record(
         device_id=device_id,
         device_provider=device_provider,
         env="dev",
-        device_props=device_props if device_props is not None else {"callback_token": "tok123"},
+        device_props=device_props
+        if device_props is not None
+        else {"callback_token": "tok123"},
         status=status,
         apply_reason=None,
         applied_by=entity_id,
@@ -108,11 +110,13 @@ def _make_service(
 class TestSafeB64Decode:
     def test_normal_padding(self):
         import base64
+
         data = base64.b64encode(b"hello world").decode()
         assert DeviceService.safe_b64decode(data) == b"hello world"
 
     def test_missing_padding_1(self):
         import base64
+
         raw = b"ab"
         encoded = base64.b64encode(raw).decode().rstrip("=")
         # remove padding to simulate missing padding
@@ -121,6 +125,7 @@ class TestSafeB64Decode:
 
     def test_missing_padding_2(self):
         import base64
+
         raw = b"abc"
         encoded = base64.b64encode(raw).decode().rstrip("=")
         result = DeviceService.safe_b64decode(encoded)
@@ -579,7 +584,9 @@ class TestGetDeviceConnection:
             )
 
     def test_other_user_public_bot_allowed(self):
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -593,7 +600,9 @@ class TestGetDeviceConnection:
         assert isinstance(conn, DeviceConnectionInfo)
 
     def test_other_user_non_public_bot_denied(self):
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -607,7 +616,9 @@ class TestGetDeviceConnection:
             )
 
     def test_other_user_bot_query_exception_denied(self):
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -622,7 +633,9 @@ class TestGetDeviceConnection:
 
     def test_other_user_collaborator_allowed(self):
         """协作者可以获取设备连接信息。"""
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -658,7 +671,9 @@ class TestGetDeviceConnection:
 
     def test_collaborator_permission_check_failed_still_denied(self):
         """协作者权限检查失败（返回无权限）仍然拒绝访问。"""
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -687,7 +702,9 @@ class TestGetDeviceConnection:
 
     def test_bot_not_found_raises_error(self):
         """Bot 不存在时抛出异常。"""
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -703,7 +720,9 @@ class TestGetDeviceConnection:
 
     def test_bot_info_incomplete_raises_error(self):
         """Bot 信息不完整（缺少 bot_id 或 owner_id）时抛出异常。"""
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -723,7 +742,9 @@ class TestGetDeviceConnection:
 
     def test_collaborator_service_unavailable_raises_error(self):
         """协作者服务不可用时抛出异常。"""
-        record = _make_record(entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value)
+        record = _make_record(
+            entity_id="bot_owner", status=DeviceBindingStatus.ACTIVE.value
+        )
         repo = MagicMock()
         repo.get_by_id.return_value = record
         bot_query = MagicMock()
@@ -874,6 +895,81 @@ class TestReportDeviceAlive:
         assert received == []
         reset_event_bus()
 
+    def test_device_alive_event_is_not_inserted_for_active_heartbeat(self):
+        from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+        from agentclaw.community.core.events.types import DeviceAliveEvent
+
+        reset_event_bus()
+        received: list[DeviceAliveEvent] = []
+        get_event_bus().subscribe(DeviceAliveEvent, received.append)
+
+        record = _make_record(
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_provider="arca",
+            device_props={"callback_token": "tok123", "sandbox_id": "sbx-current"},
+        )
+        updated = _make_record(status=DeviceBindingStatus.ACTIVE.value)
+        repo = MagicMock()
+        repo.get_by_device_id.return_value = record
+        repo.get_by_id.return_value = updated
+        svc = _make_service(repo=repo)
+
+        svc.report_device_alive(device_id="staff_u001_default", token="tok123")
+
+        assert received == []
+        reset_event_bus()
+
+    def test_required_alive_handoff_failure_keeps_pending_for_retry(self):
+        from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+        from agentclaw.community.core.events.types import DeviceAliveEvent
+
+        reset_event_bus()
+        attempts = 0
+
+        def enqueue_once_available(_event):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("queue unavailable")
+
+        get_event_bus().subscribe(
+            DeviceAliveEvent,
+            enqueue_once_available,
+            required=True,
+        )
+        record = _make_record(
+            status=DeviceBindingStatus.PENDING.value,
+            device_provider="arca",
+            device_props={"callback_token": "tok123", "sandbox_id": "sbx-current"},
+        )
+        updated = _make_record(status=DeviceBindingStatus.ACTIVE.value)
+        repo = MagicMock()
+        repo.get_by_device_id.return_value = record
+        repo.get_by_id.return_value = updated
+        bot_query = MagicMock()
+        bot_query.get_by_binding_id.return_value = None
+        svc = _make_service(repo=repo, bot_query=bot_query)
+
+        with pytest.raises(RuntimeError, match="required handler failed"):
+            svc.report_device_alive(
+                device_id="staff_u001_default",
+                token="tok123",
+            )
+        repo.update_status_and_alive_at.assert_not_called()
+
+        result = svc.report_device_alive(
+            device_id="staff_u001_default",
+            token="tok123",
+        )
+
+        assert result is updated
+        assert attempts == 2
+        repo.update_status_and_alive_at.assert_called_once_with(
+            binding_id=record.id,
+            status=DeviceBindingStatus.ACTIVE.value,
+        )
+        reset_event_bus()
+
     def test_event_publish_failure_does_not_break_report_alive(self):
         from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
         from agentclaw.community.core.events.types import DeviceActivatedEvent
@@ -961,7 +1057,10 @@ class TestReportDeviceStatus:
 
         with pytest.raises(InvalidDeviceStatusError, match="invalid token"):
             svc.report_device_status(
-                device_id="staff_u001_default", status="STARTING", message=None, token="wrong"
+                device_id="staff_u001_default",
+                status="STARTING",
+                message=None,
+                token="wrong",
             )
 
     def test_released_device_raises(self):
@@ -1031,6 +1130,7 @@ class TestExecShell:
 class TestBatchSetEnv:
     def test_batch_update(self):
         from dataclasses import replace as dc_replace
+
         repo = MagicMock()
         repo.batch_update_env.return_value = 2
 
@@ -1089,7 +1189,9 @@ class TestListConnectableDevices:
         ]
         svc = _make_service(repo=repo, bot_query=bot_query)
         # Return a valid conn from _compose_device_conn_info
-        fake_conn = DeviceConnectionInfo(type="local", target="localhost:20003", token="", engine_type="openclaw")
+        fake_conn = DeviceConnectionInfo(
+            type="local", target="localhost:20003", token="", engine_type="openclaw"
+        )
         svc._compose_device_conn_info = MagicMock(return_value=fake_conn)
 
         total, items = svc.list_connectable_devices(
@@ -1110,7 +1212,9 @@ class TestListConnectableDevices:
         )
         repo = MagicMock()
         repo.get_by_ids.return_value = [record]
-        repo.get_by_id.return_value = None  # causes DeviceNotFoundError inside get_device_connection
+        repo.get_by_id.return_value = (
+            None  # causes DeviceNotFoundError inside get_device_connection
+        )
         bot_query = MagicMock()
         bot_query.list_active_bots_by_entity.return_value = [
             {"bot_id": "b1", "binding_id": 1, "owner_id": "u001"}
@@ -1166,8 +1270,11 @@ class TestListConnectableDevices:
     def test_filters_by_env(self):
         """测试 env 过滤."""
         from dataclasses import replace as dc_replace
+
         record1 = _make_record(id=1, status=DeviceBindingStatus.ACTIVE.value)
-        record2 = dc_replace(_make_record(id=2, status=DeviceBindingStatus.ACTIVE.value), env="prod")
+        record2 = dc_replace(
+            _make_record(id=2, status=DeviceBindingStatus.ACTIVE.value), env="prod"
+        )
         repo = MagicMock()
         repo.get_by_ids.return_value = [record1, record2]
         bot_query = MagicMock()
@@ -1212,12 +1319,16 @@ class TestListConnectableDevices:
 
     def test_pagination(self):
         """测试分页."""
-        records = [_make_record(id=i, status=DeviceBindingStatus.ACTIVE.value) for i in range(1, 6)]
+        records = [
+            _make_record(id=i, status=DeviceBindingStatus.ACTIVE.value)
+            for i in range(1, 6)
+        ]
         repo = MagicMock()
         repo.get_by_ids.return_value = records
         bot_query = MagicMock()
         bot_query.list_active_bots_by_entity.return_value = [
-            {"bot_id": f"b{i}", "binding_id": i, "owner_id": "u001"} for i in range(1, 6)
+            {"bot_id": f"b{i}", "binding_id": i, "owner_id": "u001"}
+            for i in range(1, 6)
         ]
         svc = _make_service(repo=repo, bot_query=bot_query)
 
@@ -1315,8 +1426,12 @@ class TestApplyDevice:
         )
         svc._setup_directory = MagicMock(return_value=[])
 
-        with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
-            with patch("agentclaw.community.core.devices.services.device_service.threading.Thread") as thread_cls:
+        with patch(
+            "agentclaw.community.utils.env_utils.get_current_env", return_value="dev"
+        ):
+            with patch(
+                "agentclaw.community.core.devices.services.device_service.threading.Thread"
+            ) as thread_cls:
                 result = svc.apply_device(
                     apply_reason="create bot",
                     entity_id="u001",
@@ -1330,11 +1445,15 @@ class TestApplyDevice:
         assert svc.after_binding_args["binding_id"] == record.id
         assert svc.after_binding_args["bot_id"] == "bot1"
         assert svc.after_binding_args["owner_id"] == "owner-001"
-        assert svc.after_binding_args["device_props"]["provider_key"] == "provider_value"
+        assert (
+            svc.after_binding_args["device_props"]["provider_key"] == "provider_value"
+        )
         assert svc.start_called is False
         thread_cls.assert_not_called()
 
-    def test_apply_device_runs_generic_start_when_provider_hook_does_not_claim_lifecycle(self):
+    def test_apply_device_runs_generic_start_when_provider_hook_does_not_claim_lifecycle(
+        self,
+    ):
         repo = MagicMock()
         repo.exists_device_id.return_value = False
         repo.get_released_binding.return_value = None
@@ -1352,7 +1471,9 @@ class TestApplyDevice:
 
         thread = MagicMock()
 
-        with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
+        with patch(
+            "agentclaw.community.utils.env_utils.get_current_env", return_value="dev"
+        ):
             with patch(
                 "agentclaw.community.core.devices.services.device_service.threading.Thread",
                 return_value=thread,
@@ -1387,7 +1508,9 @@ class TestApplyDevice:
         repo.get_by_id.return_value = record
         svc = _make_service(repo=repo)
 
-        with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
+        with patch(
+            "agentclaw.community.utils.env_utils.get_current_env", return_value="dev"
+        ):
             result = svc.apply_device(
                 apply_reason="test",
                 entity_id="u001",
@@ -1408,7 +1531,9 @@ class TestApplyDevice:
         repo.get_by_id.return_value = record
         svc = _make_service(repo=repo)
 
-        with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
+        with patch(
+            "agentclaw.community.utils.env_utils.get_current_env", return_value="dev"
+        ):
             result = svc.apply_device(
                 apply_reason="reuse test",
                 entity_id="u001",
@@ -1428,7 +1553,9 @@ class TestApplyDevice:
         repo.get_by_id.return_value = None
         svc = _make_service(repo=repo)
 
-        with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
+        with patch(
+            "agentclaw.community.utils.env_utils.get_current_env", return_value="dev"
+        ):
             result = svc.apply_device(
                 apply_reason=None,
                 entity_id="u001",
@@ -1456,7 +1583,9 @@ class TestGetDeviceConnectionV2:
         svc = _make_service(repo=repo)
         # Local type now routes through BaaS invoke-http (same as desktop)
         fake_conn = DeviceConnectionInfo(
-            type="local", target="10.0.0.1:20003", token="mytoken",
+            type="local",
+            target="10.0.0.1:20003",
+            token="mytoken",
             engine_type="openclaw",
             baas_base_url="http://baas.test",
             bot_uuid="bot-001",
@@ -1486,14 +1615,20 @@ class TestGetDeviceConnectionV2:
         repo.get_by_id.return_value = record
         svc = _make_service(repo=repo)
         fake_conn = DeviceConnectionInfo(
-            type="arca", target="sb-abc123.proxy.net", token="mytoken", engine_type="openclaw"
+            type="arca",
+            target="sb-abc123.proxy.net",
+            token="mytoken",
+            engine_type="openclaw",
         )
         svc._compose_device_conn_info = MagicMock(return_value=fake_conn)
 
         # The ARCA proxy target is served by the mocked SandboxRuntimeClient seam
         # (``_make_sandbox_client``), not corp ``arca_io`` (B6 devendoring), so this
         # is corp-free — only the community proxy-base config is patched.
-        with patch("agentclaw.community.core.config.sofa.sofa_config.user_config", {"agentclawproxy": {"base_url": "https://proxy.example.com"}}):
+        with patch(
+            "agentclaw.community.core.config.sofa.sofa_config.user_config",
+            {"agentclawproxy": {"base_url": "https://proxy.example.com"}},
+        ):
             result = svc.get_device_connection_v2(
                 user_id="u001", nick_name="User", binding_id=1
             )
@@ -1508,6 +1643,7 @@ class TestGetDeviceConnectionV2:
         svc = _make_service(repo=repo)
 
         from agentclaw.community.core.devices.errors import DeviceServiceError
+
         with pytest.raises(DeviceServiceError):
             svc.get_device_connection_v2(user_id="u001", nick_name="User", binding_id=1)
 
@@ -1671,7 +1807,9 @@ class TestEffectiveBindingStatusUsesStoredColumn:
         svc = _make_service(repo=repo, bot_query=bot_query)
 
         total, items = svc.list_connectable_devices(
-            entity_id="u001", entity_type="staff", env=None,
+            entity_id="u001",
+            entity_type="staff",
+            env=None,
         )
         assert total == 1 and items[0].record is binding
 
@@ -1684,6 +1822,8 @@ class TestEffectiveBindingStatusUsesStoredColumn:
         svc = _make_service(repo=repo, bot_query=bot_query)
 
         total, items = svc.list_connectable_devices(
-            entity_id="u001", entity_type="staff", env=None,
+            entity_id="u001",
+            entity_type="staff",
+            env=None,
         )
         assert total == 0 and items == []

--- a/src/backend/tests/community/core/events/test_bus.py
+++ b/src/backend/tests/community/core/events/test_bus.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agentclaw.community.core.events.bus import EventBus, get_event_bus, reset_event_bus
+from agentclaw.community.core.events.bus import (
+    EventBus,
+    RequiredEventDeliveryError,
+    get_event_bus,
+    reset_event_bus,
+)
 
 
 @dataclass
@@ -64,6 +69,21 @@ class TestEventBus:
         bus.publish(_DummyEvent(value=0))
 
         good_before.assert_called_once()
+        good_after.assert_called_once()
+
+    def test_required_handler_exception_is_propagated_after_siblings_run(self):
+        bus = EventBus()
+        good_after = MagicMock()
+
+        def bad(_event):
+            raise RuntimeError("queue unavailable")
+
+        bus.subscribe(_DummyEvent, bad, required=True)
+        bus.subscribe(_DummyEvent, good_after)
+
+        with pytest.raises(RequiredEventDeliveryError):
+            bus.publish(_DummyEvent(value=0))
+
         good_after.assert_called_once()
 
     def test_handlers_only_receive_their_event_type(self):

--- a/src/backend/tests/community/core/skills_pool/test_claim_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_claim_service.py
@@ -44,6 +44,11 @@ class FakeBotPublishRepository:
         return self.draft
 
 
+class FailingBotPublishRepository:
+    def get_draft_by_publish_bot_id(self, publish_bot_id: str, env: str):
+        raise RuntimeError("database unavailable")
+
+
 class FakeLayoutRepository:
     def __init__(self) -> None:
         self.state: BotSkillLayoutState | None = None
@@ -180,6 +185,64 @@ def test_claim_is_sticky_after_whitelist_removal() -> None:
     assert repeated.state == first.state
     assert len(gate.calls) == 1
     assert layouts.claim_calls == 1
+
+
+def test_claimed_service_generation_stops_when_draft_is_no_longer_editable() -> None:
+    bot = {**personal_bot(), "bot_type": "service"}
+    drafts = FakeBotPublishRepository(
+        SimpleNamespace(
+            source_bot_pk=bot["id"],
+            source_bot_id=bot["bot_id"],
+            publish_bot_id=bot["bot_id"],
+            status="draft",
+            env=bot["env"],
+        )
+    )
+    layouts = FakeLayoutRepository()
+    gate = RecordingGate(eligible_decision())
+    service = SkillsPoolMigrationClaimService(
+        FakeBotRepository(bot),
+        drafts,
+        layouts,
+        gate,
+    )
+
+    first = claim(service)
+    drafts.draft = None
+    repeated = claim(service)
+
+    assert first.outcome is MigrationClaimOutcome.CLAIMED
+    assert repeated.outcome is MigrationClaimOutcome.RUNTIME_NOT_EDITABLE
+    assert repeated.state == first.state
+    assert len(gate.calls) == 1
+
+
+def test_claimed_service_generation_retries_current_draft_lookup_failure() -> None:
+    bot = {**personal_bot(), "bot_type": "service"}
+    layouts = FakeLayoutRepository()
+    layouts.state = BotSkillLayoutState(
+        scope=BotSkillLayoutScope(
+            env="pre",
+            entity_id="entity-1",
+            bot_id="bot-1",
+        ),
+        active_layout=SkillLayout.LEGACY,
+        target_layout=SkillLayout.POOL,
+        phase=SkillLayoutPhase.POOL_PREPARING,
+        migration_generation="generation-1",
+        persisted=True,
+    )
+    service = SkillsPoolMigrationClaimService(
+        FakeBotRepository(bot),
+        FailingBotPublishRepository(),
+        layouts,
+        RecordingGate(eligible_decision()),
+    )
+
+    result = claim(service)
+
+    assert result.outcome is MigrationClaimOutcome.TRANSIENT_ERROR
+    assert result.state == layouts.state
 
 
 def test_ineligible_bot_does_not_persist_layout_state() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -366,6 +366,37 @@ def test_pre_cutover_failure_evidence_survives_an_ordinary_retry() -> None:
     )
 
 
+def test_invalid_runtime_probe_can_be_recorded_while_pool_is_preparing() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+
+    recorded = repository.record_pre_cutover_failure(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        failure_code="INVALID",
+        failure_stage="runtime_probe",
+        retryable=False,
+        evidence={"reason": "marker_contract_mismatch"},
+    )
+
+    assert recorded
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_PREPARING
+    assert state.last_failure_code == "INVALID"
+    assert state.last_failure_stage == "runtime_probe"
+    assert state.last_failure_retryable is False
+    assert state.last_failure_evidence == {"reason": "marker_contract_mismatch"}
+
+
 def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -469,14 +500,8 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
             for row in session.query(Skill).order_by(Skill.id).all()
         }
     assert paths == {
-        1: (
-            "local:///home/admin/.openclaw/workspace/"
-            "skills-pool/skills-local/local-a"
-        ),
-        2: (
-            "local:///home/admin/.openclaw/workspace/"
-            "skills-pool/skills-local/local-b"
-        ),
+        1: ("local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-a"),
+        2: ("local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-b"),
         3: "git://business/repo",
         4: "local:///legacy/other-bot",
         5: "local:///legacy/other-env",

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
     RuntimeLayoutProbeResult,
     RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skills_pool.claim_service import (
+    MigrationClaimOutcome,
+    MigrationClaimResult,
 )
 from agentclaw.community.core.skills_pool.models import (
     OpenClawPoolPaths,
@@ -20,12 +26,18 @@ from agentclaw.community.core.skills_pool.reconcile_service import (
     SkillsPoolReconcileOutcome,
     SkillsPoolReconcileService,
 )
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SkillsPoolReconcileTaskHandler,
+    build_skills_pool_reconcile_payload,
+)
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
     SkillLayout,
     SkillLayoutPhase,
 )
+from agentclaw.community.core.task_queue.types import Complete, Retry
+from agentclaw.community.plugins.skills_pool_runtime import OpenClawSkillsPoolRuntime
 
 
 SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
@@ -69,12 +81,21 @@ class FakeLayoutRepository:
         self.events: list[str] = []
         self.committed_locators: dict[int, str] | None = None
         self.lease_valid = True
+        self.fail_once_at: str | None = None
+
+    def _should_fail(self, stage: str) -> bool:
+        if self.fail_once_at != stage:
+            return False
+        self.fail_once_at = None
+        return True
 
     def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
         assert scope == SCOPE
         return self.state
 
     def record_ready_probe(self, **kwargs: object) -> bool:
+        if self._should_fail("ready"):
+            return False
         if not self._owns(kwargs):
             return False
         self.events.append("ready")
@@ -90,6 +111,8 @@ class FakeLayoutRepository:
         return self.lease_valid and self._owns(kwargs)
 
     def record_cutover_committed(self, **kwargs: object) -> bool:
+        if self._should_fail("cutover_commit"):
+            return False
         if not self._owns(kwargs):
             return False
         self.events.append("cutover")
@@ -101,6 +124,8 @@ class FakeLayoutRepository:
         return True
 
     def begin_cutover(self, **kwargs: object) -> bool:
+        if self._should_fail("begin"):
+            return False
         if not self._owns(kwargs):
             return False
         self.events.append("begin")
@@ -129,6 +154,8 @@ class FakeLayoutRepository:
         local_locators: dict[int, str],
         **kwargs: object,
     ) -> bool:
+        if self._should_fail("database"):
+            return False
         if not self._owns(kwargs):
             return False
         self.events.append("database")
@@ -142,11 +169,17 @@ class FakeLayoutRepository:
         )
         return True
 
+    def renew_lease(self, **kwargs: object) -> bool:
+        return self._owns(kwargs)
+
+    def try_acquire_lease(self, **kwargs: object) -> bool:
+        return False
+
     def _owns(self, values: dict[str, object]) -> bool:
         return (
             values["scope"] == SCOPE
             and values["migration_generation"] == GENERATION
-            and values["lease_owner"] == "worker-1"
+            and values["lease_owner"] == self.state.lease_owner
         )
 
 
@@ -196,6 +229,8 @@ class FakeRuntime:
     def __init__(self) -> None:
         self.events: list[str] = []
         self.publish_success = True
+        self.verify_success = True
+        self.physical_cutovers = 0
         self.cutover_result = PoolCutoverResult(
             committed=True,
             status=PoolCutoverStatus.COMMITTED,
@@ -228,6 +263,11 @@ class FakeRuntime:
             f"{OpenClawPoolPaths().pool_local}/local-b",
             f"{OpenClawPoolPaths().pool_repo}/business/repo-skill",
         ]
+        if (
+            self.cutover_result.committed
+            and self.cutover_result.status is PoolCutoverStatus.COMMITTED
+        ):
+            self.physical_cutovers += 1
         return self.cutover_result
 
     async def publish_mappings(self, **kwargs: object) -> bool:
@@ -236,7 +276,7 @@ class FakeRuntime:
 
     async def verify_mappings(self, **kwargs: object) -> bool:
         self.events.append("verify")
-        return True
+        return self.verify_success
 
 
 def build_service(
@@ -266,12 +306,10 @@ async def test_ready_claimed_bot_completes_pool_activation() -> None:
     assert layouts.events == ["ready", "begin", "cutover", "database"]
     assert layouts.committed_locators == {
         11: (
-            "local:///home/admin/.openclaw/workspace/"
-            "skills-pool/skills-local/local-a"
+            "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-a"
         ),
         12: (
-            "local:///home/admin/.openclaw/workspace/"
-            "skills-pool/skills-local/local-b"
+            "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-b"
         ),
     }
 
@@ -399,6 +437,83 @@ async def test_non_ready_runtime_keeps_legacy_without_data_plane_changes() -> No
 
 
 @pytest.mark.asyncio
+async def test_invalid_probe_is_persisted_as_non_retryable_blocker() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.INVALID,
+        preparation_id=None,
+        evidence={"reason": "marker_contract_mismatch"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert layouts.events == ["failure"]
+    assert layouts.state.last_failure_code == "INVALID"
+    assert layouts.state.last_failure_stage == "runtime_probe"
+    assert layouts.state.last_failure_retryable is False
+    assert layouts.state.last_failure_evidence == {"reason": "marker_contract_mismatch"}
+    assert runtime.events == ["probe"]
+
+
+@pytest.mark.asyncio
+async def test_ready_probe_contract_mismatch_is_persisted_as_blocker() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        layout_contract_version="future-contract",
+        evidence={"reason": "contract_drift"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert layouts.events == ["failure"]
+    assert layouts.state.last_failure_code == "INVALID"
+    assert layouts.state.last_failure_stage == "runtime_probe"
+    assert layouts.state.last_failure_evidence == {"reason": "contract_drift"}
+    assert runtime.events == ["probe"]
+
+
+@pytest.mark.asyncio
+async def test_post_cutover_invalid_probe_blocks_without_pre_cutover_write() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.INVALID,
+        preparation_id=None,
+        evidence={"reason": "post_cutover_probe_invalid"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert layouts.events == []
+    assert runtime.events == ["probe"]
+
+
+@pytest.mark.asyncio
 async def test_stale_generation_or_lease_cannot_continue_activation() -> None:
     layouts = FakeLayoutRepository(
         claimed_state(lease_owner="another-worker"),
@@ -427,3 +542,224 @@ async def test_expired_lease_cannot_probe_or_publish_mappings() -> None:
 
     assert result.outcome is SkillsPoolReconcileOutcome.LEASE_NOT_HELD
     assert runtime.events == []
+
+
+class StickyClaimService:
+    """Expose the real reconciliation service through the durable task seam."""
+
+    def __init__(self, layouts: FakeLayoutRepository) -> None:
+        self._layouts = layouts
+        self._calls = 0
+
+    def claim(self, **kwargs: object) -> MigrationClaimResult:
+        self._calls += 1
+        if self._calls == 1:
+            self._layouts.state = replace(
+                self._layouts.state,
+                lease_owner=str(kwargs["lease_owner"]),
+            )
+        return MigrationClaimResult(
+            (
+                MigrationClaimOutcome.CLAIMED
+                if self._calls == 1
+                else MigrationClaimOutcome.ALREADY_CLAIMED
+            ),
+            self._layouts.state,
+        )
+
+
+def build_task_handler(
+    layouts: FakeLayoutRepository,
+    runtime: FakeRuntime,
+) -> SkillsPoolReconcileTaskHandler:
+    return SkillsPoolReconcileTaskHandler(
+        claim_service=StickyClaimService(layouts),
+        layout_repository=layouts,
+        reconcile_service=build_service(layouts, runtime),
+    )
+
+
+def task_payload() -> dict[str, object]:
+    return build_skills_pool_reconcile_payload(
+        scope=SCOPE,
+        source="test",
+        signal_identity={"binding_id": 1},
+        wakeup_id="wakeup-1",
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "transient_probe",
+        "ready_state_race",
+        "begin_state_race",
+        "retryable_cutover",
+        "cutover_ledger_state_race",
+        "mapping",
+        "verify",
+        "database",
+    ],
+)
+def test_real_reconciliation_retry_resumes_same_generation_without_repeating_cutover(
+    failure: str,
+) -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    original_generation = layouts.state.migration_generation
+
+    if failure == "transient_probe":
+        ready = runtime.probe_result
+        runtime.probe_result = replace(
+            ready,
+            status=RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
+            preparation_id=None,
+        )
+    elif failure == "ready_state_race":
+        layouts.fail_once_at = "ready"
+    elif failure == "begin_state_race":
+        layouts.fail_once_at = "begin"
+    elif failure == "retryable_cutover":
+        runtime.cutover_result = PoolCutoverResult(
+            committed=False,
+            status=PoolCutoverStatus.TRANSIENT_ERROR,
+            evidence={"reason": "runtime unavailable"},
+        )
+    elif failure == "cutover_ledger_state_race":
+        layouts.fail_once_at = "cutover_commit"
+    elif failure == "mapping":
+        runtime.publish_success = False
+    elif failure == "verify":
+        runtime.verify_success = False
+    elif failure == "database":
+        layouts.fail_once_at = "database"
+
+    handler = build_task_handler(layouts, runtime)
+    first = handler.handle(task_payload())
+    cutovers_after_first = runtime.events.count("cutover")
+
+    runtime.probe_result = RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.READY,
+        engine="openclaw",
+        layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        preparation_id=PREPARATION_ID,
+        evidence={"marker": "valid"},
+    )
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=(
+            PoolCutoverStatus.ALREADY_COMMITTED
+            if failure == "cutover_ledger_state_race"
+            else PoolCutoverStatus.COMMITTED
+        ),
+        evidence={"local_inventory": {"registered": 2}},
+    )
+    runtime.publish_success = True
+    runtime.verify_success = True
+
+    second = handler.handle(task_payload())
+
+    assert isinstance(first, Retry)
+    assert second == Complete()
+    assert layouts.state.migration_generation == original_generation
+    assert layouts.state.active_layout is SkillLayout.POOL
+    if failure in {"mapping", "verify", "database"}:
+        assert cutovers_after_first == 1
+        assert runtime.events.count("cutover") == 1
+    if failure == "cutover_ledger_state_race":
+        assert cutovers_after_first == 1
+        assert runtime.events.count("cutover") == 2
+        assert runtime.physical_cutovers == 1
+
+
+class CurrentBindingResolver:
+    def __init__(self) -> None:
+        self.current_binding = "binding-new"
+        self.calls: list[tuple[str, str]] = []
+
+    def resolve_for_bot(self, bot_id: str, user_id: str):
+        self.calls.append((bot_id, user_id))
+        return SimpleNamespace(
+            conn_info={"binding": self.current_binding},
+        )
+
+
+class RecordingTransport:
+    def __init__(self) -> None:
+        self.bindings: list[str] = []
+
+    async def invoke(
+        self,
+        conn_info,
+        method,
+        path,
+        *,
+        body,
+        timeout,
+    ):
+        self.bindings.append(conn_info["binding"])
+        if path.endswith("/activate"):
+            return {
+                "success": True,
+                "data": {
+                    "committed": True,
+                    "status": "COMMITTED",
+                    "evidence": {},
+                },
+            }
+        if path.endswith("/publish"):
+            return {"success": True}
+        return {"success": True, "data": {"valid": True}}
+
+
+class ReadyProbeService:
+    async def probe_bot(self, **kwargs):
+        return RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.READY,
+            engine="openclaw",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=PREPARATION_ID,
+            evidence={"marker": "valid"},
+        )
+
+
+def test_stale_signal_uses_current_resolved_binding_for_real_mutations() -> None:
+    layouts = FakeLayoutRepository()
+    resolver = CurrentBindingResolver()
+    transport = RecordingTransport()
+    runtime = OpenClawSkillsPoolRuntime(
+        resolver=resolver,
+        adapter_transport=transport,
+        probe_service=ReadyProbeService(),
+    )
+    reconcile = SkillsPoolReconcileService(
+        bot_repository=FakeBotRepository(),
+        layout_repository=layouts,
+        skill_repository=FakeSkillRepository(),
+        runtime=runtime,
+    )
+    handler = SkillsPoolReconcileTaskHandler(
+        claim_service=StickyClaimService(layouts),
+        layout_repository=layouts,
+        reconcile_service=reconcile,
+    )
+    payload = build_skills_pool_reconcile_payload(
+        scope=SCOPE,
+        source="arca_device_alive",
+        signal_identity={
+            "binding_id": 7,
+            "device_id": "device-old",
+            "sandbox_id": "sandbox-old",
+        },
+        wakeup_id="stale-wakeup",
+    )
+
+    outcome = handler.handle(payload)
+
+    assert outcome == Complete()
+    assert resolver.calls == [
+        ("bot-1", "owner-1"),
+        ("bot-1", "owner-1"),
+        ("bot-1", "owner-1"),
+    ]
+    assert transport.bindings == ["binding-new", "binding-new", "binding-new"]

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
@@ -1,0 +1,586 @@
+"""Skills Pool durable reconciliation task and lifecycle wake-up tests."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.events.types import (
+    BaasPublishCompletedEvent,
+    DeviceAliveEvent,
+)
+from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+)
+from agentclaw.community.core.skills_pool.claim_service import (
+    MigrationClaimOutcome,
+    MigrationClaimResult,
+)
+from agentclaw.community.core.skills_pool.reconcile_service import (
+    SkillsPoolReconcileOutcome,
+    SkillsPoolReconcileResult,
+)
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SKILLS_POOL_RECONCILE_TASK,
+    SkillsPoolReconcileTaskHandler,
+    SkillsPoolReconcileWakeupListener,
+    build_skills_pool_reconcile_payload,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+from agentclaw.community.core.task_queue.types import Complete, Fail, Reschedule, Retry
+
+
+SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+
+
+def _claimed_state(
+    *,
+    lease_owner: str = "skills-pool:wakeup-1",
+    active_layout: SkillLayout = SkillLayout.LEGACY,
+) -> BotSkillLayoutState:
+    return BotSkillLayoutState(
+        scope=SCOPE,
+        active_layout=active_layout,
+        target_layout=SkillLayout.POOL,
+        phase=(
+            SkillLayoutPhase.POOL_ACTIVE
+            if active_layout is SkillLayout.POOL
+            else SkillLayoutPhase.POOL_PREPARING
+        ),
+        migration_generation="generation-1",
+        persisted=True,
+        layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        lease_owner=lease_owner,
+    )
+
+
+def _binding(
+    *,
+    provider: str,
+    props: dict[str, object],
+    binding_id: int = 42,
+):
+    return SimpleNamespace(
+        id=binding_id,
+        env="pre",
+        entity_id="entity-1",
+        entity_type="staff",
+        device_id="device-current",
+        device_provider=provider,
+        device_props=props,
+    )
+
+
+def _bot() -> dict[str, object]:
+    return {
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "entity_id": "entity-1",
+        "env": "pre",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+
+
+def _listener(
+    *,
+    binding,
+) -> tuple[SkillsPoolReconcileWakeupListener, MagicMock]:
+    bindings = MagicMock()
+    bindings.get_by_id.return_value = binding
+    bots = MagicMock()
+    bots.get_by_binding_id.return_value = _bot()
+    queue = MagicMock()
+    return (
+        SkillsPoolReconcileWakeupListener(
+            binding_repository=bindings,
+            bot_repository=bots,
+            task_queue_service=queue,
+        ),
+        queue,
+    )
+
+
+def test_arca_wakeup_only_enqueues_durable_bot_identity() -> None:
+    listener, queue = _listener(
+        binding=_binding(
+            provider="arca",
+            props={"sandbox_id": "sandbox-current"},
+        )
+    )
+
+    listener.handle(
+        DeviceAliveEvent(
+            device_id="device-current",
+            binding_id=42,
+            entity_id="entity-1",
+            entity_type="staff",
+            device_provider="arca",
+            sandbox_id="sandbox-current",
+        )
+    )
+
+    task_type, payload = queue.enqueue.call_args.args[:2]
+    assert task_type == SKILLS_POOL_RECONCILE_TASK
+    assert payload["scope"] == {
+        "env": "pre",
+        "entity_id": "entity-1",
+        "bot_id": "bot-1",
+    }
+    assert payload["source"] == "arca_device_alive"
+    assert payload["signal_identity"] == {
+        "binding_id": 42,
+        "device_id": "device-current",
+        "sandbox_id": "sandbox-current",
+    }
+
+
+def test_arca_wakeup_rejects_obviously_stale_sandbox() -> None:
+    listener, queue = _listener(
+        binding=_binding(
+            provider="arca",
+            props={"sandbox_id": "sandbox-current"},
+        )
+    )
+
+    listener.handle(
+        DeviceAliveEvent(
+            device_id="device-old",
+            binding_id=42,
+            entity_id="entity-1",
+            entity_type="staff",
+            device_provider="arca",
+            sandbox_id="sandbox-old",
+        )
+    )
+
+    queue.enqueue.assert_not_called()
+
+
+def test_baas_publish_wakeup_validates_current_publish_before_enqueue() -> None:
+    listener, queue = _listener(
+        binding=_binding(
+            provider="baas",
+            props={"restart_publish_id": "1002"},
+        )
+    )
+
+    listener.handle(
+        BaasPublishCompletedEvent(
+            binding_id=42,
+            bot_id="bot-1",
+            owner_id="owner-1",
+            publish_id=1002,
+            publish_kind="restart",
+        )
+    )
+
+    payload = queue.enqueue.call_args.args[1]
+    assert payload["source"] == "baas_publish_completed"
+    assert payload["signal_identity"] == {
+        "binding_id": 42,
+        "publish_id": 1002,
+        "publish_kind": "restart",
+    }
+
+
+def test_baas_publish_wakeup_rejects_obviously_stale_publish() -> None:
+    listener, queue = _listener(
+        binding=_binding(
+            provider="baas",
+            props={"restart_publish_id": "2002"},
+        )
+    )
+
+    listener.handle(
+        BaasPublishCompletedEvent(
+            binding_id=42,
+            bot_id="bot-1",
+            owner_id="owner-1",
+            publish_id=1002,
+            publish_kind="restart",
+        )
+    )
+
+    queue.enqueue.assert_not_called()
+
+
+def test_wakeup_listener_subscribes_both_events_idempotently() -> None:
+    reset_event_bus()
+    try:
+        listener, _ = _listener(binding=_binding(provider="arca", props={}))
+
+        asyncio.run(listener.bootstrap())
+        asyncio.run(listener.bootstrap())
+
+        bus = get_event_bus()
+        assert bus._handlers[DeviceAliveEvent].count(listener.handle) == 1
+        assert bus._handlers[BaasPublishCompletedEvent].count(listener.handle) == 1
+    finally:
+        reset_event_bus()
+
+
+def test_required_wakeup_retries_queue_handoff_on_next_arca_heartbeat() -> None:
+    reset_event_bus()
+    try:
+        listener, queue = _listener(
+            binding=_binding(
+                provider="arca",
+                props={"sandbox_id": "sandbox-current"},
+            )
+        )
+        queue.enqueue.side_effect = [RuntimeError("queue unavailable"), MagicMock()]
+        asyncio.run(listener.bootstrap())
+        event = DeviceAliveEvent(
+            device_id="device-current",
+            binding_id=42,
+            entity_id="entity-1",
+            entity_type="staff",
+            device_provider="arca",
+            sandbox_id="sandbox-current",
+        )
+
+        with pytest.raises(RuntimeError, match="required handler failed"):
+            get_event_bus().publish(event)
+        get_event_bus().publish(event)
+
+        assert queue.enqueue.call_count == 2
+    finally:
+        reset_event_bus()
+
+
+class FakeClaimService:
+    def __init__(self, results: list[MigrationClaimResult]) -> None:
+        self.results = results
+        self.calls: list[dict[str, object]] = []
+
+    def claim(self, **kwargs: object) -> MigrationClaimResult:
+        self.calls.append(kwargs)
+        if len(self.results) > 1:
+            return self.results.pop(0)
+        return self.results[0]
+
+
+class FakeLayouts:
+    def __init__(self, state: BotSkillLayoutState) -> None:
+        self.state = state
+        self.renew_calls: list[dict[str, object]] = []
+        self.acquire_calls: list[dict[str, object]] = []
+        self.renew_result = True
+        self.acquire_result = False
+
+    def renew_lease(self, **kwargs: object) -> bool:
+        self.renew_calls.append(kwargs)
+        return self.renew_result
+
+    def try_acquire_lease(self, **kwargs: object) -> bool:
+        self.acquire_calls.append(kwargs)
+        if self.acquire_result:
+            self.state = replace(
+                self.state,
+                lease_owner=str(kwargs["lease_owner"]),
+            )
+        return self.acquire_result
+
+
+class FakeReconcileService:
+    def __init__(self, results: list[SkillsPoolReconcileResult]) -> None:
+        self.results = results
+        self.calls: list[dict[str, object]] = []
+
+    async def reconcile(self, **kwargs: object) -> SkillsPoolReconcileResult:
+        self.calls.append(kwargs)
+        if len(self.results) > 1:
+            return self.results.pop(0)
+        return self.results[0]
+
+
+def _handler(
+    *,
+    claim_results: list[MigrationClaimResult],
+    reconcile_results: list[SkillsPoolReconcileResult],
+    state: BotSkillLayoutState | None = None,
+) -> tuple[
+    SkillsPoolReconcileTaskHandler,
+    FakeClaimService,
+    FakeLayouts,
+    FakeReconcileService,
+]:
+    effective_state = state or claim_results[0].state or _claimed_state()
+    claims = FakeClaimService(claim_results)
+    layouts = FakeLayouts(effective_state)
+    reconcile = FakeReconcileService(reconcile_results)
+    return (
+        SkillsPoolReconcileTaskHandler(
+            claim_service=claims,
+            layout_repository=layouts,
+            reconcile_service=reconcile,
+            lease_seconds=300,
+        ),
+        claims,
+        layouts,
+        reconcile,
+    )
+
+
+def _payload(
+    *,
+    wakeup_id: str = "wakeup-1",
+    signal_identity: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return build_skills_pool_reconcile_payload(
+        scope=SCOPE,
+        source="arca_device_alive",
+        signal_identity=signal_identity
+        or {"binding_id": 7, "device_id": "stale-device"},
+        wakeup_id=wakeup_id,
+    )
+
+
+def test_unclaimed_task_claims_then_reconciles_same_generation() -> None:
+    state = _claimed_state()
+    handler, claims, _, reconcile = _handler(
+        claim_results=[MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state)],
+        reconcile_results=[
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE)
+        ],
+        state=state,
+    )
+
+    outcome = handler.handle(_payload())
+
+    assert outcome == Complete()
+    assert claims.calls == [
+        {
+            "scope": SCOPE,
+            "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+            "lease_owner": "skills-pool:wakeup-1",
+            "lease_seconds": 300,
+        }
+    ]
+    assert reconcile.calls == [{"scope": SCOPE, "lease_owner": "skills-pool:wakeup-1"}]
+
+
+def test_stale_signal_metadata_is_not_forwarded_as_runtime_identity() -> None:
+    state = _claimed_state()
+    handler, _, _, reconcile = _handler(
+        claim_results=[MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state)],
+        reconcile_results=[
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE)
+        ],
+        state=state,
+    )
+
+    outcome = handler.handle(
+        _payload(
+            signal_identity={
+                "binding_id": 7,
+                "device_id": "old-device",
+                "sandbox_id": "old-sandbox",
+            }
+        )
+    )
+
+    assert outcome == Complete()
+    assert reconcile.calls == [{"scope": SCOPE, "lease_owner": "skills-pool:wakeup-1"}]
+
+
+def test_claimed_generation_renews_without_rechecking_rollout_gate() -> None:
+    state = _claimed_state()
+    handler, claims, layouts, reconcile = _handler(
+        claim_results=[
+            MigrationClaimResult(MigrationClaimOutcome.ALREADY_CLAIMED, state)
+        ],
+        reconcile_results=[
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE)
+        ],
+        state=state,
+    )
+
+    outcome = handler.handle(_payload())
+
+    assert outcome == Complete()
+    assert len(claims.calls) == 1
+    assert layouts.renew_calls[0]["migration_generation"] == "generation-1"
+    assert len(reconcile.calls) == 1
+
+
+def test_busy_generation_reschedules_until_lease_can_be_acquired() -> None:
+    state = _claimed_state(lease_owner="another-worker")
+    handler, _, layouts, reconcile = _handler(
+        claim_results=[
+            MigrationClaimResult(MigrationClaimOutcome.ALREADY_CLAIMED, state)
+        ],
+        reconcile_results=[
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE)
+        ],
+        state=state,
+    )
+
+    first = handler.handle(_payload())
+    layouts.acquire_result = True
+    second = handler.handle(_payload())
+
+    assert first == Reschedule(5.0)
+    assert second == Complete()
+    assert len(reconcile.calls) == 1
+
+
+def test_claim_race_retries_before_any_runtime_mutation() -> None:
+    state = _claimed_state()
+    handler, _, _, reconcile = _handler(
+        claim_results=[
+            MigrationClaimResult(
+                MigrationClaimOutcome.CLAIM_RACE_LOST,
+                BotSkillLayoutState.legacy_default(SCOPE),
+            ),
+            MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state),
+        ],
+        reconcile_results=[
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE)
+        ],
+        state=state,
+    )
+
+    first = handler.handle(_payload())
+    second = handler.handle(_payload())
+
+    assert first == Retry("skills pool migration claim race lost")
+    assert second == Complete()
+    assert len(reconcile.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.NOT_CAPABLE),
+            Complete(),
+        ),
+        (
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.TRANSIENT_ERROR),
+            Retry("skills pool reconciliation transient_error"),
+        ),
+        (
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.INVALID),
+            Fail("skills pool reconciliation blocked: invalid"),
+        ),
+    ],
+)
+def test_probe_four_state_outcomes_drive_queue_policy(
+    result: SkillsPoolReconcileResult,
+    expected,
+) -> None:
+    state = _claimed_state()
+    handler, _, _, _ = _handler(
+        claim_results=[MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state)],
+        reconcile_results=[result],
+        state=state,
+    )
+
+    assert handler.handle(_payload()) == expected
+
+
+@pytest.mark.parametrize(
+    "retryable_outcome",
+    [
+        SkillsPoolReconcileOutcome.TRANSIENT_ERROR,
+        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+        SkillsPoolReconcileOutcome.MAPPING_FAILED,
+        SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+        SkillsPoolReconcileOutcome.DATABASE_COMMIT_FAILED,
+    ],
+)
+def test_retryable_failure_then_success_is_idempotent(
+    retryable_outcome: SkillsPoolReconcileOutcome,
+) -> None:
+    state = _claimed_state()
+    handler, claims, _, reconcile = _handler(
+        claim_results=[
+            MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state),
+            MigrationClaimResult(MigrationClaimOutcome.ALREADY_CLAIMED, state),
+        ],
+        reconcile_results=[
+            SkillsPoolReconcileResult(retryable_outcome),
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE),
+        ],
+        state=state,
+    )
+
+    first = handler.handle(_payload())
+    second = handler.handle(_payload())
+
+    assert isinstance(first, Retry)
+    assert second == Complete()
+    assert len(claims.calls) == 2
+    assert len(reconcile.calls) == 2
+
+
+def test_retryable_cutover_failure_then_success_is_idempotent() -> None:
+    state = _claimed_state()
+    handler, _, _, reconcile = _handler(
+        claim_results=[
+            MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state),
+            MigrationClaimResult(MigrationClaimOutcome.ALREADY_CLAIMED, state),
+        ],
+        reconcile_results=[
+            SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                retryable=True,
+            ),
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE),
+        ],
+        state=state,
+    )
+
+    first = handler.handle(_payload())
+    second = handler.handle(_payload())
+
+    assert first == Retry("skills pool reconciliation cutover_failed")
+    assert second == Complete()
+    assert len(reconcile.calls) == 2
+
+
+def test_non_retryable_cutover_failure_blocks() -> None:
+    state = _claimed_state()
+    handler, _, _, _ = _handler(
+        claim_results=[MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state)],
+        reconcile_results=[
+            SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                retryable=False,
+            )
+        ],
+        state=state,
+    )
+
+    assert handler.handle(_payload()) == Fail(
+        "skills pool reconciliation blocked: cutover_failed"
+    )
+
+
+def test_invalid_payload_fails_without_touching_domain_services() -> None:
+    state = _claimed_state()
+    handler, claims, _, reconcile = _handler(
+        claim_results=[MigrationClaimResult(MigrationClaimOutcome.CLAIMED, state)],
+        reconcile_results=[
+            SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.POOL_ACTIVE)
+        ],
+        state=state,
+    )
+
+    outcome = handler.handle({"scope": {"env": "pre"}})
+
+    assert isinstance(outcome, Fail)
+    assert claims.calls == []
+    assert reconcile.calls == []

--- a/src/backend/tests/community/di/test_skills_pool_wiring.py
+++ b/src/backend/tests/community/di/test_skills_pool_wiring.py
@@ -12,6 +12,12 @@ from agentclaw.community.core.skills_pool.rollout_gate import (
 from agentclaw.community.core.skills_pool.reconcile_service import (
     SkillsPoolReconcileService,
 )
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SKILLS_POOL_RECONCILE_TASK,
+    SkillsPoolReconcileTaskHandler,
+    SkillsPoolReconcileWakeupListener,
+)
+from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.skills_pool.ports import (
     SkillsPoolRuntimeProtocol,
     SkillsPoolSkillRepositoryProtocol,
@@ -50,4 +56,26 @@ def test_skills_pool_control_plane_bindings_resolve() -> None:
     assert isinstance(
         injector.get(SkillsPoolReconcileService),
         SkillsPoolReconcileService,
+    )
+    assert isinstance(
+        injector.get(SkillsPoolReconcileTaskHandler),
+        SkillsPoolReconcileTaskHandler,
+    )
+    assert isinstance(
+        injector.get(SkillsPoolReconcileWakeupListener),
+        SkillsPoolReconcileWakeupListener,
+    )
+
+
+def test_skills_pool_reconcile_handler_registers_during_bootstrap() -> None:
+    import asyncio
+
+    injector = build_injector(profile=DeployProfile.TEST)
+    listener = injector.get(SkillsPoolReconcileWakeupListener)
+
+    asyncio.run(listener.bootstrap())
+
+    assert isinstance(
+        injector.get(HandlerRegistry).get(SKILLS_POOL_RECONCILE_TASK),
+        SkillsPoolReconcileTaskHandler,
     )


### PR DESCRIPTION
## Summary

- connect ARCA pre-ACTIVE alive and BaaS publish-completed signals to durable `skills_pool.reconcile` tasks
- re-read current Bot/runtime facts on every attempt and converge with sticky migration generation plus lease fencing
- enforce READY/NOT_CAPABLE/TRANSIENT_ERROR/INVALID handling, persist invalid evidence, and preserve idempotency across cutover/mapping/DB retries
- make durable event hand-off required: ARCA stays PENDING on enqueue failure; BaaS publish tasks retry instead of losing the wake-up

## Verification

- `uv run pytest tests/community -q` — 8704 passed
- focused Skills Pool/device/event/DI/architecture suite — 233 passed
- Ruff check on all changed Python files — passed
- spec and standards dual review — no remaining blockers

Closes #371