### PR TITLE
feat: add AICoding skills pool migration

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -55,6 +55,9 @@ class RuntimePoolLayout:
         if engine == "claude_code":
             pool_root = Path(home) / ".claude_code" / "workspace" / "skills-pool"
             return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
+        if engine == "aicoding":
+            pool_root = Path(home) / ".aicoding" / "workspace" / "skills-pool"
+            return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
         raise ValueError(f"engine Pool layout not implemented: {engine}")
 
 
@@ -108,7 +111,7 @@ class CurrentRuntimeLayoutProbeService:
                 engine,
                 "engine_has_no_filesystem_pool_layout",
             )
-        if engine not in {"openclaw", "claude_code"}:
+        if engine not in {"openclaw", "claude_code", "aicoding"}:
             return self._not_capable(engine, "engine_pool_probe_not_implemented")
         layout = layout or RuntimePoolLayout.for_engine(engine)
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -3,7 +3,7 @@
 Skills Pool 控制面的 Bot 级布局状态、首次迁移认领和激活编排边界。
 容器目录准备由镜像负责；本模块通过当前 runtime adapter 完成 probe、
 受支持文件型引擎的原子数据面切换与 Pool mapping，并在最后事务性提交
-locator 和 `POOL_ACTIVE`。当前已接入 OpenClaw 与 Claude Code；完整多引擎
+locator 和 `POOL_ACTIVE`。当前已接入 OpenClaw、Claude Code 与 AICoding；完整多引擎
 Engine Layout Descriptor 仍不在本期范围内。
 
 ## 核心语义

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -26,7 +26,17 @@ class ClaudeCodePoolPaths:
     pool_repo: str = "/home/admin/.claude_code/workspace/skills-pool/skills-repo"
 
 
-PoolPaths = OpenClawPoolPaths | ClaudeCodePoolPaths
+@dataclass(frozen=True, slots=True)
+class AICodingPoolPaths:
+    """AICoding P3 的容器视角路径契约。"""
+
+    active: str = "/home/admin/.claude/skills"
+    legacy_local: str = "/home/admin/.aicoding/workspace/skills/skills-local"
+    pool_local: str = "/home/admin/.aicoding/workspace/skills-pool/skills-local"
+    pool_repo: str = "/home/admin/.aicoding/workspace/skills-pool/skills-repo"
+
+
+PoolPaths = OpenClawPoolPaths | ClaudeCodePoolPaths | AICodingPoolPaths
 
 
 def pool_paths_for_engine(engine: str) -> PoolPaths:
@@ -36,6 +46,8 @@ def pool_paths_for_engine(engine: str) -> PoolPaths:
         return OpenClawPoolPaths()
     if engine == "claude_code":
         return ClaudeCodePoolPaths()
+    if engine == "aicoding":
+        return AICodingPoolPaths()
     raise ValueError(f"engine Pool layout not implemented: {engine}")
 
 
@@ -90,6 +102,7 @@ class PoolCutoverResult:
 
 
 __all__ = [
+    "AICodingPoolPaths",
     "ClaudeCodePoolPaths",
     "OpenClawPoolPaths",
     "PoolPaths",

--- a/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
@@ -129,6 +129,47 @@ async def test_claude_code_ready_uses_current_runtime_probe():
 
 
 @pytest.mark.asyncio
+async def test_aicoding_ready_uses_current_runtime_probe():
+    service, resolver, transport, context = _service(
+        response={
+            "success": True,
+            "data": {
+                "status": "READY",
+                "engine": "aicoding",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+                "evidence": {
+                    "checks": {
+                        "stable_local_bridge_valid": True,
+                        "stable_repo_bridge_valid": True,
+                    }
+                },
+            },
+        }
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="aicoding",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.READY
+    assert result.engine == "aicoding"
+    resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
+    transport.invoke.assert_awaited_once_with(
+        context.conn_info,
+        "POST",
+        "/api/skills/layout/probe",
+        body={
+            "engine": "aicoding",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+        timeout=10.0,
+    )
+
+
+@pytest.mark.asyncio
 async def test_new_runtime_without_marker_is_not_capable():
     service, *_ = _service(
         response={

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -357,7 +357,35 @@ async def test_claude_code_uses_its_own_pool_paths_for_full_activation() -> None
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("engine", ["openclaw", "claude_code"])
+async def test_aicoding_uses_its_own_pool_paths_for_full_activation() -> None:
+    layouts = FakeLayoutRepository()
+    pool_local = "/home/admin/.aicoding/workspace/skills-pool/skills-local"
+    pool_repo = "/home/admin/.aicoding/workspace/skills-pool/skills-repo"
+    runtime = FakeRuntime(
+        engine="aicoding",
+        pool_local=pool_local,
+        pool_repo=pool_repo,
+    )
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="aicoding",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.committed_locators == {
+        11: f"local://{pool_local}/local-a",
+        12: f"local://{pool_local}/local-b",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding"])
 async def test_mapping_failure_after_cutover_does_not_commit_database(
     engine: str,
 ) -> None:

--- a/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
+++ b/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
@@ -178,13 +178,21 @@ def test_non_pool_engine_never_matches(engine_type: str) -> None:
     )
 
 
-def test_service_draft_is_editable_but_published_service_is_not() -> None:
-    gate = make_gate(enabled_config())
+@pytest.mark.parametrize("engine_type", ["openclaw", "aicoding"])
+def test_service_draft_is_editable_but_published_service_is_not(
+    engine_type: str,
+) -> None:
+    gate = make_gate(enabled_config(promoted_engines=[engine_type]))
 
-    assert evaluate(gate, runtime_form=BotRuntimeForm.SERVICE_DRAFT).eligible
+    assert evaluate(
+        gate,
+        engine_type=engine_type,
+        runtime_form=BotRuntimeForm.SERVICE_DRAFT,
+    ).eligible
     assert (
         evaluate(
             gate,
+            engine_type=engine_type,
             runtime_form=BotRuntimeForm.PUBLISHED_SERVICE,
         ).reason
         is RolloutDecisionReason.RUNTIME_NOT_EDITABLE

--- a/src/backend/tests/community/services/test_skill_set_service.py
+++ b/src/backend/tests/community/services/test_skill_set_service.py
@@ -132,6 +132,45 @@ class TestGetSymlinkMappings:
             ),
         ]
 
+    def test_aicoding_pool_locators_drive_restart_mappings(
+        self, skill_set_service, mock_skill_set_repo
+    ):
+        pool_local = (
+            "/home/admin/.aicoding/workspace/skills-pool/skills-local/handmade"
+        )
+        skill_set_service.engine_type = "aicoding"
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = [
+            {"id": "1", "name": "AICoding Pool", "is_default": False}
+        ]
+        mock_skill_set_repo.get_skills_in_set.return_value = [
+            {
+                "id": "1",
+                "name": "handmade",
+                "git_path": f"local://{pool_local}",
+            },
+            {
+                "id": "2",
+                "name": "repo-skill",
+                "git_path": "git://business/repo-skill",
+            },
+        ]
+
+        mappings = skill_set_service.get_symlink_mappings(
+            user_id="100015",
+            bolt_id="default",
+        )
+
+        assert [(mapping.source, mapping.target) for mapping in mappings] == [
+            (
+                pool_local,
+                "/home/admin/.claude/skills/handmade",
+            ),
+            (
+                "/home/admin/.aicoding/skills-repo/business/repo-skill",
+                "/home/admin/.claude/skills/repo-skill",
+            ),
+        ]
+
     def test_local_path_with_relative_name(
         self, skill_set_service, mock_skill_set_repo, mock_skill_repo
     ):

--- a/src/engine/src/engine/community/plugins/aicoding/__init__.py
+++ b/src/engine/src/engine/community/plugins/aicoding/__init__.py
@@ -1,0 +1,1 @@
+"""AICoding 的文件系统 Skills Pool engine-view 实现。"""

--- a/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
@@ -1,0 +1,78 @@
+"""AICoding Skills Pool 文件系统契约。"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable
+
+from engine.community.plugins.skills_pool.layout_activation import (
+    MappingPublishResult,
+    MappingVerificationResult,
+    PoolActivationResult,
+    PoolActivationStatus,
+    SkillMapping,
+    activate_aicoding_pool,
+    publish_pool_mappings as _publish_pool_mappings,
+    verify_skill_mappings as _verify_skill_mappings,
+)
+from engine.community.plugins.skills_pool.layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+    RuntimeLayoutInspection,
+    RuntimeLayoutInspectionStatus,
+    inspect_runtime_layout,
+)
+
+
+def inspect_aicoding_runtime_layout(
+    *,
+    expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
+    home: Path = Path("/home/admin"),
+    repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
+) -> RuntimeLayoutInspection:
+    return inspect_runtime_layout(
+        engine="aicoding",
+        expected_contract_version=expected_contract_version,
+        home=home,
+        repo_is_mounted=repo_is_mounted,
+)
+
+
+def publish_aicoding_pool_mappings(
+    *,
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+) -> MappingPublishResult:
+    return _publish_pool_mappings(
+        mappings=mappings,
+        home=home,
+        engine="aicoding",
+    )
+
+
+def verify_aicoding_pool_mappings(
+    *,
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+) -> MappingVerificationResult:
+    return _verify_skill_mappings(
+        mappings=mappings,
+        home=home,
+        engine="aicoding",
+    )
+
+
+__all__ = [
+    "LAYOUT_CONTRACT_VERSION",
+    "MappingPublishResult",
+    "MappingVerificationResult",
+    "PoolActivationResult",
+    "PoolActivationStatus",
+    "RuntimeLayoutInspection",
+    "RuntimeLayoutInspectionStatus",
+    "SkillMapping",
+    "activate_aicoding_pool",
+    "inspect_aicoding_runtime_layout",
+    "publish_aicoding_pool_mappings",
+    "verify_aicoding_pool_mappings",
+]

--- a/src/engine/src/engine/community/plugins/aicoding/tests/__init__.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/__init__.py
@@ -1,0 +1,1 @@
+"""AICoding Skills Pool plugin tests."""

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from engine.community.plugins.aicoding.layout_pool import (
+    PoolActivationStatus,
+    RuntimeLayoutInspectionStatus,
+    SkillMapping,
+    activate_aicoding_pool,
+    inspect_aicoding_runtime_layout,
+    publish_aicoding_pool_mappings,
+    verify_aicoding_pool_mappings,
+)
+
+
+PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
+
+
+def _prepared_home(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path, Path, Path]:
+    home = tmp_path / "home" / "admin"
+    workspace = home / ".aicoding" / "workspace"
+    legacy_local = workspace / "skills" / "skills-local"
+    active_root = home / ".claude" / "skills"
+    local_bridge = active_root / "skills-local"
+    repo_bridge = home / ".aicoding" / "skills-repo"
+    pool_root = workspace / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+
+    (legacy_local / "handmade").mkdir(parents=True)
+    (legacy_local / "handmade" / "SKILL.md").write_text("latest")
+    (pool_local / "handmade").mkdir(parents=True)
+    (pool_local / "handmade" / "SKILL.md").write_text("prepared")
+    (pool_repo / "business" / "shared").mkdir(parents=True)
+    (pool_repo / "business" / "shared" / "SKILL.md").write_text("repo")
+    active_root.mkdir(parents=True, exist_ok=True)
+    local_bridge.symlink_to(legacy_local, target_is_directory=True)
+    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+
+    marker = {
+        "engine": "aicoding",
+        "layout_contract_version": "skills-pool-p3-v1",
+        "preparation_id": PREPARATION_ID,
+        "prepared_at": "2026-07-24T00:00:00Z",
+        "pool_local_root": str(pool_local),
+        "pool_repo_root": str(pool_repo),
+        "validation_summary": {
+            "all_valid": True,
+            "pool_local": {"path": str(pool_local), "valid": True},
+            "pool_repo": {
+                "path": str(pool_repo),
+                "readable_mount": True,
+                "valid": True,
+            },
+            "structural_bridges": [
+                {
+                    "name": "stable_local_bridge",
+                    "path": str(local_bridge),
+                    "target": str(legacy_local),
+                    "valid": True,
+                },
+                {
+                    "name": "stable_repo_bridge",
+                    "path": str(repo_bridge),
+                    "target": str(pool_repo),
+                    "valid": True,
+                },
+            ],
+            "managed_active_entries": [],
+            "external_active_entry_count": 0,
+        },
+    }
+    (pool_root / ".pool-ready").write_text(json.dumps(marker))
+    return (
+        home,
+        legacy_local,
+        local_bridge,
+        repo_bridge,
+        pool_local,
+        pool_repo,
+    )
+
+
+def test_aicoding_probe_uses_own_pool_and_stable_bridges(tmp_path: Path) -> None:
+    home, _, _, repo_bridge, _, pool_repo = _prepared_home(tmp_path)
+
+    ready = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert ready.status is RuntimeLayoutInspectionStatus.READY
+    assert ready.engine == "aicoding"
+    assert ready.preparation_id == PREPARATION_ID
+    assert ready.evidence["checks"]["stable_local_bridge_valid"] is True
+    assert ready.evidence["checks"]["stable_repo_bridge_valid"] is True
+
+    repo_bridge.unlink()
+    repo_bridge.symlink_to(home / "wrong", target_is_directory=True)
+    invalid = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert invalid.status is RuntimeLayoutInspectionStatus.INVALID
+    assert invalid.evidence["reason"] == "stable_repo_bridge_invalid"
+
+
+def test_aicoding_activation_switches_local_and_keeps_repo_namespace(
+    tmp_path: Path,
+) -> None:
+    (
+        home,
+        legacy_local,
+        local_bridge,
+        repo_bridge,
+        pool_local,
+        pool_repo,
+    ) = _prepared_home(tmp_path)
+    mappings = [
+        SkillMapping(
+            source=str(pool_local / "handmade"),
+            target=str(local_bridge.parent / "handmade"),
+        ),
+        SkillMapping(
+            source=str(pool_repo / "business" / "shared"),
+            target=str(local_bridge.parent / "shared"),
+        ),
+    ]
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert legacy_local.is_symlink()
+    assert legacy_local.resolve() == pool_local.resolve()
+    assert local_bridge.readlink() == legacy_local
+    assert local_bridge.resolve() == pool_local.resolve()
+    assert repo_bridge.resolve() == pool_repo.resolve()
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
+
+
+def test_aicoding_publishes_and_verifies_only_its_pool_sources(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, pool_local, _ = _prepared_home(tmp_path)
+    target = local_bridge.parent / "handmade"
+    mapping = SkillMapping(
+        source=str(pool_local / "handmade"),
+        target=str(target),
+    )
+
+    published = publish_aicoding_pool_mappings(
+        mappings=[mapping],
+        home=home,
+    )
+    verified = verify_aicoding_pool_mappings(
+        mappings=[mapping],
+        home=home,
+    )
+
+    assert published.published is True
+    assert target.resolve() == (pool_local / "handmade").resolve()
+    assert verified.valid is True
+
+    wrong_source = (
+        home
+        / ".openclaw"
+        / "workspace"
+        / "skills-pool"
+        / "skills-local"
+        / "handmade"
+    )
+    wrong_source.mkdir(parents=True)
+    rejected = publish_aicoding_pool_mappings(
+        mappings=[
+            SkillMapping(
+                source=str(wrong_source),
+                target=str(target),
+            )
+        ],
+        home=home,
+    )
+
+    assert rejected.published is False
+    assert rejected.evidence["failures"][0]["reason"] == "source_outside_pool"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -422,7 +422,7 @@ def test_invalid_declared_managed_entry_is_rejected(tmp_path):
 
 def test_other_engine_is_not_capable_without_touching_home(tmp_path):
     result = inspect_runtime_layout(
-        engine="aicoding",
+        engine="hermes",
         expected_contract_version=LAYOUT_CONTRACT_VERSION,
         home=tmp_path / "missing",
         repo_is_mounted=lambda _path: (_ for _ in ()).throw(AssertionError()),

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -98,6 +98,21 @@ class _Layout:
 
     @classmethod
     def for_engine(cls, engine: str, home: Path) -> "_Layout":
+        if engine == "aicoding":
+            workspace = home / ".aicoding" / "workspace"
+            legacy_root = home / ".claude" / "skills"
+            legacy_local = workspace / "skills" / "skills-local"
+            pool_root = workspace / "skills-pool"
+            return cls(
+                legacy_root=legacy_root,
+                legacy_local=legacy_local,
+                pool_root=pool_root,
+                pool_local=pool_root / "skills-local",
+                pool_repo=pool_root / "skills-repo",
+                legacy_repo=home / ".aicoding" / "skills-repo",
+                local_bridge=legacy_root / "skills-local",
+                repo_bridge=home / ".aicoding" / "skills-repo",
+            )
         if engine == "claude_code":
             workspace = home / ".claude_code" / "workspace"
             legacy_root = home / ".claude" / "skills"
@@ -650,6 +665,30 @@ def activate_claude_code_pool(
     )
 
 
+def activate_aicoding_pool(
+    *,
+    migration_generation: str,
+    preparation_id: str,
+    registered_local_names: list[str],
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+    repo_is_mounted: Callable[[Path], bool] | None = None,
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    before_post_sync: Callable[[], None] | None = None,
+) -> PoolActivationResult:
+    return _activate_pool(
+        engine="aicoding",
+        migration_generation=migration_generation,
+        preparation_id=preparation_id,
+        registered_local_names=registered_local_names,
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=repo_is_mounted,
+        exchange_paths=exchange_paths,
+        before_post_sync=before_post_sync,
+    )
+
+
 def verify_skill_mappings(
     *,
     mappings: list[SkillMapping],
@@ -764,6 +803,7 @@ __all__ = [
     "PoolActivationResult",
     "PoolActivationStatus",
     "SkillMapping",
+    "activate_aicoding_pool",
     "activate_claude_code_pool",
     "activate_openclaw_pool",
     "atomic_exchange_paths",

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -59,6 +59,23 @@ class _FilesystemPoolLayout:
 
     @classmethod
     def for_engine(cls, engine: str, home: Path) -> "_FilesystemPoolLayout":
+        if engine == "aicoding":
+            workspace = home / ".aicoding" / "workspace"
+            legacy_root = home / ".claude" / "skills"
+            legacy_local = workspace / "skills" / "skills-local"
+            legacy_repo = home / ".aicoding" / "skills-repo"
+            pool_root = workspace / "skills-pool"
+            return cls(
+                legacy_root=legacy_root,
+                legacy_local=legacy_local,
+                legacy_repo=legacy_repo,
+                pool_root=pool_root,
+                pool_local=pool_root / "skills-local",
+                pool_repo=pool_root / "skills-repo",
+                marker=pool_root / ".pool-ready",
+                local_bridge=legacy_root / "skills-local",
+                repo_bridge=legacy_repo,
+            )
         if engine == "claude_code":
             workspace = home / ".claude_code" / "workspace"
             legacy_root = home / ".claude" / "skills"
@@ -320,7 +337,7 @@ def inspect_runtime_layout(
             expected_contract_version,
             "engine_has_no_filesystem_pool_layout",
         )
-    if engine not in {"openclaw", "claude_code"}:
+    if engine not in {"openclaw", "claude_code", "aicoding"}:
         return _not_capable(
             engine,
             expected_contract_version,
@@ -490,7 +507,7 @@ def inspect_runtime_layout(
             preparation_id=preparation_id,
         )
     required_bridges = [("legacy_repo", layout.repo_bridge, layout.pool_repo)]
-    if engine == "claude_code":
+    if engine != "openclaw":
         required_bridges = [
             ("stable_local", layout.local_bridge, layout.legacy_local),
             ("stable_repo", layout.repo_bridge, layout.pool_repo),


### PR DESCRIPTION
Closes #373

## 变更内容

- 为 AICoding 增加专属 Skills Pool layout、runtime probe、原子激活和 mapping 接口
- Backend 使用 AICoding 自身的 Pool local/repo locator，不再回退到 OpenClaw
- 保持 AICoding ONLINE 服务发布能力不变，仅允许个人 Bot 与服务草稿参与 rollout
- 补充真实文件系统、Backend reconciliation、rollout gate 与 locator 回归测试

## 兼容性

- 旧镜像没有 marker 时返回 `NOT_CAPABLE`，Bot 保持 Legacy
- 新镜像但未进入白名单时只准备 Pool，不触发激活
- 获准 Bot 在 probe、原子切换、mapping 校验成功后提交 locator 与 `POOL_ACTIVE`

## 验证

- Engine community CI：1960 passed，行覆盖率 92.42%
- Backend community CI：8713 passed，行覆盖率 83.42%
- AICoding corp tests：608 passed
- 镜像 Pool preparation tests：15 passed
- Ruff 与 `git diff --check` 通过
