### PR TITLE
feat: add Hermes skills pool migration

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -58,6 +58,9 @@ class RuntimePoolLayout:
         if engine == "aicoding":
             pool_root = Path(home) / ".aicoding" / "workspace" / "skills-pool"
             return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
+        if engine == "hermes":
+            pool_root = Path(home) / ".hermes" / "workspace" / "skills-pool"
+            return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
         raise ValueError(f"engine Pool layout not implemented: {engine}")
 
 
@@ -111,7 +114,7 @@ class CurrentRuntimeLayoutProbeService:
                 engine,
                 "engine_has_no_filesystem_pool_layout",
             )
-        if engine not in {"openclaw", "claude_code", "aicoding"}:
+        if engine not in {"openclaw", "claude_code", "aicoding", "hermes"}:
             return self._not_capable(engine, "engine_pool_probe_not_implemented")
         layout = layout or RuntimePoolLayout.for_engine(engine)
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -36,7 +36,19 @@ class AICodingPoolPaths:
     pool_repo: str = "/home/admin/.aicoding/workspace/skills-pool/skills-repo"
 
 
-PoolPaths = OpenClawPoolPaths | ClaudeCodePoolPaths | AICodingPoolPaths
+@dataclass(frozen=True, slots=True)
+class HermesPoolPaths:
+    """Hermes P3 的容器视角路径契约。"""
+
+    active: str = "/home/admin/.hermes/skills"
+    legacy_local: str = "/home/admin/.hermes/workspace/skills/skills-local"
+    pool_local: str = "/home/admin/.hermes/workspace/skills-pool/skills-local"
+    pool_repo: str = "/home/admin/.hermes/workspace/skills-pool/skills-repo"
+
+
+PoolPaths = (
+    OpenClawPoolPaths | ClaudeCodePoolPaths | AICodingPoolPaths | HermesPoolPaths
+)
 
 
 def pool_paths_for_engine(engine: str) -> PoolPaths:
@@ -48,6 +60,8 @@ def pool_paths_for_engine(engine: str) -> PoolPaths:
         return ClaudeCodePoolPaths()
     if engine == "aicoding":
         return AICodingPoolPaths()
+    if engine == "hermes":
+        return HermesPoolPaths()
     raise ValueError(f"engine Pool layout not implemented: {engine}")
 
 
@@ -104,6 +118,7 @@ class PoolCutoverResult:
 __all__ = [
     "AICodingPoolPaths",
     "ClaudeCodePoolPaths",
+    "HermesPoolPaths",
     "OpenClawPoolPaths",
     "PoolPaths",
     "PoolCutoverResult",

--- a/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
@@ -170,6 +170,48 @@ async def test_aicoding_ready_uses_current_runtime_probe():
 
 
 @pytest.mark.asyncio
+async def test_hermes_ready_requires_current_runtime_h0_evidence():
+    service, resolver, transport, context = _service(
+        response={
+            "success": True,
+            "data": {
+                "status": "READY",
+                "engine": "hermes",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+                "evidence": {
+                    "checks": {
+                        "legacy_local_bridge_valid": True,
+                        "stable_repo_bridge_valid": True,
+                    }
+                },
+            },
+        }
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="hermes",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.READY
+    assert result.engine == "hermes"
+    assert result.evidence["checks"]["legacy_local_bridge_valid"] is True
+    resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
+    transport.invoke.assert_awaited_once_with(
+        context.conn_info,
+        "POST",
+        "/api/skills/layout/probe",
+        body={
+            "engine": "hermes",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+        timeout=10.0,
+    )
+
+
+@pytest.mark.asyncio
 async def test_new_runtime_without_marker_is_not_capable():
     service, *_ = _service(
         response={

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -385,7 +385,44 @@ async def test_aicoding_uses_its_own_pool_paths_for_full_activation() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding"])
+async def test_hermes_h0_ready_uses_its_own_pool_paths_for_full_activation() -> None:
+    layouts = FakeLayoutRepository()
+    pool_local = "/home/admin/.hermes/workspace/skills-pool/skills-local"
+    pool_repo = "/home/admin/.hermes/workspace/skills-pool/skills-repo"
+    runtime = FakeRuntime(
+        engine="hermes",
+        pool_local=pool_local,
+        pool_repo=pool_repo,
+    )
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={
+            "checks": {
+                "legacy_local_bridge_valid": True,
+                "stable_repo_bridge_valid": True,
+            }
+        },
+    )
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="hermes",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.committed_locators == {
+        11: f"local://{pool_local}/local-a",
+        12: f"local://{pool_local}/local-b",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding", "hermes"])
 async def test_mapping_failure_after_cutover_does_not_commit_database(
     engine: str,
 ) -> None:

--- a/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
+++ b/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
@@ -178,7 +178,7 @@ def test_non_pool_engine_never_matches(engine_type: str) -> None:
     )
 
 
-@pytest.mark.parametrize("engine_type", ["openclaw", "aicoding"])
+@pytest.mark.parametrize("engine_type", ["openclaw", "aicoding", "hermes"])
 def test_service_draft_is_editable_but_published_service_is_not(
     engine_type: str,
 ) -> None:

--- a/src/backend/tests/community/services/test_skill_set_service.py
+++ b/src/backend/tests/community/services/test_skill_set_service.py
@@ -171,6 +171,45 @@ class TestGetSymlinkMappings:
             ),
         ]
 
+    def test_hermes_pool_locators_drive_restart_mappings(
+        self, skill_set_service, mock_skill_set_repo
+    ):
+        pool_local = (
+            "/home/admin/.hermes/workspace/skills-pool/skills-local/handmade"
+        )
+        skill_set_service.engine_type = "hermes"
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = [
+            {"id": "1", "name": "Hermes Pool", "is_default": False}
+        ]
+        mock_skill_set_repo.get_skills_in_set.return_value = [
+            {
+                "id": "1",
+                "name": "handmade",
+                "git_path": f"local://{pool_local}",
+            },
+            {
+                "id": "2",
+                "name": "repo-skill",
+                "git_path": "git://business/repo-skill",
+            },
+        ]
+
+        mappings = skill_set_service.get_symlink_mappings(
+            user_id="100015",
+            bolt_id="default",
+        )
+
+        assert [(mapping.source, mapping.target) for mapping in mappings] == [
+            (
+                pool_local,
+                "/home/admin/.hermes/skills/handmade",
+            ),
+            (
+                "/home/admin/.hermes/skills-repo/business/repo-skill",
+                "/home/admin/.hermes/skills/repo-skill",
+            ),
+        ]
+
     def test_local_path_with_relative_name(
         self, skill_set_service, mock_skill_set_repo, mock_skill_repo
     ):

--- a/src/engine/src/engine/community/plugins/hermes/__init__.py
+++ b/src/engine/src/engine/community/plugins/hermes/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes community filesystem integration helpers."""

--- a/src/engine/src/engine/community/plugins/hermes/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/hermes/layout_pool.py
@@ -1,0 +1,78 @@
+"""Hermes Skills Pool 文件系统契约。"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable
+
+from engine.community.plugins.skills_pool.layout_activation import (
+    MappingPublishResult,
+    MappingVerificationResult,
+    PoolActivationResult,
+    PoolActivationStatus,
+    SkillMapping,
+    activate_hermes_pool,
+    publish_pool_mappings as _publish_pool_mappings,
+    verify_skill_mappings as _verify_skill_mappings,
+)
+from engine.community.plugins.skills_pool.layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+    RuntimeLayoutInspection,
+    RuntimeLayoutInspectionStatus,
+    inspect_runtime_layout,
+)
+
+
+def inspect_hermes_runtime_layout(
+    *,
+    expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
+    home: Path = Path("/home/admin"),
+    repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
+) -> RuntimeLayoutInspection:
+    return inspect_runtime_layout(
+        engine="hermes",
+        expected_contract_version=expected_contract_version,
+        home=home,
+        repo_is_mounted=repo_is_mounted,
+    )
+
+
+def publish_hermes_pool_mappings(
+    *,
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+) -> MappingPublishResult:
+    return _publish_pool_mappings(
+        mappings=mappings,
+        home=home,
+        engine="hermes",
+    )
+
+
+def verify_hermes_pool_mappings(
+    *,
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+) -> MappingVerificationResult:
+    return _verify_skill_mappings(
+        mappings=mappings,
+        home=home,
+        engine="hermes",
+    )
+
+
+__all__ = [
+    "LAYOUT_CONTRACT_VERSION",
+    "MappingPublishResult",
+    "MappingVerificationResult",
+    "PoolActivationResult",
+    "PoolActivationStatus",
+    "RuntimeLayoutInspection",
+    "RuntimeLayoutInspectionStatus",
+    "SkillMapping",
+    "activate_hermes_pool",
+    "inspect_hermes_runtime_layout",
+    "publish_hermes_pool_mappings",
+    "verify_hermes_pool_mappings",
+]

--- a/src/engine/src/engine/community/plugins/hermes/tests/__init__.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes filesystem integration tests."""

--- a/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from engine.community.plugins.hermes.layout_pool import (
+    PoolActivationStatus,
+    RuntimeLayoutInspectionStatus,
+    SkillMapping,
+    activate_hermes_pool,
+    inspect_hermes_runtime_layout,
+    publish_hermes_pool_mappings,
+    verify_hermes_pool_mappings,
+)
+
+
+def test_probe_requires_verified_hermes_legacy_bridge(tmp_path: Path) -> None:
+    home = tmp_path / "home" / "admin"
+    active_root = home / ".hermes" / "skills"
+    legacy_local = home / ".hermes" / "workspace" / "skills" / "skills-local"
+    pool_root = home / ".hermes" / "workspace" / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+    local_bridge = active_root / "skills-local"
+    repo_bridge = home / ".hermes" / "skills-repo"
+
+    legacy_local.mkdir(parents=True)
+    pool_local.mkdir(parents=True)
+    pool_repo.mkdir(parents=True)
+    active_root.mkdir(parents=True)
+    local_bridge.symlink_to(legacy_local, target_is_directory=True)
+    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+    (pool_root / ".pool-ready").write_text(
+        json.dumps(
+            {
+                "engine": "hermes",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": "b7f7a125-9133-45fd-956d-fb66da81f68d",
+                "prepared_at": "2026-07-24T00:00:00Z",
+                "pool_local_root": str(pool_local),
+                "pool_repo_root": str(pool_repo),
+                "validation_summary": {
+                    "all_valid": True,
+                    "legacy_bridge_verified": True,
+                    "legacy_bridge_repaired": False,
+                    "pool_local": {"path": str(pool_local), "valid": True},
+                    "pool_repo": {
+                        "path": str(pool_repo),
+                        "readable_mount": True,
+                        "valid": True,
+                    },
+                    "managed_active_entries": [],
+                    "external_active_entry_count": 0,
+                    "structural_bridges": [
+                        {
+                            "name": "stable_local_bridge",
+                            "path": str(local_bridge),
+                            "target": str(legacy_local),
+                            "valid": True,
+                        },
+                        {
+                            "name": "stable_repo_bridge",
+                            "path": str(repo_bridge),
+                            "target": str(pool_repo),
+                            "valid": True,
+                        },
+                    ],
+                },
+            }
+        )
+    )
+
+    result = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+    assert result.engine == "hermes"
+    assert result.evidence["checks"]["legacy_local_bridge_valid"] is True
+
+    marker_path = pool_root / ".pool-ready"
+    marker = json.loads(marker_path.read_text())
+    del marker["validation_summary"]["legacy_bridge_verified"]
+    marker_path.write_text(json.dumps(marker))
+
+    missing_h0_evidence = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert missing_h0_evidence.status is RuntimeLayoutInspectionStatus.INVALID
+    assert (
+        missing_h0_evidence.evidence["reason"]
+        == "marker_contract_mismatch"
+    )
+
+
+def test_activation_switches_hermes_local_bridge_to_pool(tmp_path: Path) -> None:
+    home = tmp_path / "home" / "admin"
+    active_root = home / ".hermes" / "skills"
+    legacy_local = home / ".hermes" / "workspace" / "skills" / "skills-local"
+    pool_root = home / ".hermes" / "workspace" / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+    local_bridge = active_root / "skills-local"
+    repo_bridge = home / ".hermes" / "skills-repo"
+
+    (legacy_local / "handmade").mkdir(parents=True)
+    (legacy_local / "handmade" / "SKILL.md").write_text("latest")
+    (pool_local / "handmade").mkdir(parents=True)
+    (pool_local / "handmade" / "SKILL.md").write_text("prepared")
+    pool_repo.mkdir(parents=True)
+    active_root.mkdir(parents=True)
+    local_bridge.symlink_to(legacy_local, target_is_directory=True)
+    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+    (pool_root / ".pool-ready").write_text(
+        json.dumps(
+            {
+                "engine": "hermes",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": "b7f7a125-9133-45fd-956d-fb66da81f68d",
+                "prepared_at": "2026-07-24T00:00:00Z",
+                "pool_local_root": str(pool_local),
+                "pool_repo_root": str(pool_repo),
+                "validation_summary": {
+                    "all_valid": True,
+                    "legacy_bridge_verified": True,
+                    "legacy_bridge_repaired": False,
+                    "pool_local": {"path": str(pool_local), "valid": True},
+                    "pool_repo": {
+                        "path": str(pool_repo),
+                        "readable_mount": True,
+                        "valid": True,
+                    },
+                    "managed_active_entries": [],
+                    "external_active_entry_count": 0,
+                    "structural_bridges": [
+                        {
+                            "name": "stable_local_bridge",
+                            "path": str(local_bridge),
+                            "target": str(legacy_local),
+                            "valid": True,
+                        },
+                        {
+                            "name": "stable_repo_bridge",
+                            "path": str(repo_bridge),
+                            "target": str(pool_repo),
+                            "valid": True,
+                        },
+                    ],
+                },
+            }
+        )
+    )
+
+    result = activate_hermes_pool(
+        migration_generation="generation-1",
+        preparation_id="b7f7a125-9133-45fd-956d-fb66da81f68d",
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(active_root / "handmade"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert legacy_local.is_symlink()
+    assert legacy_local.resolve() == pool_local.resolve()
+    assert local_bridge.readlink() == legacy_local
+    assert local_bridge.resolve() == pool_local.resolve()
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
+
+    mapping = SkillMapping(
+        source=str(pool_local / "handmade"),
+        target=str(active_root / "handmade"),
+    )
+    published = publish_hermes_pool_mappings(mappings=[mapping], home=home)
+    verified = verify_hermes_pool_mappings(mappings=[mapping], home=home)
+
+    assert published.published is True
+    assert verified.valid is True
+    assert (active_root / "handmade").resolve() == (pool_local / "handmade")
+
+
+def test_mapping_rejects_openclaw_source_instead_of_falling_back(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    active_root = home / ".hermes" / "skills"
+    openclaw_source = (
+        home
+        / ".openclaw"
+        / "workspace"
+        / "skills-pool"
+        / "skills-local"
+        / "wrong-engine"
+    )
+    openclaw_source.mkdir(parents=True)
+    active_root.mkdir(parents=True)
+
+    result = publish_hermes_pool_mappings(
+        mappings=[
+            SkillMapping(
+                source=str(openclaw_source),
+                target=str(active_root / "wrong-engine"),
+            )
+        ],
+        home=home,
+    )
+
+    assert result.published is False
+    assert result.evidence["reason"] == "mapping_invalid"
+    assert result.evidence["failures"][0]["reason"] == "source_outside_pool"
+    assert not (active_root / "wrong-engine").exists()
+
+
+def test_mapping_cannot_replace_hermes_permanent_local_bridge(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    active_root = home / ".hermes" / "skills"
+    legacy_local = home / ".hermes" / "workspace" / "skills" / "skills-local"
+    pool_local = home / ".hermes" / "workspace" / "skills-pool" / "skills-local"
+    source = pool_local / "skills-local"
+    source.mkdir(parents=True)
+    legacy_local.mkdir(parents=True)
+    active_root.mkdir(parents=True)
+    local_bridge = active_root / "skills-local"
+    local_bridge.symlink_to(legacy_local, target_is_directory=True)
+
+    published = publish_hermes_pool_mappings(
+        mappings=[
+            SkillMapping(source=str(source), target=str(local_bridge)),
+        ],
+        home=home,
+    )
+    verified = verify_hermes_pool_mappings(
+        mappings=[
+            SkillMapping(source=str(source), target=str(local_bridge)),
+        ],
+        home=home,
+    )
+
+    assert published.published is False
+    assert published.evidence["failures"][0]["reason"] == "target_invalid"
+    assert verified.valid is False
+    assert verified.evidence["failures"][0]["reason"] == "target_invalid"
+    assert local_bridge.readlink() == legacy_local

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -422,7 +422,7 @@ def test_invalid_declared_managed_entry_is_rejected(tmp_path):
 
 def test_other_engine_is_not_capable_without_touching_home(tmp_path):
     result = inspect_runtime_layout(
-        engine="hermes",
+        engine="unsupported-engine",
         expected_contract_version=LAYOUT_CONTRACT_VERSION,
         home=tmp_path / "missing",
         repo_is_mounted=lambda _path: (_ for _ in ()).throw(AssertionError()),

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -98,6 +98,21 @@ class _Layout:
 
     @classmethod
     def for_engine(cls, engine: str, home: Path) -> "_Layout":
+        if engine == "hermes":
+            workspace = home / ".hermes" / "workspace"
+            legacy_root = home / ".hermes" / "skills"
+            legacy_local = workspace / "skills" / "skills-local"
+            pool_root = workspace / "skills-pool"
+            return cls(
+                legacy_root=legacy_root,
+                legacy_local=legacy_local,
+                pool_root=pool_root,
+                pool_local=pool_root / "skills-local",
+                pool_repo=pool_root / "skills-repo",
+                legacy_repo=home / ".hermes" / "skills-repo",
+                local_bridge=legacy_root / "skills-local",
+                repo_bridge=home / ".hermes" / "skills-repo",
+            )
         if engine == "aicoding":
             workspace = home / ".aicoding" / "workspace"
             legacy_root = home / ".claude" / "skills"
@@ -255,7 +270,13 @@ def _mapping_plan(
         if not reason and (
             not target.is_absolute()
             or target.parent != layout.legacy_root
-            or target in {layout.legacy_local, layout.legacy_repo}
+            or target
+            in {
+                layout.legacy_local,
+                layout.legacy_repo,
+                layout.local_bridge,
+                layout.repo_bridge,
+            }
         ):
             reason = "target_invalid"
         elif not reason and target in desired and desired[target] != source:
@@ -689,6 +710,30 @@ def activate_aicoding_pool(
     )
 
 
+def activate_hermes_pool(
+    *,
+    migration_generation: str,
+    preparation_id: str,
+    registered_local_names: list[str],
+    mappings: list[SkillMapping],
+    home: str | Path = "/home/admin",
+    repo_is_mounted: Callable[[Path], bool] | None = None,
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    before_post_sync: Callable[[], None] | None = None,
+) -> PoolActivationResult:
+    return _activate_pool(
+        engine="hermes",
+        migration_generation=migration_generation,
+        preparation_id=preparation_id,
+        registered_local_names=registered_local_names,
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=repo_is_mounted,
+        exchange_paths=exchange_paths,
+        before_post_sync=before_post_sync,
+    )
+
+
 def verify_skill_mappings(
     *,
     mappings: list[SkillMapping],
@@ -805,6 +850,7 @@ __all__ = [
     "SkillMapping",
     "activate_aicoding_pool",
     "activate_claude_code_pool",
+    "activate_hermes_pool",
     "activate_openclaw_pool",
     "atomic_exchange_paths",
     "publish_pool_mappings",

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -59,6 +59,23 @@ class _FilesystemPoolLayout:
 
     @classmethod
     def for_engine(cls, engine: str, home: Path) -> "_FilesystemPoolLayout":
+        if engine == "hermes":
+            workspace = home / ".hermes" / "workspace"
+            legacy_root = home / ".hermes" / "skills"
+            legacy_local = workspace / "skills" / "skills-local"
+            legacy_repo = home / ".hermes" / "skills-repo"
+            pool_root = workspace / "skills-pool"
+            return cls(
+                legacy_root=legacy_root,
+                legacy_local=legacy_local,
+                legacy_repo=legacy_repo,
+                pool_root=pool_root,
+                pool_local=pool_root / "skills-local",
+                pool_repo=pool_root / "skills-repo",
+                marker=pool_root / ".pool-ready",
+                local_bridge=legacy_root / "skills-local",
+                repo_bridge=legacy_repo,
+            )
         if engine == "aicoding":
             workspace = home / ".aicoding" / "workspace"
             legacy_root = home / ".claude" / "skills"
@@ -237,7 +254,7 @@ def _marker_contract_valid(
             and bridge.get("target") == str(layout.pool_repo)
             and bridge.get("valid") is True
         )
-    return summary.get("structural_bridges") == [
+    bridges_valid = summary.get("structural_bridges") == [
         {
             "name": "stable_local_bridge",
             "path": str(layout.local_bridge),
@@ -251,6 +268,9 @@ def _marker_contract_valid(
             "valid": True,
         },
     ]
+    if expected_engine == "hermes":
+        return bridges_valid and summary.get("legacy_bridge_verified") is True
+    return bridges_valid
 
 
 def _managed_entry_record(
@@ -337,7 +357,7 @@ def inspect_runtime_layout(
             expected_contract_version,
             "engine_has_no_filesystem_pool_layout",
         )
-    if engine not in {"openclaw", "claude_code", "aicoding"}:
+    if engine not in {"openclaw", "claude_code", "aicoding", "hermes"}:
         return _not_capable(
             engine,
             expected_contract_version,
@@ -585,6 +605,8 @@ def inspect_runtime_layout(
     else:
         checks["stable_local_bridge_valid"] = True
         checks["stable_repo_bridge_valid"] = True
+        if engine == "hermes":
+            checks["legacy_local_bridge_valid"] = True
     return RuntimeLayoutInspection(
         status=RuntimeLayoutInspectionStatus.READY,
         engine=engine,


### PR DESCRIPTION
## Summary

- add Hermes-specific Pool paths across runtime probe, activation, mapping, locator, and reconciliation
- require Hermes H0 bridge evidence before runtime readiness and reject OpenClaw fallback paths
- protect permanent Hermes local/repo bridges from ordinary mapping replacement
- keep published-service rollout fail-closed while allowing personal Bots and service drafts

The companion internal OCB branch `dev_skills_pool_p3_hermes` at `f383cedccf` contains the image H0-before-mount gate, OSS mount layout, and Hermes private Engine wiring. Its submodule points to this PR commit.

## Validation

- Backend CI: 8718 passed, coverage gate passed
- Engine CI: 1964 passed, coverage gate passed
- Image preparation/mount tests: 21 passed
- Hermes private Engine tests: 135 passed
- Ruff, shell syntax checks, and `git diff --check` passed
- Standards and Spec review axes passed after resolving all findings

Closes #374