### PR TITLE
feat: add Skills Pool recovery and rollback

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -82,6 +82,11 @@ from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.engine_resolver import resolve_engine_for_bot
 from agentclaw.community.core.skill_center.constants import LOCK_HELD_ERRORS
+from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditGuard,
+    SkillsPoolEditPausedError,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 from agentclaw.community.core.skill_center.services.repositories import (
     SkillRepository,
     SkillSetRepository,
@@ -318,6 +323,7 @@ async def upload_skill(
     path_factory: WorkspacePathFactory = Injected(WorkspacePathFactory),
     skill_service_factory: SkillServiceFactoryProtocol = Injected(SkillServiceFactoryProtocol),
     resolver: DeviceContextResolver = Injected(DeviceContextResolver),
+    edit_guard: SkillsPoolEditGuard = Injected(SkillsPoolEditGuard),
 ) -> UploadSkillResponse:
     """Upload a new skill from files.
 
@@ -422,7 +428,21 @@ async def upload_skill(
         effective_user_id = user_id or ctx.user_id
 
         # Call the service method (async)
-        skill = await service.upload_skill(uploaded_files, user_id=effective_user_id, bolt_id=effective_bot_id)
+        edit_lease = edit_guard.acquire_for_edit(
+            scope=BotSkillLayoutScope(
+                env=str(bot["env"]),
+                entity_id=str(bot["entity_id"]),
+                bot_id=effective_bot_id,
+            )
+        )
+        try:
+            skill = await service.upload_skill(
+                uploaded_files,
+                user_id=effective_user_id,
+                bolt_id=effective_bot_id,
+            )
+        finally:
+            edit_guard.release(edit_lease)
 
         logger.info(f"[skills.upload_skill] Success: skill_id={skill.get('id')}, name={skill.get('name')}")
 
@@ -449,6 +469,8 @@ async def upload_skill(
             ),
             message="Skill uploaded successfully"
         )
+    except SkillsPoolEditPausedError as e:
+        return UploadSkillResponse(success=False, message=str(e))
     except ValueError as e:
         error_msg = str(e)
         logger.error(f"[skills.upload_skill] Validation error: {error_msg}")
@@ -1900,6 +1922,7 @@ async def delete_skill(
     path_factory: WorkspacePathFactory = Injected(WorkspacePathFactory),
     skill_service_factory: SkillServiceFactoryProtocol = Injected(SkillServiceFactoryProtocol),
     resolver: DeviceContextResolver = Injected(DeviceContextResolver),
+    edit_guard: SkillsPoolEditGuard = Injected(SkillsPoolEditGuard),
 ) -> MessageResponse:
     """Delete a skill.
 
@@ -1933,11 +1956,11 @@ async def delete_skill(
     )
     is_desktop = False
     try:
-        _bot = bot_repo.get_by_id_and_owner(effective_bot_id, owner_id_for_lookup)
-        if _bot and _bot.get("bot_type") == "desktop":
+        bot = bot_repo.get_by_id_and_owner(effective_bot_id, owner_id_for_lookup)
+        if bot and bot.get("bot_type") == "desktop":
             is_desktop = True
     except Exception:
-        pass
+        bot = None
 
     # teclaw deletes the skill files from the (draft) container; resolve provider
     # so the device-fs path is the workspace-namespace form.
@@ -1954,10 +1977,24 @@ async def delete_skill(
         local_skill_path_adapter=local_skill_adapter,
     )
     try:
-        success = await service.delete_skill(skill_id, user_id=current_user_id)
+        if bot is None:
+            raise HTTPException(status_code=404, detail="Bot not found")
+        edit_lease = edit_guard.acquire_for_edit(
+            scope=BotSkillLayoutScope(
+                env=str(bot["env"]),
+                entity_id=str(bot["entity_id"]),
+                bot_id=effective_bot_id,
+            )
+        )
+        try:
+            success = await service.delete_skill(skill_id, user_id=current_user_id)
+        finally:
+            edit_guard.release(edit_lease)
         if not success:
             raise HTTPException(status_code=404, detail="Skill not found")
         return MessageResponse(success=True, message="Skill deleted successfully")
+    except SkillsPoolEditPausedError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
     except ValueError as e:
         error_msg = str(e)
         # 权限错误返回 403

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -44,9 +44,17 @@ Engine Layout Descriptor 仍不在本期范围内。
   阶段和独立证据；普通 probe 重试不会覆盖这份失败证据。
 - 数据面切换后先全量发布并验证 Pool mapping，再在一个 CAS 事务中更新该
   Bot 全部 local locator 和 `POOL_ACTIVE`。mapping 或事务失败只前滚重试。
-- 本模块当前只持久化尚未跨过 bridge 的结构性失败；bridge 已提交后的
-  `POST_CUTOVER_SYNC_PENDING`、mapping 与数据库提交失败的分阶段恢复和
-  审计持久化由 #376 的完整前滚恢复状态机承接，避免在 #370 重复定义状态。
+- bridge 结果未知时进入 `NEEDS_MANUAL_REPAIR`，停止普通自动重试；运维必须
+  附带操作者、备注和已核验的数据面事实，之后才会重新入队同一 generation。
+- bridge 已提交后的 `POST_CUTOVER_SYNC_PENDING`、mapping 与数据库失败均
+  持久化阶段、错误码、可重试性、证据和时间；重试只补齐 mapping、locator
+  与 `POOL_ACTIVE`，不恢复隔离副本。
+- 显式回滚先持久化 `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
+  再从当前 Pool 全量重建新的 Legacy local 并原子交换。交换后即使 mapping
+  或数据库失败也保持 `LEGACY_ROLLBACK_COMMITTED`，同一 generation 可由
+  lease 过期后的新 worker 接管并继续提交 Legacy mapping 和 locator。
+- 显式回滚不会读取迁移隔离副本，Pool 激活后产生的 local 新增和修改会被
+  带入新的 Legacy；Pool 本身保留用于证据和后续恢复。
 - local 后置合并采用 best-effort 原子 exchange：一般的切换前修改、切换后
   Pool 修改和新增路径竞争均可收敛；无写栅栏时，跨 exchange 的已打开文件
   描述符或连续同文件写入仍存在极窄竞态，作为 #370 的显式接受限制。
@@ -62,6 +70,8 @@ provides:
   - "SkillsPoolReconcileService"
   - "SkillsPoolReconcileTaskHandler"
   - "SkillsPoolReconcileWakeupListener"
+  - "SkillsPoolRecoveryService"
+  - "SkillsPoolRollbackService"
   - "PoolCutoverStatus"
   - "PoolCutoverResult"
   - "BotSkillLayoutState and migration enums"

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -53,6 +53,9 @@ Engine Layout Descriptor 仍不在本期范围内。
   再从当前 Pool 全量重建新的 Legacy local 并原子交换。交换后即使 mapping
   或数据库失败也保持 `LEGACY_ROLLBACK_COMMITTED`，同一 generation 可由
   lease 过期后的新 worker 接管并继续提交 Legacy mapping 和 locator。
+- Backend 上传、删除和显式回滚共用 Bot 级互斥锁；回滚阶段内的新 local
+  编辑 fail closed。mapping 请求同时声明 `source_layout`：激活缺省为
+  `pool`，显式回滚前后使用 `legacy`。
 - 显式回滚不会读取迁移隔离副本，Pool 激活后产生的 local 新增和修改会被
   带入新的 Legacy；Pool 本身保留用于证据和后续恢复。
 - local 后置合并采用 best-effort 原子 exchange：一般的切换前修改、切换后

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -1,0 +1,91 @@
+"""Bot-level mutual exclusion between local Skill edits and layout rollback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from injector import inject
+
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayoutPhase,
+)
+from agentclaw.community.plugin_api.cache import CachePlugin
+
+
+class SkillsPoolEditPausedError(RuntimeError):
+    """Raised when a local Skill mutation cannot safely start."""
+
+
+@dataclass(frozen=True, slots=True)
+class SkillsPoolEditLease:
+    key: str
+    token: str
+
+
+class SkillsPoolEditGuard:
+    """Serialize local mutations with Pool→Legacy filesystem reconstruction."""
+
+    _LOCK_TTL_SECONDS = 600
+    _ROLLBACK_PHASES = {
+        SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+        SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
+    }
+
+    @inject
+    def __init__(
+        self,
+        *,
+        cache: CachePlugin,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+    ) -> None:
+        self._cache = cache
+        self._layouts = layout_repository
+
+    @staticmethod
+    def _key(*, scope: BotSkillLayoutScope) -> str:
+        return (
+            "skills-pool:local-edit:"
+            f"{scope.env}:{scope.entity_id}:{scope.bot_id}"
+        )
+
+    def acquire_for_edit(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+    ) -> SkillsPoolEditLease:
+        lease = self.acquire_for_rollback(scope=scope)
+        if lease is None:
+            raise SkillsPoolEditPausedError(
+                "Skills are temporarily read-only while layout work is running"
+            )
+        if self._layouts.get(scope).phase in self._ROLLBACK_PHASES:
+            self.release(lease)
+            raise SkillsPoolEditPausedError(
+                "Skills are temporarily read-only during layout rollback"
+            )
+        return lease
+
+    def acquire_for_rollback(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+    ) -> SkillsPoolEditLease | None:
+        key = self._key(scope=scope)
+        token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
+        if token is None:
+            return None
+        return SkillsPoolEditLease(key=key, token=token)
+
+    def release(self, lease: SkillsPoolEditLease) -> bool:
+        return self._cache.release_lock(lease.key, lease.token)
+
+
+__all__ = [
+    "SkillsPoolEditGuard",
+    "SkillsPoolEditLease",
+    "SkillsPoolEditPausedError",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -12,6 +12,7 @@ class OpenClawPoolPaths:
 
     active: str = "/home/admin/.openclaw/workspace/skills"
     legacy_local: str = "/home/admin/.openclaw/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.openclaw/workspace/skills/skills-repo"
     pool_local: str = "/home/admin/.openclaw/workspace/skills-pool/skills-local"
     pool_repo: str = "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
 
@@ -22,6 +23,7 @@ class ClaudeCodePoolPaths:
 
     active: str = "/home/admin/.claude/skills"
     legacy_local: str = "/home/admin/.claude_code/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.claude_code/skills-repo"
     pool_local: str = "/home/admin/.claude_code/workspace/skills-pool/skills-local"
     pool_repo: str = "/home/admin/.claude_code/workspace/skills-pool/skills-repo"
 
@@ -32,6 +34,7 @@ class AICodingPoolPaths:
 
     active: str = "/home/admin/.claude/skills"
     legacy_local: str = "/home/admin/.aicoding/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.aicoding/skills-repo"
     pool_local: str = "/home/admin/.aicoding/workspace/skills-pool/skills-local"
     pool_repo: str = "/home/admin/.aicoding/workspace/skills-pool/skills-repo"
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -45,6 +45,7 @@ class HermesPoolPaths:
 
     active: str = "/home/admin/.hermes/skills"
     legacy_local: str = "/home/admin/.hermes/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.hermes/skills-repo"
     pool_local: str = "/home/admin/.hermes/workspace/skills-pool/skills-local"
     pool_repo: str = "/home/admin/.hermes/workspace/skills-pool/skills-repo"
 
@@ -52,6 +53,7 @@ class HermesPoolPaths:
 PoolPaths = (
     OpenClawPoolPaths | ClaudeCodePoolPaths | AICodingPoolPaths | HermesPoolPaths
 )
+FILESYSTEM_POOL_ENGINES = ("openclaw", "claude_code", "aicoding", "hermes")
 
 
 def pool_paths_for_engine(engine: str) -> PoolPaths:
@@ -68,6 +70,16 @@ def pool_paths_for_engine(engine: str) -> PoolPaths:
     raise ValueError(f"engine Pool layout not implemented: {engine}")
 
 
+def local_locator_prefixes(*, pool: bool) -> tuple[str, ...]:
+    """Return every supported engine's canonical local locator prefix."""
+
+    attribute = "pool_local" if pool else "legacy_local"
+    return tuple(
+        f"local://{getattr(pool_paths_for_engine(engine), attribute)}/"
+        for engine in FILESYSTEM_POOL_ENGINES
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class RegisteredSkillAsset:
     """Backend 中属于一个 Bot 的技能来源记录。"""
@@ -79,13 +91,20 @@ class RegisteredSkillAsset:
 
 @dataclass(frozen=True, slots=True)
 class PoolSkillMapping:
-    """显式以目标 Pool layout 构造的运行时 mapping。"""
+    """显式以声明 source layout 构造的运行时 mapping。"""
 
     source: str
     target: str
 
     def to_dict(self) -> dict[str, str]:
         return {"source": self.source, "target": self.target}
+
+
+class SkillMappingSourceLayout(StrEnum):
+    """运行时 mapping source 所属的权威 layout。"""
+
+    POOL = "pool"
+    LEGACY = "legacy"
 
 
 class PoolCutoverStatus(StrEnum):
@@ -120,6 +139,7 @@ class PoolCutoverResult:
 
 __all__ = [
     "AICodingPoolPaths",
+    "FILESYSTEM_POOL_ENGINES",
     "ClaudeCodePoolPaths",
     "HermesPoolPaths",
     "OpenClawPoolPaths",
@@ -128,5 +148,7 @@ __all__ = [
     "PoolCutoverStatus",
     "PoolSkillMapping",
     "RegisteredSkillAsset",
+    "SkillMappingSourceLayout",
+    "local_locator_prefixes",
     "pool_paths_for_engine",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/ports.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/ports.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.skills_pool.models import (
     PoolCutoverResult,
     PoolSkillMapping,
     RegisteredSkillAsset,
+    SkillMappingSourceLayout,
 )
 
 
@@ -75,6 +76,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool:
         ...
 
@@ -84,6 +86,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool:
         ...
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/ports.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/ports.py
@@ -59,6 +59,16 @@ class SkillsPoolRuntimeProtocol(Protocol):
     ) -> PoolCutoverResult:
         ...
 
+    async def rollback_to_legacy(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        rollback_generation: str,
+        registered_local_names: list[str],
+    ) -> PoolCutoverResult:
+        ...
+
     async def publish_mappings(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -31,6 +31,7 @@ from agentclaw.community.core.skills_pool.repository.protocol import (
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     SkillLayout,
+    SkillLayoutPhase,
 )
 from agentclaw.community.core.skills_pool.ports import (
     SkillsPoolRuntimeProtocol,
@@ -55,6 +56,7 @@ class SkillsPoolReconcileOutcome(StrEnum):
     MAPPING_FAILED = "mapping_failed"
     MAPPING_VERIFY_FAILED = "mapping_verify_failed"
     DATABASE_COMMIT_FAILED = "database_commit_failed"
+    MANUAL_REPAIR_REQUIRED = "manual_repair_required"
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,6 +91,13 @@ class SkillsPoolReconcileService:
         lease_owner: str,
     ) -> SkillsPoolReconcileResult:
         state = self._layouts.get(scope)
+        if state.phase is SkillLayoutPhase.NEEDS_MANUAL_REPAIR:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED,
+                preparation_id=state.preparation_id,
+                evidence=state.last_failure_evidence,
+                retryable=False,
+            )
         if state.active_layout is SkillLayout.POOL:
             return SkillsPoolReconcileResult(
                 SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
@@ -197,27 +206,31 @@ class SkillsPoolReconcileService:
                 evidence={"reason": str(error)},
             )
 
-        if not state.data_plane_cutover_committed:
-            recorded = self._layouts.record_ready_probe(
-                scope=scope,
-                migration_generation=generation,
-                lease_owner=lease_owner,
-                preparation_id=probe.preparation_id,
-                evidence=probe.evidence,
-            )
-            if not recorded:
-                return SkillsPoolReconcileResult(
-                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
+        cutover_finalizing = (
+            state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+        )
+        if not state.data_plane_cutover_committed or cutover_finalizing:
+            if not state.data_plane_cutover_committed:
+                recorded = self._layouts.record_ready_probe(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    preparation_id=probe.preparation_id,
+                    evidence=probe.evidence,
                 )
-            if not self._layouts.begin_cutover(
-                scope=scope,
-                migration_generation=generation,
-                lease_owner=lease_owner,
-                preparation_id=probe.preparation_id,
-            ):
-                return SkillsPoolReconcileResult(
-                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
-                )
+                if not recorded:
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                    )
+                if not self._layouts.begin_cutover(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    preparation_id=probe.preparation_id,
+                ):
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                    )
 
             cutover = await self._runtime.cutover(
                 bot_id=scope.bot_id,
@@ -228,6 +241,50 @@ class SkillsPoolReconcileService:
                 mappings=mappings,
             )
             if not cutover.committed:
+                evidence = cutover.to_dict()
+                if (
+                    cutover.status
+                    is PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING
+                    or cutover_finalizing
+                ):
+                    recorded = self._layouts.record_cutover_finalizing(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                        evidence=evidence,
+                    )
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            preparation_id=probe.preparation_id,
+                        )
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                        preparation_id=probe.preparation_id,
+                        evidence=evidence,
+                        retryable=True,
+                    )
+                if cutover.status is PoolCutoverStatus.UNKNOWN:
+                    recorded = self._layouts.mark_repair_required(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code=cutover.status.value,
+                        failure_stage="cutover_outcome_unknown",
+                        evidence=evidence,
+                    )
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            preparation_id=probe.preparation_id,
+                        )
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED,
+                        preparation_id=probe.preparation_id,
+                        evidence=evidence,
+                        retryable=False,
+                    )
                 failure_profile = self._cutover_failure_profile(cutover.status)
                 if failure_profile is not None:
                     outcome, stage, retryable = failure_profile
@@ -283,18 +340,30 @@ class SkillsPoolReconcileService:
             user_id=user_id,
             mappings=mappings,
         ):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.MAPPING_FAILED,
+            return self._record_post_cutover_failure(
+                scope=scope,
+                generation=generation,
+                lease_owner=lease_owner,
                 preparation_id=probe.preparation_id,
+                outcome=SkillsPoolReconcileOutcome.MAPPING_FAILED,
+                failure_code="MAPPING_PUBLISH_FAILED",
+                failure_stage="mapping_publish",
+                evidence={"mapping_count": len(mappings)},
             )
         if not await self._runtime.verify_mappings(
             bot_id=scope.bot_id,
             user_id=user_id,
             mappings=mappings,
         ):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+            return self._record_post_cutover_failure(
+                scope=scope,
+                generation=generation,
+                lease_owner=lease_owner,
                 preparation_id=probe.preparation_id,
+                outcome=SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+                failure_code="MAPPING_VERIFY_FAILED",
+                failure_stage="mapping_verify",
+                evidence={"mapping_count": len(mappings)},
             )
 
         local_locators = {
@@ -308,13 +377,52 @@ class SkillsPoolReconcileService:
             preparation_id=probe.preparation_id,
             local_locators=local_locators,
         ):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.DATABASE_COMMIT_FAILED,
+            return self._record_post_cutover_failure(
+                scope=scope,
+                generation=generation,
+                lease_owner=lease_owner,
                 preparation_id=probe.preparation_id,
+                outcome=SkillsPoolReconcileOutcome.DATABASE_COMMIT_FAILED,
+                failure_code="DATABASE_COMMIT_FAILED",
+                failure_stage="control_plane_commit",
+                evidence={"local_locator_count": len(local_locators)},
             )
         return SkillsPoolReconcileResult(
             SkillsPoolReconcileOutcome.POOL_ACTIVE,
             preparation_id=probe.preparation_id,
+        )
+
+    def _record_post_cutover_failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        outcome: SkillsPoolReconcileOutcome,
+        failure_code: str,
+        failure_stage: str,
+        evidence: dict[str, object],
+    ) -> SkillsPoolReconcileResult:
+        recorded = self._layouts.record_post_cutover_failure(
+            scope=scope,
+            migration_generation=generation,
+            lease_owner=lease_owner,
+            failure_code=failure_code,
+            failure_stage=failure_stage,
+            retryable=True,
+            evidence=evidence,
+        )
+        if not recorded:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                preparation_id=preparation_id,
+            )
+        return SkillsPoolReconcileResult(
+            outcome,
+            preparation_id=preparation_id,
+            evidence=evidence,
+            retryable=True,
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -141,17 +141,20 @@ class SkillsPoolReconcileService:
             engine=engine,
         )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
-            if (
-                probe.status is RuntimeLayoutProbeStatus.INVALID
-                and not state.data_plane_cutover_committed
-            ):
-                recorded = self._layouts.record_pre_cutover_failure(
+            if probe.status in {
+                RuntimeLayoutProbeStatus.INVALID,
+                RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
+            }:
+                recorded = self._record_failure_for_boundary(
                     scope=scope,
-                    migration_generation=generation,
+                    generation=generation,
                     lease_owner=lease_owner,
-                    failure_code="INVALID",
+                    cutover_committed=state.data_plane_cutover_committed,
+                    failure_code=probe.status.value,
                     failure_stage="runtime_probe",
-                    retryable=False,
+                    retryable=(
+                        probe.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
+                    ),
                     evidence=probe.evidence,
                 )
                 if not recorded:
@@ -167,20 +170,20 @@ class SkillsPoolReconcileService:
             probe.preparation_id is None
             or probe.layout_contract_version != state.layout_contract_version
         ):
-            if not state.data_plane_cutover_committed:
-                recorded = self._layouts.record_pre_cutover_failure(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    failure_code="INVALID",
-                    failure_stage="runtime_probe",
-                    retryable=False,
-                    evidence=probe.evidence,
+            recorded = self._record_failure_for_boundary(
+                scope=scope,
+                generation=generation,
+                lease_owner=lease_owner,
+                cutover_committed=state.data_plane_cutover_committed,
+                failure_code="INVALID",
+                failure_stage="runtime_probe",
+                retryable=False,
+                evidence=probe.evidence,
+            )
+            if not recorded:
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
                 )
-                if not recorded:
-                    return SkillsPoolReconcileResult(
-                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
-                    )
             return SkillsPoolReconcileResult(
                 SkillsPoolReconcileOutcome.INVALID,
                 evidence=probe.evidence,
@@ -201,9 +204,25 @@ class SkillsPoolReconcileService:
             local_names = [self._local_name(asset) for asset in local_assets]
             mappings = self._build_pool_mappings(active_assets, paths=paths)
         except ValueError as error:
+            evidence = {"reason": str(error)}
+            recorded = self._record_failure_for_boundary(
+                scope=scope,
+                generation=generation,
+                lease_owner=lease_owner,
+                cutover_committed=state.data_plane_cutover_committed,
+                failure_code="MAPPING_DATA_INVALID",
+                failure_stage="mapping_build",
+                retryable=False,
+                evidence=evidence,
+            )
+            if not recorded:
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                )
             return SkillsPoolReconcileResult(
                 SkillsPoolReconcileOutcome.INVALID,
-                evidence={"reason": str(error)},
+                evidence=evidence,
+                retryable=False,
             )
 
         cutover_finalizing = (
@@ -423,6 +442,33 @@ class SkillsPoolReconcileService:
             preparation_id=preparation_id,
             evidence=evidence,
             retryable=True,
+        )
+
+    def _record_failure_for_boundary(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        generation: str,
+        lease_owner: str,
+        cutover_committed: bool,
+        failure_code: str,
+        failure_stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> bool:
+        recorder = (
+            self._layouts.record_post_cutover_failure
+            if cutover_committed
+            else self._layouts.record_pre_cutover_failure
+        )
+        return recorder(
+            scope=scope,
+            migration_generation=generation,
+            lease_owner=lease_owner,
+            failure_code=failure_code,
+            failure_stage=failure_stage,
+            retryable=retryable,
+            evidence=evidence,
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
@@ -35,6 +35,7 @@ from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
     SkillLayout,
+    SkillLayoutPhase,
 )
 from agentclaw.community.core.task_queue.services.registry import (
     HandlerRegistry,
@@ -159,6 +160,8 @@ class SkillsPoolReconcileTaskHandler:
     ) -> TaskOutcome | None:
         if state.active_layout is SkillLayout.POOL:
             return Complete()
+        if state.phase is SkillLayoutPhase.NEEDS_MANUAL_REPAIR:
+            return Fail("skills pool migration requires manual repair")
         if newly_claimed:
             return None
         generation = state.migration_generation

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -1,0 +1,473 @@
+"""Operator-directed recovery for a fenced Skills Pool migration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import PurePosixPath
+
+from injector import inject
+
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotRepository,
+)
+from agentclaw.community.core.skills_pool.models import (
+    PoolCutoverStatus,
+    PoolPaths,
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+    pool_paths_for_engine,
+)
+from agentclaw.community.core.skills_pool.ports import (
+    SkillsPoolRuntimeProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
+    SKILLS_POOL_RECONCILE_TASK,
+    build_skills_pool_reconcile_payload,
+)
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayoutPhase,
+)
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
+
+
+class ManualRepairResolution(StrEnum):
+    """The filesystem fact an operator proved on the current runtime."""
+
+    POOL_COMMITTED = "pool_committed"
+    LEGACY_NOT_COMMITTED = "legacy_not_committed"
+
+
+class SkillsPoolRecoveryOutcome(StrEnum):
+    RETRIGGERED = "retriggered"
+    NOT_FOUND = "not_found"
+    NOT_REPAIR_REQUIRED = "not_repair_required"
+    STALE_GENERATION = "stale_generation"
+    INVALID_REQUEST = "invalid_request"
+    STATE_RACE_LOST = "state_race_lost"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillsPoolRecoveryResult:
+    outcome: SkillsPoolRecoveryOutcome
+
+
+class SkillsPoolRecoveryService:
+    """Record an operator finding, then durably resume the same generation."""
+
+    @inject
+    def __init__(
+        self,
+        *,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        task_queue_service: TaskQueueService,
+    ) -> None:
+        self._layouts = layout_repository
+        self._queue = task_queue_service
+
+    def resolve_repair_state(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        operator: str,
+        note: str,
+        resolution: ManualRepairResolution,
+    ) -> SkillsPoolRecoveryResult:
+        if not operator.strip() or not note.strip():
+            return SkillsPoolRecoveryResult(
+                SkillsPoolRecoveryOutcome.INVALID_REQUEST
+            )
+        state = self._layouts.get(scope)
+        if not state.persisted:
+            return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.NOT_FOUND)
+        if state.phase is not SkillLayoutPhase.NEEDS_MANUAL_REPAIR:
+            return SkillsPoolRecoveryResult(
+                SkillsPoolRecoveryOutcome.NOT_REPAIR_REQUIRED
+            )
+        if state.migration_generation != migration_generation:
+            return SkillsPoolRecoveryResult(
+                SkillsPoolRecoveryOutcome.STALE_GENERATION
+            )
+
+        committed = resolution is ManualRepairResolution.POOL_COMMITTED
+        if not self._layouts.resolve_repair(
+            scope=scope,
+            migration_generation=migration_generation,
+            operator=operator.strip(),
+            note=note.strip(),
+            cutover_committed=committed,
+        ):
+            return SkillsPoolRecoveryResult(
+                SkillsPoolRecoveryOutcome.STATE_RACE_LOST
+            )
+
+        payload = build_skills_pool_reconcile_payload(
+            scope=scope,
+            source="manual_repair_resolution",
+            signal_identity={
+                "operator": operator.strip(),
+                "resolution": resolution.value,
+            },
+        )
+        self._queue.enqueue(
+            SKILLS_POOL_RECONCILE_TASK,
+            payload,
+            deadline_seconds=SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
+        )
+        return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.RETRIGGERED)
+
+
+class SkillsPoolRollbackOutcome(StrEnum):
+    LEGACY_ACTIVE = "legacy_active"
+    NOT_FOUND = "not_found"
+    NOT_POOL_ACTIVE = "not_pool_active"
+    STALE_GENERATION = "stale_generation"
+    INVALID_REQUEST = "invalid_request"
+    BOT_CHANGED = "bot_changed"
+    STATE_RACE_LOST = "state_race_lost"
+    ROLLBACK_FAILED = "rollback_failed"
+    MAPPING_FAILED = "mapping_failed"
+    MAPPING_VERIFY_FAILED = "mapping_verify_failed"
+    DATABASE_COMMIT_FAILED = "database_commit_failed"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillsPoolRollbackResult:
+    outcome: SkillsPoolRollbackOutcome
+    evidence: dict[str, object] | None = None
+    retryable: bool | None = None
+
+
+class SkillsPoolRollbackService:
+    """显式地从当前 Pool 内容重建 Legacy，并只向 Legacy 收敛。"""
+
+    _LEASE_SECONDS = 300
+
+    @inject
+    def __init__(
+        self,
+        *,
+        bot_repository: BotRepository,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        skill_repository: SkillsPoolSkillRepositoryProtocol,
+        runtime: SkillsPoolRuntimeProtocol,
+    ) -> None:
+        self._bots = bot_repository
+        self._layouts = layout_repository
+        self._skills = skill_repository
+        self._runtime = runtime
+
+    async def rollback(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        operator: str,
+        note: str,
+    ) -> SkillsPoolRollbackResult:
+        if not all(
+            value.strip()
+            for value in (rollback_generation, lease_owner, operator, note)
+        ):
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.INVALID_REQUEST
+            )
+
+        state = self._layouts.get(scope)
+        if not state.persisted:
+            return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.NOT_FOUND)
+        if state.phase is SkillLayoutPhase.POOL_ACTIVE:
+            if not self._layouts.begin_legacy_rollback(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                operator=operator.strip(),
+                note=note.strip(),
+                lease_owner=lease_owner,
+                lease_seconds=self._LEASE_SECONDS,
+            ):
+                return SkillsPoolRollbackResult(
+                    SkillsPoolRollbackOutcome.STATE_RACE_LOST
+                )
+            state = self._layouts.get(scope)
+        elif state.phase not in {
+            SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+            SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
+        }:
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.NOT_POOL_ACTIVE
+            )
+
+        if state.migration_generation != rollback_generation:
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.STALE_GENERATION
+            )
+        if not self._layouts.try_acquire_rollback_lease(
+            scope=scope,
+            rollback_generation=rollback_generation,
+            lease_owner=lease_owner,
+            lease_seconds=self._LEASE_SECONDS,
+        ):
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.STATE_RACE_LOST
+            )
+
+        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
+        if bot is None or bot.get("env") != scope.env:
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.BOT_CHANGED
+            )
+        engine = bot.get("active_engine")
+        owner_id = bot.get("owner_id")
+        if (
+            not isinstance(engine, str)
+            or not isinstance(owner_id, (str, int))
+            or isinstance(owner_id, bool)
+        ):
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.BOT_CHANGED
+            )
+        try:
+            paths = pool_paths_for_engine(engine)
+        except ValueError:
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.BOT_CHANGED
+            )
+        user_id = str(owner_id)
+
+        local_assets = self._skills.list_bot_local_assets(
+            env=scope.env,
+            bot_id=scope.bot_id,
+        )
+        active_assets = self._skills.list_bot_active_assets(
+            env=scope.env,
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            engine=engine,
+        )
+        try:
+            local_names = [self._local_name(asset) for asset in local_assets]
+            mappings = self._build_legacy_mappings(active_assets, paths=paths)
+        except ValueError as error:
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.ROLLBACK_FAILED,
+                code="ROLLBACK_DATA_INCONSISTENT",
+                stage="rollback_validation",
+                retryable=False,
+                evidence={"reason": str(error)},
+            )
+
+        if state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING:
+            pre_cutover_mapping = await self._publish_and_verify_mappings(
+                scope=scope,
+                user_id=user_id,
+                mappings=mappings,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+            )
+            if pre_cutover_mapping is not None:
+                return pre_cutover_mapping
+            cutover = await self._runtime.rollback_to_legacy(
+                bot_id=scope.bot_id,
+                user_id=user_id,
+                rollback_generation=rollback_generation,
+                registered_local_names=local_names,
+            )
+            if not cutover.committed:
+                return self._failure(
+                    scope=scope,
+                    rollback_generation=rollback_generation,
+                    lease_owner=lease_owner,
+                    outcome=SkillsPoolRollbackOutcome.ROLLBACK_FAILED,
+                    code=f"ROLLBACK_{cutover.status.value}",
+                    stage="filesystem_rollback",
+                    # Runtime rollback is idempotent: after a lost response the
+                    # same generation can prove ALREADY_COMMITTED, so UNKNOWN
+                    # is safe to retry rather than guess filesystem truth.
+                    retryable=cutover.status
+                    in {
+                        PoolCutoverStatus.TRANSIENT_ERROR,
+                        PoolCutoverStatus.UNKNOWN,
+                    },
+                    evidence=cutover.to_dict(),
+                )
+            if not self._layouts.record_legacy_rollback_committed(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                evidence=cutover.to_dict(),
+            ):
+                return SkillsPoolRollbackResult(
+                    SkillsPoolRollbackOutcome.STATE_RACE_LOST
+                )
+
+        # Re-publish after the atomic exchange as an idempotent confirmation.
+        # A process that resumes from LEGACY_ROLLBACK_COMMITTED starts here.
+        post_cutover_mapping = await self._publish_and_verify_mappings(
+            scope=scope,
+            user_id=user_id,
+            mappings=mappings,
+            rollback_generation=rollback_generation,
+            lease_owner=lease_owner,
+        )
+        if post_cutover_mapping is not None:
+            return post_cutover_mapping
+
+        local_locators = {
+            asset.skill_id: f"local://{paths.legacy_local}/{name}"
+            for asset, name in zip(local_assets, local_names, strict=True)
+        }
+        if not self._layouts.commit_legacy_active(
+            scope=scope,
+            rollback_generation=rollback_generation,
+            lease_owner=lease_owner,
+            local_locators=local_locators,
+        ):
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.DATABASE_COMMIT_FAILED,
+                code="ROLLBACK_DATABASE_COMMIT_FAILED",
+                stage="control_plane_commit",
+                retryable=True,
+                evidence={"local_locator_count": len(local_locators)},
+            )
+        return SkillsPoolRollbackResult(
+            SkillsPoolRollbackOutcome.LEGACY_ACTIVE
+        )
+
+    async def _publish_and_verify_mappings(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        user_id: str,
+        mappings: list[PoolSkillMapping],
+        rollback_generation: str,
+        lease_owner: str,
+    ) -> SkillsPoolRollbackResult | None:
+        if not await self._runtime.publish_mappings(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            mappings=mappings,
+        ):
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.MAPPING_FAILED,
+                code="ROLLBACK_MAPPING_PUBLISH_FAILED",
+                stage="mapping_publish",
+                retryable=True,
+                evidence={"mapping_count": len(mappings)},
+            )
+        if not await self._runtime.verify_mappings(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            mappings=mappings,
+        ):
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.MAPPING_VERIFY_FAILED,
+                code="ROLLBACK_MAPPING_VERIFY_FAILED",
+                stage="mapping_verify",
+                retryable=True,
+                evidence={"mapping_count": len(mappings)},
+            )
+        return None
+
+    def _failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        outcome: SkillsPoolRollbackOutcome,
+        code: str,
+        stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> SkillsPoolRollbackResult:
+        if not self._layouts.record_rollback_failure(
+            scope=scope,
+            rollback_generation=rollback_generation,
+            lease_owner=lease_owner,
+            failure_code=code,
+            failure_stage=stage,
+            retryable=retryable,
+            evidence=evidence,
+        ):
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.STATE_RACE_LOST
+            )
+        return SkillsPoolRollbackResult(
+            outcome,
+            evidence=evidence,
+            retryable=retryable,
+        )
+
+    @staticmethod
+    def _source_tail(git_path: str, prefix: str) -> PurePosixPath:
+        raw = git_path[len(prefix) :]
+        path = PurePosixPath(raw)
+        if not raw or path.name in {"", ".", ".."}:
+            raise ValueError(f"invalid skill locator: {git_path}")
+        return path
+
+    @classmethod
+    def _local_name(cls, asset: RegisteredSkillAsset) -> str:
+        if not asset.git_path.startswith("local://"):
+            raise ValueError(f"skill {asset.skill_id} is not local")
+        return cls._source_tail(asset.git_path, "local://").name
+
+    @classmethod
+    def _build_legacy_mappings(
+        cls,
+        assets: list[RegisteredSkillAsset],
+        *,
+        paths: PoolPaths,
+    ) -> list[PoolSkillMapping]:
+        mappings: list[PoolSkillMapping] = []
+        targets: dict[str, str] = {}
+        for asset in assets:
+            if asset.git_path.startswith("local://"):
+                relative = PurePosixPath(cls._local_name(asset))
+                source = PurePosixPath(paths.legacy_local) / relative
+            elif asset.git_path.startswith("git://"):
+                relative = cls._source_tail(asset.git_path, "git://")
+                source = PurePosixPath(paths.legacy_repo) / relative
+            else:
+                continue
+            target = str(PurePosixPath(paths.active) / relative.name)
+            if targets.get(target) == str(source):
+                continue
+            if target in targets:
+                raise ValueError(f"duplicate managed target: {target}")
+            targets[target] = str(source)
+            mappings.append(PoolSkillMapping(source=str(source), target=target))
+        return mappings
+
+
+__all__ = [
+    "ManualRepairResolution",
+    "SkillsPoolRecoveryOutcome",
+    "SkillsPoolRecoveryResult",
+    "SkillsPoolRecoveryService",
+    "SkillsPoolRollbackOutcome",
+    "SkillsPoolRollbackResult",
+    "SkillsPoolRollbackService",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -16,8 +16,10 @@ from agentclaw.community.core.skills_pool.models import (
     PoolPaths,
     PoolSkillMapping,
     RegisteredSkillAsset,
+    SkillMappingSourceLayout,
     pool_paths_for_engine,
 )
+from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.ports import (
     SkillsPoolRuntimeProtocol,
     SkillsPoolSkillRepositoryProtocol,
@@ -37,6 +39,9 @@ from agentclaw.community.core.skills_pool.types import (
 from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
 )
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
 
 
 class ManualRepairResolution(StrEnum):
@@ -48,6 +53,7 @@ class ManualRepairResolution(StrEnum):
 
 class SkillsPoolRecoveryOutcome(StrEnum):
     RETRIGGERED = "retriggered"
+    RETRIGGER_FAILED = "retrigger_failed"
     NOT_FOUND = "not_found"
     NOT_REPAIR_REQUIRED = "not_repair_required"
     STALE_GENERATION = "stale_generation"
@@ -89,7 +95,19 @@ class SkillsPoolRecoveryService:
         state = self._layouts.get(scope)
         if not state.persisted:
             return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.NOT_FOUND)
-        if state.phase is not SkillLayoutPhase.NEEDS_MANUAL_REPAIR:
+        retrying_resolved_enqueue = (
+            state.migration_generation == migration_generation
+            and state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+            and state.phase
+            in {
+                SkillLayoutPhase.POOL_READY,
+                SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            }
+        )
+        if (
+            state.phase is not SkillLayoutPhase.NEEDS_MANUAL_REPAIR
+            and not retrying_resolved_enqueue
+        ):
             return SkillsPoolRecoveryResult(
                 SkillsPoolRecoveryOutcome.NOT_REPAIR_REQUIRED
             )
@@ -98,17 +116,18 @@ class SkillsPoolRecoveryService:
                 SkillsPoolRecoveryOutcome.STALE_GENERATION
             )
 
-        committed = resolution is ManualRepairResolution.POOL_COMMITTED
-        if not self._layouts.resolve_repair(
-            scope=scope,
-            migration_generation=migration_generation,
-            operator=operator.strip(),
-            note=note.strip(),
-            cutover_committed=committed,
-        ):
-            return SkillsPoolRecoveryResult(
-                SkillsPoolRecoveryOutcome.STATE_RACE_LOST
-            )
+        if not retrying_resolved_enqueue:
+            committed = resolution is ManualRepairResolution.POOL_COMMITTED
+            if not self._layouts.resolve_repair(
+                scope=scope,
+                migration_generation=migration_generation,
+                operator=operator.strip(),
+                note=note.strip(),
+                cutover_committed=committed,
+            ):
+                return SkillsPoolRecoveryResult(
+                    SkillsPoolRecoveryOutcome.STATE_RACE_LOST
+                )
 
         payload = build_skills_pool_reconcile_payload(
             scope=scope,
@@ -118,11 +137,24 @@ class SkillsPoolRecoveryService:
                 "resolution": resolution.value,
             },
         )
-        self._queue.enqueue(
-            SKILLS_POOL_RECONCILE_TASK,
-            payload,
-            deadline_seconds=SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
-        )
+        try:
+            self._queue.enqueue(
+                SKILLS_POOL_RECONCILE_TASK,
+                payload,
+                deadline_seconds=SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
+            )
+        except Exception:
+            logger.exception(
+                "[skills_pool.recovery] durable retrigger enqueue failed "
+                "env=%s entity_id=%s bot_id=%s generation=%s",
+                scope.env,
+                scope.entity_id,
+                scope.bot_id,
+                migration_generation,
+            )
+            return SkillsPoolRecoveryResult(
+                SkillsPoolRecoveryOutcome.RETRIGGER_FAILED
+            )
         return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.RETRIGGERED)
 
 
@@ -132,6 +164,7 @@ class SkillsPoolRollbackOutcome(StrEnum):
     NOT_POOL_ACTIVE = "not_pool_active"
     STALE_GENERATION = "stale_generation"
     INVALID_REQUEST = "invalid_request"
+    EDIT_BUSY = "edit_busy"
     BOT_CHANGED = "bot_changed"
     STATE_RACE_LOST = "state_race_lost"
     ROLLBACK_FAILED = "rollback_failed"
@@ -160,13 +193,42 @@ class SkillsPoolRollbackService:
         layout_repository: SkillsPoolLayoutRepositoryProtocol,
         skill_repository: SkillsPoolSkillRepositoryProtocol,
         runtime: SkillsPoolRuntimeProtocol,
+        edit_guard: SkillsPoolEditGuard,
     ) -> None:
         self._bots = bot_repository
         self._layouts = layout_repository
         self._skills = skill_repository
         self._runtime = runtime
+        self._edit_guard = edit_guard
 
     async def rollback(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        operator: str,
+        note: str,
+    ) -> SkillsPoolRollbackResult:
+        edit_lease = self._edit_guard.acquire_for_rollback(scope=scope)
+        if edit_lease is None:
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.EDIT_BUSY,
+                evidence={"reason": "local_skill_edit_in_progress"},
+                retryable=True,
+            )
+        try:
+            return await self._rollback_with_edit_pause(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                operator=operator,
+                note=note,
+            )
+        finally:
+            self._edit_guard.release(edit_lease)
+
+    async def _rollback_with_edit_pause(
         self,
         *,
         scope: BotSkillLayoutScope,
@@ -223,8 +285,15 @@ class SkillsPoolRollbackService:
 
         bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
         if bot is None or bot.get("env") != scope.env:
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.BOT_CHANGED
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.BOT_CHANGED,
+                code="ROLLBACK_BOT_CHANGED",
+                stage="rollback_bot_validation",
+                retryable=False,
+                evidence={"reason": "bot_missing_or_environment_changed"},
             )
         engine = bot.get("active_engine")
         owner_id = bot.get("owner_id")
@@ -233,14 +302,28 @@ class SkillsPoolRollbackService:
             or not isinstance(owner_id, (str, int))
             or isinstance(owner_id, bool)
         ):
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.BOT_CHANGED
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.BOT_CHANGED,
+                code="ROLLBACK_BOT_CHANGED",
+                stage="rollback_bot_validation",
+                retryable=False,
+                evidence={"reason": "bot_engine_or_owner_invalid"},
             )
         try:
             paths = pool_paths_for_engine(engine)
-        except ValueError:
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.BOT_CHANGED
+        except ValueError as error:
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.BOT_CHANGED,
+                code="ROLLBACK_ENGINE_UNSUPPORTED",
+                stage="rollback_bot_validation",
+                retryable=False,
+                evidence={"reason": str(error)},
             )
         user_id = str(owner_id)
 
@@ -362,6 +445,7 @@ class SkillsPoolRollbackService:
             bot_id=scope.bot_id,
             user_id=user_id,
             mappings=mappings,
+            source_layout=SkillMappingSourceLayout.LEGACY,
         ):
             return self._failure(
                 scope=scope,
@@ -377,6 +461,7 @@ class SkillsPoolRollbackService:
             bot_id=scope.bot_id,
             user_id=user_id,
             mappings=mappings,
+            source_layout=SkillMappingSourceLayout.LEGACY,
         ):
             return self._failure(
                 scope=scope,

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -88,6 +88,18 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """记录不可逆的数据面切换已经完成。"""
         ...
 
+    def record_cutover_finalizing(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录 bridge 已提交但切换后 local 合并仍需幂等前滚。"""
+        ...
+
     def begin_cutover(
         self,
         *,
@@ -113,6 +125,45 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """持久化尚未跨越数据面边界的结构化失败及审计证据。"""
         ...
 
+    def record_post_cutover_failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> bool:
+        """持久化不可逆边界后的失败；状态保持为只能前滚。"""
+        ...
+
+    def mark_repair_required(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """切换结果无法证明时停止自动收敛并保留证据。"""
+        ...
+
+    def resolve_repair(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        operator: str,
+        note: str,
+        cutover_committed: bool,
+    ) -> bool:
+        """记录人工核验事实并恢复到安全的前滚阶段。"""
+        ...
+
     def commit_pool_active(
         self,
         *,
@@ -123,4 +174,64 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         local_locators: dict[int, str],
     ) -> bool:
         """在一个事务中更新该 Bot 全部 local locator 并提交 Pool Active。"""
+        ...
+
+    def begin_legacy_rollback(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        operator: str,
+        note: str,
+        lease_owner: str,
+        lease_seconds: int,
+    ) -> bool:
+        """从 POOL_ACTIVE 原子认领一次显式业务回滚。"""
+        ...
+
+    def try_acquire_rollback_lease(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        lease_seconds: int,
+    ) -> bool:
+        """续租或在旧 lease 过期后接管同一回滚 generation。"""
+        ...
+
+    def record_legacy_rollback_committed(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录 Legacy 已成为数据面权威源。"""
+        ...
+
+    def record_rollback_failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> bool:
+        """持久化显式回滚阶段失败。"""
+        ...
+
+    def commit_legacy_active(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        local_locators: dict[int, str],
+    ) -> bool:
+        """原子恢复 Legacy locator 与布局状态。"""
         ...

--- a/src/backend/src/agentclaw/community/core/skills_pool/types.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/types.py
@@ -21,8 +21,11 @@ class SkillLayoutPhase(StrEnum):
     POOL_PREPARING = "pool_preparing"
     POOL_READY = "pool_ready"
     POOL_ACTIVATING_PRE_CUTOVER = "pool_activating_pre_cutover"
+    POOL_CUTOVER_FINALIZING = "pool_cutover_finalizing"
     POOL_CUTOVER_COMMITTED = "pool_cutover_committed"
     POOL_ACTIVE = "pool_active"
+    LEGACY_ROLLBACK_PREPARING = "legacy_rollback_preparing"
+    LEGACY_ROLLBACK_COMMITTED = "legacy_rollback_committed"
     NEEDS_MANUAL_REPAIR = "manual_repair_required"
 
 

--- a/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
@@ -9,6 +9,7 @@ from agentclaw.community.core.devices.repository.protocol import (
 from agentclaw.community.core.skills_pool.claim_service import (
     SkillsPoolMigrationClaimService,
 )
+from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
 )
@@ -69,6 +70,11 @@ class SkillsPoolModule(Module):
         binder.bind(
             SkillsPoolReconcileService,
             to=SkillsPoolReconcileService,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolEditGuard,
+            to=SkillsPoolEditGuard,
             scope=singleton,
         )
 

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
 )
 from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.skills_pool.models import local_locator_prefixes
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
@@ -635,11 +636,7 @@ class SkillsPoolLayoutRepository:
     ) -> bool:
         """原子提交精确 Bot 范围内的全部 local locator 和布局状态。"""
 
-        pool_prefixes = (
-            "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/",
-            "local:///home/admin/.claude_code/workspace/skills-pool/skills-local/",
-            "local:///home/admin/.aicoding/workspace/skills-pool/skills-local/",
-        )
+        pool_prefixes = local_locator_prefixes(pool=True)
         if any(
             not isinstance(skill_id, int)
             or not locator.startswith(pool_prefixes)
@@ -913,11 +910,7 @@ class SkillsPoolLayoutRepository:
     ) -> bool:
         """同事务恢复全部 local locator 与 ``LEGACY_ACTIVE``。"""
 
-        legacy_prefixes = (
-            "local:///home/admin/.openclaw/workspace/skills/skills-local/",
-            "local:///home/admin/.claude_code/workspace/skills/skills-local/",
-            "local:///home/admin/.aicoding/workspace/skills/skills-local/",
-        )
+        legacy_prefixes = local_locator_prefixes(pool=False)
         if any(
             not isinstance(skill_id, int)
             or not locator.startswith(legacy_prefixes)

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -295,6 +295,7 @@ class SkillsPoolLayoutRepository:
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
                             SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
                         )
                     ),
@@ -311,6 +312,62 @@ class SkillsPoolLayoutRepository:
                         ),
                         BotSkillLayoutStateModel.data_plane_cutover_committed: 1,
                         BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def record_cutover_finalizing(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Persist a known bridge commit whose post-sync must be retried."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
+                        ),
+                        BotSkillLayoutStateModel.data_plane_cutover_committed: 1,
+                        BotSkillLayoutStateModel.last_failure_code: (
+                            "POST_CUTOVER_SYNC_PENDING"
+                        ),
+                        BotSkillLayoutStateModel.last_failure_stage: (
+                            "post_cutover_sync"
+                        ),
+                        BotSkillLayoutStateModel.last_failure_retryable: 1,
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
+                        BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
                 )
@@ -410,6 +467,163 @@ class SkillsPoolLayoutRepository:
             )
         return affected == 1
 
+    def record_post_cutover_failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Record a forward-only failure after the data-plane commit."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.last_failure_code: failure_code,
+                        BotSkillLayoutStateModel.last_failure_stage: failure_stage,
+                        BotSkillLayoutStateModel.last_failure_retryable: int(
+                            retryable
+                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
+                        BotSkillLayoutStateModel.last_failure_at: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def mark_repair_required(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Fence automation when the atomic cutover result is unknowable."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.NEEDS_MANUAL_REPAIR.value
+                        ),
+                        BotSkillLayoutStateModel.last_failure_code: failure_code,
+                        BotSkillLayoutStateModel.last_failure_stage: failure_stage,
+                        BotSkillLayoutStateModel.last_failure_retryable: 0,
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
+                        BotSkillLayoutStateModel.last_failure_at: func.now(),
+                        BotSkillLayoutStateModel.lease_owner: None,
+                        BotSkillLayoutStateModel.lease_expires_at: None,
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def resolve_repair(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        operator: str,
+        note: str,
+        cutover_committed: bool,
+    ) -> bool:
+        """Persist an operator's filesystem finding and resume safely."""
+
+        resume_phase = (
+            SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+            if cutover_committed
+            else SkillLayoutPhase.POOL_READY
+        )
+        with self._database.transactional_orm_session() as session:
+            row = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.NEEDS_MANUAL_REPAIR.value,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                )
+                .with_for_update()
+                .first()
+            )
+            if row is None:
+                return False
+            previous_evidence = (
+                json.loads(row.last_failure_evidence)
+                if row.last_failure_evidence
+                else None
+            )
+            row.phase = resume_phase.value
+            row.data_plane_cutover_committed = int(cutover_committed)
+            row.last_failure_code = "MANUAL_REPAIR_RESOLVED"
+            row.last_failure_stage = "operator_resolution"
+            row.last_failure_retryable = 1
+            row.last_failure_evidence = json.dumps(
+                {
+                    "operator": operator,
+                    "note": note,
+                    "cutover_committed": cutover_committed,
+                    "previous_failure": previous_evidence,
+                },
+                ensure_ascii=False,
+            )
+            row.last_failure_at = func.now()
+            row.lease_owner = None
+            row.lease_expires_at = None
+        return True
+
     def commit_pool_active(
         self,
         *,
@@ -421,13 +635,14 @@ class SkillsPoolLayoutRepository:
     ) -> bool:
         """原子提交精确 Bot 范围内的全部 local locator 和布局状态。"""
 
-        pool_prefix = (
-            "local:///home/admin/.openclaw/workspace/"
-            "skills-pool/skills-local/"
+        pool_prefixes = (
+            "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/",
+            "local:///home/admin/.claude_code/workspace/skills-pool/skills-local/",
+            "local:///home/admin/.aicoding/workspace/skills-pool/skills-local/",
         )
         if any(
             not isinstance(skill_id, int)
-            or not locator.startswith(pool_prefix)
+            or not locator.startswith(pool_prefixes)
             for skill_id, locator in local_locators.items()
         ):
             return False
@@ -475,11 +690,284 @@ class SkillsPoolLayoutRepository:
                         BotSkillLayoutStateModel.pool_activated_at: func.now(),
                         BotSkillLayoutStateModel.lease_owner: None,
                         BotSkillLayoutStateModel.lease_expires_at: None,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            if affected != 1:
+                return False
+            for row in local_rows:
+                row.git_path = local_locators[row.id]
+        return True
+
+    def begin_legacy_rollback(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        operator: str,
+        note: str,
+        lease_owner: str,
+        lease_seconds: int,
+    ) -> bool:
+        """原子认领从 Pool 返回 Legacy 的显式业务回滚。"""
+
+        evidence_json = json.dumps(
+            {"operator": operator, "note": note},
+            ensure_ascii=False,
+        )
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout.is_(None),
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.POOL_ACTIVE.value,
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.target_layout: (
+                            SkillLayout.LEGACY.value
+                        ),
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value
+                        ),
+                        BotSkillLayoutStateModel.migration_generation: (
+                            rollback_generation
+                        ),
+                        BotSkillLayoutStateModel.lease_owner: lease_owner,
+                        BotSkillLayoutStateModel.lease_expires_at: self._now_plus(
+                            session, lease_seconds
+                        ),
+                        BotSkillLayoutStateModel.last_failure_code: None,
+                        BotSkillLayoutStateModel.last_failure_stage: (
+                            "rollback_requested"
+                        ),
+                        BotSkillLayoutStateModel.last_failure_retryable: None,
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
+                        BotSkillLayoutStateModel.last_failure_at: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def record_legacy_rollback_committed(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录 Legacy 已成为运行时的数据面权威源。"""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
+                            SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.migration_generation
+                    == rollback_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value
+                        ),
+                        BotSkillLayoutStateModel.data_plane_cutover_committed: 0,
                         BotSkillLayoutStateModel.last_failure_code: None,
                         BotSkillLayoutStateModel.last_failure_stage: None,
                         BotSkillLayoutStateModel.last_failure_retryable: None,
-                        BotSkillLayoutStateModel.last_failure_evidence: None,
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
                         BotSkillLayoutStateModel.last_failure_at: None,
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def try_acquire_rollback_lease(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        lease_seconds: int,
+    ) -> bool:
+        """同一 owner 可续租；旧 lease 过期后允许新 worker 接管。"""
+
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
+                            SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.migration_generation
+                    == rollback_generation,
+                    or_(
+                        BotSkillLayoutStateModel.lease_owner == lease_owner,
+                        BotSkillLayoutStateModel.lease_expires_at.is_(None),
+                        BotSkillLayoutStateModel.lease_expires_at <= func.now(),
+                    ),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.lease_owner: lease_owner,
+                        BotSkillLayoutStateModel.lease_expires_at: (
+                            self._now_plus(session, lease_seconds)
+                        ),
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def record_rollback_failure(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        failure_code: str,
+        failure_stage: str,
+        retryable: bool,
+        evidence: dict[str, object],
+    ) -> bool:
+        """持久化回滚失败，同时保留当前单向阶段。"""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
+                            SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.migration_generation
+                    == rollback_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.last_failure_code: failure_code,
+                        BotSkillLayoutStateModel.last_failure_stage: failure_stage,
+                        BotSkillLayoutStateModel.last_failure_retryable: int(
+                            retryable
+                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
+                        BotSkillLayoutStateModel.last_failure_at: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
+    def commit_legacy_active(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        local_locators: dict[int, str],
+    ) -> bool:
+        """同事务恢复全部 local locator 与 ``LEGACY_ACTIVE``。"""
+
+        legacy_prefixes = (
+            "local:///home/admin/.openclaw/workspace/skills/skills-local/",
+            "local:///home/admin/.claude_code/workspace/skills/skills-local/",
+            "local:///home/admin/.aicoding/workspace/skills/skills-local/",
+        )
+        if any(
+            not isinstance(skill_id, int)
+            or not locator.startswith(legacy_prefixes)
+            for skill_id, locator in local_locators.items()
+        ):
+            return False
+
+        with self._database.transactional_orm_session() as session:
+            local_rows = (
+                session.query(Skill)
+                .filter(
+                    Skill.env == scope.env,
+                    Skill.bolt_id == scope.bot_id,
+                    Skill.git_path.like("local://%"),
+                )
+                .with_for_update()
+                .all()
+            )
+            if {row.id for row in local_rows} != set(local_locators):
+                return False
+
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value,
+                    BotSkillLayoutStateModel.migration_generation
+                    == rollback_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.active_layout: (
+                            SkillLayout.LEGACY.value
+                        ),
+                        BotSkillLayoutStateModel.target_layout: None,
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.LEGACY_ACTIVE.value
+                        ),
+                        BotSkillLayoutStateModel.layout_contract_version: None,
+                        BotSkillLayoutStateModel.preparation_id: None,
+                        BotSkillLayoutStateModel.data_plane_cutover_committed: 0,
+                        BotSkillLayoutStateModel.lease_owner: None,
+                        BotSkillLayoutStateModel.lease_expires_at: None,
                     },
                     synchronize_session=False,
                 )

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.skills_pool.models import (
     PoolCutoverResult,
     PoolCutoverStatus,
     PoolSkillMapping,
+    SkillMappingSourceLayout,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import (
@@ -124,13 +125,17 @@ class SkillsPoolRuntime:
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool:
         try:
             response = await self._invoke(
                 bot_id=bot_id,
                 user_id=user_id,
                 path="/api/skills/layout/mappings/publish",
-                body={"mappings": [mapping.to_dict() for mapping in mappings]},
+                body={
+                    "mappings": [mapping.to_dict() for mapping in mappings],
+                    "source_layout": source_layout.value,
+                },
             )
         except Exception:
             logger.exception(
@@ -207,13 +212,17 @@ class SkillsPoolRuntime:
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool:
         try:
             response = await self._invoke(
                 bot_id=bot_id,
                 user_id=user_id,
                 path="/api/skills/layout/mappings/verify",
-                body={"mappings": [mapping.to_dict() for mapping in mappings]},
+                body={
+                    "mappings": [mapping.to_dict() for mapping in mappings],
+                    "source_layout": source_layout.value,
+                },
             )
         except Exception:
             logger.exception(

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
@@ -84,9 +84,12 @@ class SkillsPoolRuntime:
             )
             return PoolCutoverResult(
                 committed=False,
-                status=PoolCutoverStatus.TRANSIENT_ERROR,
+                # The request may have reached the runtime and crossed the
+                # atomic boundary before the response was lost. Retrying as a
+                # normal pre-cutover error would guess at filesystem truth.
+                status=PoolCutoverStatus.UNKNOWN,
                 evidence={
-                    "reason": "runtime_cutover_request_failed",
+                    "reason": "runtime_cutover_outcome_unknown",
                     "error_type": type(error).__name__,
                 },
             )
@@ -94,7 +97,7 @@ class SkillsPoolRuntime:
         if not isinstance(data, dict):
             return PoolCutoverResult(
                 committed=False,
-                status=PoolCutoverStatus.INVALID,
+                status=PoolCutoverStatus.UNKNOWN,
                 evidence={"reason": "runtime_cutover_response_invalid"},
             )
         raw_status = str(data.get("status", ""))
@@ -136,6 +139,67 @@ class SkillsPoolRuntime:
             )
             return False
         return response.get("success") is True
+
+    async def rollback_to_legacy(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        rollback_generation: str,
+        registered_local_names: list[str],
+    ) -> PoolCutoverResult:
+        try:
+            response = await self._invoke(
+                bot_id=bot_id,
+                user_id=user_id,
+                path="/api/skills/layout/rollback",
+                body={
+                    "rollback_generation": rollback_generation,
+                    "registered_local_names": registered_local_names,
+                },
+            )
+        except Exception as error:
+            logger.exception(
+                "[skills_pool.runtime] rollback outcome unknown bot_id=%s "
+                "generation=%s",
+                bot_id,
+                rollback_generation,
+            )
+            return PoolCutoverResult(
+                committed=False,
+                status=PoolCutoverStatus.UNKNOWN,
+                evidence={
+                    "reason": "runtime_rollback_outcome_unknown",
+                    "error_type": type(error).__name__,
+                },
+            )
+        data = response.get("data")
+        if not isinstance(data, dict):
+            return PoolCutoverResult(
+                committed=False,
+                status=PoolCutoverStatus.UNKNOWN,
+                evidence={"reason": "runtime_rollback_response_invalid"},
+            )
+        raw_status = str(data.get("status", ""))
+        try:
+            status = PoolCutoverStatus(raw_status)
+        except ValueError:
+            status = PoolCutoverStatus.UNKNOWN
+        evidence = dict(data.get("evidence") or {})
+        if status is PoolCutoverStatus.UNKNOWN:
+            evidence["raw_status"] = raw_status
+        return PoolCutoverResult(
+            committed=(
+                data.get("committed") is True
+                and status
+                in {
+                    PoolCutoverStatus.COMMITTED,
+                    PoolCutoverStatus.ALREADY_COMMITTED,
+                }
+            ),
+            status=status,
+            evidence=evidence,
+        )
 
     async def verify_mappings(
         self,

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -166,6 +166,8 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
     bot_record = {
         "bot_id": mock_ctx.bot_id,
         "owner_id": mock_ctx.user_id,
+        "entity_id": f"staff_{mock_ctx.user_id}",
+        "env": "local",
         "active_engine": "openclaw",
         "bot_type": bot_type,
         "status": bot_status,
@@ -188,6 +190,9 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
         bot_service = MagicMock()
         bot_service.resolve_desktop_live_status = MagicMock(return_value=None)
 
+    mock_edit_guard = MagicMock()
+    mock_edit_guard.acquire_for_edit.return_value = object()
+
     app = FastAPI()
     app.include_router(skills_router)
     app.dependency_overrides[get_request_context] = lambda: mock_ctx
@@ -200,6 +205,9 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
                 DeviceContextResolver,
             )
             from agentclaw.community.core.skill_center.factories import SkillServiceFactory
+            from agentclaw.community.core.skills_pool.edit_guard import (
+                SkillsPoolEditGuard,
+            )
             from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 
             from agentclaw.community.api.skill_service_factory import SkillServiceFactoryProtocol
@@ -209,6 +217,7 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
             binder.bind(BotRepository, to=mock_bot_repo)
             binder.bind(DeviceContextResolver, to=mock_resolver)
             binder.bind(BotServiceProtocol, to=bot_service)
+            binder.bind(SkillsPoolEditGuard, to=mock_edit_guard)
 
     injector = Injector([_TestModule()])
     attach_injector(app, injector)

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditGuard,
+    SkillsPoolEditPausedError,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+
+
+class _Cache:
+    def __init__(self) -> None:
+        self.held: dict[str, str] = {}
+
+    def acquire_lock(self, key: str, ttl: int = 30) -> str | None:
+        if key in self.held:
+            return None
+        self.held[key] = "token"
+        return "token"
+
+    def release_lock(self, key: str, token: str) -> bool:
+        if self.held.get(key) != token:
+            return False
+        del self.held[key]
+        return True
+
+
+class _Layouts:
+    def __init__(self) -> None:
+        self.state = BotSkillLayoutState(
+            scope=SCOPE,
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            migration_generation="generation-1",
+            persisted=True,
+        )
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
+
+
+def test_rollback_lease_excludes_new_local_edits() -> None:
+    layouts = _Layouts()
+    guard = SkillsPoolEditGuard(
+        cache=_Cache(),
+        layout_repository=layouts,
+    )
+    rollback_lease = guard.acquire_for_rollback(scope=SCOPE)
+    assert rollback_lease is not None
+
+    with pytest.raises(SkillsPoolEditPausedError, match="read-only"):
+        guard.acquire_for_edit(scope=SCOPE)
+
+    assert guard.release(rollback_lease)
+
+
+def test_lock_identity_includes_entity_for_reused_bot_ids() -> None:
+    guard = SkillsPoolEditGuard(
+        cache=_Cache(),
+        layout_repository=_Layouts(),
+    )
+    other_scope = replace(SCOPE, entity_id="entity-2")
+
+    first = guard.acquire_for_rollback(scope=SCOPE)
+    second = guard.acquire_for_rollback(scope=other_scope)
+
+    assert first is not None
+    assert second is not None
+    assert first.key != second.key
+
+
+def test_rollback_phase_rejects_edit_even_after_lock_becomes_available() -> None:
+    layouts = _Layouts()
+    layouts.state = replace(
+        layouts.state,
+        target_layout=SkillLayout.LEGACY,
+        phase=SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+    )
+    guard = SkillsPoolEditGuard(
+        cache=_Cache(),
+        layout_repository=layouts,
+    )
+
+    with pytest.raises(SkillsPoolEditPausedError, match="rollback"):
+        guard.acquire_for_edit(scope=SCOPE)

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -397,6 +397,190 @@ def test_invalid_runtime_probe_can_be_recorded_while_pool_is_preparing() -> None
     assert state.last_failure_evidence == {"reason": "marker_contract_mismatch"}
 
 
+def test_post_cutover_failure_remains_forward_only_and_auditable() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    assert repository.record_cutover_committed(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"bridge": "pool"},
+    )
+
+    assert repository.record_post_cutover_failure(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        failure_code="MAPPING_PUBLISH_FAILED",
+        failure_stage="mapping_publish",
+        retryable=True,
+        evidence={"mapping_count": 3},
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert state.data_plane_cutover_committed is True
+    assert state.last_failure_code == "MAPPING_PUBLISH_FAILED"
+    assert state.last_failure_stage == "mapping_publish"
+    assert state.last_failure_retryable is True
+    assert state.last_failure_evidence == {"mapping_count": 3}
+    assert state.last_failure_at is not None
+
+
+def test_unknown_cutover_is_fenced_for_manual_repair() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+
+    assert repository.mark_repair_required(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        failure_code="UNKNOWN",
+        failure_stage="cutover_outcome_unknown",
+        evidence={"reason": "response_lost"},
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.NEEDS_MANUAL_REPAIR
+    assert state.data_plane_cutover_committed is False
+    assert state.last_failure_retryable is False
+    assert state.lease_owner is None
+    assert state.last_failure_evidence == {"reason": "response_lost"}
+
+
+def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    assert repository.mark_repair_required(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        failure_code="UNKNOWN",
+        failure_stage="cutover_outcome_unknown",
+        evidence={"reason": "response_lost"},
+    )
+
+    assert repository.resolve_repair(
+        scope=scope,
+        migration_generation="generation-1",
+        operator="oncall-1",
+        note="容器内已核验 bridge 指向 Pool",
+        cutover_committed=True,
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert state.data_plane_cutover_committed is True
+    assert state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+    assert state.last_failure_stage == "operator_resolution"
+    assert state.last_failure_retryable is True
+    assert state.last_failure_evidence == {
+        "operator": "oncall-1",
+        "note": "容器内已核验 bridge 指向 Pool",
+        "cutover_committed": True,
+        "previous_failure": {"reason": "response_lost"},
+    }
+    assert repository.try_acquire_lease(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-2",
+        lease_seconds=60,
+    )
+    with database.transactional_orm_session() as session:
+        session.add(
+            Skill(
+                id=91,
+                name="local-a",
+                git_path="local:///legacy/local-a",
+                bolt_id=scope.bot_id,
+                env=scope.env,
+            )
+        )
+    assert repository.commit_pool_active(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-2",
+        preparation_id="preparation-1",
+        local_locators={
+            91: (
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/local-a"
+            )
+        },
+    )
+    active = repository.get(scope)
+    assert active.phase is SkillLayoutPhase.POOL_ACTIVE
+    assert active.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+    assert active.last_failure_evidence["previous_failure"] == {
+        "reason": "response_lost"
+    }
+
+
 def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -573,3 +757,155 @@ def test_pool_active_commit_rejects_partial_or_stale_local_locator_set() -> None
         },
     )
     assert repository.get(scope).active_layout is SkillLayout.LEGACY
+
+
+def test_explicit_rollback_is_fenced_and_commits_locator_atomically() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    with database.transactional_orm_session() as session:
+        session.add(
+            BotSkillLayoutStateModel(
+                env=scope.env,
+                entity_id=scope.entity_id,
+                bot_id=scope.bot_id,
+                active_layout=SkillLayout.POOL.value,
+                phase=SkillLayoutPhase.POOL_ACTIVE.value,
+                layout_contract_version="skills-pool-p3-v1",
+                preparation_id="preparation-1",
+                migration_generation="migration-1",
+                data_plane_cutover_committed=1,
+            )
+        )
+        session.add(
+            Skill(
+                id=101,
+                env=scope.env,
+                bolt_id=scope.bot_id,
+                user_id="owner-1",
+                name="local-a",
+                git_path=(
+                    "local:///home/admin/.openclaw/workspace/"
+                    "skills-pool/skills-local/local-a"
+                ),
+            )
+        )
+
+    assert repository.begin_legacy_rollback(
+        scope=scope,
+        rollback_generation="rollback-1",
+        operator="oncall-1",
+        note="业务回滚",
+        lease_owner="rollback-worker",
+        lease_seconds=60,
+    )
+    preparing = repository.get(scope)
+    assert preparing.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING
+    assert preparing.target_layout is SkillLayout.LEGACY
+    assert preparing.migration_generation == "rollback-1"
+    assert preparing.last_failure_stage == "rollback_requested"
+
+    assert repository.record_legacy_rollback_committed(
+        scope=scope,
+        rollback_generation="rollback-1",
+        lease_owner="rollback-worker",
+        evidence={"source": "current_pool"},
+    )
+    assert repository.record_rollback_failure(
+        scope=scope,
+        rollback_generation="rollback-1",
+        lease_owner="rollback-worker",
+        failure_code="ROLLBACK_MAPPING_PUBLISH_FAILED",
+        failure_stage="mapping_publish",
+        retryable=True,
+        evidence={"mapping_count": 1},
+    )
+    committed = repository.get(scope)
+    assert committed.phase is SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED
+    assert committed.last_failure_code == "ROLLBACK_MAPPING_PUBLISH_FAILED"
+    assert committed.last_failure_at is not None
+    with database.transactional_orm_session() as session:
+        session.query(BotSkillLayoutStateModel).filter(
+            *repository._scope_filter(scope)
+        ).update(
+            {
+                BotSkillLayoutStateModel.lease_expires_at: func.datetime(
+                    func.now(), text("'-1 second'")
+                )
+            }
+        )
+    assert repository.try_acquire_rollback_lease(
+        scope=scope,
+        rollback_generation="rollback-1",
+        lease_owner="replacement-worker",
+        lease_seconds=60,
+    )
+
+    locator = (
+        "local:///home/admin/.openclaw/workspace/"
+        "skills/skills-local/local-a"
+    )
+    assert repository.commit_legacy_active(
+        scope=scope,
+        rollback_generation="rollback-1",
+        lease_owner="replacement-worker",
+        local_locators={101: locator},
+    )
+    state = repository.get(scope)
+    assert state.active_layout is SkillLayout.LEGACY
+    assert state.target_layout is None
+    assert state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert state.layout_contract_version is None
+    assert state.preparation_id is None
+    assert state.lease_owner is None
+    with database.transactional_orm_session() as session:
+        assert session.get(Skill, 101).git_path == locator
+
+
+def test_explicit_rollback_rejects_partial_local_locator_commit() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    with database.transactional_orm_session() as session:
+        session.add(
+            BotSkillLayoutStateModel(
+                env=scope.env,
+                entity_id=scope.entity_id,
+                bot_id=scope.bot_id,
+                active_layout=SkillLayout.POOL.value,
+                target_layout=SkillLayout.LEGACY.value,
+                phase=SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value,
+                migration_generation="rollback-1",
+                lease_owner="rollback-worker",
+                lease_expires_at=func.datetime(
+                    func.now(), text("'+60 seconds'")
+                ),
+            )
+        )
+        for skill_id, name in ((101, "local-a"), (102, "local-b")):
+            session.add(
+                Skill(
+                    id=skill_id,
+                    env=scope.env,
+                    bolt_id=scope.bot_id,
+                    user_id="owner-1",
+                    name=name,
+                    git_path=f"local:///pool/{name}",
+                )
+            )
+
+    assert not repository.commit_legacy_active(
+        scope=scope,
+        rollback_generation="rollback-1",
+        lease_owner="rollback-worker",
+        local_locators={
+            101: (
+                "local:///home/admin/.openclaw/workspace/"
+                "skills/skills-local/local-a"
+            )
+        },
+    )
+    assert (
+        repository.get(scope).phase
+        is SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED
+    )

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -148,6 +148,48 @@ class FakeLayoutRepository:
         )
         return True
 
+    def record_post_cutover_failure(self, **kwargs: object) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("post_failure")
+        self.state = replace(
+            self.state,
+            last_failure_code=str(kwargs["failure_code"]),
+            last_failure_stage=str(kwargs["failure_stage"]),
+            last_failure_retryable=bool(kwargs["retryable"]),
+            last_failure_evidence=dict(kwargs["evidence"]),
+        )
+        return True
+
+    def mark_repair_required(self, **kwargs: object) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("manual_repair")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.NEEDS_MANUAL_REPAIR,
+            last_failure_code=str(kwargs["failure_code"]),
+            last_failure_stage=str(kwargs["failure_stage"]),
+            last_failure_retryable=False,
+            last_failure_evidence=dict(kwargs["evidence"]),
+        )
+        return True
+
+    def record_cutover_finalizing(self, **kwargs: object) -> bool:
+        if not self._owns(kwargs):
+            return False
+        self.events.append("finalizing")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            data_plane_cutover_committed=True,
+            last_failure_code="POST_CUTOVER_SYNC_PENDING",
+            last_failure_stage="post_cutover_sync",
+            last_failure_retryable=True,
+            last_failure_evidence=dict(kwargs["evidence"]),
+        )
+        return True
+
     def commit_pool_active(
         self,
         *,
@@ -444,6 +486,14 @@ async def test_mapping_failure_after_cutover_does_not_commit_database(
     assert layouts.state.active_layout is SkillLayout.LEGACY
     assert layouts.committed_locators is None
     assert runtime.events == ["probe", "cutover", "mapping"]
+    assert layouts.events == [
+        "ready",
+        "begin",
+        "cutover",
+        "post_failure",
+    ]
+    assert layouts.state.last_failure_stage == "mapping_publish"
+    assert layouts.state.last_failure_retryable is True
 
     runtime.publish_success = True
     runtime.events.clear()
@@ -460,6 +510,76 @@ async def test_mapping_failure_after_cutover_does_not_commit_database(
     assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "mapping", "verify"]
     assert layouts.events == ["database"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_cutover_enters_manual_repair_and_stops_automation() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.UNKNOWN,
+        evidence={"reason": "response_lost_after_request"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED
+    assert result.retryable is False
+    assert layouts.events == ["ready", "begin", "manual_repair"]
+    assert layouts.state.phase is SkillLayoutPhase.NEEDS_MANUAL_REPAIR
+    assert layouts.state.last_failure_stage == "cutover_outcome_unknown"
+    assert layouts.state.last_failure_evidence == runtime.cutover_result.to_dict()
+
+    runtime.events.clear()
+    repeated = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+    assert repeated.outcome is SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED
+    assert runtime.events == []
+
+
+@pytest.mark.asyncio
+async def test_post_cutover_sync_pending_retries_finalization_before_mappings() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING,
+        evidence={"reason": "post_cutover_sync_failed"},
+    )
+
+    first = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert first.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert first.retryable is True
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+    assert runtime.events == ["probe", "cutover"]
+    assert layouts.events == ["ready", "begin", "finalizing"]
+
+    runtime.events.clear()
+    layouts.events.clear()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"post_sync": {"copied": 1}},
+    )
+    second = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert second.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["cutover", "database"]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -701,6 +701,30 @@ async def test_invalid_probe_is_persisted_as_non_retryable_blocker() -> None:
 
 
 @pytest.mark.asyncio
+async def test_transient_probe_failure_is_persisted_as_retryable() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
+        preparation_id=None,
+        evidence={"reason": "runtime_unreachable"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.TRANSIENT_ERROR
+    assert result.retryable is True
+    assert layouts.events == ["failure"]
+    assert layouts.state.last_failure_code == "TRANSIENT_ERROR"
+    assert layouts.state.last_failure_stage == "runtime_probe"
+    assert layouts.state.last_failure_retryable is True
+
+
+@pytest.mark.asyncio
 async def test_ready_probe_contract_mismatch_is_persisted_as_blocker() -> None:
     layouts = FakeLayoutRepository()
     runtime = FakeRuntime()
@@ -725,7 +749,7 @@ async def test_ready_probe_contract_mismatch_is_persisted_as_blocker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_post_cutover_invalid_probe_blocks_without_pre_cutover_write() -> None:
+async def test_post_cutover_invalid_probe_records_forward_only_failure() -> None:
     layouts = FakeLayoutRepository(
         claimed_state(
             phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
@@ -747,7 +771,8 @@ async def test_post_cutover_invalid_probe_blocks_without_pre_cutover_write() -> 
 
     assert result.outcome is SkillsPoolReconcileOutcome.INVALID
     assert result.retryable is False
-    assert layouts.events == []
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.last_failure_stage == "runtime_probe"
     assert runtime.events == ["probe"]
 
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
@@ -569,6 +569,27 @@ def test_non_retryable_cutover_failure_blocks() -> None:
     )
 
 
+def test_manual_repair_state_stops_before_lease_reacquisition() -> None:
+    state = replace(
+        _claimed_state(),
+        phase=SkillLayoutPhase.NEEDS_MANUAL_REPAIR,
+        lease_owner=None,
+    )
+    handler, _, layouts, reconcile = _handler(
+        claim_results=[
+            MigrationClaimResult(MigrationClaimOutcome.ALREADY_CLAIMED, state)
+        ],
+        reconcile_results=[],
+        state=state,
+    )
+
+    assert handler.handle(_payload()) == Fail(
+        "skills pool migration requires manual repair"
+    )
+    assert layouts.acquire_calls == []
+    assert reconcile.calls == []
+
+
 def test_invalid_payload_fails_without_touching_domain_services() -> None:
     state = _claimed_state()
     handler, claims, _, reconcile = _handler(

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.skills_pool.models import (
     PoolCutoverResult,
     PoolCutoverStatus,
     RegisteredSkillAsset,
+    SkillMappingSourceLayout,
 )
 from agentclaw.community.core.skills_pool.reconcile_task import (
     SKILLS_POOL_RECONCILE_TASK,
@@ -66,6 +67,7 @@ class _Layouts:
                 else SkillLayoutPhase.POOL_READY
             ),
             data_plane_cutover_committed=committed,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
         )
         return True
 
@@ -73,6 +75,7 @@ class _Layouts:
 class _Queue:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
+        self.fail_next = False
 
     def enqueue(
         self,
@@ -82,6 +85,9 @@ class _Queue:
         *,
         delay_seconds: int = 0,
     ) -> object:
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("queue unavailable")
         self.calls.append(
             {
                 "task_type": task_type,
@@ -155,6 +161,36 @@ def test_non_manual_or_stale_generation_is_not_retriggered() -> None:
     assert result.outcome is SkillsPoolRecoveryOutcome.NOT_REPAIR_REQUIRED
     assert layouts.resolutions == []
     assert queue.calls == []
+
+
+def test_resolved_manual_repair_can_retry_a_failed_durable_enqueue() -> None:
+    layouts = _Layouts(_manual_state())
+    queue = _Queue()
+    queue.fail_next = True
+    service = SkillsPoolRecoveryService(
+        layout_repository=layouts,
+        task_queue_service=queue,
+    )
+
+    first = service.resolve_repair_state(
+        scope=SCOPE,
+        migration_generation="generation-1",
+        operator="oncall-1",
+        note="verified",
+        resolution=ManualRepairResolution.POOL_COMMITTED,
+    )
+    second = service.resolve_repair_state(
+        scope=SCOPE,
+        migration_generation="generation-1",
+        operator="oncall-1",
+        note="retry enqueue",
+        resolution=ManualRepairResolution.POOL_COMMITTED,
+    )
+
+    assert first.outcome is SkillsPoolRecoveryOutcome.RETRIGGER_FAILED
+    assert second.outcome is SkillsPoolRecoveryOutcome.RETRIGGERED
+    assert len(layouts.resolutions) == 1
+    assert len(queue.calls) == 1
 
 
 def _pool_state() -> BotSkillLayoutState:
@@ -248,6 +284,13 @@ class _Bots:
         }
 
 
+class _ChangedBots:
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> dict[str, object] | None:
+        return None
+
+
 class _Skills:
     local = [
         RegisteredSkillAsset(
@@ -281,6 +324,7 @@ class _RollbackRuntime:
     def __init__(self) -> None:
         self.events: list[str] = []
         self.publish_results = [True, False]
+        self.mapping_layouts: list[SkillMappingSourceLayout] = []
 
     async def rollback_to_legacy(self, **kwargs: object) -> PoolCutoverResult:
         self.events.append("rollback")
@@ -293,6 +337,7 @@ class _RollbackRuntime:
 
     async def publish_mappings(self, **kwargs: object) -> bool:
         self.events.append("mapping")
+        self.mapping_layouts.append(kwargs["source_layout"])
         mappings = kwargs["mappings"]
         assert [item.source for item in mappings] == [
             "/home/admin/.openclaw/workspace/skills/skills-local/local-a",
@@ -302,6 +347,15 @@ class _RollbackRuntime:
 
     async def verify_mappings(self, **kwargs: object) -> bool:
         self.events.append("verify")
+        self.mapping_layouts.append(kwargs["source_layout"])
+        return True
+
+
+class _EditGuard:
+    def acquire_for_rollback(self, **kwargs: object) -> object:
+        return object()
+
+    def release(self, lease: object) -> bool:
         return True
 
 
@@ -314,6 +368,7 @@ async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() 
         layout_repository=layouts,
         skill_repository=_Skills(),
         runtime=runtime,
+        edit_guard=_EditGuard(),
     )
 
     first = await service.rollback(
@@ -332,6 +387,11 @@ async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() 
         "verify",
         "rollback",
         "mapping",
+    ]
+    assert runtime.mapping_layouts == [
+        SkillMappingSourceLayout.LEGACY,
+        SkillMappingSourceLayout.LEGACY,
+        SkillMappingSourceLayout.LEGACY,
     ]
 
     runtime.publish_results = [True]
@@ -355,3 +415,25 @@ async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() 
             "skills/skills-local/local-a"
         )
     }
+
+
+@pytest.mark.asyncio
+async def test_rollback_bot_validation_failure_is_persisted() -> None:
+    layouts = _RollbackLayouts()
+    result = await SkillsPoolRollbackService(
+        bot_repository=_ChangedBots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=_RollbackRuntime(),
+        edit_guard=_EditGuard(),
+    ).rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="业务确认回滚",
+    )
+
+    assert result.outcome is SkillsPoolRollbackOutcome.BOT_CHANGED
+    assert layouts.events == ["begin", "failure"]
+    assert layouts.state.last_failure_stage == "rollback_bot_validation"

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -1,0 +1,357 @@
+"""Skills Pool operator recovery and explicit rollback domain tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from agentclaw.community.core.skills_pool.recovery_service import (
+    ManualRepairResolution,
+    SkillsPoolRollbackOutcome,
+    SkillsPoolRollbackService,
+    SkillsPoolRecoveryOutcome,
+    SkillsPoolRecoveryService,
+)
+from agentclaw.community.core.skills_pool.models import (
+    PoolCutoverResult,
+    PoolCutoverStatus,
+    RegisteredSkillAsset,
+)
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SKILLS_POOL_RECONCILE_TASK,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+
+
+def _manual_state() -> BotSkillLayoutState:
+    return BotSkillLayoutState(
+        scope=SCOPE,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=SkillLayout.POOL,
+        phase=SkillLayoutPhase.NEEDS_MANUAL_REPAIR,
+        migration_generation="generation-1",
+        persisted=True,
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id="preparation-1",
+        last_failure_evidence={"reason": "response_lost"},
+    )
+
+
+class _Layouts:
+    def __init__(self, state: BotSkillLayoutState) -> None:
+        self.state = state
+        self.resolutions: list[dict[str, object]] = []
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
+
+    def resolve_repair(self, **kwargs: object) -> bool:
+        self.resolutions.append(kwargs)
+        committed = bool(kwargs["cutover_committed"])
+        self.state = replace(
+            self.state,
+            phase=(
+                SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+                if committed
+                else SkillLayoutPhase.POOL_READY
+            ),
+            data_plane_cutover_committed=committed,
+        )
+        return True
+
+
+class _Queue:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def enqueue(
+        self,
+        task_type: str,
+        payload: dict,
+        deadline_seconds: int,
+        *,
+        delay_seconds: int = 0,
+    ) -> object:
+        self.calls.append(
+            {
+                "task_type": task_type,
+                "payload": payload,
+                "deadline_seconds": deadline_seconds,
+                "delay_seconds": delay_seconds,
+            }
+        )
+        return object()
+
+
+def test_operator_resolution_records_note_and_durably_retriggers() -> None:
+    layouts = _Layouts(_manual_state())
+    queue = _Queue()
+    service = SkillsPoolRecoveryService(
+        layout_repository=layouts,
+        task_queue_service=queue,
+    )
+
+    result = service.resolve_repair_state(
+        scope=SCOPE,
+        migration_generation="generation-1",
+        operator="oncall-1",
+        note="已在当前容器确认 legacy bridge 指向 Pool",
+        resolution=ManualRepairResolution.POOL_COMMITTED,
+    )
+
+    assert result.outcome is SkillsPoolRecoveryOutcome.RETRIGGERED
+    assert layouts.resolutions == [
+        {
+            "scope": SCOPE,
+            "migration_generation": "generation-1",
+            "operator": "oncall-1",
+            "note": "已在当前容器确认 legacy bridge 指向 Pool",
+            "cutover_committed": True,
+        }
+    ]
+    assert len(queue.calls) == 1
+    assert queue.calls[0]["task_type"] == SKILLS_POOL_RECONCILE_TASK
+    payload = queue.calls[0]["payload"]
+    assert payload["scope"] == {
+        "env": "pre",
+        "entity_id": "entity-1",
+        "bot_id": "bot-1",
+    }
+    assert payload["source"] == "manual_repair_resolution"
+    assert payload["signal_identity"] == {
+        "operator": "oncall-1",
+        "resolution": "pool_committed",
+    }
+
+
+def test_non_manual_or_stale_generation_is_not_retriggered() -> None:
+    layouts = _Layouts(
+        replace(_manual_state(), phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED)
+    )
+    queue = _Queue()
+    service = SkillsPoolRecoveryService(
+        layout_repository=layouts,
+        task_queue_service=queue,
+    )
+
+    result = service.resolve_repair_state(
+        scope=SCOPE,
+        migration_generation="stale-generation",
+        operator="oncall-1",
+        note="checked",
+        resolution=ManualRepairResolution.LEGACY_NOT_COMMITTED,
+    )
+
+    assert result.outcome is SkillsPoolRecoveryOutcome.NOT_REPAIR_REQUIRED
+    assert layouts.resolutions == []
+    assert queue.calls == []
+
+
+def _pool_state() -> BotSkillLayoutState:
+    return BotSkillLayoutState(
+        scope=SCOPE,
+        active_layout=SkillLayout.POOL,
+        target_layout=None,
+        phase=SkillLayoutPhase.POOL_ACTIVE,
+        migration_generation="generation-1",
+        persisted=True,
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id="preparation-1",
+    )
+
+
+class _RollbackLayouts:
+    def __init__(self) -> None:
+        self.state = _pool_state()
+        self.events: list[str] = []
+        self.locators: dict[int, str] | None = None
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
+
+    def begin_legacy_rollback(self, **kwargs: object) -> bool:
+        self.events.append("begin")
+        self.state = replace(
+            self.state,
+            target_layout=SkillLayout.LEGACY,
+            phase=SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+            migration_generation=str(kwargs["rollback_generation"]),
+            lease_owner=str(kwargs["lease_owner"]),
+        )
+        return True
+
+    def record_legacy_rollback_committed(self, **kwargs: object) -> bool:
+        self.events.append("cutover")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
+            data_plane_cutover_committed=False,
+        )
+        return True
+
+    def try_acquire_rollback_lease(self, **kwargs: object) -> bool:
+        self.state = replace(
+            self.state,
+            lease_owner=str(kwargs["lease_owner"]),
+        )
+        return True
+
+    def record_rollback_failure(self, **kwargs: object) -> bool:
+        self.events.append("failure")
+        self.state = replace(
+            self.state,
+            last_failure_stage=str(kwargs["failure_stage"]),
+            last_failure_retryable=bool(kwargs["retryable"]),
+            last_failure_evidence=dict(kwargs["evidence"]),
+        )
+        return True
+
+    def commit_legacy_active(
+        self, *, local_locators: dict[int, str], **kwargs: object
+    ) -> bool:
+        self.events.append("database")
+        self.locators = local_locators
+        self.state = replace(
+            self.state,
+            active_layout=SkillLayout.LEGACY,
+            target_layout=None,
+            phase=SkillLayoutPhase.LEGACY_ACTIVE,
+            layout_contract_version=None,
+            preparation_id=None,
+            lease_owner=None,
+        )
+        return True
+
+
+class _Bots:
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> dict[str, object]:
+        assert (bot_id, entity_id) == (SCOPE.bot_id, SCOPE.entity_id)
+        return {
+            "bot_id": SCOPE.bot_id,
+            "entity_id": SCOPE.entity_id,
+            "owner_id": "owner-1",
+            "env": SCOPE.env,
+            "active_engine": "openclaw",
+        }
+
+
+class _Skills:
+    local = [
+        RegisteredSkillAsset(
+            skill_id=11,
+            name="local-a",
+            git_path=(
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/skills-local/local-a"
+            ),
+        )
+    ]
+    active = [
+        *local,
+        RegisteredSkillAsset(
+            skill_id=21,
+            name="repo-a",
+            git_path="git://business/repo-a",
+        ),
+    ]
+
+    def list_bot_local_assets(self, **kwargs: object) -> list[RegisteredSkillAsset]:
+        return self.local
+
+    def list_bot_active_assets(
+        self, **kwargs: object
+    ) -> list[RegisteredSkillAsset]:
+        return self.active
+
+
+class _RollbackRuntime:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.publish_results = [True, False]
+
+    async def rollback_to_legacy(self, **kwargs: object) -> PoolCutoverResult:
+        self.events.append("rollback")
+        assert kwargs["registered_local_names"] == ["local-a"]
+        return PoolCutoverResult(
+            committed=True,
+            status=PoolCutoverStatus.COMMITTED,
+            evidence={"source": "current_pool"},
+        )
+
+    async def publish_mappings(self, **kwargs: object) -> bool:
+        self.events.append("mapping")
+        mappings = kwargs["mappings"]
+        assert [item.source for item in mappings] == [
+            "/home/admin/.openclaw/workspace/skills/skills-local/local-a",
+            "/home/admin/.openclaw/workspace/skills/skills-repo/business/repo-a",
+        ]
+        return self.publish_results.pop(0)
+
+    async def verify_mappings(self, **kwargs: object) -> bool:
+        self.events.append("verify")
+        return True
+
+
+@pytest.mark.asyncio
+async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() -> None:
+    layouts = _RollbackLayouts()
+    runtime = _RollbackRuntime()
+    service = SkillsPoolRollbackService(
+        bot_repository=_Bots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=runtime,
+    )
+
+    first = await service.rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="业务确认回滚",
+    )
+
+    assert first.outcome is SkillsPoolRollbackOutcome.MAPPING_FAILED
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED
+    assert layouts.events == ["begin", "cutover", "failure"]
+    assert runtime.events == [
+        "mapping",
+        "verify",
+        "rollback",
+        "mapping",
+    ]
+
+    runtime.publish_results = [True]
+    runtime.events.clear()
+    layouts.events.clear()
+    layouts.state = replace(layouts.state, lease_owner="dead-worker")
+    second = await service.rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-2",
+        operator="oncall-1",
+        note="重试同一回滚",
+    )
+
+    assert second.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
+    assert runtime.events == ["mapping", "verify"]
+    assert layouts.events == ["database"]
+    assert layouts.locators == {
+        11: (
+            "local:///home/admin/.openclaw/workspace/"
+            "skills/skills-local/local-a"
+        )
+    }

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -44,7 +44,7 @@ class FakeTransport:
                 "timeout": timeout,
             }
         )
-        if path.endswith("/activate"):
+        if path.endswith(("/activate", "/rollback")):
             return {
                 "success": True,
                 "data": {
@@ -108,6 +108,12 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
         registered_local_names=["a"],
         mappings=mappings,
     )
+    rollback = await runtime.rollback_to_legacy(
+        bot_id="bot-1",
+        user_id="owner-1",
+        rollback_generation="rollback-1",
+        registered_local_names=["a"],
+    )
     published = await runtime.publish_mappings(
         bot_id="bot-1",
         user_id="owner-1",
@@ -121,15 +127,19 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
 
     assert cutover.committed
     assert cutover.status is PoolCutoverStatus.COMMITTED
+    assert rollback.committed
+    assert rollback.status is PoolCutoverStatus.COMMITTED
     assert published
     assert verified
     assert resolver.calls == [
         ("bot-1", "owner-1"),
         ("bot-1", "owner-1"),
         ("bot-1", "owner-1"),
+        ("bot-1", "owner-1"),
     ]
     assert [call["path"] for call in transport.calls] == [
         "/api/skills/layout/activate",
+        "/api/skills/layout/rollback",
         "/api/skills/layout/mappings/publish",
         "/api/skills/layout/mappings/verify",
     ]

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -33,12 +33,19 @@ from engine.community.core.skills.models import (
     CenterEnsureItem,
     CenterEnsureRequest,
     CleanSymlinksRequest,
-    PoolLayoutActivateRequest as PoolLayoutActivateCommand,
-    PoolLayoutRollbackRequest as PoolLayoutRollbackCommand,
-    PoolLayoutProbeRequest as PoolLayoutProbeCommand,
+    PoolMappingSourceLayout,
     SymlinkItem,
     SyncBindPathsRequest,
     SyncSymlinksRequest,
+)
+from engine.community.core.skills.models import (
+    PoolLayoutActivateRequest as PoolLayoutActivateCommand,
+)
+from engine.community.core.skills.models import (
+    PoolLayoutProbeRequest as PoolLayoutProbeCommand,
+)
+from engine.community.core.skills.models import (
+    PoolLayoutRollbackRequest as PoolLayoutRollbackCommand,
 )
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
@@ -144,12 +151,18 @@ async def verify_runtime_skill_mappings(
     """验证当前受管入口与 Pool source 一致。"""
 
     plugin = _skills_plugin()
+    layout_kwargs = (
+        {"source_layout": PoolMappingSourceLayout.LEGACY}
+        if body.source_layout == PoolMappingSourceLayout.LEGACY.value
+        else {}
+    )
     try:
         result = await plugin.verify_pool_mappings(
             [
                 SymlinkItem(source=item.source, target=item.target)
                 for item in body.mappings
             ],
+            **layout_kwargs,
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
@@ -167,12 +180,18 @@ async def publish_runtime_skill_mappings(
     """全量发布 Pool 受管 mapping，保留结构桥和外部入口。"""
 
     plugin = _skills_plugin()
+    layout_kwargs = (
+        {"source_layout": PoolMappingSourceLayout.LEGACY}
+        if body.source_layout == PoolMappingSourceLayout.LEGACY.value
+        else {}
+    )
     try:
         result = await plugin.publish_pool_mappings(
             [
                 SymlinkItem(source=item.source, target=item.target)
                 for item in body.mappings
             ],
+            **layout_kwargs,
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -20,6 +20,7 @@ from engine.community.api.skills.schemas import (
     PoolLayoutActivateApiResponse,
     PoolLayoutActivateRequest,
     PoolLayoutActivateResponse,
+    PoolLayoutRollbackRequest,
     PoolMappingVerifyRequest,
     RuntimeLayoutProbeApiResponse,
     RuntimeLayoutProbeRequest,
@@ -33,6 +34,7 @@ from engine.community.core.skills.models import (
     CenterEnsureRequest,
     CleanSymlinksRequest,
     PoolLayoutActivateRequest as PoolLayoutActivateCommand,
+    PoolLayoutRollbackRequest as PoolLayoutRollbackCommand,
     PoolLayoutProbeRequest as PoolLayoutProbeCommand,
     SymlinkItem,
     SyncBindPathsRequest,
@@ -101,6 +103,36 @@ async def activate_runtime_skills_layout(
             "Skills Pool 数据面已提交"
             if result.committed
             else "Skills Pool 数据面未提交"
+        ),
+    )
+
+
+@router.post(
+    "/layout/rollback",
+    response_model=PoolLayoutActivateApiResponse,
+)
+async def rollback_runtime_skills_layout(
+    body: PoolLayoutRollbackRequest,
+) -> PoolLayoutActivateApiResponse:
+    """从当前权威 Pool 内容重建 Legacy，并原子切换 local bridge。"""
+
+    plugin = _skills_plugin()
+    try:
+        result = await plugin.rollback_pool_layout(
+            PoolLayoutRollbackCommand(
+                rollback_generation=body.rollback_generation,
+                registered_local_names=body.registered_local_names,
+            )
+        )
+    except CapabilityNotSupportedError as error:
+        raise HTTPException(status_code=501, detail=str(error)) from error
+    return PoolLayoutActivateApiResponse(
+        success=result.committed,
+        data=PoolLayoutActivateResponse.model_validate(result.to_data()),
+        message=(
+            "Skills Pool 已显式回滚至 Legacy"
+            if result.committed
+            else "Skills Pool 显式回滚未提交"
         ),
     )
 

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -75,6 +75,11 @@ class PoolLayoutActivateRequest(BaseModel):
     mappings: list[SymlinkItem]
 
 
+class PoolLayoutRollbackRequest(BaseModel):
+    rollback_generation: str
+    registered_local_names: list[str]
+
+
 class PoolLayoutActivateResponse(BaseModel):
     committed: bool
     status: Literal[
@@ -113,6 +118,7 @@ __all__ = [
     "RuntimeLayoutProbeResponse",
     "RuntimeLayoutProbeApiResponse",
     "PoolLayoutActivateRequest",
+    "PoolLayoutRollbackRequest",
     "PoolLayoutActivateResponse",
     "PoolLayoutActivateApiResponse",
     "PoolMappingVerifyRequest",

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -102,24 +102,25 @@ class PoolLayoutActivateApiResponse(ApiResponse):
 
 class PoolMappingVerifyRequest(BaseModel):
     mappings: list[SymlinkItem]
+    source_layout: Literal["pool", "legacy"] = "pool"
 
 
 __all__ = [
-    "SymlinkItem",
-    "SyncSymlinkRequest",
-    "CleanSymlinkRequest",
     "BindPathItem",
     "BindPathRequest",
+    "CenterEnsureFailureSchema",
     "CenterEnsureItemSchema",
     "CenterEnsureRequestSchema",
-    "CenterEnsureFailureSchema",
     "CenterEnsureResponseSchema",
+    "CleanSymlinkRequest",
+    "PoolLayoutActivateApiResponse",
+    "PoolLayoutActivateRequest",
+    "PoolLayoutActivateResponse",
+    "PoolLayoutRollbackRequest",
+    "PoolMappingVerifyRequest",
+    "RuntimeLayoutProbeApiResponse",
     "RuntimeLayoutProbeRequest",
     "RuntimeLayoutProbeResponse",
-    "RuntimeLayoutProbeApiResponse",
-    "PoolLayoutActivateRequest",
-    "PoolLayoutRollbackRequest",
-    "PoolLayoutActivateResponse",
-    "PoolLayoutActivateApiResponse",
-    "PoolMappingVerifyRequest",
+    "SymlinkItem",
+    "SyncSymlinkRequest",
 ]

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -265,6 +265,13 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
             evidence={"bridge": "valid"},
         ),
     )
+    plugin.rollback_pool_layout = AsyncMock(
+        return_value=PoolLayoutActivationResult(
+            committed=True,
+            status=PoolLayoutActivationStatus.COMMITTED,
+            evidence={"source": "current_pool"},
+        ),
+    )
     plugin.publish_pool_mappings = AsyncMock(
         return_value=PoolMappingPublishResult(
             published=True,
@@ -289,6 +296,13 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
             "mappings": mappings,
         },
     )
+    rollback = client.post(
+        "/api/skills/layout/rollback",
+        json={
+            "rollback_generation": "rollback-1",
+            "registered_local_names": ["a"],
+        },
+    )
     published = client.post(
         "/api/skills/layout/mappings/publish",
         json={"mappings": mappings},
@@ -299,9 +313,11 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
     )
 
     assert activation.json()["data"]["committed"] is True
+    assert rollback.json()["data"]["committed"] is True
     assert published.json()["data"]["published"] is True
     assert verified.json()["data"]["valid"] is True
     plugin.activate_pool_layout.assert_awaited_once()
+    plugin.rollback_pool_layout.assert_awaited_once()
     plugin.publish_pool_mappings.assert_awaited_once()
     plugin.verify_pool_mappings.assert_awaited_once()
 
@@ -325,6 +341,14 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
                 "preparation_id": "preparation-1",
                 "registered_local_names": [],
                 "mappings": [],
+            },
+        ),
+        (
+            "rollback_pool_layout",
+            "/api/skills/layout/rollback",
+            {
+                "rollback_generation": "rollback-1",
+                "registered_local_names": [],
             },
         ),
         (

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -16,10 +16,10 @@ from fastapi.testclient import TestClient
 from engine.community.api.skills.router import router as skills_router
 from engine.community.core.engine.base import BaseEngine
 from engine.community.core.engine.capability import Capability, EngineCapabilities
-from engine.community.core.engine.registry import EngineRegistry
 from engine.community.core.engine.exceptions import (
     CapabilityNotSupportedError,
 )
+from engine.community.core.engine.registry import EngineRegistry
 from engine.community.core.skills.models import (
     CleanSymlinksResult,
     PoolLayoutActivationResult,
@@ -27,7 +27,9 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeResult,
     PoolLayoutProbeStatus,
     PoolMappingPublishResult,
+    PoolMappingSourceLayout,
     PoolMappingVerificationResult,
+    SymlinkItem,
     SyncSymlinksResult,
 )
 from engine.community.manager import EngineManager
@@ -305,11 +307,11 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
     )
     published = client.post(
         "/api/skills/layout/mappings/publish",
-        json={"mappings": mappings},
+        json={"mappings": mappings, "source_layout": "legacy"},
     )
     verified = client.post(
         "/api/skills/layout/mappings/verify",
-        json={"mappings": mappings},
+        json={"mappings": mappings, "source_layout": "legacy"},
     )
 
     assert activation.json()["data"]["committed"] is True
@@ -318,8 +320,18 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
     assert verified.json()["data"]["valid"] is True
     plugin.activate_pool_layout.assert_awaited_once()
     plugin.rollback_pool_layout.assert_awaited_once()
-    plugin.publish_pool_mappings.assert_awaited_once()
-    plugin.verify_pool_mappings.assert_awaited_once()
+    plugin.publish_pool_mappings.assert_awaited_once_with(
+        [
+            SymlinkItem(source="/pool/a", target="/skills/a"),
+        ],
+        source_layout=PoolMappingSourceLayout.LEGACY,
+    )
+    plugin.verify_pool_mappings.assert_awaited_once_with(
+        [
+            SymlinkItem(source="/pool/a", target="/skills/a"),
+        ],
+        source_layout=PoolMappingSourceLayout.LEGACY,
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -48,6 +48,7 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeStatus,
     PoolLayoutRollbackRequest,
     PoolMappingPublishResult,
+    PoolMappingSourceLayout,
     PoolMappingVerificationResult,
     Skill,
     SkillConfig,
@@ -55,10 +56,10 @@ from engine.community.core.skills.models import (
     SkillExecutionResult,
     SkillStatus,
     SkillType,
+    SymlinkItem,
     SyncBindPathsRequest,
     SyncSymlinksRequest,
     SyncSymlinksResult,
-    SymlinkItem,
 )
 from engine.community.core.skills.protocol import SkillsService
 from engine.community.plugin_api.claude_code.skills import ClaudeCodeSkillsPort
@@ -424,13 +425,16 @@ class ClaudeCodeSkillsAdapter(SkillsService):
     async def publish_pool_mappings(
         self,
         mappings: list[SymlinkItem],
+        *,
+        source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         auth: AuthContext | None = None,
     ) -> PoolMappingPublishResult:
         raw = await self._port.publish_pool_mappings(
             {
                 "mappings": [
                     {"source": item.source, "target": item.target} for item in mappings
-                ]
+                ],
+                "source_layout": source_layout.value,
             }
         )
         return PoolMappingPublishResult(
@@ -441,13 +445,16 @@ class ClaudeCodeSkillsAdapter(SkillsService):
     async def verify_pool_mappings(
         self,
         mappings: list[SymlinkItem],
+        *,
+        source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         auth: AuthContext | None = None,
     ) -> PoolMappingVerificationResult:
         raw = await self._port.verify_pool_mappings(
             {
                 "mappings": [
                     {"source": item.source, "target": item.target} for item in mappings
-                ]
+                ],
+                "source_layout": source_layout.value,
             }
         )
         return PoolMappingVerificationResult(

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -46,6 +46,7 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeRequest,
     PoolLayoutProbeResult,
     PoolLayoutProbeStatus,
+    PoolLayoutRollbackRequest,
     PoolMappingPublishResult,
     PoolMappingVerificationResult,
     Skill,
@@ -386,6 +387,38 @@ class ClaudeCodeSkillsAdapter(SkillsService):
                 else None
             ),
             evidence=dict(raw.get("evidence") or {}),
+        )
+
+    async def rollback_pool_layout(
+        self,
+        request: PoolLayoutRollbackRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutActivationResult:
+        raw = await self._port.rollback_pool_layout(
+            {
+                "rollback_generation": request.rollback_generation,
+                "registered_local_names": request.registered_local_names,
+            }
+        )
+        raw_status = str(raw.get("status", ""))
+        try:
+            status = PoolLayoutActivationStatus(raw_status)
+        except ValueError:
+            status = PoolLayoutActivationStatus.UNKNOWN
+        evidence = dict(raw.get("evidence") or {})
+        if status is PoolLayoutActivationStatus.UNKNOWN:
+            evidence["raw_status"] = raw_status
+        return PoolLayoutActivationResult(
+            committed=(
+                raw.get("committed") is True
+                and status
+                in {
+                    PoolLayoutActivationStatus.COMMITTED,
+                    PoolLayoutActivationStatus.ALREADY_COMMITTED,
+                }
+            ),
+            status=status,
+            evidence=evidence,
         )
 
     async def publish_pool_mappings(

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -39,15 +39,16 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeStatus,
     PoolLayoutRollbackRequest,
     PoolMappingPublishResult,
+    PoolMappingSourceLayout,
     PoolMappingVerificationResult,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
     SkillExecutionResult,
+    SymlinkItem,
     SyncBindPathsRequest,
     SyncSymlinksRequest,
     SyncSymlinksResult,
-    SymlinkItem,
 )
 from engine.community.core.skills.protocol import SkillsService
 from engine.community.plugin_api.openclaw.skills import OpenClawSkillsPort
@@ -238,6 +239,8 @@ class OpenClawSkillsAdapter(SkillsService):
     async def publish_pool_mappings(
         self,
         mappings: list[SymlinkItem],
+        *,
+        source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         auth: AuthContext | None = None,
     ) -> PoolMappingPublishResult:
         raw = await self._port.publish_pool_mappings(
@@ -245,7 +248,8 @@ class OpenClawSkillsAdapter(SkillsService):
                 "mappings": [
                     {"source": item.source, "target": item.target}
                     for item in mappings
-                ]
+                ],
+                "source_layout": source_layout.value,
             }
         )
         return PoolMappingPublishResult(
@@ -256,6 +260,8 @@ class OpenClawSkillsAdapter(SkillsService):
     async def verify_pool_mappings(
         self,
         mappings: list[SymlinkItem],
+        *,
+        source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         auth: AuthContext | None = None,
     ) -> PoolMappingVerificationResult:
         raw = await self._port.verify_pool_mappings(
@@ -263,7 +269,8 @@ class OpenClawSkillsAdapter(SkillsService):
                 "mappings": [
                     {"source": item.source, "target": item.target}
                     for item in mappings
-                ]
+                ],
+                "source_layout": source_layout.value,
             }
         )
         return PoolMappingVerificationResult(

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -37,6 +37,7 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeRequest,
     PoolLayoutProbeResult,
     PoolLayoutProbeStatus,
+    PoolLayoutRollbackRequest,
     PoolMappingPublishResult,
     PoolMappingVerificationResult,
     Skill,
@@ -200,6 +201,38 @@ class OpenClawSkillsAdapter(SkillsService):
                 else None
             ),
             evidence=dict(raw.get("evidence") or {}),
+        )
+
+    async def rollback_pool_layout(
+        self,
+        request: PoolLayoutRollbackRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutActivationResult:
+        raw = await self._port.rollback_pool_layout(
+            {
+                "rollback_generation": request.rollback_generation,
+                "registered_local_names": request.registered_local_names,
+            }
+        )
+        raw_status = str(raw.get("status", ""))
+        try:
+            status = PoolLayoutActivationStatus(raw_status)
+        except ValueError:
+            status = PoolLayoutActivationStatus.UNKNOWN
+        evidence = dict(raw.get("evidence") or {})
+        if status is PoolLayoutActivationStatus.UNKNOWN:
+            evidence["raw_status"] = raw_status
+        return PoolLayoutActivationResult(
+            committed=(
+                raw.get("committed") is True
+                and status
+                in {
+                    PoolLayoutActivationStatus.COMMITTED,
+                    PoolLayoutActivationStatus.ALREADY_COMMITTED,
+                }
+            ),
+            status=status,
+            evidence=evidence,
         )
 
     async def publish_pool_mappings(

--- a/src/engine/src/engine/community/core/skills/models.py
+++ b/src/engine/src/engine/community/core/skills/models.py
@@ -189,6 +189,14 @@ class PoolLayoutActivateRequest:
 
 
 @dataclass
+class PoolLayoutRollbackRequest:
+    """Explicit Pool→Legacy rollback from the current authoritative Pool."""
+
+    rollback_generation: str
+    registered_local_names: list[str] = field(default_factory=list)
+
+
+@dataclass
 class PoolLayoutProbeRequest:
     """运行时 Pool layout 核验请求。"""
 
@@ -283,6 +291,7 @@ __all__ = [
     "CleanSymlinksRequest",
     "CleanSymlinksResult",
     "PoolLayoutActivateRequest",
+    "PoolLayoutRollbackRequest",
     "PoolLayoutActivationResult",
     "PoolLayoutActivationStatus",
     "PoolLayoutProbeRequest",

--- a/src/engine/src/engine/community/core/skills/models.py
+++ b/src/engine/src/engine/community/core/skills/models.py
@@ -261,6 +261,13 @@ class PoolLayoutActivationStatus(StrEnum):
     UNKNOWN = "UNKNOWN"
 
 
+class PoolMappingSourceLayout(StrEnum):
+    """Layout whose canonical roots mapping sources must use."""
+
+    POOL = "pool"
+    LEGACY = "legacy"
+
+
 @dataclass
 class PoolMappingPublishResult:
     """Pool mapping 全量发布结果。"""
@@ -291,13 +298,14 @@ __all__ = [
     "CleanSymlinksRequest",
     "CleanSymlinksResult",
     "PoolLayoutActivateRequest",
-    "PoolLayoutRollbackRequest",
     "PoolLayoutActivationResult",
     "PoolLayoutActivationStatus",
     "PoolLayoutProbeRequest",
     "PoolLayoutProbeResult",
     "PoolLayoutProbeStatus",
+    "PoolLayoutRollbackRequest",
     "PoolMappingPublishResult",
+    "PoolMappingSourceLayout",
     "PoolMappingVerificationResult",
     "Skill",
     "SkillConfig",

--- a/src/engine/src/engine/community/core/skills/protocol.py
+++ b/src/engine/src/engine/community/core/skills/protocol.py
@@ -31,19 +31,20 @@ from engine.community.core.skills.models import (
     CleanSymlinksResult,
     PoolLayoutActivateRequest,
     PoolLayoutActivationResult,
-    PoolLayoutRollbackRequest,
     PoolLayoutProbeRequest,
     PoolLayoutProbeResult,
+    PoolLayoutRollbackRequest,
     PoolMappingPublishResult,
+    PoolMappingSourceLayout,
     PoolMappingVerificationResult,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
     SkillExecutionResult,
+    SymlinkItem,
     SyncBindPathsRequest,
     SyncSymlinksRequest,
     SyncSymlinksResult,
-    SymlinkItem,
 )
 
 
@@ -195,6 +196,8 @@ class SkillsService(Protocol):
     async def publish_pool_mappings(
         self,
         mappings: list[SymlinkItem],
+        *,
+        source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         auth: AuthContext | None = None,
     ) -> PoolMappingPublishResult:
         """发布目标 Pool layout 的完整受管 mapping。"""
@@ -203,6 +206,8 @@ class SkillsService(Protocol):
     async def verify_pool_mappings(
         self,
         mappings: list[SymlinkItem],
+        *,
+        source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         auth: AuthContext | None = None,
     ) -> PoolMappingVerificationResult:
         """验证当前受管入口精确指向请求中的 Pool source。"""

--- a/src/engine/src/engine/community/core/skills/protocol.py
+++ b/src/engine/src/engine/community/core/skills/protocol.py
@@ -31,6 +31,7 @@ from engine.community.core.skills.models import (
     CleanSymlinksResult,
     PoolLayoutActivateRequest,
     PoolLayoutActivationResult,
+    PoolLayoutRollbackRequest,
     PoolLayoutProbeRequest,
     PoolLayoutProbeResult,
     PoolMappingPublishResult,
@@ -173,6 +174,14 @@ class SkillsService(Protocol):
         auth: AuthContext | None = None,
     ) -> PoolLayoutActivationResult:
         """核对登记事实、同步完整 local 并原子提交 Legacy→Pool bridge。"""
+        ...
+
+    async def rollback_pool_layout(
+        self,
+        request: PoolLayoutRollbackRequest,
+        auth: AuthContext | None = None,
+    ) -> PoolLayoutActivationResult:
+        """从当前 Pool 重建 Legacy local 并原子切回。"""
         ...
 
     async def probe_pool_layout(

--- a/src/engine/src/engine/community/plugin_api/README.md
+++ b/src/engine/src/engine/community/plugin_api/README.md
@@ -8,7 +8,8 @@ Per-engine plugin Protocol declarations — the shared abstraction both the
 ```yaml
 purpose: "Per-engine plugin Protocols (OpenClawPlugin, …) — the native-shaped interface each engine's ACL adapter delegates to."
 provides:
-  - "(none yet — per-engine ports land in F2)"
+  - "OpenClawPlugin and its per-domain native port Protocols"
+  - "ClaudeCodePlugin and its per-domain native port Protocols"
 consumes:
   []
 internal_dependencies:
@@ -17,8 +18,9 @@ internal_dependencies:
 
 ### Change impact
 
-Empty skeleton in F1. Once populated (F2+), changing a port Protocol's
-signature breaks that engine's `plugins/{prod,local}/<engine>/` impl and its
-`core/adapters/<engine>/` adapter — and nothing else, since the port is the
-only contract crossing the core↔plugins boundary. This package imports neither
-`engine.community.core` nor `engine.plugins`; that is what keeps the graph acyclic.
+Changing a port Protocol's signature affects that engine's plugin
+implementation, its `core/adapters/<engine>/` adapter, and the shared skills
+HTTP delivery surface. Skills Pool rollback is additive: new Backend and new
+Engine use `rollback_pool_layout`; old images remain compatible until an
+operator explicitly requests rollback. This package imports neither
+`engine.community.core` nor `engine.plugins`, preserving the acyclic graph.

--- a/src/engine/src/engine/community/plugin_api/claude_code/README.md
+++ b/src/engine/src/engine/community/plugin_api/claude_code/README.md
@@ -20,8 +20,10 @@ internal_dependencies:
 ### Change impact
 
 Imports only `engine.community.kernel` (+ stdlib/typing) — never `core`, `plugins`, or
-`api`. A change to a port method signature ripples to exactly two places: the
-prod impl that satisfies it and the adapter that calls it. The port grows one
+`api`. A change to a port method signature ripples to the plugin implementation,
+the adapter that calls it, and the shared skills delivery contract.
+`rollback_pool_layout` is additive and is invoked only by explicit
+Pool-to-Legacy recovery; old images remain valid for ordinary operation. The port grows one
 per-domain Protocol per vertical slice; see
 `specs/2026-07-01-engine-claude-code-acl-opensource/` for the full method
 catalog and the native-shape / token conventions.

--- a/src/engine/src/engine/community/plugin_api/claude_code/skills.py
+++ b/src/engine/src/engine/community/plugin_api/claude_code/skills.py
@@ -231,6 +231,21 @@ class ClaudeCodeSkillsPort(Protocol):
         """Atomically switch Claude Code's physical Legacy local to Pool."""
         ...
 
+    async def rollback_pool_layout(
+        self,
+        params: dict,
+    ) -> dict:
+        """Atomically rebuild and switch Claude Code back to Legacy local.
+
+        ``params`` requires ``rollback_generation`` (str) and
+        ``registered_local_names`` (list[str]). The result requires
+        ``committed`` (bool), ``status`` (a Pool activation status string),
+        and ``evidence`` (dict). Only ``COMMITTED`` and
+        ``ALREADY_COMMITTED`` mean the filesystem authority changed;
+        consumers must fail closed for unknown status values.
+        """
+        ...
+
     async def probe_pool_layout(
         self,
         params: dict,

--- a/src/engine/src/engine/community/plugin_api/claude_code/skills.py
+++ b/src/engine/src/engine/community/plugin_api/claude_code/skills.py
@@ -257,14 +257,14 @@ class ClaudeCodeSkillsPort(Protocol):
         self,
         params: dict,
     ) -> dict:
-        """Publish the complete managed mapping set under ``~/.claude/skills``."""
+        """Publish mappings from the declared ``source_layout``."""
         ...
 
     async def verify_pool_mappings(
         self,
         params: dict,
     ) -> dict:
-        """Verify managed Claude Code entries against Pool sources."""
+        """Verify mappings against the declared ``source_layout``."""
         ...
 
 

--- a/src/engine/src/engine/community/plugin_api/openclaw/README.md
+++ b/src/engine/src/engine/community/plugin_api/openclaw/README.md
@@ -20,8 +20,10 @@ internal_dependencies:
 ### Change impact
 
 Imports only `engine.community.kernel` (+ stdlib/typing) — never `core`, `plugins`, or
-`api`. A change to a port method signature ripples to exactly two places: the
-prod impl that satisfies it and the adapter that calls it. The port grows one
+`api`. A change to a port method signature ripples to the plugin implementation,
+the adapter that calls it, and the shared skills delivery contract.
+`rollback_pool_layout` is additive and is invoked only by explicit
+Pool-to-Legacy recovery; old images remain valid for ordinary operation. The port grows one
 per-domain Protocol per vertical slice in Groups C (gateway) and D (local-infra);
 see `specs/2026-05-31-engine-arch-f2-openclaw-acl/port-design-notes.md` for the
 full method catalog and the native-shape / token conventions.

--- a/src/engine/src/engine/community/plugin_api/openclaw/skills.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/skills.py
@@ -132,13 +132,13 @@ class OpenClawSkillsPort(Protocol):
     async def publish_pool_mappings(
         self, params: dict[str, Any]
     ) -> dict[str, Any]:
-        """发布目标 Pool layout 的完整受管 mapping。"""
+        """发布受管 mapping；``source_layout`` 缺省为 ``pool``。"""
         ...
 
     async def verify_pool_mappings(
         self, params: dict[str, Any]
     ) -> dict[str, Any]:
-        """验证受管入口精确解析到目标 Pool source。"""
+        """按 ``source_layout`` 验证受管入口的 source。"""
         ...
 
 

--- a/src/engine/src/engine/community/plugin_api/openclaw/skills.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/skills.py
@@ -108,6 +108,21 @@ class OpenClawSkillsPort(Protocol):
         """核对登记事实、同步完整 local 并原子提交永久兼容 bridge。"""
         ...
 
+    async def rollback_pool_layout(
+        self,
+        params: dict,
+    ) -> dict:
+        """Atomically rebuild and switch OpenClaw back to Legacy local.
+
+        ``params`` requires ``rollback_generation`` (str) and
+        ``registered_local_names`` (list[str]). The result requires
+        ``committed`` (bool), ``status`` (a Pool activation status string),
+        and ``evidence`` (dict). Only ``COMMITTED`` and
+        ``ALREADY_COMMITTED`` mean the filesystem authority changed;
+        consumers must fail closed for unknown status values.
+        """
+        ...
+
     async def probe_pool_layout(
         self, params: dict[str, Any]
     ) -> dict[str, Any]:

--- a/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
@@ -8,13 +8,18 @@ from typing import Callable
 
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingPublishResult,
+    MappingSourceLayout,
     MappingVerificationResult,
     PoolActivationResult,
     PoolActivationStatus,
     SkillMapping,
     activate_aicoding_pool,
-    publish_pool_mappings as _publish_pool_mappings,
     rollback_aicoding_pool,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
+    publish_pool_mappings as _publish_pool_mappings,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
     verify_skill_mappings as _verify_skill_mappings,
 )
 from engine.community.plugins.skills_pool.layout_probe import (
@@ -42,30 +47,35 @@ def inspect_aicoding_runtime_layout(
 def publish_aicoding_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingPublishResult:
     return _publish_pool_mappings(
         mappings=mappings,
         home=home,
         engine="aicoding",
+        source_layout=source_layout,
     )
 
 
 def verify_aicoding_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingVerificationResult:
     return _verify_skill_mappings(
         mappings=mappings,
         home=home,
         engine="aicoding",
+        source_layout=source_layout,
     )
 
 
 __all__ = [
     "LAYOUT_CONTRACT_VERSION",
     "MappingPublishResult",
+    "MappingSourceLayout",
     "MappingVerificationResult",
     "PoolActivationResult",
     "PoolActivationStatus",

--- a/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
@@ -14,6 +14,7 @@ from engine.community.plugins.skills_pool.layout_activation import (
     SkillMapping,
     activate_aicoding_pool,
     publish_pool_mappings as _publish_pool_mappings,
+    rollback_aicoding_pool,
     verify_skill_mappings as _verify_skill_mappings,
 )
 from engine.community.plugins.skills_pool.layout_probe import (
@@ -74,5 +75,6 @@ __all__ = [
     "activate_aicoding_pool",
     "inspect_aicoding_runtime_layout",
     "publish_aicoding_pool_mappings",
+    "rollback_aicoding_pool",
     "verify_aicoding_pool_mappings",
 ]

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -10,6 +10,7 @@ from engine.community.plugins.aicoding.layout_pool import (
     activate_aicoding_pool,
     inspect_aicoding_runtime_layout,
     publish_aicoding_pool_mappings,
+    rollback_aicoding_pool,
     verify_aicoding_pool_mappings,
 )
 
@@ -147,6 +148,41 @@ def test_aicoding_activation_switches_local_and_keeps_repo_namespace(
     assert local_bridge.resolve() == pool_local.resolve()
     assert repo_bridge.resolve() == pool_repo.resolve()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
+
+
+def test_aicoding_rollback_rebuilds_legacy_from_current_pool(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, _, _, pool_local, pool_repo = _prepared_home(tmp_path)
+    activated = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    (pool_local / "handmade" / "SKILL.md").write_text("after-activation")
+    (pool_local / "new-local").mkdir()
+    (pool_local / "new-local" / "SKILL.md").write_text("new")
+
+    rolled_back = rollback_aicoding_pool(
+        rollback_generation="rollback-1",
+        registered_local_names=["handmade"],
+        home=home,
+    )
+
+    assert rolled_back.status is PoolActivationStatus.COMMITTED
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert (legacy_local / "handmade" / "SKILL.md").read_text() == (
+        "after-activation"
+    )
+    assert (legacy_local / "new-local" / "SKILL.md").read_text() == "new"
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
+        "after-activation"
+    )
 
 
 def test_aicoding_publishes_and_verifies_only_its_pool_sources(

--- a/src/engine/src/engine/community/plugins/claude_code/_skills.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_skills.py
@@ -15,6 +15,7 @@ import logging
 from typing import Any
 
 from engine.community.plugins.claude_code.layout_pool import (
+    MappingSourceLayout,
     SkillMapping,
     activate_claude_code_pool,
     inspect_claude_code_runtime_layout,
@@ -94,6 +95,9 @@ class _SkillsPortMixin:
         result = await asyncio.to_thread(
             publish_claude_code_pool_mappings,
             mappings=self._pool_mappings(params),
+            source_layout=MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
         )
         return result.to_data()
 
@@ -104,6 +108,9 @@ class _SkillsPortMixin:
         result = await asyncio.to_thread(
             verify_claude_code_pool_mappings,
             mappings=self._pool_mappings(params),
+            source_layout=MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
         )
         return result.to_data()
 

--- a/src/engine/src/engine/community/plugins/claude_code/_skills.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_skills.py
@@ -19,6 +19,7 @@ from engine.community.plugins.claude_code.layout_pool import (
     activate_claude_code_pool,
     inspect_claude_code_runtime_layout,
     publish_claude_code_pool_mappings,
+    rollback_claude_code_pool,
     verify_claude_code_pool_mappings,
 )
 
@@ -60,6 +61,19 @@ class _SkillsPortMixin:
             preparation_id=params["preparation_id"],
             registered_local_names=list(params.get("registered_local_names", [])),
             mappings=self._pool_mappings(params),
+        )
+        return result.to_data()
+
+    async def rollback_pool_layout(
+        self,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        result = await asyncio.to_thread(
+            rollback_claude_code_pool,
+            rollback_generation=params["rollback_generation"],
+            registered_local_names=list(
+                params.get("registered_local_names", [])
+            ),
         )
         return result.to_data()
 

--- a/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
@@ -13,13 +13,18 @@ from typing import Callable
 
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingPublishResult,
+    MappingSourceLayout,
     MappingVerificationResult,
     PoolActivationResult,
     PoolActivationStatus,
     SkillMapping,
     activate_claude_code_pool,
-    publish_pool_mappings as _publish_pool_mappings,
     rollback_claude_code_pool,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
+    publish_pool_mappings as _publish_pool_mappings,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
     verify_skill_mappings as _verify_skill_mappings,
 )
 from engine.community.plugins.skills_pool.layout_probe import (
@@ -47,30 +52,35 @@ def inspect_claude_code_runtime_layout(
 def publish_claude_code_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingPublishResult:
     return _publish_pool_mappings(
         mappings=mappings,
         home=home,
         engine="claude_code",
+        source_layout=source_layout,
     )
 
 
 def verify_claude_code_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingVerificationResult:
     return _verify_skill_mappings(
         mappings=mappings,
         home=home,
         engine="claude_code",
+        source_layout=source_layout,
     )
 
 
 __all__ = [
     "LAYOUT_CONTRACT_VERSION",
     "MappingPublishResult",
+    "MappingSourceLayout",
     "MappingVerificationResult",
     "PoolActivationResult",
     "PoolActivationStatus",

--- a/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
@@ -19,6 +19,7 @@ from engine.community.plugins.skills_pool.layout_activation import (
     SkillMapping,
     activate_claude_code_pool,
     publish_pool_mappings as _publish_pool_mappings,
+    rollback_claude_code_pool,
     verify_skill_mappings as _verify_skill_mappings,
 )
 from engine.community.plugins.skills_pool.layout_probe import (
@@ -79,5 +80,6 @@ __all__ = [
     "activate_claude_code_pool",
     "inspect_claude_code_runtime_layout",
     "publish_claude_code_pool_mappings",
+    "rollback_claude_code_pool",
     "verify_claude_code_pool_mappings",
 ]

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
@@ -9,6 +9,7 @@ import pytest
 from engine.community.plugins.claude_code.layout_pool import (
     LAYOUT_CONTRACT_VERSION,
     MappingPublishResult,
+    MappingSourceLayout,
     MappingVerificationResult,
     PoolActivationResult,
     PoolActivationStatus,
@@ -21,7 +22,6 @@ from engine.community.plugins.claude_code.layout_pool import (
     verify_claude_code_pool_mappings,
 )
 from engine.community.plugins.claude_code.plugin_impl import ClaudeCodePluginImpl
-
 
 PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
 
@@ -298,4 +298,5 @@ async def test_claude_code_port_runs_pool_filesystem_operations_off_loop(
         "mappings": [
             SkillMapping(source="/pool/handmade", target="/skills/handmade")
         ],
+        "source_layout": MappingSourceLayout.POOL,
     }

--- a/src/engine/src/engine/community/plugins/hermes/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/hermes/layout_pool.py
@@ -8,12 +8,18 @@ from typing import Callable
 
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingPublishResult,
+    MappingSourceLayout,
     MappingVerificationResult,
     PoolActivationResult,
     PoolActivationStatus,
     SkillMapping,
     activate_hermes_pool,
+    rollback_hermes_pool,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
     publish_pool_mappings as _publish_pool_mappings,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
     verify_skill_mappings as _verify_skill_mappings,
 )
 from engine.community.plugins.skills_pool.layout_probe import (
@@ -41,30 +47,35 @@ def inspect_hermes_runtime_layout(
 def publish_hermes_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingPublishResult:
     return _publish_pool_mappings(
         mappings=mappings,
         home=home,
         engine="hermes",
+        source_layout=source_layout,
     )
 
 
 def verify_hermes_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingVerificationResult:
     return _verify_skill_mappings(
         mappings=mappings,
         home=home,
         engine="hermes",
+        source_layout=source_layout,
     )
 
 
 __all__ = [
     "LAYOUT_CONTRACT_VERSION",
     "MappingPublishResult",
+    "MappingSourceLayout",
     "MappingVerificationResult",
     "PoolActivationResult",
     "PoolActivationStatus",
@@ -74,5 +85,6 @@ __all__ = [
     "activate_hermes_pool",
     "inspect_hermes_runtime_layout",
     "publish_hermes_pool_mappings",
+    "rollback_hermes_pool",
     "verify_hermes_pool_mappings",
 ]

--- a/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
@@ -10,6 +10,7 @@ from engine.community.plugins.hermes.layout_pool import (
     activate_hermes_pool,
     inspect_hermes_runtime_layout,
     publish_hermes_pool_mappings,
+    rollback_hermes_pool,
     verify_hermes_pool_mappings,
 )
 
@@ -185,6 +186,19 @@ def test_activation_switches_hermes_local_bridge_to_pool(tmp_path: Path) -> None
     assert published.published is True
     assert verified.valid is True
     assert (active_root / "handmade").resolve() == (pool_local / "handmade")
+
+    (pool_local / "handmade" / "SKILL.md").write_text("pool-write")
+    rolled_back = rollback_hermes_pool(
+        rollback_generation="rollback-1",
+        registered_local_names=["handmade"],
+        home=home,
+    )
+
+    assert rolled_back.status is PoolActivationStatus.COMMITTED
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert (legacy_local / "handmade" / "SKILL.md").read_text() == "pool-write"
+    assert local_bridge.resolve() == legacy_local.resolve()
 
 
 def test_mapping_rejects_openclaw_source_instead_of_falling_back(

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -16,6 +16,7 @@ from engine.community.plugin_api.openclaw.skills import (
 from engine.community.plugin_api.workspace_root import workspace_root
 from engine.community.plugins.openclaw._file import _convert_path
 from engine.community.plugins.openclaw.layout_activation import (
+    MappingSourceLayout,
     SkillMapping,
     activate_openclaw_pool,
     publish_pool_mappings,
@@ -97,6 +98,9 @@ class _SkillsPortMixin:
         result = await asyncio.to_thread(
             publish_pool_mappings,
             mappings=self._pool_mappings(params),
+            source_layout=MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
         )
         return result.to_data()
 
@@ -106,6 +110,9 @@ class _SkillsPortMixin:
         result = await asyncio.to_thread(
             verify_skill_mappings,
             mappings=self._pool_mappings(params),
+            source_layout=MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
         )
         return result.to_data()
 

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -19,6 +19,7 @@ from engine.community.plugins.openclaw.layout_activation import (
     SkillMapping,
     activate_openclaw_pool,
     publish_pool_mappings,
+    rollback_openclaw_pool,
     verify_skill_mappings,
 )
 from engine.community.plugins.openclaw.layout_probe import inspect_runtime_layout
@@ -65,6 +66,18 @@ class _SkillsPortMixin:
                 params.get("registered_local_names", [])
             ),
             mappings=self._pool_mappings(params),
+        )
+        return PoolLayoutActivationPortResult(**result.to_data())
+
+    async def rollback_pool_layout(
+        self, params: dict[str, Any]
+    ) -> PoolLayoutActivationPortResult:
+        result = await asyncio.to_thread(
+            rollback_openclaw_pool,
+            rollback_generation=params["rollback_generation"],
+            registered_local_names=list(
+                params.get("registered_local_names", [])
+            ),
         )
         return PoolLayoutActivationPortResult(**result.to_data())
 

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -261,22 +262,31 @@ def test_registered_local_missing_is_structured_data_inconsistency(
 
 def test_registered_local_unreadable_is_structured_data_inconsistency(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
     skill_file = legacy_local / "handmade" / "SKILL.md"
     prepared_content = (pool_local / "handmade" / "SKILL.md").read_text()
-    skill_file.chmod(0)
-    try:
-        result = activate_openclaw_pool(
-            migration_generation="generation-1",
-            preparation_id=PREPARATION_ID,
-            registered_local_names=["handmade"],
-            mappings=[],
-            home=home,
-            repo_is_mounted=lambda path: path == pool_repo,
-        )
-    finally:
-        skill_file.chmod(0o600)
+    real_access = os.access
+
+    def access_with_unreadable_skill(path: os.PathLike[str] | str, mode: int) -> bool:
+        if Path(path) == skill_file and mode & os.R_OK:
+            return False
+        return real_access(path, mode)
+
+    monkeypatch.setattr(
+        "engine.community.plugins.skills_pool.layout_activation.os.access",
+        access_with_unreadable_skill,
+    )
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
 
     assert result.status is PoolActivationStatus.DATA_INCONSISTENT
     assert result.evidence["reason"] == "registered_local_source_unreadable"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -16,6 +16,7 @@ from engine.community.core.skills.models import (
 )
 from engine.community.plugins.openclaw.layout_activation import (
     MappingPublishResult,
+    MappingSourceLayout,
     MappingVerificationResult,
     PoolActivationResult,
     PoolActivationStatus,
@@ -26,16 +27,15 @@ from engine.community.plugins.openclaw.layout_activation import (
     rollback_openclaw_pool,
     verify_skill_mappings,
 )
-from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
-from engine.community.plugins.openclaw.layout_probe import LAYOUT_CONTRACT_VERSION
 from engine.community.plugins.openclaw.layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
     RuntimeLayoutInspection,
     RuntimeLayoutInspectionStatus,
 )
 from engine.community.plugins.openclaw.layout_sync import (
     write_baseline_manifest,
 )
-
+from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
 
 PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
 
@@ -207,6 +207,43 @@ def test_explicit_rollback_rebuilds_legacy_from_current_pool_content(
         home=home,
     )
     assert repeated.status is PoolActivationStatus.ALREADY_COMMITTED
+
+
+def test_legacy_mapping_can_replace_pool_mapping_during_explicit_rollback(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    target = legacy_local.parent / "handmade"
+    pool_mapping = SkillMapping(source=str(pool_local / "handmade"), target=str(target))
+    activated = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[pool_mapping],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    assert publish_pool_mappings(mappings=[pool_mapping], home=home).published
+
+    legacy_mapping = SkillMapping(
+        source=str(legacy_local / "handmade"),
+        target=str(target),
+    )
+    published = publish_pool_mappings(
+        mappings=[legacy_mapping],
+        source_layout=MappingSourceLayout.LEGACY,
+        home=home,
+    )
+    verified = verify_skill_mappings(
+        mappings=[legacy_mapping],
+        source_layout=MappingSourceLayout.LEGACY,
+        home=home,
+    )
+
+    assert published.published
+    assert target.readlink() == legacy_local / "handmade"
+    assert verified.valid
 
 
 def test_cutover_rejects_missing_pool_mapping_source_before_bridge(

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -22,6 +22,7 @@ from engine.community.plugins.openclaw.layout_activation import (
     activate_openclaw_pool,
     atomic_exchange_paths,
     publish_pool_mappings,
+    rollback_openclaw_pool,
     verify_skill_mappings,
 )
 from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
@@ -148,6 +149,61 @@ def test_registered_local_cutover_syncs_latest_content_and_atomically_bridges(
         mappings=mappings,
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert repeated.status is PoolActivationStatus.ALREADY_COMMITTED
+
+
+def test_explicit_rollback_rebuilds_legacy_from_current_pool_content(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    mappings = [
+        SkillMapping(
+            source=str(pool_local / "handmade"),
+            target=str(legacy_local.parent / "handmade"),
+        )
+    ]
+    activated = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+
+    # These writes happened after Pool became authoritative and must survive.
+    (pool_local / "handmade" / "SKILL.md").write_text("pool-new-write")
+    (pool_local / "created-after-activation").mkdir()
+    (pool_local / "created-after-activation" / "SKILL.md").write_text("new")
+    external = legacy_local.parent / "external-unmanaged"
+    external.symlink_to(tmp_path / "external")
+
+    result = rollback_openclaw_pool(
+        rollback_generation="rollback-1",
+        registered_local_names=["handmade", "created-after-activation"],
+        home=home,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert (legacy_local / "handmade" / "SKILL.md").read_text() == (
+        "pool-new-write"
+    )
+    assert (
+        legacy_local / "created-after-activation" / "SKILL.md"
+    ).read_text() == "new"
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
+        "pool-new-write"
+    )
+    assert external.is_symlink()
+
+    repeated = rollback_openclaw_pool(
+        rollback_generation="rollback-1",
+        registered_local_names=["handmade", "created-after-activation"],
+        home=home,
     )
     assert repeated.status is PoolActivationStatus.ALREADY_COMMITTED
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -734,6 +734,179 @@ def activate_hermes_pool(
     )
 
 
+def _rollback_pool(
+    *,
+    engine: str,
+    rollback_generation: str,
+    registered_local_names: list[str],
+    home: str | Path = "/home/admin",
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+) -> PoolActivationResult:
+    """Rebuild Legacy from the current authoritative Pool tree, then swap."""
+
+    if not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", rollback_generation
+    ):
+        return _invalid("rollback_generation_invalid")
+    layout = _Layout.for_engine(engine, Path(home))
+    normalized_names: list[str] = []
+    for name in registered_local_names:
+        path = Path(name)
+        if (
+            not name
+            or path.is_absolute()
+            or len(path.parts) != 1
+            or name in {".", ".."}
+        ):
+            return _invalid("registered_local_name_invalid", name=name)
+        if name not in normalized_names:
+            normalized_names.append(name)
+
+    rebuild = layout.legacy_local.parent / (
+        f".skills-local.pool-rollback-{rollback_generation}"
+    )
+    copy_staging = layout.pool_root / (
+        f".rollback-copy-{rollback_generation}"
+    )
+    try:
+        if layout.legacy_local.is_dir() and not layout.legacy_local.is_symlink():
+            for name in normalized_names:
+                source = layout.legacy_local / name
+                if not source.is_dir() or source.is_symlink():
+                    return _data_inconsistent(
+                        "rebuilt_legacy_source_invalid",
+                        registered_name=name,
+                        source=str(source),
+                    )
+            return PoolActivationResult(
+                PoolActivationStatus.ALREADY_COMMITTED,
+                {
+                    "legacy_local": str(layout.legacy_local),
+                    "source": str(layout.pool_local),
+                },
+            )
+        if not layout.legacy_local.is_symlink() or _lexical_target(
+            layout.legacy_local
+        ) != Path(os.path.abspath(layout.pool_local)):
+            return _invalid("pool_local_bridge_invalid")
+        if not layout.pool_local.is_dir() or layout.pool_local.is_symlink():
+            return _data_inconsistent(
+                "pool_local_not_directory",
+                source=str(layout.pool_local),
+            )
+        if rebuild.is_symlink() or (
+            rebuild.exists() and not rebuild.is_dir()
+        ):
+            return _invalid("rollback_temporary_path_occupied", path=str(rebuild))
+        rebuild.mkdir(exist_ok=True)
+        local_names = mirror_local_tree(
+            source_root=layout.pool_local,
+            pool_local=rebuild,
+            staging_root=copy_staging,
+        )
+        for name in normalized_names:
+            source = rebuild / name
+            if not source.is_dir() or source.is_symlink():
+                return _data_inconsistent(
+                    "registered_pool_source_invalid",
+                    registered_name=name,
+                    source=str(source),
+                )
+        if not exchange_paths(layout.legacy_local, rebuild):
+            return PoolActivationResult(
+                PoolActivationStatus.NOT_ATOMIC,
+                {"reason": "atomic_exchange_unavailable"},
+            )
+        if not layout.legacy_local.is_dir() or layout.legacy_local.is_symlink():
+            return _invalid("rollback_result_ambiguous")
+        # The displaced object is only the compatibility symlink. Pool content
+        # itself remains intact for evidence and forward recovery.
+        rebuild.unlink(missing_ok=True)
+        return PoolActivationResult(
+            PoolActivationStatus.COMMITTED,
+            {
+                "legacy_local": str(layout.legacy_local),
+                "source": str(layout.pool_local),
+                "local_inventory": {
+                    "registered": len(normalized_names),
+                    "unregistered": len(
+                        set(local_names) - set(normalized_names)
+                    ),
+                    "total": len(local_names),
+                },
+            },
+        )
+    except OSError as error:
+        committed = (
+            layout.legacy_local.is_dir()
+            and not layout.legacy_local.is_symlink()
+        )
+        return PoolActivationResult(
+            (
+                PoolActivationStatus.COMMITTED
+                if committed
+                else PoolActivationStatus.TRANSIENT_ERROR
+            ),
+            {
+                "reason": (
+                    "post_rollback_cleanup_failed"
+                    if committed
+                    else "rollback_filesystem_operation_failed"
+                ),
+                "error_type": type(error).__name__,
+                "errno": error.errno,
+            },
+        )
+
+
+def rollback_openclaw_pool(
+    *,
+    rollback_generation: str,
+    registered_local_names: list[str],
+    home: str | Path = "/home/admin",
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+) -> PoolActivationResult:
+    return _rollback_pool(
+        engine="openclaw",
+        rollback_generation=rollback_generation,
+        registered_local_names=registered_local_names,
+        home=home,
+        exchange_paths=exchange_paths,
+    )
+
+
+def rollback_claude_code_pool(
+    *,
+    rollback_generation: str,
+    registered_local_names: list[str],
+    home: str | Path = "/home/admin",
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+) -> PoolActivationResult:
+    return _rollback_pool(
+        engine="claude_code",
+        rollback_generation=rollback_generation,
+        registered_local_names=registered_local_names,
+        home=home,
+        exchange_paths=exchange_paths,
+    )
+
+
+def rollback_aicoding_pool(
+    *,
+    rollback_generation: str,
+    registered_local_names: list[str],
+    home: str | Path = "/home/admin",
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+) -> PoolActivationResult:
+    return _rollback_pool(
+        engine="aicoding",
+        rollback_generation=rollback_generation,
+        registered_local_names=registered_local_names,
+        home=home,
+        exchange_paths=exchange_paths,
+    )
+
+
 def verify_skill_mappings(
     *,
     mappings: list[SkillMapping],
@@ -854,5 +1027,8 @@ __all__ = [
     "activate_openclaw_pool",
     "atomic_exchange_paths",
     "publish_pool_mappings",
+    "rollback_aicoding_pool",
+    "rollback_claude_code_pool",
+    "rollback_openclaw_pool",
     "verify_skill_mappings",
 ]

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -37,6 +37,13 @@ class PoolActivationStatus(StrEnum):
     NOT_ATOMIC = "NOT_ATOMIC"
 
 
+class MappingSourceLayout(StrEnum):
+    """Authority layout that mapping sources must belong to."""
+
+    POOL = "pool"
+    LEGACY = "legacy"
+
+
 @dataclass(frozen=True, slots=True)
 class SkillMapping:
     source: str
@@ -200,18 +207,23 @@ def _canonical_pool_source(layout: _Layout, source: Path) -> Path | None:
     return None
 
 
-def _pool_source_failure(layout: _Layout, source: Path) -> str | None:
-    """证明 source 是 canonical Pool root 内真实、可读的技能目录。"""
+def _managed_source_failure(
+    source: Path,
+    *,
+    roots: tuple[Path, ...],
+    outside_reason: str,
+) -> str | None:
+    """证明 source 是指定 layout root 内真实、可读的技能目录。"""
 
     normalized = Path(os.path.abspath(source))
     containing_root: Path | None = None
-    for root in (layout.pool_local, layout.pool_repo):
+    for root in roots:
         normalized_root = Path(os.path.abspath(root))
         if normalized.is_relative_to(normalized_root):
             containing_root = normalized_root
             break
     if containing_root is None:
-        return "source_outside_pool"
+        return outside_reason
     if not normalized.exists():
         return "source_missing"
     try:
@@ -227,6 +239,44 @@ def _pool_source_failure(layout: _Layout, source: Path) -> str | None:
     if unreadable is not None:
         return "source_unreadable"
     return None
+
+
+def _source_failure(
+    layout: _Layout,
+    source: Path,
+    *,
+    source_layout: MappingSourceLayout,
+) -> str | None:
+    if source_layout is MappingSourceLayout.LEGACY:
+        return _managed_source_failure(
+            source,
+            roots=(layout.legacy_local, layout.legacy_repo),
+            outside_reason="source_outside_legacy",
+        )
+    return _managed_source_failure(
+        source,
+        roots=(layout.pool_local, layout.pool_repo),
+        outside_reason="source_outside_pool",
+    )
+
+
+def _source_for_layout(
+    layout: _Layout,
+    pool_source: Path,
+    *,
+    source_layout: MappingSourceLayout,
+) -> Path:
+    if source_layout is MappingSourceLayout.POOL:
+        return pool_source
+    normalized = Path(os.path.abspath(pool_source))
+    for pool_root, legacy_root in (
+        (layout.pool_local, layout.legacy_local),
+        (layout.pool_repo, layout.legacy_repo),
+    ):
+        normalized_pool_root = Path(os.path.abspath(pool_root))
+        if normalized.is_relative_to(normalized_pool_root):
+            return legacy_root / normalized.relative_to(normalized_pool_root)
+    return pool_source
 
 
 def _active_entry_inventory(
@@ -254,6 +304,7 @@ def _mapping_plan(
     *,
     layout: _Layout,
     mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
 ) -> _MappingPlan:
     desired: dict[Path, Path] = {}
     failures: list[dict[str, str]] = []
@@ -264,9 +315,20 @@ def _mapping_plan(
         target = Path(mapping.target)
         reason = ""
         if not source_input.is_absolute():
-            reason = "source_outside_pool"
+            reason = (
+                "source_outside_legacy"
+                if source_layout is MappingSourceLayout.LEGACY
+                else "source_outside_pool"
+            )
         else:
-            reason = _pool_source_failure(layout, source) or ""
+            reason = (
+                _source_failure(
+                    layout,
+                    source,
+                    source_layout=source_layout,
+                )
+                or ""
+            )
         if not reason and (
             not target.is_absolute()
             or target.parent != layout.legacy_root
@@ -296,8 +358,17 @@ def _mapping_plan(
             desired[target] = source
 
     discovered, external, occupied = _active_entry_inventory(layout)
-    for target, source in discovered.items():
-        reason = _pool_source_failure(layout, source)
+    for target, pool_source in discovered.items():
+        source = _source_for_layout(
+            layout,
+            pool_source,
+            source_layout=source_layout,
+        )
+        reason = _source_failure(
+            layout,
+            source,
+            source_layout=source_layout,
+        )
         if reason:
             failures.append(
                 {
@@ -307,7 +378,11 @@ def _mapping_plan(
                 }
             )
             continue
-        if target in desired and desired[target] != source:
+        if (
+            source_layout is MappingSourceLayout.POOL
+            and target in desired
+            and desired[target] != source
+        ):
             conflicts.append(
                 {
                     "target": str(target),
@@ -315,7 +390,8 @@ def _mapping_plan(
                     "existing_source": str(source),
                 }
             )
-        desired[target] = source
+        if source_layout is MappingSourceLayout.POOL or target not in desired:
+            desired[target] = source
     for target in occupied:
         if target in desired:
             conflicts.append(
@@ -907,16 +983,37 @@ def rollback_aicoding_pool(
     )
 
 
+def rollback_hermes_pool(
+    *,
+    rollback_generation: str,
+    registered_local_names: list[str],
+    home: str | Path = "/home/admin",
+    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+) -> PoolActivationResult:
+    return _rollback_pool(
+        engine="hermes",
+        rollback_generation=rollback_generation,
+        registered_local_names=registered_local_names,
+        home=home,
+        exchange_paths=exchange_paths,
+    )
+
+
 def verify_skill_mappings(
     *,
     mappings: list[SkillMapping],
     home: str | Path = "/home/admin",
     engine: str = "openclaw",
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
 ) -> MappingVerificationResult:
-    """验证受管激活入口精确解析到请求中的 Pool source。"""
+    """验证受管激活入口精确解析到声明 layout 的 source。"""
 
     layout = _Layout.for_engine(engine, Path(home))
-    plan = _mapping_plan(layout=layout, mappings=mappings)
+    plan = _mapping_plan(
+        layout=layout,
+        mappings=mappings,
+        source_layout=source_layout,
+    )
     failures: list[dict[str, str]] = []
     failures.extend(plan.failures)
     for conflict in plan.conflicts:
@@ -947,11 +1044,16 @@ def publish_pool_mappings(
     mappings: list[SkillMapping],
     home: str | Path = "/home/admin",
     engine: str = "openclaw",
+    source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
 ) -> MappingPublishResult:
-    """按文件系统事实对齐全部受管 Pool mapping，并保留外部入口。"""
+    """按声明 layout 对齐全部受管 mapping，并保留外部入口。"""
 
     layout = _Layout.for_engine(engine, Path(home))
-    plan = _mapping_plan(layout=layout, mappings=mappings)
+    plan = _mapping_plan(
+        layout=layout,
+        mappings=mappings,
+        source_layout=source_layout,
+    )
     if plan.conflicts:
         return MappingPublishResult(
             published=False,
@@ -1016,8 +1118,9 @@ def publish_pool_mappings(
 
 
 __all__ = [
-    "MappingVerificationResult",
     "MappingPublishResult",
+    "MappingSourceLayout",
+    "MappingVerificationResult",
     "PoolActivationResult",
     "PoolActivationStatus",
     "SkillMapping",
@@ -1029,6 +1132,7 @@ __all__ = [
     "publish_pool_mappings",
     "rollback_aicoding_pool",
     "rollback_claude_code_pool",
+    "rollback_hermes_pool",
     "rollback_openclaw_pool",
     "verify_skill_mappings",
 ]

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -13,6 +13,7 @@ from engine.community.core.skills.models import (
     PoolLayoutActivationStatus,
     PoolLayoutProbeRequest,
     PoolLayoutProbeStatus,
+    PoolLayoutRollbackRequest,
     SymlinkItem,
 )
 
@@ -24,6 +25,13 @@ def _port() -> SimpleNamespace:
                 "committed": True,
                 "status": "COMMITTED",
                 "evidence": {"bridge": "claude-local"},
+            }
+        ),
+        rollback_pool_layout=AsyncMock(
+            return_value={
+                "committed": True,
+                "status": "COMMITTED",
+                "evidence": {"source": "current_pool"},
             }
         ),
         probe_pool_layout=AsyncMock(
@@ -67,6 +75,12 @@ async def test_claude_code_adapter_exposes_complete_pool_runtime_contract() -> N
             mappings=[mapping],
         )
     )
+    rolled_back = await adapter.rollback_pool_layout(
+        PoolLayoutRollbackRequest(
+            rollback_generation="rollback-1",
+            registered_local_names=["handmade"],
+        )
+    )
     published = await adapter.publish_pool_mappings([mapping])
     verified = await adapter.verify_pool_mappings([mapping])
 
@@ -74,6 +88,8 @@ async def test_claude_code_adapter_exposes_complete_pool_runtime_contract() -> N
     assert probe.engine == "claude_code"
     assert activated.status is PoolLayoutActivationStatus.COMMITTED
     assert activated.committed is True
+    assert rolled_back.status is PoolLayoutActivationStatus.COMMITTED
+    assert rolled_back.committed is True
     assert published.published is True
     assert verified.valid is True
     port.probe_pool_layout.assert_awaited_once_with(
@@ -93,6 +109,12 @@ async def test_claude_code_adapter_exposes_complete_pool_runtime_contract() -> N
                     "target": mapping.target,
                 }
             ],
+        }
+    )
+    port.rollback_pool_layout.assert_awaited_once_with(
+        {
+            "rollback_generation": "rollback-1",
+            "registered_local_names": ["handmade"],
         }
     )
     port.publish_pool_mappings.assert_awaited_once_with(
@@ -132,6 +154,28 @@ async def test_claude_code_adapter_unknown_activation_fails_closed() -> None:
             migration_generation="generation-1",
             preparation_id="prep-1",
         )
+    )
+
+    assert result.status is PoolLayoutActivationStatus.UNKNOWN
+    assert result.committed is False
+    assert result.evidence == {
+        "source": "newer-plugin",
+        "raw_status": "FUTURE_STATUS",
+    }
+
+
+@pytest.mark.asyncio
+async def test_claude_code_adapter_unknown_rollback_fails_closed() -> None:
+    port = _port()
+    port.rollback_pool_layout.return_value = {
+        "committed": True,
+        "status": "FUTURE_STATUS",
+        "evidence": {"source": "newer-plugin"},
+    }
+    adapter = ClaudeCodeSkillsAdapter(port)
+
+    result = await adapter.rollback_pool_layout(
+        PoolLayoutRollbackRequest(rollback_generation="rollback-1")
     )
 
     assert result.status is PoolLayoutActivationStatus.UNKNOWN

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -124,7 +124,8 @@ async def test_claude_code_adapter_exposes_complete_pool_runtime_contract() -> N
                     "source": mapping.source,
                     "target": mapping.target,
                 }
-            ]
+            ],
+            "source_layout": "pool",
         }
     )
     port.verify_pool_mappings.assert_awaited_once_with(
@@ -134,7 +135,8 @@ async def test_claude_code_adapter_exposes_complete_pool_runtime_contract() -> N
                     "source": mapping.source,
                     "target": mapping.target,
                 }
-            ]
+            ],
+            "source_layout": "pool",
         }
     )
 

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -10,6 +10,7 @@ from engine.community.core.adapters.openclaw.skills import OpenClawSkillsAdapter
 from engine.community.core.skills.models import (
     PoolLayoutActivateRequest,
     PoolLayoutActivationStatus,
+    PoolLayoutRollbackRequest,
 )
 
 
@@ -76,3 +77,65 @@ async def test_unknown_activation_status_fails_closed_and_preserves_evidence() -
         "raw_status": "FUTURE_STATUS",
     }
     port.activate_pool_layout.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_status", "committed"),
+    [
+        ("COMMITTED", True),
+        ("ALREADY_COMMITTED", True),
+        ("TRANSIENT_ERROR", False),
+        ("UNKNOWN", False),
+    ],
+)
+async def test_rollback_status_contract_and_port_call(
+    raw_status: str,
+    committed: bool,
+) -> None:
+    port = MagicMock()
+    port.rollback_pool_layout = AsyncMock(
+        return_value={
+            "committed": committed,
+            "status": raw_status,
+            "evidence": {"source": "current_pool"},
+        }
+    )
+    request = PoolLayoutRollbackRequest(
+        rollback_generation="rollback-1",
+        registered_local_names=["handmade"],
+    )
+
+    result = await OpenClawSkillsAdapter(port).rollback_pool_layout(request)
+
+    assert result.status is PoolLayoutActivationStatus(raw_status)
+    assert result.committed is committed
+    port.rollback_pool_layout.assert_awaited_once_with(
+        {
+            "rollback_generation": "rollback-1",
+            "registered_local_names": ["handmade"],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_rollback_status_fails_closed_and_preserves_raw_value() -> None:
+    port = MagicMock()
+    port.rollback_pool_layout = AsyncMock(
+        return_value={
+            "committed": True,
+            "status": "FUTURE_STATUS",
+            "evidence": {"source": "newer-plugin"},
+        }
+    )
+
+    result = await OpenClawSkillsAdapter(port).rollback_pool_layout(
+        PoolLayoutRollbackRequest(rollback_generation="rollback-1")
+    )
+
+    assert result.status is PoolLayoutActivationStatus.UNKNOWN
+    assert result.committed is False
+    assert result.evidence == {
+        "source": "newer-plugin",
+        "raw_status": "FUTURE_STATUS",
+    }


### PR DESCRIPTION
## Summary

- persist post-cutover failures and fence unknown bridge outcomes in `NEEDS_MANUAL_REPAIR`
- add operator resolution with durable retrigger, preserved evidence, and forward-only retries
- add explicit Pool-to-Legacy rollback from current Pool content, pre/post mapping verification, lease takeover, and atomic locator/layout commit
- expose rollback through the shared Engine API and OpenClaw/Claude Code/AICoding filesystem implementations

Closes #376

## Failure direction

- before cutover: Legacy remains authoritative
- after cutover: retry mapping, locator, and control-plane commit only
- unknown cutover: stop normal automation until an operator records the verified fact
- explicit rollback: enter a Bot-level edit-pause phase, rebuild Legacy from current Pool, verify mappings, atomically exchange, then transactionally restore locators

## Contract / compatibility impact

- additive Backend `SkillsPoolRuntimeProtocol.rollback_to_legacy`
- additive Engine `SkillsService.rollback_pool_layout` and `POST /api/skills/layout/rollback`
- affected consumers: Backend recovery service and Engine skills router
- affected implementations: OpenClaw, Claude Code, AICoding; OCB companion commit `d60fc04f14` wires the private AICoding service and pins this public commit
- old images remain compatible for normal Legacy/Pool operation; rollback is sent only after an explicit operator request to a capable runtime
- operator HTTP delivery and fleet reporting remain owned by #378

## Tests

- Backend full suite: `8724 passed`
- Engine full suite: `1963 passed, 5 skipped`
- post-review Backend recovery/repository/architecture tests: `22 passed`
- post-review Engine router/contract/multi-engine tests: `75 passed`
- OCB private AICoding contract tests: `3 passed`
- Ruff and `git diff --check`: passed
