### PR TITLE
fix(bcs): gate session-file access on session participants and relax share authz

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/session_files.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/session_files.rs
@@ -284,36 +284,54 @@ async fn caller_identities(state: &HttpAppState, caller: &GroupChatCaller) -> Ve
     }
 }
 
-/// Verify the caller is a member of the session's group: the session must
-/// exist, the group must exist, and the caller (bot or human) must be a
-/// participant or own a participating bot.
+/// Verify the caller is a member of the session and return the loaded session
+/// for reuse. Returns `None` when the session or its parent group is missing,
+/// or the caller is not a member (handler should 403).
+///
+/// Membership is judged against the session's *own* participants, not the
+/// group's seed: session participants are seeded from the group at creation
+/// and then evolve independently (see `Session::participants`). A participant
+/// may be added to a session without joining the parent group
+/// (`add_session_participant`), and the group's list may change without
+/// affecting an in-flight session. Checking `group.participants` here would
+/// wrongly deny a session-only participant or drift once the session diverges.
+///
+/// Returning the session lets mutate handlers (e.g. share) reuse the already
+/// loaded `participants` for service-layer authz instead of fetching again.
 async fn ensure_session_member(
     state: &HttpAppState,
     sid: &str,
     caller: &GroupChatCaller,
-) -> bool {
+) -> Option<bcs_service_api::Session> {
     let sess = match state.services.session_management.get(sid).await {
         Ok(Some(s)) => s,
-        _ => return false,
+        _ => return None,
     };
-    let group = match state.services.group.get(&sess.group_id).await {
-        Some(g) => g,
-        None => return false,
-    };
-    match caller {
-        GroupChatCaller::Bot { bot_uuid } => group
+    // The session is always scoped to a parent group; require it to still
+    // exist. Membership, however, is judged against the session's own
+    // participants — not the group's seed.
+    if state.services.group.get(&sess.group_id).await.is_none() {
+        return None;
+    }
+    let is_member = match caller {
+        GroupChatCaller::Bot { bot_uuid } => sess
             .participants
             .iter()
             .any(|p| &p.bot_uuid == bot_uuid),
         GroupChatCaller::Human(h) => {
-            crate::routes::sessions::human_has_group_access(
+            crate::routes::sessions::human_has_session_access(
                 state,
-                &group,
+                &sess,
                 &h.actor_id,
                 &h.staff_no,
             )
             .await
         }
+    };
+    if is_member {
+        Some(sess)
+    } else {
+        None
     }
 }
 
@@ -354,7 +372,7 @@ pub async fn prepare_upload(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     let cmd = PrepareUploadCommand {
@@ -389,7 +407,7 @@ pub async fn upload_bytes(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     let part = uri
@@ -431,7 +449,7 @@ pub async fn complete_upload(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     match state
@@ -459,7 +477,7 @@ pub async fn delete_file(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     let (session_creator, driver_bot) = resolve_mutate_authz(&state, &sid).await;
@@ -488,7 +506,7 @@ pub async fn list_files(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     let status: Option<FileStatus> = match q.status.as_deref() {
@@ -530,7 +548,7 @@ pub async fn get_file(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     match state.services.session_files.get(&sid, &file_id).await {
@@ -549,7 +567,7 @@ pub async fn capabilities(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     let c: CapabilitiesView = state.services.session_files.capabilities().await;
@@ -571,7 +589,7 @@ pub async fn download_content(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
+    if ensure_session_member(&state, &sid, &caller).await.is_none() {
         return forbidden_not_participant();
     }
     download_file_by_id(&state, &sid, &file_id, q.ttl).await
@@ -636,18 +654,21 @@ pub async fn share_mint(
         Ok(c) => c,
         Err(_) => return unauthorized(),
     };
-    if !ensure_session_member(&state, &sid, &caller).await {
-        return forbidden_not_participant();
-    }
-    let (session_creator, driver_bot) = resolve_mutate_authz(&state, &sid).await;
+    let sess = match ensure_session_member(&state, &sid, &caller).await {
+        Some(s) => s,
+        None => return forbidden_not_participant(),
+    };
     let cmd = ShareMintCommand {
         session_id: sid,
         file_id,
         caller: caller_to_actor_ref(&caller),
         ttl_seconds: body.ttl_seconds,
         caller_identities: caller_identities(&state, &caller).await,
-        session_creator,
-        driver_bot,
+        session_participants: sess
+            .participants
+            .iter()
+            .map(|p| p.bot_uuid.clone())
+            .collect(),
     };
     match state.services.session_files.share_mint(cmd).await {
         Ok(r) => (

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -111,6 +111,34 @@ pub(crate) async fn human_has_group_access(
         .any(|b| group.participants.iter().any(|p| p.bot_uuid == b.bot_uuid))
 }
 
+/// Check whether the Human identified by `actor_id` / `staff_no` has access
+/// to the given session. The Human has access if any of:
+///   1. The Human's actor_id is a participant in the session.
+///   2. The Human owns at least one bot that is a participant in the session.
+///
+/// Session participants are the authoritative set for session-scoped access
+/// (seeded from the group at creation, then evolving independently); this
+/// mirrors `human_has_group_access` but judges membership against
+/// `session.participants` rather than `group.participants`.
+pub(crate) async fn human_has_session_access(
+    state: &HttpAppState,
+    session: &bcs_service_api::Session,
+    actor_id: &str,
+    staff_no: &str,
+) -> bool {
+    if session
+        .participants
+        .iter()
+        .any(|p| p.bot_uuid == actor_id)
+    {
+        return true;
+    }
+    let owned = state.services.registry.list_bots_by_creator(staff_no).await;
+    owned
+        .iter()
+        .any(|b| session.participants.iter().any(|p| p.bot_uuid == b.bot_uuid))
+}
+
 pub fn session_error_to_response(err: &bcs_service_api::SessionUseCaseError) -> Response {
     let (code, msg) = match err {
         bcs_service_api::SessionUseCaseError::NotFound(s) => (StatusCode::NOT_FOUND, s.clone()),

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_files_member_gate_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_files_member_gate_contract.rs
@@ -1,0 +1,498 @@
+//! HTTP contract tests for the session-file member gate (`ensure_session_member`)
+//! and the `human_has_session_access` helper.
+//!
+//! The gate must judge membership against the session's *own* participants
+//! (not the group seed), accept a Human caller through a bot they own, and
+//! reject non-members as well as missing sessions / missing parent groups.
+//! The share handler resolves `session_participants` from the already-loaded
+//! session and delegates membership authz to the service, so only the gate
+//! differs between share and the read routes here (the service is the noop
+//! default, which returns 500 for share_mint — proving the gate passed).
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{HeaderMap, Request, StatusCode},
+};
+use bcs_auth_api::{AuthError, UserIdentityInfo};
+use bcs_bot::BotCore;
+use bcs_group::GroupStore;
+use bcs_http::{
+    router::build_router,
+    state::{HttpAppState, HttpUserIdentity, UserIdentityPort},
+};
+use bcs_service_api::{
+    ActorKind, BotCapabilities, BotRegistryCoreService, CreateOrReactivateCommand,
+    CreateOrReactivateOutcome, Group, GroupCoreService, Participant, ParticipantMode,
+    ParticipantRole, Session, SessionKind, SessionManagementService, SessionStatus,
+    SessionUseCaseError,
+};
+use bcs_services_container::Services;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+const SID: &str = "group-1:00000001";
+
+// ---- read routes: list / capabilities ------------------------------------
+
+#[tokio::test]
+async fn gate_allows_session_member_bot_on_list() {
+    let (app, _t) = bot_app("group-1", true).await;
+    let resp = get(&app, SID, "Bearer driver-token").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn gate_allows_session_member_bot_on_capabilities() {
+    let (app, _t) = bot_app("group-1", true).await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/sessions/{SID}/files/capabilities"))
+                .header("authorization", "Bearer worker-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn gate_rejects_non_member_bot() {
+    let (app, _t) = bot_app("group-1", true).await;
+    // outsider-bot is registered but is NOT a participant of the session.
+    let resp = get(&app, SID, "Bearer outsider-token").await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn gate_allows_human_via_owned_participant_bot() {
+    let (app, _t, _r) = human_app("alice").await;
+    // Human `alice` is not a direct participant (`human_alice`), but owns
+    // `driver-bot`, which IS a session participant → `human_has_session_access`
+    // owned-bot branch must admit the call.
+    let resp = get(&app, SID, "").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn gate_rejects_human_without_owned_participant_bot() {
+    let (app, _t, _r) = human_app("bob").await;
+    // Human `bob` owns only `worker-bot`-equivalent? Here bob owns no bot in the
+    // session, so both `human_has_session_access` branches miss → 403.
+    let resp = get(&app, SID, "").await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn gate_rejects_when_session_missing() {
+    let (app, _t) = bot_app("group-1", true).await;
+    // Unknown session id → session_management.get returns None → 403.
+    let resp = get(&app, "group-1:deadbeef", "Bearer driver-token").await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn gate_rejects_when_parent_group_missing() {
+    // Session exists but references a group that is not in the store → 403.
+    let (app, _t) = bot_app("group-absent", false).await;
+    let resp = get(&app, SID, "Bearer driver-token").await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ---- share: exercises the handler's session_participants resolution -------
+
+#[tokio::test]
+async fn share_member_passes_gate_and_builds_command() {
+    let (app, _t) = bot_app("group-1", true).await;
+    // Noop share_mint returns Internal (500); reaching it proves the gate
+    // passed and the ShareMintCommand (incl. session_participants) was built.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/sessions/{SID}/files/fake-file/share"))
+                .header("authorization", "Bearer driver-token")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "ttl_seconds": 300 }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn share_rejects_non_member() {
+    let (app, _t) = bot_app("group-1", true).await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/sessions/{SID}/files/fake-file/share"))
+                .header("authorization", "Bearer outsider-token")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "ttl_seconds": 300 }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ----- helpers ------------------------------------------------------------
+
+async fn get(app: &axum::Router, sid: &str, auth: &str) -> axum::response::Response {
+    let mut b = Request::builder()
+        .method("GET")
+        .uri(format!("/sessions/{sid}/files"));
+    if !auth.is_empty() {
+        b = b.header("authorization", auth);
+    }
+    app.clone().oneshot(b.body(Body::empty()).unwrap()).await.unwrap()
+}
+
+/// Build an app whose session `SID` lives in `session_group`. When
+/// `upsert_group` is true the group `group-1` is present (driver/worker as
+/// group participants); the session participants are always driver+worker.
+/// An `outsider-bot` is registered (with token) but is NOT a session member.
+async fn bot_app(session_group: &str, upsert_group: bool) -> (axum::Router, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
+    register_bot(&registry, "driver-bot", "Driver").await;
+    register_bot(&registry, "worker-bot", "Worker").await;
+    register_bot(&registry, "outsider-bot", "Outsider").await;
+    registry.store_token_mapping("driver-token".to_string(), "driver-bot".to_string()).await;
+    registry.store_token_mapping("worker-token".to_string(), "worker-bot".to_string()).await;
+    registry.store_token_mapping("outsider-token".to_string(), "outsider-bot".to_string()).await;
+
+    let group_store = Arc::new(GroupStore::new());
+    if upsert_group {
+        let mut group = Group::new(
+            "group-1",
+            "driver-bot",
+            vec![
+                bot_participant("driver-bot", ParticipantRole::Driver),
+                bot_participant("worker-bot", ParticipantRole::Consultant),
+            ],
+        );
+        group.group_strategy = bcs_service_api::GroupStrategy::Chat;
+        group_store.upsert(group).await.unwrap();
+    }
+
+    let session = Session {
+        id: SID.to_string(),
+        group_id: session_group.to_string(),
+        session_title: None,
+        env: None,
+        status: SessionStatus::Running,
+        session_kind: SessionKind::Chat,
+        participants: vec![
+            Participant::bot("driver-bot", ParticipantRole::Driver),
+            Participant::bot("worker-bot", ParticipantRole::Consultant),
+        ],
+        group_version: Some(1),
+        caller_id: None,
+        input: None,
+        output: None,
+        error_message: None,
+        callback_status: None,
+        activation_count: 1,
+        caller_principal: None,
+        created_by: None,
+        current_msg_seq: 0,
+        participant_join_seq: None,
+        created_at: 1,
+        updated_at: 1,
+        completed_at: None,
+        meta: None,
+        collected_at: None,
+    };
+
+    let sessions = Arc::new(RecordingSessions { session: Mutex::new(Some(session)) });
+
+    let mut services = Services::noop();
+    services.registry = registry;
+    services.group = group_store;
+    services.session_management = sessions;
+
+    (build_router(HttpAppState::new(services)), temp_dir)
+}
+
+/// Human-caller app: the human `staff` is attached via a static identity port.
+/// To exercise the owned-bot branch we register `driver-bot` (a session
+/// participant) as owned by `staff` only when `staff` == "alice"; other humans
+/// own no bots in the session and must be rejected.
+async fn human_app(staff: &str) -> (axum::Router, TempDir, Arc<BotCore>) {
+    let temp_dir = TempDir::new().unwrap();
+    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
+    register_bot(&registry, "driver-bot", "Driver").await;
+    register_bot(&registry, "worker-bot", "Worker").await;
+    if staff == "alice" {
+        registry.save_created_by("driver-bot", staff, true).await.unwrap();
+    }
+
+    let group_store = Arc::new(GroupStore::new());
+    let mut group = Group::new(
+        "group-1",
+        "driver-bot",
+        vec![
+            bot_participant("driver-bot", ParticipantRole::Driver),
+            bot_participant("worker-bot", ParticipantRole::Consultant),
+        ],
+    );
+    group.group_strategy = bcs_service_api::GroupStrategy::Chat;
+    group_store.upsert(group).await.unwrap();
+
+    let session = Session {
+        id: SID.to_string(),
+        group_id: "group-1".to_string(),
+        session_title: None,
+        env: None,
+        status: SessionStatus::Running,
+        session_kind: SessionKind::Chat,
+        participants: vec![
+            Participant::bot("driver-bot", ParticipantRole::Driver),
+            Participant::bot("worker-bot", ParticipantRole::Consultant),
+        ],
+        group_version: Some(1),
+        caller_id: None,
+        input: None,
+        output: None,
+        error_message: None,
+        callback_status: None,
+        activation_count: 1,
+        caller_principal: None,
+        created_by: None,
+        current_msg_seq: 0,
+        participant_join_seq: None,
+        created_at: 1,
+        updated_at: 1,
+        completed_at: None,
+        meta: None,
+        collected_at: None,
+    };
+
+    let sessions = Arc::new(RecordingSessions { session: Mutex::new(Some(session)) });
+
+    let mut services = Services::noop();
+    services.registry = registry.clone();
+    services.group = group_store;
+    services.session_management = sessions;
+
+    let identity: Arc<dyn UserIdentityPort + Send + Sync> = Arc::new(StaticHumanIdentity {
+        staff_no: Some(staff.to_string()),
+    });
+    let app = build_router(HttpAppState::new(services).with_user_identity(identity));
+    (app, temp_dir, registry)
+}
+
+fn bot_participant(bot_uuid: &str, role: ParticipantRole) -> Participant {
+    Participant {
+        bot_uuid: bot_uuid.to_string(),
+        bot_name: None,
+        kind: None,
+        role,
+        actor_kind: ActorKind::Bot,
+        mode: Some(ParticipantMode::default_for(ActorKind::Bot)),
+    }
+}
+
+async fn register_bot(registry: &BotCore, bot_id: &str, name: &str) {
+    registry
+        .register(
+            bot_id.to_string(),
+            BotCapabilities {
+                name: Some(name.to_string()),
+                summary: Some(format!("{name} summary")),
+                visibility: "public".to_string(),
+                ..BotCapabilities::default()
+            },
+        )
+        .await
+        .unwrap();
+}
+
+#[derive(Default)]
+struct StaticHumanIdentity {
+    staff_no: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl UserIdentityPort for StaticHumanIdentity {
+    async fn extract(
+        &self,
+        _headers: &HeaderMap,
+        _uri: &axum::http::Uri,
+    ) -> Option<HttpUserIdentity> {
+        self.staff_no.as_ref().map(|sn| HttpUserIdentity {
+            staff_no: Some(sn.clone()),
+            nick_name: Some("Test".to_string()),
+        })
+    }
+
+    async fn ensure_identity(
+        &self,
+        _auth_source: &str,
+        _external_user_id: &str,
+        _external_user_name: Option<&str>,
+        _avatar: Option<&str>,
+        _env: &str,
+    ) -> Result<String, AuthError> {
+        Ok("noop-identity".to_string())
+    }
+
+    async fn get_identity_by_token(
+        &self,
+        _token: &str,
+    ) -> Result<Option<UserIdentityInfo>, AuthError> {
+        Ok(None)
+    }
+
+    async fn get_identity_by_user_id(
+        &self,
+        _user_id: &str,
+    ) -> Result<Option<UserIdentityInfo>, AuthError> {
+        Ok(None)
+    }
+
+    async fn update_token(
+        &self,
+        _user_id: &str,
+        _token: &str,
+        _expire_at: u64,
+    ) -> Result<(), AuthError> {
+        Ok(())
+    }
+}
+
+struct RecordingSessions {
+    session: Mutex<Option<Session>>,
+}
+
+#[async_trait::async_trait]
+impl SessionManagementService for RecordingSessions {
+    async fn create_or_reactivate(
+        &self,
+        _cmd: CreateOrReactivateCommand,
+    ) -> Result<CreateOrReactivateOutcome, SessionUseCaseError> {
+        unimplemented!("not used by member-gate tests")
+    }
+
+    async fn get(&self, sid: &str) -> Result<Option<Session>, SessionUseCaseError> {
+        Ok(self
+            .session
+            .lock()
+            .await
+            .as_ref()
+            .filter(|x| x.id == sid)
+            .cloned())
+    }
+
+    async fn belongs_to_group(
+        &self,
+        session_id: &str,
+        group_id: &str,
+    ) -> Result<bool, SessionUseCaseError> {
+        Ok(self
+            .session
+            .lock()
+            .await
+            .as_ref()
+            .map(|x| x.id == session_id && x.group_id == group_id)
+            .unwrap_or(false))
+    }
+
+    async fn list_by_group(
+        &self,
+        _group_id: &str,
+        _status: Option<SessionStatus>,
+        _offset: u64,
+        _limit: u64,
+        _title_contains: Option<&str>,
+        _participant_id: Option<&str>,
+    ) -> Result<Vec<Session>, SessionUseCaseError> {
+        Ok(Vec::new())
+    }
+
+    async fn count_running_service(&self, _group_id: &str) -> Result<u64, SessionUseCaseError> {
+        Ok(0)
+    }
+
+    async fn list_running_service(
+        &self,
+        _offset: u64,
+        _limit: u64,
+    ) -> Result<Vec<Session>, SessionUseCaseError> {
+        Ok(Vec::new())
+    }
+
+    async fn update_callback_status(
+        &self,
+        _session_id: &str,
+        _status: &str,
+    ) -> Result<(), SessionUseCaseError> {
+        Ok(())
+    }
+
+    async fn complete_if_running(
+        &self,
+        _sid: &str,
+        _output: Option<serde_json::Value>,
+        _error: Option<String>,
+    ) -> Result<Option<Session>, SessionUseCaseError> {
+        Ok(None)
+    }
+
+    async fn add_participant(
+        &self,
+        _session_id: &str,
+        _participant: Participant,
+    ) -> Result<Session, SessionUseCaseError> {
+        let s = self.session.lock().await.clone().unwrap();
+        Ok(s)
+    }
+
+    async fn remove_participant(
+        &self,
+        _session_id: &str,
+        _bot_uuid: &str,
+    ) -> Result<Session, SessionUseCaseError> {
+        let s = self.session.lock().await.clone().unwrap();
+        Ok(s)
+    }
+
+    async fn update_participant_mode(
+        &self,
+        _session_id: &str,
+        _bot_uuid: &str,
+        _mode: ParticipantMode,
+    ) -> Result<Session, SessionUseCaseError> {
+        let s = self.session.lock().await.clone().unwrap();
+        Ok(s)
+    }
+
+    async fn update_title(
+        &self,
+        _session_id: &str,
+        _title: Option<String>,
+    ) -> Result<Session, SessionUseCaseError> {
+        unimplemented!()
+    }
+
+    async fn list_group_ids_by_session_participant(
+        &self,
+        _bot_uuid: &str,
+    ) -> Result<Vec<String>, SessionUseCaseError> {
+        Ok(Vec::new())
+    }
+
+    async fn delete(&self, _session_id: &str) -> Result<bool, SessionUseCaseError> {
+        Ok(false)
+    }
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/session_files.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/session_files.rs
@@ -59,10 +59,17 @@ pub struct PrepareUploadResult {
     pub expires_at: u64,
 }
 
-/// Mutate (delete/share) authz is done ENTIRELY in the service, fed by values
-/// the HTTP layer pre-resolves (caller_identities + session_creator + driver_bot).
-/// HTTP fetches `session.created_by` (session_repo via session_management) and
-/// `group.driver_bot` (group_management) before constructing this command.
+/// Mutate authz is done ENTIRELY in the service, fed by values the HTTP layer
+/// pre-resolves (so the service stays transport-agnostic and free of group/bot
+/// repo dependencies).
+///
+/// Delete authz uses `caller_identities + session_creator + driver_bot`: HTTP
+/// fetches `session.created_by` (session_repo via session_management) and
+/// `group.driver_bot` (group_management) before constructing `DeleteFileCommand`.
+///
+/// Share authz uses `caller_identities + session_participants`: any session
+/// member may share. HTTP resolves `session_participants` from the session's
+/// own `participants` (the same set `ensure_session_member` gates on).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteFileCommand {
     pub session_id: String,
@@ -80,8 +87,9 @@ pub struct ShareMintCommand {
     pub caller: ActorRef,
     pub ttl_seconds: Option<u64>,
     pub caller_identities: Vec<String>,
-    pub session_creator: Option<String>,
-    pub driver_bot: Option<String>,
+    /// session 自身 participants 的 bot_uuid/actor_id，由 HTTP 从 `sess.participants`
+    /// 解析（与 `ensure_session_member` 同源）。分享鉴权 = caller 是否为 session 成员。
+    pub session_participants: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/bcs/crates/services/bcs-session-file/src/authz.rs
+++ b/src/bcs/crates/services/bcs-session-file/src/authz.rs
@@ -83,6 +83,21 @@ pub fn can_mutate(
     false
 }
 
+/// Test whether `caller` may share a file in the session. Sharing is gated on
+/// session membership only — not on file ownership: the caller is a member when
+/// any of their identities (`caller.actor_id` plus bots they own, pre-resolved
+/// by the HTTP layer as `caller_identities`) appears among the session's own
+/// `participants`. Pure set intersection — no IO — mirroring `can_mutate`'s
+/// contract that the service crate stays free of group/bot repo dependencies.
+pub fn can_share(
+    caller_identities: &[String],
+    session_participants: &[String],
+) -> bool {
+    caller_identities
+        .iter()
+        .any(|id| session_participants.iter().any(|part| part == id))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +136,29 @@ mod tests {
     fn multiple_identities_one_match_allows() {
         let ids = vec!["u1".to_string(), "bot-a".into(), "u3".into()];
         assert!(can_mutate(&ids, &actor("u3"), None, None));
+    }
+
+    // ---- can_share: membership-gated sharing ------------------------------
+
+    #[test]
+    fn share_member_allows() {
+        assert!(can_share(&["u1".into()], &["u1".into(), "u2".into()]));
+    }
+
+    #[test]
+    fn share_member_via_owned_bot_allows() {
+        let ids = vec!["human_h".to_string(), "bot_a".into()];
+        assert!(can_share(&ids, &["bot_a".into()]));
+    }
+
+    #[test]
+    fn share_non_member_denies() {
+        assert!(!can_share(&["u9".into()], &["u1".into(), "u2".into()]));
+    }
+
+    #[test]
+    fn share_empty_identities_denies() {
+        assert!(!can_share(&[], &["u1".into()]));
     }
 
     // ---- validate_file_name: path-traversal guard ---------------------------

--- a/src/bcs/crates/services/bcs-session-file/src/service.rs
+++ b/src/bcs/crates/services/bcs-session-file/src/service.rs
@@ -30,7 +30,7 @@ use bcs_storage_api::{
     StorageError, StorageHandle, UploadHandle, UploadMode, UploadPrepareRequest,
 };
 
-use crate::authz::{can_mutate, derive_key, validate_file_name};
+use crate::authz::{can_mutate, can_share, derive_key, validate_file_name};
 
 /// Fixed part size used by the local-proxy (`ProxyViaBcs`) multipart branch.
 ///
@@ -573,14 +573,9 @@ impl SessionFileService for SessionFileServiceImpl {
                 row.status,
             )));
         }
-        if !can_mutate(
-            &cmd.caller_identities,
-            &row.owner,
-            cmd.session_creator.as_deref(),
-            cmd.driver_bot.as_deref(),
-        ) {
+        if !can_share(&cmd.caller_identities, &cmd.session_participants) {
             return Err(SessionFileUseCaseError::Forbidden(format!(
-                "caller not authorized to share file {}",
+                "caller not a session member, cannot share file {}",
                 cmd.file_id,
             )));
         }
@@ -1368,16 +1363,16 @@ mod tests {
 
     // ---- share mint + consume -----------------------------------------------
 
-    fn share_cmd(file_id: &str, ids: &[&str]) -> ShareMintCommand {
+    fn share_cmd(file_id: &str, ids: &[&str], participants: &[&str]) -> ShareMintCommand {
         let caller_identities = ids.iter().map(|s| (*s).to_string()).collect();
+        let session_participants = participants.iter().map(|s| (*s).to_string()).collect();
         ShareMintCommand {
             session_id: "g1:abcd1234".into(),
             file_id: file_id.into(),
             caller: actor("human_1"),
             ttl_seconds: None,
             caller_identities,
-            session_creator: Some("creator_1".into()),
-            driver_bot: None,
+            session_participants,
         }
     }
 
@@ -1393,7 +1388,7 @@ mod tests {
     async fn share_mint_and_consume_roundtrip() {
         let (s, _, _) = build_svc(local_caps());
         let file_id = prepare_complete(&s).await;
-        let r = s.share_mint(share_cmd(&file_id, &["human_1"])).await.unwrap();
+        let r = s.share_mint(share_cmd(&file_id, &["human_1"], &["human_1"])).await.unwrap();
         assert!(r.share_url.contains("/sessions/shared-file/content?token="));
         assert!(!r.share_token.is_empty());
         assert!(r.expires_at > now_secs());
@@ -1403,18 +1398,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn share_mint_non_owner_forbidden() {
+    async fn share_mint_non_member_forbidden() {
         let (s, _, _) = build_svc(local_caps());
         let file_id = prepare_complete(&s).await;
-        let err = s.share_mint(share_cmd(&file_id, &["someone_else"])).await.unwrap_err();
+        // caller is not among session participants -> Forbidden
+        let err = s.share_mint(share_cmd(&file_id, &["someone_else"], &["human_1"])).await.unwrap_err();
         assert!(matches!(err, SessionFileUseCaseError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn share_mint_any_member_can_share() {
+        let (s, _, _) = build_svc(local_caps());
+        let file_id = prepare_complete(&s).await; // uploaded by human_1
+        // human_2 is a session member but NOT the uploader — relaxation allows sharing.
+        let r = s.share_mint(share_cmd(&file_id, &["human_2"], &["human_1", "human_2"])).await.unwrap();
+        assert!(!r.share_token.is_empty());
+    }
+
+    #[tokio::test]
+    async fn share_mint_human_via_owned_bot_can_share() {
+        let (s, _, _) = build_svc(local_caps());
+        let file_id = prepare_complete(&s).await; // uploaded by human_1
+        // human_h is NOT a direct participant, but owns bot_a which is a session
+        // member. HTTP resolves caller_identities = [human_h, bot_a], so the human
+        // shares via the owned participating bot (mirrors human_has_session_access).
+        let r = s.share_mint(share_cmd(&file_id, &["human_h", "bot_a"], &["human_1", "bot_a"])).await.unwrap();
+        assert!(!r.share_token.is_empty());
     }
 
     #[tokio::test]
     async fn share_mint_non_ready_rejects() {
         let (s, _, _) = build_svc(local_caps());
         let r = s.prepare_upload(sample_prepare(5)).await.unwrap();
-        let err = s.share_mint(share_cmd(&r.file.file_id, &["human_1"])).await.unwrap_err();
+        let err = s.share_mint(share_cmd(&r.file.file_id, &["human_1"], &["human_1"])).await.unwrap_err();
         assert!(matches!(err, SessionFileUseCaseError::InvalidState(_)));
     }
 
@@ -1437,7 +1453,7 @@ mod tests {
     async fn share_consume_tampered_token_rejected() {
         let (s, _, _) = build_svc(local_caps());
         let file_id = prepare_complete(&s).await;
-        let r = s.share_mint(share_cmd(&file_id, &["human_1"])).await.unwrap();
+        let r = s.share_mint(share_cmd(&file_id, &["human_1"], &["human_1"])).await.unwrap();
         // Tamper: flip one character in the token.
         let mut chars: Vec<char> = r.share_token.chars().collect();
         let last_idx = chars.len() - 1;
@@ -1454,7 +1470,7 @@ mod tests {
     async fn share_mint_uses_share_base_url_when_configured() {
         let (s, _, _) = build_svc_parts_for_share_base();
         let file_id = prepare_complete(&s).await;
-        let r = s.share_mint(share_cmd(&file_id, &["human_1"])).await.unwrap();
+        let r = s.share_mint(share_cmd(&file_id, &["human_1"], &["human_1"])).await.unwrap();
         assert!(r.share_url.starts_with("https://share.example.com/sessions/shared-file/content?token="));
     }
 


### PR DESCRIPTION
fix(bcs): gate session-file access on session participants and relax share authz

ensure_session_member checked group.participants, but a session seeds its
participants from the group and then evolves independently. Session-only
participants added via add_session_participant, and callers after the group
seed diverged, were wrongly denied. It now judges membership against
sess.participants. Add human_has_session_access next to human_has_group_access
so the Human caller is accepted when they, or a bot they own, is a session
participant.

Share authz is relaxed from uploader/creator/driver (can_mutate) to any
session member. Add pure can_share(caller_identities, session_participants);
ShareMintCommand now carries session_participants (resolved from the session
that ensure_session_member already loads) instead of session_creator and
driver_bot. ensure_session_member returns the loaded Session so the share
handler reuses it without an extra fetch and feeds the same participant set
to the service, keeping authz transport-agnostic.

Delete authz is unchanged: can_mutate already lets the driver bot delete any
file and lets a human delete files uploaded by a bot they own.

Tests: can_share unit tests; service-level share_mint_non_member_forbidden,
share_mint_any_member_can_share, share_mint_human_via_owned_bot_can_share.
Verified with cargo test for bcs-session-file and bcs-http contracts.
