### PR TITLE
fix(baas): bind singlebox gateways to loopback

### DIFF
--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -267,6 +267,11 @@ class LocalProcessManager:
 
         oc_config.setdefault("gateway", {})["port"] = openclaw_port
         oc_config["gateway"]["mode"] = "local"
+        # A singlebox gateway is only consumed by local BaaS/backend/adapter
+        # processes.  Be explicit instead of relying on OpenClaw's
+        # environment-dependent default: in a container it defaults to
+        # ``auto`` (0.0.0.0), which OpenClaw correctly rejects without auth.
+        oc_config["gateway"]["bind"] = "loopback"
         oc_config["gateway"].setdefault("auth", {})["mode"] = "none"
         oc_config.setdefault("agents", {}).setdefault("defaults", {})["workspace"] = (
             str(workspace_dir)

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_env.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_process_manager_env.py
@@ -274,7 +274,7 @@ def test_create_openclaw_config_merges_singlebox_model_config(monkeypatch, tmp_p
                     },
                 },
                 "agents": {"defaults": {"model": {"primary": "antchat/Kimi-K2.5"}}},
-                "gateway": {},
+                "gateway": {"bind": "auto"},
             }
         ),
         encoding="utf-8",
@@ -324,6 +324,7 @@ def test_create_openclaw_config_merges_singlebox_model_config(monkeypatch, tmp_p
     assert config["models"]["providers"]["manual-provider"]["apiKey"] == "sk-test"
     assert config["agents"]["defaults"]["model"]["primary"] == "manual-provider/model-a"
     assert config["gateway"]["port"] == 18888
+    assert config["gateway"]["bind"] == "loopback"
     assert stat.S_IMODE((config_dir / "openclaw.json").stat().st_mode) == 0o600
 
 
@@ -382,12 +383,12 @@ def test_create_openclaw_config_removes_template_model_fields_for_mock_config(
         entity_id="mock-user",
     )
 
-    defaults = json.loads((config_dir / "openclaw.json").read_text(encoding="utf-8"))[
-        "agents"
-    ]["defaults"]
+    config = json.loads((config_dir / "openclaw.json").read_text(encoding="utf-8"))
+    defaults = config["agents"]["defaults"]
     assert "model" not in defaults
     assert defaults["models"] == {}
     assert "imageModel" not in defaults
+    assert config["gateway"]["bind"] == "loopback"
 
 
 def test_create_openclaw_config_rejects_non_object_singlebox_model_config(


### PR DESCRIPTION
## 问题
CI 容器中动态 OpenClaw Bot 未显式设置 gateway.bind。OpenClaw 在容器里会默认为 auto/0.0.0.0，拒绝无鉴权启动，最终表现为 BaaS publish FAILED。

## 修复
明确将 singlebox per-bot gateway 绑定为 loopback，并覆盖模板中的 bind 值。

## 验证
- `cd src/baas && uv run pytest tests/unit/plugins/sandbox/arca/test_process_manager_env.py -q`
- 结果：19 passed, 1 skipped