### PR TITLE
fix(baas): revert device_template_router check for OperationContext

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/config_management/device_template_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/config_management/device_template_router.py
@@ -20,8 +20,7 @@ from dependency_injector.wiring import inject
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 
-from secbaas.community.adapters.web.dependencies import get_op_ctx
-from secbaas.community.api import ApiResponse, OperationContext, SuccessResponse
+from secbaas.community.api import ApiResponse, SuccessResponse
 from secbaas.community.api.template_manage import (
     DeviceTemplateManageService,
     DeviceTemplateResponse,
@@ -39,9 +38,6 @@ class StatusTransitionRequest(BaseModel):
 
     current_status: TemplateStatus = Field(..., description="当前状态（用于定位记录）")
     new_status: TemplateStatus = Field(..., description="新状态")
-    operator: str = Field(
-        default="", min_length=0, max_length=128, description="操作人 ID"
-    )
 
 
 logger = get_logger("router")
@@ -56,7 +52,6 @@ async def list_templates(
     status: Annotated[TemplateStatus | None, Query(description="模板状态过滤")] = None,
     page: Annotated[int, Query(ge=1, description="页码")] = 1,
     page_size: Annotated[int, Query(ge=1, le=100, description="每页数量")] = 20,
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -64,7 +59,7 @@ async def list_templates(
     """List device templates for a tenant with optional status filter."""
 
     logger.info(
-        f"Listing templates: tenant={tenant}, status={status}, page={page}, page_size={page_size}, operator={op_ctx.operator}"
+        f"Listing templates: tenant={tenant}, status={status}, page={page}, page_size={page_size}"
     )
     result = service.list_templates(
         tenant=tenant,
@@ -81,7 +76,6 @@ async def list_online_templates(
     tenant: Annotated[str, Query(description="租户名称")],
     page: Annotated[int, Query(ge=1, description="页码")] = 1,
     page_size: Annotated[int, Query(ge=1, le=100, description="每页数量")] = 20,
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -89,7 +83,7 @@ async def list_online_templates(
     """List ONLINE status templates for bot creation."""
 
     logger.info(
-        f"Listing ONLINE templates: tenant={tenant}, page={page}, page_size={page_size}, operator={op_ctx.operator}"
+        f"Listing ONLINE templates: tenant={tenant}, page={page}, page_size={page_size}"
     )
     result = service.list_online_templates(
         tenant=tenant,
@@ -105,7 +99,6 @@ async def list_online_templates(
 @inject
 async def get_template_by_id(
     template_id: Annotated[int, Path(ge=0, description="模板ID (PaaS平台租户业务ID)")],
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -114,9 +107,7 @@ async def get_template_by_id(
 
     Note: template_id is globally unique across all tenants.
     """
-    logger.info(
-        f"Getting template by template_id: {template_id}, operator: {op_ctx.operator}"
-    )
+    logger.info(f"Getting template by template_id: {template_id}")
 
     template = service.get_by_template_id(template_id)
 
@@ -138,7 +129,6 @@ async def resolve_template(
     template_uuid: Annotated[
         str | None, Query(description="模板UUID (可选，不提供则返回默认模板)")
     ] = None,
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -150,7 +140,7 @@ async def resolve_template(
     2. Otherwise: return tenant's default_template_uuid from extra_config
     """
     logger.info(
-        f"Resolving template: tenant={tenant}, template_uuid={template_uuid or 'default'}, operator={op_ctx.operator}"
+        f"Resolving template: tenant={tenant}, template_uuid={template_uuid or 'default'}"
     )
 
     try:
@@ -174,16 +164,13 @@ async def resolve_template(
 async def get_template(
     template_uuid: Annotated[str, Path(description="模板UUID")],
     tenant: Annotated[str, Query(description="租户名称")],
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
 ) -> ApiResponse[DeviceTemplateResponse]:
     """Get template by UUID with tenant isolation."""
 
-    logger.info(
-        f"Getting template: template_uuid={template_uuid}, tenant={tenant}, operator={op_ctx.operator}"
-    )
+    logger.info(f"Getting template: template_uuid={template_uuid}, tenant={tenant}")
 
     template = service.get_online_template_by_uuid(tenant, template_uuid)
 
@@ -203,7 +190,6 @@ async def get_template(
 async def create_template(
     request: TemplateCreate,
     tenant: Annotated[str, Query(description="租户名称")],
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -222,7 +208,7 @@ async def create_template(
         f"template_uuid={'auto' if request.template_uuid is None else 'provided'}, "
         f"template_id={request.template_id}, type={request.type}, name={request.name}"
     )
-    request.operator = op_ctx.operator
+
     result = service.create_template(tenant=tenant, data=request)
     return ApiResponse(data=result)
 
@@ -236,7 +222,6 @@ async def update_template(
     status: Annotated[
         TemplateStatus, Query(description="模板状态")
     ] = TemplateStatus.ONLINE,
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -252,7 +237,6 @@ async def update_template(
     )
 
     # Update using composite key (tenant, template_uuid, status)
-    request.operator = op_ctx.operator
     updated = service.update_template(
         tenant=tenant,
         template_uuid=template_uuid,
@@ -280,7 +264,6 @@ async def transition_template_status(
     template_uuid: Annotated[str, Path(description="模板UUID")],
     request: StatusTransitionRequest,
     tenant: Annotated[str, Query(description="租户名称")],
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -294,7 +277,6 @@ async def transition_template_status(
         f"from={request.current_status.value} to={request.new_status.value}"
     )
 
-    request.operator = op_ctx.operator
     updated = service.update_status(
         tenant=tenant,
         template_uuid=template_uuid,
@@ -326,9 +308,9 @@ class DeleteTemplateRequest(BaseModel):
 @inject
 async def delete_template(
     template_uuid: Annotated[str, Path(description="模板UUID")],
+    request: DeleteTemplateRequest,
     tenant: Annotated[str, Query(description="租户名称")],
     status: Annotated[TemplateStatus, Query(description="模板状态 (用于定位记录)")],
-    op_ctx: OperationContext = Depends(get_op_ctx),
     service: DeviceTemplateManageService = Depends(
         Provide[ApplicationContainer.services.device_template_service]
     ),
@@ -340,14 +322,14 @@ async def delete_template(
     """
     logger.info(
         f"Deleting template: template_uuid={template_uuid}, tenant={tenant}, "
-        f"status={status}, operator={op_ctx.operator}"
+        f"status={status}, operator={request.operator}"
     )
 
     success = service.soft_delete_template(
         tenant=tenant,
         template_uuid=template_uuid,
         status=status,
-        operator=op_ctx.operator,
+        operator=request.operator,
     )
 
     if not success:

--- a/src/baas/tests/unit/adapters/web/test_device_template_router.py
+++ b/src/baas/tests/unit/adapters/web/test_device_template_router.py
@@ -31,7 +31,6 @@ from secbaas.community.adapters.web.routers.config_management.device_template_ro
     transition_template_status,
     update_template,
 )
-from secbaas.community.api import OperationContext
 from secbaas.community.api.template_manage import (
     DeviceTemplateResponse,
     TemplateCreate,
@@ -42,8 +41,6 @@ from secbaas.community.api.template_manage import (
 from secbaas.community.api.template_manage._models import ArcaTemplateConfig
 
 # ==================== Helpers ====================
-
-_OP_CTX = OperationContext(operator="test_user", env="dev")
 
 
 def _make_template_response(
@@ -147,9 +144,7 @@ class TestListTemplates:
         expected = TemplateListResponse(items=[], total=0, page=1, page_size=20)
         mock_svc.list_templates.return_value = expected
 
-        result = await list_templates(
-            tenant="test_tenant", op_ctx=_OP_CTX, service=mock_svc
-        )
+        result = await list_templates(tenant="test_tenant", service=mock_svc)
 
         assert result.code == 0
         assert result.data == expected
@@ -170,7 +165,6 @@ class TestListTemplates:
         result = await list_templates(
             tenant="test_tenant",
             status=TemplateStatus.ONLINE,
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -193,7 +187,6 @@ class TestListTemplates:
             tenant="test_tenant",
             page=3,
             page_size=10,
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -213,9 +206,7 @@ class TestListTemplates:
         expected = TemplateListResponse(items=[tmpl], total=1, page=1, page_size=20)
         mock_svc.list_templates.return_value = expected
 
-        result = await list_templates(
-            tenant="test_tenant", op_ctx=_OP_CTX, service=mock_svc
-        )
+        result = await list_templates(tenant="test_tenant", service=mock_svc)
 
         assert result.code == 0
         assert result.data is not None
@@ -238,9 +229,7 @@ class TestListOnlineTemplates:
         expected = TemplateListResponse(items=[tmpl], total=1, page=1, page_size=20)
         mock_svc.list_online_templates.return_value = expected
 
-        result = await list_online_templates(
-            tenant="test_tenant", op_ctx=_OP_CTX, service=mock_svc
-        )
+        result = await list_online_templates(tenant="test_tenant", service=mock_svc)
 
         assert result.code == 0
         assert result.data == expected
@@ -261,7 +250,6 @@ class TestListOnlineTemplates:
             tenant="test_tenant",
             page=2,
             page_size=50,
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -279,9 +267,7 @@ class TestListOnlineTemplates:
         expected = TemplateListResponse(items=[], total=0, page=1, page_size=20)
         mock_svc.list_online_templates.return_value = expected
 
-        result = await list_online_templates(
-            tenant="empty_tenant", op_ctx=_OP_CTX, service=mock_svc
-        )
+        result = await list_online_templates(tenant="empty_tenant", service=mock_svc)
 
         assert result.code == 0
         assert result.data is not None
@@ -302,9 +288,7 @@ class TestGetTemplateById:
         expected = _make_template_response(id=42, template_id=999)
         mock_svc.get_by_template_id.return_value = expected
 
-        result = await get_template_by_id(
-            template_id=999, op_ctx=_OP_CTX, service=mock_svc
-        )
+        result = await get_template_by_id(template_id=999, service=mock_svc)
 
         assert result.code == 0
         assert result.data == expected
@@ -317,9 +301,7 @@ class TestGetTemplateById:
         mock_svc.get_by_template_id.return_value = None
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_template_by_id(
-                template_id=99999, op_ctx=_OP_CTX, service=mock_svc
-            )
+            await get_template_by_id(template_id=99999, service=mock_svc)
 
         assert exc_info.value.status_code == 404
         detail = exc_info.value.detail
@@ -333,9 +315,7 @@ class TestGetTemplateById:
         expected = _make_template_response(template_id=0)
         mock_svc.get_by_template_id.return_value = expected
 
-        result = await get_template_by_id(
-            template_id=0, op_ctx=_OP_CTX, service=mock_svc
-        )
+        result = await get_template_by_id(template_id=0, service=mock_svc)
 
         assert result.code == 0
         mock_svc.get_by_template_id.assert_called_once_with(0)
@@ -354,9 +334,7 @@ class TestResolveTemplate:
         expected = _make_template_response(template_uuid="DEFAULT-xyz")
         mock_svc.get_default_or_explicit_template.return_value = expected
 
-        result = await resolve_template(
-            tenant="test_tenant", op_ctx=_OP_CTX, service=mock_svc
-        )
+        result = await resolve_template(tenant="test_tenant", service=mock_svc)
 
         assert result.code == 0
         assert result.data == expected
@@ -375,7 +353,6 @@ class TestResolveTemplate:
         result = await resolve_template(
             tenant="test_tenant",
             template_uuid="EXPLICIT-abc",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -395,9 +372,7 @@ class TestResolveTemplate:
         )
 
         with pytest.raises(HTTPException) as exc_info:
-            await resolve_template(
-                tenant="bad_tenant", op_ctx=_OP_CTX, service=mock_svc
-            )
+            await resolve_template(tenant="bad_tenant", service=mock_svc)
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail["error_code"] == "TEMPLATE_NOT_FOUND"
@@ -415,7 +390,6 @@ class TestResolveTemplate:
             await resolve_template(
                 tenant="test_tenant",
                 template_uuid="MISSING",
-                op_ctx=_OP_CTX,
                 service=mock_svc,
             )
 
@@ -439,7 +413,6 @@ class TestGetTemplate:
         result = await get_template(
             template_uuid="UUID-12345",
             tenant="test_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -459,7 +432,6 @@ class TestGetTemplate:
             await get_template(
                 template_uuid="MISSING",
                 tenant="test_tenant",
-                op_ctx=_OP_CTX,
                 service=mock_svc,
             )
 
@@ -477,7 +449,6 @@ class TestGetTemplate:
             await get_template(
                 template_uuid="UUID-12345",
                 tenant="other_tenant",
-                op_ctx=_OP_CTX,
                 service=mock_svc,
             )
 
@@ -502,7 +473,6 @@ class TestCreateTemplate:
         result = await create_template(
             request=request,
             tenant="test_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -524,7 +494,6 @@ class TestCreateTemplate:
         result = await create_template(
             request=request,
             tenant="test_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -560,7 +529,6 @@ class TestCreateTemplate:
         result = await create_template(
             request=request,
             tenant="prod_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -590,7 +558,6 @@ class TestUpdateTemplate:
             request=request,
             tenant="test_tenant",
             status=TemplateStatus.ONLINE,
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -615,7 +582,6 @@ class TestUpdateTemplate:
             template_uuid="UUID-12345",
             request=request,
             tenant="test_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -638,7 +604,6 @@ class TestUpdateTemplate:
                 template_uuid="MISSING",
                 request=_make_update_request(),
                 tenant="test_tenant",
-                op_ctx=_OP_CTX,
                 service=mock_svc,
             )
 
@@ -659,7 +624,6 @@ class TestUpdateTemplate:
             request=request,
             tenant="test_tenant",
             status=TemplateStatus.OFFLINE,
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -693,7 +657,6 @@ class TestTransitionTemplateStatus:
             template_uuid="UUID-12345",
             request=request,
             tenant="test_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -721,7 +684,6 @@ class TestTransitionTemplateStatus:
             template_uuid="UUID-12345",
             request=request,
             tenant="test_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -749,7 +711,6 @@ class TestTransitionTemplateStatus:
                 template_uuid="MISSING",
                 request=request,
                 tenant="test_tenant",
-                op_ctx=_OP_CTX,
                 service=mock_svc,
             )
 
@@ -771,7 +732,6 @@ class TestTransitionTemplateStatus:
             template_uuid="UUID-12345",
             request=request,
             tenant="test_tenant",
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -795,12 +755,13 @@ class TestDeleteTemplate:
         """Test deleting a template successfully."""
         mock_svc = MagicMock()
         mock_svc.soft_delete_template.return_value = True
+        request = DeleteTemplateRequest(operator="admin")
 
         result = await delete_template(
             template_uuid="UUID-12345",
+            request=request,
             tenant="test_tenant",
             status=TemplateStatus.ONLINE,
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -812,7 +773,7 @@ class TestDeleteTemplate:
             tenant="test_tenant",
             template_uuid="UUID-12345",
             status=TemplateStatus.ONLINE,
-            operator="test_user",
+            operator="admin",
         )
 
     @pytest.mark.asyncio
@@ -820,13 +781,14 @@ class TestDeleteTemplate:
         """Test delete_template returns 404 when not found."""
         mock_svc = MagicMock()
         mock_svc.soft_delete_template.return_value = False
+        request = DeleteTemplateRequest(operator="admin")
 
         with pytest.raises(HTTPException) as exc_info:
             await delete_template(
                 template_uuid="MISSING",
+                request=request,
                 tenant="test_tenant",
                 status=TemplateStatus.OFFLINE,
-                op_ctx=_OP_CTX,
                 service=mock_svc,
             )
 
@@ -839,12 +801,13 @@ class TestDeleteTemplate:
         """Test deleting an OFFLINE template."""
         mock_svc = MagicMock()
         mock_svc.soft_delete_template.return_value = True
+        request = DeleteTemplateRequest(operator="cleanup_bot")
 
         result = await delete_template(
             template_uuid="UUID-OFF",
+            request=request,
             tenant="test_tenant",
             status=TemplateStatus.OFFLINE,
-            op_ctx=_OP_CTX,
             service=mock_svc,
         )
 
@@ -853,5 +816,5 @@ class TestDeleteTemplate:
             tenant="test_tenant",
             template_uuid="UUID-OFF",
             status=TemplateStatus.OFFLINE,
-            operator="test_user",
+            operator="cleanup_bot",
         )


### PR DESCRIPTION
Revert the `OperationContext` dependency injection from `device_template_router.py` endpoints.

## Changes
- Remove `op_ctx: OperationContext = Depends(get_op_ctx)` from all endpoint signatures
- Remove `operator` field from `StatusTransitionRequest` — not needed since `OperationContext` is no longer injected
- For `DeleteTemplateRequest`, read `operator` from the request body instead of `OperationContext`
- Update unit tests to remove `op_ctx` parameter from all router calls

## Why
The `OperationContext` dependency injection was causing issues. This reverts to reading operator information directly from request payloads where needed (only `delete_template`), and removes the unnecessary context dependency from all other endpoints.

## Files Changed
- `src/baas/src/secbaas/community/adapters/web/routers/config_management/device_template_router.py`
- `src/baas/tests/unit/adapters/web/test_device_template_router.py`