### PR TITLE
fix(baas): do not return 503 when device not available

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/http_conn_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/http_conn_router.py
@@ -59,10 +59,9 @@ class BotHttpErrorContext(BaseModel):
     "/{bot_uuid}/http-info",
     response_model=ApiResponse[BotHttpConnectionInfoResponse],
     responses={
-        404: {"model": BotHttpConnectionErrorResponse, "description": "Bot not found"},
-        503: {
+        404: {
             "model": BotHttpConnectionErrorResponse,
-            "description": "No active devices",
+            "description": "Bot not found or no active devices",
         },
         500: {"model": BotHttpConnectionErrorResponse, "description": "Internal error"},
     },
@@ -110,7 +109,7 @@ async def get_bot_http_connection_info(
 
     Raises:
         HTTPException 404: Bot not found or no devices found
-        HTTPException 503: No active devices available
+        HTTPException 404: No active devices available
         HTTPException 500: Internal error or PaaS error
     """
     logger.info(
@@ -168,7 +167,7 @@ async def get_bot_http_connection_info(
     except NoActiveDevicesError as e:
         logger.warning(f"No active devices for bot: {bot_uuid}")
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "error": "NO_ACTIVE_DEVICES",
                 "message": str(e),

--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/wss_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/wss_router.py
@@ -61,10 +61,9 @@ class BotWsErrorContext(BaseModel):
     "/{bot_uuid}/ws-info",
     response_model=ApiResponse[BotWsConnectionInfoResponse],
     responses={
-        404: {"model": BotWsConnectionErrorResponse, "description": "Bot not found"},
-        503: {
+        404: {
             "model": BotWsConnectionErrorResponse,
-            "description": "No active devices",
+            "description": "Bot not found or no active devices",
         },
         500: {"model": BotWsConnectionErrorResponse, "description": "Internal error"},
     },
@@ -120,7 +119,7 @@ async def get_bot_ws_connection_info(
 
     Raises:
         HTTPException 404: Bot not found or no devices found
-        HTTPException 503: No active devices available
+        HTTPException 404: No active devices available
         HTTPException 500: Internal error or PaaS error
     """
     logger.info(
@@ -180,7 +179,7 @@ async def get_bot_ws_connection_info(
     except NoActiveDevicesError as e:
         logger.warning(f"No active devices for bot: {bot_uuid}")
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "error": "NO_ACTIVE_DEVICES",
                 "message": str(e),

--- a/src/baas/src/secbaas/community/api/bot_runtime/_exceptions.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_exceptions.py
@@ -97,7 +97,7 @@ class NoDevicesFoundError(BotServiceError):
 
 class NoActiveDevicesError(BotServiceError):
     error_code = "NO_ACTIVE_DEVICES"
-    http_status = 503
+    http_status = 404
 
     def __init__(self, bot_uuid: str = ""):
         self.bot_uuid = bot_uuid

--- a/src/baas/tests/unit/adapters/web/test_bot_http_conn_router.py
+++ b/src/baas/tests/unit/adapters/web/test_bot_http_conn_router.py
@@ -197,7 +197,7 @@ async def test_get_http_info_no_devices_found_404(mock_dispatcher):
 
 
 @pytest.mark.asyncio
-async def test_get_http_info_no_active_devices_503(mock_dispatcher):
+async def test_get_http_info_no_active_devices_404(mock_dispatcher):
     mock_dispatcher.dispatch_bot_http_conn_info.side_effect = NoActiveDevicesError(
         "No active devices available"
     )
@@ -209,7 +209,7 @@ async def test_get_http_info_no_active_devices_503(mock_dispatcher):
             "?port=8080&path=/api/health&tenant=test_tenant",
         )
 
-    assert resp.status_code == 503
+    assert resp.status_code == 404
     detail = resp.json()["detail"]
     assert detail["error"] == "NO_ACTIVE_DEVICES"
     assert detail["bot_uuid"] == "bot-uuid-001"

--- a/src/baas/tests/unit/adapters/web/test_bot_wss_router.py
+++ b/src/baas/tests/unit/adapters/web/test_bot_wss_router.py
@@ -213,7 +213,7 @@ async def test_get_ws_info_no_devices_found_404(mock_dispatcher):
 
 
 @pytest.mark.asyncio
-async def test_get_ws_info_no_active_devices_503(mock_dispatcher):
+async def test_get_ws_info_no_active_devices_404(mock_dispatcher):
     mock_dispatcher.dispatch_bot_ws_conn_info.side_effect = NoActiveDevicesError(
         "No active devices available"
     )
@@ -225,7 +225,7 @@ async def test_get_ws_info_no_active_devices_503(mock_dispatcher):
             "?port=8080&path=/api/ws&tenant=test_tenant",
         )
 
-    assert resp.status_code == 503
+    assert resp.status_code == 404
     detail = resp.json()["detail"]
     assert detail["error"] == "NO_ACTIVE_DEVICES"
     assert detail["bot_uuid"] == "bot-uuid-001"


### PR DESCRIPTION
When a device is not available, BaaS was returning HTTP 503 to the caller. This change makes it return a proper error code instead of an infrastructure-level 503, so callers can handle the situation gracefully.