### PR TITLE
feat(bcs): propagate channel source message ids

### DIFF
--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -329,6 +329,7 @@ async fn handle_chat_send(
             }),
             thinking: params.thinking,
             idempotency_key: params.idempotency_key,
+            source_im_message_id: None,
             sender_conn_id,
         })
         .await?;

--- a/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
@@ -565,6 +565,7 @@ fn web_send_cmd() -> WebSendCommand {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/channel.rs
@@ -143,6 +143,8 @@ pub struct OutboundMessage {
     pub text: Option<String>,
     pub raw_payload: serde_json::Value,
     pub render_hint: ChannelRenderHint,
+    /// Original IM message id when this run was started by a channel message.
+    pub source_im_message_id: Option<String>,
     /// 该消息是否来自 IM(防回环:来自 IM 的不再转发回去)。
     pub source_is_channel: bool,
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
@@ -34,6 +34,8 @@ pub struct WebSendCommand {
     pub attachments: Option<Vec<Attachment>>,
     pub thinking: Option<String>,
     pub idempotency_key: Option<String>,
+    /// Original IM message id when this command came from a channel ingress.
+    pub source_im_message_id: Option<String>,
     pub sender_conn_id: Option<u64>,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/channel_delivery.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/channel_delivery.rs
@@ -52,6 +52,8 @@ pub struct ChannelOutboundEvent {
     pub text: Option<String>,
     pub raw_payload: serde_json::Value,
     pub render_hint: ChannelRenderHint,
+    /// Original IM message id that started this run, when available.
+    pub source_im_message_id: Option<String>,
 }
 
 /// 归一化投递结果(刻意极简,仿 `BotDeliveryResult`)。

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -703,6 +703,7 @@ impl ChannelService for BcsChannelService {
                     attachments: msg.attachments,
                     thinking: None,
                     idempotency_key: Some(dispatch_msg_id.clone()),
+                    source_im_message_id: Some(dispatch_msg_id.clone()),
                     sender_conn_id: None,
                 })
                 .await
@@ -855,6 +856,7 @@ impl ChannelService for BcsChannelService {
                     text: msg.text.clone(),
                     raw_payload: msg.raw_payload.clone(),
                     render_hint: msg.render_hint,
+                    source_im_message_id: msg.source_im_message_id.clone(),
                 })
                 .await
             {
@@ -2371,6 +2373,15 @@ mod tests {
         assert_eq!(web_sends.len(), 2);
         assert_eq!(web_sends[0].from_actor_id, "human_u1");
         assert_eq!(web_sends[0].session_id.as_deref(), Some(conv_a.bcs_session_id.as_str()));
+        assert_eq!(web_sends[0].idempotency_key.as_deref(), Some("msg_a"));
+        assert_eq!(
+            web_sends[0].source_im_message_id.as_deref(),
+            Some("msg_a")
+        );
+        assert_eq!(
+            web_sends[1].source_im_message_id.as_deref(),
+            Some("msg_b")
+        );
 
         let added = harness.session_repo.added_participants.lock().await;
         assert_eq!(added.len(), 2);
@@ -3267,17 +3278,16 @@ mod tests {
             })
             .await?;
 
-        harness
-            .service
-            .try_outbound(outbound(
-                "group_1:00000001",
-                ParticipantRole::Worker,
-                false,
-            ))
-            .await?;
+        let mut msg = outbound("group_1:00000001", ParticipantRole::Worker, false);
+        msg.source_im_message_id = Some("source-msg-1".to_string());
+        harness.service.try_outbound(msg).await?;
         let events = harness.delivery.events.lock().await;
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].im_conversation_id, "conv_a");
+        assert_eq!(
+            events[0].source_im_message_id.as_deref(),
+            Some("source-msg-1")
+        );
         assert!(events[0].render_sender_label);
         drop(events);
 
@@ -3778,6 +3788,7 @@ mod tests {
             text: Some("done".to_string()),
             raw_payload: serde_json::json!({"type": "chat.final"}),
             render_hint: ChannelRenderHint::Render,
+            source_im_message_id: None,
             source_is_channel,
         }
     }

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -224,6 +224,10 @@ async fn try_channel_outbound(flow: &BcsMessageFlow, cmd: &BotEventCommand) {
     };
 
     let (sender_role, sender_label) = resolve_channel_sender(flow, cmd).await;
+    let source_im_message_id = flow
+        .message_tracker
+        .channel_source_message_id(&cmd.run_id)
+        .await;
     let text = channel_outbound_text(kind, cmd);
     let raw_payload = if kind == ChannelOutboundEventKind::System {
         serde_json::json!({ "state": channel_terminal_state(&cmd.state) })
@@ -252,6 +256,7 @@ async fn try_channel_outbound(flow: &BcsMessageFlow, cmd: &BotEventCommand) {
             text: (!text.is_empty()).then_some(text),
             raw_payload,
             render_hint,
+            source_im_message_id,
             source_is_channel: false,
         })
         .await

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -615,6 +615,19 @@ pub async fn handle_web_send(
         let provider_transport = flow
             .provider_transport_preference(&target_bot_id, &delivery_kind, &delivery_target)
             .await;
+        let source_im_message_id = cmd
+            .source_im_message_id
+            .as_deref()
+            .filter(|message_id| {
+                delivery_type == DeliveryType::Send && !message_id.trim().is_empty()
+            });
+        if let Some(message_id) = source_im_message_id {
+            // Cache before delivery: a fast bot may emit its first response
+            // before the delivery call itself has returned.
+            flow.message_tracker
+                .cache_channel_source_message_id(&run_id, message_id)
+                .await;
+        }
         let delivery = flow
             .bot_delivery
             .deliver(BotDeliveryCommand {
@@ -649,6 +662,10 @@ pub async fn handle_web_send(
                         cmd.session_id.as_deref(),
                     )
                     .await;
+                } else if source_im_message_id.is_some() {
+                    flow.message_tracker
+                        .remove_channel_source_message_id(&run_id)
+                        .await;
                 }
                 delivery_results.push(delivery_result_summary(
                     &target_bot_id,
@@ -659,6 +676,11 @@ pub async fn handle_web_send(
                 bot_deliveries.push(result);
             }
             Err(error) => {
+                if source_im_message_id.is_some() {
+                    flow.message_tracker
+                        .remove_channel_source_message_id(&run_id)
+                        .await;
+                }
                 let error_text = error.to_string();
                 log_bot_deliver_result(
                     &cmd.group_id,
@@ -892,6 +914,7 @@ pub async fn handle_group_chat(
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
             sender_conn_id: None,
         },
     )
@@ -1012,6 +1035,7 @@ pub async fn handle_persistent_group_send(
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     };
     for target in &decision.targets {
@@ -1382,6 +1406,7 @@ pub async fn handle_group_callback(
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     };
 

--- a/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
@@ -51,6 +51,12 @@ pub struct MessageTracker {
     /// Cache sender metadata for the run instead of reading the group and bot
     /// registry on every streaming delta.
     channel_sender_info: Mutex<HashMap<String, (bcs_domain::ParticipantRole, String)>>,
+    /// run_id → source IM message id.
+    ///
+    /// Channel ingress attaches the IM message id to the web-send command.
+    /// Cache it before bot delivery so the first response event can target
+    /// the exact source message even when requests share one conversation.
+    channel_source_message_ids: Mutex<HashMap<String, String>>,
 }
 
 impl MessageTracker {
@@ -62,6 +68,7 @@ impl MessageTracker {
             chat_delta_mode: Mutex::new(HashSet::new()),
             streaming_thinking_buf: Mutex::new(HashMap::new()),
             channel_sender_info: Mutex::new(HashMap::new()),
+            channel_source_message_ids: Mutex::new(HashMap::new()),
         }
     }
 
@@ -147,6 +154,25 @@ impl MessageTracker {
             .insert(run_id.to_string(), info);
     }
 
+    pub async fn channel_source_message_id(&self, run_id: &str) -> Option<String> {
+        self.channel_source_message_ids
+            .lock()
+            .await
+            .get(run_id)
+            .cloned()
+    }
+
+    pub async fn cache_channel_source_message_id(&self, run_id: &str, message_id: &str) {
+        self.channel_source_message_ids
+            .lock()
+            .await
+            .insert(run_id.to_string(), message_id.to_string());
+    }
+
+    pub async fn remove_channel_source_message_id(&self, run_id: &str) {
+        self.channel_source_message_ids.lock().await.remove(run_id);
+    }
+
     /// Whether the run has received any `delta_text` frame (SSE self-accumulate
     /// mode). At `final`, delta-mode runs flush their accumulated buffer instead
     /// of overriding with the final frame's cumulative full text.
@@ -184,6 +210,40 @@ impl MessageTracker {
         self.chat_delta_mode.lock().await.remove(run_id);
         self.streaming_thinking_buf.lock().await.remove(run_id);
         self.channel_sender_info.lock().await.remove(run_id);
+        self.channel_source_message_ids.lock().await.remove(run_id);
         self.streaming_chat_buf.lock().await.remove(run_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MessageTracker;
+
+    #[tokio::test]
+    async fn channel_source_message_ids_are_scoped_to_run_and_cleaned_up() {
+        let tracker = MessageTracker::new();
+        tracker
+            .cache_channel_source_message_id("run-1", "message-1")
+            .await;
+        tracker
+            .cache_channel_source_message_id("run-2", "message-2")
+            .await;
+
+        assert_eq!(
+            tracker.channel_source_message_id("run-1").await.as_deref(),
+            Some("message-1")
+        );
+        assert_eq!(
+            tracker.channel_source_message_id("run-2").await.as_deref(),
+            Some("message-2")
+        );
+
+        tracker.cleanup_run("run-1").await;
+
+        assert!(tracker.channel_source_message_id("run-1").await.is_none());
+        assert_eq!(
+            tracker.channel_source_message_id("run-2").await.as_deref(),
+            Some("message-2")
+        );
     }
 }

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -818,6 +818,9 @@ async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
     let recording_channel = Arc::new(RecordingChannelService::default());
     let channel: Arc<dyn ChannelService> = recording_channel.clone();
     assert!(flow.channel_slot().set(channel).is_ok());
+    flow.message_tracker
+        .cache_channel_source_message_id("run-channel-delta", "source-msg-1")
+        .await;
     let group_get_count_before = support.group.get_count("group-1").await;
 
     for delta in ["你", "好"] {
@@ -840,6 +843,14 @@ async fn bot_delta_channel_outbound_uses_delta_text_not_synthesized_snapshot() {
     let outbound = recording_channel.outbound().await;
     assert_eq!(outbound.len(), 2);
     assert_eq!(outbound[0].sender_label, "Observer");
+    assert_eq!(
+        outbound[0].source_im_message_id.as_deref(),
+        Some("source-msg-1")
+    );
+    assert_eq!(
+        outbound[1].source_im_message_id.as_deref(),
+        Some("source-msg-1")
+    );
     assert_eq!(
         support
             .registry

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -1051,6 +1051,7 @@ async fn web_send_resets_message_count_routes_and_delivers() {
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
         sender_conn_id: None,
         })
         .await
@@ -1114,6 +1115,7 @@ async fn web_send_persists_public_human_owner_for_manager_worker() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await
@@ -1151,6 +1153,7 @@ async fn web_send_persists_public_human_owner_for_manager_worker() {
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
             sender_conn_id: None,
         })
         .await
@@ -1189,7 +1192,8 @@ async fn accepted_chat_send_records_run_context_for_callback() {
             mentions: vec![],
             attachments: None,
             thinking: None,
-            idempotency_key: None,
+            idempotency_key: Some("idempotency-1".to_string()),
+            source_im_message_id: Some("source-msg-1".to_string()),
             sender_conn_id: None,
         })
         .await
@@ -1204,6 +1208,13 @@ async fn accepted_chat_send_records_run_context_for_callback() {
     assert_eq!(context.group_id, "group-1");
     assert_eq!(context.bcs_session_id.as_deref(), Some("group-1:abcdef12"));
     assert!(!context.terminal);
+    assert_eq!(
+        flow.message_tracker
+            .channel_source_message_id(&outcome.primary_run_id)
+            .await
+            .as_deref(),
+        Some("source-msg-1")
+    );
     assert!(
         context.deadline_ms
             >= before_send_ms.saturating_add(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS)
@@ -1269,6 +1280,7 @@ async fn web_send_delivers_to_registered_provider_target_without_ws_connection()
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
             sender_conn_id: None,
         })
         .await
@@ -1309,6 +1321,7 @@ async fn provider_stream_gray_created_by_enables_sse_for_provider_chat_send() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await
@@ -1349,6 +1362,7 @@ async fn provider_stream_gray_created_by_miss_keeps_provider_callback() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await
@@ -1389,6 +1403,7 @@ async fn provider_stream_gray_mode_disabled_sends_provider_chat_send_over_sse() 
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await
@@ -1447,6 +1462,7 @@ async fn provider_stream_gray_created_by_still_keeps_inject_on_callback() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await
@@ -1566,6 +1582,7 @@ async fn web_send_explicit_mentions_do_not_inject_manager_worker_workers() {
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
             sender_conn_id: None,
         })
         .await
@@ -1610,6 +1627,7 @@ async fn web_send_in_human_bot_dm_uses_dm_routing_and_keeps_frontend_echo() {
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
         sender_conn_id: None,
         })
         .await
@@ -1659,6 +1677,7 @@ async fn web_send_in_human_bot_dm_omits_group_context_by_default() -> ServiceRes
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await?;
@@ -1711,6 +1730,7 @@ async fn web_send_blocking_interceptor_prevents_bot_delivery() {
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
         sender_conn_id: None,
         })
         .await
@@ -1752,6 +1772,7 @@ async fn web_send_delivery_frame_contains_recipient_group_context() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
     sender_conn_id: None,
     })
     .await
@@ -1821,6 +1842,7 @@ async fn web_send_with_session_id_routes_v2_by_substituting_wire_group_id() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
     sender_conn_id: None,
     })
     .await
@@ -1887,6 +1909,7 @@ async fn web_send_with_legacy_session_id_routes_v2_with_group_wire_id() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await
@@ -1943,6 +1966,7 @@ async fn web_send_with_session_id_routes_v3_with_explicit_bcs_session_id() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
     sender_conn_id: None,
     })
     .await
@@ -2005,6 +2029,7 @@ async fn web_send_to_provider_with_session_id_uses_explicit_bcs_session_id() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await
@@ -2069,6 +2094,7 @@ async fn web_send_direct_bot_projection_hides_bcs_group_context() -> ServiceResu
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
         sender_conn_id: None,
     })
     .await?;
@@ -2128,6 +2154,7 @@ async fn web_send_prefers_human_from_name_in_delivered_frame() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
     sender_conn_id: None,
     })
     .await
@@ -2179,6 +2206,7 @@ async fn web_send_inject_delivery_uses_event_frame() {
         attachments: None,
         thinking: None,
         idempotency_key: None,
+        source_im_message_id: None,
     sender_conn_id: None,
     })
     .await
@@ -2232,6 +2260,7 @@ async fn web_send_delivers_to_private_group_targets() {
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
         sender_conn_id: None,
         })
         .await
@@ -2278,6 +2307,7 @@ async fn web_send_partial_delivery_failure_is_represented_in_outcome() {
             attachments: None,
             thinking: None,
             idempotency_key: None,
+            source_im_message_id: None,
         sender_conn_id: None,
         })
         .await

--- a/src/bcs/docs/superpowers/specs/2026-07-24-channel-source-message-correlation-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-07-24-channel-source-message-correlation-design.md
@@ -1,0 +1,49 @@
+# Channel 源消息关联设计
+
+- 日期：2026-07-24
+- 状态：已完成
+- 范围：BCS channel 入站消息与 bot outbound event 的关联
+
+## 背景
+
+Channel provider 收到 IM 消息时知道原始消息 ID，但 bot 后续通过独立的
+`run_id` 返回 `chat.delta`、`chat.final` 或终止事件。部分 provider 需要在
+首个可见回复成功后更新原消息上的临时状态，因此 outbound delivery 必须能
+精确定位启动当前 run 的源 IM 消息。
+
+只按 conversation ID 关联不安全：同一会话内的并发请求可能互相覆盖，导致
+provider 更新错误的源消息。
+
+## 决策
+
+1. Channel ingress 在继续使用源 IM 消息 ID 作为 `idempotency_key` 的同时，
+   显式写入 `WebSendCommand.source_im_message_id`；普通 WebSocket 请求保持
+   `None`，避免把任意幂等键误当作 IM 消息 ID。
+2. Message flow 为每个实际 `Send` delivery 创建 `run_id` 后，在调用 bot
+   delivery 前缓存 `run_id -> source_im_message_id`，避免快速响应先于 delivery
+   返回。
+3. Bot event 转换为 channel `OutboundMessage` 时按 `run_id` 读取源消息 ID。
+4. Channel service 将该可选字段继续透传给 `ChannelOutboundEvent`，由具体
+   delivery adapter 决定是否使用。
+5. Bot delivery 未成功时立即清理映射；run 进入 final、error 或 aborted 后沿用
+   MessageTracker 的 terminal cleanup 清理。
+
+## Contract 传播范围
+
+- Service API：
+  - `WebSendCommand.source_im_message_id: Option<String>`
+  - `OutboundMessage.source_im_message_id: Option<String>`
+  - `ChannelOutboundEvent.source_im_message_id: Option<String>`
+- 消费方：`bcs-channel` 和所有 `ChannelDeliveryPort` 实现。
+- 生产方：`bcs-message-flow` 的 bot event outbound hook。
+- 兼容性：这些字段都是进程内、可选的 additive contract；非 channel 来源或无法
+  关联的旧路径继续传 `None`，不改变 HTTP、WebSocket 或持久化格式。
+- 部署与迁移：不需要配置、数据库迁移或协议版本切换。
+
+## 验收标准
+
+- 同一会话的不同 run 可以分别携带各自的源消息 ID。
+- 第一个 bot event 可以拿到在 delivery 返回前写入的源消息 ID。
+- Channel service 不修改该字段并将其传给 delivery adapter。
+- Delivery 失败或 run 结束后，映射不会继续保留。
+- 非 channel 消息的 outbound 行为保持不变。


### PR DESCRIPTION
## Summary

- add an explicit optional `source_im_message_id` to the internal channel message-flow contracts
- correlate each channel-originated bot run with its exact source IM message before delivery starts
- propagate the correlation through bot events and channel outbound delivery, with cleanup on delivery failure and terminal run states
- add contract tests and a design note covering concurrent requests and compatibility

## Why

The DingTalk channel needs to acknowledge an inbound message immediately with a reaction, then remove or update that reaction when the bot starts responding. Conversation-level correlation is insufficient when multiple requests share the same conversation; the original IM message ID must follow the exact BCS run.

## Validation

- `cargo check --workspace`
- `cargo test -p bcs-channel -p bcs-message-flow`
- targeted source-message correlation, outbound propagation, and cleanup tests

## Compatibility

All added fields are optional process-internal contracts. Existing WebSocket, persistence, and non-channel paths continue to use `None`; no database or wire-protocol migration is required.