### PR TITLE
fix(service-bot): re-publish after offline recreates the destroyed online bot

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -59,6 +59,16 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+# Error codes for which BaaS is telling us an upgrade's target bot is gone, so
+# the deploy atom must self-heal with a fresh first release rather than fail.
+# ``BOT_NOT_FOUND``: the bot record is gone. ``DEVICE_NOT_FOUND``: the
+# underlying device is gone — e.g. a TeClaw bot whose device was physically
+# destroyed by an offline STOP. Kept in sync with ``BOT_GONE_ERROR_CODES`` in
+# ``publish_flow.operation_runner`` (which classifies the returned result);
+# duplicated locally to keep this lower-level service free of a dependency on
+# the publish-flow orchestration package.
+_BOT_GONE_ERROR_CODES = frozenset({"BOT_NOT_FOUND", "DEVICE_NOT_FOUND"})
+
 
 class BotBuildServiceError(Exception):
     """Bot build service error."""
@@ -1108,9 +1118,15 @@ class BotBuildService:
         except Exception as e:
             error_info = self._extract_baas_error_info(e)
             error_code = error_info.get("error_code")
-            if error_code == "BOT_NOT_FOUND":
+            # BaaS signals a gone upgrade target as either BOT_NOT_FOUND (bot
+            # record gone) or DEVICE_NOT_FOUND (underlying device gone — e.g. a
+            # TeClaw bot whose device was destroyed by an offline STOP). Surface
+            # both as a structured failure so the deploy atom classifies it and
+            # the caller self-heals with a fresh first release, instead of
+            # letting DEVICE_NOT_FOUND raise and fail the publish outright.
+            if error_code in _BOT_GONE_ERROR_CODES:
                 logger.warning(
-                    f"[BotBuildService.upgrade] Upgrade hit BOT_NOT_FOUND: "
+                    f"[BotBuildService.upgrade] Upgrade hit {error_code}: "
                     f"bot_uuid={bot_uuid}, error_info={error_info}"
                 )
                 return {

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/operation_runner.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/operation_runner.py
@@ -86,8 +86,18 @@ class PublishOperationError(Exception):
     """A publish operation step failed (surfaced to the caller / task)."""
 
 
+# Error codes for which BaaS is telling us the operation's target bot no longer
+# exists, so an in-place mutation (UPDATE/RESTART) can never succeed and the
+# caller must fall back to a fresh CREATE. BaaS reports ``BOT_NOT_FOUND`` when
+# the bot record is gone and ``DEVICE_NOT_FOUND`` when the underlying device is
+# gone — e.g. a TeClaw bot whose device was physically destroyed by an offline
+# STOP. Both must trigger the recreate self-heal.
+BOT_GONE_ERROR_CODES = frozenset({"BOT_NOT_FOUND", "DEVICE_NOT_FOUND"})
+
+
 class TargetBotGoneError(Exception):
-    """BaaS reported the operation's target bot gone (``BOT_NOT_FOUND``).
+    """BaaS reported the operation's target bot gone (see
+    :data:`BOT_GONE_ERROR_CODES` — ``BOT_NOT_FOUND`` / ``DEVICE_NOT_FOUND``).
 
     Raised out of :func:`acquire_deploy_workflow` after the op has been
     ABANDONED, so the caller runs its fallback (a fresh first-release-shaped
@@ -111,7 +121,8 @@ async def acquire_deploy_workflow(
     operation (first release, upgrade, restart, and the restart-recreate leg).
 
     ``issue`` performs the BaaS mutation and returns its result dict. A result
-    of ``{success: False, error_code: "BOT_NOT_FOUND"}`` is classified
+    of ``{success: False, error_code: <bot-gone code>}`` (see
+    :data:`BOT_GONE_ERROR_CODES`) is classified
     uniformly: the op is ABANDONED (``bot_gone_reason``, naming the caller's
     fallback for ledger forensics) and :class:`TargetBotGoneError` raised so
     the caller runs that fallback as a separate, fresh op. Any other issue outcome flows through
@@ -142,7 +153,7 @@ async def acquire_deploy_workflow(
         result = await issue()
         if (
             result.get("success") is False
-            and result.get("error_code") == "BOT_NOT_FOUND"
+            and result.get("error_code") in BOT_GONE_ERROR_CODES
         ):
             raise TargetBotGoneError()
         return result

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
@@ -21,6 +21,20 @@ from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
+# BaaS bot statuses under which the previous online bot is NOT a valid in-place
+# UPGRADE (UPDATE) target — the bot is gone or not live, so re-publish must take
+# the first-release (CREATE) path instead.
+#
+# The critical case is ``STOPPED``: offlining a SUCCESS publish tears down the
+# online bot via a BaaS STOP, which for a TeClaw device physically destroys the
+# underlying bot and leaves ``baas_bot.status = STOPPED`` (not ``RELEASED``).
+# Treating only ``RELEASED`` as "gone" let a ``STOPPED`` previous bot slip
+# through as an UPGRADE target, so the re-publish issued an UPDATE against the
+# destroyed device and failed permanently with ``DEVICE_NOT_FOUND``.
+_ONLINE_UPGRADE_BLOCKING_BAAS_STATUSES = frozenset(
+    {"RELEASED", "STOPPED", "STOPPING", "FAILED"}
+)
+
 
 class UpgradeResolutionMixin:
     """Decide first-release vs. upgrade for the verify and online stages."""
@@ -107,6 +121,10 @@ class UpgradeResolutionMixin:
         1. The current publish record has a valid last_pub_id
         2. The previous publish record exists
         3. The previous publish record's status is released (i.e. PublishStatus.SUCCESS)
+        4. The previous online bot is still live in BaaS — its ``baas_bot_status``
+           is not one of the gone/not-live statuses in
+           ``_ONLINE_UPGRADE_BLOCKING_BAAS_STATUSES`` (notably ``STOPPED``, which
+           is what an offline teardown leaves behind on a destroyed TeClaw bot).
 
         Otherwise, uniformly treat it as a first release and create a new online Bot.
         """
@@ -142,7 +160,12 @@ class UpgradeResolutionMixin:
 
         baas_status_result = self.get_publish_bot_status(last_pub_id, PublishStage.ONLINE)
         baas_status = baas_status_result.get("baas_bot_status")
-        if baas_status == "RELEASED":
+        if baas_status in _ONLINE_UPGRADE_BLOCKING_BAAS_STATUSES:
+            logger.info(
+                f"[PublishFlowService._should_upgrade_online] "
+                f"Previous online bot is gone/not live, fallback to first release: "
+                f"last_pub_id={last_pub_id}, baas_bot_status={baas_status}"
+            )
             return False
 
         return True

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
@@ -267,6 +267,39 @@ def test_upgrade_teclaw_with_no_artifact_raises():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("error_code", ["BOT_NOT_FOUND", "DEVICE_NOT_FOUND"])
+def test_upgrade_teclaw_gone_bot_returns_structured_failure(error_code):
+    """Regression (#435): a teclaw upgrade against a destroyed device answers
+    with ``DEVICE_NOT_FOUND`` (a STOP physically destroys the TeClaw bot). Both
+    that and ``BOT_NOT_FOUND`` must surface as a structured ``success: False``
+    result — not a raised ``BotBuildServiceError`` — so the deploy atom
+    classifies it and self-heals with a fresh first release."""
+    from agentclaw.community.core.service_bot.services.baas_service import (
+        BaasServiceError,
+    )
+
+    svc, baas = _svc("teclaw")
+    err = BaasServiceError(f"BaaS API error: 404 - {error_code}")
+    err.response = MagicMock()
+    err.response.json.return_value = {
+        "detail": {"error_code": error_code, "message": "bot not found"}
+    }
+    baas.update_teclaw_bot.side_effect = err
+
+    result = svc.upgrade(
+        "BOT-t", _BOT, user_id="u1", migration_path="",
+        publish_stage=PublishStage.ONLINE, delivery=DeliveryArtifact(_ARTIFACT),
+    )
+
+    assert result == {
+        "success": False,
+        "error_code": error_code,
+        "message": "bot not found",
+        "bot_uuid": "BOT-t",
+    }
+
+
+@pytest.mark.unit
 def test_upgrade_routes_arca_to_upgrade_bot_unchanged():
     svc, baas = _svc("baas")
     svc.upgrade(

--- a/src/backend/tests/community/core/service_bot/services/test_operation_runner.py
+++ b/src/backend/tests/community/core/service_bot/services/test_operation_runner.py
@@ -365,6 +365,27 @@ def test_atom_bot_not_found_abandons_with_reason_and_raises(ledger, baas):
     assert op.last_error == "BOT_NOT_FOUND -> first release"
 
 
+def test_atom_device_not_found_abandons_with_reason_and_raises(ledger, baas):
+    """Regression (#435): BaaS reports a destroyed TeClaw device as
+    ``DEVICE_NOT_FOUND`` (not ``BOT_NOT_FOUND``). The deploy atom must classify
+    it the same way so the caller self-heals with a fresh first release instead
+    of failing the publish permanently."""
+    r = _runner(ledger, baas)
+
+    async def issue():
+        return {"success": False, "error_code": "DEVICE_NOT_FOUND"}
+
+    with pytest.raises(TargetBotGoneError):
+        run(acquire_deploy_workflow(
+            r, publish_id=1, kind=PublishOperationKind.UPGRADE,
+            stage=PublishStage.ONLINE, operator="op", issue=issue,
+            bot_uuid="BOT-gone", bot_gone_reason="DEVICE_NOT_FOUND -> first release",
+        ))
+    op = ledger.get_latest_by_kind(1, UPGRADE, "online")
+    assert op.state == PublishOperationState.ABANDONED.value
+    assert op.last_error == "DEVICE_NOT_FOUND -> first release"
+
+
 def test_atom_creation_requires_bot_uuid(ledger, baas):
     r = _runner(ledger, baas)
 

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -297,6 +297,27 @@ def test_should_upgrade_online_requires_last_publish_success():
     assert svc._should_upgrade_online(publish_record) is False
 
 
+@pytest.mark.parametrize("baas_status", ["RELEASED", "STOPPED", "STOPPING", "FAILED"])
+def test_should_upgrade_online_forces_first_release_when_prev_bot_gone(baas_status):
+    """Regression (#435): an offlined SUCCESS publish leaves its online bot
+    ``STOPPED`` (a TeClaw STOP physically destroys the device), not
+    ``RELEASED``. The upgrade guard must treat every gone/not-live status —
+    not only ``RELEASED`` — as first-release, or the re-publish issues an
+    UPDATE against the destroyed bot and fails with ``DEVICE_NOT_FOUND``."""
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
+
+    publish_record = _make_publish_record(last_pub_id=10)
+    publish_service.get_publish_by_id.return_value = _make_publish_record(
+        id=10,
+        status=PublishStatus.RELEASED.value,
+    )
+    svc.get_publish_bot_status = Mock(return_value={'baas_bot_status': baas_status})
+    assert svc._should_upgrade_online(publish_record) is False
+
+
 # (#197 all-auto) approve_baas_publish was removed — every BaaS mutation is
 # auto-approved server-side, so there is no client approve method to test.
 
@@ -323,6 +344,47 @@ async def test_execute_release_phase_falls_back_to_first_release_when_last_publi
 
     # DI refactor replaced the module-level get_bot_service() shim with
     # the injected self._bot_service; set it directly instead of patching.
+    bot_service = Mock()
+    bot_service.get_bot.return_value = {'bot_id': 'bot-source'}
+    svc._bot_service = bot_service
+    svc._execute_first_release = AsyncMock(return_value='FIRST')
+    svc._execute_upgrade_release = AsyncMock(return_value='UPGRADE')
+
+    result = await svc.execute_release_phase(publish_record, operator='u1')
+
+    assert result == 'FIRST'
+    svc._execute_first_release.assert_awaited_once()
+    svc._execute_upgrade_release.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_release_phase_first_release_when_offlined_online_bot_stopped():
+    """Regression (#435): the full offline→re-publish cycle. Offlining a SUCCESS
+    publish marks it RELEASED and tears its online bot down via a BaaS STOP —
+    which physically destroys the TeClaw device but leaves ``baas_bot`` STOPPED.
+    The re-publish's online stage must resolve to a fresh CREATE (first release),
+    not an UPDATE against the destroyed bot (which would 404 DEVICE_NOT_FOUND)."""
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
+
+    # The re-publish record (v2) points back at the offlined publish (5724 → id=10).
+    publish_record = _make_publish_record(
+        id=2,
+        status=PublishStatus.VALIDATING.value,
+        source_bot_id='bot-source',
+        last_pub_id=10,
+        ext={'migration_path': '/tmp/migration'},
+    )
+    # The previous publish is RELEASED (offline flipped SUCCESS→RELEASED)...
+    publish_service.get_publish_by_id.return_value = _make_publish_record(
+        id=10,
+        status=PublishStatus.RELEASED.value,
+    )
+    # ...and its online bot is STOPPED, not RELEASED (the offline STOP leaves it so).
+    svc.get_publish_bot_status = Mock(return_value={'baas_bot_status': 'STOPPED'})
+
     bot_service = Mock()
     bot_service.get_bot.return_value = {'bot_id': 'bot-source'}
     svc._bot_service = bot_service


### PR DESCRIPTION
## Summary

Fixes #435.

Offlining a **SUCCESS** service-bot publish tears down its online bot via a BaaS **STOP**, which for a TeClaw device physically destroys the underlying bot and leaves `baas_bot.status = STOPPED` (not `RELEASED`). The subsequent re-publish's online stage then took the **UPGRADE (UPDATE)** path against the already-destroyed bot and failed permanently with `[DEVICE_NOT_FOUND] bot not found`.

The root of the hole: the lifecycle that *destroys* the bot (offline → STOP → `STOPPED`) and the guard that *detects a destroyed bot* (`_should_upgrade_online`, which only treated `RELEASED` as "gone") disagreed on the terminal status, so a `STOPPED` previous bot slipped through as a valid UPGRADE target.

## Changes

**Primary fix — `_should_upgrade_online` (`upgrade_resolution_mixin.py`)**
Treat every gone/not-live BaaS bot status — `RELEASED`, `STOPPED`, `STOPPING`, `FAILED` — as first-release, not just `RELEASED`. The re-publish now issues a fresh **CREATE** instead of an UPDATE against the destroyed bot.

**Defense-in-depth — `DEVICE_NOT_FOUND` classification**
Even if an UPDATE is somehow issued against a destroyed device, the "target bot gone → recreate" self-heal now fires:
- `operation_runner.py`: the deploy atom classifies both `BOT_NOT_FOUND` and `DEVICE_NOT_FOUND` (new shared `BOT_GONE_ERROR_CODES`) as `TargetBotGoneError`, so the caller falls back to a first release.
- `bot_build_service.upgrade`: surfaces `DEVICE_NOT_FOUND` as a structured `{success: False, error_code: ...}` result (like `BOT_NOT_FOUND`) instead of raising, so it reaches the classifier rather than failing the publish outright.

The two error-code constants are kept in sync by hand (documented in comments); the lower-level `bot_build_service` deliberately does not import from the publish-flow orchestration package to keep module load order acyclic.

## Tests

- `test_should_upgrade_online_forces_first_release_when_prev_bot_gone` — parametrized over `RELEASED`/`STOPPED`/`STOPPING`/`FAILED`.
- `test_execute_release_phase_first_release_when_offlined_online_bot_stopped` — the full offline→re-publish cycle at the service layer: previous publish `RELEASED` + online bot `STOPPED` resolves to first release, not upgrade.
- `test_atom_device_not_found_abandons_with_reason_and_raises` — the deploy atom classifies `DEVICE_NOT_FOUND`.
- `test_upgrade_teclaw_gone_bot_returns_structured_failure` — parametrized over both gone-bot codes on the teclaw upgrade path.

All 671 tests under `tests/community/core/service_bot/` pass, plus the e2e publish-boundary suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wJQCZLSeZTgHg1EdJ6NSQ)_