### PR TITLE
feat: add changed-line coverage gate to local just test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,42 @@ fresh focused run, then run the default all-module gate to catch shared-stack
 interference. Do not inflate a result by excluding production Core paths or by
 adding test-only calls to domain logic.
 
+## Local Test Coverage Gate
+
+The `just test` recipes in `src/baas` and `src/gateway` enforce the same
+changed-line coverage gate as GitHub CI. They resolve a base ref via
+`scripts/lib/local_test_base.sh` and pass it to `scripts/ci_test.sh --base`,
+which runs `scripts/ci/report_check.py` with `--min-change-line-coverage 90`
+against the diff.
+
+Base resolution order:
+
+1. `AVERNET_LOCAL_TEST_BASE` — explicit override; used verbatim. Set this when
+   you want a specific merge-base (e.g. a feature branch point) or when
+   `origin/dev` is unavailable.
+2. `origin/dev` — fetched on demand (`git fetch --no-tags origin dev`) unless
+   `AVERNET_LOCAL_TEST_NO_FETCH=1`, then `git merge-base HEAD origin/dev`.
+3. If `origin/dev` cannot be resolved and no override is set, the recipe fails
+   closed rather than silently widening the diff range.
+
+Escape hatches:
+
+- `AVERNET_LOCAL_TEST_BASE=<ref>` — pin the base ref yourself (e.g.
+  `AVERNET_LOCAL_TEST_BASE=$(git merge-base HEAD upstream/dev)`).
+- `AVERNET_LOCAL_TEST_NO_FETCH=1` — skip the auto-fetch; useful in sandboxes
+  without network. `origin/dev` must already exist locally.
+- `just test-no-cov` — run the CI pipeline directly without the changed-line
+  coverage gate, for fast iteration. Switch back to `just test` before pushing.
+
+`just test` takes no parameters: it always runs the gate with the default
+`bare` mode and `e2e-sqlite` overlay that `scripts/ci_test.sh` applies
+internally. To run the pipeline with a custom mode or overlay, use
+`just test-no-cov mode=<m> overlay=<o>`, which forwards `{{mode}} {{overlay}}`
+to `run_ci_pipeline`.
+
+This keeps local `just test` aligned with `.github/workflows/unit-tests.yml`
+and the pre-push module gates described above.
+
 ## Development Guidelines
 
 Start from the requirement and the existing contract. Keep changes small and

--- a/scripts/ci/tests/test_local_test_coverage_gate.py
+++ b/scripts/ci/tests/test_local_test_coverage_gate.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BAAS_JUSTFILE = REPO_ROOT / "src" / "baas" / "justfile"
+GATEWAY_JUSTFILE = REPO_ROOT / "src" / "gateway" / "justfile"
+LOCAL_TEST_BASE_LIB = REPO_ROOT / "scripts" / "lib" / "local_test_base.sh"
+
+
+class LocalTestCoverageGateTest(unittest.TestCase):
+    """The local `just test` recipes must align with GitHub CI by routing
+    through ci_test.sh --base, while `just test-no-cov` keeps the fast feedback
+    path that skips the gate. We parse justfile text rather than running `just`
+    so the test stays hermetic."""
+
+    def test_local_test_base_lib_exists(self) -> None:
+        self.assertTrue(
+            LOCAL_TEST_BASE_LIB.is_file(),
+            f"expected shared resolver at {LOCAL_TEST_BASE_LIB}",
+        )
+
+    def test_baas_test_recipe_calls_ci_test_with_base(self) -> None:
+        text = BAAS_JUSTFILE.read_text(encoding="utf-8")
+        self.assertIn("source ../../scripts/lib/local_test_base.sh", text)
+        self.assertIn("resolve_local_test_base", text)
+        self.assertIn('./scripts/ci_test.sh --base "$base"', text)
+
+    def test_gateway_test_recipe_calls_ci_test_with_base(self) -> None:
+        text = GATEWAY_JUSTFILE.read_text(encoding="utf-8")
+        self.assertIn("source ../../scripts/lib/local_test_base.sh", text)
+        self.assertIn("resolve_local_test_base", text)
+        self.assertIn('./scripts/ci_test.sh --base "$base"', text)
+
+    def test_baas_test_no_cov_does_not_call_gate(self) -> None:
+        text = BAAS_JUSTFILE.read_text(encoding="utf-8")
+        # test-no-cov recipe must exist and must not pass --base to ci_test.sh.
+        self.assertIn("test-no-cov", text)
+        test_no_cov_block = self._recipe_block(text, "test-no-cov")
+        self.assertNotIn("--base", test_no_cov_block)
+        self.assertNotIn("resolve_local_test_base", test_no_cov_block)
+
+    def test_gateway_test_no_cov_does_not_call_gate(self) -> None:
+        text = GATEWAY_JUSTFILE.read_text(encoding="utf-8")
+        self.assertIn("test-no-cov", text)
+        test_no_cov_block = self._recipe_block(text, "test-no-cov")
+        self.assertNotIn("--base", test_no_cov_block)
+        self.assertNotIn("resolve_local_test_base", test_no_cov_block)
+
+    def test_test_no_cov_keeps_run_ci_pipeline(self) -> None:
+        for justfile in (BAAS_JUSTFILE, GATEWAY_JUSTFILE):
+            text = justfile.read_text(encoding="utf-8")
+            block = self._recipe_block(text, "test-no-cov")
+            self.assertIn("run_ci_pipeline", block)
+
+    @staticmethod
+    def _recipe_block(text: str, name: str) -> str:
+        """Return the body of a just recipe identified by its name.
+
+        just recipes start with `name params:` at column 0 and continue through
+        indented lines until the next non-indented non-blank line.
+        """
+        lines = text.splitlines()
+        start = None
+        for index, line in enumerate(lines):
+            stripped = line.lstrip()
+            if stripped == "":
+                continue
+            if line[0].isspace():
+                continue
+            # Recipe header: name optionally followed by params, then `:`.
+            head = stripped.split(":", 1)[0].strip()
+            # Sanity: ensure we don't match e.g. `test-no-covx`.
+            if head.split()[0] == name:
+                start = index
+                break
+        if start is None:
+            raise AssertionError(f"recipe '{name}' not found in justfile")
+        body: list[str] = []
+        for line in lines[start + 1:]:
+            if line.strip() == "":
+                body.append(line)
+                continue
+            if not line[0].isspace():
+                break
+            body.append(line)
+        return "\n".join(body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/lib/local_test_base.sh
+++ b/scripts/lib/local_test_base.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Shared base-ref resolver for local `just test` recipes.
+#
+# Local test recipes need a base ref to compute changed-line coverage the same
+# way GitHub CI does (merge-base of HEAD against the target branch). This helper
+# centralizes that resolution so baas and gateway justfiles stay in sync.
+#
+# Resolution order:
+#   1. AVERNET_LOCAL_TEST_BASE — explicit override; returned verbatim.
+#   2. origin/dev — fetched on demand unless AVERNET_LOCAL_TEST_NO_FETCH=1,
+#      then `git merge-base HEAD origin/dev`.
+#   3. If origin/dev is unavailable and no override is set, fail closed with a
+#      message pointing at the escape hatches.
+#
+# Output: prints the resolved base ref on stdout (single line).
+# Returns non-zero on hard failure.
+
+set -euo pipefail
+
+resolve_local_test_base() {
+    local target_ref="origin/dev"
+    local merge_base
+
+    if [[ -n "${AVERNET_LOCAL_TEST_BASE:-}" ]]; then
+        echo "${AVERNET_LOCAL_TEST_BASE}"
+        return 0
+    fi
+
+    if [[ "${AVERNET_LOCAL_TEST_NO_FETCH:-0}" != "1" ]]; then
+        # Tolerate fetch failures (offline, no remote): we still try the local
+        # origin/dev ref below. Capture stderr so noise does not leak onto the
+        # test output stream.
+        git fetch --no-tags origin dev >/dev/null 2>&1 || true
+    fi
+
+    if git rev-parse --verify "${target_ref}" >/dev/null 2>&1; then
+        merge_base="$(git merge-base HEAD "${target_ref}")" || {
+            echo "local test base: could not compute merge-base of HEAD and ${target_ref}" >&2
+            echo "set AVERNET_LOCAL_TEST_BASE=<ref>, export AVERNET_LOCAL_TEST_NO_FETCH=1," >&2
+            echo "or run 'just test-no-cov' for quick feedback without the coverage gate." >&2
+            return 1
+        }
+        echo "${merge_base}"
+        return 0
+    fi
+
+    echo "local test base: ${target_ref} is unavailable and AVERNET_LOCAL_TEST_BASE is not set." >&2
+    echo "set AVERNET_LOCAL_TEST_BASE=<ref> (e.g. the merge-base yourself)," >&2
+    echo "export AVERNET_LOCAL_TEST_NO_FETCH=1 after fetching manually," >&2
+    echo "or run 'just test-no-cov' for quick feedback without the coverage gate." >&2
+    return 1
+}

--- a/src/baas/README.md
+++ b/src/baas/README.md
@@ -114,6 +114,12 @@ just test-e2e
 just test
 ```
 
+`just test` enforces the changed-line coverage gate against
+`git merge-base HEAD origin/dev`, matching GitHub CI. Set
+`AVERNET_LOCAL_TEST_BASE=<ref>` to override the base, or
+`AVERNET_LOCAL_TEST_NO_FETCH=1` to skip the auto-fetch. Use `just test-no-cov`
+for quick feedback without the coverage gate.
+
 ### Environment Variables
 
 | Variable | Purpose |

--- a/src/baas/justfile
+++ b/src/baas/justfile
@@ -22,7 +22,19 @@ test-e2e-one test:
 test-ci group='ci' mode='bare' overlay='e2e-sqlite':
     ./scripts/ci_test.sh --group {{group}} {{mode}} {{overlay}}
 
-test mode='bare' overlay='e2e-sqlite':
+# Local test entry point. Enforces the changed-line coverage gate against the
+# merge-base of HEAD and origin/dev, mirroring GitHub CI. Set
+# AVERNET_LOCAL_TEST_BASE=<ref> to override the base, or AVERNET_LOCAL_TEST_NO_FETCH=1
+# to skip the `git fetch` step. Use `just test-no-cov` for fast feedback without
+# the gate.
+test:
+    base="$(source ../../scripts/lib/local_test_base.sh && resolve_local_test_base)" && \
+        ./scripts/ci_test.sh --base "$base"
+
+# Fast feedback path: runs the CI pipeline directly without the changed-line
+# coverage gate. Use for iterative development; switch to `just test` before
+# pushing.
+test-no-cov mode='bare' overlay='e2e-sqlite':
     source scripts/lib/pipeline.sh && run_ci_pipeline {{mode}} {{overlay}}
 
 test-full:

--- a/src/gateway/justfile
+++ b/src/gateway/justfile
@@ -22,7 +22,19 @@ test-e2e-one test:
 test-ci group='ci' mode='bare' overlay='e2e-sqlite':
     ./scripts/ci_test.sh --group {{group}} {{mode}} {{overlay}}
 
-test mode='bare' overlay='e2e-sqlite':
+# Local test entry point. Enforces the changed-line coverage gate against the
+# merge-base of HEAD and origin/dev, mirroring GitHub CI. Set
+# AVERNET_LOCAL_TEST_BASE=<ref> to override the base, or AVERNET_LOCAL_TEST_NO_FETCH=1
+# to skip the `git fetch` step. Use `just test-no-cov` for fast feedback without
+# the gate.
+test:
+    base="$(source ../../scripts/lib/local_test_base.sh && resolve_local_test_base)" && \
+        ./scripts/ci_test.sh --base "$base"
+
+# Fast feedback path: runs the CI pipeline directly without the changed-line
+# coverage gate. Use for iterative development; switch to `just test` before
+# pushing.
+test-no-cov mode='bare' overlay='e2e-sqlite':
     source scripts/lib/pipeline.sh && run_ci_pipeline {{mode}} {{overlay}}
 
 test-full:


### PR DESCRIPTION
## Summary

Align the local `just test` recipes in `src/baas` and `src/gateway` with the changed-line coverage gate enforced by GitHub CI, so a green local run no longer diverges from CI on changed-line coverage.

## Changes

- Adds `scripts/lib/local_test_base.sh`, a shared base-ref resolver that computes the merge-base of HEAD against `origin/dev` the same way CI does. Resolution order:
  1. `AVERNET_LOCAL_TEST_BASE` — explicit override, used verbatim.
  2. `origin/dev` — fetched on demand unless `AVERNET_LOCAL_TEST_NO_FETCH=1`, then `git merge-base HEAD origin/dev`.
  3. Fail closed if neither is available, with a message pointing at the escape hatches.
- Updates `src/baas/justfile` and `src/gateway/justfile` so `just test` sources the resolver and routes through `scripts/ci_test.sh --base <ref>`, which runs `report_check.py` with `--min-change-line-coverage 90` against the diff.
- Keeps `just test-no-cov` as the fast feedback path that skips the gate for iteration; switch back to `just test` before pushing.
- Documents the gate, resolution order, and escape hatches in `AGENTS.md` and cross-references it from `src/baas/README.md`.
- Adds `scripts/ci/tests/test_local_test_coverage_gate.py` asserting both justfiles route `just test` through `ci_test.sh --base`, that `test-no-cov` does not invoke the gate, and that the resolver library exists. Parses justfile text so the test stays hermetic.

## Motivation

Local `just test` previously ran the CI pipeline without enforcing changed-line coverage, so it could pass while CI failed on the same diff. This keeps local runs aligned with `.github/workflows/unit-tests.yml` and the pre-push module gates.

## Escape hatches

- `AVERNET_LOCAL_TEST_BASE=<ref>` — pin the base ref yourself.
- `AVERNET_LOCAL_TEST_NO_FETCH=1` — skip the auto-fetch (useful in sandboxes without network).
- `just test-no-cov` — run the CI pipeline directly without the coverage gate.

## Testing

- `scripts/ci/tests/test_local_test_coverage_gate.py` — hermetic unit tests for justfile wiring.
- Verified `just test` in `src/baas` and `src/gateway` against a recent `origin/dev` merge-base: the gate fires on under-covered changes and passes when coverage meets the 90% threshold.
- Confirmed `just test-no-cov` still runs the pipeline without the gate.

## Files

- `AGENTS.md`
- `scripts/ci/tests/test_local_test_coverage_gate.py`
- `scripts/lib/local_test_base.sh`
- `src/baas/README.md`
- `src/baas/justfile`
- `src/gateway/justfile`