### PR TITLE
fix(baas): prevent SQLAlchemy isce error from concurrent orm_session calls in distributed lock renew thread

### DIFF
--- a/src/baas/src/secbaas/community/core/service/distributed_lock/_service.py
+++ b/src/baas/src/secbaas/community/core/service/distributed_lock/_service.py
@@ -93,6 +93,7 @@ class DistributedLockService:
         self._renew_interval_seconds = renew_interval_seconds
         self._lock_contexts: dict[str, LockContext] = {}
         self._local_lock = threading.Lock()
+        self._renew_lock = threading.Lock()
 
     def _generate_holder_id(self) -> str:
         """生成唯一的锁持有者标识。
@@ -136,10 +137,11 @@ class DistributedLockService:
                     )
 
                     # 更新数据库中的过期时间
-                    updated = self._repository.update_expire_time(
-                        lock_name=context.lock_name,
-                        expire_time=new_expire_time,
-                    )
+                    with self._renew_lock:
+                        updated = self._repository.update_expire_time(
+                            lock_name=context.lock_name,
+                            expire_time=new_expire_time,
+                        )
 
                     if updated > 0:
                         context.expire_time = new_expire_time
@@ -306,34 +308,35 @@ class DistributedLockService:
             now = datetime.now()
             expire_time = now + timedelta(seconds=expire_seconds)
 
-            record = self._repository.get_by_lock_name(lock_name)
+            with self._renew_lock:
+                record = self._repository.get_by_lock_name(lock_name)
 
-            if record is None:
-                # 锁不存在，尝试插入
-                inserted = self._repository.insert_lock(
-                    lock_name=lock_name,
-                    lock_holder=lock_holder,
-                    expire_time=expire_time,
-                )
-                return inserted > 0
+                if record is None:
+                    # 锁不存在，尝试插入
+                    inserted = self._repository.insert_lock(
+                        lock_name=lock_name,
+                        lock_holder=lock_holder,
+                        expire_time=expire_time,
+                    )
+                    return inserted > 0
 
-            if record.expire_time and record.expire_time < now:
-                # 锁已过期，删除后重新插入
-                self._repository.delete_lock(lock_name)
-                inserted = self._repository.insert_lock(
-                    lock_name=lock_name,
-                    lock_holder=lock_holder,
-                    expire_time=expire_time,
-                )
-                return inserted > 0
+                if record.expire_time and record.expire_time < now:
+                    # 锁已过期，删除后重新插入
+                    self._repository.delete_lock(lock_name)
+                    inserted = self._repository.insert_lock(
+                        lock_name=lock_name,
+                        lock_holder=lock_holder,
+                        expire_time=expire_time,
+                    )
+                    return inserted > 0
 
-            if record.lock_holder == lock_holder:
-                # 同一持有者，续期
-                self._repository.update_expire_time(
-                    lock_name=lock_name,
-                    expire_time=expire_time,
-                )
-                return True
+                if record.lock_holder == lock_holder:
+                    # 同一持有者，续期
+                    self._repository.update_expire_time(
+                        lock_name=lock_name,
+                        expire_time=expire_time,
+                    )
+                    return True
 
             # 锁被他人持有且未过期
             return False


### PR DESCRIPTION
## Summary

Fixes the `isce` (illegal state for connection execution) SQLAlchemy error that occurs when the distributed lock's auto-renew daemon thread races with the main thread's lock acquisition on the same repository's `orm_session()`.

## Root Cause

The `DistributedLockService._renew_worker` daemon thread calls `update_expire_time()` on the shared `OrmDistributedLockRepository` instance. Simultaneously, the main thread calls `_try_acquire_lock_internal()` which also opens `orm_session()` via the plugin. When the plugin's connection pool (e.g., SQLite `StaticPool` or `ZdasOrmPlugin`) doesn't support concurrent session provisioning, SQLAlchemy raises:

```
This session is provisioning a new connection; concurrent operations are not permitted
```

## Fix

Serialize the two race paths with a dedicated `_renew_lock`:
- The renew thread acquires `_renew_lock` around its `update_expire_time` call
- `_try_acquire_lock_internal` acquires `_renew_lock` around its entire DB flow

Uses a **separate** lock (not the existing `_local_lock`) to avoid deadlock: `_stop_renew_thread` (called under `_local_lock`) calls `join()` on the renew thread, which would deadlock if the renew thread were blocked on `_local_lock`.

## Testing

- 52/52 unit tests pass
- 11/11 integration tests pass

Closes #436