### PR TITLE
feat: add Skills Pool rollout operations

### DIFF
--- a/docs/skills-pool-p3-rollout-runbook.zh-CN.md
+++ b/docs/skills-pool-p3-rollout-runbook.zh-CN.md
@@ -7,31 +7,98 @@
 ## 发布前置
 
 生产环境不由 Backend 自动建表。发布新 Backend 前，必须先通过 OceanBase
-数据库变更流程创建 `ac_skills_pool_rollout_audit`，并执行
-`SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1` 作为发布 preflight；表不存在
-或不可读写时禁止发布 Backend。Avernet 仓库只维护 ORM，数据库变更单需使用
-以下与 ORM 一致的 DDL：
+数据库变更流程创建 `ac_skill_migration_quarantine` 和
+`ac_skills_pool_rollout_audit`，并分别执行 `SELECT 1 ... LIMIT 1` 作为发布
+preflight；任一表不存在或不可读写时禁止开启 rollout。Avernet 仓库只维护
+ORM，数据库变更单需使用以下与 ORM 一致的 DDL：
 
 ```sql
+CREATE TABLE ac_skill_migration_quarantine (
+  id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT
+    COMMENT '自增主键',
+  env VARCHAR(20) NOT NULL
+    COMMENT '部署环境，如 pre、prod',
+  entity_id VARCHAR(512) NOT NULL
+    COMMENT 'Bot 所属实体或用户标识',
+  bot_id VARCHAR(128) NOT NULL
+    COMMENT 'Bot 唯一标识',
+  migration_generation VARCHAR(64) NOT NULL
+    COMMENT '本次 Skills Pool 迁移代际标识',
+  engine VARCHAR(64) NOT NULL
+    COMMENT 'Bot 使用的引擎类型',
+  path VARCHAR(1024) NOT NULL
+    COMMENT '运行时返回的隔离目录物理路径',
+  status VARCHAR(32) NOT NULL DEFAULT 'retained'
+    COMMENT '隔离记录状态',
+  source_evidence TEXT NOT NULL
+    COMMENT 'Pool cutover 时记录的隔离证据 JSON',
+  pool_activated_at TIMESTAMP NULL DEFAULT NULL
+    COMMENT 'Bot 成功进入 POOL_ACTIVE 的时间',
+  runtime_reconciled_at TIMESTAMP(6) NULL DEFAULT NULL
+    COMMENT 'Pool 激活后运行时完成 reconciliation 的时间',
+  runtime_reconciliation_status VARCHAR(16) NULL
+    COMMENT '运行时 reconciliation 结果',
+  runtime_evidence TEXT NULL
+    COMMENT '运行时 reconciliation 证据 JSON',
+  cleaned_at TIMESTAMP NULL DEFAULT NULL
+    COMMENT '隔离目录完成清理的时间',
+  cleanup_evidence TEXT NULL
+    COMMENT '隔离目录清理结果证据 JSON',
+  cleanup_lease_owner VARCHAR(128) NULL
+    COMMENT '当前持有清理租约的 Worker 标识',
+  cleanup_lease_expires_at TIMESTAMP NULL DEFAULT NULL
+    COMMENT '清理任务租约过期时间',
+  gmt_create TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    COMMENT '记录创建时间',
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ON UPDATE CURRENT_TIMESTAMP
+    COMMENT '记录最后修改时间',
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_skill_migration_quarantine_scope_generation
+    (env, entity_id, bot_id, migration_generation) GLOBAL,
+  KEY idx_skill_migration_quarantine_cleanup
+    (env, status, pool_activated_at) GLOBAL
+) DEFAULT CHARSET = utf8mb4
+  COMMENT = 'Skills Pool 迁移隔离目录生命周期及清理证据';
+
 CREATE TABLE ac_skills_pool_rollout_audit (
-  id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-  env VARCHAR(20) NOT NULL,
-  config_id BIGINT(20) UNSIGNED NOT NULL,
-  action VARCHAR(128) NOT NULL,
-  batch_id VARCHAR(128) NULL,
-  operator VARCHAR(128) NOT NULL,
-  reason VARCHAR(512) NOT NULL,
-  based_on_config_version VARCHAR(64) NULL,
-  effective_config_version VARCHAR(64) NOT NULL,
-  evidence TEXT NULL,
-  effective_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT
+    COMMENT '自增主键',
+  env VARCHAR(20) NOT NULL
+    COMMENT 'Rollout 配置所属部署环境',
+  config_id BIGINT(20) UNSIGNED NOT NULL
+    COMMENT '关联的 ac_common_config 配置记录 ID',
+  action VARCHAR(128) NOT NULL
+    COMMENT '运维操作类型',
+  batch_id VARCHAR(128) NULL
+    COMMENT '关联的灰度批次标识',
+  operator VARCHAR(128) NOT NULL
+    COMMENT '执行本次操作的人员标识',
+  reason VARCHAR(512) NOT NULL
+    COMMENT '执行本次操作的原因',
+  based_on_config_version VARCHAR(64) NULL
+    COMMENT '修改前配置版本',
+  effective_config_version VARCHAR(64) NOT NULL
+    COMMENT '修改后生效的配置版本',
+  evidence TEXT NULL
+    COMMENT '批次验收报告或其他操作证据 JSON',
+  effective_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+    COMMENT '本次配置变更的业务生效时间',
+  gmt_create TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    COMMENT '审计记录的数据库创建时间',
+  gmt_modify TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ON UPDATE CURRENT_TIMESTAMP
+    COMMENT '审计记录的数据库修改时间',
   PRIMARY KEY (id),
   UNIQUE KEY uk_skills_pool_rollout_audit_revision
     (env, effective_config_version) GLOBAL,
   KEY idx_skills_pool_rollout_audit_batch
     (env, batch_id, id) GLOBAL
 ) DEFAULT CHARSET = utf8mb4
-  COMMENT = 'Skills Pool rollout append-only audit';
+  COMMENT = 'Skills Pool 灰度配置变更追加式审计记录';
+
+SELECT 1 FROM ac_skill_migration_quarantine LIMIT 1;
+SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
 ```
 
 数据库变更顺序固定为：建表并 preflight → 发布 Backend → 保持 feature disabled

--- a/docs/skills-pool-p3-rollout-runbook.zh-CN.md
+++ b/docs/skills-pool-p3-rollout-runbook.zh-CN.md
@@ -1,0 +1,120 @@
+# Skills Pool P3 灰度发布与验收手册
+
+本文描述 #378 提供的运维入口和人工晋级规则。所有接口均位于
+`/api/ops/skills-pool`，仅 operator 可访问，并且只操作 Backend 当前部署环境；
+调用方不能通过参数跨环境写配置。
+
+## 发布前置
+
+生产环境不由 Backend 自动建表。发布新 Backend 前，必须先通过 OceanBase
+数据库变更流程创建 `ac_skills_pool_rollout_audit`，并执行
+`SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1` 作为发布 preflight；表不存在
+或不可读写时禁止发布 Backend。Avernet 仓库只维护 ORM，数据库变更单需使用
+以下与 ORM 一致的 DDL：
+
+```sql
+CREATE TABLE ac_skills_pool_rollout_audit (
+  id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+  env VARCHAR(20) NOT NULL,
+  config_id BIGINT(20) UNSIGNED NOT NULL,
+  action VARCHAR(128) NOT NULL,
+  batch_id VARCHAR(128) NULL,
+  operator VARCHAR(128) NOT NULL,
+  reason VARCHAR(512) NOT NULL,
+  based_on_config_version VARCHAR(64) NULL,
+  effective_config_version VARCHAR(64) NOT NULL,
+  evidence TEXT NULL,
+  effective_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_skills_pool_rollout_audit_revision
+    (env, effective_config_version) GLOBAL,
+  KEY idx_skills_pool_rollout_audit_batch
+    (env, batch_id, id) GLOBAL
+) DEFAULT CHARSET = utf8mb4
+  COMMENT = 'Skills Pool rollout append-only audit';
+```
+
+数据库变更顺序固定为：建表并 preflight → 发布 Backend → 保持 feature disabled
+→ 验证只读运维接口 → 开始 OpenClaw 白名单。代码回滚不删除审计表。
+
+## 灰度顺序
+
+1. 通过 `GET /rollout` 核对当前环境、配置版本、feature 状态、已晋级引擎、
+   精确白名单和对照样本。
+2. 通过 `POST /rollout/feature` 启用 rollout。初始配置固定
+   `enable_all=false`，不存在通配入口。
+3. 通过 `POST /rollout/promote` 按
+   OpenClaw、Claude Code、AICoding、Hermes 的顺序人工晋级引擎。
+   除首个 OpenClaw 外，请求必须携带上一引擎已通过验收的
+   `acceptance_batch_id`；Backend 只接受已冻结的批次验收记录。
+4. 通过 `POST /rollout/controls` 为当前批次登记至少一个同环境、同引擎、
+   未命中白名单的负对照，以及一个 Teclaw 对照。
+5. 通过 `POST /rollout/whitelist` 添加精确 `(owner_id, bot_id)` 条目和
+   `batch_id`。批次扩大仍逐 Bot 执行，不提供 `enable_all`。
+6. 容器生命周期事件会正常唤醒迁移；需要主动触发时使用
+   `POST /bots/{bot_id}/wake`。只有已持久化为可重试失败的 Bot 才使用
+   `/retry`。
+7. 通过 `GET /bots/{bot_id}` 检查单 Bot 证据，通过
+   `GET /batches/{batch_id}?engine=...` 生成批次验收报告。
+8. 只有批次报告 `promotion_ready=true` 且人工确认实际业务指标后，才调用
+   `POST /rollout/batches/accept` 冻结该批次的验收报告。扩大批次时，新
+   `batch_id` 必须引用当前引擎最近的 `acceptance_batch_id`；晋级下一引擎
+   也必须引用上一引擎已验收批次。Backend 不会自动验收、扩大或晋级。
+
+移出白名单会返回 `claimed_before` 和 `claimed_after`。未认领 Bot 将不再开始
+迁移；已经认领或已经 Pool-active 的 Bot 保持同一
+`migration_generation` 前滚，不会因移出白名单而回退。
+
+所有配置写请求必须附带非空 `reason`。写入使用配置 revision CAS；发生并发
+修改时返回 409，操作者必须重新读取配置。每次成功变更都会在配置
+`ac_skills_pool_rollout_audit` 独立追加环境隐含范围内的 action、batch、
+操作者、原因、前后 revision、生效时间及批次验收快照；配置与审计事件在同一
+事务中提交。`ac_common_config.ext_info` 只保存当前 revision 和最近操作摘要，
+不承担审计历史。
+
+## 验收报告
+
+批次报告包含：
+
+- rollout 配置 ID、版本、feature 状态和引擎晋级状态；
+- `eligible`、`attempted`、`claimed`、`preparing`、`active`、
+  `rolling_back`、`failed`；
+- `success_rate` 和 `failure_distribution`；
+- 数据不一致失败、负对照与 Teclaw 对照健康状态；
+- 隔离区清理资格和最终 `promotion_ready`。
+
+`data_consistent=false` 表示批次存在 `DATA_INCONSISTENT`、
+`ROLLBACK_DATA_INCONSISTENT`、`ACTIVE_ENTRY_CONFLICT` 或
+`MAPPING_DATA_INVALID`。任何失败、缺少对照、对照被认领或引擎未晋级都会使
+`promotion_ready=false`。
+
+## 人工恢复
+
+- `/retry`：只重新投递 `last_failure_retryable=true` 的已认领迁移。
+- `/repair`：提交 migration generation、人工核验结论和非空备注，复用
+  `SkillsPoolRecoveryService` 恢复同一迁移代际。
+- `/rollback`：提交 rollback generation 和非空备注，复用
+  `SkillsPoolRollbackService` 从当前 Pool 内容显式重建 Legacy。
+
+这些入口都先用当前环境中的精确 owner + Bot 解析真实
+`(env, entity_id, bot_id)` scope；人工唤醒通过持久化任务队列交接。
+
+## 兼容性证据
+
+| 发布场景 | 自动化证据 |
+|---|---|
+| 新 Backend + 旧镜像无 marker，保持 Legacy | `test_reconcile_service.py::test_non_ready_runtime_keeps_legacy_without_data_plane_changes` |
+| 新镜像已有 marker、未命中白名单，不认领 | `test_claim_service.py::test_ineligible_bot_does_not_persist_layout_state` |
+| 精确命中后认领，移出白名单仍前滚 | `test_claim_service.py::test_claim_is_sticky_after_whitelist_removal` |
+| ONLINE Legacy 服务不原地迁移 | `test_claim_service.py::test_published_service_and_teclaw_do_not_claim` |
+| 四个文件型引擎使用各自 Pool 路径和结构桥 | `test_reconcile_service.py::test_ready_claimed_bot_completes_pool_activation`、`::test_claude_code_uses_its_own_pool_paths_for_full_activation`、`::test_aicoding_uses_its_own_pool_paths_for_full_activation`、`::test_hermes_h0_ready_uses_its_own_pool_paths_for_full_activation` |
+| 新旧镜像对应的不同 Bot 独立收敛：新镜像可激活，旧镜像保持 Legacy | `test_reconcile_service.py::test_mixed_image_bots_reconcile_independently_in_one_environment` |
+| Teclaw 不进入文件系统迁移 | `test_rollout_gate.py` 与 `test_claim_service.py` 的 Teclaw no-op 测试 |
+| 服务发布固定草稿布局并向容器传递 | `test_arca_snapshot_producer.py::test_pool_build_freezes_the_draft_layout_into_one_versioned_artifact` 与 `::test_release_translates_frozen_layout_into_container_env` |
+| 服务重启、回滚和扩容继承冻结制品布局 | `test_publish_flow_service.py::test_restart_and_recreate_preserve_frozen_pool_layout`、`::test_execute_rollback_with_config_artifact` 与 `::test_scale_bot_success_prefers_bot_ext_device_count` |
+| 批次必须有健康负对照、Teclaw 对照且无数据不一致 | `test_operational_query.py` |
+| 同一引擎扩大批次和跨引擎晋级都必须引用已冻结验收 | `test_operations.py::test_next_batch_requires_latest_persisted_acceptance` 与 `::test_next_engine_requires_and_audits_a_passing_batch` |
+
+镜像 preparation 脚本、Hermes H0 和各引擎 companion 的验收由对应镜像/引擎
+仓库 CI 承担；本 Backend 报告只读取已提交的控制面与运行时证据，不推断容器
+文件系统事实。

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -113,6 +113,7 @@ from agentclaw.community.adapters.http.bot_chat.otel_router import router as bot
 from agentclaw.community.adapters.http.bot_chat.relation_router import router as bot_chat_relation_router  # noqa: E402
 from agentclaw.community.adapters.http.system_config.router import router as system_config_router  # noqa: E402
 from agentclaw.community.adapters.http.common_config.router import router as common_config_router  # noqa: E402
+from agentclaw.community.adapters.http.skills_pool import router as skills_pool_ops_router  # noqa: E402
 from agentclaw.community.adapters.http.beta_quota.router import router as beta_quota_router  # noqa: E402
 from agentclaw.community.adapters.http.channel.router import router as channel_router  # noqa: E402
 from agentclaw.community.adapters.http.quality.router import router as quality_router  # noqa: E402
@@ -429,6 +430,7 @@ app.include_router(user_list_router)
 app.include_router(user_router)
 app.include_router(system_config_router)
 app.include_router(common_config_router)
+app.include_router(skills_pool_ops_router)
 app.include_router(beta_quota_router)
 app.include_router(channel_router)
 app.include_router(quality_router)

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/__init__.py
@@ -1,0 +1,5 @@
+"""Skills Pool operator HTTP adapter."""
+
+from agentclaw.community.adapters.http.skills_pool.router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
@@ -1,0 +1,381 @@
+"""Operator-only Skills Pool rollout, evidence and recovery API."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from agentclaw.community.api.skills_pool_operational_query_service import (
+    SkillsPoolOperationalQueryServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_operator_commands_service import (
+    SkillsPoolOperatorCommandsServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_recovery_service import (
+    SkillsPoolRecoveryServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_rollback_service import (
+    SkillsPoolRollbackServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_rollout_service import (
+    SkillsPoolRolloutServiceProtocol,
+)
+from agentclaw.community.adapters.http.auth.dependencies import require_operator
+from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
+from agentclaw.community.adapters.http.skills_pool.schemas import (
+    ApiResponse,
+    BatchAcceptanceRequest,
+    BotIdentityRequest,
+    ControlBotRequest,
+    EnginePromotionRequest,
+    FeatureToggleRequest,
+    RepairRequest,
+    RollbackRequest,
+    WhitelistAddRequest,
+    WhitelistRemoveRequest,
+)
+from agentclaw.community.core.skills_pool.operational_query import (
+    SkillsPoolOperationalQueryError,
+)
+from agentclaw.community.core.skills_pool.operations import (
+    BatchPromotionEvidence,
+    RolloutOperationError,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.di import Injected
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+router = APIRouter(prefix="/api/ops/skills-pool", tags=["skills-pool-ops"])
+
+
+def _response(value: object, message: str = "OK") -> ApiResponse:
+    return ApiResponse(success=True, message=message, data=asdict(value))
+
+
+def _resolve_scope(
+    *,
+    query: SkillsPoolOperationalQueryServiceProtocol,
+    owner_id: str,
+    bot_id: str,
+) -> BotSkillLayoutScope:
+    try:
+        return query.get_bot(
+            env=get_current_env(),
+            owner_id=owner_id,
+            bot_id=bot_id,
+        ).scope
+    except SkillsPoolOperationalQueryError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+
+
+@router.get("/rollout", response_model=ApiResponse)
+async def get_rollout(
+    _: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(service.get_snapshot(env=get_current_env()))
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/feature", response_model=ApiResponse)
+async def set_rollout_feature(
+    request: FeatureToggleRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            service.set_feature_enabled(
+                env=get_current_env(),
+                enabled=request.enabled,
+                operator=user.staffId,
+                reason=request.reason,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/promote", response_model=ApiResponse)
+async def promote_engine(
+    request: EnginePromotionRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            service.promote_engine(
+                env=get_current_env(),
+                engine=request.engine,
+                operator=user.staffId,
+                reason=request.reason,
+                acceptance_batch_id=request.acceptance_batch_id,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/whitelist", response_model=ApiResponse)
+async def add_whitelist_bot(
+    request: WhitelistAddRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            service.add_bot(
+                env=get_current_env(),
+                owner_id=request.owner_id,
+                bot_id=request.bot_id,
+                batch_id=request.batch_id,
+                acceptance_batch_id=request.acceptance_batch_id,
+                operator=user.staffId,
+                reason=request.reason,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/whitelist/remove", response_model=ApiResponse)
+async def remove_whitelist_bot(
+    request: WhitelistRemoveRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            service.remove_bot(
+                env=get_current_env(),
+                owner_id=request.owner_id,
+                bot_id=request.bot_id,
+                operator=user.staffId,
+                reason=request.reason,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/batches/accept", response_model=ApiResponse)
+async def accept_batch(
+    request: BatchAcceptanceRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+    query: SkillsPoolOperationalQueryServiceProtocol = Injected(
+        SkillsPoolOperationalQueryServiceProtocol
+    ),
+):
+    try:
+        report = query.summarize_batch(
+            env=get_current_env(),
+            engine=request.engine,
+            batch_id=request.batch_id,
+        )
+        return _response(
+            service.accept_batch(
+                env=get_current_env(),
+                acceptance=BatchPromotionEvidence(
+                    engine=request.engine,
+                    batch_id=request.batch_id,
+                    promotion_ready=report.promotion_ready,
+                    report=asdict(report),
+                ),
+                operator=user.staffId,
+                reason=request.reason,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/controls", response_model=ApiResponse)
+async def set_control_bot(
+    request: ControlBotRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            service.set_control_bot(
+                env=get_current_env(),
+                owner_id=request.owner_id,
+                bot_id=request.bot_id,
+                batch_id=request.batch_id,
+                group=request.group,
+                present=request.present,
+                operator=user.staffId,
+                reason=request.reason,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.get("/bots/{bot_id}", response_model=ApiResponse)
+async def get_bot_evidence(
+    bot_id: str,
+    owner_id: str = Query(...),
+    _: AuthenticatedUser = Depends(require_operator),
+    query: SkillsPoolOperationalQueryServiceProtocol = Injected(
+        SkillsPoolOperationalQueryServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            query.get_bot(
+                env=get_current_env(),
+                owner_id=owner_id,
+                bot_id=bot_id,
+            )
+        )
+    except SkillsPoolOperationalQueryError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+
+
+@router.get("/batches/{batch_id}", response_model=ApiResponse)
+async def get_batch_evidence(
+    batch_id: str,
+    engine: str = Query(...),
+    _: AuthenticatedUser = Depends(require_operator),
+    query: SkillsPoolOperationalQueryServiceProtocol = Injected(
+        SkillsPoolOperationalQueryServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            query.summarize_batch(
+                env=get_current_env(),
+                engine=engine,
+                batch_id=batch_id,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/bots/{bot_id}/wake", response_model=ApiResponse)
+async def wake_bot(
+    bot_id: str,
+    request: BotIdentityRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    commands: SkillsPoolOperatorCommandsServiceProtocol = Injected(
+        SkillsPoolOperatorCommandsServiceProtocol
+    ),
+    query: SkillsPoolOperationalQueryServiceProtocol = Injected(
+        SkillsPoolOperationalQueryServiceProtocol
+    ),
+):
+    scope = _resolve_scope(
+        query=query,
+        owner_id=request.owner_id,
+        bot_id=bot_id,
+    )
+    return _response(
+        commands.wake(
+            scope=scope,
+            operator=user.staffId,
+        )
+    )
+
+
+@router.post("/bots/{bot_id}/retry", response_model=ApiResponse)
+async def retry_bot(
+    bot_id: str,
+    request: BotIdentityRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    commands: SkillsPoolOperatorCommandsServiceProtocol = Injected(
+        SkillsPoolOperatorCommandsServiceProtocol
+    ),
+    query: SkillsPoolOperationalQueryServiceProtocol = Injected(
+        SkillsPoolOperationalQueryServiceProtocol
+    ),
+):
+    scope = _resolve_scope(
+        query=query,
+        owner_id=request.owner_id,
+        bot_id=bot_id,
+    )
+    return _response(
+        commands.wake(
+            scope=scope,
+            operator=user.staffId,
+            retry_only=True,
+        )
+    )
+
+
+@router.post("/bots/{bot_id}/repair", response_model=ApiResponse)
+async def repair_bot(
+    bot_id: str,
+    request: RepairRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRecoveryServiceProtocol = Injected(
+        SkillsPoolRecoveryServiceProtocol
+    ),
+    query: SkillsPoolOperationalQueryServiceProtocol = Injected(
+        SkillsPoolOperationalQueryServiceProtocol
+    ),
+):
+    scope = _resolve_scope(
+        query=query,
+        owner_id=request.owner_id,
+        bot_id=bot_id,
+    )
+    return _response(
+        service.resolve_repair_state(
+            scope=scope,
+            migration_generation=request.migration_generation,
+            operator=user.staffId,
+            note=request.note,
+            resolution=request.resolution,
+        )
+    )
+
+
+@router.post("/bots/{bot_id}/rollback", response_model=ApiResponse)
+async def rollback_bot(
+    bot_id: str,
+    request: RollbackRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRollbackServiceProtocol = Injected(
+        SkillsPoolRollbackServiceProtocol
+    ),
+    query: SkillsPoolOperationalQueryServiceProtocol = Injected(
+        SkillsPoolOperationalQueryServiceProtocol
+    ),
+):
+    scope = _resolve_scope(
+        query=query,
+        owner_id=request.owner_id,
+        bot_id=bot_id,
+    )
+    return _response(
+        await service.rollback(
+            scope=scope,
+            rollback_generation=request.rollback_generation,
+            lease_owner=f"operator-api:{uuid4().hex}",
+            operator=user.staffId,
+            note=request.note,
+        )
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
@@ -45,7 +45,7 @@ class WhitelistRemoveRequest(BotIdentityRequest):
 
 class ControlBotRequest(BotIdentityRequest):
     bot_id: str
-    batch_id: str
+    batch_id: str = Field(min_length=1)
     group: RolloutControlGroup
     present: bool = True
     reason: str = Field(min_length=1)

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
@@ -1,0 +1,68 @@
+"""Skills Pool operator HTTP schemas."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from agentclaw.community.core.skills_pool.recovery_service import (
+    ManualRepairResolution,
+)
+from agentclaw.community.core.skills_pool.operations import RolloutControlGroup
+
+
+class ApiResponse(BaseModel):
+    success: bool
+    message: str
+    data: Any = None
+
+
+class FeatureToggleRequest(BaseModel):
+    enabled: bool
+    reason: str = Field(min_length=1)
+
+
+class EnginePromotionRequest(BaseModel):
+    engine: str
+    reason: str = Field(min_length=1)
+    acceptance_batch_id: str | None = None
+
+
+class BotIdentityRequest(BaseModel):
+    owner_id: str
+
+
+class WhitelistAddRequest(BotIdentityRequest):
+    bot_id: str
+    batch_id: str = Field(min_length=1)
+    acceptance_batch_id: str | None = None
+    reason: str = Field(min_length=1)
+
+
+class WhitelistRemoveRequest(BotIdentityRequest):
+    bot_id: str
+    reason: str = Field(min_length=1)
+
+
+class ControlBotRequest(BotIdentityRequest):
+    bot_id: str
+    batch_id: str
+    group: RolloutControlGroup
+    present: bool = True
+    reason: str = Field(min_length=1)
+
+
+class BatchAcceptanceRequest(BaseModel):
+    engine: str
+    batch_id: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+
+
+class RepairRequest(BotIdentityRequest):
+    migration_generation: str
+    note: str = Field(min_length=1)
+    resolution: ManualRepairResolution
+
+
+class RollbackRequest(BotIdentityRequest):
+    rollback_generation: str
+    note: str = Field(min_length=1)

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -65,6 +65,7 @@ internal_dependencies:
   - agentclaw.community.core.quality.repositories    # QualityTaskRecord — typed in quality_service.py and task_processor_service.py
   - agentclaw.community.core.service_bot.services.baas_service  # BotWsConnectionInfoResponse / HttpConnectionInfo — typed in baas_service.py (BaasService is a plain core service)
   - agentclaw.community.core.service_bot.types       # PublishStage enum — typed in baas_service.py
+  - agentclaw.community.core.skills_pool             # Skills Pool rollout/query/recovery domain DTOs used by operator Service API Protocols
   - agentclaw.community.kernel.device_dto            # OutBoundOperationRule — typed in baas_service.py Protocol (B6)
   - agentclaw.community.plugin_api.auth              # AuthRequestContext — typed in caller_iam_token_service.py
   - agentclaw.community.plugin_api.passport          # PassportPlugin — typed in caller_identity_service.py

--- a/src/backend/src/agentclaw/community/api/skills_pool_operational_query_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_operational_query_service.py
@@ -1,0 +1,29 @@
+"""Service API Protocol for Skills Pool operational evidence."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.operational_query import (
+    BatchOperationalReport,
+    BotOperationalView,
+)
+
+
+@runtime_checkable
+class SkillsPoolOperationalQueryServiceProtocol(Protocol):
+    def get_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+    ) -> BotOperationalView: ...
+
+    def summarize_batch(
+        self,
+        *,
+        env: str,
+        engine: str,
+        batch_id: str,
+    ) -> BatchOperationalReport: ...

--- a/src/backend/src/agentclaw/community/api/skills_pool_operator_commands_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_operator_commands_service.py
@@ -1,0 +1,21 @@
+"""Service API Protocol for operator-triggered Skills Pool commands."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.operator_commands import (
+    OperatorCommandResult,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+
+
+@runtime_checkable
+class SkillsPoolOperatorCommandsServiceProtocol(Protocol):
+    def wake(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        operator: str,
+        retry_only: bool = False,
+    ) -> OperatorCommandResult: ...

--- a/src/backend/src/agentclaw/community/api/skills_pool_recovery_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_recovery_service.py
@@ -1,0 +1,24 @@
+"""Service API Protocol for operator-directed Skills Pool repair."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.recovery_service import (
+    ManualRepairResolution,
+    SkillsPoolRecoveryResult,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+
+
+@runtime_checkable
+class SkillsPoolRecoveryServiceProtocol(Protocol):
+    def resolve_repair_state(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        operator: str,
+        note: str,
+        resolution: ManualRepairResolution,
+    ) -> SkillsPoolRecoveryResult: ...

--- a/src/backend/src/agentclaw/community/api/skills_pool_rollback_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_rollback_service.py
@@ -1,0 +1,23 @@
+"""Service API Protocol for explicit Skills Pool rollback."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.recovery_service import (
+    SkillsPoolRollbackResult,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+
+
+@runtime_checkable
+class SkillsPoolRollbackServiceProtocol(Protocol):
+    async def rollback(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        rollback_generation: str,
+        lease_owner: str,
+        operator: str,
+        note: str,
+    ) -> SkillsPoolRollbackResult: ...

--- a/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
@@ -1,0 +1,80 @@
+"""Service API Protocol for Skills Pool rollout control."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.operations import (
+    BatchPromotionEvidence,
+    RolloutConfigSnapshot,
+    RolloutControlGroup,
+    WhitelistMutationResult,
+)
+
+
+@runtime_checkable
+class SkillsPoolRolloutServiceProtocol(Protocol):
+    def get_snapshot(self, *, env: str) -> RolloutConfigSnapshot: ...
+
+    def set_feature_enabled(
+        self,
+        *,
+        env: str,
+        enabled: bool,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot: ...
+
+    def promote_engine(
+        self,
+        *,
+        env: str,
+        engine: str,
+        operator: str,
+        reason: str,
+        acceptance_batch_id: str | None = None,
+    ) -> RolloutConfigSnapshot: ...
+
+    def accept_batch(
+        self,
+        *,
+        env: str,
+        acceptance: BatchPromotionEvidence,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot: ...
+
+    def add_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        batch_id: str,
+        acceptance_batch_id: str | None,
+        operator: str,
+        reason: str,
+    ) -> WhitelistMutationResult: ...
+
+    def remove_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        operator: str,
+        reason: str,
+    ) -> WhitelistMutationResult: ...
+
+    def set_control_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        batch_id: str,
+        group: RolloutControlGroup,
+        present: bool,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot: ...

--- a/src/backend/src/agentclaw/community/core/common_config/service.py
+++ b/src/backend/src/agentclaw/community/core/common_config/service.py
@@ -13,6 +13,7 @@ from agentclaw.community.log import get_logger
 
 
 logger = get_logger()
+_PROTECTED_CONFIG_KEYS = {("skills_pool", "layout_rollout")}
 
 
 class CommonConfigService:
@@ -55,6 +56,36 @@ class CommonConfigService:
             if record.gmt_modified
             else None,
         }
+
+    @staticmethod
+    def _ensure_generic_write_allowed(
+        *,
+        business_code: str,
+        param_code: str,
+    ) -> None:
+        if (business_code, param_code) in _PROTECTED_CONFIG_KEYS:
+            raise ValueError(
+                "skills_pool layout rollout must use its operator API"
+            )
+
+    def _ensure_config_id_write_allowed(
+        self,
+        config_id: int,
+        updates: dict[str, Any] | None = None,
+    ) -> None:
+        record = self._repo.get_by_id(config_id=config_id)
+        if record is not None:
+            self._ensure_generic_write_allowed(
+                business_code=record.business_code,
+                param_code=record.param_code,
+            )
+            updates = updates or {}
+            self._ensure_generic_write_allowed(
+                business_code=str(
+                    updates.get("business_code", record.business_code)
+                ),
+                param_code=str(updates.get("param_code", record.param_code)),
+            )
 
     @staticmethod
     def _normalize_enable(enable: str) -> str:
@@ -149,6 +180,10 @@ class CommonConfigService:
         ext_info: Any = None,
         env: str,
     ) -> int:
+        self._ensure_generic_write_allowed(
+            business_code=business_code,
+            param_code=param_code,
+        )
         enable = self._normalize_enable(enable)
         config_id = self._repo.create_config(
             business_code=business_code,
@@ -170,6 +205,7 @@ class CommonConfigService:
         return config_id
 
     def update_config(self, *, config_id: int, updates: dict[str, Any]) -> bool:
+        self._ensure_config_id_write_allowed(config_id, updates)
         serialized: dict[str, Any] = {}
         for key, value in updates.items():
             if key in ("param_value", "ext_info"):
@@ -192,6 +228,10 @@ class CommonConfigService:
         ext_info: Any = None,
         env: str,
     ) -> int:
+        self._ensure_generic_write_allowed(
+            business_code=business_code,
+            param_code=param_code,
+        )
         enable = self._normalize_enable(enable)
         config_id = self._repo.upsert_config(
             business_code=business_code,
@@ -221,8 +261,13 @@ class CommonConfigService:
         env: str | None = None,
     ) -> bool:
         if config_id is not None:
+            self._ensure_config_id_write_allowed(config_id)
             return self._repo.delete_config(config_id=config_id)
         if business_code and param_code and env:
+            self._ensure_generic_write_allowed(
+                business_code=business_code,
+                param_code=param_code,
+            )
             return self._repo.delete_by_biz_param(
                 business_code=business_code, param_code=param_code, env=env
             )

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -70,6 +70,18 @@ Engine Layout Descriptor 仍不在本期范围内。
 - 七天任务由持久化任务队列延迟调度；重复执行、任务接管和目录已不存在均
   幂等。容器只接受 generation，由固定 engine Pool 根推导删除目标，不能
   删除其他 Bot 或 generation。数据库保留清理时间与证据。
+- 灰度运维入口只接受当前环境中的精确 `(owner_id, bot_id)`，不提供
+  `enable_all`。引擎按 OpenClaw、Claude Code、AICoding、Hermes 的固定
+  顺序人工晋级；每次扩大同引擎批次必须引用最近一次已冻结验收，除首个
+  引擎外，晋级还必须引用上一引擎已冻结的验收批次。配置写入使用完整旧值
+  加逻辑 revision CAS，冲突 fail closed；配置和包含前后 revision、原因及
+  验收快照的独立审计事件在同一事务提交。
+- 单 Bot 运维视图合成 engine、provider、runtime form、rollout 决策、
+  layout/generation、probe/failure 和 quarantine 证据；批次视图只有在
+  全部 eligible Bot 激活、无失败且负对照与 Teclaw 对照均健康时才报告
+  `promotion_ready`，但不会据此改写灰度配置。
+- 人工 wake/retry 通过持久化任务队列交接，repair/rollback 复用既有恢复
+  服务；所有写入口仅对 operator 开放。
 
 ## Context Boundary
 
@@ -86,6 +98,10 @@ provides:
   - "SkillsPoolRollbackService"
   - "SkillsPoolQuarantineService"
   - "SkillsPoolQuarantineCleanupTaskHandler"
+  - "SkillsPoolRolloutOperations"
+  - "SkillsPoolOperationalQuery"
+  - "SkillsPoolOperatorCommands"
+  - "SkillsPoolRolloutRepositoryProtocol"
   - "QuarantineRepositoryProtocol"
   - "QuarantineRecord, QuarantineStatus, QuarantineEligibility and QuarantineOperationalView"
   - "RuntimeQuarantineCleanupResult"
@@ -96,7 +112,7 @@ consumes:
   - "BotRepository"
   - "BotPublishRepositoryProtocol"
   - "CommonConfigService and CommonWhiteListService"
-  - "DatabasePlugin (through plugins/skills_pool_layout_repository.py)"
+  - "DatabasePlugin (through Skills Pool layout, operational and rollout repositories)"
   - "SkillsPoolRuntimeProtocol"
   - "SkillsPoolSkillRepositoryProtocol"
   - "DeviceBindingRepository"

--- a/src/backend/src/agentclaw/community/core/skills_pool/claim_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/claim_service.py
@@ -79,7 +79,7 @@ class SkillsPoolMigrationClaimService:
             or state.target_layout is SkillLayout.POOL
         )
 
-    def _resolve_runtime_form(
+    def resolve_runtime_form(
         self,
         *,
         bot: dict[str, object],
@@ -119,6 +119,19 @@ class SkillsPoolMigrationClaimService:
             return None
         return BotRuntimeForm.SERVICE_DRAFT
 
+    def inspect_runtime_form(
+        self,
+        *,
+        bot: dict[str, object],
+        scope: BotSkillLayoutScope,
+    ) -> BotRuntimeForm | None:
+        """Resolve an observable form, including non-editable published services."""
+
+        runtime_form = self.resolve_runtime_form(bot=bot, scope=scope)
+        if runtime_form is None and bot.get("bot_type") == "service":
+            return BotRuntimeForm.PUBLISHED_SERVICE
+        return runtime_form
+
     def claim(
         self,
         *,
@@ -153,7 +166,7 @@ class SkillsPoolMigrationClaimService:
             )
 
         try:
-            runtime_form = self._resolve_runtime_form(bot=bot, scope=scope)
+            runtime_form = self.resolve_runtime_form(bot=bot, scope=scope)
         except _RuntimeFormLookupError:
             return MigrationClaimResult(
                 outcome=MigrationClaimOutcome.TRANSIENT_ERROR,

--- a/src/backend/src/agentclaw/community/core/skills_pool/operational_query.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operational_query.py
@@ -1,0 +1,391 @@
+"""Read-only operational evidence views for Skills Pool rollout."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+from injector import inject
+
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.devices.repository.protocol import (
+    DeviceBindingRepository,
+)
+from agentclaw.community.core.skills_pool.claim_service import (
+    SkillsPoolMigrationClaimService,
+)
+from agentclaw.community.core.skills_pool.operations import (
+    RolloutBotEntry,
+    SkillsPoolRolloutOperations,
+)
+from agentclaw.community.core.skills_pool.quarantine import (
+    QuarantineOperationalView,
+    SkillsPoolQuarantineService,
+)
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.rollout_gate import (
+    BotRuntimeForm,
+    RolloutDecision,
+    SkillsPoolRolloutGate,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+class SkillsPoolOperationalQueryError(ValueError):
+    """An operational query cannot resolve one exact Bot identity."""
+
+
+@dataclass(frozen=True, slots=True)
+class BotOperationalView:
+    scope: BotSkillLayoutScope
+    owner_id: str
+    engine: str
+    provider: str | None
+    runtime_form: BotRuntimeForm
+    claimed: bool
+    rollout_decision: RolloutDecision
+    state: BotSkillLayoutState
+    quarantine: QuarantineOperationalView | None
+
+
+@dataclass(frozen=True, slots=True)
+class BatchOperationalReport:
+    env: str
+    engine: str
+    batch_id: str
+    rollout_config_id: int | None
+    rollout_config_version: str | None
+    rollout_enabled: bool
+    engine_promoted: bool
+    claim_config_versions: tuple[str, ...]
+    configured: int
+    invalid_batch_members: int
+    eligible: int
+    attempted: int
+    claimed: int
+    preparing: int
+    active: int
+    rolling_back: int
+    failed: int
+    success_rate: float | None
+    data_consistent: bool
+    negative_controls: int
+    negative_controls_healthy: int
+    teclaw_controls: int
+    teclaw_controls_healthy: int
+    quarantine_cleanup_eligible: int
+    failure_distribution: dict[str, int]
+    promotion_ready: bool
+
+
+class SkillsPoolOperationalQuery:
+    """Compose layout, runtime binding, rollout and quarantine evidence."""
+
+    @inject
+    def __init__(
+        self,
+        *,
+        bot_repository: BotRepository,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        binding_repository: DeviceBindingRepository,
+        claim_service: SkillsPoolMigrationClaimService,
+        rollout_gate: SkillsPoolRolloutGate,
+        rollout_operations: SkillsPoolRolloutOperations,
+        quarantine_service: SkillsPoolQuarantineService,
+    ) -> None:
+        self._bots = bot_repository
+        self._layouts = layout_repository
+        self._bindings = binding_repository
+        self._claims = claim_service
+        self._gate = rollout_gate
+        self._rollout = rollout_operations
+        self._quarantine = quarantine_service
+
+    def get_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+    ) -> BotOperationalView:
+        bot, scope = self._resolve_bot(
+            env=env,
+            owner_id=owner_id,
+            bot_id=bot_id,
+        )
+        engine = bot.get("active_engine")
+        if not isinstance(engine, str) or not engine:
+            raise SkillsPoolOperationalQueryError("bot engine is invalid")
+        runtime_form = self._claims.inspect_runtime_form(bot=bot, scope=scope)
+        if runtime_form is None:
+            raise SkillsPoolOperationalQueryError("bot runtime form is invalid")
+        state = self._layouts.get(scope)
+        binding = self._bindings.get_active_by_bot_and_owner(bot_id, owner_id)
+        decision = self._gate.evaluate(
+            env=env,
+            owner_id=owner_id,
+            bot_id=bot_id,
+            engine_type=engine,
+            runtime_form=runtime_form,
+        )
+        quarantine = (
+            self._quarantine.inspect(scope, state.migration_generation)
+            if state.migration_generation is not None
+            else None
+        )
+        return BotOperationalView(
+            scope=scope,
+            owner_id=owner_id,
+            engine=engine,
+            provider=(
+                str(binding.device_provider) if binding is not None else None
+            ),
+            runtime_form=runtime_form,
+            claimed=self._is_claimed(state),
+            rollout_decision=decision,
+            state=state,
+            quarantine=quarantine,
+        )
+
+    def summarize_batch(
+        self,
+        *,
+        env: str,
+        engine: str,
+        batch_id: str,
+    ) -> BatchOperationalReport:
+        rollout = self._rollout.get_snapshot(env=env)
+        whitelist = self._in_batch(rollout.whitelist, batch_id)
+        eligible_scopes: set[BotSkillLayoutScope] = set()
+        invalid_batch_members = 0
+        for entry in whitelist:
+            try:
+                view = self.get_bot(
+                    env=env,
+                    owner_id=entry.owner_id,
+                    bot_id=entry.bot_id,
+                )
+            except SkillsPoolOperationalQueryError:
+                invalid_batch_members += 1
+                continue
+            if view.engine != engine or not view.rollout_decision.eligible:
+                invalid_batch_members += 1
+                continue
+            eligible_scopes.add(view.scope)
+
+        states: list[BotSkillLayoutState] = []
+        for state in self._layouts.list_states(
+            env=env,
+            engine=engine,
+            batch_id=batch_id,
+        ):
+            evidence = state.rollout_evidence
+            if (
+                evidence is not None
+                and evidence.engine_type == engine
+                and evidence.batch_id == batch_id
+            ):
+                states.append(state)
+        active = sum(
+            state.phase is SkillLayoutPhase.POOL_ACTIVE for state in states
+        )
+        active_scopes = {
+            state.scope
+            for state in states
+            if state.phase is SkillLayoutPhase.POOL_ACTIVE
+        }
+        claim_config_versions = tuple(
+            sorted(
+                {
+                    evidence.config_version
+                    for state in states
+                    if (evidence := state.rollout_evidence) is not None
+                }
+            )
+        )
+        claimed = sum(self._is_claimed(state) for state in states)
+        failed_states = [
+            state
+            for state in states
+            if state.phase is not SkillLayoutPhase.POOL_ACTIVE
+            and (
+                state.last_failure_code is not None
+                or state.phase is SkillLayoutPhase.NEEDS_MANUAL_REPAIR
+            )
+        ]
+        preparing = sum(
+            state.phase
+            in {
+                SkillLayoutPhase.POOL_PREPARING,
+                SkillLayoutPhase.POOL_READY,
+                SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+                SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+                SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            }
+            for state in states
+        )
+        rolling_back = sum(
+            state.phase
+            in {
+                SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+                SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
+            }
+            for state in states
+        )
+        quarantine_eligible = 0
+        for state in states:
+            generation = state.migration_generation
+            if generation is None:
+                continue
+            view = self._quarantine.inspect(state.scope, generation)
+            if view is not None and view.eligible:
+                quarantine_eligible += 1
+        failures = Counter(
+            state.last_failure_code or SkillLayoutPhase.NEEDS_MANUAL_REPAIR.value
+            for state in failed_states
+        )
+        if invalid_batch_members:
+            failures["BATCH_MEMBER_INVALID"] += invalid_batch_members
+        data_consistent = not any(
+            code.upper()
+            in {
+                "DATA_INCONSISTENT",
+                "ROLLBACK_DATA_INCONSISTENT",
+                "ACTIVE_ENTRY_CONFLICT",
+                "MAPPING_DATA_INVALID",
+                "BATCH_MEMBER_INVALID",
+            }
+            for code in failures
+        )
+        negative_controls = self._in_batch(
+            rollout.negative_controls,
+            batch_id,
+        )
+        teclaw_controls = self._in_batch(
+            rollout.teclaw_controls,
+            batch_id,
+        )
+        negative_healthy = sum(
+            self._control_is_healthy(
+                entry=entry,
+                env=env,
+                expected_engine=engine,
+            )
+            for entry in negative_controls
+        )
+        teclaw_healthy = sum(
+            self._control_is_healthy(
+                entry=entry,
+                env=env,
+                expected_engine="teclaw",
+            )
+            for entry in teclaw_controls
+        )
+        promotion_ready = (
+            rollout.enabled
+            and engine in rollout.promoted_engines
+            and bool(states)
+            and invalid_batch_members == 0
+            and eligible_scopes.issubset(active_scopes)
+            and len(states) == active
+            and not failed_states
+            and data_consistent
+            and bool(negative_controls)
+            and negative_healthy == len(negative_controls)
+            and bool(teclaw_controls)
+            and teclaw_healthy == len(teclaw_controls)
+        )
+        return BatchOperationalReport(
+            env=env,
+            engine=engine,
+            batch_id=batch_id,
+            rollout_config_id=rollout.config_id,
+            rollout_config_version=rollout.config_version,
+            rollout_enabled=rollout.enabled,
+            engine_promoted=engine in rollout.promoted_engines,
+            claim_config_versions=claim_config_versions,
+            configured=len(whitelist),
+            invalid_batch_members=invalid_batch_members,
+            eligible=len(eligible_scopes),
+            attempted=len(states),
+            claimed=claimed,
+            preparing=preparing,
+            active=active,
+            rolling_back=rolling_back,
+            failed=len(failed_states),
+            success_rate=active / len(states) if states else None,
+            data_consistent=data_consistent,
+            negative_controls=len(negative_controls),
+            negative_controls_healthy=negative_healthy,
+            teclaw_controls=len(teclaw_controls),
+            teclaw_controls_healthy=teclaw_healthy,
+            quarantine_cleanup_eligible=quarantine_eligible,
+            failure_distribution=dict(failures),
+            promotion_ready=promotion_ready,
+        )
+
+    def _control_is_healthy(
+        self,
+        *,
+        entry: RolloutBotEntry,
+        env: str,
+        expected_engine: str,
+    ) -> bool:
+        try:
+            view = self.get_bot(
+                env=env,
+                owner_id=entry.owner_id,
+                bot_id=entry.bot_id,
+            )
+        except SkillsPoolOperationalQueryError:
+            return False
+        return (
+            view.engine == expected_engine
+            and not view.claimed
+            and view.state.active_layout is SkillLayout.LEGACY
+            and view.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+            and not view.rollout_decision.eligible
+        )
+
+    def _resolve_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+    ) -> tuple[dict[str, object], BotSkillLayoutScope]:
+        matches = self._bots.get_live_by_id_owner_and_env(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            env=env,
+        )
+        if len(matches) != 1:
+            raise SkillsPoolOperationalQueryError(
+                "bot not found" if not matches else "bot identity is ambiguous"
+            )
+        bot = matches[0]
+        entity_id = bot.get("entity_id")
+        if not isinstance(entity_id, (str, int)) or isinstance(entity_id, bool):
+            raise SkillsPoolOperationalQueryError("bot entity identity is invalid")
+        return bot, BotSkillLayoutScope(env, str(entity_id), bot_id)
+
+    @staticmethod
+    def _in_batch(
+        entries: tuple[RolloutBotEntry, ...],
+        batch_id: str,
+    ) -> tuple[RolloutBotEntry, ...]:
+        return tuple(entry for entry in entries if entry.batch_id == batch_id)
+
+    @staticmethod
+    def _is_claimed(state: BotSkillLayoutState) -> bool:
+        return (
+            state.active_layout is SkillLayout.POOL
+            or state.target_layout is SkillLayout.POOL
+        )

--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -343,6 +343,8 @@ class SkillsPoolRolloutOperations:
             batch_id=batch_id,
             action=f"whitelist_add:{owner_id}:{bot_id}",
         )
+        # Admission only persists rollout configuration. Claiming remains an
+        # asynchronous reconciliation step, so this write cannot change it.
         return WhitelistMutationResult(True, claimed, claimed, updated)
 
     def remove_bot(

--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -355,12 +355,6 @@ class SkillsPoolRolloutOperations:
         reason: str,
     ) -> WhitelistMutationResult:
         self._validate_change(operator=operator, reason=reason)
-        scope = self._resolve_scope(env=env, owner_id=owner_id, bot_id=bot_id)
-        state = self._layouts.get(scope)
-        claimed_before = self._claimed(
-            state.active_layout,
-            state.target_layout,
-        )
         current = self.get_snapshot(env=env)
         removed = next(
             (
@@ -371,6 +365,24 @@ class SkillsPoolRolloutOperations:
             ),
             None,
         )
+        scope: BotSkillLayoutScope | None = None
+        claimed_before = False
+        try:
+            scope = self._resolve_scope(
+                env=env,
+                owner_id=owner_id,
+                bot_id=bot_id,
+            )
+        except RolloutOperationError:
+            # Configuration cleanup must remain possible after the Bot row
+            # has been deleted or otherwise becomes unresolvable.
+            pass
+        if scope is not None:
+            state = self._layouts.get(scope)
+            claimed_before = self._claimed(
+                state.active_layout,
+                state.target_layout,
+            )
         whitelist = tuple(
             item
             for item in current.whitelist
@@ -399,10 +411,13 @@ class SkillsPoolRolloutOperations:
             batch_id=removed.batch_id if removed else None,
             action=f"whitelist_remove:{owner_id}:{bot_id}",
         )
-        claimed_after = self._claimed(
-            self._layouts.get(scope).active_layout,
-            self._layouts.get(scope).target_layout,
-        )
+        claimed_after = claimed_before
+        if scope is not None:
+            state_after = self._layouts.get(scope)
+            claimed_after = self._claimed(
+                state_after.active_layout,
+                state_after.target_layout,
+            )
         return WhitelistMutationResult(
             True,
             claimed_before,
@@ -623,11 +638,17 @@ class SkillsPoolRolloutOperations:
         for entry in snapshot.whitelist:
             if entry.batch_id is None or entry.batch_id in accepted:
                 continue
-            bot, _ = self._resolve_bot_and_scope(
-                env=env,
-                owner_id=entry.owner_id,
-                bot_id=entry.bot_id,
-            )
+            try:
+                bot, _ = self._resolve_bot_and_scope(
+                    env=env,
+                    owner_id=entry.owner_id,
+                    bot_id=entry.bot_id,
+                )
+            except RolloutOperationError:
+                # Keep an orphaned member's batch open until an operator
+                # explicitly removes the stale whitelist entry.
+                opened.add(entry.batch_id)
+                continue
             if bot.get("active_engine") == engine:
                 opened.add(entry.batch_id)
         for state in self._layouts.list_states(env=env, engine=engine):

--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -1,0 +1,852 @@
+"""Operator control plane for Skills Pool rollout admission."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from enum import StrEnum
+from uuid import uuid4
+
+from injector import inject
+
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotRepository,
+)
+from agentclaw.community.core.common_config.service import CommonConfigService
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.rollout_config import (
+    CONTROL_KEYS,
+    ENGINE_PROMOTION_ORDER,
+    is_valid_rollout_config_value,
+)
+from agentclaw.community.core.skills_pool.rollout_gate import (
+    SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
+    SKILLS_POOL_ROLLOUT_PARAM_CODE,
+)
+from agentclaw.community.core.skills_pool.rollout_repository import (
+    SkillsPoolRolloutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayout,
+)
+
+
+class RolloutControlGroup(StrEnum):
+    NEGATIVE = "negative"
+    TECLAW = "teclaw"
+
+
+class RolloutOperationError(ValueError):
+    """An operator request cannot be safely applied."""
+
+
+@dataclass(frozen=True, slots=True)
+class RolloutBotEntry:
+    owner_id: str
+    bot_id: str
+    batch_id: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        value = {"owner_id": self.owner_id, "bot_id": self.bot_id}
+        if self.batch_id is not None:
+            value["batch_id"] = self.batch_id
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class RolloutAuditEvent:
+    env: str
+    action: str
+    operator: str
+    reason: str
+    batch_id: str | None
+    based_on_config_version: str | None
+    effective_config_version: str
+    effective_at: str
+    evidence: dict[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "env": self.env,
+            "action": self.action,
+            "operator": self.operator,
+            "reason": self.reason,
+            "batch_id": self.batch_id,
+            "based_on_config_version": self.based_on_config_version,
+            "effective_config_version": self.effective_config_version,
+            "effective_at": self.effective_at,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BatchPromotionEvidence:
+    engine: str
+    batch_id: str
+    promotion_ready: bool
+    report: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class RolloutConfigSnapshot:
+    env: str
+    config_id: int | None
+    config_version: str | None
+    record_version: str | None
+    config_revision: str | None
+    enabled: bool
+    enable_all: bool
+    promoted_engines: tuple[str, ...]
+    whitelist: tuple[RolloutBotEntry, ...]
+    negative_controls: tuple[RolloutBotEntry, ...]
+    teclaw_controls: tuple[RolloutBotEntry, ...]
+    audit_log: tuple[RolloutAuditEvent, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class WhitelistMutationResult:
+    changed: bool
+    claimed_before: bool
+    claimed_after: bool
+    snapshot: RolloutConfigSnapshot
+
+
+class SkillsPoolRolloutOperations:
+    """Mutate the environment-scoped, exact-Bot rollout configuration."""
+
+    @inject
+    def __init__(
+        self,
+        *,
+        common_config_service: CommonConfigService,
+        bot_repository: BotRepository,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        rollout_repository: SkillsPoolRolloutRepositoryProtocol,
+    ) -> None:
+        self._configs = common_config_service
+        self._bots = bot_repository
+        self._layouts = layout_repository
+        self._repository = rollout_repository
+
+    def get_snapshot(self, *, env: str) -> RolloutConfigSnapshot:
+        snapshot = self._parse_config(env=env, config=self._get_config(env))
+        return replace(
+            snapshot,
+            audit_log=self._audit_events(
+                self._repository.list_audit_events(env=env)
+            ),
+        )
+
+    def set_feature_enabled(
+        self,
+        *,
+        env: str,
+        enabled: bool,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot:
+        self._validate_change(operator=operator, reason=reason)
+        current = self.get_snapshot(env=env)
+        if current.enabled is enabled and current.config_id is not None:
+            return current
+        return self._write(
+            snapshot=current,
+            expected_snapshot=current,
+            enabled=enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=None,
+            action="enable" if enabled else "disable",
+        )
+
+    def promote_engine(
+        self,
+        *,
+        env: str,
+        engine: str,
+        operator: str,
+        reason: str,
+        acceptance_batch_id: str | None = None,
+    ) -> RolloutConfigSnapshot:
+        self._validate_change(operator=operator, reason=reason)
+        if engine not in ENGINE_PROMOTION_ORDER:
+            raise RolloutOperationError(f"unsupported engine: {engine}")
+        current = self.get_snapshot(env=env)
+        if engine in current.promoted_engines:
+            return current
+        expected_previous = ENGINE_PROMOTION_ORDER[
+            : ENGINE_PROMOTION_ORDER.index(engine)
+        ]
+        if current.promoted_engines != expected_previous:
+            raise RolloutOperationError(
+                f"previous engine promotion is incomplete for {engine}"
+            )
+        previous_engine = (
+            expected_previous[-1] if expected_previous else None
+        )
+        acceptance = None
+        if previous_engine is not None:
+            acceptance = self._accepted_batch(
+                current,
+                engine=previous_engine,
+                batch_id=acceptance_batch_id,
+            )
+            if acceptance is None:
+                raise RolloutOperationError(
+                    f"an accepted {previous_engine} batch is required for {engine}"
+                )
+            if self._open_batches(
+                current,
+                env=env,
+                engine=previous_engine,
+            ):
+                raise RolloutOperationError(
+                    f"{previous_engine} still has an unaccepted batch"
+                )
+        return self._write(
+            snapshot=RolloutConfigSnapshot(
+                **{
+                    **self._snapshot_values(current),
+                    "promoted_engines": (*current.promoted_engines, engine),
+                }
+            ),
+            expected_snapshot=current,
+            enabled=current.enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=acceptance.batch_id if acceptance else None,
+            evidence=acceptance.report if acceptance else None,
+            action=f"promote:{engine}",
+        )
+
+    def accept_batch(
+        self,
+        *,
+        env: str,
+        acceptance: BatchPromotionEvidence,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot:
+        self._validate_change(operator=operator, reason=reason)
+        if (
+            acceptance.engine not in ENGINE_PROMOTION_ORDER
+            or not acceptance.batch_id.strip()
+            or not acceptance.promotion_ready
+        ):
+            raise RolloutOperationError("batch is not ready for acceptance")
+        current = self.get_snapshot(env=env)
+        if (
+            acceptance.report.get("rollout_config_version")
+            != current.config_version
+        ):
+            raise RolloutOperationError("batch report is stale")
+        if acceptance.engine not in current.promoted_engines:
+            raise RolloutOperationError("batch engine is not promoted")
+        existing = self._accepted_batch(
+            current,
+            engine=acceptance.engine,
+            batch_id=acceptance.batch_id,
+        )
+        if existing is not None:
+            return current
+        return self._write(
+            snapshot=current,
+            expected_snapshot=current,
+            enabled=current.enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=acceptance.batch_id,
+            evidence=acceptance.report,
+            action=f"accept_batch:{acceptance.engine}",
+        )
+
+    def add_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        batch_id: str,
+        acceptance_batch_id: str | None,
+        operator: str,
+        reason: str,
+    ) -> WhitelistMutationResult:
+        self._validate_change(operator=operator, reason=reason)
+        bot, scope = self._resolve_bot_and_scope(
+            env=env,
+            owner_id=owner_id,
+            bot_id=bot_id,
+        )
+        engine = bot.get("active_engine")
+        if not isinstance(engine, str) or engine not in ENGINE_PROMOTION_ORDER:
+            raise RolloutOperationError("bot engine is not supported")
+        state = self._layouts.get(scope)
+        claimed = self._claimed(state.active_layout, state.target_layout)
+        current = self.get_snapshot(env=env)
+        open_batches = self._open_batches(current, env=env, engine=engine)
+        if len(open_batches) > 1:
+            raise RolloutOperationError(
+                f"{engine} rollout has multiple unaccepted batches"
+            )
+        if open_batches and batch_id not in open_batches:
+            raise RolloutOperationError(
+                "the current engine batch must be accepted before expansion"
+            )
+        latest_acceptance = self._latest_accepted_batch(
+            current,
+            engine=engine,
+        )
+        if latest_acceptance is None:
+            if acceptance_batch_id is not None:
+                raise RolloutOperationError(
+                    "initial batch cannot reference an acceptance"
+                )
+        elif (
+            acceptance_batch_id != latest_acceptance.batch_id
+            or batch_id == latest_acceptance.batch_id
+        ):
+            raise RolloutOperationError(
+                "a new batch must reference the latest accepted batch"
+            )
+        entry = self._entry(owner_id=owner_id, bot_id=bot_id, batch_id=batch_id)
+        existing = next(
+            (
+                item
+                for item in current.whitelist
+                if item.owner_id == entry.owner_id and item.bot_id == entry.bot_id
+            ),
+            None,
+        )
+        if existing == entry:
+            return WhitelistMutationResult(False, claimed, claimed, current)
+        whitelist = tuple(
+            item
+            for item in current.whitelist
+            if not (
+                item.owner_id == entry.owner_id and item.bot_id == entry.bot_id
+            )
+        ) + (entry,)
+        updated = self._write(
+            snapshot=RolloutConfigSnapshot(
+                **{
+                    **self._snapshot_values(current),
+                    "whitelist": whitelist,
+                }
+            ),
+            expected_snapshot=current,
+            enabled=current.enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=batch_id,
+            action=f"whitelist_add:{owner_id}:{bot_id}",
+        )
+        return WhitelistMutationResult(True, claimed, claimed, updated)
+
+    def remove_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        operator: str,
+        reason: str,
+    ) -> WhitelistMutationResult:
+        self._validate_change(operator=operator, reason=reason)
+        scope = self._resolve_scope(env=env, owner_id=owner_id, bot_id=bot_id)
+        state = self._layouts.get(scope)
+        claimed_before = self._claimed(
+            state.active_layout,
+            state.target_layout,
+        )
+        current = self.get_snapshot(env=env)
+        removed = next(
+            (
+                item
+                for item in current.whitelist
+                if item.owner_id == str(owner_id)
+                and item.bot_id == str(bot_id)
+            ),
+            None,
+        )
+        whitelist = tuple(
+            item
+            for item in current.whitelist
+            if not (
+                item.owner_id == str(owner_id) and item.bot_id == str(bot_id)
+            )
+        )
+        if whitelist == current.whitelist:
+            return WhitelistMutationResult(
+                False,
+                claimed_before,
+                claimed_before,
+                current,
+            )
+        updated = self._write(
+            snapshot=RolloutConfigSnapshot(
+                **{
+                    **self._snapshot_values(current),
+                    "whitelist": whitelist,
+                }
+            ),
+            expected_snapshot=current,
+            enabled=current.enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=removed.batch_id if removed else None,
+            action=f"whitelist_remove:{owner_id}:{bot_id}",
+        )
+        claimed_after = self._claimed(
+            self._layouts.get(scope).active_layout,
+            self._layouts.get(scope).target_layout,
+        )
+        return WhitelistMutationResult(
+            True,
+            claimed_before,
+            claimed_after,
+            updated,
+        )
+
+    def set_control_bot(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        batch_id: str,
+        group: RolloutControlGroup,
+        present: bool,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot:
+        self._validate_change(operator=operator, reason=reason)
+        self._resolve_scope(env=env, owner_id=owner_id, bot_id=bot_id)
+        current = self.get_snapshot(env=env)
+        entry = self._entry(
+            owner_id=owner_id,
+            bot_id=bot_id,
+            batch_id=batch_id,
+        )
+        source = (
+            current.negative_controls
+            if group is RolloutControlGroup.NEGATIVE
+            else current.teclaw_controls
+        )
+        retained = tuple(
+            item
+            for item in source
+            if not (
+                item.owner_id == entry.owner_id and item.bot_id == entry.bot_id
+            )
+        )
+        updated_entries = (*retained, entry) if present else retained
+        if updated_entries == source:
+            return current
+        values = self._snapshot_values(current)
+        values[
+            "negative_controls"
+            if group is RolloutControlGroup.NEGATIVE
+            else "teclaw_controls"
+        ] = updated_entries
+        return self._write(
+            snapshot=RolloutConfigSnapshot(**values),
+            expected_snapshot=current,
+            enabled=current.enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=batch_id,
+            action=(
+                f"control_{'add' if present else 'remove'}:"
+                f"{group.value}:{owner_id}:{bot_id}"
+            ),
+        )
+
+    def _get_config(self, env: str) -> dict[str, object] | None:
+        return self._configs.get_config(
+            business_code=SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
+            param_code=SKILLS_POOL_ROLLOUT_PARAM_CODE,
+            env=env,
+            only_enabled=False,
+        )
+
+    def _write(
+        self,
+        *,
+        snapshot: RolloutConfigSnapshot,
+        expected_snapshot: RolloutConfigSnapshot,
+        enabled: bool,
+        operator: str,
+        reason: str,
+        batch_id: str | None,
+        action: str,
+        evidence: dict[str, object] | None = None,
+    ) -> RolloutConfigSnapshot:
+        next_revision = uuid4().hex
+        event = RolloutAuditEvent(
+            env=snapshot.env,
+            action=action,
+            operator=operator.strip(),
+            reason=reason.strip(),
+            batch_id=batch_id,
+            based_on_config_version=snapshot.config_version,
+            effective_config_version=next_revision,
+            effective_at=datetime.now(UTC).isoformat(),
+            evidence=evidence,
+        )
+        next_value = self._config_value(snapshot)
+        if not self._repository.commit_change(
+            env=snapshot.env,
+            config_id=expected_snapshot.config_id,
+            expected_revision=expected_snapshot.config_revision,
+            expected_enable=expected_snapshot.enabled,
+            expected_value=self._config_value(expected_snapshot),
+            next_revision=next_revision,
+            enabled=enabled,
+            value=next_value,
+            audit=event.to_dict(),
+        ):
+            raise RolloutOperationError("rollout config changed concurrently")
+        return self.get_snapshot(env=snapshot.env)
+
+    def _resolve_scope(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+    ) -> BotSkillLayoutScope:
+        _, scope = self._resolve_bot_and_scope(
+            env=env,
+            owner_id=owner_id,
+            bot_id=bot_id,
+        )
+        return scope
+
+    def _resolve_bot_and_scope(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+    ) -> tuple[dict[str, object], BotSkillLayoutScope]:
+        matches = self._bots.get_live_by_id_owner_and_env(
+            bot_id=str(bot_id),
+            owner_id=str(owner_id),
+            env=env,
+        )
+        if not matches:
+            raise RolloutOperationError("bot not found")
+        if len(matches) != 1:
+            raise RolloutOperationError("bot identity is ambiguous")
+        entity_id = matches[0].get("entity_id")
+        if not isinstance(entity_id, (str, int)) or isinstance(entity_id, bool):
+            raise RolloutOperationError("bot entity identity is invalid")
+        return (
+            matches[0],
+            BotSkillLayoutScope(
+                env=env,
+                entity_id=str(entity_id),
+                bot_id=str(bot_id),
+            ),
+        )
+
+    @staticmethod
+    def _accepted_batch(
+        snapshot: RolloutConfigSnapshot,
+        *,
+        engine: str,
+        batch_id: str | None,
+    ) -> BatchPromotionEvidence | None:
+        if batch_id is None:
+            return None
+        for event in reversed(snapshot.audit_log):
+            if (
+                event.action == f"accept_batch:{engine}"
+                and event.batch_id == batch_id
+                and event.evidence is not None
+                and event.evidence.get("promotion_ready") is True
+            ):
+                return BatchPromotionEvidence(
+                    engine=engine,
+                    batch_id=batch_id,
+                    promotion_ready=True,
+                    report=event.evidence,
+                )
+        return None
+
+    @classmethod
+    def _latest_accepted_batch(
+        cls,
+        snapshot: RolloutConfigSnapshot,
+        *,
+        engine: str,
+    ) -> BatchPromotionEvidence | None:
+        for event in reversed(snapshot.audit_log):
+            if (
+                event.action == f"accept_batch:{engine}"
+                and event.batch_id is not None
+            ):
+                return cls._accepted_batch(
+                    snapshot,
+                    engine=engine,
+                    batch_id=event.batch_id,
+                )
+        return None
+
+    @staticmethod
+    def _accepted_batch_ids(
+        snapshot: RolloutConfigSnapshot,
+        *,
+        engine: str,
+    ) -> set[str]:
+        return {
+            event.batch_id
+            for event in snapshot.audit_log
+            if event.action == f"accept_batch:{engine}"
+            and event.batch_id is not None
+            and event.evidence is not None
+            and event.evidence.get("promotion_ready") is True
+        }
+
+    def _open_batches(
+        self,
+        snapshot: RolloutConfigSnapshot,
+        *,
+        env: str,
+        engine: str,
+    ) -> set[str]:
+        accepted = self._accepted_batch_ids(snapshot, engine=engine)
+        opened: set[str] = set()
+        for entry in snapshot.whitelist:
+            if entry.batch_id is None or entry.batch_id in accepted:
+                continue
+            bot, _ = self._resolve_bot_and_scope(
+                env=env,
+                owner_id=entry.owner_id,
+                bot_id=entry.bot_id,
+            )
+            if bot.get("active_engine") == engine:
+                opened.add(entry.batch_id)
+        for state in self._layouts.list_states(env=env, engine=engine):
+            evidence = state.rollout_evidence
+            if (
+                evidence is not None
+                and evidence.engine_type == engine
+                and evidence.batch_id is not None
+                and evidence.batch_id not in accepted
+            ):
+                opened.add(evidence.batch_id)
+        return opened
+
+    @classmethod
+    def _parse_config(
+        cls,
+        *,
+        env: str,
+        config: dict[str, object] | None,
+    ) -> RolloutConfigSnapshot:
+        if config is None:
+            return RolloutConfigSnapshot(
+                env=env,
+                config_id=None,
+                config_version=None,
+                record_version=None,
+                config_revision=None,
+                enabled=False,
+                enable_all=False,
+                promoted_engines=(),
+                whitelist=(),
+                negative_controls=(),
+                teclaw_controls=(),
+                audit_log=(),
+            )
+        if config.get("env") != env:
+            raise RolloutOperationError("rollout config environment mismatch")
+        config_id = config.get("id")
+        record_version = config.get("gmt_modified")
+        ext_info = config.get("ext_info")
+        revision = (
+            ext_info.get("revision")
+            if isinstance(ext_info, dict)
+            else None
+        )
+        value = config.get("param_value")
+        if (
+            isinstance(config_id, bool)
+            or not isinstance(config_id, int)
+            or not isinstance(record_version, str)
+            or not record_version
+            or (revision is not None and not isinstance(revision, str))
+            or not is_valid_rollout_config_value(value)
+        ):
+            raise RolloutOperationError("rollout config is invalid")
+        assert isinstance(value, dict)
+        promoted = value.get("promoted_engines")
+        whitelist = value.get("whitelist")
+        assert isinstance(promoted, list)
+        assert isinstance(whitelist, list)
+        promoted_engines = tuple(promoted)
+        return RolloutConfigSnapshot(
+            env=env,
+            config_id=config_id,
+            config_version=revision or record_version,
+            record_version=record_version,
+            config_revision=revision,
+            enabled=config.get("enable") == "1",
+            enable_all=False,
+            promoted_engines=promoted_engines,
+            whitelist=cls._entries(whitelist),
+            negative_controls=cls._entries(value.get(CONTROL_KEYS[0], [])),
+            teclaw_controls=cls._entries(value.get(CONTROL_KEYS[1], [])),
+            audit_log=(),
+        )
+
+    @classmethod
+    def _audit_events(cls, raw: object) -> tuple[RolloutAuditEvent, ...]:
+        if not isinstance(raw, list):
+            raise RolloutOperationError("rollout audit log is invalid")
+        events: list[RolloutAuditEvent] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                raise RolloutOperationError("rollout audit event is invalid")
+            required = (
+                "action",
+                "env",
+                "operator",
+                "reason",
+                "effective_config_version",
+                "effective_at",
+            )
+            if any(
+                not isinstance(item.get(key), str)
+                or not str(item[key]).strip()
+                for key in required
+            ):
+                raise RolloutOperationError("rollout audit event is invalid")
+            events.append(
+                RolloutAuditEvent(
+                    env=str(item["env"]),
+                    action=str(item["action"]),
+                    operator=str(item["operator"]),
+                    reason=str(item["reason"]),
+                    batch_id=(
+                        str(item["batch_id"])
+                        if item.get("batch_id") is not None
+                        else None
+                    ),
+                    based_on_config_version=(
+                        str(item["based_on_config_version"])
+                        if item.get("based_on_config_version") is not None
+                        else None
+                    ),
+                    effective_config_version=str(
+                        item["effective_config_version"]
+                    ),
+                    effective_at=str(item["effective_at"]),
+                    evidence=(
+                        item.get("evidence")
+                        if isinstance(item.get("evidence"), dict)
+                        else None
+                    ),
+                )
+            )
+        return tuple(events)
+
+    @staticmethod
+    def _config_value(
+        snapshot: RolloutConfigSnapshot,
+    ) -> dict[str, object]:
+        return {
+            "enable_all": False,
+            "promoted_engines": list(snapshot.promoted_engines),
+            "whitelist": [item.to_dict() for item in snapshot.whitelist],
+            "negative_controls": [
+                item.to_dict() for item in snapshot.negative_controls
+            ],
+            "teclaw_controls": [
+                item.to_dict() for item in snapshot.teclaw_controls
+            ],
+        }
+
+    @classmethod
+    def _entries(cls, raw: object) -> tuple[RolloutBotEntry, ...]:
+        if not isinstance(raw, list):
+            raise RolloutOperationError("rollout control entries are invalid")
+        entries: list[RolloutBotEntry] = []
+        for value in raw:
+            if not isinstance(value, dict):
+                raise RolloutOperationError("rollout control entry is invalid")
+            entries.append(
+                cls._entry(
+                    owner_id=value.get("owner_id"),
+                    bot_id=value.get("bot_id"),
+                    batch_id=value.get("batch_id"),
+                )
+            )
+        return tuple(entries)
+
+    @staticmethod
+    def _entry(
+        *,
+        owner_id: object,
+        bot_id: object,
+        batch_id: object,
+    ) -> RolloutBotEntry:
+        values = (owner_id, bot_id)
+        if any(
+            isinstance(value, bool)
+            or not isinstance(value, (str, int))
+            or str(value).strip() in {"", "*"}
+            for value in values
+        ):
+            raise RolloutOperationError("rollout bot identity is invalid")
+        if (
+            batch_id is not None
+            and (
+                isinstance(batch_id, bool)
+                or not isinstance(batch_id, (str, int))
+                or str(batch_id).strip() in {"", "*"}
+            )
+        ):
+            raise RolloutOperationError("rollout batch identity is invalid")
+        return RolloutBotEntry(
+            owner_id=str(owner_id),
+            bot_id=str(bot_id),
+            batch_id=str(batch_id) if batch_id is not None else None,
+        )
+
+    @staticmethod
+    def _claimed(
+        active_layout: SkillLayout,
+        target_layout: SkillLayout | None,
+    ) -> bool:
+        return active_layout is SkillLayout.POOL or target_layout is SkillLayout.POOL
+
+    @staticmethod
+    def _validate_change(*, operator: str, reason: str) -> None:
+        if not operator.strip():
+            raise RolloutOperationError("operator is required")
+        if not reason.strip():
+            raise RolloutOperationError("change reason is required")
+
+    @staticmethod
+    def _snapshot_values(
+        snapshot: RolloutConfigSnapshot,
+    ) -> dict[str, object]:
+        return {
+            "env": snapshot.env,
+            "config_id": snapshot.config_id,
+            "config_version": snapshot.config_version,
+            "record_version": snapshot.record_version,
+            "config_revision": snapshot.config_revision,
+            "enabled": snapshot.enabled,
+            "enable_all": snapshot.enable_all,
+            "promoted_engines": snapshot.promoted_engines,
+            "whitelist": snapshot.whitelist,
+            "negative_controls": snapshot.negative_controls,
+            "teclaw_controls": snapshot.teclaw_controls,
+            "audit_log": snapshot.audit_log,
+        }

--- a/src/backend/src/agentclaw/community/core/skills_pool/operator_commands.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operator_commands.py
@@ -1,0 +1,78 @@
+"""Operator-triggered reconciliation and recovery commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from uuid import uuid4
+
+from injector import inject
+
+from agentclaw.community.core.skills_pool.reconcile_task import (
+    SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
+    SKILLS_POOL_RECONCILE_TASK,
+    build_skills_pool_reconcile_payload,
+)
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
+
+
+class OperatorCommandOutcome(StrEnum):
+    ENQUEUED = "enqueued"
+    NOT_CLAIMED = "not_claimed"
+    NOT_RETRYABLE = "not_retryable"
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCommandResult:
+    outcome: OperatorCommandOutcome
+    wakeup_id: str | None = None
+
+
+class SkillsPoolOperatorCommands:
+    """Durably wake one Bot without mutating its migration facts."""
+
+    @inject
+    def __init__(
+        self,
+        *,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        task_queue_service: TaskQueueService,
+    ) -> None:
+        self._layouts = layout_repository
+        self._queue = task_queue_service
+
+    def wake(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        operator: str,
+        retry_only: bool = False,
+    ) -> OperatorCommandResult:
+        if not operator.strip():
+            raise ValueError("operator is required")
+        state = self._layouts.get(scope)
+        if retry_only and not state.persisted:
+            return OperatorCommandResult(OperatorCommandOutcome.NOT_CLAIMED)
+        if retry_only and state.last_failure_retryable is not True:
+            return OperatorCommandResult(OperatorCommandOutcome.NOT_RETRYABLE)
+        wakeup_id = uuid4().hex
+        self._queue.enqueue(
+            SKILLS_POOL_RECONCILE_TASK,
+            build_skills_pool_reconcile_payload(
+                scope=scope,
+                source="operator_retry" if retry_only else "operator_wakeup",
+                signal_identity={"operator": operator.strip()},
+                wakeup_id=wakeup_id,
+            ),
+            deadline_seconds=SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
+        )
+        return OperatorCommandResult(
+            OperatorCommandOutcome.ENQUEUED,
+            wakeup_id=wakeup_id,
+        )

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
@@ -33,6 +33,12 @@ from agentclaw.community.core.skills_pool.quarantine import (
 from agentclaw.community.plugin_api.models import AutoIncrementBigInteger
 
 
+def _operational_timestamp(*, fsp: int | None = None):
+    """Use the OceanBase-approved TIMESTAMP type without changing SQLite."""
+
+    return DateTime().with_variant(mysql.TIMESTAMP(fsp=fsp), "mysql")
+
+
 class BotSkillLayoutStateModel(Base):
     """``ac_bot_skill_layout_state`` 中的一条 Bot 控制面状态。"""
 
@@ -170,7 +176,22 @@ class SkillsPoolRolloutAuditModel(Base):
     based_on_config_version = Column(String(64), nullable=True)
     effective_config_version = Column(String(64), nullable=False)
     evidence = Column(Text, nullable=True)
-    effective_at = Column(DateTime, nullable=False, server_default=func.now())
+    effective_at = Column(
+        _operational_timestamp(fsp=6),
+        nullable=False,
+        server_default=func.now(),
+    )
+    gmt_create = Column(
+        _operational_timestamp(),
+        nullable=False,
+        server_default=func.now(),
+    )
+    gmt_modify = Column(
+        _operational_timestamp(),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
     __table_args__ = (
         UniqueConstraint(
@@ -210,20 +231,27 @@ class SkillMigrationQuarantineModel(Base):
         default=QuarantineStatus.RETAINED.value,
     )
     source_evidence = Column(Text, nullable=False)
-    pool_activated_at = Column(DateTime, nullable=True)
+    pool_activated_at = Column(_operational_timestamp(), nullable=True)
     runtime_reconciled_at = Column(
-        DateTime().with_variant(mysql.DATETIME(fsp=6), "mysql"),
+        _operational_timestamp(fsp=6),
         nullable=True,
     )
     runtime_reconciliation_status = Column(String(16), nullable=True)
     runtime_evidence = Column(Text, nullable=True)
-    cleaned_at = Column(DateTime, nullable=True)
+    cleaned_at = Column(_operational_timestamp(), nullable=True)
     cleanup_evidence = Column(Text, nullable=True)
     cleanup_lease_owner = Column(String(128), nullable=True)
-    cleanup_lease_expires_at = Column(DateTime, nullable=True)
-    gmt_create = Column(DateTime, nullable=False, server_default=func.now())
+    cleanup_lease_expires_at = Column(
+        _operational_timestamp(),
+        nullable=True,
+    )
+    gmt_create = Column(
+        _operational_timestamp(),
+        nullable=False,
+        server_default=func.now(),
+    )
     gmt_modified = Column(
-        DateTime,
+        _operational_timestamp(),
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
@@ -150,6 +150,43 @@ class BotSkillLayoutStateModel(Base):
         )
 
 
+class SkillsPoolRolloutAuditModel(Base):
+    """Append-only audit event committed with one rollout config revision."""
+
+    __tablename__ = "ac_skills_pool_rollout_audit"
+
+    id = Column(
+        AutoIncrementBigInteger,
+        primary_key=True,
+        autoincrement=True,
+        nullable=False,
+    )
+    env = Column(String(20), nullable=False)
+    config_id = Column(AutoIncrementBigInteger, nullable=False)
+    action = Column(String(128), nullable=False)
+    batch_id = Column(String(128), nullable=True)
+    operator = Column(String(128), nullable=False)
+    reason = Column(String(512), nullable=False)
+    based_on_config_version = Column(String(64), nullable=True)
+    effective_config_version = Column(String(64), nullable=False)
+    evidence = Column(Text, nullable=True)
+    effective_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint(
+            "env",
+            "effective_config_version",
+            name="uk_skills_pool_rollout_audit_revision",
+        ),
+        Index(
+            "idx_skills_pool_rollout_audit_batch",
+            "env",
+            "batch_id",
+            "id",
+        ),
+    )
+
+
 class SkillMigrationQuarantineModel(Base):
     """One immutable Bot/migration-generation quarantine identity."""
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -20,6 +20,16 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """读取状态；不存在记录时返回非持久化的 Legacy 缺省状态。"""
         ...
 
+    def list_states(
+        self,
+        *,
+        env: str,
+        engine: str | None = None,
+        batch_id: str | None = None,
+    ) -> list[BotSkillLayoutState]:
+        """列出一个环境内已经认领过布局状态的 Bot。"""
+        ...
+
     def claim_pool_migration(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
@@ -1,0 +1,59 @@
+"""Shared schema validation for the Skills Pool rollout configuration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+ENGINE_PROMOTION_ORDER = ("openclaw", "claude_code", "aicoding", "hermes")
+CONTROL_KEYS = ("negative_controls", "teclaw_controls")
+_REQUIRED_KEYS = frozenset({"enable_all", "promoted_engines", "whitelist"})
+_ALLOWED_KEYS = _REQUIRED_KEYS | frozenset(CONTROL_KEYS)
+_ENTRY_KEYS = frozenset({"owner_id", "bot_id", "batch_id"})
+
+
+def _valid_identity(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (str, int))
+        and str(value).strip() not in {"", "*"}
+    )
+
+
+def _valid_entries(value: Any) -> bool:
+    if not isinstance(value, list):
+        return False
+    for entry in value:
+        if not isinstance(entry, dict) or not set(entry).issubset(_ENTRY_KEYS):
+            return False
+        if not _valid_identity(entry.get("owner_id")):
+            return False
+        if not _valid_identity(entry.get("bot_id")):
+            return False
+        batch_id = entry.get("batch_id")
+        if batch_id is not None and not _valid_identity(batch_id):
+            return False
+    return True
+
+
+def is_valid_rollout_config_value(value: Any) -> bool:
+    """Accept only the exact, fail-closed rollout configuration schema."""
+
+    if not isinstance(value, dict):
+        return False
+    keys = set(value)
+    if not _REQUIRED_KEYS.issubset(keys) or not keys.issubset(_ALLOWED_KEYS):
+        return False
+    if value.get("enable_all") is not False:
+        return False
+
+    engines = value.get("promoted_engines")
+    if not isinstance(engines, list):
+        return False
+    promoted_engines = tuple(engines)
+    if promoted_engines != ENGINE_PROMOTION_ORDER[: len(promoted_engines)]:
+        return False
+
+    return all(
+        _valid_entries(value.get(key, []))
+        for key in ("whitelist", *CONTROL_KEYS)
+    )

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_gate.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_gate.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
-
 from injector import inject
 
 from agentclaw.community.core.common_config.service import CommonConfigService
@@ -13,6 +11,9 @@ from agentclaw.community.core.common_config.whitelist_service import (
     CommonWhiteListService,
 )
 from agentclaw.community.core.skills_pool.types import RolloutEvidence
+from agentclaw.community.core.skills_pool.rollout_config import (
+    is_valid_rollout_config_value,
+)
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -71,42 +72,6 @@ class SkillsPoolRolloutGate:
     def _reject(reason: RolloutDecisionReason) -> RolloutDecision:
         return RolloutDecision(eligible=False, reason=reason)
 
-    @staticmethod
-    def _valid_identity(value: Any) -> bool:
-        return (
-            not isinstance(value, bool)
-            and isinstance(value, (str, int))
-            and str(value).strip() not in {"", "*"}
-        )
-
-    @classmethod
-    def _valid_config_value(cls, value: Any) -> bool:
-        if not isinstance(value, dict):
-            return False
-        if value.get("enable_all") is not False:
-            return value.get("enable_all") is True
-
-        engines = value.get("promoted_engines")
-        whitelist = value.get("whitelist")
-        if not isinstance(engines, list) or not isinstance(whitelist, list):
-            return False
-        if any(not isinstance(engine, str) or not engine for engine in engines):
-            return False
-        allowed_entry_keys = {"owner_id", "bot_id", "batch_id"}
-        for entry in whitelist:
-            if not isinstance(entry, dict):
-                return False
-            if not set(entry).issubset(allowed_entry_keys):
-                return False
-            if not cls._valid_identity(entry.get("owner_id")):
-                return False
-            if not cls._valid_identity(entry.get("bot_id")):
-                return False
-            batch_id = entry.get("batch_id")
-            if batch_id is not None and not cls._valid_identity(batch_id):
-                return False
-        return True
-
     def evaluate(
         self,
         *,
@@ -149,20 +114,26 @@ class SkillsPoolRolloutGate:
             return self._reject(RolloutDecisionReason.CONFIG_ENV_MISMATCH)
 
         config_id = config.get("id")
-        config_version = config.get("gmt_modified")
+        ext_info = config.get("ext_info")
+        revision = (
+            ext_info.get("revision")
+            if isinstance(ext_info, dict)
+            else None
+        )
+        config_version = revision or config.get("gmt_modified")
         value = config.get("param_value")
+        if isinstance(value, dict) and value.get("enable_all") is True:
+            return self._reject(RolloutDecisionReason.ENABLE_ALL_FORBIDDEN)
         if (
             isinstance(config_id, bool)
             or not isinstance(config_id, int)
             or not isinstance(config_version, str)
             or not config_version
-            or not self._valid_config_value(value)
+            or not is_valid_rollout_config_value(value)
         ):
             return self._reject(RolloutDecisionReason.CONFIG_INVALID)
         assert isinstance(value, dict)
 
-        if value.get("enable_all") is True:
-            return self._reject(RolloutDecisionReason.ENABLE_ALL_FORBIDDEN)
         promoted_engines = value["promoted_engines"]
         if engine_type not in promoted_engines:
             return self._reject(RolloutDecisionReason.ENGINE_NOT_PROMOTED)

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_repository.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_repository.py
@@ -1,0 +1,22 @@
+"""Persistence boundary for atomic rollout config and append-only audit."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SkillsPoolRolloutRepositoryProtocol(Protocol):
+    def commit_change(
+        self,
+        *,
+        env: str,
+        config_id: int | None,
+        expected_revision: str | None,
+        expected_enable: bool,
+        expected_value: dict[str, object],
+        next_revision: str,
+        enabled: bool,
+        value: dict[str, object],
+        audit: dict[str, object],
+    ) -> bool: ...
+
+    def list_audit_events(self, *, env: str) -> list[dict[str, object]]: ...

--- a/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
@@ -2,6 +2,21 @@
 
 from injector import Binder, Module, inject, provider, singleton
 
+from agentclaw.community.api.skills_pool_operational_query_service import (
+    SkillsPoolOperationalQueryServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_operator_commands_service import (
+    SkillsPoolOperatorCommandsServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_recovery_service import (
+    SkillsPoolRecoveryServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_rollback_service import (
+    SkillsPoolRollbackServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_rollout_service import (
+    SkillsPoolRolloutServiceProtocol,
+)
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.devices.repository.protocol import (
     DeviceBindingRepository,
@@ -10,11 +25,23 @@ from agentclaw.community.core.skills_pool.claim_service import (
     SkillsPoolMigrationClaimService,
 )
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+from agentclaw.community.core.skills_pool.operational_query import (
+    SkillsPoolOperationalQuery,
+)
+from agentclaw.community.core.skills_pool.operations import (
+    SkillsPoolRolloutOperations,
+)
+from agentclaw.community.core.skills_pool.operator_commands import (
+    SkillsPoolOperatorCommands,
+)
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
 )
 from agentclaw.community.core.skills_pool.rollout_gate import (
     SkillsPoolRolloutGate,
+)
+from agentclaw.community.core.skills_pool.rollout_repository import (
+    SkillsPoolRolloutRepositoryProtocol,
 )
 from agentclaw.community.core.skills_pool.reconcile_service import (
     SkillsPoolReconcileService,
@@ -32,6 +59,10 @@ from agentclaw.community.core.skills_pool.quarantine import (
     SkillsPoolQuarantineCleanupTaskHandler,
     SkillsPoolQuarantineService,
 )
+from agentclaw.community.core.skills_pool.recovery_service import (
+    SkillsPoolRecoveryService,
+    SkillsPoolRollbackService,
+)
 from agentclaw.community.plugins.skill_repository import SkillRepository
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.services.task_queue_service import (
@@ -40,6 +71,9 @@ from agentclaw.community.core.task_queue.services.task_queue_service import (
 from agentclaw.community.plugins.skills_pool_runtime import SkillsPoolRuntime
 from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
+)
+from agentclaw.community.plugins.skills_pool_rollout_repository import (
+    SkillsPoolRolloutRepository,
 )
 
 
@@ -87,6 +121,81 @@ class SkillsPoolModule(Module):
             to=SkillsPoolEditGuard,
             scope=singleton,
         )
+        binder.bind(
+            SkillsPoolRolloutOperations,
+            to=SkillsPoolRolloutOperations,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolRolloutRepositoryProtocol,
+            to=SkillsPoolRolloutRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolOperationalQuery,
+            to=SkillsPoolOperationalQuery,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolOperatorCommands,
+            to=SkillsPoolOperatorCommands,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolRecoveryService,
+            to=SkillsPoolRecoveryService,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillsPoolRollbackService,
+            to=SkillsPoolRollbackService,
+            scope=singleton,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def rollout_service_protocol(
+        self,
+        service: SkillsPoolRolloutOperations,
+    ) -> SkillsPoolRolloutServiceProtocol:
+        return service
+
+    @singleton
+    @provider
+    @inject
+    def operational_query_service_protocol(
+        self,
+        service: SkillsPoolOperationalQuery,
+    ) -> SkillsPoolOperationalQueryServiceProtocol:
+        return service
+
+    @singleton
+    @provider
+    @inject
+    def operator_commands_service_protocol(
+        self,
+        service: SkillsPoolOperatorCommands,
+    ) -> SkillsPoolOperatorCommandsServiceProtocol:
+        return service
+
+    @singleton
+    @provider
+    @inject
+    def recovery_service_protocol(
+        self,
+        service: SkillsPoolRecoveryService,
+    ) -> SkillsPoolRecoveryServiceProtocol:
+        return service
+
+    @singleton
+    @provider
+    @inject
+    def rollback_service_protocol(
+        self,
+        service: SkillsPoolRollbackService,
+    ) -> SkillsPoolRollbackServiceProtocol:
+        return service
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -26,12 +26,13 @@ from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
     log_missing_quarantine_path,
 )
+from agentclaw.community.plugins.skills_pool_operational_repository import SkillsPoolOperationalRepositoryMixin
 from agentclaw.community.plugins.skills_pool_quarantine_repository import (
     SkillsPoolQuarantineRepositoryMixin,
 )
 
 
-class SkillsPoolLayoutRepository(SkillsPoolQuarantineRepositoryMixin):
+class SkillsPoolLayoutRepository(SkillsPoolOperationalRepositoryMixin, SkillsPoolQuarantineRepositoryMixin):
     @inject
     def __init__(self, database: DatabasePlugin) -> None:
         self._database = database

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_operational_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_operational_repository.py
@@ -1,0 +1,70 @@
+"""Read-only ORM queries used by Skills Pool operational reporting."""
+
+from sqlalchemy import case, func
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    BotSkillLayoutStateModel,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutState
+
+
+class SkillsPoolOperationalRepositoryMixin:
+    """Keep reporting scans outside the migration state repository module."""
+
+    _database: object
+
+    def list_states(
+        self,
+        *,
+        env: str,
+        engine: str | None = None,
+        batch_id: str | None = None,
+    ) -> list[BotSkillLayoutState]:
+        with self._database.transactional_orm_session() as session:
+            query = session.query(BotSkillLayoutStateModel).filter(
+                BotSkillLayoutStateModel.env == env
+            )
+            if engine is not None or batch_id is not None:
+                query = query.filter(
+                    func.json_valid(
+                        BotSkillLayoutStateModel.rollout_evidence
+                    )
+                    == 1
+                )
+            dialect = session.get_bind().dialect.name
+            if engine is not None:
+                engine_value = case(
+                    (
+                        func.json_valid(
+                            BotSkillLayoutStateModel.rollout_evidence
+                        )
+                        == 1,
+                        func.json_extract(
+                            BotSkillLayoutStateModel.rollout_evidence,
+                            "$.engine_type",
+                        ),
+                    ),
+                    else_=None,
+                )
+                if dialect != "sqlite":
+                    engine_value = func.json_unquote(engine_value)
+                query = query.filter(engine_value == engine)
+            if batch_id is not None:
+                batch_value = case(
+                    (
+                        func.json_valid(
+                            BotSkillLayoutStateModel.rollout_evidence
+                        )
+                        == 1,
+                        func.json_extract(
+                            BotSkillLayoutStateModel.rollout_evidence,
+                            "$.batch_id",
+                        ),
+                    ),
+                    else_=None,
+                )
+                if dialect != "sqlite":
+                    batch_value = func.json_unquote(batch_value)
+                query = query.filter(batch_value == batch_id)
+            rows = query.order_by(BotSkillLayoutStateModel.id.asc()).all()
+            return [row.to_state() for row in rows]

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_rollout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_rollout_repository.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime
 
 from injector import inject
+from sqlalchemy.exc import IntegrityError
 
 from agentclaw.community.core.skills_pool.repository.models import (
     SkillsPoolRolloutAuditModel,
@@ -24,6 +25,36 @@ class SkillsPoolRolloutRepository:
         self._database = database
 
     def commit_change(
+        self,
+        *,
+        env: str,
+        config_id: int | None,
+        expected_revision: str | None,
+        expected_enable: bool,
+        expected_value: dict[str, object],
+        next_revision: str,
+        enabled: bool,
+        value: dict[str, object],
+        audit: dict[str, object],
+    ) -> bool:
+        try:
+            return self._commit_change(
+                env=env,
+                config_id=config_id,
+                expected_revision=expected_revision,
+                expected_enable=expected_enable,
+                expected_value=expected_value,
+                next_revision=next_revision,
+                enabled=enabled,
+                value=value,
+                audit=audit,
+            )
+        except IntegrityError:
+            if config_id is None:
+                return False
+            raise
+
+    def _commit_change(
         self,
         *,
         env: str,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_rollout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_rollout_repository.py
@@ -1,0 +1,153 @@
+"""Atomic Skills Pool rollout config and audit persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from injector import inject
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    SkillsPoolRolloutAuditModel,
+)
+from agentclaw.community.core.skills_pool.rollout_gate import (
+    SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
+    SKILLS_POOL_ROLLOUT_PARAM_CODE,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.plugin_api.models import CommonConfig
+
+
+class SkillsPoolRolloutRepository:
+    @inject
+    def __init__(self, database: DatabasePlugin) -> None:
+        self._database = database
+
+    def commit_change(
+        self,
+        *,
+        env: str,
+        config_id: int | None,
+        expected_revision: str | None,
+        expected_enable: bool,
+        expected_value: dict[str, object],
+        next_revision: str,
+        enabled: bool,
+        value: dict[str, object],
+        audit: dict[str, object],
+    ) -> bool:
+        with self._database.transactional_orm_session() as session:
+            row = (
+                session.query(CommonConfig)
+                .filter(
+                    CommonConfig.business_code
+                    == SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
+                    CommonConfig.param_code == SKILLS_POOL_ROLLOUT_PARAM_CODE,
+                    CommonConfig.env == env,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if row is None:
+                if config_id is not None:
+                    return False
+                row = CommonConfig(
+                    business_code=SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
+                    business_name="Skills Pool",
+                    param_code=SKILLS_POOL_ROLLOUT_PARAM_CODE,
+                    param_name="Skills Pool layout rollout",
+                    param_value=json.dumps(value, ensure_ascii=False),
+                    enable="1" if enabled else "0",
+                    ext_info=json.dumps(
+                        {
+                            "revision": next_revision,
+                            "last_action": audit["action"],
+                            "last_operator": audit["operator"],
+                            "operated_at": audit["effective_at"],
+                        },
+                        ensure_ascii=False,
+                    ),
+                    env=env,
+                )
+                session.add(row)
+                session.flush()
+            else:
+                current_ext = json.loads(row.ext_info) if row.ext_info else {}
+                current_value = (
+                    json.loads(row.param_value) if row.param_value else None
+                )
+                if (
+                    row.id != config_id
+                    or current_ext.get("revision") != expected_revision
+                    or (row.enable == "1") is not expected_enable
+                    or current_value != expected_value
+                ):
+                    return False
+                row.param_value = json.dumps(value, ensure_ascii=False)
+                row.enable = "1" if enabled else "0"
+                row.ext_info = json.dumps(
+                    {
+                        "revision": next_revision,
+                        "last_action": audit["action"],
+                        "last_operator": audit["operator"],
+                        "operated_at": audit["effective_at"],
+                    },
+                    ensure_ascii=False,
+                )
+
+            session.add(
+                SkillsPoolRolloutAuditModel(
+                    env=env,
+                    config_id=row.id,
+                    action=str(audit["action"]),
+                    batch_id=(
+                        str(audit["batch_id"])
+                        if audit.get("batch_id") is not None
+                        else None
+                    ),
+                    operator=str(audit["operator"]),
+                    reason=str(audit["reason"]),
+                    based_on_config_version=(
+                        str(audit["based_on_config_version"])
+                        if audit.get("based_on_config_version") is not None
+                        else None
+                    ),
+                    effective_config_version=next_revision,
+                    evidence=(
+                        json.dumps(audit["evidence"], ensure_ascii=False)
+                        if audit.get("evidence") is not None
+                        else None
+                    ),
+                    effective_at=datetime.fromisoformat(
+                        str(audit["effective_at"])
+                    ),
+                )
+            )
+        return True
+
+    def list_audit_events(self, *, env: str) -> list[dict[str, object]]:
+        with self._database.transactional_orm_session() as session:
+            rows = (
+                session.query(SkillsPoolRolloutAuditModel)
+                .filter(SkillsPoolRolloutAuditModel.env == env)
+                .order_by(SkillsPoolRolloutAuditModel.id.asc())
+                .all()
+            )
+            return [
+                {
+                    "env": row.env,
+                    "action": row.action,
+                    "operator": row.operator,
+                    "reason": row.reason,
+                    "batch_id": row.batch_id,
+                    "based_on_config_version": row.based_on_config_version,
+                    "effective_config_version": (
+                        row.effective_config_version
+                    ),
+                    "effective_at": row.effective_at.isoformat(),
+                    "evidence": (
+                        json.loads(row.evidence) if row.evidence else None
+                    ),
+                }
+                for row in rows
+            ]

--- a/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
+++ b/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
@@ -1,0 +1,97 @@
+"""Skills Pool operator API surface contract."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from agentclaw.community.adapters.http.auth.dependencies import require_operator
+from agentclaw.community.adapters.http.skills_pool.router import (
+    get_rollout,
+    rollback_bot,
+    router,
+)
+from agentclaw.community.adapters.http.skills_pool.schemas import RollbackRequest
+from agentclaw.community.core.skills_pool.recovery_service import (
+    SkillsPoolRollbackOutcome,
+    SkillsPoolRollbackResult,
+)
+from agentclaw.community.core.skills_pool.operations import RolloutOperationError
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+
+
+def test_all_skills_pool_operations_are_operator_only() -> None:
+    expected = {
+        "/api/ops/skills-pool/rollout",
+        "/api/ops/skills-pool/rollout/feature",
+        "/api/ops/skills-pool/rollout/promote",
+        "/api/ops/skills-pool/rollout/whitelist",
+        "/api/ops/skills-pool/rollout/whitelist/remove",
+        "/api/ops/skills-pool/rollout/batches/accept",
+        "/api/ops/skills-pool/rollout/controls",
+        "/api/ops/skills-pool/bots/{bot_id}",
+        "/api/ops/skills-pool/batches/{batch_id}",
+        "/api/ops/skills-pool/bots/{bot_id}/wake",
+        "/api/ops/skills-pool/bots/{bot_id}/retry",
+        "/api/ops/skills-pool/bots/{bot_id}/repair",
+        "/api/ops/skills-pool/bots/{bot_id}/rollback",
+    }
+
+    assert {route.path for route in router.routes} == expected
+    for route in router.routes:
+        dependency_calls = {
+            dependency.call for dependency in route.dependant.dependencies
+        }
+        assert require_operator in dependency_calls
+
+
+@pytest.mark.asyncio
+async def test_rollback_route_supplies_a_unique_lease_owner() -> None:
+    scope = BotSkillLayoutScope("pre", "entity-1", "bot-1")
+
+    class Query:
+        def get_bot(self, **_: object):
+            return SimpleNamespace(scope=scope)
+
+    class RollbackService:
+        call: dict[str, object] | None = None
+
+        async def rollback(self, **kwargs: object) -> SkillsPoolRollbackResult:
+            self.call = kwargs
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.LEGACY_ACTIVE
+            )
+
+    service = RollbackService()
+
+    await rollback_bot(
+        bot_id="bot-1",
+        request=RollbackRequest(
+            owner_id="owner-1",
+            rollback_generation="rollback-1",
+            note="operator confirmed",
+        ),
+        user=SimpleNamespace(staffId="freddie"),
+        service=service,
+        query=Query(),
+    )
+
+    assert service.call is not None
+    assert service.call["scope"] == scope
+    assert service.call["operator"] == "freddie"
+    assert str(service.call["lease_owner"]).startswith("operator-api:")
+
+
+@pytest.mark.asyncio
+async def test_invalid_rollout_config_is_an_explicit_operator_conflict() -> None:
+    class InvalidConfig:
+        def get_snapshot(self, **_: object):
+            raise RolloutOperationError("rollout config is invalid")
+
+    with pytest.raises(HTTPException) as captured:
+        await get_rollout(
+            _=SimpleNamespace(staffId="freddie"),
+            service=InvalidConfig(),
+        )
+
+    assert captured.value.status_code == 409

--- a/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
+++ b/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from agentclaw.community.adapters.http.auth.dependencies import require_operator
 from agentclaw.community.adapters.http.skills_pool.router import (
@@ -11,7 +12,10 @@ from agentclaw.community.adapters.http.skills_pool.router import (
     rollback_bot,
     router,
 )
-from agentclaw.community.adapters.http.skills_pool.schemas import RollbackRequest
+from agentclaw.community.adapters.http.skills_pool.schemas import (
+    ControlBotRequest,
+    RollbackRequest,
+)
 from agentclaw.community.core.skills_pool.recovery_service import (
     SkillsPoolRollbackOutcome,
     SkillsPoolRollbackResult,
@@ -43,6 +47,17 @@ def test_all_skills_pool_operations_are_operator_only() -> None:
             dependency.call for dependency in route.dependant.dependencies
         }
         assert require_operator in dependency_calls
+
+
+def test_control_bot_request_rejects_empty_batch_id() -> None:
+    with pytest.raises(ValidationError):
+        ControlBotRequest(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            batch_id="",
+            group="negative",
+            reason="control sample",
+        )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/common_config/test_common_config_service.py
+++ b/src/backend/tests/community/core/common_config/test_common_config_service.py
@@ -82,6 +82,59 @@ class FakeCommonConfigRepository:
         return self.rows.pop((business_code, param_code, env), None) is not None
 
 
+def test_skills_pool_rollout_rejects_generic_config_writes() -> None:
+    repo = FakeCommonConfigRepository()
+    service = CommonConfigService(repo)
+
+    with pytest.raises(ValueError, match="operator API"):
+        service.upsert_config(
+            business_code="skills_pool",
+            business_name="Skills Pool",
+            param_code="layout_rollout",
+            param_name="Rollout",
+            param_value={},
+            env="pre",
+        )
+
+    config_id = repo.create_config(
+        business_code="skills_pool",
+        business_name="Skills Pool",
+        param_code="layout_rollout",
+        param_name="Rollout",
+        param_value="{}",
+        enable="0",
+        ext_info=None,
+        env="pre",
+    )
+    with pytest.raises(ValueError, match="operator API"):
+        service.update_config(
+            config_id=config_id,
+            updates={"enable": "1"},
+        )
+
+
+def test_generic_update_cannot_rename_config_into_rollout_key() -> None:
+    repo = FakeCommonConfigRepository()
+    service = CommonConfigService(repo)
+    config_id = service.create_config(
+        business_code="other",
+        business_name="Other",
+        param_code="safe",
+        param_name="Safe",
+        param_value={},
+        env="pre",
+    )
+
+    with pytest.raises(ValueError, match="operator API"):
+        service.update_config(
+            config_id=config_id,
+            updates={
+                "business_code": "skills_pool",
+                "param_code": "layout_rollout",
+            },
+        )
+
+
 def test_common_config_service_serializes_value_and_hides_disabled_by_default():
     repo = FakeCommonConfigRepository()
     service = CommonConfigService(repo)

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -30,6 +30,7 @@ from agentclaw.community.core.skills_pool.types import (
 from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
     SkillMigrationQuarantineModel,
+    SkillsPoolRolloutAuditModel,
 )
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
@@ -77,14 +78,30 @@ class FileSqliteDB(InMemorySqliteDB):
         self._session_factory = sessionmaker(bind=engine, autoflush=False)
 
 
-def test_quarantine_runtime_timestamp_preserves_mysql_microseconds() -> None:
-    ddl = str(
+def test_skills_pool_operational_tables_use_mysql_timestamp_contract() -> None:
+    quarantine_ddl = str(
         CreateTable(SkillMigrationQuarantineModel.__table__).compile(
             dialect=mysql.dialect()
         )
-    )
+    ).upper()
+    audit_ddl = str(
+        CreateTable(SkillsPoolRolloutAuditModel.__table__).compile(
+            dialect=mysql.dialect()
+        )
+    ).upper()
 
-    assert "runtime_reconciled_at DATETIME(6)" in ddl
+    assert "DATETIME" not in quarantine_ddl
+    assert "POOL_ACTIVATED_AT TIMESTAMP" in quarantine_ddl
+    assert "RUNTIME_RECONCILED_AT TIMESTAMP(6)" in quarantine_ddl
+    assert "CLEANED_AT TIMESTAMP" in quarantine_ddl
+    assert "CLEANUP_LEASE_EXPIRES_AT TIMESTAMP" in quarantine_ddl
+    assert "GMT_CREATE TIMESTAMP" in quarantine_ddl
+    assert "GMT_MODIFIED TIMESTAMP" in quarantine_ddl
+
+    assert "DATETIME" not in audit_ddl
+    assert "EFFECTIVE_AT TIMESTAMP(6)" in audit_ddl
+    assert "GMT_CREATE TIMESTAMP" in audit_ddl
+    assert "GMT_MODIFY TIMESTAMP" in audit_ddl
 
 
 def rollout_evidence() -> RolloutEvidence:

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
@@ -162,6 +163,78 @@ def test_missing_layout_state_reads_as_legacy_without_persisting() -> None:
     assert state.phase is SkillLayoutPhase.LEGACY_ACTIVE
     assert state.migration_generation is None
     assert state.persisted is False
+
+
+def test_list_states_is_scoped_to_environment_and_only_returns_persisted_rows() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    with database.transactional_orm_session() as session:
+        session.add_all(
+            [
+                BotSkillLayoutStateModel(
+                    env="pre",
+                    entity_id="entity-2",
+                    bot_id="bot-2",
+                    active_layout=SkillLayout.LEGACY.value,
+                    phase=SkillLayoutPhase.LEGACY_ACTIVE.value,
+                ),
+                BotSkillLayoutStateModel(
+                    env="pre",
+                    entity_id="entity-1",
+                    bot_id="bot-1",
+                    active_layout=SkillLayout.LEGACY.value,
+                    phase=SkillLayoutPhase.LEGACY_ACTIVE.value,
+                ),
+                BotSkillLayoutStateModel(
+                    env="prod",
+                    entity_id="entity-3",
+                    bot_id="bot-3",
+                    active_layout=SkillLayout.LEGACY.value,
+                    phase=SkillLayoutPhase.LEGACY_ACTIVE.value,
+                ),
+            ]
+        )
+
+    states = repository.list_states(env="pre")
+
+    assert [state.scope.bot_id for state in states] == ["bot-2", "bot-1"]
+    assert all(state.persisted for state in states)
+
+    with database.transactional_orm_session() as session:
+        rows = {
+            row.bot_id: row
+            for row in session.query(BotSkillLayoutStateModel)
+            .filter(BotSkillLayoutStateModel.env == "pre")
+            .all()
+        }
+        rows["bot-1"].rollout_evidence = json.dumps(
+            {
+                "env": "pre",
+                "config_id": 1,
+                "config_version": "v1",
+                "batch_id": "batch-1",
+                "engine_type": "openclaw",
+                "decision_reason": "eligible",
+            }
+        )
+        rows["bot-2"].rollout_evidence = json.dumps(
+            {
+                "env": "pre",
+                "config_id": 1,
+                "config_version": "v1",
+                "batch_id": "batch-1",
+                "engine_type": "claude_code",
+                "decision_reason": "eligible",
+            }
+        )
+
+    filtered = repository.list_states(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert [state.scope.bot_id for state in filtered] == ["bot-1"]
 
 
 def test_claim_pool_migration_persists_generation_lease_and_rollout_evidence() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_operational_query.py
+++ b/src/backend/tests/community/core/skills_pool/test_operational_query.py
@@ -1,0 +1,391 @@
+"""Skills Pool operational evidence queries."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+from agentclaw.community.core.skills_pool.operational_query import (
+    SkillsPoolOperationalQuery,
+)
+from agentclaw.community.core.skills_pool.operations import (
+    RolloutBotEntry,
+    RolloutConfigSnapshot,
+)
+from agentclaw.community.core.skills_pool.rollout_gate import (
+    BotRuntimeForm,
+    RolloutDecision,
+    RolloutDecisionReason,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    RolloutEvidence,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+SCOPE = BotSkillLayoutScope(env="pre", entity_id="owner-1", bot_id="bot-1")
+
+
+class FakeBots:
+    default_records = [
+        {
+                "bot_id": "bot-1",
+                "owner_id": "owner-1",
+                "entity_id": "owner-1",
+                "env": "pre",
+                "bot_type": "personal",
+                "active_engine": "openclaw",
+        },
+        {
+            "bot_id": "negative-1",
+            "owner_id": "owner-2",
+            "entity_id": "owner-2",
+            "env": "pre",
+            "bot_type": "personal",
+            "active_engine": "openclaw",
+        },
+        {
+            "bot_id": "teclaw-1",
+            "owner_id": "owner-3",
+            "entity_id": "owner-3",
+            "env": "pre",
+            "bot_type": "personal",
+            "active_engine": "teclaw",
+        },
+    ]
+
+    def __init__(
+        self,
+        records: list[dict[str, object]] | None = None,
+    ) -> None:
+        self.records = records or self.default_records
+
+    def get_live_by_id_owner_and_env(self, **kwargs: object):
+        return [
+            record
+            for record in self.records
+            if record["bot_id"] == kwargs["bot_id"]
+            and record["owner_id"] == kwargs["owner_id"]
+            and record["env"] == kwargs["env"]
+        ]
+
+    def get_by_id_and_entity(self, bot_id: str, entity_id: str):
+        return next(
+            (
+                record
+                for record in self.records
+                if record["bot_id"] == bot_id
+                and record["entity_id"] == entity_id
+            ),
+            None,
+        )
+
+
+class FakeLayouts:
+    def __init__(self) -> None:
+        self.state = replace(
+            BotSkillLayoutState.legacy_default(SCOPE),
+            active_layout=SkillLayout.POOL,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            migration_generation="generation-1",
+            preparation_id="preparation-1",
+            layout_contract_version="skills-pool-p3-v1",
+            last_probe_result="READY",
+            persisted=True,
+            rollout_evidence=RolloutEvidence(
+                env="pre",
+                config_id=7,
+                config_version="v7",
+                batch_id="batch-1",
+                engine_type="openclaw",
+                decision_reason="eligible",
+            ),
+        )
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        if scope == SCOPE:
+            return self.state
+        return BotSkillLayoutState.legacy_default(scope)
+
+    def list_states(
+        self,
+        *,
+        env: str,
+        engine: str | None = None,
+        batch_id: str | None = None,
+    ) -> list[BotSkillLayoutState]:
+        assert env == "pre"
+        assert engine == "openclaw"
+        assert batch_id == "batch-1"
+        return [self.state]
+
+
+class FakeBindings:
+    def get_active_by_bot_and_owner(self, bot_id: str, owner_id: str):
+        provider = "baas" if bot_id == "teclaw-1" else "arca"
+        return SimpleNamespace(device_provider=provider, status="ACTIVE")
+
+
+class FakeClaims:
+    def inspect_runtime_form(self, **_: object) -> BotRuntimeForm:
+        return BotRuntimeForm.PERSONAL
+
+
+class FakeGate:
+    def __init__(self, eligible_bot_ids: set[str] | None = None) -> None:
+        self.eligible_bot_ids = eligible_bot_ids or {"bot-1"}
+
+    def evaluate(self, **kwargs: object) -> RolloutDecision:
+        if kwargs["bot_id"] in self.eligible_bot_ids:
+            return RolloutDecision(True, RolloutDecisionReason.ELIGIBLE)
+        reason = (
+            RolloutDecisionReason.ENGINE_NOT_SUPPORTED
+            if kwargs["engine_type"] == "teclaw"
+            else RolloutDecisionReason.BOT_NOT_WHITELISTED
+        )
+        return RolloutDecision(False, reason)
+
+
+class FakeRollout:
+    def __init__(
+        self,
+        whitelist: tuple[RolloutBotEntry, ...] | None = None,
+    ) -> None:
+        self.whitelist = (
+            (RolloutBotEntry("owner-1", "bot-1", "batch-1"),)
+            if whitelist is None
+            else whitelist
+        )
+
+    def get_snapshot(self, *, env: str) -> RolloutConfigSnapshot:
+        return RolloutConfigSnapshot(
+            env=env,
+            config_id=7,
+            config_version="v7",
+            record_version="2026-07-25T10:00:00",
+            config_revision="v7",
+            enabled=True,
+            enable_all=False,
+            promoted_engines=("openclaw",),
+            whitelist=self.whitelist,
+            negative_controls=(
+                RolloutBotEntry("owner-2", "negative-1", "batch-1"),
+            ),
+            teclaw_controls=(
+                RolloutBotEntry("owner-3", "teclaw-1", "batch-1"),
+            ),
+            audit_log=(),
+        )
+
+
+class FakeQuarantine:
+    def inspect(self, scope: BotSkillLayoutScope, generation: str):
+        assert (scope, generation) == (SCOPE, "generation-1")
+        return SimpleNamespace(
+            eligible=True,
+            blockers=(),
+            eligible_at=None,
+            age=None,
+            record=SimpleNamespace(
+                status="retained",
+                runtime_evidence={"source": "arca_device_alive"},
+            ),
+        )
+
+
+def build_query(
+    layouts: FakeLayouts | None = None,
+    *,
+    bots: FakeBots | None = None,
+    gate: FakeGate | None = None,
+    rollout: FakeRollout | None = None,
+) -> SkillsPoolOperationalQuery:
+    return SkillsPoolOperationalQuery(
+        bot_repository=bots or FakeBots(),
+        layout_repository=layouts or FakeLayouts(),
+        binding_repository=FakeBindings(),
+        claim_service=FakeClaims(),
+        rollout_gate=gate or FakeGate(),
+        rollout_operations=rollout or FakeRollout(),
+        quarantine_service=FakeQuarantine(),
+    )
+
+
+def test_single_bot_query_exposes_current_runtime_and_migration_evidence() -> None:
+    view = build_query().get_bot(
+        env="pre",
+        owner_id="owner-1",
+        bot_id="bot-1",
+    )
+
+    assert view.engine == "openclaw"
+    assert view.provider == "arca"
+    assert view.runtime_form is BotRuntimeForm.PERSONAL
+    assert view.claimed is True
+    assert view.state.phase is SkillLayoutPhase.POOL_ACTIVE
+    assert view.state.preparation_id == "preparation-1"
+    assert view.quarantine is not None
+    assert view.quarantine.eligible is True
+
+
+def test_batch_query_reports_migration_and_explicit_control_counts() -> None:
+    report = build_query().summarize_batch(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert report.eligible == 1
+    assert report.configured == 1
+    assert report.invalid_batch_members == 0
+    assert report.attempted == 1
+    assert report.claimed == 1
+    assert report.preparing == 0
+    assert report.active == 1
+    assert report.rolling_back == 0
+    assert report.failed == 0
+    assert report.negative_controls == 1
+    assert report.negative_controls_healthy == 1
+    assert report.teclaw_controls == 1
+    assert report.teclaw_controls_healthy == 1
+    assert report.quarantine_cleanup_eligible == 1
+    assert report.rollout_config_id == 7
+    assert report.rollout_config_version == "v7"
+    assert report.rollout_enabled is True
+    assert report.engine_promoted is True
+    assert report.claim_config_versions == ("v7",)
+    assert report.success_rate == 1.0
+    assert report.data_consistent is True
+    assert report.failure_distribution == {}
+    assert report.promotion_ready is True
+
+
+def test_missing_whitelist_member_blocks_batch_acceptance() -> None:
+    report = build_query(
+        rollout=FakeRollout(
+            (
+                RolloutBotEntry("owner-1", "bot-1", "batch-1"),
+                RolloutBotEntry("missing-owner", "missing-bot", "batch-1"),
+            )
+        ),
+    ).summarize_batch(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert report.configured == 2
+    assert report.invalid_batch_members == 1
+    assert report.data_consistent is False
+    assert report.failure_distribution == {"BATCH_MEMBER_INVALID": 1}
+    assert report.promotion_ready is False
+
+
+def test_wrong_engine_whitelist_member_blocks_batch_acceptance() -> None:
+    report = build_query(
+        rollout=FakeRollout(
+            (
+                RolloutBotEntry("owner-1", "bot-1", "batch-1"),
+                RolloutBotEntry("owner-3", "teclaw-1", "batch-1"),
+            )
+        ),
+    ).summarize_batch(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert report.configured == 2
+    assert report.invalid_batch_members == 1
+    assert report.data_consistent is False
+    assert report.failure_distribution == {"BATCH_MEMBER_INVALID": 1}
+    assert report.promotion_ready is False
+
+
+def test_data_inconsistency_blocks_manual_batch_promotion() -> None:
+    layouts = FakeLayouts()
+    layouts.state = replace(
+        layouts.state,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=SkillLayout.POOL,
+        phase=SkillLayoutPhase.POOL_PREPARING,
+        last_failure_code="DATA_INCONSISTENT",
+    )
+
+    report = build_query(layouts).summarize_batch(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert report.success_rate == 0.0
+    assert report.failure_distribution == {"DATA_INCONSISTENT": 1}
+    assert report.data_consistent is False
+    assert report.promotion_ready is False
+
+
+def test_resolved_historical_failure_does_not_keep_active_bot_failed() -> None:
+    layouts = FakeLayouts()
+    layouts.state = replace(
+        layouts.state,
+        last_failure_code="MAPPING_PUBLISH_FAILED",
+        last_failure_stage="mapping_publish",
+        last_failure_retryable=True,
+    )
+
+    report = build_query(layouts).summarize_batch(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert report.active == 1
+    assert report.failed == 0
+    assert report.failure_distribution == {}
+    assert report.promotion_ready is True
+
+
+def test_promotion_matches_exact_eligible_and_active_bot_scopes() -> None:
+    bot_b = {
+        "bot_id": "bot-2",
+        "owner_id": "owner-4",
+        "entity_id": "owner-4",
+        "env": "pre",
+        "bot_type": "personal",
+        "active_engine": "openclaw",
+    }
+    query = build_query(
+        bots=FakeBots([*FakeBots.default_records, bot_b]),
+        gate=FakeGate({"bot-2"}),
+        rollout=FakeRollout(
+            (RolloutBotEntry("owner-4", "bot-2", "batch-1"),)
+        ),
+    )
+
+    report = query.summarize_batch(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert report.eligible == 1
+    assert report.active == 1
+    assert report.promotion_ready is False
+
+
+def test_completed_batch_remains_promotable_after_canary_whitelist_cleanup() -> None:
+    report = build_query(
+        rollout=FakeRollout(whitelist=()),
+    ).summarize_batch(
+        env="pre",
+        engine="openclaw",
+        batch_id="batch-1",
+    )
+
+    assert report.eligible == 0
+    assert report.attempted == 1
+    assert report.active == 1
+    assert report.promotion_ready is True

--- a/src/backend/tests/community/core/skills_pool/test_operations.py
+++ b/src/backend/tests/community/core/skills_pool/test_operations.py
@@ -1,0 +1,547 @@
+"""Skills Pool operator control-plane behavior."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from agentclaw.community.core.skills_pool.operations import (
+    BatchPromotionEvidence,
+    RolloutControlGroup,
+    RolloutOperationError,
+    SkillsPoolRolloutOperations,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    RolloutEvidence,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+ENV = "pre"
+OWNER = "owner-1"
+BOT_ID = "bot-1"
+SCOPE = BotSkillLayoutScope(env=ENV, entity_id=OWNER, bot_id=BOT_ID)
+
+
+class FakeCommonConfig:
+    def __init__(self, config: dict[str, object] | None = None) -> None:
+        self.config = config
+        self.upserts: list[dict[str, object]] = []
+
+    def get_config(self, **_: object) -> dict[str, object] | None:
+        return self.config
+
+    def _save(self, kwargs: dict[str, object]) -> int:
+        self.upserts.append(kwargs)
+        value = kwargs["param_value"]
+        assert isinstance(value, dict)
+        self.config = {
+            "id": 42,
+            "enable": kwargs["enable"],
+            "env": kwargs["env"],
+            "param_value": value,
+            "ext_info": kwargs["ext_info"],
+            "gmt_modified": "2026-07-25T10:00:00+00:00",
+        }
+        return 42
+
+
+
+class FakeRolloutRepository:
+    def __init__(self, configs: FakeCommonConfig) -> None:
+        self.configs = configs
+        self.audit: list[dict[str, object]] = []
+        self.cas_succeeds = True
+
+    def list_audit_events(self, *, env: str) -> list[dict[str, object]]:
+        return [event for event in self.audit if event["env"] == env]
+
+    def commit_change(self, **kwargs: object) -> bool:
+        if not self.cas_succeeds:
+            return False
+        current = self.configs.config
+        if current is not None:
+            ext = current.get("ext_info")
+            revision = ext.get("revision") if isinstance(ext, dict) else None
+            if revision != kwargs["expected_revision"]:
+                return False
+        audit = kwargs["audit"]
+        value = kwargs["value"]
+        assert isinstance(audit, dict)
+        assert isinstance(value, dict)
+        self.audit.append(audit)
+        self.configs._save(
+            {
+                "param_value": value,
+                "ext_info": {
+                    "revision": kwargs["next_revision"],
+                    "last_action": audit["action"],
+                },
+                "enable": "1" if kwargs["enabled"] else "0",
+                "env": kwargs["env"],
+            }
+        )
+        return True
+
+
+class FakeBots:
+    def __init__(self) -> None:
+        self.matches: list[dict[str, object]] = [
+            {
+                "bot_id": BOT_ID,
+                "owner_id": OWNER,
+                "entity_id": OWNER,
+                "env": ENV,
+                "active_engine": "openclaw",
+            }
+        ]
+
+    def get_live_by_id_owner_and_env(self, **_: object) -> list[dict[str, object]]:
+        return self.matches
+
+
+class FakeLayouts:
+    def __init__(self) -> None:
+        self.state = BotSkillLayoutState.legacy_default(SCOPE)
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
+
+    def list_states(
+        self,
+        *,
+        env: str,
+        engine: str | None = None,
+        batch_id: str | None = None,
+    ) -> list[BotSkillLayoutState]:
+        evidence = self.state.rollout_evidence
+        if (
+            self.state.persisted
+            and self.state.scope.env == env
+            and (engine is None or evidence is not None and evidence.engine_type == engine)
+            and (
+                batch_id is None
+                or evidence is not None
+                and evidence.batch_id == batch_id
+            )
+        ):
+            return [self.state]
+        return []
+
+
+def build_operations(
+    *,
+    config: dict[str, object] | None = None,
+) -> tuple[
+    SkillsPoolRolloutOperations,
+    FakeCommonConfig,
+    FakeBots,
+    FakeLayouts,
+]:
+    configs = FakeCommonConfig(config)
+    bots = FakeBots()
+    layouts = FakeLayouts()
+    rollout_repository = FakeRolloutRepository(configs)
+    return (
+        SkillsPoolRolloutOperations(
+            common_config_service=configs,
+            bot_repository=bots,
+            layout_repository=layouts,
+            rollout_repository=rollout_repository,
+        ),
+        configs,
+        bots,
+        layouts,
+    )
+
+
+def rollout_config(
+    *,
+    enabled: bool = True,
+    promoted_engines: list[str] | None = None,
+    whitelist: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": 7,
+        "enable": "1" if enabled else "0",
+        "env": ENV,
+        "gmt_modified": "2026-07-25T09:00:00+00:00",
+        "ext_info": {},
+        "param_value": {
+            "enable_all": False,
+            "promoted_engines": promoted_engines or [],
+            "whitelist": whitelist or [],
+            "negative_controls": [],
+            "teclaw_controls": [],
+        },
+    }
+
+
+def test_enabling_missing_rollout_creates_safe_exact_bot_configuration() -> None:
+    operations, configs, _, _ = build_operations()
+
+    snapshot = operations.set_feature_enabled(
+        env=ENV,
+        enabled=True,
+        operator="freddie",
+        reason="start pre canary",
+    )
+
+    assert snapshot.enabled is True
+    assert snapshot.enable_all is False
+    assert snapshot.promoted_engines == ()
+    assert snapshot.whitelist == ()
+    assert configs.upserts[0]["param_value"] == {
+        "enable_all": False,
+        "promoted_engines": [],
+        "whitelist": [],
+        "negative_controls": [],
+        "teclaw_controls": [],
+    }
+
+
+def test_engine_promotion_is_manual_ordered_and_idempotent() -> None:
+    operations, configs, _, _ = build_operations(config=rollout_config())
+
+    with pytest.raises(RolloutOperationError, match="previous engine"):
+        operations.promote_engine(
+            env=ENV,
+            engine="claude_code",
+            operator="freddie",
+            reason="advance",
+        )
+
+    promoted = operations.promote_engine(
+        env=ENV,
+        engine="openclaw",
+        operator="freddie",
+        reason="start first engine",
+    )
+    repeated = operations.promote_engine(
+        env=ENV,
+        engine="openclaw",
+        operator="freddie",
+        reason="idempotent retry",
+    )
+
+    assert promoted.promoted_engines == ("openclaw",)
+    assert repeated.promoted_engines == ("openclaw",)
+    assert len(configs.upserts) == 1
+
+
+def test_next_engine_requires_and_audits_a_passing_batch() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+
+    with pytest.raises(RolloutOperationError, match="accepted openclaw batch"):
+        operations.promote_engine(
+            env=ENV,
+            engine="claude_code",
+            operator="freddie",
+            reason="advance",
+        )
+
+    operations.accept_batch(
+        env=ENV,
+        operator="freddie",
+        reason="freeze openclaw acceptance",
+        acceptance=BatchPromotionEvidence(
+            engine="openclaw",
+            batch_id="openclaw-canary-1",
+            promotion_ready=True,
+            report={
+                "rollout_config_version": "2026-07-25T09:00:00+00:00",
+                "success_rate": 1.0,
+                "promotion_ready": True,
+            },
+        ),
+    )
+    promoted = operations.promote_engine(
+        env=ENV,
+        engine="claude_code",
+        operator="freddie",
+        reason="openclaw batch accepted",
+        acceptance_batch_id="openclaw-canary-1",
+    )
+
+    assert promoted.promoted_engines == ("openclaw", "claude_code")
+    event = promoted.audit_log[-1]
+    assert event.reason == "openclaw batch accepted"
+    assert event.batch_id == "openclaw-canary-1"
+    assert event.evidence == {
+        "rollout_config_version": "2026-07-25T09:00:00+00:00",
+        "success_rate": 1.0,
+        "promotion_ready": True,
+    }
+    assert event.effective_config_version == promoted.config_revision
+
+
+def test_next_batch_requires_latest_persisted_acceptance() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+    operations.accept_batch(
+        env=ENV,
+        operator="freddie",
+        reason="canary passed",
+        acceptance=BatchPromotionEvidence(
+            engine="openclaw",
+            batch_id="batch-1",
+            promotion_ready=True,
+            report={
+                "rollout_config_version": "2026-07-25T09:00:00+00:00",
+                "promotion_ready": True,
+            },
+        ),
+    )
+
+    with pytest.raises(RolloutOperationError, match="latest accepted batch"):
+        operations.add_bot(
+            env=ENV,
+            owner_id=OWNER,
+            bot_id=BOT_ID,
+            batch_id="batch-2",
+            acceptance_batch_id=None,
+            operator="freddie",
+            reason="expand",
+        )
+
+    result = operations.add_bot(
+        env=ENV,
+        owner_id=OWNER,
+        bot_id=BOT_ID,
+        batch_id="batch-2",
+        acceptance_batch_id="batch-1",
+        operator="freddie",
+        reason="expand after acceptance",
+    )
+
+    assert result.snapshot.whitelist[0].batch_id == "batch-2"
+
+
+def test_only_one_unaccepted_batch_can_be_open_per_engine() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(
+            promoted_engines=["openclaw"],
+            whitelist=[
+                {
+                    "owner_id": OWNER,
+                    "bot_id": BOT_ID,
+                    "batch_id": "batch-1",
+                }
+            ],
+        )
+    )
+
+    with pytest.raises(
+        RolloutOperationError,
+        match="current engine batch must be accepted",
+    ):
+        operations.add_bot(
+            env=ENV,
+            owner_id=OWNER,
+            bot_id=BOT_ID,
+            batch_id="batch-2",
+            acceptance_batch_id=None,
+            operator="freddie",
+            reason="must not skip batch acceptance",
+        )
+
+
+def test_claimed_batch_stays_open_after_whitelist_removal() -> None:
+    operations, _, _, layouts = build_operations(
+        config=rollout_config(
+            promoted_engines=["openclaw"],
+            whitelist=[
+                {
+                    "owner_id": OWNER,
+                    "bot_id": BOT_ID,
+                    "batch_id": "batch-1",
+                }
+            ],
+        )
+    )
+    layouts.state = replace(
+        layouts.state,
+        target_layout=SkillLayout.POOL,
+        phase=SkillLayoutPhase.POOL_PREPARING,
+        migration_generation="generation-1",
+        persisted=True,
+        rollout_evidence=RolloutEvidence(
+            env=ENV,
+            config_id=7,
+            config_version="config-1",
+            batch_id="batch-1",
+            engine_type="openclaw",
+            decision_reason="exact_bot_whitelist",
+        ),
+    )
+    operations.remove_bot(
+        env=ENV,
+        owner_id=OWNER,
+        bot_id=BOT_ID,
+        operator="freddie",
+        reason="remove claimed bot from whitelist",
+    )
+
+    with pytest.raises(
+        RolloutOperationError,
+        match="current engine batch must be accepted",
+    ):
+        operations.add_bot(
+            env=ENV,
+            owner_id=OWNER,
+            bot_id=BOT_ID,
+            batch_id="batch-2",
+            acceptance_batch_id=None,
+            operator="freddie",
+            reason="must not bypass claimed batch",
+        )
+
+
+def test_next_engine_cannot_promote_while_previous_engine_batch_is_open() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+    operations.accept_batch(
+        env=ENV,
+        operator="freddie",
+        reason="first batch passed",
+        acceptance=BatchPromotionEvidence(
+            engine="openclaw",
+            batch_id="batch-1",
+            promotion_ready=True,
+            report={
+                "rollout_config_version": "2026-07-25T09:00:00+00:00",
+                "promotion_ready": True,
+            },
+        ),
+    )
+    operations.add_bot(
+        env=ENV,
+        owner_id=OWNER,
+        bot_id=BOT_ID,
+        batch_id="batch-2",
+        acceptance_batch_id="batch-1",
+        operator="freddie",
+        reason="open second batch",
+    )
+
+    with pytest.raises(RolloutOperationError, match="unaccepted batch"):
+        operations.promote_engine(
+            env=ENV,
+            engine="claude_code",
+            acceptance_batch_id="batch-1",
+            operator="freddie",
+            reason="must finish current engine",
+        )
+
+
+def test_stale_batch_report_cannot_be_accepted() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+
+    with pytest.raises(RolloutOperationError, match="report is stale"):
+        operations.accept_batch(
+            env=ENV,
+            operator="freddie",
+            reason="stale report",
+            acceptance=BatchPromotionEvidence(
+                engine="openclaw",
+                batch_id="batch-1",
+                promotion_ready=True,
+                report={
+                    "rollout_config_version": "old-revision",
+                    "promotion_ready": True,
+                },
+            ),
+        )
+
+
+def test_config_cas_conflict_never_overwrites_a_concurrent_change() -> None:
+    operations, configs, _, _ = build_operations(config=rollout_config())
+    operations._repository.cas_succeeds = False
+
+    with pytest.raises(RolloutOperationError, match="changed concurrently"):
+        operations.promote_engine(
+            env=ENV,
+            engine="openclaw",
+            operator="freddie",
+            reason="start first engine",
+        )
+
+    assert configs.upserts == []
+
+
+def test_operations_reject_unknown_rollout_config_keys() -> None:
+    config = rollout_config()
+    config["param_value"]["enable_pattern"] = "*"
+    operations, _, _, _ = build_operations(config=config)
+
+    with pytest.raises(RolloutOperationError, match="config is invalid"):
+        operations.get_snapshot(env=ENV)
+
+
+def test_removing_whitelist_reports_claimed_state_without_reverting_it() -> None:
+    operations, _, _, layouts = build_operations(
+        config=rollout_config(
+            promoted_engines=["openclaw"],
+            whitelist=[
+                {
+                    "owner_id": OWNER,
+                    "bot_id": BOT_ID,
+                    "batch_id": "openclaw-canary-1",
+                }
+            ],
+        )
+    )
+    layouts.state = replace(
+        layouts.state,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=SkillLayout.POOL,
+        phase=SkillLayoutPhase.POOL_PREPARING,
+        migration_generation="generation-1",
+        persisted=True,
+    )
+
+    result = operations.remove_bot(
+        env=ENV,
+        owner_id=OWNER,
+        bot_id=BOT_ID,
+        operator="freddie",
+        reason="canary completed",
+    )
+
+    assert result.changed is True
+    assert result.claimed_before is True
+    assert result.claimed_after is True
+    assert result.snapshot.whitelist == ()
+    assert layouts.state.migration_generation == "generation-1"
+
+
+def test_control_samples_are_explicit_and_never_enter_whitelist() -> None:
+    operations, _, _, _ = build_operations(config=rollout_config())
+
+    snapshot = operations.set_control_bot(
+        env=ENV,
+        owner_id=OWNER,
+        bot_id=BOT_ID,
+        batch_id="openclaw-canary-1",
+        group=RolloutControlGroup.NEGATIVE,
+        present=True,
+        operator="freddie",
+        reason="register negative control",
+    )
+
+    assert snapshot.whitelist == ()
+    assert len(snapshot.negative_controls) == 1
+    assert snapshot.negative_controls[0].owner_id == OWNER
+    assert snapshot.negative_controls[0].bot_id == BOT_ID
+    assert snapshot.negative_controls[0].batch_id == "openclaw-canary-1"

--- a/src/backend/tests/community/core/skills_pool/test_operations.py
+++ b/src/backend/tests/community/core/skills_pool/test_operations.py
@@ -100,8 +100,17 @@ class FakeBots:
             }
         ]
 
-    def get_live_by_id_owner_and_env(self, **_: object) -> list[dict[str, object]]:
-        return self.matches
+    def get_live_by_id_owner_and_env(
+        self,
+        **identity: object,
+    ) -> list[dict[str, object]]:
+        return [
+            bot
+            for bot in self.matches
+            if str(bot["bot_id"]) == str(identity["bot_id"])
+            and str(bot["owner_id"]) == str(identity["owner_id"])
+            and bot["env"] == identity["env"]
+        ]
 
 
 class FakeLayouts:
@@ -524,6 +533,63 @@ def test_removing_whitelist_reports_claimed_state_without_reverting_it() -> None
     assert result.claimed_after is True
     assert result.snapshot.whitelist == ()
     assert layouts.state.migration_generation == "generation-1"
+
+
+def test_deleted_bot_can_still_be_removed_from_whitelist() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(
+            promoted_engines=["openclaw"],
+            whitelist=[
+                {
+                    "owner_id": OWNER,
+                    "bot_id": "deleted-bot",
+                    "batch_id": "batch-1",
+                }
+            ],
+        )
+    )
+
+    result = operations.remove_bot(
+        env=ENV,
+        owner_id=OWNER,
+        bot_id="deleted-bot",
+        operator="freddie",
+        reason="remove orphaned whitelist entry",
+    )
+
+    assert result.changed is True
+    assert result.claimed_before is False
+    assert result.claimed_after is False
+    assert result.snapshot.whitelist == ()
+
+
+def test_deleted_bot_keeps_its_batch_open_until_operator_removes_it() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(
+            promoted_engines=["openclaw"],
+            whitelist=[
+                {
+                    "owner_id": OWNER,
+                    "bot_id": "deleted-bot",
+                    "batch_id": "batch-1",
+                }
+            ],
+        )
+    )
+
+    with pytest.raises(
+        RolloutOperationError,
+        match="current engine batch must be accepted",
+    ):
+        operations.add_bot(
+            env=ENV,
+            owner_id=OWNER,
+            bot_id=BOT_ID,
+            batch_id="batch-2",
+            acceptance_batch_id=None,
+            operator="freddie",
+            reason="must clean orphaned batch first",
+        )
 
 
 def test_control_samples_are_explicit_and_never_enter_whitelist() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_operator_commands.py
+++ b/src/backend/tests/community/core/skills_pool/test_operator_commands.py
@@ -1,0 +1,87 @@
+"""Skills Pool durable operator command tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from agentclaw.community.core.skills_pool.operator_commands import (
+    OperatorCommandOutcome,
+    SkillsPoolOperatorCommands,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+)
+
+
+SCOPE = BotSkillLayoutScope("pre", "owner-1", "bot-1")
+
+
+class FakeLayouts:
+    def __init__(self) -> None:
+        self.state = BotSkillLayoutState.legacy_default(SCOPE)
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
+
+
+class FakeQueue:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def enqueue(self, *args: object, **kwargs: object) -> None:
+        self.calls.append((*args, kwargs))
+
+
+def test_manual_wakeup_is_durable_and_auditable() -> None:
+    layouts = FakeLayouts()
+    queue = FakeQueue()
+    commands = SkillsPoolOperatorCommands(
+        layout_repository=layouts,
+        task_queue_service=queue,
+    )
+
+    result = commands.wake(scope=SCOPE, operator="freddie")
+
+    assert result.outcome is OperatorCommandOutcome.ENQUEUED
+    assert queue.calls[0][0] == "skills_pool.reconcile"
+    payload = queue.calls[0][1]
+    assert payload["source"] == "operator_wakeup"
+    assert payload["signal_identity"] == {"operator": "freddie"}
+
+
+def test_retry_only_accepts_structured_retryable_failure() -> None:
+    layouts = FakeLayouts()
+    queue = FakeQueue()
+    commands = SkillsPoolOperatorCommands(
+        layout_repository=layouts,
+        task_queue_service=queue,
+    )
+
+    unclaimed = commands.wake(
+        scope=SCOPE,
+        operator="freddie",
+        retry_only=True,
+    )
+    layouts.state = replace(
+        layouts.state,
+        persisted=True,
+        last_failure_retryable=False,
+    )
+    blocked = commands.wake(
+        scope=SCOPE,
+        operator="freddie",
+        retry_only=True,
+    )
+    layouts.state = replace(layouts.state, last_failure_retryable=True)
+    enqueued = commands.wake(
+        scope=SCOPE,
+        operator="freddie",
+        retry_only=True,
+    )
+
+    assert unclaimed.outcome is OperatorCommandOutcome.NOT_CLAIMED
+    assert blocked.outcome is OperatorCommandOutcome.NOT_RETRYABLE
+    assert enqueued.outcome is OperatorCommandOutcome.ENQUEUED
+    assert len(queue.calls) == 1

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -676,6 +676,118 @@ async def test_non_ready_runtime_keeps_legacy_without_data_plane_changes() -> No
 
 
 @pytest.mark.asyncio
+async def test_mixed_image_bots_reconcile_independently_in_one_environment() -> None:
+    old_scope = BotSkillLayoutScope(
+        env="pre",
+        entity_id="entity-2",
+        bot_id="bot-2",
+    )
+
+    class MultiBotRepository:
+        def get_by_id_and_entity(
+            self,
+            bot_id: str,
+            entity_id: str,
+        ) -> dict[str, object] | None:
+            bots = {
+                (SCOPE.bot_id, SCOPE.entity_id): {
+                    "bot_id": SCOPE.bot_id,
+                    "entity_id": SCOPE.entity_id,
+                    "owner_id": "owner-1",
+                    "env": SCOPE.env,
+                    "active_engine": "openclaw",
+                },
+                (old_scope.bot_id, old_scope.entity_id): {
+                    "bot_id": old_scope.bot_id,
+                    "entity_id": old_scope.entity_id,
+                    "owner_id": "owner-2",
+                    "env": old_scope.env,
+                    "active_engine": "openclaw",
+                },
+            }
+            return bots.get((bot_id, entity_id))
+
+    class MultiLayoutRepository(FakeLayoutRepository):
+        def __init__(self) -> None:
+            super().__init__(claimed_state())
+            self._current_scope = SCOPE
+            self._states = {
+                SCOPE: self.state,
+                old_scope: replace(
+                    claimed_state(),
+                    scope=old_scope,
+                    migration_generation="generation-2",
+                    lease_owner="worker-2",
+                ),
+            }
+
+        def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+            self._states[self._current_scope] = self.state
+            self._current_scope = scope
+            self.state = self._states[scope]
+            return self.state
+
+        def state_for(
+            self,
+            scope: BotSkillLayoutScope,
+        ) -> BotSkillLayoutState:
+            self._states[self._current_scope] = self.state
+            return self._states[scope]
+
+        def _owns(self, values: dict[str, object]) -> bool:
+            return (
+                values["scope"] == self._current_scope
+                and values["migration_generation"]
+                == self.state.migration_generation
+                and values["lease_owner"] == self.state.lease_owner
+            )
+
+    class MixedImageRuntime(FakeRuntime):
+        async def probe(self, **kwargs: object) -> RuntimeLayoutProbeResult:
+            if kwargs["bot_id"] == old_scope.bot_id:
+                self.events.append("probe:old-image")
+                return replace(
+                    self.probe_result,
+                    status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+                    preparation_id=None,
+                )
+            return await super().probe(**kwargs)
+
+    layouts = MultiLayoutRepository()
+    runtime = MixedImageRuntime()
+    service = SkillsPoolReconcileService(
+        bot_repository=MultiBotRepository(),
+        layout_repository=layouts,
+        skill_repository=FakeSkillRepository(),
+        runtime=runtime,
+    )
+
+    ready_result = await service.reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+    old_result = await service.reconcile(
+        scope=old_scope,
+        lease_owner="worker-2",
+    )
+
+    assert ready_result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert old_result.outcome is SkillsPoolReconcileOutcome.NOT_CAPABLE
+    assert layouts.state_for(SCOPE).active_layout is SkillLayout.POOL
+    old_state = layouts.state_for(old_scope)
+    assert old_state.active_layout is SkillLayout.LEGACY
+    assert old_state.phase is SkillLayoutPhase.POOL_PREPARING
+    assert runtime.physical_cutovers == 1
+    assert runtime.events == [
+        "probe",
+        "cutover",
+        "mapping",
+        "verify",
+        "probe:old-image",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_invalid_probe_is_persisted_as_non_retryable_blocker() -> None:
     layouts = FakeLayoutRepository()
     runtime = FakeRuntime()

--- a/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
+++ b/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
@@ -105,6 +105,18 @@ def test_exact_bot_in_promoted_engine_is_eligible_with_audit_evidence() -> None:
     assert decision.evidence.engine_type == "openclaw"
 
 
+def test_logical_config_revision_is_frozen_into_claim_evidence() -> None:
+    config = {
+        **enabled_config(),
+        "ext_info": {"revision": "revision-7", "audit_log": []},
+    }
+
+    decision = evaluate(make_gate(config))
+
+    assert decision.evidence is not None
+    assert decision.evidence.config_version == "revision-7"
+
+
 @pytest.mark.parametrize(
     ("gate", "reason"),
     [
@@ -182,7 +194,14 @@ def test_non_pool_engine_never_matches(engine_type: str) -> None:
 def test_service_draft_is_editable_but_published_service_is_not(
     engine_type: str,
 ) -> None:
-    gate = make_gate(enabled_config(promoted_engines=[engine_type]))
+    promotion_order = ["openclaw", "claude_code", "aicoding", "hermes"]
+    gate = make_gate(
+        enabled_config(
+            promoted_engines=promotion_order[
+                : promotion_order.index(engine_type) + 1
+            ]
+        )
+    )
 
     assert evaluate(
         gate,
@@ -205,3 +224,25 @@ def test_unknown_runtime_form_fails_closed(runtime_form: object) -> None:
 
     assert not decision.eligible
     assert decision.reason is RolloutDecisionReason.RUNTIME_NOT_EDITABLE
+
+
+def test_unknown_rollout_config_key_fails_closed() -> None:
+    config = enabled_config()
+    config["param_value"]["enable_pattern"] = "*"
+
+    decision = evaluate(make_gate(config))
+
+    assert not decision.eligible
+    assert decision.reason is RolloutDecisionReason.CONFIG_INVALID
+
+
+def test_invalid_control_entry_fails_closed() -> None:
+    config = enabled_config()
+    config["param_value"]["negative_controls"] = [
+        {"owner_id": "owner-2", "bot_id": "*", "batch_id": "batch-1"}
+    ]
+
+    decision = evaluate(make_gate(config))
+
+    assert not decision.eligible
+    assert decision.reason is RolloutDecisionReason.CONFIG_INVALID

--- a/src/backend/tests/community/di/test_skills_pool_wiring.py
+++ b/src/backend/tests/community/di/test_skills_pool_wiring.py
@@ -1,7 +1,37 @@
 """Skills Pool 控制面业务边界的 DI 装配测试。"""
 
+import pytest
+
+from agentclaw.community.api.skills_pool_operational_query_service import (
+    SkillsPoolOperationalQueryServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_operator_commands_service import (
+    SkillsPoolOperatorCommandsServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_recovery_service import (
+    SkillsPoolRecoveryServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_rollback_service import (
+    SkillsPoolRollbackServiceProtocol,
+)
+from agentclaw.community.api.skills_pool_rollout_service import (
+    SkillsPoolRolloutServiceProtocol,
+)
 from agentclaw.community.core.skills_pool.claim_service import (
     SkillsPoolMigrationClaimService,
+)
+from agentclaw.community.core.skills_pool.operational_query import (
+    SkillsPoolOperationalQuery,
+)
+from agentclaw.community.core.skills_pool.operations import (
+    SkillsPoolRolloutOperations,
+)
+from agentclaw.community.core.skills_pool.operator_commands import (
+    SkillsPoolOperatorCommands,
+)
+from agentclaw.community.core.skills_pool.recovery_service import (
+    SkillsPoolRecoveryService,
+    SkillsPoolRollbackService,
 )
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
@@ -28,6 +58,34 @@ from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
 )
 from agentclaw.community.plugins.skill_repository import SkillRepository
+
+
+@pytest.mark.parametrize(
+    ("protocol", "implementation"),
+    [
+        (SkillsPoolRolloutServiceProtocol, SkillsPoolRolloutOperations),
+        (
+            SkillsPoolOperationalQueryServiceProtocol,
+            SkillsPoolOperationalQuery,
+        ),
+        (
+            SkillsPoolOperatorCommandsServiceProtocol,
+            SkillsPoolOperatorCommands,
+        ),
+        (SkillsPoolRecoveryServiceProtocol, SkillsPoolRecoveryService),
+        (SkillsPoolRollbackServiceProtocol, SkillsPoolRollbackService),
+    ],
+)
+def test_skills_pool_service_api_conformance_and_alias_identity(
+    protocol: type[object],
+    implementation: type[object],
+) -> None:
+    injector = build_injector(profile=DeployProfile.TEST)
+
+    concrete = injector.get(implementation)
+
+    assert isinstance(concrete, protocol)
+    assert injector.get(protocol) is concrete
 
 
 def test_skills_pool_control_plane_bindings_resolve() -> None:

--- a/src/backend/tests/community/endpoints/test_skills_pool_ops.py
+++ b/src/backend/tests/community/endpoints/test_skills_pool_ops.py
@@ -1,0 +1,304 @@
+"""Endpoint-injection coverage for the Skills Pool operator API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from agentclaw.community.core.skills_pool.operational_query import (
+    SkillsPoolOperationalQuery,
+)
+from agentclaw.community.core.skills_pool.operations import (
+    RolloutOperationError,
+    SkillsPoolRolloutOperations,
+)
+from agentclaw.community.core.skills_pool.operator_commands import (
+    SkillsPoolOperatorCommands,
+)
+from agentclaw.community.core.skills_pool.recovery_service import (
+    SkillsPoolRecoveryService,
+    SkillsPoolRollbackService,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+
+_HEADERS = {"x-user-id": "skills-pool-operator"}
+_SCOPE = BotSkillLayoutScope("dev", "entity-1", "bot-1")
+
+
+@dataclass(frozen=True)
+class _Result:
+    outcome: str = "ok"
+    scope: BotSkillLayoutScope | None = None
+    promotion_ready: bool = True
+    rollout_config_version: str = "config-1"
+
+
+def _seed_happy_services(world) -> None:
+    result = _Result(scope=_SCOPE)
+
+    def get_snapshot(*_args, **_kwargs):
+        return result
+
+    def mutation(*_args, **_kwargs):
+        return result
+
+    def get_bot(*_args, **_kwargs):
+        return result
+
+    def summarize_batch(*_args, **_kwargs):
+        return result
+
+    def wake(*_args, **_kwargs):
+        return result
+
+    def resolve(*_args, **_kwargs):
+        return result
+
+    async def rollback(*_args, **_kwargs):
+        return result
+
+    patchers = [
+        patch.object(
+            SkillsPoolRolloutOperations,
+            "get_snapshot",
+            get_snapshot,
+        ),
+        *[
+            patch.object(SkillsPoolRolloutOperations, method, mutation)
+            for method in (
+                "set_feature_enabled",
+                "promote_engine",
+                "add_bot",
+                "remove_bot",
+                "accept_batch",
+                "set_control_bot",
+            )
+        ],
+        patch.object(SkillsPoolOperationalQuery, "get_bot", get_bot),
+        patch.object(
+            SkillsPoolOperationalQuery,
+            "summarize_batch",
+            summarize_batch,
+        ),
+        patch.object(SkillsPoolOperatorCommands, "wake", wake),
+        patch.object(
+            SkillsPoolRecoveryService,
+            "resolve_repair_state",
+            resolve,
+        ),
+        patch.object(SkillsPoolRollbackService, "rollback", rollback),
+    ]
+    for patcher in patchers:
+        patcher.start()
+    world.skills_pool_patchers = patchers
+
+
+def _seed_rollout_error(world) -> None:
+    def fail(*_args, **_kwargs):
+        raise RolloutOperationError("invalid rollout config")
+
+    patcher = patch.object(
+        SkillsPoolRolloutOperations,
+        "get_snapshot",
+        fail,
+    )
+    patcher.start()
+    world.skills_pool_patchers = [patcher]
+
+
+def _stop_patches(_response, world) -> None:
+    for patcher in reversed(getattr(world, "skills_pool_patchers", [])):
+        patcher.stop()
+
+
+_HAPPY_CASES = (
+    ("GET", "/api/ops/skills-pool/rollout", CaseInput(headers=_HEADERS)),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/feature",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={"enabled": True, "reason": "canary"},
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/promote",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={"engine": "openclaw", "reason": "first engine"},
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/whitelist",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={
+                "owner_id": "owner-1",
+                "bot_id": "bot-1",
+                "batch_id": "batch-1",
+                "reason": "canary",
+            },
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/whitelist/remove",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={
+                "owner_id": "owner-1",
+                "bot_id": "bot-1",
+                "reason": "remove",
+            },
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/batches/accept",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={
+                "engine": "openclaw",
+                "batch_id": "batch-1",
+                "reason": "accepted",
+            },
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/controls",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={
+                "owner_id": "owner-1",
+                "bot_id": "bot-1",
+                "batch_id": "batch-1",
+                "group": "negative",
+                "reason": "control",
+            },
+        ),
+    ),
+    (
+        "GET",
+        "/api/ops/skills-pool/bots/{bot_id}",
+        CaseInput(
+            headers=_HEADERS,
+            path_params={"bot_id": "bot-1"},
+            query_params={"owner_id": "owner-1"},
+        ),
+    ),
+    (
+        "GET",
+        "/api/ops/skills-pool/batches/{batch_id}",
+        CaseInput(
+            headers=_HEADERS,
+            path_params={"batch_id": "batch-1"},
+            query_params={"engine": "openclaw"},
+        ),
+    ),
+    *(
+        (
+            "POST",
+            f"/api/ops/skills-pool/bots/{{bot_id}}/{action}",
+            CaseInput(
+                headers=_HEADERS,
+                path_params={"bot_id": "bot-1"},
+                json_body={"owner_id": "owner-1"},
+            ),
+        )
+        for action in ("wake", "retry")
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/bots/{bot_id}/repair",
+        CaseInput(
+            headers=_HEADERS,
+            path_params={"bot_id": "bot-1"},
+            json_body={
+                "owner_id": "owner-1",
+                "migration_generation": "generation-1",
+                "note": "verified",
+                "resolution": "pool_committed",
+            },
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/bots/{bot_id}/rollback",
+        CaseInput(
+            headers=_HEADERS,
+            path_params={"bot_id": "bot-1"},
+            json_body={
+                "owner_id": "owner-1",
+                "rollback_generation": "rollback-1",
+                "note": "verified",
+            },
+        ),
+    ),
+)
+
+
+for _index, (_method, _path, _input) in enumerate(_HAPPY_CASES):
+    endpoint_test(
+        method=_method,
+        path=_path,
+        scenario="happy",
+        input=_input,
+        seed=_seed_happy_services,
+        expect=ExpectSuccess(
+            status=200,
+            json_contains={"success": True},
+        ),
+        extra_assertions=(_stop_patches,),
+    )(lambda: None)
+
+
+_VALIDATION_ERRORS = tuple(
+    (method, path, case_input)
+    for method, path, case_input in _HAPPY_CASES
+    if method == "POST"
+)
+
+for _index, (_method, _path, _input) in enumerate(_VALIDATION_ERRORS):
+    endpoint_test(
+        method=_method,
+        path=_path,
+        scenario="validation_error",
+        input=CaseInput(
+            headers=_HEADERS,
+            path_params=_input.path_params,
+        ),
+        expect=ExpectError(status=422),
+    )(lambda: None)
+
+
+endpoint_test(
+    method="GET",
+    path="/api/ops/skills-pool/rollout",
+    scenario="invalid_config",
+    input=CaseInput(headers=_HEADERS),
+    seed=_seed_rollout_error,
+    expect=ExpectError(status=409),
+    extra_assertions=(_stop_patches,),
+)(lambda: None)
+
+for _path, _path_params in (
+    ("/api/ops/skills-pool/bots/{bot_id}", {"bot_id": "bot-1"}),
+    ("/api/ops/skills-pool/batches/{batch_id}", {"batch_id": "batch-1"}),
+):
+    endpoint_test(
+        method="GET",
+        path=_path,
+        scenario="missing_query_identity",
+        input=CaseInput(headers=_HEADERS, path_params=_path_params),
+        expect=ExpectError(status=422),
+    )(lambda: None)

--- a/src/backend/tests/community/plugins/local/test_database_bootstrap_skills_pool.py
+++ b/src/backend/tests/community/plugins/local/test_database_bootstrap_skills_pool.py
@@ -22,4 +22,5 @@ def test_bootstrap_creates_bot_skill_layout_state_table() -> None:
     engine = db_mod._engine
     assert engine is not None
     assert "ac_bot_skill_layout_state" in inspect(engine).get_table_names()
+    assert "ac_skills_pool_rollout_audit" in inspect(engine).get_table_names()
     assert "ac_skill_migration_quarantine" in inspect(engine).get_table_names()

--- a/src/backend/tests/community/plugins/test_skills_pool_rollout_repository.py
+++ b/src/backend/tests/community/plugins/test_skills_pool_rollout_repository.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from datetime import UTC, datetime
+
+from sqlalchemy.exc import IntegrityError
 
 from agentclaw.community.core.common_config.repository import (
     CommonConfigRepository,
@@ -85,3 +88,47 @@ def test_rollout_config_and_append_only_audit_commit_atomically(test_injector):
         audit=_audit("revision-2"),
     )
     assert len(repository.list_audit_events(env="pre")) == 1
+
+
+def test_concurrent_first_config_insert_is_reported_as_cas_conflict() -> None:
+    class ConflictingSession:
+        def query(self, *_: object):
+            return self
+
+        def filter(self, *_: object):
+            return self
+
+        def with_for_update(self):
+            return self
+
+        def one_or_none(self):
+            return None
+
+        def add(self, _: object) -> None:
+            return None
+
+        def flush(self) -> None:
+            raise IntegrityError(
+                "INSERT INTO ac_common_config ...",
+                {},
+                RuntimeError("duplicate rollout config"),
+            )
+
+    class ConflictingDatabase:
+        @contextmanager
+        def transactional_orm_session(self):
+            yield ConflictingSession()
+
+    repository = SkillsPoolRolloutRepository(ConflictingDatabase())
+
+    assert not repository.commit_change(
+        env="pre",
+        config_id=None,
+        expected_revision=None,
+        expected_enable=False,
+        expected_value=_value(),
+        next_revision="revision-1",
+        enabled=True,
+        value=_value(),
+        audit=_audit("revision-1"),
+    )

--- a/src/backend/tests/community/plugins/test_skills_pool_rollout_repository.py
+++ b/src/backend/tests/community/plugins/test_skills_pool_rollout_repository.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+from agentclaw.community.core.common_config.repository import (
+    CommonConfigRepository,
+)
+from agentclaw.community.plugins.skills_pool_rollout_repository import (
+    SkillsPoolRolloutRepository,
+)
+
+
+def _value(*, bots: list[dict[str, str]] | None = None) -> dict[str, object]:
+    return {
+        "enable_all": False,
+        "promoted_engines": ["openclaw"],
+        "whitelist": bots or [],
+        "negative_controls": [],
+        "teclaw_controls": [],
+    }
+
+
+def _audit(revision: str) -> dict[str, object]:
+    return {
+        "env": "pre",
+        "action": "enable",
+        "operator": "freddie",
+        "reason": "start canary",
+        "batch_id": None,
+        "based_on_config_version": None,
+        "effective_config_version": revision,
+        "effective_at": datetime.now(UTC).isoformat(),
+        "evidence": None,
+    }
+
+
+def test_rollout_config_and_append_only_audit_commit_atomically(test_injector):
+    from agentclaw.community.plugin_api.database import DatabasePlugin
+
+    database = test_injector.get(DatabasePlugin)
+    asyncio.run(database.bootstrap())
+    repository = SkillsPoolRolloutRepository(database)
+
+    assert repository.commit_change(
+        env="pre",
+        config_id=None,
+        expected_revision=None,
+        expected_enable=False,
+        expected_value=_value(),
+        next_revision="revision-1",
+        enabled=True,
+        value=_value(),
+        audit=_audit("revision-1"),
+    )
+
+    config = CommonConfigRepository(database).get_by_biz_param(
+        business_code="skills_pool",
+        param_code="layout_rollout",
+        env="pre",
+    )
+    assert config is not None
+    events = repository.list_audit_events(env="pre")
+    assert [event["effective_config_version"] for event in events] == [
+        "revision-1"
+    ]
+
+    # A writer that bypasses the rollout API changes semantic content without
+    # advancing revision. The full expected-value CAS still rejects overwrite.
+    CommonConfigRepository(database).update_config(
+        config_id=config.id,
+        updates={"param_value": '{"enable_all":true}'},
+    )
+    assert not repository.commit_change(
+        env="pre",
+        config_id=config.id,
+        expected_revision="revision-1",
+        expected_enable=True,
+        expected_value=_value(),
+        next_revision="revision-2",
+        enabled=True,
+        value=_value(
+            bots=[{"owner_id": "owner-1", "bot_id": "bot-1"}]
+        ),
+        audit=_audit("revision-2"),
+    )
+    assert len(repository.list_audit_events(env="pre")) == 1


### PR DESCRIPTION
## What changed

- 新增 Skills Pool 灰度运维 API：按环境启停、按既定顺序晋级 engine、精确维护 `owner_id + bot_id` 白名单及对照组。
- 新增单 Bot 迁移证据查询、手动唤醒/重试/人工修复/显式回滚，以及按环境、engine、批次聚合的验收报告。
- rollout 配置采用严格 fail-closed schema：禁止 `enable_all`、通配符和未知字段；无效或错引擎批次成员会阻断 `promotion_ready`。
- rollout 配置通过 CAS 更新，并与 append-only 审计记录在同一事务提交。
- 新增中文灰度发布 runbook，覆盖新 Backend 与新旧镜像混部、四个文件型 engine、服务版本及 Teclaw no-op 的验收路径。
- HTTP adapter 仅依赖 Service API Protocol，并补齐五组 Protocol/Concrete 与 DI singleton conformance 测试。

## Compatibility and rollout

- rollout 配置缺失或未开启时保持 fail-closed，不会认领线上 Bot。
- 只有精确命中白名单的个人 Bot 或服务 Bot 草稿可以首次迁移；现有 ONLINE Legacy 服务不原地迁移。
- 生产发布前需先部署 `ac_skills_pool_rollout_audit` DDL，跟踪见 #446。
- 镜像侧兼容矩阵与四引擎/Teclaw 验收证据由已合入的 OCB companion CI 提供。

## Validation

- Backend full suite: `8951 passed`
- Focused Skills Pool, endpoint, DI and architecture suite: `126 passed`
- Ruff: passed
- `git diff --check`: passed
- Final Standards review: passed
- Final Spec review: passed

Closes #378
