### PR TITLE
Make pre-push lint-only by default instead of full CI

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,6 +14,16 @@ echo "== OCB pre-push gate =="
 echo "remote: ${remote_name} ${remote_url}"
 echo "merge target: $merge_target"
 
+# CI gates are opt-in on push. By default the hook does not run any module CI,
+# so a plain `git push` never triggers SAST/tests/coverage. Set
+# OCB_PRE_PUSH_RUN_CI=1 to re-enable the gates, or run scripts/ci/pre_push.sh
+# manually.
+run_ci="${OCB_PRE_PUSH_RUN_CI:-0}"
+if [[ "$run_ci" != "1" ]]; then
+  echo "pre-push CI gates disabled (set OCB_PRE_PUSH_RUN_CI=1 to run them)"
+  exit 0
+fi
+
 seen_ref=0
 status=0
 target_sha=""

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,16 +14,6 @@ echo "== OCB pre-push gate =="
 echo "remote: ${remote_name} ${remote_url}"
 echo "merge target: $merge_target"
 
-# CI gates are opt-in on push. By default the hook does not run any module CI,
-# so a plain `git push` never triggers SAST/tests/coverage. Set
-# OCB_PRE_PUSH_RUN_CI=1 to re-enable the gates, or run scripts/ci/pre_push.sh
-# manually.
-run_ci="${OCB_PRE_PUSH_RUN_CI:-0}"
-if [[ "$run_ci" != "1" ]]; then
-  echo "pre-push CI gates disabled (set OCB_PRE_PUSH_RUN_CI=1 to run them)"
-  exit 0
-fi
-
 seen_ref=0
 status=0
 target_sha=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,11 +101,14 @@ Install the repository hooks separately in every Git worktree:
 scripts/install_git_hooks.sh
 ```
 
-CI gates are opt-in on push. By default the pre-push hook does not run any
-module CI, so a plain `git push` never triggers SAST, unit tests, or coverage.
-Set `OCB_PRE_PUSH_RUN_CI=1` to re-enable the gates for a push, or run
-`scripts/ci/pre_push.sh` manually. The rest of this section describes the
-behavior when the gates are enabled.
+By default the pre-push hook runs in **lint-only** mode: for changed Python
+modules it runs the fast `python_sast_local.sh` SAST/lint gate, but skips the
+heavier unit tests, changed-line coverage, and Singlebox E2E. Set
+`OCB_PRE_PUSH_RUN_CI=1` to run the full gates for a push, or run
+`scripts/ci/pre_push.sh` manually. The module-gate table below describes the
+full behavior; in lint-only mode only the SAST/lint step of each Python module
+runs, and modules without a standalone lint step (`src/gateway`, `src/frontend`,
+`src/bcs`, and the singlebox coverage paths) run nothing.
 
 ```bash
 OCB_PRE_PUSH_RUN_CI=1 git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,16 @@ Install the repository hooks separately in every Git worktree:
 scripts/install_git_hooks.sh
 ```
 
+CI gates are opt-in on push. By default the pre-push hook does not run any
+module CI, so a plain `git push` never triggers SAST, unit tests, or coverage.
+Set `OCB_PRE_PUSH_RUN_CI=1` to re-enable the gates for a push, or run
+`scripts/ci/pre_push.sh` manually. The rest of this section describes the
+behavior when the gates are enabled.
+
+```bash
+OCB_PRE_PUSH_RUN_CI=1 git push
+```
+
 The pre-push hook models the change set of a pull request. Its merge target
 defaults to the remote branch `origin/dev`. Override it persistently for the
 current worktree or repository when the eventual PR targets another branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,12 @@ intentional state in the contract; required values must remain non-optional.
 Keep this file intentionally small so agent instructions do not drift. Update
 `AGENTS.md` when project-wide rules change.
 
-Before pushing, follow the pre-push target contract in `AGENTS.md`. The default
-target is `origin/dev`; set `avernet.prePush.mergeTarget` for a persistent
-override or `AVERNET_PRE_PUSH_MERGE_TARGET` for one `git push`. The hook must
-fetch that target and use its merge base rather than a direct target-to-head
-diff.
+Before pushing, follow the pre-push target contract in `AGENTS.md`. The pre-push
+hook does not run CI by default; set `OCB_PRE_PUSH_RUN_CI=1` to run the module
+gates. When the gates run, the default target is `origin/dev`; set
+`avernet.prePush.mergeTarget` for a persistent override or
+`AVERNET_PRE_PUSH_MERGE_TARGET` for one `git push`. The hook must fetch that
+target and use its merge base rather than a direct target-to-head diff.
 
 Before changing Git hooks, module CI entrypoints, Singlebox orchestration,
 acceptance E2E tests, coverage manifests, or coverage reporting, read the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,13 @@ intentional state in the contract; required values must remain non-optional.
 Keep this file intentionally small so agent instructions do not drift. Update
 `AGENTS.md` when project-wide rules change.
 
-Before pushing, follow the pre-push target contract in `AGENTS.md`. The pre-push
-hook does not run CI by default; set `OCB_PRE_PUSH_RUN_CI=1` to run the module
-gates. When the gates run, the default target is `origin/dev`; set
-`avernet.prePush.mergeTarget` for a persistent override or
-`AVERNET_PRE_PUSH_MERGE_TARGET` for one `git push`. The hook must fetch that
-target and use its merge base rather than a direct target-to-head diff.
+Before pushing, follow the pre-push target contract in `AGENTS.md`. By default
+the pre-push hook runs lint-only (SAST) and skips the heavier tests, coverage,
+and E2E; set `OCB_PRE_PUSH_RUN_CI=1` to run the full module gates. When the
+gates run, the default target is `origin/dev`; set `avernet.prePush.mergeTarget`
+for a persistent override or `AVERNET_PRE_PUSH_MERGE_TARGET` for one `git push`.
+The hook must fetch that target and use its merge base rather than a direct
+target-to-head diff.
 
 Before changing Git hooks, module CI entrypoints, Singlebox orchestration,
 acceptance E2E tests, coverage manifests, or coverage reporting, read the

--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -8,6 +8,9 @@ base=""
 head="HEAD"
 dry_run="${OCB_PRE_PUSH_DRY_RUN:-0}"
 skip_singlebox_coverage="${OCB_PRE_PUSH_SKIP_SINGLEBOX_COVERAGE:-0}"
+# 默认只跑 lint/SAST 卡点(python_sast_local.sh),跳过更重的单测、覆盖率和
+# singlebox E2E。设置 OCB_PRE_PUSH_RUN_CI=1 才会跑完整 CI。
+run_full_ci="${OCB_PRE_PUSH_RUN_CI:-0}"
 
 # 这个脚本既可以被 .githooks/pre-push 调用,也可以手动运行:
 #   scripts/ci/pre_push.sh --base origin/dev --head HEAD
@@ -76,7 +79,23 @@ run_required() {
   "$@"
 }
 
+run_heavy() {
+  # heavy gate: 单测/覆盖率/E2E。默认(lint-only)跳过,
+  # 只有 OCB_PRE_PUSH_RUN_CI=1 时才作为 required 卡点运行。
+  if [[ "$run_full_ci" != "1" ]]; then
+    echo ""
+    echo "== skipped (lint-only): $* =="
+    echo "set OCB_PRE_PUSH_RUN_CI=1 to run tests/coverage/E2E"
+    return 0
+  fi
+  run_required "$@"
+}
+
 run_singlebox_coverage_once() {
+  if [[ "$run_full_ci" != "1" ]]; then
+    echo "singlebox coverage skipped (lint-only; set OCB_PRE_PUSH_RUN_CI=1)"
+    return 0
+  fi
   if [[ "$skip_singlebox_coverage" == "1" ]]; then
     echo "singlebox coverage skipped (OCB_PRE_PUSH_SKIP_SINGLEBOX_COVERAGE=1)"
     return 0
@@ -93,6 +112,11 @@ run_singlebox_coverage_once() {
 
 echo "base: $base"
 echo "head: $head"
+if [[ "$run_full_ci" == "1" ]]; then
+  echo "mode: full CI (lint + tests + coverage + E2E)"
+else
+  echo "mode: lint-only (set OCB_PRE_PUSH_RUN_CI=1 for tests/coverage/E2E)"
+fi
 
 if [[ -z "$changed_files" ]]; then
   # pre-push 只检查已提交的 push range。
@@ -107,7 +131,7 @@ if matches_any '^src/backend/'; then
   # 2) backend ci_test.sh 跑 pytest + coverage + report_check
   # 3) singlebox coverage 默认并入 pre-push,保证 Backend 变更会跑 singlebox E2E 覆盖率入口。
   run_required "$repo_root/scripts/ci/python_sast_local.sh" src/backend 1 --base "$base" --head "$head"
-  run_required "$repo_root/src/backend/scripts/ci_test.sh" --base "$base" --head "$head"
+  run_heavy "$repo_root/src/backend/scripts/ci_test.sh" --base "$base" --head "$head"
   run_singlebox_coverage_once
 fi
 
@@ -118,7 +142,7 @@ if matches_any '^src/baas/'; then
   # 如需临时跳过 BaaS CI,显式设置 OCB_PRE_PUSH_ENABLE_BAAS=0。
   if [[ "${OCB_PRE_PUSH_ENABLE_BAAS:-1}" == "1" ]]; then
     run_required "$repo_root/scripts/ci/python_sast_local.sh" src/baas 1 --base "$base" --head "$head"
-    run_required "$repo_root/src/baas/scripts/ci_test.sh" --base "$base" --head "$head"
+    run_heavy "$repo_root/src/baas/scripts/ci_test.sh" --base "$base" --head "$head"
     run_singlebox_coverage_once
   else
     echo "BaaS changes detected; BaaS CI gate skipped (OCB_PRE_PUSH_ENABLE_BAAS=0)"
@@ -129,7 +153,7 @@ if matches_any '^src/engine/'; then
   # Engine 默认强卡点:
   # SAST 先兜底语法/高危 lint,再跑 engine 自己的 pytest/coverage gate。
   run_required "$repo_root/scripts/ci/python_sast_local.sh" src/engine 1 --base "$base" --head "$head"
-  run_required "$repo_root/src/engine/scripts/ci_test.sh" --base "$base" --head "$head"
+  run_heavy "$repo_root/src/engine/scripts/ci_test.sh" --base "$base" --head "$head"
 fi
 
 if matches_any '^src/bcs/'; then
@@ -139,7 +163,7 @@ if matches_any '^src/bcs/'; then
   #    E2E 并采集 runtime line/method、Router API、CLI command 覆盖率。
   # 如需临时跳过,显式设置 OCB_PRE_PUSH_ENABLE_BCS=0。
   if [[ "${OCB_PRE_PUSH_ENABLE_BCS:-1}" == "1" ]]; then
-    run_required "$repo_root/src/bcs/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail
+    run_heavy "$repo_root/src/bcs/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail
     run_singlebox_coverage_once
   else
     echo "BCS/BCN changes detected; BCS/BCN CI gate skipped (OCB_PRE_PUSH_ENABLE_BCS=0)"
@@ -148,12 +172,12 @@ fi
 
 if matches_any '^src/gateway/'; then
   # Gateway CI: ruff lint + pytest + coverage + diff coverage (>=90%).
-  run_required "$repo_root/src/gateway/scripts/ci_test.sh" --base "$base" --head "$head"
+  run_heavy "$repo_root/src/gateway/scripts/ci_test.sh" --base "$base" --head "$head"
 fi
 
 if matches_any '^src/frontend/'; then
   # Frontend 也通过模块自己的 ci_test.sh 作为统一入口。
-  run_required "$repo_root/src/frontend/scripts/ci_test.sh" --base "$base" --head "$head"
+  run_heavy "$repo_root/src/frontend/scripts/ci_test.sh" --base "$base" --head "$head"
 fi
 
 if matches_any '^(scripts/singlebox\.sh|scripts/modules/|scripts/ci/singlebox_coverage(_report|_manifest_check)?\.(sh|py)|scripts/ci/singlebox_coverage_modules\.yaml|scripts/ci/verify_singlebox_coverage_artifacts\.py|src/backend/tests/community/acceptance/|src/baas/tests/e2e/)'; then


### PR DESCRIPTION
## Summary

The `.githooks/pre-push` hook previously ran the full module CI bundle (SAST/lint + unit tests + changed-line coverage + Singlebox E2E) on **every** `git push`. This makes the default **lint-only**: a plain `git push` still runs the fast `python_sast_local.sh` SAST/lint gate for changed Python modules, but skips the heavier tests, coverage, and E2E. Setting `OCB_PRE_PUSH_RUN_CI=1` restores the full gates.

## Changes

- **`scripts/ci/pre_push.sh`**:
  - Add `run_full_ci` (`OCB_PRE_PUSH_RUN_CI`, default `0`) and a `run_heavy()` helper that no-ops with a clear message unless full CI is requested.
  - Route every module `ci_test.sh` entrypoint (backend, baas, engine, bcs, gateway, frontend) through `run_heavy()`.
  - Guard `run_singlebox_coverage_once` the same way.
  - Keep the `python_sast_local.sh` lint/SAST steps as required gates (they always run).
  - Print the active mode (`lint-only` vs `full CI`).
- **`.githooks/pre-push`**: unchanged from `dev` — always invokes the dispatcher; the mode decision lives in the dispatcher so manual runs behave identically.
- **`AGENTS.md` / `CLAUDE.md`**: document the lint-only default, and note that `src/gateway`, `src/frontend`, and `src/bcs` bundle their lint inside `ci_test.sh` (no standalone lint step), so they run nothing until `OCB_PRE_PUSH_RUN_CI=1`.

## Behavior

| Command | Changed module | Result |
| --- | --- | --- |
| `git push` | `src/backend` (etc.) | Runs `python_sast_local.sh` lint; skips tests/coverage/E2E |
| `git push` | `src/gateway` / `src/frontend` / `src/bcs` | Nothing (no standalone lint step) |
| `OCB_PRE_PUSH_RUN_CI=1 git push` | any | Full gates as before |

## Verification

- `bash -n` passes for `.githooks/pre-push` and `scripts/ci/pre_push.sh`.
- Dry-run against a throwaway `src/backend` change:
  - Default → `mode: lint-only`, runs `python_sast_local.sh`, skips `ci_test.sh` and singlebox coverage.
  - `OCB_PRE_PUSH_RUN_CI=1` → `mode: full CI`, runs SAST + `ci_test.sh` + singlebox coverage + artifact verifier.

## Notes

This only affects the local pre-push gate. The GitHub Actions CI (e.g. `.github/workflows/singlebox-coverage.yml`) is separate and still enforces the full checks on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7MNc3VUygJhnbfUbgPtjq