### PR TITLE
fix: release pool claim for incapable runtimes

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -139,7 +139,18 @@ class SkillsPoolReconcileService:
             engine=engine,
         )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
-            if probe.status in {
+            if probe.status is RuntimeLayoutProbeStatus.NOT_CAPABLE:
+                released = self._layouts.release_not_capable_claim(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    evidence=probe.evidence,
+                )
+                if not released:
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                    )
+            elif probe.status in {
                 RuntimeLayoutProbeStatus.INVALID,
                 RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
             }:

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -87,6 +87,17 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """以 generation/lease CAS 记录当前运行时已具备 Pool 能力。"""
         ...
 
+    def release_not_capable_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录旧运行时证据，并原子释放尚处于准备阶段的迁移认领。"""
+        ...
+
     def record_cutover_committed(
         self,
         *,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
@@ -1,0 +1,75 @@
+"""Runtime capability probe persistence for Skills Pool migration claims."""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import func
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    BotSkillLayoutStateModel,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+class SkillsPoolCapabilityRepositoryMixin:
+    """Release a pre-cutover claim when the runtime lacks Pool capability."""
+
+    _database: object
+
+    def release_not_capable_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Persist old-runtime evidence and release only a preparing claim."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    BotSkillLayoutStateModel.env == scope.env,
+                    BotSkillLayoutStateModel.entity_id == scope.entity_id,
+                    BotSkillLayoutStateModel.bot_id == scope.bot_id,
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.POOL_PREPARING.value,
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.target_layout: None,
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.LEGACY_ACTIVE.value
+                        ),
+                        BotSkillLayoutStateModel.migration_generation: None,
+                        BotSkillLayoutStateModel.preparation_id: None,
+                        BotSkillLayoutStateModel.last_probe_result: "NOT_CAPABLE",
+                        BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
+                        BotSkillLayoutStateModel.last_failure_code: None,
+                        BotSkillLayoutStateModel.last_failure_stage: None,
+                        BotSkillLayoutStateModel.last_failure_retryable: None,
+                        BotSkillLayoutStateModel.last_failure_evidence: None,
+                        BotSkillLayoutStateModel.last_failure_at: None,
+                        BotSkillLayoutStateModel.lease_owner: None,
+                        BotSkillLayoutStateModel.lease_expires_at: None,
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -277,6 +277,57 @@ class SkillsPoolLayoutRepository(SkillsPoolOperationalRepositoryMixin, SkillsPoo
             )
         return affected == 1
 
+    def release_not_capable_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """旧运行时不具备 Pool 能力时，保留证据并释放准备阶段 claim。"""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        with self._database.transactional_orm_session() as session:
+            affected = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout
+                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout
+                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase
+                    == SkillLayoutPhase.POOL_PREPARING.value,
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .update(
+                    {
+                        BotSkillLayoutStateModel.target_layout: None,
+                        BotSkillLayoutStateModel.phase: (
+                            SkillLayoutPhase.LEGACY_ACTIVE.value
+                        ),
+                        BotSkillLayoutStateModel.migration_generation: None,
+                        BotSkillLayoutStateModel.preparation_id: None,
+                        BotSkillLayoutStateModel.last_probe_result: "NOT_CAPABLE",
+                        BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
+                        BotSkillLayoutStateModel.last_failure_code: None,
+                        BotSkillLayoutStateModel.last_failure_stage: None,
+                        BotSkillLayoutStateModel.last_failure_retryable: None,
+                        BotSkillLayoutStateModel.last_failure_evidence: None,
+                        BotSkillLayoutStateModel.last_failure_at: None,
+                        BotSkillLayoutStateModel.lease_owner: None,
+                        BotSkillLayoutStateModel.lease_expires_at: None,
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return affected == 1
+
     def record_cutover_committed(
         self,
         *,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -26,13 +26,14 @@ from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
     log_missing_quarantine_path,
 )
+from agentclaw.community.plugins.skills_pool_capability_repository import SkillsPoolCapabilityRepositoryMixin
 from agentclaw.community.plugins.skills_pool_operational_repository import SkillsPoolOperationalRepositoryMixin
 from agentclaw.community.plugins.skills_pool_quarantine_repository import (
     SkillsPoolQuarantineRepositoryMixin,
 )
 
 
-class SkillsPoolLayoutRepository(SkillsPoolOperationalRepositoryMixin, SkillsPoolQuarantineRepositoryMixin):
+class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPoolOperationalRepositoryMixin, SkillsPoolQuarantineRepositoryMixin):
     @inject
     def __init__(self, database: DatabasePlugin) -> None:
         self._database = database
@@ -271,57 +272,6 @@ class SkillsPoolLayoutRepository(SkillsPoolOperationalRepositoryMixin, SkillsPoo
                         BotSkillLayoutStateModel.preparation_id: preparation_id,
                         BotSkillLayoutStateModel.last_probe_result: "READY",
                         BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
-                    },
-                    synchronize_session=False,
-                )
-            )
-        return affected == 1
-
-    def release_not_capable_claim(
-        self,
-        *,
-        scope: BotSkillLayoutScope,
-        migration_generation: str,
-        lease_owner: str,
-        evidence: dict[str, object],
-    ) -> bool:
-        """旧运行时不具备 Pool 能力时，保留证据并释放准备阶段 claim。"""
-
-        evidence_json = json.dumps(evidence, ensure_ascii=False)
-        with self._database.transactional_orm_session() as session:
-            affected = (
-                session.query(BotSkillLayoutStateModel)
-                .filter(
-                    *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase
-                    == SkillLayoutPhase.POOL_PREPARING.value,
-                    BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
-                    BotSkillLayoutStateModel.migration_generation
-                    == migration_generation,
-                    BotSkillLayoutStateModel.lease_owner == lease_owner,
-                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
-                )
-                .update(
-                    {
-                        BotSkillLayoutStateModel.target_layout: None,
-                        BotSkillLayoutStateModel.phase: (
-                            SkillLayoutPhase.LEGACY_ACTIVE.value
-                        ),
-                        BotSkillLayoutStateModel.migration_generation: None,
-                        BotSkillLayoutStateModel.preparation_id: None,
-                        BotSkillLayoutStateModel.last_probe_result: "NOT_CAPABLE",
-                        BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
-                        BotSkillLayoutStateModel.last_failure_code: None,
-                        BotSkillLayoutStateModel.last_failure_stage: None,
-                        BotSkillLayoutStateModel.last_failure_retryable: None,
-                        BotSkillLayoutStateModel.last_failure_evidence: None,
-                        BotSkillLayoutStateModel.last_failure_at: None,
-                        BotSkillLayoutStateModel.lease_owner: None,
-                        BotSkillLayoutStateModel.lease_expires_at: None,
                     },
                     synchronize_session=False,
                 )

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -282,6 +282,38 @@ def test_claim_pool_migration_persists_generation_lease_and_rollout_evidence() -
     assert claimed.persisted is True
 
 
+def test_not_capable_probe_releases_preparing_claim_and_preserves_evidence() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+
+    released = repository.release_not_capable_claim(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        evidence={"reason": "pool_marker_missing"},
+    )
+
+    assert released is True
+    state = repository.get(scope)
+    assert state.active_layout is SkillLayout.LEGACY
+    assert state.target_layout is None
+    assert state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert state.migration_generation is None
+    assert state.lease_owner is None
+    assert state.lease_expires_at is None
+    assert state.last_probe_result == "NOT_CAPABLE"
+    assert state.last_probe_evidence == {"reason": "pool_marker_missing"}
+    assert state.data_plane_cutover_committed is False
+
+
 def test_claim_updates_an_existing_unclaimed_legacy_row() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -107,6 +107,25 @@ class FakeLayoutRepository:
         )
         return True
 
+    def release_not_capable_claim(self, **kwargs: object) -> bool:
+        if self._should_fail("not_capable_release"):
+            return False
+        if not self._owns(kwargs):
+            return False
+        self.events.append("not_capable_release")
+        self.state = replace(
+            self.state,
+            target_layout=None,
+            phase=SkillLayoutPhase.LEGACY_ACTIVE,
+            migration_generation=None,
+            preparation_id=None,
+            last_probe_result="NOT_CAPABLE",
+            last_probe_evidence=dict(kwargs["evidence"]),
+            lease_owner=None,
+            lease_expires_at=None,
+        )
+        return True
+
     def holds_lease(self, **kwargs: object) -> bool:
         return self.lease_valid and self._owns(kwargs)
 
@@ -662,6 +681,7 @@ async def test_non_ready_runtime_keeps_legacy_without_data_plane_changes() -> No
         runtime.probe_result,
         status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
         preparation_id=None,
+        evidence={"reason": "pool_marker_missing"},
     )
 
     result = await build_service(layouts, runtime).reconcile(
@@ -671,8 +691,35 @@ async def test_non_ready_runtime_keeps_legacy_without_data_plane_changes() -> No
 
     assert result.outcome is SkillsPoolReconcileOutcome.NOT_CAPABLE
     assert runtime.events == ["probe"]
-    assert layouts.events == []
+    assert layouts.events == ["not_capable_release"]
     assert layouts.state.active_layout is SkillLayout.LEGACY
+    assert layouts.state.target_layout is None
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert layouts.state.migration_generation is None
+    assert layouts.state.last_probe_result == "NOT_CAPABLE"
+    assert layouts.state.last_probe_evidence == {"reason": "pool_marker_missing"}
+
+
+@pytest.mark.asyncio
+async def test_not_capable_release_race_is_not_reported_as_complete() -> None:
+    layouts = FakeLayoutRepository()
+    layouts.fail_once_at = "not_capable_release"
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        preparation_id=None,
+        evidence={"reason": "pool_marker_missing"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.STATE_RACE_LOST
+    assert layouts.state.phase is SkillLayoutPhase.POOL_PREPARING
+    assert layouts.state.migration_generation == GENERATION
 
 
 @pytest.mark.asyncio
@@ -776,7 +823,10 @@ async def test_mixed_image_bots_reconcile_independently_in_one_environment() -> 
     assert layouts.state_for(SCOPE).active_layout is SkillLayout.POOL
     old_state = layouts.state_for(old_scope)
     assert old_state.active_layout is SkillLayout.LEGACY
-    assert old_state.phase is SkillLayoutPhase.POOL_PREPARING
+    assert old_state.target_layout is None
+    assert old_state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert old_state.migration_generation is None
+    assert old_state.last_probe_result == "NOT_CAPABLE"
     assert runtime.physical_cutovers == 1
     assert runtime.events == [
         "probe",


### PR DESCRIPTION
## What changed

- persist `NOT_CAPABLE` runtime probe evidence
- atomically release a `POOL_PREPARING` migration claim back to `LEGACY_ACTIVE`
- clear the generation and lease so a later new-image lifecycle signal can claim again
- return `STATE_RACE_LOST` when the fenced release CAS does not succeed

## Why

During pre-release phase A, an old engine runtime correctly completed the queue task as `NOT_CAPABLE`, but the Bot remained stuck in `POOL_PREPARING`. This left a stale migration generation after a normal old-image compatibility outcome.

The release is intentionally limited to Legacy Bots still in `POOL_PREPARING` with no data-plane cutover. It cannot roll back a Bot that has crossed the cutover boundary.

## Impact

New Backend remains compatible with old engine images: an old runtime stays on Legacy, retains auditable probe evidence, and can be claimed again after a future restart uses a Pool-capable image.

No schema or DDL changes are required.

## Validation

- `uv run pytest tests/community/core/skills_pool -q` — 160 passed
- Ruff checks passed for all changed files
