### PR TITLE
Tenant isolation foundation (Session 0, Stage 1): mechanism + ac_bots

### DIFF
--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -45,11 +45,14 @@ and satisfies the spec's "I cannot leak data by forgetting to add a filter".
 - `src/agentclaw/community/adapters/http/middleware.py` — new
   `AvernetTenantMiddleware`, wired in `install_middleware`.
 - `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py` — the
-  public-API tenant seam (`AvernetTenantResolver`). This one **is** a genuine
-  seam: a default-tenant placeholder now, the real caller-identity verifier
-  later.
-- `src/agentclaw/community/di/modules/tenancy_module.py` (new) — binds the
-  placeholder resolver (the seam above; the listener is not bound here).
+  public-API tenant source: a single plain function `resolve_avernet_tenant`,
+  sitting beside the existing `require_principal` stub and following its exact
+  pattern. It is **not** a DI/profile seam — there is one gateway contract, so
+  one implementation for every profile; today it returns the default tenant,
+  and the auth workstream replaces this one body in place when the gateway
+  forwards a real principal (no endpoint changes when it lands). "Single
+  replaceable seam" in the spec means this drop-in point, not a per-profile
+  binding.
 - `src/agentclaw/community/plugins/bot_repository.py` — `insert` stamps
   `avernet_tenant` explicitly (parity with its explicit `env=get_current_env()`).
 
@@ -93,14 +96,11 @@ def bind_current_avernet_tenant(fn: Callable[P, R]) -> Callable[P, R]: ...
 ```
 
 ```python
-# adapters/http/openapi_v1/dependencies.py
-class AvernetTenantResolver(Protocol):
-    def resolve(self, request: Request) -> str: ...
-
-class DefaultAvernetTenantResolver:
-    """Placeholder until the caller-identity verifier lands."""
-    def resolve(self, request: Request) -> str:
-        return DEFAULT_AVERNET_TENANT
+# adapters/http/openapi_v1/dependencies.py — beside require_principal, same pattern
+def resolve_avernet_tenant(request: Request) -> str:
+    """Public-API tenant source. Placeholder until the gateway forwards a
+    verified principal; the auth workstream replaces this body in place."""
+    return DEFAULT_AVERNET_TENANT
 ```
 
 `get_current_avernet_tenant()` returns `DEFAULT_AVERNET_TENANT` outside any
@@ -126,19 +126,18 @@ request — a total function, not `str | None`, per the type contract in
   flag so a double import cannot double-register.
 - `plugins/bot_repository.py:122` — add `avernet_tenant=get_current_avernet_tenant()`
   beside `env=get_current_env()`.
-- `adapters/http/middleware.py:204` — `install_middleware` gains an
-  `avernet_tenant_resolver` parameter; `AvernetTenantMiddleware` is added
-  immediately after `UserContextMiddleware` (line 242) so it ends up *outside*
-  it, and the auth plugin's own DB reads run under the request's tenant.
-- `adapters/http/app.py:251` — pass `injector.get(AvernetTenantResolver)`.
-- `di/container.py:117` — register `TenancyModule()` beside
-  `CallerIdentityModule()`.
+- `adapters/http/middleware.py:204` — `AvernetTenantMiddleware` imports
+  `resolve_avernet_tenant` directly (a plain function, not injected) and is
+  added immediately after `UserContextMiddleware` (line 242) so it ends up
+  *outside* it, and the auth plugin's own DB reads run under the request's
+  tenant. `install_middleware` needs no new parameter and `app.py` needs no
+  change — nothing is DI-bound.
 
 `AvernetTenantMiddleware.dispatch` is four lines: pick
-`resolver.resolve(request)` when `request.url.path` starts with `/openapi/v1/`,
-otherwise `DEFAULT_AVERNET_TENANT`; enter `avernet_tenant_scope`; `await
-call_next`. Starlette copies the context into the downstream task, which is why
-the existing tracer middleware works the same way.
+`resolve_avernet_tenant(request)` when `request.url.path` starts with
+`/openapi/v1/`, otherwise `DEFAULT_AVERNET_TENANT`; enter `avernet_tenant_scope`;
+`await call_next`. Starlette copies the context into the downstream task, which
+is why the existing tracer middleware works the same way.
 
 ### Request-spawned work
 
@@ -207,10 +206,14 @@ and `with_loader_criteria`.
   for endpoints, but leaves middleware-level DB access (the auth plugin) and
   non-endpoint code outside the scope, and makes the reset path harder to
   reason about.
-- **A plain module-level `resolve_public_tenant()` function instead of a
-  DI-bound protocol.** Fewer moving parts, but the composition root is where
-  this codebase selects implementations, and the auth workstream needs a
-  binding it can override without editing a shared function body.
+- **A DI-bound `AvernetTenantResolver` protocol with a `tenancy_module.py`
+  binding, instead of a plain function.** Rejected as ceremony with nothing to
+  switch: there is one gateway contract, so one implementation for every
+  profile — a DI seam only pays off when N implementations coexist. It would
+  also diverge from `require_principal`, the sibling auth seam for this same
+  gateway boundary, which is a plain module-level function replaced in place.
+  The plain `resolve_avernet_tenant` satisfies the spec's "single replaceable
+  seam" (you replace its body) without the binding.
 - **`contextvars.copy_context()` around thread spawns** instead of a
   tenant-only helper. One line shorter, but it also carries the trace id into
   background threads — a behavior change outside this spec's scope.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -7,13 +7,25 @@ layer. A `ContextVar` carries the tenant for the lifetime of a request — the
 same mechanism the community tracer already uses for its trace id
 (`plugins/community/tracer.py:25`). A middleware sets it on the way in and
 resets it in a `finally`, so it cannot survive the request or leak into the
-next one. Enforcement is a single SQLAlchemy `do_orm_execute` listener that
-appends `with_loader_criteria(BotModel, avernet_tenant == get_current_avernet_tenant())`
-to every `SELECT`/`UPDATE`/`DELETE` touching `BotModel`. Inserts carry no
-`WHERE` clause, so the listener does not apply to them; a new row is stamped by
-the column default `default=get_current_avernet_tenant`, exactly as `env` is
-stamped today (`plugin_api/models.py:54`). That default is the single stamping
-mechanism — no per-call-site stamp is needed.
+next one. Enforcement has two active halves, both keyed on the same context and
+both impossible to forget:
+
+- **Reads / updates / deletes** — a `do_orm_execute` listener appends
+  `with_loader_criteria(BotModel, avernet_tenant == get_current_avernet_tenant())`
+  to every `SELECT`/`UPDATE`/`DELETE` touching `BotModel`.
+- **Inserts** — carry no `WHERE` clause, so the read listener cannot apply. A
+  `before_insert` mapper guard on `BotModel` instead *actively* stamps
+  `avernet_tenant = get_current_avernet_tenant()` on every new row, and raises
+  if a caller explicitly set a different tenant. This is deliberately **not** a
+  passive column default: a default only fires when the field is unset, so it
+  cannot stop a wrong value a future path (a clone, a bulk migration) carries in,
+  and it is a convenience rather than an enforced guarantee. The active guard
+  makes the insert side symmetric with the read side — one enforcement point,
+  every insert path covered.
+
+The column carries `server_default="teamclaw"` only to backfill existing rows on
+the `ALTER TABLE` and as a safety net for any non-ORM insert; the context-aware
+value always comes from the `before_insert` guard.
 
 The column and every new symbol carry the `avernet_tenant` prefix deliberately:
 the bare word `tenant` already denotes the poolab sandbox-allocator's tenant in
@@ -35,15 +47,16 @@ and satisfies the spec's "I cannot leak data by forgetting to add a filter".
   `ContextVar`, the default tenant constant, and the scope/inherit helpers.
   Sits beside `utils/env_utils.py`, its exact analogue.
 - `src/agentclaw/community/plugin_api/models.py` — `BotModel` gains
-  `avernet_tenant`, and the `do_orm_execute` listener is **defined here**, right
-  after the model, registered at model import. It is not a Plugin/seam: it needs
-  exactly one body for every profile (corp/community/test/singlebox all enforce
-  the identical rule), so it does not get a standalone file in the seam package.
-  `models.py` is the correct home — it is the one concrete file in `plugin_api/`
-  (the shared `BotModel` all plugin impls use), and the guard is welded to that
-  model. Registered on the `Session` **class**, so it applies to every session
-  in every runtime, including the out-of-tree corp `DatabasePlugin` this repo
-  does not contain.
+  `avernet_tenant`, and **both** guards (the `do_orm_execute` read guard and the
+  `before_insert` write guard) are **defined here**, right after the model,
+  registered at model import. Neither is a Plugin/seam: each needs exactly one
+  body for every profile (corp/community/test/singlebox all enforce the identical
+  rule), so they do not get a standalone file in the seam package. `models.py` is
+  the correct home — it is the one concrete file in `plugin_api/` (the shared
+  `BotModel` all plugin impls use), and the guards are welded to that model.
+  Registered on the `Session` class / the mapped class, so they apply in every
+  runtime, including the out-of-tree corp `DatabasePlugin` this repo does not
+  contain.
 - `src/agentclaw/community/adapters/http/middleware.py` — new
   `AvernetTenantMiddleware`, wired in `install_middleware`.
 - `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py` — the
@@ -57,8 +70,8 @@ and satisfies the spec's "I cannot leak data by forgetting to add a filter".
   binding.
 - `src/agentclaw/community/plugins/bot_repository.py` — **unchanged.** Listed
   only to record it was checked: `insert` builds an ORM instance and flushes, so
-  the `avernet_tenant` column default stamps the tenant automatically. It is the
-  sole `BotModel` insert path, so no explicit stamp is added anywhere.
+  the `before_insert` write guard stamps the tenant. No explicit stamp is added
+  at any call site — the guard covers them uniformly.
 
 ## Data Model Changes
 
@@ -131,22 +144,33 @@ request — a total function, not `str | None`, per the type contract in
   captures the tenant at call time and re-establishes it inside the callee;
   it is the fix for `threading.Thread`, which does not copy context vars.
 - `plugin_api/models.py:58` — add after `caller_config_revision`:
-  `avernet_tenant = Column(String(64), default=get_current_avernet_tenant, nullable=False)`.
-  The callable default mirrors `env`'s `default=get_current_env` on line 54, so
-  a bare `session.add(BotModel(...))` from any module is stamped correctly.
-- `plugin_api/models.py` (after `BotModel`) — define `_avernet_tenant_guard`
-  and register it with `event.listens_for(Session, "do_orm_execute")` at module
-  import, so any code path able to import the model is also guarded (no
-  composition-root wiring, and nothing to forget per profile). The listener
-  skips statements carrying an explicit `{"skip_avernet_tenant_guard": True}`
-  execution option (used only by the guard's own tests and by the local
-  bootstrap's table creation). Registration is idempotent on a module-level
+  `avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")`.
+  `server_default` (not a Python `default=`) so `create_all` emits the same
+  `DEFAULT 'teamclaw'` prod's DDL applies, backfilling existing rows and covering
+  any non-ORM insert. Context-aware stamping is the `before_insert` guard's job,
+  below — not this column.
+- `plugin_api/models.py` (after `BotModel`) — two guards registered at module
+  import, both idempotent on a module-level flag:
+  - `_avernet_tenant_read_guard` via `event.listens_for(Session,
+    "do_orm_execute")` — filters `SELECT`/`UPDATE`/`DELETE` (honors
+    `include_aliases`; skips statements carrying
+    `{"skip_avernet_tenant_guard": True}`, used only by the guard's own tests and
+    the local bootstrap's table creation).
+  - `_avernet_tenant_insert_guard` via `event.listens_for(BotModel,
+    "before_insert")` — stamps `target.avernet_tenant =
+    get_current_avernet_tenant()` when unset, and raises a
+    `CrossTenantInsertError` when a different tenant was explicitly set. Covers
+    every insert path (the read listener cannot, since an `INSERT` has no
+    `WHERE`).
+  Registered on the `Session` class / the mapped class, so both apply in every
+  runtime, including the out-of-tree corp `DatabasePlugin`. Registration is
+  idempotent on a module-level
   flag so a double import cannot double-register.
-- `plugins/bot_repository.py:122` — **no change.** The `avernet_tenant` column
-  default stamps the tenant at flush; the listener never applies to `INSERT`, so
-  an explicit stamp here would be redundant. This is the only `BotModel` insert
-  path, so the column default is the single guarantee. A test still asserts an
-  insert carries the current tenant (it protects the default).
+- `plugins/bot_repository.py:122` — **no change.** The `before_insert` guard
+  stamps the tenant on every `BotModel` flush, so an explicit stamp here would be
+  redundant (and would protect only this one call site). A test still asserts an
+  insert carries the current tenant, and that a cross-tenant explicit insert is
+  rejected — both exercising the guard, not this file.
 - `adapters/http/middleware.py:204` — `AvernetTenantMiddleware` imports
   `resolve_avernet_tenant` directly (a plain function, not injected) and is
   added immediately after `UserContextMiddleware` (line 242) so it ends up
@@ -267,6 +291,10 @@ Unit:
 - Writes — `update_by_owner` and `soft_delete_by_owner` against another
   tenant's bot return `None` / `False`, indistinguishable from a missing row,
   and leave the row untouched.
+- Inserts (`before_insert` guard) — a bot inserted under tenant B is stamped
+  `avernet_tenant == "B"` with no explicit stamp at the call site; constructing
+  a `BotModel` with an explicit tenant different from the current context and
+  flushing raises `CrossTenantInsertError`.
 - Non-repository access — a bare `session.query(BotModel).all()` is filtered,
   proving the guard reaches the direct-query modules.
 - `bind_current_avernet_tenant` — a spawned thread observes the spawning tenant.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -276,9 +276,10 @@ change is behavior-preserving by construction; a flag would add a second code
 path with nothing to switch between.
 
 Repository convention checks a reference DDL file into `core/<module>/sql/`
-(see `core/caller_identity/sql/2026_07_13_caller_identity.sql`). The spec
-explicitly decided against a checked-in migration file for this change, so the
-DDL lives in this plan instead. Worth reconsidering before implementation.
+(see `core/caller_identity/sql/2026_07_13_caller_identity.sql`), but **the
+decision (user, 2026-07-26) is not to check one in**: the schema change is
+always applied out-of-band on the platform, so the `ALTER TABLE` above is the
+authoritative record and no migration file lands in the repo.
 
 ## Test Strategy
 

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -84,9 +84,22 @@ One column on `ac_bots`. No new tables, no code-side migration.
 ```sql
 ALTER TABLE ac_bots
   ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
-    COMMENT 'data-isolation tenant; existing rows are the internal teamclaw tenant',
-  ADD KEY idx_bots_avernet_tenant_env (avernet_tenant, env) GLOBAL;
+    COMMENT 'data-isolation tenant; existing rows are the internal teamclaw tenant';
 ```
+
+**No index in Stage 1** (decision 2026-07-27, after inspecting `ac_bots`'s
+current indexes and every query method). With a single tenant `avernet_tenant`
+has cardinality 1, so an index on it prunes nothing; and every current query
+already leads with a more selective, already-indexed predicate (`owner_id`,
+`bot_id`/`entity_id`, `status`, `binding_id`), against which the guard's
+`avernet_tenant = 'teamclaw'` is a free residual filter — so a
+`(avernet_tenant, env)` index would never be chosen. It only earns its keep once
+(a) a second tenant makes the column selective and (b) a tenant-scoped list query
+(no more-selective predicate) exists. Revisit then — and prefer *prepending*
+`avernet_tenant` to the hot composites (`idx_owner` → `(avernet_tenant, owner_id)`,
+`idx_bot_id_entity_id` → `(avernet_tenant, bot_id, entity_id)`) so mandatory
+tenant-scoping composes with the existing access paths, rather than a standalone
+`(avernet_tenant, env)` the queries can't fully use.
 
 The fallback ("default") tenant is identified as **`teamclaw`** — the internal
 product's own name (already used throughout the code, e.g.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -1,0 +1,250 @@
+# Plan: Tenant Isolation Foundation (Stage 1)
+
+## Approach
+
+A task-local tenant, established once per request and enforced once at the ORM
+layer. A `ContextVar` carries the tenant for the lifetime of a request — the
+same mechanism the community tracer already uses for its trace id
+(`plugins/community/tracer.py:25`). A middleware sets it on the way in and
+resets it in a `finally`, so it cannot survive the request or leak into the
+next one. Enforcement is a single SQLAlchemy `do_orm_execute` listener that
+appends `with_loader_criteria(BotModel, tenant_id == current_tenant())` to
+every ORM statement touching `BotModel`; writes are stamped by an explicit
+`tenant_id` column with a context-derived default, exactly as `env` is today
+(`plugin_api/models.py:54`).
+
+The listener is the load-bearing choice. `BotModel` is queried directly from
+nine modules outside `BotRepository` (`core/bot_dormant/*`, `core/bot_chat/*`,
+`utils/cleanup_utils.py`, `plugins/caller_identity_repository.py`, and joins in
+`plugins/device_repository.py` / `plugins/skill_repository.py`). A
+per-method filter in `BotRepository` — the obvious mirror of the existing
+`_env()` helper — would leave every one of those as a leak path and would give
+reviewers ~25 places to check instead of one. One listener covers all of them
+and satisfies the spec's "I cannot leak data by forgetting to add a filter".
+
+## Affected Components
+
+- `src/agentclaw/community/utils/tenant_context.py` (new) — owns the
+  `ContextVar`, the default tenant constant, and the scope/inherit helpers.
+  Sits beside `utils/env_utils.py`, its exact analogue.
+- `src/agentclaw/community/plugin_api/models.py` — `BotModel` gains
+  `tenant_id`; installs the guard at import time.
+- `src/agentclaw/community/plugin_api/tenant_guard.py` (new) — the
+  `do_orm_execute` listener. Registered on the `Session` **class**, so it
+  applies to every session in every runtime, including the out-of-tree corp
+  `DatabasePlugin` this repo does not contain.
+- `src/agentclaw/community/adapters/http/middleware.py` — new
+  `TenantContextMiddleware`, wired in `install_middleware`.
+- `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py` — the
+  public-API tenant seam, beside the existing `require_principal` stub.
+- `src/agentclaw/community/di/modules/tenancy_module.py` (new) — binds the
+  placeholder resolver.
+- `src/agentclaw/community/plugins/bot_repository.py` — `insert` stamps
+  `tenant_id` explicitly (parity with its explicit `env=get_current_env()`).
+
+## Data Model Changes
+
+One column on `ac_bots`. No new tables, no code-side migration.
+
+```sql
+ALTER TABLE ac_bots
+  ADD COLUMN tenant_id VARCHAR(64) NOT NULL DEFAULT 'default'
+    COMMENT 'data-isolation tenant; existing rows are the default tenant',
+  ADD KEY idx_bots_tenant_env (tenant_id, env) GLOBAL;
+```
+
+The `DEFAULT 'default'` is what makes every pre-existing row belong to the
+default tenant without a backfill statement, which is the acceptance criterion
+that keeps current internal API responses unchanged.
+
+Local and singlebox runtimes need no DDL: `Base.metadata.create_all` builds the
+table from the model (`plugins/local/database.py:180`).
+
+Per the spec, no migration file is checked in — the DDL above is the
+authoritative statement of the required shape.
+
+## API / Interface Changes
+
+No HTTP surface changes. No route is added, no handler is wired, no response
+body gains a field (`tenant_id` is deliberately **not** added to
+`BotModel.to_dict()` — see Risks).
+
+New internal interfaces:
+
+```python
+# utils/tenant_context.py
+DEFAULT_TENANT_ID: Final[str] = "default"
+
+def get_current_tenant() -> str: ...                    # never None
+@contextmanager
+def tenant_scope(tenant_id: str) -> Iterator[None]: ...  # set + guaranteed reset
+def bind_current_tenant(fn: Callable[P, R]) -> Callable[P, R]: ...
+```
+
+```python
+# adapters/http/openapi_v1/dependencies.py
+class PublicTenantResolver(Protocol):
+    def resolve(self, request: Request) -> str: ...
+
+class DefaultPublicTenantResolver:
+    """Placeholder until the caller-identity verifier lands."""
+    def resolve(self, request: Request) -> str:
+        return DEFAULT_TENANT_ID
+```
+
+`get_current_tenant()` returns `DEFAULT_TENANT_ID` outside any request — a
+total function, not `str | None`, per the type contract in `AGENTS.md:197`.
+
+## Key Files & Functions
+
+- `utils/tenant_context.py` (new) — module above. `bind_current_tenant`
+  captures the tenant at call time and re-establishes it inside the callee;
+  it is the fix for `threading.Thread`, which does not copy context vars.
+- `plugin_api/models.py:58` — add after `caller_config_revision`:
+  `tenant_id = Column(String(64), default=get_current_tenant, nullable=False)`.
+  The callable default mirrors `env`'s `default=get_current_env` on line 54, so
+  a bare `session.add(BotModel(...))` from any module is stamped correctly.
+- `plugin_api/models.py` (bottom) — `install_bot_tenant_guard(BotModel)`.
+  Called from `models.py` rather than a composition root so that any code path
+  able to import the model is also guarded; taking the model as an argument
+  keeps `tenant_guard.py` free of an import cycle.
+- `plugin_api/tenant_guard.py` (new) — `event.listens_for(Session,
+  "do_orm_execute")`; skips statements carrying an explicit
+  `{"skip_tenant_guard": True}` execution option (used only by the guard's own
+  tests and by the local bootstrap's table creation).
+- `plugins/bot_repository.py:122` — add `tenant_id=get_current_tenant()`
+  beside `env=get_current_env()`.
+- `adapters/http/middleware.py:204` — `install_middleware` gains a
+  `public_tenant_resolver` parameter; `TenantContextMiddleware` is added
+  immediately after `UserContextMiddleware` (line 242) so it ends up *outside*
+  it, and the auth plugin's own DB reads run under the request's tenant.
+- `adapters/http/app.py:251` — pass `injector.get(PublicTenantResolver)`.
+- `di/container.py:117` — register `TenancyModule()` beside
+  `CallerIdentityModule()`.
+
+`TenantContextMiddleware.dispatch` is four lines: pick
+`resolver.resolve(request)` when `request.url.path` starts with `/openapi/v1/`,
+otherwise `DEFAULT_TENANT_ID`; enter `tenant_scope`; `await call_next`. Starlette
+copies the context into the downstream task, which is why the existing tracer
+middleware works the same way.
+
+### Request-spawned work
+
+Five in-request `threading.Thread` sites reach bot data and must be wrapped
+with `bind_current_tenant`:
+
+- `core/bot_management/services/bot_service.py:1618` — device allocation
+- `core/bot_management/services/bot_service.py:2255` — cron workflow update
+- `core/bot_management/services/bot_service.py:2371` — codefuse token refresh
+- `core/service_bot/services/bot_publish_service.py:1163` — post-upgrade restart
+- `core/bot_collaborator/services/collaborator_service.py:53` — sync/async bridge
+
+`asyncio.create_task` sites need no change — task creation copies the context.
+
+## Dependencies
+
+None. SQLAlchemy 2.0 (`pyproject.toml:37`) already provides `do_orm_execute`
+and `with_loader_criteria`.
+
+## Risks & Mitigations
+
+- **Risk:** `with_loader_criteria` is documented for ORM SELECT; the
+  repository's writes go through `Query.update()` / `Query.delete()`
+  (`plugins/bot_repository.py:411`, `:441`), and if the listener does not
+  apply there, cross-tenant writes stay possible.
+  **Mitigation:** first task in the build is a spike that asserts this
+  empirically. If it does not hold, add an explicit `_tenant()` filter to the
+  four write methods — bounded, and the read path still needs only the
+  listener.
+
+- **Risk:** the guard silently filters a query some internal caller expects to
+  be unfiltered — e.g. `utils/cleanup_utils.py:152` sweeping deleted rows, or
+  the `plugins/skill_repository.py:238` join.
+  **Mitigation:** all of those run under the default tenant today, so behavior
+  is unchanged now. The existing internal suite passing unmodified is the
+  acceptance criterion that proves it. The real exposure is deferred to the
+  stage where a second tenant holds data, and is recorded as such.
+
+- **Risk:** naming collision. `tenant` / `tenant_id` already mean the
+  poolab sandbox allocator's tenant in `core/service_bot/services/baas_service.py:1355`.
+  **Mitigation:** keep `tenant_id` (it is the right name for this column) and
+  name the unrelated concept explicitly in the new module's docstring. The two
+  never meet in one file.
+
+- **Risk:** `tenant_id` leaking into API responses via `to_dict()` would change
+  every current internal response body.
+  **Mitigation:** deliberately omit it from `to_dict()`
+  (`plugin_api/models.py:60`). A test asserts the returned key set is unchanged.
+
+- **Risk:** the listener is registered at import of `plugin_api/models.py`; a
+  test that imports the model twice could double-register.
+  **Mitigation:** `install_bot_tenant_guard` is idempotent on a module-level
+  flag.
+
+## Alternatives Considered
+
+- **Per-method filter in `BotRepository`, mirroring `_env()`.** Explicit and
+  in keeping with local style, but leaves the nine direct-query modules
+  unprotected and gives no single enforcement point. Rejected.
+- **Row-level security in the database.** The strongest option, but OceanBase
+  support and the out-of-band DDL process make it a much larger change than
+  Stage 1, and it would not cover the SQLite local runtime.
+- **Setting the tenant in a FastAPI dependency rather than middleware.** Works
+  for endpoints, but leaves middleware-level DB access (the auth plugin) and
+  non-endpoint code outside the scope, and makes the reset path harder to
+  reason about.
+- **A plain module-level `resolve_public_tenant()` function instead of a
+  DI-bound protocol.** Fewer moving parts, but the composition root is where
+  this codebase selects implementations, and the auth workstream needs a
+  binding it can override without editing a shared function body.
+- **`contextvars.copy_context()` around thread spawns** instead of a
+  tenant-only helper. One line shorter, but it also carries the trace id into
+  background threads — a behavior change outside this spec's scope.
+
+## Rollout
+
+Ordering is a hard constraint: **the `ALTER TABLE` must be applied before the
+code that reads the column is deployed.** A `SELECT` naming a column that does
+not exist fails outright, so a code-first deploy takes every bot read down.
+The column's `NOT NULL DEFAULT 'default'` makes the reverse order safe — the
+DDL is inert against the currently-deployed code.
+
+No feature flag. With every row and every request on the default tenant, the
+change is behavior-preserving by construction; a flag would add a second code
+path with nothing to switch between.
+
+Repository convention checks a reference DDL file into `core/<module>/sql/`
+(see `core/caller_identity/sql/2026_07_13_caller_identity.sql`). The spec
+explicitly decided against a checked-in migration file for this change, so the
+DDL lives in this plan instead. Worth reconsidering before implementation.
+
+## Test Strategy
+
+Unit:
+- `tenant_context` — default outside a request; set/reset; nesting; reset still
+  happens when the body raises.
+- `tenant_guard` — a bot inserted under tenant A is invisible to tenant B
+  through every read on the protocol: `get_by_id`, `get_by_id_and_owner`,
+  `list_by_owner`, `count_by_owner`, `exists_by_bot_name`, `search_bots`.
+- Writes — `update_by_owner` and `soft_delete_by_owner` against another
+  tenant's bot return `None` / `False`, indistinguishable from a missing row,
+  and leave the row untouched.
+- Non-repository access — a bare `session.query(BotModel).all()` is filtered,
+  proving the guard reaches the direct-query modules.
+- `bind_current_tenant` — a spawned thread observes the spawning tenant.
+- `to_dict()` key set is unchanged.
+
+Integration:
+- Two sequential requests through the ASGI app: the second sees the default
+  tenant. Same again where the first returns 500.
+- The existing internal API suite runs **unmodified**. Any edit needed there is
+  a defect in this change, not a test to update.
+
+The cross-tenant read test is the one the spec requires to fail before the
+change and pass after; it is written first and its red run is recorded.
+
+Gates: `src/backend` changes trigger backend SAST, unit tests, changed-line
+coverage, and singlebox coverage (`AGENTS.md:131`). No new coverage module is
+needed — `utils/` and `plugin_api/` are outside the per-module Core
+denominators in `scripts/ci/singlebox_coverage_modules.yaml`, and
+`bot_management` is registered there without thresholds.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -33,17 +33,23 @@ and satisfies the spec's "I cannot leak data by forgetting to add a filter".
   `ContextVar`, the default tenant constant, and the scope/inherit helpers.
   Sits beside `utils/env_utils.py`, its exact analogue.
 - `src/agentclaw/community/plugin_api/models.py` — `BotModel` gains
-  `avernet_tenant`; installs the guard at import time.
-- `src/agentclaw/community/plugin_api/avernet_tenant_guard.py` (new) — the
-  `do_orm_execute` listener. Registered on the `Session` **class**, so it
-  applies to every session in every runtime, including the out-of-tree corp
-  `DatabasePlugin` this repo does not contain.
+  `avernet_tenant`, and the `do_orm_execute` listener is **defined here**, right
+  after the model, registered at model import. It is not a Plugin/seam: it needs
+  exactly one body for every profile (corp/community/test/singlebox all enforce
+  the identical rule), so it does not get a standalone file in the seam package.
+  `models.py` is the correct home — it is the one concrete file in `plugin_api/`
+  (the shared `BotModel` all plugin impls use), and the guard is welded to that
+  model. Registered on the `Session` **class**, so it applies to every session
+  in every runtime, including the out-of-tree corp `DatabasePlugin` this repo
+  does not contain.
 - `src/agentclaw/community/adapters/http/middleware.py` — new
   `AvernetTenantMiddleware`, wired in `install_middleware`.
 - `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py` — the
-  public-API tenant seam, beside the existing `require_principal` stub.
+  public-API tenant seam (`AvernetTenantResolver`). This one **is** a genuine
+  seam: a default-tenant placeholder now, the real caller-identity verifier
+  later.
 - `src/agentclaw/community/di/modules/tenancy_module.py` (new) — binds the
-  placeholder resolver.
+  placeholder resolver (the seam above; the listener is not bound here).
 - `src/agentclaw/community/plugins/bot_repository.py` — `insert` stamps
   `avernet_tenant` explicitly (parity with its explicit `env=get_current_env()`).
 
@@ -110,14 +116,14 @@ request — a total function, not `str | None`, per the type contract in
   `avernet_tenant = Column(String(64), default=get_current_avernet_tenant, nullable=False)`.
   The callable default mirrors `env`'s `default=get_current_env` on line 54, so
   a bare `session.add(BotModel(...))` from any module is stamped correctly.
-- `plugin_api/models.py` (bottom) — `install_bot_avernet_tenant_guard(BotModel)`.
-  Called from `models.py` rather than a composition root so that any code path
-  able to import the model is also guarded; taking the model as an argument
-  keeps `avernet_tenant_guard.py` free of an import cycle.
-- `plugin_api/avernet_tenant_guard.py` (new) — `event.listens_for(Session,
-  "do_orm_execute")`; skips statements carrying an explicit
-  `{"skip_avernet_tenant_guard": True}` execution option (used only by the
-  guard's own tests and by the local bootstrap's table creation).
+- `plugin_api/models.py` (after `BotModel`) — define `_avernet_tenant_guard`
+  and register it with `event.listens_for(Session, "do_orm_execute")` at module
+  import, so any code path able to import the model is also guarded (no
+  composition-root wiring, and nothing to forget per profile). The listener
+  skips statements carrying an explicit `{"skip_avernet_tenant_guard": True}`
+  execution option (used only by the guard's own tests and by the local
+  bootstrap's table creation). Registration is idempotent on a module-level
+  flag so a double import cannot double-register.
 - `plugins/bot_repository.py:122` — add `avernet_tenant=get_current_avernet_tenant()`
   beside `env=get_current_env()`.
 - `adapters/http/middleware.py:204` — `install_middleware` gains an
@@ -186,8 +192,8 @@ and `with_loader_criteria`.
 
 - **Risk:** the listener is registered at import of `plugin_api/models.py`; a
   test that imports the model twice could double-register.
-  **Mitigation:** `install_bot_avernet_tenant_guard` is idempotent on a
-  module-level flag.
+  **Mitigation:** registration guards on a module-level flag, so a re-import is
+  a no-op.
 
 ## Alternatives Considered
 

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -97,9 +97,16 @@ already leads with a more selective, already-indexed predicate (`owner_id`,
 (a) a second tenant makes the column selective and (b) a tenant-scoped list query
 (no more-selective predicate) exists. Revisit then — and prefer *prepending*
 `avernet_tenant` to the hot composites (`idx_owner` → `(avernet_tenant, owner_id)`,
-`idx_bot_id_entity_id` → `(avernet_tenant, bot_id, entity_id)`) so mandatory
-tenant-scoping composes with the existing access paths, rather than a standalone
-`(avernet_tenant, env)` the queries can't fully use.
+`idx_bot_id_entity_id` → `(avernet_tenant, bot_id, entity_id)`, `idx_entity` →
+`(avernet_tenant, entity_id)`, and the search index) so mandatory tenant-scoping
+composes with the existing access paths, rather than a standalone
+`(avernet_tenant, env)` the queries can't fully use. Only those query-backing
+composites need it — leave the low-cardinality (`idx_status`, `idx_is_delete`)
+and unique-lookup (`idx_binding_id`) indexes alone. Because the corp naming
+convention ties an index's name to its columns, a reshape can't alter columns in
+place: **create the new (tenant-prepended, convention-named) index, then drop the
+old one** — create-before-drop so no window is left without a usable index, and
+mind online-DDL cost on the hot `ac_bots` table.
 
 The fallback ("default") tenant is identified as **`teamclaw`** — the internal
 product's own name (already used throughout the code, e.g.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -58,7 +58,11 @@ and satisfies the spec's "I cannot leak data by forgetting to add a filter".
   runtime, including the out-of-tree corp `DatabasePlugin` this repo does not
   contain.
 - `src/agentclaw/community/adapters/http/middleware.py` — new
-  `AvernetTenantMiddleware`, wired in `install_middleware`.
+  `AvernetTenantMiddleware`, wired in `install_middleware`. A **pure ASGI**
+  middleware (not `BaseHTTPMiddleware`): the tenant is a `ContextVar`, and a pure
+  ASGI middleware sets/reset it in the same coroutine that awaits the downstream
+  app — no child-task hop — so downstream visibility and a correct reset don't
+  depend on Starlette's `BaseHTTPMiddleware` context-propagation behavior.
 - `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py` — the
   public-API tenant source: a single plain function `resolve_avernet_tenant`,
   sitting beside the existing `require_principal` stub and following its exact
@@ -262,6 +266,11 @@ and `with_loader_criteria`.
 - **`contextvars.copy_context()` around thread spawns** instead of a
   tenant-only helper. One line shorter, but it also carries the trace id into
   background threads — a behavior change outside this spec's scope.
+- **`BaseHTTPMiddleware` for the tenant middleware** (matching the tracer). It
+  works on the current Starlette, but `BaseHTTPMiddleware` runs the downstream
+  app in a child anyio task, so `ContextVar` set/reset landing in the right
+  context has been version-dependent. A pure ASGI middleware sidesteps the whole
+  class of issue, so it is used instead.
 
 ## Rollout
 

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -8,10 +8,15 @@ same mechanism the community tracer already uses for its trace id
 (`plugins/community/tracer.py:25`). A middleware sets it on the way in and
 resets it in a `finally`, so it cannot survive the request or leak into the
 next one. Enforcement is a single SQLAlchemy `do_orm_execute` listener that
-appends `with_loader_criteria(BotModel, tenant_id == current_tenant())` to
-every ORM statement touching `BotModel`; writes are stamped by an explicit
-`tenant_id` column with a context-derived default, exactly as `env` is today
+appends `with_loader_criteria(BotModel, avernet_tenant == get_current_avernet_tenant())`
+to every ORM statement touching `BotModel`; writes are stamped by an explicit
+`avernet_tenant` column with a context-derived default, exactly as `env` is today
 (`plugin_api/models.py:54`).
+
+The column and every new symbol carry the `avernet_tenant` prefix deliberately:
+the bare word `tenant` already denotes the poolab sandbox-allocator's tenant in
+`core/service_bot/services/baas_service.py` (an unrelated concept), so the prefix
+keeps a grep for our isolation key from tangling with it.
 
 The listener is the load-bearing choice. `BotModel` is queried directly from
 nine modules outside `BotRepository` (`core/bot_dormant/*`, `core/bot_chat/*`,
@@ -24,23 +29,23 @@ and satisfies the spec's "I cannot leak data by forgetting to add a filter".
 
 ## Affected Components
 
-- `src/agentclaw/community/utils/tenant_context.py` (new) — owns the
+- `src/agentclaw/community/utils/avernet_tenant.py` (new) — owns the
   `ContextVar`, the default tenant constant, and the scope/inherit helpers.
   Sits beside `utils/env_utils.py`, its exact analogue.
 - `src/agentclaw/community/plugin_api/models.py` — `BotModel` gains
-  `tenant_id`; installs the guard at import time.
-- `src/agentclaw/community/plugin_api/tenant_guard.py` (new) — the
+  `avernet_tenant`; installs the guard at import time.
+- `src/agentclaw/community/plugin_api/avernet_tenant_guard.py` (new) — the
   `do_orm_execute` listener. Registered on the `Session` **class**, so it
   applies to every session in every runtime, including the out-of-tree corp
   `DatabasePlugin` this repo does not contain.
 - `src/agentclaw/community/adapters/http/middleware.py` — new
-  `TenantContextMiddleware`, wired in `install_middleware`.
+  `AvernetTenantMiddleware`, wired in `install_middleware`.
 - `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py` — the
   public-API tenant seam, beside the existing `require_principal` stub.
 - `src/agentclaw/community/di/modules/tenancy_module.py` (new) — binds the
   placeholder resolver.
 - `src/agentclaw/community/plugins/bot_repository.py` — `insert` stamps
-  `tenant_id` explicitly (parity with its explicit `env=get_current_env()`).
+  `avernet_tenant` explicitly (parity with its explicit `env=get_current_env()`).
 
 ## Data Model Changes
 
@@ -48,9 +53,9 @@ One column on `ac_bots`. No new tables, no code-side migration.
 
 ```sql
 ALTER TABLE ac_bots
-  ADD COLUMN tenant_id VARCHAR(64) NOT NULL DEFAULT 'default'
+  ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'default'
     COMMENT 'data-isolation tenant; existing rows are the default tenant',
-  ADD KEY idx_bots_tenant_env (tenant_id, env) GLOBAL;
+  ADD KEY idx_bots_avernet_tenant_env (avernet_tenant, env) GLOBAL;
 ```
 
 The `DEFAULT 'default'` is what makes every pre-existing row belong to the
@@ -66,72 +71,73 @@ authoritative statement of the required shape.
 ## API / Interface Changes
 
 No HTTP surface changes. No route is added, no handler is wired, no response
-body gains a field (`tenant_id` is deliberately **not** added to
+body gains a field (`avernet_tenant` is deliberately **not** added to
 `BotModel.to_dict()` — see Risks).
 
 New internal interfaces:
 
 ```python
-# utils/tenant_context.py
-DEFAULT_TENANT_ID: Final[str] = "default"
+# utils/avernet_tenant.py
+DEFAULT_AVERNET_TENANT: Final[str] = "default"
 
-def get_current_tenant() -> str: ...                    # never None
+def get_current_avernet_tenant() -> str: ...                    # never None
 @contextmanager
-def tenant_scope(tenant_id: str) -> Iterator[None]: ...  # set + guaranteed reset
-def bind_current_tenant(fn: Callable[P, R]) -> Callable[P, R]: ...
+def avernet_tenant_scope(tenant_id: str) -> Iterator[None]: ...  # set + guaranteed reset
+def bind_current_avernet_tenant(fn: Callable[P, R]) -> Callable[P, R]: ...
 ```
 
 ```python
 # adapters/http/openapi_v1/dependencies.py
-class PublicTenantResolver(Protocol):
+class AvernetTenantResolver(Protocol):
     def resolve(self, request: Request) -> str: ...
 
-class DefaultPublicTenantResolver:
+class DefaultAvernetTenantResolver:
     """Placeholder until the caller-identity verifier lands."""
     def resolve(self, request: Request) -> str:
-        return DEFAULT_TENANT_ID
+        return DEFAULT_AVERNET_TENANT
 ```
 
-`get_current_tenant()` returns `DEFAULT_TENANT_ID` outside any request — a
-total function, not `str | None`, per the type contract in `AGENTS.md:197`.
+`get_current_avernet_tenant()` returns `DEFAULT_AVERNET_TENANT` outside any
+request — a total function, not `str | None`, per the type contract in
+`AGENTS.md:197`.
 
 ## Key Files & Functions
 
-- `utils/tenant_context.py` (new) — module above. `bind_current_tenant`
+- `utils/avernet_tenant.py` (new) — module above. `bind_current_avernet_tenant`
   captures the tenant at call time and re-establishes it inside the callee;
   it is the fix for `threading.Thread`, which does not copy context vars.
 - `plugin_api/models.py:58` — add after `caller_config_revision`:
-  `tenant_id = Column(String(64), default=get_current_tenant, nullable=False)`.
+  `avernet_tenant = Column(String(64), default=get_current_avernet_tenant, nullable=False)`.
   The callable default mirrors `env`'s `default=get_current_env` on line 54, so
   a bare `session.add(BotModel(...))` from any module is stamped correctly.
-- `plugin_api/models.py` (bottom) — `install_bot_tenant_guard(BotModel)`.
+- `plugin_api/models.py` (bottom) — `install_bot_avernet_tenant_guard(BotModel)`.
   Called from `models.py` rather than a composition root so that any code path
   able to import the model is also guarded; taking the model as an argument
-  keeps `tenant_guard.py` free of an import cycle.
-- `plugin_api/tenant_guard.py` (new) — `event.listens_for(Session,
+  keeps `avernet_tenant_guard.py` free of an import cycle.
+- `plugin_api/avernet_tenant_guard.py` (new) — `event.listens_for(Session,
   "do_orm_execute")`; skips statements carrying an explicit
-  `{"skip_tenant_guard": True}` execution option (used only by the guard's own
-  tests and by the local bootstrap's table creation).
-- `plugins/bot_repository.py:122` — add `tenant_id=get_current_tenant()`
+  `{"skip_avernet_tenant_guard": True}` execution option (used only by the
+  guard's own tests and by the local bootstrap's table creation).
+- `plugins/bot_repository.py:122` — add `avernet_tenant=get_current_avernet_tenant()`
   beside `env=get_current_env()`.
-- `adapters/http/middleware.py:204` — `install_middleware` gains a
-  `public_tenant_resolver` parameter; `TenantContextMiddleware` is added
+- `adapters/http/middleware.py:204` — `install_middleware` gains an
+  `avernet_tenant_resolver` parameter; `AvernetTenantMiddleware` is added
   immediately after `UserContextMiddleware` (line 242) so it ends up *outside*
   it, and the auth plugin's own DB reads run under the request's tenant.
-- `adapters/http/app.py:251` — pass `injector.get(PublicTenantResolver)`.
+- `adapters/http/app.py:251` — pass `injector.get(AvernetTenantResolver)`.
 - `di/container.py:117` — register `TenancyModule()` beside
   `CallerIdentityModule()`.
 
-`TenantContextMiddleware.dispatch` is four lines: pick
+`AvernetTenantMiddleware.dispatch` is four lines: pick
 `resolver.resolve(request)` when `request.url.path` starts with `/openapi/v1/`,
-otherwise `DEFAULT_TENANT_ID`; enter `tenant_scope`; `await call_next`. Starlette
-copies the context into the downstream task, which is why the existing tracer
-middleware works the same way.
+otherwise `DEFAULT_AVERNET_TENANT`; enter `avernet_tenant_scope`; `await
+call_next`. Starlette copies the context into the downstream task, which is why
+the existing tracer middleware works the same way.
 
 ### Request-spawned work
 
 Five in-request `threading.Thread` sites reach bot data and must be wrapped
-with `bind_current_tenant`:
+with `bind_current_avernet_tenant`:
 
 - `core/bot_management/services/bot_service.py:1618` — device allocation
 - `core/bot_management/services/bot_service.py:2255` — cron workflow update
@@ -153,8 +159,8 @@ and `with_loader_criteria`.
   (`plugins/bot_repository.py:411`, `:441`), and if the listener does not
   apply there, cross-tenant writes stay possible.
   **Mitigation:** first task in the build is a spike that asserts this
-  empirically. If it does not hold, add an explicit `_tenant()` filter to the
-  four write methods — bounded, and the read path still needs only the
+  empirically. If it does not hold, add an explicit `_avernet_tenant()` filter
+  to the four write methods — bounded, and the read path still needs only the
   listener.
 
 - **Risk:** the guard silently filters a query some internal caller expects to
@@ -165,21 +171,23 @@ and `with_loader_criteria`.
   acceptance criterion that proves it. The real exposure is deferred to the
   stage where a second tenant holds data, and is recorded as such.
 
-- **Risk:** naming collision. `tenant` / `tenant_id` already mean the
-  poolab sandbox allocator's tenant in `core/service_bot/services/baas_service.py:1355`.
-  **Mitigation:** keep `tenant_id` (it is the right name for this column) and
-  name the unrelated concept explicitly in the new module's docstring. The two
-  never meet in one file.
+- **Risk:** naming collision. The bare word `tenant` (and `tenant_id`) already
+  mean the poolab sandbox allocator's tenant in
+  `core/service_bot/services/baas_service.py:1355` — an entirely unrelated
+  concept.
+  **Mitigation:** our column and every new symbol are prefixed `avernet_tenant`,
+  so a grep never conflates the two, and the new module's docstring names the
+  baas concept explicitly to warn future readers. The two never meet in one file.
 
-- **Risk:** `tenant_id` leaking into API responses via `to_dict()` would change
-  every current internal response body.
+- **Risk:** `avernet_tenant` leaking into API responses via `to_dict()` would
+  change every current internal response body.
   **Mitigation:** deliberately omit it from `to_dict()`
   (`plugin_api/models.py:60`). A test asserts the returned key set is unchanged.
 
 - **Risk:** the listener is registered at import of `plugin_api/models.py`; a
   test that imports the model twice could double-register.
-  **Mitigation:** `install_bot_tenant_guard` is idempotent on a module-level
-  flag.
+  **Mitigation:** `install_bot_avernet_tenant_guard` is idempotent on a
+  module-level flag.
 
 ## Alternatives Considered
 
@@ -221,17 +229,17 @@ DDL lives in this plan instead. Worth reconsidering before implementation.
 ## Test Strategy
 
 Unit:
-- `tenant_context` — default outside a request; set/reset; nesting; reset still
-  happens when the body raises.
-- `tenant_guard` — a bot inserted under tenant A is invisible to tenant B
-  through every read on the protocol: `get_by_id`, `get_by_id_and_owner`,
+- `avernet_tenant` context — default outside a request; set/reset; nesting;
+  reset still happens when the body raises.
+- `avernet_tenant_guard` — a bot inserted under tenant A is invisible to tenant
+  B through every read on the protocol: `get_by_id`, `get_by_id_and_owner`,
   `list_by_owner`, `count_by_owner`, `exists_by_bot_name`, `search_bots`.
 - Writes — `update_by_owner` and `soft_delete_by_owner` against another
   tenant's bot return `None` / `False`, indistinguishable from a missing row,
   and leave the row untouched.
 - Non-repository access — a bare `session.query(BotModel).all()` is filtered,
   proving the guard reaches the direct-query modules.
-- `bind_current_tenant` — a spawned thread observes the spawning tenant.
+- `bind_current_avernet_tenant` — a spawned thread observes the spawning tenant.
 - `to_dict()` key set is unchanged.
 
 Integration:

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -62,14 +62,28 @@ One column on `ac_bots`. No new tables, no code-side migration.
 
 ```sql
 ALTER TABLE ac_bots
-  ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'default'
-    COMMENT 'data-isolation tenant; existing rows are the default tenant',
+  ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
+    COMMENT 'data-isolation tenant; existing rows are the internal teamclaw tenant',
   ADD KEY idx_bots_avernet_tenant_env (avernet_tenant, env) GLOBAL;
 ```
 
-The `DEFAULT 'default'` is what makes every pre-existing row belong to the
-default tenant without a backfill statement, which is the acceptance criterion
-that keeps current internal API responses unchanged.
+The fallback ("default") tenant is identified as **`teamclaw`** — the internal
+product's own name (already used throughout the code, e.g.
+`teamclaw_service_bot_publish`, `TeamClaw bot_id`). Two reasons over a generic
+`"default"`: it is a meaningful identity for the one tenant that owns all
+current data, and it avoids the bare literal `"default"`, which is already the
+value of the *unrelated* poolab/device/mcp tenant concept in several files
+(`core/bot_management/services/bot_service.py:100`,
+`core/devices/services/device_service.py:1659`, …). This resolves the spec's
+Open Question 3 (is `default` a safe identifier): we don't use it. `teamclaw`
+must never be offered to an external registered tenant.
+
+Adding the column with `NOT NULL DEFAULT 'teamclaw'` backfills every existing
+row to `teamclaw` in place — on OceanBase/MySQL a `NOT NULL` column with a
+`DEFAULT` populates all pre-existing rows, and SQLite behaves the same (moot
+locally, where the table is created fresh from the model). No separate `UPDATE`
+is needed, and that backfill is exactly what keeps every current internal API
+response unchanged.
 
 Local and singlebox runtimes need no DDL: `Base.metadata.create_all` builds the
 table from the model (`plugins/local/database.py:180`).
@@ -87,7 +101,7 @@ New internal interfaces:
 
 ```python
 # utils/avernet_tenant.py
-DEFAULT_AVERNET_TENANT: Final[str] = "default"
+DEFAULT_AVERNET_TENANT: Final[str] = "teamclaw"  # internal tenant; owns all current data
 
 def get_current_avernet_tenant() -> str: ...                    # never None
 @contextmanager
@@ -223,7 +237,7 @@ and `with_loader_criteria`.
 Ordering is a hard constraint: **the `ALTER TABLE` must be applied before the
 code that reads the column is deployed.** A `SELECT` naming a column that does
 not exist fails outright, so a code-first deploy takes every bot read down.
-The column's `NOT NULL DEFAULT 'default'` makes the reverse order safe — the
+The column's `NOT NULL DEFAULT 'teamclaw'` makes the reverse order safe — the
 DDL is inert against the currently-deployed code.
 
 No feature flag. With every row and every request on the default tenant, the

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -9,9 +9,11 @@ same mechanism the community tracer already uses for its trace id
 resets it in a `finally`, so it cannot survive the request or leak into the
 next one. Enforcement is a single SQLAlchemy `do_orm_execute` listener that
 appends `with_loader_criteria(BotModel, avernet_tenant == get_current_avernet_tenant())`
-to every ORM statement touching `BotModel`; writes are stamped by an explicit
-`avernet_tenant` column with a context-derived default, exactly as `env` is today
-(`plugin_api/models.py:54`).
+to every `SELECT`/`UPDATE`/`DELETE` touching `BotModel`. Inserts carry no
+`WHERE` clause, so the listener does not apply to them; a new row is stamped by
+the column default `default=get_current_avernet_tenant`, exactly as `env` is
+stamped today (`plugin_api/models.py:54`). That default is the single stamping
+mechanism — no per-call-site stamp is needed.
 
 The column and every new symbol carry the `avernet_tenant` prefix deliberately:
 the bare word `tenant` already denotes the poolab sandbox-allocator's tenant in
@@ -53,8 +55,10 @@ and satisfies the spec's "I cannot leak data by forgetting to add a filter".
   forwards a real principal (no endpoint changes when it lands). "Single
   replaceable seam" in the spec means this drop-in point, not a per-profile
   binding.
-- `src/agentclaw/community/plugins/bot_repository.py` — `insert` stamps
-  `avernet_tenant` explicitly (parity with its explicit `env=get_current_env()`).
+- `src/agentclaw/community/plugins/bot_repository.py` — **unchanged.** Listed
+  only to record it was checked: `insert` builds an ORM instance and flushes, so
+  the `avernet_tenant` column default stamps the tenant automatically. It is the
+  sole `BotModel` insert path, so no explicit stamp is added anywhere.
 
 ## Data Model Changes
 
@@ -138,8 +142,11 @@ request — a total function, not `str | None`, per the type contract in
   execution option (used only by the guard's own tests and by the local
   bootstrap's table creation). Registration is idempotent on a module-level
   flag so a double import cannot double-register.
-- `plugins/bot_repository.py:122` — add `avernet_tenant=get_current_avernet_tenant()`
-  beside `env=get_current_env()`.
+- `plugins/bot_repository.py:122` — **no change.** The `avernet_tenant` column
+  default stamps the tenant at flush; the listener never applies to `INSERT`, so
+  an explicit stamp here would be redundant. This is the only `BotModel` insert
+  path, so the column default is the single guarantee. A test still asserts an
+  insert carries the current tenant (it protects the default).
 - `adapters/http/middleware.py:204` — `AvernetTenantMiddleware` imports
   `resolve_avernet_tenant` directly (a plain function, not injected) and is
   added immediately after `UserContextMiddleware` (line 242) so it ends up

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/plan.md
@@ -87,8 +87,12 @@ ALTER TABLE ac_bots
     COMMENT 'data-isolation tenant; existing rows are the internal teamclaw tenant';
 ```
 
-**No index in Stage 1** (decision 2026-07-27, after inspecting `ac_bots`'s
-current indexes and every query method). With a single tenant `avernet_tenant`
+**No index in Stage 1** (decision 2026-07-27). Tenant-leading indexes on a
+tenant-columned table are a **mandatory corp policy**, so this is a conscious
+*deferral to the dedicated index-adding work* — not an exemption; it must be
+done before this is considered complete for multi-tenant. It's deferred now
+because, after inspecting `ac_bots`'s current indexes and every query method,
+the column adds no value yet: with a single tenant `avernet_tenant`
 has cardinality 1, so an index on it prunes nothing; and every current query
 already leads with a more selective, already-indexed predicate (`owner_id`,
 `bot_id`/`entity_id`, `status`, `binding_id`), against which the guard's

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/spec.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/spec.md
@@ -1,0 +1,115 @@
+# Tenant Isolation Foundation (Stage 1)
+
+## Summary
+
+Bot data currently lives in one undifferentiated pool: nothing records which
+tenant a bot belongs to, and no read is scoped to a tenant. This adds that
+missing axis — every request carries a tenant, and every bot read and write is
+confined to it — so the new public API can serve a registered external tenant
+without ever seeing, or being seen by, the existing internal one. Stage 1
+establishes the mechanism and proves it on bot records; later stages apply the
+same mechanism to the remaining data.
+
+## Motivation
+
+The new public API surface exists today as route definitions with no
+implementations. Its callers are external registered tenants; the existing
+internal API's callers are not. Both are served by the same application, backed
+by the same tables, repositories and services.
+
+That is the problem. Isolation cannot be added endpoint-by-endpoint as each
+public category is implemented, because the very first implemented public
+endpoint would read internal data. It has to exist underneath both surfaces
+before any of them is wired. The public-API handoff identifies this as the work
+blocking all seven category implementations.
+
+Isolation is currently absent, not partial. No bot record carries a tenant and
+no query filters by one. The nearest existing concept — the deployment
+environment (dev/pre/prod) — is fixed for the whole process and cannot vary
+per caller, so it cannot stand in. The one place the word "tenant" already
+appears on the bot-provisioning path is an unrelated hint forwarded to the
+sandbox allocator, not a data-isolation key.
+
+## User Stories
+
+- As a caller of the existing internal API, I want every response to be exactly
+  what it is today, so that adding isolation is invisible to me.
+- As an external tenant calling the public API, I want my reads and writes
+  confined to my own bots, so that no other tenant's data can reach me and mine
+  cannot reach them.
+- As an engineer implementing a public API category, I want tenant scoping
+  already enforced beneath my endpoint, so that I cannot leak data by forgetting
+  to add a filter.
+- As a reviewer, I want a request's tenant to have one obvious source and one
+  obvious enforcement point, so I can tell at a glance whether a change is safe.
+- As the engineer delivering caller authentication, I want a single named seam
+  to plug the real verifier into, so that no endpoint changes when it lands.
+
+## Acceptance Criteria
+
+- [ ] Every request carries a tenant. When nothing identifies one, that tenant
+      is the default tenant.
+- [ ] A bot created during a request belongs to that request's tenant.
+- [ ] Bot reads — fetch, list, count, name-existence, search — return only
+      records belonging to the request's tenant.
+- [ ] Bot updates and deletes affect only records belonging to the request's
+      tenant. An attempt to modify another tenant's bot behaves as though that
+      bot does not exist.
+- [ ] Every bot record that exists before this change belongs to the default
+      tenant, so every current internal API response is unchanged.
+- [ ] The existing internal API test suite passes without modification.
+- [ ] A request's tenant never leaks into another request, including after a
+      request fails with an error.
+- [ ] The tenant a request carries is readable by the code handling that
+      request, not only by the layer that established it.
+- [ ] Work started during a request inherits that request's tenant.
+- [ ] The public API's tenant source is a single replaceable seam: the real
+      caller-identity verifier can be substituted without changing any endpoint.
+- [ ] Cross-tenant isolation is demonstrated by a test that fails without this
+      change and passes with it.
+
+## In Scope
+
+- A tenant carried through the lifetime of a request, with a defined default.
+- A single named seam supplying the public API's tenant, with a placeholder
+  source until the real verifier lands.
+- Bot records: tenant recorded at creation, enforced on every read, update and
+  delete.
+- Tests for isolation, for non-leakage between requests, and for the existing
+  internal API being unchanged.
+
+## Out of Scope
+
+- All other data — resources, channels, skills, MCP configuration, routines.
+  Later stages of this same foundation, using the same mechanism.
+- Implementing any public API endpoint. This change wires no handler and adds
+  no route.
+- The real caller-identity verifier, which is the authentication workstream's
+  deliverable. This change only guarantees the seam it drops into.
+- The production schema change, which is submitted and executed on the platform
+  out-of-band. Because no migration file is checked in, `plan.md` states the
+  exact required column shape and the ordering constraint against a deploy.
+- Background and scheduled work that runs outside any request. It resolves to
+  the default tenant, which is correct while all data belongs to the default
+  tenant; it must be revisited before a second tenant holds real data. Work
+  started *during* a request is in scope and inherits the request's tenant.
+- The sandbox-allocator tenant hint on the provisioning path, which is a
+  different concept and is left untouched.
+- Removal of the dead workspace-file table and its unreachable service, which is
+  confirmed dead but is a separate cleanup.
+
+## Open Questions
+
+- **What identifies the public API's tenant, and where does it come from?**
+  The seam needs a concrete answer eventually — which claim or header the
+  gateway forwards, and what the registered tenant's identifier looks like.
+  Not blocking: Stage 1 ships the seam with a default-tenant placeholder.
+- **Should a cross-tenant access attempt be indistinguishable from a missing
+  record, or an explicit refusal?** This spec assumes indistinguishable, which
+  leaks no information about other tenants' data. Worth confirming, since it
+  determines what the public API returns.
+- **Is `default` safe as the default tenant's identifier?** It must never
+  collide with a real registered tenant's identifier.
+- **Is the deployment environment still an independent axis under a tenant?**
+  This spec assumes yes — a tenant's data is still partitioned by dev/pre/prod,
+  and the two scopes compose.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -2,19 +2,24 @@
 
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
-## Task 1: Spike — confirm listener covers ORM writes
+## Task 1: Spike — confirm listener covers ORM writes  `[x]`
 - **Goal:** Empirically settle whether a `do_orm_execute` listener applying
   `with_loader_criteria(BotModel, ...)` also constrains `Query.update()` /
   `Query.delete()`, or whether the write methods need an explicit filter.
-- **Files:** throwaway probe under `tests/community/plugins/` — no production
-  change in this task.
+- **Files:** throwaway probe (scratchpad, not committed) — no production change.
+- **Finding (SQLAlchemy 2.0.51): COVERED.** A prototype listener adding
+  `with_loader_criteria(Bot, Bot.tenant == current, include_aliases=True)` in
+  `do_orm_execute` constrains the exact write shape `bot_repository` uses —
+  `db.query(Model).filter(...).update(values, synchronize_session=False)` — and
+  `Query.delete()`. Probe results: a cross-tenant `Query.update()` returned
+  rowcount 0 and left the row unchanged; a cross-tenant `Query.delete()`
+  returned rowcount 0 and left the row present; a cross-tenant read returned
+  nothing. **Task 5 needs no explicit `_avernet_tenant()` filter on the write
+  methods — the single read listener covers reads, updates, and deletes.**
 - **Done when:**
-  - [ ] A minimal reproduction inserts two bots under different tenants and runs
-        `update_by_owner` / `soft_delete_by_owner` against the other tenant's bot
-        with a prototype listener installed.
-  - [ ] The finding is recorded under this task: **covered** (read path alone
-        suffices) or **not covered** (write methods need an explicit
-        `_avernet_tenant()` filter — Task 5 adopts it).
+  - [x] Minimal reproduction run against different-tenant rows with a prototype
+        listener installed.
+  - [x] Finding recorded: **covered** — read path alone suffices for writes too.
 - **Depends on:** —
 
 ## Task 2: Tenant context primitive

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -128,20 +128,22 @@
         ordering tests (11) still pass.
 - **Depends on:** Task 2, Task 6
 
-## Task 8: Request-spawned work inherits the tenant
+## Task 8: Request-spawned work inherits the tenant  `[x]`
 - **Goal:** In-request background threads observe the request's tenant.
 - **Files:** `core/bot_management/services/bot_service.py` (3 sites),
   `core/service_bot/services/bot_publish_service.py`,
   `core/bot_collaborator/services/collaborator_service.py`,
-  `tests/community/...`.
+  `tests/community/core/test_request_spawned_tenant_inheritance.py` (new).
 - **Done when:**
-  - [ ] The five `threading.Thread` targets listed in the plan are wrapped with
-        `bind_current_avernet_tenant` (or the tenant is otherwise captured and
-        re-established inside the thread).
-  - [ ] `asyncio.create_task` sites are left unchanged (verified they inherit
-        context).
-  - [ ] Test: a bot operation performed on a spawned thread runs under the
-        spawning request's tenant.
+  - [x] The five `threading.Thread` targets are wrapped with
+        `bind_current_avernet_tenant` (do_allocate, _update_cron_workflow,
+        _refresh_codefuse_token_on_device, _do_restart, collaborator _runner).
+  - [x] `asyncio.create_task` sites left unchanged — task creation copies the
+        context (noted in the plan; no code change).
+  - [x] Test (4): the three spawn shapes I touched (target-only, target+kwargs,
+        run-and-join) inherit the tenant; kwargs still pass; outside a request
+        the default is captured. 1487 tests pass across the three touched
+        modules — no regression.
 - **Depends on:** Task 2
 
 ## Task 9: Reference DDL artifact — decision  `[x]`

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -54,21 +54,23 @@
         server_default). 5 model tests pass; existing 32 repo tests still green.
 - **Depends on:** Task 2
 
-## Task 4: Cross-tenant isolation test (red)
+## Task 4: Cross-tenant isolation test (red)  `[x]`
 - **Goal:** Write the spec-required test that fails before the guards exist and
   passes after — and record its red run.
-- **Files:** `tests/community/plugins/...` (new).
+- **Files:** `tests/community/plugins/test_bot_tenant_isolation.py` (new).
+- **Red run (recorded):** at this commit (column present, guards absent) —
+  `6 failed, 1 passed`. The 6 cross-tenant reads (`get_by_id`,
+  `get_by_id_and_owner`, `list_by_owner`, `count_by_owner`, `exists_by_bot_name`,
+  `search_bots`) fail because reads are unfiltered so tenant B sees tenant A's
+  bot; `test_own_tenant_still_visible` passes trivially (no filter yet). Task 5
+  turns the 6 green.
 - **Done when:**
-  - [ ] Test seeds a bot inside `avernet_tenant_scope("A")` and another inside
-        `avernet_tenant_scope("B")` via `BotRepository.insert`, then asserts a
-        read inside `avernet_tenant_scope("B")` does not return A's bot, across
-        `get_by_id`, `get_by_id_and_owner`, `list_by_owner`, `count_by_owner`,
-        `exists_by_bot_name`, `search_bots`.
-  - [ ] Run at this task's commit (column exists, guards not yet added) the test
-        **fails** — reads are unfiltered so B sees A's row — and the red run is
-        recorded in the commit message / task notes. Task 5 (both guards) turns
-        it green: the insert guard gives the two rows distinct tenants and the
-        read guard filters them.
+  - [x] Test seeds a bot inside `avernet_tenant_scope("tenant-a")` and another
+        inside `avernet_tenant_scope("tenant-b")` via `BotRepository.insert`, then
+        asserts a read inside `tenant-b` does not return A's bot across all six
+        read methods.
+  - [x] Run at this task's commit the test **fails** (6 failed) and the red run
+        is recorded above.
 - **Depends on:** Task 2, Task 3
 
 ## Task 5: Tenant guards — read filter + insert stamp (green)

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -110,21 +110,22 @@
   - [x] No Protocol, no DI binding, no `app.py` / `container.py` change.
 - **Depends on:** Task 2
 
-## Task 7: `AvernetTenantMiddleware`
+## Task 7: `AvernetTenantMiddleware`  `[x]`
 - **Goal:** Establish each request's tenant for its whole lifetime, reset on the
   way out including on error.
 - **Files:** `src/agentclaw/community/adapters/http/middleware.py`,
-  `tests/community/...` (integration).
+  `tests/community/adapters/http/test_avernet_tenant_middleware.py` (new).
 - **Done when:**
-  - [ ] `AvernetTenantMiddleware.dispatch` picks `resolve_avernet_tenant(request)`
+  - [x] `AvernetTenantMiddleware.dispatch` picks `resolve_avernet_tenant(request)`
         for `/openapi/v1/*` paths, else `DEFAULT_AVERNET_TENANT`; enters
         `avernet_tenant_scope`; awaits `call_next`.
-  - [ ] Added in `install_middleware` immediately after `UserContextMiddleware`
+  - [x] Added in `install_middleware` immediately after `UserContextMiddleware`
         so it is outside it (auth plugin DB reads run under the tenant); no new
         `install_middleware` parameter.
-  - [ ] Integration test: two sequential requests through the ASGI app — the
-        second sees `teamclaw`; repeated where the first handler raises 500, the
-        tenant still does not leak.
+  - [x] Integration test (4): every path defaults to `teamclaw`; a public
+        request uses the resolved tenant; the tenant does not leak between
+        requests, nor after a request raises 500. Existing middleware-stack
+        ordering tests (11) still pass.
 - **Depends on:** Task 2, Task 6
 
 ## Task 8: Request-spawned work inherits the tenant

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -206,3 +206,34 @@
 - **Group D — Finalize & verify:** Tasks 9, 10
   - Theme: resolve the checked-in-DDL decision and prove all spec acceptance
     criteria; green gates.
+
+---
+
+## Follow-ups (post-review)
+
+### F1: Extend request-spawned tenant inheritance beyond the first 5 sites  `[x]`
+- **Trigger:** review question — was the Task 8 enumeration comprehensive?
+- **Audit:** `asyncio.to_thread` and `asyncio.create_task` **copy the current
+  context**, so every such offload (the large majority in the codebase) inherits
+  the tenant automatically — no wrapping needed. Only raw `threading.Thread` and
+  bare `ThreadPoolExecutor`/`run_in_executor` don't.
+- **Wrapped now** (in-request threads whose body touches `BotModel`):
+  - `bot_dormant/activate_service.py` `_reactivate_async` (reactivate flow).
+  - `bot_management/services/bot_service.py` `create_bot_instances` — the
+    device-allocation `ThreadPoolExecutor` (bind the submitted callable).
+  - `desktop_bot/services/desktop_bot_service.py` `_poll_publish_progress`
+    (calls `_bot_repo.get_by_id_and_owner` / `update_by_owner`).
+- **Deferred** (out of Stage-1 scope — touch non-bot tables, not `ac_bots`):
+  `bot_public_service.py` auth-relationship rebuild executors;
+  `device_service.py` MCP-sync / service-start threads. Revisit when those data
+  categories get their own guards (later stages).
+- **Recommended (not done):** an arch guard that flags new raw
+  `threading.Thread` / `ThreadPoolExecutor` in core so future in-request spawns
+  can't silently drop the tenant. Tracked for follow-up.
+- **Verification:** 1005 tests pass across bot_dormant / desktop_bot /
+  bot_management.
+
+### F2: Tenant index — deferred (see plan Data Model Changes)
+- No index in Stage 1 (cardinality-1 column; existing indexes stay effective).
+  At multi-tenant, prepend `avernet_tenant` to the hot composites via
+  create-new-then-drop-old (naming convention ties index name to columns).

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -156,19 +156,35 @@
   - [x] Decision recorded; no `.sql` committed.
 - **Depends on:** —
 
-## Task 10: Verification against spec acceptance criteria
+## Task 10: Verification against spec acceptance criteria  `[x]`
 - **Goal:** Prove every spec acceptance criterion holds.
-- **Files:** — (runs suites; no production change).
-- **Done when:**
-  - [ ] The existing internal API test suite passes **unmodified**.
-  - [ ] The cross-tenant isolation test (Task 4/5) is green; its earlier red run
-        is on record.
-  - [ ] Non-leakage across requests (incl. post-error) is green (Task 7).
-  - [ ] Request-spawned work inherits the tenant (Task 8).
-  - [ ] `to_dict()` key set unchanged (Task 3) — internal responses identical.
-  - [ ] Backend unit tests, changed-line coverage, and singlebox coverage pass
-        (`AGENTS.md:131`); pre-push hooks installed via
-        `scripts/install_git_hooks.sh`.
+- **Files:** README context-boundary declarations only (arch-guard follow-up);
+  no runtime change.
+- **Spec acceptance criteria → evidence:**
+  - [x] Every request carries a tenant; default when none — `AvernetTenantMiddleware`
+        + `DEFAULT_AVERNET_TENANT` (test_avernet_tenant_middleware).
+  - [x] A bot created during a request belongs to that request's tenant —
+        `before_insert` guard (test_bot_tenant_guard::insert stamp).
+  - [x] Reads (fetch/list/count/name-existence/search) tenant-scoped — read guard
+        across all six methods (test_bot_tenant_isolation).
+  - [x] Updates/deletes tenant-scoped; cross-tenant = as if missing — read guard
+        covers `Query.update()/delete()` per Task 1 spike (test_bot_tenant_guard).
+  - [x] Pre-existing rows = default tenant; internal responses unchanged —
+        `server_default="teamclaw"` backfill; `to_dict()` key set pinned (Task 3).
+  - [x] Existing internal API suite passes **unmodified** — full run **8998
+        passed, 3 skipped**; no existing test file's logic changed (only new
+        tests added and two README boundary declarations).
+  - [x] Tenant never leaks across requests, incl. after error — scope reset in
+        `finally` (middleware tests + 200-way concurrency probe, 0 mismatches).
+  - [x] Tenant readable by request-handling code — `get_current_avernet_tenant()`.
+  - [x] Work started during a request inherits the tenant — `bind_current_avernet_tenant`
+        on the five thread sites (Task 8).
+  - [x] Public-API tenant source is a single replaceable seam — `resolve_avernet_tenant`.
+  - [x] Isolation demonstrated by a test red without / green with — Task 4 (6
+        failed) → Task 5 (green).
+- **Gates:** Backend unit suite green locally (8998). Changed-line coverage and
+  singlebox coverage run on push (pre-push hook) and in PR CI; singlebox needs a
+  product stack not available in this sandbox, so it is validated by remote CI.
 - **Depends on:** Tasks 1–8 (and Task 9's decision)
 
 ---

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -6,16 +6,15 @@
 - **Goal:** Empirically settle whether a `do_orm_execute` listener applying
   `with_loader_criteria(BotModel, ...)` also constrains `Query.update()` /
   `Query.delete()`, or whether the write methods need an explicit filter.
-- **Files:** throwaway test under
-  `tests/community/plugins/` (not committed, or committed as an xfail probe then
-  removed) — no production change in this task.
+- **Files:** throwaway probe under `tests/community/plugins/` — no production
+  change in this task.
 - **Done when:**
   - [ ] A minimal reproduction inserts two bots under different tenants and runs
         `update_by_owner` / `soft_delete_by_owner` against the other tenant's bot
         with a prototype listener installed.
-  - [ ] The finding is recorded in `tasks.md` under this task: **covered** (read
-        path alone suffices) or **not covered** (write methods need an explicit
-        `_avernet_tenant()` filter — Task 5/6 adopt it).
+  - [ ] The finding is recorded under this task: **covered** (read path alone
+        suffices) or **not covered** (write methods need an explicit
+        `_avernet_tenant()` filter — Task 5 adopts it).
 - **Depends on:** —
 
 ## Task 2: Tenant context primitive
@@ -34,18 +33,20 @@
 - **Depends on:** —
 
 ## Task 3: `avernet_tenant` column on `BotModel`
-- **Goal:** Give bot records the tenant axis, stamped by default, invisible in
-  API responses.
+- **Goal:** Give bot records the tenant axis, stamped by the column default,
+  invisible in API responses.
 - **Files:** `src/agentclaw/community/plugin_api/models.py`,
-  `tests/community/...` (to_dict test).
+  `tests/community/...` (to_dict + insert-stamp tests).
 - **Done when:**
   - [ ] `BotModel` gains `avernet_tenant = Column(String(64),
         default=get_current_avernet_tenant, nullable=False)` after
         `caller_config_revision`.
   - [ ] `avernet_tenant` is **not** added to `BotModel.to_dict()`.
   - [ ] Test asserts `to_dict()`'s key set is unchanged from before this change.
-  - [ ] `create_all` on local SQLite builds the column (a fresh insert carries a
-        tenant without any caller passing one).
+  - [ ] Test: a bot inserted via `BotRepository.insert` inside
+        `avernet_tenant_scope("t1")` has `avernet_tenant == "t1"` — proving the
+        column default stamps inserts with no explicit stamp at the call site
+        (the listener never applies to `INSERT`).
 - **Depends on:** Task 2
 
 ## Task 4: Cross-tenant isolation test (red)
@@ -61,8 +62,8 @@
 - **Depends on:** Task 2, Task 3
 
 ## Task 5: `do_orm_execute` tenant guard (green)
-- **Goal:** Install the single listener that scopes every `BotModel` statement
-  to the current tenant; turn Task 4 green.
+- **Goal:** Install the single listener that scopes every `BotModel`
+  read/update/delete to the current tenant; turn Task 4 green.
 - **Files:** `src/agentclaw/community/plugin_api/models.py`,
   `tests/community/plugins/...`.
 - **Done when:**
@@ -81,18 +82,7 @@
         query sites are covered).
 - **Depends on:** Task 1, Task 3, Task 4
 
-## Task 6: Stamp `avernet_tenant` in `BotRepository.insert`
-- **Goal:** Make bot creation set the tenant explicitly, parity with `env`.
-- **Files:** `src/agentclaw/community/plugins/bot_repository.py`,
-  `tests/community/plugins/...`.
-- **Done when:**
-  - [ ] `insert` passes `avernet_tenant=get_current_avernet_tenant()` beside
-        `env=get_current_env()`.
-  - [ ] Test: a bot inserted inside `avernet_tenant_scope("t1")` has
-        `avernet_tenant == "t1"`.
-- **Depends on:** Task 3
-
-## Task 7: Public-API tenant source (`resolve_avernet_tenant`)
+## Task 6: Public-API tenant source (`resolve_avernet_tenant`)
 - **Goal:** Add the single replaceable seam for the public API's tenant.
 - **Files:** `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py`.
 - **Done when:**
@@ -102,7 +92,7 @@
   - [ ] No Protocol, no DI binding, no `app.py` / `container.py` change.
 - **Depends on:** Task 2
 
-## Task 8: `AvernetTenantMiddleware`
+## Task 7: `AvernetTenantMiddleware`
 - **Goal:** Establish each request's tenant for its whole lifetime, reset on the
   way out including on error.
 - **Files:** `src/agentclaw/community/adapters/http/middleware.py`,
@@ -117,9 +107,9 @@
   - [ ] Integration test: two sequential requests through the ASGI app — the
         second sees `teamclaw`; repeated where the first handler raises 500, the
         tenant still does not leak.
-- **Depends on:** Task 2, Task 7
+- **Depends on:** Task 2, Task 6
 
-## Task 9: Request-spawned work inherits the tenant
+## Task 8: Request-spawned work inherits the tenant
 - **Goal:** In-request background threads observe the request's tenant.
 - **Files:** `core/bot_management/services/bot_service.py` (3 sites),
   `core/service_bot/services/bot_publish_service.py`,
@@ -135,7 +125,7 @@
         spawning request's tenant.
 - **Depends on:** Task 2
 
-## Task 10: Reference DDL artifact — decision + optional file  `[!]`
+## Task 9: Reference DDL artifact — decision + optional file  `[!]`
 - **Goal:** Resolve the spec-vs-convention tension the plan flagged: the spec
   says no migration file is checked in, but repo convention checks a reference
   `.sql` into `core/<module>/sql/` (e.g. `caller_identity`).
@@ -147,20 +137,20 @@
         deploy-ordering note; if "plan only": this task is closed with no file.
 - **Depends on:** — (decision), Task 3 (if a file is added)
 
-## Task 11: Verification against spec acceptance criteria
+## Task 10: Verification against spec acceptance criteria
 - **Goal:** Prove every spec acceptance criterion holds.
 - **Files:** — (runs suites; no production change).
 - **Done when:**
   - [ ] The existing internal API test suite passes **unmodified**.
   - [ ] The cross-tenant isolation test (Task 4/5) is green; its earlier red run
         is on record.
-  - [ ] Non-leakage across requests (incl. post-error) is green (Task 8).
-  - [ ] Request-spawned work inherits the tenant (Task 9).
+  - [ ] Non-leakage across requests (incl. post-error) is green (Task 7).
+  - [ ] Request-spawned work inherits the tenant (Task 8).
   - [ ] `to_dict()` key set unchanged (Task 3) — internal responses identical.
   - [ ] Backend unit tests, changed-line coverage, and singlebox coverage pass
         (`AGENTS.md:131`); pre-push hooks installed via
         `scripts/install_git_hooks.sh`.
-- **Depends on:** Tasks 1–9 (and Task 10's decision)
+- **Depends on:** Tasks 1–8 (and Task 9's decision)
 
 ---
 
@@ -169,12 +159,13 @@
 - **Group A — Mechanism groundwork:** Tasks 1, 2
   - Theme: confirm the write-path approach and land the tenant `ContextVar`
     primitive; pure utility + investigation, no bot-data behavior change yet.
-- **Group B — ORM enforcement:** Tasks 3, 4, 5, 6
-  - Theme: bot records carry a tenant and every read/write is scoped at the ORM
-    layer; the spec's red→green cross-tenant isolation test passes.
-- **Group C — Request wiring & inheritance:** Tasks 7, 8, 9
+- **Group B — ORM enforcement:** Tasks 3, 4, 5
+  - Theme: bot records carry a tenant (stamped by the column default) and every
+    read/write is scoped at the ORM layer; the spec's red→green cross-tenant
+    isolation test passes.
+- **Group C — Request wiring & inheritance:** Tasks 6, 7, 8
   - Theme: each request establishes its tenant (reset even on error),
     request-spawned work inherits it, and the public-API seam exists.
-- **Group D — Finalize & verify:** Tasks 10, 11
+- **Group D — Finalize & verify:** Tasks 9, 10
   - Theme: resolve the checked-in-DDL decision and prove all spec acceptance
     criteria; green gates.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -22,19 +22,20 @@
   - [x] Finding recorded: **covered** — read path alone suffices for writes too.
 - **Depends on:** —
 
-## Task 2: Tenant context primitive
+## Task 2: Tenant context primitive  `[x]`
 - **Goal:** Add the request-lifetime tenant `ContextVar` and its helpers.
 - **Files:** `src/agentclaw/community/utils/avernet_tenant.py` (new),
-  `tests/community/...` (new unit test).
+  `tests/community/utils/test_avernet_tenant.py` (new).
 - **Done when:**
-  - [ ] `DEFAULT_AVERNET_TENANT = "teamclaw"`, `get_current_avernet_tenant() -> str`
+  - [x] `DEFAULT_AVERNET_TENANT = "teamclaw"`, `get_current_avernet_tenant() -> str`
         (total, never `None`), `avernet_tenant_scope(tenant_id)` context manager,
         and `bind_current_avernet_tenant(fn)` are implemented.
-  - [ ] Module docstring names the unrelated poolab/baas `tenant` concept so a
+  - [x] Module docstring names the unrelated poolab/baas `tenant` concept so a
         future reader does not conflate them.
-  - [ ] Tests: default outside a request; set/reset; nesting; reset still runs
+  - [x] Tests: default outside a request; set/reset; nesting; reset still runs
         when the scoped body raises; a thread wrapped by
-        `bind_current_avernet_tenant` observes the spawning tenant.
+        `bind_current_avernet_tenant` observes the spawning tenant (and a bare
+        thread does not). 7 passed.
 - **Depends on:** —
 
 ## Task 3: `avernet_tenant` column on `BotModel`

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -33,53 +33,64 @@
 - **Depends on:** —
 
 ## Task 3: `avernet_tenant` column on `BotModel`
-- **Goal:** Give bot records the tenant axis, stamped by the column default,
-  invisible in API responses.
+- **Goal:** Give bot records the tenant axis, invisible in API responses. The
+  column carries only a `server_default` for backfill; context-aware stamping is
+  the `before_insert` guard's job (Task 5).
 - **Files:** `src/agentclaw/community/plugin_api/models.py`,
-  `tests/community/...` (to_dict + insert-stamp tests).
+  `tests/community/...` (to_dict test).
 - **Done when:**
-  - [ ] `BotModel` gains `avernet_tenant = Column(String(64),
-        default=get_current_avernet_tenant, nullable=False)` after
-        `caller_config_revision`.
+  - [ ] `BotModel` gains `avernet_tenant = Column(String(64), nullable=False,
+        server_default="teamclaw")` after `caller_config_revision` (matches the
+        prod DDL `DEFAULT 'teamclaw'`, so `create_all` and the backfill agree).
   - [ ] `avernet_tenant` is **not** added to `BotModel.to_dict()`.
   - [ ] Test asserts `to_dict()`'s key set is unchanged from before this change.
-  - [ ] Test: a bot inserted via `BotRepository.insert` inside
-        `avernet_tenant_scope("t1")` has `avernet_tenant == "t1"` — proving the
-        column default stamps inserts with no explicit stamp at the call site
-        (the listener never applies to `INSERT`).
 - **Depends on:** Task 2
 
 ## Task 4: Cross-tenant isolation test (red)
-- **Goal:** Write the spec-required test that fails before the guard exists and
-  will pass after — and record its red run.
+- **Goal:** Write the spec-required test that fails before the guards exist and
+  passes after — and record its red run.
 - **Files:** `tests/community/plugins/...` (new).
 - **Done when:**
-  - [ ] Test inserts a bot under tenant A and asserts a read under tenant B does
-        not return it, across `get_by_id`, `get_by_id_and_owner`, `list_by_owner`,
-        `count_by_owner`, `exists_by_bot_name`, `search_bots`.
-  - [ ] With no listener yet, the test **fails**, and the red run is recorded in
-        the commit message / task notes.
+  - [ ] Test seeds a bot inside `avernet_tenant_scope("A")` and another inside
+        `avernet_tenant_scope("B")` via `BotRepository.insert`, then asserts a
+        read inside `avernet_tenant_scope("B")` does not return A's bot, across
+        `get_by_id`, `get_by_id_and_owner`, `list_by_owner`, `count_by_owner`,
+        `exists_by_bot_name`, `search_bots`.
+  - [ ] Run at this task's commit (column exists, guards not yet added) the test
+        **fails** — reads are unfiltered so B sees A's row — and the red run is
+        recorded in the commit message / task notes. Task 5 (both guards) turns
+        it green: the insert guard gives the two rows distinct tenants and the
+        read guard filters them.
 - **Depends on:** Task 2, Task 3
 
-## Task 5: `do_orm_execute` tenant guard (green)
-- **Goal:** Install the single listener that scopes every `BotModel`
-  read/update/delete to the current tenant; turn Task 4 green.
+## Task 5: Tenant guards — read filter + insert stamp (green)
+- **Goal:** Install both active guards that scope `BotModel` to the current
+  tenant; turn Task 4 green. Reads/updates/deletes are filtered; inserts are
+  stamped and validated.
 - **Files:** `src/agentclaw/community/plugin_api/models.py`,
   `tests/community/plugins/...`.
 - **Done when:**
-  - [ ] Listener registered via `event.listens_for(Session, "do_orm_execute")`
-        at model import; registration idempotent on a module-level flag.
-  - [ ] Applies `with_loader_criteria(BotModel, avernet_tenant ==
-        get_current_avernet_tenant())`; honors `include_aliases` for joins;
-        skips statements carrying `{"skip_avernet_tenant_guard": True}`.
-  - [ ] Write coverage matches the Task 1 finding: if writes are not covered by
-        the listener, `update_by_owner` / `soft_delete_by_owner` get an explicit
+  - [ ] **Read guard:** registered via `event.listens_for(Session,
+        "do_orm_execute")` at model import; applies `with_loader_criteria(BotModel,
+        avernet_tenant == get_current_avernet_tenant())`; honors `include_aliases`
+        for joins; skips statements carrying `{"skip_avernet_tenant_guard": True}`.
+  - [ ] **Insert guard:** registered via `event.listens_for(BotModel,
+        "before_insert")`; stamps `avernet_tenant = get_current_avernet_tenant()`
+        when unset and raises `CrossTenantInsertError` when a different tenant was
+        explicitly set. Covers every insert path, not just `BotRepository.insert`.
+  - [ ] Both registrations idempotent on a module-level flag.
+  - [ ] Write coverage matches the Task 1 finding: if `Query.update()` /
+        `Query.delete()` are not covered by the read listener,
+        `update_by_owner` / `soft_delete_by_owner` get an explicit
         `_avernet_tenant()` filter.
-  - [ ] Task 4's test passes. Added tests: cross-tenant `update_by_owner` /
-        `soft_delete_by_owner` return `None` / `False` and leave the row
-        untouched (indistinguishable from missing); a bare
-        `session.query(BotModel).all()` is filtered (proves non-repository
-        query sites are covered).
+  - [ ] Task 4's test passes. Added tests:
+        - cross-tenant `update_by_owner` / `soft_delete_by_owner` return `None` /
+          `False` and leave the row untouched (indistinguishable from missing);
+        - a bare `session.query(BotModel).all()` is filtered (proves
+          non-repository query sites are covered);
+        - an insert under `avernet_tenant_scope("B")` is stamped `"B"` with no
+          explicit stamp at the call site; an explicit conflicting-tenant insert
+          raises `CrossTenantInsertError`.
 - **Depends on:** Task 1, Task 3, Task 4
 
 ## Task 6: Public-API tenant source (`resolve_avernet_tenant`)
@@ -160,9 +171,9 @@
   - Theme: confirm the write-path approach and land the tenant `ContextVar`
     primitive; pure utility + investigation, no bot-data behavior change yet.
 - **Group B — ORM enforcement:** Tasks 3, 4, 5
-  - Theme: bot records carry a tenant (stamped by the column default) and every
-    read/write is scoped at the ORM layer; the spec's red→green cross-tenant
-    isolation test passes.
+  - Theme: bot records carry a tenant, every read/update/delete is filtered and
+    every insert is stamped+validated at the ORM layer (two active guards); the
+    spec's red→green cross-tenant isolation test passes.
 - **Group C — Request wiring & inheritance:** Tasks 6, 7, 8
   - Theme: each request establishes its tenant (reset even on error),
     request-spawned work inherits it, and the public-API seam exists.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -116,9 +116,11 @@
 - **Files:** `src/agentclaw/community/adapters/http/middleware.py`,
   `tests/community/adapters/http/test_avernet_tenant_middleware.py` (new).
 - **Done when:**
-  - [x] `AvernetTenantMiddleware.dispatch` picks `resolve_avernet_tenant(request)`
-        for `/openapi/v1/*` paths, else `DEFAULT_AVERNET_TENANT`; enters
-        `avernet_tenant_scope`; awaits `call_next`.
+  - [x] `AvernetTenantMiddleware` (a **pure ASGI** middleware, not
+        `BaseHTTPMiddleware`, for `ContextVar`-propagation robustness) picks
+        `resolve_avernet_tenant(request)` for `/openapi/v1/*` paths, else
+        `DEFAULT_AVERNET_TENANT`; enters `avernet_tenant_scope`; awaits the
+        downstream app.
   - [x] Added in `install_middleware` immediately after `UserContextMiddleware`
         so it is outside it (auth plugin DB reads run under the tenant); no new
         `install_middleware` parameter.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -233,7 +233,14 @@
 - **Verification:** 1005 tests pass across bot_dormant / desktop_bot /
   bot_management.
 
-### F2: Tenant index — deferred (see plan Data Model Changes)
-- No index in Stage 1 (cardinality-1 column; existing indexes stay effective).
-  At multi-tenant, prepend `avernet_tenant` to the hot composites via
-  create-new-then-drop-old (naming convention ties index name to columns).
+### F2: Tenant-leading indexes — MANDATORY policy, deferred  `[ ]`
+- Tenant-leading indexes on a tenant-columned table are a **mandatory corp
+  policy** (confirmed by user 2026-07-27). Consciously deferred to the dedicated
+  index-adding work — **not** an exemption; must be completed before multi-tenant.
+- No index in Stage 1: cardinality-1 column, existing indexes stay effective, so
+  it buys nothing yet (see plan Data Model Changes for the full rationale).
+- When done: prepend `avernet_tenant` to the query-backing composites
+  (`idx_owner`, `idx_bot_id_entity_id`, `idx_entity`, search index) via
+  create-new-then-drop-old (naming convention ties index name to columns;
+  create before drop so no index-less window). Leave low-cardinality
+  (`idx_status`, `idx_is_delete`) and unique-lookup (`idx_binding_id`) indexes.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -38,18 +38,20 @@
         thread does not). 7 passed.
 - **Depends on:** —
 
-## Task 3: `avernet_tenant` column on `BotModel`
+## Task 3: `avernet_tenant` column on `BotModel`  `[x]`
 - **Goal:** Give bot records the tenant axis, invisible in API responses. The
   column carries only a `server_default` for backfill; context-aware stamping is
   the `before_insert` guard's job (Task 5).
 - **Files:** `src/agentclaw/community/plugin_api/models.py`,
-  `tests/community/...` (to_dict test).
+  `tests/community/plugin_api/test_models.py`.
 - **Done when:**
-  - [ ] `BotModel` gains `avernet_tenant = Column(String(64), nullable=False,
+  - [x] `BotModel` gains `avernet_tenant = Column(String(64), nullable=False,
         server_default="teamclaw")` after `caller_config_revision` (matches the
         prod DDL `DEFAULT 'teamclaw'`, so `create_all` and the backfill agree).
-  - [ ] `avernet_tenant` is **not** added to `BotModel.to_dict()`.
-  - [ ] Test asserts `to_dict()`'s key set is unchanged from before this change.
+  - [x] `avernet_tenant` is **not** added to `BotModel.to_dict()`.
+  - [x] Test asserts `to_dict()`'s key set is unchanged (pins the full 26-key
+        set; a seeded row carries `avernet_tenant == "teamclaw"` via the
+        server_default). 5 model tests pass; existing 32 repo tests still green.
 - **Depends on:** Task 2
 
 ## Task 4: Cross-tenant isolation test (red)

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -100,14 +100,14 @@
         bot_dormant / bot_chat / cleanup — the global guard regresses nothing.
 - **Depends on:** Task 1, Task 3, Task 4
 
-## Task 6: Public-API tenant source (`resolve_avernet_tenant`)
+## Task 6: Public-API tenant source (`resolve_avernet_tenant`)  `[x]`
 - **Goal:** Add the single replaceable seam for the public API's tenant.
 - **Files:** `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py`.
 - **Done when:**
-  - [ ] Plain function `resolve_avernet_tenant(request) -> str` returns
+  - [x] Plain function `resolve_avernet_tenant(request) -> str` returns
         `DEFAULT_AVERNET_TENANT`, beside `require_principal`, same stub pattern,
         docstring marking it the drop-in point for the real verifier.
-  - [ ] No Protocol, no DI binding, no `app.py` / `container.py` change.
+  - [x] No Protocol, no DI binding, no `app.py` / `container.py` change.
 - **Depends on:** Task 2
 
 ## Task 7: `AvernetTenantMiddleware`

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -73,34 +73,31 @@
         is recorded above.
 - **Depends on:** Task 2, Task 3
 
-## Task 5: Tenant guards — read filter + insert stamp (green)
+## Task 5: Tenant guards — read filter + insert stamp (green)  `[x]`
 - **Goal:** Install both active guards that scope `BotModel` to the current
   tenant; turn Task 4 green. Reads/updates/deletes are filtered; inserts are
   stamped and validated.
 - **Files:** `src/agentclaw/community/plugin_api/models.py`,
-  `tests/community/plugins/...`.
+  `tests/community/plugins/test_bot_tenant_guard.py` (new).
 - **Done when:**
-  - [ ] **Read guard:** registered via `event.listens_for(Session,
-        "do_orm_execute")` at model import; applies `with_loader_criteria(BotModel,
-        avernet_tenant == get_current_avernet_tenant())`; honors `include_aliases`
-        for joins; skips statements carrying `{"skip_avernet_tenant_guard": True}`.
-  - [ ] **Insert guard:** registered via `event.listens_for(BotModel,
-        "before_insert")`; stamps `avernet_tenant = get_current_avernet_tenant()`
-        when unset and raises `CrossTenantInsertError` when a different tenant was
-        explicitly set. Covers every insert path, not just `BotRepository.insert`.
-  - [ ] Both registrations idempotent on a module-level flag.
-  - [ ] Write coverage matches the Task 1 finding: if `Query.update()` /
-        `Query.delete()` are not covered by the read listener,
-        `update_by_owner` / `soft_delete_by_owner` get an explicit
-        `_avernet_tenant()` filter.
-  - [ ] Task 4's test passes. Added tests:
-        - cross-tenant `update_by_owner` / `soft_delete_by_owner` return `None` /
-          `False` and leave the row untouched (indistinguishable from missing);
-        - a bare `session.query(BotModel).all()` is filtered (proves
-          non-repository query sites are covered);
-        - an insert under `avernet_tenant_scope("B")` is stamped `"B"` with no
-          explicit stamp at the call site; an explicit conflicting-tenant insert
-          raises `CrossTenantInsertError`.
+  - [x] **Read guard:** `event.listen(Session, "do_orm_execute", ...)` at model
+        import; applies `with_loader_criteria(BotModel, avernet_tenant ==
+        get_current_avernet_tenant(), include_aliases=True)`; skips column /
+        relationship loads (already-authorized reloads) and statements carrying
+        `{"skip_avernet_tenant_guard": True}`.
+  - [x] **Insert guard:** `event.listen(BotModel, "before_insert", ...)`; stamps
+        `avernet_tenant` when unset, raises `CrossTenantInsertError` on an
+        explicit conflicting tenant. Covers every insert path.
+  - [x] Both registrations idempotent on `_AVERNET_TENANT_GUARDS_INSTALLED`.
+  - [x] Per the Task 1 finding, **no** explicit write-method filter added — the
+        read listener covers `Query.update()` / `Query.delete()`.
+  - [x] Task 4's isolation test passes (7). Added guard tests (7): cross-tenant
+        `update_by_owner` / `soft_delete_by_owner` are no-ops and leave the row
+        untouched; a bare `session.query(BotModel).all()` is filtered; insert
+        under a scope stamps that tenant (default outside a request); an explicit
+        conflicting-tenant insert raises `CrossTenantInsertError`; the skip option
+        sees all tenants. **1212 passed** across plugins / plugin_api /
+        bot_dormant / bot_chat / cleanup — the global guard regresses nothing.
 - **Depends on:** Task 1, Task 3, Task 4
 
 ## Task 6: Public-API tenant source (`resolve_avernet_tenant`)

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -1,0 +1,180 @@
+# Tasks: Tenant Isolation Foundation (Stage 1)
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+## Task 1: Spike — confirm listener covers ORM writes
+- **Goal:** Empirically settle whether a `do_orm_execute` listener applying
+  `with_loader_criteria(BotModel, ...)` also constrains `Query.update()` /
+  `Query.delete()`, or whether the write methods need an explicit filter.
+- **Files:** throwaway test under
+  `tests/community/plugins/` (not committed, or committed as an xfail probe then
+  removed) — no production change in this task.
+- **Done when:**
+  - [ ] A minimal reproduction inserts two bots under different tenants and runs
+        `update_by_owner` / `soft_delete_by_owner` against the other tenant's bot
+        with a prototype listener installed.
+  - [ ] The finding is recorded in `tasks.md` under this task: **covered** (read
+        path alone suffices) or **not covered** (write methods need an explicit
+        `_avernet_tenant()` filter — Task 5/6 adopt it).
+- **Depends on:** —
+
+## Task 2: Tenant context primitive
+- **Goal:** Add the request-lifetime tenant `ContextVar` and its helpers.
+- **Files:** `src/agentclaw/community/utils/avernet_tenant.py` (new),
+  `tests/community/...` (new unit test).
+- **Done when:**
+  - [ ] `DEFAULT_AVERNET_TENANT = "teamclaw"`, `get_current_avernet_tenant() -> str`
+        (total, never `None`), `avernet_tenant_scope(tenant_id)` context manager,
+        and `bind_current_avernet_tenant(fn)` are implemented.
+  - [ ] Module docstring names the unrelated poolab/baas `tenant` concept so a
+        future reader does not conflate them.
+  - [ ] Tests: default outside a request; set/reset; nesting; reset still runs
+        when the scoped body raises; a thread wrapped by
+        `bind_current_avernet_tenant` observes the spawning tenant.
+- **Depends on:** —
+
+## Task 3: `avernet_tenant` column on `BotModel`
+- **Goal:** Give bot records the tenant axis, stamped by default, invisible in
+  API responses.
+- **Files:** `src/agentclaw/community/plugin_api/models.py`,
+  `tests/community/...` (to_dict test).
+- **Done when:**
+  - [ ] `BotModel` gains `avernet_tenant = Column(String(64),
+        default=get_current_avernet_tenant, nullable=False)` after
+        `caller_config_revision`.
+  - [ ] `avernet_tenant` is **not** added to `BotModel.to_dict()`.
+  - [ ] Test asserts `to_dict()`'s key set is unchanged from before this change.
+  - [ ] `create_all` on local SQLite builds the column (a fresh insert carries a
+        tenant without any caller passing one).
+- **Depends on:** Task 2
+
+## Task 4: Cross-tenant isolation test (red)
+- **Goal:** Write the spec-required test that fails before the guard exists and
+  will pass after — and record its red run.
+- **Files:** `tests/community/plugins/...` (new).
+- **Done when:**
+  - [ ] Test inserts a bot under tenant A and asserts a read under tenant B does
+        not return it, across `get_by_id`, `get_by_id_and_owner`, `list_by_owner`,
+        `count_by_owner`, `exists_by_bot_name`, `search_bots`.
+  - [ ] With no listener yet, the test **fails**, and the red run is recorded in
+        the commit message / task notes.
+- **Depends on:** Task 2, Task 3
+
+## Task 5: `do_orm_execute` tenant guard (green)
+- **Goal:** Install the single listener that scopes every `BotModel` statement
+  to the current tenant; turn Task 4 green.
+- **Files:** `src/agentclaw/community/plugin_api/models.py`,
+  `tests/community/plugins/...`.
+- **Done when:**
+  - [ ] Listener registered via `event.listens_for(Session, "do_orm_execute")`
+        at model import; registration idempotent on a module-level flag.
+  - [ ] Applies `with_loader_criteria(BotModel, avernet_tenant ==
+        get_current_avernet_tenant())`; honors `include_aliases` for joins;
+        skips statements carrying `{"skip_avernet_tenant_guard": True}`.
+  - [ ] Write coverage matches the Task 1 finding: if writes are not covered by
+        the listener, `update_by_owner` / `soft_delete_by_owner` get an explicit
+        `_avernet_tenant()` filter.
+  - [ ] Task 4's test passes. Added tests: cross-tenant `update_by_owner` /
+        `soft_delete_by_owner` return `None` / `False` and leave the row
+        untouched (indistinguishable from missing); a bare
+        `session.query(BotModel).all()` is filtered (proves non-repository
+        query sites are covered).
+- **Depends on:** Task 1, Task 3, Task 4
+
+## Task 6: Stamp `avernet_tenant` in `BotRepository.insert`
+- **Goal:** Make bot creation set the tenant explicitly, parity with `env`.
+- **Files:** `src/agentclaw/community/plugins/bot_repository.py`,
+  `tests/community/plugins/...`.
+- **Done when:**
+  - [ ] `insert` passes `avernet_tenant=get_current_avernet_tenant()` beside
+        `env=get_current_env()`.
+  - [ ] Test: a bot inserted inside `avernet_tenant_scope("t1")` has
+        `avernet_tenant == "t1"`.
+- **Depends on:** Task 3
+
+## Task 7: Public-API tenant source (`resolve_avernet_tenant`)
+- **Goal:** Add the single replaceable seam for the public API's tenant.
+- **Files:** `src/agentclaw/community/adapters/http/openapi_v1/dependencies.py`.
+- **Done when:**
+  - [ ] Plain function `resolve_avernet_tenant(request) -> str` returns
+        `DEFAULT_AVERNET_TENANT`, beside `require_principal`, same stub pattern,
+        docstring marking it the drop-in point for the real verifier.
+  - [ ] No Protocol, no DI binding, no `app.py` / `container.py` change.
+- **Depends on:** Task 2
+
+## Task 8: `AvernetTenantMiddleware`
+- **Goal:** Establish each request's tenant for its whole lifetime, reset on the
+  way out including on error.
+- **Files:** `src/agentclaw/community/adapters/http/middleware.py`,
+  `tests/community/...` (integration).
+- **Done when:**
+  - [ ] `AvernetTenantMiddleware.dispatch` picks `resolve_avernet_tenant(request)`
+        for `/openapi/v1/*` paths, else `DEFAULT_AVERNET_TENANT`; enters
+        `avernet_tenant_scope`; awaits `call_next`.
+  - [ ] Added in `install_middleware` immediately after `UserContextMiddleware`
+        so it is outside it (auth plugin DB reads run under the tenant); no new
+        `install_middleware` parameter.
+  - [ ] Integration test: two sequential requests through the ASGI app — the
+        second sees `teamclaw`; repeated where the first handler raises 500, the
+        tenant still does not leak.
+- **Depends on:** Task 2, Task 7
+
+## Task 9: Request-spawned work inherits the tenant
+- **Goal:** In-request background threads observe the request's tenant.
+- **Files:** `core/bot_management/services/bot_service.py` (3 sites),
+  `core/service_bot/services/bot_publish_service.py`,
+  `core/bot_collaborator/services/collaborator_service.py`,
+  `tests/community/...`.
+- **Done when:**
+  - [ ] The five `threading.Thread` targets listed in the plan are wrapped with
+        `bind_current_avernet_tenant` (or the tenant is otherwise captured and
+        re-established inside the thread).
+  - [ ] `asyncio.create_task` sites are left unchanged (verified they inherit
+        context).
+  - [ ] Test: a bot operation performed on a spawned thread runs under the
+        spawning request's tenant.
+- **Depends on:** Task 2
+
+## Task 10: Reference DDL artifact — decision + optional file  `[!]`
+- **Goal:** Resolve the spec-vs-convention tension the plan flagged: the spec
+  says no migration file is checked in, but repo convention checks a reference
+  `.sql` into `core/<module>/sql/` (e.g. `caller_identity`).
+- **Files:** possibly `src/agentclaw/community/core/.../sql/2026_07_26_avernet_tenant.sql` (new).
+- **Done when:**
+  - [ ] User confirms: keep DDL in `plan.md` only (spec's stance) **or** also
+        check in a reference `.sql` (convention). Pending that decision.
+  - [ ] If "check in": the file carries exactly the plan's `ALTER TABLE` and the
+        deploy-ordering note; if "plan only": this task is closed with no file.
+- **Depends on:** — (decision), Task 3 (if a file is added)
+
+## Task 11: Verification against spec acceptance criteria
+- **Goal:** Prove every spec acceptance criterion holds.
+- **Files:** — (runs suites; no production change).
+- **Done when:**
+  - [ ] The existing internal API test suite passes **unmodified**.
+  - [ ] The cross-tenant isolation test (Task 4/5) is green; its earlier red run
+        is on record.
+  - [ ] Non-leakage across requests (incl. post-error) is green (Task 8).
+  - [ ] Request-spawned work inherits the tenant (Task 9).
+  - [ ] `to_dict()` key set unchanged (Task 3) — internal responses identical.
+  - [ ] Backend unit tests, changed-line coverage, and singlebox coverage pass
+        (`AGENTS.md:131`); pre-push hooks installed via
+        `scripts/install_git_hooks.sh`.
+- **Depends on:** Tasks 1–9 (and Task 10's decision)
+
+---
+
+## Groups
+
+- **Group A — Mechanism groundwork:** Tasks 1, 2
+  - Theme: confirm the write-path approach and land the tenant `ContextVar`
+    primitive; pure utility + investigation, no bot-data behavior change yet.
+- **Group B — ORM enforcement:** Tasks 3, 4, 5, 6
+  - Theme: bot records carry a tenant and every read/write is scoped at the ORM
+    layer; the spec's red→green cross-tenant isolation test passes.
+- **Group C — Request wiring & inheritance:** Tasks 7, 8, 9
+  - Theme: each request establishes its tenant (reset even on error),
+    request-spawned work inherits it, and the public-API seam exists.
+- **Group D — Finalize & verify:** Tasks 10, 11
+  - Theme: resolve the checked-in-DDL decision and prove all spec acceptance
+    criteria; green gates.

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -136,17 +136,15 @@
         spawning request's tenant.
 - **Depends on:** Task 2
 
-## Task 9: Reference DDL artifact — decision + optional file  `[!]`
-- **Goal:** Resolve the spec-vs-convention tension the plan flagged: the spec
-  says no migration file is checked in, but repo convention checks a reference
-  `.sql` into `core/<module>/sql/` (e.g. `caller_identity`).
-- **Files:** possibly `src/agentclaw/community/core/.../sql/2026_07_26_avernet_tenant.sql` (new).
+## Task 9: Reference DDL artifact — decision  `[x]`
+- **Goal:** Resolve the spec-vs-convention tension the plan flagged.
+- **Decision (user, 2026-07-26):** **No DDL file is checked in.** The schema
+  change is always applied out-of-band on the platform; the `ALTER TABLE` in
+  `plan.md` remains the authoritative record. No file to add — this task is
+  closed with no production change.
 - **Done when:**
-  - [ ] User confirms: keep DDL in `plan.md` only (spec's stance) **or** also
-        check in a reference `.sql` (convention). Pending that decision.
-  - [ ] If "check in": the file carries exactly the plan's `ALTER TABLE` and the
-        deploy-ordering note; if "plan only": this task is closed with no file.
-- **Depends on:** — (decision), Task 3 (if a file is added)
+  - [x] Decision recorded; no `.sql` committed.
+- **Depends on:** —
 
 ## Task 10: Verification against spec acceptance criteria
 - **Goal:** Prove every spec acceptance criterion holds.

--- a/src/backend/src/agentclaw/community/adapters/http/middleware.py
+++ b/src/backend/src/agentclaw/community/adapters/http/middleware.py
@@ -18,6 +18,7 @@ from urllib.parse import parse_qsl, urlencode
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.avernet_tenant import (
@@ -115,7 +116,7 @@ class UserContextMiddleware(BaseHTTPMiddleware):
 # =============================================================================
 # AvernetTenantMiddleware
 # =============================================================================
-class AvernetTenantMiddleware(BaseHTTPMiddleware):
+class AvernetTenantMiddleware:
     """Bind each request's data-isolation tenant for the request's lifetime.
 
     Public-API requests (``/openapi/v1/*``) resolve their tenant through the
@@ -124,24 +125,39 @@ class AvernetTenantMiddleware(BaseHTTPMiddleware):
     resets on the way out (including on error), so a tenant never survives its
     request or leaks into the next one that reuses the worker.
 
+    Deliberately a **pure ASGI middleware, not ``BaseHTTPMiddleware``**. The
+    tenant lives in a ``ContextVar``, and ``BaseHTTPMiddleware`` has a fragile
+    history with context propagation (it runs the downstream app in a child
+    anyio task, so which context a ``set``/``reset`` lands in has depended on the
+    Starlette version). A pure ASGI middleware sets the ``ContextVar`` in the
+    exact coroutine/context that then awaits the downstream app and resets it in
+    that same context — no task hop, so visibility downstream and a correct
+    reset are guaranteed regardless of Starlette internals.
+
     Installed *outside* ``UserContextMiddleware`` (see ``install_middleware``) so
     the auth plugin's own DB reads already run under the request's tenant.
     """
 
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path.startswith("/openapi/v1/"):
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if scope["path"].startswith("/openapi/v1/"):
             # Lazy import: the openapi_v1 package pulls in every public router,
-            # so keep it off the middleware module-load path (matches the
-            # lazy-import style UserContextMiddleware uses for auth).
+            # so keep it off the middleware module-load path.
             from agentclaw.community.adapters.http.openapi_v1.dependencies import (
                 resolve_avernet_tenant,
             )
-            tenant = resolve_avernet_tenant(request)
+            tenant = resolve_avernet_tenant(Request(scope))
         else:
             tenant = DEFAULT_AVERNET_TENANT
 
         with avernet_tenant_scope(tenant):
-            return await call_next(request)
+            await self.app(scope, receive, send)
 
 
 # =============================================================================

--- a/src/backend/src/agentclaw/community/adapters/http/middleware.py
+++ b/src/backend/src/agentclaw/community/adapters/http/middleware.py
@@ -20,6 +20,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from agentclaw.community.log import get_logger
+from agentclaw.community.utils.avernet_tenant import (
+    DEFAULT_AVERNET_TENANT,
+    avernet_tenant_scope,
+)
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -106,6 +110,38 @@ class UserContextMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         return response
+
+
+# =============================================================================
+# AvernetTenantMiddleware
+# =============================================================================
+class AvernetTenantMiddleware(BaseHTTPMiddleware):
+    """Bind each request's data-isolation tenant for the request's lifetime.
+
+    Public-API requests (``/openapi/v1/*``) resolve their tenant through the
+    single seam ``resolve_avernet_tenant``; every other path — the internal API
+    and anything non-public — is the default tenant. ``avernet_tenant_scope``
+    resets on the way out (including on error), so a tenant never survives its
+    request or leaks into the next one that reuses the worker.
+
+    Installed *outside* ``UserContextMiddleware`` (see ``install_middleware``) so
+    the auth plugin's own DB reads already run under the request's tenant.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path.startswith("/openapi/v1/"):
+            # Lazy import: the openapi_v1 package pulls in every public router,
+            # so keep it off the middleware module-load path (matches the
+            # lazy-import style UserContextMiddleware uses for auth).
+            from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+                resolve_avernet_tenant,
+            )
+            tenant = resolve_avernet_tenant(request)
+        else:
+            tenant = DEFAULT_AVERNET_TENANT
+
+        with avernet_tenant_scope(tenant):
+            return await call_next(request)
 
 
 # =============================================================================
@@ -240,6 +276,12 @@ def install_middleware(
 
     # 注入用户上下文中间件（在 CORS 之后，tracer 之前）
     app.add_middleware(UserContextMiddleware, auth_plugin=auth_plugin)
+
+    # Establish the request's avernet_tenant. Added right after (so, outside)
+    # UserContextMiddleware — Starlette prepends, so a later add is outer — so
+    # the auth plugin's own DB reads run under the request's tenant. No injected
+    # dependency: resolve_avernet_tenant is one function for every profile.
+    app.add_middleware(AvernetTenantMiddleware)
 
     # 关联前端 X-Request-ID 与 trace id（在 tracer 中间件内部运行）
     app.add_middleware(TraceIdMappingMiddleware, tracer=tracer)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from fastapi import Request
+
+from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
+
 # Placeholder principal type for the definition-only stubs.
 Principal = Any
 
@@ -17,3 +21,19 @@ Principal = Any
 async def require_principal() -> Principal:
     """Stub principal dependency — replaced by the gateway-JWT verifier."""
     return None
+
+
+def resolve_avernet_tenant(request: Request) -> str:
+    """Return the data-isolation tenant a public-API request belongs to.
+
+    The single replaceable seam for the public API's tenant, mirroring
+    ``require_principal``: one implementation for every deploy profile (there is
+    one gateway contract), replaced in place — not a per-profile DI binding.
+
+    Placeholder for now — every public request resolves to the default tenant,
+    so Stage 1 wires the seam without changing behavior. When the gateway
+    forwards a verified principal, the auth workstream reads the tenant from
+    ``request`` here; no endpoint or middleware changes when it lands.
+    """
+    del request  # unused until the real verifier reads the forwarded principal
+    return DEFAULT_AVERNET_TENANT

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
@@ -13,6 +13,7 @@ from agentclaw.community.core.bot_collaborator.models import (
 )
 from agentclaw.community.core.bot_collaborator.repository.protocol import CollaboratorRepositoryProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
@@ -50,7 +51,9 @@ def _run_coro_blocking(coro: Any) -> Any:
         except BaseException as e:  # noqa: BLE001 - 透传给调用线程统一处理
             box["error"] = e
 
-    thread = threading.Thread(target=_runner, daemon=True)
+    thread = threading.Thread(
+        target=bind_current_avernet_tenant(_runner), daemon=True
+    )
     thread.start()
     thread.join()
 

--- a/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
@@ -18,6 +18,7 @@ from injector import inject
 from agentclaw.community.core.bot_dormant.protocols import BotServiceProtocol
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.passport import PassportError, PassportPlugin
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 
 
 logger = get_logger()
@@ -85,7 +86,7 @@ class ActivateBotService:
 
         # Launch background task: unfreeze passport → start_bot; rollback on failure.
         thread = threading.Thread(
-            target=self._reactivate_async,
+            target=bind_current_avernet_tenant(self._reactivate_async),
             args=(bot_id, user_id, nick_name or user_id),
             daemon=True,
         )

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -51,6 +51,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.http_client
   - agentclaw.community.plugin_api.passport
   - agentclaw.community.plugin_api.auth_relationship
+  - agentclaw.community.utils.avernet_tenant
   - agentclaw.community.utils.env_utils
   - agentclaw.community.utils.secret_utils
 ```

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -60,6 +60,7 @@ from agentclaw.community.core.workspace.path_factory import (
 )
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.core.devices.errors import (
     DeviceNotFoundError,
@@ -1615,7 +1616,9 @@ class BotService:
                         )
 
         # Start device allocation in background thread
-        thread = threading.Thread(target=do_allocate, daemon=True)
+        thread = threading.Thread(
+            target=bind_current_avernet_tenant(do_allocate), daemon=True
+        )
         thread.start()
         logger.info(f"[bot_service._allocate_device_async] Started background thread for bot {bot_id} device allocation")
 
@@ -2253,7 +2256,7 @@ class BotService:
                                 )
 
                         threading.Thread(
-                            target=_update_cron_workflow,
+                            target=bind_current_avernet_tenant(_update_cron_workflow),
                             name=f"cron-workflow-update-{bot_id}",
                             daemon=True,
                         ).start()
@@ -2369,7 +2372,7 @@ class BotService:
             return
 
         thread = threading.Thread(
-            target=self._refresh_codefuse_token_on_device,
+            target=bind_current_avernet_tenant(self._refresh_codefuse_token_on_device),
             kwargs={"bot_id": bot_id, "user_id": user_id, "plaintext_token": plaintext},
             daemon=True,
             name=f"refresh-codefuse-token-{bot_id}",

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -4091,10 +4091,14 @@ class BotService:
                     return index, None, str(e)
 
             # 使用线程池并行申请设备
+            # ThreadPoolExecutor threads do NOT copy context vars, so bind the
+            # request's tenant onto the submitted callable (captured now, in the
+            # request thread) — each worker then runs under the right tenant.
+            _apply_single_device = bind_current_avernet_tenant(apply_single_device)
             with concurrent.futures.ThreadPoolExecutor(max_workers=min(instance_count, 10)) as executor:
                 # 提交所有任务
                 future_to_index = {
-                    executor.submit(apply_single_device, i): i for i in range(instance_count)
+                    executor.submit(_apply_single_device, i): i for i in range(instance_count)
                 }
 
                 # 收集结果

--- a/src/backend/src/agentclaw/community/core/desktop_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/desktop_bot/README.md
@@ -27,6 +27,7 @@ internal_dependencies:
   - agentclaw.community.log
   - agentclaw.community.plugin_api.cache
   - agentclaw.community.plugin_api.passport
+  - agentclaw.community.utils.avernet_tenant
   - agentclaw.community.utils.env_utils
 ```
 

--- a/src/backend/src/agentclaw/community/core/desktop_bot/services/desktop_bot_service.py
+++ b/src/backend/src/agentclaw/community/core/desktop_bot/services/desktop_bot_service.py
@@ -34,6 +34,7 @@ from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE, SU
 from agentclaw.community.core.errors import NotFound
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.passport import PassportPlugin, PassportError
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 
 if TYPE_CHECKING:
@@ -1606,7 +1607,7 @@ class DesktopBotService:
     ) -> None:
         """启动后台线程轮询 publish 进度。"""
         thread = threading.Thread(
-            target=self._poll_publish_progress,
+            target=bind_current_avernet_tenant(self._poll_publish_progress),
             args=(publish_id, binding_id, bot_id, owner_id, device_id, engine_type),
             daemon=True,
             name=f"poll-publish-{publish_id}",

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -10,6 +10,7 @@ from agentclaw.community.core.devices.repository.protocol import DeviceBindingRe
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.service_bot.services.publish_rollback_mixin import PublishRollbackMixin
 from agentclaw.community.core.service_bot.types import PublishStage
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
@@ -1160,7 +1161,9 @@ class BotPublishService(PublishRollbackMixin):
                 except Exception as e:
                     logger.warning(f"[upgrade_bot_to_service] Failed to restart bot: bot_id={bot_id}, owner_id={owner_id}, error={e}")
 
-            threading.Thread(target=_do_restart, daemon=True).start()
+            threading.Thread(
+                target=bind_current_avernet_tenant(_do_restart), daemon=True
+            ).start()
 
         # 8. 检查是否已有发布记录，有则不创建
         existing = self._repo.get_by_publish_bot_id(bot_id, owner_id, self._env)

--- a/src/backend/src/agentclaw/community/plugin_api/README.md
+++ b/src/backend/src/agentclaw/community/plugin_api/README.md
@@ -19,6 +19,7 @@ internal_dependencies:
   - agentclaw.community.core.service_bot.types                  # PublishStage enum, default value in BaasServiceProtocol signatures
   - agentclaw.community.core.workspace
   - agentclaw.community.kernel.device_dto                       # OutBoundOperationRule — typed in OutboundRuleProvider + BaasServiceProtocol (B6)
+  - agentclaw.community.utils.avernet_tenant                    # BotModel tenant guards read the request's current tenant
   - agentclaw.community.utils.env_utils
 ```
 

--- a/src/backend/src/agentclaw/community/plugin_api/models.py
+++ b/src/backend/src/agentclaw/community/plugin_api/models.py
@@ -56,6 +56,13 @@ class BotModel(Base):
     template_type = Column(String(64), nullable=True)  # 模板类型，如 applicationCoding
     call_type = Column(String(16), default="owner", nullable=False)
     caller_config_revision = Column(BigInteger, default=0, nullable=False)
+    # Data-isolation tenant (see utils/avernet_tenant + the BotModel guards
+    # below). server_default (not a Python default=) so create_all emits the
+    # same DEFAULT 'teamclaw' prod's out-of-band DDL applies, backfilling
+    # existing rows and covering any non-ORM insert; the context-aware value on
+    # ORM inserts comes from the before_insert guard. Deliberately absent from
+    # to_dict() so no current API response body changes.
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""

--- a/src/backend/src/agentclaw/community/plugin_api/models.py
+++ b/src/backend/src/agentclaw/community/plugin_api/models.py
@@ -126,9 +126,11 @@ def _avernet_tenant_read_guard(orm_execute_state) -> None:
 
     Column and relationship loads are skipped: they only reload an object that a
     prior (already tenant-filtered) SELECT put in the session, so they carry no
-    new exposure. An explicit ``skip_avernet_tenant_guard`` execution option
-    opts a statement out (the guard's own tests seeding/inspecting across
-    tenants).
+    new exposure. This holds because nothing maps a ``relationship()`` to
+    ``BotModel``; if one is ever added, a lazy load would emit an unfiltered
+    ``ac_bots`` SELECT — revisit this skip then. An explicit
+    ``skip_avernet_tenant_guard`` execution option opts a statement out (the
+    guard's own tests seeding/inspecting across tenants).
     """
     if orm_execute_state.is_column_load or orm_execute_state.is_relationship_load:
         return
@@ -150,7 +152,14 @@ def _avernet_tenant_read_guard(orm_execute_state) -> None:
 
 
 def _avernet_tenant_insert_guard(_mapper, _connection, target: "BotModel") -> None:
-    """Stamp the current tenant on a new ``BotModel``; reject a conflicting one."""
+    """Stamp the current tenant on a new ``BotModel``; reject a conflicting one.
+
+    ``before_insert`` covers ORM unit-of-work inserts (``session.add`` + flush),
+    which is the only insert path today (``bot_repository.insert``). Core/bulk
+    inserts (``session.execute(insert(BotModel))``, ``bulk_insert_mappings``)
+    bypass this event and would fall to ``server_default="teamclaw"``; none
+    exist now — add an equivalent stamp if one is ever introduced.
+    """
     current = get_current_avernet_tenant()
     if target.avernet_tenant is None:
         target.avernet_tenant = current

--- a/src/backend/src/agentclaw/community/plugin_api/models.py
+++ b/src/backend/src/agentclaw/community/plugin_api/models.py
@@ -6,7 +6,8 @@ in the full OpenClaw server layer.
 """
 import json
 
-from sqlalchemy import BigInteger, Column, DateTime, Index, Integer, SmallInteger, String, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Column, DateTime, Index, Integer, SmallInteger, String, Text, UniqueConstraint, event
+from sqlalchemy.orm import Session, with_loader_criteria
 from sqlalchemy.sql import func
 
 from agentclaw.community.core.base import Base  # noqa: F401  — canonical registry lives in core/
@@ -14,6 +15,7 @@ from agentclaw.community.core.workspace.constants import (  # noqa: E402,F401
     DEFAULT_ENGINE_TYPE,
     SUPPORTED_ENGINE_TYPES,
 )
+from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant  # noqa: E402
 from agentclaw.community.utils.env_utils import get_current_env  # noqa: E402
 
 
@@ -94,6 +96,85 @@ class BotModel(Base):
             "call_type": self.call_type,
             "caller_config_revision": self.caller_config_revision,
         }
+
+
+# ── Avernet tenant guards (welded to BotModel) ──────────────────────
+#
+# Two active halves of one isolation guarantee, both keyed on the request's
+# current tenant (utils/avernet_tenant) and both impossible to forget because
+# neither lives at a call site:
+#
+#   * read guard  — a do_orm_execute listener that appends a tenant WHERE
+#     clause to every SELECT/UPDATE/DELETE touching BotModel (the spike in
+#     specs/.../tasks.md Task 1 confirmed with_loader_criteria constrains the
+#     Query.update()/delete() shape bot_repository uses, so writes need no
+#     per-method filter);
+#   * insert guard — a before_insert listener that stamps the tenant on every
+#     new row (an INSERT has no WHERE, so the read guard cannot reach it) and
+#     refuses a row that explicitly names a different tenant.
+#
+# Registered on the Session class / the mapped class, so they apply in every
+# runtime (local SQLite, prod OceanBase, the out-of-tree corp DatabasePlugin).
+
+
+class CrossTenantInsertError(RuntimeError):
+    """A ``BotModel`` insert named a tenant other than the request's current one."""
+
+
+def _avernet_tenant_read_guard(orm_execute_state) -> None:
+    """Confine every ``BotModel`` SELECT/UPDATE/DELETE to the current tenant.
+
+    Column and relationship loads are skipped: they only reload an object that a
+    prior (already tenant-filtered) SELECT put in the session, so they carry no
+    new exposure. An explicit ``skip_avernet_tenant_guard`` execution option
+    opts a statement out (the guard's own tests seeding/inspecting across
+    tenants).
+    """
+    if orm_execute_state.is_column_load or orm_execute_state.is_relationship_load:
+        return
+    if not (
+        orm_execute_state.is_select
+        or orm_execute_state.is_update
+        or orm_execute_state.is_delete
+    ):
+        return
+    if orm_execute_state.execution_options.get("skip_avernet_tenant_guard"):
+        return
+    orm_execute_state.statement = orm_execute_state.statement.options(
+        with_loader_criteria(
+            BotModel,
+            BotModel.avernet_tenant == get_current_avernet_tenant(),
+            include_aliases=True,
+        )
+    )
+
+
+def _avernet_tenant_insert_guard(_mapper, _connection, target: "BotModel") -> None:
+    """Stamp the current tenant on a new ``BotModel``; reject a conflicting one."""
+    current = get_current_avernet_tenant()
+    if target.avernet_tenant is None:
+        target.avernet_tenant = current
+    elif target.avernet_tenant != current:
+        raise CrossTenantInsertError(
+            f"bot insert names tenant {target.avernet_tenant!r} but the request "
+            f"tenant is {current!r}"
+        )
+
+
+_AVERNET_TENANT_GUARDS_INSTALLED = False
+
+
+def _install_avernet_tenant_guards() -> None:
+    """Register both guards once. Idempotent so a re-import cannot double-register."""
+    global _AVERNET_TENANT_GUARDS_INSTALLED
+    if _AVERNET_TENANT_GUARDS_INSTALLED:
+        return
+    event.listen(Session, "do_orm_execute", _avernet_tenant_read_guard)
+    event.listen(BotModel, "before_insert", _avernet_tenant_insert_guard)
+    _AVERNET_TENANT_GUARDS_INSTALLED = True
+
+
+_install_avernet_tenant_guards()
 
 
 class ResourceModel(Base):

--- a/src/backend/src/agentclaw/community/utils/avernet_tenant.py
+++ b/src/backend/src/agentclaw/community/utils/avernet_tenant.py
@@ -1,0 +1,83 @@
+"""The Avernet data-isolation tenant, carried per request.
+
+Every bot read and write is confined to one *tenant* so the public API can
+serve a registered external tenant without ever seeing, or being seen by, the
+existing internal one. This module owns the tenant carrier: a task-local
+``ContextVar`` set once per request (by ``AvernetTenantMiddleware``) and read
+wherever enforcement happens (the ``BotModel`` guards in ``plugin_api/models``).
+
+It is the exact analogue of ``utils/env_utils`` — a low-level, dependency-free
+carrier for a request-scoped scalar — and mirrors how the community tracer
+carries its per-request trace id (``plugins/community/tracer``).
+
+NOTE — this is NOT the poolab sandbox-allocator ``tenant`` that appears in
+``core/service_bot/services/baas_service`` (the ``tenant`` / ``tenant_id`` on
+the BaaS provisioning path). That is an unrelated concept: a hint forwarded to
+the sandbox allocator, not a data-isolation key. The ``avernet_tenant`` prefix
+throughout this feature keeps the two from being conflated.
+"""
+from __future__ import annotations
+
+import functools
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Callable, Final, Iterator, ParamSpec, TypeVar
+
+# The fallback tenant. It owns every bot record that predates this feature and
+# every request that does not identify a tenant (the entire internal API, plus
+# background work). ``teamclaw`` is the internal product's own name; it must
+# never be offered to an external registered tenant.
+DEFAULT_AVERNET_TENANT: Final[str] = "teamclaw"
+
+# Task-local current tenant. The default makes ``get_current_avernet_tenant`` a
+# total function: there is always a tenant, even outside a request.
+_CURRENT_TENANT: ContextVar[str] = ContextVar(
+    "avernet_tenant", default=DEFAULT_AVERNET_TENANT
+)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def get_current_avernet_tenant() -> str:
+    """Return the tenant the current request belongs to.
+
+    Total function — returns :data:`DEFAULT_AVERNET_TENANT` outside any request
+    (background/scheduled work, ad-hoc scripts), never ``None``.
+    """
+    return _CURRENT_TENANT.get()
+
+
+@contextmanager
+def avernet_tenant_scope(tenant_id: str) -> Iterator[None]:
+    """Bind ``tenant_id`` for the duration of the ``with`` block.
+
+    The reset in ``finally`` always runs — including when the body raises — so a
+    tenant can never survive its scope or leak into the next request that reuses
+    the worker.
+    """
+    token = _CURRENT_TENANT.set(tenant_id)
+    try:
+        yield
+    finally:
+        _CURRENT_TENANT.reset(token)
+
+
+def bind_current_avernet_tenant(fn: Callable[P, R]) -> Callable[P, R]:
+    """Wrap ``fn`` so it runs under the tenant current at *bind* time.
+
+    ``threading.Thread`` does not copy context vars into the new thread, so a
+    thread spawned during a request would otherwise fall back to the default
+    tenant. Wrapping its target with this captures the request's tenant now and
+    re-establishes it inside the thread when the target runs.
+
+    (``asyncio.create_task`` needs no wrapping — it copies the current context.)
+    """
+    tenant = get_current_avernet_tenant()
+
+    @functools.wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        with avernet_tenant_scope(tenant):
+            return fn(*args, **kwargs)
+
+    return wrapper

--- a/src/backend/tests/community/adapters/http/test_avernet_tenant_middleware.py
+++ b/src/backend/tests/community/adapters/http/test_avernet_tenant_middleware.py
@@ -1,0 +1,84 @@
+"""AvernetTenantMiddleware — per-request tenant, reset on the way out.
+
+Proves the spec's non-leakage criteria at the ASGI boundary: a request's tenant
+is established for its lifetime and never leaks into the next request, including
+after a request fails with an error.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import agentclaw.community.adapters.http.openapi_v1.dependencies as deps
+from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
+from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
+
+pytestmark = pytest.mark.integration
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AvernetTenantMiddleware)
+
+    @app.get("/openapi/v1/bots/whoami")
+    def public_whoami():
+        return {"tenant": get_current_avernet_tenant()}
+
+    @app.get("/internal/whoami")
+    def internal_whoami():
+        return {"tenant": get_current_avernet_tenant()}
+
+    @app.get("/openapi/v1/bots/boom")
+    def boom():
+        raise RuntimeError("handler blew up")
+
+    return app
+
+
+def test_default_tenant_for_every_path():
+    # Stage 1: the seam resolves to the default tenant, and non-public paths use
+    # it too — so every current response is unchanged.
+    client = TestClient(_app())
+    assert client.get("/openapi/v1/bots/whoami").json()["tenant"] == "teamclaw"
+    assert client.get("/internal/whoami").json()["tenant"] == "teamclaw"
+
+
+def test_public_request_uses_resolved_tenant(monkeypatch):
+    # Simulate the future verifier: resolve the tenant from a forwarded header.
+    monkeypatch.setattr(
+        deps, "resolve_avernet_tenant", lambda req: req.headers.get("x-tenant", "teamclaw")
+    )
+    client = TestClient(_app())
+    r = client.get("/openapi/v1/bots/whoami", headers={"x-tenant": "acme"})
+    assert r.json()["tenant"] == "acme"
+
+
+def test_tenant_does_not_leak_between_requests(monkeypatch):
+    monkeypatch.setattr(
+        deps, "resolve_avernet_tenant", lambda req: req.headers.get("x-tenant", "teamclaw")
+    )
+    client = TestClient(_app())
+    # Request 1 runs under "acme"...
+    assert (
+        client.get("/openapi/v1/bots/whoami", headers={"x-tenant": "acme"}).json()[
+            "tenant"
+        ]
+        == "acme"
+    )
+    # ...request 2 (no header, internal path) must see the default, not "acme".
+    assert client.get("/internal/whoami").json()["tenant"] == "teamclaw"
+
+
+def test_tenant_does_not_leak_after_error(monkeypatch):
+    monkeypatch.setattr(
+        deps, "resolve_avernet_tenant", lambda req: req.headers.get("x-tenant", "teamclaw")
+    )
+    client = TestClient(_app(), raise_server_exceptions=False)
+    # A request that fails mid-handler under "acme"...
+    assert (
+        client.get("/openapi/v1/bots/boom", headers={"x-tenant": "acme"}).status_code
+        == 500
+    )
+    # ...must still reset — the next request sees the default tenant.
+    assert client.get("/internal/whoami").json()["tenant"] == "teamclaw"

--- a/src/backend/tests/community/core/test_request_spawned_tenant_inheritance.py
+++ b/src/backend/tests/community/core/test_request_spawned_tenant_inheritance.py
@@ -1,0 +1,81 @@
+"""Request-spawned threads inherit the request's avernet_tenant.
+
+Task 8 wraps five in-request ``threading.Thread`` targets with
+``bind_current_avernet_tenant`` (bot_service ×3, bot_publish_service,
+collaborator_service). These tests exercise the exact spawn shapes used at
+those sites — ``target`` only, ``target`` + ``kwargs``, and a run-and-join
+helper — so the wrapping contract they depend on stays intact.
+"""
+import threading
+
+import pytest
+
+from agentclaw.community.utils.avernet_tenant import (
+    DEFAULT_AVERNET_TENANT,
+    avernet_tenant_scope,
+    bind_current_avernet_tenant,
+    get_current_avernet_tenant,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_target_only_thread_inherits_tenant():
+    """Shape used by do_allocate / _update_cron_workflow / _do_restart."""
+    seen = {}
+
+    def work():
+        seen["tenant"] = get_current_avernet_tenant()
+
+    with avernet_tenant_scope("acme"):
+        t = threading.Thread(target=bind_current_avernet_tenant(work), daemon=True)
+    t.start()
+    t.join()
+    assert seen["tenant"] == "acme"
+
+
+def test_thread_with_kwargs_inherits_tenant_and_passes_kwargs():
+    """Shape used by _refresh_codefuse_token_on_device (target + kwargs)."""
+    seen = {}
+
+    def work(*, bot_id, user_id):
+        seen["tenant"] = get_current_avernet_tenant()
+        seen["bot_id"] = bot_id
+        seen["user_id"] = user_id
+
+    with avernet_tenant_scope("acme"):
+        t = threading.Thread(
+            target=bind_current_avernet_tenant(work),
+            kwargs={"bot_id": "b1", "user_id": "u1"},
+            daemon=True,
+        )
+    t.start()
+    t.join()
+    assert seen == {"tenant": "acme", "bot_id": "b1", "user_id": "u1"}
+
+
+def test_run_and_join_helper_inherits_tenant():
+    """Shape used by collaborator_service._run_coro_blocking (spawn + join)."""
+    box = {}
+
+    def runner():
+        box["tenant"] = get_current_avernet_tenant()
+
+    with avernet_tenant_scope("acme"):
+        t = threading.Thread(target=bind_current_avernet_tenant(runner), daemon=True)
+        t.start()
+        t.join()
+    assert box["tenant"] == "acme"
+
+
+def test_default_tenant_when_spawned_outside_a_request():
+    """Wrapping outside any scope captures the default — background-safe."""
+    seen = {}
+
+    def work():
+        seen["tenant"] = get_current_avernet_tenant()
+
+    t = threading.Thread(target=bind_current_avernet_tenant(work), daemon=True)
+    t.start()
+    t.join()
+    assert seen["tenant"] == DEFAULT_AVERNET_TENANT

--- a/src/backend/tests/community/plugin_api/test_models.py
+++ b/src/backend/tests/community/plugin_api/test_models.py
@@ -153,6 +153,68 @@ class TestBotModelToDict:
         for field in required_fields:
             assert field in result, f"Field '{field}' is missing from to_dict result"
 
+    def test_to_dict_key_set_unchanged_by_avernet_tenant(self, db):
+        """The avernet_tenant column must NOT surface in to_dict().
+
+        Isolation adds a column but must not change any current internal API
+        response body — so to_dict()'s exact key set stays what it was before
+        this feature. Pinning the full set here fails loudly if avernet_tenant
+        (or anything else) ever leaks in.
+        """
+        expected_keys = {
+            "id",
+            "bot_id",
+            "bot_name",
+            "bot_desc",
+            "entity_id",
+            "entity_type",
+            "creator_id",
+            "owner_id",
+            "owner_name",
+            "engine_types",
+            "active_engine",
+            "status",
+            "binding_id",
+            "device_id",
+            "gmt_create",
+            "gmt_modified",
+            "modifier_id",
+            "share_policy",
+            "is_delete",
+            "public",
+            "ext",
+            "env",
+            "bot_type",
+            "template_type",
+            "call_type",
+            "caller_config_revision",
+        }
+
+        bot = BotModel(
+            bot_id="test-bot",
+            bot_name="Test Bot",
+            bot_desc="Test description",
+            entity_id="entity-1",
+            entity_type="staff",
+            creator_id="user-1",
+            owner_id="user-1",
+            owner_name="Test User",
+            status="ACTIVE",
+        )
+
+        with db.orm_session() as session:
+            session.add(bot)
+            session.flush()
+            session.refresh(bot)
+            # The column exists and is populated on the row...
+            assert bot.avernet_tenant == "teamclaw"
+            result = bot.to_dict()
+
+        # ...but it is absent from the serialized form, and the full key set is
+        # exactly what it was before isolation.
+        assert "avernet_tenant" not in result
+        assert set(result.keys()) == expected_keys
+
     def test_to_dict_handles_json_fields(self, db):
         """Test that to_dict properly serializes JSON fields."""
         bot = BotModel(

--- a/src/backend/tests/community/plugins/test_bot_tenant_guard.py
+++ b/src/backend/tests/community/plugins/test_bot_tenant_guard.py
@@ -1,0 +1,171 @@
+"""Tenant guard behavior beyond the read path: writes, inserts, non-repository
+queries, and the escape hatch.
+
+Complements ``test_bot_tenant_isolation.py`` (the spec's read red→green test).
+"""
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
+from agentclaw.community.core.service_bot.repository.models import BotPublishModel
+from agentclaw.community.plugin_api.models import BotModel, CrossTenantInsertError
+from agentclaw.community.plugins.bot_repository import BotRepository
+from agentclaw.community.plugins.local.sqlite_models import EntityDeviceBinding
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+pytestmark = pytest.mark.integration
+
+
+class _FileSqliteDB:
+    def __init__(self, engine):
+        self._factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    session = orm_session
+
+
+@pytest.fixture
+def db(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'bots.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    BotModel.__table__.create(engine)
+    BotPublishModel.__table__.create(engine)
+    EntityDeviceBinding.__table__.create(engine)
+    BotCollaboratorModel.__table__.create(engine)
+    return _FileSqliteDB(engine)
+
+
+@pytest.fixture
+def repo(db):
+    return BotRepository(db)
+
+
+def _data(**ov):
+    base = dict(
+        bot_id="bot-1",
+        bot_name="Bot One",
+        bot_desc="d",
+        entity_id="staff_x",
+        entity_type="staff",
+        creator_id="emp1",
+        owner_id="emp1",
+        status="ACTIVE",
+        owner_name="Alice",
+    )
+    base.update(ov)
+    return base
+
+
+# ── insert guard: stamping ──────────────────────────────────────────
+
+def test_insert_stamps_current_tenant(repo, db):
+    with avernet_tenant_scope("tenant-b"):
+        repo.insert(_data(bot_id="bot-b", owner_id="own-b"))
+    # Read the raw row across tenants via the escape hatch to assert the value.
+    with db.orm_session() as s:
+        row = (
+            s.query(BotModel)
+            .execution_options(skip_avernet_tenant_guard=True)
+            .filter(BotModel.bot_id == "bot-b")
+            .one()
+        )
+        assert row.avernet_tenant == "tenant-b"
+
+
+def test_insert_outside_any_request_stamps_default_tenant(repo, db):
+    # No scope → the default tenant, keeping current internal behavior.
+    repo.insert(_data(bot_id="bot-d", owner_id="own-d"))
+    with db.orm_session() as s:
+        row = (
+            s.query(BotModel)
+            .execution_options(skip_avernet_tenant_guard=True)
+            .filter(BotModel.bot_id == "bot-d")
+            .one()
+        )
+        assert row.avernet_tenant == "teamclaw"
+
+
+# ── insert guard: rejection ─────────────────────────────────────────
+
+def test_explicit_conflicting_tenant_insert_raises(db):
+    with avernet_tenant_scope("tenant-b"):
+        with pytest.raises(CrossTenantInsertError):
+            with db.orm_session() as s:
+                s.add(
+                    BotModel(
+                        bot_id="bot-evil",
+                        entity_id="e",
+                        entity_type="staff",
+                        creator_id="c",
+                        owner_id="o",
+                        avernet_tenant="tenant-a",  # != current context
+                    )
+                )
+                s.flush()
+
+
+# ── write guards: cross-tenant update / delete are no-ops ────────────
+
+def test_update_by_owner_cross_tenant_is_noop(repo):
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a", bot_name="Alpha"))
+    with avernet_tenant_scope("tenant-b"):
+        result = repo.update_by_owner("bot-a", "own-a", {"bot_name": "HACKED"})
+        assert result is None  # indistinguishable from a missing row
+    with avernet_tenant_scope("tenant-a"):
+        assert repo.get_by_id("bot-a")["bot_name"] == "Alpha"  # untouched
+
+
+def test_soft_delete_by_owner_cross_tenant_is_noop(repo):
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a"))
+    with avernet_tenant_scope("tenant-b"):
+        assert repo.soft_delete_by_owner("bot-a", "own-a") is False
+    with avernet_tenant_scope("tenant-a"):
+        assert repo.get_by_id("bot-a") is not None  # still there
+
+
+# ── non-repository access is filtered too ───────────────────────────
+
+def test_bare_session_query_is_filtered(repo, db):
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a"))
+    with avernet_tenant_scope("tenant-b"):
+        repo.insert(_data(bot_id="bot-b", owner_id="own-b"))
+    # A direct query — the shape the nine non-repository modules use — is
+    # filtered without them adding any tenant clause.
+    with avernet_tenant_scope("tenant-b"):
+        with db.orm_session() as s:
+            rows = s.query(BotModel).all()
+            assert [r.bot_id for r in rows] == ["bot-b"]
+
+
+def test_skip_option_sees_all_tenants(repo, db):
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a"))
+    with avernet_tenant_scope("tenant-b"):
+        repo.insert(_data(bot_id="bot-b", owner_id="own-b"))
+    with avernet_tenant_scope("tenant-b"):
+        with db.orm_session() as s:
+            rows = (
+                s.query(BotModel)
+                .execution_options(skip_avernet_tenant_guard=True)
+                .all()
+            )
+            assert {r.bot_id for r in rows} == {"bot-a", "bot-b"}

--- a/src/backend/tests/community/plugins/test_bot_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_bot_tenant_isolation.py
@@ -1,0 +1,134 @@
+"""Cross-tenant isolation for bot records (spec's red→green test).
+
+This is the test the spec requires to FAIL before the tenant guards exist and
+PASS after. Written at Task 4 (column present, guards absent) it fails: reads
+are unfiltered, so a read under tenant B sees tenant A's bot. Task 5 installs
+the `before_insert` stamp (giving the two seeded rows distinct tenants) and the
+`do_orm_execute` read filter (confining every read to the current tenant), which
+turns it green.
+"""
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
+from agentclaw.community.core.service_bot.repository.models import BotPublishModel
+from agentclaw.community.plugin_api.models import BotModel
+from agentclaw.community.plugins.bot_repository import BotRepository
+from agentclaw.community.plugins.local.sqlite_models import EntityDeviceBinding
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+pytestmark = pytest.mark.integration
+
+
+class _FileSqliteDB:
+    def __init__(self, engine):
+        self._factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    session = orm_session
+
+
+@pytest.fixture
+def repo(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'bots.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    BotModel.__table__.create(engine)
+    BotPublishModel.__table__.create(engine)
+    EntityDeviceBinding.__table__.create(engine)
+    BotCollaboratorModel.__table__.create(engine)
+    return BotRepository(_FileSqliteDB(engine))
+
+
+def _data(**ov):
+    base = dict(
+        bot_id="bot-1",
+        bot_name="Bot One",
+        bot_desc="d",
+        entity_id="staff_x",
+        entity_type="staff",
+        creator_id="emp1",
+        owner_id="emp1",
+        status="ACTIVE",
+        owner_name="Alice",
+    )
+    base.update(ov)
+    return base
+
+
+@pytest.fixture
+def two_tenant_bots(repo):
+    """Seed one bot for tenant A and one for tenant B, each under its scope."""
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a", bot_name="Alpha Bot"))
+    with avernet_tenant_scope("tenant-b"):
+        repo.insert(_data(bot_id="bot-b", owner_id="own-b", bot_name="Beta Bot"))
+    return repo
+
+
+def test_read_by_id_is_tenant_scoped(two_tenant_bots):
+    repo = two_tenant_bots
+    with avernet_tenant_scope("tenant-b"):
+        # Tenant B can see its own bot...
+        assert repo.get_by_id("bot-b") is not None
+        # ...but never tenant A's.
+        assert repo.get_by_id("bot-a") is None
+
+
+def test_read_by_id_and_owner_is_tenant_scoped(two_tenant_bots):
+    repo = two_tenant_bots
+    with avernet_tenant_scope("tenant-b"):
+        assert repo.get_by_id_and_owner("bot-a", "own-a") is None
+
+
+def test_list_by_owner_is_tenant_scoped(two_tenant_bots):
+    repo = two_tenant_bots
+    with avernet_tenant_scope("tenant-b"):
+        total, items = repo.list_by_owner("own-a")
+        assert total == 0
+        assert items == []
+
+
+def test_count_by_owner_is_tenant_scoped(two_tenant_bots):
+    repo = two_tenant_bots
+    with avernet_tenant_scope("tenant-b"):
+        assert repo.count_by_owner("own-a") == 0
+
+
+def test_exists_by_bot_name_is_tenant_scoped(two_tenant_bots):
+    repo = two_tenant_bots
+    with avernet_tenant_scope("tenant-b"):
+        assert repo.exists_by_bot_name("Alpha Bot") is False
+
+
+def test_search_bots_is_tenant_scoped(two_tenant_bots):
+    repo = two_tenant_bots
+    with avernet_tenant_scope("tenant-b"):
+        total, items = repo.search_bots(key="Alpha")
+        assert total == 0
+        assert items == []
+
+
+def test_own_tenant_still_visible(two_tenant_bots):
+    """Isolation must not hide a tenant's own data."""
+    repo = two_tenant_bots
+    with avernet_tenant_scope("tenant-a"):
+        assert repo.get_by_id("bot-a") is not None
+        assert repo.exists_by_bot_name("Alpha Bot") is True
+        total, _ = repo.list_by_owner("own-a")
+        assert total == 1

--- a/src/backend/tests/community/utils/test_avernet_tenant.py
+++ b/src/backend/tests/community/utils/test_avernet_tenant.py
@@ -1,0 +1,85 @@
+"""Unit tests for the Avernet tenant context carrier."""
+import threading
+
+import pytest
+
+from agentclaw.community.utils.avernet_tenant import (
+    DEFAULT_AVERNET_TENANT,
+    avernet_tenant_scope,
+    bind_current_avernet_tenant,
+    get_current_avernet_tenant,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_outside_any_scope():
+    assert get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT
+    assert DEFAULT_AVERNET_TENANT == "teamclaw"
+
+
+def test_scope_sets_and_resets():
+    assert get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT
+    with avernet_tenant_scope("acme"):
+        assert get_current_avernet_tenant() == "acme"
+    assert get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT
+
+
+def test_scope_nesting():
+    with avernet_tenant_scope("outer"):
+        assert get_current_avernet_tenant() == "outer"
+        with avernet_tenant_scope("inner"):
+            assert get_current_avernet_tenant() == "inner"
+        assert get_current_avernet_tenant() == "outer"
+    assert get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT
+
+
+def test_scope_resets_even_when_body_raises():
+    with pytest.raises(RuntimeError):
+        with avernet_tenant_scope("acme"):
+            assert get_current_avernet_tenant() == "acme"
+            raise RuntimeError("boom")
+    # The tenant must not survive a failed request.
+    assert get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT
+
+
+def test_bind_current_tenant_carries_into_thread():
+    seen: dict[str, str] = {}
+
+    def work() -> None:
+        seen["tenant"] = get_current_avernet_tenant()
+
+    with avernet_tenant_scope("acme"):
+        # A bare thread would NOT copy the context var; the wrapper must.
+        target = bind_current_avernet_tenant(work)
+    # Bind captured "acme"; the thread runs after the scope has exited.
+    t = threading.Thread(target=target)
+    t.start()
+    t.join()
+
+    assert seen["tenant"] == "acme"
+
+
+def test_bare_thread_does_not_inherit_tenant():
+    # Guards the premise of bind_current_avernet_tenant: without it, a spawned
+    # thread falls back to the default tenant.
+    seen: dict[str, str] = {}
+
+    def work() -> None:
+        seen["tenant"] = get_current_avernet_tenant()
+
+    with avernet_tenant_scope("acme"):
+        t = threading.Thread(target=work)
+        t.start()
+        t.join()
+
+    assert seen["tenant"] == DEFAULT_AVERNET_TENANT
+
+
+def test_bind_preserves_args_and_return():
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    with avernet_tenant_scope("acme"):
+        bound = bind_current_avernet_tenant(add)
+    assert bound(2, 3) == 5


### PR DESCRIPTION
## What

Session 0 of the `/openapi/v1/bots` public API work — the tenant-isolation
foundation that the per-category handler sessions depend on.

**Currently in this PR: the SDD spec only** (`specify` phase). Implementation
follows in subsequent commits after the spec and plan are reviewed.

`src/backend/specs/2026-07-26-tenant-isolation-foundation/spec.md`

## Why

The public API surface exists as route definitions with no implementations. Its
callers are external registered tenants; the internal `/api/...` callers are
not. Both are served by the same application, backed by the same tables,
repositories and services.

So isolation cannot be added endpoint-by-endpoint as each public category is
implemented — the first implemented public endpoint would read internal data. It
has to exist underneath both surfaces first.

Isolation is currently absent, not partial: no bot record carries a tenant and
no query filters by one. The nearest existing concept, the `env` column, is
process-global (`utils/env_utils.py:68` reads `SERVER_ENV`/`REAL_SERVER_ENV`/
`ALIPAY_APP_ENV`) and cannot vary per caller, so it cannot stand in.

## Scope of Stage 1

Mechanism plus `ac_bots`. Later stages apply the same mechanism to
`ac_resource`, `ac_channel_config` and the skill/mcp/routine tables.

Planned approach: a request-scoped tenant carrier read by the repository through
a private predicate helper, mirroring how `plugins/bot_repository.py` already
handles `env` — ambient `_env()` at line 135 for the common path, with
`get_live_by_id_owner_and_env(env=...)` beside it as the explicit-override
variant. This keeps repository and service signatures unchanged, so no legacy
call site moves.

This departs from the handoff doc's §4.2 step 2, which prescribes an explicit
tenant parameter on every read/write/list/count/delete signature; `BotRepository`
alone has 28 protocol methods. The departure is recorded in the spec.

## Notes for reviewers

Three findings from grounding the handoff doc against HEAD that changed the
plan:

- **`OperatorContext.tenant_id` is not free to repurpose.** The handoff calls the
  hardcoded `tenant_id="default"` at `bot_management/services/bot_service.py:100`
  inert. It is inert as far as SQL goes, but it flows
  `adapters/http/devices/dependencies.py:31` →
  `service_bot/services/baas_service.py:1397` `deploy_config["poolab_tenant_id"]`
  — a sandbox-allocator hint sent upstream. Different concept, left untouched.
- **`ac_file` is dead.** `BotFileServiceFactory` is bound in DI
  (`di/modules/resources_module.py:66`) but `.create()` has no production caller,
  nothing injects `FileRepositoryProtocol` outside tests, and
  `tests/community/endpoints/test_resources_teclaw_writes.py` pins the absence of
  `ac_file` rows as the contract. Excluded here; removal is a separate cleanup.
- **No migration file is checked in.** Production DDL is submitted and executed
  on the platform out-of-band. `plan.md` will therefore carry the exact required
  column shape and the ordering constraint — the `ALTER TABLE` must land before
  this code reaches an environment, since the repository predicate references a
  column the ORM does not create in prod.

## Testing

No code changes yet, so no behavior to test in this commit. The implementation
commits will carry:

- context-carrier unit tests (default, set/reset, no leak across requests
  including after an error)
- a test proving the request's tenant is visible inside a handler, not only in
  the layer that set it
- cross-tenant isolation on the bot repository, red on unfixed HEAD
- the existing internal API suite green and unmodified

`coverage_baseline.txt` is untouched throughout: this work adds no routes and
implements no `/openapi/v1` handler.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SqDH8bzzVrweu7RwWWS94)_