### PR TITLE
feat: safely finalize Skills Pool cutover

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/resources/file_search_download_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/resources/file_search_download_router.py
@@ -51,6 +51,7 @@ from agentclaw.community.adapters.http.resources.file_router import _resolve_par
 from agentclaw.community.core.services.resource_file_service import (
     _HIDDEN_BASENAMES,
     _HIDDEN_DIRNAMES,
+    _POOL_SKILLS_LOCAL_RELPATH,
     _SKILLS_LOCAL_RELPATH,
     is_readonly,
 )
@@ -109,9 +110,12 @@ def _passes_search_filter(rel_path: str) -> bool:
         return False
     top = segments[0]
     if top in _HIDDEN_DIRNAMES:
-        return (
-            rel_path == _SKILLS_LOCAL_RELPATH
-            or rel_path.startswith(_SKILLS_LOCAL_RELPATH + "/")
+        return any(
+            rel_path == local_path or rel_path.startswith(local_path + "/")
+            for local_path in (
+                _SKILLS_LOCAL_RELPATH,
+                _POOL_SKILLS_LOCAL_RELPATH,
+            )
         )
     if len(segments) == 1 and top in _HIDDEN_BASENAMES:
         return False
@@ -134,10 +138,14 @@ def _search_should_descend(ws_dir_rel: str) -> bool:
         return True
     # Hidden system dir: descend only along the skills/skills-local path so the
     # injected subtree stays reachable; everything else under it is pruned.
-    return (
-        ws_dir_rel == _SKILLS_LOCAL_RELPATH.split("/")[0]  # "skills" — on the way down
-        or ws_dir_rel == _SKILLS_LOCAL_RELPATH
-        or ws_dir_rel.startswith(_SKILLS_LOCAL_RELPATH + "/")
+    return any(
+        ws_dir_rel == local_path.split("/")[0]
+        or ws_dir_rel == local_path
+        or ws_dir_rel.startswith(local_path + "/")
+        for local_path in (
+            _SKILLS_LOCAL_RELPATH,
+            _POOL_SKILLS_LOCAL_RELPATH,
+        )
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
@@ -98,7 +98,6 @@ async def set_rollout_feature(
             service.set_feature_enabled(
                 env=get_current_env(),
                 enabled=request.enabled,
-                engine=request.engine,
                 operator=user.staffId,
                 reason=request.reason,
             )
@@ -142,6 +141,7 @@ async def set_full_rollout(
             service.set_full_rollout(
                 env=get_current_env(),
                 enabled=request.enabled,
+                engine=request.engine,
                 operator=user.staffId,
                 reason=request.reason,
             )

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
@@ -31,6 +31,7 @@ from agentclaw.community.adapters.http.skills_pool.schemas import (
     ControlBotRequest,
     EnginePromotionRequest,
     FeatureToggleRequest,
+    FullRolloutRequest,
     RepairRequest,
     RollbackRequest,
     WhitelistAddRequest,
@@ -97,6 +98,7 @@ async def set_rollout_feature(
             service.set_feature_enabled(
                 env=get_current_env(),
                 enabled=request.enabled,
+                engine=request.engine,
                 operator=user.staffId,
                 reason=request.reason,
             )
@@ -121,6 +123,27 @@ async def promote_engine(
                 operator=user.staffId,
                 reason=request.reason,
                 acceptance_batch_id=request.acceptance_batch_id,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/full", response_model=ApiResponse)
+async def set_full_rollout(
+    request: FullRolloutRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            service.set_full_rollout(
+                env=get_current_env(),
+                enabled=request.enabled,
+                operator=user.staffId,
+                reason=request.reason,
             )
         )
     except RolloutOperationError as error:

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
@@ -21,6 +21,12 @@ class FeatureToggleRequest(BaseModel):
     reason: str = Field(min_length=1)
 
 
+class FullRolloutRequest(BaseModel):
+    enabled: bool
+    engine: str | None = None
+    reason: str = Field(min_length=1)
+
+
 class EnginePromotionRequest(BaseModel):
     engine: str
     reason: str = Field(min_length=1)

--- a/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
@@ -21,7 +21,6 @@ class SkillsPoolRolloutServiceProtocol(Protocol):
         *,
         env: str,
         enabled: bool,
-        engine: str | None = None,
         operator: str,
         reason: str,
     ) -> RolloutConfigSnapshot: ...
@@ -31,6 +30,7 @@ class SkillsPoolRolloutServiceProtocol(Protocol):
         *,
         env: str,
         enabled: bool,
+        engine: str | None = None,
         operator: str,
         reason: str,
     ) -> RolloutConfigSnapshot: ...

--- a/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
@@ -21,6 +21,16 @@ class SkillsPoolRolloutServiceProtocol(Protocol):
         *,
         env: str,
         enabled: bool,
+        engine: str | None = None,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot: ...
+
+    def set_full_rollout(
+        self,
+        *,
+        env: str,
+        enabled: bool,
         operator: str,
         reason: str,
     ) -> RolloutConfigSnapshot: ...

--- a/src/backend/src/agentclaw/community/core/services/resource_file_service.py
+++ b/src/backend/src/agentclaw/community/core/services/resource_file_service.py
@@ -66,6 +66,7 @@ logger = get_logger()
 # users can browse/edit their local skill files (arca/local layout). teclaw keeps
 # local skills flat at /workspace/skills-local, so it needs no injection.
 _SKILLS_LOCAL_RELPATH = "skills/skills-local"
+_POOL_SKILLS_LOCAL_RELPATH = "skills-pool/skills-local"
 
 # System files hidden from the resource browser (OpenClaw identity/config .md files).
 _HIDDEN_BASENAMES = {
@@ -78,6 +79,7 @@ _HIDDEN_BASENAMES = {
 _HIDDEN_DIRNAMES = {
     "state",
     "skills",
+    "skills-pool",
     "conf",
     *(f"{engine}_conf" for engine in SUPPORTED_ENGINE_TYPES),
 }
@@ -264,20 +266,40 @@ class ResourceFileService:
         # so it must be injected; teclaw keeps it flat at /workspace/skills-local and
         # lists naturally; baas/desktop never injected — don't probe it for them).
         if not path and ctx.provider in ("arca", "local", "baas"):
-            try:
-                skills_entries = await device_fs.list_dir(f"{WORKSPACE_NS}/skills")
-            except Exception as e:
-                # the skills dir is optional; a container without it returns 404.
-                # the root listing must not crash when this probe is unavailable.
-                logger.warning("[list_dir] skills-local probe skipped (no skills dir): %s", e)
-                skills_entries = None
-            for s in skills_entries or []:
-                if s.get("name") == "skills-local" and s.get("is_dir", False):
+            for local_relpath in (
+                _SKILLS_LOCAL_RELPATH,
+                _POOL_SKILLS_LOCAL_RELPATH,
+            ):
+                parent = local_relpath.rsplit("/", 1)[0]
+                try:
+                    skills_entries = await device_fs.list_dir(
+                        f"{WORKSPACE_NS}/{parent}"
+                    )
+                except Exception as e:
+                    # Either layout may be absent. Keep probing the other one
+                    # and never fail the root listing for this optional entry.
+                    logger.warning(
+                        "[list_dir] skills-local probe skipped path=%s: %s",
+                        parent,
+                        e,
+                    )
+                    continue
+                skill_local = next(
+                    (
+                        entry
+                        for entry in skills_entries or []
+                        if entry.get("name") == "skills-local"
+                        and entry.get("is_dir", False)
+                    ),
+                    None,
+                )
+                if skill_local is not None:
                     items.append({
                         "name": "skills-local",
-                        "path": _SKILLS_LOCAL_RELPATH,
+                        "path": local_relpath,
                         # the probed entry's own absolute path (logic-view fallback).
-                        "absolute_path": s.get("path") or self._logical(_SKILLS_LOCAL_RELPATH),
+                        "absolute_path": skill_local.get("path")
+                        or self._logical(local_relpath),
                         "is_dir": True,
                         "readonly": False,
                         "size": None,

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -11,6 +11,7 @@ runtime-keyed device dispatchers — which legitimately live in the DI
 layer because they bridge to ``plugins`` — so this module only
 needs the dispatcher *types* under ``TYPE_CHECKING``.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -32,7 +33,9 @@ from agentclaw.community.core.skill_center.services.skill_parameter_service impo
     SkillParameterService,
 )
 from agentclaw.community.core.skill_center.services.skill_service import SkillService
-from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
+from agentclaw.community.core.skill_center.services.skill_set_service import (
+    SkillSetService,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
@@ -52,7 +55,9 @@ if TYPE_CHECKING:
     from agentclaw.community.di.modules.skill_center_module import (
         DeviceFilesystemDispatcher,
     )
-    from agentclaw.community.core.devices.services.device_sync_dispatcher import DeviceSyncDispatcher
+    from agentclaw.community.core.devices.services.device_sync_dispatcher import (
+        DeviceSyncDispatcher,
+    )
 
 
 logger = get_logger()
@@ -131,6 +136,10 @@ class SkillSetServiceFactory:
         bot_repo: BotRepository,
         device_plugin: DeviceAccessor,
         path_factory: "WorkspacePathFactory",
+        pool_layout_paths: Callable[
+            [str, str, str],
+            tuple[str, str, str] | None,
+        ],
     ) -> None:
         self._skill_repo = skill_repo
         self._skill_set_repo = skill_set_repo
@@ -143,6 +152,7 @@ class SkillSetServiceFactory:
         self._bot_repo = bot_repo
         self._device_plugin = device_plugin
         self._path_factory = path_factory
+        self._pool_layout_paths = pool_layout_paths
 
     def create(
         self,
@@ -182,6 +192,18 @@ class SkillSetServiceFactory:
             resolved_skills = skills_dir or SKILLS_DIR
             resolved_repo = repo_dir or SKILLS_REPO_DIR
             resolved_local = local_dir or SKILLS_LOCAL_DIR
+        effective_owner = entity_id or user_id
+        if effective_owner is not None and bot_id is not None:
+            pool_paths = self._pool_layout_paths(
+                str(effective_owner),
+                str(bot_id),
+                engine_type or "",
+            )
+            if pool_paths is not None:
+                active_path, local_path, repo_path = pool_paths
+                resolved_skills = Path(active_path)
+                resolved_local = Path(local_path)
+                resolved_repo = Path(repo_path)
 
         skill_service = self._skill_service_factory.create(
             active_dir=resolved_skills,
@@ -209,6 +231,7 @@ class SkillSetServiceFactory:
             mcp_sync_service=self._mcp_sync_service,
             device_plugin=self._device_plugin,
             path_factory=self._path_factory,
+            pool_layout_paths=self._pool_layout_paths,
         )
 
 
@@ -243,7 +266,9 @@ class SkillParameterServiceFactory:
         # consumes it), so disable engine read/write for it — load/save become
         # no-ops. arca/baas/local keep reading/writing the engine-absolute default.
         engine_io_enabled = ctx.provider != "teclaw"
-        service = SkillParameterService(device_fs=device_fs, engine_io_enabled=engine_io_enabled)
+        service = SkillParameterService(
+            device_fs=device_fs, engine_io_enabled=engine_io_enabled
+        )
         if load_on_init:
             await service.async_load()
         return service

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -29,6 +29,9 @@ from agentclaw.community.core.skill_center.services.repositories import (
     SkillSetRepository,
 )
 from agentclaw.community.core.skill_center.services.skill_cache import MarketCache
+from agentclaw.community.core.skill_center.path_resolution import (
+    build_pool_local_path_adapter,
+)
 from agentclaw.community.core.skill_center.services.skill_parameter_service import (
     SkillParameterService,
 )
@@ -193,6 +196,7 @@ class SkillSetServiceFactory:
             resolved_repo = repo_dir or SKILLS_REPO_DIR
             resolved_local = local_dir or SKILLS_LOCAL_DIR
         effective_owner = entity_id or user_id
+        local_skill_path_adapter = None
         if effective_owner is not None and bot_id is not None:
             pool_paths = self._pool_layout_paths(
                 str(effective_owner),
@@ -204,11 +208,15 @@ class SkillSetServiceFactory:
                 resolved_skills = Path(active_path)
                 resolved_local = Path(local_path)
                 resolved_repo = Path(repo_path)
+                local_skill_path_adapter = build_pool_local_path_adapter(
+                    resolved_local
+                )
 
         skill_service = self._skill_service_factory.create(
             active_dir=resolved_skills,
             repo_dir=resolved_repo,
             local_dir=resolved_local,
+            local_skill_path_adapter=local_skill_path_adapter,
         )
 
         return SkillSetService(

--- a/src/backend/src/agentclaw/community/core/skill_center/path_resolution.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/path_resolution.py
@@ -1,0 +1,29 @@
+"""Path translation helpers for the Skills Pool cutover window."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+
+def canonical_pool_local_path(path_value: str, pool_local: Path) -> str:
+    """Translate a Legacy/local locator to the canonical Pool local root."""
+
+    path = Path(path_value.rstrip("/"))
+    parts = path.parts
+    if "skills-local" in parts:
+        index = len(parts) - 1 - tuple(reversed(parts)).index("skills-local")
+        relative_parts = parts[index + 1 :]
+    elif path.is_absolute():
+        relative_parts = (path.name,)
+    else:
+        relative_parts = parts
+    if any(part in {"", ".", ".."} for part in relative_parts):
+        raise ValueError(f"invalid local skill path: {path_value}")
+    return str(pool_local.joinpath(*relative_parts))
+
+
+def build_pool_local_path_adapter(pool_local: Path) -> Callable[[str], str]:
+    """Build the adapter used by SkillService during/after Pool cutover."""
+
+    return lambda path_value: canonical_pool_local_path(path_value, pool_local)

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -30,6 +30,9 @@ from agentclaw.community.core.skill_center.services.repositories import (
     SkillSetRepository,
 )
 from agentclaw.community.core.skill_center.services.skill_service import SkillService
+from agentclaw.community.core.skill_center.path_resolution import (
+    canonical_pool_local_path,
+)
 from agentclaw.community.core.skill_center.utils.skill_metadata_writer import SkillSetMetadataWriter
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE  # noqa: E402
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
@@ -226,14 +229,27 @@ class SkillSetService:
             self.repo_dir = repo_dir or SKILLS_REPO_DIR
             self.local_dir = local_dir or SKILLS_LOCAL_DIR
 
+        self._pool_layout_paths = pool_layout_paths or (
+            lambda _owner_id, _bot_id, _engine: None
+        )
+        effective_owner = entity_id or user_id
+        if not self.is_desktop and effective_owner is not None:
+            pool_paths = self._pool_layout_paths(
+                str(effective_owner),
+                str(self.bot_id),
+                self.engine_type,
+            )
+            if pool_paths is not None:
+                active_path, local_path, repo_path = pool_paths
+                self.skills_dir = Path(active_path)
+                self.local_dir = Path(local_path)
+                self.repo_dir = Path(repo_path)
+
         self.CURRENT_SET_FILE = self.skills_dir / ".current_skill_set"
 
         self._resolver = resolver
         self._device_sync_dispatcher = device_sync_dispatcher
         self._mcp_sync_service = mcp_sync_service
-        self._pool_layout_paths = pool_layout_paths or (
-            lambda _owner_id, _bot_id, _engine: None
-        )
 
     def _get_current_active_skill_set_id(self) -> str | None:
         """Get currently active skill set ID from database (is_active=1)."""
@@ -1251,7 +1267,11 @@ class SkillSetService:
                 if path_part.startswith('/'):
                     # 绝对路径格式: /aidesktop/.../skills-local/skill-name
                     skill_name = path_part.rstrip('/').split('/')[-1]
-                    source = path_part.rstrip('/')
+                    source = (
+                        canonical_pool_local_path(path_part, skills_local_dir)
+                        if pool_layout_paths is not None
+                        else path_part.rstrip('/')
+                    )
                 else:
                     # 相对名称格式: skill-name
                     skill_name = path_part.split('/')[-1] if '/' in path_part else path_part
@@ -1987,6 +2007,11 @@ class SkillSetSwitcher(_DeviceSyncMixin):
             skills_dir=self.skills_dir, repo_dir=self.repo_dir, local_dir=self.local_dir,
             user_id=user_id, entity_id=entity_id, bot_id=bot_id, engine_type=engine_type
         )
+        if isinstance(self.skill_set_service.skills_dir, Path):
+            self.skills_dir = self.skill_set_service.skills_dir
+            self.repo_dir = self.skill_set_service.repo_dir
+            self.local_dir = self.skill_set_service.local_dir
+            self.CURRENT_SET_FILE = self.skills_dir / ".current_skill_set"
 
     def get_current_skill_set(self) -> dict[str, Any] | None:
         """Get the currently active skill set."""
@@ -2463,6 +2488,10 @@ class SkillSetActivator(_DeviceSyncMixin):
             skills_dir=self.skills_dir, repo_dir=self.repo_dir, local_dir=self.local_dir,
             user_id=user_id, entity_id=entity_id, bot_id=bot_id, engine_type=engine_type
         )
+        if isinstance(self.skill_set_service.skills_dir, Path):
+            self.skills_dir = self.skill_set_service.skills_dir
+            self.repo_dir = self.skill_set_service.repo_dir
+            self.local_dir = self.skill_set_service.local_dir
 
     async def activate_skill_set(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -8,7 +8,7 @@ import zlib
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 from agentclaw.community.core.devices.models import SynlinkMappingInfo
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
@@ -148,6 +148,11 @@ class SkillSetService:
         device_plugin: DeviceAccessor | None = None,
         *,
         path_factory: WorkspacePathFactory,
+        pool_layout_paths: Callable[
+            [str, str, str],
+            tuple[str, str, str] | None,
+        ]
+        | None = None,
     ):
         """
         Args:
@@ -226,6 +231,9 @@ class SkillSetService:
         self._resolver = resolver
         self._device_sync_dispatcher = device_sync_dispatcher
         self._mcp_sync_service = mcp_sync_service
+        self._pool_layout_paths = pool_layout_paths or (
+            lambda _owner_id, _bot_id, _engine: None
+        )
 
     def _get_current_active_skill_set_id(self) -> str | None:
         """Get currently active skill set ID from database (is_active=1)."""
@@ -1169,6 +1177,17 @@ class SkillSetService:
         skills_repo_dir = Path(
             ENGINE_SKILLS_REPO_DIR_MAP.get(self.engine_type, str(base_skills_dir / "skills-repo"))
         )
+        pool_layout_paths = None
+        if not self.is_desktop and self.entity_id is not None:
+            pool_layout_paths = self._pool_layout_paths(
+                str(self.entity_id),
+                str(self.bot_id),
+                self.engine_type,
+            )
+        if pool_layout_paths is not None:
+            active_path, local_path, repo_path = pool_layout_paths
+            base_skills_dir = Path(active_path)
+            skills_repo_dir = Path(repo_path)
 
         # singlebox 本机模式: engine adapter 跑在宿主 macOS,容器视图 /home/admin/...
         # 不存在。把容器路径前缀替换成宿主 per-bot workspace 路径
@@ -1205,6 +1224,8 @@ class SkillSetService:
             )
 
         skills_local_dir = base_skills_dir / "skills-local"
+        if pool_layout_paths is not None:
+            skills_local_dir = Path(local_path)
 
         # 5. 解析 git_path 生成 SynlinkMappingInfo 列表（使用绝对路径）
         symlinks = []

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -13,8 +13,10 @@ Engine Layout Descriptor 仍不在本期范围内。
 - 首次认领同时写入 Pool 目标、初始阶段、唯一
   `migration_generation`、lease 和白名单审计证据。
 - 白名单仅控制首次认领。认领成功后状态具有粘性，移出白名单不会撤销迁移。
-- rollout 配置按环境隔离；缺失、禁用、读取失败、格式异常、`enable_all`
-  或通配配置均 fail closed。
+- rollout 配置按环境隔离；缺失、禁用、读取失败、格式异常或通配配置均
+  fail closed。`full_rollout_engines` 可逐引擎放开未来新建和后续重启的
+  Bot；`enable_all=true` 则覆盖当前环境中全部已经人工晋级并验收的引擎。
+  未晋级引擎始终拒绝，环境全量期间也禁止直接晋级新引擎。
 - owner 和 engine 来自当前 Bot 记录；服务草稿还必须由当前
   `ac_bot_publish` DRAFT 记录证明。认领入口不接受调用方自报运行形态，
   ONLINE 服务与 Teclaw 不产生认领。
@@ -35,8 +37,11 @@ Engine Layout Descriptor 仍不在本期范围内。
 - 激活只处理当前仍可编辑、已经认领、引擎已显式接入且由当前 worker 持有
   lease 的 Bot；每次执行都重新读取 Bot 和当前 provider binding，并重新
   probe 对应引擎 marker。未知引擎不回退到 OpenClaw。
-- 容器内以系统原生原子 exchange 将 Legacy local 切成指向 Pool canonical
-  local 的永久单向 bridge；不支持原子 exchange 时保持 Legacy。
+- 容器内以系统原生原子 exchange 完成最终 local 同步；随后先发布并验证
+  直接指向 canonical Pool 的 active mapping，再通过持久化
+  `.pool-active` 的 `finalizing → active` 状态移除 active root 中
+  `skills-local`、`skills-repo` 两个 corpus 入口。不支持原子 exchange
+  时保持 Legacy。
 - 激活前同时核对已登记 local，并从文件系统枚举未登记 local、受管 active
   entry 与外部 entry；完整 local 内容进入 Pool，但不会为未登记内容创建
   数据库记录，外部 entry 保持原目标。
@@ -49,7 +54,8 @@ Engine Layout Descriptor 仍不在本期范围内。
 - bridge 已提交后的 `POST_CUTOVER_SYNC_PENDING`、mapping 与数据库失败均
   持久化阶段、错误码、可重试性、证据和时间；重试只补齐 mapping、locator
   与 `POOL_ACTIVE`，不恢复隔离副本。
-- 显式回滚先持久化 `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
+- 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
+  `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并原子交换。交换后即使 mapping
   或数据库失败也保持 `LEGACY_ROLLBACK_COMMITTED`，同一 generation 可由
   lease 过期后的新 worker 接管并继续提交 Legacy mapping 和 locator。
@@ -70,8 +76,10 @@ Engine Layout Descriptor 仍不在本期范围内。
 - 七天任务由持久化任务队列延迟调度；重复执行、任务接管和目录已不存在均
   幂等。容器只接受 generation，由固定 engine Pool 根推导删除目标，不能
   删除其他 Bot 或 generation。数据库保留清理时间与证据。
-- 灰度运维入口只接受当前环境中的精确 `(owner_id, bot_id)`，不提供
-  `enable_all`。引擎按 OpenClaw、Claude Code、AICoding、Hermes 的固定
+- 灰度运维入口接受当前环境中的精确 `(owner_id, bot_id)`；单个已晋级引擎
+  完成批次验收且无负对照后，可写入 `full_rollout_engines` 单独全量；
+  所有已晋级引擎均满足条件后，可显式打开或关闭环境级 `enable_all`。
+  引擎按 OpenClaw、Claude Code、AICoding、Hermes 的固定
   顺序人工晋级；每次扩大同引擎批次必须引用最近一次已冻结验收，除首个
   引擎外，晋级还必须引用上一引擎已冻结的验收批次。配置写入使用完整旧值
   加逻辑 revision CAS，冲突 fail closed；配置和包含前后 revision、原因及
@@ -80,6 +88,13 @@ Engine Layout Descriptor 仍不在本期范围内。
   layout/generation、probe/failure 和 quarantine 证据；批次视图只有在
   全部 eligible Bot 激活、无失败且负对照与 Teclaw 对照均健康时才报告
   `promotion_ready`，但不会据此改写灰度配置。
+- 递归版 OpenClaw 属于后续独立发布；该版本开始后，已经使用递归扫描器的
+  Bot 只允许向 Pool 前滚，不再提供物理 Legacy 回滚组合。
+- 递归版 OpenClaw 发布前还必须补齐实际 OpenClaw Gateway 的业务 readiness
+  门禁：正常迁移保持异步；若 preparation/probe/activation 未收敛且 active
+  root 仍不安全，则实例进入 unhealthy、告警并由既有持久化任务重试，禁止
+  以“递归引擎 + Legacy corpus 入口”持续 serving。该门禁不能只加在 Backend
+  adapter 的 `/readiness`，否则无法覆盖直接访问 Gateway 的流量。
 - 人工 wake/retry 通过持久化任务队列交接，repair/rollback 复用既有恢复
   服务；所有写入口仅对 operator 开放。
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -104,6 +104,7 @@ class RolloutConfigSnapshot:
     negative_controls: tuple[RolloutBotEntry, ...]
     teclaw_controls: tuple[RolloutBotEntry, ...]
     audit_log: tuple[RolloutAuditEvent, ...]
+    full_rollout_engines: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,9 +136,7 @@ class SkillsPoolRolloutOperations:
         snapshot = self._parse_config(env=env, config=self._get_config(env))
         return replace(
             snapshot,
-            audit_log=self._audit_events(
-                self._repository.list_audit_events(env=env)
-            ),
+            audit_log=self._audit_events(self._repository.list_audit_events(env=env)),
         )
 
     def set_feature_enabled(
@@ -162,6 +161,83 @@ class SkillsPoolRolloutOperations:
             action="enable" if enabled else "disable",
         )
 
+    def set_full_rollout(
+        self,
+        *,
+        env: str,
+        enabled: bool,
+        engine: str | None = None,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot:
+        """Enable future claims for one engine or the whole environment."""
+
+        self._validate_change(operator=operator, reason=reason)
+        current = self.get_snapshot(env=env)
+        if engine is not None and engine not in ENGINE_PROMOTION_ORDER:
+            raise RolloutOperationError(f"unsupported engine: {engine}")
+        current_enabled = (
+            current.enable_all
+            if engine is None
+            else engine in current.full_rollout_engines
+        )
+        if current_enabled is enabled:
+            return current
+        if enabled:
+            if not current.enabled:
+                raise RolloutOperationError(
+                    "rollout feature must be enabled before full rollout"
+                )
+            target_engines = (
+                current.promoted_engines if engine is None else (engine,)
+            )
+            if not target_engines:
+                raise RolloutOperationError(
+                    "at least one engine must be promoted before full rollout"
+                )
+            if current.negative_controls:
+                raise RolloutOperationError(
+                    "negative controls must be cleared before full rollout"
+                )
+            for target_engine in target_engines:
+                if target_engine not in current.promoted_engines:
+                    raise RolloutOperationError(
+                        f"{target_engine} must be promoted before full rollout"
+                    )
+                if self._latest_accepted_batch(current, engine=target_engine) is None:
+                    raise RolloutOperationError(
+                        f"an accepted {target_engine} batch is required for full rollout"
+                    )
+                if self._open_batches(current, env=env, engine=target_engine):
+                    raise RolloutOperationError(
+                        f"{target_engine} still has an unaccepted batch"
+                    )
+        full_rollout_engines = current.full_rollout_engines
+        if engine is not None:
+            full_rollout_engines = tuple(
+                item for item in full_rollout_engines if item != engine
+            )
+            if enabled:
+                full_rollout_engines = (*full_rollout_engines, engine)
+        return self._write(
+            snapshot=RolloutConfigSnapshot(
+                **{
+                    **self._snapshot_values(current),
+                    "enable_all": enabled if engine is None else current.enable_all,
+                    "full_rollout_engines": full_rollout_engines,
+                }
+            ),
+            expected_snapshot=current,
+            enabled=current.enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=None,
+            action=(
+                f"full_rollout:{engine or 'environment'}:"
+                f"{'enable' if enabled else 'disable'}"
+            ),
+        )
+
     def promote_engine(
         self,
         *,
@@ -177,6 +253,10 @@ class SkillsPoolRolloutOperations:
         current = self.get_snapshot(env=env)
         if engine in current.promoted_engines:
             return current
+        if current.enable_all:
+            raise RolloutOperationError(
+                "disable environment full rollout before promoting another engine"
+            )
         expected_previous = ENGINE_PROMOTION_ORDER[
             : ENGINE_PROMOTION_ORDER.index(engine)
         ]
@@ -184,9 +264,7 @@ class SkillsPoolRolloutOperations:
             raise RolloutOperationError(
                 f"previous engine promotion is incomplete for {engine}"
             )
-        previous_engine = (
-            expected_previous[-1] if expected_previous else None
-        )
+        previous_engine = expected_previous[-1] if expected_previous else None
         acceptance = None
         if previous_engine is not None:
             acceptance = self._accepted_batch(
@@ -238,10 +316,7 @@ class SkillsPoolRolloutOperations:
         ):
             raise RolloutOperationError("batch is not ready for acceptance")
         current = self.get_snapshot(env=env)
-        if (
-            acceptance.report.get("rollout_config_version")
-            != current.config_version
-        ):
+        if acceptance.report.get("rollout_config_version") != current.config_version:
             raise RolloutOperationError("batch report is stale")
         if acceptance.engine not in current.promoted_engines:
             raise RolloutOperationError("batch engine is not promoted")
@@ -325,9 +400,7 @@ class SkillsPoolRolloutOperations:
         whitelist = tuple(
             item
             for item in current.whitelist
-            if not (
-                item.owner_id == entry.owner_id and item.bot_id == entry.bot_id
-            )
+            if not (item.owner_id == entry.owner_id and item.bot_id == entry.bot_id)
         ) + (entry,)
         updated = self._write(
             snapshot=RolloutConfigSnapshot(
@@ -362,8 +435,7 @@ class SkillsPoolRolloutOperations:
             (
                 item
                 for item in current.whitelist
-                if item.owner_id == str(owner_id)
-                and item.bot_id == str(bot_id)
+                if item.owner_id == str(owner_id) and item.bot_id == str(bot_id)
             ),
             None,
         )
@@ -388,9 +460,7 @@ class SkillsPoolRolloutOperations:
         whitelist = tuple(
             item
             for item in current.whitelist
-            if not (
-                item.owner_id == str(owner_id) and item.bot_id == str(bot_id)
-            )
+            if not (item.owner_id == str(owner_id) and item.bot_id == str(bot_id))
         )
         if whitelist == current.whitelist:
             return WhitelistMutationResult(
@@ -455,9 +525,7 @@ class SkillsPoolRolloutOperations:
         retained = tuple(
             item
             for item in source
-            if not (
-                item.owner_id == entry.owner_id and item.bot_id == entry.bot_id
-            )
+            if not (item.owner_id == entry.owner_id and item.bot_id == entry.bot_id)
         )
         updated_entries = (*retained, entry) if present else retained
         if updated_entries == source:
@@ -602,10 +670,7 @@ class SkillsPoolRolloutOperations:
         engine: str,
     ) -> BatchPromotionEvidence | None:
         for event in reversed(snapshot.audit_log):
-            if (
-                event.action == f"accept_batch:{engine}"
-                and event.batch_id is not None
-            ):
+            if event.action == f"accept_batch:{engine}" and event.batch_id is not None:
                 return cls._accepted_batch(
                     snapshot,
                     engine=engine,
@@ -680,6 +745,7 @@ class SkillsPoolRolloutOperations:
                 config_revision=None,
                 enabled=False,
                 enable_all=False,
+                full_rollout_engines=(),
                 promoted_engines=(),
                 whitelist=(),
                 negative_controls=(),
@@ -691,11 +757,7 @@ class SkillsPoolRolloutOperations:
         config_id = config.get("id")
         record_version = config.get("gmt_modified")
         ext_info = config.get("ext_info")
-        revision = (
-            ext_info.get("revision")
-            if isinstance(ext_info, dict)
-            else None
-        )
+        revision = ext_info.get("revision") if isinstance(ext_info, dict) else None
         value = config.get("param_value")
         if (
             isinstance(config_id, bool)
@@ -719,7 +781,8 @@ class SkillsPoolRolloutOperations:
             record_version=record_version,
             config_revision=revision,
             enabled=config.get("enable") == "1",
-            enable_all=False,
+            enable_all=bool(value["enable_all"]),
+            full_rollout_engines=tuple(value.get("full_rollout_engines", [])),
             promoted_engines=promoted_engines,
             whitelist=cls._entries(whitelist),
             negative_controls=cls._entries(value.get(CONTROL_KEYS[0], [])),
@@ -744,8 +807,7 @@ class SkillsPoolRolloutOperations:
                 "effective_at",
             )
             if any(
-                not isinstance(item.get(key), str)
-                or not str(item[key]).strip()
+                not isinstance(item.get(key), str) or not str(item[key]).strip()
                 for key in required
             ):
                 raise RolloutOperationError("rollout audit event is invalid")
@@ -765,9 +827,7 @@ class SkillsPoolRolloutOperations:
                         if item.get("based_on_config_version") is not None
                         else None
                     ),
-                    effective_config_version=str(
-                        item["effective_config_version"]
-                    ),
+                    effective_config_version=str(item["effective_config_version"]),
                     effective_at=str(item["effective_at"]),
                     evidence=(
                         item.get("evidence")
@@ -783,15 +843,14 @@ class SkillsPoolRolloutOperations:
         snapshot: RolloutConfigSnapshot,
     ) -> dict[str, object]:
         return {
-            "enable_all": False,
+            "enable_all": snapshot.enable_all,
+            "full_rollout_engines": list(snapshot.full_rollout_engines),
             "promoted_engines": list(snapshot.promoted_engines),
             "whitelist": [item.to_dict() for item in snapshot.whitelist],
             "negative_controls": [
                 item.to_dict() for item in snapshot.negative_controls
             ],
-            "teclaw_controls": [
-                item.to_dict() for item in snapshot.teclaw_controls
-            ],
+            "teclaw_controls": [item.to_dict() for item in snapshot.teclaw_controls],
         }
 
     @classmethod
@@ -826,13 +885,10 @@ class SkillsPoolRolloutOperations:
             for value in values
         ):
             raise RolloutOperationError("rollout bot identity is invalid")
-        if (
-            batch_id is not None
-            and (
-                isinstance(batch_id, bool)
-                or not isinstance(batch_id, (str, int))
-                or str(batch_id).strip() in {"", "*"}
-            )
+        if batch_id is not None and (
+            isinstance(batch_id, bool)
+            or not isinstance(batch_id, (str, int))
+            or str(batch_id).strip() in {"", "*"}
         ):
             raise RolloutOperationError("rollout batch identity is invalid")
         return RolloutBotEntry(
@@ -867,6 +923,7 @@ class SkillsPoolRolloutOperations:
             "config_revision": snapshot.config_revision,
             "enabled": snapshot.enabled,
             "enable_all": snapshot.enable_all,
+            "full_rollout_engines": snapshot.full_rollout_engines,
             "promoted_engines": snapshot.promoted_engines,
             "whitelist": snapshot.whitelist,
             "negative_controls": snapshot.negative_controls,

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
@@ -7,7 +7,7 @@ from typing import Any
 ENGINE_PROMOTION_ORDER = ("openclaw", "claude_code", "aicoding", "hermes")
 CONTROL_KEYS = ("negative_controls", "teclaw_controls")
 _REQUIRED_KEYS = frozenset({"enable_all", "promoted_engines", "whitelist"})
-_ALLOWED_KEYS = _REQUIRED_KEYS | frozenset(CONTROL_KEYS)
+_ALLOWED_KEYS = _REQUIRED_KEYS | frozenset((*CONTROL_KEYS, "full_rollout_engines"))
 _ENTRY_KEYS = frozenset({"owner_id", "bot_id", "batch_id"})
 
 
@@ -43,7 +43,7 @@ def is_valid_rollout_config_value(value: Any) -> bool:
     keys = set(value)
     if not _REQUIRED_KEYS.issubset(keys) or not keys.issubset(_ALLOWED_KEYS):
         return False
-    if value.get("enable_all") is not False:
+    if not isinstance(value.get("enable_all"), bool):
         return False
 
     engines = value.get("promoted_engines")
@@ -52,8 +52,15 @@ def is_valid_rollout_config_value(value: Any) -> bool:
     promoted_engines = tuple(engines)
     if promoted_engines != ENGINE_PROMOTION_ORDER[: len(promoted_engines)]:
         return False
+    full_rollout_engines = value.get("full_rollout_engines", [])
+    if (
+        not isinstance(full_rollout_engines, list)
+        or any(not isinstance(engine, str) for engine in full_rollout_engines)
+        or len(set(full_rollout_engines)) != len(full_rollout_engines)
+        or any(engine not in promoted_engines for engine in full_rollout_engines)
+    ):
+        return False
 
     return all(
-        _valid_entries(value.get(key, []))
-        for key in ("whitelist", *CONTROL_KEYS)
+        _valid_entries(value.get(key, [])) for key in ("whitelist", *CONTROL_KEYS)
     )

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_gate.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_gate.py
@@ -40,7 +40,6 @@ class RolloutDecisionReason(StrEnum):
     CONFIG_READ_ERROR = "config_read_error"
     CONFIG_INVALID = "config_invalid"
     CONFIG_ENV_MISMATCH = "config_env_mismatch"
-    ENABLE_ALL_FORBIDDEN = "enable_all_forbidden"
     ENGINE_NOT_SUPPORTED = "engine_not_supported"
     ENGINE_NOT_PROMOTED = "engine_not_promoted"
     BOT_NOT_WHITELISTED = "bot_not_whitelisted"
@@ -115,15 +114,9 @@ class SkillsPoolRolloutGate:
 
         config_id = config.get("id")
         ext_info = config.get("ext_info")
-        revision = (
-            ext_info.get("revision")
-            if isinstance(ext_info, dict)
-            else None
-        )
+        revision = ext_info.get("revision") if isinstance(ext_info, dict) else None
         config_version = revision or config.get("gmt_modified")
         value = config.get("param_value")
-        if isinstance(value, dict) and value.get("enable_all") is True:
-            return self._reject(RolloutDecisionReason.ENABLE_ALL_FORBIDDEN)
         if (
             isinstance(config_id, bool)
             or not isinstance(config_id, int)
@@ -138,23 +131,30 @@ class SkillsPoolRolloutGate:
         if engine_type not in promoted_engines:
             return self._reject(RolloutDecisionReason.ENGINE_NOT_PROMOTED)
 
-        whitelist = value["whitelist"]
-        entry = self._whitelist_service.find_bot_whitelist_entry(
-            whitelist,
-            owner_id=owner_id,
-            bot_id=bot_id,
-        )
-        if entry is None:
-            return self._reject(RolloutDecisionReason.BOT_NOT_WHITELISTED)
-
-        batch_id = entry.get("batch_id")
+        batch_id = None
+        decision_reason = "environment_full_rollout"
+        if value["enable_all"] is False and engine_type not in value.get(
+            "full_rollout_engines", []
+        ):
+            whitelist = value["whitelist"]
+            entry = self._whitelist_service.find_bot_whitelist_entry(
+                whitelist,
+                owner_id=owner_id,
+                bot_id=bot_id,
+            )
+            if entry is None:
+                return self._reject(RolloutDecisionReason.BOT_NOT_WHITELISTED)
+            batch_id = entry.get("batch_id")
+            decision_reason = "exact_bot_whitelist"
+        elif value["enable_all"] is False:
+            decision_reason = "engine_full_rollout"
         evidence = RolloutEvidence(
             env=env,
             config_id=config_id,
             config_version=config_version,
             batch_id=str(batch_id) if batch_id is not None else None,
             engine_type=engine_type,
-            decision_reason=RolloutDecisionReason.ELIGIBLE.value,
+            decision_reason=decision_reason,
         )
         return RolloutDecision(
             eligible=True,

--- a/src/backend/src/agentclaw/community/core/skills_pool/types.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/types.py
@@ -89,3 +89,24 @@ class BotSkillLayoutState:
             migration_generation=None,
             persisted=False,
         )
+
+
+def runtime_uses_pool_paths(state: BotSkillLayoutState) -> bool:
+    """Whether canonical Pool paths already own runtime reads and writes.
+
+    Runtime cutover retires Legacy storage bridges before the Backend CAS can
+    persist ``POOL_ACTIVE``. ``begin_cutover`` is the durable fence immediately
+    before that remote call; from that point onward, consumers must stop
+    dereferencing Legacy locators even while ``active_layout`` is still Legacy.
+    """
+
+    return (
+        state.active_layout is SkillLayout.POOL
+        or state.data_plane_cutover_committed
+        or state.phase
+        in {
+            SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+        }
+    )

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -434,7 +434,7 @@ class SkillCenterModule(Module):
             _requested_engine: str,
         ) -> tuple[str, str, str] | None:
             bot = bot_repo.get_by_id_and_owner(bot_id, owner_id)
-            if bot is None:
+            if bot is None or bot.get("bot_type") == "desktop":
                 return None
             engine = bot.get("active_engine")
             if not isinstance(engine, str):

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -119,7 +119,7 @@ from agentclaw.community.core.skills_pool.repository.protocol import (
 from agentclaw.community.core.skills_pool.models import pool_paths_for_engine
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
-    SkillLayout,
+    runtime_uses_pool_paths,
 )
 from agentclaw.community.core.skill_center.services.skill_symlink_listener import (
     SkillSymlinkListener,
@@ -446,7 +446,7 @@ class SkillCenterModule(Module):
                     bot_id=str(bot["bot_id"]),
                 )
             )
-            if state.active_layout is not SkillLayout.POOL:
+            if not runtime_uses_pool_paths(state):
                 return None
             paths = pool_paths_for_engine(engine)
             return paths.active, paths.pool_local, paths.pool_repo

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -27,6 +27,7 @@ This module never branches on mode. Local / test boots layer
 ``TestingSkillCenterModule`` on top to override the database-mode-keyed
 plugin_api and repos.
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -36,17 +37,31 @@ from injector import Binder, Injector, Module, inject, provider, singleton
 
 from agentclaw.community.api.git_sync_service import GitSyncServiceProtocol
 from agentclaw.community.api.skill_auth_service import SkillAuthServiceProtocol
-from agentclaw.community.api.skill_batch_sync_service import SkillBatchSyncServiceProtocol
-from agentclaw.community.api.skill_center_sync_service import SkillCenterSyncServiceProtocol
+from agentclaw.community.api.skill_batch_sync_service import (
+    SkillBatchSyncServiceProtocol,
+)
+from agentclaw.community.api.skill_center_sync_service import (
+    SkillCenterSyncServiceProtocol,
+)
 from agentclaw.community.api.skill_member_service import SkillMemberServiceProtocol
-from agentclaw.community.api.skill_parameter_service_factory import SkillParameterServiceFactoryProtocol
-from agentclaw.community.api.skill_propagation_service import SkillPropagationServiceProtocol
+from agentclaw.community.api.skill_parameter_service_factory import (
+    SkillParameterServiceFactoryProtocol,
+)
+from agentclaw.community.api.skill_propagation_service import (
+    SkillPropagationServiceProtocol,
+)
 from agentclaw.community.api.skill_publish_service import SkillPublishServiceProtocol
 from agentclaw.community.api.skill_scan_service import SkillScanServiceProtocol
 from agentclaw.community.api.skill_service_factory import SkillServiceFactoryProtocol
-from agentclaw.community.api.skill_set_activator_factory import SkillSetActivatorFactoryProtocol
-from agentclaw.community.api.skill_set_service_factory import SkillSetServiceFactoryProtocol
-from agentclaw.community.api.skill_set_switcher_factory import SkillSetSwitcherFactoryProtocol
+from agentclaw.community.api.skill_set_activator_factory import (
+    SkillSetActivatorFactoryProtocol,
+)
+from agentclaw.community.api.skill_set_service_factory import (
+    SkillSetServiceFactoryProtocol,
+)
+from agentclaw.community.api.skill_set_switcher_factory import (
+    SkillSetSwitcherFactoryProtocol,
+)
 from agentclaw.community.di import config as cfg
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.devices.services.device_context_resolver import (
@@ -54,14 +69,19 @@ from agentclaw.community.core.devices.services.device_context_resolver import (
 )
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
-from agentclaw.community.core.skill_center.services.git_sync import GitSyncConfig, GitSyncService
+from agentclaw.community.core.skill_center.services.git_sync import (
+    GitSyncConfig,
+    GitSyncService,
+)
 from agentclaw.community.core.skill_center.services.repositories import (
     SkillCategoryRepository,
     SkillMemberRepository,
     SkillRepository,
     SkillSetRepository,
 )
-from agentclaw.community.core.skill_center.services.skill_auth_service import SkillAuthService
+from agentclaw.community.core.skill_center.services.skill_auth_service import (
+    SkillAuthService,
+)
 from agentclaw.community.core.skill_center.services.skill_batch_sync_service import (
     SkillBatchSyncService,
 )
@@ -69,7 +89,9 @@ from agentclaw.community.core.skill_center.services.skill_center_sync_service im
     SkillCenterSyncService,
     SkillCenterSyncLogRepository,
 )
-from agentclaw.community.core.skill_center.services.skill_member_service import SkillMemberService
+from agentclaw.community.core.skill_center.services.skill_member_service import (
+    SkillMemberService,
+)
 from agentclaw.community.core.skill_center.services.market_sync import MarketSyncService
 from agentclaw.community.core.skill_center.services.skill_cache import MarketCache
 from agentclaw.community.core.skill_center.services.skill_scan import SkillScanService
@@ -77,7 +99,9 @@ from agentclaw.community.core.skill_center.services.skill_propagation_service im
     SkillPropagationLogRepository,
     SkillPropagationService,
 )
-from agentclaw.community.core.skill_center.services.skill_publish_service import SkillPublishService
+from agentclaw.community.core.skill_center.services.skill_publish_service import (
+    SkillPublishService,
+)
 from agentclaw.community.plugin_api.object_storage import ObjectStoragePlugin
 from agentclaw.community.core.skill_center.factories import (
     SkillParameterServiceFactory,
@@ -89,13 +113,23 @@ from agentclaw.community.core.skill_center.services.skill_set_service import (
     SkillSetSwitcherFactory,
 )
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.models import pool_paths_for_engine
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayout,
+)
 from agentclaw.community.core.skill_center.services.skill_symlink_listener import (
     SkillSymlinkListener,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.cache import CachePlugin
 from agentclaw.community.plugin_api.database import DatabasePlugin
-from agentclaw.community.core.devices.services.device_sync_dispatcher import DeviceSyncDispatcher
+from agentclaw.community.core.devices.services.device_sync_dispatcher import (
+    DeviceSyncDispatcher,
+)
 from agentclaw.community.core.devices.services.device_filesystem_dispatcher import (
     DeviceFilesystemDispatcher,
     DeviceFileSystemResolver,
@@ -274,7 +308,8 @@ class SkillCenterModule(Module):
         # LOCAL → permissive; community → CommunitySecretResolver, unregistered →
         # permissive.)
         _bound_modes = {
-            entry.mode for entry in IMPL_REGISTRY
+            entry.mode
+            for entry in IMPL_REGISTRY
             if entry.cls is secret_resolver.__class__
         }
         allow_missing_repo_url = Mode.PROD not in _bound_modes
@@ -387,11 +422,35 @@ class SkillCenterModule(Module):
         bot_repo: BotRepository,
         device_plugin: DeviceAccessor,
         path_factory: WorkspacePathFactory,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
         injector: Injector,
     ) -> SkillSetServiceFactory:
         # resolver / device_sync_dispatcher 走 lazy thunk:防止构造期 DI 循环
         # ``BotService → SkillSetServiceFactory → DeviceContextResolver
         # → ArcaConnInfoBuilder → DeviceService → BotService``。
+        def resolve_pool_paths(
+            owner_id: str,
+            bot_id: str,
+            _requested_engine: str,
+        ) -> tuple[str, str, str] | None:
+            bot = bot_repo.get_by_id_and_owner(bot_id, owner_id)
+            if bot is None:
+                return None
+            engine = bot.get("active_engine")
+            if not isinstance(engine, str):
+                return None
+            state = layout_repository.get(
+                BotSkillLayoutScope(
+                    env=str(bot["env"]),
+                    entity_id=str(bot["entity_id"]),
+                    bot_id=str(bot["bot_id"]),
+                )
+            )
+            if state.active_layout is not SkillLayout.POOL:
+                return None
+            paths = pool_paths_for_engine(engine)
+            return paths.active, paths.pool_local, paths.pool_repo
+
         return SkillSetServiceFactory(
             skill_repo=skill_repo,
             skill_set_repo=skill_set_repo,
@@ -404,6 +463,7 @@ class SkillCenterModule(Module):
             bot_repo=bot_repo,
             device_plugin=device_plugin,
             path_factory=path_factory,
+            pool_layout_paths=resolve_pool_paths,
         )
 
     @singleton
@@ -587,7 +647,9 @@ class SkillCenterModule(Module):
     @singleton
     @provider
     @inject
-    def _skill_auth_service_protocol(self, svc: SkillAuthService) -> SkillAuthServiceProtocol:
+    def _skill_auth_service_protocol(
+        self, svc: SkillAuthService
+    ) -> SkillAuthServiceProtocol:
         return svc
 
     @singleton

--- a/src/backend/tests/community/adapters/http/resources/test_file_search_download_helpers.py
+++ b/src/backend/tests/community/adapters/http/resources/test_file_search_download_helpers.py
@@ -19,7 +19,9 @@ from agentclaw.community.adapters.http.resources.file_search_download_router imp
     _device_fs_for_bot,
     _download_arcname,
     _download_logical,
+    _passes_search_filter,
     _resolve_walk_device_fs,
+    _search_should_descend,
     _walk_device_fs,
     _zip_dir_entry,
     _zip_file_entry,
@@ -202,6 +204,13 @@ class TestWalkDeviceFs:
         rels = {e["rel"] for e in out}
         assert "skills/skills-local/a.md" in rels
         assert "skills/other/b.md" not in rels  # pruned before listing
+
+    def test_pool_local_subtree_is_visible_but_pool_repo_is_hidden(self):
+        assert _search_should_descend("skills-pool")
+        assert _search_should_descend("skills-pool/skills-local")
+        assert _passes_search_filter("skills-pool/skills-local/a/SKILL.md")
+        assert not _search_should_descend("skills-pool/skills-repo")
+        assert not _passes_search_filter("skills-pool/skills-repo/a/SKILL.md")
 
     @pytest.mark.asyncio
     async def test_root_list_failure_returns_none(self):
@@ -511,4 +520,3 @@ class TestDownloadDirectoryZipMetadata:
             assert file_attr & 0o170000 == stat.S_IFREG, oct(file_attr)
             assert zf.read("memory/foo.txt") == b"FOO"
         os.unlink(resp.path)
-

--- a/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
+++ b/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
@@ -1,5 +1,6 @@
 """Skills Pool operator API surface contract."""
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
@@ -11,9 +12,11 @@ from agentclaw.community.adapters.http.skills_pool.router import (
     get_rollout,
     rollback_bot,
     router,
+    set_full_rollout,
 )
 from agentclaw.community.adapters.http.skills_pool.schemas import (
     ControlBotRequest,
+    FullRolloutRequest,
     RollbackRequest,
 )
 from agentclaw.community.core.skills_pool.recovery_service import (
@@ -28,6 +31,7 @@ def test_all_skills_pool_operations_are_operator_only() -> None:
     expected = {
         "/api/ops/skills-pool/rollout",
         "/api/ops/skills-pool/rollout/feature",
+        "/api/ops/skills-pool/rollout/full",
         "/api/ops/skills-pool/rollout/promote",
         "/api/ops/skills-pool/rollout/whitelist",
         "/api/ops/skills-pool/rollout/whitelist/remove",
@@ -58,6 +62,40 @@ def test_control_bot_request_rejects_empty_batch_id() -> None:
             group="negative",
             reason="control sample",
         )
+
+
+@pytest.mark.asyncio
+async def test_full_rollout_route_forwards_optional_engine() -> None:
+    @dataclass(frozen=True)
+    class Result:
+        enabled: bool = True
+
+    class RolloutService:
+        call: dict[str, object] | None = None
+
+        def set_full_rollout(self, **kwargs: object):
+            self.call = kwargs
+            return Result()
+
+    service = RolloutService()
+
+    await set_full_rollout(
+        request=FullRolloutRequest(
+            enabled=True,
+            engine="openclaw",
+            reason="promote future OpenClaw claims",
+        ),
+        user=SimpleNamespace(staffId="freddie"),
+        service=service,
+    )
+
+    assert service.call == {
+        "env": "dev",
+        "enabled": True,
+        "engine": "openclaw",
+        "operator": "freddie",
+        "reason": "promote future OpenClaw claims",
+    }
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/resources/test_resource_file_service.py
+++ b/src/backend/tests/community/core/resources/test_resource_file_service.py
@@ -157,6 +157,36 @@ async def test_skills_local_injected_for_arca_when_present():
 
 
 @pytest.mark.asyncio
+async def test_pool_skills_local_is_injected_when_legacy_bridge_is_retired():
+    device_fs = MagicMock()
+    device_fs.list_dir = AsyncMock(side_effect=[
+        [
+            {"name": "skills-pool", "is_dir": True},
+            {"name": "data", "is_dir": True},
+        ],
+        [],
+        [
+            {
+                "name": "skills-local",
+                "is_dir": True,
+                "path": (
+                    "/home/admin/.openclaw/workspace/"
+                    "skills-pool/skills-local"
+                ),
+            }
+        ],
+    ])
+    svc, _ = _svc(provider="arca", device_fs=device_fs)
+
+    items = await svc.list_dir(**_COORDS, path="")
+
+    assert {item["name"] for item in items} == {"data", "skills-local"}
+    injected = next(item for item in items if item["name"] == "skills-local")
+    assert injected["path"] == "skills-pool/skills-local"
+    assert injected["absolute_path"].endswith("/skills-pool/skills-local")
+
+
+@pytest.mark.asyncio
 async def test_skills_local_not_injected_for_teclaw():
     device_fs = MagicMock()
     device_fs.list_dir = AsyncMock(return_value=[{"name": "skills-local", "is_dir": True}])
@@ -194,12 +224,13 @@ async def test_root_listing_survives_skills_probe_404():
     device_fs.list_dir = AsyncMock(side_effect=[
         [{"name": "data", "is_dir": True}],                 # root → 200
         FileNotFoundError("workspace/skills not found"),    # skills probe → 404
+        FileNotFoundError("workspace/skills-pool not found"),
     ])
     svc, _ = _svc(provider="baas", device_fs=device_fs)
     items = await svc.list_dir(**_COORDS, path="")
     assert [i["name"] for i in items] == ["data"]
     assert all(i["path"] != "skills/skills-local" for i in items)
-    assert device_fs.list_dir.await_count == 2
+    assert device_fs.list_dir.await_count == 3
 
 
 # ── read / download-limit forwarding ─────────────────────────────────────────

--- a/src/backend/tests/community/core/resources/test_resource_file_service.py
+++ b/src/backend/tests/community/core/resources/test_resource_file_service.py
@@ -187,6 +187,41 @@ async def test_pool_skills_local_is_injected_when_legacy_bridge_is_retired():
 
 
 @pytest.mark.asyncio
+async def test_root_returns_only_one_skills_local_when_both_layouts_exist():
+    device_fs = MagicMock()
+    device_fs.list_dir = AsyncMock(side_effect=[
+        [{"name": "data", "is_dir": True}],
+        [
+            {
+                "name": "skills-local",
+                "is_dir": True,
+                "path": (
+                    "/home/admin/.openclaw/workspace/skills/skills-local"
+                ),
+            }
+        ],
+        [
+            {
+                "name": "skills-local",
+                "is_dir": True,
+                "path": (
+                    "/home/admin/.openclaw/workspace/"
+                    "skills-pool/skills-local"
+                ),
+            }
+        ],
+    ])
+    svc, _ = _svc(provider="arca", device_fs=device_fs)
+
+    items = await svc.list_dir(**_COORDS, path="")
+
+    injected = [item for item in items if item["name"] == "skills-local"]
+    assert len(injected) == 1
+    assert injected[0]["path"] == "skills/skills-local"
+    assert device_fs.list_dir.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_skills_local_not_injected_for_teclaw():
     device_fs = MagicMock()
     device_fs.list_dir = AsyncMock(return_value=[{"name": "skills-local", "is_dir": True}])

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -46,8 +46,32 @@ def test_real_skill_set_service_factory_create_bot_paths_branch(test_injector):
     """user_id/entity_id present → the _get_bot_paths (if) branch the
     routers actually take (skills.py passes user_id/entity_id/bot_id)."""
     factory = test_injector.get(SkillSetServiceFactory)
+    factory._pool_layout_paths = lambda *_: None
     svc = factory.create(user_id="u1", entity_id="e1", bot_id="b1")
     assert isinstance(svc, SkillSetService)
+
+
+def test_pool_active_factory_scopes_skill_writes_to_canonical_pool(test_injector):
+    factory = test_injector.get(SkillSetServiceFactory)
+    factory._pool_layout_paths = lambda *_: (
+        "/home/admin/.openclaw/workspace/skills",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+    )
+
+    svc = factory.create(
+        user_id="u1",
+        entity_id="e1",
+        bot_id="b1",
+        engine_type="openclaw",
+    )
+
+    assert str(svc.skill_service.local_dir).endswith(
+        "/skills-pool/skills-local"
+    )
+    assert str(svc.skill_service.repo_dir).endswith(
+        "/skills-pool/skills-repo"
+    )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -72,6 +72,11 @@ def test_pool_active_factory_scopes_skill_writes_to_canonical_pool(test_injector
     assert str(svc.skill_service.repo_dir).endswith(
         "/skills-pool/skills-repo"
     )
+    assert str(svc.local_dir).endswith("/skills-pool/skills-local")
+    assert str(svc.repo_dir).endswith("/skills-pool/skills-repo")
+    assert svc.skill_service._local_skill_path_adapter(
+        "/home/admin/.openclaw/workspace/skills/skills-local/handmade"
+    ).endswith("/skills-pool/skills-local/handmade")
 
 
 @pytest.mark.asyncio
@@ -115,3 +120,29 @@ def test_real_skill_set_switcher_factory_create(test_injector):
 def test_real_skill_set_activator_factory_create(test_injector):
     factory = test_injector.get(SkillSetActivatorFactory)
     assert isinstance(factory.create(), SkillSetActivator)
+
+
+def test_pool_paths_propagate_to_switcher_and_activator(test_injector):
+    pool_paths = (
+        "/home/admin/.openclaw/workspace/skills",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+    )
+    skill_set_factory = test_injector.get(SkillSetServiceFactory)
+    skill_set_factory._pool_layout_paths = lambda *_: pool_paths
+
+    switcher = test_injector.get(SkillSetSwitcherFactory).create(
+        entity_id="staff_1",
+        bot_id="bot-1",
+        engine_type="openclaw",
+    )
+    activator = test_injector.get(SkillSetActivatorFactory).create(
+        entity_id="staff_1",
+        bot_id="bot-1",
+        engine_type="openclaw",
+    )
+
+    assert str(switcher.local_dir).endswith("/skills-pool/skills-local")
+    assert str(switcher.repo_dir).endswith("/skills-pool/skills-repo")
+    assert str(activator.local_dir).endswith("/skills-pool/skills-local")
+    assert str(activator.repo_dir).endswith("/skills-pool/skills-repo")

--- a/src/backend/tests/community/core/skills_pool/test_operations.py
+++ b/src/backend/tests/community/core/skills_pool/test_operations.py
@@ -172,6 +172,8 @@ def build_operations(
 def rollout_config(
     *,
     enabled: bool = True,
+    enable_all: bool = False,
+    full_rollout_engines: list[str] | None = None,
     promoted_engines: list[str] | None = None,
     whitelist: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
@@ -182,7 +184,8 @@ def rollout_config(
         "gmt_modified": "2026-07-25T09:00:00+00:00",
         "ext_info": {},
         "param_value": {
-            "enable_all": False,
+            "enable_all": enable_all,
+            "full_rollout_engines": full_rollout_engines or [],
             "promoted_engines": promoted_engines or [],
             "whitelist": whitelist or [],
             "negative_controls": [],
@@ -207,6 +210,7 @@ def test_enabling_missing_rollout_creates_safe_exact_bot_configuration() -> None
     assert snapshot.whitelist == ()
     assert configs.upserts[0]["param_value"] == {
         "enable_all": False,
+        "full_rollout_engines": [],
         "promoted_engines": [],
         "whitelist": [],
         "negative_controls": [],
@@ -241,6 +245,99 @@ def test_engine_promotion_is_manual_ordered_and_idempotent() -> None:
     assert promoted.promoted_engines == ("openclaw",)
     assert repeated.promoted_engines == ("openclaw",)
     assert len(configs.upserts) == 1
+
+
+def test_full_rollout_requires_accepted_promoted_engine_then_admits_environment(
+) -> None:
+    operations, configs, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+
+    with pytest.raises(RolloutOperationError, match="accepted openclaw batch"):
+        operations.set_full_rollout(
+            env=ENV,
+            enabled=True,
+            operator="freddie",
+            reason="too early",
+        )
+
+    operations.accept_batch(
+        env=ENV,
+        operator="freddie",
+        reason="canary passed",
+        acceptance=BatchPromotionEvidence(
+            engine="openclaw",
+            batch_id="openclaw-canary-1",
+            promotion_ready=True,
+            report={
+                "rollout_config_version": "2026-07-25T09:00:00+00:00",
+                "promotion_ready": True,
+            },
+        ),
+    )
+    snapshot = operations.set_full_rollout(
+        env=ENV,
+        enabled=True,
+        operator="freddie",
+        reason="promote pre openclaw",
+    )
+
+    assert snapshot.enable_all is True
+    assert configs.config is not None
+    assert configs.config["param_value"]["enable_all"] is True
+    assert snapshot.audit_log[-1].action == "full_rollout:environment:enable"
+
+
+def test_engine_full_rollout_does_not_admit_other_promoted_engine() -> None:
+    operations, configs, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+    operations.accept_batch(
+        env=ENV,
+        operator="freddie",
+        reason="canary passed",
+        acceptance=BatchPromotionEvidence(
+            engine="openclaw",
+            batch_id="openclaw-canary-1",
+            promotion_ready=True,
+            report={
+                "rollout_config_version": "2026-07-25T09:00:00+00:00",
+                "promotion_ready": True,
+            },
+        ),
+    )
+
+    snapshot = operations.set_full_rollout(
+        env=ENV,
+        engine="openclaw",
+        enabled=True,
+        operator="freddie",
+        reason="promote only openclaw",
+    )
+
+    assert snapshot.enable_all is False
+    assert snapshot.full_rollout_engines == ("openclaw",)
+    assert configs.config["param_value"]["full_rollout_engines"] == ["openclaw"]
+    assert snapshot.audit_log[-1].action == "full_rollout:openclaw:enable"
+
+
+def test_full_rollout_can_be_disabled_without_reverting_claimed_bots() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(
+            enable_all=True,
+            promoted_engines=["openclaw"],
+        )
+    )
+
+    snapshot = operations.set_full_rollout(
+        env=ENV,
+        enabled=False,
+        operator="freddie",
+        reason="pause new claims",
+    )
+
+    assert snapshot.enable_all is False
+    assert snapshot.promoted_engines == ("openclaw",)
 
 
 def test_next_engine_requires_and_audits_a_passing_batch() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
+++ b/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
@@ -38,6 +38,7 @@ def enabled_config(
     promoted_engines: object = None,
     whitelist: object = None,
     enable_all: object = False,
+    full_rollout_engines: object = None,
 ) -> dict[str, Any]:
     return {
         "id": 42,
@@ -46,6 +47,9 @@ def enabled_config(
         "gmt_modified": "2026-07-23T12:00:00",
         "param_value": {
             "enable_all": enable_all,
+            "full_rollout_engines": (
+                [] if full_rollout_engines is None else full_rollout_engines
+            ),
             "promoted_engines": (
                 ["openclaw"] if promoted_engines is None else promoted_engines
             ),
@@ -147,10 +151,6 @@ def test_logical_config_revision_is_frozen_into_claim_evidence() -> None:
             ),
             RolloutDecisionReason.CONFIG_INVALID,
         ),
-        (
-            make_gate(enabled_config(enable_all=True)),
-            RolloutDecisionReason.ENABLE_ALL_FORBIDDEN,
-        ),
     ],
 )
 def test_missing_disabled_failed_or_invalid_config_fails_closed(
@@ -178,6 +178,56 @@ def test_environment_engine_and_exact_identity_are_all_required() -> None:
         evaluate(gate, owner_id="other-owner").reason
         is RolloutDecisionReason.BOT_NOT_WHITELISTED
     )
+
+
+def test_full_rollout_admits_future_bot_in_promoted_engine() -> None:
+    decision = evaluate(
+        make_gate(enabled_config(enable_all=True, whitelist=[])),
+        owner_id="future-owner",
+        bot_id="future-bot",
+    )
+
+    assert decision.eligible
+    assert decision.evidence is not None
+    assert decision.evidence.batch_id is None
+    assert decision.evidence.decision_reason == "environment_full_rollout"
+
+
+def test_engine_full_rollout_admits_only_that_promoted_engine() -> None:
+    gate = make_gate(
+        enabled_config(
+            promoted_engines=["openclaw", "claude_code"],
+            full_rollout_engines=["openclaw"],
+            whitelist=[],
+        )
+    )
+
+    openclaw = evaluate(
+        gate,
+        owner_id="future-owner",
+        bot_id="future-bot",
+    )
+    claude = evaluate(
+        gate,
+        owner_id="future-owner",
+        bot_id="future-bot",
+        engine_type="claude_code",
+    )
+
+    assert openclaw.eligible
+    assert openclaw.evidence is not None
+    assert openclaw.evidence.decision_reason == "engine_full_rollout"
+    assert claude.reason is RolloutDecisionReason.BOT_NOT_WHITELISTED
+
+
+def test_full_rollout_still_rejects_unpromoted_engine() -> None:
+    decision = evaluate(
+        make_gate(enabled_config(enable_all=True, whitelist=[])),
+        engine_type="claude_code",
+    )
+
+    assert not decision.eligible
+    assert decision.reason is RolloutDecisionReason.ENGINE_NOT_PROMOTED
 
 
 @pytest.mark.parametrize("engine_type", ["teclaw", "moltis", "", "unknown"])

--- a/src/backend/tests/community/core/skills_pool/test_types.py
+++ b/src/backend/tests/community/core/skills_pool/test_types.py
@@ -1,0 +1,55 @@
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+    runtime_uses_pool_paths,
+)
+
+
+def _state(
+    *,
+    active_layout: SkillLayout = SkillLayout.LEGACY,
+    phase: SkillLayoutPhase = SkillLayoutPhase.LEGACY_ACTIVE,
+    data_plane_cutover_committed: bool = False,
+) -> BotSkillLayoutState:
+    return BotSkillLayoutState(
+        scope=BotSkillLayoutScope(env="pre", entity_id="staff_1", bot_id="bot-1"),
+        active_layout=active_layout,
+        target_layout=(
+            SkillLayout.POOL
+            if active_layout is SkillLayout.LEGACY
+            else None
+        ),
+        phase=phase,
+        migration_generation="generation-1",
+        persisted=True,
+        data_plane_cutover_committed=data_plane_cutover_committed,
+    )
+
+
+def test_pool_paths_become_authoritative_during_cutover_finalizing() -> None:
+    assert runtime_uses_pool_paths(
+        _state(phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING)
+    )
+
+
+def test_pool_paths_remain_authoritative_after_data_plane_commit() -> None:
+    assert runtime_uses_pool_paths(
+        _state(
+            phase=SkillLayoutPhase.NEEDS_MANUAL_REPAIR,
+            data_plane_cutover_committed=True,
+        )
+    )
+
+
+def test_begin_cutover_fences_backend_consumers_to_pool_paths() -> None:
+    assert runtime_uses_pool_paths(
+        _state(phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER)
+    )
+
+
+def test_pool_paths_are_not_used_while_only_preparing() -> None:
+    assert not runtime_uses_pool_paths(
+        _state(phase=SkillLayoutPhase.POOL_READY)
+    )

--- a/src/backend/tests/community/endpoints/test_skills_pool_ops.py
+++ b/src/backend/tests/community/endpoints/test_skills_pool_ops.py
@@ -74,6 +74,7 @@ def _seed_happy_services(world) -> None:
             patch.object(SkillsPoolRolloutOperations, method, mutation)
             for method in (
                 "set_feature_enabled",
+                "set_full_rollout",
                 "promote_engine",
                 "add_bot",
                 "remove_bot",
@@ -134,6 +135,14 @@ _HAPPY_CASES = (
         CaseInput(
             headers=_HEADERS,
             json_body={"engine": "openclaw", "reason": "first engine"},
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/full",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={"enabled": True, "reason": "promote environment"},
         ),
     ),
     (

--- a/src/backend/tests/community/services/test_skill_set_service.py
+++ b/src/backend/tests/community/services/test_skill_set_service.py
@@ -93,6 +93,47 @@ class TestGetSymlinkMappings:
         assert mappings[0].source == pool_source
         assert mappings[0].target.endswith("/openclaw/workspace/skills/handmade")
 
+    def test_cutover_finalizing_rewrites_legacy_locator_to_pool_source(
+        self, skill_set_service, mock_skill_set_repo
+    ):
+        pool_local = (
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+        )
+        skill_set_service.engine_type = "openclaw"
+        skill_set_service.entity_id = "100015"
+        skill_set_service._pool_layout_paths = lambda *_: (
+            "/home/admin/.openclaw/workspace/skills",
+            pool_local,
+            "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+        )
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = [
+            {"id": "1", "name": "Pool cutover", "is_default": False}
+        ]
+        mock_skill_set_repo.get_skills_in_set.return_value = [
+            {
+                "id": "1",
+                "name": "handmade",
+                "git_path": (
+                    "local:///home/admin/.openclaw/workspace/skills/"
+                    "skills-local/handmade"
+                ),
+            }
+        ]
+
+        with patch(
+            "agentclaw.community.utils.env_utils.is_local_mode",
+            return_value=False,
+        ):
+            mappings = skill_set_service.get_symlink_mappings(
+                user_id="100015",
+                bolt_id="default",
+            )
+
+        assert mappings[0].source == f"{pool_local}/handmade"
+        assert mappings[0].target == (
+            "/home/admin/.openclaw/workspace/skills/handmade"
+        )
+
     def test_claude_pool_locators_drive_restart_mappings(
         self, skill_set_service, mock_skill_set_repo
     ):

--- a/src/backend/tests/community/services/test_skill_set_service.py
+++ b/src/backend/tests/community/services/test_skill_set_service.py
@@ -100,6 +100,12 @@ class TestGetSymlinkMappings:
             "/home/admin/.claude_code/workspace/skills-pool/skills-local/handmade"
         )
         skill_set_service.engine_type = "claude_code"
+        skill_set_service.entity_id = "100015"
+        skill_set_service._pool_layout_paths = lambda *_: (
+            "/home/admin/.claude/skills",
+            "/home/admin/.claude_code/workspace/skills-pool/skills-local",
+            "/home/admin/.claude_code/workspace/skills-pool/skills-repo",
+        )
         mock_skill_set_repo.get_all_active_skill_sets.return_value = [
             {"id": "1", "name": "Claude Pool", "is_default": False}
         ]
@@ -127,7 +133,7 @@ class TestGetSymlinkMappings:
                 "/home/admin/.claude/skills/handmade",
             ),
             (
-                "/home/admin/.claude/skills/skills-repo/business/repo-skill",
+                "/home/admin/.claude_code/workspace/skills-pool/skills-repo/business/repo-skill",
                 "/home/admin/.claude/skills/repo-skill",
             ),
         ]
@@ -139,6 +145,12 @@ class TestGetSymlinkMappings:
             "/home/admin/.aicoding/workspace/skills-pool/skills-local/handmade"
         )
         skill_set_service.engine_type = "aicoding"
+        skill_set_service.entity_id = "100015"
+        skill_set_service._pool_layout_paths = lambda *_: (
+            "/home/admin/.claude/skills",
+            "/home/admin/.aicoding/workspace/skills-pool/skills-local",
+            "/home/admin/.aicoding/workspace/skills-pool/skills-repo",
+        )
         mock_skill_set_repo.get_all_active_skill_sets.return_value = [
             {"id": "1", "name": "AICoding Pool", "is_default": False}
         ]
@@ -166,7 +178,7 @@ class TestGetSymlinkMappings:
                 "/home/admin/.claude/skills/handmade",
             ),
             (
-                "/home/admin/.aicoding/skills-repo/business/repo-skill",
+                "/home/admin/.aicoding/workspace/skills-pool/skills-repo/business/repo-skill",
                 "/home/admin/.claude/skills/repo-skill",
             ),
         ]
@@ -178,6 +190,12 @@ class TestGetSymlinkMappings:
             "/home/admin/.hermes/workspace/skills-pool/skills-local/handmade"
         )
         skill_set_service.engine_type = "hermes"
+        skill_set_service.entity_id = "100015"
+        skill_set_service._pool_layout_paths = lambda *_: (
+            "/home/admin/.hermes/skills",
+            "/home/admin/.hermes/workspace/skills-pool/skills-local",
+            "/home/admin/.hermes/workspace/skills-pool/skills-repo",
+        )
         mock_skill_set_repo.get_all_active_skill_sets.return_value = [
             {"id": "1", "name": "Hermes Pool", "is_default": False}
         ]
@@ -205,10 +223,48 @@ class TestGetSymlinkMappings:
                 "/home/admin/.hermes/skills/handmade",
             ),
             (
-                "/home/admin/.hermes/skills-repo/business/repo-skill",
+                "/home/admin/.hermes/workspace/skills-pool/skills-repo/business/repo-skill",
                 "/home/admin/.hermes/skills/repo-skill",
             ),
         ]
+
+    def test_pool_active_repo_only_skill_uses_canonical_pool_source(
+        self, skill_set_service, mock_skill_set_repo
+    ):
+        skill_set_service.entity_id = "100015"
+        skill_set_service.engine_type = "openclaw"
+        skill_set_service._pool_layout_paths = lambda *_: (
+            "/home/admin/.openclaw/workspace/skills",
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+            "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+        )
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = [
+            {"id": "1", "name": "Pool", "is_default": False}
+        ]
+        mock_skill_set_repo.get_skills_in_set.return_value = [
+            {
+                "id": "2",
+                "name": "repo-skill",
+                "git_path": "git://business/repo-skill",
+            }
+        ]
+
+        with patch(
+            "agentclaw.community.utils.env_utils.is_local_mode",
+            return_value=False,
+        ):
+            mappings = skill_set_service.get_symlink_mappings(
+                user_id="100015",
+                bolt_id="default",
+            )
+
+        assert mappings[0].source == (
+            "/home/admin/.openclaw/workspace/skills-pool/"
+            "skills-repo/business/repo-skill"
+        )
+        assert mappings[0].target == (
+            "/home/admin/.openclaw/workspace/skills/repo-skill"
+        )
 
     def test_local_path_with_relative_name(
         self, skill_set_service, mock_skill_set_repo, mock_skill_repo

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -144,9 +144,10 @@ def test_aicoding_activation_switches_local_and_keeps_repo_namespace(
     assert result.status is PoolActivationStatus.COMMITTED
     assert legacy_local.is_symlink()
     assert legacy_local.resolve() == pool_local.resolve()
-    assert local_bridge.readlink() == legacy_local
-    assert local_bridge.resolve() == pool_local.resolve()
-    assert repo_bridge.resolve() == pool_repo.resolve()
+    assert not local_bridge.exists()
+    assert not local_bridge.is_symlink()
+    assert not repo_bridge.exists()
+    assert not repo_bridge.is_symlink()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
 
 

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
@@ -168,9 +168,10 @@ def test_claude_code_activation_atomically_switches_physical_local(
     assert result.status is PoolActivationStatus.COMMITTED
     assert legacy_local.is_symlink()
     assert legacy_local.resolve() == pool_local.resolve()
-    assert local_bridge.readlink() == legacy_local
-    assert local_bridge.resolve() == pool_local.resolve()
-    assert repo_bridge.resolve() == pool_repo.resolve()
+    assert not local_bridge.exists()
+    assert not local_bridge.is_symlink()
+    assert not repo_bridge.exists()
+    assert not repo_bridge.is_symlink()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
 
 

--- a/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
@@ -172,8 +172,10 @@ def test_activation_switches_hermes_local_bridge_to_pool(tmp_path: Path) -> None
     assert result.status is PoolActivationStatus.COMMITTED
     assert legacy_local.is_symlink()
     assert legacy_local.resolve() == pool_local.resolve()
-    assert local_bridge.readlink() == legacy_local
-    assert local_bridge.resolve() == pool_local.resolve()
+    assert not local_bridge.exists()
+    assert not local_bridge.is_symlink()
+    assert not repo_bridge.exists()
+    assert not repo_bridge.is_symlink()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
 
     mapping = SkillMapping(

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -140,6 +140,11 @@ def test_registered_local_cutover_syncs_latest_content_and_atomically_bridges(
     assert not legacy_local.is_symlink()
     assert not (legacy_local.parent / "skills-repo").exists()
     assert not (legacy_local.parent / "skills-repo").is_symlink()
+    active_marker = json.loads(
+        (pool_local.parent / ".pool-active").read_text()
+    )
+    assert active_marker["activation_state"] == "active"
+    assert active_marker["mappings"] == []
     verification = verify_skill_mappings(mappings=mappings, home=home)
     assert verification.valid
     assert (legacy_local.parent / "handmade" / "SKILL.md").read_text() == "latest"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -112,10 +112,10 @@ def test_registered_local_cutover_syncs_latest_content_and_atomically_bridges(
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
-    assert legacy_local.is_symlink()
-    assert legacy_local.resolve() == pool_local.resolve()
-    assert (legacy_local / "handmade" / "SKILL.md").read_text() == "latest"
-    assert not (legacy_local / "handmade" / "stale.txt").exists()
+    assert not legacy_local.exists()
+    assert not legacy_local.is_symlink()
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
+    assert not (pool_local / "handmade" / "stale.txt").exists()
     quarantine = (
         pool_local.parent
         / ".migration-quarantine"
@@ -136,8 +136,10 @@ def test_registered_local_cutover_syncs_latest_content_and_atomically_bridges(
     assert published.published
     assert external_entry.is_symlink()
     assert unclassified_entry.is_symlink()
-    assert legacy_local.is_symlink()
-    assert (legacy_local.parent / "skills-repo").is_symlink()
+    assert not legacy_local.exists()
+    assert not legacy_local.is_symlink()
+    assert not (legacy_local.parent / "skills-repo").exists()
+    assert not (legacy_local.parent / "skills-repo").is_symlink()
     verification = verify_skill_mappings(mappings=mappings, home=home)
     assert verification.valid
     assert (legacy_local.parent / "handmade" / "SKILL.md").read_text() == "latest"
@@ -225,6 +227,12 @@ def test_legacy_mapping_can_replace_pool_mapping_during_explicit_rollback(
     )
     assert activated.committed
     assert publish_pool_mappings(mappings=[pool_mapping], home=home).published
+    rolled_back = rollback_openclaw_pool(
+        rollback_generation="rollback-1",
+        registered_local_names=["handmade"],
+        home=home,
+    )
+    assert rolled_back.committed
 
     legacy_mapping = SkillMapping(
         source=str(legacy_local / "handmade"),
@@ -776,7 +784,7 @@ def test_post_exchange_new_file_uses_atomic_no_clobber(
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
-    assert (legacy_local / "handmade" / "raced.txt").read_text() == (
+    assert (pool_local / "handmade" / "raced.txt").read_text() == (
         "pool-after-exchange"
     )
     assert result.evidence["post_sync"]["conflicts_preserved_in_pool"] == [

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -106,6 +106,190 @@ def test_active_marker_requires_direct_pool_mappings_and_absent_storage_entries(
     assert result.evidence["checks"]["legacy_storage_entries_absent"] is True
 
 
+def _active_marker_path(home: Path) -> Path:
+    return (
+        home
+        / ".openclaw"
+        / "workspace"
+        / "skills-pool"
+        / ".pool-active"
+    )
+
+
+def _write_active_marker(
+    home: Path,
+    *,
+    activation_state: str = "finalizing",
+    mappings: object = None,
+) -> Path:
+    marker_path = _active_marker_path(home)
+    marker_path.write_text(
+        json.dumps(
+            {
+                "engine": "openclaw",
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+                "migration_generation": "generation-1",
+                "activation_state": activation_state,
+                "mappings": [] if mappings is None else mappings,
+            }
+        )
+    )
+    return marker_path
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda marker: "not-a-marker",
+        lambda marker: {**marker, "engine": "claude_code"},
+        lambda marker: {**marker, "mappings": "not-a-list"},
+        lambda marker: {**marker, "mappings": ["not-a-mapping"]},
+        lambda marker: {
+            **marker,
+            "mappings": [{"source": 1, "target": "target"}],
+        },
+        lambda marker: {
+            **marker,
+            "mappings": [{"source": "/outside/pool", "target": "/tmp/skill"}],
+        },
+        lambda marker: {
+            **marker,
+            "mappings": [
+                {
+                    "source": marker["pool_local"],
+                    "target": marker["pool_local"],
+                }
+            ],
+        },
+    ],
+)
+def test_active_marker_contract_mismatch_is_invalid(tmp_path, mutate):
+    home, _, pool_local, pool_repo = _ready_home(tmp_path)
+    marker_path = _write_active_marker(home)
+    marker = json.loads(marker_path.read_text())
+    marker["pool_local"] = str(pool_local)
+    marker_path.write_text(json.dumps(mutate(marker)))
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "active_marker_contract_mismatch"
+
+
+def test_active_marker_must_be_regular_file(tmp_path):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    _active_marker_path(home).mkdir()
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "active_marker_not_regular_file"
+
+
+def test_invalid_active_marker_payload_is_invalid(tmp_path):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    _active_marker_path(home).write_text("{")
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "active_marker_invalid"
+
+
+@pytest.mark.parametrize(
+    ("error", "status", "reason"),
+    [
+        (
+            PermissionError("denied"),
+            RuntimeLayoutInspectionStatus.INVALID,
+            "active_marker_unreadable",
+        ),
+        (
+            OSError(errno.ESTALE, "stale NAS handle"),
+            RuntimeLayoutInspectionStatus.TRANSIENT_ERROR,
+            "active_marker_temporarily_unavailable",
+        ),
+    ],
+)
+def test_active_marker_stat_error_is_classified(
+    tmp_path, monkeypatch, error, status, reason
+):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    active_marker = _write_active_marker(home)
+    original_lstat = Path.lstat
+
+    def fail_active_marker_lstat(path):
+        if path == active_marker:
+            raise error
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", fail_active_marker_lstat)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is status
+    assert result.evidence["reason"] == reason
+
+
+def test_active_marker_read_io_error_is_transient(tmp_path, monkeypatch):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    active_marker = _write_active_marker(home)
+    original_read_bytes = Path.read_bytes
+
+    def fail_active_marker_read(path):
+        if path == active_marker:
+            raise OSError(errno.ESTALE, "stale NAS handle")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fail_active_marker_read)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.TRANSIENT_ERROR
+    assert result.evidence["reason"] == "active_marker_temporarily_unavailable"
+
+
+def test_active_marker_rejects_unretired_repo_bridge(tmp_path):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    _write_active_marker(home, activation_state="active")
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "retired_repo_bridge_present"
+
+
 def test_absent_marker_is_not_capable(tmp_path):
     result = inspect_runtime_layout(
         engine="openclaw",

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -69,6 +69,43 @@ def test_ready_requires_real_bridge_mount_and_readable_repo(tmp_path):
     assert result.evidence["checks"]["legacy_repo_bridge_valid"] is True
 
 
+def test_active_marker_requires_direct_pool_mappings_and_absent_storage_entries(
+    tmp_path,
+):
+    home, active_root, pool_local, pool_repo = _ready_home(tmp_path)
+    source = pool_local / "handmade"
+    source.mkdir()
+    target = active_root / "handmade"
+    target.symlink_to(source, target_is_directory=True)
+    (active_root / "skills-repo").unlink()
+    pool_root = pool_local.parent
+    (pool_root / ".pool-active").write_text(
+        json.dumps(
+            {
+                "engine": "openclaw",
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+                "migration_generation": "generation-1",
+                "activation_state": "active",
+                "mappings": [
+                    {"source": str(source), "target": str(target)}
+                ],
+            }
+        )
+    )
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+    assert result.evidence["activation_state"] == "active"
+    assert result.evidence["checks"]["legacy_storage_entries_absent"] is True
+
+
 def test_absent_marker_is_not_capable(tmp_path):
     result = inspect_runtime_layout(
         engine="openclaw",

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -87,9 +87,6 @@ def test_active_marker_requires_direct_pool_mappings_and_absent_storage_entries(
                 "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
                 "migration_generation": "generation-1",
                 "activation_state": "active",
-                "mappings": [
-                    {"source": str(source), "target": str(target)}
-                ],
             }
         )
     )
@@ -104,6 +101,73 @@ def test_active_marker_requires_direct_pool_mappings_and_absent_storage_entries(
     assert result.status is RuntimeLayoutInspectionStatus.READY
     assert result.evidence["activation_state"] == "active"
     assert result.evidence["checks"]["legacy_storage_entries_absent"] is True
+
+
+def test_active_marker_allows_normal_skill_deactivation(tmp_path):
+    home, active_root, pool_local, pool_repo = _ready_home(tmp_path)
+    source = pool_local / "handmade"
+    source.mkdir()
+    target = active_root / "handmade"
+    target.symlink_to(source, target_is_directory=True)
+    (active_root / "skills-repo").unlink()
+    _write_active_marker(
+        home,
+        activation_state="active",
+        mappings=[{"source": str(source), "target": str(target)}],
+    )
+
+    target.unlink()
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_finalizing_marker_allows_concurrent_skill_deactivation(tmp_path):
+    home, active_root, pool_local, pool_repo = _ready_home(tmp_path)
+    source = pool_local / "handmade"
+    source.mkdir()
+    target = active_root / "handmade"
+    target.symlink_to(source, target_is_directory=True)
+    _write_active_marker(
+        home,
+        activation_state="finalizing",
+        mappings=[{"source": str(source), "target": str(target)}],
+    )
+
+    target.unlink()
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_active_marker_allows_normal_skill_activation(tmp_path):
+    home, active_root, pool_local, pool_repo = _ready_home(tmp_path)
+    (active_root / "skills-repo").unlink()
+    _write_active_marker(home, activation_state="active")
+    source = pool_local / "new-skill"
+    source.mkdir()
+    (active_root / "new-skill").symlink_to(source, target_is_directory=True)
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
 
 
 def _active_marker_path(home: Path) -> Path:
@@ -123,17 +187,17 @@ def _write_active_marker(
     mappings: object = None,
 ) -> Path:
     marker_path = _active_marker_path(home)
+    marker = {
+        "engine": "openclaw",
+        "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+        "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+        "migration_generation": "generation-1",
+        "activation_state": activation_state,
+    }
+    if activation_state == "finalizing" or mappings is not None:
+        marker["mappings"] = [] if mappings is None else mappings
     marker_path.write_text(
-        json.dumps(
-            {
-                "engine": "openclaw",
-                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
-                "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
-                "migration_generation": "generation-1",
-                "activation_state": activation_state,
-                "mappings": [] if mappings is None else mappings,
-            }
-        )
+        json.dumps(marker)
     )
     return marker_path
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -220,10 +220,18 @@ def _write_active_marker(
         "migration_generation": migration_generation,
         "activation_state": activation_state,
         "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        "mappings": [
-            {"source": mapping.source, "target": mapping.target} for mapping in mappings
-        ],
+        # Keep the key for compatibility with already-published image startup
+        # scripts. Only finalizing carries recovery mappings; active is stable.
+        "mappings": [],
     }
+    if activation_state == "finalizing":
+        # Recovery material for the short cutover window only. Once active,
+        # skill mappings are mutable product state and must not become part of
+        # the persisted layout contract.
+        value["mappings"] = [
+            {"source": mapping.source, "target": mapping.target}
+            for mapping in mappings
+        ]
     payload = json.dumps(
         value,
         ensure_ascii=False,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import os
 import re
+import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Callable
@@ -98,6 +100,7 @@ class _Layout:
     legacy_repo: Path
     local_bridge: Path
     repo_bridge: Path
+    active_marker: Path
 
     @classmethod
     def for_home(cls, home: Path) -> "_Layout":
@@ -119,6 +122,7 @@ class _Layout:
                 legacy_repo=home / ".hermes" / "skills-repo",
                 local_bridge=legacy_root / "skills-local",
                 repo_bridge=home / ".hermes" / "skills-repo",
+                active_marker=pool_root / ".pool-active",
             )
         if engine == "aicoding":
             workspace = home / ".aicoding" / "workspace"
@@ -134,6 +138,7 @@ class _Layout:
                 legacy_repo=home / ".aicoding" / "skills-repo",
                 local_bridge=legacy_root / "skills-local",
                 repo_bridge=home / ".aicoding" / "skills-repo",
+                active_marker=pool_root / ".pool-active",
             )
         if engine == "claude_code":
             workspace = home / ".claude_code" / "workspace"
@@ -149,6 +154,7 @@ class _Layout:
                 legacy_repo=home / ".claude_code" / "skills-repo",
                 local_bridge=legacy_root / "skills-local",
                 repo_bridge=legacy_root / "skills-repo",
+                active_marker=pool_root / ".pool-active",
             )
         if engine != "openclaw":
             raise ValueError(f"unsupported filesystem Pool engine: {engine}")
@@ -166,6 +172,7 @@ class _Layout:
             legacy_repo=legacy_repo,
             local_bridge=legacy_local,
             repo_bridge=legacy_repo,
+            active_marker=pool_root / ".pool-active",
         )
 
 
@@ -182,6 +189,133 @@ class _PostCutoverFinalization:
     post_sync: dict[str, object]
     cleanup_pending: bool
     failure: PoolActivationResult | None = None
+
+
+def _read_active_marker(path: Path) -> dict[str, object] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (
+        FileNotFoundError,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _write_active_marker(
+    *,
+    layout: _Layout,
+    engine: str,
+    migration_generation: str,
+    preparation_id: str,
+    mappings: list[SkillMapping],
+    activation_state: str,
+) -> None:
+    value = {
+        "engine": engine,
+        "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+        "preparation_id": preparation_id,
+        "migration_generation": migration_generation,
+        "activation_state": activation_state,
+        "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "mappings": [
+            {"source": mapping.source, "target": mapping.target} for mapping in mappings
+        ],
+    }
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    temporary = layout.pool_root / (f".pool-active.tmp-{migration_generation}")
+    with temporary.open("wb") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, layout.active_marker)
+    directory_fd = os.open(layout.pool_root, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _retire_bridge(path: Path, *, allowed_targets: tuple[Path, ...]) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    if not path.is_symlink():
+        raise OSError(f"legacy storage entry is not a symlink: {path}")
+    target = _lexical_target(path)
+    normalized_targets = {
+        Path(os.path.abspath(candidate)) for candidate in allowed_targets
+    }
+    if target not in normalized_targets:
+        raise OSError(f"legacy storage entry points elsewhere: {path}")
+    path.unlink()
+
+
+def _finalize_active_root(
+    *,
+    layout: _Layout,
+    engine: str,
+    migration_generation: str,
+    preparation_id: str,
+    mappings: list[SkillMapping],
+) -> PoolActivationResult | None:
+    published = publish_pool_mappings(
+        mappings=mappings,
+        home=layout.pool_root.parents[2],
+        engine=engine,
+    )
+    if not published.published:
+        return PoolActivationResult(
+            PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+            {
+                "reason": "pool_mapping_publish_failed",
+                "mapping": published.evidence,
+            },
+        )
+    verified = verify_skill_mappings(
+        mappings=mappings,
+        home=layout.pool_root.parents[2],
+        engine=engine,
+    )
+    if not verified.valid:
+        return PoolActivationResult(
+            PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+            {
+                "reason": "pool_mapping_verify_failed",
+                "mapping": verified.evidence,
+            },
+        )
+    _write_active_marker(
+        layout=layout,
+        engine=engine,
+        migration_generation=migration_generation,
+        preparation_id=preparation_id,
+        mappings=mappings,
+        activation_state="finalizing",
+    )
+    _retire_bridge(
+        layout.local_bridge,
+        allowed_targets=(layout.legacy_local, layout.pool_local),
+    )
+    _retire_bridge(
+        layout.repo_bridge,
+        allowed_targets=(layout.legacy_repo, layout.pool_repo),
+    )
+    _write_active_marker(
+        layout=layout,
+        engine=engine,
+        migration_generation=migration_generation,
+        preparation_id=preparation_id,
+        mappings=mappings,
+        activation_state="active",
+    )
+    return None
 
 
 def _lexical_target(link: Path) -> Path:
@@ -534,6 +668,43 @@ def _activate_pool(
             preparation_id=inspection.preparation_id,
         )
 
+    active_marker = _read_active_marker(layout.active_marker)
+    if active_marker is not None:
+        if (
+            active_marker.get("engine") != engine
+            or active_marker.get("layout_contract_version") != LAYOUT_CONTRACT_VERSION
+            or active_marker.get("preparation_id") != preparation_id
+            or active_marker.get("migration_generation") != migration_generation
+            or active_marker.get("activation_state") not in {"finalizing", "active"}
+        ):
+            return _invalid("active_marker_identity_mismatch")
+        try:
+            completion_failure = _finalize_active_root(
+                layout=layout,
+                engine=engine,
+                migration_generation=migration_generation,
+                preparation_id=preparation_id,
+                mappings=mappings,
+            )
+        except OSError as error:
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "active_root_retirement_failed",
+                    "error_type": type(error).__name__,
+                    "errno": error.errno,
+                },
+            )
+        if completion_failure is not None:
+            return completion_failure
+        return PoolActivationResult(
+            PoolActivationStatus.ALREADY_COMMITTED,
+            {
+                "active_marker": str(layout.active_marker),
+                "legacy_storage_entries_absent": True,
+            },
+        )
+
     temporary = layout.legacy_local.parent / (
         f".skills-local.pool-cutover-{migration_generation}"
     )
@@ -581,11 +752,20 @@ def _activate_pool(
                 )
                 if finalization.failure is not None:
                     return finalization.failure
+            completion_failure = _finalize_active_root(
+                layout=layout,
+                engine=engine,
+                migration_generation=migration_generation,
+                preparation_id=preparation_id,
+                mappings=mappings,
+            )
+            if completion_failure is not None:
+                return completion_failure
             return PoolActivationResult(
                 PoolActivationStatus.ALREADY_COMMITTED,
                 {
-                    "bridge": str(layout.legacy_local),
-                    "target": str(layout.pool_local),
+                    "active_marker": str(layout.active_marker),
+                    "legacy_storage_entries_absent": True,
                     "quarantine": str(quarantine),
                     "quarantine_cleanup_pending": (finalization.cleanup_pending),
                     "post_sync": finalization.post_sync,
@@ -671,11 +851,20 @@ def _activate_pool(
         )
         if finalization.failure is not None:
             return finalization.failure
+        completion_failure = _finalize_active_root(
+            layout=layout,
+            engine=engine,
+            migration_generation=migration_generation,
+            preparation_id=preparation_id,
+            mappings=mappings,
+        )
+        if completion_failure is not None:
+            return completion_failure
         return PoolActivationResult(
             PoolActivationStatus.COMMITTED,
             {
-                "bridge": str(layout.legacy_local),
-                "target": str(layout.pool_local),
+                "active_marker": str(layout.active_marker),
+                "legacy_storage_entries_absent": True,
                 "quarantine": str(quarantine),
                 "quarantine_cleanup_pending": finalization.cleanup_pending,
                 "registered_local_count": len(normalized_names),
@@ -818,11 +1007,9 @@ def _rollback_pool(
     home: str | Path = "/home/admin",
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
 ) -> PoolActivationResult:
-    """Rebuild Legacy from the current authoritative Pool tree, then swap."""
+    """Rebuild Legacy from Pool for the pre-recursive-engine rollout window."""
 
-    if not re.fullmatch(
-        r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", rollback_generation
-    ):
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", rollback_generation):
         return _invalid("rollback_generation_invalid")
     layout = _Layout.for_engine(engine, Path(home))
     normalized_names: list[str] = []
@@ -841,9 +1028,7 @@ def _rollback_pool(
     rebuild = layout.legacy_local.parent / (
         f".skills-local.pool-rollback-{rollback_generation}"
     )
-    copy_staging = layout.pool_root / (
-        f".rollback-copy-{rollback_generation}"
-    )
+    copy_staging = layout.pool_root / (f".rollback-copy-{rollback_generation}")
     try:
         if layout.legacy_local.is_dir() and not layout.legacy_local.is_symlink():
             for name in normalized_names:
@@ -861,18 +1046,21 @@ def _rollback_pool(
                     "source": str(layout.pool_local),
                 },
             )
-        if not layout.legacy_local.is_symlink() or _lexical_target(
-            layout.legacy_local
-        ) != Path(os.path.abspath(layout.pool_local)):
+        legacy_local_absent = (
+            not layout.legacy_local.exists() and not layout.legacy_local.is_symlink()
+        )
+        if not legacy_local_absent and (
+            not layout.legacy_local.is_symlink()
+            or _lexical_target(layout.legacy_local)
+            != Path(os.path.abspath(layout.pool_local))
+        ):
             return _invalid("pool_local_bridge_invalid")
         if not layout.pool_local.is_dir() or layout.pool_local.is_symlink():
             return _data_inconsistent(
                 "pool_local_not_directory",
                 source=str(layout.pool_local),
             )
-        if rebuild.is_symlink() or (
-            rebuild.exists() and not rebuild.is_dir()
-        ):
+        if rebuild.is_symlink() or (rebuild.exists() and not rebuild.is_dir()):
             return _invalid("rollback_temporary_path_occupied", path=str(rebuild))
         rebuild.mkdir(exist_ok=True)
         local_names = mirror_local_tree(
@@ -888,7 +1076,9 @@ def _rollback_pool(
                     registered_name=name,
                     source=str(source),
                 )
-        if not exchange_paths(layout.legacy_local, rebuild):
+        if legacy_local_absent:
+            os.replace(rebuild, layout.legacy_local)
+        elif not exchange_paths(layout.legacy_local, rebuild):
             return PoolActivationResult(
                 PoolActivationStatus.NOT_ATOMIC,
                 {"reason": "atomic_exchange_unavailable"},
@@ -898,6 +1088,23 @@ def _rollback_pool(
         # The displaced object is only the compatibility symlink. Pool content
         # itself remains intact for evidence and forward recovery.
         rebuild.unlink(missing_ok=True)
+        layout.repo_bridge.parent.mkdir(parents=True, exist_ok=True)
+        if not layout.repo_bridge.exists() and not layout.repo_bridge.is_symlink():
+            layout.repo_bridge.symlink_to(
+                layout.pool_repo,
+                target_is_directory=True,
+            )
+        if layout.local_bridge != layout.legacy_local:
+            layout.local_bridge.parent.mkdir(parents=True, exist_ok=True)
+            if (
+                not layout.local_bridge.exists()
+                and not layout.local_bridge.is_symlink()
+            ):
+                layout.local_bridge.symlink_to(
+                    layout.legacy_local,
+                    target_is_directory=True,
+                )
+        layout.active_marker.unlink(missing_ok=True)
         return PoolActivationResult(
             PoolActivationStatus.COMMITTED,
             {
@@ -905,17 +1112,14 @@ def _rollback_pool(
                 "source": str(layout.pool_local),
                 "local_inventory": {
                     "registered": len(normalized_names),
-                    "unregistered": len(
-                        set(local_names) - set(normalized_names)
-                    ),
+                    "unregistered": len(set(local_names) - set(normalized_names)),
                     "total": len(local_names),
                 },
             },
         )
     except OSError as error:
         committed = (
-            layout.legacy_local.is_dir()
-            and not layout.legacy_local.is_symlink()
+            layout.legacy_local.is_dir() and not layout.legacy_local.is_symlink()
         )
         return PoolActivationResult(
             (

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -366,6 +366,8 @@ def _active_marker_valid(
         or not isinstance(marker.get("migration_generation"), str)
     ):
         return False
+    if marker["activation_state"] == "active":
+        return True
     mappings = marker.get("mappings")
     if not isinstance(mappings, list):
         return False
@@ -388,12 +390,43 @@ def _active_marker_valid(
             target.parent != Path(os.path.abspath(layout.legacy_root))
             or target in {layout.local_bridge, layout.repo_bridge}
             or target in seen_targets
-            or not source.is_dir()
-            or not target.is_symlink()
-            or _lexical_symlink_target(target) != source
         ):
             return False
         seen_targets.add(target)
+    return True
+
+
+def _active_entries_valid(layout: _FilesystemPoolLayout) -> bool:
+    """Validate mutable managed entries without freezing an old mapping set."""
+
+    pool_roots = tuple(
+        Path(os.path.abspath(root))
+        for root in (layout.pool_local, layout.pool_repo)
+    )
+    retired_roots = tuple(
+        Path(os.path.abspath(root))
+        for root in (
+            layout.legacy_local,
+            layout.legacy_repo,
+            layout.local_bridge,
+            layout.repo_bridge,
+        )
+    )
+    for entry in layout.legacy_root.iterdir():
+        if not entry.is_symlink():
+            continue
+        target = _lexical_symlink_target(entry)
+        if any(target.is_relative_to(root) for root in pool_roots):
+            try:
+                target_stat = entry.stat()
+            except (FileNotFoundError, NotADirectoryError):
+                return False
+            if not stat.S_ISDIR(target_stat.st_mode):
+                return False
+            continue
+        if any(target.is_relative_to(root) for root in retired_roots):
+            return False
+        # External active entries predate Pool and remain outside this migration.
     return True
 
 
@@ -657,6 +690,27 @@ def inspect_runtime_layout(
                         reason=f"retired_{bridge_name}_bridge_present",
                         preparation_id=preparation_id,
                     )
+            try:
+                active_entries_valid = _active_entries_valid(layout)
+            except PermissionError:
+                active_entries_valid = False
+            except OSError as error:
+                return _transient(
+                    engine=engine,
+                    contract_version=expected_contract_version,
+                    layout=layout,
+                    reason="active_entries_temporarily_unavailable",
+                    error=error,
+                    preparation_id=preparation_id,
+                )
+            if not active_entries_valid:
+                return _invalid(
+                    engine=engine,
+                    contract_version=expected_contract_version,
+                    layout=layout,
+                    reason="active_managed_entry_invalid",
+                    preparation_id=preparation_id,
+                )
         return RuntimeLayoutInspection(
             status=RuntimeLayoutInspectionStatus.READY,
             engine=engine,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -50,6 +50,7 @@ class _FilesystemPoolLayout:
     pool_local: Path
     pool_repo: Path
     marker: Path
+    active_marker: Path
     local_bridge: Path
     repo_bridge: Path
 
@@ -73,6 +74,7 @@ class _FilesystemPoolLayout:
                 pool_local=pool_root / "skills-local",
                 pool_repo=pool_root / "skills-repo",
                 marker=pool_root / ".pool-ready",
+                active_marker=pool_root / ".pool-active",
                 local_bridge=legacy_root / "skills-local",
                 repo_bridge=legacy_repo,
             )
@@ -90,6 +92,7 @@ class _FilesystemPoolLayout:
                 pool_local=pool_root / "skills-local",
                 pool_repo=pool_root / "skills-repo",
                 marker=pool_root / ".pool-ready",
+                active_marker=pool_root / ".pool-active",
                 local_bridge=legacy_root / "skills-local",
                 repo_bridge=legacy_repo,
             )
@@ -107,6 +110,7 @@ class _FilesystemPoolLayout:
                 pool_local=pool_root / "skills-local",
                 pool_repo=pool_root / "skills-repo",
                 marker=pool_root / ".pool-ready",
+                active_marker=pool_root / ".pool-active",
                 local_bridge=legacy_root / "skills-local",
                 repo_bridge=legacy_root / "skills-repo",
             )
@@ -125,6 +129,7 @@ class _FilesystemPoolLayout:
             pool_local=pool_root / "skills-local",
             pool_repo=pool_root / "skills-repo",
             marker=pool_root / ".pool-ready",
+            active_marker=pool_root / ".pool-active",
             local_bridge=legacy_local,
             repo_bridge=legacy_repo,
         )
@@ -343,6 +348,55 @@ def _managed_entries_valid(
     return True
 
 
+def _active_marker_valid(
+    marker: object,
+    *,
+    layout: _FilesystemPoolLayout,
+    engine: str,
+    expected_contract_version: str,
+    preparation_id: str,
+) -> bool:
+    if not isinstance(marker, dict):
+        return False
+    if (
+        marker.get("engine") != engine
+        or marker.get("layout_contract_version") != expected_contract_version
+        or marker.get("preparation_id") != preparation_id
+        or marker.get("activation_state") not in {"finalizing", "active"}
+        or not isinstance(marker.get("migration_generation"), str)
+    ):
+        return False
+    mappings = marker.get("mappings")
+    if not isinstance(mappings, list):
+        return False
+    seen_targets: set[Path] = set()
+    for mapping in mappings:
+        if not isinstance(mapping, dict):
+            return False
+        source_value = mapping.get("source")
+        target_value = mapping.get("target")
+        if not isinstance(source_value, str) or not isinstance(target_value, str):
+            return False
+        source = Path(os.path.abspath(source_value))
+        target = Path(os.path.abspath(target_value))
+        if not (
+            source.is_relative_to(Path(os.path.abspath(layout.pool_local)))
+            or source.is_relative_to(Path(os.path.abspath(layout.pool_repo)))
+        ):
+            return False
+        if (
+            target.parent != Path(os.path.abspath(layout.legacy_root))
+            or target in {layout.local_bridge, layout.repo_bridge}
+            or target in seen_targets
+            or not source.is_dir()
+            or not target.is_symlink()
+            or _lexical_symlink_target(target) != source
+        ):
+            return False
+        seen_targets.add(target)
+    return True
+
+
 def inspect_runtime_layout(
     *,
     engine: str,
@@ -525,6 +579,106 @@ def inspect_runtime_layout(
             reason="pool_repo_temporarily_unavailable",
             error=error,
             preparation_id=preparation_id,
+        )
+    active_marker: dict[str, Any] | None = None
+    try:
+        active_marker_stat = layout.active_marker.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        active_marker_stat = None
+    except PermissionError:
+        return _invalid(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="active_marker_unreadable",
+            preparation_id=preparation_id,
+        )
+    except OSError as error:
+        return _transient(
+            engine=engine,
+            contract_version=expected_contract_version,
+            layout=layout,
+            reason="active_marker_temporarily_unavailable",
+            error=error,
+            preparation_id=preparation_id,
+        )
+    if active_marker_stat is not None:
+        if not stat.S_ISREG(active_marker_stat.st_mode):
+            return _invalid(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="active_marker_not_regular_file",
+                preparation_id=preparation_id,
+            )
+        try:
+            active_marker = json.loads(layout.active_marker.read_bytes())
+        except (PermissionError, UnicodeDecodeError, json.JSONDecodeError):
+            return _invalid(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="active_marker_invalid",
+                preparation_id=preparation_id,
+            )
+        except OSError as error:
+            return _transient(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="active_marker_temporarily_unavailable",
+                error=error,
+                preparation_id=preparation_id,
+            )
+        if not _active_marker_valid(
+            active_marker,
+            layout=layout,
+            engine=engine,
+            expected_contract_version=expected_contract_version,
+            preparation_id=preparation_id,
+        ):
+            return _invalid(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="active_marker_contract_mismatch",
+                preparation_id=preparation_id,
+            )
+        if active_marker["activation_state"] == "active":
+            for bridge_name, bridge_path in (
+                ("local", layout.local_bridge),
+                ("repo", layout.repo_bridge),
+            ):
+                if bridge_path.exists() or bridge_path.is_symlink():
+                    return _invalid(
+                        engine=engine,
+                        contract_version=expected_contract_version,
+                        layout=layout,
+                        reason=f"retired_{bridge_name}_bridge_present",
+                        preparation_id=preparation_id,
+                    )
+        return RuntimeLayoutInspection(
+            status=RuntimeLayoutInspectionStatus.READY,
+            engine=engine,
+            layout_contract_version=expected_contract_version,
+            preparation_id=preparation_id,
+            evidence={
+                "marker": str(layout.marker),
+                "active_marker": str(layout.active_marker),
+                "prepared_at": marker["prepared_at"],
+                "activation_state": active_marker["activation_state"],
+                "checks": {
+                    "marker_valid": True,
+                    "active_marker_valid": True,
+                    "pool_local_valid": True,
+                    "pool_repo_mounted": True,
+                    "pool_repo_readable": True,
+                    "pool_mappings_valid": True,
+                    "legacy_storage_entries_absent": (
+                        active_marker["activation_state"] == "active"
+                    ),
+                },
+            },
         )
     required_bridges = [("legacy_repo", layout.repo_bridge, layout.pool_repo)]
     if engine != "openclaw":


### PR DESCRIPTION
## Summary

Finalize Pool activation without leaving corpus directory bridges in the engine active root, and add controlled engine/environment full-rollout operations for future and restarted bots. Pool-active skill edits, mappings, and resource browsing now resolve canonical Pool paths.

## Changes

- publish and verify direct active-skill mappings before retiring `skills-local` and `skills-repo` bridge entries
- persist and probe `.pool-active` finalization evidence across runtime retries
- resolve Pool-active skill writes, mapping sources, and resource browsing to canonical Pool paths
- add per-engine and environment-wide full-rollout admission after accepted canary batches
- preserve the pre-recursive-engine rollback window and document the forward-only recursive-engine release gate

## Companion

Requires the OCB image companion on branch `dev_skills_pool_p3_safe_cutover` so restarts do not recreate retired bridges.

## Test Plan

- `252 passed` — Backend Skills Pool, operator API, skill paths, resource browser
- `70 passed` — OpenClaw/Claude Code/AICoding/Hermes activation and probe
- `15 passed` — architecture and protocol boundaries
- Ruff checks passed for all changed Python files
