### PR TITLE
add relay ws_url

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/devices/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/devices/schemas.py
@@ -187,7 +187,7 @@ class DeviceConnectionResponse(BaseModel):
     engine_type: str = Field(..., description="Engine type")
     available: bool = Field(True, description="Whether the device is reachable")
     message: str = Field("", description="Human-readable status message when unavailable")
-    url: str = Field("", description="HTTP base URL (plan-01 added; e.g. http://10.0.0.1:20010)")
+    url: str = Field("", description="Connection URL (HTTP or WebSocket, depending on connection mode)")
 
 
 class DeviceProps(BaseModel):

--- a/src/backend/src/agentclaw/community/core/devices/models.py
+++ b/src/backend/src/agentclaw/community/core/devices/models.py
@@ -129,11 +129,12 @@ class DeviceConnectionInfo:
     tenant: str = ""
     engine_port: int = 20003
     url: str = ""
-    """HTTP base_url（如 "http://10.0.0.1:20010"）—— plan-01 新增字段。
+    """连接 URL；随模式返回 HTTP base URL 或 WebSocket URL。
 
-    由 LocalDeviceService._compose_device_conn_info 通过 BaaS get_http_info 填充；
+    LocalDeviceService 通过 BaaS get_http_info 填充 HTTP URL；BaaS relay
+    WebSocket 链路透传 ws-info 返回的 ws_url。BaaS 非 relay 模式保持为空。
     expert_chat 等 3 处 caller 已用 `conn.get("url") or f"http://{conn['target']}"`
-    模式优先取 url，故 plan-01 填它即可让 caller 自动走 BaaS 路由（无需 caller 改动）。
+    模式优先取 url，保持现有调用方兼容。
     """
 
 

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
@@ -804,6 +804,7 @@ class BaasDeviceService(DeviceService):
             target=ws_info.target,
             token=ws_info.token,
             engine_type=engine_type,
+            url=ws_info.ws_url if ws_conn_mode == "relay" else "",
             baas_base_url=ws_info.baas_base_url,
             bot_uuid=ws_info.bot_uuid,
             tenant=ws_info.tenant,

--- a/src/backend/tests/community/core/devices/services/test_baas_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_device_service.py
@@ -270,6 +270,7 @@ class TestUpdateDeviceHeaders:
 class TestGetDeviceConnection:
     def _ws_info(self):
         info = MagicMock()
+        info.ws_url = "wss://proxy.example/wsrelay/session-1"
         info.target = "BAAS_DEVICE@template:20003"
         info.token = "token-1"
         info.baas_base_url = "http://baas.local"
@@ -302,6 +303,32 @@ class TestGetDeviceConnection:
         assert result.token == "token-1"
         assert result.engine_type == "claude_code"
         assert result.bot_uuid == "BOT-1"
+        assert result.url == ""
+
+    def test_relay_mode_returns_baas_ws_url_in_compatible_url_field(self):
+        baas = MagicMock()
+        baas.get_ws_info.return_value = self._ws_info()
+        bot_query = MagicMock()
+        bot_query.get_by_binding_id.return_value = {
+            "bot_id": "desktop-1",
+            "bot_type": "desktop",
+            "active_engine": "openclaw",
+        }
+        svc = _make_service(baas_service=baas, bot_query=bot_query)
+
+        result = svc.get_device_connection(
+            binding_id=8,
+            operator=_operator("u001"),
+            ws_conn_mode="relay",
+        )
+
+        baas.get_ws_info.assert_called_once_with(
+            bind_id=8,
+            device_affinity="u001",
+            device_uuid=None,
+            ws_conn_mode="relay",
+        )
+        assert result.url == "wss://proxy.example/wsrelay/session-1"
 
     def test_desktop_bot_returns_desktop_connection_type(self):
         baas = MagicMock()


### PR DESCRIPTION

GET /api/v1/devices/1366927/connection?ws_conn_mode=relay
对该接口增加ws_conn_mode=relay模式，当relay模式时，桌面BOT启用proxy代理模式，前端使用baas的ws_url

