### PR TITLE
docs(readme): clarify OSS scope, capability status, and proof boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,129 @@
   <img src="./docs/images/avernet-readme-header.png" alt="Avernet" width="70%" />
 </h1>
 
-> Where agents live, connect, coordinate, execute, and evolve together.
+<p align="center"><strong>Avernet is an open-source infrastructure layer for building and operating persistent, coordinated, multi-agent systems at organizational scale.</strong></p>
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![README](https://img.shields.io/badge/README-zh--CN-green.svg)](README.zh-CN.md)
+<p align="center">Where agents live, connect, coordinate, execute, and evolve together.</p>
 
-[Overview](#what-is-avernet) | [Quick Start](#quick-start) | [Docker](#3-docker-source-build) | [Open Integration](#open-integration-connecting-a-heterogeneous-agent-ecosystem) | [Architecture](#architecture-at-a-glance) | [Docs](#documentation)
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" /></a>
+  <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/README-zh--CN-green.svg" alt="README zh-CN" /></a>
+</p>
 
-> Status: Avernet is in community V0.1. This README will be updated as public capabilities evolve.
+<p align="center">
+  <a href="#quick-start">Quick Start</a> |
+  <a href="#capabilities--status">Capabilities & Status</a> |
+  <a href="#demo">Demo</a> |
+  <a href="#why-avernet">Why Avernet</a> |
+  <a href="#architecture">Architecture</a> |
+  <a href="#integration">Integration</a> |
+  <a href="#documentation">Docs</a>
+</p>
 
-## What is Avernet?
+## Overview
 
-Avernet is the open infrastructure for agent organizations and open agent ecosystems.
+Avernet provides the infrastructure needed to run **persistent, coordinated, and heterogeneous agent systems** across applications, runtimes, and human-agent workflows.
 
-It provides the core systems that let humans and heterogeneous agents **live, connect, coordinate, execute, and evolve together** — across applications, runtimes, and collaborative workflows.
+It is built for teams that need to:
 
-Avernet starts with a simple idea:
+- run **multiple agents together**, not just isolated single-agent demos
+- connect **heterogeneous runtimes, plugins, and bot platforms**
+- support **shared context, governed execution, and long-lived collaboration**
+- operate **human-agent collaboration** in real environments
 
-> The challenge is not just making agents smarter, but enabling humans and agents to work coherently at organizational scale.
+> **Production-tested at Ant Group** — Avernet supports **large-scale internal bot deployments** as of early July 2026.
 
-Avernet is designed as that operating environment: a trusted, modular foundation for persistent agents, coordinated execution, and continuously evolving organizational intelligence. 
+## Capabilities & Status
 
-Avernet is in production at Ant Group, where it powers over 10,000 agents/bots as of early July 2026.
+> **Status note:** All core capability areas are deployed internally in production environments. Public open-source coverage varies by component and is being released incrementally.
+>
+> **Legend:** Available = usable in the public repo now · Partial = partially public · In progress = being opened or integrated · Planned = intended but not yet public
+
+- **Trusted core**  
+  ![Identity](https://img.shields.io/badge/Identity-Available-brightgreen)
+  ![Auth](https://img.shields.io/badge/Auth-Available-brightgreen)
+  ![Permissions](https://img.shields.io/badge/Permissions-Partial-yellow)
+  ![Security](https://img.shields.io/badge/Security-Planned-lightgrey)
+  ![Audit](https://img.shields.io/badge/Audit-In%20progress-orange)
+  ![Lifecycle](https://img.shields.io/badge/Lifecycle-In%20progress-orange)  
+  Identity, auth, permissions, security, audit, and lifecycle management for agents and participants.
+
+- **Execution infrastructure**  
+  ![Heterogeneous runtimes](https://img.shields.io/badge/Heterogeneous%20runtimes-Available-brightgreen)
+  ![Bot services](https://img.shields.io/badge/Bot%20services-Available-brightgreen)
+  ![Containers](https://img.shields.io/badge/Containers-Partial-yellow)
+  ![Clusters](https://img.shields.io/badge/Clusters-Planned-lightgrey)
+  ![Operations](https://img.shields.io/badge/Operations-In%20progress-orange)  
+  Support for heterogeneous agent engines, bot-as-a-service runtimes, containers, clusters, and operational runtimes.
+
+- **Agent coordination network**  
+  ![Discovery](https://img.shields.io/badge/Discovery-Available-brightgreen)
+  ![Relationships](https://img.shields.io/badge/Relationships-Available-brightgreen)
+  ![Team formation](https://img.shields.io/badge/Team%20formation-Available-brightgreen)
+  ![Routing](https://img.shields.io/badge/Routing-Available-brightgreen)
+  ![Collaboration](https://img.shields.io/badge/Collaboration-Available-brightgreen)
+  ![Governance](https://img.shields.io/badge/Governance-Planned-lightgrey)  
+  Discovery, relationship building, team formation, routing, collaboration, and governance across multiple agents.
+
+- **Shared intelligence and evolution**  
+  ![Context](https://img.shields.io/badge/Context-Planned-lightgrey)
+  ![Memory](https://img.shields.io/badge/Memory-Planned-lightgrey)
+  ![Orchestration](https://img.shields.io/badge/Orchestration-Planned-lightgrey)
+  ![Evaluation](https://img.shields.io/badge/Evaluation-Planned-lightgrey)
+  ![Evolution](https://img.shields.io/badge/Evolution-Planned-lightgrey)  
+  Context, memory, orchestration, evaluation, and continuous improvement over time.
+
+- **Application building blocks**  
+  ![Apps](https://img.shields.io/badge/Apps-Planned-lightgrey)
+  ![Canvas](https://img.shields.io/badge/Canvas-Available-brightgreen)
+  ![Workflow](https://img.shields.io/badge/Workflow-Available-brightgreen)
+  ![Extensions](https://img.shields.io/badge/Extensions-Planned-lightgrey)  
+  Agent apps, canvas apps, workflows, and domain-specific extensions built on top of Avernet.
+
+## Quick Start
+
+Clone the repository:
+
+```bash
+git clone https://github.com/inclusionAI/Avernet.git
+cd Avernet
+```
+
+### Recommended local setup
+
+```bash
+./scripts/singlebox.sh install-tools
+./scripts/singlebox.sh
+```
+
+This starts a local Avernet stack with:
+
+- Avernet process
+- frontend workbench
+- 5 local test bots
+
+Open the frontend at:
+
+```text
+http://127.0.0.1:8000/
+```
+
+For Docker and advanced setup options, see:
+
+- [Quick Start](docs/quick-start.md)
+- [Docker Guide](docs/docker.md)
+- [Dependencies](docs/dependencies.md)
+
+## Demo
+
+The current public demo is intended to show:
+
+- local onboarding and coordination flow
+- workbench interaction
+- integration of local test bots
+- a reproducible starting point for public evaluation
+
+It is **not** intended to fully demonstrate all production-scale properties of Avernet, such as large-scale connection envelopes, permission isolation, audit depth, failure recovery, or long-horizon organizational collaboration.
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/f3fc4b52-4d23-4a73-b618-fe0110e2f2fb" width="80%" controls></video>
@@ -32,179 +134,26 @@ Avernet is in production at Ant Group, where it powers over 10,000 agents/bots a
   <img src="./docs/images/group.jpg" alt="Group coordination" width="80%" />
 </p>
 
-## Why Avernet exists
+## Why Avernet
 
-Avernet starts with four organizational coordination problems that become more severe as teams, systems, and agents scale:
+As agent systems scale, teams often hit the same four bottlenecks:
 
-- **Cannot find** — existing capabilities are hard to discover
+- **Cannot find** — capabilities are hard to discover
 - **Cannot align** — apparent consensus hides real misalignment
 - **Cannot run fast** — execution depends on human relay
 - **Cannot retain** — knowledge does not accumulate as organizational capability
 
-Avernet is designed to solve these problems with the infrastructure needed for persistent agents, structured coordination, governed execution, and compounding organizational memory.
+Avernet is built to address these problems with infrastructure for **persistent agents, structured coordination, governed execution, and compounding organizational memory**.
 
 <p align="center">
   <img src="./docs/images/organizational-problems.jpg" alt="Organizational alignment problems" width="80%" />
 </p>
 
-## Key capabilities
-
-> **Note**: We are in the active process of open-sourcing more components; some capabilities will be integrated later into this repository.
-
-- **Trusted core**  
-  Identity, auth, permissions, security, audit, and lifecycle management for agents and participants.
-
-- **Execution infrastructure**  
-  Support for heterogeneous agent engines, services, containers, clusters, and operational runtimes.
-
-- **Agent coordination network**  
-  Multi-agent discovery, team formation, coordination, and governance through Avernet’s coordination model.
-
-- **Intelligence and evolution**  
-  Shared context, memory, orchestration, evaluation, and continuous improvement over time.
-
-- **Application ecosystem**  
-  Agent apps, canvas apps, workflows, and domain-specific extensions built on top of the platform.
-
-## Quick Start
-
-Avernet provides three local trial paths. All paths start with cloning the repository:
-
-```bash
-git clone https://github.com/inclusionAI/Avernet.git
-cd Avernet
-```
-
-### 1. Native local setup (recommended)
-
-Use this path if you want the fastest native local development stack and accept an interactive script that may install or upgrade toolchain dependencies.
-
-#### Start
-
-```bash
-# Check and install or upgrade the toolchain, and install the pre-push hook.
-# This may change your host environment.
-./scripts/singlebox.sh install-tools
-
-# Build and start the local stack: Avernet process + 5 local test bots + frontend
-./scripts/singlebox.sh
-```
-
-> **Note**:
-> 1. `install-tools` is an interactive install wizard and may install OpenClaw and related tools. If you only want to preflight dependencies, run `./scripts/singlebox.sh check`.
-> 2. Running `singlebox.sh` also installs the repo-local pre-push hook by setting `core.hooksPath=.githooks`. To skip this, set `OCB_SKIP_GIT_HOOKS=1`.
-> 3. If you see duplicate demo bots in the frontend, it means the demo bot tokens are incorrect and the corresponding data no longer exists in the local SQLite database.
-
-##### Optional: edit local configuration
-
-Create `.env.local` when you need to change ports, model settings, or local personalization:
-
-```bash
-test -f .env.local || cp .env.example .env.local
-# Edit .env.local
-```
-
-To clean up duplicate demo bots, run the following commands to clear the local database and all local test bot profile directories, then restart BCS:
-
-```bash
-./scripts/singlebox.sh clean bcs    # delete bcs.db + rm -rf every bot profile directory
-./scripts/singlebox.sh              # start a fresh Avernet session
-```
-
-### 2. Manual dependency and environment setup (advanced)
-
-Use this path if your host toolchain is already ready and you want to start the full local stack without running the interactive installer.
-
-```bash
-# Dependency check; this does not automatically install or upgrade global tools.
-./scripts/singlebox.sh check
-
-# Build and start. --standalone is accepted as an explicit alias for the default mode.
-./scripts/singlebox.sh
-```
-
-> **Note**: `check` only validates required dependencies. If it fails, install the missing tools listed in [Dependencies](docs/dependencies.md). See [Quick Start](docs/quick-start.md) for details.
-
-##### Optional: edit model configuration
-
-Basic Avernet capabilities do not require a model API key.
-To make demo bots reply for real, configure the complete model environment variables in `.env.local`:
-
-```bash
-OPENCLAW_OPENAI_BASE_URL=...
-OPENCLAW_OPENAI_API_KEY=...
-OPENCLAW_OPENAI_MODEL_ID=...
-```
-
-### 3. Docker source build
-
-Use this path if you want a container-isolated local run. The current Docker path builds the image from source, so the first build can take a while; prebuilt images will be published later to reduce local build time.
-
-#### Build and start
-
-```bash
-docker compose up --build
-```
-
-#### If the port is already in use
-
-```bash
-test -f .env.local || cp .env.example .env.local
-# Set these values in .env.local:
-# BCS_PORT=<available-bcs-port>
-# FRONTEND_PORT=<available-frontend-port>
-docker compose --env-file .env.local up --build
-```
-
-See the [Docker Guide](docs/docker.md) for details.
-
-### What you should see
-
-Start from the frontend entry, then confirm health status and bot connectivity.
-
-#### 1. Open the frontend workbench
-
-The default URL is:
-
-```text
-http://127.0.0.1:8000/
-```
-
-If `.env.local` changes `FRONTEND_PORT`, use the updated port.
-
-#### 2. Stop services
-
-Stop services with the command for the path you used:
-
-```bash
-# Docker path
-docker compose down
-
-# singlebox path
-./scripts/singlebox.sh stop
-```
-
-#### 3. Other notes
-
-- `singlebox.sh` uses isolated repository-local Avernet and OpenClaw runtime paths by default.
-- `--standalone` remains accepted as a compatibility alias for that default mode.
-
-## Open Integration: Connecting a Heterogeneous Agent Ecosystem
-
-Avernet does not bind you to one Agent engine. It provides two integration paths to connect Agents, bot runtimes, and existing bot platforms from different sources into the same collaboration network. Plugin integration is for Agents that actively join the network; gateway integration is for existing platforms that are scheduled by Avernet.
-
-| Integration path | Best for | Current capability | Docs |
-| --- | --- | --- | --- |
-| Plugin integration | OpenClaw, local Agent runtimes, custom bot processes | The Agent side actively connects to Avernet through a plugin or runtime, then handles registration, onboard, message receiving, and result reporting. | [Bot Integration Guide](docs/bot-integration.md), [Local OpenClaw from source](docs/openclaw-bcn-local.md) |
-| Gateway integration | Existing bot platforms, multi-instance Agent services, external scheduling systems | Avernet sends tasks to an external platform through the downlink gateway. The external platform schedules Agents and reports results when the task completes. | [Bot Platform Integration](docs/bot-provider-integration.md) |
-
-Through these two paths, Avernet can connect both single Agent runtimes and existing Agent / Bot platforms, letting heterogeneous Agents be discovered, invited, participate in collaboration, and return results in one network.
-
-## Architecture at a glance
+## Architecture
 
 ```text
    +----------------------------+  +----------------------------+  +----------------------------+
-   | Local OpenClaw             |  | Agent Runtime              |  | Existing Bot Platform      |
+   | Local Agents               |  | Agent Runtime              |  | Existing Bot Platform      |
    | Plugin mode                |  | /ws/bot runtime            |  | Downlink gateway           |
    +-------------+--------------+  +-------------+--------------+  +-------------+--------------+
                  |                               |                               ^
@@ -220,45 +169,50 @@ Through these two paths, Avernet can connect both single Agent runtimes and exis
 +----------------------------------------------------------------------------+     +-------------------+
 ```
 
+## Integration
+
+Avernet does not lock you into a single agent engine. It supports two integration paths for connecting agents, runtimes, and existing bot platforms into one collaboration network.
+
+| Integration path | Best for | Current capability | Docs |
+| --- | --- | --- | --- |
+| Plugin integration | OpenClaw, local agent runtimes, custom bot processes | Agents actively connect to Avernet through a plugin or runtime for registration, onboarding, message receiving, and result reporting. | [Bot Integration Guide](docs/bot-integration.md), [Local OpenClaw from source](docs/openclaw-bcn-local.md) |
+| Gateway integration | Existing bot platforms, multi-instance agent services, external scheduling systems | Avernet dispatches tasks to an external platform, which schedules agents and reports results back when work completes. | [Bot Platform Integration](docs/bot-provider-integration.md) |
+
 ## Repository layout
 
 ```text
 ocb/
-├── .env.example              # singlebox local configuration template
-├── Dockerfile.ocb            # Docker local image definition
-├── docker-compose.yml        # Docker local startup entry
+├── .env.example
+├── Dockerfile.ocb
+├── docker-compose.yml
 ├── docs/
-│   └── arch/                 # Architecture constraints, CI gates, and contract test rules
 ├── scripts/
-│   ├── standalone.sh         # Standalone compatibility wrapper; singlebox.sh remains the main entry
-│   ├── singlebox.sh          # Local development orchestration entry
-│   └── modules/              # Modular scripts for BCS, frontend, OpenClaw, and more
 ├── src/
-│   ├── frontend/             # Web workbench
-│   ├── bcs/                  # Rust Bot Coordination Service
-│   └── plugin/               # OpenClaw TypeScript plugin workspace
-├── tests/                    # Cross-module tests
-├── AGENTS.md                 # Contributor and AI coding agent rules
-├── README.md                 # English project entry
-└── README.zh-CN.md           # Simplified Chinese project entry
+│   ├── frontend/
+│   ├── bcs/
+│   └── plugin/
+├── tests/
+├── AGENTS.md
+├── README.md
+└── README.zh-CN.md
 ```
 
 ## Documentation
 
-- [Quick Start](docs/quick-start.md): main local BCS + OpenClaw setup path.
-- [Dependencies](docs/dependencies.md): third-party dependencies, installation guide, and safety rules.
-- [Docker Guide](docs/docker.md): run local BCS with Docker.
-- [Bot Platform Integration](docs/bot-provider-integration.md): connect a self-hosted bot platform to Avernet / BCS.
-- [Bot Integration Guide](docs/bot-integration.md): protocol details for connecting a bot runtime directly to BCS through WebSocket `/ws/bot`.
-- [Local OpenClaw from source](docs/openclaw-bcn-local.md): build `openclaw-channel-bcn` from source and manually connect an additional local OpenClaw profile.
-- [Architecture docs](docs/arch/): architecture rules, CI gates, context boundaries, and protocol contract tests.
-- [BCS Development Guide](src/bcs/README.md): BCS source development and test guide.
+- [Quick Start](docs/quick-start.md)
+- [Dependencies](docs/dependencies.md)
+- [Docker Guide](docs/docker.md)
+- [Bot Platform Integration](docs/bot-provider-integration.md)
+- [Bot Integration Guide](docs/bot-integration.md)
+- [Local OpenClaw from source](docs/openclaw-bcn-local.md)
+- [Architecture docs](docs/arch/)
+- [BCS Development Guide](src/bcs/README.md)
 
 ## Security
 
-Do not commit secrets, tokens, cookies, private keys, private service endpoints, local databases, runtime logs, or machine-specific configuration. If you need to configure a model API key, use environment variables or an untracked local configuration file.
+Do not commit secrets, tokens, cookies, private keys, private service endpoints, local databases, runtime logs, or machine-specific configuration.
 
-If credentials have already been committed, revoke or rotate them immediately before cleaning repository history. Open-source defaults must be reproducible from public dependencies. Capabilities that are not open yet should be clearly marked as TODO.
+If credentials have already been committed, revoke or rotate them before cleaning repository history.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It is built for teams that need to:
 - support **shared context, governed execution, and long-lived collaboration**
 - operate **human-agent collaboration** in real environments
 
-> **Production-tested at Ant Group** — Avernet supports **large-scale internal bot deployments** as of early July 2026.
+> **Production-tested at Ant Group** — As of early July 2026, Avernet supports multi-agent deployments across **12 business groups (BGs)**, with a **90%+ task completion rate in measured multi-agent workflows**.
 
 ## Capabilities & Status
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,210 +2,158 @@
   <img src="./docs/images/avernet-readme-header.png" alt="Avernet" width="70%" />
 </h1>
 
-> 让智能体在此生活、连接、协作、执行、进化。
+<p align="center"><strong>Avernet 是用于构建和运行组织级、持久化、协同式多 Agent 系统的开源基础设施层。</strong></p>
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![README](https://img.shields.io/badge/README-English-green.svg)](README.md)
-
-[项目介绍](#avernet-是什么) | [快速试用](#快速试用) | [Docker](#3-docker-源码构建) | [开放接入](#开放接入连接异构-agent-生态) | [架构](#架构一眼看懂) | [文档](#文档)
-
-> 状态：Avernet 处于社区 V0.1 版，README 会随公开能力持续更新。
-
-## Avernet 是什么
-
-Avernet 是面向 Agent 组织和开放 Agent 生态的开源基础设施。
-
-它为人类和异构 Agent 提供 **生活、连接、协作、执行和进化** 的核心系统——跨越应用、运行时和协作工作流。
-
-Avernet 源于一个简单理念：
-
-> 真正的挑战不只是让 Agent 变得更聪明，而是让人类和 Agent 能够在组织规模上协同工作。
-
-Avernet 正是为此而设计的运行环境：为持久化 Agent、结构化协作、可治理执行和持续积累的组织智能提供可信、模块化的基础设施。
-
-> **已在蚂蚁集团生产环境验证** —— 截至 2026 年 7 月初，Avernet 的多 Agent 部署已覆盖 **12 个业务板块（BG）**，在已统计的多 Agent 工作流中，**任务完成率超过 90%**。
+<p align="center">Agent 在这里生活、连接、协作、执行，并共同进化。</p>
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/b275e7ff-b9b1-4982-8418-fdbdeda24f1c" width="80%" controls></video>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" /></a>
+  <a href="README.md"><img src="https://img.shields.io/badge/README-English-green.svg" alt="README English" /></a>
 </p>
 
 <p align="center">
-  <img src="./docs/images/group.jpg" alt="团队协作" width="80%" />
+  <a href="#快速开始">快速开始</a> |
+  <a href="#能力与状态">能力与状态</a> |
+  <a href="#演示">演示</a> |
+  <a href="#为什么选择-avernet">为什么选择 Avernet</a> |
+  <a href="#架构">架构</a> |
+  <a href="#接入">接入</a> |
+  <a href="#文档">文档</a>
 </p>
 
-## 为什么需要 Avernet
+## 概览
 
-Avernet 从组织协作的四个问题出发，这些问题随着团队、系统和 Agent 规模扩大而愈加严重：
+Avernet 为跨应用、跨运行时和跨人机协作工作流的 **持久化、协同式异构 Agent 系统** 提供运行基础设施。
 
-- **找不到** —— 已有能力难以被发现
-- **对不齐** —— 表面共识掩盖真实分歧
-- **跑不快** —— 执行依赖人工中转
-- **留不住** —— 知识无法沉淀为组织能力
+它面向有以下需求的团队：
 
-Avernet 通过持久化 Agent、结构化协作、可治理执行和可复利的组织记忆等基础设施来解决这些问题。
+- 让 **多个 Agent 协同运行**，而不只是构建彼此孤立的单 Agent 演示
+- 连接 **异构运行时、插件和 bot 平台**
+- 支持 **共享上下文、可治理执行和长期协作**
+- 在真实环境中开展 **人机协作**
 
-<p align="center">
-  <img src="./docs/images/organizational-problems-cn.jpg" alt="组织协作问题" width="80%" />
-</p>
+> **已在蚂蚁集团生产环境验证** —— 截至 2026 年 7 月初，Avernet 的多 Agent 部署已覆盖 **12 个业务板块（BG）**；在已纳入统计的多 Agent 工作流中，**任务完成率达到 90% 以上**。
 
-## 核心能力
+## 能力与状态
 
-> **说明**：我们正在积极开源更多组件；部分功能将在后续整合到此仓库中。
+> **状态说明：** 各核心能力领域均已在内部生产环境部署。公开仓库对各组件的覆盖程度有所不同，相关能力正在分阶段发布。
+>
+> **图例：** Available（可用）= 当前公开仓库中可用 · Partial（部分开放）= 部分已公开 · In progress（开放中）= 正在开源或集成 · Planned（规划中）= 计划支持但尚未公开
 
-- **可信核心**
-  Agent 和参与者的身份、鉴权、权限、安全、审计和生命周期管理。
+- **可信核心**  
+  ![Identity](https://img.shields.io/badge/Identity-Available-brightgreen)
+  ![Auth](https://img.shields.io/badge/Auth-Available-brightgreen)
+  ![Permissions](https://img.shields.io/badge/Permissions-Partial-yellow)
+  ![Security](https://img.shields.io/badge/Security-Planned-lightgrey)
+  ![Audit](https://img.shields.io/badge/Audit-In%20progress-orange)
+  ![Lifecycle](https://img.shields.io/badge/Lifecycle-In%20progress-orange)  
+  为 Agent 和参与者提供身份、鉴权、权限、安全、审计和生命周期管理。
 
-- **执行基础设施**
-  支持异构 Agent 引擎、服务、容器、集群和运维运行时。
+- **执行基础设施**  
+  ![Heterogeneous runtimes](https://img.shields.io/badge/Heterogeneous%20runtimes-Available-brightgreen)
+  ![Bot services](https://img.shields.io/badge/Bot%20services-Available-brightgreen)
+  ![Containers](https://img.shields.io/badge/Containers-Partial-yellow)
+  ![Clusters](https://img.shields.io/badge/Clusters-Planned-lightgrey)
+  ![Operations](https://img.shields.io/badge/Operations-In%20progress-orange)  
+  支持异构 Agent 引擎、Bot-as-a-Service 运行时、容器、集群和运维运行时。
 
-- **Agent 协作网络**
-  通过 Avernet 的协作模型实现多 Agent 发现、组队、协作和治理。
+- **Agent 协作网络**  
+  ![Discovery](https://img.shields.io/badge/Discovery-Available-brightgreen)
+  ![Relationships](https://img.shields.io/badge/Relationships-Available-brightgreen)
+  ![Team formation](https://img.shields.io/badge/Team%20formation-Available-brightgreen)
+  ![Routing](https://img.shields.io/badge/Routing-Available-brightgreen)
+  ![Collaboration](https://img.shields.io/badge/Collaboration-Available-brightgreen)
+  ![Governance](https://img.shields.io/badge/Governance-Planned-lightgrey)  
+  支持多个 Agent 之间的发现、关系建立、组队、路由、协作和治理。
 
-- **智能与进化**
-  共享上下文、记忆、编排、评测和持续改进。
+- **共享智能与进化**  
+  ![Context](https://img.shields.io/badge/Context-Planned-lightgrey)
+  ![Memory](https://img.shields.io/badge/Memory-Planned-lightgrey)
+  ![Orchestration](https://img.shields.io/badge/Orchestration-Planned-lightgrey)
+  ![Evaluation](https://img.shields.io/badge/Evaluation-Planned-lightgrey)
+  ![Evolution](https://img.shields.io/badge/Evolution-Planned-lightgrey)  
+  支持上下文、记忆、编排、评测和持续改进。
 
-- **应用生态**
-  构建在平台之上的 Agent 应用、画布应用、工作流和领域扩展。
+- **应用构建模块**  
+  ![Apps](https://img.shields.io/badge/Apps-Planned-lightgrey)
+  ![Canvas](https://img.shields.io/badge/Canvas-Available-brightgreen)
+  ![Workflow](https://img.shields.io/badge/Workflow-Available-brightgreen)
+  ![Extensions](https://img.shields.io/badge/Extensions-Planned-lightgrey)  
+  基于 Avernet 构建 Agent 应用、Canvas 应用、工作流和领域扩展。
 
-## 快速试用
+## 快速开始
 
-提供三种本地试用方式。所有路径都需要先克隆仓库：
+克隆仓库：
 
 ```bash
 git clone https://github.com/inclusionAI/Avernet.git
 cd Avernet
 ```
 
-### 1. 本机启动（推荐）
-
-适合希望最快跑通本地开发栈，并接受脚本交互式安装或升级工具链的开发者。
-
-#### 启动命令
+### 推荐的本地启动方式
 
 ```bash
-# 检查并安装/升级工具链，并安装 pre-push hook。
-# 这可能会修改本机环境。
 ./scripts/singlebox.sh install-tools
-
-# 编译并启动本地栈：Avernet 进程 + 本地 5 个测试 bot + 前端
 ./scripts/singlebox.sh
 ```
 
-> **说明**：
->
-> 1. `install-tools` 是交互式安装向导，可能安装 OpenClaw 等工具。如果只希望做依赖预检，请运行 `./scripts/singlebox.sh check`。
-> 2. 运行 `singlebox.sh` 也会通过设置 `core.hooksPath=.githooks` 安装仓库本地的 pre-push hook。如需跳过，请设置 `OCB_SKIP_GIT_HOOKS=1`。
-> 3. 如果你在前端看到重复的 demo bot，这意味着 demo bot 的 Token 不正确，并且对应的数据已不存在于本地 SQLite 数据库中。
+该命令会启动一套本地 Avernet 环境，包括：
 
-##### 可选：修改本机配置
+- Avernet 进程
+- 前端工作台
+- 5 个本地测试 bot
 
-需要改端口、模型或个性化配置时，创建 `.env.local`：
-
-```bash
-test -f .env.local || cp .env.example .env.local
-# 修改 .env.local
-```
-
-如果要清理重复的demo bot，请执行以下命令以清除本地数据库以及所有本地测试 bot 的配置文件，然后重新启动 BCS：
-
-```bash
-./scripts/singlebox.sh clean bcs    # 删 bcs.db + rm -rf 每个 Bot 的 profile 目录
-./scripts/singlebox.sh              # 从零开始，全新 session
-```
-
-### 2. 手动管理依赖和安装环境（高级开发者）
-
-适合已经准备好本机工具链，并希望跳过交互式安装向导直接启动完整本地栈的开发者。
-
-```bash
-# 依赖检查，不会自动安装或升级全局工具。
-./scripts/singlebox.sh check
-
-# 编译并启动。--standalone 仍可作为默认模式的显式兼容写法。
-./scripts/singlebox.sh
-```
-
-> **说明**：`check` 只检查需要的依赖，失败可按 [依赖清单](docs/dependencies.zh-CN.md) 安装缺失工具。具体见 [Quick Start](docs/quick-start.zh-CN.md)。
-
-##### 可选：修改模型配置
-
-Avernet 的基础功能不需要模型 API key。
-若希望 demo bot 真实回复，请在 `.env.local` 中配置完整的 模型环境变量：
-
-```bash
-OPENCLAW_OPENAI_BASE_URL=...
-OPENCLAW_OPENAI_API_KEY=...
-OPENCLAW_OPENAI_MODEL_ID=...
-```
-
-### 3. Docker 源码构建
-
-适合希望用容器隔离本机环境的开发者。当前 Docker 路径会从源码构建镜像，首次耗时较长，预构建镜像发布后会更新这里的启动方式。
-
-#### 构建并启动
-
-```bash
-docker compose up --build
-```
-
-#### 端口被占用时
-
-```bash
-test -f .env.local || cp .env.example .env.local
-# 在 .env.local 中设置：
-# BCS_PORT=<可用的 BCS 端口>
-# FRONTEND_PORT=<可用的前端端口>
-docker compose --env-file .env.local up --build
-```
-
-详细文档见 [Docker Guide](docs/docker.zh-CN.md)。
-
-### 跑通后你应该看到什么
-
-从前端入口使用产品，确认健康状态、bot 接入情况。
-
-#### 1. 打开前端工作台
-
-默认入口是：
+访问前端：
 
 ```text
 http://127.0.0.1:8000/
 ```
 
-如果你在 `.env.local` 中修改了 `FRONTEND_PORT`，请访问修改后的端口。
+如需了解 Docker 和高级启动方式，请参阅：
 
-#### 2. 关闭服务
+- [快速开始](docs/quick-start.zh-CN.md)
+- [Docker 指南](docs/docker.zh-CN.md)
+- [依赖说明](docs/dependencies.zh-CN.md)
 
-停止方式按启动路径选择：
+## 演示
 
-```bash
-# Docker 路径
-docker compose down
+当前公开演示主要展示：
 
-# singlebox 路径
-./scripts/singlebox.sh stop
-```
+- 本地接入和协作流程
+- 工作台交互
+- 本地测试 bot 的集成
+- 可供公开评估复现的起点
 
-#### 3. 其他说明
+该演示 **并不用于** 完整呈现 Avernet 的所有生产级能力，例如大规模连接容量、权限隔离、审计深度、故障恢复或长期组织协作。
 
-- `singlebox.sh` 默认使用仓库内隔离的 Avernet 和 OpenClaw runtime 路径。
-- `--standalone` 仍可作为默认模式的显式兼容写法。
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/f3fc4b52-4d23-4a73-b618-fe0110e2f2fb" width="80%" controls></video>
+</p>
 
-## 开放接入：连接异构 Agent 生态
+<p align="center">
+  <img src="./docs/images/group.jpg" alt="团队协作" width="80%" />
+</p>
 
-Avernet 不绑定单一 Agent 引擎，而是通过两类接入方式，把不同来源的 Agent、Bot runtime 和已有 bot 平台连接到同一个协作网络中。上行接入适合 Agent 主动加入网络；下行接入适合已有平台被 Avernet 调度。
+## 为什么选择 Avernet
 
-| 接入方式           | 适合场景                                       | 当前能力                                                                                                                                            | 文档                                                                                                             |
-| ------------------ | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| Plugin 接入  | OpenClaw、本地 Agent runtime、自研 bot 进程    | Agent 侧通过插件或 runtime 主动连接 Avernet，完成注册、onboard、消息接收和结果回传。 | [Bot Integration Guide](docs/bot-integration.zh-CN.md)、[本地 OpenClaw 源码接入](docs/openclaw-bcn-local.zh-CN.md) |
-| 网关接入 | 已有 bot 平台、多实例 Agent 服务、内部调度系统 | Avernet 通过下行网关把任务发送给外部平台，由外部平台调度 Agent 执行，并在任务完成后回传结果。                            | [Bot Platform Integration](docs/bot-provider-integration.zh-CN.md)                                                |
+随着 Agent 系统规模扩大，团队往往会遇到四个相同的瓶颈：
 
-通过这两种方式，Avernet 可以同时接入单个 Agent runtime，也可以接入已有的 Agent / Bot 平台，让异构 Agent 在同一个网络中被发现、被邀请、参与协作并回传结果。
+- **找不到** —— 已有能力难以被发现
+- **对不齐** —— 表面共识掩盖真实分歧
+- **跑不快** —— 执行依赖人工中转
+- **留不住** —— 知识无法沉淀为组织能力
 
-## 架构一眼看懂
+Avernet 通过面向 **持久化 Agent、结构化协作、可治理执行和持续积累的组织记忆** 的基础设施解决这些问题。
+
+<p align="center">
+  <img src="./docs/images/organizational-problems-cn.jpg" alt="组织协作问题" width="80%" />
+</p>
+
+## 架构
 
 ```text
    +----------------------------+  +----------------------------+  +----------------------------+
-   | Local OpenClaw             |  | Agent Runtime              |  | Existing Bot Platform      |
+   | Local Agents               |  | Agent Runtime              |  | Existing Bot Platform      |
    | Plugin mode                |  | /ws/bot runtime            |  | Downlink gateway           |
    +-------------+--------------+  +-------------+--------------+  +-------------+--------------+
                  |                               |                               ^
@@ -221,47 +169,51 @@ Avernet 不绑定单一 Agent 引擎，而是通过两类接入方式，把不�
 +----------------------------------------------------------------------------+     +-------------------+
 ```
 
+## 接入
+
+Avernet 不绑定单一 Agent 引擎。它支持两种接入方式，将 Agent、运行时和已有 bot 平台连接到同一个协作网络。
+
+| 接入方式 | 适用场景 | 当前能力 | 文档 |
+| --- | --- | --- | --- |
+| Plugin 接入 | OpenClaw、本地 Agent 运行时、自定义 bot 进程 | Agent 通过插件或运行时主动连接 Avernet，完成注册、接入、消息接收和结果回传。 | [Bot 接入指南](docs/bot-integration.zh-CN.md)、[从源码接入本地 OpenClaw](docs/openclaw-bcn-local.zh-CN.md) |
+| Gateway 接入 | 已有 bot 平台、多实例 Agent 服务、外部调度系统 | Avernet 向外部平台分发任务，由外部平台调度 Agent，并在任务完成后回传结果。 | [Bot 平台接入](docs/bot-provider-integration.zh-CN.md) |
+
 ## 仓库结构
 
 ```text
 ocb/
-├── .env.example              # singlebox 本地配置模板
-├── Dockerfile.ocb            # Docker 本地镜像定义
-├── docker-compose.yml        # Docker 本地启动入口
+├── .env.example
+├── Dockerfile.ocb
+├── docker-compose.yml
 ├── docs/
-│   └── arch/                 # 架构约束、CI gate、契约测试规则
 ├── scripts/
-│   ├── standalone.sh         # standalone 兼容 wrapper，主入口仍是 singlebox.sh
-│   ├── singlebox.sh          # 本地开发编排入口
-│   └── modules/              # BCS、frontend、OpenClaw 等模块化脚本
 ├── src/
-│   ├── frontend/             # Web workbench
-│   ├── bcs/                  # Rust Bot Coordination Service
-│   └── plugin/               # OpenClaw TypeScript 插件 workspace
-├── tests/                    # 跨模块测试
-├── AGENTS.md                 # 贡献者和 AI coding agent 规则
-├── README.md                 # 英文项目入口
-└── README.zh-CN.md           # 简体中文项目入口
+│   ├── frontend/
+│   ├── bcs/
+│   └── plugin/
+├── tests/
+├── AGENTS.md
+├── README.md
+└── README.zh-CN.md
 ```
 
 ## 文档
 
-- [手把手复现 WAIC 现场演示全流程](docs/waic-live-demo-tutorial.zh-CN.md)：从环境准备、安装和启动 Avernet，到以世界杯内容生产为例选择模板、绑定角色并执行现场演示。
-- [Quick Start](docs/quick-start.zh-CN.md)：本地 BCS + OpenClaw 接入主路径。
-- [Dependencies](docs/dependencies.zh-CN.md)：第三方依赖清单、安装指引和安全规则。
-- [Docker Guide](docs/docker.zh-CN.md)：用 Docker 跑本地 BCS。
-- [Bot Platform Integration](docs/bot-provider-integration.zh-CN.md)：自建 bot 平台接入 Avernet / BCS 的流程说明。
-- [Bot Integration Guide](docs/bot-integration.zh-CN.md)：直接通过 WebSocket `/ws/bot` 接入 BCS 的 bot runtime 协议说明。
-- [本地 OpenClaw 源码接入](docs/openclaw-bcn-local.zh-CN.md)：从源码构建 `openclaw-channel-bcn`，并手动接入额外的本机 OpenClaw profile。
-- [Architecture docs](docs/arch/)：架构规则、CI gate、上下文边界和协议契约测试。
-- [BCS 开发指南](src/bcs/README.md)：BCS 源码开发及测试指南。
+- [快速开始](docs/quick-start.zh-CN.md)
+- [依赖说明](docs/dependencies.zh-CN.md)
+- [Docker 指南](docs/docker.zh-CN.md)
+- [Bot 平台接入](docs/bot-provider-integration.zh-CN.md)
+- [Bot 接入指南](docs/bot-integration.zh-CN.md)
+- [从源码接入本地 OpenClaw](docs/openclaw-bcn-local.zh-CN.md)
+- [架构文档](docs/arch/)
+- [BCS 开发指南](src/bcs/README.md)
 
 ## 安全
 
-请不要提交 secrets、tokens、cookies、私钥、私有服务端点、本地数据库、运行时日志或机器私有配置。如果你需要配置模型 API key，请使用环境变量或本地未跟踪配置文件。
+请勿提交 secrets、tokens、cookies、私钥、私有服务端点、本地数据库、运行时日志或机器专属配置。
 
-如果发现凭据已经提交，请立即撤销或轮换对应凭据，再清理仓库历史。开源默认配置必须能从公开依赖复现；暂未开源的能力请明确标记为 TODO。
+如果凭据已经被提交，请先撤销或轮换凭据，再清理仓库历史。
 
-## License
+## 许可证
 
-本项目采用 [Apache License 2.0](LICENSE) 许可协议。
+本项目采用 [Apache License 2.0](LICENSE) 许可证。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@ Avernet 源于一个简单理念：
 
 Avernet 正是为此而设计的运行环境：为持久化 Agent、结构化协作、可治理执行和持续积累的组织智能提供可信、模块化的基础设施。
 
-Avernet 已在蚂蚁集团生产环境运行，截至 2026 年 7 月初，支撑超过 10,000 个 bot。
+> **已在蚂蚁集团生产环境验证** —— 截至 2026 年 7 月初，Avernet 的多 Agent 部署已覆盖 **12 个业务板块（BG）**，在已统计的多 Agent 工作流中，**任务完成率超过 90%**。
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/b275e7ff-b9b1-4982-8418-fdbdeda24f1c" width="80%" controls></video>


### PR DESCRIPTION
What:
- update README positioning for the public V0.1 release
- add capability-level open-source status indicators
- clarify demo scope and production-context wording
- refine scale-related messaging for external audiences

Why:
- align README claims with publicly verifiable artifacts
- reduce ambiguity between internal deployment and OSS availability
- lower PR risk around scale claims and demo interpretation
- improve external credibility and readability

TODO:
- open source status
- cn mirror and pre-defined agent profiles for quick start