### PR TITLE
feat(test): add local just test coverage gate with target-branch baseline resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,53 @@ fresh focused run, then run the default all-module gate to catch shared-stack
 interference. Do not inflate a result by excluding production Core paths or by
 adding test-only calls to domain logic.
 
+## Local `just test` Baseline
+
+The repository-root `justfile` exposes local test entry points that run the
+same changed-line coverage gate as GitHub CI
+(`.github/workflows/unit-tests.yml`) and the pre-push hook:
+
+```bash
+just test              # run affected modules WITH the changed-line coverage gate
+just test-base <ref>   # explicit baseline (commit-ish or <remote>/<branch>)
+just test-no-cov       # fast iteration: skip the changed-line coverage gate
+```
+
+`just test` dispatches to `scripts/ci/local_test.sh`, which mirrors
+`scripts/ci/pre_push.sh`'s module selection and invokes each affected module's
+`scripts/ci_test.sh --base <baseline> --head HEAD` — the same entry GitHub CI
+uses. The baseline is resolved by `scripts/ci/resolve_test_baseline.sh`, which
+reuses the pre-push merge-target contract (`fetch -> rev-parse -> merge-base`)
+with this priority (high to low):
+
+1. `--base <commit-or-ref>` on the recipe / script (see `just test-base`)
+2. `AVERNET_TEST_BASE_REF` environment variable (same semantics as `--base`)
+3. `git config avernet.test.mergeTarget <remote>/<branch>` (persistent)
+4. the current branch's upstream tracking branch (`@{upstream}`)
+5. `origin/dev` — last-resort default, used **only** when it can be fetched
+   and shares a merge-base with HEAD
+
+The resolver is fail-closed: if no baseline can be resolved it exits non-zero
+with an actionable message listing the four explicit overrides above, and it
+never silently falls back to a stale target, the old remote SHA, or the root
+commit. This matches the pre-push hook's contract — when the eventual PR
+targets a non-`dev` branch (`release/*`, `stable/*`, etc.), set
+`avernet.test.mergeTarget` (or pass `--base` / `AVERNET_TEST_BASE_REF`) so the
+local diff range matches the PR's real base; otherwise the local gate can
+drift from the remote gate.
+
+`just test-no-cov` runs unit tests without the changed-line coverage gate for
+fast iteration. It is **not** a substitute for the pre-push / PR coverage
+gate; the script's banner says so explicitly, and the pre-push hook and
+GitHub CI continue to enforce the changed-line gate regardless of local
+`--no-cov` use. Empty change sets (`base..HEAD` is empty) print "coverage gate
+skipped" and exit 0, matching the pre-push hook's empty-range behavior.
+
+Automated tests for baseline resolution live in
+`scripts/test_local_test_baseline.sh` (run
+`bash scripts/test_local_test_baseline.sh`). Add a case whenever the priority
+order, the fail-closed message, or the module-dispatch forwarding changes.
+
 ## Development Guidelines
 
 Start from the requirement and the existing contract. Keep changes small and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,8 @@ Before changing Git hooks, module CI entrypoints, Singlebox orchestration,
 acceptance E2E tests, coverage manifests, or coverage reporting, read the
 `Pre-push Module Selection` section in `AGENTS.md` and treat it together with
 the referenced scripts as one contract.
+
+For local `just test` / `just test-no-cov`, read the `Local just test Baseline`
+section in `AGENTS.md` and treat `scripts/ci/resolve_test_baseline.sh`,
+`scripts/ci/local_test.sh`, and the root `justfile` as one contract with the
+pre-push merge-target resolution.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,27 @@
+# Avernet root justfile — local development entry points for the
+# changed-line coverage gate. The recipes dispatch to
+# scripts/ci/local_test.sh, which mirrors scripts/ci/pre_push.sh's module
+# selection and GitHub CI's changed-line coverage gate
+# (.github/workflows/unit-tests.yml).
+#
+# Install `just` (https://github.com/casey/just) to use these recipes;
+# `bash scripts/ci/local_test.sh ...` remains a fully equivalent fallback.
+
+_default:
+    @just --list
+
+# Local tests with the GitHub-CI-consistent changed-line coverage gate.
+# Resolves the target branch via (in priority order) --base, AVERNET_TEST_BASE_REF,
+# avernet.test.mergeTarget, the upstream tracking branch, or origin/dev
+# (fail-closed). Run `just test-base <ref>` to override the baseline explicitly.
+test:
+    bash scripts/ci/local_test.sh
+
+# Local tests with an explicit baseline (commit-ish or <remote>/<branch>).
+test-base ref:
+    bash scripts/ci/local_test.sh --base "{{ref}}"
+
+# Fast local iteration: run unit tests WITHOUT the changed-line coverage gate.
+# This does NOT satisfy the pre-push / PR coverage gate.
+test-no-cov:
+    bash scripts/ci/local_test.sh --no-cov

--- a/scripts/ci/local_test.sh
+++ b/scripts/ci/local_test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Local test orchestration for Avernet. Mirrors scripts/ci/pre_push.sh's module
+# selection and dispatch logic, but is invoked by the root `justfile` for local
+# developers. Each affected module's `scripts/ci_test.sh --base <base> --head HEAD`
+# is invoked, which enforces the same changed-line coverage gate as GitHub CI
+# (.github/workflows/unit-tests.yml).
+#
+# Baseline resolution: see scripts/ci/resolve_test_baseline.sh. The resolved
+# baseline (merge-base with HEAD of the configured target branch) is the diff
+# range used by every module's changed-line coverage gate.
+#
+# Modes:
+#   default            run tests WITH the changed-line coverage gate (--base)
+#   --no-cov           skip the changed-line coverage gate (fast iteration;
+#                      does NOT satisfy the pre-push/PR coverage gate)
+#   --base <ref>       pass an explicit baseline to resolve_test_baseline.sh
+#   AVERNET_TEST_BASE_REF, avernet.test.mergeTarget honored via resolver
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" \
+  || { echo "error: must run inside a git repository" >&2; exit 1; }
+cd "$repo_root"
+
+no_cov=0
+explicit_base=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --no-cov)
+      no_cov=1
+      shift
+      ;;
+    --base)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --base requires an argument" >&2
+        exit 2
+      fi
+      explicit_base="$2"
+      shift 2
+      ;;
+    -h|--help)
+      cat >&2 <<'USAGE'
+usage: local_test.sh [--no-cov] [--base <commit-or-ref>]
+
+Runs the affected Avernet module tests, mirroring the pre-push module dispatch
+and GitHub CI changed-line coverage gate.
+
+  --no-cov      skip the changed-line coverage gate (fast iteration only;
+                not a substitute for the pre-push / PR coverage gate)
+  --base <ref>  explicit baseline (commit-ish or <remote>/<branch>)
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+head="HEAD"
+if ! head_sha="$(git rev-parse --verify "${head}^{commit}" 2>/dev/null)"; then
+  echo "error: cannot resolve HEAD commit" >&2
+  exit 1
+fi
+
+echo "== Avernet local test =="
+echo "head: $head_sha"
+
+resolver="$repo_root/scripts/ci/resolve_test_baseline.sh"
+
+if [[ "$no_cov" == "1" ]]; then
+  echo "mode: no-cov (changed-line coverage gate DISABLED)"
+  echo "note: --no-cov does NOT satisfy the pre-push/PR changed-line coverage gate."
+  base=""
+else
+  if [[ ! -x "$resolver" ]]; then
+    echo "error: missing baseline resolver: $resolver" >&2
+    exit 1
+  fi
+  if [[ -n "$explicit_base" ]]; then
+    if ! base="$("$resolver" --base "$explicit_base")"; then
+      exit 1
+    fi
+  else
+    if ! base="$("$resolver")"; then
+      exit 1
+    fi
+  fi
+  echo "base: $base"
+  echo "mode: with changed-line coverage gate (matches GitHub CI)"
+fi
+
+# --- Compute changed files for module selection ----------------------------
+if [[ -n "$base" ]]; then
+  changed_files="$(git diff --name-only "$base" "$head")"
+else
+  # No coverage gate -> still compute a best-effort change set from origin/dev
+  # so module dispatch matches what changed. Failures here fall through to
+  # "no changes detected" and the script exits 0 with a clear banner.
+  changed_files="$(git diff --name-only "origin/dev" "$head" 2>/dev/null || true)"
+fi
+
+matches_any() {
+  local pattern="$1"
+  printf '%s\n' "$changed_files" | grep -Eq "$pattern"
+}
+
+run_module() {
+  # $@ -> module ci_test.sh invocation (already includes --base/--head as needed)
+  echo ""
+  echo "== module: $* =="
+  "$@"
+}
+
+# --- Empty-change fast path ------------------------------------------------
+if [[ -z "$changed_files" ]]; then
+  if [[ -n "$base" ]]; then
+    echo "no committed changes in ($base..$head); changed-line coverage gate skipped (matches pre-push)"
+  else
+    echo "no committed changes detected (no origin/dev baseline); nothing to gate"
+  fi
+  exit 0
+fi
+
+# --- Module dispatch (mirrors scripts/ci/pre_push.sh) ----------------------
+if matches_any '^src/backend/'; then
+  if [[ "$no_cov" == "1" ]]; then
+    run_module "$repo_root/src/backend/scripts/ci_test.sh"
+  else
+    run_module "$repo_root/src/backend/scripts/ci_test.sh" --base "$base" --head "$head"
+  fi
+fi
+
+if matches_any '^src/baas/'; then
+  if [[ "${OCB_LOCAL_TEST_ENABLE_BAAS:-1}" == "1" ]]; then
+    if [[ "$no_cov" == "1" ]]; then
+      run_module "$repo_root/src/baas/scripts/ci_test.sh"
+    else
+      run_module "$repo_root/src/baas/scripts/ci_test.sh" --base "$base" --head "$head"
+    fi
+  else
+    echo "BaaS changes detected; BaaS local gate skipped (OCB_LOCAL_TEST_ENABLE_BAAS=0)"
+  fi
+fi
+
+if matches_any '^src/engine/'; then
+  if [[ "$no_cov" == "1" ]]; then
+    run_module "$repo_root/src/engine/scripts/ci_test.sh"
+  else
+    run_module "$repo_root/src/engine/scripts/ci_test.sh" --base "$base" --head "$head"
+  fi
+fi
+
+if matches_any '^src/bcs/'; then
+  if [[ "${OCB_LOCAL_TEST_ENABLE_BCS:-1}" == "1" ]]; then
+    if [[ "$no_cov" == "1" ]]; then
+      run_module "$repo_root/src/bcs/scripts/ci_test.sh" --fast-fail
+    else
+      # BCS uses cov_gate.py for the changed-line gate; its ci_test.sh accepts
+      # --base/--head and forwards to cov_gate.py the same way pre_push.sh does.
+      run_module "$repo_root/src/bcs/scripts/ci_test.sh" --base "$base" --head "$head" --fast-fail
+    fi
+  else
+    echo "BCS/BCN changes detected; BCS/BCN local gate skipped (OCB_LOCAL_TEST_ENABLE_BCS=0)"
+  fi
+fi
+
+if matches_any '^src/gateway/'; then
+  if [[ "$no_cov" == "1" ]]; then
+    run_module "$repo_root/src/gateway/scripts/ci_test.sh"
+  else
+    run_module "$repo_root/src/gateway/scripts/ci_test.sh" --base "$base" --head "$head"
+  fi
+fi
+
+if matches_any '^src/frontend/'; then
+  if [[ "$no_cov" == "1" ]]; then
+    run_module "$repo_root/src/frontend/scripts/ci_test.sh"
+  else
+    run_module "$repo_root/src/frontend/scripts/ci_test.sh" --base "$base" --head "$head"
+  fi
+fi
+
+echo ""
+if [[ "$no_cov" == "1" ]]; then
+  echo "Avernet local test (no-cov) done. Changed-line coverage gate was NOT enforced."
+else
+  echo "Avernet local test done. Changed-line coverage gate passed."
+fi

--- a/scripts/ci/resolve_test_baseline.sh
+++ b/scripts/ci/resolve_test_baseline.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Resolve the local `just test` baseline commit for the changed-line coverage
+# gate. Mirrors the pre-push merge-target contract (`.githooks/pre-push`) so the
+# local gate and GitHub CI use the same diff range for the same target branch.
+#
+# Resolution priority (high -> low):
+#   1. --base <commit-or-ref>     explicit CLI argument
+#   2. AVERNET_TEST_BASE_REF       environment variable (same semantics as --base)
+#   3. avernet.test.mergeTarget    persistent git config (<remote>/<branch>)
+#   4. upstream tracking branch    @{upstream} of the current branch
+#   5. origin/dev                  last-resort default, but only if it can be
+#                                  fetched and has a merge-base with HEAD;
+#                                  otherwise fail closed.
+#
+# Output: stdout  -> baseline commit SHA (suitable for `ci_test.sh --base`)
+#         stderr  -> human-readable diagnostics
+# Exit:   0 on success, non-zero with an actionable message otherwise.
+# The script never silently falls back to a stale target, an old remote SHA,
+# or the root commit.
+set -euo pipefail
+
+print_usage() {
+  cat >&2 <<'USAGE'
+usage: resolve_test_baseline.sh [--base <commit-or-ref>]
+
+Resolve the local-test baseline commit (merge-base with HEAD) used by the
+changed-line coverage gate. Specify the target branch explicitly in one of
+these ways (highest priority first):
+
+  1. --base <ref>                <remote>/<branch>, branch, or commit-ish
+  2. AVERNET_TEST_BASE_REF=<ref> environment variable (same semantics)
+  3. git config avernet.test.mergeTarget <remote>/<branch>
+  4. (auto) upstream tracking branch of the current branch
+  5. (default) origin/dev        only when fetchable and has a merge-base
+
+The script fails closed when no baseline can be resolved; it never silently
+falls back to a wrong default or skips the coverage gate.
+USAGE
+}
+
+fail_closed() {
+  echo "error: $1" >&2
+  echo "error: could not resolve a local-test baseline." >&2
+  echo "error: specify one via (in priority order):" >&2
+  echo "error:   --base <commit-or-ref>" >&2
+  echo "error:   AVERNET_TEST_BASE_REF=<commit-or-ref>" >&2
+  echo "error:   git config avernet.test.mergeTarget <remote>/<branch>" >&2
+  echo "error:   set an upstream tracking branch for the current branch" >&2
+  echo "error: refusing to fall back to a stale or wrong default." >&2
+  exit 1
+}
+
+explicit_base=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --base)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --base requires an argument" >&2
+        exit 2
+      fi
+      explicit_base="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      print_usage
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" \
+  || fail_closed "must run inside a git repository"
+cd "$repo_root"
+
+head="HEAD"
+if ! head_sha="$(git rev-parse --verify "${head}^{commit}" 2>/dev/null)"; then
+  fail_closed "cannot resolve HEAD commit"
+fi
+
+# Validate a <remote>/<branch> token, fetch it, and echo its commit SHA on
+# stdout. Fails closed on any error.
+resolve_remote_branch_sha() {
+  local target="$1"
+  local target_remote target_branch target_ref target_sha
+  if [[ "$target" != */* ]]; then
+    fail_closed "merge target must use <remote>/<branch> form: $target"
+  fi
+  target_remote="${target%%/*}"
+  target_branch="${target#*/}"
+  if [[ -z "$target_remote" || -z "$target_branch" ]] \
+    || ! git remote get-url "$target_remote" >/dev/null 2>&1 \
+    || ! git check-ref-format "refs/heads/$target_branch" >/dev/null 2>&1; then
+    fail_closed "invalid merge target: $target"
+  fi
+  target_ref="refs/remotes/$target_remote/$target_branch"
+  if ! git fetch --quiet --no-tags "$target_remote" \
+        "+refs/heads/$target_branch:$target_ref" 2>/dev/null; then
+    fail_closed "failed to fetch merge target $target"
+  fi
+  if ! target_sha="$(git rev-parse --verify "${target_ref}^{commit}" 2>/dev/null)"; then
+    fail_closed "merge target $target is not a commit"
+  fi
+  printf '%s\n' "$target_sha"
+}
+
+# Resolve an arbitrary ref token (CLI arg or env override) to a commit SHA.
+# Accepts:
+#   - <remote>/<branch>  -> fetch via resolve_remote_branch_sha
+#   - branch name        -> resolve via refs/heads/<branch> or refs/remotes/*/<branch>
+#   - commit-ish         -> git rev-parse --verify <ref>^{commit}
+resolve_ref_to_sha() {
+  local token="$1" sha
+  if [[ "$token" == */* ]] && git remote get-url "${token%%/*}" >/dev/null 2>&1; then
+    # Treat as <remote>/<branch>: fetch then resolve.
+    sha="$(resolve_remote_branch_sha "$token")"
+  elif [[ "$token" != */* ]] \
+    && sha="$(git rev-parse --verify "refs/heads/$token^{commit}" 2>/dev/null)"; then
+    : # already resolved
+  else
+    if ! sha="$(git rev-parse --verify "${token}^{commit}" 2>/dev/null)"; then
+      fail_closed "cannot resolve ref to commit: $token"
+    fi
+  fi
+  printf '%s\n' "$sha"
+}
+
+# Compute merge-base of HEAD and a resolved target SHA, printing the baseline
+# SHA on stdout. Fails closed when there is no common ancestor.
+emit_baseline_for_target_sha() {
+  local target_sha="$1" base
+  if ! base="$(git merge-base "$head_sha" "$target_sha" 2>/dev/null)" || [[ -z "$base" ]]; then
+    fail_closed "no merge base between HEAD ($head_sha) and target ($target_sha)"
+  fi
+  printf '%s\n' "$base"
+}
+
+# ---- Priority 1/2: explicit --base / AVERNET_TEST_BASE_REF -----------------
+if [[ -n "${AVERNET_TEST_BASE_REF:-}" ]]; then
+  if [[ -z "$explicit_base" ]]; then
+    explicit_base="$AVERNET_TEST_BASE_REF"
+  fi
+fi
+
+if [[ -n "$explicit_base" ]]; then
+  target_sha="$(resolve_ref_to_sha "$explicit_base")"
+  echo "test baseline source: explicit ($explicit_base)" >&2
+  echo "test baseline target sha: $target_sha" >&2
+  emit_baseline_for_target_sha "$target_sha"
+  exit 0
+fi
+
+# ---- Priority 3: git config avernet.test.mergeTarget ----------------------
+configured_target="$(git config --get avernet.test.mergeTarget 2>/dev/null || true)"
+if [[ -n "$configured_target" ]]; then
+  target_sha="$(resolve_remote_branch_sha "$configured_target")"
+  echo "test baseline source: avernet.test.mergeTarget=$configured_target" >&2
+  echo "test baseline target sha: $target_sha" >&2
+  emit_baseline_for_target_sha "$target_sha"
+  exit 0
+fi
+
+# ---- Priority 4: upstream tracking branch ---------------------------------
+upstream_ref=""
+if upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)" \
+  && [[ -n "$upstream_ref" && "$upstream_ref" != "HEAD" ]]; then
+  # Fetch the upstream so the resolution reflects the current remote state.
+  upstream_remote="${upstream_ref%%/*}"
+  upstream_branch="${upstream_ref#*/}"
+  if [[ -n "$upstream_remote" && -n "$upstream_branch" ]] \
+    && git remote get-url "$upstream_remote" >/dev/null 2>&1; then
+    git fetch --quiet --no-tags "$upstream_remote" \
+      "+refs/heads/$upstream_branch:refs/remotes/$upstream_remote/$upstream_branch" 2>/dev/null || true
+  fi
+  if target_sha="$(git rev-parse --verify "${upstream_ref}^{commit}" 2>/dev/null)"; then
+    echo "test baseline source: upstream tracking branch ($upstream_ref)" >&2
+    echo "test baseline target sha: $target_sha" >&2
+    emit_baseline_for_target_sha "$target_sha"
+    exit 0
+  fi
+fi
+
+# ---- Priority 5: default origin/dev, but fail-closed if unusable ---------
+if git remote get-url origin >/dev/null 2>&1; then
+  if git fetch --quiet --no-tags origin "+refs/heads/dev:refs/remotes/origin/dev" 2>/dev/null \
+    && target_sha="$(git rev-parse --verify "refs/remotes/origin/dev^{commit}" 2>/dev/null)"; then
+    echo "test baseline source: default origin/dev" >&2
+    echo "test baseline target sha: $target_sha" >&2
+    emit_baseline_for_target_sha "$target_sha"
+    exit 0
+  fi
+fi
+
+fail_closed "no baseline source resolved (--base, AVERNET_TEST_BASE_REF, avernet.test.mergeTarget, upstream tracking branch, or default origin/dev)"

--- a/scripts/test_local_test_baseline.sh
+++ b/scripts/test_local_test_baseline.sh
@@ -1,0 +1,473 @@
+#!/usr/bin/env bash
+# Automated tests for scripts/ci/resolve_test_baseline.sh and the local_test.sh
+# dispatcher. Uses temporary git repositories to exercise baseline resolution
+# for dev->dev, non-dev target branches, explicit overrides, fail-closed
+# behavior, and --no-cov argument forwarding.
+#
+# Run:  bash scripts/test_local_test_baseline.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOLVER="$REPO_ROOT/scripts/ci/resolve_test_baseline.sh"
+LOCAL_TEST="$REPO_ROOT/scripts/ci/local_test.sh"
+
+passed=0
+failed=0
+global_tmp=""
+
+cleanup() {
+  if [[ -n "$global_tmp" && -d "$global_tmp" ]]; then
+    rm -rf "$global_tmp"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failed=$((failed + 1))
+}
+
+pass() {
+  printf 'PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+# Set up an isolated HOME and git env so tests don't touch the real user config.
+setup_isolated_env() {
+  local tmp="$1"
+  export HOME="$tmp/home"
+  export GIT_CONFIG_GLOBAL=/dev/null
+  export GIT_CONFIG_NOSYSTEM=1
+  mkdir -p "$HOME"
+}
+
+# Create a bare remote + a developer clone. The repo is shaped so the
+# `origin/release-2026-07` branch has its own ancestry NOT shared with the
+# current `origin/dev` tip:
+#
+#   A (initial, shared)
+#     \
+#      dev:        A -> D1 (dev tip)
+#      release:    A -> R1 (release tip, R1 NOT in dev)
+#      feature-x:  based on dev tip (D1), add F1 -> HEAD
+#
+# Therefore:
+#   merge-base(HEAD, origin/dev)            = D1  (dev tip)
+#   merge-base(HEAD, origin/release-2026-07)= A   (initial commit)
+# These two baselines differ, which is what the silent-fallback test asserts.
+make_fake_repo() {
+  local tmp="$1"
+  local remote="$tmp/remote.git"
+  local dev="$tmp/dev"
+
+  mkdir -p "$remote" "$dev"
+  git init --bare -q "$remote" >/dev/null
+
+  git init -q --initial-branch=dev "$dev" >/dev/null
+  git -C "$dev" config user.name "CI Test"
+  git -C "$dev" config user.email "ci-test@example.com"
+  git -C "$dev" config commit.gpgsign false
+
+  # Commit A (shared ancestor) on dev.
+  mkdir -p "$dev/src/backend"
+  echo "print('hi')" > "$dev/src/backend/a.py"
+  git -C "$dev" add .
+  git -C "$dev" commit -q -m "A: shared ancestor"
+  git -C "$dev" remote add origin "$remote"
+
+  # Branch release-2026-07 off A, add commit R1 (independent ancestry).
+  git -C "$dev" checkout -q -b release-2026-07
+  echo "print('release')" > "$dev/src/backend/release_only.py"
+  git -C "$dev" add .
+  git -C "$dev" commit -q -m "R1: release-only change"
+  git -C "$dev" push -q -u origin release-2026-07
+
+  # Back to dev, advance it with D1 (so dev tip != A).
+  git -C "$dev" checkout -q dev
+  echo "dev-only = 1" >> "$dev/src/backend/a.py"
+  git -C "$dev" add .
+  git -C "$dev" commit -q -m "D1: dev-only advance"
+  git -C "$dev" push -q -u origin dev
+
+  # feature-x off dev tip (D1), add F1 -> HEAD.
+  git -C "$dev" checkout -q -b feature-x
+  echo "x = 1" >> "$dev/src/backend/a.py"
+  git -C "$dev" add .
+  git -C "$dev" commit -q -m "F1: feature change"
+
+  printf '%s\n' "$dev"
+}
+
+# Copy the resolver into a fake repo so local_test.sh's with-cov path can find
+# it. The fake repo's scripts/ci tree is created if needed.
+install_resolver() {
+  local dev="$1"
+  mkdir -p "$dev/scripts/ci"
+  cp "$RESOLVER" "$dev/scripts/ci/resolve_test_baseline.sh"
+  chmod +x "$dev/scripts/ci/resolve_test_baseline.sh"
+}
+
+# Resolve baseline in a given repo, capturing stdout/stderr and exit code.
+run_resolver() {
+  local repo="$1"; shift
+  local out err rc
+  out_file="$(mktemp)"
+  err_file="$(mktemp)"
+  set +e
+  ( cd "$repo" && "$RESOLVER" "$@" ) >"$out_file" 2>"$err_file"
+  rc=$?
+  set -e
+  printf '%s|' "$rc"
+  cat "$out_file"
+  printf '|'
+  cat "$err_file"
+  rm -f "$out_file" "$err_file"
+}
+
+test_dev_default_baseline() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "dev->dev: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # origin/dev exists and is an ancestor of HEAD feature-x.
+  local result
+  result="$(cd "$dev" && "$RESOLVER")" || {
+    fail "dev->dev: resolver exit non-zero on origin/dev default"
+    rm -rf "$tmp"; return; }
+
+  # The baseline must be origin/dev's tip (HEAD of dev branch).
+  local dev_tip
+  dev_tip="$(git -C "$dev" rev-parse origin/dev)"
+  if [[ "$result" == "$dev_tip" ]]; then
+    pass "dev->dev: default origin/dev baseline resolves to dev tip"
+  else
+    fail "dev->dev: expected $dev_tip got $result"
+  fi
+  rm -rf "$tmp"
+}
+
+test_non_dev_target_branch() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "non-dev: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # Configure a non-dev target via git config.
+  git -C "$dev" config avernet.test.mergeTarget origin/release-2026-07
+
+  local result
+  result="$(cd "$dev" && "$RESOLVER")" || {
+    fail "non-dev: resolver exit non-zero for origin/release-2026-07"
+    rm -rf "$tmp"; return; }
+
+  local release_tip release_base expected
+  release_tip="$(git -C "$dev" rev-parse origin/release-2026-07)"
+  expected="$(git -C "$dev" merge-base HEAD "$release_tip")"
+  if [[ "$result" == "$expected" ]]; then
+    pass "non-dev: avernet.test.mergeTarget=origin/release-2026-07 resolves to release merge-base"
+  else
+    fail "non-dev: expected $expected got $result"
+  fi
+
+  # Make sure it is NOT the dev tip (would indicate silent fallback to origin/dev).
+  local dev_tip
+  dev_tip="$(git -C "$dev" rev-parse origin/dev)"
+  if [[ "$result" != "$dev_tip" ]]; then
+    pass "non-dev: baseline differs from origin/dev tip (no silent fallback)"
+  else
+    fail "non-dev: baseline equals origin/dev tip — silent fallback detected"
+  fi
+  rm -rf "$tmp"
+}
+
+test_env_override_priority() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "env-override: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # Set a git config target AND an env override pointing at the release branch.
+  git -C "$dev" config avernet.test.mergeTarget origin/dev
+  local result
+  result="$(cd "$dev" && AVERNET_TEST_BASE_REF=origin/release-2026-07 "$RESOLVER")" || {
+    fail "env-override: resolver exit non-zero"
+    rm -rf "$tmp"; return; }
+
+  local release_tip expected
+  release_tip="$(git -C "$dev" rev-parse origin/release-2026-07)"
+  expected="$(git -C "$dev" merge-base HEAD "$release_tip")"
+  if [[ "$result" == "$expected" ]]; then
+    pass "env-override: AVERNET_TEST_BASE_REF wins over avernet.test.mergeTarget"
+  else
+    fail "env-override: expected $expected got $result"
+  fi
+  rm -rf "$tmp"
+}
+
+test_cli_base_override() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "cli-base: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # --base with a bare commit SHA should resolve directly.
+  local release_tip expected result
+  release_tip="$(git -C "$dev" rev-parse origin/release-2026-07)"
+  expected="$(git -C "$dev" merge-base HEAD "$release_tip")"
+
+  result="$(cd "$dev" && "$RESOLVER" --base "$release_tip")" || {
+    fail "cli-base: resolver exit non-zero"
+    rm -rf "$tmp"; return; }
+
+  if [[ "$result" == "$expected" ]]; then
+    pass "cli-base: --base <sha> resolves to merge-base"
+  else
+    fail "cli-base: expected $expected got $result"
+  fi
+  rm -rf "$tmp"
+}
+
+test_fail_closed_on_bad_target() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "fail-closed: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # Point at a remote that doesn't exist locally; resolver must fail non-zero
+  # and the diagnostic must mention an actionable hint.
+  git -C "$dev" config avernet.test.mergeTarget upstream/no-such-branch
+  local out err rc
+  set +e
+  ( cd "$dev" && "$RESOLVER" ) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    pass "fail-closed: non-zero exit when target remote is unknown"
+  else
+    fail "fail-closed: expected non-zero exit, got 0"
+  fi
+  err="$(cat "$tmp/err")"
+  if printf '%s' "$err" | grep -q 'avernet.test.mergeTarget'; then
+    pass "fail-closed: diagnostic references avernet.test.mergeTarget"
+  else
+    fail "fail-closed: diagnostic missing actionable hint"
+  fi
+  rm -rf "$tmp"
+}
+
+test_fail_closed_on_no_merge_base() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "no-merge-base: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # Create an orphan commit without ancestry sharing, point --base at it.
+  local orphan
+  orphan="$(git -C "$dev" commit-tree -m "orphan" "$(git -C "$dev" write-tree)")" || {
+    fail "no-merge-base: could not create orphan commit"; rm -rf "$tmp"; return; }
+
+  local rc
+  set +e
+  ( cd "$dev" && "$RESOLVER" --base "$orphan" ) >/dev/null 2>"$tmp/err"
+  rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    pass "no-merge-base: non-zero exit when target has no merge-base with HEAD"
+  else
+    fail "no-merge-base: expected non-zero exit, got 0"
+  fi
+  rm -rf "$tmp"
+}
+
+test_upstream_tracking_branch() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "upstream: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # feature-x has no upstream yet. Set its upstream to origin/release-2026-07.
+  git -C "$dev" checkout -q feature-x
+  git -C "$dev" branch --set-upstream-to=origin/release-2026-07 feature-x >/dev/null 2>&1
+
+  local result
+  result="$(cd "$dev" && "$RESOLVER")" || {
+    fail "upstream: resolver exit non-zero"
+    rm -rf "$tmp"; return; }
+
+  local release_tip expected
+  release_tip="$(git -C "$dev" rev-parse origin/release-2026-07)"
+  expected="$(git -C "$dev" merge-base HEAD "$release_tip")"
+  if [[ "$result" == "$expected" ]]; then
+    pass "upstream: baseline resolves from upstream tracking branch (origin/release-2026-07)"
+  else
+    fail "upstream: expected $expected got $result"
+  fi
+  rm -rf "$tmp"
+}
+
+test_no_cov_forwards_no_base() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "no-cov: make_fake_repo"; rm -rf "$tmp"; return; }
+
+  # Install a stub backend ci_test.sh that records its arguments.
+  mkdir -p "$dev/src/backend/scripts"
+  cat > "$dev/src/backend/scripts/ci_test.sh" <<'SH'
+#!/usr/bin/env bash
+echo "stub-ci_test-args:$*" >> "${LOCAL_TEST_STUB_LOG:?}"
+exit 0
+SH
+  chmod +x "$dev/src/backend/scripts/ci_test.sh"
+
+  export LOCAL_TEST_STUB_LOG="$tmp/stub.log"
+  rm -f "$LOCAL_TEST_STUB_LOG"
+
+  # Run local_test.sh --no-cov; it must NOT pass --base to the stub.
+  ( cd "$dev" && bash "$LOCAL_TEST" --no-cov ) >/dev/null 2>"$tmp/lt_err" || {
+    fail "no-cov: local_test.sh --no-cov exited non-zero"
+    cat "$tmp/lt_err" >&2
+    rm -rf "$tmp"; return; }
+
+  if [[ ! -s "$LOCAL_TEST_STUB_LOG" ]]; then
+    fail "no-cov: stub ci_test.sh was not invoked"
+    rm -rf "$tmp"; return
+  fi
+  local log
+  log="$(cat "$LOCAL_TEST_STUB_LOG")"
+  if printf '%s' "$log" | grep -q -- '--base'; then
+    fail "no-cov: --base was forwarded to ci_test.sh under --no-cov: $log"
+  else
+    pass "no-cov: ci_test.sh invoked without --base under --no-cov"
+  fi
+  rm -rf "$tmp"
+}
+
+test_with_cov_forwards_base() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "with-cov: make_fake_repo"; rm -rf "$tmp"; return; }
+  install_resolver "$dev"
+
+  mkdir -p "$dev/src/backend/scripts"
+  cat > "$dev/src/backend/scripts/ci_test.sh" <<'SH'
+#!/usr/bin/env bash
+echo "stub-ci_test-args:$*" >> "${LOCAL_TEST_STUB_LOG:?}"
+exit 0
+SH
+  chmod +x "$dev/src/backend/scripts/ci_test.sh"
+
+  export LOCAL_TEST_STUB_LOG="$tmp/stub.log"
+  rm -f "$LOCAL_TEST_STUB_LOG"
+
+  # Run local_test.sh with coverage gate (default). Baseline resolves to
+  # origin/dev, then --base <sha> --head HEAD must be forwarded.
+  ( cd "$dev" && bash "$LOCAL_TEST" ) >/dev/null 2>"$tmp/lt_err" || {
+    fail "with-cov: local_test.sh exited non-zero"
+    cat "$tmp/lt_err" >&2
+    rm -rf "$tmp"; return; }
+
+  local log
+  log="$(cat "$LOCAL_TEST_STUB_LOG")"
+  if printf '%s' "$log" | grep -q -- '--base'; then
+    pass "with-cov: ci_test.sh invoked with --base"
+  else
+    fail "with-cov: --base not forwarded to ci_test.sh: $log"
+  fi
+  rm -rf "$tmp"
+}
+
+test_with_cov_non_dev_baseline_forwarded() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "with-cov-non-dev: make_fake_repo"; rm -rf "$tmp"; return; }
+  install_resolver "$dev"
+  git -C "$dev" config avernet.test.mergeTarget origin/release-2026-07
+
+  mkdir -p "$dev/src/backend/scripts"
+  cat > "$dev/src/backend/scripts/ci_test.sh" <<'SH'
+#!/usr/bin/env bash
+echo "stub-ci_test-args:$*" >> "${LOCAL_TEST_STUB_LOG:?}"
+exit 0
+SH
+  chmod +x "$dev/src/backend/scripts/ci_test.sh"
+
+  export LOCAL_TEST_STUB_LOG="$tmp/stub.log"
+  rm -f "$LOCAL_TEST_STUB_LOG"
+
+  ( cd "$dev" && bash "$LOCAL_TEST" ) >/dev/null 2>"$tmp/lt_err" || {
+    fail "with-cov-non-dev: local_test.sh exited non-zero"
+    cat "$tmp/lt_err" >&2
+    rm -rf "$tmp"; return; }
+
+  local log expected_initial dev_tip
+  log="$(cat "$LOCAL_TEST_STUB_LOG")"
+  # Initial commit A is the merge-base of HEAD and origin/release-2026-07.
+  expected_initial="$(git -C "$dev" rev-list --max-parents=0 HEAD | tail -1)"
+  dev_tip="$(git -C "$dev" rev-parse origin/dev)"
+  if printf '%s' "$log" | grep -q -- "--base $expected_initial"; then
+    pass "with-cov-non-dev: ci_test.sh got the release merge-base as --base"
+  else
+    fail "with-cov-non-dev: expected --base $expected_initial in: $log"
+  fi
+  if ! printf '%s' "$log" | grep -q -- "--base $dev_tip"; then
+    pass "with-cov-non-dev: ci_test.sh did NOT receive the dev tip as --base"
+  else
+    fail "with-cov-non-dev: ci_test.sh incorrectly received dev tip as --base"
+  fi
+  rm -rf "$tmp"
+}
+
+test_empty_change_skips_gate() {
+  local tmp=$(mktemp -d)
+  local dev
+  dev="$(make_fake_repo "$tmp")" || { fail "empty-change: make_fake_repo"; rm -rf "$tmp"; return; }
+  install_resolver "$dev"
+
+  # Move HEAD to dev tip (no changes vs origin/dev).
+  git -C "$dev" checkout -q dev
+  local out rc
+  set +e
+  out="$(cd "$dev" && bash "$LOCAL_TEST" 2>&1)"
+  rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    pass "empty-change: local_test.sh exits 0 when no changes vs baseline"
+  else
+    fail "empty-change: expected exit 0, got $rc"
+  fi
+  if printf '%s' "$out" | grep -q 'coverage gate skipped\|nothing to gate'; then
+    pass "empty-change: banner explains gate was skipped"
+  else
+    fail "empty-change: missing skip banner"
+  fi
+  rm -rf "$tmp"
+}
+
+main() {
+  if [[ ! -x "$RESOLVER" ]]; then
+    echo "error: resolver not executable: $RESOLVER" >&2
+    exit 1
+  fi
+  if [[ ! -f "$LOCAL_TEST" ]]; then
+    echo "error: missing local_test.sh: $LOCAL_TEST" >&2
+    exit 1
+  fi
+
+  global_tmp="$(mktemp -d)"
+  setup_isolated_env "$global_tmp"
+
+  test_dev_default_baseline
+  test_non_dev_target_branch
+  test_env_override_priority
+  test_cli_base_override
+  test_fail_closed_on_bad_target
+  test_fail_closed_on_no_merge_base
+  test_upstream_tracking_branch
+  test_no_cov_forwards_no_base
+  test_with_cov_forwards_base
+  test_with_cov_non_dev_baseline_forwarded
+  test_empty_change_skips_gate
+
+  echo ""
+  echo "summary: $passed passed, $failed failed"
+  if [[ "$failed" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add local `just test` coverage gate that aligns with GitHub CI changed-line coverage checks. The baseline resolution follows the existing pre-push hook contract, supporting configurable target branches and fail-closed semantics when the baseline cannot be determined.

## Changes

- Root `justfile` with `test`, `test-base <ref>`, `test-no-cov` recipes
- `scripts/ci/resolve_test_baseline.sh` — baseline resolver following pre-push contract
- `scripts/ci/local_test.sh` — module-dispatch orchestration
- `scripts/test_local_test_baseline.sh` — 15 automated test cases
- `AGENTS.md`/`CLAUDE.md` — documentation

## Test plan

- [x] `bash scripts/test_local_test_baseline.sh` — 15/15 passed
- [x] `bash -n` syntax check on all shell scripts
- [x] End-to-end resolve_test_baseline.sh + local_test.sh against real repo
- [x] No internal domain/credential/code leaks in diff