### PR TITLE
fix(bcs): decouple HumanInput start from caller auth

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/collaboration_runs.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/collaboration_runs.rs
@@ -253,7 +253,7 @@ async fn authenticated_human(
         .ok_or_else(unauthenticated_response)
 }
 
-async fn optional_authenticated_human(
+pub(super) async fn optional_authenticated_human(
     state: &HttpAppState,
     headers: &HeaderMap,
     uri: &Uri,

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -35,6 +35,7 @@ use super::{
     reject_judge_definition_when_unavailable, reject_judge_yaml_when_unavailable,
     validate_container_header,
 };
+use super::collaboration_runs::optional_authenticated_human;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -323,9 +324,14 @@ pub async fn create_group(
             .await
             .map_err(collaboration_runtime_error_to_http)?;
         if result.group_strategy == bcs_service_api::GroupStrategy::StateMachine {
-            if let Some(run_id) =
-                start_initial_state_machine_run_for_group(&state, &result, caller_actor_id.clone())
-                    .await?
+            let authenticated_human = optional_authenticated_human(&state, &headers, &uri).await;
+            if let Some(run_id) = start_initial_state_machine_run_for_group(
+                &state,
+                &result,
+                caller_actor_id.clone(),
+                authenticated_human,
+            )
+            .await?
             {
                 tracing::info!(
                     group_id = %result.group_id,
@@ -352,6 +358,7 @@ async fn start_initial_state_machine_run_for_group(
     state: &HttpAppState,
     group: &GroupDetailResult,
     caller_id: Option<String>,
+    authenticated_human: Option<bcs_service_api::AuthenticatedHumanCaller>,
 ) -> Result<Option<String>, HttpAdapterError> {
     let Some(session_id) = group.latest_running_session_id.as_deref() else {
         return Ok(None);
@@ -386,7 +393,7 @@ async fn start_initial_state_machine_run_for_group(
             definition_ref: None,
             input: session.input.clone().unwrap_or(Value::Null),
             caller_id,
-            authenticated_human: None,
+            authenticated_human,
         })
         .await
         .map_err(collaboration_runtime_error_to_http)?;

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -2525,7 +2525,7 @@ fn detail_from_create(cmd: &GroupCreateCommand) -> GroupDetailResult {
         service_mode: None,
         group_kind: Default::default(),
         dm_pair_key: None,
-        group_strategy: Default::default(),
+        group_strategy: cmd.group_strategy.unwrap_or_default(),
         created_at: 10,
         updated_at: 10,
         chat_url: None,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -6,6 +6,7 @@ use bcs_auth_api::{AuthConfig, AuthPluginChain, AuthPrincipal};
 use bcs_auth_local::StaticAuthPlugin;
 use bcs_bot::BotCore;
 use bcs_group::GroupStore;
+use bcs_group_store::MemoryGroupRepo;
 use bcs_http::{
     router::build_router,
     state::{ChainUserIdentityPort, HttpAppState},
@@ -31,7 +32,12 @@ use bcs_service_api::{
     StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus, StateMachineRunView, Workspace,
     ValidateCollaborationDefinitionYamlCommand,
 };
+use bcs_service_api::{
+    CreateOrReactivateCommand, NewSessionParams, SessionKind, SessionManagementService,
+};
 use bcs_services_container::Services;
+use bcs_session::SessionManagementServiceImpl;
+use bcs_session_store::MemorySessionRepo;
 use bcs_test_support::{NoopBotRegistryCoreService, NoopFriendCoreService};
 use serde_json::Value;
 use std::sync::Arc;
@@ -61,6 +67,7 @@ fn static_bot_auth_chain(bot_uuid: &str) -> Arc<AuthPluginChain> {
 #[derive(Default)]
 struct RecordingGroupManagement {
     create_calls: Mutex<Vec<GroupCreateCommand>>,
+    latest_running_session_id: Mutex<Option<String>>,
     create_dm_calls: Mutex<Vec<DmCreateCommand>>,
     status_calls: Mutex<Vec<GroupStatusCommand>>,
     add_member_calls: Mutex<Vec<GroupAddMemberCommand>>,
@@ -339,7 +346,8 @@ impl GroupManagementService for RecordingGroupManagement {
         &self,
         cmd: GroupCreateCommand,
     ) -> Result<GroupDetailResult, bcs_service_api::GroupUseCaseError> {
-        let result = detail_from_create(&cmd);
+        let mut result = detail_from_create(&cmd);
+        result.latest_running_session_id = self.latest_running_session_id.lock().await.clone();
         self.create_calls.lock().await.push(cmd);
         Ok(result)
     }
@@ -820,6 +828,91 @@ runtime:
             .get("speaker_b")
             .map(|binding| (binding.source.as_str(), binding.bot_ids.as_slice())),
         Some(("manual", &["target-bot".to_string()][..]))
+    );
+}
+
+#[tokio::test]
+async fn post_groups_auto_start_forwards_authenticated_human_to_runtime() {
+    let temp_dir = TempDir::new().unwrap();
+    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
+    register_bot(&registry, "driver-bot", "Driver").await;
+    let session_management = Arc::new(SessionManagementServiceImpl::new(
+        Arc::new(MemorySessionRepo::new()),
+        Arc::new(MemoryGroupRepo::new()),
+    ));
+    let session = session_management
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: "group-human-auto-start".to_string(),
+            session_id: None,
+            params: NewSessionParams {
+                session_kind: SessionKind::ServiceInvocation,
+                ..Default::default()
+            },
+        })
+        .await
+        .expect("seed service invocation session")
+        .session;
+    let recorder = Arc::new(RecordingGroupManagement::default());
+    *recorder.latest_running_session_id.lock().await = Some(session.id);
+    let collaboration_runtime = Arc::new(RecordingCollaborationRuntime::default());
+    let services = Services::builder()
+        .registry(registry)
+        .group(Arc::new(GroupStore::new()))
+        .group_management(recorder)
+        .session_management(session_management)
+        .collaboration_runtime(collaboration_runtime.clone())
+        .build_for_test();
+    let app = build_router(HttpAppState::new(services).with_user_identity(Arc::new(
+        ChainUserIdentityPort::new(static_auth_chain("alice", "Alice")),
+    )));
+    let definition_yaml = r#"
+api_version: bcs.collaboration/v1
+name: Human Auto Start
+participants: {}
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      review:
+        kind: human_input
+        display_name: Review
+        instruction: Review the input.
+        node_timeout_ms: 60000
+"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/groups")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "id": "group-human-auto-start",
+                        "driver_bot": "driver-bot",
+                        "group_strategy": "state_machine",
+                        "auto_start_on_service_invocation": true,
+                        "collaboration_definition_yaml": definition_yaml
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let commands = collaboration_runtime.start_commands.lock().await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].caller_id.as_deref(), Some("human_alice"));
+    assert_eq!(
+        commands[0]
+            .authenticated_human
+            .as_ref()
+            .map(|human| (human.actor_id.as_str(), human.display_name.as_deref())),
+        Some(("human_alice", Some("Alice")))
     );
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -868,7 +868,10 @@ async fn post_groups_auto_start_forwards_authenticated_human_to_runtime() {
     let definition_yaml = r#"
 api_version: bcs.collaboration/v1
 name: Human Auto Start
-participants: {}
+participants:
+  driver:
+    bot_id: driver-bot
+    required: true
 runtime:
   kind: state_machine
   state_machine:

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -1640,17 +1640,12 @@ impl CollaborationRuntimeService for CollaborationRuntime {
         let definition = &compiled.definition;
         let authenticated_human = cmd.authenticated_human.clone();
         let has_human_input = compiled_has_human_input(&compiled);
-        // COSEC: caller_id is not proof of Human identity. HumanInput runs
-        // require identity established by the server-side authentication port.
-        if has_human_input && authenticated_human.is_none() {
-            return Err(CollaborationRuntimeError::Unauthenticated);
-        }
         let resolved_participant_bindings =
             resolve_participant_bindings(&group, &compiled, group_binding.as_ref())?;
         if should_upsert_definition {
             self.definitions.upsert(definition.clone()).await?;
         }
-        let (session_id, session_title, session) = match cmd.session_id {
+        let (session_id, session_title, mut session) = match cmd.session_id {
             Some(session_id) => {
                 let session = self
                     .sessions
@@ -1703,6 +1698,48 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                     "state-machine session does not belong to the target group".to_string(),
                 ));
             }
+            // COSEC: caller_id is not proof of Human identity. Only a Human
+            // established by the server-side authentication port may be
+            // materialized into the session.
+            if let Some(human) = authenticated_human.as_ref() {
+                let existing = session
+                    .participants
+                    .iter()
+                    .find(|participant| participant.bot_uuid == human.actor_id);
+                if existing.is_some_and(|participant| !participant.is_human()) {
+                    return Err(CollaborationRuntimeError::Forbidden(
+                        "authenticated Human actor ID conflicts with a non-Human session participant"
+                            .to_string(),
+                    ));
+                }
+                if existing.is_none() {
+                    let mut participant =
+                        Participant::human(human.actor_id.clone(), ParticipantRole::Observer);
+                    participant.bot_name = human.display_name.clone();
+                    participant.mode = Some(ParticipantMode::Present);
+                    session = self
+                        .sessions
+                        .add_participant(&session_id, participant)
+                        .await
+                        .map_err(|error| {
+                            CollaborationRuntimeError::InvalidRequest(error.to_string())
+                        })?;
+                } else if existing.is_some_and(|participant| {
+                    participant.effective_mode() != ParticipantMode::Present
+                }) {
+                    session = self
+                        .sessions
+                        .update_participant_mode(
+                            &session_id,
+                            &human.actor_id,
+                            ParticipantMode::Present,
+                        )
+                        .await
+                        .map_err(|error| {
+                            CollaborationRuntimeError::InvalidRequest(error.to_string())
+                        })?;
+                }
+            }
             let present_humans = session
                 .participants
                 .iter()
@@ -1715,15 +1752,6 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 return Err(CollaborationRuntimeError::InvalidRequest(
                     "state-machine definitions with human_input require a Present Human session participant"
                         .to_string(),
-                ));
-            }
-            if let Some(human) = authenticated_human.as_ref()
-                && !present_humans
-                    .iter()
-                    .any(|participant| participant.bot_uuid == human.actor_id)
-            {
-                return Err(CollaborationRuntimeError::Forbidden(
-                    "authenticated Human is not present in the selected session".to_string(),
                 ));
             }
         }

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -1721,9 +1721,7 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                         .sessions
                         .add_participant(&session_id, participant)
                         .await
-                        .map_err(|error| {
-                            CollaborationRuntimeError::InvalidRequest(error.to_string())
-                        })?;
+                        .map_err(|error| CollaborationRuntimeError::InvalidRequest(error.to_string()))?;
                 } else if existing.is_some_and(|participant| {
                     participant.effective_mode() != ParticipantMode::Present
                 }) {
@@ -1735,9 +1733,7 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                             ParticipantMode::Present,
                         )
                         .await
-                        .map_err(|error| {
-                            CollaborationRuntimeError::InvalidRequest(error.to_string())
-                        })?;
+                        .map_err(|error| CollaborationRuntimeError::InvalidRequest(error.to_string()))?;
                 }
             }
             let present_humans = session

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -31,6 +31,7 @@ use bcs_service_api::{
     StartStateMachineRunCommand, StateMachineDefinitionRepoPort, StateMachineNodeSubStatus,
     StateMachineRunAccessCommand, StateMachineRunRepoPort,
 };
+use bcs_service_api::{CreateOrReactivateCommand, NewSessionParams, SessionKind};
 use bcs_session::SessionManagementServiceImpl;
 use bcs_session_store::MemorySessionRepo;
 use serde_json::{Value, json};
@@ -140,7 +141,7 @@ fn assert_inferred_default_requires(definition: &CollaborationDefinition) {
 }
 
 #[tokio::test]
-async fn human_input_requires_authenticated_human_before_persisting_run_state() {
+async fn human_input_without_authenticated_or_present_human_is_invalid_request() {
     let group = Arc::new(GroupStore::new());
     group
         .upsert(state_machine_test_group())
@@ -172,16 +173,183 @@ async fn human_input_requires_authenticated_human_before_persisting_run_state() 
             authenticated_human: None,
         })
         .await
-        .expect_err("HumanInput must require authenticated Human identity");
+        .expect_err("HumanInput must require a Present Human session participant");
 
-    assert!(matches!(error, CollaborationRuntimeError::Unauthenticated));
-    assert!(
-        StateMachineDefinitionRepoPort::get(&*store, "human_input_single", 1)
-            .await
-            .expect("query definition")
-            .is_none()
-    );
+    assert!(matches!(
+        error,
+        CollaborationRuntimeError::InvalidRequest(message)
+            if message.contains("Present Human session participant")
+    ));
     assert!(delivery.commands.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn human_input_can_start_without_authenticated_human_when_session_has_present_human() {
+    let group = Arc::new(GroupStore::new());
+    let seeded_group = state_machine_test_group();
+    group
+        .upsert(seeded_group.clone())
+        .await
+        .expect("seed group");
+    let sessions = test_sessions();
+    let mut reviewer = Participant::human("human_1001", ParticipantRole::Observer);
+    reviewer.mode = Some(ParticipantMode::Present);
+    let session = sessions
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: seeded_group.id.clone(),
+            session_id: None,
+            params: NewSessionParams {
+                session_kind: SessionKind::ServiceInvocation,
+                participants: vec![reviewer],
+                ..Default::default()
+            },
+        })
+        .await
+        .expect("seed session")
+        .session;
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions,
+        Arc::new(RecordingDelivery::default()),
+        noop_judge(),
+    );
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: seeded_group.id,
+            session_id: Some(session.id),
+            definition_yaml: Some(human_input_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"proposal": "ship it"}),
+            caller_id: Some("bot_driver".to_string()),
+            authenticated_human: None,
+        })
+        .await
+        .expect("existing Present Human should allow service invocation");
+
+    assert_eq!(
+        started.view.nodes[0].status,
+        StateMachineNodeStatus::Running
+    );
+}
+
+#[tokio::test]
+async fn authenticated_human_is_added_or_restored_before_human_input_starts() {
+    let group = Arc::new(GroupStore::new());
+    let seeded_group = state_machine_test_group();
+    group
+        .upsert(seeded_group.clone())
+        .await
+        .expect("seed group");
+    let sessions = test_sessions();
+    let session = sessions
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: seeded_group.id.clone(),
+            session_id: None,
+            params: NewSessionParams {
+                session_kind: SessionKind::ServiceInvocation,
+                participants: seeded_group.participants.clone(),
+                ..Default::default()
+            },
+        })
+        .await
+        .expect("seed session")
+        .session;
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions.clone(),
+        Arc::new(RecordingDelivery::default()),
+        noop_judge(),
+    );
+
+    runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: seeded_group.id.clone(),
+            session_id: Some(session.id.clone()),
+            definition_yaml: Some(human_input_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"proposal": "ship it"}),
+            caller_id: Some("bot_driver".to_string()),
+            authenticated_human: Some(AuthenticatedHumanCaller {
+                actor_id: "human_1001".to_string(),
+                display_name: Some("Reviewer".to_string()),
+            }),
+        })
+        .await
+        .expect("authenticated Human should be materialized into session");
+
+    let updated = sessions
+        .get(&session.id)
+        .await
+        .expect("read session")
+        .expect("session exists");
+    let reviewer = updated
+        .participants
+        .iter()
+        .find(|participant| participant.bot_uuid == "human_1001")
+        .expect("Human added");
+    assert!(reviewer.is_human());
+    assert_eq!(reviewer.role, ParticipantRole::Observer);
+    assert_eq!(reviewer.effective_mode(), ParticipantMode::Present);
+    assert_eq!(reviewer.bot_name.as_deref(), Some("Reviewer"));
+
+    let mut returning_reviewer =
+        Participant::human("human_2002", ParticipantRole::Observer);
+    returning_reviewer.mode = Some(ParticipantMode::Absent);
+    let returning_session = sessions
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: seeded_group.id.clone(),
+            session_id: None,
+            params: NewSessionParams {
+                session_kind: SessionKind::ServiceInvocation,
+                participants: vec![returning_reviewer],
+                ..Default::default()
+            },
+        })
+        .await
+        .expect("seed session with absent Human")
+        .session;
+
+    runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: seeded_group.id,
+            session_id: Some(returning_session.id.clone()),
+            definition_yaml: Some(human_input_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"proposal": "ship it"}),
+            caller_id: Some("bot_driver".to_string()),
+            authenticated_human: Some(AuthenticatedHumanCaller {
+                actor_id: "human_2002".to_string(),
+                display_name: Some("Returning Reviewer".to_string()),
+            }),
+        })
+        .await
+        .expect("authenticated Human should be restored to Present");
+
+    let updated = sessions
+        .get(&returning_session.id)
+        .await
+        .expect("read returning session")
+        .expect("returning session exists");
+    let reviewer = updated
+        .participants
+        .iter()
+        .find(|participant| participant.bot_uuid == "human_2002")
+        .expect("returning Human retained");
+    assert_eq!(reviewer.effective_mode(), ParticipantMode::Present);
 }
 
 #[tokio::test]

--- a/src/bcs/docs/plans/2026-07-21-human-node-implementation.md
+++ b/src/bcs/docs/plans/2026-07-21-human-node-implementation.md
@@ -179,6 +179,12 @@ session。这样既不改变 Bot creator 语义，也能满足 HumanInput 的权
 不能由请求体指定，普通 Chat session 不执行这项自动加入逻辑。创建协作群时自动生成的首个
 `ServiceInvocation` session 与后续手工新建的 session 使用相同规则。
 
+启动包含 `human_input` 的 State Machine 不要求启动者本身是 Human。若请求中有服务端认证的
+Human，Runtime 会将其幂等加入目标 session，并确保其 mode 为 `Present`；若请求中没有 Human
+身份，但 session 已经存在至少一个 `Present Human`，也允许启动。两者都不满足时按业务参数
+错误返回 `400`，而不是认证错误 `401`。读取 pending 节点和提交 Human response 仍然要求可信
+Human 身份及对应 session 的 `Present` 成员资格。
+
 ```text
 GET  /state-machine-runs/{run_id}/pending-human-nodes
 POST /state-machine-runs/{run_id}/nodes/{node_id}/respond


### PR DESCRIPTION
## What changed

- allow a `human_input` state-machine run to start without an authenticated Human when the selected session already has a `Present Human`
- materialize a server-authenticated Human into the selected session as `Observer + Present`, restoring an existing absent Human when needed
- forward trusted Human identity through the group auto-start path
- keep pending-node reads and Human responses protected by authenticated `Present Human` membership
- document the distinction between run-start validation and Human response authorization

## Root cause

The runtime treated the absence of `authenticated_human` as an authentication failure for every definition containing `human_input`. ServiceInvocation may legitimately be started by a Bot or system caller, so the real start invariant is session readiness: at least one `Present Human` must be available.

## Validation

- `git diff --check`
- added runtime regression coverage for no-Human rejection as HTTP/business invalid input, existing Present Human startup, authenticated Human enrollment, and absent Human restoration
- added HTTP contract coverage for forwarding authenticated Human identity during group auto-start
- local tests intentionally not run per requested workflow; PR CI is the validation source