### PR TITLE
fix: domain-bots remove auth and remove iam_token (cherry-pick #442 to REL20260728)

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -1806,7 +1806,6 @@ async def search_bots(
 @router.get("/search/domain-bots", response_model=ApiResponse)
 async def list_domain_bots(
     request: Request,
-    user: AuthenticatedUser = Depends(require_operator),  # noqa: B008
     page: Optional[int] = Query(None, ge=1, description="Page number (1-based). Omit for all results"),
     page_size: Optional[int] = Query(None, ge=1, description="Items per page. Omit for all results"),
     keyword: Optional[str] = Query(None, description="Keyword to fuzzy-match on bot name"),
@@ -1828,6 +1827,14 @@ async def list_domain_bots(
             page_size=page_size,
             keyword=keyword,
         )
+
+        # iam_token 是调用方 IAM 凭据(由 cookie 写入 bot.ext,见
+        # update_bot_ext/trigger_data_init_api)。此端点不对调用方做 operator
+        # 鉴权,公开的域 Bot 列表不应回传该凭据,逐条剔除。
+        for item in result.get("items", []):
+            ext = item.get("ext") if isinstance(item, dict) else None
+            if isinstance(ext, dict):
+                ext.pop("iam_token", None)
 
         return ApiResponse(
             success=True,

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -1762,20 +1762,20 @@ class TestListDomainBots:
         assert data["error_code"] == 500
         assert "查询失败" in data["message"] or "失败" in data["message"]
 
-    def test_list_domain_bots_non_operator_forbidden(self, client):
-        """An authenticated non-operator cannot enumerate domain bots."""
+    def test_list_domain_bots_strips_iam_token(self, client):
+        """iam_token 是调用方 IAM 凭据,公开域 Bot 列表响应中必须剔除。"""
         tc, svc, _ = client
-
-        async def _deny_operator():
-            raise HTTPException(status_code=403, detail="operator required")
-
-        tc.app.dependency_overrides[require_operator] = _deny_operator
-        svc.list_domain_bots.reset_mock()
+        bot_with_token = {**BOT_SAMPLE, "ext": {"iam_token": "secret-token", "is_domain_bot": True}}
+        svc.list_domain_bots.return_value = {"total": 1, "items": [bot_with_token]}
 
         resp = tc.get("/api/bots/search/domain-bots")
 
-        assert resp.status_code == 403
-        svc.list_domain_bots.assert_not_called()
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        item = data["data"]["items"][0]
+        assert "iam_token" not in item["ext"]
+        assert item["ext"]["is_domain_bot"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/community/endpoints/test_bots_domain_bots.py
+++ b/src/backend/tests/community/endpoints/test_bots_domain_bots.py
@@ -134,14 +134,3 @@ def list_domain_bots_keyword_no_match():
 )
 def list_domain_bots_invalid_page():
     """Error path: page=0 violates Query(ge=1) → 422 (real validation, no mock)."""
-
-
-@endpoint_test(
-    method="GET",
-    path="/api/bots/search/domain-bots",
-    scenario="unauthenticated",
-    input=CaseInput(),
-    expect=ExpectError(status=401),
-)
-def list_domain_bots_requires_authentication():
-    """An unauthenticated caller cannot enumerate platform domain bots."""


### PR DESCRIPTION
Cherry-pick of #442 onto REL20260728.

#442 已合入 REL20260724;REL20260728 从更早分叉(e0006e83)未含此 fix,本 PR 将同一改动应用到 REL20260728。

改动:
- list_domain_bots 端点移除 Depends(require_operator) operator 鉴权
- 返回前逐条 ext.pop("iam_token"),避免公开域 Bot 列表回传调用方 IAM 凭据

diff 与 #442 一致(3 files, +18/-22),本地 commit 9db9d39f。