### PR TITLE
fix: ignore empty template config on bot update

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -2299,11 +2299,17 @@ async def update_bot(
         if avatar_url:
             ext = {**(ext or {}), "avatar_url": avatar_url}
 
+        # ``template_config`` is optional for a metadata-only update.  Some
+        # callers serialize an omitted object field as ``{}``; normalize that
+        # representation at the HTTP boundary so it does not trigger an
+        # invalid empty template create/update in the domain service.
         template_config = data.get("template_config")
+        if template_config == {}:
+            template_config = None
         logger.info(
             "[bot_router.update_bot] bot_id=%s, template_config=%s",
             bot_id,
-            "provided" if template_config else "None",
+            "provided" if template_config is not None else "None",
         )
 
         resolved_owner_id = owner_id or operator_id

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -673,6 +673,19 @@ class TestUpdateBot:
         svc.update_bot.assert_called_once()
         assert svc.update_bot.call_args.kwargs.get("bot_name") is None
 
+    def test_empty_template_config_is_treated_as_omitted(self, client):
+        # 部分调用方会把未填写的可选对象序列化为 {}。这不应触发模板写入，
+        # 否则模板服务会因空内容校验失败。
+        tc, svc, _ = client
+        resp = tc.put("/api/bots/default", json={
+            "bot_name": "NewName",
+            "template_config": {},
+        })
+
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert svc.update_bot.call_args.kwargs["template_config"] is None
+
     def test_valid_name_strips_and_passes(self, client):
         # 合法名首尾空格被 strip 后透传给 service。
         tc, svc, _ = client


### PR DESCRIPTION
## 变更
- 将普通 Bot 更新请求中的 `template_config: {}` 归一化为未提供配置，避免触发空模板持久化。
- 修正该字段日志的存在性判断，并补充接口回归测试。

## 根因
部分调用方会将未填写的可选对象序列化为 `{}`；普通更新接口此前将其传入模板服务，后者正确拒绝空模板内容。

## 影响与兼容性
仅影响 `PUT /api/bots/{bot_id}` 的空对象输入。非空模板配置仍原样透传；管理员沙箱配置接口不变。无契约变更。

## 验证
- `uv run pytest tests/community/api/bot_management/test_router.py`（140 passed）
- `uv run ruff check src/agentclaw/community/adapters/http/bot_management/router.py`

## Dima
关联缺陷：[2026072700117774117](https://project.alipay.com/workItem?workItemId=2026072700117774117)。后续 OCB 调用方修复应关联同一缺陷。