### PR TITLE
fix(backend): tenant isolation gaps from PR #456 review (raw SQL + threads)

### DIFF
--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -223,15 +223,34 @@
     device-allocation `ThreadPoolExecutor` (bind the submitted callable).
   - `desktop_bot/services/desktop_bot_service.py` `_poll_publish_progress`
     (calls `_bot_repo.get_by_id_and_owner` / `update_by_owner`).
-- **Deferred** (out of Stage-1 scope — touch non-bot tables, not `ac_bots`):
-  `bot_public_service.py` auth-relationship rebuild executors;
-  `device_service.py` MCP-sync / service-start threads. Revisit when those data
-  categories get their own guards (later stages).
+- **CORRECTION (post-merge review, FreddieSun on PR #456):** the "deferred —
+  non-bot tables" classification below was **wrong**. Re-traced, these sites DO
+  read/write `BotModel` on bare `Thread`/`ThreadPoolExecutor`, so they were fixed
+  in the follow-up PR (F3):
+  - `bot_public_service.py:176` `_do_sync` → `get_by_id_and_owner`; `:1119`
+    `ThreadPoolExecutor` → `get_by_id_and_owner`.
+  - `device_service.py:729` `start_service_async` → `_mark_service_start_failed`
+    → `_bot_query.get_by_binding_id`; `:1545` `report_device_alive` `_run` →
+    `_bot_query.get_by_binding_id`.
+  - `baas_publish_poller.py:55` `_poll` → updates `BotModel` on publish completion.
 - **Recommended (not done):** an arch guard that flags new raw
   `threading.Thread` / `ThreadPoolExecutor` in core so future in-request spawns
   can't silently drop the tenant. Tracked for follow-up.
 - **Verification:** 1005 tests pass across bot_dormant / desktop_bot /
-  bot_management.
+  bot_management (original 3 sites); the 5 corrected sites are covered in F3.
+
+### F3: Fix post-merge review findings (raw SQL + thread mis-classification)  `[x]`
+- **Trigger:** two P1 review comments on merged PR #456 (FreddieSun).
+- **Raw SQL bypass:** `bot_discover_service._batch_get_public_bots` read `ac_bots`
+  via a raw `cursor.execute` — never triggers `do_orm_execute`, so unguarded.
+  Migrated to `BotRepository.list_public_bots_by_owner_bot_pairs` (ORM →
+  guard-covered). Regression test proves it is tenant-scoped.
+- **Threads:** wrapped the 5 mis-classified sites above with
+  `bind_current_avernet_tenant`. Regression test proves a repo read inside a
+  bound thread stays tenant-scoped (and a bare thread drops to the default).
+- **Both are latent** (single-tenant-safe today); they bite once a 2nd tenant /
+  the real resolver exists. Delivered as a new PR off `dev` (the merged PR can't
+  be reopened).
 
 ### F2: Tenant-leading indexes — MANDATORY policy, deferred  `[ ]`
 - Tenant-leading indexes on a tenant-columned table are a **mandatory corp

--- a/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
+++ b/src/backend/specs/2026-07-26-tenant-isolation-foundation/tasks.md
@@ -248,6 +248,14 @@
 - **Threads:** wrapped the 5 mis-classified sites above with
   `bind_current_avernet_tenant`. Regression test proves a repo read inside a
   bound thread stays tenant-scoped (and a bare thread drops to the default).
+- **Threads (2nd pass, Codex review note on #478):** two more in-request bare
+  threads that touch `BotModel` were wrapped for completeness —
+  `device_service.py` `_trigger_data_init_on_device_ready` `_run_init` (data-init
+  → `trigger_init` updates `bot.ext.data_init_status`) and its local variant
+  `local_device_service.py` `start_service_async` (→ `_mark_service_start_failed`
+  → `_bot_query.get_by_binding_id`). The `bot_public_service.py:300`
+  auth-relationship-rebuild executor is left alone — it touches auth-relationship
+  data, not `ac_bots` (a later category's stage).
 - **Both are latent** (single-tenant-safe today); they bite once a 2nd tenant /
   the real resolver exists. Delivered as a new PR off `dev` (the merged PR can't
   be reopened).

--- a/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
@@ -108,6 +108,12 @@ class BotRepository(Protocol):
         """List bots with pagination and search."""
         ...
 
+    def list_public_bots_by_owner_bot_pairs(
+        self, pairs: List[tuple[str, str]]
+    ) -> List[Dict[str, Any]]:
+        """Live public bots matching any ``(bot_id, owner_id)`` pair, this env."""
+        ...
+
     def list_domain_bots(
         self,
         page: int | None = None,

--- a/src/backend/src/agentclaw/community/core/bot_public/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_public/README.md
@@ -29,6 +29,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.device_sync
   - agentclaw.community.plugin_api.models
   - agentclaw.community.plugin_api.passport
+  - agentclaw.community.utils.avernet_tenant
   - agentclaw.community.utils.env_utils
 ```
 

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_discover_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_discover_service.py
@@ -271,107 +271,62 @@ class BotDiscoverService:
             [(bot_detail, rec), ...] 列表，只包含 public 的 bot
         """
         try:
-            # 访问 repository 的 _db 属性执行 SQL
-            if not hasattr(self._bot_repository, "_db"):
-                logger.warning("[BotDiscover] Repository 没有 _db 属性，无法验证")
-                return []
-
-            db = self._bot_repository._db
-            from agentclaw.community.utils.env_utils import get_current_env
-
             # 构建 (bot_id, owner_id) 条件列表
-            conditions = []
-            params = []
-            bot_id_to_rec = {}  # (bot_id, owner_id) -> rec
+            pairs: list[tuple[str, str]] = []
+            bot_id_to_rec = {}  # (bot_id, owner_id) -> (worker_id, rec)
             for worker_id, bot_id, owner_id, rec in bot_entries:
-                conditions.append("(bot_id = %s AND owner_id = %s)")
-                params.extend([bot_id, owner_id])
+                pairs.append((bot_id, owner_id))
                 bot_id_to_rec[(bot_id, owner_id)] = (worker_id, rec)
 
-            if not conditions:
+            if not pairs:
                 return []
 
-            # 添加 env 条件
-            params.append(get_current_env())
+            # ORM 查询（经 do_orm_execute tenant guard 覆盖，自动按 tenant 隔离）。
+            # 曾经是对 ac_bots 的 raw cursor SQL —— raw SQL 绕过了 BotModel 的
+            # tenant guard（listener 只覆盖 ORM statement），故改走仓储的 ORM 方法。
+            bots = self._bot_repository.list_public_bots_by_owner_bot_pairs(pairs)
 
-            # 构建 IN 查询
-            where_clause = " OR ".join(conditions)
-            sql = f"""
-                SELECT id, bot_id, bot_name, bot_desc, entity_id, entity_type,
-                       creator_id, owner_id, engine_types, status, binding_id,
-                       gmt_create, gmt_modified, modifier_id, share_policy,
-                       is_delete, active_engine, device_id, env, ext, public
-                FROM ac_bots
-                WHERE ({where_clause}) AND is_delete = 0 AND env = %s AND public = '1'
-            """
+            result = []
+            for bot in bots:
+                key = (bot["bot_id"], bot["owner_id"])
+                worker_id, rec = bot_id_to_rec.get(key, (None, None))
+                if not rec:
+                    continue
 
-            with db.session() as conn:
-                with conn.cursor() as cursor:
-                    cursor.execute(sql, params)
-                    rows = cursor.fetchall()
+                # 构建完整的 bot 详情（与 search 接口格式一致，to_dict() 已解析 JSON）
+                ext = bot.get("ext")
+                bot_detail = {
+                    "id": bot["id"],
+                    "bot_id": bot["bot_id"],
+                    "bot_name": bot["bot_name"],
+                    "bot_desc": bot["bot_desc"],
+                    "entity_id": bot["entity_id"],
+                    "entity_type": bot["entity_type"],
+                    "creator_id": bot["creator_id"],
+                    "owner_id": bot["owner_id"],
+                    "engine_types": bot["engine_types"],
+                    "status": bot["status"],
+                    "binding_id": bot["binding_id"],
+                    "gmt_create": bot["gmt_create"],
+                    "gmt_modified": bot["gmt_modified"],
+                    "modifier_id": bot["modifier_id"],
+                    "share_policy": bot["share_policy"],
+                    "is_delete": bot["is_delete"],
+                    "active_engine": bot["active_engine"],
+                    "device_id": bot["device_id"],
+                    "env": bot["env"],
+                    "ext": ext,
+                    "public": bot["public"],
+                    "owner_name": (ext or {}).get("owner_name") if ext else None,
+                }
+                result.append((bot_detail, rec))
 
-                    result = []
-                    for row in rows:
-                        bot_id = row[1]
-                        owner_id = row[7]
-                        worker_id, rec = bot_id_to_rec.get((bot_id, owner_id), (None, None))
-                        if not rec:
-                            continue
-
-                        # 构建完整的 bot 详情（与 search 接口格式一致）
-                        bot_detail = {
-                            "id": row[0],
-                            "bot_id": row[1],
-                            "bot_name": row[2],
-                            "bot_desc": row[3],
-                            "entity_id": row[4],
-                            "entity_type": row[5],
-                            "creator_id": row[6],
-                            "owner_id": row[7],
-                            "engine_types": self._parse_json(row[8]),
-                            "status": row[9],
-                            "binding_id": row[10],
-                            "gmt_create": row[11].isoformat() if row[11] else None,
-                            "gmt_modified": row[12].isoformat() if row[12] else None,
-                            "modifier_id": row[13],
-                            "share_policy": row[14],
-                            "is_delete": row[15],
-                            "active_engine": row[16],
-                            "device_id": row[17],
-                            "env": row[18],
-                            "ext": self._parse_json(row[19]),
-                            "public": row[20],
-                            "owner_name": self._parse_json(row[19], {}).get("owner_name") if row[19] else None,
-                        }
-                        result.append((bot_detail, rec))
-
-                    logger.debug(f"[BotDiscover] 批量查询完成: {len(result)}/{len(bot_entries)} 个 public")
-                    return result
+            logger.debug(f"[BotDiscover] 批量查询完成: {len(result)}/{len(bot_entries)} 个 public")
+            return result
 
         except Exception as e:
             logger.warning(f"[BotDiscover] 批量获取 public bot 信息失败: {e}")
             return []
-
-    @staticmethod
-    def _parse_json(value: Any, default: Any = None) -> Any:
-        """解析 JSON 字符串.
-
-        Args:
-            value: 可能是 JSON 字符串或 Python 对象
-            default: 默认值
-
-        Returns:
-            解析后的对象
-        """
-        if value is None:
-            return default
-        if isinstance(value, str):
-            import json
-            try:
-                return json.loads(value)
-            except json.JSONDecodeError:
-                return default
-        return value
 
     @staticmethod
     def _sanitize_ext_fields(items: list[dict[str, Any]]) -> None:

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 from agentclaw.community.plugin_api.approval_workflow import ApprovalWorkflowPlugin
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.core.bot_public.repository.bot_friend_repository import BotFriendRepositoryProtocol
 from agentclaw.community.core.bot_public.repository.models import BotFriendQueryKey, BotFriendStatus, ApprovalStatus, ApprovalType
 from agentclaw.community.core.operator_context import OperatorContext
@@ -173,7 +174,11 @@ class BotPublicService:
                     f"access_mode={access_mode}, public={public}"
                 )
 
-        thread = threading.Thread(target=_do_sync, daemon=False)
+        # Bare threads don't copy context vars; carry the request tenant so the
+        # BotRepository reads inside _do_sync stay tenant-scoped.
+        thread = threading.Thread(
+            target=bind_current_avernet_tenant(_do_sync), daemon=False
+        )
         thread.start()
         logger.info(f"[_sync_access_mode_and_relations] Started background thread: bot_id={bot_id}, owner_id={owner_id}")
 
@@ -1116,9 +1121,14 @@ class BotPublicService:
 
             # 并发查询 bot 信息
             bot_map = {}
+            # ThreadPoolExecutor workers don't copy context vars; bind the
+            # request tenant so these BotRepository reads stay tenant-scoped.
+            _get_bot = bind_current_avernet_tenant(
+                self._bot_repository.get_by_id_and_owner
+            )
             with ThreadPoolExecutor(max_workers=10) as executor:
                 future_to_key = {
-                    executor.submit(self._bot_repository.get_by_id_and_owner, bot_id, owner_id): (owner_id, bot_id)
+                    executor.submit(_get_bot, bot_id, owner_id): (owner_id, bot_id)
                     for owner_id, bot_id in unique_keys
                 }
                 for future in as_completed(future_to_key):

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -12,7 +12,10 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 from agentclaw.community.plugin_api.approval_workflow import ApprovalWorkflowPlugin
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import BotService
-from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
+from agentclaw.community.utils.avernet_tenant import (
+    bind_current_avernet_tenant,
+    get_current_avernet_tenant,
+)
 from agentclaw.community.core.bot_public.repository.bot_friend_repository import BotFriendRepositoryProtocol
 from agentclaw.community.core.bot_public.repository.models import BotFriendQueryKey, BotFriendStatus, ApprovalStatus, ApprovalType
 from agentclaw.community.core.operator_context import OperatorContext
@@ -129,7 +132,14 @@ class BotPublicService:
         普通发布流程保留后台执行语义；失败会被线程入口记录。审批回调必须改用
         ``_sync_access_mode_and_relations_or_raise``，同步等待并传播失败。
         """
-        sync_key = f"{owner_id}:{bot_id}"
+        # Tenant-scope the coalescing key: (owner_id, bot_id) is unique only
+        # WITHIN a tenant, but _syncing_bots / _pending_syncs are process-wide.
+        # Without the tenant prefix, a second tenant's sync for a colliding
+        # (owner_id, bot_id) would be queued under the first tenant's key and
+        # applied to the first tenant's bot by its (tenant-bound) thread, while
+        # its own bot is never synced. The key is built in the request thread,
+        # so get_current_avernet_tenant() is the request's tenant.
+        sync_key = f"{get_current_avernet_tenant()}:{owner_id}:{bot_id}"
         with self._sync_lock:
             if sync_key in self._syncing_bots:
                 # 当前已有同步任务在执行，把最新参数存入 pending。

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_poller.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_poller.py
@@ -14,6 +14,7 @@ import time
 from typing import TYPE_CHECKING, Callable
 
 from agentclaw.community.log import get_logger
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 
 if TYPE_CHECKING:
     from agentclaw.community.core.devices.services.device_service import DeviceService
@@ -53,7 +54,7 @@ class BaasPublishPoller:
     def start(self, *, publish_id: str, device_id: str, binding_id: int) -> None:
         """启动后台 thread 轮询，daemon=True 不阻塞进程退出。"""
         thread = threading.Thread(
-            target=self._poll,
+            target=bind_current_avernet_tenant(self._poll),
             args=(publish_id, device_id, binding_id),
             daemon=True,
             name=f"baas-poll-{publish_id}",

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -1644,7 +1644,11 @@ class DeviceService:
                         exc_info=True,
                     )
 
-            thread = threading.Thread(target=_run_init, daemon=True, name=f"data-init-{bot_id}")
+            thread = threading.Thread(
+                target=bind_current_avernet_tenant(_run_init),
+                daemon=True,
+                name=f"data-init-{bot_id}",
+            )
             thread.start()
 
             logger.info(f"bot_id={bot_id} data_init_trigger dispatched source=status_succeeded thread={thread.name}")

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -45,6 +45,7 @@ from agentclaw.community.core.devices.errors import (
 )
 from agentclaw.community.core.bot_management.token_vault import TokenVault
 from agentclaw.community.core.bot_management.engines import resolve_provisioning
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.core.devices.protocols import (
     BotQueryProtocol,
     BotSyncProtocol,
@@ -736,7 +737,9 @@ class DeviceService:
                 logger.exception(f"[apply_device] start service failed for device {allocated.device_id}: {e}")
                 self._mark_service_start_failed(binding_id=binding_id, error=str(e))
 
-        thread = threading.Thread(target=start_service_async, daemon=True)
+        thread = threading.Thread(
+            target=bind_current_avernet_tenant(start_service_async), daemon=True
+        )
         thread.start()
 
         record = self._repo.get_by_id(binding_id)
@@ -1542,7 +1545,9 @@ class DeviceService:
                     record.device_id, sync_error,
                 )
 
-        threading.Thread(target=_run, daemon=True).start()
+        threading.Thread(
+            target=bind_current_avernet_tenant(_run), daemon=True
+        ).start()
 
     def _trigger_data_init_on_device_ready(self, *, device_id: str, record) -> None:
         """当设备自报 SUCCEEDED 时触发 data-init。

--- a/src/backend/src/agentclaw/community/core/devices/services/local_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/local_device_service.py
@@ -56,6 +56,7 @@ from agentclaw.community.core.devices.services.device_service import (
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE  # noqa: E402
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils import env_utils
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 
 
 logger = get_logger()
@@ -726,7 +727,9 @@ class LocalDeviceService(DeviceService):
                     error=str(e),
                 )
 
-        thread = threading.Thread(target=start_service_async, daemon=True)
+        thread = threading.Thread(
+            target=bind_current_avernet_tenant(start_service_async), daemon=True
+        )
         thread.start()
 
         return result

--- a/src/backend/src/agentclaw/community/plugins/bot_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_repository.py
@@ -41,7 +41,7 @@ import json
 from typing import Any, Dict, List, Optional
 
 from injector import inject
-from sqlalchemy import func, or_
+from sqlalchemy import and_, func, or_
 
 from agentclaw.community.core.bot_management.repository.protocol import (
     BotLookupAmbiguousError,
@@ -376,6 +376,41 @@ class BotRepository:
                 .all()
             )
             return total, [b.to_dict() for b in bots]
+
+    def list_public_bots_by_owner_bot_pairs(
+        self, pairs: List[tuple[str, str]]
+    ) -> List[Dict[str, Any]]:
+        """Live public bots matching any ``(bot_id, owner_id)`` pair, this env.
+
+        ORM-based replacement for a former raw ``cursor.execute("… FROM
+        ac_bots …")`` in ``bot_discover_service`` — raw SQL bypasses the
+        ``BotModel`` tenant guard (``do_orm_execute`` only fires for ORM
+        statements), so this read now goes through the ORM and is tenant-scoped
+        automatically. Returns ``to_dict()`` dicts (the search-interface shape
+        the caller wants).
+        """
+        if not pairs:
+            return []
+        with self._db.orm_session() as db:
+            bots = (
+                db.query(self.Model)
+                .filter(
+                    or_(
+                        *[
+                            and_(
+                                self.Model.bot_id == bot_id,
+                                self.Model.owner_id == owner_id,
+                            )
+                            for bot_id, owner_id in pairs
+                        ]
+                    ),
+                    self.Model.is_delete == 0,
+                    self._env(),
+                    self.Model.public == "1",
+                )
+                .all()
+            )
+            return [b.to_dict() for b in bots]
 
     def list_by_search(
         self,

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -9,6 +9,10 @@ from agentclaw.community.core.bot_public.services.bot_public_service import (
 )
 from agentclaw.community.core.bot_public.repository.models import BotFriendStatus
 from agentclaw.community.core.operator_context import OperatorContext
+from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
+
+# The coalescing key is tenant-scoped; unscoped tests run under the default tenant.
+_SYNC_KEY = f"{DEFAULT_AVERNET_TENANT}:owner1:bot1"
 
 
 # ---------------------------------------------------------------------------
@@ -1260,28 +1264,28 @@ class TestSyncAccessModeAndRelations:
         bot_repo.get_by_id_and_owner.return_value = _make_bot()
 
         svc = _make_service(bot_repository=bot_repo)
-        svc._syncing_bots.add("owner1:bot1")
+        svc._syncing_bots.add(_SYNC_KEY)
 
         svc._sync_access_mode_and_relations(
             bot_id="bot1", owner_id="owner1",
             access_mode="RESTRICTED", public="1"
         )
 
-        assert svc._pending_syncs["owner1:bot1"] == ("RESTRICTED", "1")
+        assert svc._pending_syncs[_SYNC_KEY] == ("RESTRICTED", "1")
         # Should not start a new thread
-        assert "owner1:bot1" in svc._syncing_bots
+        assert _SYNC_KEY in svc._syncing_bots
 
     def test_overwrites_pending_with_latest_params(self):
         svc = _make_service()
-        svc._syncing_bots.add("owner1:bot1")
-        svc._pending_syncs["owner1:bot1"] = ("OLD_MODE", "0")
+        svc._syncing_bots.add(_SYNC_KEY)
+        svc._pending_syncs[_SYNC_KEY] = ("OLD_MODE", "0")
 
         svc._sync_access_mode_and_relations(
             bot_id="bot1", owner_id="owner1",
             access_mode="OPEN", public="1"
         )
 
-        assert svc._pending_syncs["owner1:bot1"] == ("OPEN", "1")
+        assert svc._pending_syncs[_SYNC_KEY] == ("OPEN", "1")
 
     @patch("agentclaw.community.core.bot_management.utils.resolve_agent_code", return_value=None)
     def test_raises_when_agent_code_empty(self, _mock_resolve):

--- a/src/backend/tests/community/core/bot_public/test_sync_access_mode_tenant.py
+++ b/src/backend/tests/community/core/bot_public/test_sync_access_mode_tenant.py
@@ -1,0 +1,116 @@
+"""The access-mode sync coalescing key is tenant-scoped.
+
+`_sync_access_mode_and_relations` coalesces concurrent syncs for a bot via
+process-wide `_syncing_bots` / `_pending_syncs` dicts keyed by `sync_key`. Since
+`(owner_id, bot_id)` is unique only *within* a tenant, the key must include the
+tenant — otherwise a second tenant's sync for a colliding `(owner_id, bot_id)`
+is queued under the first tenant's key and applied to the first tenant's bot by
+its (tenant-bound) thread, while its own bot is never synced.
+
+Regression for the P1 review finding on PR #478.
+"""
+import threading
+import time
+
+import pytest
+
+from agentclaw.community.core.bot_public.services.bot_public_service import (
+    BotPublicService,
+)
+from agentclaw.community.utils.avernet_tenant import (
+    avernet_tenant_scope,
+    get_current_avernet_tenant,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _wait_until(pred, timeout: float = 5.0) -> None:
+    end = time.time() + timeout
+    while time.time() < end:
+        if pred():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+def _bare_service() -> BotPublicService:
+    """Only the slice `_sync_access_mode_and_relations` touches."""
+    svc = BotPublicService.__new__(BotPublicService)
+    svc._sync_lock = threading.Lock()
+    svc._syncing_bots = set()
+    svc._pending_syncs = {}
+    return svc
+
+
+def test_sync_key_includes_the_current_tenant(monkeypatch):
+    svc = _bare_service()
+    snap: dict = {}
+
+    def _or_raise(*, bot_id, owner_id, access_mode, public):
+        # Snapshot the in-flight key set from inside the running sync thread.
+        snap["syncing"] = set(svc._syncing_bots)
+
+    svc._sync_access_mode_and_relations_or_raise = _or_raise
+
+    threads = []
+    real_thread = threading.Thread
+    monkeypatch.setattr(
+        threading,
+        "Thread",
+        lambda *a, **k: threads.append(real_thread(*a, **k)) or threads[-1],
+    )
+
+    with avernet_tenant_scope("tenant-x"):
+        svc._sync_access_mode_and_relations("b1", "u1", "OPEN", "1")
+    for t in threads:
+        t.join(timeout=5)
+
+    assert snap["syncing"] == {"tenant-x:u1:b1"}
+
+
+def test_colliding_ids_across_tenants_do_not_coalesce(monkeypatch):
+    """Tenant B's sync for the same (owner_id, bot_id) must run on its own bot,
+    not be swallowed into tenant A's in-flight bucket."""
+    svc = _bare_service()
+
+    gate = threading.Event()
+    calls = []
+
+    def _or_raise(*, bot_id, owner_id, access_mode, public):
+        calls.append((get_current_avernet_tenant(), access_mode, public))
+        gate.wait(timeout=5)  # hold the sync so it stays 'in-flight'
+
+    svc._sync_access_mode_and_relations_or_raise = _or_raise
+
+    threads = []
+    real_thread = threading.Thread
+    monkeypatch.setattr(
+        threading,
+        "Thread",
+        lambda *a, **k: threads.append(real_thread(*a, **k)) or threads[-1],
+    )
+
+    # Tenant A starts a sync and is held in _or_raise (in-flight).
+    with avernet_tenant_scope("tenant-a"):
+        svc._sync_access_mode_and_relations("b1", "u1", "OPEN", "1")
+    _wait_until(lambda: len(calls) == 1)
+
+    # Tenant B syncs the SAME (owner_id, bot_id) — its own, different bot.
+    with avernet_tenant_scope("tenant-b"):
+        svc._sync_access_mode_and_relations("b1", "u1", "RESTRICTED", "0")
+
+    # B must NOT have been queued into A's bucket — it starts its own sync.
+    assert svc._pending_syncs == {}
+    _wait_until(lambda: len(calls) == 2)
+
+    gate.set()
+    for t in threads:
+        t.join(timeout=5)
+
+    # Each tenant applied its own values under its own tenant — no crossover.
+    by_tenant = {tenant: (am, pub) for tenant, am, pub in calls}
+    assert by_tenant == {
+        "tenant-a": ("OPEN", "1"),
+        "tenant-b": ("RESTRICTED", "0"),
+    }

--- a/src/backend/tests/community/core/devices/test_data_init_thread_tenant.py
+++ b/src/backend/tests/community/core/devices/test_data_init_thread_tenant.py
@@ -1,0 +1,74 @@
+"""The device data-init thread inherits the request's tenant.
+
+`_trigger_data_init_on_device_ready` (the device-SUCCEEDED callback) spawns a
+bare `threading.Thread` that runs `DataInitService.trigger_init`, which
+reads/writes `BotModel` (data_init_status lives in `bot.ext`). Bare threads don't
+copy `ContextVar`s, so it is wrapped with `bind_current_avernet_tenant`; this
+proves the wrapped thread runs under the spawning request's tenant.
+
+Flagged by a review note on PR #478.
+"""
+import threading
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.devices.services.device_service import DeviceService
+from agentclaw.community.utils.avernet_tenant import (
+    avernet_tenant_scope,
+    get_current_avernet_tenant,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeDataInit:
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def trigger_init(self, **kwargs):
+        self._sink["tenant"] = get_current_avernet_tenant()
+        self._sink["kwargs"] = kwargs
+
+
+def test_data_init_thread_inherits_request_tenant(monkeypatch):
+    sink: dict = {}
+
+    # Construct only the slice of DeviceService the callback touches.
+    svc = DeviceService.__new__(DeviceService)
+    svc._bot_query = Mock()
+    svc._bot_query.get_by_binding_id.return_value = {
+        "bot_id": "b1",
+        "owner_id": "o1",
+        "entity_id": "e1",
+        "entity_type": "staff",
+        "ext": {"data_init_status": "pending_init"},
+        "status": "ACTIVE",
+    }
+    svc._data_init_service_provider = lambda: _FakeDataInit(sink)
+
+    # Capture the spawned thread so we can join it deterministically.
+    created: dict = {}
+    real_thread_cls = threading.Thread
+
+    def _capturing_thread(*args, **kwargs):
+        t = real_thread_cls(*args, **kwargs)
+        created["t"] = t
+        return t
+
+    monkeypatch.setattr(threading, "Thread", _capturing_thread)
+
+    record = Mock()
+    record.id = 42
+    record.entity_id = "e1"
+    record.entity_type = "staff"
+
+    with avernet_tenant_scope("tenant-x"):
+        svc._trigger_data_init_on_device_ready(device_id="dev-1", record=record)
+
+    assert "t" in created, "data-init thread was not spawned"
+    created["t"].join(timeout=5)
+
+    # The thread ran under the spawning request's tenant, not the default.
+    assert sink["tenant"] == "tenant-x"
+    assert sink["kwargs"]["bot_id"] == "b1"

--- a/src/backend/tests/community/plugins/test_bot_tenant_raw_sql_and_threads.py
+++ b/src/backend/tests/community/plugins/test_bot_tenant_raw_sql_and_threads.py
@@ -1,0 +1,154 @@
+"""Regression tests for the two post-merge review findings on PR #456.
+
+1. Raw SQL bypassed the guard — `bot_discover_service` read `ac_bots` via a raw
+   cursor, which never triggers `do_orm_execute`. It now goes through
+   `BotRepository.list_public_bots_by_owner_bot_pairs` (ORM → guard-covered);
+   this test proves that method is tenant-scoped.
+2. Bare threads dropped the tenant — several in-request `Thread`/`ThreadPoolExecutor`
+   sites read `BotRepository` and, without `bind_current_avernet_tenant`, would
+   fall back to `teamclaw`. This proves a repo read inside a bound thread stays
+   under the spawning tenant (and a bare thread does not).
+"""
+import threading
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
+from agentclaw.community.core.service_bot.repository.models import BotPublishModel
+from agentclaw.community.plugin_api.models import BotModel
+from agentclaw.community.plugins.bot_repository import BotRepository
+from agentclaw.community.plugins.local.sqlite_models import EntityDeviceBinding
+from agentclaw.community.utils.avernet_tenant import (
+    DEFAULT_AVERNET_TENANT,
+    avernet_tenant_scope,
+    bind_current_avernet_tenant,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _FileSqliteDB:
+    def __init__(self, engine):
+        self._factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    session = orm_session
+
+
+@pytest.fixture
+def repo(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'bots.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    BotModel.__table__.create(engine)
+    BotPublishModel.__table__.create(engine)
+    EntityDeviceBinding.__table__.create(engine)
+    BotCollaboratorModel.__table__.create(engine)
+    return BotRepository(_FileSqliteDB(engine))
+
+
+def _data(**ov):
+    base = dict(
+        bot_id="bot-1",
+        bot_name="Bot One",
+        bot_desc="d",
+        entity_id="staff_x",
+        entity_type="staff",
+        creator_id="emp1",
+        owner_id="emp1",
+        status="ACTIVE",
+        owner_name="Alice",
+        public="1",
+    )
+    base.update(ov)
+    return base
+
+
+# ── Comment 1: the raw-SQL replacement is tenant-scoped ─────────────
+
+def test_list_public_bots_by_owner_bot_pairs_is_tenant_scoped(repo):
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a"))
+    with avernet_tenant_scope("tenant-b"):
+        repo.insert(_data(bot_id="bot-b", owner_id="own-b"))
+
+    pairs = [("bot-a", "own-a"), ("bot-b", "own-b")]
+    with avernet_tenant_scope("tenant-b"):
+        got = repo.list_public_bots_by_owner_bot_pairs(pairs)
+        assert [b["bot_id"] for b in got] == ["bot-b"]  # not A's
+    with avernet_tenant_scope("tenant-a"):
+        got = repo.list_public_bots_by_owner_bot_pairs(pairs)
+        assert [b["bot_id"] for b in got] == ["bot-a"]
+
+
+def test_list_public_bots_excludes_non_public_and_deleted(repo):
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="pub", owner_id="o", public="1"))
+        repo.insert(_data(bot_id="priv", owner_id="o", public="0"))
+    with avernet_tenant_scope("tenant-a"):
+        got = repo.list_public_bots_by_owner_bot_pairs([("pub", "o"), ("priv", "o")])
+        assert [b["bot_id"] for b in got] == ["pub"]
+
+
+def test_list_public_bots_empty_pairs(repo):
+    assert repo.list_public_bots_by_owner_bot_pairs([]) == []
+
+
+# ── Comment 2: a repo read inside a bound thread keeps the tenant ───
+
+def test_repo_read_in_bound_thread_is_tenant_scoped(repo):
+    """Mirrors the bot_public / device_service pattern: a BotRepository read
+    runs on a spawned thread and must observe the spawning request's tenant."""
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a"))
+
+    seen = {}
+
+    def read():
+        # get_by_id_and_owner is the exact call the wrapped sites make.
+        seen["bot"] = repo.get_by_id_and_owner("bot-a", "own-a")
+
+    # Bound under tenant-a → the thread finds A's bot.
+    with avernet_tenant_scope("tenant-a"):
+        target = bind_current_avernet_tenant(read)
+    t = threading.Thread(target=target)
+    t.start()
+    t.join()
+    assert seen["bot"] is not None
+    assert seen["bot"]["bot_id"] == "bot-a"
+
+
+def test_repo_read_in_bare_thread_drops_tenant(repo):
+    """Guards the premise: without binding, the thread falls back to the default
+    tenant and cannot see tenant-a's bot."""
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(_data(bot_id="bot-a", owner_id="own-a"))
+
+    seen = {}
+
+    def read():
+        seen["tenant_default"] = True
+        seen["bot"] = repo.get_by_id_and_owner("bot-a", "own-a")
+
+    with avernet_tenant_scope("tenant-a"):
+        t = threading.Thread(target=read)  # NOT bound
+        t.start()
+        t.join()
+    # Thread ran under DEFAULT_AVERNET_TENANT ("teamclaw"), so A's bot is hidden.
+    assert DEFAULT_AVERNET_TENANT == "teamclaw"
+    assert seen["bot"] is None

--- a/src/backend/tests/community/plugins/test_bot_tenant_raw_sql_and_threads.py
+++ b/src/backend/tests/community/plugins/test_bot_tenant_raw_sql_and_threads.py
@@ -17,7 +17,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
+from agentclaw.community.core.bot_public.services.bot_discover_service import (
+    BotDiscoverService,
+)
 from agentclaw.community.core.service_bot.repository.models import BotPublishModel
+from agentclaw.community.di.config import BcsFuseConfig
 from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.plugins.bot_repository import BotRepository
 from agentclaw.community.plugins.local.sqlite_models import EntityDeviceBinding
@@ -107,6 +111,49 @@ def test_list_public_bots_excludes_non_public_and_deleted(repo):
 
 def test_list_public_bots_empty_pairs(repo):
     assert repo.list_public_bots_by_owner_bot_pairs([]) == []
+
+
+# ── Comment 1: the real caller (_batch_get_public_bots) end-to-end ──
+
+def _discover_service(repo):
+    return BotDiscoverService(bot_repository=repo, bcsfuse_config=BcsFuseConfig())
+
+
+def test_batch_get_public_bots_returns_detail_and_is_tenant_scoped(repo):
+    with avernet_tenant_scope("tenant-a"):
+        repo.insert(
+            _data(
+                bot_id="bot-a",
+                owner_id="own-a",
+                bot_name="Alpha",
+                public="1",
+                ext={"owner_name": "Bob"},
+            )
+        )
+    svc = _discover_service(repo)
+    rec = {"score": 0.9}
+    entries = [("own-a:worker", "bot-a", "own-a", rec)]
+
+    # Under tenant-a: the detail comes back, ext parsed, rec threaded through.
+    with avernet_tenant_scope("tenant-a"):
+        result = svc._batch_get_public_bots(entries, user_id="own-a")
+    assert len(result) == 1
+    bot_detail, got_rec = result[0]
+    assert bot_detail["bot_id"] == "bot-a"
+    assert bot_detail["public"] == "1"
+    assert bot_detail["ext"] == {"owner_name": "Bob"}  # already parsed by to_dict
+    assert bot_detail["owner_name"] == "Bob"
+    assert got_rec is rec
+
+    # Under tenant-b: the ORM guard hides tenant-a's bot — the real leak the
+    # raw SQL allowed is now closed at the service entry point.
+    with avernet_tenant_scope("tenant-b"):
+        assert svc._batch_get_public_bots(entries, user_id="own-a") == []
+
+
+def test_batch_get_public_bots_empty_entries(repo):
+    svc = _discover_service(repo)
+    assert svc._batch_get_public_bots([], user_id="u") == []
 
 
 # ── Comment 2: a repo read inside a bound thread keeps the tenant ───


### PR DESCRIPTION
## What

Follow-up to the two **P1** review comments FreddieSun left on the merged tenant-isolation foundation (#456). Both are confirmed real; both are **latent** (single-tenant-safe today, they bite once a second tenant / the real resolver exists).

### 1. Raw SQL bypassed the tenant guard
`bot_discover_service._batch_get_public_bots` read `ac_bots` via a raw `cursor.execute("… FROM ac_bots …")`. The `do_orm_execute` read guard only fires for ORM statements, so this query had no `avernet_tenant` filter — a caller's discovery would surface other tenants' public bots.

- Migrated to a new ORM method `BotRepository.list_public_bots_by_owner_bot_pairs` (guard-covered), added to the repository protocol.
- Removed the now-dead `_parse_json` helper.
- `share_policy` in the result is now the parsed dict `to_dict()` returns (matching the search interface this path's own comment says it mirrors — the raw string was the inconsistency).

### 2. Thread mis-classification (my F1 error)
Five in-request bare `Thread`/`ThreadPoolExecutor` sites read/write `BotModel` and were wrongly deferred as "non-bot tables." Bare threads don't copy `ContextVar`s, so a non-default tenant fell back to `teamclaw`. Wrapped each with `bind_current_avernet_tenant`:

- `bot_public_service.py` — `_do_sync` thread, `get_by_id_and_owner` `ThreadPoolExecutor`
- `device_service.py` — `start_service_async`, `report_device_alive` `_run`
- `baas_publish_poller.py` — `_poll`

## Tests

- The ORM method is tenant-scoped (cross-tenant read returns only the caller's bots; excludes non-public/deleted).
- A repo read inside a `bind_current_avernet_tenant` thread stays under the spawning tenant; a bare thread drops to the default.
- Declared `utils.avernet_tenant` in `core/bot_public`'s context boundary; corrected the F1 record and added F3 in `tasks.md`.

**1702 tests pass** across plugins / bot_public / devices / architecture.

## Note on CI

`tests/community/architecture/test_e2e_module_coverage.py::test_every_core_module_covered_or_exempt` (core `files` module uncovered) **fails on clean `origin/dev` independently of this change** — verified by stashing this diff. It is a pre-existing dev breakage unrelated to tenant isolation, not introduced here.

## Why a new PR

The original PR #456 is merged and can't be reopened; this lands the review fixes on a fresh branch off `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SqDH8bzzVrweu7RwWWS94

---
_Generated by [Claude Code](https://claude.ai/code/session_011SqDH8bzzVrweu7RwWWS94)_