### PR TITLE
fix: backport legacy skills pool rollout CAS to REL20260728

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -82,8 +82,9 @@ Engine Layout Descriptor 仍不在本期范围内。
   引擎按 OpenClaw、Claude Code、AICoding、Hermes 的固定
   顺序人工晋级；每次扩大同引擎批次必须引用最近一次已冻结验收，除首个
   引擎外，晋级还必须引用上一引擎已冻结的验收批次。配置写入使用完整旧值
-  加逻辑 revision CAS，冲突 fail closed；配置和包含前后 revision、原因及
-  验收快照的独立审计事件在同一事务提交。
+  加逻辑 revision CAS，冲突 fail closed；缺少可选默认字段的旧配置按规范化
+  语义参与 CAS，并在首次成功写入时原子升级为完整形状；配置和包含前后
+  revision、原因及验收快照的独立审计事件在同一事务提交。
 - 单 Bot 运维视图合成 engine、provider、runtime form、rollout 决策、
   layout/generation、probe/failure 和 quarantine 证据；批次视图只有在
   全部 eligible Bot 激活、无失败且负对照与 Teclaw 对照均健康时才报告

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
@@ -64,3 +64,39 @@ def is_valid_rollout_config_value(value: Any) -> bool:
     return all(
         _valid_entries(value.get(key, [])) for key in ("whitelist", *CONTROL_KEYS)
     )
+
+
+def normalize_rollout_config_value(value: Any) -> dict[str, object] | None:
+    """Return the canonical persisted shape for a valid rollout config.
+
+    Older records predate optional control fields.  Their missing keys are
+    semantically equivalent to empty lists, but the canonical shape always
+    writes every field so the first successful operator mutation upgrades the
+    record atomically.
+    """
+
+    if not is_valid_rollout_config_value(value):
+        return None
+    assert isinstance(value, dict)
+
+    def entries(key: str) -> list[dict[str, str]]:
+        normalized: list[dict[str, str]] = []
+        for raw in value.get(key, []):
+            assert isinstance(raw, dict)
+            entry = {
+                "owner_id": str(raw["owner_id"]),
+                "bot_id": str(raw["bot_id"]),
+            }
+            if raw.get("batch_id") is not None:
+                entry["batch_id"] = str(raw["batch_id"])
+            normalized.append(entry)
+        return normalized
+
+    return {
+        "enable_all": value["enable_all"],
+        "full_rollout_engines": list(value.get("full_rollout_engines", [])),
+        "promoted_engines": list(value["promoted_engines"]),
+        "whitelist": entries("whitelist"),
+        "negative_controls": entries(CONTROL_KEYS[0]),
+        "teclaw_controls": entries(CONTROL_KEYS[1]),
+    }

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_rollout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_rollout_repository.py
@@ -11,6 +11,9 @@ from sqlalchemy.exc import IntegrityError
 from agentclaw.community.core.skills_pool.repository.models import (
     SkillsPoolRolloutAuditModel,
 )
+from agentclaw.community.core.skills_pool.rollout_config import (
+    normalize_rollout_config_value,
+)
 from agentclaw.community.core.skills_pool.rollout_gate import (
     SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
     SKILLS_POOL_ROLLOUT_PARAM_CODE,
@@ -107,11 +110,15 @@ class SkillsPoolRolloutRepository:
                 current_value = (
                     json.loads(row.param_value) if row.param_value else None
                 )
+                normalized_current = normalize_rollout_config_value(current_value)
+                normalized_expected = normalize_rollout_config_value(expected_value)
                 if (
                     row.id != config_id
                     or current_ext.get("revision") != expected_revision
                     or (row.enable == "1") is not expected_enable
-                    or current_value != expected_value
+                    or normalized_current is None
+                    or normalized_expected is None
+                    or normalized_current != normalized_expected
                 ):
                     return False
                 row.param_value = json.dumps(value, ensure_ascii=False)

--- a/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
+++ b/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
@@ -1,5 +1,6 @@
 """Skills Pool operator API surface contract."""
 
+import json
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -13,18 +14,34 @@ from agentclaw.community.adapters.http.skills_pool.router import (
     rollback_bot,
     router,
     set_full_rollout,
+    set_rollout_feature,
 )
 from agentclaw.community.adapters.http.skills_pool.schemas import (
     ControlBotRequest,
+    FeatureToggleRequest,
     FullRolloutRequest,
     RollbackRequest,
+)
+from agentclaw.community.api.skills_pool_rollout_service import (
+    SkillsPoolRolloutServiceProtocol,
+)
+from agentclaw.community.core.common_config.repository import (
+    CommonConfigRepository,
 )
 from agentclaw.community.core.skills_pool.recovery_service import (
     SkillsPoolRollbackOutcome,
     SkillsPoolRollbackResult,
 )
 from agentclaw.community.core.skills_pool.operations import RolloutOperationError
+from agentclaw.community.core.skills_pool.rollout_gate import (
+    SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
+    SKILLS_POOL_ROLLOUT_PARAM_CODE,
+)
+from agentclaw.community.core.skills_pool.rollout_repository import (
+    SkillsPoolRolloutRepositoryProtocol,
+)
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.plugin_api.database import DatabasePlugin
 
 
 def test_all_skills_pool_operations_are_operator_only() -> None:
@@ -51,6 +68,71 @@ def test_all_skills_pool_operations_are_operator_only() -> None:
             dependency.call for dependency in route.dependant.dependencies
         }
         assert require_operator in dependency_calls
+
+
+@pytest.mark.asyncio
+async def test_feature_post_normalizes_legacy_config_and_audits_once(
+    test_injector,
+) -> None:
+    database = test_injector.get(DatabasePlugin)
+    await database.bootstrap()
+    configs = CommonConfigRepository(database)
+    config_id = configs.create_config(
+        business_code=SKILLS_POOL_ROLLOUT_BUSINESS_CODE,
+        business_name="Skills Pool",
+        param_code=SKILLS_POOL_ROLLOUT_PARAM_CODE,
+        param_name="Skills Pool layout rollout",
+        param_value=json.dumps(
+            {
+                "enable_all": False,
+                "promoted_engines": ["openclaw"],
+                "whitelist": [],
+                "negative_controls": [],
+                "teclaw_controls": [],
+            }
+        ),
+        enable="0",
+        ext_info=json.dumps({"revision": "legacy-revision"}),
+        env="dev",
+    )
+    service = test_injector.get(SkillsPoolRolloutServiceProtocol)
+
+    response = await set_rollout_feature(
+        request=FeatureToggleRequest(
+            enabled=True,
+            reason="resume pre canary",
+        ),
+        user=SimpleNamespace(staffId="freddie"),
+        service=service,
+    )
+    repeated = await set_rollout_feature(
+        request=FeatureToggleRequest(
+            enabled=True,
+            reason="idempotent retry",
+        ),
+        user=SimpleNamespace(staffId="freddie"),
+        service=service,
+    )
+
+    assert response.success is True
+    assert repeated.success is True
+    assert response.data["enabled"] is True
+    assert response.data["enable_all"] is False
+    assert response.data["full_rollout_engines"] == ()
+    stored = configs.get_by_id(config_id=config_id)
+    assert stored is not None
+    assert json.loads(stored.param_value or "{}") == {
+        "enable_all": False,
+        "full_rollout_engines": [],
+        "promoted_engines": ["openclaw"],
+        "whitelist": [],
+        "negative_controls": [],
+        "teclaw_controls": [],
+    }
+    audit = test_injector.get(SkillsPoolRolloutRepositoryProtocol).list_audit_events(
+        env="dev"
+    )
+    assert [event["action"] for event in audit] == ["enable"]
 
 
 def test_control_bot_request_rejects_empty_batch_id() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
+++ b/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
@@ -9,11 +9,43 @@ import pytest
 from agentclaw.community.core.common_config.whitelist_service import (
     CommonWhiteListService,
 )
+from agentclaw.community.core.skills_pool.rollout_config import (
+    normalize_rollout_config_value,
+)
 from agentclaw.community.core.skills_pool.rollout_gate import (
     BotRuntimeForm,
     RolloutDecisionReason,
     SkillsPoolRolloutGate,
 )
+
+
+def test_legacy_rollout_entries_are_normalized_to_canonical_shape() -> None:
+    assert normalize_rollout_config_value(
+        {
+            "enable_all": False,
+            "promoted_engines": ["openclaw"],
+            "whitelist": [
+                {
+                    "owner_id": 168944,
+                    "bot_id": 42,
+                    "batch_id": 7,
+                }
+            ],
+        }
+    ) == {
+        "enable_all": False,
+        "full_rollout_engines": [],
+        "promoted_engines": ["openclaw"],
+        "whitelist": [
+            {
+                "owner_id": "168944",
+                "bot_id": "42",
+                "batch_id": "7",
+            }
+        ],
+        "negative_controls": [],
+        "teclaw_controls": [],
+    }
 
 
 class FakeCommonConfigService:


### PR DESCRIPTION
## Summary

Backport #473 to the active REL20260728 release line without pulling unrelated dev commits.

- preserve the raw legacy rollout config as the CAS expected value
- normalize only the next value written by the operator
- cover legacy records missing `full_rollout_engines`

## Verification

- `uv run pytest tests/community/core/skills_pool/test_rollout_gate.py -q` (24 passed)
- `uv run pytest tests/community/adapters/http/test_skills_pool_ops_router.py -q` (6 passed)
- `git diff --check origin/REL20260728...HEAD`