### PR TITLE
feat(backend): add open bot chat queriesDev

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -109,6 +109,7 @@ from agentclaw.community.adapters.http.access.router import user_list_router  # 
 from agentclaw.community.adapters.http.access.router import user_router  # noqa: E402
 from agentclaw.community.adapters.http.expert_chat import router as expert_chats_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_chat import router as bot_chat_router  # noqa: E402
+from agentclaw.community.adapters.http.bot_chat.open_router import router as bot_chat_open_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_chat.otel_router import router as bot_chat_otel_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_chat.relation_router import router as bot_chat_relation_router  # noqa: E402
 from agentclaw.community.adapters.http.system_config.router import router as system_config_router  # noqa: E402
@@ -423,6 +424,7 @@ app.include_router(yuque_router)
 app.include_router(device_router)
 app.include_router(expert_chats_router)  # 新增：用户与专家Bot对话管理
 app.include_router(bot_chat_router)  # 个人对话（Langfuse trace 查询）
+app.include_router(bot_chat_open_router)  # embed 精确日志查询（不按 owner 过滤）
 app.include_router(bot_chat_otel_router)  # bot-chat OTLP 日志写入
 app.include_router(bot_chat_relation_router)  # bot-chat 业务任务关系写入
 app.include_router(whitelist_router)

--- a/src/backend/src/agentclaw/community/adapters/http/bot_chat/open_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_chat/open_router.py
@@ -1,0 +1,58 @@
+"""Read-only bot-chat endpoints for exact embed lookups."""
+
+from fastapi import APIRouter, Query
+
+from agentclaw.community.api.bot_chat_service import BotChatServiceProtocol
+from agentclaw.community.core.bot_chat.errors import SessionNotFoundError
+from agentclaw.community.core.bot_chat.schemas import (
+    ApiResponse,
+    ConversationDetail,
+    SessionListResponse,
+)
+from agentclaw.community.di import Injected
+
+router = APIRouter(prefix="/api/v1/open/bot-chats", tags=["bot-chats-open"])
+
+
+@router.get("", response_model=ApiResponse[SessionListResponse])
+async def list_open_sessions(
+    session_key: str | None = Query(default=None, max_length=512),
+    biz_scene: str | None = Query(default=None, max_length=128),
+    biz_task_id: str | None = Query(default=None, max_length=256),
+    group_id: str | None = Query(default=None, max_length=256),
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=100, ge=1, le=100),
+    service: BotChatServiceProtocol = Injected(BotChatServiceProtocol),
+):
+    """List traces for one exact Session, Task, or BCS group identifier."""
+    try:
+        result = await service.list_open_sessions(
+            session_key=session_key,
+            biz_scene=biz_scene,
+            biz_task_id=biz_task_id,
+            group_id=group_id,
+            page=page,
+            limit=limit,
+        )
+        return ApiResponse(success=True, message="ok", data=result)
+    except ValueError as exc:
+        return ApiResponse(success=False, message=str(exc), error_code=4000)
+    except Exception as exc:
+        return ApiResponse(success=False, message=str(exc), error_code=5999)
+
+
+@router.get("/{trace_id}", response_model=ApiResponse[ConversationDetail])
+async def get_open_session(
+    trace_id: str,
+    service: BotChatServiceProtocol = Injected(BotChatServiceProtocol),
+):
+    """Get an exact trace and observation tree without owner filtering."""
+    try:
+        result = await service.get_open_session(trace_id)
+        return ApiResponse(success=True, message="ok", data=result)
+    except ValueError as exc:
+        return ApiResponse(success=False, message=str(exc), error_code=4000)
+    except SessionNotFoundError as exc:
+        return ApiResponse(success=False, message=str(exc), error_code=4004)
+    except Exception as exc:
+        return ApiResponse(success=False, message=str(exc), error_code=5999)

--- a/src/backend/src/agentclaw/community/api/bot_chat_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_chat_service.py
@@ -43,4 +43,16 @@ class BotChatServiceProtocol(Protocol):
         log_source: str | None = None,
     ) -> ConversationDetail: ...
 
+    async def list_open_sessions(
+        self,
+        session_key: str | None = None,
+        biz_scene: str | None = None,
+        biz_task_id: str | None = None,
+        group_id: str | None = None,
+        page: int = 1,
+        limit: int = 100,
+    ) -> SessionListResponse: ...
+
+    async def get_open_session(self, trace_id: str) -> ConversationDetail: ...
+
     async def health_check(self) -> HealthCheckData: ...

--- a/src/backend/src/agentclaw/community/core/bot_chat/open_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/open_service.py
@@ -1,0 +1,70 @@
+"""Open exact-query service entry points for bot-chat embeds."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from agentclaw.community.core.bot_chat.query_support import QueryScope
+from agentclaw.community.core.bot_chat.schemas import (
+    ConversationDetail,
+    SessionListResponse,
+)
+
+_OPEN_PAGE_SIZE = 100
+
+
+class OpenBotChatServiceMixin:
+    """Expose narrow cross-owner reads while reusing the standard DB pipeline."""
+
+    _list_sessions_db: Any
+    _get_session_db: Any
+
+    async def list_open_sessions(
+        self,
+        session_key: str | None = None,
+        biz_scene: str | None = None,
+        biz_task_id: str | None = None,
+        group_id: str | None = None,
+        page: int = 1,
+        limit: int = _OPEN_PAGE_SIZE,
+    ) -> SessionListResponse:
+        """List traces by one exact public identifier without owner filtering."""
+        session_key = (session_key.strip() or None) if session_key is not None else None
+        biz_scene = (biz_scene.strip() or None) if biz_scene is not None else None
+        biz_task_id = (biz_task_id.strip() or None) if biz_task_id is not None else None
+        group_id = (group_id.strip() or None) if group_id is not None else None
+
+        session_mode = session_key is not None
+        task_mode = biz_scene is not None or biz_task_id is not None
+        group_mode = group_id is not None
+        if sum((session_mode, task_mode, group_mode)) != 1:
+            raise ValueError(
+                "provide exactly one of session_key, biz_scene+biz_task_id, or group_id"
+            )
+        if task_mode and (biz_scene is None or biz_task_id is None):
+            raise ValueError("biz_scene and biz_task_id must be provided together")
+
+        return await self._list_sessions_db(
+            owner_id=None,
+            from_date=datetime(1970, 1, 1, tzinfo=timezone.utc),
+            to_date=datetime.now(timezone.utc),
+            page=max(1, page),
+            limit=min(max(1, limit), _OPEN_PAGE_SIZE),
+            bot_id=None,
+            trace_id=None,
+            session_id=None,
+            session_key=session_key,
+            query=None,
+            biz_scene=biz_scene,
+            biz_task_id=biz_task_id,
+            group_id=group_id,
+            match_mode="exact",
+            include_output_match=False,
+            query_scope=QueryScope.OPEN,
+        )
+
+    async def get_open_session(self, trace_id: str) -> ConversationDetail:
+        """Get an exact trace detail without applying owner access filters."""
+        trace_id = trace_id.strip()
+        if not trace_id:
+            raise ValueError("trace_id must not be empty")
+        return await self._get_session_db(trace_id, owner_id=None)

--- a/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
@@ -1,6 +1,7 @@
 """SQL query construction and display-label enrichment for bot-chat reads."""
 
 from enum import Enum
+from hashlib import sha256
 from typing import Any
 
 from sqlalchemy import and_, or_
@@ -128,6 +129,113 @@ def list_group_sessions(
         )
         result.setdefault(session_key, row.session_kind)
     return result
+
+
+def enrich_group_labels(
+    session: Any,
+    rows: list[Any],
+    group_id: str | None = None,
+    group_sessions: dict[str, str | None] | None = None,
+) -> None:
+    """Batch-attach group labels to one page of detached trace rows."""
+    if group_id:
+        labels = {
+            session_key: (group_id, session_kind)
+            for session_key, session_kind in (group_sessions or {}).items()
+        }
+    else:
+        candidate_to_keys: dict[str, set[str]] = {}
+        for row in rows:
+            session_key = getattr(row, "session_key", None)
+            if not session_key:
+                continue
+            candidate_to_keys.setdefault(session_key, set()).add(session_key)
+            if session_key.startswith(_GROUP_SESSION_KEY_PREFIX):
+                fragment = session_key[len(_GROUP_SESSION_KEY_PREFIX):]
+                candidate_to_keys.setdefault(fragment, set()).add(session_key)
+        labels: dict[str, tuple[str, str | None]] = {}
+        if candidate_to_keys:
+            try:
+                relations = (
+                    session.query(BcsGroupSession)
+                    .filter(
+                        BcsGroupSession.env == get_current_env(),
+                        BcsGroupSession.session_id.in_(list(candidate_to_keys)),
+                    )
+                    .order_by(
+                        BcsGroupSession.gmt_create.desc(),
+                        BcsGroupSession.id.desc(),
+                    )
+                    .all()
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Group label enrichment failed; returning null labels: "
+                    "error_type=%s",
+                    type(exc).__name__,
+                )
+                return
+            for relation in relations:
+                for session_key in candidate_to_keys.get(relation.session_id, ()):
+                    labels.setdefault(
+                        session_key,
+                        (relation.group_id, relation.session_kind),
+                    )
+    for row in rows:
+        label = labels.get(getattr(row, "session_key", None))
+        if label:
+            row.group_id, row.session_kind = label
+
+
+def enrich_task_labels(session: Any, rows: list[Any]) -> None:
+    """Batch-fill missing task labels using indexed runtime-ID relations."""
+    candidate_rows: dict[tuple[str, str], list[Any]] = {}
+    digests_by_type: dict[str, set[str]] = {}
+    for row in rows:
+        for ref_type, attribute in (
+            ("trace_id", "trace_id"),
+            ("session_id", "session_id"),
+            ("session_key", "session_key"),
+        ):
+            ref_value = getattr(row, attribute, None)
+            if not ref_value:
+                continue
+            candidate_rows.setdefault((ref_type, ref_value), []).append(row)
+            digest = f"sha256:{sha256(ref_value.encode('utf-8')).hexdigest()}"
+            digests_by_type.setdefault(ref_type, set()).add(digest)
+
+    if not candidate_rows:
+        return
+    conditions = [
+        and_(
+            AcOtelLogBizRef.ref_type == ref_type,
+            AcOtelLogBizRef.ref_digest.in_(digests),
+        )
+        for ref_type, digests in digests_by_type.items()
+    ]
+    relations = (
+        session.query(AcOtelLogBizRef)
+        .filter(or_(*conditions))
+        .order_by(
+            AcOtelLogBizRef.gmt_modified.desc(),
+            AcOtelLogBizRef.gmt_create.desc(),
+            AcOtelLogBizRef.id.desc(),
+        )
+        .all()
+    )
+    enriched_rows: set[int] = set()
+    for relation in relations:
+        for row in candidate_rows.get(
+            (relation.ref_type, relation.ref_value), ()
+        ):
+            row_identity = id(row)
+            if row_identity in enriched_rows:
+                continue
+            if not getattr(row, "biz_scene", None):
+                row.biz_scene = relation.biz_scene
+            if not getattr(row, "biz_task_id", None):
+                row.biz_task_id = relation.biz_task_id
+            enriched_rows.add(row_identity)
 
 
 def load_bot_names(session: Any, bot_ids: set[str]) -> dict[str, str]:

--- a/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
@@ -1,5 +1,6 @@
 """SQL query construction and display-label enrichment for bot-chat reads."""
 
+from enum import Enum
 from typing import Any
 
 from sqlalchemy import and_, or_
@@ -18,6 +19,13 @@ logger = get_logger()
 _GROUP_SESSION_KEY_PREFIX = "agent:main:"
 
 
+class QueryScope(str, Enum):
+    """Visibility boundary selected by the service entry point."""
+
+    OWNER = "owner"
+    OPEN = "open"
+
+
 def match_column(column: Any, value: str, match_mode: str) -> Any:
     """Build exact or substring matching for a SQLAlchemy column."""
     return column.like(f"%{value}%") if match_mode == "contains" else column == value
@@ -28,8 +36,9 @@ def load_task_refs(
     biz_scene: str | None,
     biz_task_id: str | None,
     match_mode: str,
-    owner_id: str,
+    owner_id: str | None,
     bot_id: str | None,
+    query_scope: QueryScope = QueryScope.OWNER,
 ) -> dict[str, set[str]]:
     """Load task references visible to the current user/Bot scope."""
     if not biz_scene and not biz_task_id:
@@ -43,13 +52,16 @@ def load_task_refs(
         query = query.filter(
             match_column(AcOtelLogBizRef.biz_task_id, biz_task_id, match_mode)
         )
-    query = query.filter(
-        or_(
-            AcOtelLogBizRef.user_id == owner_id,
-            AcOtelLogBizRef.user_id.is_(None),
+    if query_scope == QueryScope.OWNER:
+        if not owner_id:
+            raise ValueError("owner_id is required for owner-scoped queries")
+        query = query.filter(
+            or_(
+                AcOtelLogBizRef.user_id == owner_id,
+                AcOtelLogBizRef.user_id.is_(None),
+            )
         )
-    )
-    if bot_id:
+    if query_scope == QueryScope.OWNER and bot_id:
         relation_bot_ids = [bot_id]
         if bot_id == "default":
             relation_bot_ids.append(f"{owner_id}_default")

--- a/src/backend/src/agentclaw/community/core/bot_chat/repository.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/repository.py
@@ -19,6 +19,8 @@ from agentclaw.community.core.bot_chat.models import (
 from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
 from agentclaw.community.core.bot_chat.query_support import (
     QueryScope,
+    enrich_group_labels,
+    enrich_task_labels,
     enrich_trace_labels,
     list_group_sessions,
     load_bot_names,
@@ -580,14 +582,13 @@ class BotChatDbRepository:
             )
 
             detached = [self._detach_trace_row(row) for row in rows]
+            enrich_group_labels(session, detached, group_id, group_sessions)
+            enrich_task_labels(session, detached)
             bot_names = load_bot_names(
                 session, {row.bot_id for row in detached if row.bot_id}
             )
             for row in detached:
                 row.bot_name = bot_names.get(row.bot_id)
-                if group_id:
-                    row.group_id = group_id
-                    row.session_kind = group_sessions.get(row.session_key)
                 if biz_scene or biz_task_id:
                     row.match_sources = ["biz_ref"]
             sessions = [self._row_to_session(row) for row in detached]
@@ -678,6 +679,7 @@ class BotChatDbRepository:
                 self._detach_ocb_trace_row(row)
                 for row in rows
             ]
+            enrich_group_labels(session, detached, group_id, group_sessions)
             bot_names = load_bot_names(
                 session,
                 {row.bot_id for row in detached if row.bot_id},
@@ -687,9 +689,6 @@ class BotChatDbRepository:
             ref_session_keys = task_refs.get("session_key", set())
             for row in detached:
                 row.bot_name = bot_names.get(row.bot_id)
-                if group_id:
-                    row.group_id = group_id
-                    row.session_kind = group_sessions.get(row.session_key)
                 sources = []
                 direct_scene = not biz_scene or (
                     biz_scene in (row.biz_scene or "")
@@ -710,6 +709,7 @@ class BotChatDbRepository:
                 ):
                     sources.append("biz_ref")
                 row.match_sources = sources
+            enrich_task_labels(session, detached)
             sessions = [
                 self._row_to_session(row)
                 for row in detached

--- a/src/backend/src/agentclaw/community/core/bot_chat/repository.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/repository.py
@@ -18,6 +18,7 @@ from agentclaw.community.core.bot_chat.models import (
 )
 from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
 from agentclaw.community.core.bot_chat.query_support import (
+    QueryScope,
     enrich_trace_labels,
     list_group_sessions,
     load_bot_names,
@@ -468,7 +469,7 @@ class BotChatDbRepository:
 
     def list_traces(
         self,
-        owner_id: str,
+        owner_id: str | None,
         from_ms: int,
         to_ms: int,
         page: int,
@@ -483,6 +484,7 @@ class BotChatDbRepository:
         group_id: str | None = None,
         match_mode: str = "exact",
         include_output_match: bool = False,
+        query_scope: QueryScope = QueryScope.OWNER,
     ) -> tuple[list[ConversationSession], int]:
         """List traces from DB with pagination."""
         with self._db.orm_session() as session:
@@ -496,14 +498,17 @@ class BotChatDbRepository:
             # - bot_id is None: filter by user_id = owner_id
             # - bot_id == "default": filter by user_id = owner_id AND bot_id = "default"
             # - bot_id != "default": caller must verify ownership; here only filter by bot_id
-            if bot_id is None:
-                conditions.append(AwLangfuseTrace.user_id == owner_id)
-            elif bot_id == "default":
-                conditions.append(AwLangfuseTrace.user_id == owner_id)
-                conditions.append(AwLangfuseTrace.bot_id == "default")
-            else:
-                # Non-default bot: only filter by bot_id (ownership verified by caller)
-                conditions.append(AwLangfuseTrace.bot_id == bot_id)
+            if query_scope == QueryScope.OWNER:
+                if not owner_id:
+                    raise ValueError("owner_id is required for owner-scoped queries")
+                if bot_id is None:
+                    conditions.append(AwLangfuseTrace.user_id == owner_id)
+                elif bot_id == "default":
+                    conditions.append(AwLangfuseTrace.user_id == owner_id)
+                    conditions.append(AwLangfuseTrace.bot_id == "default")
+                else:
+                    # Non-default bot: only filter by bot_id (ownership verified by caller)
+                    conditions.append(AwLangfuseTrace.bot_id == bot_id)
 
             if trace_id:
                 conditions.append(match_column(AwLangfuseTrace.trace_id, trace_id, match_mode))
@@ -523,6 +528,7 @@ class BotChatDbRepository:
                 match_mode,
                 owner_id,
                 bot_id,
+                query_scope,
             )
             if biz_scene or biz_task_id:
                 ref_conditions = []
@@ -589,7 +595,7 @@ class BotChatDbRepository:
 
     def list_ocb_traces(
         self,
-        owner_id: str,
+        owner_id: str | None,
         from_ms: int,
         to_ms: int,
         page: int,
@@ -604,19 +610,23 @@ class BotChatDbRepository:
         group_id: str | None = None,
         match_mode: str = "exact",
         include_output_match: bool = False,
+        query_scope: QueryScope = QueryScope.OWNER,
     ) -> tuple[list[ConversationSession], int]:
         with self._db.orm_session() as session:
             conditions = [
                 AcOtelLogTrace.start_time_ms >= from_ms,
                 AcOtelLogTrace.start_time_ms <= to_ms,
             ]
-            if bot_id is None:
-                conditions.append(AcOtelLogTrace.user_id == owner_id)
-            elif bot_id == "default":
-                conditions.append(AcOtelLogTrace.user_id == owner_id)
-                conditions.append(AcOtelLogTrace.bot_id.in_(["default", f"{owner_id}_default"]))
-            else:
-                conditions.append(AcOtelLogTrace.bot_id == bot_id)
+            if query_scope == QueryScope.OWNER:
+                if not owner_id:
+                    raise ValueError("owner_id is required for owner-scoped queries")
+                if bot_id is None:
+                    conditions.append(AcOtelLogTrace.user_id == owner_id)
+                elif bot_id == "default":
+                    conditions.append(AcOtelLogTrace.user_id == owner_id)
+                    conditions.append(AcOtelLogTrace.bot_id.in_(["default", f"{owner_id}_default"]))
+                else:
+                    conditions.append(AcOtelLogTrace.bot_id == bot_id)
             if trace_id:
                 conditions.append(match_column(AcOtelLogTrace.trace_id, trace_id, match_mode))
             if session_key:
@@ -630,6 +640,7 @@ class BotChatDbRepository:
                 match_mode,
                 owner_id,
                 bot_id,
+                query_scope,
             )
             if biz_scene or biz_task_id:
                 conditions.append(

--- a/src/backend/src/agentclaw/community/core/bot_chat/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/service.py
@@ -6,7 +6,9 @@ import aiohttp
 from injector import inject
 
 from agentclaw.community.core.bot_chat.errors import LangfuseAPIError, SessionNotFoundError
+from agentclaw.community.core.bot_chat.open_service import OpenBotChatServiceMixin
 from agentclaw.community.core.bot_chat.repository import BotChatDbRepository
+from agentclaw.community.core.bot_chat.query_support import QueryScope
 from agentclaw.community.core.bot_chat.schemas import (
     ConversationDetail,
     ConversationObservation,
@@ -309,7 +311,7 @@ def _apply_client_side_filters(
 # BotChatService
 # ---------------------------------------------------------------------------
 
-class BotChatService:
+class BotChatService(OpenBotChatServiceMixin):
     """Service for querying bot conversation sessions."""
 
     @inject
@@ -483,7 +485,7 @@ class BotChatService:
 
     async def _list_sessions_db(
         self,
-        owner_id: str,
+        owner_id: str | None,
         from_date: datetime,
         to_date: datetime,
         page: int,
@@ -498,6 +500,7 @@ class BotChatService:
         group_id: str | None,
         match_mode: str,
         include_output_match: bool,
+        query_scope: QueryScope = QueryScope.OWNER,
     ) -> SessionListResponse:
         """List sessions using one DB source per request.
 
@@ -526,6 +529,7 @@ class BotChatService:
             group_id=group_id,
             match_mode=match_mode,
             include_output_match=include_output_match,
+            query_scope=query_scope,
         )
 
         if total == 0:
@@ -545,6 +549,7 @@ class BotChatService:
                 group_id=group_id,
                 match_mode=match_mode,
                 include_output_match=include_output_match,
+                query_scope=query_scope,
             )
 
         has_more = page * limit < total

--- a/src/backend/tests/community/api/bot_chat/test_open_bot_chat_router.py
+++ b/src/backend/tests/community/api/bot_chat/test_open_bot_chat_router.py
@@ -1,0 +1,88 @@
+"""HTTP-adapter tests for exact open bot-chat lookups."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.bot_chat.errors import SessionNotFoundError
+from agentclaw.community.core.bot_chat.schemas import SessionListResponse
+
+
+@pytest.mark.asyncio
+async def test_open_list_forwards_exact_group_without_owner():
+    from agentclaw.community.adapters.http.bot_chat.open_router import (
+        list_open_sessions,
+    )
+
+    service = MagicMock()
+    service.list_open_sessions = AsyncMock(
+        return_value=SessionListResponse(
+            sessions=[],
+            total=0,
+            page=1,
+            limit=100,
+            has_more=False,
+        )
+    )
+
+    result = await list_open_sessions(
+        session_key=None,
+        biz_scene=None,
+        biz_task_id=None,
+        group_id="group_fixture",
+        page=1,
+        limit=100,
+        service=service,
+    )
+
+    assert result.success is True
+    service.list_open_sessions.assert_awaited_once_with(
+        session_key=None,
+        biz_scene=None,
+        biz_task_id=None,
+        group_id="group_fixture",
+        page=1,
+        limit=100,
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_list_maps_invalid_combination_to_existing_error_envelope():
+    from agentclaw.community.adapters.http.bot_chat.open_router import (
+        list_open_sessions,
+    )
+
+    service = MagicMock()
+    service.list_open_sessions = AsyncMock(
+        side_effect=ValueError("provide exactly one query mode")
+    )
+
+    result = await list_open_sessions(
+        session_key="session_fixture",
+        biz_scene="scene_fixture",
+        biz_task_id="task_fixture",
+        group_id=None,
+        page=1,
+        limit=100,
+        service=service,
+    )
+
+    assert result.success is False
+    assert result.error_code == 4000
+
+
+@pytest.mark.asyncio
+async def test_open_detail_maps_missing_trace_to_existing_error_envelope():
+    from agentclaw.community.adapters.http.bot_chat.open_router import (
+        get_open_session,
+    )
+
+    service = MagicMock()
+    service.get_open_session = AsyncMock(
+        side_effect=SessionNotFoundError("trace not found")
+    )
+
+    result = await get_open_session("trace_fixture", service=service)
+
+    assert result.success is False
+    assert result.error_code == 4004

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.bot_chat.models import (
     BcsGroupSession,
 )
 from agentclaw.community.core.bot_chat.repository import BotChatDbRepository
+from agentclaw.community.core.bot_chat.query_support import QueryScope
 from agentclaw.community.core.bot_chat.service import (
     BotChatService,
     _apply_client_side_filters,
@@ -54,6 +55,7 @@ def _write_trace(
     biz_scene: str | None = None,
     biz_task_id: str | None = None,
     output: str = "synthetic output",
+    user_id: str = "user_fixture",
 ) -> None:
     repo.upsert_ocb_trace(
         {
@@ -62,7 +64,7 @@ def _write_trace(
             "session_key": session_key,
             "biz_scene": biz_scene,
             "biz_task_id": biz_task_id,
-            "user_id": "user_fixture",
+            "user_id": user_id,
             "bot_id": "bot_fixture",
             "name": "Synthetic trace",
             "input": "synthetic input",
@@ -184,6 +186,84 @@ def test_task_relations_are_isolated_by_user_when_identity_is_present():
     assert total == 0
 
 
+def test_open_task_query_ignores_trace_and_relation_owner():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    _write_trace(
+        repo,
+        trace_id="trace_other_owner",
+        session_id="session_other_owner",
+        session_key="agent:main:session_other_owner",
+        user_id="other_owner_fixture",
+    )
+    repo.upsert_biz_refs(
+        {
+            "biz_scene": "scene_fixture",
+            "biz_task_id": "task_fixture",
+            "user_id": "other_owner_fixture",
+            "bot_id": "other_bot_fixture",
+            "refs": [
+                {"ref_type": "trace_id", "ref_value": "trace_other_owner"},
+            ],
+        }
+    )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id=None,
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        biz_scene="scene_fixture",
+        biz_task_id="task_fixture",
+        query_scope=QueryScope.OPEN,
+    )
+
+    assert total == 1
+    assert [row.id for row in rows] == ["trace_other_owner"]
+
+
+def test_owner_scope_remains_the_default_for_session_queries():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    _write_trace(
+        repo,
+        trace_id="trace_owned",
+        session_id="shared_session",
+        session_key="agent:main:shared_session",
+    )
+    _write_trace(
+        repo,
+        trace_id="trace_other",
+        session_id="shared_session",
+        session_key="agent:main:shared_session",
+        user_id="other_owner_fixture",
+    )
+
+    owned, owned_total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        session_key="agent:main:shared_session",
+    )
+    opened, open_total = repo.list_ocb_traces(
+        owner_id=None,
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        session_key="agent:main:shared_session",
+        query_scope=QueryScope.OPEN,
+    )
+
+    assert owned_total == 1
+    assert [row.id for row in owned] == ["trace_owned"]
+    assert open_total == 2
+    assert {row.id for row in opened} == {"trace_owned", "trace_other"}
+
+
 def test_group_query_normalizes_session_key_and_returns_optional_labels():
     db = _LocalDb()
     repo = BotChatDbRepository(db)
@@ -256,6 +336,7 @@ def test_group_query_supports_multiple_sessions_and_existing_agent_prefix():
         trace_id="trace_group_two",
         session_id="session_two",
         session_key=prefixed,
+        user_id="other_owner_fixture",
     )
     with db.orm_session() as session:
         session.add_all(
@@ -276,12 +357,13 @@ def test_group_query_supports_multiple_sessions_and_existing_agent_prefix():
         )
 
     rows, total = repo.list_ocb_traces(
-        owner_id="user_fixture",
+        owner_id=None,
         from_ms=0,
         to_ms=2_000,
         page=1,
         limit=20,
         group_id="group_fixture",
+        query_scope=QueryScope.OPEN,
     )
 
     assert total == 2
@@ -309,19 +391,20 @@ def test_group_query_supports_legacy_trace_storage():
                 gmt_trace=1_000,
                 session_id=full_session_key,
                 real_session_id="legacy_session_fixture",
-                user_id="user_fixture",
+                user_id="other_owner_fixture",
                 bot_id="default",
                 name="Synthetic legacy trace",
             )
         )
 
     rows, total = repo.list_traces(
-        owner_id="user_fixture",
+        owner_id=None,
         from_ms=0,
         to_ms=2_000,
         page=1,
         limit=20,
         group_id="group_fixture",
+        query_scope=QueryScope.OPEN,
     )
 
     assert total == 1

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
@@ -2,6 +2,7 @@
 
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,12 +10,17 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.bot_chat.models import (
+    AcOtelLogBizRef,
     AcOtelLogTrace,
     AwLangfuseTrace,
     BcsGroupSession,
 )
 from agentclaw.community.core.bot_chat.repository import BotChatDbRepository
-from agentclaw.community.core.bot_chat.query_support import QueryScope
+from agentclaw.community.core.bot_chat.query_support import (
+    QueryScope,
+    enrich_group_labels,
+    enrich_task_labels,
+)
 from agentclaw.community.core.bot_chat.service import (
     BotChatService,
     _apply_client_side_filters,
@@ -371,6 +377,140 @@ def test_group_query_supports_multiple_sessions_and_existing_agent_prefix():
     assert {row.session_kind for row in rows} == {"chat", "service_invocation"}
 
 
+def test_regular_list_batch_enriches_group_labels_for_100_traces():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    with db.orm_session() as session:
+        for index in range(100):
+            fragment = f"group_fixture:session_{index}"
+            session.add(
+                BcsGroupSession(
+                    session_id=fragment,
+                    group_id=f"group_{index}",
+                    env=get_current_env(),
+                    session_kind="chat",
+                )
+            )
+    for index in range(100):
+        _write_trace(
+            repo,
+            trace_id=f"trace_{index}",
+            session_id=f"session_{index}",
+            session_key=f"agent:main:group_fixture:session_{index}",
+        )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=100,
+    )
+
+    assert total == 100
+    assert len(rows) == 100
+    assert {row.group_id for row in rows} == {
+        f"group_{index}" for index in range(100)
+    }
+    assert all(row.session_kind == "chat" for row in rows)
+
+
+def test_group_label_enrichment_failure_keeps_regular_list_compatible():
+    session = MagicMock()
+    session.query.side_effect = RuntimeError("synthetic table unavailable")
+    row = SimpleNamespace(
+        session_key="agent:main:session_fixture",
+        group_id=None,
+        session_kind=None,
+    )
+
+    enrich_group_labels(session, [row])
+
+    assert row.group_id is None
+    assert row.session_kind is None
+
+
+def test_task_label_enrichment_batches_100_traces_and_uses_latest_relation():
+    db = _LocalDb()
+    rows = []
+    with db.orm_session() as session:
+        for index in range(100):
+            session_key = f"agent:main:session_{index}:user_fixture"
+            rows.append(
+                SimpleNamespace(
+                    trace_id=f"trace_{index}",
+                    session_id=f"session_{index}",
+                    session_key=session_key,
+                    biz_scene=None,
+                    biz_task_id=None,
+                )
+            )
+            digest = BotChatDbRepository._ref_digest(None, session_key)
+            session.add(
+                AcOtelLogBizRef(
+                    biz_scene=f"scene_{index}",
+                    biz_task_id=f"task_{index}",
+                    ref_type="session_key",
+                    ref_value=session_key,
+                    ref_digest=digest,
+                )
+            )
+        session.add(
+            AcOtelLogBizRef(
+                biz_scene="newest_scene",
+                biz_task_id="newest_task",
+                ref_type="trace_id",
+                ref_value="trace_0",
+                ref_digest=BotChatDbRepository._ref_digest(None, "trace_0"),
+                gmt_modified=datetime.now(timezone.utc) + timedelta(seconds=1),
+            )
+        )
+
+    with db.orm_session() as session:
+        enrich_task_labels(session, rows)
+
+    assert rows[0].biz_scene == "newest_scene"
+    assert rows[0].biz_task_id == "newest_task"
+    assert {
+        (row.biz_scene, row.biz_task_id) for row in rows[1:]
+    } == {
+        (f"scene_{index}", f"task_{index}") for index in range(1, 100)
+    }
+
+
+def test_task_label_enrichment_preserves_direct_trace_values():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    session_key = "agent:main:session_fixture:user_fixture"
+    _write_trace(
+        repo,
+        trace_id="trace_fixture",
+        session_id="session_fixture",
+        session_key=session_key,
+        biz_scene="direct_scene",
+        biz_task_id="direct_task",
+    )
+    repo.upsert_biz_refs(
+        {
+            "biz_scene": "relation_scene",
+            "biz_task_id": "relation_task",
+            "refs": [{"ref_type": "session_key", "ref_value": session_key}],
+        }
+    )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+    )
+
+    assert total == 1
+    assert rows[0].biz_scene == "direct_scene"
+    assert rows[0].biz_task_id == "direct_task"
+
+
 def test_group_query_supports_legacy_trace_storage():
     db = _LocalDb()
     repo = BotChatDbRepository(db)
@@ -410,6 +550,19 @@ def test_group_query_supports_legacy_trace_storage():
     assert total == 1
     assert rows[0].id == "trace_legacy_fixture"
     assert rows[0].group_id == "group_fixture"
+
+    regular_rows, regular_total = repo.list_traces(
+        owner_id=None,
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        query_scope=QueryScope.OPEN,
+    )
+
+    assert regular_total == 1
+    assert regular_rows[0].group_id == "group_fixture"
+    assert regular_rows[0].session_kind == "chat"
 
 
 def test_bot_id_falls_back_to_metadata_and_missing_bot_name_stays_null():

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.bot_chat.service import (
 )
 from agentclaw.community.core.bot_chat.schemas import ConversationDetail, ConversationObservation, ConversationSession, SessionMetadata
 from agentclaw.community.core.bot_chat.errors import SessionNotFoundError, LangfuseAPIError
+from agentclaw.community.core.bot_chat.query_support import QueryScope
 from agentclaw.community.di.config import BotChatConfig
 
 # Langfuse creds are deployment config (BotChatConfig) now, injected into the
@@ -1740,8 +1741,66 @@ class TestBotChatServiceGetSession:
 
 
 # ---------------------------------------------------------------------------
+# BotChatService open exact queries
+# ---------------------------------------------------------------------------
+
+
+class TestBotChatServiceOpenQueries:
+
+    @pytest.fixture
+    def service(self):
+        return BotChatService(db=MagicMock(), config=_TEST_BOTCHAT_CONFIG)
+
+    @pytest.mark.asyncio
+    async def test_open_group_query_uses_open_scope_without_owner(self, service):
+        service._db_repo = MagicMock()
+        service._db_repo.list_ocb_traces.return_value = ([], 0)
+        service._db_repo.list_traces.return_value = ([], 0)
+
+        await service.list_open_sessions(group_id=" group_fixture ")
+
+        kwargs = service._db_repo.list_ocb_traces.call_args.kwargs
+        assert kwargs["owner_id"] is None
+        assert kwargs["group_id"] == "group_fixture"
+        assert kwargs["query_scope"] == QueryScope.OPEN
+        assert kwargs["match_mode"] == "exact"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {"biz_scene": "scene_fixture"},
+            {"biz_task_id": "task_fixture"},
+            {
+                "session_key": "session_fixture",
+                "group_id": "group_fixture",
+            },
+        ],
+    )
+    async def test_open_query_rejects_invalid_mode_combinations(
+        self, service, params
+    ):
+        with pytest.raises(ValueError):
+            await service.list_open_sessions(**params)
+
+    @pytest.mark.asyncio
+    async def test_open_detail_skips_owner_filter(self, service):
+        detail = MagicMock(spec=ConversationDetail)
+        service._get_session_db = AsyncMock(return_value=detail)
+
+        result = await service.get_open_session(" trace_fixture ")
+
+        assert result is detail
+        service._get_session_db.assert_awaited_once_with(
+            "trace_fixture", owner_id=None
+        )
+
+
+# ---------------------------------------------------------------------------
 # BotChatService.health_check
 # ---------------------------------------------------------------------------
+
 
 class TestBotChatServiceHealthCheck:
 

--- a/src/backend/tests/community/endpoints/test_open_bot_chat.py
+++ b/src/backend/tests/community/endpoints/test_open_bot_chat.py
@@ -1,0 +1,103 @@
+"""Endpoint coverage for owner-independent bot-chat reads."""
+from __future__ import annotations
+
+from agentclaw.community.core.bot_chat.repository import BotChatDbRepository
+from agentclaw.community.plugin_api.database import DatabasePlugin
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+
+_LIST_PATH = "/api/v1/open/bot-chats"
+_DETAIL_PATH = "/api/v1/open/bot-chats/{trace_id}"
+_TRACE_ID = "trace_open_endpoint_fixture"
+_SESSION_ID = "session_open_endpoint_fixture"
+_SESSION_KEY = "agent:main:session:open-endpoint-fixture:user:test"
+
+
+def _seed_trace(world) -> None:
+    db = world.get(DatabasePlugin)
+    BotChatDbRepository(db).upsert_ocb_trace(
+        {
+            "trace_id": _TRACE_ID,
+            "session_id": _SESSION_ID,
+            "session_key": _SESSION_KEY,
+            "user_id": "user_open_endpoint_fixture",
+            "bot_id": "bot_open_endpoint_fixture",
+            "name": "Open endpoint fixture",
+            "input": "synthetic input",
+            "output": "synthetic output",
+            "start_time_ms": 1_000,
+            "status": "SUCCESS",
+            "usage": {},
+        }
+    )
+
+
+@endpoint_test(
+    method="GET",
+    path=_LIST_PATH,
+    scenario="happy",
+    seed=_seed_trace,
+    input=CaseInput(query_params={"session_key": _SESSION_KEY}),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {
+                "total": 1,
+                "sessions": [{"id": _TRACE_ID, "session_key": _SESSION_KEY}],
+            },
+        },
+    ),
+)
+def open_bot_chat_list_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_LIST_PATH,
+    scenario="missing_query_mode",
+    expect=ExpectError(
+        status=200,
+        json_contains={"success": False, "error_code": 4000},
+    ),
+)
+def open_bot_chat_list_missing_query_mode():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_DETAIL_PATH,
+    scenario="happy",
+    seed=_seed_trace,
+    input=CaseInput(path_params={"trace_id": _TRACE_ID}),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {"id": _TRACE_ID, "session_key": _SESSION_KEY},
+        },
+    ),
+)
+def open_bot_chat_detail_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_DETAIL_PATH,
+    scenario="not_found",
+    input=CaseInput(path_params={"trace_id": "missing_trace_fixture"}),
+    expect=ExpectError(
+        status=200,
+        json_contains={"success": False, "error_code": 4004},
+    ),
+)
+def open_bot_chat_detail_not_found():
+    """The framework owns invocation."""


### PR DESCRIPTION
本次改动分为两部分。

  ## 一、修复 Bot 对话列表缺少群聊信息

  问题表现：

  - GET /api/v1/bot-chats 列表响应中的 group_id、session_kind 为空；
  - 点击 Trace 进入详情后，又能正确显示群聊信息。

  原因：

  - 列表只有在请求显式传入 group_id 时才填充群聊字段；
  - 详情接口会根据 session_key 反查 bcs_group_sessions。

  修复后：

  - 普通 Bot 对话列表即使没有传 group_id，也会根据当前页 Trace 的 session_key 批量反查群聊关系；
  - 自动补充：
      - group_id
      - session_kind

  - 同时支持 OTel 和 legacy 数据；
  - 兼容完整 Session Key 和去掉 agent:main: 前缀后的 BCS Session ID；
  - 单页最多100条 Trace 只执行一次群聊关系批量查询，避免 N+1；
  - 群聊关系查询失败时降级返回空标签，不影响原日志列表。

  ## 二、添加遗漏的 Bot Chat OpenAPI （需要公开的接口）
 
  OpenAPI 不受当前登录用户的 owner_id 和 bot_id 限制，只提供精确、只读查询。

  本次公开4种接口能力：

   OpenAPI                                                                       功能
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   GET /api/v1/open/bot-chats?session_key={session_key}                          查询指定 Session 下的全部 Trace
  ────────────────────────────────────────────────────────────────────────────  ───────────────────────────────────────────────
   GET /api/v1/open/bot-chats?biz_scene={biz_scene}&biz_task_id={biz_task_id}    查询指定业务任务关联的全部 Trace
  ────────────────────────────────────────────────────────────────────────────  ───────────────────────────────────────────────
   GET /api/v1/open/bot-chats?group_id={group_id}                                查询指定群聊多个 Agent Session 下的全部 Trace
  ────────────────────────────────────────────────────────────────────────────  ───────────────────────────────────────────────
   GET /api/v1/open/bot-chats/{trace_id}                                         查询指定 Trace 详情及 Observation 树

  说明：HTTP 路由实际是两个，但提供四种公开查询能力。

  ### Session 查询

  GET /api/v1/open/bot-chats
    ?session_key={session_key}
    &page=1
    &limit=100

  ### Task 查询

  GET /api/v1/open/bot-chats
    ?biz_scene={biz_scene}
    &biz_task_id={biz_task_id}
    &page=1
    &limit=100

  Task 查询合并：

  - Trace 直接保存的 biz_scene + biz_task_id
  - ac_otel_log_biz_ref 保存的 trace_id/session_id/session_key

  ### 群聊查询

  GET /api/v1/open/bot-chats
    ?group_id={group_id}
    &page=1
    &limit=100

  查询流程：

  group_id
  → 查询群内全部 bcs_group_sessions
  → 补齐 agent:main: 前缀
  → 查询多个 Agent Session 的 Trace
  → 去重、倒序、分页

  ### Trace 详情

  GET /api/v1/open/bot-chats/{trace_id}

  返回 Trace 信息、Input/Output、业务字段、群聊字段及 Observation 树。

  ## 兼容性

  原接口保持不变：

  GET /api/v1/bot-chats
  GET /api/v1/bot-chats/{trace_id}

  - 原接口继续使用 OWNER 查询范围；
  - OpenAPI 使用独立的 OPEN 查询范围；
  - 外部不能通过参数将原接口切换为开放查询；
  - 原接口的参数、分页和响应结构未改变。