### PR TITLE
[Feat] 社区层 get_device_connection_by_bot 支持 default_tag 评测沙箱路由

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/devices/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/devices/router.py
@@ -481,6 +481,7 @@ async def get_device_connection_by_bot(
     port: int | None = None,
     device_uuid: str | None = Query(None, description="锁定多实例中的特定实例；不传则自动选活跃实例"),
     ws_conn_mode: str | None = Query(None, description="WebSocket connection mode: 'direct'(default)/'relay'"),
+    default_tag: str | None = Query(None, description="default 区标签（传入则路由到评测沙箱 binding）"),
     user: AuthenticatedUser = Depends(get_current_user),
     service: DeviceServiceProtocol = Injected(DeviceServiceProtocol),
 ) -> ApiResponse[DeviceConnectionResponse]:
@@ -491,6 +492,11 @@ async def get_device_connection_by_bot(
     ``device_uuid`` (optional) targets a specific instance for multi-instance
     service bots; when it can't be resolved the provider raises instead of
     silently falling back to another instance.
+
+    When ``default_tag`` is provided, the binding resolution switches from
+    ``ext.binding.online`` to finding the ACTIVE binding whose
+    ``device_props.AGENTCLAW_DEFAULT_TAG`` matches the given tag value.
+    This routes the conversation to an eval sandbox device.
     """
     try:
         from agentclaw.community.core.devices.errors import (
@@ -506,6 +512,7 @@ async def get_device_connection_by_bot(
             port=port,
             device_uuid=device_uuid,
             ws_conn_mode=ws_conn_mode,
+            default_tag=default_tag,
         )
 
         return ApiResponse(

--- a/src/backend/src/agentclaw/community/core/devices/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/devices/repository/protocol.py
@@ -185,6 +185,32 @@ class DeviceBindingRepository(Protocol):
         """根据ID列表批量获取绑定记录."""
         ...
 
+    def get_active_bindings_by_entity(
+        self,
+        *,
+        entity_id: str,
+        entity_type: str,
+        env: str,
+    ) -> list[DeviceBindingRecord]:
+        """按 entity_id + entity_type 查询所有 ACTIVE 状态的绑定记录.
+
+        与 ``get_active_by_bot_and_owner`` 不同，本方法**不通过**
+        ``ac_bots.binding_id`` JOIN，而是直接查 ``ac_entity_device_binding``
+        表中该实体下所有 status='ACTIVE' 的记录。
+
+        用途：default 区评测沙箱的 binding 不被 ``ac_bots.binding_id``
+        引用，只能通过实体 + device_props 标记来查找。
+
+        Args:
+            entity_id: 实体 ID（与 ac_bots.owner_id 一致）
+            entity_type: 实体类型（如 "staff"）
+            env: 环境标识（dev/pre/prod）
+
+        Returns:
+            该实体下所有 ACTIVE 绑定记录列表（可能为空）
+        """
+        ...
+
     def update_bot_start_status(self, *, binding_id: int, status: str, message: str | None) -> None:
         """更新 ac_bots 表 ext 字段中的启动状态."""
         ...

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -1284,11 +1284,16 @@ class DeviceService:
         port: int | None = None,
         ttl: int | None = None,
         device_uuid: str | None = None,
+        default_tag: str | None = None,
     ) -> DeviceConnectionInfo:
         """Get connection info by bot_id (hook — router overrides).
 
         Resolution from bot_id → runtime binding lives in the router; a plain
         provider does not implement it.
+
+        When ``default_tag`` is provided, the router resolves the binding
+        from the eval sandbox (matched by ``device_props.AGENTCLAW_DEFAULT_TAG``)
+        instead of the production ``ext.binding.online``.
         """
         raise NotImplementedError(
             f"{type(self).__name__} does not support bot_id connection entry"

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
@@ -48,6 +48,7 @@ from agentclaw.community.core.service_bot.repository.bot_publish_repository impo
     BotPublishRepositoryProtocol,
 )
 from agentclaw.community.log import get_logger
+from agentclaw.community.utils import env_utils
 
 
 logger = get_logger()
@@ -881,6 +882,7 @@ class DeviceServiceRouter(DeviceService):
         ttl: int | None = None,
         device_uuid: str | None = None,
         ws_conn_mode: str | None = None,
+        default_tag: str | None = None,
     ):
         """通过 bot_id 获取设备连接信息（对话页主入口，§3）。
 
@@ -889,10 +891,20 @@ class DeviceServiceRouter(DeviceService):
         入口同一解析），再复用 ``get_device_connection``。``device_uuid`` 透传
         锁定多实例中的特定实例；不传则由 provider 自动选活跃实例。
 
+        当 ``default_tag`` 非空时，跳过 ``ext.binding.online`` 解析，
+        改为在绑定表中查找 ``device_props`` 含 ``AGENTCLAW_DEFAULT_TAG``
+        匹配的 ACTIVE 绑定，支持路由到评测沙箱设备。
+
         Raises:
             BotPublishNotFoundError: bot_id 无 success 发布单 / ext.binding.online 缺失
+            DeviceNotBoundError: default_tag 指定但无匹配的评测沙箱绑定
         """
-        binding_id = self._instance_service()._resolve_binding_id_by_bot_id(bot_id)
+        if default_tag:
+            binding_id = self._resolve_binding_id_by_default_tag(
+                bot_id=bot_id, default_tag=default_tag,
+            )
+        else:
+            binding_id = self._instance_service()._resolve_binding_id_by_bot_id(bot_id)
         return self.get_device_connection(
             binding_id=binding_id,
             operator=operator,
@@ -901,6 +913,73 @@ class DeviceServiceRouter(DeviceService):
             device_uuid=device_uuid,
             ws_conn_mode=ws_conn_mode,
         )
+
+    # ── default_tag 绑定解析 ──
+
+    _DEFAULT_ENV_TAG_KEY = "AGENTCLAW_DEFAULT_TAG"
+
+    def _resolve_binding_id_by_default_tag(
+        self,
+        *,
+        bot_id: str,
+        default_tag: str,
+    ) -> int:
+        """按 default_tag 在绑定表中查找评测沙箱的 binding_id。
+
+        查找路径：
+        1. 通过 BotQueryProtocol 获取 bot 的 owner_id / entity_type
+        2. 通过 DeviceBindingRepository.get_active_bindings_by_entity 查该实体下所有 ACTIVE 绑定
+        3. 按 device_props[AGENTCLAW_DEFAULT_TAG] == default_tag 精确匹配
+        4. 无精确匹配时取第一个含 AGENTCLAW_DEFAULT_TAG 的绑定并打 warning
+
+        Raises:
+            DeviceNotBoundError: bot 不存在或无匹配的评测沙箱绑定
+        """
+        from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
+
+        bot_info = self._bot_query.get_by_id(bot_id)
+        if not bot_info:
+            raise DeviceNotBoundError(
+                f"Bot {bot_id!r} 不存在，无法解析 default_tag 绑定"
+            )
+
+        owner_id = bot_info.get("owner_id", "")
+        entity_type = bot_info.get("entity_type", "staff")
+        env = env_utils.get_current_env()
+
+        bindings = self._repo.get_active_bindings_by_entity(
+            entity_id=owner_id,
+            entity_type=entity_type,
+            env=env,
+        )
+
+        # 精确匹配 default_tag
+        matched = None
+        fallback = None
+        for b in bindings:
+            props = b.device_props or {}
+            tag_value = props.get(self._DEFAULT_ENV_TAG_KEY)
+            if tag_value == default_tag:
+                matched = b
+                break
+            if tag_value is not None and fallback is None:
+                fallback = b
+
+        result = matched or fallback
+        if result is None:
+            raise DeviceNotBoundError(
+                f"未找到 bot_id={bot_id!r} 的 default_tag={default_tag!r} 评测沙箱绑定"
+            )
+
+        if fallback and not matched:
+            logger.warning(
+                "[DeviceServiceRouter] default_tag=%s 无精确匹配，"
+                "回退到 binding_id=%d (tag=%s)",
+                default_tag, result.id,
+                (result.device_props or {}).get(self._DEFAULT_ENV_TAG_KEY),
+            )
+
+        return result.id
 
     @override
     def get_instances(

--- a/src/backend/src/agentclaw/community/plugins/device_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/device_repository.py
@@ -363,6 +363,31 @@ class DeviceRepository(_DeviceBindingRepositoryProtocol):
                 .count()
             )
 
+    def get_active_bindings_by_entity(
+        self,
+        *,
+        entity_id: str,
+        entity_type: str,
+        env: str,
+    ) -> list[DeviceBindingRecord]:
+        """按 entity_id + entity_type 查询所有 ACTIVE 状态的绑定记录。
+
+        不通过 ac_bots.binding_id JOIN，直接查 ac_entity_device_binding。
+        """
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(EntityDeviceBinding)
+                .filter(
+                    EntityDeviceBinding.entity_id == entity_id,
+                    EntityDeviceBinding.entity_type == entity_type,
+                    EntityDeviceBinding.env == env,
+                    EntityDeviceBinding.status == _DeviceBindingStatus.ACTIVE,
+                )
+                .order_by(EntityDeviceBinding.id.desc())
+                .all()
+            )
+            return [r for r in (_to_record(m) for m in rows) if r]
+
     # ── updates (single bulk statements; gmt_modified DB-side) ──
 
     def release_binding(

--- a/src/backend/tests/community/core/devices/services/test_device_service_router.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service_router.py
@@ -986,3 +986,183 @@ class TestApplyDeviceTemplateConfigPassthrough:
 
             # Confirm template_config was forwarded to _do_allocate
             assert mock_alloc.call_args.kwargs.get("template_config") == {"image": "img"}
+
+
+# ---------------------------------------------------------------------------
+# Default tag binding resolution (get_device_connection_by_bot + default_tag)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBindingIdByDefaultTag:
+    """DeviceServiceRouter._resolve_binding_id_by_default_tag 测试。"""
+
+    def _make_router_with_repo(self):
+        """构建 Router 并暴露 repo/bot_query mock。"""
+        router, repo, bot_query, _ = _make_router(is_local=False)
+        return router, repo, bot_query
+
+    def _make_tagged_record(self, *, id: int, tag: str, entity_id: str = "u001") -> DeviceBindingRecord:
+        """创建带 AGENTCLAW_DEFAULT_TAG 的 binding record。"""
+        return DeviceBindingRecord(
+            id=id,
+            entity_id=entity_id,
+            entity_type="staff",
+            device_id=f"device-{id}",
+            device_provider=ARCA_DEVICE_PROVIDER,
+            env="dev",
+            device_props={"AGENTCLAW_DEFAULT_TAG": tag, "callback_token": "tok"},
+            status=DeviceBindingStatus.ACTIVE.value,
+            apply_reason=None,
+            applied_by=entity_id,
+            release_reason=None,
+            released_by=None,
+            released_at=None,
+            last_alive_at=None,
+            gmt_create=datetime(2024, 1, 1),
+            gmt_modified=datetime(2024, 1, 1),
+        )
+
+    def test_exact_tag_match(self):
+        """default_tag 精确匹配返回对应 binding_id。"""
+        router, repo, bot_query = self._make_router_with_repo()
+        bot_query.get_by_id.return_value = {
+            "owner_id": "u001", "entity_type": "staff",
+        }
+        b1 = self._make_tagged_record(id=10, tag="eval-v2")
+        b2 = self._make_tagged_record(id=20, tag="default")
+        repo.get_active_bindings_by_entity.return_value = [b1, b2]
+
+        with patch("agentclaw.community.core.devices.services.device_service_router.env_utils") as mock_env:
+            mock_env.get_current_env.return_value = "dev"
+            result = router._resolve_binding_id_by_default_tag(
+                bot_id="bot001", default_tag="eval-v2",
+            )
+        assert result == 10
+
+    def test_fallback_when_no_exact_match(self):
+        """无精确匹配时取第一个含 AGENTCLAW_DEFAULT_TAG 的绑定。"""
+        router, repo, bot_query = self._make_router_with_repo()
+        bot_query.get_by_id.return_value = {
+            "owner_id": "u001", "entity_type": "staff",
+        }
+        b1 = self._make_tagged_record(id=30, tag="other")
+        repo.get_active_bindings_by_entity.return_value = [b1]
+
+        with patch("agentclaw.community.core.devices.services.device_service_router.env_utils") as mock_env:
+            mock_env.get_current_env.return_value = "dev"
+            result = router._resolve_binding_id_by_default_tag(
+                bot_id="bot001", default_tag="nonexistent",
+            )
+        assert result == 30
+
+    def test_bot_not_found_raises(self):
+        """bot 不存在时抛 DeviceNotBoundError。"""
+        router, repo, bot_query = self._make_router_with_repo()
+        bot_query.get_by_id.return_value = None
+
+        with pytest.raises(Exception, match="不存在"):
+            router._resolve_binding_id_by_default_tag(
+                bot_id="missing", default_tag="default",
+            )
+
+    def test_no_matching_binding_raises(self):
+        """无匹配的评测沙箱绑定时抛 DeviceNotBoundError。"""
+        router, repo, bot_query = self._make_router_with_repo()
+        bot_query.get_by_id.return_value = {
+            "owner_id": "u001", "entity_type": "staff",
+        }
+        # 只有生产 binding，没有 AGENTCLAW_DEFAULT_TAG
+        b1 = _make_record(id=5, entity_id="u001")
+        repo.get_active_bindings_by_entity.return_value = [b1]
+
+        with patch("agentclaw.community.core.devices.services.device_service_router.env_utils") as mock_env:
+            mock_env.get_current_env.return_value = "dev"
+            with pytest.raises(Exception, match="未找到"):
+                router._resolve_binding_id_by_default_tag(
+                    bot_id="bot001", default_tag="default",
+                )
+
+    def test_empty_bindings_raises(self):
+        """无任何 ACTIVE 绑定时抛 DeviceNotBoundError。"""
+        router, repo, bot_query = self._make_router_with_repo()
+        bot_query.get_by_id.return_value = {
+            "owner_id": "u001", "entity_type": "staff",
+        }
+        repo.get_active_bindings_by_entity.return_value = []
+
+        with patch("agentclaw.community.core.devices.services.device_service_router.env_utils") as mock_env:
+            mock_env.get_current_env.return_value = "dev"
+            with pytest.raises(Exception, match="未找到"):
+                router._resolve_binding_id_by_default_tag(
+                    bot_id="bot001", default_tag="default",
+                )
+
+
+class TestGetDeviceConnectionByBotWithDefaultTag:
+    """DeviceServiceRouter.get_device_connection_by_bot default_tag 透传测试。"""
+
+    def test_default_tag_triggers_resolve_by_tag(self):
+        """传 default_tag 时走 _resolve_binding_id_by_default_tag 路径。"""
+        router, repo, bot_query, _ = _make_router(is_local=False)
+        bot_query.get_by_id.return_value = {
+            "owner_id": "u001", "entity_type": "staff",
+        }
+        eval_record = DeviceBindingRecord(
+            id=42,
+            entity_id="u001",
+            entity_type="staff",
+            device_id="device-42",
+            device_provider=ARCA_DEVICE_PROVIDER,
+            env="dev",
+            device_props={"AGENTCLAW_DEFAULT_TAG": "default", "callback_token": "tok"},
+            status=DeviceBindingStatus.ACTIVE.value,
+            apply_reason=None,
+            applied_by="u001",
+            release_reason=None,
+            released_by=None,
+            released_at=None,
+            last_alive_at=None,
+            gmt_create=datetime(2024, 1, 1),
+            gmt_modified=datetime(2024, 1, 1),
+        )
+        repo.get_active_bindings_by_entity.return_value = [eval_record]
+
+        # mock get_device_connection 避免真正走 provider
+        conn_info = DeviceConnectionInfo(
+            type="arca", target="ws://eval", token="t1", engine_type="openclaw"
+        )
+        router.get_device_connection = MagicMock(return_value=conn_info)
+
+        with patch("agentclaw.community.core.devices.services.device_service_router.env_utils") as mock_env:
+            mock_env.get_current_env.return_value = "dev"
+            result = router.get_device_connection_by_bot(
+                bot_id="bot001",
+                operator=_make_operator(),
+                default_tag="default",
+            )
+        assert result is conn_info
+        router.get_device_connection.assert_called_once()
+        call_kwargs = router.get_device_connection.call_args.kwargs
+        assert call_kwargs["binding_id"] == 42
+
+    def test_no_default_tag_uses_production_path(self):
+        """不传 default_tag 时走 _resolve_binding_id_by_bot_id 生产路径。"""
+        router, _, _, _ = _make_router(is_local=False)
+
+        # mock 两条路径
+        production_binding_id = 99
+        router._instance_service = MagicMock()
+        router._instance_service()._resolve_binding_id_by_bot_id.return_value = production_binding_id
+
+        conn_info = DeviceConnectionInfo(
+            type="arca", target="ws://prod", token="t2", engine_type="openclaw"
+        )
+        router.get_device_connection = MagicMock(return_value=conn_info)
+
+        result = router.get_device_connection_by_bot(
+            bot_id="bot001",
+            operator=_make_operator(),
+        )
+        assert result is conn_info
+        call_kwargs = router.get_device_connection.call_args.kwargs
+        assert call_kwargs["binding_id"] == 99


### PR DESCRIPTION
## Summary

- 社区层统一入口 `GET /api/v1/devices/bots/{bot_id}/connection?default_tag=xxx`，前端无需区分生产/评测对话端点
- `DeviceBindingRepository` 新增 `get_active_bindings_by_entity` 协议方法及实现，直接查绑定表不依赖 `ac_bots.binding_id` JOIN
- `DeviceServiceRouter.get_device_connection_by_bot` 增加 `default_tag` 参数，新增 `_resolve_binding_id_by_default_tag` 方法
- `DeviceService` 基类 stub 签名同步，HTTP 端点增加 `default_tag` Query 参数
- 新增 7 个测试用例覆盖 default_tag 路由逻辑

## Test plan

- [x] `TestResolveBindingIdByDefaultTag` — 精确匹配 / fallback / bot 不存在 / 无匹配绑定 / 空 bindings（5 个）
- [x] `TestGetDeviceConnectionByBotWithDefaultTag` — default_tag 触发评测路径 / 无 default_tag 走生产路径（2 个）
- [x] 全套 49 个 device_service_router 测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)