### PR TITLE
[BCS] Add exact multi-skill filtering to discover

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -954,6 +954,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "uuid",
 ]

--- a/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
+++ b/src/bcs/crates/adapters/http/bcs-http/Cargo.toml
@@ -41,6 +41,7 @@ tower-http      = { workspace = true, features = ["trace"] }
 opentelemetry   = { workspace = true }
 opentelemetry-http = { workspace = true }
 urlencoding     = { workspace = true }
+url             = { workspace = true }
 uuid            = { workspace = true }
 sha2            = { workspace = true }
 hex             = { workspace = true }

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/discover.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/discover.rs
@@ -81,9 +81,9 @@ pub async fn discover_bots(
     headers: HeaderMap,
     uri: Uri,
 ) -> Result<Json<Value>, HttpAdapterError> {
-    let query = DiscoverBotsQuery::parse(uri.query())?;
     let _caller_actor_id =
         require_caller_actor_id_from_headers(&state, &headers, &uri).await?;
+    let query = DiscoverBotsQuery::parse(uri.query())?;
     let requester_bot_id = bot_id_from_headers(&state, &headers).await;
     if query.organization_code.is_some() && requester_bot_id.is_none() {
         return Err(HttpAdapterError::Forbidden(

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/discover.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/discover.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
+
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::State,
     http::{HeaderMap, Uri},
 };
 use bcs_service_api::{BotDiscoveryCommand, BotDiscoveryEntry, BotUseCaseError};
-use serde::Deserialize;
 use serde_json::Value;
 
 use crate::error::HttpAdapterError;
@@ -13,34 +14,74 @@ use crate::state::HttpAppState;
 
 use super::{bot_id_from_headers, require_caller_actor_id_from_headers};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default)]
 pub struct DiscoverBotsQuery {
-    #[serde(default)]
     pub q: Option<String>,
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub skills: Option<String>,
-    #[serde(default)]
-    pub domains: Option<String>,
-    #[serde(default)]
-    pub scopes: Option<String>,
-    #[serde(default)]
+    pub skills: Vec<String>,
     pub visibility: Option<String>,
-    #[serde(default)]
     pub collaborate_bot: Option<String>,
-    #[serde(default)]
     pub organization_code: Option<String>,
-    #[serde(default)]
     pub role: Option<String>,
+}
+
+impl DiscoverBotsQuery {
+    fn parse(raw_query: Option<&str>) -> Result<Self, HttpAdapterError> {
+        let mut query = Self::default();
+        let mut seen_skills = HashSet::new();
+
+        for (key, value) in
+            url::form_urlencoded::parse(raw_query.unwrap_or_default().as_bytes())
+        {
+            let key = key.into_owned();
+            let value = value.into_owned();
+            match key.as_str() {
+                "q" => set_once(&mut query.q, &key, value)?,
+                "skill" => {
+                    let skill = value.trim();
+                    if skill.is_empty() {
+                        return Err(HttpAdapterError::BadRequest(
+                            "skill must not be empty".to_string(),
+                        ));
+                    }
+                    if seen_skills.insert(skill.to_ascii_lowercase()) {
+                        query.skills.push(skill.to_string());
+                    }
+                }
+                "visibility" => set_once(&mut query.visibility, &key, value)?,
+                "collaborate_bot" => set_once(&mut query.collaborate_bot, &key, value)?,
+                "organization_code" => set_once(&mut query.organization_code, &key, value)?,
+                "role" => set_once(&mut query.role, &key, value)?,
+                _ => {
+                    return Err(HttpAdapterError::BadRequest(format!(
+                        "unknown discover query parameter '{key}'"
+                    )));
+                }
+            }
+        }
+
+        Ok(query)
+    }
+}
+
+fn set_once(
+    target: &mut Option<String>,
+    key: &str,
+    value: String,
+) -> Result<(), HttpAdapterError> {
+    if target.replace(value).is_some() {
+        return Err(HttpAdapterError::BadRequest(format!(
+            "discover query parameter '{key}' must not be repeated"
+        )));
+    }
+    Ok(())
 }
 
 pub async fn discover_bots(
     State(state): State<HttpAppState>,
     headers: HeaderMap,
     uri: Uri,
-    Query(query): Query<DiscoverBotsQuery>,
 ) -> Result<Json<Value>, HttpAdapterError> {
+    let query = DiscoverBotsQuery::parse(uri.query())?;
     let _caller_actor_id =
         require_caller_actor_id_from_headers(&state, &headers, &uri).await?;
     let requester_bot_id = bot_id_from_headers(&state, &headers).await;
@@ -54,10 +95,7 @@ pub async fn discover_bots(
         .bot_discovery
         .discover_bots(BotDiscoveryCommand {
             q: query.q,
-            name: query.name,
             skills: query.skills,
-            domains: query.domains,
-            scopes: query.scopes,
             visibility: query.visibility,
             collaborate_bot: query.collaborate_bot,
             requester_bot_id,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/discover_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/discover_contract.rs
@@ -228,24 +228,34 @@ async fn discover_route_rejects_organization_scope_for_human_callers() {
 }
 
 #[tokio::test]
-async fn discover_route_rejects_missing_caller() {
+async fn discover_route_rejects_missing_caller_before_validating_query() {
     let discovery = Arc::new(RecordingBotDiscoveryService::default());
     let services = Services::builder()
         .bot_discovery(discovery.clone())
         .build_for_test();
     let app = build_router(HttpAppState::new(services));
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/bots/discover?collaborate_bot=driver&q=planner")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    for uri in [
+        "/bots/discover?collaborate_bot=driver&q=planner",
+        "/bots/discover?query=legacy",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "missing caller must take precedence for {uri}"
+        );
+    }
     assert!(discovery.commands.lock().await.is_empty());
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/discover_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/discover_contract.rs
@@ -98,7 +98,9 @@ async fn discover_route_delegates_filters_to_bot_discovery_service() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/bots/discover?collaborate_bot=driver&q=planner")
+                .uri(
+                    "/bots/discover?collaborate_bot=driver&q=planner&skill=%20code_review%20&skill=Code_Review&skill=sql",
+                )
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -121,10 +123,52 @@ async fn discover_route_delegates_filters_to_bot_discovery_service() {
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].collaborate_bot.as_deref(), Some("driver"));
     assert_eq!(commands[0].q.as_deref(), Some("planner"));
-    assert_eq!(commands[0].name, None);
-    assert_eq!(commands[0].skills, None);
+    assert_eq!(
+        commands[0].skills,
+        vec!["code_review".to_string(), "sql".to_string()]
+    );
 }
 
+#[tokio::test]
+async fn discover_route_rejects_empty_removed_unknown_and_duplicate_scalar_parameters() {
+    let discovery = Arc::new(RecordingBotDiscoveryService::default());
+    let services = Services::builder()
+        .bot_discovery(discovery.clone())
+        .build_for_test();
+    let chain = static_auth_chain("alice", "Alice");
+    let app = build_router(HttpAppState::new(services).with_user_identity(Arc::new(
+        ChainUserIdentityPort::new(chain),
+    )));
+
+    for query in [
+        "skill=code_review&skill=%20%20",
+        "name=legacy",
+        "skills=legacy",
+        "domains=legacy",
+        "scopes=legacy",
+        "unknown=value",
+        "q=one&q=two",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/bots/discover?{query}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "query should be rejected: {query}"
+        );
+    }
+
+    assert!(discovery.commands.lock().await.is_empty());
+}
 
 #[tokio::test]
 async fn discover_route_forwards_organization_scope_for_bot_callers() {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/discover_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/discover_contract.rs
@@ -141,6 +141,7 @@ async fn discover_route_rejects_empty_removed_unknown_and_duplicate_scalar_param
     )));
 
     for query in [
+        "skill=",
         "skill=code_review&skill=%20%20",
         "name=legacy",
         "skills=legacy",

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
@@ -8,7 +8,7 @@
 //!
 //! Tests cover:
 //! - Discover gracefully degrades when bcsfuse is unreachable (returns registry-only results)
-//! - Discover `name` parameter filtering (case-insensitive contains, q-priority)
+//! - Discover repeated exact skill filtering combined with `q` using AND semantics
 //! - leave_bot completes without errors (set_worker_offline call was removed)
 //! - set_visibility succeeds with fire-and-forget sync (sync failure is non-blocking)
 //!
@@ -141,33 +141,56 @@ async fn discover_without_fuse_returns_registry_results() {
 }
 
 // ============================================================================
-// 12.2: Discover name parameter tests
+// 12.2: Discover query + repeated skill parameter tests
 // ============================================================================
 
-/// Discover with `?name=xxx` returns bots matching by name (case-insensitive contains).
+/// Repeated `skill` values are exact, case-insensitive, and all combine with
+/// `q` using AND semantics.
 #[tokio::test]
-async fn discover_by_name_returns_matching_bots() {
+async fn discover_q_and_repeated_skills_use_and_semantics() {
     let tmp = create_temp_bots_dir();
     let bots_dir = tmp.path().to_path_buf();
     let (addr, _handle) = start_test_server(&bots_dir).await;
 
-    let mut bot1 = MockBot::connect(addr).await;
-    bot1.register("ArchBot", &["architecture"], addr).await;
-    bot1.send_heartbeat().await;
+    let mut exact = MockBot::connect(addr).await;
+    exact
+        .register("Deployment Reviewer", &["Code_Review", "SQL"], addr)
+        .await;
+    exact.send_heartbeat().await;
 
-    let mut bot2 = MockBot::connect(addr).await;
-    bot2.register("DBABot", &["database"], addr).await;
-    bot2.send_heartbeat().await;
+    let mut missing_skill = MockBot::connect(addr).await;
+    missing_skill
+        .register("Deployment Generalist", &["code_review"], addr)
+        .await;
+    missing_skill.send_heartbeat().await;
 
-    let mut bot3 = MockBot::connect(addr).await;
-    bot3.register("ArchHelper", &["design"], addr).await;
-    bot3.send_heartbeat().await;
+    let mut partial_skill = MockBot::connect(addr).await;
+    partial_skill
+        .register(
+            "Deployment Extended SQL",
+            &["code_review", "sql_extended"],
+            addr,
+        )
+        .await;
+    partial_skill.send_heartbeat().await;
 
-    // Search by name "arch" — should match ArchBot and ArchHelper (case-insensitive)
-    let url = format!("http://{}/bots/discover?name=arch", addr);
+    let mut skills_without_query = MockBot::connect(addr).await;
+    skills_without_query
+        .register("Documentation Reviewer", &["code_review", "sql"], addr)
+        .await;
+    skills_without_query.send_heartbeat().await;
+
+    let mut caller = MockBot::connect(addr).await;
+    caller.register("Caller", &["coordination"], addr).await;
+    caller.send_heartbeat().await;
+
+    let url = format!(
+        "http://{}/bots/discover?q=deployment&skill=code_review&skill=sql",
+        addr
+    );
     let response: serde_json::Value = reqwest::Client::new()
         .get(&url)
-        .header("Authorization", format!("Bearer {}", bot2.token.as_str()))
+        .header("Authorization", format!("Bearer {}", caller.token.as_str()))
         .send()
         .await
         .expect("Failed to call discover")
@@ -176,84 +199,11 @@ async fn discover_by_name_returns_matching_bots() {
         .expect("Failed to parse response");
 
     let bots = response["bots"].as_array().expect("bots should be array");
-    assert!(bots.len() >= 2, "Should match at least 2 bots with 'arch' in name, got {}", bots.len());
-
-    // All returned bots should have "arch" in their name (case-insensitive)
-    for bot in bots {
-        let name = bot["capabilities"]["name"].as_str().unwrap_or("");
-        assert!(
-            name.to_lowercase().contains("arch"),
-            "Bot name '{}' should contain 'arch'", name
-        );
-    }
-}
-
-/// Discover with `?name=xxx` does NOT trigger fuse recommend (name-only path).
-#[tokio::test]
-async fn discover_by_name_does_not_trigger_fuse() {
-    let tmp = create_temp_bots_dir();
-    let bots_dir = tmp.path().to_path_buf();
-
-    let config = create_config_bcsfuse_enabled(&bots_dir);
-    let server = BcsServer::new(config);
-    let (addr, _handle) = server.run_on_random_port().await.expect("start server");
-
-    let mut bot1 = MockBot::connect(addr).await;
-    bot1.register("TestBot", &["testing"], addr).await;
-    bot1.send_heartbeat().await;
-
-    let mut bot2 = MockBot::connect(addr).await;
-    bot2.register("ObserverBot", &["observation"], addr).await;
-    bot2.send_heartbeat().await;
-
-    // name search should NOT call fuse recommend — should succeed even with fuse unreachable
-    let url = format!("http://{}/bots/discover?name=test", addr);
-    let response = reqwest::Client::new()
-        .get(&url)
-        .header("Authorization", format!("Bearer {}", bot2.token.as_str()))
-        .send()
-        .await
-        .expect("Failed to call discover");
-    assert!(response.status().is_success(), "name search should succeed without fuse");
-
-    let body: serde_json::Value = response.json().await.expect("Failed to parse");
-    let bots = body["bots"].as_array().expect("bots should be array");
-    assert!(!bots.is_empty(), "Should find bot by name");
-}
-
-/// When both `q` and `name` are provided, `q` takes priority.
-#[tokio::test]
-async fn discover_q_takes_priority_over_name() {
-    let tmp = create_temp_bots_dir();
-    let bots_dir = tmp.path().to_path_buf();
-    let (addr, _handle) = start_test_server(&bots_dir).await;
-
-    let mut bot1 = MockBot::connect(addr).await;
-    bot1.register("ArchBot", &["architecture"], addr).await;
-    bot1.send_heartbeat().await;
-
-    let mut bot2 = MockBot::connect(addr).await;
-    bot2.register("DBABot", &["database"], addr).await;
-    bot2.send_heartbeat().await;
-
-    // q=database&name=arch — q should take priority, returning DBABot not ArchBot
-    let url = format!("http://{}/bots/discover?q=database&name=arch", addr);
-    let response: serde_json::Value = reqwest::Client::new()
-        .get(&url)
-        .header("Authorization", format!("Bearer {}", bot1.token.as_str()))
-        .send()
-        .await
-        .expect("Failed to call discover")
-        .json()
-        .await
-        .expect("Failed to parse response");
-
-    let bots = response["bots"].as_array().expect("bots should be array");
-    // q=database should match DBABot (by domain), not ArchBot (by name)
-    let has_dba = bots.iter().any(|b| {
-        b["capabilities"]["name"].as_str().unwrap_or("") == "DBABot"
-    });
-    assert!(has_dba, "q should take priority: DBABot should be in results");
+    let names = bots
+        .iter()
+        .filter_map(|bot| bot["capabilities"]["name"].as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["Deployment Reviewer"]);
 }
 
 // ============================================================================

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
@@ -86,10 +86,7 @@ pub struct BotQueryByIdsResult {
 #[derive(Debug, Clone, Default)]
 pub struct BotDiscoveryCommand {
     pub q: Option<String>,
-    pub name: Option<String>,
-    pub skills: Option<String>,
-    pub domains: Option<String>,
-    pub scopes: Option<String>,
+    pub skill: Option<String>,
     pub visibility: Option<String>,
     pub collaborate_bot: Option<String>,
     /// Authenticated bot requester. When present, discovery excludes this bot.

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
@@ -86,7 +86,7 @@ pub struct BotQueryByIdsResult {
 #[derive(Debug, Clone, Default)]
 pub struct BotDiscoveryCommand {
     pub q: Option<String>,
-    pub skill: Option<String>,
+    pub skills: Vec<String>,
     pub visibility: Option<String>,
     pub collaborate_bot: Option<String>,
     /// Authenticated bot requester. When present, discovery excludes this bot.

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/provider.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/provider.rs
@@ -17,7 +17,7 @@ pub enum ProviderBotDiscoverySelector {
     All,
     ProviderIds(Vec<String>),
     Query(String),
-    Skill(String),
+    RequiredSkills(Vec<String>),
 }
 
 impl Default for ProviderBotDiscoverySelector {

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/provider.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/provider.rs
@@ -17,10 +17,7 @@ pub enum ProviderBotDiscoverySelector {
     All,
     ProviderIds(Vec<String>),
     Query(String),
-    Name(String),
-    Skills(Vec<String>),
-    Domains(Vec<String>),
-    Scopes(Vec<String>),
+    Skill(String),
 }
 
 impl Default for ProviderBotDiscoverySelector {

--- a/src/bcs/crates/services/bcs-bot-store/src/provider.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/provider.rs
@@ -1172,10 +1172,12 @@ fn append_provider_discovery_selector_sql(
                 params.push(DbValue::from(pattern.as_str()));
             }
         }
-        ProviderBotDiscoverySelector::Skill(skill) => {
-            sql.push_str(" AND LOWER(COALESCE(b.bot_info, '')) LIKE ?");
-            let pattern = like_pattern(skill);
-            params.push(DbValue::from(pattern.as_str()));
+        ProviderBotDiscoverySelector::RequiredSkills(skills) => {
+            for skill in skills {
+                sql.push_str(" AND LOWER(COALESCE(b.bot_info, '')) LIKE ?");
+                let pattern = like_pattern(skill);
+                params.push(DbValue::from(pattern.as_str()));
+            }
         }
     }
 }
@@ -1645,9 +1647,12 @@ mod tests {
         assert_eq!(query_records[0].bot_uuid, "bot-query");
 
         let skill_records = store
-            .list_discoverable_provider_bot_records(&ProviderBotDiscoverySelector::Skill(
-                "sql".to_string(),
-            ))
+            .list_discoverable_provider_bot_records(
+                &ProviderBotDiscoverySelector::RequiredSkills(vec![
+                    "sql".to_string(),
+                    "ops".to_string(),
+                ]),
+            )
             .await
             .expect("skill records");
         assert_eq!(skill_records.len(), 1);

--- a/src/bcs/crates/services/bcs-bot-store/src/provider.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/provider.rs
@@ -1172,19 +1172,10 @@ fn append_provider_discovery_selector_sql(
                 params.push(DbValue::from(pattern.as_str()));
             }
         }
-        ProviderBotDiscoverySelector::Name(name) => {
-            sql.push_str(" AND LOWER(b.name) LIKE ?");
-            let pattern = like_pattern(name);
+        ProviderBotDiscoverySelector::Skill(skill) => {
+            sql.push_str(" AND LOWER(COALESCE(b.bot_info, '')) LIKE ?");
+            let pattern = like_pattern(skill);
             params.push(DbValue::from(pattern.as_str()));
-        }
-        ProviderBotDiscoverySelector::Skills(terms)
-        | ProviderBotDiscoverySelector::Domains(terms)
-        | ProviderBotDiscoverySelector::Scopes(terms) => {
-            for term in terms {
-                sql.push_str(" AND LOWER(COALESCE(b.bot_info, '')) LIKE ?");
-                let pattern = like_pattern(term);
-                params.push(DbValue::from(pattern.as_str()));
-            }
         }
     }
 }
@@ -1653,20 +1644,10 @@ mod tests {
         assert_eq!(query_records.len(), 1);
         assert_eq!(query_records[0].bot_uuid, "bot-query");
 
-        let name_records = store
-            .list_discoverable_provider_bot_records(&ProviderBotDiscoverySelector::Name(
-                "skill".to_string(),
-            ))
-            .await
-            .expect("name records");
-        assert_eq!(name_records.len(), 1);
-        assert_eq!(name_records[0].bot_uuid, "bot-skill");
-
         let skill_records = store
-            .list_discoverable_provider_bot_records(&ProviderBotDiscoverySelector::Skills(vec![
+            .list_discoverable_provider_bot_records(&ProviderBotDiscoverySelector::Skill(
                 "sql".to_string(),
-                "ops".to_string(),
-            ]))
+            ))
             .await
             .expect("skill records");
         assert_eq!(skill_records.len(), 1);

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -1182,51 +1182,29 @@ fn is_organization_discover_visible(visibility: &str) -> bool {
 fn provider_discovery_selector(command: &BotDiscoveryCommand) -> ProviderBotDiscoverySelector {
     if let Some(q) = command.q.as_deref() {
         ProviderBotDiscoverySelector::Query(q.to_string())
-    } else if let Some(name) = command.name.as_deref() {
-        ProviderBotDiscoverySelector::Name(name.to_string())
-    } else if let Some(skills_str) = command.skills.as_deref() {
-        ProviderBotDiscoverySelector::Skills(split_csv_strings(skills_str))
-    } else if let Some(domains_str) = command.domains.as_deref() {
-        ProviderBotDiscoverySelector::Domains(split_csv_strings(domains_str))
-    } else if let Some(scopes_str) = command.scopes.as_deref() {
-        ProviderBotDiscoverySelector::Scopes(split_csv_strings(scopes_str))
+    } else if let Some(skill) = command.skill.as_deref() {
+        ProviderBotDiscoverySelector::Skill(skill.trim().to_string())
     } else {
         ProviderBotDiscoverySelector::All
     }
 }
 
 fn matches_discovery_selector(bot: &RegisteredBot, command: &BotDiscoveryCommand) -> bool {
-    if let Some(q) = command.q.as_deref() {
-        matches_query(bot, q)
-    } else if let Some(name) = command.name.as_deref() {
-        bot.capabilities
-            .name
-            .as_deref()
-            .is_some_and(|value| contains_ignore_case(value, name))
-    } else if let Some(skills_str) = command.skills.as_deref() {
-        split_csv(skills_str).iter().all(|skill| {
-            bot.capabilities
+    let matches_q = command
+        .q
+        .as_deref()
+        .is_none_or(|query| matches_query(bot, query));
+    let matches_skill = command.skill.as_deref().is_none_or(|skill| {
+        let skill = skill.trim();
+        !skill.is_empty()
+            && bot
+                .capabilities
                 .skills
                 .iter()
-                .any(|candidate| contains_ignore_case(&candidate.name, skill))
-        })
-    } else if let Some(domains_str) = command.domains.as_deref() {
-        split_csv(domains_str).iter().all(|domain| {
-            bot.capabilities
-                .domains
-                .iter()
-                .any(|candidate| contains_ignore_case(candidate, domain))
-        })
-    } else if let Some(scopes_str) = command.scopes.as_deref() {
-        split_csv(scopes_str).iter().all(|scope| {
-            bot.capabilities
-                .scopes
-                .iter()
-                .any(|candidate| contains_ignore_case(candidate, scope))
-        })
-    } else {
-        true
-    }
+                .any(|candidate| candidate.name.eq_ignore_ascii_case(skill))
+    });
+
+    matches_q && matches_skill
 }
 
 fn matches_query(bot: &RegisteredBot, query: &str) -> bool {
@@ -1264,14 +1242,6 @@ fn matches_query(bot: &RegisteredBot, query: &str) -> bool {
 
 fn contains_ignore_case(value: &str, query: &str) -> bool {
     value.to_lowercase().contains(&query.to_lowercase())
-}
-
-fn split_csv(value: &str) -> Vec<&str> {
-    value.split(',').map(str::trim).collect()
-}
-
-fn split_csv_strings(value: &str) -> Vec<String> {
-    split_csv(value).into_iter().map(str::to_string).collect()
 }
 
 fn non_empty_text(value: Option<&str>) -> Option<String> {

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -1182,8 +1182,8 @@ fn is_organization_discover_visible(visibility: &str) -> bool {
 fn provider_discovery_selector(command: &BotDiscoveryCommand) -> ProviderBotDiscoverySelector {
     if let Some(q) = command.q.as_deref() {
         ProviderBotDiscoverySelector::Query(q.to_string())
-    } else if let Some(skill) = command.skill.as_deref() {
-        ProviderBotDiscoverySelector::Skill(skill.trim().to_string())
+    } else if !command.skills.is_empty() {
+        ProviderBotDiscoverySelector::RequiredSkills(command.skills.clone())
     } else {
         ProviderBotDiscoverySelector::All
     }
@@ -1194,17 +1194,15 @@ fn matches_discovery_selector(bot: &RegisteredBot, command: &BotDiscoveryCommand
         .q
         .as_deref()
         .is_none_or(|query| matches_query(bot, query));
-    let matches_skill = command.skill.as_deref().is_none_or(|skill| {
-        let skill = skill.trim();
-        !skill.is_empty()
-            && bot
-                .capabilities
-                .skills
-                .iter()
-                .any(|candidate| candidate.name.eq_ignore_ascii_case(skill))
+    let matches_skills = command.skills.iter().all(|skill| {
+        bot
+            .capabilities
+            .skills
+            .iter()
+            .any(|candidate| candidate.name.eq_ignore_ascii_case(skill))
     });
 
-    matches_q && matches_skill
+    matches_q && matches_skills
 }
 
 fn matches_query(bot: &RegisteredBot, query: &str) -> bool {

--- a/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
@@ -804,6 +804,78 @@ async fn discover_bots_applies_visibility_and_friend_matrix() {
 }
 
 #[tokio::test]
+async fn discover_bots_matches_one_skill_exactly_ignoring_case() {
+    let fixture = RegistryFixture::new();
+    let service = fixture.service();
+
+    for (bot_id, skill) in [
+        ("exact-lower", "code_review"),
+        ("exact-mixed", "Code_Review"),
+        ("partial", "code_review_extended"),
+        ("unrelated", "deployment"),
+    ] {
+        register_bot(
+            &fixture.registry,
+            bot_id,
+            caps_with_skill(Some(bot_id), Some("review helper"), "public", skill),
+            None,
+        )
+        .await;
+    }
+
+    let result = service
+        .discover_bots(BotDiscoveryCommand {
+            skill: Some(" code_review ".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("discover by exact skill");
+
+    let bot_ids = result
+        .bots
+        .iter()
+        .map(|entry| entry.bot_uuid.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(bot_ids, vec!["exact-lower", "exact-mixed"]);
+}
+
+#[tokio::test]
+async fn discover_bots_combines_q_and_skill() {
+    let fixture = RegistryFixture::new();
+    let service = fixture.service();
+
+    for (bot_id, summary, skill) in [
+        ("query-and-skill", "deployment helper", "code_review"),
+        ("query-only", "deployment helper", "release"),
+        ("skill-only", "documentation helper", "code_review"),
+    ] {
+        register_bot(
+            &fixture.registry,
+            bot_id,
+            caps_with_skill(Some(bot_id), Some(summary), "public", skill),
+            None,
+        )
+        .await;
+    }
+
+    let result = service
+        .discover_bots(BotDiscoveryCommand {
+            q: Some("deployment".to_string()),
+            skill: Some("code_review".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("discover by query and exact skill");
+
+    let bot_ids = result
+        .bots
+        .iter()
+        .map(|entry| entry.bot_uuid.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(bot_ids, vec!["query-and-skill"]);
+}
+
+#[tokio::test]
 async fn discover_provider_bots_returns_provider_metadata_and_agent_code() {
     let fixture = ProviderRegistryFixture::new();
     let service = fixture.service();
@@ -1718,5 +1790,17 @@ fn caps(name: Option<&str>, summary: Option<&str>, visibility: &str) -> BotCapab
         summary: summary.map(str::to_string),
         visibility: visibility.to_string(),
         ..Default::default()
+    }
+}
+
+fn caps_with_skill(
+    name: Option<&str>,
+    summary: Option<&str>,
+    visibility: &str,
+    skill: &str,
+) -> BotCapabilities {
+    BotCapabilities {
+        skills: vec![bcs_service_api::Skill::new(skill)],
+        ..caps(name, summary, visibility)
     }
 }

--- a/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
@@ -825,7 +825,7 @@ async fn discover_bots_matches_one_skill_exactly_ignoring_case() {
 
     let result = service
         .discover_bots(BotDiscoveryCommand {
-            skill: Some(" code_review ".to_string()),
+            skills: vec!["code_review".to_string()],
             ..Default::default()
         })
         .await
@@ -840,19 +840,67 @@ async fn discover_bots_matches_one_skill_exactly_ignoring_case() {
 }
 
 #[tokio::test]
-async fn discover_bots_combines_q_and_skill() {
+async fn discover_bots_requires_all_exact_skills() {
     let fixture = RegistryFixture::new();
     let service = fixture.service();
 
-    for (bot_id, summary, skill) in [
-        ("query-and-skill", "deployment helper", "code_review"),
-        ("query-only", "deployment helper", "release"),
-        ("skill-only", "documentation helper", "code_review"),
+    for (bot_id, skills) in [
+        ("all-exact", vec!["code_review", "SQL"]),
+        ("missing-sql", vec!["code_review"]),
+        ("partial-sql", vec!["code_review", "sql_extended"]),
     ] {
         register_bot(
             &fixture.registry,
             bot_id,
-            caps_with_skill(Some(bot_id), Some(summary), "public", skill),
+            caps_with_skills(
+                Some(bot_id),
+                Some("review helper"),
+                "public",
+                skills.as_slice(),
+            ),
+            None,
+        )
+        .await;
+    }
+
+    let result = service
+        .discover_bots(BotDiscoveryCommand {
+            skills: vec!["code_review".to_string(), "sql".to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("discover by all exact skills");
+
+    let bot_ids = result
+        .bots
+        .iter()
+        .map(|entry| entry.bot_uuid.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(bot_ids, vec!["all-exact"]);
+}
+
+#[tokio::test]
+async fn discover_bots_combines_q_and_all_skills() {
+    let fixture = RegistryFixture::new();
+    let service = fixture.service();
+
+    for (bot_id, summary, skills) in [
+        (
+            "query-and-skills",
+            "deployment helper",
+            vec!["code_review", "sql"],
+        ),
+        ("query-one-skill", "deployment helper", vec!["code_review"]),
+        (
+            "skills-only",
+            "documentation helper",
+            vec!["code_review", "sql"],
+        ),
+    ] {
+        register_bot(
+            &fixture.registry,
+            bot_id,
+            caps_with_skills(Some(bot_id), Some(summary), "public", skills.as_slice()),
             None,
         )
         .await;
@@ -861,18 +909,18 @@ async fn discover_bots_combines_q_and_skill() {
     let result = service
         .discover_bots(BotDiscoveryCommand {
             q: Some("deployment".to_string()),
-            skill: Some("code_review".to_string()),
+            skills: vec!["code_review".to_string(), "sql".to_string()],
             ..Default::default()
         })
         .await
-        .expect("discover by query and exact skill");
+        .expect("discover by query and all exact skills");
 
     let bot_ids = result
         .bots
         .iter()
         .map(|entry| entry.bot_uuid.as_str())
         .collect::<Vec<_>>();
-    assert_eq!(bot_ids, vec!["query-and-skill"]);
+    assert_eq!(bot_ids, vec!["query-and-skills"]);
 }
 
 #[tokio::test]
@@ -901,16 +949,55 @@ async fn discover_provider_bots_returns_provider_metadata_and_agent_code() {
                 summary: Some("Finds provider bots".to_string()),
                 owners: vec!["alice".to_string()],
                 provider_bot_ref: "agent-code-1".to_string(),
-                skills: vec![bcs_service_api::Skill::new("search")],
+                skills: vec![
+                    bcs_service_api::Skill::new("search"),
+                    bcs_service_api::Skill::new("sql"),
+                ],
                 ..Default::default()
             },
         )
         .await
         .expect("register provider bot");
+    fixture
+        .provider
+        .register_provider_bot_with_bot_uuid(
+            &provider.provider.provider_id,
+            &provider.provider_admin_token,
+            RegisterProviderBotParams {
+                bot_name: "Provider Searcher Missing Skill".to_string(),
+                summary: Some("Finds provider bots".to_string()),
+                owners: vec!["alice".to_string()],
+                provider_bot_ref: "agent-code-2".to_string(),
+                skills: vec![bcs_service_api::Skill::new("search")],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("register provider query-only bot");
+    fixture
+        .provider
+        .register_provider_bot_with_bot_uuid(
+            &provider.provider.provider_id,
+            &provider.provider_admin_token,
+            RegisterProviderBotParams {
+                bot_name: "Provider Writer".to_string(),
+                summary: Some("Writes documentation".to_string()),
+                owners: vec!["alice".to_string()],
+                provider_bot_ref: "agent-code-3".to_string(),
+                skills: vec![
+                    bcs_service_api::Skill::new("search"),
+                    bcs_service_api::Skill::new("sql"),
+                ],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("register provider skills-only bot");
 
     let result = service
         .discover_bots(BotDiscoveryCommand {
             q: Some("searcher".to_string()),
+            skills: vec!["search".to_string(), "sql".to_string()],
             ..Default::default()
         })
         .await
@@ -935,6 +1022,7 @@ async fn organization_scoped_discovery_filters_effective_members_and_attaches_me
         org_member("bot-b", "traffic_analyst"),
         org_member("bot-c", "traffic_analyst"),
         org_member("bot-d", "traffic_analyst"),
+        org_member("bot-e", "traffic_analyst"),
     ]));
     let service = Bot::new_with_friend(
         registry,
@@ -944,14 +1032,71 @@ async fn organization_scoped_discovery_filters_effective_members_and_attaches_me
     .with_organization(organization);
 
     register_bot(&fixture.registry, "bot-a", caps(Some("Requester"), Some("traffic"), "public"), None).await;
-    register_bot(&fixture.registry, "bot-b", caps(Some("Traffic Public"), Some("traffic"), "protected"), None).await;
-    register_bot(&fixture.registry, "bot-c", caps(Some("Traffic Private"), Some("traffic"), "private"), None).await;
-    register_bot(&fixture.registry, "bot-d", caps(Some("Traffic Friend"), Some("traffic"), "private"), None).await;
-    register_bot(&fixture.registry, "bot-x", caps(Some("Traffic Global"), Some("traffic"), "public"), None).await;
+    register_bot(
+        &fixture.registry,
+        "bot-b",
+        caps_with_skills(
+            Some("Traffic Public"),
+            Some("traffic"),
+            "protected",
+            &["routing", "sql"],
+        ),
+        None,
+    )
+    .await;
+    register_bot(
+        &fixture.registry,
+        "bot-c",
+        caps_with_skills(
+            Some("Traffic Private"),
+            Some("traffic"),
+            "private",
+            &["routing", "sql"],
+        ),
+        None,
+    )
+    .await;
+    register_bot(
+        &fixture.registry,
+        "bot-d",
+        caps_with_skills(
+            Some("Traffic Friend"),
+            Some("traffic"),
+            "private",
+            &["routing", "sql"],
+        ),
+        None,
+    )
+    .await;
+    register_bot(
+        &fixture.registry,
+        "bot-e",
+        caps_with_skills(
+            Some("Traffic Missing Skill"),
+            Some("traffic"),
+            "public",
+            &["routing"],
+        ),
+        None,
+    )
+    .await;
+    register_bot(
+        &fixture.registry,
+        "bot-x",
+        caps_with_skills(
+            Some("Traffic Global"),
+            Some("traffic"),
+            "public",
+            &["routing", "sql"],
+        ),
+        None,
+    )
+    .await;
 
     let result = service
         .discover_bots(BotDiscoveryCommand {
             q: Some("traffic".to_string()),
+            skills: vec!["routing".to_string(), "sql".to_string()],
             requester_bot_id: Some("bot-a".to_string()),
             organization_code: Some("promo-2026".to_string()),
             role: Some("traffic_analyst".to_string()),
@@ -1801,6 +1946,21 @@ fn caps_with_skill(
 ) -> BotCapabilities {
     BotCapabilities {
         skills: vec![bcs_service_api::Skill::new(skill)],
+        ..caps(name, summary, visibility)
+    }
+}
+
+fn caps_with_skills(
+    name: Option<&str>,
+    summary: Option<&str>,
+    visibility: &str,
+    skills: &[&str],
+) -> BotCapabilities {
+    BotCapabilities {
+        skills: skills
+            .iter()
+            .map(|skill| bcs_service_api::Skill::new(*skill))
+            .collect(),
         ..caps(name, summary, visibility)
     }
 }

--- a/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_use_cases.rs
@@ -980,10 +980,29 @@ async fn discover_provider_bots_returns_provider_metadata_and_agent_code() {
             &provider.provider.provider_id,
             &provider.provider_admin_token,
             RegisterProviderBotParams {
+                bot_name: "Provider Searcher Partial Skill".to_string(),
+                summary: Some("Finds provider bots".to_string()),
+                owners: vec!["alice".to_string()],
+                provider_bot_ref: "agent-code-3".to_string(),
+                skills: vec![
+                    bcs_service_api::Skill::new("search"),
+                    bcs_service_api::Skill::new("sql_extended"),
+                ],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("register provider partial-skill bot");
+    fixture
+        .provider
+        .register_provider_bot_with_bot_uuid(
+            &provider.provider.provider_id,
+            &provider.provider_admin_token,
+            RegisterProviderBotParams {
                 bot_name: "Provider Writer".to_string(),
                 summary: Some("Writes documentation".to_string()),
                 owners: vec!["alice".to_string()],
-                provider_bot_ref: "agent-code-3".to_string(),
+                provider_bot_ref: "agent-code-4".to_string(),
                 skills: vec![
                     bcs_service_api::Skill::new("search"),
                     bcs_service_api::Skill::new("sql"),
@@ -1023,6 +1042,7 @@ async fn organization_scoped_discovery_filters_effective_members_and_attaches_me
         org_member("bot-c", "traffic_analyst"),
         org_member("bot-d", "traffic_analyst"),
         org_member("bot-e", "traffic_analyst"),
+        org_member("bot-f", "traffic_analyst"),
     ]));
     let service = Bot::new_with_friend(
         registry,
@@ -1076,6 +1096,18 @@ async fn organization_scoped_discovery_filters_effective_members_and_attaches_me
             Some("traffic"),
             "public",
             &["routing"],
+        ),
+        None,
+    )
+    .await;
+    register_bot(
+        &fixture.registry,
+        "bot-f",
+        caps_with_skills(
+            Some("Traffic Partial Skill"),
+            Some("traffic"),
+            "public",
+            &["routing", "sql_extended"],
         ),
         None,
     )

--- a/src/bcs/crates/tools/bcs-cli/SKILL.md
+++ b/src/bcs/crates/tools/bcs-cli/SKILL.md
@@ -171,7 +171,11 @@ bcs-cli list
 
 ```bash
 bcs-cli discover --query "database"
+bcs-cli discover --query "deployment" --skill "code_review" --skill "sql"
 ```
+
+`--skill` 按技能名精确匹配并忽略大小写，可重复指定；多个 skill 以及
+`--query` 之间均为 AND 关系。
 
 ---
 

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/bot.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/bot.md
@@ -95,6 +95,8 @@ bcs discover --query "<搜索关键词>"
 **可选参数：**
 
 - `--query`: 搜索关键词（按名称、摘要、技能匹配）
+- `--skill <技能名>`: 按技能名精确匹配（忽略大小写）；可重复指定，
+  多个 skill 以及 `--query` 之间均为 AND 关系
 - `--collaborate-bot "<Bot UUID>"`: 查找当前 Bot 能够协作的所有 Bot（Public Bot + 好友）
 - `--visibility <public|protected>`: 按可见性过滤
 
@@ -103,6 +105,9 @@ bcs discover --query "<搜索关键词>"
 ```bash
 # 搜索数据库相关 Bot
 bcs discover --query "database"
+
+# 搜索同时具备 code_review 和 sql 的部署相关 Bot
+bcs discover --query "deployment" --skill "code_review" --skill "sql"
 
 # 查找可协作的 Bot
 bcs discover --query "database" --collaborate-bot "$BCS_BOT_UUID"

--- a/src/bcs/crates/tools/bcs-cli/bcs-http-skills/SKILL.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-http-skills/SKILL.md
@@ -41,6 +41,8 @@ files. Use environment variables or the session file instead.
 ```bash
 # Discover bots
 bcs-cli --url "$BCS_API_BASE_URL" discover --query "database"
+bcs-cli --url "$BCS_API_BASE_URL" discover --query "deployment" \
+  --skill "code_review" --skill "sql"
 
 # Ask for group help
 bcs-cli --url "$BCS_API_BASE_URL" request-group-help --topic "Investigate a production issue"
@@ -62,6 +64,9 @@ bcs-cli --url "$BCS_API_BASE_URL" chat \
   --bot-uuid "bot-dba" \
   --message "Please inspect the migration plan."
 ```
+
+`discover --skill` is repeatable. Each value is an exact, case-insensitive
+skill match; all skills and `--query` are combined with AND semantics.
 
 ## References
 

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -832,6 +832,7 @@ impl BcsClient {
     pub async fn discover_bots_extended(
         &self,
         query: Option<&str>,
+        skills: &[String],
         visibility: Option<&str>,
         collaborate_bot: Option<&str>,
         organization_code: Option<&str>,
@@ -840,6 +841,9 @@ impl BcsClient {
         let mut params: Vec<String> = Vec::new();
         if let Some(q) = query {
             params.push(format!("q={}", urlencoding::encode(q)));
+        }
+        for skill in skills {
+            params.push(format!("skill={}", urlencoding::encode(skill)));
         }
         if let Some(vis) = visibility {
             params.push(format!("visibility={}", urlencoding::encode(vis)));
@@ -876,32 +880,6 @@ impl BcsClient {
             response.json().await.context("Invalid discover response")?;
 
         Ok(result)
-    }
-
-    /// Find bots by skills.
-    pub async fn find_bots_by_skills(&self, skills: &[&str]) -> Result<Vec<BotInfo>> {
-        let url = format!(
-            "{}/bots/discover?skills={}",
-            self.base_url,
-            skills.join(",")
-        );
-
-        let response = self
-            .http_client
-            .get(&url)
-            .send()
-            .await
-            .context("Failed to find bots by skills")?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(anyhow!("Find bots failed ({}): {}", status, body));
-        }
-
-        let result: DiscoverBotsResponse = response.json().await.context("Invalid response")?;
-
-        Ok(result.bots)
     }
 
     // ========================================================================
@@ -3345,6 +3323,7 @@ mod tests {
         let result = client
             .discover_bots_extended(
                 None,
+                &["code review".to_string(), "sql/ops".to_string()],
                 None,
                 None,
                 Some("promo 2026"),
@@ -3357,6 +3336,8 @@ mod tests {
         assert_eq!(result.count, 0);
         let line = request_line.lock().unwrap();
         assert!(line.contains("GET /bots/discover?"), "{line}");
+        assert!(line.contains("skill=code%20review"), "{line}");
+        assert!(line.contains("skill=sql%2Fops"), "{line}");
         assert!(line.contains("organization_code=promo%202026"), "{line}");
         assert!(line.contains("role=traffic%2Fanalyst"), "{line}");
     }

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -5492,6 +5492,15 @@ mod tests {
     }
 
     #[test]
+    fn test_discover_command_rejects_legacy_plural_skills_filter() {
+        let error = Cli::try_parse_from(["bcs-cli", "discover", "--skills", "sql"])
+            .err()
+            .expect("legacy --skills must be rejected");
+
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
     fn test_chat_command_accepts_organization_code() {
         let cli = Cli::try_parse_from([
             "bcs-cli",

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -1018,9 +1018,9 @@ enum Commands {
         #[arg(short, long)]
         query: Option<String>,
 
-        /// Filter by skills (comma-separated)
-        #[arg(short, long, hide = true)]
-        skills: Option<String>,
+        /// Require an exact skill match (repeat for multiple required skills)
+        #[arg(long = "skill")]
+        skills: Vec<String>,
 
         /// Filter by visibility ("public" or "protected")
         #[arg(long)]
@@ -2535,7 +2535,7 @@ async fn main() -> Result<()> {
         Commands::Discover {
             token,
             query,
-            skills: _,
+            skills,
             visibility,
             collaborate_bot,
             organization_code,
@@ -2556,6 +2556,7 @@ async fn main() -> Result<()> {
                 "/bots/discover",
                 json!({
                     "q": &query,
+                    "skills": &skills,
                     "visibility": &visibility,
                     "collaborate_bot": &collaborate_bot,
                     "organization_code": &organization_code,
@@ -2566,6 +2567,7 @@ async fn main() -> Result<()> {
             let result = client
                 .discover_bots_extended(
                     query.as_deref(),
+                    &skills,
                     visibility.as_deref(),
                     collaborate_bot.as_deref(),
                     organization_code.as_deref(),
@@ -5458,6 +5460,32 @@ mod tests {
             } => {
                 assert_eq!(organization_code.as_deref(), Some("promo-2026"));
                 assert_eq!(role.as_deref(), Some("traffic_analyst"));
+            }
+            _ => panic!("expected discover command"),
+        }
+    }
+
+    #[test]
+    fn test_discover_command_accepts_repeated_skill_filters() {
+        let cli = Cli::try_parse_from([
+            "bcs-cli",
+            "discover",
+            "-q",
+            "deployment",
+            "--skill",
+            "code_review",
+            "--skill",
+            "sql",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Discover { query, skills, .. } => {
+                assert_eq!(query.as_deref(), Some("deployment"));
+                assert_eq!(
+                    skills,
+                    vec!["code_review".to_string(), "sql".to_string()]
+                );
             }
             _ => panic!("expected discover command"),
         }

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/discover_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/discover_test.rs
@@ -2,7 +2,7 @@
 
 use crate::common::{assert_success, TestContext};
 use wiremock::{
-    matchers::{method, path},
+    matchers::{method, path, query_param},
     Mock, ResponseTemplate,
 };
 
@@ -66,4 +66,37 @@ async fn discover_no_json_preserves_human_output() {
     assert!(stdout.contains("bot-1 (Helper) [public]"));
     assert!(stdout.contains("provider=Provider One/provider-1"));
     assert!(serde_json::from_str::<serde_json::Value>(&stdout).is_err());
+}
+
+#[tokio::test]
+async fn discover_forwards_query_and_repeated_skill_filters() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    Mock::given(method("GET"))
+        .and(path("/bots/discover"))
+        .and(query_param("q", "deployment"))
+        .and(query_param("skill", "code_review"))
+        .and(query_param("skill", "sql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "count": 0,
+            "bots": []
+        })))
+        .expect(1)
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .args([
+            "discover",
+            "-q",
+            "deployment",
+            "--skill",
+            "code_review",
+            "--skill",
+            "sql",
+        ])
+        .output()
+        .expect("Failed to execute discover with skill filters");
+
+    assert_success(&output);
 }


### PR DESCRIPTION
## Summary

- add repeatable `--skill` filtering to `bcs-cli discover`
- use exact, case-insensitive matching with AND semantics across multiple skills
- combine `q` and all requested skills with AND semantics
- reject empty, removed, unknown, and duplicate non-repeatable HTTP query parameters
- remove legacy BCS discover selectors and the unused client helper
- update BCS CLI documentation and add acceptance-edge coverage

## Scope

This change is limited to `src/bcs`. It does not modify Backend or Frontend code.

## Validation

- `cargo test --package bcs-service-api --package bcs-bot-store --package bcs-bot --package bcs-http -- --test-threads=1`
- `cargo test --package bcs-cli discover -- --test-threads=1`
- `cargo test --package bcs --test integration_discover_fuse discover_q_and_repeated_skills_use_and_semantics -- --exact --test-threads=1`
- pre-push hook passed against `upstream/dev` at `a102088eceb6edf9f5938469ef88d877e82c2e79`

Closes #488