### PR TITLE
fix: promote Skills Pool cutover recovery to REL20260728

### DIFF
--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -14,7 +14,6 @@ from engine.community.plugins.aicoding.layout_pool import (
     verify_aicoding_pool_mappings,
 )
 
-
 PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
 
 
@@ -142,8 +141,8 @@ def test_aicoding_activation_switches_local_and_keeps_repo_namespace(
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
-    assert legacy_local.is_symlink()
-    assert legacy_local.resolve() == pool_local.resolve()
+    assert not legacy_local.exists()
+    assert not legacy_local.is_symlink()
     assert not local_bridge.exists()
     assert not local_bridge.is_symlink()
     assert not repo_bridge.exists()

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
@@ -134,7 +134,7 @@ def test_claude_code_probe_rejects_non_file_marker(tmp_path: Path) -> None:
     assert result.evidence["reason"] == "marker_not_regular_file"
 
 
-def test_claude_code_activation_atomically_switches_physical_local(
+def test_claude_code_activation_retires_physical_legacy_local(
     tmp_path: Path,
 ) -> None:
     (
@@ -166,8 +166,8 @@ def test_claude_code_activation_atomically_switches_physical_local(
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
-    assert legacy_local.is_symlink()
-    assert legacy_local.resolve() == pool_local.resolve()
+    assert not legacy_local.exists()
+    assert not legacy_local.is_symlink()
     assert not local_bridge.exists()
     assert not local_bridge.is_symlink()
     assert not repo_bridge.exists()

--- a/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
@@ -97,7 +97,7 @@ def test_probe_requires_verified_hermes_legacy_bridge(tmp_path: Path) -> None:
     )
 
 
-def test_activation_switches_hermes_local_bridge_to_pool(tmp_path: Path) -> None:
+def test_activation_retires_hermes_legacy_storage_bridges(tmp_path: Path) -> None:
     home = tmp_path / "home" / "admin"
     active_root = home / ".hermes" / "skills"
     legacy_local = home / ".hermes" / "workspace" / "skills" / "skills-local"
@@ -170,8 +170,8 @@ def test_activation_switches_hermes_local_bridge_to_pool(tmp_path: Path) -> None
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
-    assert legacy_local.is_symlink()
-    assert legacy_local.resolve() == pool_local.resolve()
+    assert not legacy_local.exists()
+    assert not legacy_local.is_symlink()
     assert not local_bridge.exists()
     assert not local_bridge.is_symlink()
     assert not repo_bridge.exists()

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -24,7 +24,6 @@ from engine.community.plugins.openclaw.layout_activation import (
     PoolActivationStatus,
     SkillMapping,
     activate_openclaw_pool,
-    atomic_exchange_paths,
     publish_pool_mappings,
     rollback_openclaw_pool,
     verify_skill_mappings,
@@ -35,6 +34,7 @@ from engine.community.plugins.openclaw.layout_probe import (
     RuntimeLayoutInspectionStatus,
 )
 from engine.community.plugins.openclaw.layout_sync import (
+    mirror_local_tree,
     write_baseline_manifest,
 )
 from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
@@ -90,7 +90,7 @@ def _prepared_home(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
     return home, legacy_local, pool_local, pool_repo
 
 
-def test_registered_local_cutover_syncs_latest_content_and_atomically_bridges(
+def test_registered_local_cutover_syncs_latest_content_and_retires_bridges(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
@@ -599,16 +599,15 @@ def test_mapping_source_cannot_escape_canonical_pool_root(
     assert not legacy_local.is_symlink()
 
 
-def test_post_exchange_sync_captures_write_after_initial_copy(
+def test_post_rename_sync_captures_write_after_initial_copy(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def write_then_exchange(left: Path, right: Path) -> bool:
-        (left / "handmade" / "created-during-cutover.txt").write_text(
+    def write_before_retire() -> None:
+        (legacy_local / "handmade" / "created-during-cutover.txt").write_text(
             "must-survive"
         )
-        return atomic_exchange_paths(left, right)
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -617,7 +616,7 @@ def test_post_exchange_sync_captures_write_after_initial_copy(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=write_then_exchange,
+        before_legacy_retire=write_before_retire,
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
@@ -626,16 +625,97 @@ def test_post_exchange_sync_captures_write_after_initial_copy(
     ).read_text() == "must-survive"
 
 
-def test_post_exchange_sync_captures_new_unregistered_skill_root(
+def test_initial_mirror_preserves_pool_write_during_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import layout_sync
+
+    home, _legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    real_copy2 = layout_sync.shutil.copy2
+    wrote_pool = False
+
+    def copy_and_write_pool(
+        source: Path,
+        destination: Path,
+        *args: object,
+        **kwargs: object,
+    ) -> Path:
+        nonlocal wrote_pool
+        if not wrote_pool and ".final-sync-generation-1" in str(destination):
+            wrote_pool = True
+            (pool_local / "handmade" / "SKILL.md").write_text(
+                "backend-write-during-sync"
+            )
+        return real_copy2(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(layout_sync.shutil, "copy2", copy_and_write_pool)
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert wrote_pool is True
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
+        "backend-write-during-sync"
+    )
+
+
+def test_staging_baseline_detects_legacy_write_before_retire(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import layout_activation
+
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    real_write_baseline = layout_activation.write_baseline_manifest
+    wrote_legacy = False
+
+    def write_baseline_after_legacy_change(
+        **kwargs: object,
+    ) -> dict[str, tuple[str, str]]:
+        nonlocal wrote_legacy
+        wrote_legacy = True
+        (legacy_local / "handmade" / "SKILL.md").write_text(
+            "legacy-write-after-staging"
+        )
+        return real_write_baseline(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        layout_activation,
+        "write_baseline_manifest",
+        write_baseline_after_legacy_change,
+    )
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert wrote_legacy is True
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
+        "legacy-write-after-staging"
+    )
+
+
+def test_post_rename_sync_captures_new_unregistered_skill_root(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def create_skill_then_exchange(left: Path, right: Path) -> bool:
-        late_skill = left / "created-during-cutover"
+    def create_skill_before_retire() -> None:
+        late_skill = legacy_local / "created-during-cutover"
         late_skill.mkdir()
         (late_skill / "SKILL.md").write_text("must-survive")
-        return atomic_exchange_paths(left, right)
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -644,7 +724,7 @@ def test_post_exchange_sync_captures_new_unregistered_skill_root(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=create_skill_then_exchange,
+        before_legacy_retire=create_skill_before_retire,
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
@@ -657,14 +737,15 @@ def test_post_exchange_sync_captures_new_unregistered_skill_root(
     ]
 
 
-def test_post_exchange_sync_captures_existing_file_update_before_exchange(
+def test_post_rename_sync_captures_existing_file_update_before_retire(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def update_then_exchange(left: Path, right: Path) -> bool:
-        (left / "handmade" / "SKILL.md").write_text("updated-before-exchange")
-        return atomic_exchange_paths(left, right)
+    def update_before_retire() -> None:
+        (legacy_local / "handmade" / "SKILL.md").write_text(
+            "updated-before-retire"
+        )
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -673,27 +754,26 @@ def test_post_exchange_sync_captures_existing_file_update_before_exchange(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=update_then_exchange,
+        before_legacy_retire=update_before_retire,
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
     assert (pool_local / "handmade" / "SKILL.md").read_text() == (
-        "updated-before-exchange"
+        "updated-before-retire"
     )
     assert result.evidence["post_sync"]["applied"] == ["handmade/SKILL.md"]
 
 
-def test_post_exchange_sync_preserves_new_pool_write_on_same_file(
+def test_post_rename_sync_preserves_new_pool_write_on_same_file(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def update_legacy_then_exchange(left: Path, right: Path) -> bool:
-        (left / "handmade" / "SKILL.md").write_text("pre-exchange")
-        return atomic_exchange_paths(left, right)
+    def update_legacy_before_retire() -> None:
+        (legacy_local / "handmade" / "SKILL.md").write_text("pre-retire")
 
     def update_pool_after_exchange() -> None:
-        (legacy_local / "handmade" / "SKILL.md").write_text("post-exchange")
+        (pool_local / "handmade" / "SKILL.md").write_text("post-retire")
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -702,18 +782,18 @@ def test_post_exchange_sync_preserves_new_pool_write_on_same_file(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=update_legacy_then_exchange,
+        before_legacy_retire=update_legacy_before_retire,
         before_post_sync=update_pool_after_exchange,
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
-    assert (pool_local / "handmade" / "SKILL.md").read_text() == "post-exchange"
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == "post-retire"
     assert result.evidence["post_sync"]["conflicts_preserved_in_pool"] == [
         "handmade/SKILL.md"
     ]
 
 
-def test_atomic_file_exchange_preserves_write_at_replacement_boundary(
+def test_post_rename_sync_publishes_update_with_plain_replace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -721,24 +801,22 @@ def test_atomic_file_exchange_preserves_write_at_replacement_boundary(
 
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def update_then_exchange(left: Path, right: Path) -> bool:
-        (left / "handmade" / "SKILL.md").write_text("legacy-window")
-        return atomic_exchange_paths(left, right)
+    def update_before_retire() -> None:
+        (legacy_local / "handmade" / "SKILL.md").write_text("legacy-window")
 
-    real_exchange = layout_sync.atomic_exchange_paths
-    exchange_count = 0
+    real_replace = layout_sync.os.replace
+    pool_replace_count = 0
 
-    def write_pool_at_exchange(left: Path, right: Path) -> bool:
-        nonlocal exchange_count
-        if exchange_count == 0:
-            right.write_text("pool-at-exchange")
-        exchange_count += 1
-        return real_exchange(left, right)
+    def track_replace(left: Path, right: Path) -> None:
+        nonlocal pool_replace_count
+        if Path(right) == pool_local / "handmade" / "SKILL.md":
+            pool_replace_count += 1
+        real_replace(left, right)
 
     monkeypatch.setattr(
-        layout_sync,
-        "atomic_exchange_paths",
-        write_pool_at_exchange,
+        layout_sync.os,
+        "replace",
+        track_replace,
     )
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -747,19 +825,15 @@ def test_atomic_file_exchange_preserves_write_at_replacement_boundary(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=update_then_exchange,
+        before_legacy_retire=update_before_retire,
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
-    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
-        "pool-at-exchange"
-    )
-    assert result.evidence["post_sync"][
-        "conflicts_preserved_in_pool"
-    ] == ["handmade/SKILL.md"]
+    assert pool_replace_count >= 1
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == "legacy-window"
 
 
-def test_post_exchange_new_file_uses_atomic_no_clobber(
+def test_post_rename_new_file_uses_no_clobber_create(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -769,9 +843,8 @@ def test_post_exchange_new_file_uses_atomic_no_clobber(
 
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def add_legacy_file_then_exchange(left: Path, right: Path) -> bool:
-        (left / "handmade" / "raced.txt").write_text("legacy-window")
-        return atomic_exchange_paths(left, right)
+    def add_legacy_file_before_retire() -> None:
+        (legacy_local / "handmade" / "raced.txt").write_text("legacy-window")
 
     real_link = os.link
 
@@ -788,7 +861,7 @@ def test_post_exchange_new_file_uses_atomic_no_clobber(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=add_legacy_file_then_exchange,
+        before_legacy_retire=add_legacy_file_before_retire,
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
@@ -800,17 +873,18 @@ def test_post_exchange_new_file_uses_atomic_no_clobber(
     ]
 
 
-def test_post_exchange_pool_parent_deletion_is_not_resurrected(
+def test_post_rename_pool_parent_deletion_is_not_resurrected(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def add_child_then_exchange(left: Path, right: Path) -> bool:
-        (left / "handmade" / "late-child.txt").write_text("legacy-window")
-        return atomic_exchange_paths(left, right)
+    def add_child_before_retire() -> None:
+        (legacy_local / "handmade" / "late-child.txt").write_text(
+            "legacy-window"
+        )
 
     def delete_pool_parent() -> None:
-        shutil.rmtree(legacy_local / "handmade")
+        shutil.rmtree(pool_local / "handmade")
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -819,7 +893,7 @@ def test_post_exchange_pool_parent_deletion_is_not_resurrected(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=add_child_then_exchange,
+        before_legacy_retire=add_child_before_retire,
         before_post_sync=delete_pool_parent,
     )
 
@@ -830,19 +904,18 @@ def test_post_exchange_pool_parent_deletion_is_not_resurrected(
     ] == ["handmade/late-child.txt"]
 
 
-def test_post_exchange_deleted_parent_does_not_stall_new_subdirectory(
+def test_post_rename_deleted_parent_does_not_stall_new_subdirectory(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
-    def add_subtree_then_exchange(left: Path, right: Path) -> bool:
-        new_dir = left / "handmade" / "late-directory"
+    def add_subtree_before_retire() -> None:
+        new_dir = legacy_local / "handmade" / "late-directory"
         new_dir.mkdir()
         (new_dir / "child.txt").write_text("legacy-window")
-        return atomic_exchange_paths(left, right)
 
     def delete_pool_parent() -> None:
-        shutil.rmtree(legacy_local / "handmade")
+        shutil.rmtree(pool_local / "handmade")
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -851,7 +924,7 @@ def test_post_exchange_deleted_parent_does_not_stall_new_subdirectory(
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=add_subtree_then_exchange,
+        before_legacy_retire=add_subtree_before_retire,
         before_post_sync=delete_pool_parent,
     )
 
@@ -897,7 +970,249 @@ def test_retry_after_exchange_finishes_quarantine_move(tmp_path: Path) -> None:
     assert not temporary.exists()
 
 
-def test_cutover_stays_legacy_when_atomic_exchange_is_unavailable(
+def test_retry_after_legacy_rename_finishes_from_quarantine(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    mirror_local_tree(
+        source_root=legacy_local,
+        pool_local=pool_local,
+        staging_root=pool_local.parent / ".final-sync-generation-1",
+    )
+    write_baseline_manifest(
+        pool_local=pool_local,
+        local_names=["handmade"],
+        manifest_path=pool_local.parent
+        / ".cutover-baseline-generation-1.json",
+    )
+    quarantine = (
+        pool_local.parent
+        / ".migration-quarantine"
+        / "generation-1"
+        / "skills-local"
+    )
+    quarantine.parent.mkdir(parents=True)
+    legacy_local.rename(quarantine)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(legacy_local.parent / "handmade"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert quarantine.is_dir()
+    assert not legacy_local.exists()
+    assert (legacy_local.parent / "handmade").resolve() == (
+        pool_local / "handmade"
+    )
+
+
+def test_finalizing_marker_retry_collects_recreated_legacy_local(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    mirror_local_tree(
+        source_root=legacy_local,
+        pool_local=pool_local,
+        staging_root=pool_local.parent / ".final-sync-generation-1",
+    )
+    write_baseline_manifest(
+        pool_local=pool_local,
+        local_names=["handmade"],
+        manifest_path=pool_local.parent
+        / ".cutover-baseline-generation-1.json",
+    )
+    quarantine = (
+        pool_local.parent
+        / ".migration-quarantine"
+        / "generation-1"
+        / "skills-local"
+    )
+    quarantine.parent.mkdir(parents=True)
+    legacy_local.rename(quarantine)
+    (pool_local.parent / ".pool-active").write_text(
+        json.dumps(
+            {
+                "engine": "openclaw",
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                "preparation_id": PREPARATION_ID,
+                "migration_generation": "generation-1",
+                "activation_state": "finalizing",
+                "mappings": [],
+            }
+        )
+    )
+    late_skill = legacy_local / "created-after-finalizing"
+    late_skill.mkdir(parents=True)
+    (late_skill / "SKILL.md").write_text("must-survive")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert not legacy_local.exists()
+    assert (
+        pool_local / "created-after-finalizing" / "SKILL.md"
+    ).read_text() == "must-survive"
+    marker = json.loads((pool_local.parent / ".pool-active").read_text())
+    assert marker["activation_state"] == "active"
+
+
+def test_cutover_collects_recreated_legacy_local_before_commit(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def recreate_legacy_local() -> None:
+        late_skill = legacy_local / "created-after-retire"
+        late_skill.mkdir(parents=True)
+        (late_skill / "SKILL.md").write_text("must-survive")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        before_post_sync=recreate_legacy_local,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert not legacy_local.exists()
+    assert (
+        pool_local / "created-after-retire" / "SKILL.md"
+    ).read_text() == "must-survive"
+    assert result.evidence["legacy_residue"]["captured_count"] == 1
+
+
+def test_cutover_retry_replays_residue_after_merge_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import layout_activation
+
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    real_merge = layout_activation.merge_post_cutover_changes
+    fail_residue_once = True
+
+    def recreate_legacy_local() -> None:
+        late_skill = legacy_local / "created-before-merge-failure"
+        late_skill.mkdir(parents=True)
+        (late_skill / "SKILL.md").write_text("must-survive")
+
+    def flaky_merge(**kwargs: object) -> dict[str, object]:
+        nonlocal fail_residue_once
+        source_root = Path(str(kwargs["source_root"]))
+        if (
+            fail_residue_once
+            and source_root.name.startswith("skills-local-residue-")
+        ):
+            fail_residue_once = False
+            raise OSError(5, "injected merge failure")
+        return real_merge(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        layout_activation,
+        "merge_post_cutover_changes",
+        flaky_merge,
+    )
+    first = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        before_post_sync=recreate_legacy_local,
+    )
+
+    assert first.status is PoolActivationStatus.TRANSIENT_ERROR
+    assert (
+        pool_local.parent / ".cutover-baseline-generation-1.json"
+    ).is_file()
+
+    retry = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert not legacy_local.exists()
+    assert (
+        pool_local / "created-before-merge-failure" / "SKILL.md"
+    ).read_text() == "must-survive"
+
+
+def test_cutover_retry_continues_after_repeated_legacy_recreation(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    recreate_count = 0
+
+    def recreate_legacy_local() -> None:
+        late_skill = legacy_local / f"created-{recreate_count}"
+        late_skill.mkdir(parents=True)
+        (late_skill / "SKILL.md").write_text("must-survive")
+
+    def retire_and_recreate(source: Path, target: Path) -> None:
+        nonlocal recreate_count
+        os.replace(source, target)
+        if target.name.startswith("skills-local-residue-"):
+            recreate_count += 1
+            recreate_legacy_local()
+
+    first = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_path=retire_and_recreate,
+        before_post_sync=recreate_legacy_local,
+    )
+
+    assert first.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert first.evidence["reason"] == "legacy_local_recreated_during_cutover"
+
+    retry = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert not legacy_local.exists()
+    for index in range(4):
+        assert (
+            pool_local / f"created-{index}" / "SKILL.md"
+        ).read_text() == "must-survive"
+
+
+def test_cutover_commits_without_atomic_exchange_and_retires_storage_bridges(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
@@ -917,9 +1232,13 @@ def test_cutover_stays_legacy_when_atomic_exchange_is_unavailable(
         exchange_paths=lambda _left, _right: False,
     )
 
-    assert result.status is PoolActivationStatus.NOT_ATOMIC
-    assert legacy_local.is_dir()
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert not legacy_local.exists()
     assert not legacy_local.is_symlink()
+    assert not (legacy_local.parent / "skills-repo").exists()
+    assert (legacy_local.parent / "handmade").resolve() == (
+        pool_local / "handmade"
+    )
 
 
 def test_atomic_exchange_treats_einval_as_unavailable(
@@ -966,10 +1285,9 @@ def test_cutover_retry_recovers_owned_temporary_symlink(tmp_path: Path) -> None:
         exchange_paths=lambda _left, _right: False,
     )
 
-    assert result.status is PoolActivationStatus.NOT_ATOMIC
-    assert result.evidence["reason"] == "atomic_exchange_unavailable"
+    assert result.status is PoolActivationStatus.COMMITTED
     assert result.evidence["recovered_temporary"] is True
-    assert legacy_local.is_dir()
+    assert not legacy_local.exists()
     assert not legacy_local.is_symlink()
     assert not temporary.exists()
     assert not temporary.is_symlink()
@@ -1072,7 +1390,7 @@ def test_cutover_cleans_stale_staging_and_replaces_pool_symlink(
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
 
 
-def test_cutover_rejects_occupied_temporary_and_ambiguous_exchange(
+def test_cutover_rejects_occupied_legacy_exchange_temporary(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
@@ -1089,24 +1407,112 @@ def test_cutover_rejects_occupied_temporary_and_ambiguous_exchange(
     )
     assert occupied.evidence["reason"] == "cutover_temporary_path_occupied"
 
-    temporary.unlink()
-    ambiguous = activate_openclaw_pool(
+
+def test_cutover_rejects_unowned_quarantine_generation(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    generation_dir = (
+        pool_local.parent
+        / ".migration-quarantine"
+        / "generation-1"
+    )
+    generation_dir.mkdir(parents=True)
+    unknown = generation_dir / "unknown"
+    unknown.write_text("external")
+
+    result = activate_openclaw_pool(
         migration_generation="generation-1",
         preparation_id=PREPARATION_ID,
-        registered_local_names=[],
+        registered_local_names=["handmade"],
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=lambda _left, _right: True,
     )
-    assert ambiguous.evidence["reason"] == "cutover_result_ambiguous"
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == (
+        "cutover_quarantine_ownership_unproven"
+    )
+    assert legacy_local.is_dir()
+    assert unknown.read_text() == "external"
+    assert not (pool_local.parent / ".pool-active").exists()
+
+
+def test_cutover_recovers_truncated_quarantine_owner(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    generation_dir = (
+        pool_local.parent
+        / ".migration-quarantine"
+        / "generation-1"
+    )
+    generation_dir.mkdir(parents=True)
+    (generation_dir / ".owner.json").write_text("{")
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert not legacy_local.exists()
+    owner = json.loads((generation_dir / ".owner.json").read_text())
+    assert owner["migration_generation"] == "generation-1"
+    assert list(generation_dir.glob(".owner.invalid-*"))
+
+
+def test_cutover_accepts_same_owner_marker_publish_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import layout_activation
+
+    home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
+    real_link = layout_activation.os.link
+    raced = False
+
+    def race_owner_link(source: Path, target: Path) -> None:
+        nonlocal raced
+        if not raced and Path(target).name == ".owner.json":
+            raced = True
+            Path(target).write_text(
+                json.dumps(
+                    {
+                        "engine": "openclaw",
+                        "migration_generation": "generation-1",
+                        "preparation_id": PREPARATION_ID,
+                    }
+                )
+            )
+            raise FileExistsError
+        real_link(source, target)
+
+    monkeypatch.setattr(layout_activation.os, "link", race_owner_link)
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert raced is True
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert not legacy_local.exists()
 
 
 def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
     home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
     temporary = legacy_local.parent / ".skills-local.pool-cutover-generation-1"
 
-    def fail_exchange(_left: Path, _right: Path) -> bool:
+    def fail_retire(_left: Path, _right: Path) -> None:
         raise OSError(5, "io")
 
     result = activate_openclaw_pool(
@@ -1116,7 +1522,7 @@ def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=fail_exchange,
+        retire_path=fail_retire,
     )
 
     assert result.status is PoolActivationStatus.TRANSIENT_ERROR
@@ -1132,10 +1538,8 @@ def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
         mappings=[],
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
-        exchange_paths=lambda _left, _right: False,
     )
-    assert retry.status is PoolActivationStatus.NOT_ATOMIC
-    assert retry.evidence["reason"] == "atomic_exchange_unavailable"
+    assert retry.status is PoolActivationStatus.COMMITTED
 
 
 def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ctypes
+import errno
 import json
 import os
 import shutil
@@ -36,6 +38,7 @@ from engine.community.plugins.openclaw.layout_sync import (
     write_baseline_manifest,
 )
 from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
+from engine.community.plugins.skills_pool import layout_atomic
 
 PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
 
@@ -919,6 +922,84 @@ def test_cutover_stays_legacy_when_atomic_exchange_is_unavailable(
     assert not legacy_local.is_symlink()
 
 
+def test_atomic_exchange_treats_einval_as_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRenameAt2:
+        argtypes: list[object] = []
+        restype: object | None = None
+
+        def __call__(self, *_args: object) -> int:
+            ctypes.set_errno(errno.EINVAL)
+            return -1
+
+    class FakeLibc:
+        renameat2 = FakeRenameAt2()
+
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    left.mkdir()
+    right.symlink_to(left, target_is_directory=True)
+    monkeypatch.setattr(layout_atomic.sys, "platform", "linux")
+    monkeypatch.setattr(
+        layout_atomic.ctypes,
+        "CDLL",
+        lambda *_args, **_kwargs: FakeLibc(),
+    )
+
+    assert layout_atomic.atomic_exchange_paths(left, right) is False
+
+
+def test_cutover_retry_recovers_owned_temporary_symlink(tmp_path: Path) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    temporary = legacy_local.parent / ".skills-local.pool-cutover-generation-1"
+    temporary.symlink_to(pool_local, target_is_directory=True)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=lambda _left, _right: False,
+    )
+
+    assert result.status is PoolActivationStatus.NOT_ATOMIC
+    assert result.evidence["reason"] == "atomic_exchange_unavailable"
+    assert result.evidence["recovered_temporary"] is True
+    assert legacy_local.is_dir()
+    assert not legacy_local.is_symlink()
+    assert not temporary.exists()
+    assert not temporary.is_symlink()
+
+
+def test_cutover_retry_rejects_noncanonical_temporary_symlink(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
+    temporary = legacy_local.parent / ".skills-local.pool-cutover-generation-1"
+    external = tmp_path / "external"
+    external.mkdir()
+    temporary.symlink_to(external, target_is_directory=True)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == "cutover_temporary_path_occupied"
+    assert temporary.is_symlink()
+    assert temporary.readlink() == external
+    assert legacy_local.is_dir()
+
+
 @pytest.mark.parametrize(
     ("generation", "preparation_id", "names", "reason"),
     [
@@ -1023,6 +1104,7 @@ def test_cutover_rejects_occupied_temporary_and_ambiguous_exchange(
 
 def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
     home, legacy_local, _pool_local, pool_repo = _prepared_home(tmp_path)
+    temporary = legacy_local.parent / ".skills-local.pool-cutover-generation-1"
 
     def fail_exchange(_left: Path, _right: Path) -> bool:
         raise OSError(5, "io")
@@ -1040,6 +1122,20 @@ def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
     assert result.status is PoolActivationStatus.TRANSIENT_ERROR
     assert result.evidence["reason"] == "filesystem_operation_failed"
     assert legacy_local.is_dir()
+    assert not temporary.exists()
+    assert not temporary.is_symlink()
+
+    retry = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        exchange_paths=lambda _left, _right: False,
+    )
+    assert retry.status is PoolActivationStatus.NOT_ATOMIC
+    assert retry.evidence["reason"] == "atomic_exchange_unavailable"
 
 
 def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -333,6 +333,30 @@ def _lexical_target(link: Path) -> Path:
     return Path(os.path.abspath(target))
 
 
+def _cleanup_owned_cutover_temporary(
+    *,
+    temporary: Path,
+    legacy_local: Path,
+    pool_local: Path,
+) -> bool:
+    """清理由当前 generation 创建、且交换尚未发生的 canonical 临时桥。"""
+
+    if (
+        not temporary.is_symlink()
+        or not legacy_local.is_dir()
+        or legacy_local.is_symlink()
+    ):
+        return False
+    try:
+        target = _lexical_target(temporary)
+    except OSError:
+        return False
+    if target != Path(os.path.abspath(pool_local)):
+        return False
+    temporary.unlink()
+    return True
+
+
 def _canonical_pool_source(layout: _Layout, source: Path) -> Path | None:
     source = Path(os.path.abspath(source))
     for root, pool_root in (
@@ -833,14 +857,41 @@ def _activate_pool(
                 failures=list(mapping_plan.failures),
             )
 
+        recovered_temporary = False
         if temporary.exists() or temporary.is_symlink():
-            return _invalid("cutover_temporary_path_occupied", path=str(temporary))
+            recovered_temporary = _cleanup_owned_cutover_temporary(
+                temporary=temporary,
+                legacy_local=layout.legacy_local,
+                pool_local=layout.pool_local,
+            )
+            if not recovered_temporary:
+                return _invalid(
+                    "cutover_temporary_path_occupied",
+                    path=str(temporary),
+                )
         temporary.symlink_to(layout.pool_local, target_is_directory=True)
-        if not exchange_paths(layout.legacy_local, temporary):
-            temporary.unlink(missing_ok=True)
+        try:
+            exchanged = exchange_paths(layout.legacy_local, temporary)
+        except OSError:
+            _cleanup_owned_cutover_temporary(
+                temporary=temporary,
+                legacy_local=layout.legacy_local,
+                pool_local=layout.pool_local,
+            )
+            raise
+        if not exchanged:
+            if not _cleanup_owned_cutover_temporary(
+                temporary=temporary,
+                legacy_local=layout.legacy_local,
+                pool_local=layout.pool_local,
+            ):
+                return _invalid("cutover_result_ambiguous")
             return PoolActivationResult(
                 PoolActivationStatus.NOT_ATOMIC,
-                {"reason": "atomic_exchange_unavailable"},
+                {
+                    "reason": "atomic_exchange_unavailable",
+                    "recovered_temporary": recovered_temporary,
+                },
             )
 
         if not layout.legacy_local.is_symlink() or _lexical_target(

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1,15 +1,16 @@
-"""文件型引擎 Skills Pool 的完整收敛与原子 local bridge 切换。"""
+"""文件型引擎 Skills Pool 的完整收敛与单向 Legacy storage 退役。"""
 
 from __future__ import annotations
 
+import json
 import os
 import re
-import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Callable
+from uuid import uuid4
 
 from engine.community.plugins.skills_pool.layout_atomic import (
     atomic_exchange_paths,
@@ -272,6 +273,8 @@ def _finalize_active_root(
     migration_generation: str,
     preparation_id: str,
     mappings: list[SkillMapping],
+    quarantine: Path,
+    retire_path: Callable[[Path, Path], None],
 ) -> PoolActivationResult | None:
     published = publish_pool_mappings(
         mappings=mappings,
@@ -307,6 +310,13 @@ def _finalize_active_root(
         mappings=mappings,
         activation_state="finalizing",
     )
+    _residue_evidence, residue_failure = _capture_recreated_legacy_local(
+        layout=layout,
+        quarantine=quarantine,
+        retire_path=retire_path,
+    )
+    if residue_failure is not None:
+        return residue_failure
     _retire_bridge(
         layout.local_bridge,
         allowed_targets=(layout.legacy_local, layout.pool_local),
@@ -315,6 +325,28 @@ def _finalize_active_root(
         layout.repo_bridge,
         allowed_targets=(layout.legacy_repo, layout.pool_repo),
     )
+    if layout.legacy_local != layout.local_bridge:
+        _retire_bridge(
+            layout.legacy_local,
+            allowed_targets=(layout.pool_local,),
+        )
+    remaining_storage_entries = [
+        str(path)
+        for path in {
+            layout.legacy_local,
+            layout.local_bridge,
+            layout.repo_bridge,
+        }
+        if path.exists() or path.is_symlink()
+    ]
+    if remaining_storage_entries:
+        return PoolActivationResult(
+            PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+            {
+                "reason": "legacy_storage_entries_remain",
+                "paths": sorted(remaining_storage_entries),
+            },
+        )
     _write_active_marker(
         layout=layout,
         engine=engine,
@@ -656,13 +688,280 @@ def _finalize_post_cutover(
 
     quarantine.parent.mkdir(parents=True, exist_ok=True)
     cleanup_pending = quarantine.exists() or quarantine.is_symlink()
-    if not cleanup_pending:
+    if temporary != quarantine:
+        if cleanup_pending:
+            raise OSError(f"cutover quarantine already exists: {quarantine}")
         temporary.rename(quarantine)
-    baseline_path.unlink(missing_ok=True)
+        cleanup_pending = True
     return _PostCutoverFinalization(
         post_sync=post_sync,
         cleanup_pending=cleanup_pending,
     )
+
+
+def _capture_recreated_legacy_local(
+    *,
+    layout: _Layout,
+    quarantine: Path,
+    retire_path: Callable[[Path, Path], None],
+    max_captures: int = 3,
+) -> tuple[dict[str, object], PoolActivationResult | None]:
+    """收集 rename 后被容器内旧路径 writer 重新创建的极窄窗口增量。
+
+    ``begin_cutover`` 后 Backend 已写 canonical Pool，但运行中 Agent 仍可能
+    在几秒窗口内直接重建 Legacy local。这里只将 Pool 中不存在的新路径
+    best-effort 合入；冲突保留 Pool 权威版本，完整 residue 留在同 generation
+    quarantine 供审计和后续清理。
+    """
+
+    captured: list[dict[str, object]] = []
+    residue_index = 1
+    existing_residues: list[tuple[int, Path]] = []
+    if quarantine.parent.is_dir() and not quarantine.parent.is_symlink():
+        for entry in quarantine.parent.iterdir():
+            match = re.fullmatch(r"skills-local-residue-([1-9][0-9]*)", entry.name)
+            if match is None:
+                continue
+            if not entry.is_dir() or entry.is_symlink():
+                return (
+                    {
+                        "captured_count": len(captured),
+                        "captures": captured,
+                    },
+                    _invalid(
+                        "legacy_local_residue_invalid",
+                        path=str(entry),
+                    ),
+                )
+            existing_residues.append((int(match.group(1)), entry))
+    for index, residue in sorted(existing_residues):
+        post_sync = merge_post_cutover_changes(
+            source_root=residue,
+            pool_local=layout.pool_local,
+            baseline={},
+        )
+        captured.append(
+            {
+                "path": str(residue),
+                "post_sync": post_sync,
+                "replayed": True,
+            }
+        )
+        residue_index = max(residue_index, index + 1)
+
+    for _capture_index in range(1, max_captures + 1):
+        if not layout.legacy_local.exists() and not layout.legacy_local.is_symlink():
+            return (
+                {
+                    "captured_count": len(captured),
+                    "captures": captured,
+                },
+                None,
+            )
+        if layout.legacy_local.is_symlink():
+            return (
+                {
+                    "captured_count": len(captured),
+                    "captures": captured,
+                },
+                None,
+            )
+        if not layout.legacy_local.is_dir():
+            return (
+                {
+                    "captured_count": len(captured),
+                    "captures": captured,
+                },
+                _invalid(
+                    "legacy_local_residue_invalid",
+                    path=str(layout.legacy_local),
+                ),
+            )
+
+        while residue_index <= 128:
+            residue = (
+                quarantine.parent
+                / f"skills-local-residue-{residue_index}"
+            )
+            residue_index += 1
+            if not residue.exists() and not residue.is_symlink():
+                break
+        else:
+            return (
+                {
+                    "captured_count": len(captured),
+                    "captures": captured,
+                },
+                _invalid(
+                    "legacy_local_residue_quarantine_exhausted",
+                    path=str(quarantine.parent),
+                ),
+            )
+        retire_path(layout.legacy_local, residue)
+        post_sync = merge_post_cutover_changes(
+            source_root=residue,
+            pool_local=layout.pool_local,
+            baseline={},
+        )
+        captured.append(
+            {
+                "path": str(residue),
+                "post_sync": post_sync,
+            }
+        )
+
+    if layout.legacy_local.exists() or layout.legacy_local.is_symlink():
+        return (
+            {
+                "captured_count": len(captured),
+                "captures": captured,
+            },
+            PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "legacy_local_recreated_during_cutover",
+                    "captured_count": len(captured),
+                },
+            ),
+        )
+    return (
+        {
+            "captured_count": len(captured),
+            "captures": captured,
+        },
+        None,
+    )
+
+
+def _ensure_quarantine_generation_owned(
+    *,
+    quarantine: Path,
+    engine: str,
+    migration_generation: str,
+    preparation_id: str,
+    baseline_path: Path,
+) -> PoolActivationResult | None:
+    """以 generation 目录和 owner marker 证明 quarantine 写入所有权。
+
+    初次调用以 exclusive mkdir 取得 generation namespace；后续调用必须
+    匹配 owner marker。兼容旧实现已完成 rename、但尚未写 owner 的可恢复
+    状态时，只允许 baseline 存在且目录内全部是已知 quarantine 项。
+    """
+
+    generation_dir = quarantine.parent
+    quarantine_root = generation_dir.parent
+    quarantine_root.mkdir(parents=True, exist_ok=True)
+    created = False
+    try:
+        generation_dir.mkdir()
+        created = True
+    except FileExistsError:
+        if not generation_dir.is_dir() or generation_dir.is_symlink():
+            return _invalid(
+                "cutover_quarantine_generation_invalid",
+                path=str(generation_dir),
+            )
+
+    owner_path = generation_dir / ".owner.json"
+    expected_owner = {
+        "engine": engine,
+        "migration_generation": migration_generation,
+        "preparation_id": preparation_id,
+    }
+    known_entry = re.compile(
+        r"(?:skills-local(?:-residue-[1-9][0-9]*)?|"
+        r"\.owner\.json|\.owner\.invalid-[A-Fa-f0-9]+|"
+        r"\.owner\.tmp-[A-Fa-f0-9]+)"
+    )
+    unknown_entries = sorted(
+        entry.name
+        for entry in generation_dir.iterdir()
+        if known_entry.fullmatch(entry.name) is None
+    )
+
+    if owner_path.is_file() and not owner_path.is_symlink():
+        try:
+            owner = json.loads(owner_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            if (
+                not baseline_path.is_file()
+                or baseline_path.is_symlink()
+                or unknown_entries
+            ):
+                return _invalid(
+                    "cutover_quarantine_owner_invalid",
+                    path=str(owner_path),
+                )
+            owner_path.rename(
+                generation_dir / f".owner.invalid-{uuid4().hex}"
+            )
+            owner = None
+        if owner == expected_owner:
+            return None
+        if owner is not None:
+            return _invalid(
+                "cutover_quarantine_owner_mismatch",
+                path=str(owner_path),
+            )
+    if owner_path.exists() or owner_path.is_symlink():
+        return _invalid(
+            "cutover_quarantine_owner_invalid",
+            path=str(owner_path),
+        )
+
+    if not created and (
+        not baseline_path.is_file()
+        or baseline_path.is_symlink()
+        or unknown_entries
+    ):
+        return _invalid(
+            "cutover_quarantine_ownership_unproven",
+            path=str(generation_dir),
+            unknown_entries=unknown_entries,
+        )
+
+    owner_temporary = generation_dir / f".owner.tmp-{uuid4().hex}"
+    try:
+        with owner_temporary.open("x", encoding="utf-8") as stream:
+            json.dump(
+                expected_owner,
+                stream,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(owner_temporary, owner_path)
+        except FileExistsError:
+            try:
+                raced_owner = json.loads(
+                    owner_path.read_text(encoding="utf-8")
+                )
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                return _invalid(
+                    "cutover_quarantine_owner_raced_invalid",
+                    path=str(owner_path),
+                )
+            if raced_owner != expected_owner:
+                return _invalid(
+                    "cutover_quarantine_owner_raced_mismatch",
+                    path=str(owner_path),
+                )
+        directory_fd = os.open(generation_dir, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except FileExistsError:
+        return _invalid(
+            "cutover_quarantine_owner_temporary_raced",
+            path=str(owner_temporary),
+        )
+    finally:
+        owner_temporary.unlink(missing_ok=True)
+    return None
 
 
 def _activate_pool(
@@ -674,10 +973,19 @@ def _activate_pool(
     mappings: list[SkillMapping],
     home: str | Path = "/home/admin",
     repo_is_mounted: Callable[[Path], bool] | None = None,
-    exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    retire_path: Callable[[Path, Path], None] = os.replace,
+    before_legacy_retire: Callable[[], None] | None = None,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
-    """校验登记事实、同步完整 local，并原子提交 Legacy→Pool bridge。"""
+    """校验登记事实、同步完整 local，并单向退役 Legacy storage 入口。
+
+    Backend 在调用本接口前已通过 ``begin_cutover`` 将路径消费者切到
+    canonical Pool。这里先镜像完整 local corpus，再以同文件系统普通
+    rename 将 Legacy local 移入 quarantine，最后发布逐 Skill 映射并删除
+    Legacy storage 入口。切换窗口内允许短暂断链，但最终 active root
+    绝不保留指向整个 Pool corpus 的目录 bridge。
+
+    """
 
     home_path = Path(home)
     layout = _Layout.for_engine(engine, home_path)
@@ -700,43 +1008,6 @@ def _activate_pool(
             preparation_id=inspection.preparation_id,
         )
 
-    active_marker = _read_active_marker(layout.active_marker)
-    if active_marker is not None:
-        if (
-            active_marker.get("engine") != engine
-            or active_marker.get("layout_contract_version") != LAYOUT_CONTRACT_VERSION
-            or active_marker.get("preparation_id") != preparation_id
-            or active_marker.get("migration_generation") != migration_generation
-            or active_marker.get("activation_state") not in {"finalizing", "active"}
-        ):
-            return _invalid("active_marker_identity_mismatch")
-        try:
-            completion_failure = _finalize_active_root(
-                layout=layout,
-                engine=engine,
-                migration_generation=migration_generation,
-                preparation_id=preparation_id,
-                mappings=mappings,
-            )
-        except OSError as error:
-            return PoolActivationResult(
-                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
-                {
-                    "reason": "active_root_retirement_failed",
-                    "error_type": type(error).__name__,
-                    "errno": error.errno,
-                },
-            )
-        if completion_failure is not None:
-            return completion_failure
-        return PoolActivationResult(
-            PoolActivationStatus.ALREADY_COMMITTED,
-            {
-                "active_marker": str(layout.active_marker),
-                "legacy_storage_entries_absent": True,
-            },
-        )
-
     temporary = layout.legacy_local.parent / (
         f".skills-local.pool-cutover-{migration_generation}"
     )
@@ -749,6 +1020,56 @@ def _activate_pool(
     baseline_path = layout.pool_root / (
         f".cutover-baseline-{migration_generation}.json"
     )
+    active_marker = _read_active_marker(layout.active_marker)
+    if active_marker is not None:
+        if (
+            active_marker.get("engine") != engine
+            or active_marker.get("layout_contract_version") != LAYOUT_CONTRACT_VERSION
+            or active_marker.get("preparation_id") != preparation_id
+            or active_marker.get("migration_generation") != migration_generation
+            or active_marker.get("activation_state") not in {"finalizing", "active"}
+        ):
+            return _invalid("active_marker_identity_mismatch")
+        if active_marker.get("activation_state") == "finalizing":
+            ownership_failure = _ensure_quarantine_generation_owned(
+                quarantine=quarantine,
+                engine=engine,
+                migration_generation=migration_generation,
+                preparation_id=preparation_id,
+                baseline_path=baseline_path,
+            )
+            if ownership_failure is not None:
+                return ownership_failure
+        try:
+            completion_failure = _finalize_active_root(
+                layout=layout,
+                engine=engine,
+                migration_generation=migration_generation,
+                preparation_id=preparation_id,
+                mappings=mappings,
+                quarantine=quarantine,
+                retire_path=retire_path,
+            )
+        except OSError as error:
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "active_root_retirement_failed",
+                    "error_type": type(error).__name__,
+                    "errno": error.errno,
+                },
+            )
+        if completion_failure is not None:
+            return completion_failure
+        baseline_path.unlink(missing_ok=True)
+        return PoolActivationResult(
+            PoolActivationStatus.ALREADY_COMMITTED,
+            {
+                "active_marker": str(layout.active_marker),
+                "legacy_storage_entries_absent": True,
+            },
+        )
+
     normalized_names: list[str] = []
     for name in registered_local_names:
         path = Path(name)
@@ -769,6 +1090,15 @@ def _activate_pool(
                 return _invalid("legacy_local_bridge_invalid")
             finalization = _PostCutoverFinalization({}, False)
             if temporary.is_dir() and not temporary.is_symlink():
+                ownership_failure = _ensure_quarantine_generation_owned(
+                    quarantine=quarantine,
+                    engine=engine,
+                    migration_generation=migration_generation,
+                    preparation_id=preparation_id,
+                    baseline_path=baseline_path,
+                )
+                if ownership_failure is not None:
+                    return ownership_failure
                 for name in normalized_names:
                     source = temporary / name
                     if not source.is_dir() or source.is_symlink():
@@ -790,9 +1120,12 @@ def _activate_pool(
                 migration_generation=migration_generation,
                 preparation_id=preparation_id,
                 mappings=mappings,
+                quarantine=quarantine,
+                retire_path=retire_path,
             )
             if completion_failure is not None:
                 return completion_failure
+            baseline_path.unlink(missing_ok=True)
             return PoolActivationResult(
                 PoolActivationStatus.ALREADY_COMMITTED,
                 {
@@ -801,6 +1134,75 @@ def _activate_pool(
                     "quarantine": str(quarantine),
                     "quarantine_cleanup_pending": (finalization.cleanup_pending),
                     "post_sync": finalization.post_sync,
+                },
+            )
+        if quarantine.is_dir() and not quarantine.is_symlink():
+            ownership_failure = _ensure_quarantine_generation_owned(
+                quarantine=quarantine,
+                engine=engine,
+                migration_generation=migration_generation,
+                preparation_id=preparation_id,
+                baseline_path=baseline_path,
+            )
+            if ownership_failure is not None:
+                return ownership_failure
+            if not baseline_path.is_file() or baseline_path.is_symlink():
+                return _invalid(
+                    "cutover_baseline_missing_after_legacy_retire",
+                    path=str(baseline_path),
+                )
+            for name in normalized_names:
+                source = quarantine / name
+                if not source.is_dir() or source.is_symlink():
+                    return _data_inconsistent(
+                        "registered_local_source_invalid",
+                        registered_name=name,
+                        source=str(source),
+                    )
+            mapping_plan = _mapping_plan(layout=layout, mappings=mappings)
+            if mapping_plan.conflicts:
+                return _active_entry_conflict(mapping_plan.conflicts)
+            if mapping_plan.failures:
+                return _invalid(
+                    "mapping_source_invalid",
+                    failures=list(mapping_plan.failures),
+                )
+            finalization = _finalize_post_cutover(
+                temporary=quarantine,
+                pool_local=layout.pool_local,
+                quarantine=quarantine,
+                baseline_path=baseline_path,
+            )
+            if finalization.failure is not None:
+                return finalization.failure
+            residue_evidence, residue_failure = _capture_recreated_legacy_local(
+                layout=layout,
+                quarantine=quarantine,
+                retire_path=retire_path,
+            )
+            if residue_failure is not None:
+                return residue_failure
+            completion_failure = _finalize_active_root(
+                layout=layout,
+                engine=engine,
+                migration_generation=migration_generation,
+                preparation_id=preparation_id,
+                mappings=mappings,
+                quarantine=quarantine,
+                retire_path=retire_path,
+            )
+            if completion_failure is not None:
+                return completion_failure
+            baseline_path.unlink(missing_ok=True)
+            return PoolActivationResult(
+                PoolActivationStatus.ALREADY_COMMITTED,
+                {
+                    "active_marker": str(layout.active_marker),
+                    "legacy_storage_entries_absent": True,
+                    "quarantine": str(quarantine),
+                    "quarantine_cleanup_pending": True,
+                    "post_sync": finalization.post_sync,
+                    "legacy_residue": residue_evidence,
                 },
             )
         if not layout.legacy_local.is_dir():
@@ -829,15 +1231,18 @@ def _activate_pool(
                     unreadable_path=str(unreadable),
                 )
 
-        local_names = mirror_local_tree(
+        local_names, staged_legacy_baseline = mirror_local_tree(
             source_root=layout.legacy_local,
             pool_local=layout.pool_local,
             staging_root=layout.pool_root / f".final-sync-{migration_generation}",
         )
         baseline = write_baseline_manifest(
-            pool_local=layout.pool_local,
+            # Freeze the exact staging snapshot. Reading live Legacy here
+            # would miss writes landing after staging copy but before rename.
+            pool_local=layout.legacy_local,
             local_names=local_names,
             manifest_path=baseline_path,
+            manifest=staged_legacy_baseline,
         )
 
         mapping_plan = _mapping_plan(layout=layout, mappings=mappings)
@@ -857,6 +1262,8 @@ def _activate_pool(
                 failures=list(mapping_plan.failures),
             )
 
+        if before_legacy_retire is not None:
+            before_legacy_retire()
         recovered_temporary = False
         if temporary.exists() or temporary.is_symlink():
             recovered_temporary = _cleanup_owned_cutover_temporary(
@@ -869,40 +1276,26 @@ def _activate_pool(
                     "cutover_temporary_path_occupied",
                     path=str(temporary),
                 )
-        temporary.symlink_to(layout.pool_local, target_is_directory=True)
-        try:
-            exchanged = exchange_paths(layout.legacy_local, temporary)
-        except OSError:
-            _cleanup_owned_cutover_temporary(
-                temporary=temporary,
-                legacy_local=layout.legacy_local,
-                pool_local=layout.pool_local,
+        ownership_failure = _ensure_quarantine_generation_owned(
+            quarantine=quarantine,
+            engine=engine,
+            migration_generation=migration_generation,
+            preparation_id=preparation_id,
+            baseline_path=baseline_path,
+        )
+        if ownership_failure is not None:
+            return ownership_failure
+        if quarantine.exists() or quarantine.is_symlink():
+            return _invalid(
+                "cutover_quarantine_path_occupied",
+                path=str(quarantine),
             )
-            raise
-        if not exchanged:
-            if not _cleanup_owned_cutover_temporary(
-                temporary=temporary,
-                legacy_local=layout.legacy_local,
-                pool_local=layout.pool_local,
-            ):
-                return _invalid("cutover_result_ambiguous")
-            return PoolActivationResult(
-                PoolActivationStatus.NOT_ATOMIC,
-                {
-                    "reason": "atomic_exchange_unavailable",
-                    "recovered_temporary": recovered_temporary,
-                },
-            )
-
-        if not layout.legacy_local.is_symlink() or _lexical_target(
-            layout.legacy_local
-        ) != Path(os.path.abspath(layout.pool_local)):
-            return _invalid("cutover_result_ambiguous")
+        retire_path(layout.legacy_local, quarantine)
 
         if before_post_sync is not None:
             before_post_sync()
         finalization = _finalize_post_cutover(
-            temporary=temporary,
+            temporary=quarantine,
             pool_local=layout.pool_local,
             quarantine=quarantine,
             baseline_path=baseline_path,
@@ -910,15 +1303,25 @@ def _activate_pool(
         )
         if finalization.failure is not None:
             return finalization.failure
+        residue_evidence, residue_failure = _capture_recreated_legacy_local(
+            layout=layout,
+            quarantine=quarantine,
+            retire_path=retire_path,
+        )
+        if residue_failure is not None:
+            return residue_failure
         completion_failure = _finalize_active_root(
             layout=layout,
             engine=engine,
             migration_generation=migration_generation,
             preparation_id=preparation_id,
             mappings=mappings,
+            quarantine=quarantine,
+            retire_path=retire_path,
         )
         if completion_failure is not None:
             return completion_failure
+        baseline_path.unlink(missing_ok=True)
         return PoolActivationResult(
             PoolActivationStatus.COMMITTED,
             {
@@ -926,6 +1329,7 @@ def _activate_pool(
                 "legacy_storage_entries_absent": True,
                 "quarantine": str(quarantine),
                 "quarantine_cleanup_pending": finalization.cleanup_pending,
+                "recovered_temporary": recovered_temporary,
                 "registered_local_count": len(normalized_names),
                 "local_inventory": {
                     "registered": len(normalized_names),
@@ -938,6 +1342,7 @@ def _activate_pool(
                     "external": len(mapping_plan.external),
                 },
                 "post_sync": finalization.post_sync,
+                "legacy_residue": residue_evidence,
             },
         )
     except OSError as error:
@@ -971,8 +1376,13 @@ def activate_openclaw_pool(
     home: str | Path = "/home/admin",
     repo_is_mounted: Callable[[Path], bool] | None = None,
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    retire_path: Callable[[Path, Path], None] = os.replace,
+    before_legacy_retire: Callable[[], None] | None = None,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
+    # Deprecated compatibility seam for existing in-process callers. Forward
+    # activation no longer depends on atomic exchange.
+    del exchange_paths
     return _activate_pool(
         engine="openclaw",
         migration_generation=migration_generation,
@@ -981,7 +1391,8 @@ def activate_openclaw_pool(
         mappings=mappings,
         home=home,
         repo_is_mounted=repo_is_mounted,
-        exchange_paths=exchange_paths,
+        retire_path=retire_path,
+        before_legacy_retire=before_legacy_retire,
         before_post_sync=before_post_sync,
     )
 
@@ -995,8 +1406,11 @@ def activate_claude_code_pool(
     home: str | Path = "/home/admin",
     repo_is_mounted: Callable[[Path], bool] | None = None,
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    retire_path: Callable[[Path, Path], None] = os.replace,
+    before_legacy_retire: Callable[[], None] | None = None,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
+    del exchange_paths
     return _activate_pool(
         engine="claude_code",
         migration_generation=migration_generation,
@@ -1005,7 +1419,8 @@ def activate_claude_code_pool(
         mappings=mappings,
         home=home,
         repo_is_mounted=repo_is_mounted,
-        exchange_paths=exchange_paths,
+        retire_path=retire_path,
+        before_legacy_retire=before_legacy_retire,
         before_post_sync=before_post_sync,
     )
 
@@ -1019,8 +1434,11 @@ def activate_aicoding_pool(
     home: str | Path = "/home/admin",
     repo_is_mounted: Callable[[Path], bool] | None = None,
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    retire_path: Callable[[Path, Path], None] = os.replace,
+    before_legacy_retire: Callable[[], None] | None = None,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
+    del exchange_paths
     return _activate_pool(
         engine="aicoding",
         migration_generation=migration_generation,
@@ -1029,7 +1447,8 @@ def activate_aicoding_pool(
         mappings=mappings,
         home=home,
         repo_is_mounted=repo_is_mounted,
-        exchange_paths=exchange_paths,
+        retire_path=retire_path,
+        before_legacy_retire=before_legacy_retire,
         before_post_sync=before_post_sync,
     )
 
@@ -1043,8 +1462,11 @@ def activate_hermes_pool(
     home: str | Path = "/home/admin",
     repo_is_mounted: Callable[[Path], bool] | None = None,
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    retire_path: Callable[[Path, Path], None] = os.replace,
+    before_legacy_retire: Callable[[], None] | None = None,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
+    del exchange_paths
     return _activate_pool(
         engine="hermes",
         migration_generation=migration_generation,
@@ -1053,7 +1475,8 @@ def activate_hermes_pool(
         mappings=mappings,
         home=home,
         repo_is_mounted=repo_is_mounted,
-        exchange_paths=exchange_paths,
+        retire_path=retire_path,
+        before_legacy_retire=before_legacy_retire,
         before_post_sync=before_post_sync,
     )
 
@@ -1122,7 +1545,7 @@ def _rollback_pool(
         if rebuild.is_symlink() or (rebuild.exists() and not rebuild.is_dir()):
             return _invalid("rollback_temporary_path_occupied", path=str(rebuild))
         rebuild.mkdir(exist_ok=True)
-        local_names = mirror_local_tree(
+        local_names, _rollback_baseline = mirror_local_tree(
             source_root=layout.pool_local,
             pool_local=rebuild,
             staging_root=copy_staging,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_atomic.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_atomic.py
@@ -45,6 +45,7 @@ def atomic_exchange_paths(left: Path, right: Path) -> bool:
         return True
     current_errno = ctypes.get_errno()
     if current_errno in {
+        errno.EINVAL,
         errno.ENOSYS,
         errno.ENOTSUP,
         getattr(errno, "EOPNOTSUPP", errno.ENOTSUP),

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_sync.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_sync.py
@@ -10,10 +10,6 @@ import stat
 from pathlib import Path
 from uuid import uuid4
 
-from engine.community.plugins.skills_pool.layout_atomic import (
-    atomic_exchange_paths,
-)
-
 Fingerprint = tuple[str, str]
 Manifest = dict[str, Fingerprint]
 
@@ -23,21 +19,39 @@ def mirror_local_tree(
     source_root: Path,
     pool_local: Path,
     staging_root: Path,
-) -> list[str]:
-    """交换前把 Legacy local 的完整文件系统真相精确镜像到 Pool。"""
+) -> tuple[list[str], Manifest]:
+    """把 Legacy local 收敛到 Pool，同时保留同步窗口内的 Pool 新写入。
 
+    调用前 Backend 已开始把路径消费者切到 canonical Pool。先记录 Pool
+    baseline，再把 Legacy 复制到 staging，最后做三方 best-effort 合并：
+    Pool 仍等于 baseline 的路径应用 Legacy；已变化的路径保留 Pool。Legacy
+    已删除且 Pool 未变化的路径才会被清理。
+    """
+
+    pool_baseline = snapshot_local(pool_local)
     _remove_path(staging_root)
     staging_root.mkdir()
     source_entries = sorted(source_root.iterdir(), key=lambda path: path.name)
     for source in source_entries:
         _copy_entry(source, staging_root / source.name)
 
-    for destination in list(pool_local.iterdir()):
-        _remove_path(destination)
-    for staged in list(staging_root.iterdir()):
-        staged.rename(pool_local / staged.name)
-    staging_root.rmdir()
-    return [entry.name for entry in source_entries]
+    staged_manifest = snapshot_local(staging_root)
+    merge_post_cutover_changes(
+        source_root=staging_root,
+        pool_local=pool_local,
+        baseline=pool_baseline,
+    )
+    deleted = sorted(
+        set(pool_baseline) - set(staged_manifest),
+        key=lambda key: (-key.count("/"), key),
+    )
+    for key in deleted:
+        _remove_if_unchanged(
+            target=pool_local / key,
+            expected=pool_baseline[key],
+        )
+    _remove_path(staging_root)
+    return [entry.name for entry in source_entries], staged_manifest
 
 
 def write_baseline_manifest(
@@ -45,17 +59,29 @@ def write_baseline_manifest(
     pool_local: Path,
     local_names: list[str],
     manifest_path: Path,
+    manifest: Manifest | None = None,
 ) -> Manifest:
-    """持久化交换前 Pool 快照，供交换后或失败重试执行三方合并。"""
+    """持久化 retire 前的 Legacy 快照，供失败重试执行三方合并。
 
-    manifest = snapshot_local(pool_local, local_names=local_names)
+    ``pool_local`` 参数名为向前兼容保留；调用方传入的是 final sync 完成后
+    尚未退役的 Legacy local。Pool 可能已承接 Backend 新写入，不能作为
+    Legacy 窗口变化的比较基线。
+    """
+
+    effective_manifest = (
+        manifest
+        if manifest is not None
+        else snapshot_local(pool_local, local_names=local_names)
+    )
     temporary = manifest_path.with_name(f".{manifest_path.name}.{uuid4().hex}.tmp")
     temporary.write_text(
-        json.dumps({key: list(value) for key, value in manifest.items()}),
+        json.dumps(
+            {key: list(value) for key, value in effective_manifest.items()}
+        ),
         encoding="utf-8",
     )
     os.replace(temporary, manifest_path)
-    return manifest
+    return effective_manifest
 
 
 def load_baseline_manifest(manifest_path: Path) -> Manifest:
@@ -81,18 +107,17 @@ def merge_post_cutover_changes(
     pool_local: Path,
     baseline: Manifest,
 ) -> dict[str, object]:
-    """三方合并交换窗口内的 Legacy 变化，保留交换后的 Pool 新写入。
+    """三方合并 rename 窗口内的 Legacy 变化，保留 Pool 新写入。
 
-    ``baseline`` 是首次 final sync 后的 Pool；``source_root`` 是原子交换
-    后换出的 Legacy 快照；``pool_local`` 是交换后继续承接新写入的目标。
-    交换后 Pool 是唯一写入权威源：新路径使用原子 no-clobber 创建；已有
-    路径使用原子 exchange 检查交换瞬间换出的实际版本，Pool 已变化时立即
-    回滚并保留 Pool。删除和无法安全收敛的 delta 留在 quarantine 供审计。
+    ``baseline`` 是首次 staging copy 得到的 Legacy 快照；``source_root``
+    是普通 rename 后进入 quarantine 的 Legacy；``pool_local`` 已承接
+    Backend 新写入。新路径使用 no-clobber 创建；已有路径仅在 Pool 仍等于
+    baseline 时以普通 replace 发布。Pool 已变化时保留 Pool，无法安全收敛
+    的 delta 留在 quarantine 供审计。
 
-    这是本期明确接受的 best-effort 边界：没有写栅栏时，跨 exchange 持有
-    的已打开文件描述符，或连续命中回滚后再次交换窗口的同文件写入，仍可能
-    落到随后清理的临时 inode。完整消除此竞态需要所有 writer 遵守共享的
-    quiesce/lock 协议，不属于 #370。
+    这是本期明确接受的 best-effort 边界：没有共享写栅栏时，fingerprint
+    校验与 replace 之间仍有极窄 TOCTOU。完整消除此竞态需要所有 writer
+    遵守 quiesce/lock 协议，不属于本期。
     """
 
     source = snapshot_local(source_root)
@@ -260,12 +285,12 @@ def _replace_if_unchanged(
     expected: Fingerprint,
     desired: Fingerprint,
 ) -> bool:
-    """以 exchange 瞬间换出的对象判断 Pool 是否仍为 baseline。
+    """当 Pool 仍为 baseline 时，以普通 rename 发布 Legacy 窗口变化。
 
-    先交换再检查，避免 check-then-replace 的 TOCTOU。若换出的 Pool 已变化，
-    立即原子换回；若回滚窗口内 canonical path 又收到写入，则该更晚写入
-    随临时项再次换回 canonical。调用方接受无协作写锁时跨 inode 写入仍有
-    极窄残余竞态；此处不声称提供文件内容 CAS。
+    目标 NAS/FUSE 不支持 ``RENAME_EXCHANGE``，因此这里在最后一次 fingerprint
+    校验后使用同文件系统 ``os.replace``。校验与 replace 之间仍存在极窄
+    TOCTOU；这是无共享写栅栏方案明确接受的 best-effort 边界。若校验时
+    Pool 已变化，则保留 Pool 权威版本并把 Legacy 变化留在 quarantine。
     """
 
     if desired == expected:
@@ -280,23 +305,39 @@ def _replace_if_unchanged(
             temporary.mkdir()
         else:
             return False
-        if not atomic_exchange_paths(temporary, target):
-            raise OSError("atomic file exchange unavailable")
-        displaced = _fingerprint(temporary)
-        if displaced == expected:
-            return _fingerprint(target) == desired
-
-        if not atomic_exchange_paths(temporary, target):
-            raise OSError("failed to restore concurrently changed Pool file")
-        candidate_after_rollback = _fingerprint(temporary)
-        if candidate_after_rollback != desired:
-            if not atomic_exchange_paths(temporary, target):
-                raise OSError("failed to restore newer Pool file")
+        if _fingerprint(target) != expected:
+            return False
+        try:
+            os.replace(temporary, target)
+        except (IsADirectoryError, NotADirectoryError):
+            # POSIX rename cannot replace across entry kinds on every
+            # filesystem. Recheck above, then remove only the exact baseline
+            # entry; a non-empty concurrently changed directory is preserved.
+            if expected[0] == "dir":
+                target.rmdir()
+            else:
+                target.unlink()
+            os.replace(temporary, target)
         return _fingerprint(target) == desired
-    except (FileNotFoundError, NotADirectoryError):
+    except (FileNotFoundError, NotADirectoryError, OSError):
         return False
     finally:
         _remove_path(temporary)
+
+
+def _remove_if_unchanged(*, target: Path, expected: Fingerprint) -> bool:
+    """仅清理仍等于同步前 baseline 的 Legacy deletion。"""
+
+    if _fingerprint(target) != expected:
+        return False
+    try:
+        if expected[0] == "dir":
+            target.rmdir()
+        else:
+            target.unlink()
+    except (FileNotFoundError, NotADirectoryError, OSError):
+        return False
+    return _fingerprint(target) is None
 
 
 def _remove_path(path: Path) -> None:


### PR DESCRIPTION
## Summary

将已在 `dev` 验证并合入的 Skills Pool cutover 修复提升到 `REL20260728`：

- 包含前置提交 `6d0e57b1`：恢复旧 B1 失败现场遗留的同 generation 临时软链，并将 `EINVAL` 识别为 exchange 不可用。
- 包含最终提交 `a102088e`（PR #487）：不再依赖 `RENAME_EXCHANGE`，使用普通 rename 将 Legacy local 隔离到 generation quarantine。
- 激活完成后不保留 `skills-local` / `skills-repo` 整库 bridge，仅保留逐 Skill mapping 和非受管 external symlink。
- 保留 staging baseline、三方收敛、residue replay、quarantine ownership 和失败重试语义。

## Why

真实 sandbox 文件系统不支持 `RENAME_EXCHANGE`；同时，整库 bridge 会被递归版 OpenClaw 扫描，破坏“仅激活技能生效”的产品语义。两笔提交存在明确依赖，必须按顺序一起进入 release。

## Release patch evidence

`git range-diff` 证明 release 分支上的两笔提交与 dev 原始提交逐笔等价：

- `6d0e57b1 = b289869f`
- `a102088e = e2bbd64b`

没有携带其它 dev 提交。

## Validation

- 定向迁移与 contract 测试：95 passed
- Engine Community 全量：2015 passed, 5 skipped
- `git diff --check`：通过
- 唯一 warning 为既有 Starlette/httpx deprecation warning