### PR TITLE
feat(singlebox): add rule-driven bots

### DIFF
--- a/scripts/modules/bots.sh
+++ b/scripts/modules/bots.sh
@@ -51,15 +51,200 @@ bots_dynamic_group_key() {
     base="$(basename "$dir")"
     safe_base="$(printf '%s' "$base" | tr -c 'A-Za-z0-9_-' '-')"
     if command -v shasum >/dev/null 2>&1; then
-        hash="$(printf '%s' "$dir" | shasum -a 256 | awk '{print substr($1,1,12)}')"
+        hash="$(printf '%s' "$dir" | LC_ALL=C LANG=C shasum -a 256 | awk '{print substr($1,1,12)}')"
     else
         hash="$(printf '%s' "$dir" | cksum | awk '{print $1}')"
     fi
     printf '%s-%s\n' "${safe_base:-bots}" "$hash"
 }
 
+bots_dynamic_manifest_version() {
+    jq -r '.version // empty' "$(bots_dynamic_manifest)"
+}
+
+bots_dynamic_has_runtime() {
+    local runtime="$1"
+    jq -e --arg runtime "$runtime" \
+        'any(.bots[]; (.runtime.type // "openclaw") == $runtime)' \
+        "$(bots_dynamic_manifest)" >/dev/null 2>&1
+}
+
 bots_dynamic_log_file() {
     printf '%s/bots_%s.log\n' "$LOG_DIR" "$(bots_dynamic_group_key)"
+}
+
+bots_dynamic_rule_pid_file() {
+    printf '%s/bots_%s_rule.pid\n' "$DEP_DIR" "$(bots_dynamic_group_key)"
+}
+
+bots_dynamic_rule_status_file() {
+    printf '%s/bots_%s_rule.status.json\n' "$LOG_DIR" "$(bots_dynamic_group_key)"
+}
+
+bots_dynamic_rule_log_file() {
+    printf '%s/bots_%s_rule.log\n' "$LOG_DIR" "$(bots_dynamic_group_key)"
+}
+
+bots_dynamic_rule_binary() {
+    if [ -n "${BCS_RULE_BOT_BIN:-}" ]; then
+        printf '%s\n' "$BCS_RULE_BOT_BIN"
+        return
+    fi
+
+    local target_dir="${CARGO_TARGET_DIR:-${BCS_DIR}/target}"
+    case "$target_dir" in
+        /*) printf '%s/debug/bcs-rule-bot\n' "$target_dir" ;;
+        *) printf '%s/%s/debug/bcs-rule-bot\n' "$BCS_DIR" "$target_dir" ;;
+    esac
+}
+
+bots_dynamic_rule_process_matches() {
+    local pid_file pid command manifest binary
+    pid_file="$(bots_dynamic_rule_pid_file)"
+    [ -f "$pid_file" ] || return 1
+    pid="$(cat "$pid_file" 2>/dev/null || true)"
+    case "$pid" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    kill -0 "$pid" 2>/dev/null || return 1
+
+    command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+    manifest="$(bots_dynamic_manifest)"
+    binary="$(bots_dynamic_rule_binary)"
+    case "$command" in
+        *"${binary}"*" run "*"--manifest ${manifest}"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+bots_dynamic_rule_profile_ready() {
+    local profile="$1"
+    local status_file updated_at now_ms max_age_ms
+    bots_dynamic_rule_process_matches || return 1
+    status_file="$(bots_dynamic_rule_status_file)"
+    [ -f "$status_file" ] || return 1
+    jq -e --arg profile "$profile" \
+        '.bots[$profile].state == "connected"' \
+        "$status_file" >/dev/null 2>&1 || return 1
+    updated_at="$(jq -r '.updated_at // 0' "$status_file" 2>/dev/null)"
+    case "$updated_at" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    now_ms=$(( $(date +%s) * 1000 ))
+    max_age_ms="${BCS_RULE_BOT_STATUS_MAX_AGE_MS:-90000}"
+    case "$max_age_ms" in
+        ''|*[!0-9]*) max_age_ms=90000 ;;
+    esac
+    [ "$updated_at" -le "$now_ms" ] && [ $((now_ms - updated_at)) -le "$max_age_ms" ]
+}
+
+bots_dynamic_rule_profile_behavior() {
+    local profile="$1"
+    jq -r --arg profile "$profile" \
+        '.bots[$profile].behavior // "unknown"' \
+        "$(bots_dynamic_rule_status_file)" 2>/dev/null
+}
+
+bots_dynamic_build_rule_bot() {
+    local binary
+    binary="$(bots_dynamic_rule_binary)"
+    if [ -n "${BCS_RULE_BOT_BIN:-}" ] && [ -x "$binary" ]; then
+        return 0
+    fi
+    if ! check_command cargo; then
+        if [ -x "$binary" ]; then
+            return 0
+        fi
+        log_error "cargo not found; it is required to build bcs-rule-bot"
+        return 1
+    fi
+
+    log_info "Building bcs-rule-bot..."
+    if ! (cd "$BCS_DIR" && cargo build -p bcs-rule-bot) >> "$(bots_dynamic_log_file)" 2>&1; then
+        log_error "Failed to build bcs-rule-bot; check $(bots_dynamic_log_file)"
+        return 1
+    fi
+    if [ ! -x "$binary" ]; then
+        log_error "bcs-rule-bot binary not found after build: ${binary}"
+        return 1
+    fi
+}
+
+bots_dynamic_validate_v2_manifest() {
+    bots_dynamic_build_rule_bot || return 1
+    if ! "$(bots_dynamic_rule_binary)" validate \
+        --manifest "$(bots_dynamic_manifest)" >> "$(bots_dynamic_log_file)" 2>&1; then
+        log_error "Invalid version 2 bot manifest; check $(bots_dynamic_log_file)"
+        return 1
+    fi
+}
+
+bots_dynamic_start_rule_host() {
+    local pid_file status_file log_file binary profile_root profile_prefix pid waited=0
+    if bots_dynamic_rule_process_matches; then
+        log_error "Rule bot host is already running for --profile-dir ${BOTS_PROFILE_DIR}"
+        return 1
+    fi
+
+    pid_file="$(bots_dynamic_rule_pid_file)"
+    status_file="$(bots_dynamic_rule_status_file)"
+    log_file="$(bots_dynamic_rule_log_file)"
+    binary="$(bots_dynamic_rule_binary)"
+    profile_root="${OPENCLAW_PROFILE_ROOT:-$HOME}"
+    profile_prefix="${OPENCLAW_PROFILE_PREFIX-.openclaw-}"
+    rm -f "$pid_file" "$status_file"
+
+    log_info "Starting rule bot host for --profile-dir ${BOTS_PROFILE_DIR}..."
+    RUST_LOG="${RUST_LOG:-bcs_rule_bot=info}" \
+    nohup "$binary" run \
+        --manifest "$(bots_dynamic_manifest)" \
+        --bcs-url "ws://127.0.0.1:${BCS_PORT}/ws/bot" \
+        --profile-root "$profile_root" \
+        --profile-prefix "$profile_prefix" \
+        --status-file "$status_file" > "$log_file" 2>&1 < /dev/null &
+    pid="$!"
+    printf '%s\n' "$pid" > "$pid_file"
+
+    while [ "$waited" -lt 5 ]; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            log_error "Rule bot host exited during startup; check ${log_file}"
+            rm -f "$pid_file"
+            return 1
+        fi
+        if [ -f "$status_file" ]; then
+            log_info "Rule bot host started (PID: ${pid})"
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    log_info "Rule bot host started (PID: ${pid}); waiting for BCS connections"
+}
+
+bots_dynamic_stop_rule_host() {
+    local pid_file pid waited=0
+    pid_file="$(bots_dynamic_rule_pid_file)"
+    if ! bots_dynamic_rule_process_matches; then
+        if [ -f "$pid_file" ]; then
+            log_warn "Removing stale rule bot PID file: ${pid_file}"
+        fi
+        rm -f "$pid_file" "$(bots_dynamic_rule_status_file)"
+        return 0
+    fi
+
+    pid="$(cat "$pid_file")"
+    log_info "Stopping rule bot host (PID: ${pid})..."
+    kill "$pid" 2>/dev/null || true
+    while [ "$waited" -lt 10 ] && kill -0 "$pid" 2>/dev/null; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null && bots_dynamic_rule_process_matches; then
+        log_warn "Rule bot host did not stop gracefully; terminating PID ${pid}"
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+    rm -f "$pid_file" "$(bots_dynamic_rule_status_file)"
 }
 
 bots_dynamic_workspace_root() {
@@ -110,22 +295,24 @@ bots_dynamic_specs() {
     manifest="$(bots_dynamic_manifest)"
     jq -r '
       . as $root
-      | ($root.port_start | tonumber) as $start
-      | ($root.port_step | tonumber) as $step
+      | ($root.port_start // 0 | tonumber) as $start
+      | ($root.port_step // 1 | tonumber) as $step
       | ($root.scopes // "local") as $default_scopes
       | $root.bots
       | to_entries[]
       | .key as $idx
       | .value as $bot
+      | ($bot.runtime.type // "openclaw") as $runtime
       | [
           $bot.name,
           $bot.profile,
-          ($start + ($idx * $step) | tostring),
-          $bot.source,
+          (if $runtime == "openclaw" then ($start + ($idx * $step) | tostring) else "-" end),
+          ($bot.source // "-"),
           $bot.summary,
           $bot.domains,
           $bot.skills,
-          ($bot.scopes // $default_scopes)
+          ($bot.scopes // $default_scopes),
+          $runtime
         ]
       | @tsv
     ' "$manifest"
@@ -158,62 +345,108 @@ bots_dynamic_validate_manifest() {
         return 1
     fi
     if ! jq -e '
-        .version == 1
-        and (.port_start | type == "number")
-        and (.port_step | type == "number")
-        and (.port_step > 0)
-        and (.bots | type == "array")
-        and (.bots | length > 0)
-        and all(.bots[];
-            (.source | type == "string" and length > 0)
-            and (.profile | type == "string" and test("^[A-Za-z0-9_-]+$"))
+        def keys_allowed($allowed):
+            ((keys - $allowed) | length) == 0;
+        def common_bot:
+            (.profile | type == "string" and test("^[A-Za-z0-9_-]+$"))
             and (.name | type == "string" and length > 0)
             and (.summary | type == "string" and length > 0)
             and (.domains | type == "string" and length > 0)
-            and (.skills | type == "string" and length > 0)
+            and (.skills | type == "string" and length > 0);
+        def ports:
+            (.port_start | type == "number")
+            and (.port_step | type == "number")
+            and (.port_step > 0);
+        (.bots | type == "array")
+        and (.bots | length > 0)
+        and (
+            (
+                .version == 1
+                and ports
+                and all(.bots[];
+                    common_bot
+                    and (.source | type == "string" and length > 0)
+                )
+            )
+            or
+            (
+                .version == 2
+                and keys_allowed(["version", "name", "port_start", "port_step", "scopes", "bots"])
+                and (.name | type == "string" and length > 0)
+                and all(.bots[];
+                    common_bot
+                    and keys_allowed(["source", "profile", "name", "summary", "domains", "skills", "scopes", "runtime"])
+                    and ((.runtime.type // "openclaw") as $runtime
+                        | ($runtime == "openclaw" or $runtime == "rule")
+                        and (
+                            if has("runtime")
+                            then (.runtime | type == "object")
+                                and (.runtime | keys_allowed(
+                                    if $runtime == "rule"
+                                    then ["type", "response_delay_ms", "behavior"]
+                                    else ["type"]
+                                    end
+                                ))
+                            else true
+                            end
+                        )
+                        and if $runtime == "rule"
+                            then ((has("source") | not) and (.runtime.behavior | type == "object"))
+                            else (.source | type == "string" and length > 0)
+                            end)
+                )
+                and (
+                    if any(.bots[]; (.runtime.type // "openclaw") == "openclaw")
+                    then ports
+                    else true
+                    end
+                )
+            )
         )
       ' "$manifest" >/dev/null; then
         log_error "Invalid bot manifest schema: ${manifest}"
-        log_error "Required root fields: version=1, port_start, port_step, bots[]."
-        log_error "Required per-bot fields: source, profile, name, summary, domains, skills."
+        log_error "Supported versions: 1 (OpenClaw only) and 2 (OpenClaw/rule runtimes)."
+        log_error "Required per-bot fields: profile, name, summary, domains, skills."
         log_error "Runtime profile must match: [A-Za-z0-9_-]"
         return 1
     fi
 
     local seen_profiles="" seen_ports="" has_error=false
-    local name profile port source summary domains skills scopes source_dir file
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
-        case "$source" in
-            ""|*/*|*..*)
-                log_error "${name}: source must be a direct child directory name, got: ${source}"
-                has_error=true
-                ;;
-        esac
-        source_dir="${dir}/${source}"
-        if [ ! -d "$source_dir" ]; then
-            log_error "${name}: source directory not found: ${source_dir}"
-            has_error=true
-        else
-            for file in "${BOTS_DYNAMIC_PROFILE_FILES[@]}"; do
-                if [ ! -f "${source_dir}/${file}" ]; then
-                    log_error "${name}: required profile file missing: ${source_dir}/${file}"
+    local name profile port source summary domains skills scopes runtime source_dir file
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
+        if [ "$runtime" = "openclaw" ]; then
+            case "$source" in
+                ""|"-"|*/*|*..*)
+                    log_error "${name}: source must be a direct child directory name, got: ${source}"
                     has_error=true
-                fi
-            done
-        fi
+                    ;;
+            esac
+            source_dir="${dir}/${source}"
+            if [ ! -d "$source_dir" ]; then
+                log_error "${name}: source directory not found: ${source_dir}"
+                has_error=true
+            else
+                for file in "${BOTS_DYNAMIC_PROFILE_FILES[@]}"; do
+                    if [ ! -f "${source_dir}/${file}" ]; then
+                        log_error "${name}: required profile file missing: ${source_dir}/${file}"
+                        has_error=true
+                    fi
+                done
+            fi
 
-        case "$port" in
-            ''|*[!0-9]*)
-                log_error "${name}: computed port is not numeric: ${port}"
-                has_error=true
-                ;;
-            *)
-                if [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
-                    log_error "${name}: computed port out of range: ${port}"
+            case "$port" in
+                ''|*[!0-9]*)
+                    log_error "${name}: computed port is not numeric: ${port}"
                     has_error=true
-                fi
-                ;;
-        esac
+                    ;;
+                *)
+                    if [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+                        log_error "${name}: computed port out of range: ${port}"
+                        has_error=true
+                    fi
+                    ;;
+            esac
+        fi
 
         case " ${seen_profiles} " in
             *" ${profile} "*)
@@ -221,14 +454,16 @@ bots_dynamic_validate_manifest() {
                 has_error=true
                 ;;
         esac
-        case " ${seen_ports} " in
-            *" ${port} "*)
-                log_error "Duplicate computed bot port in manifest: ${port}"
-                has_error=true
-                ;;
-        esac
+        if [ "$runtime" = "openclaw" ]; then
+            case " ${seen_ports} " in
+                *" ${port} "*)
+                    log_error "Duplicate computed bot port in manifest: ${port}"
+                    has_error=true
+                    ;;
+            esac
+            seen_ports="${seen_ports} ${port}"
+        fi
         seen_profiles="${seen_profiles} ${profile}"
-        seen_ports="${seen_ports} ${port}"
     done < <(bots_dynamic_specs)
 
     [ "$has_error" = false ]
@@ -299,10 +534,14 @@ bots_dynamic_runtime_matches() {
 
 bots_dynamic_group_fully_running() {
     local count=0
-    local name profile port source summary domains skills scopes
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    local name profile port source summary domains skills scopes runtime
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
         count=$((count + 1))
-        bots_dynamic_runtime_matches "$name" "$profile" "$port" "$source" || return 1
+        if [ "$runtime" = "rule" ]; then
+            bots_dynamic_rule_profile_ready "$profile" || return 1
+        else
+            bots_dynamic_runtime_matches "$name" "$profile" "$port" "$source" || return 1
+        fi
     done < <(bots_dynamic_specs)
     [ "$count" -gt 0 ]
 }
@@ -359,8 +598,9 @@ bots_dynamic_agent_model_fields_json() {
 
 bots_dynamic_check_profile_configs() {
     local has_error=false
-    local name profile port source summary domains skills scopes profile_dir
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    local name profile port source summary domains skills scopes runtime profile_dir
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
+        [ "$runtime" = "openclaw" ] || continue
         profile_dir="$(bcs_bot_profile_dir "$profile")"
         if [ -f "${profile_dir}/openclaw.json" ] && ! bots_dynamic_config_matches "$name" "$profile" "$port" "$source"; then
             if bots_dynamic_config_base_matches "$name" "$profile" "$port" "$source"; then
@@ -378,8 +618,9 @@ bots_dynamic_check_profile_configs() {
 
 bots_dynamic_check_ports_free() {
     local has_error=false
-    local name profile port source summary domains skills scopes listener
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    local name profile port source summary domains skills scopes runtime listener
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
+        [ "$runtime" = "openclaw" ] || continue
         if port_is_listening "$port"; then
             listener="$(port_listener_summary "$port")"
             log_error "${name} port ${port} is already in use. Current listener: ${listener}"
@@ -673,13 +914,21 @@ bots_dynamic_wait_ready() {
     while [ "$elapsed" -lt "$max_wait" ]; do
         local all_ready=true
         missing=""
-        local name profile port source summary domains skills scopes session_file
-        while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+        local name profile port source summary domains skills scopes runtime session_file
+        while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
             session_file="$(bcs_bot_profile_dir "$profile")/.bcs/session.json"
-            if ! port_is_listening "$port"; then
-                all_ready=false
-                missing="${missing}${name}:port ${port}; "
-                continue
+            if [ "$runtime" = "rule" ]; then
+                if ! bots_dynamic_rule_profile_ready "$profile"; then
+                    all_ready=false
+                    missing="${missing}${name}:rule connection; "
+                    continue
+                fi
+            else
+                if ! port_is_listening "$port"; then
+                    all_ready=false
+                    missing="${missing}${name}:port ${port}; "
+                    continue
+                fi
             fi
             if ! session_has_token "$session_file"; then
                 all_ready=false
@@ -704,9 +953,9 @@ bots_dynamic_wait_ready() {
 
 bots_dynamic_onboard() {
     local bcs_cli; bcs_cli="$(bcs_cli_path)"
-    local name profile port source summary domains skills scopes profile_dir session_file token
+    local name profile port source summary domains skills scopes runtime profile_dir session_file token
 
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
         profile_dir="$(bcs_bot_profile_dir "$profile")"
         session_file="${profile_dir}/.bcs/session.json"
         token="$(bots_session_token "$session_file")"
@@ -746,8 +995,8 @@ bots_dynamic_capture_session_uuids() {
     rm -rf "$sessions_dir"
     mkdir -p "$sessions_dir"
 
-    local name profile port source summary domains skills scopes session_file bot_uuid token_present
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    local name profile port source summary domains skills scopes runtime session_file bot_uuid token_present
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
         session_file="$(bcs_bot_profile_dir "$profile")/.bcs/session.json"
         bot_uuid="$(bots_session_bot_uuid "$session_file")"
         if session_has_token "$session_file"; then
@@ -765,9 +1014,9 @@ bots_dynamic_capture_session_uuids() {
 bots_dynamic_preflight_existing_sessions() {
     local token_count=0
     local missing_count=0
-    local name profile port source summary domains skills scopes session_file token
+    local name profile port source summary domains skills scopes runtime session_file token
 
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
         session_file="$(bcs_bot_profile_dir "$profile")/.bcs/session.json"
         token="$(bots_session_token "$session_file")"
         if [ -n "$token" ]; then
@@ -820,9 +1069,15 @@ bots_dynamic_validate_session_uuids() {
 
 bots_dynamic_setup() {
     bots_dynamic_validate_manifest || return 1
-    bots_dynamic_check_ports_free || return 1
     mkdir -p "${LOG_DIR}"
-    setup_bcn_plugin || return 1
+    : > "$(bots_dynamic_log_file)"
+    if [ "$(bots_dynamic_manifest_version)" = "2" ] && bots_dynamic_has_runtime rule; then
+        bots_dynamic_validate_v2_manifest || return 1
+    fi
+    bots_dynamic_check_ports_free || return 1
+    if bots_dynamic_has_runtime openclaw; then
+        setup_bcn_plugin || return 1
+    fi
     log_info "Dynamic bot profile directory is valid: $(bots_dynamic_profile_dir)"
     log_info "Dynamic bot count: $(bots_dynamic_count)"
 }
@@ -842,12 +1097,22 @@ bots_dynamic_start() {
     bots_dynamic_check_profile_configs || return 1
     bots_dynamic_check_ports_free || return 1
 
-    setup_bcn_plugin || return 1
+    if [ "$(bots_dynamic_manifest_version)" = "2" ] && bots_dynamic_has_runtime rule; then
+        bots_dynamic_validate_v2_manifest || return 1
+    fi
+    if bots_dynamic_has_runtime openclaw; then
+        setup_bcn_plugin || return 1
+    fi
 
-    local name profile port source summary domains skills scopes
-    log_info "Preparing $(bots_dynamic_count) OpenClaw bot profile(s) from ${BOTS_PROFILE_DIR}..."
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
-        if ! bots_dynamic_setup_profile "$name" "$profile" "$port" "$source" "$summary" "$domains" "$skills" "$scopes"; then
+    local name profile port source summary domains skills scopes runtime
+    log_info "Preparing $(bots_dynamic_count) bot profile(s) from ${BOTS_PROFILE_DIR}..."
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
+        if [ "$runtime" = "rule" ]; then
+            if ! mkdir -p "$(bcs_bot_profile_dir "$profile")/.bcs"; then
+                log_error "Failed to prepare rule bot profile: ${name}"
+                return 1
+            fi
+        elif ! bots_dynamic_setup_profile "$name" "$profile" "$port" "$source" "$summary" "$domains" "$skills" "$scopes"; then
             log_error "Failed to prepare dynamic bot profile: ${name}"
             return 1
         fi
@@ -867,9 +1132,23 @@ bots_dynamic_start() {
     fi
     bots_dynamic_capture_session_uuids "$snapshot"
 
-    log_info "Starting $(bots_dynamic_count) OpenClaw bot(s) from ${BOTS_PROFILE_DIR}..."
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    local rule_host_started=false
+    if bots_dynamic_has_runtime rule; then
+        if ! bots_dynamic_start_rule_host; then
+            bots_restore_session_snapshot "$snapshot"
+            bots_remove_session_snapshot "$snapshot"
+            return 1
+        fi
+        rule_host_started=true
+    fi
+
+    log_info "Starting configured bot runtime(s) from ${BOTS_PROFILE_DIR}..."
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
+        [ "$runtime" = "openclaw" ] || continue
         if ! bots_dynamic_start_openclaw "$name" "$profile" "$port" "$(dirname "$(bots_dynamic_log_file)")/${profile}.log" "$source"; then
+            if [ "$rule_host_started" = true ]; then
+                bots_dynamic_stop_rule_host
+            fi
             bots_restore_session_snapshot "$snapshot"
             bots_remove_session_snapshot "$snapshot"
             return 1
@@ -877,12 +1156,18 @@ bots_dynamic_start() {
     done < <(bots_dynamic_specs)
 
     if ! bots_dynamic_wait_ready "${BCS_LOCAL_BOTS_READY_TIMEOUT:-120}"; then
+        if [ "$rule_host_started" = true ]; then
+            bots_dynamic_stop_rule_host
+        fi
         bots_restore_session_snapshot "$snapshot"
         bots_remove_session_snapshot "$snapshot"
-        log_error "Dynamic OpenClaw bots did not become ready; check $(bots_dynamic_log_file)"
+        log_error "Dynamic bots did not become ready; check $(bots_dynamic_log_file) and $(bots_dynamic_rule_log_file)"
         return 1
     fi
     if ! bots_dynamic_validate_session_uuids "$snapshot"; then
+        if [ "$rule_host_started" = true ]; then
+            bots_dynamic_stop_rule_host
+        fi
         bots_restore_session_snapshot "$snapshot"
         bots_remove_session_snapshot "$snapshot"
         return 1
@@ -890,7 +1175,7 @@ bots_dynamic_start() {
     bots_remove_session_snapshot "$snapshot"
 
     if bots_dynamic_onboard; then
-        log_info "Dynamic OpenClaw bots onboarded"
+        log_info "Dynamic bots onboarded"
     else
         return 1
     fi
@@ -900,31 +1185,40 @@ bots_dynamic_stop() {
     bots_dynamic_validate_manifest || return 1
     mkdir -p "${LOG_DIR}"
 
-    local name profile port source summary domains skills scopes
-    log_info "Stopping $(bots_dynamic_count) OpenClaw bot(s) from ${BOTS_PROFILE_DIR}..."
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    local name profile port source summary domains skills scopes runtime
+    log_info "Stopping dynamic bot runtime(s) from ${BOTS_PROFILE_DIR}..."
+    if bots_dynamic_has_runtime rule; then
+        bots_dynamic_stop_rule_host
+    fi
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
+        [ "$runtime" = "openclaw" ] || continue
         if bots_dynamic_runtime_matches "$name" "$profile" "$port" "$source"; then
             stop_port_processes_if_owned "$port" "${PROJECT_ROOT}" "${name} OpenClaw bot" || true
         elif port_is_listening "$port"; then
             log_warn "Skipping ${name} port ${port}: listener does not match this --profile-dir bot config"
         fi
     done < <(bots_dynamic_specs)
-    log_info "Dynamic OpenClaw bots stopped"
+    log_info "Dynamic bots stopped"
 }
 
 bots_dynamic_clean() {
     bots_dynamic_validate_manifest || return 1
     bots_dynamic_stop || true
 
-    local name profile port source summary domains skills scopes profile_dir workspace_dir
+    local name profile port source summary domains skills scopes runtime profile_dir workspace_dir
     log_info "Cleaning dynamic bot runtime data from ${BOTS_PROFILE_DIR}..."
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
         profile_dir="$(bcs_bot_profile_dir "$profile")"
-        workspace_dir="$(bots_dynamic_workspace_dir "$name" "$profile" "$source")"
-        rm -rf "$profile_dir" "$workspace_dir"
-        rm -f "$(dirname "$(bots_dynamic_log_file)")/${profile}.log"
+        if [ "$runtime" = "openclaw" ]; then
+            workspace_dir="$(bots_dynamic_workspace_dir "$name" "$profile" "$source")"
+            rm -rf "$profile_dir" "$workspace_dir"
+            rm -f "$(dirname "$(bots_dynamic_log_file)")/${profile}.log"
+        else
+            rm -rf "$profile_dir"
+        fi
     done < <(bots_dynamic_specs)
-    rm -f "$(bots_dynamic_log_file)"
+    rm -f "$(bots_dynamic_log_file)" "$(bots_dynamic_rule_log_file)" \
+        "$(bots_dynamic_rule_status_file)" "$(bots_dynamic_rule_pid_file)"
     log_info "Dynamic bot runtime data cleaned"
 }
 
@@ -932,11 +1226,20 @@ bots_dynamic_status() {
     bots_dynamic_validate_manifest || return 1
     echo "  Bots (--profile-dir ${BOTS_PROFILE_DIR}):"
 
-    local name profile port source summary domains skills scopes session_file bot_uuid
-    while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+    local name profile port source summary domains skills scopes runtime session_file bot_uuid behavior
+    while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
         session_file="$(bcs_bot_profile_dir "$profile")/.bcs/session.json"
         bot_uuid="$(bots_session_bot_uuid "$session_file")"
-        if port_is_listening "$port"; then
+        if [ "$runtime" = "rule" ] && bots_dynamic_rule_profile_ready "$profile"; then
+            behavior="$(bots_dynamic_rule_profile_behavior "$profile")"
+            if [ -n "$bot_uuid" ]; then
+                echo "    ${name}: Running (runtime: rule, behavior: ${behavior}, profile: ${profile}, bot_uuid: ${bot_uuid})"
+            else
+                echo "    ${name}: Connected (runtime: rule, behavior: ${behavior}, profile: ${profile}, session: missing bot_uuid)"
+            fi
+        elif [ "$runtime" = "rule" ]; then
+            echo "    ${name}: Stopped (runtime: rule, profile: ${profile})"
+        elif port_is_listening "$port"; then
             if [ -n "$bot_uuid" ]; then
                 echo "    ${name}: Running (port: ${port}, profile: ${profile}, bot_uuid: ${bot_uuid})"
             else
@@ -958,13 +1261,6 @@ bots_dynamic_prereqs() {
 
     echo -e "${CYAN}[bots:${BOTS_PROFILE_DIR}] Prerequisites${NC}"
 
-    if check_openclaw_installed; then
-        prereq_ok "openclaw: $(command -v openclaw)"
-    else
-        prereq_error "openclaw command not found. Run: ./scripts/singlebox.sh install-tools"
-        has_error=true
-    fi
-
     if check_command jq; then
         prereq_ok "jq: $(command -v jq)"
     else
@@ -979,26 +1275,46 @@ bots_dynamic_prereqs() {
         has_error=true
     fi
 
-    if [ "$(bcn_plugin_mode)" = "source" ]; then
-        if check_node_available; then
-            prereq_ok "node: $(node --version 2>&1)"
-        else
-            prereq_error "Node.js >= 22 not found (required to build BCN plugin in source mode). Install: brew install node@22 (macOS)"
-            has_error=true
-        fi
-
-        if check_command npm; then
-            prereq_ok "npm: $(npm --version 2>&1)"
-        else
-            prereq_error "npm not found (required to build BCN plugin in source mode). Install Node.js 22+ with npm."
-            has_error=true
-        fi
-    else
-        prereq_ok "BCN plugin mode: npm (source build not required)"
-    fi
-
     if bots_dynamic_validate_manifest; then
         prereq_ok "profile-dir manifest: $(bots_dynamic_manifest)"
+
+        if bots_dynamic_has_runtime openclaw; then
+            if check_openclaw_installed; then
+                prereq_ok "openclaw: $(command -v openclaw)"
+            else
+                prereq_error "openclaw command not found. Run: ./scripts/singlebox.sh install-tools"
+                has_error=true
+            fi
+
+            if [ "$(bcn_plugin_mode)" = "source" ]; then
+                if check_node_available; then
+                    prereq_ok "node: $(node --version 2>&1)"
+                else
+                    prereq_error "Node.js >= 22 not found (required to build BCN plugin in source mode). Install: brew install node@22 (macOS)"
+                    has_error=true
+                fi
+
+                if check_command npm; then
+                    prereq_ok "npm: $(npm --version 2>&1)"
+                else
+                    prereq_error "npm not found (required to build BCN plugin in source mode). Install Node.js 22+ with npm."
+                    has_error=true
+                fi
+            else
+                prereq_ok "BCN plugin mode: npm (source build not required)"
+            fi
+        fi
+
+        if [ "$(bots_dynamic_manifest_version)" = "2" ] && bots_dynamic_has_runtime rule; then
+            if [ -x "$(bots_dynamic_rule_binary)" ]; then
+                prereq_ok "bcs-rule-bot: $(bots_dynamic_rule_binary)"
+            elif check_command cargo; then
+                prereq_ok "cargo: $(command -v cargo) (will build bcs-rule-bot)"
+            else
+                prereq_error "cargo not found and bcs-rule-bot has not been built"
+                has_error=true
+            fi
+        fi
     else
         has_error=true
     fi
@@ -1009,8 +1325,9 @@ bots_dynamic_prereqs() {
             return 1
         fi
 
-        local name profile port source summary domains skills scopes listener
-        while IFS=$'\t' read -r name profile port source summary domains skills scopes; do
+        local name profile port source summary domains skills scopes runtime listener
+        while IFS=$'\t' read -r name profile port source summary domains skills scopes runtime; do
+            [ "$runtime" = "openclaw" ] || continue
             if port_is_listening "$port"; then
                 listener="$(port_listener_summary "$port")"
                 prereq_error "${name} port ${port} is in use. Current listener: ${listener}"

--- a/scripts/rule_bots_profile/bots.json
+++ b/scripts/rule_bots_profile/bots.json
@@ -1,0 +1,112 @@
+{
+  "version": 2,
+  "name": "BCS Rule Bot 示例组",
+  "scopes": "local,utility",
+  "bots": [
+    {
+      "profile": "friendly",
+      "name": "友善助手",
+      "summary": "依次使用预设内容回复",
+      "domains": "utility",
+      "skills": "preset-reply",
+      "runtime": {
+        "type": "rule",
+        "behavior": {
+          "type": "fixed",
+          "replies": ["你好", "是的", "没错", "好的"],
+          "scope": "session"
+        }
+      }
+    },
+    {
+      "profile": "random-greeter",
+      "name": "随机问候",
+      "summary": "从预设列表随机回复",
+      "domains": "utility",
+      "skills": "random-reply",
+      "runtime": {
+        "type": "rule",
+        "behavior": {
+          "type": "random_reply",
+          "replies": ["你好", "是的", "没错", "好的"],
+          "seed": 42,
+          "scope": "session"
+        }
+      }
+    },
+    {
+      "profile": "repeater",
+      "name": "复读机",
+      "summary": "重复并拼接输入消息",
+      "domains": "utility",
+      "skills": "echo",
+      "runtime": {
+        "type": "rule",
+        "response_delay_ms": 1500,
+        "behavior": {
+          "type": "echo",
+          "repeat": 3,
+          "separator": "、",
+          "prefix": "复读：",
+          "suffix": "。"
+        }
+      }
+    },
+    {
+      "profile": "random-number",
+      "name": "随机数字",
+      "summary": "返回指定范围内的随机整数",
+      "domains": "utility",
+      "skills": "random-number",
+      "runtime": {
+        "type": "rule",
+        "behavior": {
+          "type": "random_number",
+          "min": 1,
+          "max": 100,
+          "seed": 42,
+          "scope": "session"
+        }
+      }
+    },
+    {
+      "profile": "task-worker",
+      "name": "任务执行员",
+      "summary": "按规则完成任务协调者分配的任务",
+      "domains": "utility",
+      "skills": "task-worker",
+      "runtime": {
+        "type": "rule",
+        "behavior": {
+          "type": "task_worker",
+          "result": {
+            "type": "echo",
+            "prefix": "已完成："
+          }
+        }
+      }
+    },
+    {
+      "profile": "supervisor",
+      "name": "任务协调者",
+      "summary": "协调群成员任务并汇总结果",
+      "domains": "coordination",
+      "skills": "supervision",
+      "runtime": {
+        "type": "rule",
+        "behavior": {
+          "type": "supervisor",
+          "assignment": {
+            "mode": "each_member",
+            "task_template": "请处理以下任务：{input}"
+          },
+          "completion": {
+            "timeout_ms": 30000,
+            "max_retries": 0
+          },
+          "summary_template": "任务完成：成功 {success_count}，未完成 {failed_count}。\n{results}"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/test_bcn_plugin_source.sh
+++ b/scripts/test_bcn_plugin_source.sh
@@ -407,7 +407,7 @@ JSON
     . "${SCRIPT_DIR}/modules/bcs.sh"
     . "${SCRIPT_DIR}/modules/bots.sh"
     bots_bcn_plugin_load_dir() { printf '%s\n' "$npm_plugin"; }
-    bots_dynamic_specs() { printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "CEO" "ceo" "30001" "ceo" "CEO summary" "strategy" "routing" "production"; }
+    bots_dynamic_specs() { printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "CEO" "ceo" "30001" "ceo" "CEO summary" "strategy" "routing" "production" "openclaw"; }
     bots_dynamic_copy_profile_files() { return 0; }
     bots_dynamic_setup_bcs_skill() { return 0; }
     bots_dynamic_model_source_has_fields() { return 1; }

--- a/scripts/test_singlebox_rule_bots.sh
+++ b/scripts/test_singlebox_rule_bots.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FAILS=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    FAILS=$((FAILS + 1))
+}
+
+write_rule_manifest() {
+    local directory="$1"
+    mkdir -p "$directory"
+    cat > "${directory}/bots.json" <<'JSON'
+{
+  "version": 2,
+  "name": "rules",
+  "bots": [
+    {
+      "profile": "friendly",
+      "name": "友善助手",
+      "summary": "fixed",
+      "domains": "utility",
+      "skills": "reply",
+      "runtime": {
+        "type": "rule",
+        "behavior": {
+          "type": "fixed",
+          "replies": ["你好"]
+        }
+      }
+    },
+    {
+      "profile": "echo",
+      "name": "复读机",
+      "summary": "echo",
+      "domains": "utility",
+      "skills": "echo",
+      "runtime": {
+        "type": "rule",
+        "behavior": {
+          "type": "echo",
+          "repeat": 1000000
+        }
+      }
+    }
+  ]
+}
+JSON
+}
+
+with_rule_test_env() {
+    local temporary="$1"
+    BCS_DIR="${PROJECT_ROOT}/src/bcs"
+    LOG_DIR="${temporary}/logs"
+    DEP_DIR="${temporary}/dependencies"
+    BCS_PORT=21000
+    BOTS_PROFILE_DIR="${temporary}/profile"
+    OPENCLAW_PROFILE_ROOT="${temporary}/profiles"
+    OPENCLAW_PROFILE_PREFIX=""
+    mkdir -p "$LOG_DIR" "$DEP_DIR" "$OPENCLAW_PROFILE_ROOT"
+    . "${SCRIPT_DIR}/utils.sh"
+    . "${SCRIPT_DIR}/modules/bcs.sh"
+    . "${SCRIPT_DIR}/modules/bots.sh"
+}
+
+test_rule_manifest_has_no_ports_or_sources() {
+    local temporary
+    temporary="$(mktemp -d)"
+    write_rule_manifest "${temporary}/profile"
+    (
+        with_rule_test_env "$temporary"
+        bots_dynamic_validate_manifest
+        local specs
+        specs="$(bots_dynamic_specs)"
+        [ "$(printf '%s\n' "$specs" | wc -l | tr -d ' ')" = "2" ]
+        printf '%s\n' "$specs" | awk -F '\t' '
+            NF != 9 { exit 1 }
+            $3 != "-" { exit 1 }
+            $4 != "-" { exit 1 }
+            $9 != "rule" { exit 1 }
+        '
+        ! bots_dynamic_has_runtime openclaw
+        bots_dynamic_has_runtime rule
+    ) || fail "version 2 rule-only manifest should not require ports or source directories"
+    rm -rf "$temporary"
+}
+
+test_rule_prereqs_do_not_require_openclaw() {
+    local temporary
+    temporary="$(mktemp -d)"
+    write_rule_manifest "${temporary}/profile"
+    (
+        with_rule_test_env "$temporary"
+        check_openclaw_installed() {
+            echo "OpenClaw prerequisite must not be checked for a rule-only profile" >&2
+            return 1
+        }
+        check_bcs_cli_binary() { return 0; }
+        bcs_cli_path() { printf '/usr/bin/true\n'; }
+        bots_dynamic_rule_binary() { printf '/usr/bin/true\n'; }
+        bots_dynamic_prereqs
+    ) || fail "rule-only prerequisites should not require OpenClaw, Node.js, npm, or ports"
+    rm -rf "$temporary"
+}
+
+test_version_two_rejects_unknown_fields_early() {
+    local temporary
+    temporary="$(mktemp -d)"
+    write_rule_manifest "${temporary}/profile"
+    jq '.unexpected = true' "${temporary}/profile/bots.json" \
+        > "${temporary}/profile/bots.invalid.json"
+    mv "${temporary}/profile/bots.invalid.json" "${temporary}/profile/bots.json"
+    (
+        with_rule_test_env "$temporary"
+        ! bots_dynamic_validate_manifest
+    ) || fail "version 2 manifests must reject unknown root fields before startup"
+    rm -rf "$temporary"
+}
+
+test_version_one_defaults_to_openclaw() {
+    local temporary
+    temporary="$(mktemp -d)"
+    (
+        with_rule_test_env "$temporary"
+        BOTS_PROFILE_DIR="${PROJECT_ROOT}/scripts/5bots_profile"
+        bots_dynamic_validate_manifest
+        bots_dynamic_has_runtime openclaw
+        ! bots_dynamic_has_runtime rule
+        bots_dynamic_specs | awk -F '\t' '
+            NF != 9 { exit 1 }
+            $3 !~ /^[0-9]+$/ { exit 1 }
+            $4 == "-" { exit 1 }
+            $9 != "openclaw" { exit 1 }
+        '
+    ) || fail "version 1 manifests should retain the existing OpenClaw defaults"
+    rm -rf "$temporary"
+}
+
+test_rule_manifest_has_no_ports_or_sources
+test_rule_prereqs_do_not_require_openclaw
+test_version_two_rejects_unknown_fields_early
+test_version_one_defaults_to_openclaw
+
+if [ "$FAILS" -eq 0 ]; then
+    echo "ALL PASS"
+else
+    echo "${FAILS} FAILURE(S)"
+    exit 1
+fi

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1221,6 +1221,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs-rule-bot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs-protocol",
+ "clap",
+ "futures",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "bcs-secret"
 version = "0.1.0"
 dependencies = [

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     # tools
     "crates/tools/bcs-admin",
     "crates/tools/bcs-cli",
+    "crates/tools/bcs-rule-bot",
     # auxiliary
     "crates/auxiliary/bcs-telemetry",
     "crates/auxiliary/ding-logger",
@@ -106,6 +107,7 @@ version      = "0.1.0"
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 
 # HTTP server
 axum       = { version = "0.8", features = ["ws"] }
@@ -202,6 +204,7 @@ redis = { version = "0.27.6", features = ["tokio-comp"] }
 bcs            = { path = "crates/bootstrap/bcs" }
 bcs-admin      = { path = "crates/tools/bcs-admin" }
 bcs-cli        = { path = "crates/tools/bcs-cli" }
+bcs-rule-bot   = { path = "crates/tools/bcs-rule-bot" }
 bcs-bot   = { path = "crates/services/bcs-bot" }
 bcs-bot-store = { path = "crates/services/bcs-bot-store" }
 bcs-channel-store = { path = "crates/services/bcs-channel-store" }

--- a/src/bcs/crates/tools/bcs-rule-bot/CONTEXT.md
+++ b/src/bcs/crates/tools/bcs-rule-bot/CONTEXT.md
@@ -1,0 +1,39 @@
+# bcs-rule-bot Context
+
+## Provides
+
+- A deterministic, non-LLM bot runtime for BCS development and end-to-end tests.
+- One host process for all `runtime.type=rule` entries in a profile manifest.
+- Fixed, random reply, echo, random number, task worker, and supervisor behaviors.
+- Native BCS WebSocket sessions, heartbeats, history, abort, and session cleanup.
+
+## Consumes
+
+- `bcs-protocol` WebSocket DTOs.
+- Version 2 `bots.json` profile manifests.
+- Per-profile `.bcs/session.json` identity files.
+- Existing BCS `task.dispatch` and `task.complete` methods.
+
+## Allowed dependencies
+
+- `bcs-protocol`
+- Async runtime, WebSocket client, CLI, serialization, random, and logging crates
+
+## Forbidden dependencies
+
+- `bootstrap/bcs`
+- `adapters/*`
+- `services/*`
+- `plugins/*`
+- LLM clients and model configuration
+
+## Runtime ownership
+
+This crate owns Rule Bot behavior and client-side session state. It does not
+change BCS routing policy, server application services, or persistence.
+
+## Tests
+
+- `cargo test --package bcs-rule-bot --manifest-path src/bcs/Cargo.toml`
+- `cargo clippy --package bcs-rule-bot --all-targets --no-deps --manifest-path src/bcs/Cargo.toml -- -D warnings`
+- `bash scripts/test_singlebox_rule_bots.sh`

--- a/src/bcs/crates/tools/bcs-rule-bot/Cargo.toml
+++ b/src/bcs/crates/tools/bcs-rule-bot/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "bcs-rule-bot"
+description = "Rule-driven BCS bot runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+bcs-protocol = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tokio-tungstenite = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/bcs/crates/tools/bcs-rule-bot/src/behavior/mod.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/behavior/mod.rs
@@ -1,0 +1,437 @@
+use std::collections::HashMap;
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use thiserror::Error;
+
+use crate::config::{BehaviorConfig, StateScope, SupervisorAssignment, SupervisorCompletion};
+
+#[derive(Debug, Clone)]
+pub struct BehaviorInput {
+    pub session_key: String,
+    pub bcs_group_id: String,
+    pub bcs_session_id: Option<String>,
+    pub message_text: String,
+    pub context_message: String,
+    pub task_id: Option<String>,
+    pub sender_name: String,
+    pub recipient_role: Option<String>,
+    pub group_type: Option<String>,
+    pub participants: Vec<String>,
+}
+
+impl BehaviorInput {
+    pub fn effective_session_key(&self) -> &str {
+        self.bcs_session_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .or_else(|| (!self.session_key.is_empty()).then_some(self.session_key.as_str()))
+            .unwrap_or(self.bcs_group_id.as_str())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum BehaviorOutcome {
+    Reply(String),
+    StartSupervisor(SupervisorStart),
+}
+
+#[derive(Debug, Clone)]
+pub struct SupervisorStart {
+    pub assignment: SupervisorAssignment,
+    pub completion: SupervisorCompletion,
+    pub summary_template: String,
+}
+
+#[derive(Debug, Error)]
+pub enum BehaviorError {
+    #[error("echo output size overflow")]
+    OutputSizeOverflow,
+    #[error("unable to reserve memory for echo output")]
+    ResourceExhausted,
+}
+
+pub struct BehaviorRuntime {
+    kind: BehaviorKind,
+}
+
+enum BehaviorKind {
+    Fixed {
+        replies: Vec<String>,
+        scope: StateScope,
+        cursors: HashMap<String, usize>,
+    },
+    RandomReply {
+        replies: Vec<String>,
+        scope: StateScope,
+        random: ScopedRandom,
+    },
+    Echo {
+        repeat: u64,
+        separator: String,
+        prefix: String,
+        suffix: String,
+    },
+    RandomNumber {
+        min: i64,
+        max: i64,
+        scope: StateScope,
+        random: ScopedRandom,
+    },
+    TaskWorker {
+        result: Box<BehaviorRuntime>,
+    },
+    Supervisor {
+        start: SupervisorStart,
+    },
+}
+
+struct ScopedRandom {
+    base_seed: u64,
+    generators: HashMap<String, StdRng>,
+}
+
+impl BehaviorRuntime {
+    pub fn new(config: &BehaviorConfig) -> Self {
+        let kind = match config {
+            BehaviorConfig::Fixed { replies, scope } => BehaviorKind::Fixed {
+                replies: replies.clone(),
+                scope: *scope,
+                cursors: HashMap::new(),
+            },
+            BehaviorConfig::RandomReply {
+                replies,
+                seed,
+                scope,
+            } => BehaviorKind::RandomReply {
+                replies: replies.clone(),
+                scope: *scope,
+                random: ScopedRandom::new(*seed),
+            },
+            BehaviorConfig::Echo {
+                repeat,
+                separator,
+                prefix,
+                suffix,
+            } => BehaviorKind::Echo {
+                repeat: *repeat,
+                separator: separator.clone(),
+                prefix: prefix.clone(),
+                suffix: suffix.clone(),
+            },
+            BehaviorConfig::RandomNumber {
+                min,
+                max,
+                seed,
+                scope,
+            } => BehaviorKind::RandomNumber {
+                min: *min,
+                max: *max,
+                scope: *scope,
+                random: ScopedRandom::new(*seed),
+            },
+            BehaviorConfig::TaskWorker { result } => BehaviorKind::TaskWorker {
+                result: Box::new(Self::new(result)),
+            },
+            BehaviorConfig::Supervisor {
+                assignment,
+                completion,
+                summary_template,
+            } => BehaviorKind::Supervisor {
+                start: SupervisorStart {
+                    assignment: assignment.clone(),
+                    completion: completion.clone(),
+                    summary_template: summary_template.clone(),
+                },
+            },
+        };
+        Self { kind }
+    }
+
+    pub fn handle_send(&mut self, input: &BehaviorInput) -> Result<BehaviorOutcome, BehaviorError> {
+        match &mut self.kind {
+            BehaviorKind::Fixed {
+                replies,
+                scope,
+                cursors,
+            } => {
+                let key = scope_key(*scope, input);
+                let cursor = cursors.entry(key).or_insert(0);
+                let reply = replies[*cursor % replies.len()].clone();
+                *cursor = (*cursor + 1) % replies.len();
+                Ok(BehaviorOutcome::Reply(reply))
+            }
+            BehaviorKind::RandomReply {
+                replies,
+                scope,
+                random,
+            } => {
+                let key = scope_key(*scope, input);
+                let index = random.generator(&key).gen_range(0..replies.len());
+                Ok(BehaviorOutcome::Reply(replies[index].clone()))
+            }
+            BehaviorKind::Echo {
+                repeat,
+                separator,
+                prefix,
+                suffix,
+            } => Ok(BehaviorOutcome::Reply(build_echo(
+                &input.message_text,
+                *repeat,
+                separator,
+                prefix,
+                suffix,
+            )?)),
+            BehaviorKind::RandomNumber {
+                min,
+                max,
+                scope,
+                random,
+            } => {
+                let key = scope_key(*scope, input);
+                let number = random.generator(&key).gen_range(*min..=*max);
+                Ok(BehaviorOutcome::Reply(number.to_string()))
+            }
+            BehaviorKind::TaskWorker { result } => result.handle_send(input),
+            BehaviorKind::Supervisor { start } => {
+                Ok(BehaviorOutcome::StartSupervisor(start.clone()))
+            }
+        }
+    }
+
+    pub fn clear_session(&mut self, session_key: &str) {
+        match &mut self.kind {
+            BehaviorKind::Fixed { cursors, .. } => {
+                cursors.remove(session_key);
+            }
+            BehaviorKind::RandomReply { random, .. }
+            | BehaviorKind::RandomNumber { random, .. } => {
+                random.generators.remove(session_key);
+            }
+            BehaviorKind::TaskWorker { result } => result.clear_session(session_key),
+            BehaviorKind::Echo { .. } | BehaviorKind::Supervisor { .. } => {}
+        }
+    }
+}
+
+impl ScopedRandom {
+    fn new(seed: Option<u64>) -> Self {
+        Self {
+            base_seed: seed.unwrap_or_else(rand::random),
+            generators: HashMap::new(),
+        }
+    }
+
+    fn generator(&mut self, key: &str) -> &mut StdRng {
+        self.generators
+            .entry(key.to_string())
+            .or_insert_with(|| StdRng::seed_from_u64(derive_seed(self.base_seed, key)))
+    }
+}
+
+fn scope_key(scope: StateScope, input: &BehaviorInput) -> String {
+    match scope {
+        StateScope::Session => input.effective_session_key().to_string(),
+        StateScope::Bot => "__bot__".to_string(),
+    }
+}
+
+fn derive_seed(base_seed: u64, key: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64 ^ base_seed;
+    for byte in key.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn build_echo(
+    message: &str,
+    repeat: u64,
+    separator: &str,
+    prefix: &str,
+    suffix: &str,
+) -> Result<String, BehaviorError> {
+    if message.is_empty() && separator.is_empty() {
+        let output_bytes = prefix
+            .len()
+            .checked_add(suffix.len())
+            .ok_or(BehaviorError::OutputSizeOverflow)?;
+        let mut output = String::new();
+        output
+            .try_reserve_exact(output_bytes)
+            .map_err(|_| BehaviorError::ResourceExhausted)?;
+        output.push_str(prefix);
+        output.push_str(suffix);
+        return Ok(output);
+    }
+
+    let count = usize::try_from(repeat).map_err(|_| BehaviorError::OutputSizeOverflow)?;
+    let repeated_bytes = message
+        .len()
+        .checked_mul(count)
+        .ok_or(BehaviorError::OutputSizeOverflow)?;
+    let separator_bytes = separator
+        .len()
+        .checked_mul(count.saturating_sub(1))
+        .ok_or(BehaviorError::OutputSizeOverflow)?;
+    let output_bytes = prefix
+        .len()
+        .checked_add(repeated_bytes)
+        .and_then(|size| size.checked_add(separator_bytes))
+        .and_then(|size| size.checked_add(suffix.len()))
+        .ok_or(BehaviorError::OutputSizeOverflow)?;
+    if output_bytes > isize::MAX as usize {
+        return Err(BehaviorError::OutputSizeOverflow);
+    }
+
+    let mut output = String::new();
+    output
+        .try_reserve_exact(output_bytes)
+        .map_err(|_| BehaviorError::ResourceExhausted)?;
+    output.push_str(prefix);
+    for index in 0..count {
+        if index > 0 {
+            output.push_str(separator);
+        }
+        output.push_str(message);
+    }
+    output.push_str(suffix);
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(session: &str, message: &str) -> BehaviorInput {
+        BehaviorInput {
+            session_key: session.to_string(),
+            bcs_group_id: "group".to_string(),
+            bcs_session_id: None,
+            message_text: message.to_string(),
+            context_message: message.to_string(),
+            task_id: None,
+            sender_name: "human".to_string(),
+            recipient_role: None,
+            group_type: None,
+            participants: Vec::new(),
+        }
+    }
+
+    fn reply(runtime: &mut BehaviorRuntime, input: &BehaviorInput) -> String {
+        match runtime
+            .handle_send(input)
+            .unwrap_or_else(|error| panic!("{error}"))
+        {
+            BehaviorOutcome::Reply(reply) => reply,
+            BehaviorOutcome::StartSupervisor(_) => panic!("unexpected supervisor"),
+        }
+    }
+
+    #[test]
+    fn fixed_cycles_per_session() {
+        let mut runtime = BehaviorRuntime::new(&BehaviorConfig::Fixed {
+            replies: vec!["你好".to_string(), "好的".to_string()],
+            scope: StateScope::Session,
+        });
+
+        assert_eq!(reply(&mut runtime, &input("a", "x")), "你好");
+        assert_eq!(reply(&mut runtime, &input("a", "x")), "好的");
+        assert_eq!(reply(&mut runtime, &input("a", "x")), "你好");
+        assert_eq!(reply(&mut runtime, &input("b", "x")), "你好");
+    }
+
+    #[test]
+    fn fixed_single_reply_is_constant() {
+        let mut runtime = BehaviorRuntime::new(&BehaviorConfig::Fixed {
+            replies: vec!["你好".to_string()],
+            scope: StateScope::Session,
+        });
+
+        assert_eq!(reply(&mut runtime, &input("a", "x")), "你好");
+        assert_eq!(reply(&mut runtime, &input("a", "x")), "你好");
+    }
+
+    #[test]
+    fn random_reply_is_seeded_and_in_pool() {
+        let config = BehaviorConfig::RandomReply {
+            replies: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            seed: Some(42),
+            scope: StateScope::Session,
+        };
+        let mut first = BehaviorRuntime::new(&config);
+        let mut second = BehaviorRuntime::new(&config);
+
+        let first_values = (0..8)
+            .map(|_| reply(&mut first, &input("session", "x")))
+            .collect::<Vec<_>>();
+        let second_values = (0..8)
+            .map(|_| reply(&mut second, &input("session", "x")))
+            .collect::<Vec<_>>();
+
+        assert_eq!(first_values, second_values);
+        assert!(
+            first_values
+                .iter()
+                .all(|value| ["a", "b", "c"].contains(&value.as_str()))
+        );
+    }
+
+    #[test]
+    fn echo_repeats_without_business_limit() {
+        let mut runtime = BehaviorRuntime::new(&BehaviorConfig::Echo {
+            repeat: 3,
+            separator: "、".to_string(),
+            prefix: "复读：".to_string(),
+            suffix: "。".to_string(),
+        });
+
+        assert_eq!(
+            reply(&mut runtime, &input("session", "你好")),
+            "复读：你好、你好、你好。"
+        );
+    }
+
+    #[test]
+    fn echo_reports_address_space_overflow() {
+        let result = build_echo("x", u64::MAX, "", "", "");
+
+        assert!(matches!(result, Err(BehaviorError::OutputSizeOverflow)));
+    }
+
+    #[test]
+    fn echo_avoids_unbounded_work_for_empty_repeated_content() {
+        let result = build_echo("", u64::MAX, "", "前", "后")
+            .unwrap_or_else(|error| panic!("empty echo failed: {error}"));
+
+        assert_eq!(result, "前后");
+    }
+
+    #[test]
+    fn random_number_is_inclusive_and_seeded() {
+        let config = BehaviorConfig::RandomNumber {
+            min: -2,
+            max: 2,
+            seed: Some(9),
+            scope: StateScope::Bot,
+        };
+        let mut first = BehaviorRuntime::new(&config);
+        let mut second = BehaviorRuntime::new(&config);
+
+        let first_values = (0..10)
+            .map(|_| reply(&mut first, &input("a", "x")))
+            .collect::<Vec<_>>();
+        let second_values = (0..10)
+            .map(|_| reply(&mut second, &input("b", "x")))
+            .collect::<Vec<_>>();
+
+        assert_eq!(first_values, second_values);
+        assert!(first_values.iter().all(|value| {
+            value
+                .parse::<i64>()
+                .map(|number| (-2..=2).contains(&number))
+                .unwrap_or(false)
+        }));
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/config.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/config.rs
@@ -1,0 +1,426 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    pub version: u32,
+    pub name: String,
+    #[serde(default)]
+    pub port_start: Option<u16>,
+    #[serde(default)]
+    pub port_step: Option<u16>,
+    #[serde(default)]
+    pub scopes: Option<String>,
+    pub bots: Vec<BotProfile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BotProfile {
+    #[serde(default)]
+    pub source: Option<String>,
+    pub profile: String,
+    pub name: String,
+    pub summary: String,
+    pub domains: String,
+    pub skills: String,
+    #[serde(default)]
+    pub scopes: Option<String>,
+    #[serde(default)]
+    pub runtime: RuntimeConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RuntimeConfig {
+    #[default]
+    Openclaw,
+    Rule {
+        #[serde(default = "default_response_delay_ms")]
+        response_delay_ms: u64,
+        behavior: BehaviorConfig,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StateScope {
+    #[default]
+    Session,
+    Bot,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum BehaviorConfig {
+    Fixed {
+        replies: Vec<String>,
+        #[serde(default)]
+        scope: StateScope,
+    },
+    RandomReply {
+        replies: Vec<String>,
+        #[serde(default)]
+        seed: Option<u64>,
+        #[serde(default)]
+        scope: StateScope,
+    },
+    Echo {
+        #[serde(default = "default_repeat")]
+        repeat: u64,
+        #[serde(default)]
+        separator: String,
+        #[serde(default)]
+        prefix: String,
+        #[serde(default)]
+        suffix: String,
+    },
+    RandomNumber {
+        min: i64,
+        max: i64,
+        #[serde(default)]
+        seed: Option<u64>,
+        #[serde(default)]
+        scope: StateScope,
+    },
+    TaskWorker {
+        result: Box<BehaviorConfig>,
+    },
+    Supervisor {
+        assignment: SupervisorAssignment,
+        completion: SupervisorCompletion,
+        summary_template: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorAssignment {
+    pub mode: SupervisorAssignmentMode,
+    pub task_template: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SupervisorAssignmentMode {
+    EachMember,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorCompletion {
+    pub timeout_ms: u64,
+    #[serde(default)]
+    pub max_retries: u32,
+}
+
+fn default_repeat() -> u64 {
+    1
+}
+
+fn default_response_delay_ms() -> u64 {
+    1_000
+}
+
+impl Manifest {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read manifest {}", path.display()))?;
+        let manifest: Self = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse manifest {}", path.display()))?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.version != 2 {
+            bail!(
+                "bcs-rule-bot requires manifest version 2, got {}",
+                self.version
+            );
+        }
+        require_non_empty("name", &self.name)?;
+        if self.bots.is_empty() {
+            bail!("bots must not be empty");
+        }
+
+        let mut profiles = HashSet::new();
+        let mut has_openclaw = false;
+        for (index, bot) in self.bots.iter().enumerate() {
+            bot.validate(index)?;
+            if !profiles.insert(bot.profile.as_str()) {
+                bail!("bots[{index}].profile is duplicated: {}", bot.profile);
+            }
+            has_openclaw |= matches!(bot.runtime, RuntimeConfig::Openclaw);
+        }
+        if has_openclaw {
+            if self.port_start.is_none() {
+                bail!("port_start is required when an OpenClaw runtime is present");
+            }
+            match self.port_step {
+                Some(0) | None => {
+                    bail!("port_step must be greater than 0 when an OpenClaw runtime is present")
+                }
+                Some(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    pub fn rule_bots(&self) -> impl Iterator<Item = &BotProfile> {
+        self.bots
+            .iter()
+            .filter(|bot| matches!(bot.runtime, RuntimeConfig::Rule { .. }))
+    }
+}
+
+impl BotProfile {
+    fn validate(&self, index: usize) -> Result<()> {
+        validate_profile_name(index, &self.profile)?;
+        require_non_empty(&format!("bots[{index}].name"), &self.name)?;
+        require_non_empty(&format!("bots[{index}].summary"), &self.summary)?;
+        require_non_empty(&format!("bots[{index}].domains"), &self.domains)?;
+        require_non_empty(&format!("bots[{index}].skills"), &self.skills)?;
+
+        match &self.runtime {
+            RuntimeConfig::Openclaw => {
+                let source = self.source.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!("bots[{index}].source is required for OpenClaw")
+                })?;
+                require_non_empty(&format!("bots[{index}].source"), source)?;
+                if source.contains('/') || source.contains('\\') || source.contains("..") {
+                    bail!("bots[{index}].source must be a direct child directory name");
+                }
+            }
+            RuntimeConfig::Rule { behavior, .. } => {
+                if self.source.is_some() {
+                    bail!("bots[{index}].source is not allowed for rule runtime");
+                }
+                behavior.validate(&format!("bots[{index}].runtime.behavior"))?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn response_delay_ms(&self) -> u64 {
+        match self.runtime {
+            RuntimeConfig::Rule {
+                response_delay_ms, ..
+            } => response_delay_ms,
+            RuntimeConfig::Openclaw => 0,
+        }
+    }
+
+    pub fn behavior(&self) -> Option<&BehaviorConfig> {
+        match &self.runtime {
+            RuntimeConfig::Rule { behavior, .. } => Some(behavior),
+            RuntimeConfig::Openclaw => None,
+        }
+    }
+
+    pub fn effective_scopes<'a>(&'a self, manifest: &'a Manifest) -> &'a str {
+        self.scopes
+            .as_deref()
+            .or(manifest.scopes.as_deref())
+            .unwrap_or("local")
+    }
+
+    pub fn behavior_name(&self) -> &'static str {
+        self.behavior().map_or("openclaw", BehaviorConfig::name)
+    }
+}
+
+impl BehaviorConfig {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Fixed { .. } => "fixed",
+            Self::RandomReply { .. } => "random_reply",
+            Self::Echo { .. } => "echo",
+            Self::RandomNumber { .. } => "random_number",
+            Self::TaskWorker { .. } => "task_worker",
+            Self::Supervisor { .. } => "supervisor",
+        }
+    }
+
+    fn validate(&self, path: &str) -> Result<()> {
+        match self {
+            Self::Fixed { replies, .. } | Self::RandomReply { replies, .. } => {
+                validate_replies(path, replies)?;
+            }
+            Self::Echo { repeat, .. } => {
+                if *repeat == 0 {
+                    bail!("{path}.repeat must be greater than 0");
+                }
+            }
+            Self::RandomNumber { min, max, .. } => {
+                if min > max {
+                    bail!("{path}.min must be less than or equal to {path}.max");
+                }
+            }
+            Self::TaskWorker { result } => {
+                if matches!(
+                    result.as_ref(),
+                    Self::TaskWorker { .. } | Self::Supervisor { .. }
+                ) {
+                    bail!("{path}.result must be fixed, random_reply, echo, or random_number");
+                }
+                result.validate(&format!("{path}.result"))?;
+            }
+            Self::Supervisor {
+                assignment,
+                completion,
+                summary_template,
+            } => {
+                require_non_empty(
+                    &format!("{path}.assignment.task_template"),
+                    &assignment.task_template,
+                )?;
+                if assignment.mode != SupervisorAssignmentMode::EachMember {
+                    bail!("{path}.assignment.mode is not supported");
+                }
+                if completion.timeout_ms == 0 {
+                    bail!("{path}.completion.timeout_ms must be greater than 0");
+                }
+                require_non_empty(&format!("{path}.summary_template"), summary_template)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_profile_name(index: usize, value: &str) -> Result<()> {
+    require_non_empty(&format!("bots[{index}].profile"), value)?;
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+    {
+        bail!("bots[{index}].profile must match ^[A-Za-z0-9_-]+$");
+    }
+    Ok(())
+}
+
+fn validate_replies(path: &str, replies: &[String]) -> Result<()> {
+    if replies.is_empty() {
+        bail!("{path}.replies must not be empty");
+    }
+    if let Some(index) = replies.iter().position(|reply| reply.trim().is_empty()) {
+        bail!("{path}.replies[{index}] must not be empty");
+    }
+    Ok(())
+}
+
+fn require_non_empty(path: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{path} must not be empty");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(value: serde_json::Value) -> Result<Manifest> {
+        let manifest: Manifest = serde_json::from_value(value)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    fn rule_bot(behavior: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "profile": "rule",
+            "name": "Rule",
+            "summary": "Rule bot",
+            "domains": "utility",
+            "skills": "reply",
+            "runtime": {
+                "type": "rule",
+                "behavior": behavior
+            }
+        })
+    }
+
+    #[test]
+    fn accepts_rule_only_manifest_without_ports() {
+        let manifest = parse(serde_json::json!({
+            "version": 2,
+            "name": "rules",
+            "bots": [rule_bot(serde_json::json!({
+                "type": "fixed",
+                "replies": ["你好"]
+            }))]
+        }))
+        .unwrap_or_else(|error| panic!("rule-only manifest: {error}"));
+
+        assert_eq!(manifest.rule_bots().count(), 1);
+        assert_eq!(manifest.bots[0].response_delay_ms(), 1_000);
+    }
+
+    #[test]
+    fn explicit_zero_response_delay_remains_supported() {
+        let mut bot = rule_bot(serde_json::json!({
+            "type": "fixed",
+            "replies": ["ok"]
+        }));
+        bot["runtime"]["response_delay_ms"] = serde_json::json!(0);
+        let manifest = parse(serde_json::json!({
+            "version": 2,
+            "name": "rules",
+            "bots": [bot]
+        }))
+        .unwrap_or_else(|error| panic!("explicit zero delay must be valid: {error}"));
+
+        assert_eq!(manifest.bots[0].response_delay_ms(), 0);
+    }
+
+    #[test]
+    fn rejects_unknown_behavior_fields() {
+        let result = parse(serde_json::json!({
+            "version": 2,
+            "name": "rules",
+            "bots": [rule_bot(serde_json::json!({
+                "type": "echo",
+                "repeat": 1,
+                "unknown": true
+            }))]
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accepts_unbounded_positive_echo_repeat() {
+        let manifest = parse(serde_json::json!({
+            "version": 2,
+            "name": "rules",
+            "bots": [rule_bot(serde_json::json!({
+                "type": "echo",
+                "repeat": u64::MAX
+            }))]
+        }))
+        .unwrap_or_else(|error| panic!("large repeat must pass config validation: {error}"));
+
+        assert_eq!(manifest.rule_bots().count(), 1);
+    }
+
+    #[test]
+    fn rejects_rule_source() {
+        let mut bot = rule_bot(serde_json::json!({
+            "type": "fixed",
+            "replies": ["ok"]
+        }));
+        bot["source"] = serde_json::Value::String("persona".to_string());
+        let result = parse(serde_json::json!({
+            "version": 2,
+            "name": "rules",
+            "bots": [bot]
+        }));
+
+        assert!(result.is_err());
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/config.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/config.rs
@@ -423,4 +423,366 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[test]
+    fn loads_mixed_manifest_and_resolves_runtime_metadata() {
+        let temp = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("temporary directory should be created: {error}"));
+        let path = temp.path().join("bots.json");
+        let value = serde_json::json!({
+            "version": 2,
+            "name": "mixed",
+            "port_start": 18_000,
+            "port_step": 10,
+            "scopes": "group",
+            "bots": [
+                {
+                    "source": "assistant",
+                    "profile": "openclaw",
+                    "name": "OpenClaw",
+                    "summary": "LLM assistant",
+                    "domains": "general",
+                    "skills": "reasoning"
+                },
+                {
+                    "profile": "echo",
+                    "name": "Echo",
+                    "summary": "Repeats messages",
+                    "domains": "utility",
+                    "skills": "reply",
+                    "scopes": "local",
+                    "runtime": {
+                        "type": "rule",
+                        "behavior": {
+                            "type": "echo"
+                        }
+                    }
+                }
+            ]
+        });
+        fs::write(
+            &path,
+            serde_json::to_vec(&value)
+                .unwrap_or_else(|error| panic!("manifest should serialize: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("manifest fixture should be written: {error}"));
+
+        let manifest = Manifest::load(&path)
+            .unwrap_or_else(|error| panic!("mixed manifest should load: {error}"));
+
+        assert_eq!(manifest.name, "mixed");
+        assert_eq!(manifest.rule_bots().count(), 1);
+        assert_eq!(manifest.bots[0].response_delay_ms(), 0);
+        assert!(manifest.bots[0].behavior().is_none());
+        assert_eq!(manifest.bots[0].behavior_name(), "openclaw");
+        assert_eq!(manifest.bots[0].effective_scopes(&manifest), "group");
+        assert_eq!(manifest.bots[1].effective_scopes(&manifest), "local");
+        assert_eq!(manifest.bots[1].behavior_name(), "echo");
+        match manifest.bots[1].behavior() {
+            Some(BehaviorConfig::Echo { repeat, .. }) => assert_eq!(*repeat, 1),
+            other => panic!("expected echo behavior, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn effective_scopes_default_to_local() {
+        let manifest = parse(serde_json::json!({
+            "version": 2,
+            "name": "rules",
+            "bots": [rule_bot(serde_json::json!({
+                "type": "fixed",
+                "replies": ["ok"]
+            }))]
+        }))
+        .unwrap_or_else(|error| panic!("rule manifest should parse: {error}"));
+
+        assert_eq!(manifest.bots[0].effective_scopes(&manifest), "local");
+        assert_eq!(manifest.bots[0].behavior_name(), "fixed");
+    }
+
+    #[test]
+    fn rejects_invalid_manifest_structure() {
+        let openclaw = serde_json::json!({
+            "source": "assistant",
+            "profile": "openclaw",
+            "name": "OpenClaw",
+            "summary": "LLM assistant",
+            "domains": "general",
+            "skills": "reasoning"
+        });
+        let cases = vec![
+            (
+                serde_json::json!({
+                    "version": 1,
+                    "name": "invalid",
+                    "bots": [rule_bot(serde_json::json!({
+                        "type": "fixed",
+                        "replies": ["ok"]
+                    }))]
+                }),
+                "manifest version 2",
+            ),
+            (
+                serde_json::json!({
+                    "version": 2,
+                    "name": " ",
+                    "bots": [rule_bot(serde_json::json!({
+                        "type": "fixed",
+                        "replies": ["ok"]
+                    }))]
+                }),
+                "name must not be empty",
+            ),
+            (
+                serde_json::json!({"version": 2, "name": "empty", "bots": []}),
+                "bots must not be empty",
+            ),
+            (
+                serde_json::json!({
+                    "version": 2,
+                    "name": "duplicate",
+                    "bots": [
+                        rule_bot(serde_json::json!({
+                            "type": "fixed",
+                            "replies": ["ok"]
+                        })),
+                        rule_bot(serde_json::json!({
+                            "type": "echo"
+                        }))
+                    ]
+                }),
+                "profile is duplicated",
+            ),
+            (
+                serde_json::json!({
+                    "version": 2,
+                    "name": "openclaw",
+                    "bots": [openclaw.clone()]
+                }),
+                "port_start is required",
+            ),
+            (
+                serde_json::json!({
+                    "version": 2,
+                    "name": "openclaw",
+                    "port_start": 18_000,
+                    "bots": [openclaw.clone()]
+                }),
+                "port_step must be greater than 0",
+            ),
+            (
+                serde_json::json!({
+                    "version": 2,
+                    "name": "openclaw",
+                    "port_start": 18_000,
+                    "port_step": 0,
+                    "bots": [openclaw]
+                }),
+                "port_step must be greater than 0",
+            ),
+        ];
+
+        for (value, expected) in cases {
+            let error = parse(value)
+                .err()
+                .unwrap_or_else(|| panic!("invalid manifest should fail"));
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_profile_fields_and_sources() {
+        let mutations = [
+            ("profile", serde_json::json!("bad/name"), "profile must match"),
+            ("name", serde_json::json!(" "), "name must not be empty"),
+            (
+                "summary",
+                serde_json::json!(" "),
+                "summary must not be empty",
+            ),
+            (
+                "domains",
+                serde_json::json!(" "),
+                "domains must not be empty",
+            ),
+            ("skills", serde_json::json!(" "), "skills must not be empty"),
+        ];
+        for (field, value, expected) in mutations {
+            let mut bot = rule_bot(serde_json::json!({
+                "type": "fixed",
+                "replies": ["ok"]
+            }));
+            bot[field] = value;
+            let error = parse(serde_json::json!({
+                "version": 2,
+                "name": "invalid",
+                "bots": [bot]
+            }))
+            .err()
+            .unwrap_or_else(|| panic!("invalid profile field should fail"));
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?}, got {error}"
+            );
+        }
+
+        for source in [None, Some(" "), Some("nested/source"), Some("..")] {
+            let mut bot = serde_json::json!({
+                "profile": "openclaw",
+                "name": "OpenClaw",
+                "summary": "LLM assistant",
+                "domains": "general",
+                "skills": "reasoning"
+            });
+            if let Some(source) = source {
+                bot["source"] = serde_json::json!(source);
+            }
+            let error = parse(serde_json::json!({
+                "version": 2,
+                "name": "invalid",
+                "port_start": 18_000,
+                "port_step": 10,
+                "bots": [bot]
+            }))
+            .err()
+            .unwrap_or_else(|| panic!("invalid source should fail"));
+            assert!(error.to_string().contains("source"));
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_behavior_contracts() {
+        let cases = vec![
+            (
+                serde_json::json!({"type": "fixed", "replies": []}),
+                "replies must not be empty",
+            ),
+            (
+                serde_json::json!({"type": "random_reply", "replies": ["ok", " "]}),
+                "replies[1] must not be empty",
+            ),
+            (
+                serde_json::json!({"type": "echo", "repeat": 0}),
+                "repeat must be greater than 0",
+            ),
+            (
+                serde_json::json!({"type": "random_number", "min": 2, "max": 1}),
+                "min must be less than or equal",
+            ),
+            (
+                serde_json::json!({
+                    "type": "task_worker",
+                    "result": {
+                        "type": "task_worker",
+                        "result": {"type": "fixed", "replies": ["ok"]}
+                    }
+                }),
+                "result must be fixed",
+            ),
+            (
+                serde_json::json!({
+                    "type": "task_worker",
+                    "result": {"type": "fixed", "replies": []}
+                }),
+                "replies must not be empty",
+            ),
+            (
+                serde_json::json!({
+                    "type": "supervisor",
+                    "assignment": {
+                        "mode": "each_member",
+                        "task_template": " "
+                    },
+                    "completion": {"timeout_ms": 1},
+                    "summary_template": "done"
+                }),
+                "task_template must not be empty",
+            ),
+            (
+                serde_json::json!({
+                    "type": "supervisor",
+                    "assignment": {
+                        "mode": "each_member",
+                        "task_template": "{task}"
+                    },
+                    "completion": {"timeout_ms": 0},
+                    "summary_template": "done"
+                }),
+                "timeout_ms must be greater than 0",
+            ),
+            (
+                serde_json::json!({
+                    "type": "supervisor",
+                    "assignment": {
+                        "mode": "each_member",
+                        "task_template": "{task}"
+                    },
+                    "completion": {"timeout_ms": 1},
+                    "summary_template": " "
+                }),
+                "summary_template must not be empty",
+            ),
+        ];
+
+        for (behavior, expected) in cases {
+            let error = parse(serde_json::json!({
+                "version": 2,
+                "name": "invalid",
+                "bots": [rule_bot(behavior)]
+            }))
+            .err()
+            .unwrap_or_else(|| panic!("invalid behavior should fail"));
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn behavior_names_cover_every_supported_variant() {
+        let values = [
+            (
+                serde_json::json!({"type": "fixed", "replies": ["ok"]}),
+                "fixed",
+            ),
+            (
+                serde_json::json!({"type": "random_reply", "replies": ["ok"]}),
+                "random_reply",
+            ),
+            (serde_json::json!({"type": "echo"}), "echo"),
+            (
+                serde_json::json!({"type": "random_number", "min": 1, "max": 2}),
+                "random_number",
+            ),
+            (
+                serde_json::json!({
+                    "type": "task_worker",
+                    "result": {"type": "fixed", "replies": ["done"]}
+                }),
+                "task_worker",
+            ),
+            (
+                serde_json::json!({
+                    "type": "supervisor",
+                    "assignment": {
+                        "mode": "each_member",
+                        "task_template": "{task}"
+                    },
+                    "completion": {"timeout_ms": 1},
+                    "summary_template": "done"
+                }),
+                "supervisor",
+            ),
+        ];
+
+        for (value, expected) in values {
+            let behavior: BehaviorConfig = serde_json::from_value(value)
+                .unwrap_or_else(|error| panic!("behavior should parse: {error}"));
+            assert_eq!(behavior.name(), expected);
+        }
+    }
 }

--- a/src/bcs/crates/tools/bcs-rule-bot/src/host.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/host.rs
@@ -1,0 +1,144 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+use crate::config::Manifest;
+use crate::instance::{InstanceConfig, run_instance};
+use crate::status::{StatusCommand, StatusReporter};
+
+#[derive(Debug, Clone)]
+pub struct HostConfig {
+    pub manifest_path: PathBuf,
+    pub bcs_url: String,
+    pub profile_root: PathBuf,
+    pub profile_prefix: String,
+    pub status_file: PathBuf,
+}
+
+pub async fn run_host(config: HostConfig) -> Result<()> {
+    let manifest = Manifest::load(&config.manifest_path)?;
+    let rule_bots = manifest.rule_bots().cloned().collect::<Vec<_>>();
+    if rule_bots.is_empty() {
+        bail!("manifest does not contain any rule bots");
+    }
+
+    let cancellation = CancellationToken::new();
+    let (status_tx, mut status_rx) = mpsc::unbounded_channel();
+    let mut reporter =
+        StatusReporter::new(config.status_file.clone(), config.manifest_path.clone());
+    let mut tasks = JoinSet::new();
+
+    for bot in rule_bots {
+        let instance_config = InstanceConfig {
+            scopes: bot.effective_scopes(&manifest).to_string(),
+            profile_dir: config
+                .profile_root
+                .join(format!("{}{}", config.profile_prefix, bot.profile)),
+            bcs_url: config.bcs_url.clone(),
+            bot,
+        };
+        let instance_cancellation = cancellation.child_token();
+        let instance_status = status_tx.clone();
+        tasks.spawn(async move {
+            let profile = instance_config.bot.profile.clone();
+            let result =
+                run_instance(instance_config, instance_cancellation, instance_status).await;
+            (profile, result)
+        });
+    }
+    drop(status_tx);
+
+    info!(
+        manifest = %config.manifest_path.display(),
+        bot_count = tasks.len(),
+        "BCS Rule Bot host started"
+    );
+
+    loop {
+        tokio::select! {
+            () = shutdown_signal() => {
+                info!("shutdown signal received");
+                break;
+            }
+            command = status_rx.recv() => {
+                match command {
+                    Some(StatusCommand::Update(update)) => {
+                        if let Err(error) = reporter.apply(update) {
+                            warn!(error = %error, "failed to update rule bot status file");
+                        }
+                    }
+                    Some(StatusCommand::Touch(profile)) => {
+                        if let Err(error) = reporter.touch(&profile) {
+                            warn!(error = %error, "failed to touch rule bot status file");
+                        }
+                    }
+                    None => {
+                        bail!("all rule bot status channels closed");
+                    }
+                }
+            }
+            joined = tasks.join_next() => {
+                match joined {
+                    Some(Ok((profile, Ok(())))) => {
+                        if !cancellation.is_cancelled() {
+                            bail!("rule bot instance exited unexpectedly: {profile}");
+                        }
+                    }
+                    Some(Ok((profile, Err(error)))) => {
+                        error!(profile, error = %error, "rule bot instance failed");
+                        bail!("rule bot instance failed: {profile}: {error}");
+                    }
+                    Some(Err(error)) => {
+                        return Err(error).context("rule bot instance task panicked");
+                    }
+                    None => bail!("all rule bot instances exited"),
+                }
+            }
+        }
+    }
+
+    cancellation.cancel();
+    while let Some(joined) = tasks.join_next().await {
+        match joined {
+            Ok((profile, Ok(()))) => {
+                info!(profile, "rule bot instance stopped");
+            }
+            Ok((profile, Err(error))) => {
+                warn!(profile, error = %error, "rule bot instance stopped with error");
+            }
+            Err(error) => {
+                warn!(error = %error, "rule bot instance task join failed");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut terminate = match signal(SignalKind::terminate()) {
+            Ok(signal) => signal,
+            Err(_) => {
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                let _ = result;
+            }
+            _ = terminate.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/instance.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/instance.rs
@@ -1782,6 +1782,121 @@ mod tests {
         assert!(tagged_task("[SERVICE GROUP CONTEXT]").is_none());
     }
 
+    #[tokio::test]
+    async fn cancelled_instance_reports_starting_then_stopped() {
+        let behavior = BehaviorConfig::Fixed {
+            replies: vec!["你好".to_string()],
+            scope: StateScope::Session,
+        };
+        let config = instance_config(behavior);
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let (status_tx, mut status_rx) = mpsc::unbounded_channel();
+
+        run_instance(config, cancellation, status_tx)
+            .await
+            .unwrap_or_else(|error| panic!("cancelled instance should stop cleanly: {error}"));
+
+        assert!(matches!(
+            status_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("starting status is missing: {error}")),
+            StatusCommand::Update(StatusUpdate {
+                state: InstanceState::Starting,
+                ..
+            })
+        ));
+        assert!(matches!(
+            status_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("stopped status is missing: {error}")),
+            StatusCommand::Update(StatusUpdate {
+                state: InstanceState::Stopped,
+                ..
+            })
+        ));
+        assert!(status_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn incoming_dispatch_rejects_invalid_requests_and_ignores_notifications() {
+        let behavior = BehaviorConfig::Fixed {
+            replies: vec!["你好".to_string()],
+            scope: StateScope::Session,
+        };
+        let config = instance_config(behavior.clone());
+        let mut state = RuntimeState::new(&behavior);
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
+        let cases = [
+            ("send", "chat.send", json!({})),
+            ("inject", "chat.inject", json!({})),
+            ("history", "chat.history", json!({})),
+            ("abort", "chat.abort", json!({"run_id": false})),
+            ("delete", "session.delete", json!({})),
+            ("unknown", "unsupported.method", json!({})),
+        ];
+
+        for (id, method, params) in cases {
+            handle_incoming(
+                &config,
+                &mut state,
+                BcsFrame::Request(RequestFrame::new(id, method, Some(params))),
+                &outgoing_tx,
+                &internal_tx,
+            )
+            .unwrap_or_else(|error| panic!("{method} should return a protocol error: {error}"));
+            let BcsFrame::Response(response) = outgoing_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("{method} response is missing: {error}"))
+            else {
+                panic!("{method} should return a response frame");
+            };
+            assert_eq!(response.id, id);
+            assert!(!response.ok);
+            assert!(response.error.is_some());
+        }
+
+        for (id, method, params) in [
+            ("history-ok", "chat.history", json!({"session_key": "missing"})),
+            ("abort-ok", "chat.abort", json!({"session_key": "missing"})),
+        ] {
+            handle_incoming(
+                &config,
+                &mut state,
+                BcsFrame::Request(RequestFrame::new(id, method, Some(params))),
+                &outgoing_tx,
+                &internal_tx,
+            )
+            .unwrap_or_else(|error| panic!("{method} should succeed: {error}"));
+            let BcsFrame::Response(response) = outgoing_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("{method} response is missing: {error}"))
+            else {
+                panic!("{method} should return a response frame");
+            };
+            assert!(response.ok);
+        }
+
+        handle_incoming(
+            &config,
+            &mut state,
+            BcsFrame::Response(ResponseFrame::ok("untracked", json!({}))),
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("untracked response should be ignored: {error}"));
+        handle_incoming(
+            &config,
+            &mut state,
+            BcsFrame::Event(bcs_protocol::EventFrame::new("noop", None, None)),
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("notification should be ignored: {error}"));
+        assert!(outgoing_rx.try_recv().is_err());
+    }
+
     #[test]
     fn system_supervisor_task_prefers_session_task_and_falls_back_to_group_goal() {
         let goal_only = "\

--- a/src/bcs/crates/tools/bcs-rule-bot/src/instance.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/instance.rs
@@ -1,0 +1,2418 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use bcs_protocol::{
+    BCS_PROTOCOL_VERSION, BcsFrame, BotConnectParams, BotConnectResponse, BotStatus,
+    BotStatusParams, ChatAbortParams, ChatInjectParams, ChatSendParams, ChatSendResponse,
+    RequestFrame, ResponseFrame,
+};
+use futures::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::behavior::{
+    BehaviorError, BehaviorInput, BehaviorOutcome, BehaviorRuntime, SupervisorStart,
+};
+use crate::config::{BehaviorConfig, BotProfile};
+use crate::protocol::{
+    ChatHistoryParams, HistoryMessage, SessionDeleteParams, TaskCompleteParams, TaskDispatchParams,
+    TaskDispatchResponse, error_chat_event, error_response, final_chat_event, history_response,
+    message_text, ok_response,
+};
+use crate::session_store::{SessionInfo, SessionStore};
+use crate::status::{InstanceState, StatusCommand, StatusUpdate};
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+const IDEMPOTENCY_CACHE_SIZE: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub struct InstanceConfig {
+    pub bot: BotProfile,
+    pub scopes: String,
+    pub bcs_url: String,
+    pub profile_dir: PathBuf,
+}
+
+pub async fn run_instance(
+    config: InstanceConfig,
+    cancellation: CancellationToken,
+    status_tx: mpsc::UnboundedSender<StatusCommand>,
+) -> Result<()> {
+    let behavior_config = config
+        .bot
+        .behavior()
+        .context("rule bot is missing behavior")?
+        .clone();
+    let mut state = RuntimeState::new(&behavior_config);
+    let mut reconnect_attempt = 0_u32;
+    send_status(&config, &status_tx, InstanceState::Starting, None, None);
+
+    loop {
+        if cancellation.is_cancelled() {
+            send_status(&config, &status_tx, InstanceState::Stopped, None, None);
+            return Ok(());
+        }
+
+        match run_connection(&config, &mut state, &cancellation, &status_tx).await {
+            Ok(()) if cancellation.is_cancelled() => {
+                send_status(&config, &status_tx, InstanceState::Stopped, None, None);
+                return Ok(());
+            }
+            Ok(()) => {
+                reconnect_attempt = 0;
+            }
+            Err(error) => {
+                warn!(
+                    profile = %config.bot.profile,
+                    error = %error,
+                    "rule bot connection ended"
+                );
+                send_status(
+                    &config,
+                    &status_tx,
+                    InstanceState::Reconnecting,
+                    state.bot_uuid.clone(),
+                    Some(error.to_string()),
+                );
+            }
+        }
+
+        let delay_secs = 1_u64
+            .checked_shl(reconnect_attempt.min(5))
+            .unwrap_or(32)
+            .min(30);
+        reconnect_attempt = reconnect_attempt.saturating_add(1);
+        tokio::select! {
+            () = cancellation.cancelled() => {
+                send_status(&config, &status_tx, InstanceState::Stopped, state.bot_uuid.clone(), None);
+                return Ok(());
+            }
+            () = tokio::time::sleep(Duration::from_secs(delay_secs)) => {}
+        }
+    }
+}
+
+async fn run_connection(
+    config: &InstanceConfig,
+    state: &mut RuntimeState,
+    cancellation: &CancellationToken,
+    status_tx: &mpsc::UnboundedSender<StatusCommand>,
+) -> Result<()> {
+    let session_store = SessionStore::new(&config.profile_dir);
+    let saved_session = session_store.load()?;
+    if let Some(session) = &saved_session
+        && session.bcs_url != config.bcs_url
+    {
+        bail!(
+            "saved BCS URL {} does not match configured URL {}; clean the bot session before reconnecting",
+            session.bcs_url,
+            config.bcs_url
+        );
+    }
+
+    info!(
+        profile = %config.bot.profile,
+        bcs_url = %config.bcs_url,
+        "connecting rule bot"
+    );
+    let (mut socket, _) = connect_async(&config.bcs_url)
+        .await
+        .with_context(|| format!("failed to connect {}", config.bcs_url))?;
+    let connect_id = Uuid::new_v4().to_string();
+    let connect = BcsFrame::Request(RequestFrame::new(
+        &connect_id,
+        "bot.connect",
+        Some(serde_json::to_value(BotConnectParams {
+            token: saved_session.as_ref().map(|session| session.token.clone()),
+            bot_id: saved_session
+                .as_ref()
+                .and_then(|session| session.bot_uuid.clone()),
+            protocol_version: Some(BCS_PROTOCOL_VERSION),
+            client_kind: None,
+        })?),
+    ));
+    socket
+        .send(Message::Text(serde_json::to_string(&connect)?.into()))
+        .await
+        .context("failed to send bot.connect")?;
+
+    let connect_response = tokio::time::timeout(CONNECT_TIMEOUT, async {
+        loop {
+            match socket.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    let frame: BcsFrame = serde_json::from_str(&text)?;
+                    if let BcsFrame::Response(response) = frame
+                        && response.id == connect_id
+                    {
+                        if !response.ok {
+                            let message = response
+                                .error
+                                .map_or_else(|| "unknown error".to_string(), |error| error.message);
+                            bail!("bot.connect rejected: {message}");
+                        }
+                        let payload = response
+                            .payload
+                            .context("bot.connect response is missing payload")?;
+                        let response: BotConnectResponse = serde_json::from_value(payload)?;
+                        return Ok(response);
+                    }
+                }
+                Some(Ok(Message::Ping(payload))) => {
+                    socket.send(Message::Pong(payload)).await?;
+                }
+                Some(Ok(Message::Close(_))) | None => {
+                    bail!("connection closed before bot.connect completed");
+                }
+                Some(Ok(_)) => {}
+                Some(Err(error)) => return Err(anyhow::Error::from(error)),
+            }
+        }
+    })
+    .await
+    .context("bot.connect timed out")??;
+
+    let bot_uuid = connect_response.bot_uuid;
+    session_store.save(&SessionInfo {
+        bot_uuid: Some(bot_uuid.clone()),
+        token: connect_response.token,
+        bcs_url: config.bcs_url.clone(),
+    })?;
+    state.bot_uuid = Some(bot_uuid.clone());
+    send_status(
+        config,
+        status_tx,
+        InstanceState::Connected,
+        Some(bot_uuid.clone()),
+        None,
+    );
+    info!(
+        profile = %config.bot.profile,
+        bot_uuid = %bot_uuid,
+        is_new = connect_response.is_new,
+        "rule bot connected"
+    );
+
+    let (mut writer, mut reader) = socket.split();
+    let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<BcsFrame>();
+    let (internal_tx, mut internal_rx) = mpsc::unbounded_channel::<InternalEvent>();
+    let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            () = cancellation.cancelled() => {
+                let _ = writer.send(Message::Close(None)).await;
+                return Ok(());
+            }
+            Some(frame) = outgoing_rx.recv() => {
+                writer
+                    .send(Message::Text(serde_json::to_string(&frame)?.into()))
+                    .await
+                    .context("failed to send BCS frame")?;
+            }
+            Some(event) = internal_rx.recv() => {
+                match event {
+                    InternalEvent::RunFinished(run_id) => {
+                        state.pending_runs.remove(&run_id);
+                    }
+                    InternalEvent::SupervisorAnnouncementFinished {
+                        session_key,
+                        manager_run_id,
+                    } => {
+                        state.pending_runs.remove(&manager_run_id);
+                        begin_supervisor_dispatch(
+                            state,
+                            &session_key,
+                            &manager_run_id,
+                            &outgoing_tx,
+                            &internal_tx,
+                        )?;
+                    }
+                    InternalEvent::SupervisorTimeout {
+                        session_key,
+                        generation,
+                    } => {
+                        handle_supervisor_timeout(
+                            state,
+                            &session_key,
+                            generation,
+                            &outgoing_tx,
+                            &internal_tx,
+                        )?;
+                    }
+                }
+            }
+            _ = heartbeat.tick() => {
+                let heartbeat_id = Uuid::new_v4().to_string();
+                let busy = !state.pending_runs.is_empty() || !state.supervisions.is_empty();
+                let frame = BcsFrame::Request(RequestFrame::new(
+                    heartbeat_id,
+                    "bot.status",
+                    Some(serde_json::to_value(BotStatusParams {
+                        status: Some(if busy {
+                            BotStatus::Busy
+                        } else {
+                            BotStatus::Idle
+                        }),
+                        dynamic_summary: Some(format!("rule:{}", config.bot.behavior_name())),
+                        load: Some(if busy { 1.0 } else { 0.0 }),
+                    })?),
+                ));
+                writer
+                    .send(Message::Text(serde_json::to_string(&frame)?.into()))
+                    .await
+                    .context("failed to send heartbeat")?;
+                let _ = status_tx.send(StatusCommand::Touch(config.bot.profile.clone()));
+            }
+            incoming = reader.next() => {
+                match incoming {
+                    Some(Ok(Message::Text(text))) => {
+                        let frame: BcsFrame = match serde_json::from_str(&text) {
+                            Ok(frame) => frame,
+                            Err(error) => {
+                                warn!(
+                                    profile = %config.bot.profile,
+                                    error = %error,
+                                    "ignoring invalid BCS frame"
+                                );
+                                continue;
+                            }
+                        };
+                        handle_incoming(
+                            config,
+                            state,
+                            frame,
+                            &outgoing_tx,
+                            &internal_tx,
+                        )?;
+                    }
+                    Some(Ok(Message::Ping(payload))) => {
+                        writer.send(Message::Pong(payload)).await?;
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        bail!("BCS WebSocket closed");
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(error)) => return Err(error.into()),
+                }
+            }
+        }
+    }
+}
+
+fn handle_incoming(
+    config: &InstanceConfig,
+    state: &mut RuntimeState,
+    frame: BcsFrame,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<()> {
+    match frame {
+        BcsFrame::Request(request) => match request.method.as_str() {
+            "chat.send" => handle_chat_send(config, state, request, outgoing_tx, internal_tx),
+            "chat.inject" => handle_chat_inject(state, request, outgoing_tx),
+            "chat.history" => handle_chat_history(state, request, outgoing_tx),
+            "chat.abort" => handle_chat_abort(state, request, outgoing_tx),
+            "session.delete" => handle_session_delete(state, request, outgoing_tx),
+            method => {
+                send(
+                    outgoing_tx,
+                    error_response(
+                        request.id,
+                        "unknown_method",
+                        format!("unknown method: {method}"),
+                        false,
+                    ),
+                );
+                Ok(())
+            }
+        },
+        BcsFrame::Response(response) => {
+            handle_bcs_response(state, response, outgoing_tx, internal_tx)
+        }
+        BcsFrame::Event(event) => {
+            debug!(event = %event.event, "received BCS event");
+            Ok(())
+        }
+    }
+}
+
+fn handle_chat_send(
+    config: &InstanceConfig,
+    state: &mut RuntimeState,
+    request: RequestFrame,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<()> {
+    let task_id = request
+        .params
+        .as_ref()
+        .and_then(|params| params.get("task_id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let params: ChatSendParams = match parse_params(&request) {
+        Ok(params) => params,
+        Err(error) => {
+            send(
+                outgoing_tx,
+                error_response(request.id, "invalid_params", error.to_string(), false),
+            );
+            return Ok(());
+        }
+    };
+    let input = behavior_input(&params, task_id);
+    let cache_key = state.cache_key(&input, params.idempotency_key.as_deref(), &request.id);
+
+    if let Some(cached) = state.idempotency.get(&cache_key).cloned() {
+        send(
+            outgoing_tx,
+            ok_response(
+                &request.id,
+                serde_json::to_value(ChatSendResponse {
+                    run_id: cached.run_id.clone(),
+                })?,
+            ),
+        );
+        if let Some(reply) = cached.reply
+            && !state.pending_runs.contains_key(&cached.run_id)
+        {
+            schedule_reply(
+                state,
+                cached.run_id,
+                cached.group_id,
+                cached.session_key,
+                reply,
+                0,
+                outgoing_tx.clone(),
+                internal_tx.clone(),
+            );
+        }
+        return Ok(());
+    }
+
+    let run_id = request.id.clone();
+    send(
+        outgoing_tx,
+        ok_response(
+            &request.id,
+            serde_json::to_value(ChatSendResponse {
+                run_id: run_id.clone(),
+            })?,
+        ),
+    );
+    state.append_history(
+        input.effective_session_key(),
+        HistoryMessage {
+            id: request.id.clone(),
+            role: params.message.role.clone(),
+            content: input.message_text.clone(),
+            timestamp: params.message.timestamp,
+        },
+    );
+
+    if input.task_id.is_some() && handle_supervisor_result(state, &input, outgoing_tx, internal_tx)?
+    {
+        state.idempotency.insert(
+            cache_key,
+            CachedRun {
+                run_id,
+                group_id: params.bcs_group_id,
+                session_key: input.effective_session_key().to_string(),
+                reply: None,
+            },
+        );
+        return Ok(());
+    }
+
+    if state
+        .supervisions
+        .contains_key(input.effective_session_key())
+    {
+        complete_reply(
+            state,
+            cache_key,
+            run_id,
+            params.bcs_group_id,
+            input.effective_session_key(),
+            "当前会话已有协调任务正在执行，请等待任务完成。".to_string(),
+            config.bot.response_delay_ms(),
+            outgoing_tx,
+            internal_tx,
+        );
+        return Ok(());
+    }
+
+    match state.behavior.handle_send(&input) {
+        Ok(BehaviorOutcome::Reply(reply)) => {
+            state.idempotency.insert(
+                cache_key,
+                CachedRun {
+                    run_id: run_id.clone(),
+                    group_id: params.bcs_group_id.clone(),
+                    session_key: input.effective_session_key().to_string(),
+                    reply: Some(reply.clone()),
+                },
+            );
+            state.append_history(
+                input.effective_session_key(),
+                HistoryMessage {
+                    id: format!("rule-{run_id}"),
+                    role: "assistant".to_string(),
+                    content: reply.clone(),
+                    timestamp: bcs_protocol::now_ms(),
+                },
+            );
+            schedule_reply(
+                state,
+                run_id,
+                params.bcs_group_id,
+                input.effective_session_key().to_string(),
+                reply,
+                config.bot.response_delay_ms(),
+                outgoing_tx.clone(),
+                internal_tx.clone(),
+            );
+        }
+        Ok(BehaviorOutcome::StartSupervisor(start)) => {
+            start_supervisor(
+                config,
+                state,
+                &input,
+                run_id,
+                params.bcs_group_id,
+                cache_key,
+                start,
+                outgoing_tx,
+                internal_tx,
+            )?;
+        }
+        Err(error) => {
+            let (kind, message) = behavior_error(&error);
+            send(
+                outgoing_tx,
+                error_chat_event(run_id, params.bcs_group_id, kind, message),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn handle_chat_inject(
+    state: &mut RuntimeState,
+    request: RequestFrame,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+) -> Result<()> {
+    let params: ChatInjectParams = match parse_params(&request) {
+        Ok(params) => params,
+        Err(error) => {
+            send(
+                outgoing_tx,
+                error_response(request.id, "invalid_params", error.to_string(), false),
+            );
+            return Ok(());
+        }
+    };
+    let effective_session = params
+        .bcs_session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(params.session_key.as_str())
+        .to_string();
+    let content = message_text(&params.message);
+    state.append_history(
+        &effective_session,
+        HistoryMessage {
+            id: request.id.clone(),
+            role: params.message.role,
+            content,
+            timestamp: params.message.timestamp,
+        },
+    );
+    send(
+        outgoing_tx,
+        ok_response(request.id, json!({"injected": true})),
+    );
+    Ok(())
+}
+
+fn handle_chat_history(
+    state: &mut RuntimeState,
+    request: RequestFrame,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+) -> Result<()> {
+    let params: ChatHistoryParams = match parse_params(&request) {
+        Ok(params) => params,
+        Err(error) => {
+            send(
+                outgoing_tx,
+                error_response(request.id, "invalid_params", error.to_string(), false),
+            );
+            return Ok(());
+        }
+    };
+    let messages = state
+        .history
+        .get(&params.session_key)
+        .map_or(&[][..], Vec::as_slice);
+    send(
+        outgoing_tx,
+        history_response(&request.id, &params.session_key, messages, &params),
+    );
+    Ok(())
+}
+
+fn handle_chat_abort(
+    state: &mut RuntimeState,
+    request: RequestFrame,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+) -> Result<()> {
+    let params: ChatAbortParams = match parse_params(&request) {
+        Ok(params) => params,
+        Err(error) => {
+            send(
+                outgoing_tx,
+                error_response(request.id, "invalid_params", error.to_string(), false),
+            );
+            return Ok(());
+        }
+    };
+    let mut aborted = 0_usize;
+    if let Some(run_id) = params.run_id {
+        if let Some(pending) = state.pending_runs.remove(&run_id) {
+            pending.cancellation.cancel();
+            aborted = 1;
+        }
+        let supervision_session = state
+            .supervisions
+            .iter()
+            .find_map(|(session, run)| (run.manager_run_id == run_id).then(|| session.clone()));
+        if let Some(session) = supervision_session {
+            state.supervisions.remove(&session);
+            state
+                .dispatch_requests
+                .retain(|_, pending| pending.session_key != session);
+            aborted = aborted.saturating_add(1);
+        }
+    } else {
+        for (_, pending) in state.pending_runs.drain() {
+            pending.cancellation.cancel();
+            aborted = aborted.saturating_add(1);
+        }
+        aborted = aborted.saturating_add(state.supervisions.len());
+        state.supervisions.clear();
+        state.dispatch_requests.clear();
+    }
+    send(
+        outgoing_tx,
+        ok_response(request.id, json!({"aborted": aborted})),
+    );
+    Ok(())
+}
+
+fn handle_session_delete(
+    state: &mut RuntimeState,
+    request: RequestFrame,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+) -> Result<()> {
+    let params: SessionDeleteParams = match parse_params(&request) {
+        Ok(params) => params,
+        Err(error) => {
+            send(
+                outgoing_tx,
+                error_response(request.id, "invalid_params", error.to_string(), false),
+            );
+            return Ok(());
+        }
+    };
+    let matching = state
+        .history
+        .keys()
+        .filter(|key| session_belongs_to_group(key, &params.bcs_group_id))
+        .cloned()
+        .collect::<Vec<_>>();
+    let pending_run_ids = state
+        .pending_runs
+        .iter()
+        .filter(|(_, pending)| session_belongs_to_group(&pending.session_key, &params.bcs_group_id))
+        .map(|(run_id, _)| run_id.clone())
+        .collect::<Vec<_>>();
+    for run_id in pending_run_ids {
+        if let Some(pending) = state.pending_runs.remove(&run_id) {
+            pending.cancellation.cancel();
+        }
+    }
+    for key in matching {
+        state.history.remove(&key);
+        state.behavior.clear_session(&key);
+    }
+    state.idempotency.remove_group(&params.bcs_group_id);
+    state
+        .supervisions
+        .retain(|session, _| !session_belongs_to_group(session, &params.bcs_group_id));
+    state
+        .dispatch_requests
+        .retain(|_, pending| !session_belongs_to_group(&pending.session_key, &params.bcs_group_id));
+    send(
+        outgoing_tx,
+        ok_response(request.id, json!({"deleted": true})),
+    );
+    Ok(())
+}
+
+fn session_belongs_to_group(session_key: &str, group_id: &str) -> bool {
+    session_key == group_id
+        || session_key
+            .strip_prefix(group_id)
+            .is_some_and(|suffix| suffix.starts_with(':'))
+}
+
+fn behavior_input(params: &ChatSendParams, task_id: Option<String>) -> BehaviorInput {
+    let wire_message = message_text(&params.message);
+    let routed_message = if params.session_context.message.is_empty() {
+        wire_message
+    } else {
+        params.session_context.message.clone()
+    };
+    let normalized_message = strip_leading_recipient_mention(
+        &routed_message,
+        params.session_context.you_are_mentioned,
+        params.session_context.recipient_name.as_deref(),
+        params.session_context.recipient.as_deref(),
+        &params.session_context.mentions,
+    );
+    BehaviorInput {
+        session_key: params.session_key.clone(),
+        bcs_group_id: params.bcs_group_id.clone(),
+        bcs_session_id: params.bcs_session_id.clone(),
+        message_text: normalized_message.clone(),
+        context_message: normalized_message,
+        task_id,
+        sender_name: params.session_context.from.clone(),
+        recipient_role: params.session_context.recipient_role.clone(),
+        group_type: params.session_context.group_type.clone(),
+        participants: params.session_context.participants.clone(),
+    }
+}
+
+fn strip_leading_recipient_mention(
+    message: &str,
+    you_are_mentioned: bool,
+    recipient_name: Option<&str>,
+    recipient_id: Option<&str>,
+    mentions: &[String],
+) -> String {
+    if !you_are_mentioned {
+        return message.to_string();
+    }
+
+    let trimmed = message.trim_start();
+    let without_at = trimmed.strip_prefix('@').unwrap_or(trimmed);
+    let candidates = recipient_name
+        .into_iter()
+        .chain(recipient_id)
+        .chain(mentions.iter().map(String::as_str));
+    for candidate in candidates {
+        let candidate = candidate.strip_prefix('@').unwrap_or(candidate);
+        if candidate.is_empty() {
+            continue;
+        }
+        let Some(remainder) = without_at.strip_prefix(candidate) else {
+            continue;
+        };
+        if remainder.is_empty() {
+            return String::new();
+        }
+        if remainder.chars().next().is_some_and(is_mention_separator) {
+            return remainder
+                .trim_start_matches(is_mention_separator)
+                .to_string();
+        }
+    }
+    message.to_string()
+}
+
+fn is_mention_separator(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, ':' | '：' | ',' | '，')
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_supervisor(
+    config: &InstanceConfig,
+    state: &mut RuntimeState,
+    input: &BehaviorInput,
+    run_id: String,
+    reply_group_id: String,
+    cache_key: String,
+    start: SupervisorStart,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<()> {
+    let session_key = input.effective_session_key().to_string();
+    let invalid_context = if input.group_type.as_deref() != Some("manager_worker") {
+        Some("任务协调者只能在 manager_worker 群中启动。")
+    } else if input.recipient_role.as_deref() != Some("manager") {
+        Some("只有 manager 角色可以启动任务协调。")
+    } else {
+        None
+    };
+    if let Some(message) = invalid_context {
+        complete_reply(
+            state,
+            cache_key,
+            run_id,
+            reply_group_id,
+            &session_key,
+            message.to_string(),
+            config.bot.response_delay_ms(),
+            outgoing_tx,
+            internal_tx,
+        );
+        return Ok(());
+    }
+    let supervisor_input = if input.sender_name == "bcs-system-message" {
+        match supervisor_system_task(&input.message_text) {
+            Some(task) => task,
+            None => {
+                complete_reply(
+                    state,
+                    cache_key,
+                    run_id,
+                    reply_group_id,
+                    &session_key,
+                    "任务协调者已就绪，等待任务。".to_string(),
+                    config.bot.response_delay_ms(),
+                    outgoing_tx,
+                    internal_tx,
+                );
+                return Ok(());
+            }
+        }
+    } else {
+        input.message_text.clone()
+    };
+
+    let own_bot_uuid = state.bot_uuid.as_deref();
+    let members = input
+        .participants
+        .iter()
+        .map(|member| parse_participant_identity(member))
+        .filter(|member| {
+            member.name != config.bot.name && Some(member.target.as_str()) != own_bot_uuid
+        })
+        .collect::<Vec<_>>();
+    if members.is_empty() {
+        complete_reply(
+            state,
+            cache_key,
+            run_id,
+            reply_group_id,
+            &session_key,
+            "任务协调者没有找到可分配任务的成员。".to_string(),
+            config.bot.response_delay_ms(),
+            outgoing_tx,
+            internal_tx,
+        );
+        return Ok(());
+    }
+    let mut unique = HashSet::new();
+    if let Some(duplicate) = members
+        .iter()
+        .find(|member| !unique.insert(member.name.as_str()))
+    {
+        complete_reply(
+            state,
+            cache_key,
+            run_id,
+            reply_group_id,
+            &session_key,
+            format!(
+                "任务协调者无法派发任务：成员名称重复（{}）。",
+                duplicate.name
+            ),
+            config.bot.response_delay_ms(),
+            outgoing_tx,
+            internal_tx,
+        );
+        return Ok(());
+    }
+
+    let total = members.len();
+    let announcement = format!("已收到任务，开始分配给 {total} 位成员。");
+    let member_runs = members
+        .into_iter()
+        .enumerate()
+        .map(|(index, member)| SupervisionMember {
+            task_message: render_assignment(
+                &start.assignment.task_template,
+                &supervisor_input,
+                &member.name,
+                index + 1,
+                total,
+            ),
+            name: member.name,
+            target_bot: member.target,
+            attempts: 0,
+            status: SupervisionMemberStatus::Dispatching,
+        })
+        .collect::<Vec<_>>();
+    let scope_id = input
+        .bcs_session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(input.bcs_group_id.as_str())
+        .to_string();
+
+    state.idempotency.insert(
+        cache_key.clone(),
+        CachedRun {
+            run_id: run_id.clone(),
+            group_id: reply_group_id.clone(),
+            session_key: session_key.clone(),
+            reply: Some(announcement.clone()),
+        },
+    );
+    state.append_history(
+        &session_key,
+        HistoryMessage {
+            id: format!("rule-{run_id}"),
+            role: "assistant".to_string(),
+            content: announcement.clone(),
+            timestamp: bcs_protocol::now_ms(),
+        },
+    );
+    state.supervisions.insert(
+        session_key.clone(),
+        SupervisionRun {
+            manager_run_id: run_id.clone(),
+            scope_id,
+            original_input: supervisor_input,
+            summary_template: start.summary_template,
+            response_delay_ms: config.bot.response_delay_ms(),
+            timeout_ms: start.completion.timeout_ms,
+            max_retries: start.completion.max_retries,
+            generation: 1,
+            dispatch_started: false,
+            members: member_runs,
+        },
+    );
+
+    let response_delay_ms = config.bot.response_delay_ms();
+    if response_delay_ms == 0 {
+        send(
+            outgoing_tx,
+            final_chat_event(&run_id, reply_group_id, announcement),
+        );
+        begin_supervisor_dispatch(state, &session_key, &run_id, outgoing_tx, internal_tx)?;
+    } else {
+        schedule_supervisor_announcement(
+            state,
+            run_id,
+            reply_group_id,
+            session_key,
+            announcement,
+            response_delay_ms,
+            outgoing_tx.clone(),
+            internal_tx.clone(),
+        );
+    }
+    Ok(())
+}
+
+fn begin_supervisor_dispatch(
+    state: &mut RuntimeState,
+    session_key: &str,
+    manager_run_id: &str,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<()> {
+    let Some(run) = state.supervisions.get_mut(session_key) else {
+        return Ok(());
+    };
+    if run.manager_run_id != manager_run_id || run.dispatch_started {
+        return Ok(());
+    }
+    run.dispatch_started = true;
+    let member_count = run.members.len();
+    let generation = run.generation;
+    let timeout_ms = run.timeout_ms;
+
+    for member_index in 0..member_count {
+        dispatch_supervision_member(state, session_key, member_index, outgoing_tx)?;
+    }
+    schedule_supervisor_timeout(
+        session_key.to_string(),
+        generation,
+        timeout_ms,
+        internal_tx.clone(),
+    );
+    Ok(())
+}
+
+fn supervisor_system_task(message: &str) -> Option<String> {
+    tagged_task(message).or_else(|| manager_worker_group_goal(message))
+}
+
+fn tagged_task(message: &str) -> Option<String> {
+    let (_, after_open) = message.split_once("[任务]")?;
+    let (task, _) = after_open.split_once("[/任务]")?;
+    let task = task.trim();
+    (!task.is_empty()).then(|| task.to_string())
+}
+
+fn manager_worker_group_goal(message: &str) -> Option<String> {
+    let (_, service_context) = message.split_once("[SERVICE GROUP CONTEXT]")?;
+    let (service_context, _) = service_context.split_once("[/SERVICE GROUP CONTEXT]")?;
+    let (_, participants_and_goal) = service_context.split_once("参与者:\n")?;
+    let (roster_and_goal, _) = participants_and_goal.rsplit_once("\n[协同提醒]")?;
+    let (_, goal) = roster_and_goal.split_once("\n\n")?;
+    let goal = goal.trim();
+    (!goal.is_empty()).then(|| goal.to_string())
+}
+
+fn parse_participant_identity(value: &str) -> ParticipantIdentity {
+    let Some(without_closing) = value.strip_suffix(')') else {
+        return ParticipantIdentity {
+            name: value.to_string(),
+            target: value.to_string(),
+        };
+    };
+    let Some((name, identifier)) = without_closing.rsplit_once('(') else {
+        return ParticipantIdentity {
+            name: value.to_string(),
+            target: value.to_string(),
+        };
+    };
+    if name.is_empty() || identifier.is_empty() {
+        return ParticipantIdentity {
+            name: value.to_string(),
+            target: value.to_string(),
+        };
+    }
+    ParticipantIdentity {
+        name: name.to_string(),
+        target: identifier.to_string(),
+    }
+}
+
+fn render_assignment(
+    template: &str,
+    input: &str,
+    member: &str,
+    index: usize,
+    total: usize,
+) -> String {
+    template
+        .replace("{input}", input)
+        .replace("{member}", member)
+        .replace("{index}", &index.to_string())
+        .replace("{total}", &total.to_string())
+}
+
+fn dispatch_supervision_member(
+    state: &mut RuntimeState,
+    session_key: &str,
+    member_index: usize,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+) -> Result<()> {
+    let request_id = Uuid::new_v4().to_string();
+    let (scope_id, target_bot, message) = {
+        let run = state
+            .supervisions
+            .get_mut(session_key)
+            .context("supervision run disappeared before dispatch")?;
+        let member = run
+            .members
+            .get_mut(member_index)
+            .context("supervision member disappeared before dispatch")?;
+        member.attempts = member.attempts.saturating_add(1);
+        member.status = SupervisionMemberStatus::Dispatching;
+        (
+            run.scope_id.clone(),
+            member.target_bot.clone(),
+            member.task_message.clone(),
+        )
+    };
+    state.dispatch_requests.insert(
+        request_id.clone(),
+        PendingDispatch {
+            session_key: session_key.to_string(),
+            member_index,
+        },
+    );
+    send(
+        outgoing_tx,
+        BcsFrame::Request(RequestFrame::new(
+            request_id,
+            "task.dispatch",
+            Some(serde_json::to_value(TaskDispatchParams {
+                group_id: &scope_id,
+                target_bot: &target_bot,
+                message: &message,
+            })?),
+        )),
+    );
+    Ok(())
+}
+
+fn handle_bcs_response(
+    state: &mut RuntimeState,
+    response: ResponseFrame,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<()> {
+    let Some(pending) = state.dispatch_requests.remove(&response.id) else {
+        debug!(id = %response.id, ok = response.ok, "received BCS response");
+        return Ok(());
+    };
+    let Some(run) = state.supervisions.get_mut(&pending.session_key) else {
+        return Ok(());
+    };
+    let Some(member) = run.members.get_mut(pending.member_index) else {
+        return Ok(());
+    };
+    if !matches!(member.status, SupervisionMemberStatus::Dispatching) {
+        return Ok(());
+    }
+
+    let dispatch_result = if response.ok {
+        response
+            .payload
+            .ok_or_else(|| "task.dispatch response is missing payload".to_string())
+            .and_then(|payload| {
+                serde_json::from_value::<TaskDispatchResponse>(payload)
+                    .map_err(|error| format!("invalid task.dispatch response: {error}"))
+            })
+            .map(|result| result.task_id)
+    } else {
+        Err(response
+            .error
+            .map_or_else(|| "task.dispatch failed".to_string(), |error| error.message))
+    };
+
+    match dispatch_result {
+        Ok(task_id) => {
+            member.status = SupervisionMemberStatus::Waiting { task_id };
+        }
+        Err(message) => {
+            if member.attempts <= run.max_retries {
+                dispatch_supervision_member(
+                    state,
+                    &pending.session_key,
+                    pending.member_index,
+                    outgoing_tx,
+                )?;
+            } else {
+                member.status = SupervisionMemberStatus::DispatchFailed { message };
+            }
+        }
+    }
+    maybe_finalize_supervision(state, &pending.session_key, outgoing_tx, internal_tx)?;
+    Ok(())
+}
+
+fn handle_supervisor_result(
+    state: &mut RuntimeState,
+    input: &BehaviorInput,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<bool> {
+    let Some(task_id) = input.task_id.as_deref() else {
+        return Ok(false);
+    };
+    let matching_session = state.supervisions.iter().find_map(|(session_key, run)| {
+        run.members
+            .iter()
+            .any(|member| {
+                member.name == input.sender_name
+                    && match &member.status {
+                        SupervisionMemberStatus::Waiting { task_id: expected }
+                        | SupervisionMemberStatus::Completed {
+                            task_id: expected, ..
+                        } => expected == task_id,
+                        _ => false,
+                    }
+            })
+            .then(|| session_key.clone())
+    });
+    let Some(session_key) = matching_session else {
+        return Ok(false);
+    };
+    let run = state
+        .supervisions
+        .get_mut(&session_key)
+        .context("matching supervision run disappeared")?;
+    let Some(member) = run.members.iter_mut().find(|member| {
+        member.name == input.sender_name
+            && match &member.status {
+                SupervisionMemberStatus::Waiting { task_id: expected }
+                | SupervisionMemberStatus::Completed {
+                    task_id: expected, ..
+                } => expected == task_id,
+                _ => false,
+            }
+    }) else {
+        return Ok(false);
+    };
+
+    if matches!(member.status, SupervisionMemberStatus::Completed { .. }) {
+        return Ok(true);
+    }
+    let result = if input.context_message.is_empty() {
+        input.message_text.clone()
+    } else {
+        input.context_message.clone()
+    };
+    member.status = SupervisionMemberStatus::Completed {
+        task_id: task_id.to_string(),
+        result,
+    };
+    maybe_finalize_supervision(state, &session_key, outgoing_tx, internal_tx)?;
+    Ok(true)
+}
+
+fn handle_supervisor_timeout(
+    state: &mut RuntimeState,
+    session_key: &str,
+    generation: u64,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<()> {
+    let Some(run) = state.supervisions.get(session_key) else {
+        return Ok(());
+    };
+    if run.generation != generation {
+        return Ok(());
+    }
+
+    let retry_indexes = run
+        .members
+        .iter()
+        .enumerate()
+        .filter_map(|(index, member)| {
+            (!member.status.is_terminal() && member.attempts <= run.max_retries).then_some(index)
+        })
+        .collect::<Vec<_>>();
+    if retry_indexes.is_empty() {
+        if let Some(run) = state.supervisions.get_mut(session_key) {
+            for member in &mut run.members {
+                if !member.status.is_terminal() {
+                    member.status = SupervisionMemberStatus::Timeout;
+                }
+            }
+        }
+        state
+            .dispatch_requests
+            .retain(|_, pending| pending.session_key != session_key);
+        maybe_finalize_supervision(state, session_key, outgoing_tx, internal_tx)?;
+        return Ok(());
+    }
+
+    state
+        .dispatch_requests
+        .retain(|_, pending| pending.session_key != session_key);
+    let (next_generation, timeout_ms) = {
+        let run = state
+            .supervisions
+            .get_mut(session_key)
+            .context("supervision run disappeared before retry")?;
+        run.generation = run.generation.saturating_add(1);
+        (run.generation, run.timeout_ms)
+    };
+    for member_index in retry_indexes {
+        dispatch_supervision_member(state, session_key, member_index, outgoing_tx)?;
+    }
+    schedule_supervisor_timeout(
+        session_key.to_string(),
+        next_generation,
+        timeout_ms,
+        internal_tx.clone(),
+    );
+    Ok(())
+}
+
+fn schedule_supervisor_timeout(
+    session_key: String,
+    generation: u64,
+    timeout_ms: u64,
+    internal_tx: mpsc::UnboundedSender<InternalEvent>,
+) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(timeout_ms)).await;
+        let _ = internal_tx.send(InternalEvent::SupervisorTimeout {
+            session_key,
+            generation,
+        });
+    });
+}
+
+fn maybe_finalize_supervision(
+    state: &mut RuntimeState,
+    session_key: &str,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) -> Result<()> {
+    let complete = state
+        .supervisions
+        .get(session_key)
+        .is_some_and(|run| run.members.iter().all(|member| member.status.is_terminal()));
+    if !complete {
+        return Ok(());
+    }
+    let run = state
+        .supervisions
+        .remove(session_key)
+        .context("completed supervision run disappeared")?;
+    state
+        .dispatch_requests
+        .retain(|_, pending| pending.session_key != session_key);
+
+    let success_count = run
+        .members
+        .iter()
+        .filter(|member| matches!(member.status, SupervisionMemberStatus::Completed { .. }))
+        .count();
+    let failed_count = run.members.len().saturating_sub(success_count);
+    let results = run
+        .members
+        .iter()
+        .map(SupervisionMember::result_line)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let summary = run
+        .summary_template
+        .replace("{success_count}", &success_count.to_string())
+        .replace("{failed_count}", &failed_count.to_string())
+        .replace("{results}", &results)
+        .replace("{input}", &run.original_input);
+
+    send(
+        outgoing_tx,
+        BcsFrame::Request(RequestFrame::new(
+            Uuid::new_v4().to_string(),
+            "task.complete",
+            Some(serde_json::to_value(TaskCompleteParams {
+                group_id: &run.scope_id,
+                summary: &summary,
+                status: "completed",
+            })?),
+        )),
+    );
+    let summary_run_id = Uuid::new_v4().to_string();
+    let summary_group_id = run.scope_id;
+    let response_delay_ms = run.response_delay_ms;
+    state.append_history(
+        session_key,
+        HistoryMessage {
+            id: format!("rule-{summary_run_id}"),
+            role: "assistant".to_string(),
+            content: summary.clone(),
+            timestamp: bcs_protocol::now_ms(),
+        },
+    );
+    schedule_reply(
+        state,
+        summary_run_id,
+        summary_group_id,
+        session_key.to_string(),
+        summary,
+        response_delay_ms,
+        outgoing_tx.clone(),
+        internal_tx.clone(),
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn complete_reply(
+    state: &mut RuntimeState,
+    cache_key: String,
+    run_id: String,
+    group_id: String,
+    session_key: &str,
+    reply: String,
+    response_delay_ms: u64,
+    outgoing_tx: &mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: &mpsc::UnboundedSender<InternalEvent>,
+) {
+    state.append_history(
+        session_key,
+        HistoryMessage {
+            id: format!("rule-{run_id}"),
+            role: "assistant".to_string(),
+            content: reply.clone(),
+            timestamp: bcs_protocol::now_ms(),
+        },
+    );
+    state.idempotency.insert(
+        cache_key,
+        CachedRun {
+            run_id: run_id.clone(),
+            group_id: group_id.clone(),
+            session_key: session_key.to_string(),
+            reply: Some(reply.clone()),
+        },
+    );
+    schedule_reply(
+        state,
+        run_id,
+        group_id,
+        session_key.to_string(),
+        reply,
+        response_delay_ms,
+        outgoing_tx.clone(),
+        internal_tx.clone(),
+    );
+}
+
+fn parse_params<T: serde::de::DeserializeOwned>(request: &RequestFrame) -> Result<T> {
+    let params = request
+        .params
+        .clone()
+        .context("request is missing params")?;
+    serde_json::from_value(params).context("invalid request params")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn schedule_reply(
+    state: &mut RuntimeState,
+    run_id: String,
+    group_id: String,
+    session_key: String,
+    reply: String,
+    delay_ms: u64,
+    outgoing_tx: mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: mpsc::UnboundedSender<InternalEvent>,
+) {
+    if delay_ms == 0 {
+        send(&outgoing_tx, final_chat_event(run_id, group_id, reply));
+        return;
+    }
+    if let Some(previous) = state.pending_runs.remove(&run_id) {
+        previous.cancellation.cancel();
+    }
+    let cancellation = CancellationToken::new();
+    state.pending_runs.insert(
+        run_id.clone(),
+        PendingRun {
+            session_key,
+            cancellation: cancellation.clone(),
+        },
+    );
+    tokio::spawn(async move {
+        tokio::select! {
+            () = cancellation.cancelled() => {}
+            () = tokio::time::sleep(Duration::from_millis(delay_ms)) => {
+                let _ = outgoing_tx.send(final_chat_event(&run_id, group_id, reply));
+            }
+        }
+        let _ = internal_tx.send(InternalEvent::RunFinished(run_id));
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn schedule_supervisor_announcement(
+    state: &mut RuntimeState,
+    run_id: String,
+    group_id: String,
+    session_key: String,
+    announcement: String,
+    delay_ms: u64,
+    outgoing_tx: mpsc::UnboundedSender<BcsFrame>,
+    internal_tx: mpsc::UnboundedSender<InternalEvent>,
+) {
+    if let Some(previous) = state.pending_runs.remove(&run_id) {
+        previous.cancellation.cancel();
+    }
+    let cancellation = CancellationToken::new();
+    state.pending_runs.insert(
+        run_id.clone(),
+        PendingRun {
+            session_key: session_key.clone(),
+            cancellation: cancellation.clone(),
+        },
+    );
+    tokio::spawn(async move {
+        tokio::select! {
+            () = cancellation.cancelled() => {
+                let _ = internal_tx.send(InternalEvent::RunFinished(run_id));
+            }
+            () = tokio::time::sleep(Duration::from_millis(delay_ms)) => {
+                let _ = outgoing_tx.send(final_chat_event(&run_id, group_id, announcement));
+                let _ = internal_tx.send(InternalEvent::SupervisorAnnouncementFinished {
+                    session_key,
+                    manager_run_id: run_id,
+                });
+            }
+        }
+    });
+}
+
+fn behavior_error(error: &BehaviorError) -> (&'static str, String) {
+    match error {
+        BehaviorError::OutputSizeOverflow => ("output_size_overflow", error.to_string()),
+        BehaviorError::ResourceExhausted => ("resource_exhausted", error.to_string()),
+    }
+}
+
+fn send(outgoing_tx: &mpsc::UnboundedSender<BcsFrame>, frame: BcsFrame) {
+    let _ = outgoing_tx.send(frame);
+}
+
+fn send_status(
+    config: &InstanceConfig,
+    status_tx: &mpsc::UnboundedSender<StatusCommand>,
+    state: InstanceState,
+    bot_uuid: Option<String>,
+    last_error: Option<String>,
+) {
+    let _ = status_tx.send(StatusCommand::Update(StatusUpdate {
+        profile: config.bot.profile.clone(),
+        name: config.bot.name.clone(),
+        behavior: config.bot.behavior_name().to_string(),
+        state,
+        bot_uuid,
+        last_error,
+    }));
+}
+
+struct RuntimeState {
+    bot_uuid: Option<String>,
+    behavior: BehaviorRuntime,
+    history: HashMap<String, Vec<HistoryMessage>>,
+    idempotency: IdempotencyCache,
+    pending_runs: HashMap<String, PendingRun>,
+    supervisions: HashMap<String, SupervisionRun>,
+    dispatch_requests: HashMap<String, PendingDispatch>,
+}
+
+impl RuntimeState {
+    fn new(config: &BehaviorConfig) -> Self {
+        Self {
+            bot_uuid: None,
+            behavior: BehaviorRuntime::new(config),
+            history: HashMap::new(),
+            idempotency: IdempotencyCache::new(IDEMPOTENCY_CACHE_SIZE),
+            pending_runs: HashMap::new(),
+            supervisions: HashMap::new(),
+            dispatch_requests: HashMap::new(),
+        }
+    }
+
+    fn append_history(&mut self, session_key: &str, message: HistoryMessage) {
+        self.history
+            .entry(session_key.to_string())
+            .or_default()
+            .push(message);
+    }
+
+    fn cache_key(
+        &self,
+        input: &BehaviorInput,
+        idempotency_key: Option<&str>,
+        request_id: &str,
+    ) -> String {
+        format!(
+            "{}\0{}",
+            input.effective_session_key(),
+            idempotency_key.unwrap_or(request_id)
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedRun {
+    run_id: String,
+    group_id: String,
+    session_key: String,
+    reply: Option<String>,
+}
+
+struct PendingRun {
+    session_key: String,
+    cancellation: CancellationToken,
+}
+
+struct SupervisionRun {
+    manager_run_id: String,
+    scope_id: String,
+    original_input: String,
+    summary_template: String,
+    response_delay_ms: u64,
+    timeout_ms: u64,
+    max_retries: u32,
+    generation: u64,
+    dispatch_started: bool,
+    members: Vec<SupervisionMember>,
+}
+
+struct SupervisionMember {
+    name: String,
+    target_bot: String,
+    task_message: String,
+    attempts: u32,
+    status: SupervisionMemberStatus,
+}
+
+struct ParticipantIdentity {
+    name: String,
+    target: String,
+}
+
+enum SupervisionMemberStatus {
+    Dispatching,
+    Waiting { task_id: String },
+    Completed { task_id: String, result: String },
+    DispatchFailed { message: String },
+    Timeout,
+}
+
+impl SupervisionMemberStatus {
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Completed { .. } | Self::DispatchFailed { .. } | Self::Timeout
+        )
+    }
+}
+
+impl SupervisionMember {
+    fn result_line(&self) -> String {
+        match &self.status {
+            SupervisionMemberStatus::Completed { result, .. } => {
+                format!("- {} [completed]: {}", self.name, result)
+            }
+            SupervisionMemberStatus::DispatchFailed { message } => {
+                format!("- {} [dispatch_failed]: {}", self.name, message)
+            }
+            SupervisionMemberStatus::Timeout => {
+                format!("- {} [timeout]: 未在期限内返回", self.name)
+            }
+            SupervisionMemberStatus::Dispatching | SupervisionMemberStatus::Waiting { .. } => {
+                format!("- {} [incomplete]: 状态未结束", self.name)
+            }
+        }
+    }
+}
+
+struct PendingDispatch {
+    session_key: String,
+    member_index: usize,
+}
+
+struct IdempotencyCache {
+    capacity: usize,
+    values: HashMap<String, CachedRun>,
+    order: VecDeque<String>,
+}
+
+impl IdempotencyCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            values: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<&CachedRun> {
+        self.values.get(key)
+    }
+
+    fn insert(&mut self, key: String, value: CachedRun) {
+        if let Some(existing) = self.values.get_mut(&key) {
+            *existing = value;
+            return;
+        }
+        while self.values.len() >= self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.values.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+        self.order.push_back(key.clone());
+        self.values.insert(key, value);
+    }
+
+    fn remove_group(&mut self, group_id: &str) {
+        self.values
+            .retain(|_, cached| !session_belongs_to_group(&cached.session_key, group_id));
+        let values = &self.values;
+        self.order.retain(|key| values.contains_key(key));
+    }
+}
+
+enum InternalEvent {
+    RunFinished(String),
+    SupervisorAnnouncementFinished {
+        session_key: String,
+        manager_run_id: String,
+    },
+    SupervisorTimeout {
+        session_key: String,
+        generation: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        RuntimeConfig, StateScope, SupervisorAssignment, SupervisorAssignmentMode,
+        SupervisorCompletion,
+    };
+
+    fn supervisor_behavior() -> BehaviorConfig {
+        BehaviorConfig::Supervisor {
+            assignment: SupervisorAssignment {
+                mode: SupervisorAssignmentMode::EachMember,
+                task_template: "{index}/{total} {member}: {input}".to_string(),
+            },
+            completion: SupervisorCompletion {
+                timeout_ms: 1_000,
+                max_retries: 0,
+            },
+            summary_template: "成功 {success_count}，失败 {failed_count}\n{results}\n输入：{input}"
+                .to_string(),
+        }
+    }
+
+    fn instance_config(behavior: BehaviorConfig) -> InstanceConfig {
+        InstanceConfig {
+            bot: BotProfile {
+                source: None,
+                profile: "supervisor".to_string(),
+                name: "任务协调者".to_string(),
+                summary: "规则任务协调者".to_string(),
+                domains: "testing".to_string(),
+                skills: "supervision".to_string(),
+                scopes: None,
+                runtime: RuntimeConfig::Rule {
+                    response_delay_ms: 0,
+                    behavior,
+                },
+            },
+            scopes: "local".to_string(),
+            bcs_url: "ws://127.0.0.1/ws/bot".to_string(),
+            profile_dir: PathBuf::from("/tmp/rule-bot-test"),
+        }
+    }
+
+    fn supervisor_input() -> BehaviorInput {
+        BehaviorInput {
+            session_key: "group:session".to_string(),
+            bcs_group_id: "group".to_string(),
+            bcs_session_id: Some("group:session".to_string()),
+            message_text: "检查发布".to_string(),
+            context_message: "检查发布".to_string(),
+            task_id: None,
+            sender_name: "human".to_string(),
+            recipient_role: Some("manager".to_string()),
+            group_type: Some("manager_worker".to_string()),
+            participants: vec![
+                "任务协调者(manager-id)".to_string(),
+                "成员A(worker-a)".to_string(),
+                "成员B(worker-b)".to_string(),
+            ],
+        }
+    }
+
+    fn take_dispatch(outgoing_rx: &mut mpsc::UnboundedReceiver<BcsFrame>) -> (String, String) {
+        match outgoing_rx
+            .try_recv()
+            .unwrap_or_else(|error| panic!("missing task.dispatch: {error}"))
+        {
+            BcsFrame::Request(request) => {
+                assert_eq!(request.method, "task.dispatch");
+                let target = request
+                    .params
+                    .as_ref()
+                    .and_then(|params| params.get("target_bot"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_else(|| panic!("task.dispatch target_bot is missing"))
+                    .to_string();
+                (request.id, target)
+            }
+            other => panic!("expected task.dispatch, got {other:?}"),
+        }
+    }
+
+    fn take_chat_text(outgoing_rx: &mut mpsc::UnboundedReceiver<BcsFrame>) -> String {
+        let frame = outgoing_rx
+            .try_recv()
+            .unwrap_or_else(|error| panic!("missing chat.event: {error}"));
+        let BcsFrame::Event(event) = frame else {
+            panic!("expected chat.event");
+        };
+        assert_eq!(event.event, "chat.event");
+        event
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.get("message"))
+            .and_then(|message| message.get("content"))
+            .and_then(|content| content.as_array())
+            .and_then(|content| content.first())
+            .and_then(|block| block.get("text"))
+            .and_then(|text| text.as_str())
+            .unwrap_or_else(|| panic!("chat.event text is missing"))
+            .to_string()
+    }
+
+    #[test]
+    fn participant_identity_prefers_uuid_suffix() {
+        let identity = parse_participant_identity("成员(worker-id)");
+        assert_eq!(identity.name, "成员");
+        assert_eq!(identity.target, "worker-id");
+
+        let plain = parse_participant_identity("worker-id");
+        assert_eq!(plain.name, "worker-id");
+        assert_eq!(plain.target, "worker-id");
+        assert_eq!(
+            tagged_task("context\n[任务]\n检查上线\n[/任务]\nend").as_deref(),
+            Some("检查上线")
+        );
+        assert!(tagged_task("[SERVICE GROUP CONTEXT]").is_none());
+    }
+
+    #[test]
+    fn system_supervisor_task_prefers_session_task_and_falls_back_to_group_goal() {
+        let goal_only = "\
+[SERVICE GROUP CONTEXT]\n\
+群组ID: group\n\
+会话ID: group:session\n\
+模式: manager_worker\n\
+你的角色: manager\n\
+参与者:\n\
+- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
+- 名称: 成员A | ID: worker-a | 角色: worker\n\
+\n\
+测试协作目标\n\
+\n\
+[协同提醒] 本群为任务群，你是主 Bot。\n\
+[/SERVICE GROUP CONTEXT]";
+        assert_eq!(
+            supervisor_system_task(goal_only).as_deref(),
+            Some("测试协作目标")
+        );
+
+        let goal_and_task = "\
+[SERVICE GROUP CONTEXT]\n\
+参与者:\n\
+- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
+\n\
+长期协作目标\n\
+\n\
+[任务]\n\
+本次会话任务\n\
+[/任务]\n\
+\n\
+[协同提醒] 本群为任务群，你是主 Bot。\n\
+[/SERVICE GROUP CONTEXT]";
+        assert_eq!(
+            supervisor_system_task(goal_and_task).as_deref(),
+            Some("本次会话任务")
+        );
+
+        let no_goal = "\
+[SERVICE GROUP CONTEXT]\n\
+参与者:\n\
+- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
+\n\
+[协同提醒] 本群为任务群，你是主 Bot。\n\
+[/SERVICE GROUP CONTEXT]";
+        assert!(supervisor_system_task(no_goal).is_none());
+    }
+
+    #[test]
+    fn targeted_message_removes_only_the_leading_recipient_mention() {
+        let mentions = vec!["bot-id".to_string()];
+
+        assert_eq!(
+            strip_leading_recipient_mention(
+                "复读机 在吗",
+                true,
+                Some("复读机"),
+                Some("bot-id"),
+                &mentions,
+            ),
+            "在吗"
+        );
+        assert_eq!(
+            strip_leading_recipient_mention(
+                "@任务协调者：开始",
+                true,
+                Some("任务协调者"),
+                Some("manager-id"),
+                &[],
+            ),
+            "开始"
+        );
+        assert_eq!(
+            strip_leading_recipient_mention(
+                "复读机 在吗",
+                false,
+                Some("复读机"),
+                Some("bot-id"),
+                &mentions,
+            ),
+            "复读机 在吗"
+        );
+        assert_eq!(
+            strip_leading_recipient_mention(
+                "复读机今天在吗",
+                true,
+                Some("复读机"),
+                Some("bot-id"),
+                &mentions,
+            ),
+            "复读机今天在吗"
+        );
+    }
+
+    #[tokio::test]
+    async fn supervisor_dispatches_every_worker_and_summarizes_results() {
+        let behavior = supervisor_behavior();
+        let config = instance_config(behavior.clone());
+        let mut state = RuntimeState::new(&behavior);
+        state.bot_uuid = Some("manager-id".to_string());
+        let input = supervisor_input();
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
+        let start = match BehaviorRuntime::new(&behavior)
+            .handle_send(&input)
+            .unwrap_or_else(|error| panic!("supervisor behavior failed: {error}"))
+        {
+            BehaviorOutcome::StartSupervisor(start) => start,
+            BehaviorOutcome::Reply(reply) => panic!("unexpected reply: {reply}"),
+        };
+
+        start_supervisor(
+            &config,
+            &mut state,
+            &input,
+            "manager-run".to_string(),
+            "group".to_string(),
+            "group:session\0request".to_string(),
+            start,
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("failed to start supervisor: {error}"));
+
+        assert_eq!(
+            take_chat_text(&mut outgoing_rx),
+            "已收到任务，开始分配给 2 位成员。"
+        );
+        let (dispatch_a, target_a) = take_dispatch(&mut outgoing_rx);
+        let (dispatch_b, target_b) = take_dispatch(&mut outgoing_rx);
+        assert_eq!(target_a, "worker-a");
+        assert_eq!(target_b, "worker-b");
+        handle_bcs_response(
+            &mut state,
+            ResponseFrame::ok(
+                dispatch_a,
+                json!({"task_id": "task-a", "status": "dispatched"}),
+            ),
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("dispatch response failed: {error}"));
+        handle_bcs_response(
+            &mut state,
+            ResponseFrame::ok(
+                dispatch_b,
+                json!({"task_id": "task-b", "status": "dispatched"}),
+            ),
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("dispatch response failed: {error}"));
+
+        let mut result_a = input.clone();
+        result_a.bcs_session_id = Some("wire-result-session".to_string());
+        result_a.sender_name = "成员A".to_string();
+        result_a.task_id = Some("task-a".to_string());
+        result_a.context_message = "A完成".to_string();
+        assert!(
+            handle_supervisor_result(&mut state, &result_a, &outgoing_tx, &internal_tx)
+                .unwrap_or_else(|error| panic!("worker result failed: {error}"))
+        );
+        assert!(outgoing_rx.try_recv().is_err());
+
+        let mut result_b = input;
+        result_b.bcs_session_id = Some("wire-result-session".to_string());
+        result_b.sender_name = "成员B".to_string();
+        result_b.task_id = Some("task-b".to_string());
+        result_b.context_message = "B完成".to_string();
+        assert!(
+            handle_supervisor_result(&mut state, &result_b, &outgoing_tx, &internal_tx)
+                .unwrap_or_else(|error| panic!("worker result failed: {error}"))
+        );
+
+        let complete = outgoing_rx
+            .try_recv()
+            .unwrap_or_else(|error| panic!("missing task.complete: {error}"));
+        let final_event = outgoing_rx
+            .try_recv()
+            .unwrap_or_else(|error| panic!("missing final event: {error}"));
+        match complete {
+            BcsFrame::Request(request) => assert_eq!(request.method, "task.complete"),
+            other => panic!("expected task.complete, got {other:?}"),
+        }
+        let final_json = serde_json::to_string(&final_event)
+            .unwrap_or_else(|error| panic!("failed to serialize final event: {error}"));
+        assert!(final_json.contains("成功 2，失败 0"));
+        assert!(final_json.contains("成员A [completed]: A完成"));
+        assert!(final_json.contains("成员B [completed]: B完成"));
+        assert!(final_json.contains("\"bcs_group_id\":\"group:session\""));
+        assert!(!state.supervisions.contains_key("group:session"));
+    }
+
+    #[tokio::test]
+    async fn supervisor_dispatches_group_goal_from_initial_system_context() {
+        let behavior = supervisor_behavior();
+        let config = instance_config(behavior.clone());
+        let mut state = RuntimeState::new(&behavior);
+        state.bot_uuid = Some("manager-id".to_string());
+        let mut input = supervisor_input();
+        input.sender_name = "bcs-system-message".to_string();
+        input.message_text = "\
+[SERVICE GROUP CONTEXT]\n\
+参与者:\n\
+- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
+- 名称: 成员A | ID: worker-a | 角色: worker\n\
+- 名称: 成员B | ID: worker-b | 角色: worker\n\
+\n\
+初始化协作目标\n\
+\n\
+[协同提醒] 本群为任务群，你是主 Bot。\n\
+[/SERVICE GROUP CONTEXT]"
+            .to_string();
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
+        let start = match BehaviorRuntime::new(&behavior)
+            .handle_send(&input)
+            .unwrap_or_else(|error| panic!("supervisor behavior failed: {error}"))
+        {
+            BehaviorOutcome::StartSupervisor(start) => start,
+            BehaviorOutcome::Reply(reply) => panic!("unexpected reply: {reply}"),
+        };
+
+        start_supervisor(
+            &config,
+            &mut state,
+            &input,
+            "manager-run".to_string(),
+            "group".to_string(),
+            "group:session\0request".to_string(),
+            start,
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("failed to start supervisor: {error}"));
+
+        assert_eq!(
+            take_chat_text(&mut outgoing_rx),
+            "已收到任务，开始分配给 2 位成员。"
+        );
+        for _ in 0..2 {
+            let dispatch = outgoing_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("missing task.dispatch: {error}"));
+            let BcsFrame::Request(request) = dispatch else {
+                panic!("expected task.dispatch request");
+            };
+            assert_eq!(request.method, "task.dispatch");
+            let message = request
+                .params
+                .as_ref()
+                .and_then(|params| params.get("message"))
+                .and_then(|value| value.as_str())
+                .unwrap_or_else(|| panic!("task.dispatch message is missing"));
+            assert!(message.contains("初始化协作目标"));
+        }
+        assert!(state.supervisions.contains_key("group:session"));
+    }
+
+    #[tokio::test]
+    async fn supervisor_timeout_finishes_without_retry() {
+        let behavior = supervisor_behavior();
+        let config = instance_config(behavior.clone());
+        let mut state = RuntimeState::new(&behavior);
+        state.bot_uuid = Some("manager-id".to_string());
+        let input = supervisor_input();
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
+        let start = match BehaviorRuntime::new(&behavior)
+            .handle_send(&input)
+            .unwrap_or_else(|error| panic!("supervisor behavior failed: {error}"))
+        {
+            BehaviorOutcome::StartSupervisor(start) => start,
+            BehaviorOutcome::Reply(reply) => panic!("unexpected reply: {reply}"),
+        };
+        start_supervisor(
+            &config,
+            &mut state,
+            &input,
+            "manager-run".to_string(),
+            "group".to_string(),
+            "group:session\0request".to_string(),
+            start,
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("failed to start supervisor: {error}"));
+        assert_eq!(
+            take_chat_text(&mut outgoing_rx),
+            "已收到任务，开始分配给 2 位成员。"
+        );
+        let _ = take_dispatch(&mut outgoing_rx);
+        let _ = take_dispatch(&mut outgoing_rx);
+
+        handle_supervisor_timeout(&mut state, "group:session", 1, &outgoing_tx, &internal_tx)
+            .unwrap_or_else(|error| panic!("timeout handling failed: {error}"));
+
+        let complete = outgoing_rx
+            .try_recv()
+            .unwrap_or_else(|error| panic!("missing task.complete: {error}"));
+        let final_event = outgoing_rx
+            .try_recv()
+            .unwrap_or_else(|error| panic!("missing final event: {error}"));
+        assert!(matches!(complete, BcsFrame::Request(_)));
+        let final_json = serde_json::to_string(&final_event)
+            .unwrap_or_else(|error| panic!("failed to serialize final event: {error}"));
+        assert!(final_json.contains("成功 0，失败 2"));
+        assert!(final_json.contains("[timeout]"));
+    }
+
+    #[tokio::test]
+    async fn supervisor_visible_reply_uses_configured_delay() {
+        let behavior = supervisor_behavior();
+        let mut config = instance_config(behavior.clone());
+        config.bot.runtime = RuntimeConfig::Rule {
+            response_delay_ms: 60_000,
+            behavior: behavior.clone(),
+        };
+        let mut state = RuntimeState::new(&behavior);
+        state.bot_uuid = Some("manager-id".to_string());
+        let mut input = supervisor_input();
+        input.sender_name = "bcs-system-message".to_string();
+        input.message_text = "[MANAGER-WORKER GROUP CONTEXT]".to_string();
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
+        let start = match BehaviorRuntime::new(&behavior)
+            .handle_send(&input)
+            .unwrap_or_else(|error| panic!("supervisor behavior failed: {error}"))
+        {
+            BehaviorOutcome::StartSupervisor(start) => start,
+            BehaviorOutcome::Reply(reply) => panic!("unexpected reply: {reply}"),
+        };
+
+        start_supervisor(
+            &config,
+            &mut state,
+            &input,
+            "manager-run".to_string(),
+            "group".to_string(),
+            "group:session\0request".to_string(),
+            start,
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("failed to start supervisor: {error}"));
+
+        assert!(outgoing_rx.try_recv().is_err());
+        assert!(state.pending_runs.contains_key("manager-run"));
+        for (_, pending) in state.pending_runs.drain() {
+            pending.cancellation.cancel();
+        }
+    }
+
+    #[tokio::test]
+    async fn supervisor_waits_for_delayed_announcement_before_dispatching() {
+        let behavior = supervisor_behavior();
+        let mut config = instance_config(behavior.clone());
+        config.bot.runtime = RuntimeConfig::Rule {
+            response_delay_ms: 10,
+            behavior: behavior.clone(),
+        };
+        let mut state = RuntimeState::new(&behavior);
+        state.bot_uuid = Some("manager-id".to_string());
+        let input = supervisor_input();
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
+        let start = match BehaviorRuntime::new(&behavior)
+            .handle_send(&input)
+            .unwrap_or_else(|error| panic!("supervisor behavior failed: {error}"))
+        {
+            BehaviorOutcome::StartSupervisor(start) => start,
+            BehaviorOutcome::Reply(reply) => panic!("unexpected reply: {reply}"),
+        };
+
+        start_supervisor(
+            &config,
+            &mut state,
+            &input,
+            "manager-run".to_string(),
+            "group".to_string(),
+            "group:session\0request".to_string(),
+            start,
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("failed to start supervisor: {error}"));
+
+        assert!(outgoing_rx.try_recv().is_err());
+        assert!(state.dispatch_requests.is_empty());
+        let event = tokio::time::timeout(Duration::from_secs(1), internal_rx.recv())
+            .await
+            .unwrap_or_else(|_| panic!("announcement did not finish"))
+            .unwrap_or_else(|| panic!("internal channel closed"));
+        let InternalEvent::SupervisorAnnouncementFinished {
+            session_key,
+            manager_run_id,
+        } = event
+        else {
+            panic!("unexpected internal event");
+        };
+        state.pending_runs.remove(&manager_run_id);
+        begin_supervisor_dispatch(
+            &mut state,
+            &session_key,
+            &manager_run_id,
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("failed to dispatch after announcement: {error}"));
+
+        assert_eq!(
+            take_chat_text(&mut outgoing_rx),
+            "已收到任务，开始分配给 2 位成员。"
+        );
+        let _ = take_dispatch(&mut outgoing_rx);
+        let _ = take_dispatch(&mut outgoing_rx);
+    }
+
+    #[test]
+    fn inject_does_not_advance_fixed_behavior() {
+        let behavior = BehaviorConfig::Fixed {
+            replies: vec!["第一条".to_string(), "第二条".to_string()],
+            scope: StateScope::Session,
+        };
+        let mut state = RuntimeState::new(&behavior);
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let inject = RequestFrame::new(
+            "inject",
+            "chat.inject",
+            Some(json!({
+                "session_key": "session",
+                "bcs_group_id": "group",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "静默消息"}],
+                    "timestamp": 1
+                },
+                "channel": {"source": "api"},
+                "session_context": {
+                    "session_id": "session",
+                    "participants": [],
+                    "originator": "human",
+                    "from": "human",
+                    "message": "静默消息"
+                }
+            })),
+        );
+        handle_chat_inject(&mut state, inject, &outgoing_tx)
+            .unwrap_or_else(|error| panic!("inject failed: {error}"));
+        assert!(matches!(
+            outgoing_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("missing inject ACK: {error}")),
+            BcsFrame::Response(_)
+        ));
+
+        let reply = state
+            .behavior
+            .handle_send(&BehaviorInput {
+                session_key: "session".to_string(),
+                bcs_group_id: "group".to_string(),
+                bcs_session_id: None,
+                message_text: "正常消息".to_string(),
+                context_message: "正常消息".to_string(),
+                task_id: None,
+                sender_name: "human".to_string(),
+                recipient_role: None,
+                group_type: None,
+                participants: Vec::new(),
+            })
+            .unwrap_or_else(|error| panic!("fixed behavior failed: {error}"));
+        assert!(matches!(reply, BehaviorOutcome::Reply(value) if value == "第一条"));
+    }
+
+    #[test]
+    fn session_delete_cancels_only_matching_group_runs_and_cache() {
+        let behavior = BehaviorConfig::Fixed {
+            replies: vec!["你好".to_string()],
+            scope: StateScope::Session,
+        };
+        let mut state = RuntimeState::new(&behavior);
+        state
+            .history
+            .insert("group-a:session".to_string(), Vec::new());
+        state
+            .history
+            .insert("group-b:session".to_string(), Vec::new());
+
+        let deleted_run = CancellationToken::new();
+        let retained_run = CancellationToken::new();
+        state.pending_runs.insert(
+            "run-a".to_string(),
+            PendingRun {
+                session_key: "group-a:session".to_string(),
+                cancellation: deleted_run.clone(),
+            },
+        );
+        state.pending_runs.insert(
+            "run-b".to_string(),
+            PendingRun {
+                session_key: "group-b:session".to_string(),
+                cancellation: retained_run.clone(),
+            },
+        );
+        state.idempotency.insert(
+            "group-a:session\0request".to_string(),
+            CachedRun {
+                run_id: "run-a".to_string(),
+                group_id: "group-a".to_string(),
+                session_key: "group-a:session".to_string(),
+                reply: Some("你好".to_string()),
+            },
+        );
+        state.idempotency.insert(
+            "group-b:session\0request".to_string(),
+            CachedRun {
+                run_id: "run-b".to_string(),
+                group_id: "group-b".to_string(),
+                session_key: "group-b:session".to_string(),
+                reply: Some("你好".to_string()),
+            },
+        );
+
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        handle_session_delete(
+            &mut state,
+            RequestFrame::new(
+                "delete",
+                "session.delete",
+                Some(json!({"bcs_group_id": "group-a"})),
+            ),
+            &outgoing_tx,
+        )
+        .unwrap_or_else(|error| panic!("session delete failed: {error}"));
+
+        assert!(matches!(
+            outgoing_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("missing delete ACK: {error}")),
+            BcsFrame::Response(_)
+        ));
+        assert!(deleted_run.is_cancelled());
+        assert!(!retained_run.is_cancelled());
+        assert!(!state.pending_runs.contains_key("run-a"));
+        assert!(state.pending_runs.contains_key("run-b"));
+        assert!(!state.history.contains_key("group-a:session"));
+        assert!(state.history.contains_key("group-b:session"));
+        assert!(
+            !state
+                .idempotency
+                .values
+                .contains_key("group-a:session\0request")
+        );
+        assert!(
+            state
+                .idempotency
+                .values
+                .contains_key("group-b:session\0request")
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_request_does_not_accelerate_pending_reply() {
+        let behavior = BehaviorConfig::Fixed {
+            replies: vec!["你好".to_string(), "再见".to_string()],
+            scope: StateScope::Session,
+        };
+        let mut config = instance_config(behavior.clone());
+        config.bot.runtime = RuntimeConfig::Rule {
+            response_delay_ms: 60_000,
+            behavior: behavior.clone(),
+        };
+        let mut state = RuntimeState::new(&behavior);
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
+        let params = json!({
+            "session_key": "session",
+            "bcs_group_id": "group",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "消息"}],
+                "timestamp": 1
+            },
+            "channel": {"source": "api"},
+            "session_context": {
+                "session_id": "session",
+                "participants": [],
+                "originator": "human",
+                "from": "human",
+                "message": "消息"
+            },
+            "idempotency_key": "same-request"
+        });
+
+        handle_chat_send(
+            &config,
+            &mut state,
+            RequestFrame::new("first", "chat.send", Some(params.clone())),
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("first send failed: {error}"));
+        assert!(matches!(
+            outgoing_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("missing first ACK: {error}")),
+            BcsFrame::Response(_)
+        ));
+        assert!(state.pending_runs.contains_key("first"));
+
+        handle_chat_send(
+            &config,
+            &mut state,
+            RequestFrame::new("duplicate", "chat.send", Some(params)),
+            &outgoing_tx,
+            &internal_tx,
+        )
+        .unwrap_or_else(|error| panic!("duplicate send failed: {error}"));
+        assert!(matches!(
+            outgoing_rx
+                .try_recv()
+                .unwrap_or_else(|error| panic!("missing duplicate ACK: {error}")),
+            BcsFrame::Response(_)
+        ));
+        assert!(outgoing_rx.try_recv().is_err());
+        assert_eq!(state.pending_runs.len(), 1);
+        assert!(state.pending_runs.contains_key("first"));
+
+        for (_, pending) in state.pending_runs.drain() {
+            pending.cancellation.cancel();
+        }
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/lib.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod behavior;
+pub mod config;
+pub mod host;
+pub mod instance;
+pub mod protocol;
+pub mod session_store;
+pub mod status;

--- a/src/bcs/crates/tools/bcs-rule-bot/src/main.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/main.rs
@@ -1,0 +1,76 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use bcs_rule_bot::config::Manifest;
+use bcs_rule_bot::host::{HostConfig, run_host};
+use clap::{Parser, Subcommand};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Debug, Parser)]
+#[command(name = "bcs-rule-bot")]
+#[command(about = "Rule-driven BCS bot runtime")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Validate a version 2 profile manifest.
+    Validate {
+        #[arg(long)]
+        manifest: PathBuf,
+    },
+    /// Run every rule bot declared in a profile manifest.
+    Run {
+        #[arg(long)]
+        manifest: PathBuf,
+        #[arg(long)]
+        bcs_url: String,
+        #[arg(long)]
+        profile_root: PathBuf,
+        #[arg(long, default_value = "")]
+        profile_prefix: String,
+        #[arg(long)]
+        status_file: PathBuf,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("bcs_rule_bot=info")),
+        )
+        .with_target(false)
+        .init();
+
+    match Cli::parse().command {
+        Command::Validate { manifest } => {
+            let parsed = Manifest::load(&manifest)?;
+            println!(
+                "valid rule bot manifest: {} ({} bot(s))",
+                manifest.display(),
+                parsed.rule_bots().count()
+            );
+            Ok(())
+        }
+        Command::Run {
+            manifest,
+            bcs_url,
+            profile_root,
+            profile_prefix,
+            status_file,
+        } => {
+            run_host(HostConfig {
+                manifest_path: manifest,
+                bcs_url,
+                profile_root,
+                profile_prefix,
+                status_file,
+            })
+            .await
+        }
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/protocol.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/protocol.rs
@@ -198,4 +198,106 @@ mod tests {
 
         assert_eq!(message_text(&message), "你好");
     }
+
+    #[test]
+    fn chat_history_params_use_the_default_limit() {
+        let params: ChatHistoryParams = serde_json::from_value(serde_json::json!({
+            "session_key": "group-1"
+        }))
+        .unwrap_or_else(|error| panic!("history params should deserialize: {error}"));
+
+        assert_eq!(params.session_key, "group-1");
+        assert_eq!(params.limit, 50);
+        assert!(params.before.is_none());
+        assert!(params.after.is_none());
+    }
+
+    #[test]
+    fn error_response_preserves_error_details() {
+        let response = error_response("request-1", "not_supported", "not supported", false);
+
+        match response {
+            BcsFrame::Response(response) => {
+                assert_eq!(response.id, "request-1");
+                assert!(!response.ok);
+                assert!(response.payload.is_none());
+                let error = response
+                    .error
+                    .unwrap_or_else(|| panic!("error details should be present"));
+                assert_eq!(error.code, "not_supported");
+                assert_eq!(error.message, "not supported");
+                assert!(!error.retryable);
+            }
+            other => panic!("expected response frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_chat_event_includes_error_details() {
+        let event = error_chat_event("run-1", "group-1", "behavior", "boom");
+
+        match event {
+            BcsFrame::Event(event) => {
+                assert_eq!(event.event, "chat.event");
+                let params = event
+                    .payload
+                    .unwrap_or_else(|| panic!("event params should be present"));
+                assert_eq!(params["run_id"], "run-1");
+                assert_eq!(params["bcs_group_id"], "group-1");
+                assert_eq!(params["state"], "error");
+                assert_eq!(params["errorKind"], "behavior");
+                assert_eq!(params["errorMessage"], "boom");
+                assert_eq!(params["is_error"], true);
+                assert_eq!(params["success"], false);
+            }
+            other => panic!("expected event frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn history_response_filters_and_limits_newest_messages() {
+        let messages = vec![
+            HistoryMessage {
+                id: "message-1".to_owned(),
+                role: "user".to_owned(),
+                content: "first".to_owned(),
+                timestamp: 10,
+            },
+            HistoryMessage {
+                id: "message-2".to_owned(),
+                role: "assistant".to_owned(),
+                content: "second".to_owned(),
+                timestamp: 20,
+            },
+            HistoryMessage {
+                id: "message-3".to_owned(),
+                role: "user".to_owned(),
+                content: "third".to_owned(),
+                timestamp: 30,
+            },
+        ];
+        let params = ChatHistoryParams {
+            session_key: "group-1".to_owned(),
+            limit: 1,
+            before: Some(30),
+            after: Some(5),
+        };
+
+        let response = history_response("request-1", "group-1", &messages, &params);
+
+        match response {
+            BcsFrame::Response(response) => {
+                assert!(response.ok);
+                let result = response
+                    .payload
+                    .unwrap_or_else(|| panic!("history result should be present"));
+                assert_eq!(result["session_key"], "group-1");
+                assert_eq!(result["messages"][0]["id"], "message-2");
+                assert_eq!(result["messages"][0]["content"], "second");
+                assert_eq!(result["messages"][0]["timestamp"], 20);
+                assert_eq!(result["has_more"], true);
+            }
+            other => panic!("expected response frame, got {other:?}"),
+        }
+    }
 }

--- a/src/bcs/crates/tools/bcs-rule-bot/src/protocol.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/protocol.rs
@@ -1,0 +1,201 @@
+use bcs_protocol::{
+    BcsFrame, ChatEventPayload, ChatEventState, ContentBlock, ErrorShape, EventFrame,
+    MessageContent, ResponseFrame,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryMessage {
+    pub id: String,
+    pub role: String,
+    pub content: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChatHistoryParams {
+    pub session_key: String,
+    #[serde(default = "default_history_limit")]
+    pub limit: usize,
+    #[serde(default)]
+    pub before: Option<u64>,
+    #[serde(default)]
+    pub after: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SessionDeleteParams {
+    pub bcs_group_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskDispatchParams<'a> {
+    pub group_id: &'a str,
+    pub target_bot: &'a str,
+    pub message: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskCompleteParams<'a> {
+    pub group_id: &'a str,
+    pub summary: &'a str,
+    pub status: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TaskDispatchResponse {
+    pub task_id: String,
+}
+
+fn default_history_limit() -> usize {
+    50
+}
+
+pub fn message_text(message: &MessageContent) -> String {
+    message
+        .content
+        .iter()
+        .filter(|block| block.block_type == "text")
+        .filter_map(|block| block.text.as_deref())
+        .collect()
+}
+
+pub fn ok_response(id: impl Into<String>, payload: Value) -> BcsFrame {
+    BcsFrame::Response(ResponseFrame::ok(id, payload))
+}
+
+pub fn error_response(
+    id: impl Into<String>,
+    code: impl Into<String>,
+    message: impl Into<String>,
+    retryable: bool,
+) -> BcsFrame {
+    BcsFrame::Response(ResponseFrame::err(
+        id,
+        ErrorShape {
+            code: code.into(),
+            message: message.into(),
+            details: None,
+            retryable,
+            retry_after_ms: None,
+        },
+    ))
+}
+
+pub fn final_chat_event(
+    run_id: impl Into<String>,
+    group_id: impl Into<String>,
+    text: impl Into<String>,
+) -> BcsFrame {
+    let payload = ChatEventPayload {
+        run_id: run_id.into(),
+        bcs_group_id: group_id.into(),
+        state: ChatEventState::Final,
+        message: Some(MessageContent {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::text(text)],
+            timestamp: bcs_protocol::now_ms(),
+        }),
+        delta_text: None,
+        usage: None,
+        stop_reason: Some("complete".to_string()),
+        error_message: None,
+        error_kind: None,
+        tool_call_id: None,
+        tool_name: None,
+        args: None,
+        result: None,
+        is_error: None,
+        success: None,
+        routing: None,
+    };
+    BcsFrame::Event(EventFrame::new(
+        "chat.event",
+        Some(serde_json::to_value(payload).unwrap_or(Value::Null)),
+        Some(0),
+    ))
+}
+
+pub fn error_chat_event(
+    run_id: impl Into<String>,
+    group_id: impl Into<String>,
+    error_kind: impl Into<String>,
+    message: impl Into<String>,
+) -> BcsFrame {
+    let payload = ChatEventPayload {
+        run_id: run_id.into(),
+        bcs_group_id: group_id.into(),
+        state: ChatEventState::Error,
+        message: None,
+        delta_text: None,
+        usage: None,
+        stop_reason: Some("error".to_string()),
+        error_message: Some(message.into()),
+        error_kind: Some(error_kind.into()),
+        tool_call_id: None,
+        tool_name: None,
+        args: None,
+        result: None,
+        is_error: Some(true),
+        success: Some(false),
+        routing: None,
+    };
+    BcsFrame::Event(EventFrame::new(
+        "chat.event",
+        Some(serde_json::to_value(payload).unwrap_or(Value::Null)),
+        Some(0),
+    ))
+}
+
+pub fn history_response(
+    id: &str,
+    session_key: &str,
+    messages: &[HistoryMessage],
+    params: &ChatHistoryParams,
+) -> BcsFrame {
+    let mut filtered = messages
+        .iter()
+        .filter(|message| {
+            params
+                .before
+                .is_none_or(|before| message.timestamp < before)
+                && params.after.is_none_or(|after| message.timestamp > after)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    filtered.sort_by_key(|message| std::cmp::Reverse(message.timestamp));
+    let limit = params.limit.clamp(1, 1000);
+    let has_more = filtered.len() > limit;
+    filtered.truncate(limit);
+
+    ok_response(
+        id,
+        json!({
+            "session_key": session_key,
+            "session_id": session_key,
+            "messages": filtered,
+            "has_more": has_more
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn joins_text_blocks_only() {
+        let message = MessageContent {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::text("你"),
+                ContentBlock::image("https://example.test/image"),
+                ContentBlock::text("好"),
+            ],
+            timestamp: 0,
+        };
+
+        assert_eq!(message_text(&message), "你好");
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/session_store.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/session_store.rs
@@ -103,4 +103,37 @@ mod tests {
         assert_eq!(actual.token, expected.token);
         assert_eq!(actual.bcs_url, expected.bcs_url);
     }
+
+    #[test]
+    fn missing_and_empty_tokens_are_not_restored() {
+        let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("{error}"));
+        let store = SessionStore::new(temp.path());
+
+        assert!(
+            store
+                .load()
+                .unwrap_or_else(|error| panic!("missing token should be accepted: {error}"))
+                .is_none()
+        );
+        fs::create_dir_all(
+            store
+                .path()
+                .parent()
+                .unwrap_or_else(|| panic!("session path should have a parent")),
+        )
+        .unwrap_or_else(|error| panic!("session directory should be created: {error}"));
+        fs::write(
+            store.path(),
+            r#"{"bot_uuid":null,"token":"  ","bcs_url":"ws://localhost"}"#,
+        )
+        .unwrap_or_else(|error| panic!("empty session fixture should be written: {error}"));
+
+        assert!(
+            store
+                .load()
+                .unwrap_or_else(|error| panic!("empty token should be accepted: {error}"))
+                .is_none()
+        );
+        assert!(store.path().ends_with(".bcs/session.json"));
+    }
 }

--- a/src/bcs/crates/tools/bcs-rule-bot/src/session_store.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/session_store.rs
@@ -1,0 +1,106 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub bot_uuid: Option<String>,
+    pub token: String,
+    pub bcs_url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionStore {
+    path: PathBuf,
+}
+
+impl SessionStore {
+    pub fn new(profile_dir: &Path) -> Self {
+        Self {
+            path: profile_dir.join(".bcs").join("session.json"),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load(&self) -> Result<Option<SessionInfo>> {
+        if !self.path.exists() {
+            return Ok(None);
+        }
+        let content = fs::read_to_string(&self.path)
+            .with_context(|| format!("failed to read {}", self.path.display()))?;
+        let session: SessionInfo = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse {}", self.path.display()))?;
+        if session.token.trim().is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(session))
+    }
+
+    pub fn save(&self, session: &SessionInfo) -> Result<()> {
+        let parent = self
+            .path
+            .parent()
+            .context("session path has no parent directory")?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+        let temporary = self.path.with_extension("json.tmp");
+        let content = serde_json::to_vec_pretty(session)?;
+
+        let mut options = OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temporary)
+            .with_context(|| format!("failed to open {}", temporary.display()))?;
+        file.write_all(&content)
+            .with_context(|| format!("failed to write {}", temporary.display()))?;
+        file.sync_all()
+            .with_context(|| format!("failed to sync {}", temporary.display()))?;
+        fs::rename(&temporary, &self.path).with_context(|| {
+            format!(
+                "failed to replace {} with {}",
+                self.path.display(),
+                temporary.display()
+            )
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_round_trip() {
+        let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("{error}"));
+        let store = SessionStore::new(temp.path());
+        let expected = SessionInfo {
+            bot_uuid: Some("bot-1".to_string()),
+            token: "secret".to_string(),
+            bcs_url: "ws://127.0.0.1:21000/ws/bot".to_string(),
+        };
+
+        store
+            .save(&expected)
+            .unwrap_or_else(|error| panic!("{error}"));
+        let actual = store
+            .load()
+            .unwrap_or_else(|error| panic!("{error}"))
+            .unwrap_or_else(|| panic!("session is missing"));
+
+        assert_eq!(actual.bot_uuid, expected.bot_uuid);
+        assert_eq!(actual.token, expected.token);
+        assert_eq!(actual.bcs_url, expected.bcs_url);
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/status.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/status.rs
@@ -144,3 +144,79 @@ fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |duration| duration.as_millis() as u64)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_names_match_the_status_contract() {
+        assert_eq!(InstanceState::Starting.as_str(), "starting");
+        assert_eq!(InstanceState::Connected.as_str(), "connected");
+        assert_eq!(InstanceState::Reconnecting.as_str(), "reconnecting");
+        assert_eq!(InstanceState::Error.as_str(), "error");
+        assert_eq!(InstanceState::Stopped.as_str(), "stopped");
+    }
+
+    #[test]
+    fn reporter_writes_updates_and_heartbeats_atomically() {
+        let temp = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("temporary directory should be created: {error}"));
+        let status_path = temp.path().join("nested").join("status.json");
+        let manifest_path = temp.path().join("bots.json");
+        let mut reporter = StatusReporter::new(status_path.clone(), manifest_path.clone());
+
+        reporter
+            .apply(StatusUpdate {
+                profile: "friendly".to_owned(),
+                name: "Friendly".to_owned(),
+                behavior: "fixed".to_owned(),
+                state: InstanceState::Connected,
+                bot_uuid: Some("bot-1".to_owned()),
+                last_error: None,
+            })
+            .unwrap_or_else(|error| panic!("connected status should be written: {error}"));
+        reporter
+            .apply(StatusUpdate {
+                profile: "random".to_owned(),
+                name: "Random".to_owned(),
+                behavior: "random".to_owned(),
+                state: InstanceState::Error,
+                bot_uuid: None,
+                last_error: Some("connection lost".to_owned()),
+            })
+            .unwrap_or_else(|error| panic!("error status should be written: {error}"));
+        reporter
+            .touch("friendly")
+            .unwrap_or_else(|error| panic!("heartbeat should be written: {error}"));
+        reporter
+            .touch("unknown")
+            .unwrap_or_else(|error| panic!("unknown heartbeat should be harmless: {error}"));
+
+        let contents = fs::read_to_string(&status_path)
+            .unwrap_or_else(|error| panic!("status file should be readable: {error}"));
+        let status: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|error| panic!("status file should contain JSON: {error}"));
+        assert_eq!(status["pid"], std::process::id());
+        assert_eq!(
+            status["manifest"],
+            manifest_path.to_string_lossy().as_ref()
+        );
+        assert_eq!(status["bots"]["friendly"]["name"], "Friendly");
+        assert_eq!(status["bots"]["friendly"]["bot_uuid"], "bot-1");
+        assert_eq!(status["bots"]["friendly"]["state"], "connected");
+        assert_eq!(status["bots"]["random"]["behavior"], "random");
+        assert_eq!(status["bots"]["random"]["state"], "error");
+        assert_eq!(
+            status["bots"]["random"]["last_error"],
+            "connection lost"
+        );
+        assert!(status["updated_at"].as_u64().is_some());
+        assert!(
+            status["bots"]["friendly"]["last_heartbeat_at"]
+                .as_u64()
+                .is_some()
+        );
+        assert!(!status_path.with_extension("json.tmp").exists());
+    }
+}

--- a/src/bcs/crates/tools/bcs-rule-bot/src/status.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/status.rs
@@ -1,0 +1,146 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+#[derive(Debug, Clone)]
+pub struct StatusUpdate {
+    pub profile: String,
+    pub name: String,
+    pub behavior: String,
+    pub state: InstanceState,
+    pub bot_uuid: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum StatusCommand {
+    Update(StatusUpdate),
+    Touch(String),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum InstanceState {
+    Starting,
+    Connected,
+    Reconnecting,
+    Error,
+    Stopped,
+}
+
+impl InstanceState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Connected => "connected",
+            Self::Reconnecting => "reconnecting",
+            Self::Error => "error",
+            Self::Stopped => "stopped",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct HostStatus {
+    pid: u32,
+    manifest: String,
+    updated_at: u64,
+    bots: BTreeMap<String, BotStatus>,
+}
+
+#[derive(Debug, Serialize)]
+struct BotStatus {
+    name: String,
+    state: String,
+    behavior: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bot_uuid: Option<String>,
+    last_heartbeat_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
+}
+
+pub struct StatusReporter {
+    path: PathBuf,
+    manifest: PathBuf,
+    bots: BTreeMap<String, BotStatus>,
+}
+
+impl StatusReporter {
+    pub fn new(path: PathBuf, manifest: PathBuf) -> Self {
+        Self {
+            path,
+            manifest,
+            bots: BTreeMap::new(),
+        }
+    }
+
+    pub fn apply(&mut self, update: StatusUpdate) -> Result<()> {
+        self.bots.insert(
+            update.profile,
+            BotStatus {
+                name: update.name,
+                state: update.state.as_str().to_string(),
+                behavior: update.behavior,
+                bot_uuid: update.bot_uuid,
+                last_heartbeat_at: now_ms(),
+                last_error: update.last_error,
+            },
+        );
+        self.write()
+    }
+
+    pub fn touch(&mut self, profile: &str) -> Result<()> {
+        if let Some(status) = self.bots.get_mut(profile) {
+            status.last_heartbeat_at = now_ms();
+        }
+        self.write()
+    }
+
+    fn write(&self) -> Result<()> {
+        let parent = self
+            .path
+            .parent()
+            .context("status path has no parent directory")?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+        let status = HostStatus {
+            pid: std::process::id(),
+            manifest: self.manifest.display().to_string(),
+            updated_at: now_ms(),
+            bots: self.bots.clone(),
+        };
+        write_json_atomic(&self.path, &status)
+    }
+}
+
+impl Clone for BotStatus {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            state: self.state.clone(),
+            behavior: self.behavior.clone(),
+            bot_uuid: self.bot_uuid.clone(),
+            last_heartbeat_at: self.last_heartbeat_at,
+            last_error: self.last_error.clone(),
+        }
+    }
+}
+
+fn write_json_atomic(path: &Path, value: &impl Serialize) -> Result<()> {
+    let temporary = path.with_extension("json.tmp");
+    let content = serde_json::to_vec_pretty(value)?;
+    fs::write(&temporary, content)
+        .with_context(|| format!("failed to write {}", temporary.display()))?;
+    fs::rename(&temporary, path)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_millis() as u64)
+}


### PR DESCRIPTION
Add a rule-driven bot runtime for Singlebox that can run deterministic bots without invoking an LLM.

- Support fixed, random reply, echo, random number, task worker, and supervisor behaviors
- Run multiple logical rule bots in a single host process
- Preserve bot identities and sessions across restarts
- Keep chat.inject silent and support configurable response delays
- Let the task coordinator announce work before dispatching tasks and summarize worker results
- Add a version 2 profile manifest, example bot profiles, validation, and launcher tests
- Preserve compatibility with existing version 1 OpenClaw profiles