### PR TITLE
fix: route Pool-active skill CRUD to canonical paths

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -302,6 +302,25 @@ def _get_skill_by_id_or_link_name(service, skill_id: str, *bolt_ids: str | None)
     return None
 
 
+def _require_pool_runtime_sync_success(
+    service,
+    sync_result,
+    *,
+    detail: str,
+) -> None:
+    """Fail closed when a Pool-owned CRUD could not reach runtime state.
+
+    Legacy bots retain their historical best-effort behavior. Pool-owned I/O
+    cannot do that safely: its DB locator, canonical files and active mapping
+    must describe one committed layout.
+    """
+
+    if getattr(service, "runtime_uses_pool_paths", False) is not True:
+        return
+    if not isinstance(sync_result, dict) or sync_result.get("success") is not True:
+        raise HTTPException(status_code=502, detail=detail)
+
+
 # ==================== Core CRUD APIs ====================
 
 @router.post("/upload", response_model=UploadSkillResponse)
@@ -984,6 +1003,17 @@ async def activate_skill(
         logger.info(f"[skills.activate_skill] Device sync result: {sync_result}")
     except Exception as e:
         logger.warning(f"[skills.activate_skill] Device sync skipped or failed: {e}")
+        _require_pool_runtime_sync_success(
+            service,
+            None,
+            detail="Failed to synchronize activated skills to runtime",
+        )
+    else:
+        _require_pool_runtime_sync_success(
+            service,
+            sync_result,
+            detail="Failed to synchronize activated skills to runtime",
+        )
 
     logger.info(f"[skills.activate_skill] Success: skill_id={actual_skill_id}, link_name={link_name}")
     return ActivateResponse(success=True, message="Skill activated successfully", link_name=link_name)
@@ -1057,6 +1087,17 @@ async def deactivate_skill(
         logger.info(f"[skills.deactivate_skill] Device sync result: {sync_result}")
     except Exception as e:
         logger.warning(f"[skills.deactivate_skill] Device sync skipped or failed: {e}")
+        _require_pool_runtime_sync_success(
+            service,
+            None,
+            detail="Failed to synchronize deactivated skills to runtime",
+        )
+    else:
+        _require_pool_runtime_sync_success(
+            service,
+            sync_result,
+            detail="Failed to synchronize deactivated skills to runtime",
+        )
 
     logger.info(f"[skills.deactivate_skill] Success: skill_id={skill_id}")
     return DeactivateResponse(success=True, message="Skill deactivated successfully")
@@ -1492,6 +1533,17 @@ async def activate_skills_batch(
         logger.info(f"[skills.activate_skills_batch] Device sync result: {sync_result}")
     except Exception as e:
         logger.warning(f"[skills.activate_skills_batch] Device sync skipped or failed: {e}")
+        _require_pool_runtime_sync_success(
+            service,
+            None,
+            detail="Failed to synchronize activated skills to runtime",
+        )
+    else:
+        _require_pool_runtime_sync_success(
+            service,
+            sync_result,
+            detail="Failed to synchronize activated skills to runtime",
+        )
 
     logger.info(f"[skills.activate_skills_batch] Success: {len(results['success'])} activated, {len(results['failed'])} failed")
     return ActivateSkillsResponse(

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -381,6 +381,9 @@ async def upload_skill(
         repo_dir=repo_dir,
         local_dir=local_dir,
         local_skill_path_adapter=local_skill_adapter,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     logger.info(f"[skills.upload_skill] Processing {len(files)} files")
@@ -576,7 +579,12 @@ async def create_skill(
     repo_dir = path_factory.get_bot_skills_repo_dir(
         entity_id, bot_id, engine_type, entity_type, is_desktop=is_desktop
     )
-    service = skill_service_factory.create(repo_dir=repo_dir)
+    service = skill_service_factory.create(
+        repo_dir=repo_dir,
+        entity_id=entity_id,
+        bot_id=bot_id,
+        engine_type=engine_type,
+    )
     try:
         skill = service.create_skill(
             name=request.name,
@@ -643,6 +651,9 @@ async def get_active_skills(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     active_skills = service.get_active_skills()
@@ -932,6 +943,9 @@ async def activate_skill(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     actual_skill_id = request.relative_path if request.relative_path else skill_id
@@ -1007,6 +1021,9 @@ async def deactivate_skill(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # deactivate_skill is async — must await; previously a direct sync call
@@ -1137,6 +1154,9 @@ async def get_skill_readme(
         repo_dir=initial_repo_dir,
         local_dir=initial_local_dir,
         local_skill_path_adapter=None,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     skill = _get_skill_by_id_or_link_name(service, skill_id, effective_bot_id, ctx.bot_id)
@@ -1217,6 +1237,9 @@ async def get_skill_readme(
         repo_dir=read_repo_dir,
         local_dir=read_local_dir,
         local_skill_path_adapter=read_local_skill_adapter,
+        entity_id=read_owner_id,
+        bot_id=read_bot_id,
+        engine_type=read_engine,
     )
 
     # Default: local://, git://, or repo lookup via service.
@@ -1304,6 +1327,9 @@ async def list_local_market_skills(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     skills = service.get_skills_in_path("")
@@ -1339,6 +1365,9 @@ async def get_market_tree(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     tree = service.get_market_tree()
@@ -1384,6 +1413,9 @@ async def list_market_skills(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # 从数据库查询 git_path 以 git:// 开头的技能 (marketplace 不区分 bolt_id)
@@ -1426,6 +1458,9 @@ async def activate_skills_batch(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # activate_skills_batch is async — direct await. run_in_threadpool over
@@ -1499,6 +1534,9 @@ async def search_market_skills(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # 使用缓存搜索市场技能（复用 list_git_skills 缓存，limit=100）
@@ -1545,6 +1583,9 @@ async def sync_market(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # Step 1: Sync repository (git pull/clone)
@@ -1621,6 +1662,9 @@ async def get_sync_status(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     status = service.get_sync_status()
@@ -1975,6 +2019,9 @@ async def delete_skill(
         repo_dir=repo_dir,
         local_dir=local_dir,
         local_skill_path_adapter=local_skill_adapter,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
     try:
         if bot is None:
@@ -2069,6 +2116,9 @@ async def save_skill_parameters(
         repo_dir=path_factory.get_bot_skills_repo_dir(entity_id, bot_id, engine_type, is_desktop=is_desktop),
         local_dir=path_factory.get_bot_skills_local_dir(entity_id, bot_id, engine_type, is_desktop=is_desktop, is_teclaw=is_teclaw),
         local_skill_path_adapter=local_skill_adapter,
+        entity_id=entity_id,
+        bot_id=bot_id,
+        engine_type=engine_type,
     )
     if is_teclaw:
         skill_info = await service.parse_local_skill_config(skill.get('git_path', ''), bot_id, entity_id)

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -701,6 +701,9 @@ async def init_and_sync_default_skills(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # Step 1: Ensure default skill set exists
@@ -833,6 +836,9 @@ async def set_default_skills(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # Step 1: Ensure default skill set exists
@@ -1053,6 +1059,9 @@ async def set_default_skills_fast(
         active_dir=skills_dir,
         repo_dir=repo_dir,
         local_dir=local_dir,
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # Step 1: Ensure default skill set exists
@@ -1145,7 +1154,10 @@ async def set_default_skills_fast(
 
     # Step 5: 文件同步已移除
     # 软链通过 get_symlink_mappings() 从 DB 动态生成，不再需要复制文件到 skills-default 目录
-    logger.info(f"[set_default_skills_fast] DB update completed, skipping file sync (symlinks generated dynamically)")
+    logger.info(
+        "[set_default_skills_fast] DB update completed, skipping file sync "
+        "(symlinks generated dynamically)"
+    )
 
     return SetDefaultSkillsFastResponse(
         success=True,

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -122,6 +122,7 @@ class SkillServiceFactory:
         bot_id: str | None = None,
         engine_type: str | None = None,
     ) -> SkillService:
+        uses_pool_paths = False
         if entity_id is not None and bot_id is not None:
             pool_paths = self.resolve_pool_paths(
                 str(entity_id),
@@ -129,6 +130,7 @@ class SkillServiceFactory:
                 engine_type or "",
             )
             if pool_paths is not None:
+                uses_pool_paths = True
                 active_path, local_path, repo_path = pool_paths
                 active_dir = Path(active_path)
                 local_dir = Path(local_path)
@@ -150,6 +152,7 @@ class SkillServiceFactory:
             git_sync_service_factory=self._git_sync_service_factory,
             local_skill_path_adapter=local_skill_path_adapter,
             local_skill_locator_adapter=local_skill_locator_adapter,
+            runtime_uses_pool_paths=uses_pool_paths,
         )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -84,6 +84,10 @@ class SkillServiceFactory:
         device_fs_dispatcher: "DeviceFilesystemDispatcher",
         market_cache: MarketCache,
         git_sync_service_factory: Callable[[], GitSyncService],
+        pool_layout_paths: Callable[
+            [str, str, str],
+            tuple[str, str, str] | None,
+        ],
     ) -> None:
         self._skill_repo = skill_repo
         self._skill_repo_sync = skill_repo_sync
@@ -91,6 +95,17 @@ class SkillServiceFactory:
         self._device_fs_dispatcher = device_fs_dispatcher
         self._market_cache = market_cache
         self._git_sync_service_factory = git_sync_service_factory
+        self._pool_layout_paths = pool_layout_paths
+
+    def resolve_pool_paths(
+        self,
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+    ) -> tuple[str, str, str] | None:
+        """Resolve canonical Pool paths for a Bot when its layout owns IO."""
+
+        return self._pool_layout_paths(entity_id, bot_id, engine_type)
 
     def create(
         self,
@@ -100,7 +115,25 @@ class SkillServiceFactory:
         global_repo_dir: Optional[Path] = None,
         device_fs_factory=None,
         local_skill_path_adapter: Optional[Callable[[str], str]] = None,
+        entity_id: str | None = None,
+        bot_id: str | None = None,
+        engine_type: str | None = None,
     ) -> SkillService:
+        if entity_id is not None and bot_id is not None:
+            pool_paths = self.resolve_pool_paths(
+                str(entity_id),
+                str(bot_id),
+                engine_type or "",
+            )
+            if pool_paths is not None:
+                active_path, local_path, repo_path = pool_paths
+                active_dir = Path(active_path)
+                local_dir = Path(local_path)
+                repo_dir = Path(repo_path)
+                local_skill_path_adapter = build_pool_local_path_adapter(
+                    local_dir
+                )
+
         return SkillService(
             skill_repo=self._skill_repo,
             skill_repo_sync=self._skill_repo_sync,

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -115,6 +115,9 @@ class SkillServiceFactory:
         global_repo_dir: Optional[Path] = None,
         device_fs_factory=None,
         local_skill_path_adapter: Optional[Callable[[str], str]] = None,
+        local_skill_locator_adapter: Optional[
+            Callable[[str], str]
+        ] = None,
         entity_id: str | None = None,
         bot_id: str | None = None,
         engine_type: str | None = None,
@@ -130,9 +133,9 @@ class SkillServiceFactory:
                 active_dir = Path(active_path)
                 local_dir = Path(local_path)
                 repo_dir = Path(repo_path)
-                local_skill_path_adapter = build_pool_local_path_adapter(
-                    local_dir
-                )
+                pool_local_adapter = build_pool_local_path_adapter(local_dir)
+                local_skill_path_adapter = pool_local_adapter
+                local_skill_locator_adapter = pool_local_adapter
 
         return SkillService(
             skill_repo=self._skill_repo,
@@ -146,6 +149,7 @@ class SkillServiceFactory:
             device_fs_factory=device_fs_factory or self._device_fs_dispatcher.for_bot,
             git_sync_service_factory=self._git_sync_service_factory,
             local_skill_path_adapter=local_skill_path_adapter,
+            local_skill_locator_adapter=local_skill_locator_adapter,
         )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -517,6 +517,28 @@ class SkillService:
             logger.error(f"[SkillService.activate_skill] Invalid skill_path: {e}")
             return False
 
+        device_fs = self._device_fs_factory(bolt_id, user_id)
+        if protocol == "local":
+            source = Path(self._local_skill_path_adapter(str(source)))
+            try:
+                source_exists = await device_fs.exists(str(source))
+            except Exception as e:
+                logger.warning(
+                    "[SkillService.activate_skill] Failed to verify local "
+                    "source %s: %s",
+                    source,
+                    e,
+                    exc_info=True,
+                )
+                return False
+            if not source_exists:
+                logger.error(
+                    "[SkillService.activate_skill] Refusing to activate "
+                    "missing local source: %s",
+                    source,
+                )
+                return False
+
         # 生成链接名称 —— 软链名取尾名 patent-quality-audit，与 local 分支
         # (Path(path).name) 及 get_symlink_mappings (split('/')[-1]) 对齐。
         # 注意：DB link_name 字段仍用全路径下划线格式（get_link_name），二者口径不同。
@@ -563,7 +585,6 @@ class SkillService:
 
         if target_link.exists() or target_link.is_symlink():
             # Phase 4: engine-view path — 让 engine 在 VM 内删，不要宿主机 shutil.rmtree
-            device_fs = self._device_fs_factory(bolt_id, user_id)
             success = await self._delete_active_entry(device_fs, target_link)
             if not success:
                 logger.error(
@@ -1808,18 +1829,21 @@ class SkillService:
             if existing_skill is not None
             else ""
         )
-        skill_dir = (
+        locator_skill_dir = (
             Path(existing_locator)
             if existing_locator.startswith("/")
             else self.local_dir / skill_name
         )
-        skill_dir_str = str(skill_dir)
-        # The DB ``git_path`` keeps ``skill_dir_str`` (logical for teclaw, host for
-        # arca); the device-fs delete/write use the adapter-expanded engine path
-        # (identity for non-teclaw, ``workspace/skills-local/...`` for teclaw).
-        engine_skill_dir_str = self._local_skill_path_adapter(skill_dir_str)
+        # During cutover the existing DB locator can still point at Legacy.
+        # Resolve it before both file I/O and persistence so a same-name upload
+        # becomes a controlled copy-forward into canonical Pool rather than
+        # continuing to write Legacy.
+        skill_dir_str = self._local_skill_path_adapter(
+            str(locator_skill_dir)
+        )
+        engine_skill_dir_str = skill_dir_str
         logger.info(
-            f"[SkillService.upload_skill] Skill directory: {skill_dir} "
+            f"[SkillService.upload_skill] Skill directory: {skill_dir_str} "
             f"(engine: {engine_skill_dir_str})"
         )
 
@@ -1846,6 +1870,7 @@ class SkillService:
                     'description': skill_info.get("description", ""),
                     'category': skill_info.get("category", "general"),
                     'tags': json.dumps(skill_info.get("tags", [])),
+                    'git_path': skill_path,
                     'gmt_modified': datetime.utcnow()
                 }
                 if user_id:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -76,6 +76,7 @@ class SkillService:
         local_dir: Path | None = None,
         global_repo_dir: Path | None = None,
         local_skill_path_adapter: "Callable[[str], str] | None" = None,
+        local_skill_locator_adapter: "Callable[[str], str] | None" = None,
     ):
         """
         Args:
@@ -116,6 +117,14 @@ class SkillService:
         # ``git_path`` always keeps the un-adapted logical/host path.
         self._local_skill_path_adapter: "Callable[[str], str]" = (
             local_skill_path_adapter or (lambda p: p)
+        )
+        # Adapter applied only when persisting a local:// DB locator. It is
+        # deliberately separate from the device-I/O adapter above: Teclaw
+        # expands its logical locator for container I/O but must keep the
+        # minimal logical value in DB. Pool-active file engines set both
+        # adapters to the canonical Pool resolver.
+        self._local_skill_locator_adapter: "Callable[[str], str]" = (
+            local_skill_locator_adapter or (lambda p: p)
         )
 
         # Lazy GitSyncService lookup — eager injection would close the cycle
@@ -1838,10 +1847,10 @@ class SkillService:
         # Resolve it before both file I/O and persistence so a same-name upload
         # becomes a controlled copy-forward into canonical Pool rather than
         # continuing to write Legacy.
-        skill_dir_str = self._local_skill_path_adapter(
+        skill_dir_str = self._local_skill_locator_adapter(
             str(locator_skill_dir)
         )
-        engine_skill_dir_str = skill_dir_str
+        engine_skill_dir_str = self._local_skill_path_adapter(skill_dir_str)
         logger.info(
             f"[SkillService.upload_skill] Skill directory: {skill_dir_str} "
             f"(engine: {engine_skill_dir_str})"

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -77,6 +77,7 @@ class SkillService:
         global_repo_dir: Path | None = None,
         local_skill_path_adapter: "Callable[[str], str] | None" = None,
         local_skill_locator_adapter: "Callable[[str], str] | None" = None,
+        runtime_uses_pool_paths: bool = False,
     ):
         """
         Args:
@@ -126,6 +127,11 @@ class SkillService:
         self._local_skill_locator_adapter: "Callable[[str], str]" = (
             local_skill_locator_adapter or (lambda p: p)
         )
+        # Public request-scope policy consumed by the HTTP adapter. Legacy
+        # runtimes historically tolerate an unavailable device-sync endpoint;
+        # once Pool owns I/O, reporting CRUD success without committing the
+        # runtime mapping would leave DB/filesystem/runtime inconsistent.
+        self.runtime_uses_pool_paths = runtime_uses_pool_paths
 
         # Lazy GitSyncService lookup — eager injection would close the cycle
         # GitSyncService → SkillServiceFactory → SkillService → GitSyncService.
@@ -513,10 +519,10 @@ class SkillService:
             bolt_id: Bolt ID（用于 device_fs 路由）
 
         Note:
-            不再检查源路径是否存在，因为：
-            1. 管理时 repo_dir 可能是空目录或不存在（软链接未创建）
-            2. 运行时 skills-repo 被 mount，软链接才能解析
-            3. 软链接指向相对路径 skills-repo/... 或 skills-local/...
+            Pool-owned local skill 必须先通过 DeviceFileSystem 验证源路径
+            存在，避免向运行时发布 dangling mapping。Legacy 保留历史
+            best-effort 行为；git skill 继续由运行时 repo mount 解析，不在
+            Backend 管理视图预检源路径。
         """
         logger.info(f"[SkillService.activate_skill] Start: skill_path={skill_path}")
 
@@ -527,7 +533,7 @@ class SkillService:
             return False
 
         device_fs = self._device_fs_factory(bolt_id, user_id)
-        if protocol == "local":
+        if protocol == "local" and self.runtime_uses_pool_paths:
             source = Path(self._local_skill_path_adapter(str(source)))
             try:
                 source_exists = await device_fs.exists(str(source))

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -664,6 +664,17 @@ class SkillSetService:
                             "name": skill_name,
                             "reason": str(result)
                         })
+                    elif result is not True:
+                        logger.warning(
+                            "[add_skills_to_set] Auto-activation source is "
+                            "unavailable for skill %s",
+                            skill_name,
+                        )
+                        activation_failed.append({
+                            "skill_id": skill_id,
+                            "name": skill_name,
+                            "reason": "activation source is unavailable",
+                        })
                     else:
                         logger.debug(f"[add_skills_to_set] Auto-activated skill {skill_name}: {result}")
 
@@ -672,8 +683,11 @@ class SkillSetService:
                     results["activation_failed"] = activation_failed
                     logger.warning(f"[add_skills_to_set] {len(activation_failed)} skills failed to auto-activate")
 
-            # 关键修复：同步软链到设备（本地模式和 Arca 模式都需要）
-            self._sync_symlinks_to_device_if_needed(user_id)
+            # Do not publish a mapping set containing a missing source. A
+            # failed local activation is intentionally fail-closed so the
+            # runtime never receives a dangling active link.
+            if not results["activation_failed"]:
+                self._sync_symlinks_to_device_if_needed(user_id)
 
         return results
 

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -398,36 +398,9 @@ class SkillCenterModule(Module):
         device_fs_dispatcher: DeviceFilesystemDispatcher,
         market_cache: MarketCache,
         git_sync_service_factory: Callable[[], GitSyncService],
-    ) -> SkillServiceFactory:
-        return SkillServiceFactory(
-            skill_repo=skill_repo,
-            skill_repo_sync=skill_repo_sync,
-            category_repo=category_repo,
-            device_fs_dispatcher=device_fs_dispatcher,
-            market_cache=market_cache,
-            git_sync_service_factory=git_sync_service_factory,
-        )
-
-    @singleton
-    @provider
-    @inject
-    def skill_set_service_factory(
-        self,
-        skill_repo: SkillRepository,
-        skill_set_repo: SkillSetRepository,
-        mcp_center: MCPCenterPlugin,
-        mcp_config_service: MCPConfigService,
-        skill_service_factory: SkillServiceFactory,
-        mcp_sync_service: MCPSyncService,
         bot_repo: BotRepository,
-        device_plugin: DeviceAccessor,
-        path_factory: WorkspacePathFactory,
         layout_repository: SkillsPoolLayoutRepositoryProtocol,
-        injector: Injector,
-    ) -> SkillSetServiceFactory:
-        # resolver / device_sync_dispatcher 走 lazy thunk:防止构造期 DI 循环
-        # ``BotService → SkillSetServiceFactory → DeviceContextResolver
-        # → ArcaConnInfoBuilder → DeviceService → BotService``。
+    ) -> SkillServiceFactory:
         def resolve_pool_paths(
             owner_id: str,
             bot_id: str,
@@ -451,6 +424,32 @@ class SkillCenterModule(Module):
             paths = pool_paths_for_engine(engine)
             return paths.active, paths.pool_local, paths.pool_repo
 
+        return SkillServiceFactory(
+            skill_repo=skill_repo,
+            skill_repo_sync=skill_repo_sync,
+            category_repo=category_repo,
+            device_fs_dispatcher=device_fs_dispatcher,
+            market_cache=market_cache,
+            git_sync_service_factory=git_sync_service_factory,
+            pool_layout_paths=resolve_pool_paths,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def skill_set_service_factory(
+        self,
+        skill_repo: SkillRepository,
+        skill_set_repo: SkillSetRepository,
+        mcp_center: MCPCenterPlugin,
+        mcp_config_service: MCPConfigService,
+        skill_service_factory: SkillServiceFactory,
+        mcp_sync_service: MCPSyncService,
+        bot_repo: BotRepository,
+        device_plugin: DeviceAccessor,
+        path_factory: WorkspacePathFactory,
+        injector: Injector,
+    ) -> SkillSetServiceFactory:
         return SkillSetServiceFactory(
             skill_repo=skill_repo,
             skill_set_repo=skill_set_repo,
@@ -463,7 +462,7 @@ class SkillCenterModule(Module):
             bot_repo=bot_repo,
             device_plugin=device_plugin,
             path_factory=path_factory,
-            pool_layout_paths=resolve_pool_paths,
+            pool_layout_paths=skill_service_factory.resolve_pool_paths,
         )
 
     @singleton

--- a/src/backend/tests/community/api/skill_center/test_create_skill_router_kwargs.py
+++ b/src/backend/tests/community/api/skill_center/test_create_skill_router_kwargs.py
@@ -32,7 +32,14 @@ class _StrictService:
 
 
 class _Factory:
-    def create(self, *, repo_dir=None):  # router scopes via repo_dir
+    def create(
+        self,
+        *,
+        repo_dir=None,
+        entity_id=None,
+        bot_id=None,
+        engine_type=None,
+    ):
         return _StrictService()
 
 

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -36,7 +36,12 @@ def mock_ctx():
 
 
 @contextmanager
-def _skill_service_di_app(mock_ctx):
+def _skill_service_di_app(
+    mock_ctx,
+    *,
+    device_sync_result=None,
+    runtime_uses_pool_paths=False,
+):
     """Build a TestClient whose SkillService has AsyncMock methods.
 
     Yields (client, mock_skill_service).  The mock_skill_service is the SAME
@@ -51,6 +56,7 @@ def _skill_service_di_app(mock_ctx):
         return_value={"success": ["a"], "failed": []}
     )
     mock_skill_service.get_link_name = MagicMock(return_value="link_name")
+    mock_skill_service.runtime_uses_pool_paths = runtime_uses_pool_paths
 
     # Factory that returns the mock service from create()
     mock_skill_service_factory = MagicMock()
@@ -71,7 +77,11 @@ def _skill_service_di_app(mock_ctx):
 
     # Mock device_sync
     mock_device_sync = MagicMock()
-    mock_device_sync.sync_symlinks.return_value = MagicMock()
+    mock_device_sync.sync_symlinks.return_value = (
+        device_sync_result
+        if device_sync_result is not None
+        else {"success": True, "message": "synced"}
+    )
 
     # Mock bot_repo - runtime-checkable Protocol
     mock_bot_repo = MagicMock()
@@ -494,6 +504,23 @@ class TestActivateSkillAsyncAwait:
                 f"got {call.kwargs['user_id']!r}"
             )
 
+    def test_activate_skill_fails_when_runtime_mapping_sync_fails(self, mock_ctx):
+        with _skill_service_di_app(
+            mock_ctx,
+            device_sync_result={"success": False, "message": "source missing"},
+            runtime_uses_pool_paths=True,
+        ) as (client, mock_svc):
+            response = client.post(
+                "/api/skills/my-skill-id/activate",
+                json={"source_path": "local://skills-local/my-skill"},
+            )
+
+            assert response.status_code == 502
+            assert response.json()["detail"] == (
+                "Failed to synchronize activated skills to runtime"
+            )
+            mock_svc.activate_skill.assert_awaited_once()
+
 
 # ── deactivate_skill ─────────────────────────────────────────────────────────
 
@@ -533,6 +560,22 @@ class TestDeactivateSkillAsyncAwait:
                 f"user_id should be ctx.user_id ({mock_ctx.user_id!r}); "
                 f"got {call.kwargs['user_id']!r}"
             )
+
+    def test_deactivate_skill_fails_when_runtime_mapping_sync_fails(
+        self, mock_ctx
+    ):
+        with _skill_service_di_app(
+            mock_ctx,
+            device_sync_result={"success": False, "message": "runtime unavailable"},
+            runtime_uses_pool_paths=True,
+        ) as (client, mock_svc):
+            response = client.post("/api/skills/my-skill-id/deactivate")
+
+            assert response.status_code == 502
+            assert response.json()["detail"] == (
+                "Failed to synchronize deactivated skills to runtime"
+            )
+            mock_svc.deactivate_skill.assert_awaited_once()
 
 
 # ── activate_skills_batch ─────────────────────────────────────────────────────
@@ -582,3 +625,22 @@ class TestActivateSkillsBatchAsyncAwait:
                 f"bolt_id must be a kwarg; got call={call}"
             )
             assert call.kwargs["user_id"] == mock_ctx.user_id
+
+    def test_activate_skills_batch_fails_when_runtime_mapping_sync_fails(
+        self, mock_ctx
+    ):
+        with _skill_service_di_app(
+            mock_ctx,
+            device_sync_result={"success": False, "message": "source missing"},
+            runtime_uses_pool_paths=True,
+        ) as (client, mock_svc):
+            response = client.post(
+                "/api/skills/market/activate-batch",
+                json={"skill_paths": ["git://path/a"]},
+            )
+
+            assert response.status_code == 502
+            assert response.json()["detail"] == (
+                "Failed to synchronize activated skills to runtime"
+            )
+            mock_svc.activate_skills_batch.assert_awaited_once()

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -222,7 +222,7 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
     injector = Injector([_TestModule()])
     attach_injector(app, injector)
     client = TestClient(app, raise_server_exceptions=False)
-    yield client, mock_skill_service, mock_bot_repo
+    yield client, mock_skill_service, mock_bot_repo, mock_skill_service_factory
 
 
 # ── activate_skill ────────────────────────────────────────────────────────────
@@ -230,7 +230,7 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
 
 class TestUploadSkillValidation:
     def test_upload_rejects_non_active_bot(self, mock_ctx):
-        with _upload_skill_di_app(mock_ctx, bot_status="PENDING") as (client, mock_svc, _):
+        with _upload_skill_di_app(mock_ctx, bot_status="PENDING") as (client, mock_svc, _, _):
             response = client.post(
                 "/api/skills/upload",
                 files=[
@@ -246,7 +246,7 @@ class TestUploadSkillValidation:
             mock_svc.upload_skill.assert_not_called()
 
     def test_upload_rejects_missing_bot(self, mock_ctx):
-        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, mock_bot_repo):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, mock_bot_repo, _):
             mock_bot_repo.get_by_id_and_owner.return_value = None
 
             response = client.post(
@@ -263,7 +263,7 @@ class TestUploadSkillValidation:
             mock_svc.upload_skill.assert_not_called()
 
     def test_upload_rejects_file_paths_length_mismatch(self, mock_ctx):
-        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _, _):
             response = client.post(
                 "/api/skills/upload",
                 files=[
@@ -279,7 +279,7 @@ class TestUploadSkillValidation:
             mock_svc.upload_skill.assert_not_called()
 
     def test_upload_active_bot_calls_service(self, mock_ctx):
-        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _, _):
             response = client.post(
                 "/api/skills/upload",
                 files=[
@@ -292,8 +292,34 @@ class TestUploadSkillValidation:
             assert body["success"] is True
             assert mock_svc.upload_skill.await_count == 1
 
+    def test_upload_passes_bot_scope_to_layout_aware_factory(self, mock_ctx):
+        with _upload_skill_di_app(
+            mock_ctx,
+            bot_status="ACTIVE",
+        ) as (client, mock_svc, _, mock_factory):
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    (
+                        "files",
+                        (
+                            "SKILL.md",
+                            b"---\nname: a\ndescription: a\n---",
+                            "text/markdown",
+                        ),
+                    )
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            assert response.json()["success"] is True
+            create_kwargs = mock_factory.create.call_args.kwargs
+            assert create_kwargs["entity_id"] == mock_ctx.user_id
+            assert create_kwargs["bot_id"] == mock_ctx.bot_id
+            assert create_kwargs["engine_type"] == "openclaw"
+
     def test_upload_normalizes_runtime_unavailable_error_message(self, mock_ctx):
-        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _, _):
             mock_svc.upload_skill.side_effect = ValueError(
                 "Upload processing error: 502 Bad Gateway"
             )
@@ -335,7 +361,7 @@ class TestUploadSkillDesktopLiveStatus:
             bot_type="desktop",
             device_id="dev-1",
             bot_service=mock_bot_service,
-        ) as (client, mock_svc, _):
+        ) as (client, mock_svc, _, _):
             response = self._post_upload(client)
             body = response.json()
             assert body["success"] is True
@@ -352,7 +378,7 @@ class TestUploadSkillDesktopLiveStatus:
             bot_type="desktop",
             device_id="dev-1",
             bot_service=mock_bot_service,
-        ) as (client, mock_svc, _):
+        ) as (client, mock_svc, _, _):
             response = self._post_upload(client)
             body = response.json()
             assert body["success"] is False
@@ -369,7 +395,7 @@ class TestUploadSkillDesktopLiveStatus:
             bot_type="desktop",
             device_id="dev-1",
             bot_service=mock_bot_service,
-        ) as (client, mock_svc, _):
+        ) as (client, mock_svc, _, _):
             response = self._post_upload(client)
             body = response.json()
             assert body["success"] is False
@@ -386,7 +412,7 @@ class TestUploadSkillDesktopLiveStatus:
             bot_type="desktop",
             device_id="dev-1",
             bot_service=mock_bot_service,
-        ) as (client, mock_svc, _):
+        ) as (client, mock_svc, _, _):
             response = self._post_upload(client)
             body = response.json()
             assert body["success"] is False
@@ -403,7 +429,7 @@ class TestUploadSkillDesktopLiveStatus:
             bot_status="ACTIVE",
             bot_type="personal",
             bot_service=mock_bot_service,
-        ) as (client, mock_svc, _):
+        ) as (client, mock_svc, _, _):
             response = self._post_upload(client)
             body = response.json()
             assert body["success"] is True

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -1019,6 +1019,58 @@ class TestAddSkillsToSetOwnerIdResolution:
         )
 
     @pytest.mark.asyncio
+    async def test_auto_activate_false_is_reported_and_not_synced(self):
+        bot_repo = MagicMock()
+        bot_repo.get_by_id.return_value = {
+            "id": "bot-1",
+            "owner_id": "owner_abc",
+        }
+        skill_repo = MagicMock()
+        skill_repo.get_by_id.return_value = {
+            "id": "10",
+            "name": "skill-a",
+            "git_path": "local:///legacy/skills-local/skill-a",
+        }
+        skill_service = MagicMock()
+        skill_service.activate_skill = AsyncMock(return_value=False)
+        skill_service.RESERVED_SKILL_NAMES = set()
+        mock_set_repo = MagicMock()
+        mock_set_repo.get_by_id.return_value = {
+            "id": "1",
+            "is_default": False,
+            "is_active": True,
+        }
+        mock_set_repo.get_skills_in_set.return_value = []
+        mock_set_repo.list_all.return_value = []
+        mock_set_repo.add_skill_to_set.return_value = True
+        svc = self._make_svc(
+            bot_repo=bot_repo,
+            skill_repo=skill_repo,
+            skill_service=skill_service,
+        )
+        svc.skill_set_repo = mock_set_repo
+        svc._sync_symlinks_to_device_if_needed = MagicMock()
+
+        with patch(
+            "agentclaw.community.core.skill_center.services."
+            "skill_set_service.SkillSetMetadataWriter"
+        ):
+            result = await svc.add_skills_to_set(
+                "1",
+                ["10"],
+                user_id="user1",
+            )
+
+        assert result["activation_failed"] == [
+            {
+                "skill_id": "10",
+                "name": "skill-a",
+                "reason": "activation source is unavailable",
+            }
+        ]
+        svc._sync_symlinks_to_device_if_needed.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_auto_activate_fallback_to_entity_id_when_no_owner(self):
         """When bot exists but owner_id is None, fallback to entity_id."""
         bot_repo = MagicMock()

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -69,6 +69,12 @@ def test_pool_active_factory_scopes_direct_skill_crud_to_canonical_pool(
         "/home/admin/.openclaw/workspace/skills-pool/"
         "skills-local/handmade"
     )
+    assert svc._local_skill_locator_adapter(
+        "/home/admin/.openclaw/workspace/skills/skills-local/handmade"
+    ) == (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        "skills-local/handmade"
+    )
 
 
 def test_real_skill_set_service_factory_create_default_branch(test_injector):

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -9,6 +9,8 @@ These resolve the REAL factories from the test injector and invoke
 ``create()`` the way the routers do — covering every skill-center
 factory ``create()`` body (both branches where they differ).
 """
+from pathlib import Path
+
 import pytest
 
 from agentclaw.community.core.skill_center.factories import (
@@ -33,6 +35,40 @@ def test_real_skill_service_factory_create(test_injector):
     factory = test_injector.get(SkillServiceFactory)
     svc = factory.create()
     assert isinstance(svc, SkillService)
+
+
+def test_pool_active_factory_scopes_direct_skill_crud_to_canonical_pool(
+    test_injector,
+):
+    factory = test_injector.get(SkillServiceFactory)
+    factory._pool_layout_paths = lambda *_: (
+        "/home/admin/.openclaw/workspace/skills",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+    )
+
+    svc = factory.create(
+        active_dir="/legacy/skills",
+        local_dir="/legacy/skills/skills-local",
+        repo_dir="/legacy/skills/skills-repo",
+        entity_id="staff-1",
+        bot_id="bot-1",
+        engine_type="openclaw",
+    )
+
+    assert svc.active_dir == Path("/home/admin/.openclaw/workspace/skills")
+    assert svc.local_dir == Path(
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+    )
+    assert svc.repo_dir == Path(
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
+    )
+    assert svc._local_skill_path_adapter(
+        "/home/admin/.openclaw/workspace/skills/skills-local/handmade"
+    ) == (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        "skills-local/handmade"
+    )
 
 
 def test_real_skill_set_service_factory_create_default_branch(test_injector):

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -35,6 +35,7 @@ def test_real_skill_service_factory_create(test_injector):
     factory = test_injector.get(SkillServiceFactory)
     svc = factory.create()
     assert isinstance(svc, SkillService)
+    assert svc.runtime_uses_pool_paths is False
 
 
 def test_pool_active_factory_scopes_direct_skill_crud_to_canonical_pool(
@@ -63,6 +64,7 @@ def test_pool_active_factory_scopes_direct_skill_crud_to_canonical_pool(
     assert svc.repo_dir == Path(
         "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
     )
+    assert svc.runtime_uses_pool_paths is True
     assert svc._local_skill_path_adapter(
         "/home/admin/.openclaw/workspace/skills/skills-local/handmade"
     ) == (

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -146,9 +146,9 @@ class TestSkillServiceAsyncRouting:
         repo.update.return_value = updated
         service, device_fs, _ = self._service(tmp_path, mock_repo=repo)
         service.local_dir = pool_local
-        service._local_skill_path_adapter = build_pool_local_path_adapter(
-            pool_local
-        )
+        pool_adapter = build_pool_local_path_adapter(pool_local)
+        service._local_skill_path_adapter = pool_adapter
+        service._local_skill_locator_adapter = pool_adapter
 
         result = await service.upload_skill(
             [

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -193,6 +193,7 @@ class TestSkillServiceAsyncRouting:
         service._local_skill_path_adapter = build_pool_local_path_adapter(
             pool_local
         )
+        service.runtime_uses_pool_paths = True
         device_fs.exists = AsyncMock(return_value=False)
 
         activated = await service.activate_skill(
@@ -208,6 +209,22 @@ class TestSkillServiceAsyncRouting:
         device_fs.exists.assert_awaited_once_with(
             f"{pool_local}/writing-beats"
         )
+
+    @pytest.mark.asyncio
+    async def test_legacy_activate_keeps_best_effort_source_semantics(
+        self, tmp_path
+    ):
+        service, device_fs, _ = self._service(tmp_path)
+        device_fs.exists = AsyncMock(return_value=False)
+
+        activated = await service.activate_skill(
+            f"local://{service.local_dir}/legacy-skill",
+            user_id="user1",
+            bolt_id="bot1",
+        )
+
+        assert activated is True
+        device_fs.exists.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_upload_does_not_overwrite_global_local_skill(

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -114,6 +114,102 @@ class TestSkillServiceAsyncRouting:
         repo.create.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_reupload_migrates_existing_legacy_locator_to_pool(
+        self, tmp_path
+    ):
+        from pathlib import Path
+
+        from agentclaw.community.core.skill_center.path_resolution import (
+            build_pool_local_path_adapter,
+        )
+
+        legacy_path = (
+            "/home/admin/.openclaw/workspace/"
+            "skills/skills-local/writing-beats"
+        )
+        pool_local = Path(
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+        )
+        pool_path = str(pool_local / "writing-beats")
+        existing = {
+            "id": "1119874",
+            "name": "writing-beats",
+            "user_id": "user1",
+            "git_path": f"local://{legacy_path}",
+        }
+        updated = {
+            **existing,
+            "git_path": f"local://{pool_path}",
+        }
+        repo = MagicMock()
+        repo.get_bot_local_by_name.return_value = existing
+        repo.update.return_value = updated
+        service, device_fs, _ = self._service(tmp_path, mock_repo=repo)
+        service.local_dir = pool_local
+        service._local_skill_path_adapter = build_pool_local_path_adapter(
+            pool_local
+        )
+
+        result = await service.upload_skill(
+            [
+                {
+                    "filename": "SKILL.md",
+                    "content": (
+                        b"---\nname: writing-beats\ndescription: test\n"
+                        b"---\n# Test"
+                    ),
+                    "relative_path": "SKILL.md",
+                }
+            ],
+            user_id="user1",
+            bolt_id="bot1",
+        )
+
+        assert result == updated
+        device_fs.delete_tree.assert_awaited_once_with(pool_path)
+        device_fs.write_file.assert_awaited_once_with(
+            f"{pool_path}/SKILL.md",
+            b"---\nname: writing-beats\ndescription: test\n---\n# Test",
+        )
+        update_data = repo.update.call_args.args[1]
+        assert update_data["git_path"] == f"local://{pool_path}"
+        repo.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_activate_local_skill_fails_closed_when_pool_source_is_absent(
+        self, tmp_path
+    ):
+        from pathlib import Path
+
+        from agentclaw.community.core.skill_center.path_resolution import (
+            build_pool_local_path_adapter,
+        )
+
+        pool_local = Path(
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+        )
+        service, device_fs, _ = self._service(tmp_path)
+        service.local_dir = pool_local
+        service._local_skill_path_adapter = build_pool_local_path_adapter(
+            pool_local
+        )
+        device_fs.exists = AsyncMock(return_value=False)
+
+        activated = await service.activate_skill(
+            (
+                "local:///home/admin/.openclaw/workspace/skills/"
+                "skills-local/writing-beats"
+            ),
+            user_id="user1",
+            bolt_id="bot1",
+        )
+
+        assert activated is False
+        device_fs.exists.assert_awaited_once_with(
+            f"{pool_local}/writing-beats"
+        )
+
+    @pytest.mark.asyncio
     async def test_upload_does_not_overwrite_global_local_skill(
         self, tmp_path
     ):
@@ -310,6 +406,44 @@ class TestSkillServiceAsyncRouting:
         assert any(p == "/path/test" for p in called_paths)
 
     @pytest.mark.asyncio
+    async def test_pool_delete_resolves_legacy_locator_to_pool(self, tmp_path):
+        from pathlib import Path
+
+        from agentclaw.community.core.skill_center.path_resolution import (
+            build_pool_local_path_adapter,
+        )
+
+        legacy_path = (
+            "/home/admin/.openclaw/workspace/"
+            "skills/skills-local/writing-beats"
+        )
+        pool_local = Path(
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+        )
+        service, device_fs, repo = self._service(tmp_path)
+        service.active_dir = Path(
+            "/home/admin/.openclaw/workspace/skills"
+        )
+        service.local_dir = pool_local
+        service._local_skill_path_adapter = build_pool_local_path_adapter(
+            pool_local
+        )
+        repo.get_by_id.return_value = {
+            "id": "1119874",
+            "name": "writing-beats",
+            "git_path": f"local://{legacy_path}",
+            "bolt_id": "bot1",
+            "user_id": "user1",
+        }
+        repo.delete.return_value = True
+        device_fs.delete_tree.return_value = True
+
+        assert await service.delete_skill("1119874", user_id="user1")
+        assert device_fs.delete_tree.await_args_list[-1].args[0] == (
+            f"{pool_local}/writing-beats"
+        )
+
+    @pytest.mark.asyncio
     async def test_readme_reads_via_device_filesystem(self, tmp_path):
         """Test get_skill_readme reads via DeviceFileSystemPlugin."""
         from agentclaw.community.core.skill_center.services.skill_service import SkillService
@@ -338,3 +472,42 @@ class TestSkillServiceAsyncRouting:
         result = await service.get_skill_readme("1", user_id="user1")
         assert result == "# Test Skill"
         mock_device_fs.read_file.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_pool_read_resolves_legacy_locator_to_pool(self, tmp_path):
+        from pathlib import Path
+
+        from agentclaw.community.core.skill_center.path_resolution import (
+            build_pool_local_path_adapter,
+        )
+
+        legacy_path = (
+            "/home/admin/.openclaw/workspace/"
+            "skills/skills-local/writing-beats"
+        )
+        pool_local = Path(
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+        )
+        service, device_fs, repo = self._service(tmp_path)
+        service.local_dir = pool_local
+        service._local_skill_path_adapter = build_pool_local_path_adapter(
+            pool_local
+        )
+        repo.get_by_id.return_value = {
+            "id": "1119874",
+            "name": "writing-beats",
+            "git_path": f"local://{legacy_path}",
+            "bolt_id": "bot1",
+            "user_id": "user1",
+        }
+        device_fs.read_file.return_value = b"# Writing Beats"
+
+        result = await service.get_skill_readme(
+            "1119874",
+            user_id="user1",
+        )
+
+        assert result == "# Writing Beats"
+        device_fs.read_file.assert_awaited_once_with(
+            f"{pool_local}/writing-beats/SKILL.md"
+        )

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -444,6 +444,19 @@ class _SkillsPortMixin:
         removed: list[str] = []
         to_recreate: set[Path] = set()
 
+        # Validate the complete desired set before mutating any target. This
+        # boundary is shared by direct CRUD sync and restart reconciliation;
+        # rejecting here prevents both paths from creating dangling active
+        # links. The source can disappear after this check, but that unavoidable
+        # filesystem race is narrower than committing a known-missing source.
+        missing_sources = sorted(
+            {str(source) for source in desired.values() if not source.exists()}
+        )
+        if missing_sources:
+            raise RuntimeError(
+                "bindpath source does not exist: " + ", ".join(missing_sources)
+            )
+
         for target, source in desired.items():
             target.parent.mkdir(parents=True, exist_ok=True)
             if target.is_symlink():

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_skills_bindpaths.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_skills_bindpaths.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
+
+
+@pytest.mark.asyncio
+async def test_sync_bindpaths_rejects_missing_source_before_mutating_targets(
+    tmp_path: Path,
+) -> None:
+    plugin = OpenClawPluginImpl()
+    valid_source = tmp_path / "skills-pool" / "skills-local" / "valid"
+    valid_source.mkdir(parents=True)
+    missing_source = tmp_path / "skills-pool" / "skills-local" / "missing"
+    active_root = tmp_path / "skills"
+    valid_target = active_root / "valid"
+    missing_target = active_root / "missing"
+
+    with pytest.raises(RuntimeError, match="bindpath source does not exist"):
+        await plugin.sync_bindpaths(
+            {
+                "symlinks": [
+                    {
+                        "source": str(valid_source),
+                        "target": str(valid_target),
+                    },
+                    {
+                        "source": str(missing_source),
+                        "target": str(missing_target),
+                    },
+                ]
+            }
+        )
+
+    assert not valid_target.exists()
+    assert not valid_target.is_symlink()
+    assert not missing_target.exists()
+    assert not missing_target.is_symlink()
+
+
+@pytest.mark.asyncio
+async def test_sync_bindpaths_creates_link_when_every_source_exists(
+    tmp_path: Path,
+) -> None:
+    plugin = OpenClawPluginImpl()
+    source = tmp_path / "skills-pool" / "skills-local" / "writing"
+    source.mkdir(parents=True)
+    target = tmp_path / "skills" / "writing"
+
+    result = await plugin.sync_bindpaths(
+        {
+            "symlinks": [
+                {
+                    "source": str(source),
+                    "target": str(target),
+                }
+            ]
+        }
+    )
+
+    assert result["created"] == [str(target)]
+    assert target.is_symlink()
+    assert target.resolve() == source


### PR DESCRIPTION
## Summary
- resolve direct SkillService CRUD paths from the Bot layout state and use canonical Pool local/repo roots after runtime cutover
- copy forward same-name local skill uploads from a legacy locator into Pool and update the existing DB locator without creating duplicates
- fail closed when a local activation source is absent, including active skill-set batch activation
- preserve legacy, desktop, Teclaw, and global marketplace behavior

## B2 incident covered
For a POOL_ACTIVE Bot, `writing-beats` was written under the legacy `skills/skills-local` path while the active mapping targeted `skills-pool/skills-local`, producing a dangling link. This change makes file IO, locator persistence, and mapping source resolution agree on the canonical Pool path.

## Tests
- `uv run ruff check ...`
- `uv run pytest tests/community/api/skill_center -q` (150 passed)
- `uv run pytest tests/community/core/skill_center/test_skill_factories.py tests/community/core/skill_center/services/test_skill_set_service.py tests/community/core/skill_center/services/test_skill_service.py -q` (84 passed)
- `uv run pytest tests/community/services/test_skill_service_async.py tests/community/services/test_skill_set_service.py tests/community/endpoints/test_skill_set_auto_activate.py -q` (42 passed)