### PR TITLE
fix: harden multi-engine Skills Pool runtime

### DIFF
--- a/docs/skills-pool-p3-rollout-runbook.zh-CN.md
+++ b/docs/skills-pool-p3-rollout-runbook.zh-CN.md
@@ -127,6 +127,28 @@ SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
    `POST /rollout/batches/accept` 冻结该批次的验收报告。扩大批次时，新
    `batch_id` 必须引用当前引擎最近的 `acceptance_batch_id`；晋级下一引擎
    也必须引用上一引擎已验收批次。Backend 不会自动验收、扩大或晋级。
+9. 如需在当前环境内按员工覆盖其存量重启和未来新建 Bot，调用
+   `POST /rollout/owners`，传入精确 `owner_id`、`engine`、`enabled` 和该
+   引擎最近一次已验收的 `acceptance_batch_id`。规则按
+   `(owner_id, engine)` 隔离，不会越过引擎晋级顺序，也不会影响其他员工。
+   精确负对照优先于 owner 全量并保持 Legacy；关闭规则只阻止尚未认领的
+   Bot，已认领 Bot 继续前滚。
+
+示例：预发 OpenClaw 验收完成后，为员工 `168944` 开启 owner 全量：
+
+```json
+{
+  "owner_id": "168944",
+  "engine": "openclaw",
+  "enabled": true,
+  "acceptance_batch_id": "openclaw-pre-canary-1",
+  "reason": "OpenClaw canary accepted; enable all owner bots in pre"
+}
+```
+
+该请求只写当前 Backend 所属环境的 `full_rollout_owners`。它不会立即扫描并
+重启员工名下所有 Bot；后续创建、重启、ARCA alive、BaaS publish-completed
+或人工 wake 事件会触发首次认领。
 
 移出白名单会返回 `claimed_before` 和 `claimed_after`。未认领 Bot 将不再开始
 迁移；已经认领或已经 Pool-active 的 Bot 保持同一
@@ -173,6 +195,7 @@ SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
 | 新 Backend + 旧镜像无 marker，保持 Legacy | `test_reconcile_service.py::test_non_ready_runtime_keeps_legacy_without_data_plane_changes` |
 | 新镜像已有 marker、未命中白名单，不认领 | `test_claim_service.py::test_ineligible_bot_does_not_persist_layout_state` |
 | 精确命中后认领，移出白名单仍前滚 | `test_claim_service.py::test_claim_is_sticky_after_whitelist_removal` |
+| owner + engine 全量覆盖未来新建与后续重启，且不影响其他 owner/engine | `test_rollout_gate.py::test_owner_full_rollout_admits_future_and_restarted_bots_for_that_engine` 与 `test_operations.py::test_owner_full_rollout_requires_and_audits_latest_engine_acceptance` |
 | ONLINE Legacy 服务不原地迁移 | `test_claim_service.py::test_published_service_and_teclaw_do_not_claim` |
 | 四个文件型引擎使用各自 Pool 路径和结构桥 | `test_reconcile_service.py::test_ready_claimed_bot_completes_pool_activation`、`::test_claude_code_uses_its_own_pool_paths_for_full_activation`、`::test_aicoding_uses_its_own_pool_paths_for_full_activation`、`::test_hermes_h0_ready_uses_its_own_pool_paths_for_full_activation` |
 | 新旧镜像对应的不同 Bot 独立收敛：新镜像可激活，旧镜像保持 Legacy | `test_reconcile_service.py::test_mixed_image_bots_reconcile_independently_in_one_environment` |

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
@@ -32,6 +32,7 @@ from agentclaw.community.adapters.http.skills_pool.schemas import (
     EnginePromotionRequest,
     FeatureToggleRequest,
     FullRolloutRequest,
+    OwnerFullRolloutRequest,
     RepairRequest,
     RollbackRequest,
     WhitelistAddRequest,
@@ -165,6 +166,30 @@ async def add_whitelist_bot(
                 owner_id=request.owner_id,
                 bot_id=request.bot_id,
                 batch_id=request.batch_id,
+                acceptance_batch_id=request.acceptance_batch_id,
+                operator=user.staffId,
+                reason=request.reason,
+            )
+        )
+    except RolloutOperationError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@router.post("/rollout/owners", response_model=ApiResponse)
+async def set_owner_full_rollout(
+    request: OwnerFullRolloutRequest,
+    user: AuthenticatedUser = Depends(require_operator),
+    service: SkillsPoolRolloutServiceProtocol = Injected(
+        SkillsPoolRolloutServiceProtocol
+    ),
+):
+    try:
+        return _response(
+            service.set_owner_full_rollout(
+                env=get_current_env(),
+                owner_id=request.owner_id,
+                engine=request.engine,
+                enabled=request.enabled,
                 acceptance_batch_id=request.acceptance_batch_id,
                 operator=user.staffId,
                 reason=request.reason,

--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/schemas.py
@@ -27,6 +27,14 @@ class FullRolloutRequest(BaseModel):
     reason: str = Field(min_length=1)
 
 
+class OwnerFullRolloutRequest(BaseModel):
+    owner_id: str = Field(min_length=1)
+    engine: str = Field(min_length=1)
+    enabled: bool
+    acceptance_batch_id: str | None = None
+    reason: str = Field(min_length=1)
+
+
 class EnginePromotionRequest(BaseModel):
     engine: str
     reason: str = Field(min_length=1)

--- a/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_rollout_service.py
@@ -35,6 +35,18 @@ class SkillsPoolRolloutServiceProtocol(Protocol):
         reason: str,
     ) -> RolloutConfigSnapshot: ...
 
+    def set_owner_full_rollout(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        engine: str,
+        enabled: bool,
+        acceptance_batch_id: str | None,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot: ...
+
     def promote_engine(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -3,7 +3,8 @@
 Skills Pool 控制面的 Bot 级布局状态、首次迁移认领和激活编排边界。
 容器目录准备由镜像负责；本模块通过当前 runtime adapter 完成 probe、
 受支持文件型引擎的原子数据面切换与 Pool mapping，并在最后事务性提交
-locator 和 `POOL_ACTIVE`。当前已接入 OpenClaw、Claude Code 与 AICoding；完整多引擎
+locator 和 `POOL_ACTIVE`。当前已接入 OpenClaw、Claude Code、AICoding 与
+Hermes；完整多引擎
 Engine Layout Descriptor 仍不在本期范围内。
 
 ## 核心语义
@@ -37,11 +38,12 @@ Engine Layout Descriptor 仍不在本期范围内。
 - 激活只处理当前仍可编辑、已经认领、引擎已显式接入且由当前 worker 持有
   lease 的 Bot；每次执行都重新读取 Bot 和当前 provider binding，并重新
   probe 对应引擎 marker。未知引擎不回退到 OpenClaw。
-- 容器内以系统原生原子 exchange 完成最终 local 同步；随后先发布并验证
-  直接指向 canonical Pool 的 active mapping，再通过持久化
-  `.pool-active` 的 `finalizing → active` 状态移除 active root 中
-  `skills-local`、`skills-repo` 两个 corpus 入口。不支持原子 exchange
-  时保持 Legacy。
+- 容器内先把 Legacy local 以 generation-scoped rename 移入隔离区，再执行
+  best-effort 后置合并；随后发布并验证直接指向 canonical Pool 的 active
+  mapping。持久化 `.pool-active` 的 `finalizing → active` 后，active root
+  中的 local corpus bridge 必须退役；OpenClaw、Claude Code 位于 active
+  root 内的 repo bridge 同时退役，AICoding、Hermes 位于 active root 外的
+  稳定 repo namespace 则保留并继续只读指向 canonical Pool。
 - 激活前同时核对已登记 local，并从文件系统枚举未登记 local、受管 active
   entry 与外部 entry；完整 local 内容进入 Pool，但不会为未登记内容创建
   数据库记录，外部 entry 保持原目标。
@@ -56,7 +58,7 @@ Engine Layout Descriptor 仍不在本期范围内。
   与 `POOL_ACTIVE`，不恢复隔离副本。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
-  再从当前 Pool 全量重建新的 Legacy local 并原子交换。交换后即使 mapping
+  再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping
   或数据库失败也保持 `LEGACY_ROLLBACK_COMMITTED`，同一 generation 可由
   lease 过期后的新 worker 接管并继续提交 Legacy mapping 和 locator。
 - Backend 上传、删除和显式回滚共用 Bot 级互斥锁；回滚阶段内的新 local
@@ -64,8 +66,8 @@ Engine Layout Descriptor 仍不在本期范围内。
   `pool`，显式回滚前后使用 `legacy`。
 - 显式回滚不会读取迁移隔离副本，Pool 激活后产生的 local 新增和修改会被
   带入新的 Legacy；Pool 本身保留用于证据和后续恢复。
-- local 后置合并采用 best-effort 原子 exchange：一般的切换前修改、切换后
-  Pool 修改和新增路径竞争均可收敛；无写栅栏时，跨 exchange 的已打开文件
+- local 后置合并采用 best-effort、无覆盖的文件级收敛：一般的切换前修改、
+  切换后 Pool 修改和新增路径竞争均可收敛；无写栅栏时，跨 rename 的已打开文件
   描述符或连续同文件写入仍存在极窄竞态，作为 #370 的显式接受限制。
 - 原子切换留下的旧 local 以 Bot 与 migration generation 独立登记为
   Migration Quarantine，只用于审计和人工取证，不参与 locator、mapping、

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -15,8 +15,10 @@ Engine Layout Descriptor 仍不在本期范围内。
   `migration_generation`、lease 和白名单审计证据。
 - 白名单仅控制首次认领。认领成功后状态具有粘性，移出白名单不会撤销迁移。
 - rollout 配置按环境隔离；缺失、禁用、读取失败、格式异常或通配配置均
-  fail closed。`full_rollout_engines` 可逐引擎放开未来新建和后续重启的
-  Bot；`enable_all=true` 则覆盖当前环境中全部已经人工晋级并验收的引擎。
+  fail closed。`full_rollout_owners` 可在一个已晋级且已有验收批次的引擎内，
+  按 owner 放开其未来新建和后续重启的全部 Bot；`full_rollout_engines`
+  可逐引擎放开全环境，`enable_all=true` 则覆盖当前环境中全部已经人工晋级
+  并验收的引擎。精确负对照优先于所有扩大规则，始终保持不认领。
   未晋级引擎始终拒绝，环境全量期间也禁止直接晋级新引擎。
 - owner 和 engine 来自当前 Bot 记录；服务草稿还必须由当前
   `ac_bot_publish` DRAFT 记录证明。认领入口不接受调用方自报运行形态，
@@ -79,6 +81,8 @@ Engine Layout Descriptor 仍不在本期范围内。
   幂等。容器只接受 generation，由固定 engine Pool 根推导删除目标，不能
   删除其他 Bot 或 generation。数据库保留清理时间与证据。
 - 灰度运维入口接受当前环境中的精确 `(owner_id, bot_id)`；单个已晋级引擎
+  完成批次验收后，可引用最近一次验收通过
+  `POST /rollout/owners` 按 `(owner_id, engine)` 放开该员工全部未来认领；
   完成批次验收且无负对照后，可写入 `full_rollout_engines` 单独全量；
   所有已晋级引擎均满足条件后，可显式打开或关闭环境级 `enable_all`。
   引擎按 OpenClaw、Claude Code、AICoding、Hermes 的固定

--- a/src/backend/src/agentclaw/community/core/skills_pool/operation_models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operation_models.py
@@ -1,0 +1,97 @@
+"""Value objects exposed by the Skills Pool rollout operator service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class RolloutControlGroup(StrEnum):
+    NEGATIVE = "negative"
+    TECLAW = "teclaw"
+
+
+class RolloutOperationError(ValueError):
+    """An operator request cannot be safely applied."""
+
+
+@dataclass(frozen=True, slots=True)
+class RolloutBotEntry:
+    owner_id: str
+    bot_id: str
+    batch_id: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        value = {"owner_id": self.owner_id, "bot_id": self.bot_id}
+        if self.batch_id is not None:
+            value["batch_id"] = self.batch_id
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class RolloutOwnerEntry:
+    owner_id: str
+    engine: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"owner_id": self.owner_id, "engine": self.engine}
+
+
+@dataclass(frozen=True, slots=True)
+class RolloutAuditEvent:
+    env: str
+    action: str
+    operator: str
+    reason: str
+    batch_id: str | None
+    based_on_config_version: str | None
+    effective_config_version: str
+    effective_at: str
+    evidence: dict[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "env": self.env,
+            "action": self.action,
+            "operator": self.operator,
+            "reason": self.reason,
+            "batch_id": self.batch_id,
+            "based_on_config_version": self.based_on_config_version,
+            "effective_config_version": self.effective_config_version,
+            "effective_at": self.effective_at,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BatchPromotionEvidence:
+    engine: str
+    batch_id: str
+    promotion_ready: bool
+    report: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class RolloutConfigSnapshot:
+    env: str
+    config_id: int | None
+    config_version: str | None
+    record_version: str | None
+    config_revision: str | None
+    enabled: bool
+    enable_all: bool
+    promoted_engines: tuple[str, ...]
+    whitelist: tuple[RolloutBotEntry, ...]
+    negative_controls: tuple[RolloutBotEntry, ...]
+    teclaw_controls: tuple[RolloutBotEntry, ...]
+    audit_log: tuple[RolloutAuditEvent, ...]
+    full_rollout_engines: tuple[str, ...] = ()
+    full_rollout_owners: tuple[RolloutOwnerEntry, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class WhitelistMutationResult:
+    changed: bool
+    claimed_before: bool
+    claimed_after: bool
+    snapshot: RolloutConfigSnapshot

--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from datetime import UTC, datetime
-from enum import StrEnum
 from uuid import uuid4
 
 from injector import inject
@@ -13,6 +12,16 @@ from agentclaw.community.core.bot_management.repository.protocol import (
     BotRepository,
 )
 from agentclaw.community.core.common_config.service import CommonConfigService
+from agentclaw.community.core.skills_pool.operation_models import (
+    BatchPromotionEvidence,
+    RolloutAuditEvent,
+    RolloutBotEntry,
+    RolloutConfigSnapshot,
+    RolloutControlGroup,
+    RolloutOperationError,
+    RolloutOwnerEntry,
+    WhitelistMutationResult,
+)
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
 )
@@ -32,97 +41,6 @@ from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     SkillLayout,
 )
-
-
-class RolloutControlGroup(StrEnum):
-    NEGATIVE = "negative"
-    TECLAW = "teclaw"
-
-
-class RolloutOperationError(ValueError):
-    """An operator request cannot be safely applied."""
-
-
-@dataclass(frozen=True, slots=True)
-class RolloutBotEntry:
-    owner_id: str
-    bot_id: str
-    batch_id: str | None = None
-
-    def to_dict(self) -> dict[str, str]:
-        value = {"owner_id": self.owner_id, "bot_id": self.bot_id}
-        if self.batch_id is not None:
-            value["batch_id"] = self.batch_id
-        return value
-
-
-@dataclass(frozen=True, slots=True)
-class RolloutOwnerEntry:
-    owner_id: str
-    engine: str
-
-    def to_dict(self) -> dict[str, str]:
-        return {"owner_id": self.owner_id, "engine": self.engine}
-
-
-@dataclass(frozen=True, slots=True)
-class RolloutAuditEvent:
-    env: str
-    action: str
-    operator: str
-    reason: str
-    batch_id: str | None
-    based_on_config_version: str | None
-    effective_config_version: str
-    effective_at: str
-    evidence: dict[str, object] | None = None
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "env": self.env,
-            "action": self.action,
-            "operator": self.operator,
-            "reason": self.reason,
-            "batch_id": self.batch_id,
-            "based_on_config_version": self.based_on_config_version,
-            "effective_config_version": self.effective_config_version,
-            "effective_at": self.effective_at,
-            "evidence": self.evidence,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class BatchPromotionEvidence:
-    engine: str
-    batch_id: str
-    promotion_ready: bool
-    report: dict[str, object]
-
-
-@dataclass(frozen=True, slots=True)
-class RolloutConfigSnapshot:
-    env: str
-    config_id: int | None
-    config_version: str | None
-    record_version: str | None
-    config_revision: str | None
-    enabled: bool
-    enable_all: bool
-    promoted_engines: tuple[str, ...]
-    whitelist: tuple[RolloutBotEntry, ...]
-    negative_controls: tuple[RolloutBotEntry, ...]
-    teclaw_controls: tuple[RolloutBotEntry, ...]
-    audit_log: tuple[RolloutAuditEvent, ...]
-    full_rollout_engines: tuple[str, ...] = ()
-    full_rollout_owners: tuple[RolloutOwnerEntry, ...] = ()
-
-
-@dataclass(frozen=True, slots=True)
-class WhitelistMutationResult:
-    changed: bool
-    claimed_before: bool
-    claimed_after: bool
-    snapshot: RolloutConfigSnapshot
 
 
 class SkillsPoolRolloutOperations:

--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -57,6 +57,15 @@ class RolloutBotEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class RolloutOwnerEntry:
+    owner_id: str
+    engine: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"owner_id": self.owner_id, "engine": self.engine}
+
+
+@dataclass(frozen=True, slots=True)
 class RolloutAuditEvent:
     env: str
     action: str
@@ -105,6 +114,7 @@ class RolloutConfigSnapshot:
     teclaw_controls: tuple[RolloutBotEntry, ...]
     audit_log: tuple[RolloutAuditEvent, ...]
     full_rollout_engines: tuple[str, ...] = ()
+    full_rollout_owners: tuple[RolloutOwnerEntry, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,9 +198,7 @@ class SkillsPoolRolloutOperations:
                 raise RolloutOperationError(
                     "rollout feature must be enabled before full rollout"
                 )
-            target_engines = (
-                current.promoted_engines if engine is None else (engine,)
-            )
+            target_engines = current.promoted_engines if engine is None else (engine,)
             if not target_engines:
                 raise RolloutOperationError(
                     "at least one engine must be promoted before full rollout"
@@ -234,6 +242,70 @@ class SkillsPoolRolloutOperations:
             batch_id=None,
             action=(
                 f"full_rollout:{engine or 'environment'}:"
+                f"{'enable' if enabled else 'disable'}"
+            ),
+        )
+
+    def set_owner_full_rollout(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        engine: str,
+        enabled: bool,
+        acceptance_batch_id: str | None,
+        operator: str,
+        reason: str,
+    ) -> RolloutConfigSnapshot:
+        """Enable future claims for every Bot owned by one person and engine."""
+
+        self._validate_change(operator=operator, reason=reason)
+        entry = self._owner_entry(owner_id=owner_id, engine=engine)
+        current = self.get_snapshot(env=env)
+        present = entry in current.full_rollout_owners
+        if present is enabled:
+            return current
+
+        acceptance = None
+        if enabled:
+            if not current.enabled:
+                raise RolloutOperationError(
+                    "rollout feature must be enabled before owner full rollout"
+                )
+            if engine not in current.promoted_engines:
+                raise RolloutOperationError(
+                    f"{engine} must be promoted before owner full rollout"
+                )
+            acceptance = self._latest_accepted_batch(current, engine=engine)
+            if acceptance is None:
+                raise RolloutOperationError(
+                    f"an accepted {engine} batch is required for owner full rollout"
+                )
+            if acceptance_batch_id != acceptance.batch_id:
+                raise RolloutOperationError(
+                    "owner full rollout must reference the latest accepted batch"
+                )
+            if self._open_batches(current, env=env, engine=engine):
+                raise RolloutOperationError(f"{engine} still has an unaccepted batch")
+
+        owners = tuple(item for item in current.full_rollout_owners if item != entry)
+        if enabled:
+            owners = (*owners, entry)
+        return self._write(
+            snapshot=RolloutConfigSnapshot(
+                **{
+                    **self._snapshot_values(current),
+                    "full_rollout_owners": owners,
+                }
+            ),
+            expected_snapshot=current,
+            enabled=current.enabled,
+            operator=operator,
+            reason=reason,
+            batch_id=acceptance.batch_id if acceptance else None,
+            evidence=acceptance.report if acceptance else None,
+            action=(
+                f"owner_full_rollout:{entry.owner_id}:{entry.engine}:"
                 f"{'enable' if enabled else 'disable'}"
             ),
         )
@@ -746,6 +818,7 @@ class SkillsPoolRolloutOperations:
                 enabled=False,
                 enable_all=False,
                 full_rollout_engines=(),
+                full_rollout_owners=(),
                 promoted_engines=(),
                 whitelist=(),
                 negative_controls=(),
@@ -783,6 +856,9 @@ class SkillsPoolRolloutOperations:
             enabled=config.get("enable") == "1",
             enable_all=bool(value["enable_all"]),
             full_rollout_engines=tuple(value.get("full_rollout_engines", [])),
+            full_rollout_owners=cls._owner_entries(
+                value.get("full_rollout_owners", [])
+            ),
             promoted_engines=promoted_engines,
             whitelist=cls._entries(whitelist),
             negative_controls=cls._entries(value.get(CONTROL_KEYS[0], [])),
@@ -845,6 +921,9 @@ class SkillsPoolRolloutOperations:
         return {
             "enable_all": snapshot.enable_all,
             "full_rollout_engines": list(snapshot.full_rollout_engines),
+            "full_rollout_owners": [
+                item.to_dict() for item in snapshot.full_rollout_owners
+            ],
             "promoted_engines": list(snapshot.promoted_engines),
             "whitelist": [item.to_dict() for item in snapshot.whitelist],
             "negative_controls": [
@@ -869,6 +948,34 @@ class SkillsPoolRolloutOperations:
                 )
             )
         return tuple(entries)
+
+    @classmethod
+    def _owner_entries(cls, raw: object) -> tuple[RolloutOwnerEntry, ...]:
+        if not isinstance(raw, list):
+            raise RolloutOperationError("rollout owner entries are invalid")
+        entries: list[RolloutOwnerEntry] = []
+        for value in raw:
+            if not isinstance(value, dict):
+                raise RolloutOperationError("rollout owner entry is invalid")
+            entries.append(
+                cls._owner_entry(
+                    owner_id=value.get("owner_id"),
+                    engine=value.get("engine"),
+                )
+            )
+        return tuple(entries)
+
+    @staticmethod
+    def _owner_entry(*, owner_id: object, engine: object) -> RolloutOwnerEntry:
+        if (
+            isinstance(owner_id, bool)
+            or not isinstance(owner_id, (str, int))
+            or str(owner_id).strip() in {"", "*"}
+        ):
+            raise RolloutOperationError("rollout owner identity is invalid")
+        if not isinstance(engine, str) or engine not in ENGINE_PROMOTION_ORDER:
+            raise RolloutOperationError("rollout owner engine is invalid")
+        return RolloutOwnerEntry(owner_id=str(owner_id), engine=engine)
 
     @staticmethod
     def _entry(
@@ -924,6 +1031,7 @@ class SkillsPoolRolloutOperations:
             "enabled": snapshot.enabled,
             "enable_all": snapshot.enable_all,
             "full_rollout_engines": snapshot.full_rollout_engines,
+            "full_rollout_owners": snapshot.full_rollout_owners,
             "promoted_engines": snapshot.promoted_engines,
             "whitelist": snapshot.whitelist,
             "negative_controls": snapshot.negative_controls,

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
@@ -7,8 +7,11 @@ from typing import Any
 ENGINE_PROMOTION_ORDER = ("openclaw", "claude_code", "aicoding", "hermes")
 CONTROL_KEYS = ("negative_controls", "teclaw_controls")
 _REQUIRED_KEYS = frozenset({"enable_all", "promoted_engines", "whitelist"})
-_ALLOWED_KEYS = _REQUIRED_KEYS | frozenset((*CONTROL_KEYS, "full_rollout_engines"))
+_ALLOWED_KEYS = _REQUIRED_KEYS | frozenset(
+    (*CONTROL_KEYS, "full_rollout_engines", "full_rollout_owners")
+)
 _ENTRY_KEYS = frozenset({"owner_id", "bot_id", "batch_id"})
+_OWNER_ENTRY_KEYS = frozenset({"owner_id", "engine"})
 
 
 def _valid_identity(value: Any) -> bool:
@@ -35,6 +38,25 @@ def _valid_entries(value: Any) -> bool:
     return True
 
 
+def _valid_owner_entries(value: Any) -> bool:
+    if not isinstance(value, list):
+        return False
+    identities: set[tuple[str, str]] = set()
+    for entry in value:
+        if not isinstance(entry, dict) or set(entry) != _OWNER_ENTRY_KEYS:
+            return False
+        if not _valid_identity(entry.get("owner_id")):
+            return False
+        engine = entry.get("engine")
+        if not isinstance(engine, str) or engine not in ENGINE_PROMOTION_ORDER:
+            return False
+        identity = (str(entry["owner_id"]), engine)
+        if identity in identities:
+            return False
+        identities.add(identity)
+    return True
+
+
 def is_valid_rollout_config_value(value: Any) -> bool:
     """Accept only the exact, fail-closed rollout configuration schema."""
 
@@ -58,6 +80,13 @@ def is_valid_rollout_config_value(value: Any) -> bool:
         or any(not isinstance(engine, str) for engine in full_rollout_engines)
         or len(set(full_rollout_engines)) != len(full_rollout_engines)
         or any(engine not in promoted_engines for engine in full_rollout_engines)
+    ):
+        return False
+    if not _valid_owner_entries(value.get("full_rollout_owners", [])):
+        return False
+    if any(
+        entry["engine"] not in promoted_engines
+        for entry in value.get("full_rollout_owners", [])
     ):
         return False
 
@@ -92,9 +121,18 @@ def normalize_rollout_config_value(value: Any) -> dict[str, object] | None:
             normalized.append(entry)
         return normalized
 
+    owner_entries = [
+        {
+            "owner_id": str(raw["owner_id"]),
+            "engine": str(raw["engine"]),
+        }
+        for raw in value.get("full_rollout_owners", [])
+    ]
+
     return {
         "enable_all": value["enable_all"],
         "full_rollout_engines": list(value.get("full_rollout_engines", [])),
+        "full_rollout_owners": owner_entries,
         "promoted_engines": list(value["promoted_engines"]),
         "whitelist": entries("whitelist"),
         "negative_controls": entries(CONTROL_KEYS[0]),

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_gate.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_gate.py
@@ -42,6 +42,7 @@ class RolloutDecisionReason(StrEnum):
     CONFIG_ENV_MISMATCH = "config_env_mismatch"
     ENGINE_NOT_SUPPORTED = "engine_not_supported"
     ENGINE_NOT_PROMOTED = "engine_not_promoted"
+    BOT_NEGATIVE_CONTROL = "bot_negative_control"
     BOT_NOT_WHITELISTED = "bot_not_whitelisted"
     RUNTIME_NOT_EDITABLE = "runtime_not_editable"
 
@@ -131,10 +132,24 @@ class SkillsPoolRolloutGate:
         if engine_type not in promoted_engines:
             return self._reject(RolloutDecisionReason.ENGINE_NOT_PROMOTED)
 
+        negative_control = self._whitelist_service.find_bot_whitelist_entry(
+            value.get("negative_controls", []),
+            owner_id=owner_id,
+            bot_id=bot_id,
+        )
+        if negative_control is not None:
+            return self._reject(RolloutDecisionReason.BOT_NEGATIVE_CONTROL)
+
         batch_id = None
         decision_reason = "environment_full_rollout"
-        if value["enable_all"] is False and engine_type not in value.get(
-            "full_rollout_engines", []
+        owner_full_rollout = any(
+            str(entry["owner_id"]) == str(owner_id) and entry["engine"] == engine_type
+            for entry in value.get("full_rollout_owners", [])
+        )
+        if (
+            value["enable_all"] is False
+            and engine_type not in value.get("full_rollout_engines", [])
+            and not owner_full_rollout
         ):
             whitelist = value["whitelist"]
             entry = self._whitelist_service.find_bot_whitelist_entry(
@@ -146,6 +161,8 @@ class SkillsPoolRolloutGate:
                 return self._reject(RolloutDecisionReason.BOT_NOT_WHITELISTED)
             batch_id = entry.get("batch_id")
             decision_reason = "exact_bot_whitelist"
+        elif value["enable_all"] is False and owner_full_rollout:
+            decision_reason = "owner_full_rollout"
         elif value["enable_all"] is False:
             decision_reason = "engine_full_rollout"
         evidence = RolloutEvidence(

--- a/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
+++ b/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
@@ -14,12 +14,14 @@ from agentclaw.community.adapters.http.skills_pool.router import (
     rollback_bot,
     router,
     set_full_rollout,
+    set_owner_full_rollout,
     set_rollout_feature,
 )
 from agentclaw.community.adapters.http.skills_pool.schemas import (
     ControlBotRequest,
     FeatureToggleRequest,
     FullRolloutRequest,
+    OwnerFullRolloutRequest,
     RollbackRequest,
 )
 from agentclaw.community.api.skills_pool_rollout_service import (
@@ -49,6 +51,7 @@ def test_all_skills_pool_operations_are_operator_only() -> None:
         "/api/ops/skills-pool/rollout",
         "/api/ops/skills-pool/rollout/feature",
         "/api/ops/skills-pool/rollout/full",
+        "/api/ops/skills-pool/rollout/owners",
         "/api/ops/skills-pool/rollout/promote",
         "/api/ops/skills-pool/rollout/whitelist",
         "/api/ops/skills-pool/rollout/whitelist/remove",
@@ -119,11 +122,13 @@ async def test_feature_post_normalizes_legacy_config_and_audits_once(
     assert response.data["enabled"] is True
     assert response.data["enable_all"] is False
     assert response.data["full_rollout_engines"] == ()
+    assert response.data["full_rollout_owners"] == ()
     stored = configs.get_by_id(config_id=config_id)
     assert stored is not None
     assert json.loads(stored.param_value or "{}") == {
         "enable_all": False,
         "full_rollout_engines": [],
+        "full_rollout_owners": [],
         "promoted_engines": ["openclaw"],
         "whitelist": [],
         "negative_controls": [],
@@ -181,6 +186,44 @@ async def test_full_rollout_route_forwards_optional_engine() -> None:
 
 
 @pytest.mark.asyncio
+async def test_owner_full_rollout_route_forwards_owner_engine_and_acceptance() -> None:
+    @dataclass(frozen=True)
+    class Result:
+        enabled: bool = True
+
+    class RolloutService:
+        call: dict[str, object] | None = None
+
+        def set_owner_full_rollout(self, **kwargs: object):
+            self.call = kwargs
+            return Result()
+
+    service = RolloutService()
+
+    await set_owner_full_rollout(
+        request=OwnerFullRolloutRequest(
+            owner_id="168944",
+            engine="openclaw",
+            enabled=True,
+            acceptance_batch_id="openclaw-canary-1",
+            reason="enable all owner bots in pre",
+        ),
+        user=SimpleNamespace(staffId="freddie"),
+        service=service,
+    )
+
+    assert service.call == {
+        "env": "dev",
+        "owner_id": "168944",
+        "engine": "openclaw",
+        "enabled": True,
+        "acceptance_batch_id": "openclaw-canary-1",
+        "operator": "freddie",
+        "reason": "enable all owner bots in pre",
+    }
+
+
+@pytest.mark.asyncio
 async def test_rollback_route_supplies_a_unique_lease_owner() -> None:
     scope = BotSkillLayoutScope("pre", "entity-1", "bot-1")
 
@@ -193,9 +236,7 @@ async def test_rollback_route_supplies_a_unique_lease_owner() -> None:
 
         async def rollback(self, **kwargs: object) -> SkillsPoolRollbackResult:
             self.call = kwargs
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.LEGACY_ACTIVE
-            )
+            return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.LEGACY_ACTIVE)
 
     service = RollbackService()
 

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -38,14 +38,42 @@ def test_real_skill_service_factory_create(test_injector):
     assert svc.runtime_uses_pool_paths is False
 
 
+@pytest.mark.parametrize(
+    ("engine", "engine_root", "active_dir"),
+    [
+        (
+            "openclaw",
+            "/home/admin/.openclaw/workspace",
+            "/home/admin/.openclaw/workspace/skills",
+        ),
+        (
+            "claude_code",
+            "/home/admin/.claude_code/workspace",
+            "/home/admin/.claude/skills",
+        ),
+        (
+            "aicoding",
+            "/home/admin/.aicoding/workspace",
+            "/home/admin/.claude/skills",
+        ),
+        (
+            "hermes",
+            "/home/admin/.hermes/workspace",
+            "/home/admin/.hermes/skills",
+        ),
+    ],
+)
 def test_pool_active_factory_scopes_direct_skill_crud_to_canonical_pool(
     test_injector,
+    engine,
+    engine_root,
+    active_dir,
 ):
     factory = test_injector.get(SkillServiceFactory)
     factory._pool_layout_paths = lambda *_: (
-        "/home/admin/.openclaw/workspace/skills",
-        "/home/admin/.openclaw/workspace/skills-pool/skills-local",
-        "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+        active_dir,
+        f"{engine_root}/skills-pool/skills-local",
+        f"{engine_root}/skills-pool/skills-repo",
     )
 
     svc = factory.create(
@@ -54,29 +82,19 @@ def test_pool_active_factory_scopes_direct_skill_crud_to_canonical_pool(
         repo_dir="/legacy/skills/skills-repo",
         entity_id="staff-1",
         bot_id="bot-1",
-        engine_type="openclaw",
+        engine_type=engine,
     )
 
-    assert svc.active_dir == Path("/home/admin/.openclaw/workspace/skills")
-    assert svc.local_dir == Path(
-        "/home/admin/.openclaw/workspace/skills-pool/skills-local"
-    )
-    assert svc.repo_dir == Path(
-        "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
-    )
+    assert svc.active_dir == Path(active_dir)
+    assert svc.local_dir == Path(f"{engine_root}/skills-pool/skills-local")
+    assert svc.repo_dir == Path(f"{engine_root}/skills-pool/skills-repo")
     assert svc.runtime_uses_pool_paths is True
     assert svc._local_skill_path_adapter(
-        "/home/admin/.openclaw/workspace/skills/skills-local/handmade"
-    ) == (
-        "/home/admin/.openclaw/workspace/skills-pool/"
-        "skills-local/handmade"
-    )
+        f"{engine_root}/skills/skills-local/handmade"
+    ) == f"{engine_root}/skills-pool/skills-local/handmade"
     assert svc._local_skill_locator_adapter(
-        "/home/admin/.openclaw/workspace/skills/skills-local/handmade"
-    ) == (
-        "/home/admin/.openclaw/workspace/skills-pool/"
-        "skills-local/handmade"
-    )
+        f"{engine_root}/skills/skills-local/handmade"
+    ) == f"{engine_root}/skills-pool/skills-local/handmade"
 
 
 def test_real_skill_set_service_factory_create_default_branch(test_injector):

--- a/src/backend/tests/community/core/skills_pool/test_operations.py
+++ b/src/backend/tests/community/core/skills_pool/test_operations.py
@@ -10,6 +10,7 @@ from agentclaw.community.core.skills_pool.operations import (
     BatchPromotionEvidence,
     RolloutControlGroup,
     RolloutOperationError,
+    RolloutOwnerEntry,
     SkillsPoolRolloutOperations,
 )
 from agentclaw.community.core.skills_pool.types import (
@@ -48,7 +49,6 @@ class FakeCommonConfig:
             "gmt_modified": "2026-07-25T10:00:00+00:00",
         }
         return 42
-
 
 
 class FakeRolloutRepository:
@@ -132,7 +132,11 @@ class FakeLayouts:
         if (
             self.state.persisted
             and self.state.scope.env == env
-            and (engine is None or evidence is not None and evidence.engine_type == engine)
+            and (
+                engine is None
+                or evidence is not None
+                and evidence.engine_type == engine
+            )
             and (
                 batch_id is None
                 or evidence is not None
@@ -174,6 +178,7 @@ def rollout_config(
     enabled: bool = True,
     enable_all: bool = False,
     full_rollout_engines: list[str] | None = None,
+    full_rollout_owners: list[dict[str, object]] | None = None,
     promoted_engines: list[str] | None = None,
     whitelist: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
@@ -186,6 +191,7 @@ def rollout_config(
         "param_value": {
             "enable_all": enable_all,
             "full_rollout_engines": full_rollout_engines or [],
+            "full_rollout_owners": full_rollout_owners or [],
             "promoted_engines": promoted_engines or [],
             "whitelist": whitelist or [],
             "negative_controls": [],
@@ -211,6 +217,7 @@ def test_enabling_missing_rollout_creates_safe_exact_bot_configuration() -> None
     assert configs.upserts[0]["param_value"] == {
         "enable_all": False,
         "full_rollout_engines": [],
+        "full_rollout_owners": [],
         "promoted_engines": [],
         "whitelist": [],
         "negative_controls": [],
@@ -247,8 +254,9 @@ def test_engine_promotion_is_manual_ordered_and_idempotent() -> None:
     assert len(configs.upserts) == 1
 
 
-def test_full_rollout_requires_accepted_promoted_engine_then_admits_environment(
-) -> None:
+def test_full_rollout_requires_accepted_promoted_engine_then_admits_environment() -> (
+    None
+):
     operations, configs, _, _ = build_operations(
         config=rollout_config(promoted_engines=["openclaw"])
     )
@@ -319,6 +327,87 @@ def test_engine_full_rollout_does_not_admit_other_promoted_engine() -> None:
     assert snapshot.full_rollout_engines == ("openclaw",)
     assert configs.config["param_value"]["full_rollout_engines"] == ["openclaw"]
     assert snapshot.audit_log[-1].action == "full_rollout:openclaw:enable"
+
+
+def test_owner_full_rollout_requires_and_audits_latest_engine_acceptance() -> None:
+    operations, configs, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+
+    with pytest.raises(RolloutOperationError, match="accepted openclaw batch"):
+        operations.set_owner_full_rollout(
+            env=ENV,
+            owner_id=OWNER,
+            engine="openclaw",
+            enabled=True,
+            acceptance_batch_id=None,
+            operator="freddie",
+            reason="too early",
+        )
+
+    operations.accept_batch(
+        env=ENV,
+        operator="freddie",
+        reason="canary passed",
+        acceptance=BatchPromotionEvidence(
+            engine="openclaw",
+            batch_id="openclaw-canary-1",
+            promotion_ready=True,
+            report={
+                "rollout_config_version": "2026-07-25T09:00:00+00:00",
+                "promotion_ready": True,
+            },
+        ),
+    )
+    snapshot = operations.set_owner_full_rollout(
+        env=ENV,
+        owner_id=OWNER,
+        engine="openclaw",
+        enabled=True,
+        acceptance_batch_id="openclaw-canary-1",
+        operator="freddie",
+        reason="expand to all owner bots",
+    )
+
+    assert snapshot.full_rollout_owners == (
+        RolloutOwnerEntry(owner_id=OWNER, engine="openclaw"),
+    )
+    assert configs.config is not None
+    assert configs.config["param_value"]["full_rollout_owners"] == [
+        {"owner_id": OWNER, "engine": "openclaw"}
+    ]
+    event = snapshot.audit_log[-1]
+    assert event.action == f"owner_full_rollout:{OWNER}:openclaw:enable"
+    assert event.batch_id == "openclaw-canary-1"
+
+
+def test_owner_full_rollout_is_engine_scoped_and_can_be_disabled() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(
+            promoted_engines=["openclaw", "claude_code"],
+            full_rollout_owners=[
+                {"owner_id": OWNER, "engine": "openclaw"},
+                {"owner_id": "owner-2", "engine": "claude_code"},
+            ],
+        )
+    )
+
+    snapshot = operations.set_owner_full_rollout(
+        env=ENV,
+        owner_id=OWNER,
+        engine="openclaw",
+        enabled=False,
+        acceptance_batch_id=None,
+        operator="freddie",
+        reason="pause owner claims",
+    )
+
+    assert snapshot.full_rollout_owners == (
+        RolloutOwnerEntry(owner_id="owner-2", engine="claude_code"),
+    )
+    assert snapshot.audit_log[-1].action == (
+        f"owner_full_rollout:{OWNER}:openclaw:disable"
+    )
 
 
 def test_full_rollout_can_be_disabled_without_reverting_claimed_bots() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
+++ b/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
@@ -35,6 +35,7 @@ def test_legacy_rollout_entries_are_normalized_to_canonical_shape() -> None:
     ) == {
         "enable_all": False,
         "full_rollout_engines": [],
+        "full_rollout_owners": [],
         "promoted_engines": ["openclaw"],
         "whitelist": [
             {
@@ -71,6 +72,7 @@ def enabled_config(
     whitelist: object = None,
     enable_all: object = False,
     full_rollout_engines: object = None,
+    full_rollout_owners: object = None,
 ) -> dict[str, Any]:
     return {
         "id": 42,
@@ -81,6 +83,9 @@ def enabled_config(
             "enable_all": enable_all,
             "full_rollout_engines": (
                 [] if full_rollout_engines is None else full_rollout_engines
+            ),
+            "full_rollout_owners": (
+                [] if full_rollout_owners is None else full_rollout_owners
             ),
             "promoted_engines": (
                 ["openclaw"] if promoted_engines is None else promoted_engines
@@ -252,6 +257,86 @@ def test_engine_full_rollout_admits_only_that_promoted_engine() -> None:
     assert claude.reason is RolloutDecisionReason.BOT_NOT_WHITELISTED
 
 
+def test_owner_full_rollout_admits_future_and_restarted_bots_for_that_engine() -> None:
+    gate = make_gate(
+        enabled_config(
+            promoted_engines=["openclaw", "claude_code"],
+            full_rollout_owners=[
+                {"owner_id": "owner-1", "engine": "openclaw"},
+            ],
+            whitelist=[],
+        )
+    )
+
+    future_openclaw = evaluate(
+        gate,
+        owner_id="owner-1",
+        bot_id="future-bot",
+    )
+    restarted_claude = evaluate(
+        gate,
+        owner_id="owner-1",
+        bot_id="existing-bot",
+        engine_type="claude_code",
+    )
+    other_owner = evaluate(
+        gate,
+        owner_id="owner-2",
+        bot_id="future-bot",
+    )
+
+    assert future_openclaw.eligible
+    assert future_openclaw.evidence is not None
+    assert future_openclaw.evidence.decision_reason == "owner_full_rollout"
+    assert restarted_claude.reason is RolloutDecisionReason.BOT_NOT_WHITELISTED
+    assert other_owner.reason is RolloutDecisionReason.BOT_NOT_WHITELISTED
+
+
+def test_exact_negative_control_overrides_owner_full_rollout() -> None:
+    config = enabled_config(
+        full_rollout_owners=[
+            {"owner_id": "owner-1", "engine": "openclaw"},
+        ],
+        whitelist=[],
+    )
+    config["param_value"]["negative_controls"] = [
+        {
+            "owner_id": "owner-1",
+            "bot_id": "control-bot",
+            "batch_id": "openclaw-canary-1",
+        }
+    ]
+    gate = make_gate(config)
+
+    control = evaluate(gate, owner_id="owner-1", bot_id="control-bot")
+    ordinary = evaluate(gate, owner_id="owner-1", bot_id="ordinary-bot")
+
+    assert not control.eligible
+    assert control.reason is RolloutDecisionReason.BOT_NEGATIVE_CONTROL
+    assert ordinary.eligible
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"owner_id": "*", "engine": "openclaw"},
+        {"owner_id": "owner-1", "engine": "unknown"},
+        {"owner_id": "owner-1", "engine": "claude_code"},
+        {"owner_id": "owner-1"},
+        {"owner_id": "owner-1", "engine": "openclaw", "bot_id": "bot-1"},
+    ],
+)
+def test_invalid_owner_full_rollout_entry_fails_closed(
+    entry: dict[str, object],
+) -> None:
+    decision = evaluate(
+        make_gate(enabled_config(full_rollout_owners=[entry], whitelist=[]))
+    )
+
+    assert not decision.eligible
+    assert decision.reason is RolloutDecisionReason.CONFIG_INVALID
+
+
 def test_full_rollout_still_rejects_unpromoted_engine() -> None:
     decision = evaluate(
         make_gate(enabled_config(enable_all=True, whitelist=[])),
@@ -279,9 +364,7 @@ def test_service_draft_is_editable_but_published_service_is_not(
     promotion_order = ["openclaw", "claude_code", "aicoding", "hermes"]
     gate = make_gate(
         enabled_config(
-            promoted_engines=promotion_order[
-                : promotion_order.index(engine_type) + 1
-            ]
+            promoted_engines=promotion_order[: promotion_order.index(engine_type) + 1]
         )
     )
 

--- a/src/backend/tests/community/endpoints/test_skills_pool_ops.py
+++ b/src/backend/tests/community/endpoints/test_skills_pool_ops.py
@@ -75,6 +75,7 @@ def _seed_happy_services(world) -> None:
             for method in (
                 "set_feature_enabled",
                 "set_full_rollout",
+                "set_owner_full_rollout",
                 "promote_engine",
                 "add_bot",
                 "remove_bot",
@@ -143,6 +144,20 @@ _HAPPY_CASES = (
         CaseInput(
             headers=_HEADERS,
             json_body={"enabled": True, "reason": "promote environment"},
+        ),
+    ),
+    (
+        "POST",
+        "/api/ops/skills-pool/rollout/owners",
+        CaseInput(
+            headers=_HEADERS,
+            json_body={
+                "owner_id": "owner-1",
+                "engine": "openclaw",
+                "enabled": True,
+                "acceptance_batch_id": "batch-1",
+                "reason": "promote owner bots",
+            },
         ),
     ),
     (

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -82,7 +82,7 @@ async def probe_runtime_skills_layout(
 async def activate_runtime_skills_layout(
     body: PoolLayoutActivateRequest,
 ) -> PoolLayoutActivateApiResponse:
-    """在当前容器的持久化文件系统上提交 OpenClaw Pool 数据面。"""
+    """在当前容器的持久化文件系统上提交对应引擎的 Pool 数据面。"""
 
     plugin = _skills_plugin()
     try:

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -145,9 +145,16 @@ def test_aicoding_activation_switches_local_and_keeps_repo_namespace(
     assert not legacy_local.is_symlink()
     assert not local_bridge.exists()
     assert not local_bridge.is_symlink()
-    assert not repo_bridge.exists()
-    assert not repo_bridge.is_symlink()
+    assert repo_bridge.is_symlink()
+    assert repo_bridge.resolve() == pool_repo.resolve()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
+
+    ready = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert ready.status is RuntimeLayoutInspectionStatus.READY
+    assert ready.evidence["checks"]["stable_repo_bridge_valid"] is True
 
 
 def test_aicoding_rollback_rebuilds_legacy_from_current_pool(

--- a/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
@@ -97,7 +97,9 @@ def test_probe_requires_verified_hermes_legacy_bridge(tmp_path: Path) -> None:
     )
 
 
-def test_activation_retires_hermes_legacy_storage_bridges(tmp_path: Path) -> None:
+def test_activation_retires_hermes_local_bridges_and_keeps_repo_namespace(
+    tmp_path: Path,
+) -> None:
     home = tmp_path / "home" / "admin"
     active_root = home / ".hermes" / "skills"
     legacy_local = home / ".hermes" / "workspace" / "skills" / "skills-local"
@@ -174,9 +176,16 @@ def test_activation_retires_hermes_legacy_storage_bridges(tmp_path: Path) -> Non
     assert not legacy_local.is_symlink()
     assert not local_bridge.exists()
     assert not local_bridge.is_symlink()
-    assert not repo_bridge.exists()
-    assert not repo_bridge.is_symlink()
+    assert repo_bridge.is_symlink()
+    assert repo_bridge.resolve() == pool_repo.resolve()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
+
+    ready = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert ready.status is RuntimeLayoutInspectionStatus.READY
+    assert ready.evidence["checks"]["stable_repo_bridge_valid"] is True
 
     mapping = SkillMapping(
         source=str(pool_local / "handmade"),

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -51,20 +51,10 @@ def test_mapping_source_classifier_selects_one_managed_layout(
 ) -> None:
     home = tmp_path / "home" / "admin"
     pool_source = (
-        home
-        / ".openclaw"
-        / "workspace"
-        / "skills-pool"
-        / "skills-local"
-        / "pool-skill"
+        home / ".openclaw" / "workspace" / "skills-pool" / "skills-local" / "pool-skill"
     )
     legacy_source = (
-        home
-        / ".openclaw"
-        / "workspace"
-        / "skills"
-        / "skills-local"
-        / "legacy-skill"
+        home / ".openclaw" / "workspace" / "skills" / "skills-local" / "legacy-skill"
     )
     external_source = home / "external-skills" / "external"
 
@@ -84,6 +74,54 @@ def test_mapping_source_classifier_selects_one_managed_layout(
             sources=[legacy_source, pool_source],
             home=home,
         )
+
+
+def test_external_only_mapping_fails_closed_on_invalid_active_marker(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    active_marker = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-active"
+    active_marker.parent.mkdir(parents=True)
+    active_marker.write_text("{invalid")
+
+    with pytest.raises(ValueError, match="marker"):
+        mapping_sources_use_pool(
+            engine="openclaw",
+            sources=[home / "external-skills" / "external"],
+            home=home,
+        )
+
+
+def test_external_only_mapping_uses_active_marker_as_layout_authority(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    external_source = home / "external-skills" / "external"
+    assert not mapping_sources_use_pool(
+        engine="openclaw",
+        sources=[external_source],
+        home=home,
+    )
+
+    active_marker = home / ".openclaw" / "workspace" / "skills-pool" / ".pool-active"
+    active_marker.parent.mkdir(parents=True)
+    active_marker.write_text(
+        json.dumps(
+            {
+                "engine": "openclaw",
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                "preparation_id": PREPARATION_ID,
+                "migration_generation": "generation-1",
+                "activation_state": "active",
+            }
+        )
+    )
+
+    assert mapping_sources_use_pool(
+        engine="openclaw",
+        sources=[external_source],
+        home=home,
+    )
 
 
 def _prepared_home(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
@@ -163,10 +201,7 @@ def test_registered_local_cutover_syncs_latest_content_and_retires_bridges(
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
     assert not (pool_local / "handmade" / "stale.txt").exists()
     quarantine = (
-        pool_local.parent
-        / ".migration-quarantine"
-        / "generation-1"
-        / "skills-local"
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
     )
     assert (quarantine / "handmade" / "SKILL.md").read_text() == "latest"
 
@@ -175,9 +210,7 @@ def test_registered_local_cutover_syncs_latest_content_and_retires_bridges(
     external_entry = legacy_local.parent / "external"
     external_entry.symlink_to(external_source, target_is_directory=True)
     unclassified_entry = legacy_local.parent / "unclassified"
-    unclassified_entry.symlink_to(
-        pool_local / "handmade", target_is_directory=True
-    )
+    unclassified_entry.symlink_to(pool_local / "handmade", target_is_directory=True)
     published = publish_pool_mappings(mappings=mappings, home=home)
     assert published.published
     assert external_entry.is_symlink()
@@ -186,9 +219,7 @@ def test_registered_local_cutover_syncs_latest_content_and_retires_bridges(
     assert not legacy_local.is_symlink()
     assert not (legacy_local.parent / "skills-repo").exists()
     assert not (legacy_local.parent / "skills-repo").is_symlink()
-    active_marker = json.loads(
-        (pool_local.parent / ".pool-active").read_text()
-    )
+    active_marker = json.loads((pool_local.parent / ".pool-active").read_text())
     assert active_marker["activation_state"] == "active"
     assert active_marker["mappings"] == []
     verification = verify_skill_mappings(mappings=mappings, home=home)
@@ -243,15 +274,9 @@ def test_explicit_rollback_rebuilds_legacy_from_current_pool_content(
     assert result.status is PoolActivationStatus.COMMITTED
     assert legacy_local.is_dir()
     assert not legacy_local.is_symlink()
-    assert (legacy_local / "handmade" / "SKILL.md").read_text() == (
-        "pool-new-write"
-    )
-    assert (
-        legacy_local / "created-after-activation" / "SKILL.md"
-    ).read_text() == "new"
-    assert (pool_local / "handmade" / "SKILL.md").read_text() == (
-        "pool-new-write"
-    )
+    assert (legacy_local / "handmade" / "SKILL.md").read_text() == ("pool-new-write")
+    assert (legacy_local / "created-after-activation" / "SKILL.md").read_text() == "new"
+    assert (pool_local / "handmade" / "SKILL.md").read_text() == ("pool-new-write")
     assert external.is_symlink()
 
     repeated = rollback_openclaw_pool(
@@ -440,9 +465,7 @@ def test_unregistered_local_and_managed_entry_follow_filesystem_truth(
     verified = verify_skill_mappings(mappings=[], home=home)
 
     assert activated.status is PoolActivationStatus.COMMITTED
-    assert (
-        pool_local / "agent-created" / "SKILL.md"
-    ).read_text() == "filesystem-only"
+    assert (pool_local / "agent-created" / "SKILL.md").read_text() == "filesystem-only"
     assert activated.evidence["local_inventory"] == {
         "registered": 1,
         "unregistered": 1,
@@ -786,9 +809,7 @@ def test_post_rename_sync_captures_existing_file_update_before_retire(
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
     def update_before_retire() -> None:
-        (legacy_local / "handmade" / "SKILL.md").write_text(
-            "updated-before-retire"
-        )
+        (legacy_local / "handmade" / "SKILL.md").write_text("updated-before-retire")
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -922,9 +943,7 @@ def test_post_rename_pool_parent_deletion_is_not_resurrected(
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
 
     def add_child_before_retire() -> None:
-        (legacy_local / "handmade" / "late-child.txt").write_text(
-            "legacy-window"
-        )
+        (legacy_local / "handmade" / "late-child.txt").write_text("legacy-window")
 
     def delete_pool_parent() -> None:
         shutil.rmtree(pool_local / "handmade")
@@ -942,9 +961,9 @@ def test_post_rename_pool_parent_deletion_is_not_resurrected(
 
     assert result.status is PoolActivationStatus.COMMITTED
     assert not (pool_local / "handmade").exists()
-    assert result.evidence["post_sync"][
-        "conflicts_preserved_in_pool"
-    ] == ["handmade/late-child.txt"]
+    assert result.evidence["post_sync"]["conflicts_preserved_in_pool"] == [
+        "handmade/late-child.txt"
+    ]
 
 
 def test_post_rename_deleted_parent_does_not_stall_new_subdirectory(
@@ -973,9 +992,7 @@ def test_post_rename_deleted_parent_does_not_stall_new_subdirectory(
 
     assert result.status is PoolActivationStatus.COMMITTED
     assert not (pool_local / "handmade").exists()
-    assert set(
-        result.evidence["post_sync"]["conflicts_preserved_in_pool"]
-    ) == {
+    assert set(result.evidence["post_sync"]["conflicts_preserved_in_pool"]) == {
         "handmade/late-directory",
         "handmade/late-directory/child.txt",
     }
@@ -986,8 +1003,7 @@ def test_retry_after_exchange_finishes_quarantine_move(tmp_path: Path) -> None:
     write_baseline_manifest(
         pool_local=pool_local,
         local_names=["handmade"],
-        manifest_path=pool_local.parent
-        / ".cutover-baseline-generation-1.json",
+        manifest_path=pool_local.parent / ".cutover-baseline-generation-1.json",
     )
     temporary = legacy_local.parent / ".skills-local.pool-cutover-generation-1"
     legacy_local.rename(temporary)
@@ -1003,10 +1019,7 @@ def test_retry_after_exchange_finishes_quarantine_move(tmp_path: Path) -> None:
     )
 
     quarantine = (
-        pool_local.parent
-        / ".migration-quarantine"
-        / "generation-1"
-        / "skills-local"
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
     )
     assert result.status is PoolActivationStatus.ALREADY_COMMITTED
     assert quarantine.is_dir()
@@ -1025,14 +1038,10 @@ def test_retry_after_legacy_rename_finishes_from_quarantine(
     write_baseline_manifest(
         pool_local=pool_local,
         local_names=["handmade"],
-        manifest_path=pool_local.parent
-        / ".cutover-baseline-generation-1.json",
+        manifest_path=pool_local.parent / ".cutover-baseline-generation-1.json",
     )
     quarantine = (
-        pool_local.parent
-        / ".migration-quarantine"
-        / "generation-1"
-        / "skills-local"
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
     )
     quarantine.parent.mkdir(parents=True)
     legacy_local.rename(quarantine)
@@ -1054,9 +1063,7 @@ def test_retry_after_legacy_rename_finishes_from_quarantine(
     assert result.status is PoolActivationStatus.ALREADY_COMMITTED
     assert quarantine.is_dir()
     assert not legacy_local.exists()
-    assert (legacy_local.parent / "handmade").resolve() == (
-        pool_local / "handmade"
-    )
+    assert (legacy_local.parent / "handmade").resolve() == (pool_local / "handmade")
 
 
 def test_finalizing_marker_retry_collects_recreated_legacy_local(
@@ -1071,14 +1078,10 @@ def test_finalizing_marker_retry_collects_recreated_legacy_local(
     write_baseline_manifest(
         pool_local=pool_local,
         local_names=["handmade"],
-        manifest_path=pool_local.parent
-        / ".cutover-baseline-generation-1.json",
+        manifest_path=pool_local.parent / ".cutover-baseline-generation-1.json",
     )
     quarantine = (
-        pool_local.parent
-        / ".migration-quarantine"
-        / "generation-1"
-        / "skills-local"
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
     )
     quarantine.parent.mkdir(parents=True)
     legacy_local.rename(quarantine)
@@ -1162,10 +1165,7 @@ def test_cutover_retry_replays_residue_after_merge_failure(
     def flaky_merge(**kwargs: object) -> dict[str, object]:
         nonlocal fail_residue_once
         source_root = Path(str(kwargs["source_root"]))
-        if (
-            fail_residue_once
-            and source_root.name.startswith("skills-local-residue-")
-        ):
+        if fail_residue_once and source_root.name.startswith("skills-local-residue-"):
             fail_residue_once = False
             raise OSError(5, "injected merge failure")
         return real_merge(**kwargs)  # type: ignore[arg-type]
@@ -1186,9 +1186,7 @@ def test_cutover_retry_replays_residue_after_merge_failure(
     )
 
     assert first.status is PoolActivationStatus.TRANSIENT_ERROR
-    assert (
-        pool_local.parent / ".cutover-baseline-generation-1.json"
-    ).is_file()
+    assert (pool_local.parent / ".cutover-baseline-generation-1.json").is_file()
 
     retry = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -1279,9 +1277,7 @@ def test_cutover_commits_without_atomic_exchange_and_retires_storage_bridges(
     assert not legacy_local.exists()
     assert not legacy_local.is_symlink()
     assert not (legacy_local.parent / "skills-repo").exists()
-    assert (legacy_local.parent / "handmade").resolve() == (
-        pool_local / "handmade"
-    )
+    assert (legacy_local.parent / "handmade").resolve() == (pool_local / "handmade")
 
 
 def test_atomic_exchange_treats_einval_as_unavailable(
@@ -1364,9 +1360,19 @@ def test_cutover_retry_rejects_noncanonical_temporary_symlink(
 @pytest.mark.parametrize(
     ("generation", "preparation_id", "names", "reason"),
     [
-        ("bad generation", PREPARATION_ID, ["handmade"], "migration_generation_invalid"),
+        (
+            "bad generation",
+            PREPARATION_ID,
+            ["handmade"],
+            "migration_generation_invalid",
+        ),
         ("generation-1", "stale-preparation", ["handmade"], "runtime_layout_not_ready"),
-        ("generation-1", PREPARATION_ID, ["../escape"], "registered_local_name_invalid"),
+        (
+            "generation-1",
+            PREPARATION_ID,
+            ["../escape"],
+            "registered_local_name_invalid",
+        ),
     ],
 )
 def test_cutover_rejects_invalid_inputs(
@@ -1416,9 +1422,7 @@ def test_cutover_cleans_stale_staging_and_replaces_pool_symlink(
     staging = pool_local.parent / ".final-sync-generation-1"
     staging.symlink_to(tmp_path / "unused", target_is_directory=True)
     shutil.rmtree(pool_local / "handmade")
-    (pool_local / "handmade").symlink_to(
-        tmp_path / "old", target_is_directory=True
-    )
+    (pool_local / "handmade").symlink_to(tmp_path / "old", target_is_directory=True)
 
     result = activate_openclaw_pool(
         migration_generation="generation-1",
@@ -1455,11 +1459,7 @@ def test_cutover_rejects_unowned_quarantine_generation(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
-    generation_dir = (
-        pool_local.parent
-        / ".migration-quarantine"
-        / "generation-1"
-    )
+    generation_dir = pool_local.parent / ".migration-quarantine" / "generation-1"
     generation_dir.mkdir(parents=True)
     unknown = generation_dir / "unknown"
     unknown.write_text("external")
@@ -1474,9 +1474,7 @@ def test_cutover_rejects_unowned_quarantine_generation(
     )
 
     assert result.status is PoolActivationStatus.INVALID
-    assert result.evidence["reason"] == (
-        "cutover_quarantine_ownership_unproven"
-    )
+    assert result.evidence["reason"] == ("cutover_quarantine_ownership_unproven")
     assert legacy_local.is_dir()
     assert unknown.read_text() == "external"
     assert not (pool_local.parent / ".pool-active").exists()
@@ -1486,11 +1484,7 @@ def test_cutover_recovers_truncated_quarantine_owner(
     tmp_path: Path,
 ) -> None:
     home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
-    generation_dir = (
-        pool_local.parent
-        / ".migration-quarantine"
-        / "generation-1"
-    )
+    generation_dir = pool_local.parent / ".migration-quarantine" / "generation-1"
     generation_dir.mkdir(parents=True)
     (generation_dir / ".owner.json").write_text("{")
 
@@ -1614,9 +1608,7 @@ def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:
     )
 
     assert not result.valid
-    assert {
-        failure["reason"] for failure in result.evidence["failures"]
-    } == {
+    assert {failure["reason"] for failure in result.evidence["failures"]} == {
         "source_outside_pool",
         "source_missing",
         "target_invalid",
@@ -1695,12 +1687,8 @@ async def test_openclaw_service_api_translates_pool_port_contract() -> None:
             "evidence": {},
         }
     )
-    port.publish_pool_mappings = AsyncMock(
-        return_value={"published": True, "total": 1}
-    )
-    port.verify_pool_mappings = AsyncMock(
-        return_value={"valid": True, "checked": 1}
-    )
+    port.publish_pool_mappings = AsyncMock(return_value={"published": True, "total": 1})
+    port.verify_pool_mappings = AsyncMock(return_value={"valid": True, "checked": 1})
     service = OpenClawSkillsAdapter(port)
     mapping = SymlinkItem(source="/pool/a", target="/skills/a")
 

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -39,8 +39,51 @@ from engine.community.plugins.openclaw.layout_sync import (
 )
 from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
 from engine.community.plugins.skills_pool import layout_atomic
+from engine.community.plugins.skills_pool.layout_activation import (
+    mapping_sources_use_pool,
+)
 
 PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
+
+
+def test_mapping_source_classifier_selects_one_managed_layout(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    pool_source = (
+        home
+        / ".openclaw"
+        / "workspace"
+        / "skills-pool"
+        / "skills-local"
+        / "pool-skill"
+    )
+    legacy_source = (
+        home
+        / ".openclaw"
+        / "workspace"
+        / "skills"
+        / "skills-local"
+        / "legacy-skill"
+    )
+    external_source = home / "external-skills" / "external"
+
+    assert mapping_sources_use_pool(
+        engine="openclaw",
+        sources=[pool_source, external_source],
+        home=home,
+    )
+    assert not mapping_sources_use_pool(
+        engine="openclaw",
+        sources=[legacy_source, external_source],
+        home=home,
+    )
+    with pytest.raises(ValueError, match="mix Legacy and Pool"):
+        mapping_sources_use_pool(
+            engine="openclaw",
+            sources=[legacy_source, pool_source],
+            home=home,
+        )
 
 
 def _prepared_home(tmp_path: Path) -> tuple[Path, Path, Path, Path]:

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -194,12 +194,9 @@ def mapping_sources_use_pool(
     rejected because it cannot represent one authoritative runtime layout.
     """
 
-    if not sources:
-        return False
     layout = _Layout.for_engine(engine, Path(home))
     pool_roots = tuple(
-        Path(os.path.abspath(root))
-        for root in (layout.pool_local, layout.pool_repo)
+        Path(os.path.abspath(root)) for root in (layout.pool_local, layout.pool_repo)
     )
     legacy_roots = tuple(
         Path(os.path.abspath(root))
@@ -223,7 +220,38 @@ def mapping_sources_use_pool(
             has_legacy = True
     if has_pool and has_legacy:
         raise ValueError("mapping sources mix Legacy and Pool managed roots")
-    return has_pool
+    if has_pool:
+        return True
+    if has_legacy or not sources:
+        return False
+    return _active_marker_selects_pool(layout=layout, engine=engine)
+
+
+def _active_marker_selects_pool(*, layout: _Layout, engine: str) -> bool:
+    """Resolve an external-only mapping set from the persisted runtime layout.
+
+    External mappings intentionally survive Pool migration, so their source
+    paths cannot identify the authoritative managed layout.  In that narrow
+    case the runtime-owned active marker is the stable authority.
+    """
+
+    marker_path = layout.active_marker
+    if not marker_path.exists() and not marker_path.is_symlink():
+        return False
+    marker = _read_active_marker(marker_path)
+    if marker is None:
+        raise ValueError("Pool active marker is unreadable or malformed")
+    if (
+        marker.get("engine") != engine
+        or marker.get("layout_contract_version") != LAYOUT_CONTRACT_VERSION
+        or not isinstance(marker.get("preparation_id"), str)
+        or not marker["preparation_id"]
+        or not isinstance(marker.get("migration_generation"), str)
+        or not marker["migration_generation"]
+        or marker.get("activation_state") not in {"finalizing", "active"}
+    ):
+        raise ValueError("Pool active marker contract is invalid")
+    return True
 
 
 def _retired_storage_entries(
@@ -298,8 +326,7 @@ def _write_active_marker(
         # skill mappings are mutable product state and must not become part of
         # the persisted layout contract.
         value["mappings"] = [
-            {"source": mapping.source, "target": mapping.target}
-            for mapping in mappings
+            {"source": mapping.source, "target": mapping.target} for mapping in mappings
         ]
     payload = json.dumps(
         value,
@@ -844,10 +871,7 @@ def _capture_recreated_legacy_local(
             )
 
         while residue_index <= 128:
-            residue = (
-                quarantine.parent
-                / f"skills-local-residue-{residue_index}"
-            )
+            residue = quarantine.parent / f"skills-local-residue-{residue_index}"
             residue_index += 1
             if not residue.exists() and not residue.is_symlink():
                 break
@@ -957,9 +981,7 @@ def _ensure_quarantine_generation_owned(
                     "cutover_quarantine_owner_invalid",
                     path=str(owner_path),
                 )
-            owner_path.rename(
-                generation_dir / f".owner.invalid-{uuid4().hex}"
-            )
+            owner_path.rename(generation_dir / f".owner.invalid-{uuid4().hex}")
             owner = None
         if owner == expected_owner:
             return None
@@ -975,9 +997,7 @@ def _ensure_quarantine_generation_owned(
         )
 
     if not created and (
-        not baseline_path.is_file()
-        or baseline_path.is_symlink()
-        or unknown_entries
+        not baseline_path.is_file() or baseline_path.is_symlink() or unknown_entries
     ):
         return _invalid(
             "cutover_quarantine_ownership_unproven",
@@ -1001,9 +1021,7 @@ def _ensure_quarantine_generation_owned(
             os.link(owner_temporary, owner_path)
         except FileExistsError:
             try:
-                raced_owner = json.loads(
-                    owner_path.read_text(encoding="utf-8")
-                )
+                raced_owner = json.loads(owner_path.read_text(encoding="utf-8"))
             except (OSError, UnicodeDecodeError, json.JSONDecodeError):
                 return _invalid(
                     "cutover_quarantine_owner_raced_invalid",

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -177,6 +177,74 @@ class _Layout:
         )
 
 
+def mapping_sources_use_pool(
+    *,
+    engine: str,
+    sources: list[str | Path],
+    home: str | Path = "/home/admin",
+) -> bool:
+    """Return whether a mapping set selects canonical Pool managed sources.
+
+    The regular bindpath API predates Skills Pool and has no explicit layout
+    field.  Backend nevertheless sends the complete desired mapping set with
+    canonical Pool sources once runtime cutover has committed.  Engine
+    adapters use this shared classifier to avoid recreating retired Legacy
+    corpus bridges during subsequent CRUD reconciliation. External mappings
+    may coexist with managed Pool mappings; a managed Legacy/Pool mixture is
+    rejected because it cannot represent one authoritative runtime layout.
+    """
+
+    if not sources:
+        return False
+    layout = _Layout.for_engine(engine, Path(home))
+    pool_roots = tuple(
+        Path(os.path.abspath(root))
+        for root in (layout.pool_local, layout.pool_repo)
+    )
+    legacy_roots = tuple(
+        Path(os.path.abspath(root))
+        for root in (
+            layout.legacy_local,
+            layout.legacy_repo,
+            layout.local_bridge,
+            layout.repo_bridge,
+        )
+    )
+    has_pool = False
+    has_legacy = False
+    for raw_source in sources:
+        source = Path(raw_source)
+        if not source.is_absolute():
+            continue
+        normalized = Path(os.path.abspath(source))
+        if any(normalized.is_relative_to(root) for root in pool_roots):
+            has_pool = True
+        elif any(normalized.is_relative_to(root) for root in legacy_roots):
+            has_legacy = True
+    if has_pool and has_legacy:
+        raise ValueError("mapping sources mix Legacy and Pool managed roots")
+    return has_pool
+
+
+def _retired_storage_entries(
+    *,
+    layout: _Layout,
+    engine: str,
+) -> tuple[Path, ...]:
+    """Entries that must disappear once the active layout is Pool.
+
+    AICoding and Hermes keep a stable repo namespace outside their engine's
+    active scan root.  It remains a valid read-only bridge to canonical Pool.
+    OpenClaw and Claude Code place the repo bridge inside the active root, so
+    it must be retired together with the local corpus bridge.
+    """
+
+    entries = [layout.legacy_local, layout.local_bridge]
+    if engine in {"openclaw", "claude_code"}:
+        entries.append(layout.repo_bridge)
+    return tuple(dict.fromkeys(entries))
+
+
 @dataclass(frozen=True, slots=True)
 class _MappingPlan:
     managed: dict[Path, Path]
@@ -321,10 +389,11 @@ def _finalize_active_root(
         layout.local_bridge,
         allowed_targets=(layout.legacy_local, layout.pool_local),
     )
-    _retire_bridge(
-        layout.repo_bridge,
-        allowed_targets=(layout.legacy_repo, layout.pool_repo),
-    )
+    if engine in {"openclaw", "claude_code"}:
+        _retire_bridge(
+            layout.repo_bridge,
+            allowed_targets=(layout.legacy_repo, layout.pool_repo),
+        )
     if layout.legacy_local != layout.local_bridge:
         _retire_bridge(
             layout.legacy_local,
@@ -332,11 +401,7 @@ def _finalize_active_root(
         )
     remaining_storage_entries = [
         str(path)
-        for path in {
-            layout.legacy_local,
-            layout.local_bridge,
-            layout.repo_bridge,
-        }
+        for path in _retired_storage_entries(layout=layout, engine=engine)
         if path.exists() or path.is_symlink()
     ]
     if remaining_storage_entries:
@@ -1815,6 +1880,7 @@ __all__ = [
     "activate_hermes_pool",
     "activate_openclaw_pool",
     "atomic_exchange_paths",
+    "mapping_sources_use_pool",
     "publish_pool_mappings",
     "rollback_aicoding_pool",
     "rollback_claude_code_pool",

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -678,16 +678,40 @@ def inspect_runtime_layout(
                 preparation_id=preparation_id,
             )
         if active_marker["activation_state"] == "active":
-            for bridge_name, bridge_path in (
-                ("local", layout.local_bridge),
-                ("repo", layout.repo_bridge),
-            ):
+            retired_bridges = [("local", layout.local_bridge)]
+            if engine in {"openclaw", "claude_code"}:
+                retired_bridges.append(("repo", layout.repo_bridge))
+            for bridge_name, bridge_path in retired_bridges:
                 if bridge_path.exists() or bridge_path.is_symlink():
                     return _invalid(
                         engine=engine,
                         contract_version=expected_contract_version,
                         layout=layout,
                         reason=f"retired_{bridge_name}_bridge_present",
+                        preparation_id=preparation_id,
+                    )
+            if engine in {"aicoding", "hermes"}:
+                try:
+                    repo_bridge_valid = (
+                        layout.repo_bridge.is_symlink()
+                        and _lexical_symlink_target(layout.repo_bridge)
+                        == layout.pool_repo
+                    )
+                except OSError as error:
+                    return _transient(
+                        engine=engine,
+                        contract_version=expected_contract_version,
+                        layout=layout,
+                        reason="stable_repo_bridge_temporarily_unavailable",
+                        error=error,
+                        preparation_id=preparation_id,
+                    )
+                if not repo_bridge_valid:
+                    return _invalid(
+                        engine=engine,
+                        contract_version=expected_contract_version,
+                        layout=layout,
+                        reason="stable_repo_bridge_invalid",
                         preparation_id=preparation_id,
                     )
             try:
@@ -730,6 +754,9 @@ def inspect_runtime_layout(
                     "pool_mappings_valid": True,
                     "legacy_storage_entries_absent": (
                         active_marker["activation_state"] == "active"
+                    ),
+                    "stable_repo_bridge_valid": (
+                        engine in {"aicoding", "hermes"}
                     ),
                 },
             },


### PR DESCRIPTION
## Summary

横向补齐 Skills Pool 多引擎运行时兼容性，并新增环境隔离的 owner + engine 全量切流能力。

## Changes

- 统一多引擎 Pool mapping source 校验，Legacy/Pool 混合来源 fail-closed
- Claude Code 补齐 rollback、quarantine cleanup 与 source_layout 透传
- AICoding/Hermes 补齐 quarantine cleanup，并保留稳定 repo namespace
- Pool 模式下禁止重新创建已退役的 Legacy corpus bridge
- 新增 `full_rollout_owners`，按 `(owner_id, engine)` 覆盖该员工未来新建和后续重启 Bot
- 新增 `POST /api/ops/skills-pool/rollout/owners`
- owner 全开必须引用对应引擎最近一次已验收批次
- 精确负对照优先于 owner/engine/environment 扩大规则
- 兼容旧 rollout config：缺少 `full_rollout_owners` 时按空列表规范化，并在首次成功写入时升级
- Teclaw 继续保持 no-op

## Test Plan

- Skills Pool core/API/DI/architecture focused suite: 202 passed
- Shared cutover/probe/quarantine: 109 passed
- Corp Claude/AICoding/Hermes: 944 passed
- Backend focused: 63 passed
- Image preparation: 26 passed
- Engine full suite: 1471 passed
- Changed-line coverage: 90.98%
