### PR TITLE
fix(community): route notify probe by device_provider (BaaS ENGINE_HTTP_500)

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/notify_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/notify_router.py
@@ -3,7 +3,10 @@ Notify router — aggregates pending HITL interactions from all bots via Engine.
 
 GET /api/v1/notify:
   1. Get user's active device bindings (bots with sandboxes)
-  2. Parallel probe each bot's Engine /api/notify endpoint via proxypass
+  2. Parallel probe each bot's Engine /api/notify endpoint — routed by
+     ``device_provider`` via ``DeviceContextResolver`` (same path chat / cron
+     use), so BaaS (desktop + cloud), Arca, teclaw and local each reach their
+     engine through the correct transport.
   3. Return grouped result: [{bot_id, bot_name, sandbox_id, notifications}]
 """
 from __future__ import annotations
@@ -17,14 +20,31 @@ from pydantic import BaseModel
 
 from agentclaw.community.adapters.http.auth.dependencies import get_current_user
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
-from agentclaw.community.core.notify.protocol import NotifyBotLister
+from agentclaw.community.core.devices.services.device_context import (
+    ConnInfoBuildError,
+    DeviceNotBoundError,
+    UnknownProviderError,
+)
+from agentclaw.community.core.devices.services.device_context_resolver import (
+    DeviceContextResolver,
+)
+from agentclaw.community.core.notify.protocol import NotifyBotLister, NotifyTarget
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
+    DeviceAdapterTimeoutError,
+    DeviceAdapterTransport,
+)
 
 logger = get_logger()
 
 router = APIRouter(prefix="/api/v1/notify", tags=["notify"])
+
+_NOTIFY_API_PATH = "/api/notify"
+_PROBE_TIMEOUT = 5.0
+_LOCAL_ENGINE_URL = "http://127.0.0.1:20003"
 
 
 class NotifyEntry(BaseModel):
@@ -60,86 +80,185 @@ class NotifySummaryResponse(BaseModel):
     data: list[BotNotifySummary]
 
 
-async def _probe_bot_notify(
+def _summarize_engine_response(
     bot_id: str,
     bot_name: str,
     sandbox_id: str,
-    sandbox_client: SandboxRuntimeClient,
-) -> BotNotifySummary | None:
-    """Call Engine /api/notify via proxypass for a single bot."""
-    # 没有 sandbox 的 bot —— 与 by-owner 一致仍然回一条记录,但不去探活,
-    # 通知列表给空。这样前端能感知到 bot 存在但未绑定设备。
-    if not sandbox_id:
-        logger.info(f"[notify] bot={bot_id} has no sandbox, skipping probe")
-        return BotNotifySummary(
-            bot_id=bot_id,
-            bot_name=bot_name,
-            sandbox_id="",
-            notifications=[],
+    result: dict[str, Any],
+) -> BotNotifySummary:
+    """Map an Engine ``/api/notify`` ApiResponse dict to a BotNotifySummary.
+
+    Engine returns ``{success, data, message}``:
+      - ``success=False`` carries a ``"CODE: detail"`` message (e.g. relay
+        ``RELAY_UNAVAILABLE``) — split it so the wire error code surfaces in
+        ``error_code`` and downstream can classify without parsing logs.
+      - ``success=True`` wraps the pending interaction list under ``data``.
+    """
+    if not result.get("success"):
+        logger.warning(f"[notify] probe failed for bot={bot_id}: {result}")
+        message = str(
+            result.get("message")
+            or result.get("error")
+            or "Engine notify failed"
         )
-
-    try:
-        # Local 模式：直接调用本地 Engine
-        if sandbox_id == "local":
-            url = "http://127.0.0.1:20003/api/notify"
-            headers = {}
-        else:
-            # Prod/Pre 模式：通过设备运行时代理调用（vendor 细节在 prod 实现）
-            req = sandbox_client.build_proxy_request(
-                sandbox_id=sandbox_id, api_path="/api/notify"
-            )
-            url = req.url
-            headers = req.headers
-
-        logger.info(f"[notify] probing bot={bot_id} at {url}")
-
-        # 使用 httpx 直接调用 Engine API
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(url, headers=headers)
-            logger.info(f"[notify] bot={bot_id} response status={resp.status_code}")
-            if resp.status_code != 200:
-                logger.warning(f"[notify] HTTP {resp.status_code} for bot={bot_id}")
-                return BotNotifySummary(
-                    bot_id=bot_id,
-                    bot_name=bot_name,
-                    sandbox_id=sandbox_id,
-                    notifications=[],
-                    status="error",
-                    error_code=f"ENGINE_HTTP_{resp.status_code}",
-                    error_message=f"Engine notify returned HTTP {resp.status_code}",
-                )
-            result = resp.json()
-
-        if not result.get("success"):
-            logger.warning(f"[notify] probe failed for bot={bot_id}: {result}")
-            message = str(
-                result.get("message")
-                or result.get("error")
-                or "Engine notify failed"
-            )
-            code, separator, detail = message.partition(":")
-            return BotNotifySummary(
-                bot_id=bot_id,
-                bot_name=bot_name,
-                sandbox_id=sandbox_id,
-                notifications=[],
-                status="error",
-                error_code=code.strip() if separator else "ENGINE_NOTIFY_ERROR",
-                error_message=detail.strip() if separator else message,
-            )
-
-        notifications_data = result.get("data", [])
-        logger.info(f"[notify] bot={bot_id} got {len(notifications_data)} notifications from engine")
-
-        notifications = [
-            NotifyEntry(**n) for n in notifications_data
-        ] if notifications_data else []
-
+        code, separator, detail = message.partition(":")
         return BotNotifySummary(
             bot_id=bot_id,
             bot_name=bot_name,
             sandbox_id=sandbox_id,
-            notifications=notifications,
+            notifications=[],
+            status="error",
+            error_code=code.strip() if separator else "ENGINE_NOTIFY_ERROR",
+            error_message=detail.strip() if separator else message,
+        )
+
+    notifications_data = result.get("data", [])
+    logger.info(
+        f"[notify] bot={bot_id} got {len(notifications_data)} notifications from engine"
+    )
+
+    notifications = [NotifyEntry(**n) for n in notifications_data] if notifications_data else []
+
+    return BotNotifySummary(
+        bot_id=bot_id,
+        bot_name=bot_name,
+        sandbox_id=sandbox_id,
+        notifications=notifications,
+    )
+
+
+def _http_error_summary(
+    bot_id: str, bot_name: str, sandbox_id: str, status_code: int
+) -> BotNotifySummary:
+    return BotNotifySummary(
+        bot_id=bot_id,
+        bot_name=bot_name,
+        sandbox_id=sandbox_id,
+        notifications=[],
+        status="error",
+        error_code=f"ENGINE_HTTP_{status_code}",
+        error_message=f"Engine notify returned HTTP {status_code}",
+    )
+
+
+async def _probe_local(
+    bot_id: str, bot_name: str, sandbox_id: str
+) -> BotNotifySummary | None:
+    """Local dev probe: direct httpx to the local engine process.
+
+    Preserves legacy local-mode behavior. Routed through the transport in
+    local/singlebox boots would miss: the test/singlebox transport is a
+    cron-only in-memory adapter that does not serve ``/api/notify``.
+    """
+    url = f"{_LOCAL_ENGINE_URL}{_NOTIFY_API_PATH}"
+    logger.info(f"[notify] probing bot={bot_id} at {url} (local)")
+    try:
+        async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+            resp = await client.get(url)
+        if resp.status_code != 200:
+            logger.warning(f"[notify] HTTP {resp.status_code} for bot={bot_id}")
+            return _http_error_summary(bot_id, bot_name, sandbox_id, resp.status_code)
+        result = resp.json()
+        logger.info(f"[notify] bot={bot_id} response status={resp.status_code}")
+        return _summarize_engine_response(bot_id, bot_name, sandbox_id, result)
+    except Exception as e:
+        logger.error(f"[notify] error probing bot={bot_id}: {e}")
+        return BotNotifySummary(
+            bot_id=bot_id,
+            bot_name=bot_name,
+            sandbox_id=sandbox_id,
+            notifications=[],
+            status="error",
+            error_code="NOTIFY_PROBE_ERROR",
+            error_message=str(e),
+        )
+
+
+async def _probe_bot_notify(
+    target: NotifyTarget,
+    resolver: DeviceContextResolver,
+    transport: DeviceAdapterTransport,
+) -> BotNotifySummary | None:
+    """Call Engine ``/api/notify`` for a single bot, routed by provider.
+
+    Provider routing (baas / arca / teclaw / local) is resolved via
+    ``DeviceContextResolver`` from ``(bot_id, owner_id)`` — the same single
+    source of truth chat / cron use. Before this, every bot was probed through
+    ``ArcaSandboxClient.build_proxy_request`` (Arca proxypass only), which
+    produced an unroutable target ``ARCA_BOT-…:20003`` for every BaaS bot and
+    surfaced as ``ENGINE_HTTP_500``.
+    """
+    bot_id = target.bot_id
+    bot_name = target.bot_name
+    sandbox_id = target.sandbox_id
+    owner_id = target.owner_id
+
+    # owner_id is the binding owner (== user for own bots; the real owner for
+    # collaborator bots) so the right binding is resolved — mirrors
+    # collaborator_service / session_resources callers.
+    try:
+        ctx = resolver.resolve_for_bot(bot_id, owner_id)
+    except DeviceNotBoundError:
+        logger.info(f"[notify] bot={bot_id} has no active binding, skipping probe")
+        return BotNotifySummary(
+            bot_id=bot_id,
+            bot_name=bot_name,
+            sandbox_id=sandbox_id,
+            notifications=[],
+        )
+    except (UnknownProviderError, ConnInfoBuildError) as e:
+        logger.error(f"[notify] resolve failed bot={bot_id}: {e}")
+        return BotNotifySummary(
+            bot_id=bot_id,
+            bot_name=bot_name,
+            sandbox_id=sandbox_id,
+            notifications=[],
+            status="error",
+            error_code="NOTIFY_RESOLVE_ERROR",
+            error_message=str(e),
+        )
+
+    logger.info(
+        f"[notify] probing bot={bot_id} provider={ctx.provider} bot_type={ctx.bot_type}"
+    )
+
+    if ctx.provider == "local":
+        return await _probe_local(bot_id, bot_name, sandbox_id)
+
+    try:
+        result = await transport.invoke(
+            ctx.conn_info, "GET", _NOTIFY_API_PATH, timeout=_PROBE_TIMEOUT
+        )
+        # summarize inside the try so malformed notification payloads (e.g. a
+        # NotifyEntry missing required fields) are caught and surfaced as a
+        # probe error rather than escaping to the caller.
+        return _summarize_engine_response(bot_id, bot_name, sandbox_id, result)
+    except DeviceAdapterHTTPStatusError as e:
+        logger.warning(
+            f"[notify] HTTP {e.status_code} for bot={bot_id} provider={ctx.provider}"
+        )
+        return _http_error_summary(bot_id, bot_name, sandbox_id, e.status_code)
+    except DeviceAdapterEndpointNotFoundError as e:
+        logger.warning(f"[notify] endpoint not found for bot={bot_id}: {e}")
+        return BotNotifySummary(
+            bot_id=bot_id,
+            bot_name=bot_name,
+            sandbox_id=sandbox_id,
+            notifications=[],
+            status="error",
+            error_code="ENGINE_HTTP_404",
+            error_message="Engine notify endpoint not found",
+        )
+    except DeviceAdapterTimeoutError as e:
+        logger.warning(f"[notify] timeout for bot={bot_id}: {e}")
+        return BotNotifySummary(
+            bot_id=bot_id,
+            bot_name=bot_name,
+            sandbox_id=sandbox_id,
+            notifications=[],
+            status="error",
+            error_code="ENGINE_TIMEOUT",
+            error_message=str(e),
         )
     except Exception as e:
         logger.error(f"[notify] error probing bot={bot_id}: {e}")
@@ -158,7 +277,8 @@ async def _probe_bot_notify(
 async def get_notify_summary(
     user: AuthenticatedUser = Depends(get_current_user),
     bot_lister: NotifyBotLister = Injected(NotifyBotLister),
-    sandbox_client: SandboxRuntimeClient = Injected(SandboxRuntimeClient),
+    resolver: DeviceContextResolver = Injected(DeviceContextResolver),
+    transport: DeviceAdapterTransport = Injected(DeviceAdapterTransport),
 ):
     """
     Get aggregated pending notifications from all user bots.
@@ -167,15 +287,15 @@ async def get_notify_summary(
     interactions from that bot's engine.
     """
     user_id = user.staffId
-    bot_mappings = bot_lister.list_bot_mappings(user_id)
+    targets = bot_lister.list_bot_mappings(user_id)
 
-    if not bot_mappings:
+    if not targets:
         return NotifySummaryResponse(success=True, data=[])
 
     # Parallel probe all bots
     summaries = await asyncio.gather(*[
-        _probe_bot_notify(bot_id, bot_name, sandbox_id, sandbox_client)
-        for bot_id, bot_name, sandbox_id in bot_mappings
+        _probe_bot_notify(target, resolver, transport)
+        for target in targets
     ])
 
     # Filter out None results and empty notification lists for cleaner response

--- a/src/backend/src/agentclaw/community/core/notify/bot_lister.py
+++ b/src/backend/src/agentclaw/community/core/notify/bot_lister.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.bot_collaborator.repository.protocol import (
 )
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.core.notify.protocol import NotifyTarget
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -44,7 +45,7 @@ class RepositoryNotifyBotLister:
         # 仅 owner 列表，保持兼容（不阻断 notify 接口）。
         self._collaborator_repo = collaborator_repo
 
-    def list_bot_mappings(self, user_id: str) -> list[tuple[str, str, str]]:
+    def list_bot_mappings(self, user_id: str) -> list[NotifyTarget]:
         env = get_current_env()
         _total, bindings = self._binding_repo.list_bindings(
             entity_id=user_id,
@@ -58,7 +59,7 @@ class RepositoryNotifyBotLister:
             f"[notify_bot_lister] user={user_id} env={env} "
             f"active bindings count={len(bindings)}"
         )
-        result: list[tuple[str, str, str]] = []
+        result: list[NotifyTarget] = []
         seen_bot_ids: set[str] = set()
         for b in bindings:
             props = b.device_props or {}
@@ -67,7 +68,10 @@ class RepositoryNotifyBotLister:
                 continue
             bot_id = str(props.get("bolt_id") or b.device_id)
             bot_name = self._resolve_bot_name(bot_id, user_id)
-            result.append((bot_id, bot_name, sandbox_id))
+            result.append(NotifyTarget(
+                bot_id=bot_id, bot_name=bot_name,
+                owner_id=user_id, sandbox_id=str(sandbox_id),
+            ))
             seen_bot_ids.add(bot_id)
         logger.info(
             f"[notify_bot_lister] user={user_id} owner mappings={len(result)}"
@@ -111,7 +115,7 @@ class RepositoryNotifyBotLister:
         user_id: str,
         env: str,
         seen_bot_ids: set[str],
-    ) -> list[tuple[str, str, str]]:
+    ) -> list[NotifyTarget]:
         """当前用户以「协作者」身份参与的 Bot 的 (bot_id, bot_name, sandbox_id)。
 
         协作者记录里的 ``owner_id`` 是 Bot 拥有者工号——设备绑定挂在 owner
@@ -121,7 +125,7 @@ class RepositoryNotifyBotLister:
         if self._collaborator_repo is None:
             return []
 
-        mappings: list[tuple[str, str, str]] = []
+        mappings: list[NotifyTarget] = []
         try:
             collaborators = self._collaborator_repo.list_by_user(user_id, env)
         except Exception as e:
@@ -164,6 +168,9 @@ class RepositoryNotifyBotLister:
             if not sandbox_id:
                 continue
             bot_name = self._resolve_bot_name(bot_id, owner_id)
-            mappings.append((bot_id, bot_name, str(sandbox_id)))
+            mappings.append(NotifyTarget(
+                bot_id=bot_id, bot_name=bot_name,
+                owner_id=owner_id, sandbox_id=str(sandbox_id),
+            ))
             seen_bot_ids.add(bot_id)
         return mappings

--- a/src/backend/src/agentclaw/community/core/notify/local_bot_lister.py
+++ b/src/backend/src/agentclaw/community/core/notify/local_bot_lister.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.notify.protocol import NotifyTarget
 
 
 class LocalNotifyBotLister:
@@ -9,13 +10,13 @@ class LocalNotifyBotLister:
     def __init__(self, bot_repository: BotRepository) -> None:
         self._bot_repository = bot_repository
 
-    def list_bot_mappings(self, user_id: str) -> list[tuple[str, str, str]]:
+    def list_bot_mappings(self, user_id: str) -> list[NotifyTarget]:
         bots = self._bot_repository.list_active_bots_by_entity(
             entity_id=user_id,
             entity_type="staff",
             bot_type="personal",
         )
-        mappings: list[tuple[str, str, str]] = []
+        mappings: list[NotifyTarget] = []
         for bot in bots:
             binding_id = bot.get("binding_id")
             if not binding_id:
@@ -24,5 +25,8 @@ class LocalNotifyBotLister:
             if not bot_id:
                 continue
             bot_name = str(bot.get("bot_name") or bot_id)
-            mappings.append((bot_id, bot_name, str(binding_id)))
+            mappings.append(NotifyTarget(
+                bot_id=bot_id, bot_name=bot_name,
+                owner_id=user_id, sandbox_id=str(binding_id),
+            ))
         return mappings

--- a/src/backend/src/agentclaw/community/core/notify/protocol.py
+++ b/src/backend/src/agentclaw/community/core/notify/protocol.py
@@ -1,12 +1,43 @@
 """Protocol for listing bots eligible for notification polling."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class NotifyTarget:
+    """A bot eligible for notification polling, with just enough context to
+    route the engine probe by ``device_provider``.
+
+    The probe URL / transport is resolved at probe time via
+    ``DeviceContextResolver`` from ``owner_id`` (provider-driven: baas / arca /
+    teclaw / local) — exactly the path chat / cron use. It is **not** derived
+    from ``sandbox_id``; ``sandbox_id`` is kept only to echo the pre-existing
+    response field and is intentionally not used for routing. Routing off
+    ``sandbox_id`` was the root cause of desktop (BaaS) bots returning
+    ``ENGINE_HTTP_500``: every bot was forced through the Arca proxypass
+    formula regardless of provider.
+
+    Attributes:
+        bot_id: business bot id.
+        bot_name: display name.
+        owner_id: the binding's owner staff id — equals the requesting user
+            for own bots, the real owner for collaborator bots. Passed to
+            ``DeviceContextResolver`` so the right binding is resolved.
+        sandbox_id: informational device/sandbox id echoed in the response
+            (``""`` when unknown). NOT used for routing.
+    """
+
+    bot_id: str
+    bot_name: str
+    owner_id: str
+    sandbox_id: str = ""
 
 
 @runtime_checkable
 class NotifyBotLister(Protocol):
-    """Returns (bot_id, bot_name, sandbox_id) tuples for notification polling."""
+    """Returns ``NotifyTarget``s eligible for notification polling."""
 
-    def list_bot_mappings(self, user_id: str) -> list[tuple[str, str, str]]:
+    def list_bot_mappings(self, user_id: str) -> list[NotifyTarget]:
         ...

--- a/src/backend/tests/community/api/aicoding/test_notify_router.py
+++ b/src/backend/tests/community/api/aicoding/test_notify_router.py
@@ -15,7 +15,17 @@ from agentclaw.community.adapters.http.aicoding.notify_router import (
     NotifySummaryResponse,
 )
 from agentclaw.community.core.auth.models import AuthenticatedIdentity
-from agentclaw.community.core.notify.protocol import NotifyBotLister
+from agentclaw.community.core.notify.protocol import NotifyBotLister, NotifyTarget
+from agentclaw.community.core.devices.services.device_context import (
+    ConnInfoBuildError,
+    DeviceNotBoundError,
+    UnknownProviderError,
+)
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
+    DeviceAdapterTimeoutError,
+)
 
 
 def _create_notify_client(test_injector, mock_user, mock_bot_lister):
@@ -49,6 +59,45 @@ def mock_user():
     user.operatorName = "Test User"
     user.nickName = "Test User"
     return user
+
+
+
+def _make_ctx(provider="arca", bot_type="personal", conn_info=None):
+    """A fake DeviceContext returned by resolver.resolve_for_bot."""
+    ctx = MagicMock()
+    ctx.provider = provider
+    ctx.bot_type = bot_type
+    ctx.conn_info = conn_info if conn_info is not None else {
+        "url": "http://engine/proxypass/target",
+        "headers": {"x-proxypass-token": "t"},
+    }
+    return ctx
+
+
+def _make_resolver(ctx=None, exc=None):
+    resolver = MagicMock()
+    if exc is not None:
+        resolver.resolve_for_bot.side_effect = exc
+    else:
+        resolver.resolve_for_bot.return_value = ctx if ctx is not None else _make_ctx()
+    return resolver
+
+
+def _make_transport(response=None, exc=None):
+    transport = MagicMock()
+    if exc is not None:
+        transport.invoke = AsyncMock(side_effect=exc)
+    else:
+        transport.invoke = AsyncMock(
+            return_value=response if response is not None else {"success": True, "data": []}
+        )
+    return transport
+
+
+def _target(bot_id="bot_001", bot_name="Bot One", owner_id="owner1", sandbox_id="sb1"):
+    return NotifyTarget(
+        bot_id=bot_id, bot_name=bot_name, owner_id=owner_id, sandbox_id=sandbox_id,
+    )
 
 
 class TestNotifyModels:
@@ -105,116 +154,89 @@ class TestNotifyModels:
 
 
 class TestProbeBotNotify:
-    """Test the _probe_bot_notify function."""
+    """Test _probe_bot_notify — provider-routed via resolver + transport."""
 
     @pytest.mark.asyncio
-    async def test_probe_bot_notify_success_with_notifications(self):
-        """Test successful probe with notifications."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": True,
-            "data": [
-                {
-                    "interactionId": "123",
-                    "sessionKey": "session_001",
-                    "runId": "run_001",
-                    "kind": "confirm",
-                    "prompt": "Confirm action?",
-                    "status": "pending",
-                    "createdAtMs": 1234567890,
-                }
-            ],
-        }
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_001", "Bot One", "sandbox_001", MagicMock())
+    async def test_probe_success_with_notifications(self):
+        data = [
+            {
+                "interactionId": "123",
+                "sessionKey": "session_001",
+                "runId": "run_001",
+                "kind": "confirm",
+                "prompt": "Confirm action?",
+                "status": "pending",
+                "createdAtMs": 1234567890,
+            }
+        ]
+        result = await _probe_bot_notify(
+            _target("bot_001", "Bot One"),
+            _make_resolver(),
+            _make_transport({"success": True, "data": data}),
+        )
 
         assert result is not None
         assert result.bot_id == "bot_001"
-        assert result.bot_name == "Bot One"
-        assert result.sandbox_id == "sandbox_001"
+        assert result.sandbox_id == "sb1"
         assert len(result.notifications) == 1
         assert result.notifications[0].interactionId == "123"
         assert result.notifications[0].kind == "confirm"
 
     @pytest.mark.asyncio
-    async def test_probe_bot_notify_success_empty_notifications(self):
-        """Test successful probe with empty notifications."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": True,
-            "data": [],
-        }
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_002", "Bot Two", "sandbox_002", MagicMock())
+    async def test_probe_success_empty_notifications(self):
+        result = await _probe_bot_notify(
+            _target("bot_002", "Bot Two", sandbox_id="sandbox_002"),
+            _make_resolver(),
+            _make_transport({"success": True, "data": []}),
+        )
 
         assert result is not None
         assert result.bot_id == "bot_002"
         assert result.notifications == []
 
     @pytest.mark.asyncio
-    async def test_probe_bot_notify_data_is_list(self):
-        """Test probe with data as list."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": True,
-            "data": [],
-        }
+    async def test_probe_desktop_routes_through_transport(self):
+        """A desktop (BaaS) bot must probe via the transport's invoke-http path,
+        not the legacy Arca proxypass — this is the regression the fix targets.
+        Before the fix every BaaS bot produced ENGINE_HTTP_500."""
+        resolver = _make_resolver(_make_ctx(
+            provider="baas",
+            bot_type="desktop",
+            conn_info={
+                "url": "ignored-by-desktop-branch",
+                "type": "desktop",
+                "binding_id": 7,
+                "bot_uuid": "BOT-xyz",
+                "tenant": "t",
+                "baas_base_url": "http://baas",
+                "engine_port": 20003,
+                "headers": {},
+            },
+        ))
+        transport = _make_transport({"success": True, "data": []})
 
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_003", "Bot Three", "sandbox_003", MagicMock())
+        result = await _probe_bot_notify(
+            _target("bot_desk", "Desktop Bot"), resolver, transport
+        )
 
         assert result is not None
+        assert result.bot_id == "bot_desk"
         assert result.notifications == []
+        transport.invoke.assert_awaited_once()
+        args, _kwargs = transport.invoke.call_args
+        # (conn_info, method, path, ...) — method/path must target /api/notify
+        assert args[1] == "GET"
+        assert args[2] == "/api/notify"
+        # conn_info flows through so the transport can pick the desktop branch
+        assert args[0]["type"] == "desktop"
 
     @pytest.mark.asyncio
-    async def test_probe_bot_notify_not_ok(self):
-        """Test probe returns not success."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": False,
-            "error": "Connection failed",
-        }
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_004", "Bot Four", "sandbox_004", MagicMock())
+    async def test_probe_not_ok(self):
+        result = await _probe_bot_notify(
+            _target("bot_004", "Bot Four"),
+            _make_resolver(),
+            _make_transport({"success": False, "error": "Connection failed"}),
+        )
 
         assert result is not None
         assert result.notifications == []
@@ -223,23 +245,12 @@ class TestProbeBotNotify:
         assert result.error_message == "Connection failed"
 
     @pytest.mark.asyncio
-    async def test_probe_bot_notify_preserves_engine_error_code(self):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": False,
-            "data": [],
-            "message": "RELAY_UNAVAILABLE: relay down",
-        }
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch("httpx.AsyncClient", return_value=mock_client):
-            result = await _probe_bot_notify(
-                "bot_relay", "Relay Bot", "sandbox_relay", MagicMock()
-            )
+    async def test_probe_preserves_engine_error_code(self):
+        result = await _probe_bot_notify(
+            _target("bot_relay", "Relay Bot", sandbox_id="sb_relay"),
+            _make_resolver(),
+            _make_transport({"success": False, "data": [], "message": "RELAY_UNAVAILABLE: relay down"}),
+        )
 
         assert result is not None
         assert result.status == "error"
@@ -248,18 +259,12 @@ class TestProbeBotNotify:
         assert result.notifications == []
 
     @pytest.mark.asyncio
-    async def test_probe_bot_notify_exception(self):
-        """Test probe raises exception."""
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(side_effect=Exception("Network error"))
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_005", "Bot Five", "sandbox_005", MagicMock())
+    async def test_probe_transport_exception(self):
+        result = await _probe_bot_notify(
+            _target("bot_005", "Bot Five"),
+            _make_resolver(),
+            _make_transport(exc=Exception("Network error")),
+        )
 
         assert result is not None
         assert result.bot_id == "bot_005"
@@ -269,56 +274,122 @@ class TestProbeBotNotify:
         assert result.error_message == "Network error"
 
     @pytest.mark.asyncio
-    async def test_probe_bot_notify_local_mode(self):
-        """Test probe in local mode (sandbox_id is 'local')."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": True,
-            "data": [],
-        }
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_006", "Bot Six", "local", MagicMock())
-
-        assert result is not None
-        assert result.bot_id == "bot_006"
-        assert result.sandbox_id == "local"
-        # Verify it called the local URL
-        mock_client.get.assert_called_once()
-        call_args = mock_client.get.call_args
-        assert "127.0.0.1:20003" in str(call_args)
-
-    @pytest.mark.asyncio
-    async def test_probe_bot_notify_non_200_status(self):
-        """Test probe returns non-200 status."""
-        mock_response = MagicMock()
-        mock_response.status_code = 500
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_007", "Bot Seven", "local", MagicMock())
+    async def test_probe_http_500(self):
+        result = await _probe_bot_notify(
+            _target("bot_007", "Bot Seven"),
+            _make_resolver(),
+            _make_transport(exc=DeviceAdapterHTTPStatusError(500, "boom")),
+        )
 
         assert result is not None
         assert result.bot_id == "bot_007"
         assert result.notifications == []
         assert result.status == "error"
         assert result.error_code == "ENGINE_HTTP_500"
+
+    @pytest.mark.asyncio
+    async def test_probe_http_404(self):
+        result = await _probe_bot_notify(
+            _target("bot_404", "Bot 404"),
+            _make_resolver(),
+            _make_transport(exc=DeviceAdapterEndpointNotFoundError("no endpoint")),
+        )
+
+        assert result is not None
+        assert result.error_code == "ENGINE_HTTP_404"
+
+    @pytest.mark.asyncio
+    async def test_probe_timeout(self):
+        result = await _probe_bot_notify(
+            _target("bot_to", "Bot TO"),
+            _make_resolver(),
+            _make_transport(exc=DeviceAdapterTimeoutError("timed out")),
+        )
+
+        assert result is not None
+        assert result.error_code == "ENGINE_TIMEOUT"
+
+    @pytest.mark.asyncio
+    async def test_probe_device_not_bound_returns_empty(self):
+        result = await _probe_bot_notify(
+            _target("bot_nb", "Bot NB"),
+            _make_resolver(exc=DeviceNotBoundError("no binding")),
+            _make_transport(),
+        )
+
+        assert result is not None
+        assert result.bot_id == "bot_nb"
+        assert result.notifications == []
+        # bot exists but (transiently) has no active binding → benign empty
+        assert result.status == "ok"
+
+    @pytest.mark.asyncio
+    async def test_probe_resolve_error(self):
+        result = await _probe_bot_notify(
+            _target("bot_re", "Bot RE"),
+            _make_resolver(exc=ConnInfoBuildError("build failed")),
+            _make_transport(),
+        )
+
+        assert result is not None
+        assert result.status == "error"
+        assert result.error_code == "NOTIFY_RESOLVE_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_probe_unknown_provider(self):
+        result = await _probe_bot_notify(
+            _target("bot_up", "Bot UP"),
+            _make_resolver(exc=UnknownProviderError("weird provider")),
+            _make_transport(),
+        )
+
+        assert result is not None
+        assert result.error_code == "NOTIFY_RESOLVE_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_probe_local_mode(self):
+        """provider=local → direct httpx to 127.0.0.1:20003 (legacy local dev)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True, "data": []}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await _probe_bot_notify(
+                _target("bot_006", "Bot Six", sandbox_id="local"),
+                _make_resolver(_make_ctx(provider="local")),
+                _make_transport(),
+            )
+
+        assert result is not None
+        assert result.bot_id == "bot_006"
+        assert result.sandbox_id == "local"
+        mock_client.get.assert_called_once()
+        assert "127.0.0.1:20003" in str(mock_client.get.call_args)
+
+    @pytest.mark.asyncio
+    async def test_probe_local_non_200(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await _probe_bot_notify(
+                _target("bot_l", "Bot L", sandbox_id="local"),
+                _make_resolver(_make_ctx(provider="local")),
+                _make_transport(),
+            )
+
+        assert result is not None
+        assert result.error_code == "ENGINE_HTTP_503"
 
 
 class TestGetNotifySummaryNoBots:
@@ -342,7 +413,7 @@ class TestGetNotifySummaryWithBots:
 
     def test_single_bot(self, test_injector, mock_user, mock_bot_lister):
         mock_bot_lister.list_bot_mappings.return_value = [
-            ("bot_001", "Test Bot", "sandbox_001"),
+            NotifyTarget("bot_001", "Test Bot", "testuser", "sandbox_001"),
         ]
         mock_summary = BotNotifySummary(
             bot_id="bot_001",
@@ -364,25 +435,25 @@ class TestGetNotifySummaryWithBots:
 
     def test_multiple_bots(self, test_injector, mock_user, mock_bot_lister):
         mock_bot_lister.list_bot_mappings.return_value = [
-            ("bot_001", "Bot One", "sandbox_001"),
-            ("bot_002", "Bot Two", "sandbox_002"),
+            NotifyTarget("bot_001", "Bot One", "testuser", "sandbox_001"),
+            NotifyTarget("bot_002", "Bot Two", "testuser", "sandbox_002"),
         ]
         call_count = 0
 
-        async def mock_probe(bot_id, bot_name, sandbox_id, sandbox_client=None):
+        async def mock_probe(target, resolver, transport):
             nonlocal call_count
             call_count += 1
             return BotNotifySummary(
-                bot_id=bot_id,
-                bot_name=bot_name,
-                sandbox_id=sandbox_id,
+                bot_id=target.bot_id,
+                bot_name=target.bot_name,
+                sandbox_id=target.sandbox_id,
                 notifications=[
                     NotifyEntry(
-                        interactionId=f"int_{bot_id}",
-                        sessionKey=f"session_{bot_id}",
-                        runId=f"run_{bot_id}",
+                        interactionId=f"int_{target.bot_id}",
+                        sessionKey=f"session_{target.bot_id}",
+                        runId=f"run_{target.bot_id}",
                         kind="confirm",
-                        prompt=f"Prompt for {bot_id}",
+                        prompt=f"Prompt for {target.bot_id}",
                         status="pending",
                         createdAtMs=1234567890,
                     )
@@ -420,7 +491,7 @@ class TestGetNotifySummaryWithBots:
 
     def test_with_notifications_in_response(self, test_injector, mock_user, mock_bot_lister):
         mock_bot_lister.list_bot_mappings.return_value = [
-            ("bot_full", "Full Bot", "sb_full"),
+            NotifyTarget("bot_full", "Full Bot", "testuser", "sb_full"),
         ]
         notification = NotifyEntry(
             interactionId="int_full",
@@ -433,10 +504,10 @@ class TestGetNotifySummaryWithBots:
             expiresAtMs=19999999,
         )
 
-        async def mock_probe(bot_id, bot_name, sandbox_id, sandbox_client=None):
+        async def mock_probe(target, resolver, transport):
             return BotNotifySummary(
-                bot_id=bot_id, bot_name=bot_name,
-                sandbox_id=sandbox_id, notifications=[notification],
+                bot_id=target.bot_id, bot_name=target.bot_name,
+                sandbox_id=target.sandbox_id, notifications=[notification],
             )
 
         client = _create_notify_client(test_injector, mock_user, mock_bot_lister)
@@ -458,17 +529,17 @@ class TestGetNotifySummaryWithBots:
     def test_mixed_probe_results(self, test_injector, mock_user, mock_bot_lister):
         """One probe succeeds, one returns None — only successful one in output."""
         mock_bot_lister.list_bot_mappings.return_value = [
-            ("bot_ok", "OK Bot", "sb_ok"),
-            ("bot_fail", "Fail Bot", "sb_fail"),
+            NotifyTarget("bot_ok", "OK Bot", "testuser", "sb_ok"),
+            NotifyTarget("bot_fail", "Fail Bot", "testuser", "sb_fail"),
         ]
 
-        async def mock_probe(bot_id, bot_name, sandbox_id, sandbox_client=None):
-            if bot_id == "bot_fail":
+        async def mock_probe(target, resolver, transport):
+            if target.bot_id == "bot_fail":
                 return None
             return BotNotifySummary(
-                bot_id=bot_id,
-                bot_name=bot_name,
-                sandbox_id=sandbox_id,
+                bot_id=target.bot_id,
+                bot_name=target.bot_name,
+                sandbox_id=target.sandbox_id,
                 notifications=[],
             )
 
@@ -594,98 +665,38 @@ class TestProbeBotNotifyEdgeCases:
 
     @pytest.mark.asyncio
     async def test_probe_data_not_list_returns_empty(self):
-        """Test when data is a dict instead of list - should return empty notifications."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": True,
-            "data": {"status": "ok", "count": 0},
-        }
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_e1", "Bot E1", "sandbox_e1", MagicMock())
+        result = await _probe_bot_notify(
+            _target("bot_e1", "Bot E1"),
+            _make_resolver(),
+            _make_transport({"success": True, "data": {"status": "ok", "count": 0}}),
+        )
 
         assert result is not None
         assert result.notifications == []
 
     @pytest.mark.asyncio
     async def test_probe_data_is_none(self):
-        """Test when data field is None - should return empty notifications."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"success": True, "data": None}
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_none", "Bot None", "sb_none", MagicMock())
+        result = await _probe_bot_notify(
+            _target("bot_none", "Bot None"),
+            _make_resolver(),
+            _make_transport({"success": True, "data": None}),
+        )
 
         assert result is not None
         assert result.notifications == []
 
     @pytest.mark.asyncio
     async def test_probe_multiple_notifications(self):
-        """Test with multiple notifications in response."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": True,
-            "data": [
-                {
-                    "interactionId": "n1",
-                    "sessionKey": "s1",
-                    "runId": "r1",
-                    "kind": "confirm",
-                    "prompt": "Confirm?",
-                    "status": "pending",
-                    "createdAtMs": 1000,
-                },
-                {
-                    "interactionId": "n2",
-                    "sessionKey": "s2",
-                    "runId": "r2",
-                    "kind": "input",
-                    "prompt": "Enter value:",
-                    "status": "active",
-                    "createdAtMs": 2000,
-                    "expiresAtMs": 9000,
-                },
-                {
-                    "interactionId": "n3",
-                    "sessionKey": "s3",
-                    "runId": "r3",
-                    "kind": "select",
-                    "options": [{"value": "a"}, {"value": "b"}],
-                    "status": "pending",
-                    "createdAtMs": 3000,
-                },
-            ],
-        }
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_m", "Multi Bot", "sandbox_m", MagicMock())
+        data = [
+            {"interactionId": "n1", "sessionKey": "s1", "runId": "r1", "kind": "confirm", "prompt": "Confirm?", "status": "pending", "createdAtMs": 1000},
+            {"interactionId": "n2", "sessionKey": "s2", "runId": "r2", "kind": "input", "prompt": "Enter value:", "status": "active", "createdAtMs": 2000, "expiresAtMs": 9000},
+            {"interactionId": "n3", "sessionKey": "s3", "runId": "r3", "kind": "select", "options": [{"value": "a"}, {"value": "b"}], "status": "pending", "createdAtMs": 3000},
+        ]
+        result = await _probe_bot_notify(
+            _target("bot_m", "Multi Bot"),
+            _make_resolver(),
+            _make_transport({"success": True, "data": data}),
+        )
 
         assert result is not None
         assert len(result.notifications) == 3
@@ -696,109 +707,27 @@ class TestProbeBotNotifyEdgeCases:
         assert len(result.notifications[2].options) == 2
 
     @pytest.mark.asyncio
-    async def test_probe_exception_building_proxy_request(self):
-        """Exception building the proxy request → empty summary (swallowed)."""
-        client = MagicMock()
-        client.build_proxy_request.side_effect = Exception("proxy build failed")
-        result = await _probe_bot_notify("bot_ex1", "Bot EX1", "sandbox_ex1", client)
-
-        assert result is not None
-        assert result.bot_id == "bot_ex1"
-        assert result.notifications == []
-
-    @pytest.mark.asyncio
-    async def test_probe_exception_building_proxy_request_headers(self):
-        """A second proxy-build failure path → empty summary (swallowed)."""
-        client = MagicMock()
-        client.build_proxy_request.side_effect = RuntimeError("no token")
-        result = await _probe_bot_notify("bot_ex2", "Bot EX2", "sandbox_ex2", client)
-
-        assert result is not None
-        assert result.bot_id == "bot_ex2"
-        assert result.notifications == []
-
-    @pytest.mark.asyncio
     async def test_probe_response_missing_success_key(self):
-        """Test response missing success key - should return empty notifications."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"data": []}
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_no_ok", "Bot NoOK", "sb_no_ok", MagicMock())
+        result = await _probe_bot_notify(
+            _target("bot_no_ok", "Bot NoOK"),
+            _make_resolver(),
+            _make_transport({"data": []}),
+        )
 
         assert result is not None
         assert result.notifications == []
+        assert result.status == "error"
 
     @pytest.mark.asyncio
-    async def test_probe_invalid_notification_data_raises_exception(self):
-        """Test invalid notification data - exception should be caught and return empty."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "success": True,
-            "data": [
-                {"invalid_key": "no required fields"},
-            ]
-        }
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            result = await _probe_bot_notify("bot_bad", "Bot Bad", "sb_bad", MagicMock())
+    async def test_probe_invalid_notification_data_returns_probe_error(self):
+        """Malformed notification payload → caught and surfaced as NOTIFY_PROBE_ERROR."""
+        result = await _probe_bot_notify(
+            _target("bot_bad", "Bot Bad"),
+            _make_resolver(),
+            _make_transport({"success": True, "data": [{"invalid_key": "no required fields"}]}),
+        )
 
         assert result is not None
-        # Invalid notification data causes exception which returns empty list
         assert result.notifications == []
+        assert result.error_code == "NOTIFY_PROBE_ERROR"
 
-    @pytest.mark.asyncio
-    async def test_probe_uses_client_proxy_request_url(self):
-        """The probe GETs the URL the SandboxRuntimeClient builds for /api/notify."""
-        from agentclaw.community.kernel.device_dto import ProxyRequest
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"success": True, "data": []}
-        captured_url = None
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        async def capture_get(url, headers=None):
-            nonlocal captured_url
-            captured_url = url
-            return mock_response
-
-        mock_client.get = AsyncMock(side_effect=capture_get)
-
-        sandbox_client = MagicMock()
-        sandbox_client.build_proxy_request.return_value = ProxyRequest(
-            url="http://base.local:8080/proxypass/my-target/api/notify",
-            headers={"x-proxypass-token": "t"},
-        )
-
-        with patch(
-            "httpx.AsyncClient",
-            return_value=mock_client,
-        ):
-            await _probe_bot_notify("bot_url", "Bot URL", "sb_url", sandbox_client)
-
-        sandbox_client.build_proxy_request.assert_called_once_with(
-            sandbox_id="sb_url", api_path="/api/notify"
-        )
-        assert captured_url == "http://base.local:8080/proxypass/my-target/api/notify"

--- a/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
+++ b/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
@@ -13,6 +13,7 @@ from agentclaw.community.core.bot_collaborator.models import (
 )
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.notify.bot_lister import RepositoryNotifyBotLister
+from agentclaw.community.core.notify.protocol import NotifyTarget
 
 
 def _binding(
@@ -120,8 +121,8 @@ class TestRepositoryNotifyBotLister:
         result = lister.list_bot_mappings("u001")
 
         assert result == [
-            ("bot1", "Alpha", "sb1"),
-            ("bot2", "Beta", "sb2"),
+            NotifyTarget("bot1", "Alpha", "u001", "sb1"),
+            NotifyTarget("bot2", "Beta", "u001", "sb2"),
         ]
 
     def test_owner_bindings_without_sandbox_are_skipped(self):
@@ -138,7 +139,7 @@ class TestRepositoryNotifyBotLister:
         )
         result = lister.list_bot_mappings("u001")
         # bot_id comes from device_props.bolt_id; sandbox falls back to device_id
-        assert result == [("bot1", "Alpha", "dev1")]
+        assert result == [NotifyTarget("bot1", "Alpha", "u001", "dev1")]
 
     # ------------------------------------------------------------------
     # Collaborator fold-in
@@ -163,8 +164,8 @@ class TestRepositoryNotifyBotLister:
 
         result = lister.list_bot_mappings("u001")
 
-        assert ("owned", "Mine", "sb1") in result
-        assert ("cobra", "Collab", "sbCobra") in result
+        assert NotifyTarget("owned", "Mine", "u001", "sb1") in result
+        assert NotifyTarget("cobra", "Collab", "ownerA", "sbCobra") in result
 
         # collaborator binding resolved via owner's active binding (owner = ownerA)
         binding_repo.get_active_by_bot_and_owner.assert_any_call(
@@ -196,7 +197,7 @@ class TestRepositoryNotifyBotLister:
 
         result = lister.list_bot_mappings("u001")
 
-        assert result == [("shared", "Shared", "sb1")]
+        assert result == [NotifyTarget("shared", "Shared", "u001", "sb1")]
         # The collaborator branch should not ask for the owner binding because the
         # bot was already seen.
         binding_repo.get_active_by_bot_and_owner.assert_not_called()
@@ -218,7 +219,7 @@ class TestRepositoryNotifyBotLister:
 
         result = lister.list_bot_mappings("u001")
 
-        assert result == [("cbot1", "cbot1", "sbA")]
+        assert result == [NotifyTarget("cbot1", "cbot1", "ownerA", "sbA")]
         collab_repo.list_by_user.assert_called_once()
 
     def test_collaborator_record_with_empty_owner_id_is_skipped(self):
@@ -240,7 +241,7 @@ class TestRepositoryNotifyBotLister:
 
         result = lister.list_bot_mappings("u001")
 
-        assert result == [("cbot1", "cbot1", "sbA")]
+        assert result == [NotifyTarget("cbot1", "cbot1", "ownerA", "sbA")]
         # only the valid record triggers a binding lookup; the empty-owner
         # record is short-circuited.
         binding_repo.get_active_by_bot_and_owner.assert_called_once_with(
@@ -265,7 +266,7 @@ class TestRepositoryNotifyBotLister:
 
         result = lister.list_bot_mappings("u001")
 
-        assert result == [("cbot1", "cbot1", "sbA")]
+        assert result == [NotifyTarget("cbot1", "cbot1", "ownerA", "sbA")]
 
     def test_collaborator_repo_failure_does_not_break_owner_path(self):
         lister, _, _, collab_repo = _make_lister(
@@ -280,7 +281,7 @@ class TestRepositoryNotifyBotLister:
         result = lister.list_bot_mappings("u001")
 
         # owner path intact; collaborator branch degraded to empty (logged)
-        assert result == [("owned", "Mine", "sb1")]
+        assert result == [NotifyTarget("owned", "Mine", "u001", "sb1")]
 
     def test_collaborator_binding_lookup_failure_skips_that_bot(self):
         lister, binding_repo, _, collab_repo = _make_lister(
@@ -306,5 +307,5 @@ class TestRepositoryNotifyBotLister:
 
         result = lister.list_bot_mappings("u001")
 
-        assert result == [("cbot1", "cbot1", "sbA")]
+        assert result == [NotifyTarget("cbot1", "cbot1", "ownerA", "sbA")]
         collab_repo.list_by_user.assert_called_once()

--- a/src/backend/tests/community/plugins/local/test_notify_bot_lister.py
+++ b/src/backend/tests/community/plugins/local/test_notify_bot_lister.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from agentclaw.community.core.notify.local_bot_lister import LocalNotifyBotLister
+from agentclaw.community.core.notify.protocol import NotifyTarget
 
 
 def test_list_bot_mappings_uses_active_personal_bots_from_repository():
@@ -13,8 +14,8 @@ def test_list_bot_mappings_uses_active_personal_bots_from_repository():
     lister = LocalNotifyBotLister(bot_repository=bot_repo)
 
     assert lister.list_bot_mappings("u001") == [
-        ("bot1", "Alpha", "101"),
-        ("bot3", "bot3", "103"),
+        NotifyTarget("bot1", "Alpha", "u001", "101"),
+        NotifyTarget("bot3", "bot3", "u001", "103"),
     ]
     bot_repo.list_active_bots_by_entity.assert_called_once_with(
         entity_id="u001",
@@ -31,4 +32,4 @@ def test_list_bot_mappings_skips_empty_bot_id():
         {"bot_id": "real", "bot_name": "OK", "binding_id": 201},
     ]
     lister = LocalNotifyBotLister(bot_repository=bot_repo)
-    assert lister.list_bot_mappings("u002") == [("real", "OK", "201")]
+    assert lister.list_bot_mappings("u002") == [NotifyTarget("real", "OK", "u002", "201")]


### PR DESCRIPTION
## Background

`GET /api/v1/notify` (aggregated pending HITL notifications across a user's bots) returned `ENGINE_HTTP_500` for every BaaS bot, while Arca bots succeeded.

## Root cause

The probe reached each bot's engine through `SandboxRuntimeClient.build_proxy_request`, which only knows the Arca proxypass URL formula:

```
{proxy_base}/proxypass/ARCA_{sandbox_id}:{port}{api_path}
```

For any `device_provider=baas` bot this builds an unroutable target (`ARCA_BOT-…:20003`), so the proxypass gateway returns 500 and the bot is recorded as `ENGINE_HTTP_500`. The request never reaches the engine. Desktop bots (`device_id` shaped `BOT-…`) were the visible casualty, but the gap affects all BaaS bots — chat / cron already reach these bots through a different, provider-aware transport, so only the notify probe was wrong.

Routing is decided by `ac_entity_device_binding.device_provider` (`baas` / `arca` / `teclaw` / `local`), resolved centrally by `DeviceContextResolver`. The notify probe bypassed that resolver and hardcoded the Arca-only formula.

## Fix

Route the probe through `DeviceContextResolver` + `DeviceAdapterTransport` — the same provider-driven path chat / cron use — so each provider reaches its engine via the correct transport:

- `baas` + `bot_type=desktop` → BaaS invoke-http (`{baas_base}/api/v1/bots/{tenant}/{bot_uuid}/invoke-http/{port}{path}`)
- `baas` cloud → `BaasService.invoke_http`
- `arca` → Arca proxypass (unchanged behavior; no regression for legacy Arca bots)
- `teclaw` → container URL
- `local` → direct `127.0.0.1:20003` (preserved; the test/singlebox transport is cron-only and does not serve `/api/notify`)

### Changes
- `NotifyBotLister.list_bot_mappings` returns `NotifyTarget(bot_id, bot_name, owner_id, sandbox_id)`. `owner_id` is the binding owner (the real owner for collaborator bots) so the resolver picks the right binding. `sandbox_id` is kept only as a response echo and is intentionally **not** used for routing.
- `notify_router` injects `DeviceContextResolver` + `DeviceAdapterTransport` (replaces `SandboxRuntimeClient`) and probes via `resolver.resolve_for_bot(bot_id, owner_id)` → `transport.invoke(conn_info, "GET", "/api/notify")`.
- Local provider keeps a direct httpx probe.

## Error contract (preserved)

`ENGINE_HTTP_{code}` (incl. 500, now from `DeviceAdapterHTTPStatusError`), `ENGINE_HTTP_404`, `ENGINE_TIMEOUT`, relay `"CODE: detail"` passthrough (e.g. `RELAY_UNAVAILABLE`), `NOTIFY_PROBE_ERROR`, and a benign empty record when a bot has no active binding (so the frontend still sees the bot exists).

## Tests

`DEPLOY_PROFILE=test pytest tests/community/api/aicoding tests/community/core/notify tests/community/plugins/local tests/community/core/devices` → **884 passed**.

`_probe_bot_notify` unit tests rewritten to mock resolver + transport; added `test_probe_desktop_routes_through_transport` asserting a desktop bot goes through the transport's invoke-http branch instead of the legacy Arca proxypass.
