### PR TITLE
fix(engine): hide internal BCS group sessions

### DIFF
--- a/src/engine/src/engine/community/core/adapters/openclaw/session.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/session.py
@@ -199,8 +199,9 @@ class OpenClawSessionAdapter(SessionService):
         """List sessions matching the request filter.
 
         The port handles the complete legacy ordering: sessions.list RPC →
-        bcs:group filter (keeping bcs_grp DM/bcs-cli) → agent_id/session_key filters → paginate →
-        chat.history (page only) → Bot 初始化配置 filter → model normalisation.
+        internal BCS and bcs:group filters (keeping namespaced bcs_grp DM/bcs-cli) →
+        agent_id/session_key filters → paginate → chat.history (page only) →
+        Bot 初始化配置 filter → model normalisation.
         The adapter receives the already-filtered, already-paginated page and
         only builds DTOs.
         """

--- a/src/engine/src/engine/community/plugin_api/openclaw/session.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/session.py
@@ -32,7 +32,8 @@ class OpenClawSessionPort(Protocol):
 
         Exact ordering (matches legacy `engines/openclaw/session.py:list`):
           1. `sessions.list` RPC → raw sessions
-          2. Filter out `bcs:group` sessions (keep `bcs_grp_*_dm_*` and bcs-cli)
+          2. Filter internal `agent:main:bcs_grp_` sessions and `bcs:group`
+             sessions (keep namespaced `bcs_grp_*_dm_*` and bcs-cli)
           3. Filter by `agent_id` if provided (request-param-driven but primitive)
           4. Filter by exact non-blank `session_key` if provided
           5. Paginate: slice `[offset : offset+limit]`

--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -13,6 +13,7 @@ from engine.community.openclaw.client.gateway_client import OpenClawGatewayClien
 log = logging.getLogger("openclaw-port")
 
 _BCS_GROUP_SESSION_MARKER = "bcs:group:"
+_BCS_INTERNAL_SESSION_PREFIX = "agent:main:bcs_grp_"
 
 
 def _is_bcs_dm_session_key(key: str) -> bool:
@@ -28,6 +29,8 @@ def _should_keep_session(session: dict[str, Any]) -> bool:
     """Return whether a valid gateway session should remain visible."""
     key = session.get("key")
     if not isinstance(key, str):
+        return False
+    if key.startswith(_BCS_INTERNAL_SESSION_PREFIX):
         return False
     return (
         "bcs:group" not in key
@@ -131,7 +134,8 @@ class _SessionPortMixin:
 
         Exact sequence (mirrors `engines/openclaw/session.py:list`):
           1. `sessions.list` RPC → raw sessions
-          2. Filter `bcs:group` sessions, keeping `bcs_grp_*_dm_*` and bcs-cli
+          2. Filter internal BCS sessions and `bcs:group` sessions, keeping
+             namespaced `bcs_grp_*_dm_*` and bcs-cli
           3. Filter by `agent_id` if provided
           4. Filter by exact non-blank `session_key` if provided
           5. Paginate: slice `[offset : offset+limit]` — BEFORE history fetch

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -6,8 +6,8 @@ Session DTOs — those are covered by core/adapters/openclaw/tests/test_session.
 
 Coverage preserved from engines/openclaw/tests/test_session.py (legacy):
   - sessions_list: sessions.list + per-page chat.history + providers.available
-  - sessions_list: bcs:group filter with bcs_grp DM/bcs-cli exceptions,
-    "Bot 初始化配置" filter
+  - sessions_list: internal BCS and bcs:group filters with namespaced bcs_grp
+    DM/bcs-cli exceptions, "Bot 初始化配置" filter
   - sessions_list: pagination (offset/limit BEFORE history fetch)
   - sessions_list: model normalization via _normalized_model key
   - session_create: sessions.patch RPC method + params + raw return
@@ -173,15 +173,17 @@ class TestSessionsList:
         assert s["_message_count"] == 1
         assert s["_messages"] == messages
 
-    async def test_bcs_group_sessions_hide_group_chats_and_keep_dm_sessions(self):
-        """BCS group chats are hidden while bcs_grp DM sessions remain visible."""
+    async def test_bcs_sessions_hide_internal_and_group_chats_and_keep_dm_sessions(self):
+        """Internal/group chats are hidden while namespaced BCS DMs stay visible."""
         token = "bc7d52974947474da2f1cdea1c5642b6"
+        internal_group_key = f"agent:main:bcs_grp_{token}:e69117ce_1"
         channel_dm_key = f"agent:main:bcs:group:bcs_grp_dingtalk_dm_{token}"
         native_dm_key = f"agent:main:bcs:group:bcs_grp_dm_{token}"
         flexible_dm_key = "agent:main:bcs:group:bcs_grp_dingtalk_dm_not-a-token"
         sessions = [
             {"key": None, "label": "Null key"},
             {"label": "Missing key"},
+            {"key": internal_group_key, "label": "Internal BCS group"},
             {"key": "bcs:group:room-42", "label": "Group"},
             {
                 "key": f"agent:main:bcs:group:bcs_grp_dingtalk_{token}",
@@ -201,6 +203,7 @@ class TestSessionsList:
         })
         result = await impl.sessions_list(token="tok")
         keys = [s["key"] for s in result]
+        assert internal_group_key not in keys
         assert "bcs:group:room-42" not in keys
         assert f"agent:main:bcs:group:bcs_grp_dingtalk_{token}" not in keys
         assert "agent:main:bcs:group:legacy_dm_session" not in keys


### PR DESCRIPTION
## Summary

- filter OpenClaw sessions whose keys start with `agent:main:bcs_grp_`
- preserve the existing namespaced channel DM and `bcs-cli` visibility rules
- update the OpenClaw session Plugin API documentation and regression coverage

## Root cause

The existing OpenClaw session filter only classified keys containing the `bcs:group` namespace. Internal BCS group sessions using the newer `agent:main:bcs_grp_...` shape therefore passed through as normal user-visible sessions.

## Impact

Internal BCS group sessions are hidden from Engine session listings. Existing `agent:main:bcs:group:bcs_grp_*_dm_*` channel DM sessions and the `bcs:group:bcs-cli` exception remain visible.

## Structural impact

- Contract: backward-compatible OpenClaw Plugin API visibility narrowing for internal sessions
- Consumer: OpenClaw session adapter
- Implementation: OpenClaw session plugin
- Migration or waiver: none

## Validation

- OpenClaw session port tests: 46 passed
- OpenClaw local plugin contract tests: 3 passed
- Engine architecture tests: 3 passed
- changed-file SAST/lint: passed
- `git diff --check`: passed

Commit and push were intentionally run with `--no-verify` as requested; the relevant checks above were run explicitly before publishing.