### PR TITLE
fix(bcs): add milliseconds to common error timestamps

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/src/logging.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/logging.rs
@@ -189,6 +189,18 @@ impl<'a> MakeWriter<'a> for RotatingFileWriter {
 
 // ─── Init ───────────────────────────────────────────────────────────────────
 
+fn timer_for_output<F: Clone>(
+    output_name: &str,
+    timer: &LocalTime<F>,
+    millisecond_timer: &LocalTime<F>,
+) -> LocalTime<F> {
+    if output_name == "common-error" {
+        millisecond_timer.clone()
+    } else {
+        timer.clone()
+    }
+}
+
 /// Initialize the tracing subscriber based on `LoggingConfig`.
 ///
 /// Console, file, and BCN OpenTelemetry output use independent layer filters.
@@ -217,11 +229,7 @@ pub fn init(config: &LoggingConfig, tracer: SdkTracer) {
             let writer = RotatingFileWriter::new(&dir, &output.file);
 
             let filter = build_output_targets_filter(output);
-            let output_timer = if output.name == "common-error" {
-                millisecond_timer.clone()
-            } else {
-                timer.clone()
-            };
+            let output_timer = timer_for_output(&output.name, &timer, &millisecond_timer);
             match output.format {
                 LogOutputFormat::Text => Some(
                     tracing_subscriber::fmt::layer()
@@ -425,10 +433,21 @@ mod tests {
             max_keep_days: 7,
         };
 
+        let timer = LocalTime::new(format_description!(
+            "[year]-[month]-[day] [hour]:[minute]:[second]"
+        ));
+        let millisecond_timer = LocalTime::new(format_description!(
+            "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]"
+        ));
         let subscriber = tracing_subscriber::registry()
             .with(
                 tracing_subscriber::fmt::layer()
                     .with_writer(RotatingFileWriter::new(dir.path(), &main_output.file))
+                    .with_timer(timer_for_output(
+                        &main_output.name,
+                        &timer,
+                        &millisecond_timer,
+                    ))
                     .with_ansi(false)
                     .with_filter(build_output_targets_filter(&main_output)),
             )
@@ -438,9 +457,11 @@ mod tests {
                         dir.path(),
                         &common_error_output.file,
                     ))
-                    .with_timer(LocalTime::new(format_description!(
-                        "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]"
-                    )))
+                    .with_timer(timer_for_output(
+                        &common_error_output.name,
+                        &timer,
+                        &millisecond_timer,
+                    ))
                     .with_ansi(false)
                     .with_filter(build_output_targets_filter(&common_error_output)),
             );
@@ -457,6 +478,22 @@ mod tests {
 
         assert!(main.contains("warning stays in main only"));
         assert!(main.contains("error is duplicated"));
+        let main_error_line = main
+            .lines()
+            .find(|line| line.contains("error is duplicated"))
+            .expect("main error log line should exist");
+        let main_timestamp = main_error_line
+            .get(..19)
+            .expect("main timestamp should include seconds");
+        assert!(
+            chrono::NaiveDateTime::parse_from_str(main_timestamp, "%Y-%m-%d %H:%M:%S").is_ok(),
+            "main timestamp should use YYYY-MM-DD HH:mm:ss: {main_timestamp}"
+        );
+        assert_eq!(
+            main_error_line.as_bytes().get(19),
+            Some(&b' '),
+            "main timestamp should not include fractional seconds"
+        );
         assert!(!common_error.contains("warning stays in main only"));
         assert!(common_error.contains("error is duplicated"));
         let common_error_line = common_error

--- a/src/bcs/crates/bootstrap/bcs/src/logging.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/logging.rs
@@ -196,6 +196,9 @@ pub fn init(config: &LoggingConfig, tracer: SdkTracer) {
     let timer = LocalTime::new(format_description!(
         "[year]-[month]-[day] [hour]:[minute]:[second]"
     ));
+    let millisecond_timer = LocalTime::new(format_description!(
+        "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]"
+    ));
 
     let file_layers: Vec<Box<dyn Layer<_> + Send + Sync>> = config
         .outputs
@@ -214,11 +217,16 @@ pub fn init(config: &LoggingConfig, tracer: SdkTracer) {
             let writer = RotatingFileWriter::new(&dir, &output.file);
 
             let filter = build_output_targets_filter(output);
+            let output_timer = if output.name == "common-error" {
+                millisecond_timer.clone()
+            } else {
+                timer.clone()
+            };
             match output.format {
                 LogOutputFormat::Text => Some(
                     tracing_subscriber::fmt::layer()
                         .with_writer(writer)
-                        .with_timer(timer.clone())
+                        .with_timer(output_timer)
                         .with_ansi(false)
                         .with_filter(filter)
                         .boxed(),
@@ -230,7 +238,7 @@ pub fn init(config: &LoggingConfig, tracer: SdkTracer) {
                         .with_current_span(false)
                         .with_span_list(false)
                         .with_writer(writer)
-                        .with_timer(timer.clone())
+                        .with_timer(output_timer)
                         .with_ansi(false)
                         .with_filter(filter)
                         .boxed(),
@@ -430,6 +438,9 @@ mod tests {
                         dir.path(),
                         &common_error_output.file,
                     ))
+                    .with_timer(LocalTime::new(format_description!(
+                        "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]"
+                    )))
                     .with_ansi(false)
                     .with_filter(build_output_targets_filter(&common_error_output)),
             );
@@ -448,6 +459,17 @@ mod tests {
         assert!(main.contains("error is duplicated"));
         assert!(!common_error.contains("warning stays in main only"));
         assert!(common_error.contains("error is duplicated"));
+        let common_error_line = common_error
+            .lines()
+            .find(|line| line.contains("error is duplicated"))
+            .expect("common error log line should exist");
+        let timestamp = common_error_line
+            .get(..23)
+            .expect("common error timestamp should include milliseconds");
+        assert!(
+            chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M:%S%.3f").is_ok(),
+            "common error timestamp should use YYYY-MM-DD HH:mm:ss.SSS: {timestamp}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add three-digit millisecond precision to timestamps written by the `common-error` logging output
- keep the existing second-level timestamp format unchanged for other file outputs and the console
- extend the common error logging test to validate the `YYYY-MM-DD HH:mm:ss.SSS` format

## Why

The dedicated `common-error.log` currently records timestamps only to the second, which makes ordering closely spaced error events difficult during incident investigation.

## Impact

Only the output named `common-error` changes its timestamp format. Existing routing, log levels, rotation behavior, other log files, and console output are unchanged.

## Validation

- `cargo test -p bcs --lib logging::tests` — 4 passed before rebasing onto the latest `dev`
- rebase onto latest `origin/dev` completed without conflicts
- `git diff --check origin/dev...HEAD`

A post-rebase rerun was started but stopped while Cargo was downloading dependency updates introduced by the latest `dev`; it had not reached compilation or reported a test failure.