### PR TITLE
fix(bcs): preserve run correlation for channel replies

### DIFF
--- a/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/bot/dispatcher.rs
@@ -549,8 +549,8 @@ async fn handle_response_frame(
             );
         }
 
-        // If this is a task dispatch ACK, delegate alias registration to master_slave strategy
-        handle_master_slave_response(state, run_id, res, registered_bot_id).await;
+        // Reconcile any accepted run id before processing streaming events.
+        handle_accepted_run_id_response(state, run_id, res, registered_bot_id).await;
         handle_state_machine_response(state, run_id, res).await;
     } else {
         // Error response - request was rejected
@@ -1146,8 +1146,8 @@ fn to_app_chat_event_state(state: &ChatEventState) -> AppChatEventState {
     }
 }
 
-/// master_slave mode: register sub bot's run_id as alias for the task_id.
-async fn handle_master_slave_response(
+/// Reconcile a bot-accepted run id with the request run id.
+async fn handle_accepted_run_id_response(
     state: &Arc<BotDispatchState>,
     run_id: &str,
     res: &ResponseFrame,
@@ -1160,6 +1160,22 @@ async fn handle_master_slave_response(
         .and_then(|v| v.as_str())
     {
         if sub_run_id != run_id {
+            let channel_source_message_rebound = match state
+                .message_flow
+                .rebind_channel_source_message(run_id, sub_run_id)
+                .await
+            {
+                Ok(rebound) => rebound,
+                Err(error) => {
+                    warn!(
+                        source_run_id = %run_id,
+                        accepted_run_id = %sub_run_id,
+                        error = %error,
+                        "failed to rebind channel source message to accepted run id"
+                    );
+                    false
+                }
+            };
             let task_alias_registration = match registered_bot_id.as_deref() {
                 Some(bot_id) => match state
                     .message_flow
@@ -1195,6 +1211,7 @@ async fn handle_master_slave_response(
                 task_id = %run_id,
                 sub_bot_run_id = %sub_run_id,
                 task_alias_registration = ?task_alias_registration,
+                channel_source_message_rebound = channel_source_message_rebound,
                 run_channel_alias_registered = run_channel_alias_registered,
                 trace_context_linked = trace_context_linked,
                 "master_slave: registered sub bot run_id alias"

--- a/src/bcs/crates/bootstrap/bcs/src/metrics.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/metrics.rs
@@ -817,6 +817,16 @@ impl MessageFlowService for InstrumentedMessageFlowService {
         result
     }
 
+    async fn rebind_channel_source_message(
+        &self,
+        source_run_id: &str,
+        accepted_run_id: &str,
+    ) -> ServiceResult<bool> {
+        self.inner
+            .rebind_channel_source_message(source_run_id, accepted_run_id)
+            .await
+    }
+
     async fn register_task_run_alias(
         &self,
         task_id: &str,

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -3,7 +3,7 @@
  *
  * Handles chat.send requests from BCS:
  * 1. Extract text from message content blocks
- * 2. Generate run_id, ACK immediately
+ * 2. Resolve run_id, ACK immediately
  * 3. Dispatch to OpenClaw agent via SDK
  * 4. Stream response back to BCS as event frames
  */
@@ -842,6 +842,13 @@ function extractGroupContext(sessionContext: GroupContext): Record<string, unkno
   };
 }
 
+export function resolveChatRunId(requestId: unknown, idempotencyKey: unknown): string {
+  const upstreamRunId = typeof idempotencyKey === 'string' ? idempotencyKey.trim() : '';
+  if (upstreamRunId) return upstreamRunId;
+  const frameRunId = typeof requestId === 'string' ? requestId.trim() : '';
+  return frameRunId || randomUUID();
+}
+
 /** Handle chat.send request from BCS. */
 export async function handleChatSend(
   request: RequestFrame,
@@ -867,8 +874,9 @@ export async function handleChatSend(
     return;
   }
 
-  // Generate run_id and ACK immediately
-  const runId = randomUUID();
+  // Preserve the BCS correlation id when available. Older callers that do not
+  // provide one still receive a stable request-id or generated run-id fallback.
+  const runId = resolveChatRunId(request.id, params.idempotency_key);
   client.sendResponse(request.id, true, { run_id: runId });
 
   const { senderName, text: strippedText } = extractFromPrefix(text);

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -14,6 +14,7 @@ import {
   handleBcsRouteTool,
   initAgentEventsSubscription,
   rememberTaskToolSession,
+  resolveChatRunId,
   resolveGroupIdFromSessionKey,
 } from '../src/inbound-handler.js';
 import type { RequestFrame, ResolvedBcsAccount } from '../src/types.js';
@@ -36,6 +37,15 @@ function listSourceFiles(dir: string): string[] {
 }
 
 describe('openclaw-channel-bcn', () => {
+  it('preserves the upstream BCS run id with backward-compatible fallbacks', () => {
+    assert.equal(resolveChatRunId('request-run', ' upstream-run '), 'upstream-run');
+    assert.equal(resolveChatRunId(' request-run ', undefined), 'request-run');
+    assert.match(
+      resolveChatRunId(undefined, '  '),
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
   it('resolves default and named BCS accounts', () => {
     const cfg = {
       channels: {
@@ -561,6 +571,7 @@ describe('openclaw-channel-bcn', () => {
       id: 'chat-1',
       method: 'chat.send',
       params: {
+        idempotency_key: 'upstream-run-1',
         bcs_group_id: 'group-1',
         channel: { source: 'api', user_id: 'user-1' },
         session_context: {},
@@ -584,7 +595,7 @@ describe('openclaw-channel-bcn', () => {
       assert.equal(responses.length, 1);
       assert.equal(responses[0].ok, true);
       const runId = responses[0].payload?.run_id;
-      assert.equal(typeof runId, 'string');
+      assert.equal(runId, 'upstream-run-1');
       assert.equal(capturedReplyOptions?.disableBlockStreaming, false);
       assert.equal(capturedReplyOptions?.sourceReplyDeliveryMode, 'automatic');
       assert.equal(capturedInboundContext?.Body, '[Image: diagram.png]');

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
@@ -301,6 +301,13 @@ pub trait MessageFlowService: Send + Sync {
         cmd: GroupCallbackCommand,
     ) -> ServiceResult<GroupCallbackOutcome>;
     async fn handle_chat_abort(&self, cmd: ChatAbortCommand) -> ServiceResult<ChatAbortOutcome>;
+    async fn rebind_channel_source_message(
+        &self,
+        _source_run_id: &str,
+        _accepted_run_id: &str,
+    ) -> ServiceResult<bool> {
+        Ok(false)
+    }
     async fn register_task_run_alias(
         &self,
         task_id: &str,

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -252,6 +252,17 @@ impl MessageFlowService for BcsMessageFlow {
         handle_chat_abort(self, cmd).await
     }
 
+    async fn rebind_channel_source_message(
+        &self,
+        source_run_id: &str,
+        accepted_run_id: &str,
+    ) -> ServiceResult<bool> {
+        Ok(self
+            .message_tracker
+            .rebind_channel_source_message_id(source_run_id, accepted_run_id)
+            .await)
+    }
+
     async fn register_task_run_alias(
         &self,
         task_id: &str,

--- a/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
@@ -169,6 +169,26 @@ impl MessageTracker {
             .insert(run_id.to_string(), message_id.to_string());
     }
 
+    pub async fn rebind_channel_source_message_id(
+        &self,
+        source_run_id: &str,
+        accepted_run_id: &str,
+    ) -> bool {
+        if source_run_id == accepted_run_id {
+            return self
+                .channel_source_message_ids
+                .lock()
+                .await
+                .contains_key(source_run_id);
+        }
+        let mut message_ids = self.channel_source_message_ids.lock().await;
+        let Some(message_id) = message_ids.remove(source_run_id) else {
+            return false;
+        };
+        message_ids.insert(accepted_run_id.to_string(), message_id);
+        true
+    }
+
     pub async fn remove_channel_source_message_id(&self, run_id: &str) {
         self.channel_source_message_ids.lock().await.remove(run_id);
     }
@@ -244,6 +264,41 @@ mod tests {
         assert_eq!(
             tracker.channel_source_message_id("run-2").await.as_deref(),
             Some("message-2")
+        );
+    }
+
+    #[tokio::test]
+    async fn channel_source_message_id_follows_accepted_run_id() {
+        let tracker = MessageTracker::new();
+        tracker
+            .cache_channel_source_message_id("source-run", "message-1")
+            .await;
+
+        assert!(
+            tracker
+                .rebind_channel_source_message_id("source-run", "accepted-run")
+                .await
+        );
+        assert!(
+            tracker
+                .channel_source_message_id("source-run")
+                .await
+                .is_none()
+        );
+        assert_eq!(
+            tracker
+                .channel_source_message_id("accepted-run")
+                .await
+                .as_deref(),
+            Some("message-1")
+        );
+
+        tracker.cleanup_run("accepted-run").await;
+        assert!(
+            tracker
+                .channel_source_message_id("accepted-run")
+                .await
+                .is_none()
         );
     }
 }

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -1672,6 +1672,41 @@ async fn task_run_alias_requires_target_bot_and_dispatched_task() {
 }
 
 #[tokio::test]
+async fn channel_source_message_can_be_rebound_to_accepted_run_id() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+    flow.message_tracker
+        .cache_channel_source_message_id("source-run", "source-message")
+        .await;
+
+    let rebound = flow
+        .rebind_channel_source_message("source-run", "accepted-run")
+        .await
+        .unwrap();
+
+    assert!(rebound);
+    assert!(
+        flow.message_tracker
+            .channel_source_message_id("source-run")
+            .await
+            .is_none()
+    );
+    assert_eq!(
+        flow.message_tracker
+            .channel_source_message_id("accepted-run")
+            .await
+            .as_deref(),
+        Some("source-message")
+    );
+}
+
+#[tokio::test]
 async fn task_ledger_notifications_are_sent_to_driver_after_dispatch_and_reply() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let mut group = support.group.get("group-1").await.unwrap();


### PR DESCRIPTION
## Summary

- reuse the upstream BCS request/run ID in the BCN plugin instead of generating an unrelated UUID
- rebind channel source-message correlation when a legacy bot ACK returns a different run ID
- keep task-alias handling independent from source-message correlation

## Why

The plugin could return a new run ID while BCS still stored the DingTalk source message under the original request run. The final channel reply then could not find the reaction state, leaving the acknowledgment reaction visible.

## Impact

The compatibility path only moves channel source-message metadata. Implementations that do not support this metadata retain the service API's default no-op behavior, so non-channel flows are unchanged.

## Validation

- BCN plugin lint and build passed
- BCN plugin tests: 53 passed
- `cargo test --manifest-path src/bcs/Cargo.toml -p bcs-message-flow`: 201 passed
- `cargo test --manifest-path src/bcs/Cargo.toml -p bcs-ws`: passed
- `git diff --check`: passed