### PR TITLE
fix(baas): use gmt_modified instead of gmt_create for publish timeout baseline

### DIFF
--- a/src/baas/src/secbaas/community/core/repository/publish_record/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/publish_record/_orm_repository.py
@@ -447,7 +447,7 @@ class OrmPublishRecordRepository(OrmConnectionMixin, PublishRecordRepository):
             LEFT JOIN baas_device d ON pr.device_id = d.id AND d.is_deleted = 0
             WHERE pr.publish_id = :publish_id
               AND pr.result_status = 'PROCESSING'
-              AND pr.gmt_create < :cutoff
+              AND pr.gmt_modified < :cutoff
               AND pr.tenant = :tenant AND pr.env = :env AND pr.is_deleted = 0"""
         )
         result = self._session.execute(


### PR DESCRIPTION
## Problem
`list_stale_processing_records` used `pr.gmt_create < :cutoff` as the timeout condition. However, the record is created at the beginning of the publish batch lifecycle — before devices are actually provisioned. For multi-device publishes spanning many batches, records created early can appear stale before deployment even begins.

## Fix
Change the SQL in `list_stale_processing_records` from `pr.gmt_create < :cutoff` to `pr.gmt_modified < :cutoff`.

When the record transitions to `PROCESSING` status (which happens right before actual deployment starts), `update_result` explicitly sets `gmt_modified = func.now()`. So `gmt_modified` correctly reflects when deployment began, not when the record was first inserted.

## Changed Files
- `src/secbaas/community/core/repository/publish_record/_orm_repository.py`: 1 line change (line 450)