### PR TITLE
fix(bcs-session-file-store): flavor-aware expires_at cast in sweep + trim session-file skill ref

### DIFF
--- a/src/bcs/crates/services/bcs-session-file-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-file-store/src/mysql.rs
@@ -35,7 +35,8 @@ const SELECT_BASE_COLS: &str = "file_id, session_id, file_name, mime_type, size,
 /// are projected from those on read (epoch seconds) in a flavor-aware way
 /// (`UNIX_TIMESTAMP` on MySQL, `strftime('%s', …)` on SQLite), and `list`
 /// orders by `gmt_create`. `json_extract` is lowercase for MySQL/SQLite
-/// portability, so the only dialect branch is the timestamp projection.
+/// portability, so the dialect branches are the timestamp projection and the
+/// `expires_at` JSON cast (`... AS SIGNED` on MySQL, `... AS INTEGER` on SQLite).
 #[derive(Clone)]
 pub struct MySqlSessionFileStore {
     db: Arc<dyn DbPlugin>,
@@ -84,6 +85,16 @@ fn column_u64(row: &DbRow, name: &str) -> u64 {
 fn parse_status(raw: &str) -> ServiceResult<FileStatus> {
     serde_json::from_value(serde_json::Value::String(raw.to_string()))
         .map_err(|e| ServiceError::InternalError(format!("parse status: {e}")))
+}
+
+/// Flavor-aware SQL cast of `object_handle->'$.expires_at'` to an integer for
+/// comparison. MySQL/OceanBase only accept `CAST(... AS SIGNED)` (their `CAST`
+/// has no `INTEGER` target); SQLite only accepts `CAST(... AS INTEGER)`.
+fn expires_at_cast(flavor: DbSqlFlavor) -> &'static str {
+    match flavor {
+        DbSqlFlavor::Mysql => "CAST(json_extract(object_handle, '$.expires_at') AS SIGNED)",
+        DbSqlFlavor::Sqlite => "CAST(json_extract(object_handle, '$.expires_at') AS INTEGER)",
+    }
 }
 
 impl MySqlSessionFileStore {
@@ -421,10 +432,14 @@ impl SessionFileRepoPort for MySqlSessionFileStore {
         limit: u32,
     ) -> ServiceResult<Vec<SessionFile>> {
         // Use lowercase `json_extract` for both MySQL and SQLite portability.
+        // The `expires_at` cast must be flavor-aware (see [`expires_at_cast`]):
+        // MySQL/OceanBase reject `CAST(... AS INTEGER)` (only `AS SIGNED`),
+        // SQLite needs `AS INTEGER`.
+        let expires_at_cast = expires_at_cast(self.flavor);
         let sql = format!(
             "SELECT {} FROM bcs_session_files \
              WHERE env = ? AND status = 'Pending' \
-             AND CAST(json_extract(object_handle, '$.expires_at') AS INTEGER) < ? \
+             AND {expires_at_cast} < ? \
              LIMIT ?",
             self.select_cols()
         );
@@ -545,5 +560,11 @@ mod tests {
         assert_eq!(sf.created_at, 1000);
         assert_eq!(sf.updated_at, 2000);
         assert_eq!(sf.status, FileStatus::Pending);
+    }
+    #[test]
+    fn expires_at_cast_is_flavor_aware() {
+        assert!(expires_at_cast(DbSqlFlavor::Mysql).contains("AS SIGNED"));
+        assert!(!expires_at_cast(DbSqlFlavor::Mysql).contains("AS INTEGER"));
+        assert!(expires_at_cast(DbSqlFlavor::Sqlite).contains("AS INTEGER"));
     }
 }

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/session-file.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/session-file.md
@@ -7,34 +7,15 @@
 - **会话工作区（session workspace）** = 一个 Session 内 bot/human 共享的文件存储区
 - **file_id** 全局唯一、URL-safe、不透明；同一会话允许同名文件（靠 file_id 区分）
 - **FileStatus**：
-  - `Pending` — 已 prepare，等待上传完成
+  - `Pending` — 上传进行中，尚未完成
   - `Ready` — 上传完成，可下载/分享/删除
   - `Failed` — 上传失败，可删除后重传
 - 仅 `Ready` 状态的文件可下载、分享、删除
 
-### 三阶段上传
-
-```
-prepare → PUT → complete
-```
-
-`upload` 命令自动封装三阶段：
-1. `prepare` 创建 file_id 并返回 `upload_url`
-2. `PUT` 将文件字节写入 `upload_url`（presign 后端直传 OSS，local 后端经 BCS）
-3. `complete` 标记上传完成，状态变为 Ready
-
-失败时 CLI 会尝试 `DELETE` 取消未完成的上传。
-
-### Multipart 上传
-
-- **100MB 是单片/分段阈值（非硬截断）**：超过 100MB 自动走 multipart 串行 PUT（v1；可并行优化为后续）
-- multipart 响应的最外层包含 `expires_at` 和 `method` 字段
-
 ### 分享链接
 
-- 分享链接使用独立密钥签发，过期前不可撤销
 - 删除文件即令分享链接失效
-- 返回的 `share_url` 为裸 URL（格式 `{base}/sessions/shared-file/content?token=...`），不含 session id——消费端凭 token 即可下载，无需 CLI 子命令（直接 HTTP GET 即可）
+- 返回的 `share_url` 为裸 URL，不含 session id；接收方直接 HTTP GET 即可下载，无需 CLI 子命令
 
 ## 权限
 
@@ -45,13 +26,13 @@ prepare → PUT → complete
 | `list` | 会话参与者 |
 | `share` | 会话参与者 |
 | `delete` | 上传者，或会话创建者，或该 group 的 driver bot |
-| `capabilities` | 会话参与者 |
+| `capabilities` | 查询后端能力 |
 
 ## 命令列表
 
 | 命令 | 必需参数 | 说明 |
 |------|----------|------|
-| `session file upload` | `--session`, `--path` | 上传本地文件（自动三阶段） |
+| `session file upload` | `--session`, `--path` | 上传本地文件 |
 | `session file list` | `--session` | 列出工作区文件 |
 | `session file download` | `--session`, `--file-id` | 下载文件字节 |
 | `session file delete` | `--session`, `--file-id` | 删除文件 / 取消上传 |
@@ -66,7 +47,7 @@ prepare → PUT → complete
 
 ## session file upload - 上传
 
-上传本地文件到 Session 工作区，自动封装三阶段（prepare → PUT → complete）。
+上传本地文件到 Session 工作区。
 
 ```bash
 bcs session file upload --session "<session_id>" --path <本地路径> [--name <文件名>] [--mime <MIME 类型>]
@@ -82,17 +63,15 @@ bcs session file upload --session "<session_id>" --path <本地路径> [--name <
 **示例：**
 
 ```bash
-# 上传小文件（<100MB，单片上传）
+# 上传文件
 bcs session file upload --session "grp-001:1a2b3c4d" --path ./report.pdf
 
-# 上传大文件（≥100MB，自动 multipart 串行 PUT（v1；可并行优化为后续））
+# 指定 MIME 类型
 bcs session file upload --session "grp-001:1a2b3c4d" --path ./model.bin --mime application/octet-stream
 
 # 自定义文件名
 bcs session file upload --session "grp-001:1a2b3c4d" --path ./data.csv --name "2026-Q3-report.csv"
 ```
-
-> **注意**：presign 后端（baas/OSS）要求本机/进程网络可达 OSS；仅能连 BCS 的环境应使用 local 后端。跨主机 PUT 到后端 OSS URL 时 Bearer 不应发送（OSS 预签名 URL 自鉴权），`bcs` CLI 已自动处理。
 
 ---
 
@@ -139,8 +118,6 @@ bcs session file download --session "grp-001:1a2b3c4d" --file-id "f1a2b3c4" --ou
 bcs session file download --session "grp-001:1a2b3c4d" --file-id "f1a2b3c4" --ttl 3600
 ```
 
-> 下载时 CLI 自动跟随 presigned 302 重定向获取文件字节。
-
 ---
 
 ## session file delete - 删除
@@ -185,8 +162,6 @@ bcs session file share --session "grp-001:1a2b3c4d" --file-id "f1a2b3c4" --ttl 8
 }
 ```
 
-> 返回的 `share_url` 为裸 URL（不含 session id），接收方直接 HTTP GET 即可下载，无需 CLI 子命令。
-
 ---
 
 ## session file capabilities - 查询能力
@@ -214,7 +189,7 @@ bcs session file capabilities --session "grp-001:1a2b3c4d"
 
 > 返回字段含义：
 > - `storage`: 后端存储类型（`local` / `baas` / `oss`）
-> - `presign_upload`: 是否支持直传后端（为 `true` 时需本机网络可达 OSS）
+> - `presign_upload`: 是否支持直传后端（为 `true` 时需本机网络可达后端存储）
 > - `presign_download`: 是否支持预签名下载
 > - `max_size`: 单文件最大字节数
 
@@ -226,7 +201,7 @@ bcs session file capabilities --session "grp-001:1a2b3c4d"
 |------|-------------|
 | `upload` | `file_id`, `status`, `name`, `size`, `mime_type` |
 | `list` | `items[]`: `file_id`, `status`, `name`, `size`, `uploader`, `created_at`, `total` |
-| `download` | 文件字节流（或跟随 302 重定向） |
+| `download` | 文件字节流 |
 | `delete` | 空或确认信息 |
 | `share` | `share_url`, `expires_at` |
 | `capabilities` | `storage`, `presign_upload`, `presign_download`, `max_size` |


### PR DESCRIPTION
## What
- Fix the `list_expired_pending` sweep query so it runs on MySQL/OceanBase.
- Trim the `session-file` skill reference to usage-only content.

## Why
- The sweep hardcoded `CAST(json_extract(...) AS INTEGER)` — SQLite syntax, invalid on MySQL/OceanBase where `CAST` has no `INTEGER` target (only `AS SIGNED`). The 300s sweep failed with `ERROR 1064 ... near 'INTEGER) < ... LIMIT'`, so expired `Pending` files were never reclaimed.
- The skill reference leaked internal upload mechanics that don't help callers use it.

## Changes
- `bcs-session-file-store`: add a flavor-aware `expires_at_cast` helper (`AS SIGNED` on MySQL, `AS INTEGER` on SQLite), mirroring `select_cols`; use it in the sweep SQL. Add a unit test asserting the per-flavor cast.
- `bcs-cli` `session-file` skill reference: drop three-stage / multipart / presign / 302 internals; keep concepts, permissions, params, examples, and return fields.

## Verification
- `cargo test -p bcs-session-file-store --lib`: 9 passed (incl. new `expires_at_cast_is_flavor_aware`).
- Docs change verified by review.
