### PR TITLE
feat(bot_run): treat agent final event as session termination

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -742,6 +742,25 @@ class AsyncChatClient:
             )
             return
 
+        if agent_state and agent_state == "final":
+            # agent final 事件视为整个会话的结束标志：
+            # 设置 agent_complete + chat_complete 唤醒等待方，并 emit final chunk
+            # 让流式迭代器终止。
+            state.state = "final"
+            state.agent_complete.set()
+            state.chat_complete.set()
+            content = payload.get("message", {}).get("content", [])
+            text = content[0].get("text", "") if content else ""
+            state.content = text
+            self._emit_stream_chunk(
+                state, StreamChunk(type="final", content=text)
+            )
+            if self.verbose:
+                logger.info(
+                    "[agent] final: sessionKey=%s, stream=%s", session_key, stream
+                )
+            return
+
         if self.verbose:
             logger.info(
                 "[agent] sessionKey=%s, stream=%s, has_state=%s",

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -7,7 +7,7 @@ Covers:
 - close: normal close, close when not connected
 - context manager: async with pattern, __aexit__ calls close
 - _on_chat: delta, final, error, ignored states
-- _on_agent: tool/result, assistant, lifecycle/end events
+- _on_agent: tool/result, assistant, lifecycle/end, final events
 """
 
 import asyncio
@@ -737,6 +737,60 @@ class TestOnAgent:
         }
         client._on_agent(payload)
         assert state.last_stream_is_assistant is False
+
+    @pytest.mark.asyncio
+    async def test_on_agent_final_sets_complete_events(self, mock_bot_ws):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client)
+        state.stream_queue = asyncio.Queue()
+
+        payload = {
+            "sessionKey": _TEST_SESSION_KEY,
+            "state": "final",
+            "message": {
+                "content": [{"type": "text", "text": "agent final text"}],
+            },
+        }
+        client._on_agent(payload)
+
+        assert state.state == "final"
+        assert state.agent_complete.is_set()
+        assert state.chat_complete.is_set()
+        assert state.content == "agent final text"
+
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "final"
+        assert chunk.content == "agent final text"
+
+    @pytest.mark.asyncio
+    async def test_on_agent_final_empty_message(self, mock_bot_ws):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client)
+        state.stream_queue = asyncio.Queue()
+
+        payload = {
+            "sessionKey": _TEST_SESSION_KEY,
+            "state": "final",
+            "message": {},
+        }
+        client._on_agent(payload)
+
+        assert state.state == "final"
+        assert state.agent_complete.is_set()
+        assert state.chat_complete.is_set()
+        assert state.content == ""
+
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "final"
+        assert chunk.content == ""
 
 
 # ==================== integration: full flow ====================

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -559,6 +559,76 @@ class TestOnAgentAdditional:
         assert state.last_stream_is_assistant is False
 
 
+# ==================== _on_agent final state ====================
+
+
+class TestOnAgentFinal:
+    @pytest.mark.asyncio
+    async def test_on_agent_final_sets_complete_events(self, mock_bot_ws):
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_agent(
+            {
+                "sessionKey": "sk1",
+                "state": "final",
+                "message": {
+                    "content": [{"type": "text", "text": "agent done"}],
+                },
+            }
+        )
+        assert state.state == "final"
+        assert state.agent_complete.is_set()
+        assert state.chat_complete.is_set()
+        assert state.content == "agent done"
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "final"
+        assert chunk.content == "agent done"
+
+    @pytest.mark.asyncio
+    async def test_on_agent_final_empty_content(self, mock_bot_ws):
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_agent(
+            {
+                "sessionKey": "sk1",
+                "state": "final",
+                "message": {},
+            }
+        )
+        assert state.state == "final"
+        assert state.agent_complete.is_set()
+        assert state.chat_complete.is_set()
+        assert state.content == ""
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "final"
+        assert chunk.content == ""
+
+    @pytest.mark.asyncio
+    async def test_on_agent_final_verbose(self, mock_bot_ws):
+        client = AsyncChatClient(uri="ws://host/ws", verbose=True)
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_agent(
+            {
+                "sessionKey": "sk1",
+                "state": "final",
+                "stream": "lifecycle",
+                "message": {
+                    "content": [{"type": "text", "text": "final text"}],
+                },
+            }
+        )
+        assert state.state == "final"
+        assert state.agent_complete.is_set()
+        assert state.chat_complete.is_set()
+        assert state.content == "final text"
+
+
 # ==================== _on_error ====================
 
 


### PR DESCRIPTION
Agent events with state=final were not handled as a terminal signal, causing send_message to hang waiting for chat_complete and stream iterators to never finish.

Handle agent_state == final in _on_agent by setting both agent_complete and chat_complete, extracting content[0].text (matching the _on_chat pattern), and emitting a final StreamChunk so _drain_stream_queue terminates.

Add unit tests covering final with content, empty message, and verbose mode.