### PR TITLE
fix: serialize BaaS bootstrap with container init

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/README.md
+++ b/src/backend/src/agentclaw/community/core/devices/README.md
@@ -8,6 +8,7 @@ Device / engine domain — engine binding, health probing, readiness, sandbox pr
 purpose: "Device / engine domain — engine binding, health probing, readiness, sandbox provisioning, OSS↔NAS migration."
 provides:
   - "DeviceService"
+  - "build_baas_bootstrap_guard_command"
   - "DeviceBindingRepository protocol"
   - "Engine health & readiness services"
   - "Device error types"
@@ -20,6 +21,7 @@ consumes:
   - "BaasService"
   - "PassportPlugin"
   - "DeviceAccessor (models only)"
+  - "DaaS image bootstrap lifecycle contract"
 internal_dependencies:
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.bot_collaborator
@@ -54,3 +56,29 @@ internal_dependencies:
 ### Change impact
 
 Owns the engine/device binding lifecycle. Schema changes (binding table, engine config dir) require migration. Health-probe contract is consumed by Prom-style monitoring outside the repo.
+
+## BaaS bootstrap readiness contract
+
+本节是 Backend 与 DaaS 容器镜像之间启动契约的规范性事实源。
+
+- **生产者**：镜像 `entrypoint.sh` / `root_init.sh` 完成依赖安装后创建
+  `/var/run/agentclaw/.install_dependency_file`；旧镜像若没有 marker，则以
+  PID 1 已进入 `supervisord` 作为兼容 ready 信号。
+- **消费者**：`BaasContainerInitializer` 和服务 Bot 的 BaaS 启动命令在调用
+  `install_engine.sh` 前共同执行 `baas_bootstrap_guard`。
+- **版本身份**：checkout 必须位于精确 Git tag；合法基础版本为
+  `v0.<minor>=3+.<patch>` 或 `v<major>=1+.<minor>.<patch>`。`dev` 只接受
+  `_dev`、`pre` 只接受 `_pre`、`prod` 只接受无环境后缀的 release tag。
+  空值或未知 `AGENTCLAW_ENV`/`env` 非法并 fail closed。
+- **完整性**：release properties、checkout 中的 install/start 脚本必须存在，
+  且与 `/home/admin/bin` 的镜像脚本逐字节一致。完整 checkout 直接复用。
+- **并发控制**：Backend 以 root 在 `/var/run/agentclaw/.baas-bootstrap.lock`
+  获取进程锁，但 Git 检查和补偿 bootstrap 以 checkout owner `admin` 执行。
+  活锁可在持有进程消失后回收；未知占用不被覆盖。
+- **超时与失败**：等待镜像 ready 和等待 bootstrap lock 各最多 120 秒。
+  不完整 checkout 只允许在锁内补偿一次并再次验证。超时、环境/tag 不匹配、
+  补偿失败或复验失败均返回非零；Backend 必须停止后续 install/start，不能把
+  发布误报为成功。
+
+修改 marker、tag 命名、checkout 内容、脚本复制位置、锁或超时语义时，必须同时
+更新两个消费者及其兼容测试。

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_bootstrap_guard.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_bootstrap_guard.py
@@ -1,0 +1,103 @@
+"""Build the guarded DaaS bootstrap command shared by BaaS startup paths."""
+
+from __future__ import annotations
+
+
+def build_baas_bootstrap_guard_command(*, as_admin: bool) -> str:
+    """Wait for image init, reuse a complete checkout, or bootstrap once.
+
+    The image ``root_init.sh`` and Backend container initialization can overlap.
+    Waiting for root init before inspecting the checkout prevents a compensating
+    bootstrap from clearing files while ``install_engine.sh`` consumes them.
+    """
+    git_tag_command = (
+        "git -C /home/admin/agentclaw-daas-scripts describe --tags --exact-match"
+    )
+    bootstrap = "bash /home/admin/bin/bootstrap_minimal.sh"
+    if as_admin:
+        git_tag_command = f"su admin -c '{git_tag_command}'"
+        bootstrap = f"su admin -c '{bootstrap}'"
+
+    return (
+        "("
+        "_agentclaw_cleanup_lock() { "
+        'rm -f "$_agentclaw_lock_dir/pid"; '
+        'rmdir "$_agentclaw_lock_dir"; '
+        "}; "
+        "_agentclaw_release_tag_valid() { "
+        '_agentclaw_release_tag="$1"; '
+        'echo "$_agentclaw_release_tag" | '
+        "grep -Eq '^v(0\\.([3-9]|[1-9][0-9]+)\\.[0-9]+|"
+        "[1-9][0-9]*\\.[0-9]+\\.[0-9]+)(_dev|_pre)?$' || return 1; "
+        '_agentclaw_runtime_env="${AGENTCLAW_ENV:-${env:-}}"; '
+        'case "$_agentclaw_runtime_env" in '
+        'dev) case "$_agentclaw_release_tag" in *_dev) return 0;; *) return 1;; esac;; '
+        'pre) case "$_agentclaw_release_tag" in *_pre) return 0;; *) return 1;; esac;; '
+        'prod) case "$_agentclaw_release_tag" in *_dev|*_pre) return 1;; *) return 0;; esac;; '
+        "*) return 1;; "
+        "esac; "
+        "}; "
+        "_agentclaw_checkout_valid() { "
+        '[ -d "$_agentclaw_bootstrap_dir/.git" ] || return 1; '
+        f'_agentclaw_release_tag="$({git_tag_command} 2>/dev/null)" || return 1; '
+        '_agentclaw_release_tag_valid "$_agentclaw_release_tag" || return 1; '
+        '[ -s "$_agentclaw_bootstrap_dir/installations/openClawEnterprise.properties" ] || return 1; '
+        '[ -s "$_agentclaw_bootstrap_dir/bootstrapping/install_engine.sh" ] || return 1; '
+        '[ -s "$_agentclaw_bootstrap_dir/bootstrapping/start_service.sh" ] || return 1; '
+        "cmp -s "
+        '"$_agentclaw_bootstrap_dir/bootstrapping/install_engine.sh" '
+        "/home/admin/bin/install_engine.sh || return 1; "
+        "cmp -s "
+        '"$_agentclaw_bootstrap_dir/bootstrapping/start_service.sh" '
+        "/home/admin/bin/start_service.sh || return 1; "
+        "return 0; "
+        "}; "
+        "_agentclaw_init_ready=0; "
+        "for _agentclaw_wait in $(seq 1 120); do "
+        "if [ -f /var/run/agentclaw/.install_dependency_file ] || "
+        '[ "$(cat /proc/1/comm 2>/dev/null)" = "supervisord" ]; then '
+        "_agentclaw_init_ready=1; break; "
+        "fi; "
+        "sleep 1; "
+        "done; "
+        'if [ "$_agentclaw_init_ready" != "1" ]; then '
+        "echo '[bootstrap] container initialization timed out' >&2; "
+        "exit 1; "
+        "fi; "
+        "_agentclaw_bootstrap_dir=/home/admin/agentclaw-daas-scripts; "
+        "mkdir -p /var/run/agentclaw; "
+        "_agentclaw_lock_dir=/var/run/agentclaw/.baas-bootstrap.lock; "
+        "_agentclaw_lock_acquired=0; "
+        "for _agentclaw_lock_wait in $(seq 1 120); do "
+        'if mkdir "$_agentclaw_lock_dir" 2>/dev/null; then '
+        'echo "$$" > "$_agentclaw_lock_dir/pid"; '
+        "_agentclaw_lock_acquired=1; break; "
+        "fi; "
+        'if [ -f "$_agentclaw_lock_dir/pid" ]; then '
+        '_agentclaw_lock_pid="$(cat "$_agentclaw_lock_dir/pid" 2>/dev/null)"; '
+        'case "$_agentclaw_lock_pid" in '
+        "''|*[!0-9]*) ;; "
+        '*) if ! kill -0 "$_agentclaw_lock_pid" 2>/dev/null; then '
+        'rm -f "$_agentclaw_lock_dir/pid"; '
+        'rmdir "$_agentclaw_lock_dir" 2>/dev/null || true; '
+        "fi;; "
+        "esac; "
+        "fi; "
+        "sleep 1; "
+        "done; "
+        'if [ "$_agentclaw_lock_acquired" != "1" ]; then '
+        "echo '[bootstrap] bootstrap lock timed out' >&2; "
+        "exit 1; "
+        "fi; "
+        "trap '_agentclaw_cleanup_lock' EXIT; "
+        "trap 'exit 1' INT TERM; "
+        "_agentclaw_result=0; "
+        "if _agentclaw_checkout_valid; then "
+        "echo '[bootstrap] reusing completed bootstrap checkout'; "
+        f"else {bootstrap} && _agentclaw_checkout_valid || _agentclaw_result=$?; "
+        "fi; "
+        "_agentclaw_cleanup_lock || _agentclaw_result=1; "
+        "trap - EXIT INT TERM; "
+        'exit "$_agentclaw_result"'
+        ")"
+    )

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_container_init.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_container_init.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 
 from agentclaw.community.core.devices.models import AllocatedDevice, SynlinkMappingInfo
+from agentclaw.community.core.devices.services.baas_bootstrap_guard import (
+    build_baas_bootstrap_guard_command,
+)
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -64,11 +67,17 @@ class BaasContainerInitializer:
         write_codefuse_token_baas(self._baas_service, bot_uuid, codefuse_token)
 
     def _run_baas_bootstrap(self, bot_uuid: str) -> None:
-        self._baas_service.exec_command_on_bot(
+        result = self._baas_service.exec_command_on_bot(
             bot_uuid=bot_uuid,
-            cmd="bash /home/admin/bin/bootstrap_minimal.sh",
-            timeout_seconds=60,
+            # BaaS exec runs as root, while root_init creates and owns the
+            # checkout as admin. Keep the lock/root lifecycle outside, but
+            # inspect or repair the checkout as its owning user.
+            cmd=build_baas_bootstrap_guard_command(as_admin=True),
+            timeout_seconds=300,
         )
+        exit_code = result.get("exit_code") if isinstance(result, dict) else None
+        if exit_code != 0:
+            raise RuntimeError(f"BaaS bootstrap guard failed: exit_code={exit_code}")
         logger.info("[_run_baas_bootstrap] done: bot_uuid=%s", bot_uuid)
 
     def _run_baas_install_engine(self, bot_uuid: str) -> None:

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -54,6 +54,10 @@ Publication path is the user-visible go-live for bots — bugs here block custom
 Service artifacts freeze the persisted Skills Pool layout state at build time;
 changes to the Skills Pool contract or repository therefore affect publication
 compatibility and must be reviewed together with this module.
+服务 Bot 的 BaaS 启动同样消费 `core.devices` 中定义的
+“BaaS bootstrap readiness contract”：只有镜像初始化 ready、DaaS checkout
+版本和内容复验通过后，才允许执行 engine install/start；bootstrap 非零必须
+终止发布链路。
 
 ## Publish operation ledger (#197)
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -49,6 +49,9 @@ from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxProvider, EngineSandboxRegistry
 
 from agentclaw.community.core.devices.protocols import StoragePathProtocol
+from agentclaw.community.core.devices.services.baas_bootstrap_guard import (
+    build_baas_bootstrap_guard_command,
+)
 from agentclaw.community.core.devices.services.sandbox_overrides import (
     InvalidSandboxOverridesError,
     SandboxOverrides,
@@ -2228,8 +2231,19 @@ class BaasService:  # pragma: no cover
         return "supervisorctl stop sync"
 
     def _get_bootstrap_cmp(self):
-        """执行 bootstrap 补偿脚本。"""
-        return "su admin -c 'bash /home/admin/bin/bootstrap_minimal.sh'"
+        """等待镜像初始化结束，复用完整 checkout，必要时才执行 bootstrap 补偿。
+
+        arca-openclaw 的 root_init.sh 会先执行 bootstrap_minimal.sh。BaaS 的
+        after-create hook 可能在 root_init 尚未结束时进入；若此处无条件再次
+        bootstrap，两次脚本会并发清空同一个 DaaS checkout，随后
+        install_engine.sh 可能读到一个瞬时不完整的目录。
+
+        .install_dependency_file 在当前镜像中位于 root_init 之后创建；
+        supervisord 成为 PID 1 则兼容没有该 marker 的旧镜像。两种信号都能
+        证明 root_init 不会再修改 checkout。等待或补偿失败时返回非零，
+        由 after-create 的 ``&&`` 链阻止 install/start，保持 fail-closed。
+        """
+        return build_baas_bootstrap_guard_command(as_admin=True)
 
     def _get_setup_sync_service_cmd(self, engine: str = ""):
         """执行 setup_supervisor_sync_service.sh 脚本。"""

--- a/src/backend/tests/community/core/devices/services/test_baas_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_device_service.py
@@ -1158,14 +1158,19 @@ class TestStartServiceInitSteps:
         if not cmds[0]:
             cmds = [c[1]["cmd"] for c in calls]
 
+        assert "/var/run/agentclaw/.install_dependency_file" in cmds[0]
+        assert "describe --tags --exact-match" in cmds[0]
+        assert "openClawEnterprise.properties" in cmds[0]
+        assert "reusing completed bootstrap checkout" in cmds[0]
         assert "bootstrap_minimal.sh" in cmds[0]
+        assert calls[0].kwargs["timeout_seconds"] == 300
         assert "install_engine.sh" in cmds[1]
         assert "setup_supervisor_sync_service.sh" in cmds[2]
         assert "setup_engine_dirs.sh" in cmds[3]
         assert "start_service.sh" in cmds[-2]
         assert "starting_watchdog.sh" in cmds[-1]
 
-    def test_no_su_admin_in_commands(self):
+    def test_only_bootstrap_checkout_operations_drop_to_admin(self):
         svc, baas = self._make_success_svc()
 
         with patch(
@@ -1174,9 +1179,21 @@ class TestStartServiceInitSteps:
         ):
             svc._start_service(device=_device_with_publish())
 
-        for call in baas.exec_command_on_bot.call_args_list:
+        calls = baas.exec_command_on_bot.call_args_list
+        bootstrap_cmd = calls[0].kwargs["cmd"]
+        assert (
+            "su admin -c 'git -C /home/admin/agentclaw-daas-scripts "
+            "describe --tags --exact-match'" in bootstrap_cmd
+        )
+        assert (
+            "su admin -c 'bash /home/admin/bin/bootstrap_minimal.sh'"
+            in bootstrap_cmd
+        )
+
+        # install_engine.sh itself requires root and drops privileges internally.
+        for call in calls[1:]:
             cmd = call.kwargs.get("cmd", "")
-            assert "su admin" not in cmd, f"BaaS container should not use su admin: {cmd}"
+            assert "su admin" not in cmd, f"root lifecycle command used su admin: {cmd}"
 
     def test_init_uses_correct_bot_uuid(self):
         svc, baas = self._make_success_svc()
@@ -1210,6 +1227,25 @@ class TestStartServiceInitSteps:
         assert "init failed" in msg.lower() or "bootstrap" in msg.lower()
         svc.report_device_alive.assert_not_called()
 
+    def test_bootstrap_nonzero_exit_stops_remaining_init_steps(self):
+        svc, baas = self._make_success_svc()
+        baas.exec_command_on_bot.return_value = {
+            "exit_code": 1,
+            "stdout": "",
+            "stderr": "bootstrap guard failed",
+        }
+
+        with patch(
+            "agentclaw.community.core.devices.services.baas_device_service.time.sleep",
+            return_value=None,
+        ):
+            ok, msg = svc._start_service(device=_device_with_publish())
+
+        assert ok is False
+        assert "bootstrap guard failed" in msg
+        assert baas.exec_command_on_bot.call_count == 1
+        svc.report_device_alive.assert_not_called()
+
     def test_start_service_passes_bot_type(self):
         svc, baas = self._make_success_svc()
 
@@ -1225,7 +1261,7 @@ class TestStartServiceInitSteps:
 
         start_cmd_calls = [
             c for c in baas.exec_command_on_bot.call_args_list
-            if "start_service.sh" in c.kwargs.get("cmd", "")
+            if "start_service.sh --token" in c.kwargs.get("cmd", "")
         ]
         assert len(start_cmd_calls) == 1
         assert "--bot_type personalCoding" in start_cmd_calls[0].kwargs["cmd"]

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -55,9 +55,15 @@ def _make_baas_device_service(
     vault: TokenVault | None = None,
     template_service: MagicMock | None = None,
 ) -> BaasDeviceService:
+    baas_service = MagicMock()
+    baas_service.exec_command_on_bot.return_value = {
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": "",
+    }
     return BaasDeviceService(
         repository=repo,
-        baas_service=MagicMock(),
+        baas_service=baas_service,
         bot_query=bot_query or MagicMock(),
         bot_sync=MagicMock(),
         oss_record_repo=MagicMock(),

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_start_cmd.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_start_cmd.py
@@ -70,8 +70,8 @@ class TestGetStartCmdOrdering:
             version="1",
         )
         bootstrap_idx = cmd.index("bootstrap_minimal.sh")
-        install_idx = cmd.index("install_engine.sh")
-        start_idx = cmd.index("start_service.sh")
+        install_idx = cmd.rindex("install_engine.sh")
+        start_idx = cmd.rindex("start_service.sh")
         assert bootstrap_idx < install_idx < start_idx
 
     def test_steps_chained_with_and(self):
@@ -92,8 +92,75 @@ class TestGetStartCmdOrdering:
         assert "install_engine.sh" in cmd
         # The substring between install_engine and start_service must
         # contain a chained `&&` (not `;` or a backgrounded `&`).
-        between = cmd[cmd.index("install_engine.sh") : cmd.index("start_service.sh")]
+        between = cmd[cmd.rindex("install_engine.sh") : cmd.rindex("start_service.sh")]
         assert "&&" in between
+
+
+class TestBootstrapReadinessGuard:
+    def test_waits_for_container_init_before_bootstrap_decision(self):
+        cmd = _make_service()._get_start_cmd(
+            bot_id="bot-1",
+            owner_id="owner-1",
+            entity_id="entity-1",
+            entity_type="user",
+            migration_pat="",
+            bot_type="personal",
+            engine="claude_code",
+            stage="online",
+            version="1",
+        )
+
+        marker_idx = cmd.index("/var/run/agentclaw/.install_dependency_file")
+        lock_idx = cmd.index(
+            "_agentclaw_lock_dir=/var/run/agentclaw/.baas-bootstrap.lock"
+        )
+        repo_validation_idx = cmd.rindex("if _agentclaw_checkout_valid")
+        bootstrap_idx = cmd.rindex("bootstrap_minimal.sh")
+        install_idx = cmd.rindex("install_engine.sh")
+
+        assert marker_idx < lock_idx < repo_validation_idx < bootstrap_idx < install_idx
+
+    def test_reuses_complete_release_checkout_instead_of_unconditionally_bootstrapping(
+        self,
+    ):
+        cmd = _make_service()._get_bootstrap_cmp()
+
+        assert "git -C" in cmd
+        assert "describe --tags --exact-match" in cmd
+        assert "_agentclaw_release_tag_valid" in cmd
+        assert "*_dev" in cmd
+        assert "*_pre" in cmd
+        assert "openClawEnterprise.properties" in cmd
+        assert "cmp -s" in cmd
+        assert "/home/admin/bin/install_engine.sh" in cmd
+        assert "/home/admin/bin/start_service.sh" in cmd
+        assert "reusing completed bootstrap checkout" in cmd
+        assert "else su admin -c 'bash /home/admin/bin/bootstrap_minimal.sh'" in cmd
+
+    def test_release_tag_validation_rejects_unknown_runtime_environment(self):
+        cmd = _make_service()._get_bootstrap_cmp()
+
+        assert (
+            'prod) case "$_agentclaw_release_tag" in *_dev|*_pre) '
+            "return 1;; *) return 0;; esac;;" in cmd
+        )
+        assert "*) return 1;; esac;" in cmd
+
+    def test_serializes_checkout_validation_and_compensation(self):
+        cmd = _make_service()._get_bootstrap_cmp()
+
+        assert 'mkdir "$_agentclaw_lock_dir"' in cmd
+        assert 'kill -0 "$_agentclaw_lock_pid"' in cmd
+        assert "_agentclaw_cleanup_lock" in cmd
+        assert "bootstrap lock timed out" in cmd
+
+    def test_fails_closed_when_container_init_does_not_finish(self):
+        cmd = _make_service()._get_bootstrap_cmp()
+
+        assert "/proc/1/comm" in cmd
+        assert "seq 1 120" in cmd
+        assert "container initialization timed out" in cmd
+        assert "exit 1" in cmd
 
 
 class TestGetStartSandboxServiceCmdNasFlag:


### PR DESCRIPTION
## Summary

- serialize Backend bootstrap against image `root_init.sh` with a container-scoped PID lock
- reuse only a complete, exact-tagged DaaS checkout; otherwise compensate once under the lock and revalidate
- run checkout Git/bootstrap operations as `admin` while keeping lifecycle/install commands as root
- fail closed on init timeout, lock timeout, invalid environment/tag, incomplete checkout, or nonzero bootstrap result
- share the same guard across personal-device and service-bot BaaS startup paths

## Root cause

The image entrypoint and Backend after-create initialization could invoke `bootstrap_minimal.sh` concurrently. One invocation could clear `/home/admin/agentclaw-daas-scripts` while the other was running `install_engine.sh`, causing the release properties file to disappear and the BaaS publish to fail.

## Compatibility and safety

- existing image readiness marker is preferred; PID 1 `supervisord` remains the old-image compatibility signal
- no Skills Pool DB/layout/locator changes
- no fallback to partially initialized checkout
- downstream install/start is not dispatched after guard failure

## Tests

- `734 passed` for BaaS device and service-bot focused suites
- guard shell generated for both execution modes passes `bash -n`
- focused Ruff fatal checks, Python compile, and `git diff --check` pass