### PR TITLE
fix(backend): guard against duplicate online instance on restart_for_others

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/online_instance_guard.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/online_instance_guard.py
@@ -1,0 +1,78 @@
+"""Guard against duplicate online instances in the restart flow.
+
+When a restart targets a FAILED online bot, the recreate path mints a new
+FIRST_RELEASE with a brand-new bot + binding + device. If the existing binding
+is still in ACTIVE or FAILED state, re-creating would produce duplicate
+``baas_device`` online rows. This module provides a read-only check that
+raises before the duplicate is created."""
+from __future__ import annotations
+
+from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.service_bot.types import PublishStage
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+class DuplicateOnlineInstanceError(Exception):
+    """An online instance already occupies the slot for this publish+stage."""
+
+
+# Binding statuses that indicate the slot is still occupied and a recreate
+# must NOT proceed — doing so would leave a second online row in baas_device.
+_OCCUPIED_STATUSES = frozenset({
+    DeviceBindingStatus.ACTIVE,
+    DeviceBindingStatus.FAILED,
+})
+
+
+def check_existing_online_instance(
+    publish_service,
+    publish_id: int,
+    stage: PublishStage,
+) -> None:
+    """Check whether an occupied online instance exists for the given publish+stage.
+
+    Resolves the publish record's ext, finds the binding for *stage*, and
+    inspects the device binding's ``status``. If the status is ACTIVE or FAILED
+    the slot is still occupied and a ``DuplicateOnlineInstanceError`` is raised.
+
+    A RELEASED binding means the slot is free — restart is allowed.
+
+    This function is read-only and side-effect-free (easy to unit test).
+
+    At-least-once safety: the guard re-reads the current binding status on
+    each call. If a FAILED binding transitions to RELEASED between the
+    ``restart_bot`` guard check and the ``execute_restart`` guard check
+    (e.g. during a durable task redelivery), the guard correctly passes
+    because the slot is genuinely free. No duplicate is created.
+
+    Args:
+        publish_service: The publish service used to look up records.
+        publish_id: The publish record ID.
+        stage: The publish stage to check.
+
+    Raises:
+        DuplicateOnlineInstanceError: When the binding status is ACTIVE or FAILED,
+            meaning an online instance still occupies the slot.
+    """
+    record = publish_service.get_publish_by_id(publish_id)
+    if record is None:
+        return
+
+    ext = record.ext if isinstance(record.ext, dict) else (record.ext or {})
+    binding_id = (ext.get("binding") or {}).get(stage.value)
+    if not binding_id:
+        return
+
+    binding = publish_service.get_device_binding_by_id(binding_id)
+    if binding is None:
+        return
+
+    if binding.status in _OCCUPIED_STATUSES:
+        raise DuplicateOnlineInstanceError(
+            f"An online instance already exists for publish {publish_id} "
+            f"at stage {stage.value} (binding_id={binding_id}, "
+            f"status={binding.status}). Please clean up the existing "
+            f"instance before restarting."
+        )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -62,6 +62,16 @@ class RestartMixin:
         if error is not None:
             return error
 
+        # Guard: refuse restart when an online instance already exists for this publish
+        if stage == PublishStage.ONLINE:
+            guard_result = self._check_online_instance_guard(
+                publish_id=publish_id,
+                stage=stage,
+                log_prefix="restart_bot",
+            )
+            if guard_result is not None:
+                return guard_result
+
         # (#197) Enqueue the DURABLE restart task instead of a fire-and-forget
         # asyncio task. The handler re-resolves and runs the re-deploy through the
         # operation runner (crash-safe, idempotent).
@@ -88,6 +98,39 @@ class RestartMixin:
             "stage": stage.value,
             "bot_uuid": bot_uuid,
         }
+
+    def _check_online_instance_guard(
+        self,
+        publish_id: int,
+        stage: PublishStage,
+        log_prefix: str,
+    ):
+        """Check for an existing occupied online instance; return error dict
+        or None. Shared by ``restart_bot`` and ``execute_restart`` to avoid
+        duplicating the guard logic at both insertion points."""
+        from agentclaw.community.core.service_bot.services.publish_flow.online_instance_guard import (
+            check_existing_online_instance,
+            DuplicateOnlineInstanceError,
+        )
+        try:
+            check_existing_online_instance(
+                publish_service=self._publish_service,
+                publish_id=publish_id,
+                stage=stage,
+            )
+        except DuplicateOnlineInstanceError as exc:
+            logger.warning(
+                "[PublishFlowService.%s] rejecting: "
+                "existing online instance: publish_id=%s stage=%s detail=%s",
+                log_prefix, publish_id, stage.value, exc,
+            )
+            return {
+                "success": False,
+                "message": str(exc),
+                "error_code": "duplicate_online_instance",
+                "stage": stage.value,
+            }
+        return None
 
     def _resolve_restart_request(self, publish_id: int):
         """Validate + resolve a restart request from ``publish_id``.
@@ -281,6 +324,15 @@ class RestartMixin:
                 bot_gone_reason="BOT_NOT_FOUND -> recreate",
             )
         except TargetBotGoneError:
+            # Guard: before recreating, check for existing online instance
+            if stage_enum == PublishStage.ONLINE:
+                guard_result = self._check_online_instance_guard(
+                    publish_id=publish_id,
+                    stage=stage_enum,
+                    log_prefix="execute_restart",
+                )
+                if guard_result is not None:
+                    return guard_result
             logger.warning(
                 "[PublishFlowService.execute_restart] target bot not found, "
                 "recreating via first release: publish_id=%s bot_uuid=%s stage=%s",

--- a/src/backend/tests/community/core/service_bot/services/test_online_instance_guard.py
+++ b/src/backend/tests/community/core/service_bot/services/test_online_instance_guard.py
@@ -1,0 +1,167 @@
+"""Unit tests for online_instance_guard — the duplicate-online-instance check."""
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
+from agentclaw.community.core.service_bot.services.publish_flow.online_instance_guard import (
+    check_existing_online_instance,
+    DuplicateOnlineInstanceError,
+)
+from agentclaw.community.core.service_bot.types import PublishStage
+
+
+def _make_record(ext=None, **kwargs):
+    from datetime import datetime
+    from agentclaw.community.core.service_bot.repository.models import PublishStatus
+    data = dict(
+        id=kwargs.get('id', 1),
+        source_bot_pk=kwargs.get('source_bot_pk', 11),
+        source_bot_id=kwargs.get('source_bot_id', 'bot-source'),
+        publish_bot_id=kwargs.get('publish_bot_id', 'bot-pub-1'),
+        name=kwargs.get('name', 'demo'),
+        description=kwargs.get('description', 'desc'),
+        owner_id=kwargs.get('owner_id', 'u1'),
+        owner_name=kwargs.get('owner_name', 'user1'),
+        status=kwargs.get('status', PublishStatus.SUCCESS.value),
+        version=kwargs.get('version', 1),
+        last_pub_id=kwargs.get('last_pub_id', 0),
+        env=kwargs.get('env', 'dev'),
+        ext=ext if ext is not None else {},
+        permission_owner=kwargs.get('permission_owner', 'u1'),
+        gmt_create=kwargs.get('gmt_create', datetime.now()),
+        gmt_modified=kwargs.get('gmt_modified', datetime.now()),
+    )
+    return BotPublishRecord(**data)
+
+
+def test_check_passes_when_no_binding():
+    """No binding for stage -- passes without error."""
+    publish_service = Mock()
+    record = _make_record(ext={})
+    publish_service.get_publish_by_id.return_value = record
+
+    # Should not raise
+    check_existing_online_instance(
+        publish_service=publish_service,
+        publish_id=1,
+        stage=PublishStage.ONLINE,
+    )
+
+    # get_device_binding_by_id is never called when there is no binding_id
+    publish_service.get_device_binding_by_id.assert_not_called()
+
+
+def test_check_passes_when_binding_has_released_status():
+    """Binding exists but status is RELEASED -- slot is free, passes without error."""
+    publish_service = Mock()
+    record = _make_record(ext={"binding": {"online": 42}})
+    publish_service.get_publish_by_id.return_value = record
+    binding = Mock(status=DeviceBindingStatus.RELEASED)
+    publish_service.get_device_binding_by_id.return_value = binding
+
+    # Should not raise -- RELEASED means the slot is free
+    check_existing_online_instance(
+        publish_service=publish_service,
+        publish_id=1,
+        stage=PublishStage.ONLINE,
+    )
+
+    publish_service.get_device_binding_by_id.assert_called_once_with(42)
+
+
+def test_check_raises_when_binding_has_active_status():
+    """Binding has ACTIVE status -- raises DuplicateOnlineInstanceError."""
+    publish_service = Mock()
+    record = _make_record(ext={"binding": {"online": 42}})
+    publish_service.get_publish_by_id.return_value = record
+    binding = Mock(status=DeviceBindingStatus.ACTIVE)
+    publish_service.get_device_binding_by_id.return_value = binding
+
+    with pytest.raises(DuplicateOnlineInstanceError):
+        check_existing_online_instance(
+            publish_service=publish_service,
+            publish_id=1,
+            stage=PublishStage.ONLINE,
+        )
+
+
+def test_check_raises_when_binding_has_failed_status():
+    """Binding has FAILED status -- raises DuplicateOnlineInstanceError.
+
+    This is the core bug scenario: a FAILED online bot still occupies the slot,
+    and recreating would produce duplicate baas_device rows.
+    """
+    publish_service = Mock()
+    record = _make_record(ext={"binding": {"online": 42}})
+    publish_service.get_publish_by_id.return_value = record
+    binding = Mock(status=DeviceBindingStatus.FAILED)
+    publish_service.get_device_binding_by_id.return_value = binding
+
+    with pytest.raises(DuplicateOnlineInstanceError):
+        check_existing_online_instance(
+            publish_service=publish_service,
+            publish_id=1,
+            stage=PublishStage.ONLINE,
+        )
+
+
+def test_check_raises_message_includes_publish_id_and_stage():
+    """Error message contains publish_id and stage for debugging."""
+    publish_service = Mock()
+    record = _make_record(ext={"binding": {"online": 42}})
+    publish_service.get_publish_by_id.return_value = record
+    binding = Mock(status=DeviceBindingStatus.ACTIVE)
+    publish_service.get_device_binding_by_id.return_value = binding
+
+    with pytest.raises(DuplicateOnlineInstanceError, match=r"publish 1.*stage online"):
+        check_existing_online_instance(
+            publish_service=publish_service,
+            publish_id=1,
+            stage=PublishStage.ONLINE,
+        )
+
+
+def test_check_passes_when_record_not_found():
+    """Publish record not found -- passes without error (no record to guard)."""
+    publish_service = Mock()
+    publish_service.get_publish_by_id.return_value = None
+
+    check_existing_online_instance(
+        publish_service=publish_service,
+        publish_id=999,
+        stage=PublishStage.ONLINE,
+    )
+
+    publish_service.get_device_binding_by_id.assert_not_called()
+
+
+def test_check_passes_when_binding_not_found():
+    """Binding record not found -- passes without error."""
+    publish_service = Mock()
+    record = _make_record(ext={"binding": {"online": 42}})
+    publish_service.get_publish_by_id.return_value = record
+    publish_service.get_device_binding_by_id.return_value = None
+
+    check_existing_online_instance(
+        publish_service=publish_service,
+        publish_id=1,
+        stage=PublishStage.ONLINE,
+    )
+
+
+def test_check_passes_when_binding_has_stopped_status():
+    """Binding with STOPPED status -- not in occupied set, passes."""
+    publish_service = Mock()
+    record = _make_record(ext={"binding": {"online": 42}})
+    publish_service.get_publish_by_id.return_value = record
+    binding = Mock(status=DeviceBindingStatus.STOPPED)
+    publish_service.get_device_binding_by_id.return_value = binding
+
+    # STOPPED is not in _OCCUPIED_STATUSES, so check passes
+    check_existing_online_instance(
+        publish_service=publish_service,
+        publish_id=1,
+        stage=PublishStage.ONLINE,
+    )

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -18,6 +18,7 @@ from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
     PROGRESS_POLL_TASK,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.operation_runner import (
+    TargetBotGoneError,
     operation_request_id,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
@@ -3462,3 +3463,102 @@ async def test_retry_from_built_source_enqueues_verify_flow():
     tq.enqueue.assert_called_once()
     assert tq.enqueue.call_args.args[0] == "service_bot.publish.verify_flow"
     assert result.action == "process"
+
+
+# ── Online instance guard integration tests ─────────────────────────────────
+
+
+def test_restart_bot_rejects_when_online_instance_exists():
+    """restart_bot returns error dict when guard detects existing online instance."""
+    from agentclaw.community.core.devices.models import DeviceBindingStatus
+    from agentclaw.community.core.service_bot.services.publish_flow.online_instance_guard import (
+        DuplicateOnlineInstanceError,
+    )
+
+    publish_service = Mock()
+    record = _make_publish_record(
+        status=PublishStatus.SUCCESS.value,
+        ext={"binding": {"online": 42}, "migration_path": "/m"},
+    )
+    publish_service.get_publish_by_id.return_value = record
+    binding = Mock(device_id="BOT-x", status=DeviceBindingStatus.ACTIVE)
+    publish_service.get_device_binding_by_id.return_value = binding
+    svc = _pf(publish_service, Mock(), Mock(), Mock(), _arca_router())
+    svc._bot_service.get_bot = Mock(return_value={"bot_id": "bot-source"})
+
+    # Patch the guard to raise, simulating an occupied online slot.
+    import agentclaw.community.core.service_bot.services.publish_flow.online_instance_guard as guard_mod
+    original_check = guard_mod.check_existing_online_instance
+
+    def _raising_check(publish_service, publish_id, stage):
+        raise DuplicateOnlineInstanceError(
+            f"An online instance already exists for publish {publish_id} "
+            f"at stage {stage.value}. Please clean up the existing instance "
+            f"before restarting."
+        )
+
+    guard_mod.check_existing_online_instance = _raising_check
+    try:
+        result = svc.restart_bot(publish_id=1, operator="op")
+    finally:
+        guard_mod.check_existing_online_instance = original_check
+
+    assert result["success"] is False
+    assert result["error_code"] == "duplicate_online_instance"
+    assert result["stage"] == PublishStage.ONLINE.value
+    assert "online instance already exists" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_execute_restart_blocks_recreate_when_online_instance_exists():
+    """The recreate path in execute_restart is blocked by the online instance guard."""
+    from agentclaw.community.core.devices.models import DeviceBindingStatus
+    from agentclaw.community.core.service_bot.services.publish_flow.online_instance_guard import (
+        DuplicateOnlineInstanceError,
+    )
+
+    publish_service = Mock()
+    build_service = Mock()
+    # upgrade_async triggers BOT_NOT_FOUND -> recreate path
+    build_service.upgrade_async = AsyncMock(
+        side_effect=TargetBotGoneError("BOT_NOT_FOUND -> recreate"),
+    )
+    build_service.release_async = AsyncMock()
+    svc = _pf(
+        publish_service, build_service, Mock(), Mock(), _arca_router(build_service)
+    )
+
+    artifact = {"schema_version": 2, "skills": []}
+    record = _make_publish_record(
+        status=PublishStatus.SUCCESS.value,
+        ext={"binding": {"online": 1}, "config_artifact": artifact},
+    )
+    # Binding has ACTIVE status, meaning the slot is occupied
+    binding = Mock(device_id="BOT-x", status=DeviceBindingStatus.ACTIVE)
+    _setup_restart(svc, record, bot_uuid="BOT-x")
+    # Override the binding mock set by _setup_restart to carry ACTIVE status
+    svc._publish_service.get_device_binding_by_id.return_value = binding
+
+    # Patch the guard to raise
+    import agentclaw.community.core.service_bot.services.publish_flow.online_instance_guard as guard_mod
+    original_check = guard_mod.check_existing_online_instance
+
+    def _raising_check(publish_service, publish_id, stage):
+        raise DuplicateOnlineInstanceError(
+            f"An online instance already exists for publish {publish_id} "
+            f"at stage {stage.value}. Please clean up the existing instance "
+            f"before restarting."
+        )
+
+    guard_mod.check_existing_online_instance = _raising_check
+    try:
+        result = await svc.execute_restart(publish_id=1, stage="online", operator="op")
+    finally:
+        guard_mod.check_existing_online_instance = original_check
+
+    assert result["success"] is False
+    assert result["error_code"] == "duplicate_online_instance"
+    assert result["stage"] == "online"
+    assert "online instance already exists" in result["message"]
+    # The recreate must NOT have been called
+    build_service.release_async.assert_not_awaited()

--- a/src/backend/tests/community/core/service_bot/services/test_restart_online_guard.py
+++ b/src/backend/tests/community/core/service_bot/services/test_restart_online_guard.py
@@ -1,0 +1,511 @@
+"""Tests for the online-instance guard in the restart flow.
+
+When a FAILED or ACTIVE online binding already occupies the slot,
+restart_bot and execute_restart must reject the request (error_code
+``duplicate_online_instance``) instead of creating a duplicate online
+row in baas_device via _recreate_restart_target.
+"""
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.service_bot.repository.models import (
+    BotPublishRecord,
+    PublishStatus,
+)
+from agentclaw.community.core.service_bot.services.publish_flow.online_instance_guard import (
+    DuplicateOnlineInstanceError,
+    check_existing_online_instance,
+)
+from agentclaw.community.core.service_bot.services.publish_flow_service import (
+    PublishFlowService,
+)
+from agentclaw.community.core.service_bot.services.publish_flow.operation_runner import (
+    TargetBotGoneError,
+)
+from agentclaw.community.core.service_bot.types import PublishStage
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_publish_flow_service.py)
+# ---------------------------------------------------------------------------
+
+def _make_publish_record(**kwargs):
+    from datetime import datetime
+
+    data = dict(
+        id=kwargs.get("id", 1),
+        source_bot_pk=kwargs.get("source_bot_pk", 11),
+        source_bot_id=kwargs.get("source_bot_id", "bot-source"),
+        publish_bot_id=kwargs.get("publish_bot_id", "bot-pub-1"),
+        name=kwargs.get("name", "demo"),
+        description=kwargs.get("description", "desc"),
+        owner_id=kwargs.get("owner_id", "u1"),
+        owner_name=kwargs.get("owner_name", "user1"),
+        status=kwargs.get("status", PublishStatus.VALIDATING.value),
+        version=kwargs.get("version", 1),
+        last_pub_id=kwargs.get("last_pub_id", 0),
+        env=kwargs.get("env", "dev"),
+        ext=kwargs.get("ext", {}),
+        permission_owner=kwargs.get("permission_owner", "u1"),
+        gmt_create=kwargs.get("gmt_create", datetime.now()),
+        gmt_modified=kwargs.get("gmt_modified", datetime.now()),
+    )
+    return BotPublishRecord(**data)
+
+
+def _arca_router(build_service=None):
+    from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
+        ArcaSnapshotProducer,
+    )
+    from agentclaw.community.core.service_bot.services.deploy.producer import (
+        DeployArtifactProducerRouter,
+    )
+
+    skills_builder = Mock()
+    skills_builder.capture.return_value = None
+    arca = ArcaSnapshotProducer(build_service or Mock(), skills_builder)
+    return DeployArtifactProducerRouter(
+        providers={"arca": arca, "baas": arca}, default_provider_key="baas"
+    )
+
+
+def _pf(*args, **kw):
+    """Construct PublishFlowService for tests."""
+    from contextlib import contextmanager
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from agentclaw.community.core.base import Base
+    from agentclaw.community.core.service_bot.repository.models import (  # noqa: F401
+        PublishOperationModel,
+    )
+    from agentclaw.community.plugins.publish_operation_repository import (
+        OrmPublishOperationRepository as PublishOperationRepository,
+    )
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+
+    class _DB:
+        def __init__(self, e):
+            self._f = sessionmaker(bind=e, autoflush=False)
+
+        @contextmanager
+        def orm_session(self):
+            db = self._f()
+            try:
+                yield db
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
+            finally:
+                db.close()
+
+    kw.setdefault("common_config_service", Mock())
+    kw.setdefault("task_queue_service", Mock())
+    kw.setdefault("resolver", Mock())
+    kw.setdefault("device_fs_dispatcher", Mock())
+    kw.setdefault("teclaw_file_promotion", Mock())
+    kw.setdefault("device_binding_repo", Mock())
+    kw.setdefault("publish_operation_repo", PublishOperationRepository(_DB(engine)))
+    baas = args[2] if len(args) >= 3 else kw.get("baas_service")
+    if isinstance(baas, Mock):
+        baas.list_bot_publishes.return_value = []
+    if "channel_overrides_reader" not in kw:
+        reader = Mock()
+        reader.overrides_for_stage.return_value = {}
+        kw["channel_overrides_reader"] = reader
+    return PublishFlowService(*args, **kw)
+
+
+def _svc_with_record(record, *, build_service=None, baas_service=None,
+                     bot_service=None, task_queue_service=None):
+    """PublishFlowService whose publish_service.get_publish_by_id returns `record`."""
+    publish_service = Mock()
+    publish_service.get_publish_by_id.return_value = record
+    build_service = build_service or Mock()
+    kw = {}
+    if task_queue_service is not None:
+        kw["task_queue_service"] = task_queue_service
+    svc = _pf(
+        publish_service,
+        build_service,
+        baas_service or Mock(),
+        bot_service or Mock(),
+        _arca_router(build_service),
+        **kw,
+    )
+    return svc, publish_service
+
+
+def _binding_mock(device_id="BOT-x", status=DeviceBindingStatus.ACTIVE):
+    """Create a Mock binding with the specified status."""
+    return Mock(device_id=device_id, status=status)
+
+
+def _setup_restart(svc, record, bot_uuid="BOT-x"):
+    """Wire the resolution mocks execute_restart re-reads from publish_id."""
+    svc._publish_service.get_publish_by_id = Mock(return_value=record)
+    svc._publish_service.get_device_binding_by_id = Mock(
+        return_value=Mock(device_id=bot_uuid)
+    )
+    svc._bot_service.get_bot = Mock(return_value={"bot_id": "b", "entity_id": "u"})
+    svc._mutate_and_update_ext = Mock()
+    svc.refresh_publish_handle = Mock()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for check_existing_online_instance
+# ---------------------------------------------------------------------------
+
+class TestCheckExistingOnlineInstance:
+    """Unit tests for the standalone guard function."""
+
+    def test_raises_when_binding_active(self):
+        publish_service = Mock()
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 42}},
+        )
+        publish_service.get_publish_by_id.return_value = record
+        publish_service.get_device_binding_by_id.return_value = _binding_mock(
+            status=DeviceBindingStatus.ACTIVE,
+        )
+
+        with pytest.raises(DuplicateOnlineInstanceError) as exc_info:
+            check_existing_online_instance(publish_service, 1, PublishStage.ONLINE)
+
+        assert "duplicate" in str(exc_info.value).lower() or "already exists" in str(exc_info.value).lower()
+
+    def test_raises_when_binding_failed(self):
+        publish_service = Mock()
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 42}},
+        )
+        publish_service.get_publish_by_id.return_value = record
+        publish_service.get_device_binding_by_id.return_value = _binding_mock(
+            status=DeviceBindingStatus.FAILED,
+        )
+
+        with pytest.raises(DuplicateOnlineInstanceError):
+            check_existing_online_instance(publish_service, 1, PublishStage.ONLINE)
+
+    def test_passes_when_binding_released(self):
+        publish_service = Mock()
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 42}},
+        )
+        publish_service.get_publish_by_id.return_value = record
+        publish_service.get_device_binding_by_id.return_value = _binding_mock(
+            status=DeviceBindingStatus.RELEASED,
+        )
+
+        # Should not raise
+        check_existing_online_instance(publish_service, 1, PublishStage.ONLINE)
+
+    def test_passes_when_no_record(self):
+        publish_service = Mock()
+        publish_service.get_publish_by_id.return_value = None
+
+        # Should not raise
+        check_existing_online_instance(publish_service, 1, PublishStage.ONLINE)
+
+    def test_passes_when_no_binding_id_in_ext(self):
+        publish_service = Mock()
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={},
+        )
+        publish_service.get_publish_by_id.return_value = record
+
+        # Should not raise
+        check_existing_online_instance(publish_service, 1, PublishStage.ONLINE)
+
+    def test_passes_when_binding_not_found(self):
+        publish_service = Mock()
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 42}},
+        )
+        publish_service.get_publish_by_id.return_value = record
+        publish_service.get_device_binding_by_id.return_value = None
+
+        # Should not raise
+        check_existing_online_instance(publish_service, 1, PublishStage.ONLINE)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: restart_bot guard
+# ---------------------------------------------------------------------------
+
+class TestRestartBotOnlineGuard:
+    """Guard in restart_bot rejects duplicate online instances before enqueue."""
+
+    def test_reject_restart_when_online_binding_active(self):
+        """ONLINE stage, binding status=ACTIVE -> restart_bot returns
+        success=False, error_code=duplicate_online_instance."""
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 42}, "migration_path": "/m"},
+        )
+        svc, publish_service = _svc_with_record(record)
+        publish_service.get_device_binding_by_id.return_value = _binding_mock(
+            device_id="BOT-x",
+            status=DeviceBindingStatus.ACTIVE,
+        )
+        svc._bot_service.get_bot = Mock(return_value={"bot_id": "bot-source"})
+        svc._task_queue_service = Mock()
+
+        result = svc.restart_bot(publish_id=1, operator="op")
+
+        assert result["success"] is False
+        assert result["error_code"] == "duplicate_online_instance"
+        # Must NOT have enqueued a restart task
+        svc._task_queue_service.enqueue.assert_not_called()
+
+    def test_reject_restart_when_online_binding_failed(self):
+        """ONLINE stage, binding status=FAILED -> restart_bot returns
+        success=False, error_code=duplicate_online_instance."""
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 42}, "migration_path": "/m"},
+        )
+        svc, publish_service = _svc_with_record(record)
+        publish_service.get_device_binding_by_id.return_value = _binding_mock(
+            device_id="BOT-x",
+            status=DeviceBindingStatus.FAILED,
+        )
+        svc._bot_service.get_bot = Mock(return_value={"bot_id": "bot-source"})
+        svc._task_queue_service = Mock()
+
+        result = svc.restart_bot(publish_id=1, operator="op")
+
+        assert result["success"] is False
+        assert result["error_code"] == "duplicate_online_instance"
+        svc._task_queue_service.enqueue.assert_not_called()
+
+    def test_allow_restart_when_online_binding_released(self):
+        """ONLINE stage, binding status=RELEASED -> restart proceeds (enqueue called)."""
+        from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
+            RESTART_TASK,
+        )
+
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 42}, "migration_path": "/m"},
+        )
+        svc, publish_service = _svc_with_record(record)
+        publish_service.get_device_binding_by_id.return_value = _binding_mock(
+            device_id="BOT-x",
+            status=DeviceBindingStatus.RELEASED,
+        )
+        svc._bot_service.get_bot = Mock(return_value={"bot_id": "bot-source"})
+        svc._task_queue_service = Mock()
+
+        result = svc.restart_bot(publish_id=1, operator="op")
+
+        assert result["success"] is True
+        assert result["stage"] == PublishStage.ONLINE.value
+        svc._task_queue_service.enqueue.assert_called_once()
+        assert svc._task_queue_service.enqueue.call_args.args[0] == RESTART_TASK
+
+    def test_allow_restart_when_verify_stage_binding_active(self):
+        """VERIFY stage, binding status=ACTIVE -> restart proceeds (guard only
+        applies to ONLINE stage)."""
+        from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
+            RESTART_TASK,
+        )
+
+        record = _make_publish_record(
+            status=PublishStatus.VALIDATING.value,
+            ext={"binding": {"verify": 7}, "migration_path": "/m"},
+        )
+        svc, publish_service = _svc_with_record(record)
+        publish_service.get_device_binding_by_id.return_value = _binding_mock(
+            device_id="BOT-v",
+            status=DeviceBindingStatus.ACTIVE,
+        )
+        svc._bot_service.get_bot = Mock(return_value={"bot_id": "bot-source"})
+        svc._task_queue_service = Mock()
+
+        result = svc.restart_bot(publish_id=1, operator="op")
+
+        assert result["success"] is True
+        assert result["stage"] == PublishStage.VERIFY.value
+        svc._task_queue_service.enqueue.assert_called_once()
+        assert svc._task_queue_service.enqueue.call_args.args[0] == RESTART_TASK
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: execute_restart guard (recreate path)
+# ---------------------------------------------------------------------------
+
+_ACQUIRE_PATH = (
+    "agentclaw.community.core.service_bot.services.publish_flow."
+    "restart_mixin.acquire_deploy_workflow"
+)
+
+
+class TestExecuteRestartOnlineGuard:
+    """Guard in execute_restart prevents _recreate_restart_target when an
+    ACTIVE or FAILED online binding still occupies the slot."""
+
+    @pytest.mark.asyncio
+    async def test_execute_restart_rejects_recreate_when_binding_failed(self):
+        """execute_restart catches TargetBotGoneError but binding is FAILED ->
+        returns error, does NOT call _recreate_restart_target."""
+        build_service = Mock()
+        build_service.upgrade_async = AsyncMock(
+            side_effect=TargetBotGoneError("BOT_NOT_FOUND -> recreate"),
+        )
+        build_service.release_async = AsyncMock()
+        publish_service = Mock()
+        publish_service.create_device_binding.return_value = 55
+
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 1}, "migration_path": "/m"},
+        )
+        svc = _pf(
+            publish_service, build_service, Mock(), Mock(),
+            _arca_router(build_service),
+        )
+        _setup_restart(svc, record, bot_uuid="BOT-gone")
+        # Override binding mock with FAILED status for the guard check
+        svc._publish_service.get_device_binding_by_id = Mock(
+            return_value=_binding_mock(
+                device_id="BOT-gone", status=DeviceBindingStatus.FAILED,
+            )
+        )
+        svc._finalize_dangling_recreate_op = Mock(return_value=None)
+
+        result = await svc.execute_restart(
+            publish_id=1, stage="online", operator="op",
+        )
+
+        assert result["success"] is False
+        assert result["error_code"] == "duplicate_online_instance"
+        # _recreate_restart_target must NOT have been called
+        build_service.release_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_restart_rejects_recreate_when_binding_active(self):
+        """execute_restart catches TargetBotGoneError but binding is ACTIVE ->
+        returns error, does NOT call _recreate_restart_target."""
+        build_service = Mock()
+        build_service.upgrade_async = AsyncMock(
+            side_effect=TargetBotGoneError("BOT_NOT_FOUND -> recreate"),
+        )
+        build_service.release_async = AsyncMock()
+        publish_service = Mock()
+        publish_service.create_device_binding.return_value = 55
+
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 1}, "migration_path": "/m"},
+        )
+        svc = _pf(
+            publish_service, build_service, Mock(), Mock(),
+            _arca_router(build_service),
+        )
+        _setup_restart(svc, record, bot_uuid="BOT-gone")
+        svc._publish_service.get_device_binding_by_id = Mock(
+            return_value=_binding_mock(
+                device_id="BOT-gone", status=DeviceBindingStatus.ACTIVE,
+            )
+        )
+        svc._finalize_dangling_recreate_op = Mock(return_value=None)
+
+        with patch(_ACQUIRE_PATH, side_effect=TargetBotGoneError("BOT_NOT_FOUND -> recreate")):
+            result = await svc.execute_restart(
+                publish_id=1, stage="online", operator="op",
+            )
+
+        assert result["success"] is False
+        assert result["error_code"] == "duplicate_online_instance"
+        build_service.release_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_restart_allows_recreate_when_binding_released(self):
+        """execute_restart catches TargetBotGoneError and binding is RELEASED ->
+        proceeds with _recreate_restart_target."""
+        build_service = Mock()
+        build_service.upgrade_async = AsyncMock(
+            side_effect=TargetBotGoneError("BOT_NOT_FOUND -> recreate"),
+        )
+        build_service.release_async = AsyncMock(
+            return_value={"publish_id": 99, "bot_uuid": "BOT-recreated"}
+        )
+        publish_service = Mock()
+        publish_service.create_device_binding.return_value = 55
+
+        record = _make_publish_record(
+            status=PublishStatus.SUCCESS.value,
+            ext={"binding": {"online": 1}, "migration_path": "/m"},
+        )
+        svc = _pf(
+            publish_service, build_service, Mock(), Mock(),
+            _arca_router(build_service),
+        )
+        _setup_restart(svc, record, bot_uuid="BOT-gone")
+        svc._publish_service.get_device_binding_by_id = Mock(
+            return_value=_binding_mock(
+                device_id="BOT-gone", status=DeviceBindingStatus.RELEASED,
+            )
+        )
+        svc._finalize_dangling_recreate_op = Mock(return_value=None)
+
+        result = await svc.execute_restart(
+            publish_id=1, stage="online", operator="op",
+        )
+
+        assert result["success"] is True
+        build_service.release_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_restart_verify_stage_allows_recreate_when_binding_active(self):
+        """VERIFY stage: the guard does not apply, so TargetBotGoneError
+        proceeds to recreate even when binding is ACTIVE."""
+        build_service = Mock()
+        build_service.upgrade_async = AsyncMock(
+            side_effect=TargetBotGoneError("BOT_NOT_FOUND -> recreate"),
+        )
+        build_service.release_async = AsyncMock(
+            return_value={"publish_id": 98, "bot_uuid": "BOT-v-recreated"}
+        )
+        publish_service = Mock()
+        publish_service.create_device_binding.return_value = 55
+
+        record = _make_publish_record(
+            status=PublishStatus.VALIDATING.value,
+            ext={"binding": {"verify": 1}, "migration_path": "/m"},
+        )
+        svc = _pf(
+            publish_service, build_service, Mock(), Mock(),
+            _arca_router(build_service),
+        )
+        _setup_restart(svc, record, bot_uuid="BOT-v")
+        svc._publish_service.get_device_binding_by_id = Mock(
+            return_value=_binding_mock(
+                device_id="BOT-v", status=DeviceBindingStatus.ACTIVE,
+            )
+        )
+        svc._finalize_dangling_recreate_op = Mock(return_value=None)
+
+        result = await svc.execute_restart(
+            publish_id=1, stage="verify", operator="op",
+        )
+
+        assert result["success"] is True
+        build_service.release_async.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes a production bug where `restart_for_others` creates duplicate online-instance dirty data when a FAILED online service bot exists.

## Root Cause

When `execute_restart` catches `TargetBotGoneError` (BaaS reports BOT_NOT_FOUND for a FAILED bot), it falls through to `_recreate_restart_target` which creates a brand-new `FIRST_RELEASE` with a new bot + binding + device **without checking whether an existing ACTIVE or FAILED binding already occupies the online slot**. This results in duplicate `baas_device` online rows.

## Fix

- Added `online_instance_guard.py` module with `check_existing_online_instance()` that checks binding status
- Guard in `restart_bot`: when stage=ONLINE and binding status is ACTIVE/FAILED, reject with `duplicate_online_instance` error code
- Guard in `execute_restart`: before `_recreate_restart_target`, same check
- RELEASED bindings allow restart (slot is free)
- VERIFY stage is unaffected

## Testing

- 8 unit tests for the guard module
- 14 integration tests covering both `restart_bot` and `execute_restart` paths
- 2 additional tests in existing `test_publish_flow_service.py`
- All 45 tests pass, no regression in existing 23 restart tests