### PR TITLE
fix(bcs): correct spelling of dependency directory name

### DIFF
--- a/scripts/run_bcs_mixed_provider.sh
+++ b/scripts/run_bcs_mixed_provider.sh
@@ -21,7 +21,7 @@ BCS_DIR="${PROJECT_ROOT}/src/bcs"
 BCS_CLI="${BCS_DIR}/target/debug/bcs-cli"
 BRIDGE="${PROJECT_ROOT}/src/bcs/scripts/mock_provider_bridge.py"
 SINGLEBOX="${SCRIPT_DIR}/singlebox.sh"
-DEP_DIR="${SCRIPT_DIR}/.dependences"
+DEP_DIR="${SCRIPT_DIR}/.dependencies"
 LOG_DIR="${DEP_DIR}/logs"
 STATE_DIR="${DEP_DIR}/mixed_provider"
 

--- a/src/backend/tests/community/acceptance/conftest.py
+++ b/src/backend/tests/community/acceptance/conftest.py
@@ -186,7 +186,7 @@ def live_baas():
         if not _wait_for_baas_healthy():
             raise RuntimeError(
                 f"baas not healthy within {BAAS_HEALTH_TIMEOUT_SEC}s; "
-                f"check scripts/.dependences/logs/baas.log"
+                f"check scripts/.dependencies/logs/baas.log"
             )
         yield BAAS_URL
         return
@@ -215,7 +215,7 @@ def live_baas():
         if not _wait_for_baas_healthy():
             raise RuntimeError(
                 f"baas not healthy within {BAAS_HEALTH_TIMEOUT_SEC}s; "
-                f"check scripts/.dependences/logs/baas.log"
+                f"check scripts/.dependencies/logs/baas.log"
             )
         yield BAAS_URL
     finally:

--- a/src/bcsfuse/src/infra/logging/__init__.py
+++ b/src/bcsfuse/src/infra/logging/__init__.py
@@ -24,7 +24,7 @@ DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - [%(process)d] - [%(pr
 DEFAULT_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 # 日志文件路径（与 local_setup.sh 一致）
-DEFAULT_LOG_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "scripts" / ".dependences" / "logs"
+DEFAULT_LOG_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "scripts" / ".dependencies" / "logs"
 LOG_FILE = DEFAULT_LOG_DIR / "bcsfuse_app.log"
 
 # 确保日志目录存在

--- a/src/bcsfuse/src/infra/logging/logging_config.py
+++ b/src/bcsfuse/src/infra/logging/logging_config.py
@@ -182,7 +182,7 @@ def configure_logging(
             file_path = (
                 Path(__file__).parent.parent.parent.parent.parent.parent
                 / "scripts"
-                / ".dependences"
+                / ".dependencies"
                 / "logs"
                 / "bcsfuse.log"
             )


### PR DESCRIPTION
# What changed
- 代码配置中同时存在.dependences、.dependencies目录配置，将 `.dependences` 统一改为 `.dependencies`
- 更新相关日志路径和脚本引用