### PR TITLE
feat: consume template factory config for coding bots

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/capabilities.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/capabilities.py
@@ -7,6 +7,20 @@ nodes default to false and legacy template_type fallbacks must not be mixed in.
 from typing import Any, Dict, Optional
 
 
+TEMPLATE_FACTORY_MARKER_KEYS = frozenset({
+    "template_key",
+    "template_uid",
+    "template_version_id",
+    "template_version",
+})
+
+
+def is_template_factory_config(template_config: Optional[Dict[str, Any]]) -> bool:
+    return isinstance(template_config, dict) and any(
+        key in template_config for key in TEMPLATE_FACTORY_MARKER_KEYS
+    )
+
+
 def has_declared_capabilities(template_config: Optional[Dict[str, Any]]) -> bool:
     return isinstance(template_config, dict) and "capabilities" in template_config
 

--- a/src/backend/src/agentclaw/community/core/bot_management/capabilities.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/capabilities.py
@@ -18,7 +18,30 @@ def _capabilities(template_config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     return capabilities if isinstance(capabilities, dict) else {}
 
 
+def _bool_capability(
+    capabilities: Dict[str, Any],
+    flat_key: str,
+    nested_key: str,
+    nested_value_key: str,
+) -> bool:
+    flat_value = capabilities.get(flat_key)
+    if isinstance(flat_value, bool):
+        return flat_value
+
+    nested_value = capabilities.get(nested_key)
+    if isinstance(nested_value, bool):
+        return nested_value
+    if isinstance(nested_value, dict):
+        return bool(nested_value.get(nested_value_key))
+
+    return False
+
+
 def can_join_bcn_as_provider(template_config: Optional[Dict[str, Any]]) -> bool:
     capabilities = _capabilities(template_config)
-    bcn = capabilities.get("bcn")
-    return isinstance(bcn, dict) and bool(bcn.get("join_as_provider"))
+    return _bool_capability(
+        capabilities,
+        "enable_bcn_network",
+        "bcn",
+        "join_as_provider",
+    )

--- a/src/backend/src/agentclaw/community/core/bot_management/capabilities.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/capabilities.py
@@ -1,0 +1,24 @@
+"""Helpers for consuming template-factory capability snapshots.
+
+AC template factory resolved snapshots may declare ``template_config.capabilities``.
+When this key is present it is the only truth source for capability gates: missing
+nodes default to false and legacy template_type fallbacks must not be mixed in.
+"""
+from typing import Any, Dict, Optional
+
+
+def has_declared_capabilities(template_config: Optional[Dict[str, Any]]) -> bool:
+    return isinstance(template_config, dict) and "capabilities" in template_config
+
+
+def _capabilities(template_config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(template_config, dict):
+        return {}
+    capabilities = template_config.get("capabilities")
+    return capabilities if isinstance(capabilities, dict) else {}
+
+
+def can_join_bcn_as_provider(template_config: Optional[Dict[str, Any]]) -> bool:
+    capabilities = _capabilities(template_config)
+    bcn = capabilities.get("bcn")
+    return isinstance(bcn, dict) and bool(bcn.get("join_as_provider"))

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/__init__.py
@@ -3,11 +3,9 @@
 from .strategy import (
     AicodingProvisioningStrategy,
     CODING_TEMPLATE_TYPES,
-    TEMPLATE_CONFIG_CONSUMING_TYPES,
 )
 
 __all__ = [
     "AicodingProvisioningStrategy",
     "CODING_TEMPLATE_TYPES",
-    "TEMPLATE_CONFIG_CONSUMING_TYPES",
 ]

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/__init__.py
@@ -1,5 +1,13 @@
 """AICoding provisioning strategy."""
 
-from .strategy import AicodingProvisioningStrategy, CODING_TEMPLATE_TYPES
+from .strategy import (
+    AicodingProvisioningStrategy,
+    CODING_TEMPLATE_TYPES,
+    TEMPLATE_CONFIG_CONSUMING_TYPES,
+)
 
-__all__ = ["AicodingProvisioningStrategy", "CODING_TEMPLATE_TYPES"]
+__all__ = [
+    "AicodingProvisioningStrategy",
+    "CODING_TEMPLATE_TYPES",
+    "TEMPLATE_CONFIG_CONSUMING_TYPES",
+]

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -7,13 +7,22 @@ services.
 from __future__ import annotations
 
 import json
-from typing import Dict
+from typing import Any, Dict
+
+from agentclaw.community.core.bot_management.capabilities import (
+    is_template_factory_config,
+)
 
 from ..provisioning import BotProvisioningContext, EngineProvisioningStrategy
 
 
+# Legacy coding template types.  This is only used for old call sites that
+# identify coding bots by template_type (applicationCoding/personalCoding).
+# Template-factory templates (normalCC/architect/user-created templates) must be
+# detected from active_engine + template_config snapshot, not by extending this
+# set with template keys.
 CODING_TEMPLATE_TYPES = frozenset({"applicationCoding", "personalCoding"})
-TEMPLATE_CONFIG_CONSUMING_TYPES = CODING_TEMPLATE_TYPES | frozenset({"normalCC", "architect"})
+TEMPLATE_CONFIG_CONSUMING_ENGINES = frozenset({"aicoding", "claude_code"})
 BOT_TYPE_ENV_MAP = {
     "personalCoding": "personal",
     "applicationCoding": "application",
@@ -34,16 +43,36 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
     def is_coding_template(template_type: str | None) -> bool:
         return template_type in CODING_TEMPLATE_TYPES
 
-    @staticmethod
-    def consumes_template_config(template_type: str | None) -> bool:
-        return template_type in TEMPLATE_CONFIG_CONSUMING_TYPES
+    has_template_factory_config = staticmethod(is_template_factory_config)
+
+    @classmethod
+    def consumes_template_config(
+        cls,
+        template_type: str | None,
+        *,
+        active_engine: str | None = None,
+        template_config: dict[str, Any] | None = None,
+    ) -> bool:
+        # Keep historical/built-in template types working even where legacy call
+        # sites only know template_type.  For user-created AC templates, do not
+        # require backend enum updates: as long as the bot is a coding engine and
+        # carries a template-factory config snapshot, consume it.
+        if template_type in CODING_TEMPLATE_TYPES:
+            return True
+        return (
+            active_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES
+            and cls.has_template_factory_config(template_config)
+        )
 
     def build_extra_envs(self, ctx: BotProvisioningContext) -> Dict[str, str] | None:
         template_type = ctx.template_type
-        if not self.consumes_template_config(template_type):
-            return None
-
         template_config = ctx.template_config or {}
+        if not self.consumes_template_config(
+            template_type,
+            active_engine=ctx.active_engine,
+            template_config=template_config,
+        ):
+            return None
         envs: Dict[str, str] = {}
 
         bot_type = BOT_TYPE_ENV_MAP.get(template_type or "")
@@ -60,20 +89,18 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         if aix_devflow_info:
             envs["AIX_DEVFLOW_INFO"] = aix_devflow_info
 
+        legacy_repo_keys = {"backend_repo", "frontend_repo", "lib_repo"}
+        repo_keys = list(legacy_repo_keys)
+        if is_template_factory_config(template_config):
+            repo_keys.extend(["repos", "init_repos", "application_repo_urls"])
+
         repo_list: list[str] = []
-        for repo_key in (
-            "backend_repo",
-            "frontend_repo",
-            "lib_repo",
-            "repos",
-            "init_repos",
-            "application_repo_urls",
-        ):
+        for repo_key in repo_keys:
             repos = template_config.get(repo_key)
             if not isinstance(repos, list):
                 continue
             for repo in repos:
-                if isinstance(repo, str) and repo.strip():
+                if isinstance(repo, str) and repo_key not in legacy_repo_keys and repo.strip():
                     repo_list.append(repo.strip())
                 elif isinstance(repo, dict):
                     for url_key in ("repo_url", "url", "git_url", "ssh_url"):
@@ -97,10 +124,18 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         return envs or None
 
     def should_encrypt_template_token(self, ctx: BotProvisioningContext) -> bool:
-        return self.consumes_template_config(ctx.template_type)
+        return self.consumes_template_config(
+            ctx.template_type,
+            active_engine=ctx.active_engine,
+            template_config=ctx.template_config,
+        )
 
     def extract_runtime_token(self, ctx: BotProvisioningContext) -> str | None:
-        if not self.consumes_template_config(ctx.template_type):
+        if not self.consumes_template_config(
+            ctx.template_type,
+            active_engine=ctx.active_engine,
+            template_config=ctx.template_config,
+        ):
             return None
         token = (ctx.template_config or {}).get("token")
         return token if isinstance(token, str) and token else None

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -89,7 +89,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         if aix_devflow_info:
             envs["AIX_DEVFLOW_INFO"] = aix_devflow_info
 
-        legacy_repo_keys = {"backend_repo", "frontend_repo", "lib_repo"}
+        legacy_repo_keys = ("backend_repo", "frontend_repo", "lib_repo")
         repo_keys = list(legacy_repo_keys)
         if is_template_factory_config(template_config):
             repo_keys.extend(["repos", "init_repos", "application_repo_urls"])

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -13,6 +13,7 @@ from ..provisioning import BotProvisioningContext, EngineProvisioningStrategy
 
 
 CODING_TEMPLATE_TYPES = frozenset({"applicationCoding", "personalCoding"})
+TEMPLATE_CONFIG_CONSUMING_TYPES = CODING_TEMPLATE_TYPES | frozenset({"normalCC", "architect"})
 BOT_TYPE_ENV_MAP = {
     "personalCoding": "personal",
     "applicationCoding": "application",
@@ -33,9 +34,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
     def is_coding_template(template_type: str | None) -> bool:
         return template_type in CODING_TEMPLATE_TYPES
 
+    @staticmethod
+    def consumes_template_config(template_type: str | None) -> bool:
+        return template_type in TEMPLATE_CONFIG_CONSUMING_TYPES
+
     def build_extra_envs(self, ctx: BotProvisioningContext) -> Dict[str, str] | None:
         template_type = ctx.template_type
-        if not self.is_coding_template(template_type):
+        if not self.consumes_template_config(template_type):
             return None
 
         template_config = ctx.template_config or {}
@@ -56,20 +61,32 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             envs["AIX_DEVFLOW_INFO"] = aix_devflow_info
 
         repo_list: list[str] = []
-        for repo_key in ("backend_repo", "frontend_repo", "lib_repo"):
+        for repo_key in (
+            "backend_repo",
+            "frontend_repo",
+            "lib_repo",
+            "repos",
+            "init_repos",
+            "application_repo_urls",
+        ):
             repos = template_config.get(repo_key)
             if not isinstance(repos, list):
                 continue
             for repo in repos:
-                if isinstance(repo, dict):
-                    repo_url = repo.get("repo_url")
-                    if repo_url:
-                        repo_list.append(repo_url)
+                if isinstance(repo, str) and repo.strip():
+                    repo_list.append(repo.strip())
+                elif isinstance(repo, dict):
+                    for url_key in ("repo_url", "url", "git_url", "ssh_url"):
+                        repo_url = repo.get(url_key)
+                        if isinstance(repo_url, str) and repo_url.strip():
+                            repo_list.append(repo_url.strip())
+                            break
         if repo_list:
             envs["GIT_ADDRESSES"] = json.dumps(repo_list, ensure_ascii=False)
 
         # Bug-fix semantics: both applicationCoding and personalCoding may set
-        # relay default model/runtime.  Non-coding templates are rejected above.
+        # relay default model/runtime.  Template-factory normalCC/architect bots
+        # reuse the same runtime configuration consumption via template_config.
         model = template_config.get("model")
         if isinstance(model, str) and model.strip():
             envs["RELAY_DEFAULT_MODEL"] = model.strip()
@@ -80,10 +97,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         return envs or None
 
     def should_encrypt_template_token(self, ctx: BotProvisioningContext) -> bool:
-        return self.is_coding_template(ctx.template_type)
+        return self.consumes_template_config(ctx.template_type)
 
     def extract_runtime_token(self, ctx: BotProvisioningContext) -> str | None:
-        if not self.is_coding_template(ctx.template_type):
+        if not self.consumes_template_config(ctx.template_type):
             return None
         token = (ctx.template_config or {}).get("token")
         return token if isinstance(token, str) and token else None

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .aicoding.strategy import AicodingProvisioningStrategy, CODING_TEMPLATE_TYPES
+from .aicoding.strategy import (
+    AicodingProvisioningStrategy,
+    TEMPLATE_CONFIG_CONSUMING_TYPES,
+)
 from .default import DefaultProvisioningStrategy
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
 
@@ -41,13 +44,15 @@ class EngineProvisioningRegistry:
         Prefer ``active_engine``.  If older call sites only pass
         ``template_type``, route known coding templates to the coding strategy
         so historical TemplateService signatures keep working while keeping the
-        rule in one place.  An explicit (non-empty) engine always wins over a
-        coding ``template_type``, so dirty data such as ``openclaw`` +
+        rule in one place.  Template-factory normalCC/architect templates also
+        route here so TemplateService can apply the same token policy when it
+        only receives template_type.  An explicit (non-empty) engine always wins
+        over a coding ``template_type``, so dirty data such as ``openclaw`` +
         ``personalCoding`` does not accidentally get AICoding provisioning.
         """
         if ctx.active_engine:
             return self.resolve(ctx.active_engine)
-        if ctx.template_type in CODING_TEMPLATE_TYPES:
+        if ctx.template_type in TEMPLATE_CONFIG_CONSUMING_TYPES:
             return self.resolve("aicoding")
         return self._default
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .aicoding.strategy import (
-    AicodingProvisioningStrategy,
-    TEMPLATE_CONFIG_CONSUMING_TYPES,
-)
+from .aicoding.strategy import AicodingProvisioningStrategy, CODING_TEMPLATE_TYPES
 from .default import DefaultProvisioningStrategy
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
 
@@ -42,17 +39,18 @@ class EngineProvisioningRegistry:
         """Resolve a strategy for legacy call sites with partial metadata.
 
         Prefer ``active_engine``.  If older call sites only pass
-        ``template_type``, route known coding templates to the coding strategy
-        so historical TemplateService signatures keep working while keeping the
-        rule in one place.  Template-factory normalCC/architect templates also
-        route here so TemplateService can apply the same token policy when it
-        only receives template_type.  An explicit (non-empty) engine always wins
-        over a coding ``template_type``, so dirty data such as ``openclaw`` +
-        ``personalCoding`` does not accidentally get AICoding provisioning.
+        ``template_type``, route known legacy coding templates to the coding
+        strategy so historical TemplateService signatures keep working while
+        keeping the rule in one place.  Template-factory templates should be
+        detected from active_engine + template_config at the strategy layer; do
+        not infer them here from template keys or engine_config lists.  An
+        explicit (non-empty) engine always wins over a coding ``template_type``,
+        so dirty data such as ``openclaw`` + ``personalCoding`` does not
+        accidentally get AICoding provisioning.
         """
         if ctx.active_engine:
             return self.resolve(ctx.active_engine)
-        if ctx.template_type in TEMPLATE_CONFIG_CONSUMING_TYPES:
+        if ctx.template_type in CODING_TEMPLATE_TYPES:
             return self.resolve("aicoding")
         return self._default
 

--- a/src/backend/src/agentclaw/community/core/bot_management/repository/template_repository_protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/repository/template_repository_protocol.py
@@ -71,6 +71,17 @@ class TemplateRepository(Protocol):
         """
         ...
 
+    def list_by_bot_ids(self, bot_ids: List[str]) -> List[Dict[str, Any]]:
+        """List templates by bot IDs.
+
+        Args:
+            bot_ids: Bot IDs
+
+        Returns:
+            List of template records
+        """
+        ...
+
     def list_by_architect_bot_id(self, architect_bot_id: str) -> List[Dict[str, Any]]:
         """List templates whose ext JSON contains the given architect_bot_id.
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -1778,6 +1778,47 @@ class BotService:
 
         return coding_bots
 
+    def _attach_template_configs_to_bots(self, items: List[Dict[str, Any]]) -> None:
+        """Attach ac_templates.ext as template_config for bot list items in batch.
+
+        create/get/update paths store template details in ac_templates.ext while
+        list repository methods read only ac_bots fields.  Keep list APIs
+        consistent with get_bot() by enriching template-backed bots here.
+        Best-effort: template lookup failure must not break bot lists.
+        """
+        if not items:
+            return
+
+        bot_ids = list(dict.fromkeys(
+            str(bot.get("bot_id"))
+            for bot in items
+            if bot.get("bot_id") and bot.get("template_type")
+        ))
+        if not bot_ids:
+            return
+
+        try:
+            templates = self._template_service.list_templates_by_bot_ids(bot_ids)
+            ext_by_bot_id = {
+                str(template.get("bot_id")): template.get("ext")
+                for template in templates
+                if template.get("bot_id") and template.get("ext") is not None
+            }
+            if not ext_by_bot_id:
+                return
+            for bot in items:
+                bot_id = bot.get("bot_id")
+                if bot_id is None:
+                    continue
+                ext = ext_by_bot_id.get(str(bot_id))
+                if ext is not None:
+                    bot["template_config"] = ext
+        except Exception as e:
+            logger.warning(
+                "[bot_service._attach_template_configs_to_bots] Failed to attach template configs: %s",
+                e, exc_info=True,
+            )
+
     def list_bots(
         self,
         entity_id: Optional[str] = None,
@@ -1807,6 +1848,7 @@ class BotService:
         # Note: Device binding info is stored in ac_entity_device_binding table
         # To avoid N+1 queries, we don't fetch binding info for list operations
         # Use get_bot() to get detailed info including device_binding
+        self._attach_template_configs_to_bots(items)
 
         return {
             "total": total,
@@ -1844,6 +1886,7 @@ class BotService:
             page=page,
             page_size=page_size,
         )
+        self._attach_template_configs_to_bots(items)
         return {
             "total": total,
             "items": items,
@@ -1869,6 +1912,7 @@ class BotService:
             Dictionary with 'total' and 'items' keys
         """
         total, items = self._repository.list_by_search(public=public, search=search, page=page, page_size=page_size)
+        self._attach_template_configs_to_bots(items)
         return {"total": total, "items": items}
 
     def list_domain_bots(
@@ -1975,6 +2019,8 @@ class BotService:
         except Exception as e:
             logger.warning(f"[bot_service.search_bots] Failed to add can_delete_bot/can_upgrade_publish: {e}")
 
+        self._attach_template_configs_to_bots(items)
+
         return {
             "total": total,
             "items": items,
@@ -2029,6 +2075,8 @@ class BotService:
         except Exception as e:
             logger.warning(f"[bot_service.list_bots_by_owner] Failed to add can_edit_bot: {e}")
 
+        self._attach_template_configs_to_bots(items)
+
         return {
             "total": total,
             "items": items,
@@ -2068,6 +2116,7 @@ class BotService:
 
         # List reads use the persisted status. Live desktop status is reconciled
         # outside this request path so a slow BaaS cannot delay first paint.
+        self._attach_template_configs_to_bots(items)
 
         return {
             "total": total,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -18,6 +18,7 @@ from typing import Callable, Optional, Dict, Any, List, Tuple, TYPE_CHECKING
 from agentclaw.community.core.bot_management.capabilities import (
     can_join_bcn_as_provider,
     has_declared_capabilities,
+    is_template_factory_config,
 )
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.bot_management.services.aicoding.workspace_hosting_service import WorkspaceHostingService
@@ -448,15 +449,23 @@ class BotService:
     ) -> bool:
         """Whether to reuse the AppCoding memory/Wiki initialization path.
 
-        New template-factory normalCC/architect bots consume business Wiki /
-        RepoWiki through the same AppCoding runtime pipeline, but the source of
-        truth is AC resolved ``template_config``.  Keep applicationCoding legacy
-        behavior on create, and let normalCC/architect trigger only when their
-        template snapshot actually declares repo/wiki sources.
+        Template-factory bots consume business Wiki / RepoWiki through the same
+        AppCoding runtime pipeline, but the source of truth is AC resolved
+        ``template_config``.  Keep applicationCoding legacy behavior on create,
+        and let template-factory bots trigger only when their template snapshot
+        actually declares repo/wiki sources.
         """
         if active_engine != "claude_code" or not isinstance(template_config, dict):
             return False
-        if template_type not in ("applicationCoding", "normalCC", "architect"):
+
+        # Legacy applicationCoding keeps the original always-init-on-create
+        # behavior.  Template-factory bots (normalCC / architect / user-created)
+        # are detected from the resolved template snapshot instead of a backend
+        # template_type whitelist, and only initialize memory when repo/wiki
+        # sources are declared.
+        is_legacy_application_coding = template_type == "applicationCoding"
+        is_template_factory_bot = is_template_factory_config(template_config)
+        if not is_legacy_application_coding and not is_template_factory_bot:
             return False
 
         try:
@@ -467,7 +476,7 @@ class BotService:
             empty_config: Dict[str, Any] = {}
             has_sources = memory_sources_changed(empty_config, template_config)
             if on_create:
-                return template_type == "applicationCoding" or has_sources
+                return is_legacy_application_coding or has_sources
             return memory_sources_changed(old_template_config or empty_config, template_config)
         except Exception as e:
             logger.warning(
@@ -1171,6 +1180,7 @@ class BotService:
                         bot_id=bot_id,
                         template_config=template_config,
                         template_type=template_type,
+                        active_engine=resolved_active_engine,
                     )
                     logger.info(f"[bot_service.create_bot] Template created for bot {bot_id}")
                 except Exception as e:
@@ -2251,6 +2261,7 @@ class BotService:
                         bot_id=bot_id,
                         template_config=template_config,
                         template_type=bot.get("template_type"),
+                        active_engine=bot.get("active_engine"),
                     )
                 else:
                     # Create new template (this should not normally happen in update)
@@ -2259,6 +2270,7 @@ class BotService:
                         bot_id=bot_id,
                         template_config=template_config,
                         template_type=bot.get("template_type"),
+                        active_engine=bot.get("active_engine"),
                     )
                 logger.info(f"[bot_service.update_bot] Template updated for bot {bot_id}")
 
@@ -2634,12 +2646,14 @@ class BotService:
                     bot_id=bot_id,
                     template_config=merged_config,
                     template_type=bot.get("template_type"),
+                    active_engine=bot.get("active_engine"),
                 )
             else:
                 self._template_service.create_template(
                     bot_id=bot_id,
                     template_config=merged_config,
                     template_type=bot.get("template_type"),
+                    active_engine=bot.get("active_engine"),
                 )
             logger.info("[bot_service.admin_update_bot] Template updated for bot %s by admin", bot_id)
 
@@ -2730,7 +2744,7 @@ class BotService:
         缺失能力节点按 False，不再混用 legacy template_type fallback。旧 Bot 没有
         capabilities 时继续保留历史逻辑。
         """
-        if has_declared_capabilities(template_config):
+        if is_template_factory_config(template_config) and has_declared_capabilities(template_config):
             return can_join_bcn_as_provider(template_config)
 
         is_coding_personal = (

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -15,6 +15,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional, Dict, Any, List, Tuple, TYPE_CHECKING
 
+from agentclaw.community.core.bot_management.capabilities import (
+    can_join_bcn_as_provider,
+    has_declared_capabilities,
+)
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.bot_management.services.aicoding.workspace_hosting_service import WorkspaceHostingService
 from agentclaw.community.core.desktop_bot.device_status_client import DeviceStatusClient
@@ -432,6 +436,48 @@ class BotService:
                 e,
             )
             return None
+
+    @staticmethod
+    def _should_trigger_memory_initialization(
+        *,
+        active_engine: "str | None",
+        template_type: "str | None",
+        template_config: "Optional[Dict[str, Any]]",
+        old_template_config: "Optional[Dict[str, Any]]" = None,
+        on_create: bool = False,
+    ) -> bool:
+        """Whether to reuse the AppCoding memory/Wiki initialization path.
+
+        New template-factory normalCC/architect bots consume business Wiki /
+        RepoWiki through the same AppCoding runtime pipeline, but the source of
+        truth is AC resolved ``template_config``.  Keep applicationCoding legacy
+        behavior on create, and let normalCC/architect trigger only when their
+        template snapshot actually declares repo/wiki sources.
+        """
+        if active_engine != "claude_code" or not isinstance(template_config, dict):
+            return False
+        if template_type not in ("applicationCoding", "normalCC", "architect"):
+            return False
+
+        try:
+            from agentclaw.community.core.bot_management.utils import (
+                memory_sources_changed,
+            )
+
+            empty_config: Dict[str, Any] = {}
+            has_sources = memory_sources_changed(empty_config, template_config)
+            if on_create:
+                return template_type == "applicationCoding" or has_sources
+            return memory_sources_changed(old_template_config or empty_config, template_config)
+        except Exception as e:
+            logger.warning(
+                "[bot_service.memory_init] source detection failed: "
+                "template_type=%s active_engine=%s error=%s",
+                template_type,
+                active_engine,
+                e,
+            )
+            return template_type == "applicationCoding" and on_create
 
     def _attach_template_uid_context(
         self,
@@ -1271,6 +1317,7 @@ class BotService:
                     active_engine=resolved_active_engine,
                     bot_type=resolved_bot_type,
                     template_type=template_type,
+                    template_config=template_config,
                 )
                 if should_register_bcn:
                     logger.info(
@@ -1341,11 +1388,18 @@ class BotService:
                 if template_config and template_type:
                     bot_record["template_config"] = template_config
 
-                # 对于 applicationCoding 类型且使用 claude_code 引擎的 bot，触发 memory 初始化
-                if template_type == "applicationCoding" and resolved_active_engine == "claude_code":
+                # applicationCoding 保留原 memory 初始化；新通用 CC / 架构师 Bot
+                # 的业务知识库、Wiki、RepoWiki 复用同一链路，但从
+                # template_config resolved 快照检测配置来源。
+                if self._should_trigger_memory_initialization(
+                    active_engine=resolved_active_engine,
+                    template_type=template_type,
+                    template_config=template_config,
+                    on_create=True,
+                ):
                     logger.info(
                         f"[bot_service.create_bot] Triggering memory initialization for "
-                        f"applicationCoding bot {bot_id}"
+                        f"template-backed bot {bot_id}, template_type={template_type}"
                     )
                     from agentclaw.community.core.bot_management.utils import trigger_memory_initialization
 
@@ -2193,13 +2247,13 @@ class BotService:
                 bot_active_engine = bot.get("active_engine")
                 from agentclaw.community.core.bot_management.utils import (
                     trigger_memory_initialization,
-                    memory_sources_changed,
                 )
 
-                if (
-                    bot_template_type == "applicationCoding"
-                    and bot_active_engine == "claude_code"
-                    and memory_sources_changed(old_template_config, template_config)
+                if self._should_trigger_memory_initialization(
+                    active_engine=bot_active_engine,
+                    template_type=bot_template_type,
+                    template_config=template_config,
+                    old_template_config=old_template_config,
                 ):
                     logger.info(
                         f"[bot_service.update_bot] memory sources changed for bot {bot_id}, "
@@ -2619,8 +2673,17 @@ class BotService:
         active_engine: Optional[str],
         bot_type: Optional[str],
         template_type: Optional[str],
+        template_config: Optional[Dict[str, Any]] = None,
     ) -> bool:
-        """统一 create / start 注册 BCN Provider 的触发条件."""
+        """统一 create / start 注册 BCN Provider 的触发条件.
+
+        如果 AC 模板工厂快照显式声明 capabilities，则 capabilities 是唯一事实源；
+        缺失能力节点按 False，不再混用 legacy template_type fallback。旧 Bot 没有
+        capabilities 时继续保留历史逻辑。
+        """
+        if has_declared_capabilities(template_config):
+            return can_join_bcn_as_provider(template_config)
+
         is_coding_personal = (
             active_engine in ("claude_code", "aicoding")
             and template_type == "personalCoding"
@@ -3354,6 +3417,14 @@ class BotService:
         resolved_nick_name = nick_name or user_id
         bot_owner_id = bot.get("owner_id") or user_id
 
+        try:
+            resolved_template_config = self._template_service.get_template_config(bot_id)
+        except Exception as e:
+            logger.warning(
+                f"[bot_service.start_bot] Failed to get template config for bot {bot_id}: {e}"
+            )
+            resolved_template_config = None
+
         # 启动前先在 BCN 注册为 Provider bot (下行链路).
         # 触发条件:
         #   - active_engine == "claude_code" 且 template_type == "normalCC"
@@ -3367,6 +3438,7 @@ class BotService:
             active_engine=active_engine,
             bot_type=bot_type,
             template_type=template_type,
+            template_config=resolved_template_config,
         )
         if should_register_bcn:
             logger.info(
@@ -3698,12 +3770,23 @@ class BotService:
         bot_type = bot.get("bot_type") or "personal"
         bot_template_type = (bot.get("template_type") or "").strip()
 
+        # 先读取模板快照：BCN 能力门控与后续 BaaS restart 均使用同一份 resolved config。
+        try:
+            resolved_template_config = self._template_service.get_template_config(bot_id)
+        except Exception as e:
+            logger.warning(
+                "[bot_service._restart_bot_baas] Failed to get template for bot %s: %s",
+                bot_id, e,
+            )
+            resolved_template_config = None
+
         # BaaS 原地重启不会经过 start_bot，这里补齐启动链路的 BCN Provider 注册。
         # 注册接口幂等：已注册时直接返回，也能重试创建阶段失败的注册。
         if self._should_register_bcn_provider(
             active_engine=active_engine,
             bot_type=bot_type,
             template_type=bot_template_type,
+            template_config=resolved_template_config,
         ):
             logger.info(
                 "[bot_service._restart_bot_baas] register bot to BCN as provider: "
@@ -3730,17 +3813,7 @@ class BotService:
             else None
         )
 
-        # 仅用于解析 template_uuid（避免 BaasService 走默认模板覆盖当前引擎模板）。
-        # 解析失败仅记 warning：template_uuid 退化为 None，upgrade 走 BaaS 默认模板。
-        try:
-            resolved_template_config = self._template_service.get_template_config(bot_id)
-        except Exception as e:
-            logger.warning(
-                "[bot_service._restart_bot_baas] Failed to get template for bot %s: %s",
-                bot_id, e,
-            )
-            resolved_template_config = None
-
+        # resolved_template_config 已在 BCN 能力门控前读取，后续 BaaS restart 复用同一快照。
         # 与 _allocate_device_async（create / arca-restart 路径）同口径构造 extra_envs
         # 与 template_config，让 BaaS 原地重启也消费 BOT_TYPE / RELAY_DEFAULT_MODEL /
         # RELAY_DEFAULT_RUNTIME / AIX_DEVFLOW_INFO / GIT_ADDRESSES 及 sandbox overrides。

--- a/src/backend/src/agentclaw/community/core/bot_management/services/template_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/template_service.py
@@ -20,7 +20,7 @@ The repository is injected via constructor (DI), following the same pattern
 as BotService / BotRepository.
 """
 
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from injector import inject
 
@@ -201,6 +201,25 @@ class TemplateService:
                 bot_id, e, exc_info=True,
             )
             return None
+
+    def list_templates_by_bot_ids(self, bot_ids: List[str]) -> List[Dict[str, Any]]:
+        """List template records by bot IDs.
+
+        This is used by bot list APIs to attach ac_templates.ext as
+        template_config in batch, avoiding N+1 calls to get_template().
+        Failures are treated as non-fatal so list APIs can still return bots.
+        """
+        if not bot_ids:
+            return []
+
+        try:
+            return self._repository.list_by_bot_ids(bot_ids)
+        except Exception as e:
+            logger.error(
+                "[template_service.list_templates_by_bot_ids] Failed to list templates for %d bots: %s",
+                len(bot_ids), e, exc_info=True,
+            )
+            return []
 
     def get_template_config(
         self,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/template_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/template_service.py
@@ -93,7 +93,10 @@ class TemplateService:
             raise TemplateValidationError("Template ext content cannot be empty")
 
     def _encrypt_token_field(
-        self, template_config: Dict[str, Any], template_type: Optional[str]
+        self,
+        template_config: Dict[str, Any],
+        template_type: Optional[str],
+        active_engine: Optional[str] = None,
     ) -> Dict[str, Any]:
         """按引擎策略决定是否加密 token 字段。幂等。
 
@@ -108,7 +111,7 @@ class TemplateService:
             bot_id="",
             owner_id="",
             bot_type="",
-            active_engine=None,
+            active_engine=active_engine,
             template_type=template_type,
             template_config=template_config,
         )
@@ -124,6 +127,7 @@ class TemplateService:
         bot_id: str,
         template_config: Dict[str, Any],
         template_type: Optional[str] = None,
+        active_engine: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a new template record for a bot.
 
@@ -136,6 +140,8 @@ class TemplateService:
             template_config: Template configuration dictionary (stored in ext field)
             template_type: Optional template type gate; when the engine provisioning
                 strategy supports runtime tokens, ``token`` is encrypted before persist.
+            active_engine: Optional engine gate used for user-created AC templates
+                whose template_type is not known by this backend.
 
         Returns:
             Created template record
@@ -149,7 +155,9 @@ class TemplateService:
         try:
             # Validate ext content (template_config is stored in the ext field)
             self._validate_ext_content(template_config)
-            template_config = self._encrypt_token_field(template_config, template_type)
+            template_config = self._encrypt_token_field(
+                template_config, template_type, active_engine
+            )
 
             template_data = {
                 "bot_id": bot_id,
@@ -295,6 +303,7 @@ class TemplateService:
         bot_id: str,
         template_config: Dict[str, Any],
         template_type: Optional[str] = None,
+        active_engine: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Update template configuration for a bot.
 
@@ -321,7 +330,9 @@ class TemplateService:
         try:
             # Validate ext content (template_config is stored in the ext field)
             self._validate_ext_content(template_config)
-            template_config = self._encrypt_token_field(template_config, template_type)
+            template_config = self._encrypt_token_field(
+                template_config, template_type, active_engine
+            )
 
             # Check if template exists
             if not self.exists_template(bot_id):
@@ -460,6 +471,7 @@ class TemplateService:
         bot_id: str,
         template_config: Dict[str, Any],
         template_type: Optional[str] = None,
+        active_engine: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create or update template configuration for a bot.
 
@@ -493,14 +505,18 @@ class TemplateService:
                     "[template_service.create_or_update_template] Template exists, updating for bot %s",
                     bot_id,
                 )
-                return self.update_template(bot_id, template_config, template_type)
+                return self.update_template(
+                    bot_id, template_config, template_type, active_engine
+                )
             else:
                 # Create new template
                 logger.debug(
                     "[template_service.create_or_update_template] Template not found, creating for bot %s",
                     bot_id,
                 )
-                return self.create_template(bot_id, template_config, template_type)
+                return self.create_template(
+                    bot_id, template_config, template_type, active_engine
+                )
         except TemplateValidationError:
             logger.warning(
                 "[template_service.create_or_update_template] Validation error for bot %s",

--- a/src/backend/src/agentclaw/community/core/bot_management/utils.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/utils.py
@@ -160,6 +160,67 @@ def build_aix_extra_envs(
     )
     return strategy.build_extra_envs(ctx)
 
+
+YUQUE_KNOWLEDGE_KEYS = (
+    "yuque_kb_repos",
+    "wiki_knowledge_spaces",
+    "business_wiki_spaces",
+    "repo_wiki_spaces",
+)
+
+CODE_REPO_KEYS = (
+    "backend_repo",
+    "frontend_repo",
+    "lib_repo",
+    "repos",
+    "init_repos",
+    "application_repo_urls",
+)
+
+
+def _extract_item_url(item: Any, *, url_keys: tuple[str, ...]) -> str:
+    """Extract a URL-like value from either a string item or a dict item."""
+    if isinstance(item, str):
+        return item.strip()
+    if not isinstance(item, dict):
+        return ""
+    for key in url_keys:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _extract_item_token(item: Any) -> str:
+    """Extract the Yuque team token from known field names."""
+    if not isinstance(item, dict):
+        return ""
+    for key in ("token", "teamToken", "team_token"):
+        value = item.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _iter_template_list_items(
+    template_config: Dict[str, Any], keys: tuple[str, ...]
+) -> List[Any]:
+    """Iterate list values for top-level template_config keys.
+
+    AC resolved snapshots may expose the same AppCoding-compatible shape under
+    different semantic keys.  The backend runtime keeps using the existing
+    AppCoding consumers, so these helpers normalize aliases at the edge instead
+    of adding new hard-coded product branches in callers.
+    """
+    if not isinstance(template_config, dict):
+        return []
+    result: List[Any] = []
+    for key in keys:
+        value = template_config.get(key)
+        if isinstance(value, list):
+            result.extend(value)
+    return result
+
 def trigger_memory_initialization(
     bot_id: str,
     bot_name: str,
@@ -197,35 +258,20 @@ def trigger_memory_initialization(
             "userId": user_id,
         }
 
-        # Extract code repo URLs from template_config
-        code_repo_urls: List[str] = []
-        for repo_key in ["backend_repo", "frontend_repo", "lib_repo"]:
-            repos = template_config.get(repo_key, [])
-            if repos:
-                for repo in repos:
-                    repo_url = repo.get("repo_url")
-                    if repo_url:
-                        code_repo_urls.append(repo_url)
-
+        # Extract code repo URLs from template_config.  New template-factory
+        # bots reuse the AppCoding memory/knowledge pipeline but their resolved
+        # snapshots may carry repo aliases such as repos/init_repos.
+        code_repo_urls = _extract_code_repo_urls(template_config)
         if code_repo_urls:
             payload["codeRepoUrls"] = code_repo_urls
 
-        # Extract yuque URLs from template_config (yuque_kb_repos field)
-        # 每一项形如 {"url": ..., "teamToken": ...}，teamToken 取自 template_config 中的 token 字段
-        yuque_urls: List[Dict[str, str]] = []
-        yuque_kb_repos = template_config.get("yuque_kb_repos", [])
-        if yuque_kb_repos:
-            for item in yuque_kb_repos:
-                if not isinstance(item, dict):
-                    continue
-                url = item.get("url")
-                if not url:
-                    continue
-                yuque_urls.append(
-                    {"url": url, "teamToken": item.get("token") or ""}
-                )
-            if yuque_urls:
-                payload["yuqueUrls"] = yuque_urls
+        # Extract Yuque/Wiki URLs from AppCoding-compatible and semantic keys.
+        yuque_urls: List[Dict[str, str]] = [
+            {"url": url, "teamToken": token}
+            for url, token in _extract_yuque_pairs(template_config)
+        ]
+        if yuque_urls:
+            payload["yuqueUrls"] = yuque_urls
 
         # Call the memoryos init API with cookie (environment-dependent)
         current_env = get_current_env()
@@ -286,38 +332,41 @@ def trigger_memory_initialization(
 
 
 def _extract_yuque_pairs(template_config: Dict[str, Any]) -> List[tuple]:
-    """从 template_config.yuque_kb_repos 中提取 (url, token) 列表（已过滤空 url）。
+    """Extract (url, token) pairs from template_config knowledge fields.
 
-    token 缺省视为空字符串。用于变更检测，能同时捕获 url 与 teamToken 的变化。
+    Historical AppCoding bots use ``yuque_kb_repos``.  New template-factory bots
+    reuse the same memory/knowledge consumers but AC may resolve semantic keys
+    such as ``wiki_knowledge_spaces``, ``business_wiki_spaces`` or
+    ``repo_wiki_spaces``.  Treat all of them as AppCoding-compatible knowledge
+    sources at the backend edge.  Empty URLs are skipped; missing token is the
+    empty string so token changes still participate in diff detection.
     """
     if not isinstance(template_config, dict):
         return []
-    items = template_config.get("yuque_kb_repos") or []
-    if not isinstance(items, list):
-        return []
     pairs: List[tuple] = []
-    for item in items:
-        if isinstance(item, dict):
-            url = item.get("url")
-            if url:
-                pairs.append((url, item.get("token") or ""))
+    for item in _iter_template_list_items(template_config, YUQUE_KNOWLEDGE_KEYS):
+        # Preserve AppCoding compatibility: arbitrary non-dict list entries are
+        # ignored.  A direct string is only accepted if it is clearly a URL.
+        if isinstance(item, str) and not item.strip().startswith(("http://", "https://")):
+            continue
+        url = _extract_item_url(
+            item,
+            url_keys=("url", "wiki_url", "repo_wiki_url", "space_url", "link"),
+        )
+        if url:
+            pairs.append((url, _extract_item_token(item)))
     return pairs
 
 
 def _extract_code_repo_urls(template_config: Dict[str, Any]) -> List[str]:
-    """从 template_config 的 backend_repo/frontend_repo/lib_repo 中提取 repo_url 列表。"""
+    """Extract repository URLs from AppCoding and template-factory aliases."""
     if not isinstance(template_config, dict):
         return []
     urls: List[str] = []
-    for repo_key in ["backend_repo", "frontend_repo", "lib_repo"]:
-        repos = template_config.get(repo_key) or []
-        if not isinstance(repos, list):
-            continue
-        for repo in repos:
-            if isinstance(repo, dict):
-                repo_url = repo.get("repo_url")
-                if repo_url:
-                    urls.append(repo_url)
+    for item in _iter_template_list_items(template_config, CODE_REPO_KEYS):
+        url = _extract_item_url(item, url_keys=("repo_url", "url", "git_url", "ssh_url"))
+        if url:
+            urls.append(url)
     return urls
 
 

--- a/src/backend/src/agentclaw/community/core/bot_management/utils.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/utils.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 import requests
 
+from agentclaw.community.core.bot_management.capabilities import (
+    is_template_factory_config,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -161,17 +164,15 @@ def build_aix_extra_envs(
     return strategy.build_extra_envs(ctx)
 
 
-YUQUE_KNOWLEDGE_KEYS = (
-    "yuque_kb_repos",
+LEGACY_YUQUE_KNOWLEDGE_KEYS = ("yuque_kb_repos",)
+TEMPLATE_FACTORY_YUQUE_KNOWLEDGE_KEYS = (
     "wiki_knowledge_spaces",
     "business_wiki_spaces",
     "repo_wiki_spaces",
 )
 
-CODE_REPO_KEYS = (
-    "backend_repo",
-    "frontend_repo",
-    "lib_repo",
+LEGACY_CODE_REPO_KEYS = ("backend_repo", "frontend_repo", "lib_repo")
+TEMPLATE_FACTORY_CODE_REPO_KEYS = (
     "repos",
     "init_repos",
     "application_repo_urls",
@@ -344,17 +345,28 @@ def _extract_yuque_pairs(template_config: Dict[str, Any]) -> List[tuple]:
     if not isinstance(template_config, dict):
         return []
     pairs: List[tuple] = []
-    for item in _iter_template_list_items(template_config, YUQUE_KNOWLEDGE_KEYS):
-        # Preserve AppCoding compatibility: arbitrary non-dict list entries are
-        # ignored.  A direct string is only accepted if it is clearly a URL.
-        if isinstance(item, str) and not item.strip().startswith(("http://", "https://")):
+    keys = LEGACY_YUQUE_KNOWLEDGE_KEYS
+    if is_template_factory_config(template_config):
+        keys = keys + TEMPLATE_FACTORY_YUQUE_KNOWLEDGE_KEYS
+    for key in keys:
+        value = template_config.get(key)
+        if not isinstance(value, list):
             continue
-        url = _extract_item_url(
-            item,
-            url_keys=("url", "wiki_url", "repo_wiki_url", "space_url", "link"),
-        )
-        if url:
-            pairs.append((url, _extract_item_token(item)))
+        for item in value:
+            # Preserve AppCoding compatibility: legacy yuque_kb_repos only
+            # accepts object items.  Template-factory alias keys may use direct
+            # URL strings.
+            if isinstance(item, str):
+                if key in LEGACY_YUQUE_KNOWLEDGE_KEYS:
+                    continue
+                if not item.strip().startswith(("http://", "https://")):
+                    continue
+            url = _extract_item_url(
+                item,
+                url_keys=("url", "wiki_url", "repo_wiki_url", "space_url", "link"),
+            )
+            if url:
+                pairs.append((url, _extract_item_token(item)))
     return pairs
 
 
@@ -363,10 +375,23 @@ def _extract_code_repo_urls(template_config: Dict[str, Any]) -> List[str]:
     if not isinstance(template_config, dict):
         return []
     urls: List[str] = []
-    for item in _iter_template_list_items(template_config, CODE_REPO_KEYS):
-        url = _extract_item_url(item, url_keys=("repo_url", "url", "git_url", "ssh_url"))
-        if url:
-            urls.append(url)
+    keys = LEGACY_CODE_REPO_KEYS
+    if is_template_factory_config(template_config):
+        keys = keys + TEMPLATE_FACTORY_CODE_REPO_KEYS
+    for key in keys:
+        value = template_config.get(key)
+        if not isinstance(value, list):
+            continue
+        for item in value:
+            # Preserve AppCoding compatibility: legacy repo keys only accept
+            # object items.  Template-factory alias keys may use direct strings.
+            if isinstance(item, str) and key in LEGACY_CODE_REPO_KEYS:
+                continue
+            url = _extract_item_url(
+                item, url_keys=("repo_url", "url", "git_url", "ssh_url")
+            )
+            if url:
+                urls.append(url)
     return urls
 
 

--- a/src/backend/src/agentclaw/community/core/devices/services/sandbox_overrides.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/sandbox_overrides.py
@@ -45,8 +45,32 @@ class SandboxOverrides:
             return cls()
 
         image = tc.get("image")
+        if image is None:
+            raw_image_config = tc.get("image_config")
+            if isinstance(raw_image_config, dict):
+                # AC template-factory snapshots keep administrator-chosen
+                # image data under image_config.  Consume it at the device edge
+                # so TC frontend/BotService never hard-code architect CLI setup.
+                image = (
+                    raw_image_config.get("image")
+                    or raw_image_config.get("name")
+                    or raw_image_config.get("docker_image")
+                )
+                tag = raw_image_config.get("tag")
+                if (
+                    isinstance(image, str)
+                    and image.strip()
+                    and isinstance(tag, str)
+                    and tag.strip()
+                    and ":" not in image.rsplit("/", 1)[-1]
+                ):
+                    image = f"{image}:{tag}"
 
         raw_command = tc.get("command")
+        if raw_command is None:
+            raw_startup_config = tc.get("startup_config")
+            if isinstance(raw_startup_config, dict):
+                raw_command = raw_startup_config.get("command")
         command: Optional[str] = None
         if raw_command is not None:
             if isinstance(raw_command, list):

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/devices.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 from injector import Binder, Module, inject, provider, singleton
 
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.token_vault import TokenVault
 from agentclaw.community.core.devices.models import (
@@ -181,6 +182,7 @@ class SingleboxDevicesModule(Module):
         mcp_sync_service: MCPSyncService,
         token_vault: TokenVault,
         task_queue_service: TaskQueueService,
+        template_service: TemplateService,
     ) -> BaasDeviceService:
         """Keep BaaS lifecycle wiring while projecting local engine connections."""
         return SingleboxBaasDeviceService(
@@ -193,6 +195,7 @@ class SingleboxDevicesModule(Module):
             template_resolver=SystemConfigBaasTemplateResolver(system_config_service),
             vault=token_vault,
             task_queue_service=task_queue_service,
+            template_service=template_service,
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
@@ -15,6 +15,7 @@ from agentclaw.community.utils import env_utils
 logger = get_logger()
 
 _LOCAL_TEMPLATE_UID = "local_default"
+_TEMPLATE_UID_ALIASES = (_LOCAL_TEMPLATE_UID, "aicoding")
 _SUPPORTED_ENGINES = ("openclaw", "moltis", "hermes", "aicoding", "claude_code")
 
 
@@ -39,12 +40,41 @@ class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):
             config_key=BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
             env=env,
         )
-        if isinstance(existing, dict):
-            return
         if not self._template_uuid.startswith("TEMPLATE-"):
             raise RuntimeError(
                 "singlebox requires baas.template_uuid in TEMPLATE-* format"
             )
+        if isinstance(existing, dict):
+            templates = existing.get("templates")
+            if not isinstance(templates, dict):
+                templates = {}
+            missing_aliases = [
+                alias for alias in _TEMPLATE_UID_ALIASES if alias not in templates
+            ]
+            if not missing_aliases:
+                return
+            updated = dict(existing)
+            updated_templates = dict(templates)
+            for alias in missing_aliases:
+                updated_templates[alias] = {"template_uuid": self._template_uuid}
+            updated["templates"] = updated_templates
+            config_id = self._config_service.set_config(
+                category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+                config_key=BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
+                config_value=updated,
+                env=env,
+                description="Generated from the local deployment configuration",
+                operator="local-bootstrap",
+            )
+            if not config_id:
+                raise RuntimeError("failed to migrate local BaaS template mapping")
+            logger.info(
+                "Migrated local BaaS template mapping aliases: env=%s aliases=%s template_uuid=%s",
+                env,
+                missing_aliases,
+                self._template_uuid,
+            )
+            return
 
         self._config_service.create_category(
             category=BAAS_TEMPLATE_MAPPING_CATEGORY,
@@ -63,9 +93,10 @@ class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):
                     for engine in _SUPPORTED_ENGINES
                 ],
                 "templates": {
-                    _LOCAL_TEMPLATE_UID: {
+                    alias: {
                         "template_uuid": self._template_uuid,
                     }
+                    for alias in _TEMPLATE_UID_ALIASES
                 },
             },
             env=env,

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/template_config.py
@@ -47,7 +47,10 @@ class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):
         if isinstance(existing, dict):
             templates = existing.get("templates")
             if not isinstance(templates, dict):
-                templates = {}
+                return
+            local_template = templates.get(_LOCAL_TEMPLATE_UID)
+            if not isinstance(local_template, dict):
+                return
             missing_aliases = [
                 alias for alias in _TEMPLATE_UID_ALIASES if alias not in templates
             ]
@@ -56,7 +59,7 @@ class SingleboxBaasTemplateConfigLifecycle(LifecycleBase):
             updated = dict(existing)
             updated_templates = dict(templates)
             for alias in missing_aliases:
-                updated_templates[alias] = {"template_uuid": self._template_uuid}
+                updated_templates[alias] = dict(local_template)
             updated["templates"] = updated_templates
             config_id = self._config_service.set_config(
                 category=BAAS_TEMPLATE_MAPPING_CATEGORY,

--- a/src/backend/src/agentclaw/community/plugins/template_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/template_repository.py
@@ -128,6 +128,26 @@ class TemplateRepository:
             ).count()
             return count > 0
 
+    def list_by_bot_ids(self, bot_ids: List[str]) -> List[Dict[str, Any]]:
+        """List templates by bot IDs.
+
+        Used by bot list APIs to enrich list items with template_config without
+        issuing one template query per bot.
+        """
+        if not bot_ids:
+            return []
+
+        # Preserve only meaningful, unique IDs while keeping the IN clause small.
+        unique_bot_ids = list(dict.fromkeys(str(bot_id) for bot_id in bot_ids if bot_id))
+        if not unique_bot_ids:
+            return []
+
+        with self._db.orm_session() as db:
+            templates = db.query(TemplateModel).filter(
+                TemplateModel.bot_id.in_(unique_bot_ids)
+            ).all()
+            return [t.to_dict() for t in templates]
+
     def list_by_architect_bot_id(self, architect_bot_id: str) -> List[Dict[str, Any]]:
         """List templates whose ext JSON contains the given architect_bot_id.
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -674,3 +674,84 @@ class TestListBots:
         svc._repository.list_by_entity.assert_called_once_with(
             entity_id=None, entity_type=None, page=1, page_size=20,
         )
+
+
+class TestTemplateFactoryBranchCoverage:
+
+    def test_memory_initialization_update_compares_old_and_new_sources(self):
+        assert BotService._should_trigger_memory_initialization(
+            active_engine="claude_code",
+            template_type="normalCC",
+            template_config={
+                "template_key": "normalCC",
+                "business_wiki_spaces": [{"url": "https://yuque/new"}],
+            },
+            old_template_config={
+                "template_key": "normalCC",
+                "business_wiki_spaces": [{"url": "https://yuque/old"}],
+            },
+            on_create=False,
+        ) is True
+
+    def test_memory_initialization_detection_error_keeps_legacy_create_fallback(self):
+        with patch(
+            "agentclaw.community.core.bot_management.utils.memory_sources_changed",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert BotService._should_trigger_memory_initialization(
+                active_engine="claude_code",
+                template_type="applicationCoding",
+                template_config={"yuque_kb_repos": [{"url": "https://yuque/a"}]},
+                on_create=True,
+            ) is True
+            assert BotService._should_trigger_memory_initialization(
+                active_engine="claude_code",
+                template_type="normalCC",
+                template_config={"template_key": "normalCC"},
+                on_create=True,
+            ) is False
+
+    def test_attach_template_configs_to_bots_attaches_ext_and_skips_missing_bot_id(self):
+        svc = _make_service()
+        items = [
+            {"bot_id": "b1", "template_type": "normalCC"},
+            {"bot_id": None, "template_type": "normalCC"},
+        ]
+        svc._template_service.list_templates_by_bot_ids.return_value = [
+            {"bot_id": "b1", "ext": {"template_key": "normalCC"}},
+        ]
+
+        svc._attach_template_configs_to_bots(items)
+
+        svc._template_service.list_templates_by_bot_ids.assert_called_once_with(["b1"])
+        assert items[0]["template_config"] == {"template_key": "normalCC"}
+        assert "template_config" not in items[1]
+
+    def test_attach_template_configs_to_bots_swallows_template_service_failure(self):
+        svc = _make_service()
+        items = [{"bot_id": "b1", "template_type": "normalCC"}]
+        svc._template_service.list_templates_by_bot_ids.side_effect = RuntimeError("boom")
+
+        svc._attach_template_configs_to_bots(items)
+
+        assert items == [{"bot_id": "b1", "template_type": "normalCC"}]
+
+    def test_list_bots_by_conditions_returns_items_after_template_enrichment(self):
+        svc = _make_service()
+        items = [{"bot_id": "b1", "template_type": "normalCC"}]
+        svc._repository.list_by_conditions.return_value = (1, items)
+        svc._template_service.list_templates_by_bot_ids.return_value = [
+            {"bot_id": "b1", "ext": {"template_key": "normalCC"}},
+        ]
+
+        result = svc.list_bots_by_conditions(page=1, page_size=10)
+
+        assert result == {"total": 1, "items": items}
+        assert result["items"][0]["template_config"] == {"template_key": "normalCC"}
+
+    def test_aicoding_personal_coding_uses_legacy_bcn_provider_fallback(self):
+        assert BotService._should_register_bcn_provider(
+            active_engine="aicoding",
+            bot_type="personal",
+            template_type="personalCoding",
+        ) is True

--- a/src/backend/tests/community/core/bot_management/services/test_template_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_template_service.py
@@ -174,3 +174,30 @@ class TestTemplateService:
         }
         # Should not raise any exception
         template_service._validate_ext_content(ext_content)
+
+
+def _make_template_service_for_list_by_bot_ids():
+    repo = Mock()
+    return TemplateService(repository=repo, vault=TokenVault(master_key=""))
+
+
+def test_list_templates_by_bot_ids_empty_returns_empty():
+    template_service = _make_template_service_for_list_by_bot_ids()
+
+    assert template_service.list_templates_by_bot_ids([]) == []
+    template_service._repository.list_by_bot_ids.assert_not_called()
+
+
+def test_list_templates_by_bot_ids_delegates_to_repository():
+    template_service = _make_template_service_for_list_by_bot_ids()
+    template_service._repository.list_by_bot_ids.return_value = [{"bot_id": "b1", "ext": {}}]
+
+    assert template_service.list_templates_by_bot_ids(["b1"]) == [{"bot_id": "b1", "ext": {}}]
+    template_service._repository.list_by_bot_ids.assert_called_once_with(["b1"])
+
+
+def test_list_templates_by_bot_ids_repository_failure_returns_empty():
+    template_service = _make_template_service_for_list_by_bot_ids()
+    template_service._repository.list_by_bot_ids.side_effect = RuntimeError("boom")
+
+    assert template_service.list_templates_by_bot_ids(["b1"]) == []

--- a/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
+++ b/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from agentclaw.community.core.bot_management.engines import (
     BotProvisioningContext,
     resolve_provisioning,
@@ -187,3 +189,48 @@ def test_resolve_provisioning_routes_legacy_template_only_context():
     )
     assert strategy.engine_type == "aicoding"
     assert strategy.should_encrypt_template_token(ctx) is True
+
+
+def test_template_factory_normal_cc_consumes_model_runtime_repos_and_token():
+    strategy = AicodingProvisioningStrategy("claude_code")
+    ctx = BotProvisioningContext(
+        active_engine="claude_code",
+        template_type="normalCC",
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="service",
+        template_config={
+            "model": "  m-normal  ",
+            "runtime": "  codefuse-antcc  ",
+            "token": "tok-normal",
+            "repos": ["https://code/repo1"],
+            "init_repos": [{"url": "https://code/repo2"}],
+        },
+    )
+
+    envs = strategy.build_extra_envs(ctx)
+    assert envs is not None
+    assert envs["RELAY_DEFAULT_MODEL"] == "m-normal"
+    assert envs["RELAY_DEFAULT_RUNTIME"] == "codefuse-antcc"
+    assert json.loads(envs["GIT_ADDRESSES"]) == [
+        "https://code/repo1",
+        "https://code/repo2",
+    ]
+    assert "BOT_TYPE" not in envs
+    assert strategy.should_encrypt_template_token(ctx) is True
+    assert strategy.extract_runtime_token(ctx) == "tok-normal"
+
+
+def test_template_factory_architect_routes_template_only_context_for_token_policy():
+    ctx, strategy = resolve_provisioning(
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="service",
+        active_engine=None,
+        template_type="architect",
+        template_config={"token": "tok-architect"},
+    )
+
+    assert strategy.engine_type == "aicoding"
+    assert strategy.should_encrypt_template_token(ctx) is True
+    assert strategy.extract_runtime_token(ctx) == "tok-architect"

--- a/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
+++ b/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
@@ -200,6 +200,11 @@ def test_template_factory_normal_cc_consumes_model_runtime_repos_and_token():
         owner_id="u1",
         bot_type="service",
         template_config={
+            "template_key": "normalCC",
+            "template_uid": "aicoding",
+            "bot_template_config": {
+                "engine_config": {"type": ["claude-code", "codefuse-antcc"]},
+            },
             "model": "  m-normal  ",
             "runtime": "  codefuse-antcc  ",
             "token": "tok-normal",
@@ -221,16 +226,103 @@ def test_template_factory_normal_cc_consumes_model_runtime_repos_and_token():
     assert strategy.extract_runtime_token(ctx) == "tok-normal"
 
 
-def test_template_factory_architect_routes_template_only_context_for_token_policy():
+def test_template_factory_architect_routes_by_template_config_not_template_type_enum():
     ctx, strategy = resolve_provisioning(
         bot_id="b1",
         owner_id="u1",
         bot_type="service",
-        active_engine=None,
+        active_engine="claude_code",
         template_type="architect",
-        template_config={"token": "tok-architect"},
+        template_config={
+            "template_key": "architect",
+            "template_uid": "aicoding",
+            "bot_template_config": {
+                "engine_config": {"type": ["claude-code"]},
+            },
+            "token": "tok-architect",
+        },
     )
 
-    assert strategy.engine_type == "aicoding"
+    assert strategy.engine_type == "claude_code"
     assert strategy.should_encrypt_template_token(ctx) is True
     assert strategy.extract_runtime_token(ctx) == "tok-architect"
+
+
+def test_user_created_template_factory_config_consumed_without_backend_template_type_enum():
+    """AC 用户自建模板不应要求后端为每个 template_type 发版加枚举。"""
+    strategy = AicodingProvisioningStrategy("claude_code")
+    ctx = BotProvisioningContext(
+        active_engine="claude_code",
+        template_type="userCustomTemplate",
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="personal",
+        template_config={
+            "template_key": "userCustomTemplate",
+            "template_uid": "aicoding",
+            "bot_template_config": {
+                "engine_config": {"type": ["claude-code"]},
+            },
+            "model": "  custom-model  ",
+            "runtime": "  codefuse-antcc  ",
+            "token": "tok-custom",
+            "repos": ["https://code/custom-repo"],
+        },
+    )
+
+    envs = strategy.build_extra_envs(ctx)
+    assert envs is not None
+    assert envs["RELAY_DEFAULT_MODEL"] == "custom-model"
+    assert envs["RELAY_DEFAULT_RUNTIME"] == "codefuse-antcc"
+    assert json.loads(envs["GIT_ADDRESSES"]) == ["https://code/custom-repo"]
+    assert "BOT_TYPE" not in envs
+    assert strategy.should_encrypt_template_token(ctx) is True
+    assert strategy.extract_runtime_token(ctx) == "tok-custom"
+
+
+def test_non_coding_engine_does_not_consume_user_template_factory_config():
+    """非 coding 引擎即便带模板工厂形态配置，也不能误走 AICoding provisioning。"""
+    ctx = BotProvisioningContext(
+        active_engine="openclaw",
+        template_type="userCustomTemplate",
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="service",
+        template_config={
+            "template_key": "userCustomTemplate",
+            "template_uid": "aicoding",
+            "bot_template_config": {
+                "engine_config": {"type": ["claude-code"]},
+            },
+            "model": "custom-model",
+            "runtime": "codefuse-antcc",
+            "token": "tok-custom",
+        },
+    )
+    strategy = get_engine_provisioning_registry().resolve_for_context(ctx)
+
+    assert strategy.build_extra_envs(ctx) is None
+    assert strategy.should_encrypt_template_token(ctx) is False
+    assert strategy.extract_runtime_token(ctx) is None
+
+
+def test_template_only_user_template_factory_config_without_active_engine_is_noop():
+    """用户自建模板不能靠后端遍历 engine_config.type 猜策略；创建链路应传 active_engine。"""
+    ctx, strategy = resolve_provisioning(
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="personal",
+        active_engine=None,
+        template_type="userCustomTemplate",
+        template_config={
+            "template_key": "userCustomTemplate",
+            "bot_template_config": {
+                "engine_config": {"type": ["claude-code"]},
+            },
+            "token": "tok-custom",
+        },
+    )
+
+    assert strategy.engine_type == "default"
+    assert strategy.should_encrypt_template_token(ctx) is False
+    assert strategy.extract_runtime_token(ctx) is None

--- a/src/backend/tests/community/core/bot_management/test_utils_yuque.py
+++ b/src/backend/tests/community/core/bot_management/test_utils_yuque.py
@@ -275,3 +275,84 @@ class TestTriggerMemoryInitYuquePayload:
             )
 
         assert called["post"] is False
+
+
+class TestTemplateFactoryKnowledgeAliases:
+    def test_yuque_pairs_include_template_factory_wiki_aliases(self):
+        config = {
+            "wiki_knowledge_spaces": [
+                {"url": "https://yuque/wiki", "teamToken": "TK1"},
+            ],
+            "business_wiki_spaces": [
+                {"wiki_url": "https://yuque/business", "team_token": "TK2"},
+            ],
+            "repo_wiki_spaces": [
+                {"repo_wiki_url": "https://yuque/repo"},
+            ],
+        }
+
+        assert _extract_yuque_pairs(config) == [
+            ("https://yuque/wiki", "TK1"),
+            ("https://yuque/business", "TK2"),
+            ("https://yuque/repo", ""),
+        ]
+
+    def test_code_repo_urls_include_template_factory_aliases(self):
+        config = {
+            "repos": ["https://code/repos-string"],
+            "init_repos": [{"url": "https://code/init"}],
+            "application_repo_urls": [{"git_url": "git@example.com:a/b.git"}],
+        }
+
+        assert _extract_code_repo_urls(config) == [
+            "https://code/repos-string",
+            "https://code/init",
+            "git@example.com:a/b.git",
+        ]
+
+    def test_memory_sources_changed_detects_template_factory_aliases(self):
+        old = {"business_wiki_spaces": [{"url": "https://yuque/old"}]}
+        new = {"business_wiki_spaces": [{"url": "https://yuque/new"}]}
+
+        assert memory_sources_changed(old, new) is True
+
+    def test_trigger_memory_initialization_payload_uses_aliases(self):
+        payload = self._run_with_aliases(
+            {
+                "business_wiki_spaces": [
+                    {"wiki_url": "https://yuque/business", "teamToken": "TK"},
+                ],
+                "init_repos": [{"repo_url": "https://code/init"}],
+            }
+        )
+
+        assert payload["yuqueUrls"] == [
+            {"url": "https://yuque/business", "teamToken": "TK"},
+        ]
+        assert payload["codeRepoUrls"] == ["https://code/init"]
+
+    def _run_with_aliases(self, template_config):
+        captured = {}
+
+        def fake_post(url, headers=None, json=None, timeout=None):
+            captured["payload"] = json
+            resp = MagicMock()
+            resp.status_code = 200
+            return resp
+
+        with patch(
+            "agentclaw.community.core.bot_management.utils.get_current_env",
+            return_value="pre",
+        ), patch(
+            "agentclaw.community.core.bot_management.utils.requests.post",
+            side_effect=fake_post,
+        ):
+            trigger_memory_initialization(
+                bot_id="b1",
+                bot_name="n",
+                user_id="u",
+                template_config=template_config,
+                cookie="c=1",
+                aixcore_base_url_pre="https://aixcore.example.com",
+            )
+        return captured.get("payload", {})

--- a/src/backend/tests/community/core/bot_management/test_utils_yuque.py
+++ b/src/backend/tests/community/core/bot_management/test_utils_yuque.py
@@ -359,3 +359,26 @@ class TestTemplateFactoryKnowledgeAliases:
                 aixcore_base_url_pre="https://aixcore.example.com",
             )
         return captured.get("payload", {})
+
+
+def test_iter_template_list_items_ignores_non_dict_and_extends_lists():
+    from agentclaw.community.core.bot_management.utils import _iter_template_list_items
+
+    assert _iter_template_list_items(None, ("repos",)) == []  # type: ignore[arg-type]
+    assert _iter_template_list_items({"repos": ["a"], "init_repos": "bad"}, ("repos", "init_repos")) == ["a"]
+
+
+def test_template_factory_yuque_string_alias_skips_invalid_and_keeps_valid_urls():
+    config = {
+        "template_uid": "aicoding",
+        "business_wiki_spaces": [
+            "not-a-url",
+            " https://yuque.antfin.com/securitytec/wiki ",
+            {"space_url": "https://yuque.antfin.com/securitytec/space", "team_token": "TK"},
+        ],
+    }
+
+    assert _extract_yuque_pairs(config) == [
+        ("https://yuque.antfin.com/securitytec/wiki", ""),
+        ("https://yuque.antfin.com/securitytec/space", "TK"),
+    ]

--- a/src/backend/tests/community/core/bot_management/test_utils_yuque.py
+++ b/src/backend/tests/community/core/bot_management/test_utils_yuque.py
@@ -280,6 +280,7 @@ class TestTriggerMemoryInitYuquePayload:
 class TestTemplateFactoryKnowledgeAliases:
     def test_yuque_pairs_include_template_factory_wiki_aliases(self):
         config = {
+            "template_key": "normalCC",
             "wiki_knowledge_spaces": [
                 {"url": "https://yuque/wiki", "teamToken": "TK1"},
             ],
@@ -299,6 +300,7 @@ class TestTemplateFactoryKnowledgeAliases:
 
     def test_code_repo_urls_include_template_factory_aliases(self):
         config = {
+            "template_key": "normalCC",
             "repos": ["https://code/repos-string"],
             "init_repos": [{"url": "https://code/init"}],
             "application_repo_urls": [{"git_url": "git@example.com:a/b.git"}],
@@ -311,14 +313,15 @@ class TestTemplateFactoryKnowledgeAliases:
         ]
 
     def test_memory_sources_changed_detects_template_factory_aliases(self):
-        old = {"business_wiki_spaces": [{"url": "https://yuque/old"}]}
-        new = {"business_wiki_spaces": [{"url": "https://yuque/new"}]}
+        old = {"template_key": "normalCC", "business_wiki_spaces": [{"url": "https://yuque/old"}]}
+        new = {"template_key": "normalCC", "business_wiki_spaces": [{"url": "https://yuque/new"}]}
 
         assert memory_sources_changed(old, new) is True
 
     def test_trigger_memory_initialization_payload_uses_aliases(self):
         payload = self._run_with_aliases(
             {
+                "template_key": "normalCC",
                 "business_wiki_spaces": [
                     {"wiki_url": "https://yuque/business", "teamToken": "TK"},
                 ],

--- a/src/backend/tests/community/core/devices/services/test_sandbox_overrides.py
+++ b/src/backend/tests/community/core/devices/services/test_sandbox_overrides.py
@@ -333,3 +333,26 @@ class TestToCreateKwargs:
         """envs are handled via merged_envs(), not to_create_kwargs()."""
         so = SandboxOverrides(envs={"KEY": "VAL"})
         assert so.to_create_kwargs() == {}
+
+
+class TestTemplateFactoryImageConfig:
+    def test_image_config_name_and_tag_fallback(self):
+        so = SandboxOverrides.from_template_config(
+            {"image_config": {"name": "registry.example.com/architect", "tag": "v1"}}
+        )
+        assert so.image == "registry.example.com/architect:v1"
+
+    def test_top_level_image_wins_over_image_config(self):
+        so = SandboxOverrides.from_template_config(
+            {
+                "image": "registry.example.com/top:v2",
+                "image_config": {"name": "registry.example.com/nested", "tag": "v1"},
+            }
+        )
+        assert so.image == "registry.example.com/top:v2"
+
+    def test_startup_config_command_fallback(self):
+        so = SandboxOverrides.from_template_config(
+            {"startup_config": {"command": ["/bin/sh", "start.sh"]}}
+        )
+        assert so.command == "/bin/sh start.sh"

--- a/src/backend/tests/community/di/test_singlebox_baas_template_config.py
+++ b/src/backend/tests/community/di/test_singlebox_baas_template_config.py
@@ -70,3 +70,68 @@ def test_template_uuid_rejects_none_at_construction():
             config_service=MagicMock(),
             template_uuid=None,  # type: ignore[arg-type]
         )
+
+
+@pytest.mark.asyncio
+async def test_migrates_existing_local_template_to_aicoding_alias():
+    config_service = MagicMock()
+    config_service.get_config.return_value = {
+        "version": "custom",
+        "templates": {
+            "local_default": {"template_uuid": "TEMPLATE-local", "keep": True},
+        },
+    }
+    config_service.set_config.return_value = 8
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid="TEMPLATE-local",
+    )
+
+    with patch(
+        "agentclaw.community.di.modules.infrastructure.singlebox.template_config."
+        "env_utils.get_current_env",
+        return_value="dev",
+    ):
+        await lifecycle.startup()
+
+    mapping = config_service.set_config.call_args.kwargs["config_value"]
+    assert mapping["templates"]["local_default"] == {"template_uuid": "TEMPLATE-local", "keep": True}
+    assert mapping["templates"]["aicoding"] == {"template_uuid": "TEMPLATE-local", "keep": True}
+    assert config_service.set_config.call_args.kwargs["env"] == "dev"
+
+
+@pytest.mark.asyncio
+async def test_skips_migration_when_template_alias_already_exists():
+    config_service = MagicMock()
+    config_service.get_config.return_value = {
+        "version": "custom",
+        "templates": {
+            "local_default": {"template_uuid": "TEMPLATE-local"},
+            "aicoding": {"template_uuid": "TEMPLATE-aicoding"},
+        },
+    }
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid="TEMPLATE-local",
+    )
+
+    await lifecycle.startup()
+
+    config_service.set_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_local_template_alias_migration_failure_is_clear():
+    config_service = MagicMock()
+    config_service.get_config.return_value = {
+        "version": "custom",
+        "templates": {"local_default": {"template_uuid": "TEMPLATE-local"}},
+    }
+    config_service.set_config.return_value = None
+    lifecycle = SingleboxBaasTemplateConfigLifecycle(
+        config_service=config_service,
+        template_uuid="TEMPLATE-local",
+    )
+
+    with pytest.raises(RuntimeError, match="failed to migrate local BaaS template mapping"):
+        await lifecycle.startup()

--- a/src/backend/tests/community/plugins/test_template_repository_list_by_bot_ids.py
+++ b/src/backend/tests/community/plugins/test_template_repository_list_by_bot_ids.py
@@ -1,0 +1,13 @@
+from agentclaw.community.plugins.template_repository import TemplateRepository
+
+
+def test_list_by_bot_ids_empty_returns_empty_without_db():
+    repo = TemplateRepository.__new__(TemplateRepository)
+
+    assert repo.list_by_bot_ids([]) == []
+
+
+def test_list_by_bot_ids_blank_values_return_empty_without_db():
+    repo = TemplateRepository.__new__(TemplateRepository)
+
+    assert repo.list_by_bot_ids(["", None]) == []  # type: ignore[list-item]

--- a/src/backend/tests/community/unit/test_template_capabilities.py
+++ b/src/backend/tests/community/unit/test_template_capabilities.py
@@ -1,0 +1,24 @@
+from agentclaw.community.core.bot_management.capabilities import (
+    can_join_bcn_as_provider,
+    has_declared_capabilities,
+)
+
+
+def test_declared_capabilities_empty_dict_still_takes_over():
+    template_config = {"capabilities": {}}
+
+    assert has_declared_capabilities(template_config) is True
+    assert can_join_bcn_as_provider(template_config) is False
+
+
+def test_can_join_bcn_as_provider_reads_nested_flag():
+    template_config = {"capabilities": {"bcn": {"join_as_provider": True}}}
+
+    assert can_join_bcn_as_provider(template_config) is True
+
+
+def test_missing_or_invalid_capabilities_default_false():
+    assert has_declared_capabilities(None) is False
+    assert can_join_bcn_as_provider(None) is False
+    assert can_join_bcn_as_provider({"capabilities": None}) is False
+    assert can_join_bcn_as_provider({"capabilities": {"bcn": None}}) is False

--- a/src/backend/tests/community/unit/test_template_capabilities.py
+++ b/src/backend/tests/community/unit/test_template_capabilities.py
@@ -22,3 +22,21 @@ def test_missing_or_invalid_capabilities_default_false():
     assert can_join_bcn_as_provider(None) is False
     assert can_join_bcn_as_provider({"capabilities": None}) is False
     assert can_join_bcn_as_provider({"capabilities": {"bcn": None}}) is False
+
+
+def test_can_join_bcn_as_provider_reads_flat_available_tc_flag():
+    template_config = {"capabilities": {"enable_bcn_network": True}}
+
+    assert can_join_bcn_as_provider(template_config) is True
+
+
+def test_flat_false_takes_over_legacy_shape():
+    template_config = {
+        "capabilities": {
+            "enable_bcn_network": False,
+            "bcn": {"join_as_provider": True},
+        }
+    }
+
+    assert can_join_bcn_as_provider(template_config) is False
+

--- a/src/backend/tests/community/unit/test_template_capabilities.py
+++ b/src/backend/tests/community/unit/test_template_capabilities.py
@@ -46,3 +46,9 @@ def test_template_factory_config_marker_detection():
     assert is_template_factory_config({"template_key": "normalCC"}) is True
     assert is_template_factory_config({"template_uid": "aicoding"}) is True
     assert is_template_factory_config({"capabilities": {}}) is False
+
+
+def test_can_join_bcn_as_provider_reads_legacy_nested_bool():
+    template_config = {"capabilities": {"bcn": True}}
+
+    assert can_join_bcn_as_provider(template_config) is True

--- a/src/backend/tests/community/unit/test_template_capabilities.py
+++ b/src/backend/tests/community/unit/test_template_capabilities.py
@@ -1,6 +1,7 @@
 from agentclaw.community.core.bot_management.capabilities import (
     can_join_bcn_as_provider,
     has_declared_capabilities,
+    is_template_factory_config,
 )
 
 
@@ -40,3 +41,8 @@ def test_flat_false_takes_over_legacy_shape():
 
     assert can_join_bcn_as_provider(template_config) is False
 
+
+def test_template_factory_config_marker_detection():
+    assert is_template_factory_config({"template_key": "normalCC"}) is True
+    assert is_template_factory_config({"template_uid": "aicoding"}) is True
+    assert is_template_factory_config({"capabilities": {}}) is False


### PR DESCRIPTION
## Summary
- consume Template Factory template_config snapshots for coding bots via active_engine + snapshot markers
- support template-driven repo/wiki/env/model/runtime config for normalCC, architect, and user-created AC templates
- enrich bot list responses with persisted template_config and add targeted unit coverage

## Validation
- py_compile targeted backend files and tests
- git diff --check dev for community backend/test paths
- pre-push lint-only gate passed