### PR TITLE
feat(bcs): add Bot-Human-Bot collaboration template

### DIFF
--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
@@ -156,12 +156,14 @@ fn authoring_validation_rejects_fields_not_supported_by_the_current_runtime() {
 #[test]
 fn validates_collaboration_template_seed_definitions() {
     for file_name in [
+        "en-US/bot-human-bot-review.yaml",
         "en-US/solution-and-risk-review.yaml",
         "en-US/single-bot-guided-answer.yaml",
         "en-US/parallel-expert-review.yaml",
         "en-US/write-and-review.yaml",
         "en-US/world-cup-preview-content-production.yaml",
         "en-US/micro-merchant-event-orchestration.yaml",
+        "zh-CN/bot-human-bot-review.yaml",
         "zh-CN/solution-and-risk-review.yaml",
         "zh-CN/single-bot-guided-answer.yaml",
         "zh-CN/parallel-expert-review.yaml",

--- a/src/bcs/crates/services/bcs-collaboration-template/src/lib.rs
+++ b/src/bcs/crates/services/bcs-collaboration-template/src/lib.rs
@@ -714,6 +714,7 @@ runtime:
                 "write-and-review",
                 "parallel-expert-review",
                 "solution-and-risk-review",
+                "bot-human-bot-review",
                 "world-cup-preview-content-production",
                 "micro-merchant-event-orchestration",
                 "single-bot-guided-answer",
@@ -753,6 +754,7 @@ runtime:
                 "world-cup-preview-content-production",
                 "micro-merchant-event-orchestration",
                 "single-bot-guided-answer",
+                "bot-human-bot-review",
                 "write-and-review",
             ]
         );
@@ -770,10 +772,17 @@ runtime:
                 tags: vec!["judge".to_string()],
             })
             .await?;
-        assert_eq!(english_response.templates.len(), 1);
+        assert_eq!(english_response.templates.len(), 2);
         assert_eq!(
-            english_response.templates[0].name,
-            "Write & Review (requires LLM)"
+            english_response
+                .templates
+                .iter()
+                .map(|template| template.name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "Bot-Human-Bot Review (requires LLM)",
+                "Write & Review (requires LLM)",
+            ]
         );
 
         Ok(())
@@ -833,6 +842,41 @@ runtime:
         assert!(detail.yaml.contains("# 写作质检协同模板。"));
         assert_eq!(detail.definition["name"], "写作质检协同");
         assert!(detail.definition.get("id").is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn returns_bot_human_bot_template_with_human_input_node(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let repo = Arc::new(FileCollaborationTemplateRepo::new(seed_template_dir()));
+        let service =
+            CollaborationTemplateServiceImpl::new(repo, "zh-CN").with_judge_templates_enabled(true);
+
+        let detail = service
+            .get_template(GetCollaborationTemplateQuery {
+                template_id: "bot-human-bot-review".to_string(),
+                requested_language: Some("zh-CN".to_string()),
+                accept_language: None,
+                format: CollaborationTemplateFormat::Json,
+            })
+            .await?;
+
+        assert_eq!(detail.name, "Bot-Human-Bot 三节点协作");
+        assert_eq!(
+            detail.definition["runtime"]["state_machine"]["nodes"]["human_review"]["kind"],
+            "human_input"
+        );
+        assert!(
+            detail.definition["runtime"]["state_machine"]["nodes"]["human_review"]
+                .get("assignee")
+                .is_none()
+        );
+        assert_eq!(
+            detail.definition["runtime"]["state_machine"]["nodes"]["human_review"]
+                ["node_timeout_ms"],
+            86_400_000
+        );
 
         Ok(())
     }

--- a/src/bcs/crates/tools/bcs-admin/src/seed_loader.rs
+++ b/src/bcs/crates/tools/bcs-admin/src/seed_loader.rs
@@ -297,6 +297,7 @@ mod tests {
                 "write-and-review",
                 "parallel-expert-review",
                 "solution-and-risk-review",
+                "bot-human-bot-review",
                 "world-cup-preview-content-production",
                 "micro-merchant-event-orchestration",
                 "single-bot-guided-answer",
@@ -325,6 +326,39 @@ mod tests {
         assert!(zh_cn.participant_summary_json.get("writer").is_some());
         assert!(zh_cn.definition_json.get("id").is_none());
         assert!(zh_cn.definition_json.get("version").is_none());
+
+        let bot_human_bot = catalog
+            .templates
+            .iter()
+            .find(|template| template.id == "bot-human-bot-review")
+            .with_context(|| "missing bot-human-bot-review")?;
+        assert_eq!(bot_human_bot.priority, 25);
+        assert_eq!(bot_human_bot.contents.len(), 2);
+        assert!(bot_human_bot.tags.contains(&"judge".to_string()));
+        assert!(bot_human_bot.tags.contains(&"serial".to_string()));
+
+        let human_review = bot_human_bot
+            .contents
+            .iter()
+            .find(|content| content.lang == "zh-CN")
+            .with_context(|| "missing bot-human-bot-review zh-CN content")?;
+        assert_eq!(human_review.name, "Bot-Human-Bot 三节点协作");
+        assert!(
+            human_review
+                .participant_summary_json
+                .get("worker")
+                .is_some()
+        );
+        assert_eq!(
+            human_review.definition_json["runtime"]["state_machine"]["nodes"]["human_review"]
+                ["kind"],
+            "human_input"
+        );
+        assert!(
+            human_review.definition_json["runtime"]["state_machine"]["nodes"]["human_review"]
+                .get("assignee")
+                .is_none()
+        );
 
         Ok(())
     }

--- a/src/bcs/seeds/collaboration-templates/en-US/bot-human-bot-review.yaml
+++ b/src/bcs/seeds/collaboration-templates/en-US/bot-human-bot-review.yaml
@@ -1,0 +1,62 @@
+# Bot-Human-Bot three-node collaboration template.
+# participants declares only logical roles that must bind to actual bots. The Human is
+# the current group member, so the human_input node has no assignee or participant binding.
+
+api_version: bcs.collaboration/v1
+name: Bot-Human-Bot Review
+
+metadata:
+  description: A Bot creates a draft, waits for Human review, and then produces the final result from the approval or revision feedback.
+
+participants:
+  worker:
+    display_name: Worker Bot
+    description: Creates the draft and produces the final result from Human feedback.
+    required: true
+
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      generate_draft:
+        kind: bot_task
+        display_name: Generate Draft
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: Create a concise draft for the task requested by the user.
+        transitions:
+          complete:
+            targets:
+              - human_review
+
+      human_review:
+        kind: human_input
+        display_name: Human Review
+        instruction: Review the Bot draft. Approve it as-is or provide specific revision feedback.
+        node_timeout_ms: 86400000
+        judge:
+          type: llm
+          criteria:
+            - Determine whether the Human approved the current result or requested revisions.
+          outcomes:
+            - approved
+            - rejected
+        transitions:
+          approved:
+            targets:
+              - finalize
+          rejected:
+            targets:
+              - finalize
+
+      finalize:
+        kind: bot_task
+        display_name: Generate Final Result
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: Read the upstream draft and Human review. If approved, refine and confirm the result. If revisions were requested, apply the feedback and produce the final result.
+        final_output: true

--- a/src/bcs/seeds/collaboration-templates/registry.yaml
+++ b/src/bcs/seeds/collaboration-templates/registry.yaml
@@ -15,6 +15,10 @@ templates:
     tags: [parallel]
     priority: 20
 
+  bot-human-bot-review:
+    tags: [judge, serial]
+    priority: 25
+
   world-cup-preview-content-production:
     tags: [parallel]
     priority: 30

--- a/src/bcs/seeds/collaboration-templates/zh-CN/bot-human-bot-review.yaml
+++ b/src/bcs/seeds/collaboration-templates/zh-CN/bot-human-bot-review.yaml
@@ -1,0 +1,62 @@
+# Bot-Human-Bot 三节点协作模板。
+# participants 只声明需要绑定实际 bot 的逻辑角色；Human 由群内当前用户参与，
+# 因此 human_input 节点不配置 assignee，也不需要额外的 participant binding。
+
+api_version: bcs.collaboration/v1
+name: Bot-Human-Bot 三节点协作
+
+metadata:
+  description: Bot 先生成初稿，等待人工审核，再根据人工结论或修改意见生成最终结果。
+
+participants:
+  worker:
+    display_name: 执行 Bot
+    description: 负责生成初稿，并根据人工反馈输出最终结果。
+    required: true
+
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      generate_draft:
+        kind: bot_task
+        display_name: 生成初稿
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: 根据用户提出的任务生成一份简洁的初稿。
+        transitions:
+          complete:
+            targets:
+              - human_review
+
+      human_review:
+        kind: human_input
+        display_name: 人工审核
+        instruction: 请审核 Bot 生成的初稿。可以直接表示同意，也可以提出具体修改意见。
+        node_timeout_ms: 86400000
+        judge:
+          type: llm
+          criteria:
+            - 判断用户是同意当前结果，还是要求 Bot 修改。
+          outcomes:
+            - approved
+            - rejected
+        transitions:
+          approved:
+            targets:
+              - finalize
+          rejected:
+            targets:
+              - finalize
+
+      finalize:
+        kind: bot_task
+        display_name: 生成最终结果
+        assignee:
+          type: bot_binding
+          binding: worker
+        instruction: 阅读上游初稿和人工审核意见。如果人工同意，则整理并确认最终结果；如果人工提出了修改意见，则根据意见修改后输出最终结果。
+        final_output: true


### PR DESCRIPTION
## Summary

- add localized `Bot-Human-Bot` collaboration template seeds for `zh-CN` and `en-US`
- register the template for backend-driven discovery in the frontend
- model the Human review step as a `human_input` node without an assignee or participant binding
- cover template listing/detail behavior and validate both seed definitions against the collaboration runtime

## Why

The frontend already loads collaboration templates and YAML definitions from Avernet. Adding this seed makes a Human-in-the-loop example available without introducing frontend-owned template data.

## Human Input behavior

- only the Bot role is declared in `participants` and bound during group creation
- the Human is the current group member, so the `human_input` node has no `assignee`
- the Human node has an explicit 24-hour timeout and uses Judge outcomes to continue to the final Bot node

## Validation

- `cargo test -p bcs-collaboration-template -p bcs-collaboration-runtime`
- 67 tests passed
- `git diff --check`