### PR TITLE
fix: resume Skills Pool repair after committed cutover

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -344,17 +344,20 @@ class SkillsPoolReconcileService:
                     preparation_id=probe.preparation_id,
                     evidence=cutover.to_dict(),
                 )
-            if not self._layouts.record_cutover_committed(
-                scope=scope,
-                migration_generation=generation,
-                lease_owner=lease_owner,
-                preparation_id=probe.preparation_id,
-                evidence=cutover.to_dict(),
+            if not (
+                state.data_plane_cutover_committed and repair_evidence_refresh
             ):
-                return SkillsPoolReconcileResult(
-                    SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                if not self._layouts.record_cutover_committed(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
                     preparation_id=probe.preparation_id,
-                )
+                    evidence=cutover.to_dict(),
+                ):
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        preparation_id=probe.preparation_id,
+                    )
 
         if not self._layouts.holds_lease(
             scope=scope,

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -564,6 +564,34 @@ async def test_unknown_cutover_enters_manual_repair_and_stops_automation() -> No
 
 
 @pytest.mark.asyncio
+async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["database"]
+    assert layouts.state.active_layout is SkillLayout.POOL
+
+
+@pytest.mark.asyncio
 async def test_post_cutover_sync_pending_retries_finalization_before_mappings() -> None:
     layouts = FakeLayoutRepository()
     runtime = FakeRuntime()


### PR DESCRIPTION
## Summary

- skip the duplicate cutover-ledger CAS after an operator has resolved an UNKNOWN cutover as `pool_committed`
- still re-invoke the runtime idempotently to prove the same generation returns `ALREADY_COMMITTED`
- continue mapping, locator, and `POOL_ACTIVE` convergence after that evidence refresh
- add a regression for the exact `MANUAL_REPAIR_RESOLVED + data_plane_cutover_committed=1` state

## Root cause

The repair endpoint persisted `POOL_CUTOVER_COMMITTED` before enqueueing reconcile. Reconcile then successfully received `ALREADY_COMMITTED` from the runtime but called `record_cutover_committed()` again. That repository CAS only accepts pre-cutover/finalizing phases, so repair always stopped with `state_race_lost`.

## Tests on latest dev

- `uv run pytest tests/community/core/skills_pool -q` (171 passed)