### PR TITLE
fix(baas): raise ChatErrorMessageError on WebSocket error state

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -101,6 +101,16 @@ class NotConnectedError(Exception):
     """连接未建立或已断开时抛出。"""
 
 
+class ChatErrorMessageError(Exception):
+    """Chat 事件以 ``state=error`` 终止时由 :meth:`AsyncChatClient.send_message` 抛出。
+
+    Raised when a chat event terminates with ``state=error`` (e.g. relay
+    ``CONNECTION_ERROR``). The exception carries ``state.content`` (or the
+    fallback ``"chat error"``) as its message so callers can surface the
+    upstream error instead of silently treating the run as completed.
+    """
+
+
 class AsyncChatClient:
     """WebSocket 聊天客户端封装类（纯异步版本）
 
@@ -394,6 +404,12 @@ class AsyncChatClient:
                     # 无超时等待
                     await state.chat_complete.wait()
 
+                # 6. chat 事件以 error 态终止时，抛出异常以触发上层错误路径
+                # （baas_bot_run / baas_bot_session 标记为 FAILED）。仅在
+                # chat_complete 被 set 后判定，纯 timeout（state.state 仍为 ""）
+                # 不抛异常，维持原有“return anyway”行为。
+                if state.state == "error":
+                    raise ChatErrorMessageError(state.content or "chat error")
                 return state.content, state.agent_payloads
 
             finally:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -397,7 +397,7 @@ class BaasBotService(BotService):
         try:
             auth_token = context.build_auth_token() if context else None
             app_id = context.app_id if context else None
-            content, state = await client.send_message(
+            content, _agent_events = await client.send_message(
                 message=message,
                 session_key=session_id,
                 wait_result=wait_result,
@@ -406,10 +406,6 @@ class BaasBotService(BotService):
                 app_id=app_id,
                 chat_metadata=chat_metadata,
             )
-
-            if state == "error":  # type: ignore[comparison-overlap]
-                self._mark_session_failed(baas_session_id, err_msg=content)
-                raise BotServiceError(content)
 
             self._mark_session_completed(baas_session_id, result={"content": content})
             return BotResponse(content=content)

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -370,6 +370,70 @@ class TestSendMessage:
         assert content == ""
 
     @pytest.mark.asyncio
+    async def test_send_message_error_state_raises(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """When chat event terminates with state=error, send_message raises
+        ChatErrorMessageError carrying state.content as its message."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+            ChatErrorMessageError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        async def fire_chat_error(*args, **kwargs):
+            sk = kwargs["session_key"]
+            state = client._sessions.get(sk)
+            if state:
+                state.content = "connection error"
+                state.state = "error"
+                state.chat_complete.set()
+
+        mock_bot_ws_instance.chat_send.side_effect = fire_chat_error
+
+        with pytest.raises(ChatErrorMessageError, match="connection error"):
+            await client.send_message("Hi")
+
+    @pytest.mark.asyncio
+    async def test_send_message_error_state_empty_content_raises(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """When state=error and state.content is empty, send_message raises
+        ChatErrorMessageError with the fallback ``"chat error"`` message."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+            ChatErrorMessageError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        async def fire_chat_error_no_content(*args, **kwargs):
+            sk = kwargs["session_key"]
+            state = client._sessions.get(sk)
+            if state:
+                state.content = ""
+                state.state = "error"
+                state.chat_complete.set()
+
+        mock_bot_ws_instance.chat_send.side_effect = fire_chat_error_no_content
+
+        with pytest.raises(ChatErrorMessageError, match="chat error"):
+            await client.send_message("Hi")
+
+    @pytest.mark.asyncio
     async def test_send_message_resets_state(self, mock_bot_ws, mock_bot_ws_instance):
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -29,6 +29,7 @@ from secbaas.community.api.bot_runtime import (
 )
 from secbaas.community.core.service.bot_run import BaasBotService, BaasBotServiceConfig
 from secbaas.community.core.service.bot_run._async_chat_client import (
+    ChatErrorMessageError,
     ConcurrentSessionError,
 )
 from secbaas.community.core.service.bot_run._async_chat_client_pool import (
@@ -377,7 +378,7 @@ class TestSendMessage:
         binding = _make_binding_info(baas_session_id="SESSION-xyz")
 
         mock_client = AsyncMock()
-        mock_client.send_message = AsyncMock(return_value=("response content", "done"))
+        mock_client.send_message = AsyncMock(return_value=("response content", []))
         mock_pool.get.return_value = mock_client
 
         with (
@@ -404,11 +405,13 @@ class TestSendMessage:
     async def test_send_message_error_state_marks_failed(
         self, service, wss_resolver, mock_pool
     ):
-        """ChatClient returning error state marks session as FAILED and raises."""
+        """ChatClient raising ChatErrorMessageError marks session as FAILED and raises."""
         binding = _make_binding_info(baas_session_id="SESSION-xyz")
 
         mock_client = AsyncMock()
-        mock_client.send_message = AsyncMock(return_value=("error msg", "error"))
+        mock_client.send_message = AsyncMock(
+            side_effect=ChatErrorMessageError("error msg")
+        )
         mock_pool.get.return_value = mock_client
 
         with (
@@ -418,8 +421,9 @@ class TestSendMessage:
                 return_value=_make_conn_info(),
             ),
             patch.object(service, "_mark_session_failed") as mock_failed,
+            patch.object(service, "_mark_session_completed") as mock_completed,
         ):
-            with pytest.raises(BotServiceError, match="error msg"):
+            with pytest.raises(BotServiceError, match="Failed to send message"):
                 await service.send_message(
                     session_id=SESSION_ID,
                     message="hello",
@@ -427,6 +431,7 @@ class TestSendMessage:
                     timeout=30.0,
                 )
             mock_failed.assert_called_once_with("SESSION-xyz", err_msg="error msg")
+            mock_completed.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_message_exception_marks_failed(


### PR DESCRIPTION
## Summary

Convert silent-success bug into proper failure signaling when chat event terminates with `state=error` (e.g. CONNECTION_ERROR). Fixes bot run being marked COMPLETED instead of FAILED for WebSocket error states.

## Root Cause

`AsyncChatClient.send_message` returns `(state.content, state.agent_payloads)` — never `state.state`. `_baas_service.send_message` at line 410 unpacked the second element as `state` and compared `state == "error"` — a dead branch since `state` is a list. The dispatcher's `_do_send` then took the success path (`update_result`) and wrote `baas_bot_run` as COMPLETED instead of FAILED.

## Changes (4 files, +90/-9)

- **`_async_chat_client.py`**: Added `ChatErrorMessageError(Exception)` raised in `send_message` when `state.state == "error"` after `chat_complete` wait. Pure-timeout path unchanged.
- **`_baas_service.py`**: Fixed unpacking to `content, _agent_events`; removed dead `if state == "error"` branch and `# type: ignore` annotation. Error now flows through existing `except Exception` → `_mark_session_failed` → `BotServiceError`.
- **`test_async_chat_client.py`**: 2 new test cases (error-state raise, empty-content fallback).
- **`test_baas_service.py`**: Updated error-state test with `ChatErrorMessageError` side_effect + `_mark_session_completed.assert_not_called()` regression guard. Corrected success-path mock second element to `[]`.

## Verification

- 757 tests passed, 8 xpassed, 0 failed
- Ruff: clean
- basedpyright: zero new errors (preexisting errors confirmed at baseCommit)
- No new attack surface, no info leak, no secrets in diff

## Out of scope (P2 follow-up)

Stream-path `send_message_stream` / `_stream_with_status` error-state marking deferred.

Closes Dima 2026072400117710691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>