### PR TITLE
feat(engine): add depth limit to aicoding file tree

### DIFF
--- a/src/engine/src/engine/community/api/aicoding_sessions/router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/router.py
@@ -4,7 +4,7 @@ Ten read-only endpoints, all served directly by the engine running inside
 the aicoding container:
 
 * ``GET /api/aicoding/sessions``                     — sessions list + run_status enrich
-* ``GET /api/aicoding/sessions/file-tree``           — recursive workspace tree
+* ``GET /api/aicoding/sessions/file-tree``           — depth-limited workspace tree
 * ``GET /api/aicoding/sessions/files/preview``       — file content (size-bounded)
 * ``GET /api/aicoding/sessions/git-diff``            — changed files (tree per project)
 * ``GET /api/aicoding/sessions/files/diff``          — unified diff for one file
@@ -61,6 +61,7 @@ from engine.community.api.session.router import _session_to_dict
 from engine.community.core.aicoding.models import DiffTreeNode, FileTreeNode
 from engine.community.core.aicoding.runstatus_service import RunStatusService
 from engine.community.core.aicoding.workspace_service import (
+    DEFAULT_FILE_TREE_MAX_DEPTH,
     FilePreviewTooLargeError,
     WorkspaceService,
 )
@@ -146,8 +147,13 @@ async def list_file_tree(
         None,
         description="可选：前端直传工作目录绝对路径；与 session_id 至少提供一个",
     ),
+    depth: int = Query(
+        DEFAULT_FILE_TREE_MAX_DEPTH,
+        ge=0,
+        description="最大遍历层数；默认 3，0 表示返回所有层级",
+    ),
 ) -> FileTreeResponse:
-    """Return the full workspace tree (recursive, filtered, sorted)."""
+    """Return a depth-limited workspace tree (filtered and sorted)."""
     normalized_session_id = (session_id.strip() or None) if session_id else None
     normalized_cwd = (cwd.strip() or None) if cwd else None
     if not normalized_session_id and not normalized_cwd:
@@ -162,6 +168,7 @@ async def list_file_tree(
         tree = await service.list_file_tree(
             normalized_session_id,
             normalized_cwd,
+            max_depth=depth,
         )
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e

--- a/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
@@ -65,9 +65,21 @@ class FakeWorkspaceService:
     calls: list[tuple[str, dict]] = field(default_factory=list)
 
     async def list_file_tree(
-        self, session_id: str | None, cwd: str | None = None
+        self,
+        session_id: str | None,
+        cwd: str | None = None,
+        max_depth: int = 3,
     ):
-        self.calls.append(("list_file_tree", {"session_id": session_id, "cwd": cwd}))
+        self.calls.append(
+            (
+                "list_file_tree",
+                {
+                    "session_id": session_id,
+                    "cwd": cwd,
+                    "max_depth": max_depth,
+                },
+            )
+        )
         if self.list_file_tree_raise:
             raise self.list_file_tree_raise
         return self.list_file_tree_return or []
@@ -274,6 +286,42 @@ def test_file_tree_success(client, workspace_svc):
     assert body["tree"][0]["children"][0]["name"] == "README.md"
 
 
+def test_file_tree_defaults_to_three_levels(client, workspace_svc):
+    workspace_svc.list_file_tree_return = []
+
+    resp = client.get(
+        "/api/aicoding/sessions/file-tree",
+        params={"session_id": "s1"},
+    )
+
+    assert resp.status_code == 200
+    assert workspace_svc.calls[-1][1]["max_depth"] == 3
+
+
+@pytest.mark.parametrize("depth", [0, 1, 5])
+def test_file_tree_forwards_depth(client, workspace_svc, depth):
+    workspace_svc.list_file_tree_return = []
+
+    resp = client.get(
+        "/api/aicoding/sessions/file-tree",
+        params={"session_id": "s1", "depth": depth},
+    )
+
+    assert resp.status_code == 200
+    assert workspace_svc.calls[-1][1]["max_depth"] == depth
+
+
+@pytest.mark.parametrize("depth", [-1, "abc", "1.5"])
+def test_file_tree_rejects_invalid_depth(client, workspace_svc, depth):
+    resp = client.get(
+        "/api/aicoding/sessions/file-tree",
+        params={"session_id": "s1", "depth": depth},
+    )
+
+    assert resp.status_code == 422
+    assert workspace_svc.calls == []
+
+
 def test_file_tree_keeps_size_field_when_service_leaves_it_unset(
     client, workspace_svc,
 ):
@@ -307,7 +355,7 @@ def test_file_tree_accepts_cwd_with_blank_session_id(client, workspace_svc):
     assert resp.json()["session_id"] is None
     assert workspace_svc.calls[-1] == (
         "list_file_tree",
-        {"session_id": None, "cwd": cwd},
+        {"session_id": None, "cwd": cwd, "max_depth": 3},
     )
 
 
@@ -327,6 +375,7 @@ def test_file_tree_normalizes_optional_locators(client, workspace_svc):
     assert workspace_svc.calls[-1][1] == {
         "session_id": "s1",
         "cwd": "/home/admin/.aicoding/workspace/s1",
+        "max_depth": 3,
     }
 
 

--- a/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
@@ -322,12 +322,72 @@ async def test_list_file_tree_prunes_mounts_and_returns_sorted_tree(
     command, cwd, timeout = bash_plugin.calls[0]
     assert cwd == str(workspace_dir)
     assert timeout == 30
+    assert "-mindepth 1" in command
+    assert "-maxdepth 3" in command
     assert "-name .git" in command
     assert "-name node_modules" in command
     assert "-path './skills'" in command
     assert "-path './.repos'" in command
     assert "%s" not in command
     assert file_plugin.calls == []
+
+
+@pytest.mark.parametrize("max_depth", [1, 2, 5])
+async def test_list_file_tree_applies_requested_max_depth(
+    workspace_dir: Path,
+    max_depth: int,
+) -> None:
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(stdout="", stderr="", exit_code=0),
+    )
+
+    await _make_service(bash_plugin=bash_plugin).list_file_tree(
+        SESSION_ID,
+        max_depth=max_depth,
+    )
+
+    command = bash_plugin.calls[0][0]
+    assert f"-maxdepth {max_depth}" in command
+
+
+async def test_list_file_tree_zero_depth_means_unlimited(
+    workspace_dir: Path,
+) -> None:
+    bash_plugin = FakeBashPlugin()
+    bash_plugin.add(
+        "find -P .",
+        str(workspace_dir),
+        BashExecResult(stdout="", stderr="", exit_code=0),
+    )
+
+    await _make_service(bash_plugin=bash_plugin).list_file_tree(
+        SESSION_ID,
+        max_depth=0,
+    )
+
+    command = bash_plugin.calls[0][0]
+    assert "-mindepth 1" in command
+    assert "-maxdepth" not in command
+
+
+async def test_list_file_tree_rejects_negative_max_depth(
+    workspace_dir: Path,
+) -> None:
+    bash_plugin = FakeBashPlugin()
+
+    with pytest.raises(
+        ValueError,
+        match="max_depth must be greater than or equal to 0",
+    ):
+        await _make_service(bash_plugin=bash_plugin).list_file_tree(
+            SESSION_ID,
+            max_depth=-1,
+        )
+
+    assert bash_plugin.calls == []
 
 
 async def test_list_file_tree_leaves_size_unset(

--- a/src/engine/src/engine/community/core/aicoding/workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/workspace_service.py
@@ -45,17 +45,36 @@ CONTAINER_WORKSPACE_BASE = "/home/admin/.aicoding/workspace"
 # 10 MiB cap for inline preview to keep responses bounded.
 PREVIEW_MAX_BYTES = 10 * 1024 * 1024
 
-# Keep this command static and pass the validated workspace separately as
-# BashService.cwd.  GNU find's ``%y`` supplies the entry type and ``%P`` the
+# Default number of workspace-relative levels returned by the file-tree API.
+# ``0`` is reserved for an unlimited recursive scan.
+DEFAULT_FILE_TREE_MAX_DEPTH = 3
+
+# Keep the expression static and pass the validated workspace separately as
+# BashService.cwd. GNU find's ``%y`` supplies the entry type and ``%P`` the
 # workspace-relative path; NUL delimiters preserve whitespace/newlines in file
-# names.  Deliberately omit ``%s`` so NAS-backed workspaces do not pay one
+# names. Deliberately omit ``%s`` so NAS-backed workspaces do not pay one
 # explicit size metadata lookup per file.
-_FILE_TREE_FIND_COMMAND = (
-    r"find -P . -ignore_readdir_race -mindepth 1 "
+_FILE_TREE_FIND_EXPRESSION = (
     r"\( -type d \( -name .git -o -name node_modules "
     r"-o -path './skills' -o -path './.repos' \) -prune \) "
     r"-o -printf '%y\0%P\0'"
 )
+
+
+def _build_file_tree_find_command(max_depth: int) -> str:
+    """Build the GNU find command for a depth-limited workspace scan.
+
+    ``find`` counts direct children of ``.`` at depth 1. A ``max_depth`` of
+    zero means unlimited traversal, so no ``-maxdepth`` option is emitted.
+    """
+    if max_depth < 0:
+        raise ValueError("max_depth must be greater than or equal to 0")
+
+    max_depth_arg = "" if max_depth == 0 else f"-maxdepth {max_depth} "
+    return (
+        "find -P . -ignore_readdir_race -mindepth 1 "
+        f"{max_depth_arg}{_FILE_TREE_FIND_EXPRESSION}"
+    )
 
 
 def _resolve_workspace_base() -> str:
@@ -249,9 +268,16 @@ class WorkspaceService:
     # ── file tree ─────────────────────────────────────────────────────
 
     async def list_file_tree(
-        self, session_id: str | None, cwd: str | None = None
+        self,
+        session_id: str | None,
+        cwd: str | None = None,
+        max_depth: int = DEFAULT_FILE_TREE_MAX_DEPTH,
     ) -> list[FileTreeNode]:
-        """List workspace files recursively, excluding AICoding mounts."""
+        """List workspace files up to ``max_depth``, excluding mounts.
+
+        Direct children of the workspace are level 1. ``max_depth=0`` means
+        unlimited recursive traversal.
+        """
         normalized_session_id = (
             (session_id.strip() or None) if session_id else None
         )
@@ -259,12 +285,13 @@ class WorkspaceService:
         if not normalized_session_id and not normalized_cwd:
             raise ValueError("session_id and cwd cannot both be empty")
 
+        find_command = _build_file_tree_find_command(max_depth)
         workspace = self.ensure_workspace_exists(
             normalized_session_id or "",
             normalized_cwd,
         )
         result = await self._bash.exec(
-            cmd=_FILE_TREE_FIND_COMMAND,
+            cmd=find_command,
             cwd=workspace,
             timeout=30,
         )


### PR DESCRIPTION
## Summary
- add a `depth` query parameter to the AICoding file-tree endpoint
- default to 3 workspace-relative levels
- treat `depth=0` as unlimited traversal
- use GNU `find -maxdepth` to avoid scanning deeper directories
- validate and test default, bounded, unlimited, and invalid depth values

## Test plan
- `PYTHONPATH=src pytest src/engine/community/api/aicoding_sessions/tests/test_router.py src/engine/community/core/aicoding/tests/test_workspace_service.py -q`
- 154 passed