### PR TITLE
docs(release): add v2026.07.28 (REL20260728) release note

### DIFF
--- a/docs/releases/v2026.07.28.md
+++ b/docs/releases/v2026.07.28.md
@@ -1,0 +1,166 @@
+# Avernet v2026.07.28
+
+> Release branch: `REL20260728` · previous release: [v2026.07.15](https://github.com/inclusionAI/Avernet/releases/tag/v2026.07.15)
+
+## Overview
+
+**Avernet v2026.07.28** is the second open-source release of Avernet, the open
+infrastructure for agent organizations and open agent ecosystems.
+
+This release grows the platform along three lines: a **config-driven external
+API gateway** that gives third-party developers a stable public surface, a
+**shared session workspace** so humans and bots can collaborate over the same
+files inside a session, and an engine-agnostic **Skills Pool** that migrates,
+rolls out, and recovers bot skill layouts across OpenClaw, Claude Code,
+AICoding, and Hermes runtimes. Alongside those, service-bot publishing became
+markedly more reliable under container churn.
+
+Releases follow the `vYYYY.MM.DD` CalVer scheme.
+
+## Highlights
+
+- **Gateway v1 external API** — config-driven, domain-transparent forwarding with
+  a Forwarder/SchemaCatalog SPI, user-principal auth strategy and route-security
+  config, and a generated, backward-compatibility-checked OpenAPI document served
+  for the `/openapi/v1/bots` groups (bots, channels, skills, identity, resources,
+  MCP, routines).
+- **Session workspace** — shared per-session files with pluggable storage and CLI
+  support, access gated on session participants, system messages on upload
+  completion, and a v2 session filesystem.
+- **Human-in-the-loop collaboration** — humans auto-join session chat and emit
+  join events, human-input state machine nodes are supported in workflows, and
+  custom collaboration workflows ship with frontend YAML validation and role
+  checks.
+- **Skills Pool (P3)** — layout claim gating, complete OpenClaw filesystem
+  migration, per-engine migrations for Claude Code / AICoding / Hermes, lifecycle
+  reconciliation, quarantine management, recovery and rollback, owner-scoped
+  rollout operations, and a safe cutover finalization path.
+- **Service bot publish reliability** — superseded online bots are retired so
+  publishes no longer leave orphan or duplicate BaaS bots, the teclaw passport
+  token is delivered only after the container actually starts (retryable and
+  idempotent), and bots stuck in `pending` can be recovered.
+- **Bot coordination** — group listing for the authenticated actor, discovery
+  that excludes the requester, channel bindings scoped by environment, channel
+  source message id propagation, unified provider callback timeouts, and
+  stricter bot credential validation.
+- **Docs and developer experience** — the WAIC live demo tutorial, gateway CI
+  coverage checks, and a pre-push hook that is lint-only by default instead of
+  running full CI.
+
+## Getting Started
+
+See the documentation for installation and local setup:
+
+- [README](https://github.com/inclusionAI/Avernet/tree/v2026.07.28#readme)
+- [Quick Start](https://github.com/inclusionAI/Avernet/blob/v2026.07.28/docs/quick-start.md)
+- [Docker Guide](https://github.com/inclusionAI/Avernet/blob/v2026.07.28/docs/docker.md)
+
+## Known Limitations
+
+Prebuilt container images are still not published, so the Docker workflow builds
+from source. The Gateway v1 external API and the Skills Pool migration are
+rolling out progressively — their configuration surfaces may still change in a
+following release. Installation flows, integration protocols, and deployment
+options will continue to evolve.
+
+Please report problems through [GitHub Issues](https://github.com/inclusionAI/Avernet/issues).
+
+## Feedback and Contributions
+
+We welcome bug reports, feature requests, documentation improvements, and code
+contributions from the community.
+
+## What's Changed
+
+<details>
+<summary>View the complete list of merged pull requests</summary>
+
+* feat(bcs): list groups for authenticated actor by @vzvince in https://github.com/inclusionAI/Avernet/pull/352
+* Gateway v1 API — Group B: user-principal auth strategy, route-security config + bots sample by @totalfrank in https://github.com/inclusionAI/Avernet/pull/359
+* fix(bcs): scope channel bindings by environment by @RaymondHX in https://github.com/inclusionAI/Avernet/pull/362
+* feat(bcs): auto-join humans for session chat by @RaymondHX in https://github.com/inclusionAI/Avernet/pull/364
+* fix(bcs): expose async judge progress and cover provider timeout by @zh-bupt in https://github.com/inclusionAI/Avernet/pull/384
+* fix: avoid reusing incomplete singlebox bot sessions by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/354
+* fix(bcs): reject invalid explicit bot credentials by @vzvince in https://github.com/inclusionAI/Avernet/pull/365
+* fix(bcs-cli): restore discover JSON output by @vzvince in https://github.com/inclusionAI/Avernet/pull/380
+* fix(bcs): unify provider callback timeout by @vzvince in https://github.com/inclusionAI/Avernet/pull/386
+* fix(backend): preserve per-bot notify probe failures — Refs ocb#9 by @maicaisongxiaocong in https://github.com/inclusionAI/Avernet/pull/388
+* feat(bcs): complete custom collaboration workflow by @zh-bupt in https://github.com/inclusionAI/Avernet/pull/385
+* [Skills Pool P3] OpenClaw 暗准备 Pool 并支持运行时探测 by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/392
+* feat: add skills pool layout claim gate by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/367
+* Gateway v1 API — remaining groups: channels, skills, identity, resources, mcp, routines by @totalfrank in https://github.com/inclusionAI/Avernet/pull/389
+* feat(bcs): session workspace — shared per-session files, pluggable storage, CLI by @zh-bupt in https://github.com/inclusionAI/Avernet/pull/343
+* fix(harness): raise LLM call success rate for diagnostics and patch g… by @pddbend in https://github.com/inclusionAI/Avernet/pull/402
+* feat: activate OpenClaw skills pool migration by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/369
+* fix(baas): preserve configured engine venv symlink by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/408
+* feat: migrate complete OpenClaw filesystem truth by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/370
+* fix(bcs): emit human join event for session chat by @RaymondHX in https://github.com/inclusionAI/Avernet/pull/403
+* fix(baas): convert aicoding command output by @vzvince in https://github.com/inclusionAI/Avernet/pull/407
+* fix(bcn): emit empty final for tool-only runs by @RaymondHX in https://github.com/inclusionAI/Avernet/pull/296
+* docs: complete WAIC demo tutorial docs by @ziminz19 in https://github.com/inclusionAI/Avernet/pull/337
+* feat: wire skills pool lifecycle reconciliation by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/410
+* feat: add Claude Code skills pool migration by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/411
+* fix(bcs): avoid single upload multipart misclassification by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/412
+* feat: add AICoding skills pool migration by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/414
+* Rel20260723 to dev by @quhongwei in https://github.com/inclusionAI/Avernet/pull/413
+* feat(backend)botchat统一接口+开放api by @3h-william in https://github.com/inclusionAI/Avernet/pull/366
+* test(gateway): add ci coverage check by @cassiuscai in https://github.com/inclusionAI/Avernet/pull/406
+* feat: add Hermes skills pool migration by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/415
+* chore(baas): Revert code change for device_template_router.py by @cassiuscai in https://github.com/inclusionAI/Avernet/pull/424
+* fix(bcs): exclude requester from discovery by @vzvince in https://github.com/inclusionAI/Avernet/pull/400
+* fix(bcs): gate session-file access on session participants and relax share authz by @zh-bupt in https://github.com/inclusionAI/Avernet/pull/423
+* fix(health_check): 调整沙盒设备告警处理逻辑 by @WZhutian in https://github.com/inclusionAI/Avernet/pull/422
+* fix(baas): bind singlebox gateways to loopback by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/427
+* fix(bcs): allow bot owner to remove their bot from a session by @zh-bupt in https://github.com/inclusionAI/Avernet/pull/426
+* feat(frontend): improve custom collaboration YAML validation and role… by @quechao76 in https://github.com/inclusionAI/Avernet/pull/425
+* fix(baas): do not return 503 when device not available by @cassiuscai in https://github.com/inclusionAI/Avernet/pull/429
+* fix(bcs): allow driver bot and its owner to delete a session by @zh-bupt in https://github.com/inclusionAI/Avernet/pull/433
+* feat(bcs): propagate channel source message ids by @RaymondHX in https://github.com/inclusionAI/Avernet/pull/432
+* feat(bcs): support human input state machine nodes by @RaymondHX in https://github.com/inclusionAI/Avernet/pull/421
+* feat: freeze service bot skills layout artifact by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/375
+* fix(baas): prevent SQLAlchemy isce error from concurrent orm_session calls in distributed lock renew thread by @cassiuscai in https://github.com/inclusionAI/Avernet/pull/441
+* feat: add Skills Pool recovery and rollback by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/417
+* feat: manage skills pool migration quarantine by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/418
+* feat: add Skills Pool rollout operations by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/447
+* fix(service-bot): retire superseded online bot to stop orphan/duplicate BaaS bots by @totalfrank in https://github.com/inclusionAI/Avernet/pull/512
+* Config-driven gateway forwarding by @totalfrank in https://github.com/inclusionAI/Avernet/pull/420
+* fix: release pool claim for incapable runtimes by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/451
+* Remove the retired ac_file table and its dead call graph by @totalfrank in https://github.com/inclusionAI/Avernet/pull/454
+* Make pre-push lint-only by default instead of full CI by @totalfrank in https://github.com/inclusionAI/Avernet/pull/450
+* feat(bcs): fire system message on session file upload complete by @zh-bupt in https://github.com/inclusionAI/Avernet/pull/445
+* add relay ws_url by @liaoxianhao in https://github.com/inclusionAI/Avernet/pull/462
+* fix lock by @xxxxpenny in https://github.com/inclusionAI/Avernet/pull/460
+* feat: safely finalize Skills Pool cutover by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/459
+* fix(backend): recover bots stuck in pending by @XIEAN99 in https://github.com/inclusionAI/Avernet/pull/468
+* fix: domain-bots remove auth and remove iam_token (cherry-pick #442 to REL20260728) by @chendsy in https://github.com/inclusionAI/Avernet/pull/472
+* Bugfix/fix error status by @xxxxpenny in https://github.com/inclusionAI/Avernet/pull/466
+* fix: backport legacy skills pool rollout CAS to REL20260728 by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/479
+* feat(mcp): add app info to claude code defaults by @CapQing in https://github.com/inclusionAI/Avernet/pull/477
+* fix auth on api resources  url and node by @liaoxianhao in https://github.com/inclusionAI/Avernet/pull/484
+* fix lock by @xxxxpenny in https://github.com/inclusionAI/Avernet/pull/489
+* fix: promote Skills Pool cutover recovery to REL20260728 by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/496
+* Session fs v2 by @pfmiles in https://github.com/inclusionAI/Avernet/pull/486
+* fix: route Pool-active skill CRUD to canonical paths by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/500
+* feat(mcp): show real names for claude_code default MCPs by @CapQing in https://github.com/inclusionAI/Avernet/pull/504
+* fix(community): route notify probe by device_provider (BaaS ENGINE_HTTP_500) by @maicaisongxiaocong in https://github.com/inclusionAI/Avernet/pull/508
+* remove packages by @xxxxpenny in https://github.com/inclusionAI/Avernet/pull/505
+* fix: harden multi-engine Skills Pool runtime by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/502
+* fix(baas): use gmt_modified instead of gmt_create for publish timeout baseline by @cassiuscai in https://github.com/inclusionAI/Avernet/pull/513
+* feat(bot_run): treat agent final event as session termination by @xxxxpenny in https://github.com/inclusionAI/Avernet/pull/518
+* Oss endpoint div by @pfmiles in https://github.com/inclusionAI/Avernet/pull/520
+* fix: serialize BaaS bootstrap with container init by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/519
+* fix(teclaw): deliver the passport token after the container actually starts by @totalfrank in https://github.com/inclusionAI/Avernet/pull/527
+* revert: restore historical BaaS bootstrap behavior by @FreddieSun in https://github.com/inclusionAI/Avernet/pull/533
+
+</details>
+
+## New Contributors
+* @pddbend made their first contribution in https://github.com/inclusionAI/Avernet/pull/402
+* @ziminz19 made their first contribution in https://github.com/inclusionAI/Avernet/pull/337
+* @3h-william made their first contribution in https://github.com/inclusionAI/Avernet/pull/366
+* @WZhutian made their first contribution in https://github.com/inclusionAI/Avernet/pull/422
+* @liaoxianhao made their first contribution in https://github.com/inclusionAI/Avernet/pull/462
+* @chendsy made their first contribution in https://github.com/inclusionAI/Avernet/pull/472
+* @CapQing made their first contribution in https://github.com/inclusionAI/Avernet/pull/477
+
+**Full Changelog**: https://github.com/inclusionAI/Avernet/compare/v2026.07.15...v2026.07.28


### PR DESCRIPTION
## What

Adds `docs/releases/v2026.07.28.md` — the release note for the `REL20260728` line, written to be pasted directly into a GitHub release body. It follows the structure of [v2026.07.15](https://github.com/inclusionAI/Avernet/releases/tag/v2026.07.15): Overview, Highlights, Getting Started, Known Limitations, Feedback and Contributions, a collapsible "What's Changed" list, New Contributors, and the full changelog link.

## How the changelog was derived

The 76 listed pull requests come from the 152 commits in `v2026.07.15..origin/REL20260728`, mapped back to their PRs:

- squash-merge commits carrying a `(#N)` ref;
- rebase-merged blocks whose individual commits carry no ref (e.g. the gateway forwarding work in #420, the service-bot supersede cleanup in #512, the teclaw token delivery in #527);
- pull requests merged directly into the `REL20260728` branch, including the backports (#479, #496) and the cherry-pick (#472).

Where a change reached the release line through a backport, the release-branch PR is listed rather than the dev PR, so a single change is not counted twice. New contributors are those with no commits in `v2026.07.15`'s history.

## Notes

- The `v2026.07.28` links in Getting Started and the compare link resolve once the tag is cut; they 404 until then.
- Both #519 and its revert #533 are listed, matching what actually landed on the branch.
- Docs only — no code or CI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwxDvtJ3egXfMk2f4ueGSr)_