### PR TITLE
feat(baas): increase default provision timeouts from 900s to 1800s

### DIFF
--- a/src/baas/src/secbaas/community/api/publish_manage/_models.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/_models.py
@@ -44,10 +44,10 @@ from ._enums import PublishType, RestartScope  # noqa: E402 — cyclic import gu
 
 # ==================== Constants ====================
 
-DEFAULT_CALLBACK_TIMEOUT_SECONDS = 900
+DEFAULT_CALLBACK_TIMEOUT_SECONDS = 1800
 """Device callback timeout in seconds."""
 
-DEFAULT_PUBLISH_LEVEL_TIMEOUT_SECONDS = 900
+DEFAULT_PUBLISH_LEVEL_TIMEOUT_SECONDS = 1800
 """Maximum time a publish can stay in non-terminal state before auto-resolution.
 
 When a publish is stuck in PENDING/ACTIVE/APPROVING for longer than this

--- a/src/baas/src/secbaas/community/core/service/config/_constants.py
+++ b/src/baas/src/secbaas/community/core/service/config/_constants.py
@@ -34,10 +34,10 @@ class SystemConfigKey(StrEnum):
     CALLBACK_TIMEOUT_SECONDS = "publish.callback_timeout_seconds"
     """System-level callback timeout in seconds.
 
-    Value: integer string (e.g., "900")
+    Value: integer string (e.g., "1800")
     Usage: Override for bot callback timeout at system level,
     applied when no user-specified value exists.
-    Falls back to DEFAULT_CALLBACK_TIMEOUT_SECONDS (900).
+    Falls back to DEFAULT_CALLBACK_TIMEOUT_SECONDS (1800).
     """
 
     # SessionKey matching configuration

--- a/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
+++ b/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
@@ -19,6 +19,7 @@ from secbaas.community.api.bot_manage import BotManageService, BotStatus
 from secbaas.community.api.bot_runtime import BotNotFoundError
 from secbaas.community.api.device_manage import DeviceService
 from secbaas.community.api.publish_manage import (
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
     DEFAULT_PUBLISH_LEVEL_TIMEOUT_SECONDS,
     BatchDeviceProgress,
     BatchResult,
@@ -4248,7 +4249,7 @@ class DefaultPublishService(PublishService):
         full callback pipeline (device update, record update, batch/stage check).
         """
         env = get_current_env()
-        timeout_seconds = 600  # default
+        timeout_seconds = DEFAULT_CALLBACK_TIMEOUT_SECONDS  # default
 
         publish_config = _extra_config_to_publish_config(publish_record.extra_config)
         if publish_config is not None:

--- a/src/baas/tests/unit/api/publish_manage/test_models.py
+++ b/src/baas/tests/unit/api/publish_manage/test_models.py
@@ -62,7 +62,7 @@ class TestPublishConfig:
         assert cfg.batch_capacity_default == 5
         assert cfg.auto_complete is True
         assert cfg.auto_execute_max_iterations == 20
-        assert cfg.callback_timeout_seconds == 900
+        assert cfg.callback_timeout_seconds == 1800
 
     def test_custom_values(self):
         cfg = PublishConfig(

--- a/src/baas/tests/unit/core/service/publish_manage/test_publish_service.py
+++ b/src/baas/tests/unit/core/service/publish_manage/test_publish_service.py
@@ -8,6 +8,7 @@ import pytest
 
 from secbaas.community.api.bot_manage import BotStatus
 from secbaas.community.api.publish_manage import (
+    DEFAULT_CALLBACK_TIMEOUT_SECONDS,
     BatchStatus,
     DrainResult,
     ProgressSummary,
@@ -6891,7 +6892,7 @@ class TestCheckAndHandleTimeout:
 
             _publish_service_instance._publish_record_repo.list_stale_processing_records.assert_called_once_with(
                 publish_id=1,
-                timeout_seconds=600,
+                timeout_seconds=DEFAULT_CALLBACK_TIMEOUT_SECONDS,
                 tenant="test_tenant",
                 env=mock_env,
             )


### PR DESCRIPTION
## What
Increase two default timeout constants from 900s (15 min) to 1800s (30 min) in BaaS to accommodate real-world device provisioning scenarios where sandbox/container platform callbacks frequently take 20–30 minutes.

### Changes
- `DEFAULT_CALLBACK_TIMEOUT_SECONDS`: 900 → 1800 (per-device callback timeout)
- `DEFAULT_PUBLISH_LEVEL_TIMEOUT_SECONDS`: 900 → 1800 (publish-level staleness detection)
- Fix inconsistent hardcoded `600` fallback in `_check_and_handle_timeout` → now references `DEFAULT_CALLBACK_TIMEOUT_SECONDS`
- Update docstrings and unit test assertions

### Design Notes
- 3-tier resolution chain (user config → system config → code default) unchanged
- `le=3600` validation bound already accommodates 1800 — no schema changes
- No migration needed — only fallback defaults change
- Backend (`src/backend/`) has zero references — no backend changes

## Verification
- 396/396 unit tests pass

Closes #539