### PR TITLE
fix(bcs-storage-baas): delete transfer via sessions transfers path, not files

### DIFF
--- a/src/bcs/crates/plugins/bcs-storage-baas/src/lib.rs
+++ b/src/bcs/crates/plugins/bcs-storage-baas/src/lib.rs
@@ -42,16 +42,21 @@ impl BaasStoragePlugin {
         Self { cfg, caps, http }
     }
 
-    /// Build the baas base path: {endpoint}/api/v1/sessions/{tenant}/{session_id percent-encoded}/files.
-    /// transfer_id and session_id are percent-encoded to be safe path segments.
-    fn base_for_session(&self, session_id: &str) -> String {
-        let sid = percent_encode_path(session_id);
+    /// Build the baas session root path (files/transfers are siblings under it):
+    /// {endpoint}/api/v1/sessions/{tenant}/{session_id percent-encoded}.
+    /// tenant and session_id are percent-encoded to be safe path segments.
+    fn session_path_root(&self, session_id: &str) -> String {
         format!(
-            "{}/api/v1/sessions/{}/{}/files",
+            "{}/api/v1/sessions/{}/{}",
             self.cfg.endpoint.trim_end_matches('/'),
             percent_encode_path(&self.cfg.tenant),
-            sid
+            percent_encode_path(session_id)
         )
+    }
+
+    /// Build the baas files base path: {session_path_root}/files.
+    fn base_for_session(&self, session_id: &str) -> String {
+        format!("{}/files", self.session_path_root(session_id))
     }
 
     fn auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
@@ -320,8 +325,8 @@ impl StoragePlugin for BaasStoragePlugin {
                         .map(|p| BaasReadyHandle { transfer_id: p.transfer_id }))
             .map_err(|e| StorageError::Backend(e.into()))?;
         let session_id = session_id_from_key(&handle.key);
-        let base = self.base_for_session(session_id);
-        let resp = self.auth(self.http.delete(format!("{base}/transfers/{}",
+        let root = self.session_path_root(session_id);
+        let resp = self.auth(self.http.delete(format!("{root}/transfers/{}",
                     percent_encode_path(&ready.transfer_id)))).send().await
             .map_err(|e| StorageError::Backend(e.into()))?;
         if resp.status().is_success() {

--- a/src/bcs/crates/plugins/bcs-storage-baas/tests/delete.rs
+++ b/src/bcs/crates/plugins/bcs-storage-baas/tests/delete.rs
@@ -15,7 +15,7 @@ fn h(key: &str, tid: &str) -> StorageHandle {
 #[tokio::test]
 async fn delete_returns_ok_on_deleted() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE")).and(path("/api/v1/sessions/t/sid/files/transfers/tid"))
+    Mock::given(method("DELETE")).and(path("/api/v1/sessions/t/sid/transfers/tid"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"code":0,"data":{"transfer_id":"tid","previous_status":"DONE","new_status":"DELETED"}})))
         .mount(&server).await;
     plugin(server.uri()).delete(&h("session-files/prod/sid/f/f", "tid")).await.unwrap();
@@ -24,7 +24,7 @@ async fn delete_returns_ok_on_deleted() {
 #[tokio::test]
 async fn delete_idempotent_on_transfer_not_found() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE")).and(path("/api/v1/sessions/t/sid/files/transfers/tid"))
+    Mock::given(method("DELETE")).and(path("/api/v1/sessions/t/sid/transfers/tid"))
         .respond_with(ResponseTemplate::new(404).set_body_json(json!({"detail":{"error":"TRANSFER_NOT_FOUND","message":"gone"}})))
         .mount(&server).await;
     plugin(server.uri()).delete(&h("session-files/prod/sid/f/f", "tid")).await.unwrap(); // 404 -> Ok idempotent
@@ -33,7 +33,7 @@ async fn delete_idempotent_on_transfer_not_found() {
 #[tokio::test]
 async fn delete_not_terminal_maps_conflict() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE")).and(path("/api/v1/sessions/t/sid/files/transfers/tid"))
+    Mock::given(method("DELETE")).and(path("/api/v1/sessions/t/sid/transfers/tid"))
         .respond_with(ResponseTemplate::new(409).set_body_json(json!({"detail":{"error":"TRANSFER_NOT_TERMINAL","message":"UPLOADING"}})))
         .mount(&server).await;
     let err = plugin(server.uri()).delete(&h("session-files/prod/sid/f/f", "tid")).await.unwrap_err();


### PR DESCRIPTION
## What
Fix the baas session-file `delete` transfer path so it targets the baas `transfers` resource as a sibling of `files`, not nested under it.

## Why
`delete` built `{base_for_session}/transfers/{id}` = `.../sessions/{tenant}/{sid}/files/transfers/{id}`, but baas expects `DELETE /api/v1/sessions/{tenant}/{sid}/transfers/{transferId}` (the extra `/files` segment is wrong). As a result deletes were sent to a non-existent path and failed.

## Changes
- `bcs-storage-baas`: add `session_path_root` returning `.../sessions/{tenant}/{sid}` (the shared parent of `files` and `transfers`); route `delete` through it so the path becomes `.../sessions/{tenant}/{sid}/transfers/{id}`.
- `base_for_session` now wraps `session_path_root` (`{root}/files`), keeping `complete` / `abort` / `prepare` paths unchanged.
- `tests/delete.rs`: update the 3 mock path assertions to `/api/v1/sessions/t/sid/transfers/tid`.

## Verification
`cargo test -p bcs-storage-baas` (full suite) green:
- `delete.rs` 3 passed, `complete_abort.rs` 4 passed (confirms `base_for_session` refactor doesn't regress complete/abort `files`-rooted paths), `presign`/`prepare`/`health`/`factory`/`error_map` all pass.
