### PR TITLE
fix(bcs): keep frontend HumanInput channel optional

### DIFF
--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/definition.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/definition.rs
@@ -164,41 +164,46 @@ pub fn validate_definition(
                 None => return invalid(format!("node {node_id} assignee is required")),
             },
             StateMachineNodeKind::HumanInput => {
-                match &node.assignee {
-                    Some(StateMachineAssignee::RuntimeActor { actor })
-                        if !actor.trim().is_empty() => {}
-                    Some(StateMachineAssignee::RuntimeActor { .. }) => {
+                match (&node.notification, &node.assignee) {
+                    (None, None) => {}
+                    (None, Some(_)) => {
+                        return invalid(format!(
+                            "frontend human_input node {node_id} must not define assignee"
+                        ));
+                    }
+                    (
+                        Some(notification),
+                        Some(StateMachineAssignee::RuntimeActor { actor }),
+                    ) if !actor.trim().is_empty() => {
+                        let channel =
+                            state_machine.human_input_channel.as_ref().ok_or_else(|| {
+                                CollaborationRuntimeError::InvalidDefinition(format!(
+                                    "human_input node {node_id} with notification requires state_machine.human_input_channel"
+                                ))
+                            })?;
+                        if notification.mode == HumanInputNotificationMode::FixedGroup
+                            && channel.fixed_group.is_none()
+                        {
+                            return invalid(format!(
+                                "human_input node {node_id} fixed_group notification requires state_machine.human_input_channel.fixed_group"
+                            ));
+                        }
+                    }
+                    (Some(_), Some(StateMachineAssignee::RuntimeActor { .. })) => {
                         return invalid(format!(
                             "human_input node {node_id} assignee actor must not be empty"
                         ));
                     }
-                    Some(StateMachineAssignee::BotBinding { .. }) => {
+                    (Some(_), Some(StateMachineAssignee::BotBinding { .. })) => {
                         return invalid(format!(
                             "human_input node {node_id} assignee must be runtime_actor"
                         ));
                     }
-                    None => {
+                    (Some(_), None) => {
                         return invalid(format!(
-                            "human_input node {node_id} runtime_actor assignee is required"
+                            "human_input node {node_id} with notification requires runtime_actor assignee"
                         ));
                     }
-                }
-                let notification = node.notification.as_ref().ok_or_else(|| {
-                    CollaborationRuntimeError::InvalidDefinition(format!(
-                        "human_input node {node_id} notification is required"
-                    ))
-                })?;
-                let channel = state_machine.human_input_channel.as_ref().ok_or_else(|| {
-                    CollaborationRuntimeError::InvalidDefinition(format!(
-                        "human_input node {node_id} requires state_machine.human_input_channel"
-                    ))
-                })?;
-                if notification.mode == HumanInputNotificationMode::FixedGroup
-                    && channel.fixed_group.is_none()
-                {
-                    return invalid(format!(
-                        "human_input node {node_id} fixed_group notification requires state_machine.human_input_channel.fixed_group"
-                    ));
                 }
                 if node.max_attempts.is_some() {
                     return invalid(format!(

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -381,28 +381,6 @@ impl CollaborationRuntime {
         let node = state_machine.nodes.get(node_id).ok_or_else(|| {
             CollaborationRuntimeError::InvalidDefinition(format!("node not found: {node_id}"))
         })?;
-        let assignee_actor_id = match &node.assignee {
-            Some(StateMachineAssignee::RuntimeActor { actor }) => actor.clone(),
-            _ => {
-                return Err(CollaborationRuntimeError::InvalidDefinition(format!(
-                    "human_input node {node_id} requires runtime_actor assignee"
-                )));
-            }
-        };
-        let notification_mode = node
-            .notification
-            .as_ref()
-            .ok_or_else(|| {
-                CollaborationRuntimeError::InvalidDefinition(format!(
-                    "human_input node {node_id} notification is required"
-                ))
-            })?
-            .mode;
-        let human_input_channel = state_machine.human_input_channel.as_ref().ok_or_else(|| {
-            CollaborationRuntimeError::InvalidDefinition(format!(
-                "human_input node {node_id} requires state_machine.human_input_channel"
-            ))
-        })?;
         let node_run = self
             .runs
             .get_node_run(&run.run_id, node_id)
@@ -418,7 +396,6 @@ impl CollaborationRuntime {
             ))
         })?;
         let deadline = now.saturating_add(timeout_ms);
-        let event_id = format!("human-ready:{}:{}", run.run_id, node_id);
         let marked = self
             .runs
             .mark_human_node_running_if_run_active(MarkHumanNodeRunningCommand {
@@ -432,6 +409,27 @@ impl CollaborationRuntime {
         if !marked {
             return Ok(());
         }
+        self.publish_state_machine_panel_event(group, run, None)
+            .await;
+        let Some(notification) = node.notification.as_ref() else {
+            return Ok(());
+        };
+        let assignee_actor_id = match &node.assignee {
+            Some(StateMachineAssignee::RuntimeActor { actor }) => actor.clone(),
+            _ => {
+                return Err(CollaborationRuntimeError::InvalidDefinition(format!(
+                    "human_input node {node_id} with notification requires runtime_actor assignee"
+                )));
+            }
+        };
+        let human_input_channel = state_machine.human_input_channel.as_ref().ok_or_else(|| {
+            CollaborationRuntimeError::InvalidDefinition(format!(
+                "human_input node {node_id} with notification requires state_machine.human_input_channel"
+            ))
+        })?;
+        let Some(outbound) = self.session_channel_outbound.as_ref() else {
+            return Ok(());
+        };
         let running_node = self
             .runs
             .get_node_run(&run.run_id, node_id)
@@ -443,13 +441,8 @@ impl CollaborationRuntime {
         let pending = self
             .pending_human_node_view(compiled, run, &running_node)
             .await?;
-        self.publish_state_machine_panel_event(group, run, None)
-            .await;
-        let Some(outbound) = self.session_channel_outbound.as_ref() else {
-            return Ok(());
-        };
         let event = HumanInputReadyEvent {
-            event_id,
+            event_id: format!("human-ready:{}:{}", run.run_id, node_id),
             group_id: run.group_id.clone(),
             session_id: run.session_id.clone(),
             run_id: run.run_id.clone(),
@@ -458,7 +451,7 @@ impl CollaborationRuntime {
             instruction: pending.instruction,
             assignee_actor_id,
             channel_type: human_input_channel.channel_type.clone(),
-            notification_mode,
+            notification_mode: notification.mode,
             fixed_group_conversation_id: human_input_channel
                 .fixed_group
                 .as_ref()
@@ -2047,12 +2040,15 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 cmd.node_id
             )));
         }
-        // COSEC: a channel sender must match the assignee frozen in the run
-        // definition; being any Present Human in the session is insufficient.
-        if !matches!(
-            &node_definition.assignee,
-            Some(StateMachineAssignee::RuntimeActor { actor }) if actor == &cmd.caller_actor_id
-        ) {
+        // COSEC: IM-targeted input is restricted to its frozen assignee. A
+        // frontend-only node has no assignee and retains the existing rule
+        // that any Present Human participant in the run session may respond.
+        let caller_matches_node = match &node_definition.assignee {
+            None => true,
+            Some(StateMachineAssignee::RuntimeActor { actor }) => actor == &cmd.caller_actor_id,
+            Some(StateMachineAssignee::BotBinding { .. }) => false,
+        };
+        if !caller_matches_node {
             return Err(CollaborationRuntimeError::Forbidden(
                 "caller is not the HumanInput node assignee".to_string(),
             ));
@@ -2197,17 +2193,16 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             {
                 continue;
             }
-            if !state_machine
-                .nodes
-                .get(&node_run.node_id)
-                .is_some_and(|node| {
-                    node.kind == StateMachineNodeKind::HumanInput
-                        && matches!(
-                            &node.assignee,
-                            Some(StateMachineAssignee::RuntimeActor { actor })
-                                if actor == &cmd.caller_actor_id
-                        )
-                })
+            if !state_machine.nodes.get(&node_run.node_id).is_some_and(|node| {
+                node.kind == StateMachineNodeKind::HumanInput
+                    && match &node.assignee {
+                        None => true,
+                        Some(StateMachineAssignee::RuntimeActor { actor }) => {
+                            actor == &cmd.caller_actor_id
+                        }
+                        Some(StateMachineAssignee::BotBinding { .. }) => false,
+                    }
+            })
             {
                 continue;
             }

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
@@ -552,6 +552,53 @@ fn validates_human_input_with_natural_language_judge_outcomes() {
 }
 
 #[test]
+fn validates_frontend_human_input_without_channel_or_assignee() {
+    let mut definition = human_review_definition();
+    let state_machine = match &mut definition.runtime {
+        CollaborationRuntimeDefinition::StateMachine(state_machine) => state_machine,
+        _ => panic!("expected state machine"),
+    };
+    state_machine.human_input_channel = None;
+    let review = state_machine.nodes.get_mut("review").expect("review node");
+    review.assignee = None;
+    review.notification = None;
+
+    validate_definition(definition).expect("frontend HumanInput should remain valid");
+}
+
+#[test]
+fn rejects_im_human_input_without_channel() {
+    let mut definition = human_review_definition();
+    let state_machine = match &mut definition.runtime {
+        CollaborationRuntimeDefinition::StateMachine(state_machine) => state_machine,
+        _ => panic!("expected state machine"),
+    };
+    state_machine.human_input_channel = None;
+
+    let error = validate_definition(definition).expect_err("IM HumanInput requires a channel");
+    assert!(
+        error
+            .to_string()
+            .contains("with notification requires state_machine.human_input_channel")
+    );
+}
+
+#[test]
+fn rejects_frontend_human_input_with_assignee() {
+    let mut definition = human_review_definition();
+    let review = human_node_mut(&mut definition);
+    review.notification = None;
+
+    let error =
+        validate_definition(definition).expect_err("frontend HumanInput has no fixed assignee");
+    assert!(
+        error
+            .to_string()
+            .contains("frontend human_input node review must not define assignee")
+    );
+}
+
+#[test]
 fn validates_human_input_without_judge_uses_complete_transition() {
     let mut definition = human_review_definition();
     let state_machine = match &mut definition.runtime {

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
@@ -584,6 +584,28 @@ fn rejects_im_human_input_without_channel() {
 }
 
 #[test]
+fn rejects_fixed_group_human_input_without_fixed_group_channel() {
+    let mut definition = human_review_definition();
+    let state_machine = match &mut definition.runtime {
+        CollaborationRuntimeDefinition::StateMachine(state_machine) => state_machine,
+        _ => panic!("expected state machine"),
+    };
+    state_machine
+        .human_input_channel
+        .as_mut()
+        .expect("HumanInput channel")
+        .fixed_group = None;
+
+    let error =
+        validate_definition(definition).expect_err("fixed_group notification requires a group");
+    assert!(
+        error
+            .to_string()
+            .contains("fixed_group notification requires state_machine.human_input_channel.fixed_group")
+    );
+}
+
+#[test]
 fn rejects_frontend_human_input_with_assignee() {
     let mut definition = human_review_definition();
     let review = human_node_mut(&mut definition);

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -562,6 +562,149 @@ async fn human_input_waits_without_bot_delivery_and_completes_from_natural_langu
 }
 
 #[tokio::test]
+async fn frontend_human_input_skips_im_delivery_and_accepts_present_human() {
+    let group = Arc::new(GroupStore::new());
+    group
+        .upsert(state_machine_test_group())
+        .await
+        .expect("seed group");
+    let sessions = test_sessions();
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let channel_outbound = Arc::new(RecordingSessionChannelOutbound::default());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions,
+        Arc::new(RecordingDelivery::default()),
+        noop_judge(),
+    )
+    .with_session_channel_outbound(channel_outbound.clone());
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: Some(frontend_human_input_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"proposal": "review in frontend"}),
+            caller_id: Some("human_1001".to_string()),
+            authenticated_human: Some(AuthenticatedHumanCaller {
+                actor_id: "human_1001".to_string(),
+                display_name: Some("Reviewer".to_string()),
+            }),
+        })
+        .await
+        .expect("start frontend HumanInput run");
+
+    assert_eq!(
+        started.view.nodes[0].status,
+        StateMachineNodeStatus::Running
+    );
+    assert!(channel_outbound.events.lock().await.is_empty());
+
+    let pending = runtime
+        .list_pending_human_nodes(ListPendingHumanNodesCommand {
+            run_id: started.view.run.run_id.clone(),
+            caller_actor_id: "human_1001".to_string(),
+        })
+        .await
+        .expect("frontend Human lists pending node");
+    assert_eq!(pending.len(), 1);
+
+    let completed = runtime
+        .respond_human_node(RespondHumanNodeCommand {
+            run_id: started.view.run.run_id,
+            node_id: "review".to_string(),
+            caller_actor_id: "human_1001".to_string(),
+            content: "approved in frontend".to_string(),
+            source: HumanResponseSource::Http,
+        })
+        .await
+        .expect("Present Human responds from frontend");
+
+    assert_eq!(completed.node.status, StateMachineNodeStatus::Completed);
+    assert_eq!(completed.run.status, StateMachineRunStatus::Completed);
+}
+
+#[tokio::test]
+async fn im_human_input_rejects_a_different_present_human() {
+    let group = Arc::new(GroupStore::new());
+    let seeded_group = state_machine_test_group();
+    group
+        .upsert(seeded_group.clone())
+        .await
+        .expect("seed group");
+    let sessions = test_sessions();
+    let mut assigned = Participant::human("human_1001", ParticipantRole::Observer);
+    assigned.mode = Some(ParticipantMode::Present);
+    let mut other = Participant::human("human_2002", ParticipantRole::Observer);
+    other.mode = Some(ParticipantMode::Present);
+    let session = sessions
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: seeded_group.id.clone(),
+            session_id: None,
+            params: NewSessionParams {
+                session_kind: SessionKind::ServiceInvocation,
+                participants: vec![assigned, other],
+                ..Default::default()
+            },
+        })
+        .await
+        .expect("seed session")
+        .session;
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions,
+        Arc::new(RecordingDelivery::default()),
+        noop_judge(),
+    );
+
+    let started = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: seeded_group.id,
+            session_id: Some(session.id),
+            definition_yaml: Some(human_input_yaml()),
+            definition: None,
+            definition_ref: None,
+            input: json!({"proposal": "assigned review"}),
+            caller_id: Some("bot_driver".to_string()),
+            authenticated_human: None,
+        })
+        .await
+        .expect("start assigned IM HumanInput run");
+
+    let pending = runtime
+        .list_pending_human_nodes(ListPendingHumanNodesCommand {
+            run_id: started.view.run.run_id.clone(),
+            caller_actor_id: "human_2002".to_string(),
+        })
+        .await
+        .expect("other Present Human may inspect the run");
+    assert!(pending.is_empty());
+
+    let error = runtime
+        .respond_human_node(RespondHumanNodeCommand {
+            run_id: started.view.run.run_id,
+            node_id: "review".to_string(),
+            caller_actor_id: "human_2002".to_string(),
+            content: "attempted response".to_string(),
+            source: HumanResponseSource::Http,
+        })
+        .await
+        .expect_err("IM HumanInput must reject a non-assignee");
+    assert!(matches!(error, CollaborationRuntimeError::Forbidden(_)));
+}
+
+#[tokio::test]
 async fn state_machine_session_rejects_message_without_pending_human_input() {
     let group = Arc::new(GroupStore::new());
     group
@@ -3021,6 +3164,28 @@ runtime:
         notification:
           mode: fixed_group
         instruction: 请用自然语言给出你的意见。
+        node_timeout_ms: 60000
+"#
+    .to_string()
+}
+
+fn frontend_human_input_yaml() -> String {
+    r#"
+api_version: bcs.collaboration/v1
+id: frontend_human_input
+version: 1
+name: Frontend Human Review
+participants: {}
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      review:
+        kind: human_input
+        display_name: Review
+        instruction: 请在前端给出你的意见。
         node_timeout_ms: 60000
 "#
     .to_string()

--- a/src/bcs/docs/plans/2026-07-27-human-input-dingtalk-im.md
+++ b/src/bcs/docs/plans/2026-07-27-human-input-dingtalk-im.md
@@ -36,9 +36,12 @@ pending HumanInput”的启发式判断，无法覆盖以下场景：
 
 ### 2.1 节点通知模式
 
+- 不配置 `notification` 时沿用现有 Workbench HumanInput，不要求
+  `assignee` 或 `human_input_channel`；
 - `fixed_group`：发送到当前 collaboration YAML 声明的唯一固定钉钉群；
 - `direct_assignee`：发送给节点 assignee 对应的钉钉用户；
-- 两种模式都必须配置一个固定 BCS Human actor；
+- 选择任一 IM notification mode 时，必须同时配置
+  `human_input_channel` 和固定 BCS Human actor；
 - 一个节点只能选择一种模式，不同时向群和个人广播。
 
 ### 2.2 YAML 固定群与机器人解析


### PR DESCRIPTION
## Summary

- Keep `human_input_channel` optional for frontend-only HumanInput nodes.
- Require `human_input_channel` and a `runtime_actor` assignee only when IM notification is configured.
- Preserve exact-assignee authorization for IM replies while allowing any present Human participant in the run session to answer frontend HumanInput nodes.
- Add definition validation and runtime progression coverage for both modes, and update the implementation plan.

## Root cause

PR #493 applied the DingTalk IM requirements unconditionally to every HumanInput node. This made the pre-existing `bot-human-bot-review.yaml` frontend-only seed invalid because it intentionally has no IM channel or assignee.

## Impact

Existing frontend HumanInput workflows continue to work without channel configuration. Workflows that opt into IM notification retain the stricter channel and assignee requirements.

## Validation

- `cargo test -p bcs-collaboration-runtime` — 66 tests passed
- Changed-line coverage for the PR production-code diff: `34/42` (`80.95%`)