### PR TITLE
docs(openapi-v1): record Track B bots (#494) on the handoff board

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -19,17 +19,26 @@ what, and how the pieces fit together._
 > and edit any prose that's now wrong. Small edits, often.
 
 Read this alongside the deeper engineering handoff and the SDD docs in
-`src/backend/specs/2026-07-26-tenant-isolation-foundation/`
-(`spec.md`, `plan.md`, `tasks.md` — these arrive with PR #456).
+`src/backend/specs/` — `2026-07-26-tenant-isolation-foundation/` (Track A
+Stage 1, merged as PR #456) and `2026-07-27-openapi-v1-bots-track-b/` (Track B
+bots, merged as PR #494). Each carries `spec.md`, `plan.md`, `tasks.md`.
 
 ---
 
 ## The big picture (read this first)
 
 **Goal:** implement the public `/openapi/v1` API, whose callers are **external
-registered tenants**. Today it exists only as **route definitions with stub
-handlers** under
-`src/backend/src/agentclaw/community/adapters/http/openapi_v1/*`.
+registered tenants**. It lives under
+`src/backend/src/agentclaw/community/adapters/http/openapi_v1/*`. The **bots**
+category is implemented (PR #494); the other six are still **route definitions
+with stub handlers**.
+
+> 🔒 **The surface is not callable yet, by design.** `require_principal` is
+> still a stub returning `None`, so every real request to `/openapi/v1/...`
+> answers `401` — including the implemented bots endpoints. The real caller
+> authenticator is a separate workstream, and the DoD gates the public surface
+> on it. "bots is done" means the handlers, contracts and tests are done, not
+> that an external tenant can call them.
 
 The catch: the internal `/api/...` surface and the public `/openapi/v1` surface
 share the **same tables, repositories, and services**. So a public endpoint
@@ -42,14 +51,14 @@ The work therefore splits into **two tracks**:
   tenant-scoped *underneath both API surfaces*, before any public endpoint is
   wired. **Track A implements NO endpoint by design** — it's plumbing.
 - **Track B — Public API implementation.** Wire the seven `/openapi/v1`
-  category handlers (currently stubs) to the existing services. **This is where
-  the endpoint/API code actually lands.** Each category depends on its data
-  being isolated (Track A) first.
+  category handlers to the existing services. **This is where the endpoint/API
+  code actually lands.** Each category depends on its data being isolated
+  (Track A) first. **1 of 7 done: bots (PR #494).**
 
-> ⚠️ **The one confusion to avoid:** "isolation Stage 1 is done" does **not**
-> mean any API endpoint was implemented. Stage 1 is Track A only (the reusable
-> mechanism + bot records). The API endpoints land in Track B, which has not
-> started.
+> ⚠️ **The one confusion to avoid:** "isolation Stage N is done" does **not**
+> mean any API endpoint was implemented. A Track A stage is plumbing only (the
+> reusable mechanism + that category's records). The API endpoints land in
+> Track B — done for bots, still stubs for the other six.
 
 ---
 
@@ -87,9 +96,9 @@ owner.)
 Within each lane, do your **P1** slices before P2 before P3. Skills (P3) is the
 shared, complex one — tackle it together once the P1/P2 work is moving.
 
-> **Shared gate:** anything touching bots (both people) waits on **PR #456**
-> merging — a one-time gate, not an ongoing cross-person dependency. Once it
-> merges, both owners are free to run their slices in parallel.
+> **Shared gate — LIFTED 2026-07-27.** Anything touching bots waited on
+> **PR #456**; it merged, so that one-time gate is gone. Both owners can run
+> their slices in parallel now.
 
 _See **Endpoints per component** below for exactly which endpoints each slice
 must implement._
@@ -101,7 +110,7 @@ must implement._
 ### Track A — Tenant-isolation foundation
 | Stage | Scope (data) | Owner | Pri | State | Done-when |
 |---|---|---|---|---|---|
-| 1 | Bot records (`ac_bots` / `BotModel`) | totalfrank | P1 | ✅ DONE — **PR #456 (awaiting approval, not yet merged)** | PR #456 merges |
+| 1 | Bot records (`ac_bots` / `BotModel`) | totalfrank | P1 | ✅ **DONE — PR #456 merged 2026-07-27** | — |
 | 2 | Resources (`ac_resource`) | lucas-xzp | P1 | ⬜ TODO | column + guards + tests green; internal API unchanged |
 | 3 | Channels (`ac_channel_config`) | totalfrank | P2 | ⬜ TODO | same |
 | 4 | Skills (skill tables) | totalfrank + lucas-xzp | P3 | ⬜ TODO | same |
@@ -111,24 +120,32 @@ must implement._
 > Stage 1 also builds the **reusable mechanism** (see below) that every later
 > stage copies. It's the foundation, not just "bots."
 
-### Track B — Public API implementation (where the endpoints land — NOT STARTED)
+### Track B — Public API implementation (where the endpoints land — 1 of 7 done)
 _Ordered by priority tier._
-| Category | Owner | Pri | Router (stubs today) | State | Depends on |
+| Category | Owner | Pri | Router | State | Depends on |
 |---|---|---|---|---|---|
-| bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ⬜ TODO | Track A stage 1 (PR #456) |
-| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` | ⬜ TODO | Track A mcp (totalfrank) |
-| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | ⬜ TODO | Track A resources (lucas-xzp) |
-| routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` | ⬜ TODO | Track A routines (lucas-xzp) |
-| channels | totalfrank | P2 | `openapi_v1/channels/router.py` | ⬜ TODO | Track A channels (totalfrank) |
-| identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` | ⬜ TODO | bots isolation (Stage 1 ✅) |
-| skills | totalfrank + lucas-xzp | P3 | `openapi_v1/skills/router.py` | ⬜ TODO | Track A skills (shared) |
+| bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ✅ **DONE — PR #494 merged 2026-07-29** (13/13 endpoints) | ~~Track A stage 1~~ ✅ |
+| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` *(stub)* | ⬜ TODO | Track A mcp (totalfrank) |
+| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` *(stub)* | ⬜ TODO | Track A resources (lucas-xzp) |
+| routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` *(stub)* | ⬜ TODO | Track A routines (lucas-xzp) |
+| channels | totalfrank | P2 | `openapi_v1/channels/router.py` *(stub)* | ⬜ TODO | Track A channels (totalfrank) |
+| identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` *(stub)* | ⬜ TODO | bots isolation (Stage 1 ✅) |
+| skills | totalfrank + lucas-xzp | P3 | `openapi_v1/skills/router.py` *(stub)* | ⬜ TODO | Track A skills (shared) |
 
 ### Cross-cutting (not per-stage)
 | Item | State | Note |
 |---|---|---|
-| Real caller-identity verifier (auth workstream) | ⬜ TODO (other team) | swap `resolve_avernet_tenant` body to read the gateway principal's tenant; unblocks a real 2nd tenant |
+| Real caller-identity verifier (auth workstream) | ⬜ TODO (other team) | swap `require_principal` + `resolve_avernet_tenant` bodies to read the gateway principal; **the whole public surface answers 401 until this lands** |
 | Tenant-leading indexes (F2, **MANDATORY** policy) | ⬜ TODO | before multi-tenant go-live |
 | Background/scheduled work revisit | ⬜ TODO | before a 2nd tenant holds real data |
+| **Bot identity keys collide across tenants** ([#556](https://github.com/inclusionAI/Avernet/issues/556)) | ⬜ TODO (totalfrank) | Passport, auth relationships, BCN, policy row are keyed on `bot_id`/`owner_id` with no tenant axis, and every owner's first bot is literally `"default"`. **Should gate enabling multi-tenancy.** Stopgapped in #494 by `sync_to_bcn=False` on the public update path |
+| Async create ≠ authorized bot ([#559](https://github.com/inclusionAI/Avernet/issues/559)) | ⬜ TODO (totalfrank) | the pending create spec is never persisted; completion rebuilds it from the polling request. Pre-existing on `dev`; latent (community Passport always issues) |
+| Swallowed external identity writes ([#560](https://github.com/inclusionAI/Avernet/issues/560)) | ⬜ TODO (totalfrank) | owner-grant on create and Passport metadata on update log-and-continue, against `AGENTS.md:203-204`. One ruling settles both sites; recommendation is *report partial success* |
+
+> The three issues above came out of #494's review and are **pre-existing on
+> `dev`**, not regressions — they're recorded here because they are decisions
+> the whole effort inherits, not bots-only bugs. #556 in particular is the one
+> that must be settled before a second tenant holds real data.
 
 > **Sequencing decision — DECIDED 2026-07-27:** per-category **vertical slices**.
 > Each owner isolates a category (Track A) then implements its endpoints
@@ -139,7 +156,7 @@ _Ordered by priority tier._
 
 ## Track A — the reusable mechanism (built in Stage 1, PR #456)
 
-Category-agnostic; reuse as-is. These files arrive with PR #456:
+Category-agnostic; reuse as-is. These files are **on `dev`** (PR #456):
 
 - `utils/avernet_tenant.py` — per-request tenant carrier.
   `DEFAULT_AVERNET_TENANT = "teamclaw"` (internal tenant; owns all current
@@ -163,8 +180,9 @@ Category-agnostic; reuse as-is. These files arrive with PR #456:
   touch it.**
 - `adapters/http/openapi_v1/dependencies.py` — `resolve_avernet_tenant(request)`:
   the single seam. Returns the default tenant today; the auth workstream swaps
-  the body in place. Category-agnostic. _(Today this file holds only the
-  `require_principal` stub; `resolve_avernet_tenant` lands with PR #456.)_
+  the body in place. Category-agnostic. _(This file holds both stubs today —
+  `require_principal` and `resolve_avernet_tenant`; the owner-side seam on top
+  of the former is `openapi_v1/principal.py::caller_owner_id`.)_
 
 All paths are under
 `src/backend/src/agentclaw/community/`.
@@ -203,18 +221,83 @@ CI all-green. Then **update the status board above.**
 
 ---
 
-## Track B — implementing a category's endpoints (where the API lands)
+## Track B — the reusable primitives (built with bots, PR #494)
 
-Not started. Per category: replace the stub handlers in
-`openapi_v1/<category>/router.py` with real implementations that call the
-existing services, returning the standard `Envelope`/`Page` shapes from
-`openapi_v1/contracts.py`, depending on `require_principal` /
-`resolve_avernet_tenant` for identity + tenant. Because Track A already scopes
-the underlying reads/writes, a correctly-written handler cannot leak across
-tenants — and it runs under the request tenant the middleware set
-automatically. Each category needs its own spec/plan/tasks (SDD) and its own
-PR. (Per-category service-wiring details are scoped when that category's
-session starts.)
+**Read this before starting any category.** The bots slice built the shared
+public-API layer once; the remaining six categories are meant to *use* it, not
+rebuild it. Everything below is category-agnostic and lives in
+`adapters/http/openapi_v1/`:
+
+- **`responses.py`** — the envelope builders (`envelope`, `page`, `created`,
+  `accepted`, `deleted`) and the `@envelope_errors` decorator. The decorator
+  maps domain errors to enveloped responses via `ENVELOPE_ERRORS`, a
+  `{exception type: (http status, fixed message)}` dict. The rules it enforces,
+  all of which your category inherits:
+  - **Messages are fixed, never `str(exc)`** — internal ids and internal-language
+    text must not reach an external caller.
+  - **Both 404 paths are byte-identical** ("not found" vs "exists but not
+    yours / other tenant"), so a caller cannot probe for existence.
+  - Order matters: **list specific leaf errors before their base class**; lookup
+    returns on the first `isinstance` match in insertion order.
+  - Add *your* category's errors to `ENVELOPE_ERRORS`. Anything unmapped escapes
+    to the app 500 handler — which now envelopes it too, but with a generic
+    message.
+- **`contracts.py`** — `Envelope[T]` / `Page[T]` / `Deleted` / `NameCheck` plus
+  `ErrorEnvelope` and `ERROR_RESPONSES`. `ERROR_RESPONSES` is attached **once**
+  in `openapi_v1/__init__.py::build_public_router()`, so every route on every
+  group documents the real failure shape in the generated schema. You get this
+  for free; don't re-declare it per handler.
+- **`principal.py::caller_owner_id(principal)`** — the single seam that turns the
+  `require_principal` value into the caller's owner id. **Scope every service
+  call with it.** Tenant confines data to the tenant; owner id confines it to
+  the caller. Both are needed.
+- **`clusters.py`** — the public `cluster_name` enum (`ACRA` / `ANDC`) in strict
+  bijection with the engine (`ANDC` ⟺ `teclaw`, `ACRA` ⟺ everything else),
+  derived on read and validated on create. Reuse if your category exposes a
+  cluster; don't invent a second mapping.
+- **`errors.py`** — dependency-free public error types (`MissingPrincipalError`,
+  `ClusterMismatchError`, `UnsupportedEngineError`) so the schema / cluster modules
+  can raise without importing the service layer.
+- **`PUBLIC_API_PREFIX`** + the app-level handlers in `adapters/http/app.py` —
+  `RequestValidationError`, `DomainError`, `StarletteHTTPException` and the
+  catch-all are all path-scoped to the public prefix, so a failure raised
+  *before* or *outside* a handler (unknown path, wrong method, body validation)
+  still answers with the envelope. Internal `/api` routes keep FastAPI's
+  `{"detail": ...}`. **This is closed structurally — you don't need to add
+  anything per category.**
+
+### Recipe — implement a category's endpoints
+
+1. Land that category's **Track A stage first** (see the Track A recipe above).
+   Without it a correct handler still reads the internal tenant's rows.
+2. Replace the stub handlers in `openapi_v1/<category>/router.py` with real ones
+   that call the existing services. Depend on `require_principal`, take
+   `request: Request` (the `@envelope_errors` decorator needs it for
+   `request_id`), and scope every call with `caller_owner_id(principal)`.
+3. Return `Envelope`/`Page` via the `responses.py` builders. Binary streams
+   (e.g. resource download) bypass the envelope — that's the one exception.
+4. Add your domain errors to `ENVELOPE_ERRORS` with fixed public messages.
+5. Put `extra="forbid"` on public request models. An unknown or immutable field
+   should be a 422, not a silent no-op — that's how `engine` is rejected on bot
+   update.
+6. **If a behavior is shared with the internal `/api` surface, extract it into
+   `core/` and call it from both** rather than copying. #494 did this for the
+   create + Passport orchestration (`core/bot_management/create_flow.py`) and
+   the readiness policy (`core/bot_management/readiness.py`) — otherwise the two
+   surfaces answer the same question differently within a release.
+7. Tests: unit (response builders / mapping), endpoint (all handlers, success +
+   each mapped error), and **cross-tenant isolation against the real Track A
+   guard** (a foreign `{id}` must be a masked 404). Keep the internal suite
+   unmodified and green.
+8. Own SDD (`spec.md`/`plan.md`/`tasks.md`) and own PR per category. Use
+   `src/backend/specs/2026-07-27-openapi-v1-bots-track-b/` and
+   `openapi_v1/bots/router.py` as the worked reference.
+
+> **Architecture gate:** `tests/community/architecture/` now also runs
+> `test_service_api_conformance.py` — the Service API gate that `api/README.md`
+> had promised in two places but that was never written. If you give a Protocol
+> in `api/` real signatures, register its `(Protocol, ConcreteService)` pair
+> there.
 
 ---
 
@@ -222,23 +305,33 @@ session starts.)
 
 The tables below are the **per-component endpoint checklists** for Track B —
 who owns them, and exactly what lands. Source of truth is the **served router**
-(`openapi_v1/<category>/router.py` — the stubs already carry these route
-definitions); descriptions are cross-checked against the v1 contract overview
-in **PR #363** (`docs/api-endpoints.zh-CN.md`, a Chinese endpoint reference by
-totalfrank — still open/draft, being closed soon; kept here as reference).
+(`openapi_v1/<category>/router.py` — implemented for bots, stubs carrying the
+route definitions for the rest); descriptions are cross-checked against the v1
+contract overview in **PR #363** (`docs/api-endpoints.zh-CN.md`, a Chinese
+endpoint reference by totalfrank — still open/draft as of 2026-07-29; kept here
+as reference).
 
-> ⚠️ **Path divergence to reconcile.** The router stubs nest every non-`bots`
-> group under `/openapi/v1/bots/...` (e.g. `/openapi/v1/bots/resources`,
-> `/openapi/v1/bots/mcp`). PR #363's overview used **top-level** paths
-> (`/openapi/v1/resources`, `/openapi/v1/mcp`, …). The **router is
-> authoritative** for implementation — the paths below match it. Owners: if the
-> top-level shape is the intended public surface, change the router `prefix`
-> and update this section in the same PR.
+> ⚠️ **Path divergence — still open for the six stub groups.** The routers nest
+> every non-`bots` group under `/openapi/v1/bots/...` (e.g.
+> `/openapi/v1/bots/resources`, `/openapi/v1/bots/mcp`). PR #363's overview used
+> **top-level** paths (`/openapi/v1/resources`, `/openapi/v1/mcp`, …). The
+> **router is authoritative** for implementation — the paths below match it.
+> Owners: if the top-level shape is the intended public surface, change the
+> router `prefix` and update this section in the same PR. _(bots is unaffected:
+> it is `/openapi/v1/bots` under either reading, and shipped that way in #494.)_
+>
+> **Mount order is load-bearing.** `build_public_router()` includes the six
+> literal sub-groups **before** the bots group, so `/openapi/v1/bots/channels`
+> resolves ahead of the `/openapi/v1/bots/{bot_id}` wildcard. Keep any new group
+> in the `_SUBGROUPS` list, above the bots router.
 
 All responses use the `Envelope[T]` / `Page[T]` shapes from
 `openapi_v1/contracts.py` unless noted (binary streams bypass the envelope).
 
-### 🟦 totalfrank · P1 — bots (13 endpoints) · `openapi_v1/bots/router.py`
+### ✅ totalfrank · P1 — bots (13 endpoints) · `openapi_v1/bots/router.py` — **IMPLEMENTED (PR #494)**
+All 13 wired to the internal bot services. Kept here as the reference shape for
+the other six: this is what "done" looks like per category.
+
 | Method | Path | Purpose | Success |
 |---|---|---|---|
 | POST | `/openapi/v1/bots` | Create a bot; may need Passport authorization | `201 Envelope[Bot]` or `202 Envelope[BotAuthPending]` |
@@ -254,6 +347,18 @@ All responses use the `Envelope[T]` / `Page[T]` shapes from
 | GET | `/openapi/v1/bots/{bot_id}/passport` | Get the bot's Agent Passport | `Envelope[Passport]` |
 | GET | `/openapi/v1/bots/{bot_id}/engine-config` | Read engine config (free-form JSON) | `Envelope[dict]` |
 | PUT | `/openapi/v1/bots/{bot_id}/engine-config` | Write engine config (free-form JSON) | `Envelope[dict]` |
+
+_Deliberately **not** exposed on bots: `engine_options` on create (nothing
+downstream reads `BotCreateSpec.extra_properties` yet, so advertising it would
+promise something the server ignores), and `cluster_name`/`engine_options` on
+update. With `extra="forbid"` these are now a 422 rather than a silent drop._
+
+_Internal `/api/bots` changed too, all intentional and covered by #494: the
+create preflight also rejects a taken bot name (so a duplicate fails **before**
+the external Passport application); create persists the configured engine
+registry widened to include the bot's own active engine; update's duplicate-name
+check compares owner **and** `bot_id` together; deleting the default bot raises
+`BotOperationNotAllowedError` (internal response shape unchanged, public → 409)._
 
 ### 🟦 totalfrank · P2 — channels (6 endpoints) · `openapi_v1/channels/router.py`
 DingTalk (`dingding`) config CRUD + status toggle.
@@ -350,14 +455,20 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
 
 1. **Track A:** every data category (bots, resources, channels, skills, mcp,
    routines) carries `avernet_tenant` and is guarded, Stage-1 test shape green.
+   — _1 of 6 (bots ✅)._
 2. Internal API unchanged throughout (no `to_dict()` leaks; internal suites
-   unmodified).
+   unmodified). — _holding: full `tests/community` green at #494 (9171 passed,
+   3 skipped)._
 3. **Track B:** the seven `/openapi/v1` categories' handlers implemented and
-   tenant-safe, each with its own tests + PR.
-4. F2 tenant-leading indexes in place (mandatory policy).
-5. Background/scheduled work revisited for per-tenant correctness.
-6. `resolve_avernet_tenant` wired to the real verifier (auth workstream) — the
-   point at which a second tenant can safely hold real data.
+   tenant-safe, each with its own tests + PR. — _1 of 7 (bots ✅)._
+4. F2 tenant-leading indexes in place (mandatory policy). — _⬜_
+5. Background/scheduled work revisited for per-tenant correctness. — _⬜_
+6. `require_principal` / `resolve_avernet_tenant` wired to the real verifier
+   (auth workstream) — the point at which a second tenant can safely hold real
+   data, and the point at which the public surface stops answering 401. — _⬜_
+7. **Cross-tenant external identity settled ([#556](https://github.com/inclusionAI/Avernet/issues/556))** — Passport, auth
+   relationships and BCN carry a tenant axis, so the BCN sync can be re-enabled
+   on the public path. — _⬜ (added 2026-07-29; gates enabling multi-tenancy)._
 
 ---
 
@@ -372,8 +483,11 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
   index's name to its columns; create before drop so there's no index-less
   window). Leave low-cardinality (`idx_status`, `idx_is_delete`) and
   unique-lookup (`idx_binding_id`) indexes alone.
-- **Real caller-identity verifier.** Swap `resolve_avernet_tenant`'s body to
-  return the gateway-forwarded principal's tenant. The seam is ready.
+- **Real caller-identity verifier.** Swap `require_principal`'s body to return
+  the gateway-forwarded principal, and `resolve_avernet_tenant`'s to return its
+  tenant. Both seams are ready, and `caller_owner_id` already accepts either a
+  bare id string or an object/dict with `user_id`, so handlers don't change.
+  **Until this lands the public surface answers 401 to everything.**
 - **Background/scheduled work.** Resolves to the default tenant now (correct
   while all data is `teamclaw`); revisit before a 2nd tenant holds real data
   (scheduled scans, pollers, sync loops in skill_center / governance / dormant /
@@ -384,7 +498,7 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
 
 ---
 
-## Gotchas learned in Stage 1 (save yourself the round-trips)
+## Gotchas learned in Track A Stage 1 (save yourself the round-trips)
 
 - Register the `do_orm_execute` read guard on the **`Session` class** (covers
   every runtime incl. the out-of-tree corp DB plugin), not one plugin.
@@ -403,6 +517,37 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
   out).
 - cwd drifts to repo root after `git` commands that `cd` there; `cd src/backend`
   before `uv run`.
+
+## Gotchas learned in Track B bots (PR #494)
+
+- **The envelope leaks where you don't look.** A handler-level decorator only
+  covers failures *inside* the handler. Unknown path (404), wrong method (405)
+  and body-validation (422) are raised **before** the router runs and were
+  answering `{"detail": ...}` — the first three things a new integrator hits.
+  Fixed once in `app.py`, path-scoped to `/openapi/v1`; don't re-solve it.
+- **Map the base class last.** `ENVELOPE_ERRORS` returns on the first
+  `isinstance` match in insertion order, so a specific leaf listed *after* its
+  base never wins.
+- **Errors that aren't in your category's hierarchy still escape.** The
+  engine-config failures are plain `RuntimeError` siblings, not
+  `BotServiceError` subclasses — each documented propagation path needed its own
+  entry. Grep what your service can actually raise; don't assume one base covers it.
+- **Never forward the exception's body headers** on an error response —
+  `Content-Length`/`Content-Type` from the discarded body describe the wrong
+  bytes. Do forward the protocol ones (`Allow` on 405, `WWW-Authenticate` on 401).
+- **`extra="forbid"` is how immutability is expressed.** Without it, `engine` on
+  a bot update is silently dropped and the caller thinks it worked.
+- **Extract, don't copy, anything the internal surface also does.** Two copies of
+  the create/Passport orchestration would have drifted within a release. The
+  extraction must be behavior-preserving — prove it by leaving the internal
+  suite unmodified.
+- **A behavior-preserving extraction still surfaces internal bugs.** Four
+  internal `/api/bots` defects only became visible once the logic was read out of
+  the router (see the bots table note). Expect that, and decide deliberately
+  whether to fix them in the same PR.
+- Sixteen rounds of automated review on one wiring PR is what it took. Budget
+  for review rounds, and file the questions that can't be settled inside a wiring
+  PR as issues (#556 / #559 / #560) rather than patching around them.
 
 ---
 
@@ -425,3 +570,25 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
 - **2026-07-27** — Skills endpoints merged from two tables (5 in-stub + 2
   proposed) into a **single 7-row table with a Status column**, so the full
   surface reads as 7 at a glance instead of looking like 2.
+- **2026-07-27** — **Track A Stage 1 merged (PR #456).** Bots carry
+  `avernet_tenant`; the reusable mechanism (carrier, guards, middleware,
+  `resolve_avernet_tenant` seam) is on `dev`. The shared bots gate is lifted.
+- **2026-07-29** — **Track B bots merged (PR #494) — first public category
+  implemented.** All 13 `/openapi/v1/bots` endpoints wired to the internal
+  services, owner-scoped via `caller_owner_id`, tenant-scoped by the Track A
+  guard (cross-tenant `{bot_id}` → masked 404, proven against the real guard).
+  Added the **shared Track B primitives** the other six categories reuse
+  (`responses.py`, `contracts.py`/`ERROR_RESPONSES`, `principal.py`,
+  `clusters.py` ACRA/ANDC, `errors.py`) and closed envelope escape structurally
+  in `app.py`. Extracted `core/bot_management/create_flow.py` +
+  `readiness.py` so both surfaces share one implementation. New architecture
+  gate `test_service_api_conformance.py`. Full suite 9171 passed / 3 skipped.
+  Board moved: Track A stage 1 → merged, Track B bots → done; added the
+  **Track B primitives + recipe** section and the Track B gotchas.
+- **2026-07-29** — Three inherited decisions filed as issues from #494's review
+  and added to the cross-cutting board: **[#556](https://github.com/inclusionAI/Avernet/issues/556)** cross-tenant bot identity
+  collision (**gates enabling multi-tenancy**; now DoD item 7),
+  **[#559](https://github.com/inclusionAI/Avernet/issues/559)** async create can provision a bot other than the one authorized,
+  **[#560](https://github.com/inclusionAI/Avernet/issues/560)** swallowed external identity writes. All pre-existing on `dev`.
+  Also recorded the **401-until-auth-lands** state prominently up top — the
+  public surface is implemented but not yet callable.

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -15,17 +15,24 @@ _这是一份"活文档"，用于协调跨多个会话交付公共 `/openapi/v1`
 > `✅ DONE — PR #___`），在底部的 **Changelog（变更记录）** 里追加一条带日期的记录，
 > 并修正任何已经过时的描述。小步更新，勤更新。
 
-请结合更深入的工程交接文档，以及
-`src/backend/specs/2026-07-26-tenant-isolation-foundation/`
-下的 SDD 文档（`spec.md`、`plan.md`、`tasks.md` —— 这些随 PR #456 一起到来）一起阅读。
+请结合更深入的工程交接文档，以及 `src/backend/specs/` 下的 SDD 文档一起阅读 ——
+`2026-07-26-tenant-isolation-foundation/`（Track A Stage 1，已随 PR #456 合并）
+与 `2026-07-27-openapi-v1-bots-track-b/`（Track B bots，已随 PR #494 合并）。
+两者各自都带有 `spec.md`、`plan.md`、`tasks.md`。
 
 ---
 
 ## 全局视角（请先读这一节）
 
-**目标：** 实现公共 `/openapi/v1` API，其调用方是**外部注册租户**。今天它仅以
-**带桩（stub）处理器的路由定义**形式存在，位于
-`src/backend/src/agentclaw/community/adapters/http/openapi_v1/*`。
+**目标：** 实现公共 `/openapi/v1` API，其调用方是**外部注册租户**。它位于
+`src/backend/src/agentclaw/community/adapters/http/openapi_v1/*`。其中 **bots**
+类别已经实现（PR #494）；其余六个仍然是**带桩（stub）处理器的路由定义**。
+
+> 🔒 **这套界面目前还不可被真正调用 —— 这是设计如此。** `require_principal` 仍是
+> 返回 `None` 的桩，因此任何真实请求打到 `/openapi/v1/...` 都会得到 `401` ——
+> 已实现的 bots 端点也不例外。真实的调用方认证器属于另一条工作线，DoD 也把公共界面
+> 的开放门槛压在它上面。"bots 做完了"指的是处理器、契约和测试做完了，**不是**指
+> 外部租户已经可以调用它们。
 
 关键难点：内部的 `/api/...` 界面与公共的 `/openapi/v1` 界面**共享同一批表、仓储
 （repositories）和服务（services）**。因此，一个会返回真实数据的公共端点，如果没有隔离，
@@ -35,13 +42,13 @@ _这是一份"活文档"，用于协调跨多个会话交付公共 `/openapi/v1`
 
 - **Track A —— 租户隔离基础设施。** 在接通任何公共端点之前，先让*两套 API 界面之下的*
   每一类数据都做到按租户隔离。**Track A 按设计不实现任何端点** —— 它是底层管道。
-- **Track B —— 公共 API 实现。** 把七个 `/openapi/v1` 类别处理器（目前是桩）接到已有的
-  服务上。**这才是真正落地端点/API 代码的地方。** 每个类别都依赖于其数据已先经过
-  Track A 的隔离。
+- **Track B —— 公共 API 实现。** 把七个 `/openapi/v1` 类别处理器接到已有的服务上。
+  **这才是真正落地端点/API 代码的地方。** 每个类别都依赖于其数据已先经过 Track A 的
+  隔离。**七个里已完成一个：bots（PR #494）。**
 
-> ⚠️ **唯一需要避免的误解：** "隔离 Stage 1 已完成"**并不**意味着任何 API 端点被实现了。
-> Stage 1 只属于 Track A（可复用机制 + 机器人记录）。API 端点落在 Track B，而 Track B
-> 尚未开始。
+> ⚠️ **唯一需要避免的误解：** "隔离 Stage N 已完成"**并不**意味着任何 API 端点被实现了。
+> Track A 的每个阶段都只是底层管道（可复用机制 + 该类别的记录）。API 端点落在
+> Track B —— bots 已完成，其余六个仍是桩。
 
 ---
 
@@ -76,8 +83,8 @@ Track A，所以两者都归同一个人。）
 在各自的分工里，先做 **P1** 切片，再做 P2，最后做 P3。skills（P3）是共担且最复杂的那个 ——
 等 P1/P2 的工作跑起来后两人一起攻。
 
-> **共同的闸口：** 任何触及 bots 的工作（两人都有）都要等 **PR #456** 合并 —— 这是一次性的
-> 闸口，不是持续的跨人依赖。一旦合并，两位负责人就能各自并行推进自己的切片。
+> **共同的闸口 —— 已解除（2026-07-27）。** 任何触及 bots 的工作原本都要等 **PR #456**
+> 合并；它已经合并，这个一次性闸口不复存在。两位负责人现在可以各自并行推进自己的切片。
 
 _具体每个切片要实现哪些端点，见下方的 **各组件端点清单**。_
 
@@ -88,7 +95,7 @@ _具体每个切片要实现哪些端点，见下方的 **各组件端点清单*
 ### Track A —— 租户隔离基础设施
 | 阶段 | 范围（数据） | 负责人 | 优先级 | 状态 | 完成判据 |
 |---|---|---|---|---|---|
-| 1 | 机器人记录（`ac_bots` / `BotModel`） | totalfrank | P1 | ✅ DONE —— **PR #456（等待审批，尚未合并）** | PR #456 合并后 |
+| 1 | 机器人记录（`ac_bots` / `BotModel`） | totalfrank | P1 | ✅ **DONE —— PR #456 已于 2026-07-27 合并** | —— |
 | 2 | 资源（`ac_resource`） | lucas-xzp | P1 | ⬜ TODO | 列 + 守卫 + 测试通过；内部 API 不变 |
 | 3 | 渠道（`ac_channel_config`） | totalfrank | P2 | ⬜ TODO | 同上 |
 | 4 | 技能（skill 相关表） | totalfrank + lucas-xzp | P3 | ⬜ TODO | 同上 |
@@ -98,24 +105,31 @@ _具体每个切片要实现哪些端点，见下方的 **各组件端点清单*
 > Stage 1 同时构建了后续每个阶段都会复制的**可复用机制**（见下文）。它是地基，
 > 不只是"机器人"。
 
-### Track B —— 公共 API 实现（端点真正落地之处 —— 尚未开始）
+### Track B —— 公共 API 实现（端点真正落地之处 —— 七个里已完成一个）
 _按优先级分层排序。_
-| 类别 | 负责人 | 优先级 | 路由（今天是桩） | 状态 | 依赖 |
+| 类别 | 负责人 | 优先级 | 路由 | 状态 | 依赖 |
 |---|---|---|---|---|---|
-| bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ⬜ TODO | Track A 阶段 1（PR #456） |
-| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` | ⬜ TODO | Track A mcp（totalfrank） |
-| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | ⬜ TODO | Track A resources（lucas-xzp） |
-| routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` | ⬜ TODO | Track A routines（lucas-xzp） |
-| channels | totalfrank | P2 | `openapi_v1/channels/router.py` | ⬜ TODO | Track A channels（totalfrank） |
-| identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` | ⬜ TODO | bots 隔离（Stage 1 ✅） |
-| skills | totalfrank + lucas-xzp | P3 | `openapi_v1/skills/router.py` | ⬜ TODO | Track A skills（共担） |
+| bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ✅ **DONE —— PR #494 已于 2026-07-29 合并**（13/13 端点） | ~~Track A 阶段 1~~ ✅ |
+| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` *(桩)* | ⬜ TODO | Track A mcp（totalfrank） |
+| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` *(桩)* | ⬜ TODO | Track A resources（lucas-xzp） |
+| routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` *(桩)* | ⬜ TODO | Track A routines（lucas-xzp） |
+| channels | totalfrank | P2 | `openapi_v1/channels/router.py` *(桩)* | ⬜ TODO | Track A channels（totalfrank） |
+| identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` *(桩)* | ⬜ TODO | bots 隔离（Stage 1 ✅） |
+| skills | totalfrank + lucas-xzp | P3 | `openapi_v1/skills/router.py` *(桩)* | ⬜ TODO | Track A skills（共担） |
 
 ### 横切事项（非按阶段划分）
 | 事项 | 状态 | 备注 |
 |---|---|---|
-| 真实的调用方身份验证器（认证工作线） | ⬜ TODO（其他团队） | 把 `resolve_avernet_tenant` 的函数体替换为读取网关 principal 的租户；这样才能解锁真正的第二个租户 |
+| 真实的调用方身份验证器（认证工作线） | ⬜ TODO（其他团队） | 把 `require_principal` 与 `resolve_avernet_tenant` 的函数体替换为读取网关 principal；**在它落地之前，整个公共界面都只会返回 401** |
 | 租户前导索引（F2，**强制**策略） | ⬜ TODO | 多租户上线前必须完成 |
 | 后台/定时任务的复查 | ⬜ TODO | 在第二个租户持有真实数据之前完成 |
+| **Agent 身份标识在租户之间会撞车**（[#556](https://github.com/inclusionAI/Avernet/issues/556)） | ⬜ TODO（totalfrank） | Passport、授权关系、BCN、策略行都只用 `bot_id`/`owner_id` 作键，没有租户维度，而每个 owner 的第一个 bot 的 id 就是字符串 `"default"`。**应当成为开启多租户的前置闸口。** #494 里以公共更新路径上的 `sync_to_bcn=False` 做了临时止血 |
+| 异步创建出的 bot 可能不是被授权的那个（[#559](https://github.com/inclusionAI/Avernet/issues/559)） | ⬜ TODO（totalfrank） | pending 状态的创建规格从未被持久化，完成时是用轮询请求重建的。`dev` 上既有问题；当前潜伏（社区版 Passport 总是直接签发） |
+| 外部身份写入失败被吞掉（[#560](https://github.com/inclusionAI/Avernet/issues/560)） | ⬜ TODO（totalfrank） | 创建时的 owner 授权写入、更新时的 Passport 元数据写入都是"记日志然后继续"，违反 `AGENTS.md:203-204`。一次决策同时覆盖两处；建议做法是*报告部分成功* |
+
+> 上面三条来自 #494 的评审，都是 `dev` 上的**既有问题**而非本次引入的回归 —— 记在这里
+> 是因为它们是整个工作都要继承的决策，而不是 bots 独有的 bug。其中 #556 尤其必须在
+> 第二个租户持有真实数据之前定下来。
 
 > **排序决定 —— 已定（2026-07-27）：** 采用按类别的**纵向切片**。每位负责人先隔离一个类别
 > （Track A），紧接着就实现它的端点（Track B），而不是先把整个 Track A 全部做完再做
@@ -125,7 +139,7 @@ _按优先级分层排序。_
 
 ## Track A —— 可复用机制（在 Stage 1 / PR #456 中构建）
 
-与具体类别无关；可原样复用。以下文件随 PR #456 到来：
+与具体类别无关；可原样复用。以下文件**已在 `dev` 上**（PR #456）：
 
 - `utils/avernet_tenant.py` —— 每请求（per-request）的租户载体。
   `DEFAULT_AVERNET_TENANT = "teamclaw"`（内部租户；拥有当前的全部数据；**绝不能把它交给
@@ -146,8 +160,8 @@ _按优先级分层排序。_
   设置租户。**已覆盖所有请求；Track A 阶段 2 及以后无需改动它。**
 - `adapters/http/openapi_v1/dependencies.py` —— `resolve_avernet_tenant(request)`：
   唯一的接缝（seam）。今天返回默认租户；认证工作线会就地替换其函数体。与具体类别无关。
-  _（今天这个文件里只有 `require_principal` 桩；`resolve_avernet_tenant` 随 PR #456
-  到来。）_
+  _（这个文件里现在是两个桩：`require_principal` 与 `resolve_avernet_tenant`；建立在
+  前者之上的 owner 侧接缝是 `openapi_v1/principal.py::caller_owner_id`。）_
 
 以上所有路径都位于
 `src/backend/src/agentclaw/community/` 之下。
@@ -182,34 +196,99 @@ _按优先级分层排序。_
 
 ---
 
-## Track B —— 实现某个类别的端点（API 真正落地之处）
+## Track B —— 可复用的公共 API 基建（随 bots 一起构建，PR #494）
 
-尚未开始。每个类别：把 `openapi_v1/<category>/router.py` 里的桩处理器替换为真正的实现，
-它们调用已有的服务，返回 `openapi_v1/contracts.py` 里标准的 `Envelope`/`Page` 结构，并依赖
-`require_principal` / `resolve_avernet_tenant` 来获取身份 + 租户。因为 Track A 已经对底层
-读写做了按租户限定，一个写得正确的处理器不可能跨租户泄漏 —— 而且它会自动运行在中间件设置的
-请求租户之下。每个类别都需要有自己的 spec/plan/tasks（SDD）和自己的 PR。（每个类别接服务的
-具体细节不在本交接文档范围内 —— 在该类别的会话开始时再界定。）
+**动手做任何一个类别之前，先读这一节。** bots 切片已经把公共 API 的共享层做了一遍；
+其余六个类别应当**复用**它，而不是重造。以下内容都与具体类别无关，位于
+`adapters/http/openapi_v1/`：
+
+- **`responses.py`** —— 信封构造器（`envelope`、`page`、`created`、`accepted`、
+  `deleted`）以及 `@envelope_errors` 装饰器。装饰器通过 `ENVELOPE_ERRORS` 这个
+  `{异常类型: (HTTP 状态码, 固定文案)}` 字典把领域错误映射成信封响应。它强制的规则，
+  你的类别都会继承：
+  - **文案是固定的，绝不用 `str(exc)`** —— 内部标识符和内部语言的文本不能流到外部调用方。
+  - **两条 404 路径逐字节相同**（"不存在" vs "存在但不属于你/属于其他租户"），
+    这样调用方无法借此探测某个对象是否存在。
+  - 顺序有意义：**具体的叶子错误必须列在其基类之前**；查找会按插入顺序在第一个
+    `isinstance` 命中时返回。
+  - 把*你自己*类别的错误加进 `ENVELOPE_ERRORS`。没有映射的异常会逃逸到应用级 500
+    处理器 —— 那里现在也会套信封，但只能给出泛化文案。
+- **`contracts.py`** —— `Envelope[T]` / `Page[T]` / `Deleted` / `NameCheck`，
+  外加 `ErrorEnvelope` 与 `ERROR_RESPONSES`。`ERROR_RESPONSES` 在
+  `openapi_v1/__init__.py::build_public_router()` 里**统一挂一次**，因此每个组的
+  每条路由都会在生成的 schema 里描述真实的失败结构。这是白拿的；不要再逐个处理器声明。
+- **`principal.py::caller_owner_id(principal)`** —— 把 `require_principal` 的返回值
+  转成调用方 owner id 的唯一接缝。**每一次服务调用都要用它来限定范围。** 租户把数据
+  限定在租户内，owner id 把数据限定在调用者自己 —— 两者缺一不可。
+- **`clusters.py`** —— 公共 `cluster_name` 枚举（`ACRA` / `ANDC`），与引擎严格一一对应
+  （`ANDC` ⟺ `teclaw`，`ACRA` ⟺ 其余全部）：读取时推导，创建时校验。如果你的类别也要
+  暴露 cluster，请复用它，不要另造一套映射。
+- **`errors.py`** —— 不带重依赖的公共错误类型（`MissingPrincipalError`、
+  `ClusterMismatchError`、`UnsupportedEngineError`），让 schema / cluster 这些轻量模块
+  可以直接抛错而不必导入服务层。
+- **`PUBLIC_API_PREFIX`** 以及 `adapters/http/app.py` 里的应用级处理器 ——
+  `RequestValidationError`、`DomainError`、`StarletteHTTPException` 和兜底的
+  `Exception` 都按路径限定在公共前缀上，因此即使失败发生在处理器*之前*或*之外*
+  （未知路径、方法不对、请求体校验失败），响应也仍然是信封。内部 `/api` 路由保持
+  FastAPI 原本的 `{"detail": ...}`。**这是从结构上封死的 —— 每个类别都不需要再做一遍。**
+
+### 操作手册（Recipe）—— 实现一个类别的端点
+
+1. 先让该类别的 **Track A 阶段落地**（见上面的 Track A 手册）。没有它，即使处理器写得
+   完全正确，读到的仍然是内部租户的数据。
+2. 把 `openapi_v1/<category>/router.py` 里的桩处理器换成真正的实现，去调用已有的服务。
+   依赖 `require_principal`，参数里带上 `request: Request`（`@envelope_errors`
+   需要它来取 `request_id`），并且每一次调用都用 `caller_owner_id(principal)` 限定范围。
+3. 用 `responses.py` 的构造器返回 `Envelope`/`Page`。二进制流（如资源下载）不走信封 ——
+   这是唯一的例外。
+4. 把你的领域错误加进 `ENVELOPE_ERRORS`，配上固定的对外文案。
+5. 公共请求模型加 `extra="forbid"`。未知字段或不可变字段应当是 422，而不是被悄悄忽略 ——
+   bot 更新时的 `engine` 就是这样被拒绝的。
+6. **如果某个行为与内部 `/api` 界面共享，就把它抽到 `core/` 里让两边都调用**，不要复制。
+   #494 对创建 + Passport 编排（`core/bot_management/create_flow.py`）和就绪判定
+   （`core/bot_management/readiness.py`）就是这么做的 —— 否则两套界面会在一个版本之内
+   就对同一个问题给出不同答案。
+7. 测试：单元测试（响应构造器/错误映射）、端点测试（所有处理器，成功路径 + 每一条被映射的
+   错误），以及**针对真实 Track A 守卫的跨租户隔离测试**（别的租户的 `{id}` 必须是被掩盖
+   的 404）。内部测试套件保持不修改且全绿。
+8. 每个类别有自己的 SDD（`spec.md`/`plan.md`/`tasks.md`）和自己的 PR。可以把
+   `src/backend/specs/2026-07-27-openapi-v1-bots-track-b/` 和
+   `openapi_v1/bots/router.py` 当作已经做过一遍的参考样板。
+
+> **架构门禁：** `tests/community/architecture/` 现在还会跑
+> `test_service_api_conformance.py` —— 这就是 `api/README.md` 在两处承诺过、但一直没有
+> 写出来的 Service API 门禁。如果你给 `api/` 里的某个 Protocol 补上了真实签名，记得把它的
+> `(Protocol, ConcreteService)` 组合注册进去。
 
 ---
 
 ## 各组件端点清单（每个切片需要实现哪些端点）
 
 下面的表格就是 Track B 的**各组件端点清单** —— 谁负责、以及具体要落地哪些端点。**权威来源是
-已服务的路由**（`openapi_v1/<category>/router.py` —— 这些桩里已经带有这些路由定义）；描述则与
-**PR #363**（`docs/api-endpoints.zh-CN.md`，totalfrank 写的中文端点参考 —— 目前仍是
-open/draft，很快会关闭；此处作为参考保留）中的 v1 契约总览做了交叉核对。
+已服务的路由**（`openapi_v1/<category>/router.py` —— bots 已实现，其余仍是带着路由定义的
+桩）；描述则与
+**PR #363**（`docs/api-endpoints.zh-CN.md`，totalfrank 写的中文端点参考 —— 截至
+2026-07-29 仍是 open/draft；此处作为参考保留）中的 v1 契约总览做了交叉核对。
 
-> ⚠️ **需要对齐的路径分歧。** 路由桩把所有非 `bots` 的组都嵌套在 `/openapi/v1/bots/...` 之下
-> （如 `/openapi/v1/bots/resources`、`/openapi/v1/bots/mcp`）。而 PR #363 的总览用的是
-> **顶层**路径（`/openapi/v1/resources`、`/openapi/v1/mcp` 等）。实现以**路由为准** ——
-> 下面的路径与路由一致。负责人：如果顶层形态才是想要的对外形状，请修改路由的 `prefix`，并在
-> 同一个 PR 里更新本节。
+> ⚠️ **路径分歧 —— 对其余六个桩组仍未对齐。** 路由把所有非 `bots` 的组都嵌套在
+> `/openapi/v1/bots/...` 之下（如 `/openapi/v1/bots/resources`、`/openapi/v1/bots/mcp`）。
+> 而 PR #363 的总览用的是**顶层**路径（`/openapi/v1/resources`、`/openapi/v1/mcp` 等）。
+> 实现以**路由为准** —— 下面的路径与路由一致。负责人：如果顶层形态才是想要的对外形状，
+> 请修改路由的 `prefix`，并在同一个 PR 里更新本节。_（bots 不受影响：两种读法下它都是
+> `/openapi/v1/bots`，#494 也正是按这个形状上线的。）_
+>
+> **挂载顺序是有承重作用的。** `build_public_router()` 会先挂那六个字面量子组，再挂
+> bots 组，这样 `/openapi/v1/bots/channels` 才能排在通配的
+> `/openapi/v1/bots/{bot_id}` 前面被解析。新增的组要放进 `_SUBGROUPS` 列表里，位于
+> bots 路由之前。
 
 除注明外，所有响应都使用 `openapi_v1/contracts.py` 里的 `Envelope[T]` / `Page[T]` 结构
 （二进制流不走信封）。
 
-### 🟦 totalfrank · P1 —— bots（13 个端点）· `openapi_v1/bots/router.py`
+### ✅ totalfrank · P1 —— bots（13 个端点）· `openapi_v1/bots/router.py` —— **已实现（PR #494）**
+13 个端点已全部接到内部 bot 服务上。这里保留下来，是作为其余六个类别的参照形态：
+一个类别"做完了"长什么样。
+
 | 方法 | 路径 | 用途 | 成功响应 |
 |---|---|---|---|
 | POST | `/openapi/v1/bots` | 创建 Agent；可能需要 Passport 授权 | `201 Envelope[Bot]` 或 `202 Envelope[BotAuthPending]` |
@@ -225,6 +304,17 @@ open/draft，很快会关闭；此处作为参考保留）中的 v1 契约总览
 | GET | `/openapi/v1/bots/{bot_id}/passport` | 获取 Agent Passport | `Envelope[Passport]` |
 | GET | `/openapi/v1/bots/{bot_id}/engine-config` | 读取引擎配置（自由格式 JSON） | `Envelope[dict]` |
 | PUT | `/openapi/v1/bots/{bot_id}/engine-config` | 写入引擎配置（自由格式 JSON） | `Envelope[dict]` |
+
+_bots 上**刻意不暴露**的字段：创建时的 `engine_options`（下游目前没有任何代码会读
+`BotCreateSpec.extra_properties`，暴露它等于承诺一个服务端其实会忽略的东西），以及更新时的
+`cluster_name`/`engine_options`。有了 `extra="forbid"`，这些字段现在会得到 422，而不是被
+悄悄丢弃。_
+
+_内部 `/api/bots` 也有变化，全部是有意为之，并由 #494 覆盖：创建前置检查现在也会拒绝已被
+占用的 bot 名字（于是重名会在申请外部 Passport **之前**就失败）；创建时持久化的是配置化的
+引擎注册表，并且会补上该 bot 自己的 active engine；更新时的重名检查会把 owner **和**
+`bot_id` 一起比较；删除默认 bot 会抛 `BotOperationNotAllowedError`（内部响应结构不变，
+公共界面映射为 409）。_
 
 ### 🟦 totalfrank · P2 —— channels（6 个端点）· `openapi_v1/channels/router.py`
 钉钉（`dingding`）渠道配置 CRUD + 状态切换。
@@ -315,13 +405,18 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
 ## 完成的定义（整个 `/openapi/v1` 工作）
 
 1. **Track A：** 每一类数据（bots、resources、channels、skills、mcp、routines）都带有
-   `avernet_tenant` 并被守卫，Stage-1 的测试形态全绿。
-2. 全程内部 API 保持不变（`to_dict()` 无泄漏；内部套件不作修改）。
+   `avernet_tenant` 并被守卫，Stage-1 的测试形态全绿。—— _6 个里完成 1 个（bots ✅）。_
+2. 全程内部 API 保持不变（`to_dict()` 无泄漏；内部套件不作修改）。—— _仍然成立：#494
+   时整个 `tests/community` 全绿（9171 通过，3 跳过）。_
 3. **Track B：** 七个 `/openapi/v1` 类别的处理器均已实现且租户安全，各自带测试 + PR。
-4. F2 租户前导索引就位（强制策略）。
-5. 后台/定时任务已针对按租户正确性完成复查。
-6. `resolve_avernet_tenant` 已接到真实验证器（认证工作线）—— 到此，第二个租户才能安全地持有
-   真实数据。
+   —— _7 个里完成 1 个（bots ✅）。_
+4. F2 租户前导索引就位（强制策略）。—— _⬜_
+5. 后台/定时任务已针对按租户正确性完成复查。—— _⬜_
+6. `require_principal` / `resolve_avernet_tenant` 已接到真实验证器（认证工作线）——
+   到此，第二个租户才能安全地持有真实数据，公共界面也才会停止一律返回 401。—— _⬜_
+7. **跨租户的外部身份问题已定案（[#556](https://github.com/inclusionAI/Avernet/issues/556)）** —— Passport、授权关系与 BCN 都带上
+   租户维度，从而可以在公共路径上重新打开 BCN 同步。—— _⬜（2026-07-29 新增；它是开启
+   多租户的前置闸口）。_
 
 ---
 
@@ -333,8 +428,10 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
   `idx_entity`、搜索索引），采用**先建新、再删旧**（命名约定把索引名与其列绑定，因此先建后删，
   避免出现无索引的窗口）。低基数索引（`idx_status`、`idx_is_delete`）与唯一查找索引
   （`idx_binding_id`）保持不动。
-- **真实的调用方身份验证器。** 把 `resolve_avernet_tenant` 的函数体换成返回网关转发的
-  principal 的租户。接缝已就绪。
+- **真实的调用方身份验证器。** 把 `require_principal` 的函数体换成返回网关转发的
+  principal，把 `resolve_avernet_tenant` 换成返回它的租户。两处接缝都已就绪，而且
+  `caller_owner_id` 既接受裸的 id 字符串、也接受带 `user_id` 的对象/字典，因此处理器
+  不需要改动。**在它落地之前，公共界面对任何请求都只会返回 401。**
 - **后台/定时任务。** 现在都解析为默认租户（在全部数据都是 `teamclaw` 时是正确的）；在第二个
   租户持有真实数据之前需复查（skill_center / governance / dormant / 设备轮询器中的定时扫描、
   轮询器、同步循环）。
@@ -343,7 +440,7 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
 
 ---
 
-## Stage 1 中踩过的坑（帮你省下往返）
+## Track A Stage 1 中踩过的坑（帮你省下往返）
 
 - 把 `do_orm_execute` 读守卫注册在 **`Session` 类**上（可覆盖所有运行时，包括树外的公司 DB
   插件），而不是注册在某一个插件上。
@@ -358,6 +455,29 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
   **`--no-verify` 对 force-push 同样适用**（普通 `git push` 会运行约 10 分钟的钩子并超时）。
 - 执行会 `cd` 到仓库根目录的 `git` 命令后，cwd 会漂移到仓库根；跑 `uv run` 前先
   `cd src/backend`。
+
+## Track B bots 中踩过的坑（PR #494）
+
+- **信封会从你没看的地方漏出去。** 处理器级别的装饰器只覆盖处理器*内部*的失败。未知路径
+  （404）、方法不对（405）、请求体校验失败（422）都在路由跑起来*之前*就抛出了，此前它们
+  返回的是 `{"detail": ...}` —— 而这恰恰是新接入方最先撞上的三件事。已在 `app.py` 里按
+  路径限定于 `/openapi/v1` 一次性解决，不要再重复解决。
+- **基类必须映射在最后。** `ENVELOPE_ERRORS` 按插入顺序在第一个 `isinstance` 命中时返回，
+  因此列在基类*之后*的具体子类永远轮不到。
+- **不在你类别继承体系里的错误照样会逃逸。** engine-config 的几个失败是平级的
+  `RuntimeError` 兄弟类，不是 `BotServiceError` 的子类 —— 每一条有据可查的传播路径都得单独
+  加一条映射。请 grep 你的服务实际会抛什么，不要假设一个基类就都覆盖了。
+- **绝不要转发异常自带的实体头**（`Content-Length`/`Content-Type`）—— 它们描述的是被丢弃的
+  那个响应体。但协议头要转发（405 的 `Allow`、401 的 `WWW-Authenticate`）。
+- **`extra="forbid"` 是表达"不可变"的方式。** 没有它，bot 更新里的 `engine` 会被悄悄丢掉，
+  而调用方以为改成功了。
+- **凡是内部界面也在做的事，抽出来，别复制。** 创建/Passport 编排如果有两份拷贝，一个版本
+  之内就会漂移。抽取必须是行为保持的 —— 用"内部测试套件不作修改"来证明这一点。
+- **即便是行为保持的抽取，也会照出内部的既有 bug。** 有四个内部 `/api/bots` 的缺陷，是把
+  逻辑从路由里读出来之后才看见的（见 bots 表下方的说明）。要预期到这一点，并明确决定要不要
+  在同一个 PR 里修。
+- 一个"只是接线"的 PR 走了十六轮自动评审。请为评审轮次留出预算；那些在接线 PR 里无法定案的
+  问题，应当立成 issue（#556 / #559 / #560），而不是绕着它们打补丁。
 
 ---
 
@@ -375,3 +495,22 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
   层级。
 - **2026-07-27** —— skills 端点从两张表（桩里 5 个 + 提议 2 个）合并为**一张带"状态"列的
   7 行表**，这样一眼就能看出是 7 个端点，而不是看起来像 2 个。
+- **2026-07-27** —— **Track A Stage 1 已合并（PR #456）。** bots 带上了
+  `avernet_tenant`；可复用机制（租户载体、守卫、中间件、`resolve_avernet_tenant` 接缝）
+  已在 `dev` 上。bots 的共同闸口就此解除。
+- **2026-07-29** —— **Track B bots 已合并（PR #494）—— 第一个落地的公共类别。**
+  13 个 `/openapi/v1/bots` 端点全部接到内部服务，通过 `caller_owner_id` 做 owner 限定，
+  并由 Track A 守卫做租户限定（别的租户的 `{bot_id}` → 被掩盖的 404，且是针对真实守卫
+  验证过的）。同时沉淀了其余六个类别可复用的 **Track B 共享基建**（`responses.py`、
+  `contracts.py`/`ERROR_RESPONSES`、`principal.py`、`clusters.py` 的 ACRA/ANDC、
+  `errors.py`），并在 `app.py` 里从结构上封死了信封逃逸。抽出了
+  `core/bot_management/create_flow.py` 与 `readiness.py`，让两套界面共用一份实现。
+  新增架构门禁 `test_service_api_conformance.py`。全量测试 9171 通过 / 3 跳过。
+  看板更新：Track A 阶段 1 → 已合并，Track B bots → 已完成；新增 **Track B 基建 +
+  操作手册**一节以及 Track B 的踩坑记录。
+- **2026-07-29** —— 从 #494 的评审中沉淀出三条需要继承的决策，并加入横切看板：
+  **[#556](https://github.com/inclusionAI/Avernet/issues/556)** 跨租户的 Agent 身份撞车（**开启多租户的前置闸口**，现已列为 DoD 第 7 条）、
+  **[#559](https://github.com/inclusionAI/Avernet/issues/559)** 异步创建出的 bot 可能不是被授权的那个、
+  **[#560](https://github.com/inclusionAI/Avernet/issues/560)** 外部身份写入失败被吞掉。三者都是 `dev` 上的既有问题。
+  同时把**"认证落地前一律返回 401"**这一状态写到了文档开头 —— 公共界面虽已实现，但尚不可
+  被真正调用。


### PR DESCRIPTION
## What

Brings `src/backend/docs/openapi-v1/README.md` and `README.zh-CN.md` — the living
handoff board for the `/openapi/v1` effort — up to date with **PR #494 (Track B
bots)** and **PR #456 (Track A Stage 1)**, both now merged.

Docs-only change; no code touched.

## Why

The board still said *"Track B — NOT STARTED"* and *"PR #456 (awaiting approval,
not yet merged)"*. Per the doc's own rule (_"a stale board is worse than none —
it makes someone redo or collide"_), the next person to pick up a category would
have been reading a map two PRs out of date — and, more expensively, would have
rebuilt the shared public-API layer that #494 already built.

## Changes

**Status board**
- Track A stage 1 → ✅ DONE, merged 2026-07-27. Shared bots gate marked lifted.
- Track B bots → ✅ DONE, PR #494 merged 2026-07-29, 13/13 endpoints. Header now
  reads "1 of 7 done"; the other six routers are marked *(stub)*.
- Cross-cutting board gains the three issues #494 filed rather than fixed:
  #556 (cross-tenant bot identity collision), #559 (async create vs authorized
  bot), #560 (swallowed external identity writes) — all pre-existing on `dev`.
  #556 also becomes DoD item 7, since it gates enabling multi-tenancy.

**New: "Track B — the reusable primitives (built with bots, PR #494)"**

Replaces the old two-sentence *"not started"* stub with what the remaining six
categories actually need to not rebuild: `responses.py` (envelope builders, the
`ENVELOPE_ERRORS` mapping and its ordering/fixed-message/identical-404 rules),
`contracts.py`'s `ERROR_RESPONSES` attached once in `build_public_router()`,
`principal.py::caller_owner_id`, the ACRA/ANDC cluster enum, `errors.py`, and the
path-scoped `app.py` handlers that close envelope escape structurally. Plus a
per-category recipe mirroring the existing Track A one, and the mount-order rule
(literal sub-groups before the `{bot_id}` wildcard).

**New: "Gotchas learned in Track B bots"** — the things that cost review rounds:
envelope escape before the handler runs, base-class-last mapping order, errors
outside your category's hierarchy, never forwarding an exception's body headers,
`extra="forbid"` as the way to express immutability, extract-don't-copy for
behavior shared with `/api`.

**Clarified up top:** the surface answers `401` to everything until the real
authenticator lands. "bots is done" means handlers, contracts and tests are done
— not that an external tenant can call them. This was implicit before and is the
single most misreadable thing on the board.

**Also:** bots endpoint table marked IMPLEMENTED and kept as the reference shape,
with notes on what is deliberately not exposed (`engine_options`, `cluster_name`
on update) and the four intentional internal `/api/bots` behavior changes; path
divergence note scoped to the six stub groups (bots is unaffected either way);
future-tense references to #456 corrected; changelog entries appended.

English and Chinese kept in lockstep, section for section (heading structure
verified 1:1).

## Testing

Docs-only — no tests apply. Every claim was checked against merged code on `dev`
(`openapi_v1/*.py`, `app.py`, `build_public_router()`) and against the merge
state, bodies and linked issues of PRs #456/#494/#363 rather than the previous
text of the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc2ZoTGCeYMxsesEtVrNRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yc2ZoTGCeYMxsesEtVrNRA)_