### PR TITLE
feat(bcs): list session files newest-first by default

### DIFF
--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/session_file.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/session_file.rs
@@ -25,7 +25,7 @@ pub struct SessionFileListParams {
     pub prefix: Option<String>,
     pub status: Option<FileStatus>,
     pub limit: u32,   // 0 => 100, clamped to [1, 1000] in impls
-    pub offset: u32,  // skip this many (in created_at,file_id order)
+    pub offset: u32,  // skip this many (in created_at DESC, file_id DESC order)
 }
 
 #[derive(Debug, Clone)]

--- a/src/bcs/crates/services/bcs-session-file-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-session-file-store/src/memory.rs
@@ -166,7 +166,7 @@ impl SessionFileRepoPort for MemorySessionFileRepo {
             })
             .cloned()
             .collect();
-        items.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.file_id.cmp(&b.file_id)));
+        items.sort_by(|a, b| b.created_at.cmp(&a.created_at).then(b.file_id.cmp(&a.file_id)));
 
         let total = items.len() as u64;
 
@@ -381,6 +381,33 @@ mod tests {
             .unwrap();
         assert_eq!(p3.items.len(), 1);
         assert_eq!(p3.total, 5);
+    }
+
+    #[tokio::test]
+    async fn list_defaults_to_newest_first() {
+        // Default order is created_at DESC, file_id DESC — newest uploads first.
+        // f5 is inserted last, so it must be the first item returned.
+        let repo = MemorySessionFileRepo::new();
+        for i in 1u8..=5 {
+            repo.insert(params(&format!("f{i}"), "s_order", 9999)).await.unwrap();
+        }
+        let page = repo
+            .list(
+                "s_order",
+                SessionFileListParams {
+                    prefix: None,
+                    status: None,
+                    limit: 100,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        let ids: Vec<&str> = page.items.iter().map(|f| f.file_id.as_str()).collect();
+        // Last-inserted file_id is first; tie-broken by file_id DESC.
+        assert_eq!(ids.first().copied(), Some("f5"), "newest upload must lead: {ids:?}");
+        // And the full order is f5..f1 (reverse insertion), not insertion order.
+        assert_eq!(ids, vec!["f5", "f4", "f3", "f2", "f1"], "order should be DESC: {ids:?}");
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-session-file-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-file-store/src/mysql.rs
@@ -34,7 +34,7 @@ const SELECT_BASE_COLS: &str = "file_id, session_id, file_name, mime_type, size,
 /// DB-managed `gmt_create`/`gmt_modified` audit timestamps. The domain fields
 /// are projected from those on read (epoch seconds) in a flavor-aware way
 /// (`UNIX_TIMESTAMP` on MySQL, `strftime('%s', …)` on SQLite), and `list`
-/// orders by `gmt_create`. `json_extract` is lowercase for MySQL/SQLite
+/// orders by `gmt_create DESC` (newest uploads first). `json_extract` is lowercase for MySQL/SQLite
 /// portability, so the dialect branches are the timestamp projection and the
 /// `expires_at` JSON cast (`... AS SIGNED` on MySQL, `... AS INTEGER` on SQLite).
 #[derive(Clone)]
@@ -405,7 +405,7 @@ impl SessionFileRepoPort for MySqlSessionFileStore {
         let page_sql = format!(
             "SELECT {} FROM bcs_session_files \
              WHERE {where_clause} \
-             ORDER BY gmt_create, file_id LIMIT ? OFFSET ?",
+             ORDER BY gmt_create DESC, file_id DESC LIMIT ? OFFSET ?",
             self.select_cols()
         );
 


### PR DESCRIPTION
## What
Make `GET /sessions/{sid}/files` (`list_files`) return files newest-first by default — the most recently uploaded file leads.

## Why
The list returned files ascending by `created_at, file_id`, so the newest uploads were last. For a workspace listing the most recent shared file is usually what the caller wants first; this matches that expectation and keeps pagination consistent with it.

## Changes
- `bcs-session-file-store` MySQL: `ORDER BY gmt_create, file_id` → `ORDER BY gmt_create DESC, file_id DESC`.
- `bcs-session-file-store` memory: reverse the `sort_by` comparator to `created_at DESC, file_id DESC`, matching MySQL.
- `service-api` `SessionFileListParams.offset`: update the ordering doc comment to `created_at DESC, file_id DESC`.
- `bcs-session-file-store` struct doc: note `list` orders by `gmt_create DESC (newest uploads first)`.
- Add `list_defaults_to_newest_first` test (memory): inserts f1..f5, asserts returned order is `f5..f1`.

The `list_files` route and `SessionFileListParams` are unchanged — no new sort parameter is introduced; `prefix`/`status`/`limit`/`offset` behave exactly as before, just over a descending baseline.

## Verification
- `cargo test -p bcs-session-file-store --lib`: 10 passed (incl. new `list_defaults_to_newest_first`).
- `cargo test -p bcs-http --lib session_files::`: 27 passed (no `list_files` route regression).
