### PR TITLE
fix: harden committed skills pool reconciliation

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -57,7 +57,9 @@ Engine Layout Descriptor 仍不在本期范围内。
   附带操作者、备注和已核验的数据面事实，之后才会重新入队同一 generation。
 - bridge 已提交后的 `POST_CUTOVER_SYNC_PENDING`、mapping 与数据库失败均
   持久化阶段、错误码、可重试性、证据和时间；重试只补齐 mapping、locator
-  与 `POOL_ACTIVE`，不恢复隔离副本。
+  与 `POOL_ACTIVE`，不恢复隔离副本。已提交状态的 runtime 重入只补齐
+  quarantine/marker 证据，不重复执行数据面 commit CAS；transport 或校验失败
+  只记录 forward-only failure。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -273,6 +273,30 @@ class SkillsPoolReconcileService:
             )
             if not cutover.committed:
                 evidence = cutover.to_dict()
+                if state.data_plane_cutover_committed:
+                    outcome, stage, retryable = (
+                        self._post_commit_cutover_failure_profile(cutover.status)
+                    )
+                    recorded = self._layouts.record_post_cutover_failure(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code=cutover.status.value,
+                        failure_stage=stage,
+                        retryable=retryable,
+                        evidence=evidence,
+                    )
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            preparation_id=probe.preparation_id,
+                        )
+                    return SkillsPoolReconcileResult(
+                        outcome,
+                        preparation_id=probe.preparation_id,
+                        evidence=evidence,
+                        retryable=retryable,
+                    )
                 if (
                     cutover.status is PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING
                     or cutover_finalizing
@@ -344,9 +368,19 @@ class SkillsPoolReconcileService:
                     preparation_id=probe.preparation_id,
                     evidence=cutover.to_dict(),
                 )
-            if not (
-                state.data_plane_cutover_committed and repair_evidence_refresh
-            ):
+            if state.data_plane_cutover_committed:
+                if not self._layouts.record_post_cutover_evidence(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    preparation_id=probe.preparation_id,
+                    evidence=cutover.to_dict(),
+                ):
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        preparation_id=probe.preparation_id,
+                    )
+            else:
                 if not self._layouts.record_cutover_committed(
                     scope=scope,
                     migration_generation=generation,
@@ -582,6 +616,33 @@ class SkillsPoolReconcileService:
                 True,
             ),
         }.get(status)
+
+    @classmethod
+    def _post_commit_cutover_failure_profile(
+        cls,
+        status: PoolCutoverStatus,
+    ) -> tuple[SkillsPoolReconcileOutcome, str, bool]:
+        """Classify refresh failures after the irreversible boundary is known."""
+
+        if status in {
+            PoolCutoverStatus.UNKNOWN,
+            PoolCutoverStatus.TRANSIENT_ERROR,
+            PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING,
+        }:
+            return (
+                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                "post_cutover_refresh",
+                True,
+            )
+        profile = cls._cutover_failure_profile(status)
+        if profile is not None:
+            outcome, _, retryable = profile
+            return outcome, "post_cutover_refresh", retryable
+        return (
+            SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+            "post_cutover_refresh",
+            False,
+        )
 
     @staticmethod
     def _source_tail(git_path: str, prefix: str) -> PurePosixPath:

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -110,6 +110,18 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """记录不可逆的数据面切换已经完成。"""
         ...
 
+    def record_post_cutover_evidence(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """在边界已提交时补齐运行时证据，不重复提交数据面边界。"""
+        ...
+
     def record_cutover_finalizing(
         self,
         *,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -26,14 +26,22 @@ from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
     log_missing_quarantine_path,
 )
-from agentclaw.community.plugins.skills_pool_capability_repository import SkillsPoolCapabilityRepositoryMixin
-from agentclaw.community.plugins.skills_pool_operational_repository import SkillsPoolOperationalRepositoryMixin
+from agentclaw.community.plugins.skills_pool_capability_repository import (
+    SkillsPoolCapabilityRepositoryMixin,
+)
+from agentclaw.community.plugins.skills_pool_operational_repository import (
+    SkillsPoolOperationalRepositoryMixin,
+)
 from agentclaw.community.plugins.skills_pool_quarantine_repository import (
     SkillsPoolQuarantineRepositoryMixin,
 )
 
 
-class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPoolOperationalRepositoryMixin, SkillsPoolQuarantineRepositoryMixin):
+class SkillsPoolLayoutRepository(
+    SkillsPoolCapabilityRepositoryMixin,
+    SkillsPoolOperationalRepositoryMixin,
+    SkillsPoolQuarantineRepositoryMixin,
+):
     @inject
     def __init__(self, database: DatabasePlugin) -> None:
         self._database = database
@@ -188,8 +196,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     *self._scope_filter(scope),
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     or_(
                         BotSkillLayoutStateModel.lease_expires_at.is_(None),
                         BotSkillLayoutStateModel.lease_expires_at <= func.now(),
@@ -248,10 +255,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_PREPARING.value,
@@ -299,10 +304,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
@@ -351,15 +354,19 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
         evidence: dict[str, object],
     ) -> bool:
         evidence_json = json.dumps(evidence, ensure_ascii=False)
+        runtime_evidence = evidence.get("evidence")
+        quarantine_path = (
+            runtime_evidence.get("quarantine")
+            if isinstance(runtime_evidence, dict)
+            else None
+        )
         with self._database.transactional_orm_session() as session:
-            affected = (
+            row = (
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
@@ -372,28 +379,96 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     BotSkillLayoutStateModel.lease_owner == lease_owner,
                     BotSkillLayoutStateModel.lease_expires_at > func.now(),
                 )
-                .update(
-                    {
-                        BotSkillLayoutStateModel.phase: (
-                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
-                        ),
-                        BotSkillLayoutStateModel.data_plane_cutover_committed: 1,
-                        BotSkillLayoutStateModel.last_failure_code: (
-                            "POST_CUTOVER_SYNC_PENDING"
-                        ),
-                        BotSkillLayoutStateModel.last_failure_stage: (
-                            "post_cutover_sync"
-                        ),
-                        BotSkillLayoutStateModel.last_failure_retryable: 1,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
-                        BotSkillLayoutStateModel.last_failure_at: func.now(),
-                    },
-                    synchronize_session=False,
-                )
+                .with_for_update()
+                .one_or_none()
             )
-        return affected == 1
+            if row is None or row.rollout_evidence is None:
+                return False
+            engine = json.loads(row.rollout_evidence).get("engine_type")
+            if not isinstance(engine, str) or not engine:
+                return False
+            if not isinstance(quarantine_path, str) or not quarantine_path:
+                log_missing_quarantine_path(scope, migration_generation)
+                return False
+            if not self._upsert_quarantine(
+                session,
+                scope=scope,
+                migration_generation=migration_generation,
+                engine=engine,
+                path=quarantine_path,
+                evidence_json=evidence_json,
+            ):
+                return False
+            row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
+            row.data_plane_cutover_committed = 1
+            row.last_failure_code = "POST_CUTOVER_SYNC_PENDING"
+            row.last_failure_stage = "post_cutover_sync"
+            row.last_failure_retryable = 1
+            row.last_failure_evidence = evidence_json
+            row.last_failure_at = func.now()
+        return True
+
+    def record_post_cutover_evidence(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Reconcile runtime evidence without re-crossing the cutover boundary."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        runtime_evidence = evidence.get("evidence")
+        quarantine_path = (
+            runtime_evidence.get("quarantine")
+            if isinstance(runtime_evidence, dict)
+            else None
+        )
+        with self._database.transactional_orm_session() as session:
+            row = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if row is None or row.rollout_evidence is None:
+                return False
+            engine = json.loads(row.rollout_evidence).get("engine_type")
+            if not isinstance(engine, str) or not engine:
+                return False
+            if not isinstance(quarantine_path, str) or not quarantine_path:
+                log_missing_quarantine_path(scope, migration_generation)
+                return False
+            if not self._upsert_quarantine(
+                session,
+                scope=scope,
+                migration_generation=migration_generation,
+                engine=engine,
+                path=quarantine_path,
+                evidence_json=evidence_json,
+            ):
+                return False
+            row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
+            row.last_probe_evidence = evidence_json
+        return True
 
     def begin_cutover(
         self,
@@ -410,12 +485,9 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase
-                    == SkillLayoutPhase.POOL_READY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase == SkillLayoutPhase.POOL_READY.value,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
                     BotSkillLayoutStateModel.preparation_id == preparation_id,
@@ -452,10 +524,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_PREPARING.value,
@@ -472,15 +542,9 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 .update(
                     {
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
-                        BotSkillLayoutStateModel.last_failure_stage: (
-                            failure_stage
-                        ),
-                        BotSkillLayoutStateModel.last_failure_retryable: int(
-                            retryable
-                        ),
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_stage: (failure_stage),
+                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -507,12 +571,14 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase
-                    == SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                        )
+                    ),
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
@@ -523,12 +589,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     {
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
                         BotSkillLayoutStateModel.last_failure_stage: failure_stage,
-                        BotSkillLayoutStateModel.last_failure_retryable: int(
-                            retryable
-                        ),
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -554,10 +616,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
@@ -574,9 +634,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
                         BotSkillLayoutStateModel.last_failure_stage: failure_stage,
                         BotSkillLayoutStateModel.last_failure_retryable: 0,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                         BotSkillLayoutStateModel.lease_owner: None,
                         BotSkillLayoutStateModel.lease_expires_at: None,
@@ -607,10 +665,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.NEEDS_MANUAL_REPAIR.value,
                     BotSkillLayoutStateModel.migration_generation
@@ -658,8 +714,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
 
         pool_prefixes = local_locator_prefixes(pool=True)
         if any(
-            not isinstance(skill_id, int)
-            or not locator.startswith(pool_prefixes)
+            not isinstance(skill_id, int) or not locator.startswith(pool_prefixes)
             for skill_id, locator in local_locators.items()
         ):
             return False
@@ -682,10 +737,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
@@ -745,8 +798,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.target_layout.is_(None),
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.POOL_ACTIVE.value,
@@ -772,9 +824,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                             "rollback_requested"
                         ),
                         BotSkillLayoutStateModel.last_failure_retryable: None,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -798,10 +848,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
@@ -822,9 +870,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                         BotSkillLayoutStateModel.last_failure_code: None,
                         BotSkillLayoutStateModel.last_failure_stage: None,
                         BotSkillLayoutStateModel.last_failure_retryable: None,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: None,
                     },
                     synchronize_session=False,
@@ -847,10 +893,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
@@ -896,10 +940,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
@@ -915,12 +957,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     {
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
                         BotSkillLayoutStateModel.last_failure_stage: failure_stage,
-                        BotSkillLayoutStateModel.last_failure_retryable: int(
-                            retryable
-                        ),
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -940,8 +978,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
 
         legacy_prefixes = local_locator_prefixes(pool=False)
         if any(
-            not isinstance(skill_id, int)
-            or not locator.startswith(legacy_prefixes)
+            not isinstance(skill_id, int) or not locator.startswith(legacy_prefixes)
             for skill_id, locator in local_locators.items()
         ):
             return False
@@ -964,10 +1001,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value,
                     BotSkillLayoutStateModel.migration_generation

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -387,18 +387,19 @@ class SkillsPoolLayoutRepository(
             engine = json.loads(row.rollout_evidence).get("engine_type")
             if not isinstance(engine, str) or not engine:
                 return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
-            if not self._upsert_quarantine(
-                session,
-                scope=scope,
-                migration_generation=migration_generation,
-                engine=engine,
-                path=quarantine_path,
-                evidence_json=evidence_json,
-            ):
-                return False
+            # Some post-boundary Engine failures cannot yet report the
+            # quarantine path. Persist the irreversible boundary first and
+            # keep FINALIZING until a later successful refresh supplies it.
+            if isinstance(quarantine_path, str) and quarantine_path:
+                if not self._upsert_quarantine(
+                    session,
+                    scope=scope,
+                    migration_generation=migration_generation,
+                    engine=engine,
+                    path=quarantine_path,
+                    evidence_json=evidence_json,
+                ):
+                    return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
             row.data_plane_cutover_committed = 1
             row.last_failure_code = "POST_CUTOVER_SYNC_PENDING"
@@ -567,7 +568,7 @@ class SkillsPoolLayoutRepository(
 
         evidence_json = json.dumps(evidence, ensure_ascii=False)
         with self._database.transactional_orm_session() as session:
-            affected = (
+            row = (
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
@@ -585,18 +586,22 @@ class SkillsPoolLayoutRepository(
                     BotSkillLayoutStateModel.lease_owner == lease_owner,
                     BotSkillLayoutStateModel.lease_expires_at > func.now(),
                 )
-                .update(
-                    {
-                        BotSkillLayoutStateModel.last_failure_code: failure_code,
-                        BotSkillLayoutStateModel.last_failure_stage: failure_stage,
-                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
-                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
-                        BotSkillLayoutStateModel.last_failure_at: func.now(),
-                    },
-                    synchronize_session=False,
-                )
+                .with_for_update()
+                .one_or_none()
             )
-        return affected == 1
+            if row is None:
+                return False
+            # Older Backend versions used this failure code as the durable
+            # "runtime evidence still missing" signal. Move that signal into
+            # the phase before replacing the code with the latest failure.
+            if row.last_failure_code == "MANUAL_REPAIR_RESOLVED":
+                row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
+            row.last_failure_code = failure_code
+            row.last_failure_stage = failure_stage
+            row.last_failure_retryable = int(retryable)
+            row.last_failure_evidence = evidence_json
+            row.last_failure_at = func.now()
+        return True
 
     def mark_repair_required(
         self,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -32,6 +32,9 @@ from agentclaw.community.plugins.skills_pool_capability_repository import (
 from agentclaw.community.plugins.skills_pool_operational_repository import (
     SkillsPoolOperationalRepositoryMixin,
 )
+from agentclaw.community.plugins.skills_pool_post_cutover_repository import (
+    SkillsPoolPostCutoverRepositoryMixin,
+)
 from agentclaw.community.plugins.skills_pool_quarantine_repository import (
     SkillsPoolQuarantineRepositoryMixin,
 )
@@ -40,6 +43,7 @@ from agentclaw.community.plugins.skills_pool_quarantine_repository import (
 class SkillsPoolLayoutRepository(
     SkillsPoolCapabilityRepositoryMixin,
     SkillsPoolOperationalRepositoryMixin,
+    SkillsPoolPostCutoverRepositoryMixin,
     SkillsPoolQuarantineRepositoryMixin,
 ):
     @inject
@@ -407,68 +411,6 @@ class SkillsPoolLayoutRepository(
             row.last_failure_retryable = 1
             row.last_failure_evidence = evidence_json
             row.last_failure_at = func.now()
-        return True
-
-    def record_post_cutover_evidence(
-        self,
-        *,
-        scope: BotSkillLayoutScope,
-        migration_generation: str,
-        lease_owner: str,
-        preparation_id: str,
-        evidence: dict[str, object],
-    ) -> bool:
-        """Reconcile runtime evidence without re-crossing the cutover boundary."""
-
-        evidence_json = json.dumps(evidence, ensure_ascii=False)
-        runtime_evidence = evidence.get("evidence")
-        quarantine_path = (
-            runtime_evidence.get("quarantine")
-            if isinstance(runtime_evidence, dict)
-            else None
-        )
-        with self._database.transactional_orm_session() as session:
-            row = (
-                session.query(BotSkillLayoutStateModel)
-                .filter(
-                    *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase.in_(
-                        (
-                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
-                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
-                        )
-                    ),
-                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
-                    BotSkillLayoutStateModel.migration_generation
-                    == migration_generation,
-                    BotSkillLayoutStateModel.preparation_id == preparation_id,
-                    BotSkillLayoutStateModel.lease_owner == lease_owner,
-                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
-                )
-                .with_for_update()
-                .one_or_none()
-            )
-            if row is None or row.rollout_evidence is None:
-                return False
-            engine = json.loads(row.rollout_evidence).get("engine_type")
-            if not isinstance(engine, str) or not engine:
-                return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
-            if not self._upsert_quarantine(
-                session,
-                scope=scope,
-                migration_generation=migration_generation,
-                engine=engine,
-                path=quarantine_path,
-                evidence_json=evidence_json,
-            ):
-                return False
-            row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
-            row.last_probe_evidence = evidence_json
         return True
 
     def begin_cutover(

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
@@ -1,0 +1,87 @@
+"""Post-cutover runtime evidence persistence for Skills Pool migrations."""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import func
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    BotSkillLayoutStateModel,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
+    log_missing_quarantine_path,
+)
+
+
+class SkillsPoolPostCutoverRepositoryMixin:
+    """Reconcile runtime evidence after the irreversible cutover boundary."""
+
+    _database: object
+
+    def record_post_cutover_evidence(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Reconcile runtime evidence without re-crossing the cutover boundary."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        runtime_evidence = evidence.get("evidence")
+        quarantine_path = (
+            runtime_evidence.get("quarantine")
+            if isinstance(runtime_evidence, dict)
+            else None
+        )
+        with self._database.transactional_orm_session() as session:
+            row = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if row is None or row.rollout_evidence is None:
+                return False
+            engine = json.loads(row.rollout_evidence).get("engine_type")
+            if not isinstance(engine, str) or not engine:
+                return False
+            if not isinstance(quarantine_path, str) or not quarantine_path:
+                log_missing_quarantine_path(scope, migration_generation)
+                return False
+            if not self._upsert_quarantine(
+                session,
+                scope=scope,
+                migration_generation=migration_generation,
+                engine=engine,
+                path=quarantine_path,
+                evidence_json=evidence_json,
+            ):
+                return False
+            row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
+            row.last_probe_evidence = evidence_json
+        return True

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -709,6 +709,57 @@ def test_unknown_cutover_is_fenced_for_manual_repair() -> None:
     assert state.last_failure_evidence == {"reason": "response_lost"}
 
 
+def test_cutover_finalizing_persists_quarantine_at_irreversible_boundary() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    quarantine_path = (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+
+    assert repository.record_cutover_finalizing(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": False,
+            "status": "POST_CUTOVER_SYNC_PENDING",
+            "evidence": {"quarantine": quarantine_path},
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert state.data_plane_cutover_committed is True
+    with database.transactional_orm_session() as session:
+        quarantine = session.query(SkillMigrationQuarantineModel).one()
+        assert quarantine.path == quarantine_path
+        assert quarantine.pool_activated_at is None
+
+
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -769,7 +820,7 @@ def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
         lease_owner="worker-2",
         lease_seconds=60,
     )
-    assert repository.record_cutover_committed(
+    assert repository.record_post_cutover_evidence(
         scope=scope,
         migration_generation="generation-1",
         lease_owner="worker-2",

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -760,6 +760,51 @@ def test_cutover_finalizing_persists_quarantine_at_irreversible_boundary() -> No
         assert quarantine.pool_activated_at is None
 
 
+def test_cutover_finalizing_accepts_pending_evidence_without_quarantine() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+
+    assert repository.record_cutover_finalizing(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": False,
+            "status": "POST_CUTOVER_SYNC_PENDING",
+            "evidence": {"reason": "post_cutover_sync_failed"},
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert state.data_plane_cutover_committed is True
+    with database.transactional_orm_session() as session:
+        assert session.query(SkillMigrationQuarantineModel).count() == 0
+
+
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -864,6 +909,68 @@ def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     assert active.last_failure_evidence["previous_failure"] == {
         "reason": "response_lost"
     }
+
+
+def test_legacy_committed_repair_refresh_failure_keeps_refresh_phase() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    assert repository.mark_repair_required(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        failure_code="UNKNOWN",
+        failure_stage="cutover_outcome_unknown",
+        evidence={"reason": "response_lost"},
+    )
+    assert repository.resolve_repair(
+        scope=scope,
+        migration_generation="generation-1",
+        operator="oncall-1",
+        note="legacy backend resolved this row as committed",
+        cutover_committed=True,
+    )
+    assert repository.try_acquire_lease(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-2",
+        lease_seconds=60,
+    )
+    assert repository.record_post_cutover_failure(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-2",
+        failure_code="TRANSIENT_ERROR",
+        failure_stage="post_cutover_refresh",
+        retryable=True,
+        evidence={"reason": "adapter_temporarily_unreachable"},
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert state.data_plane_cutover_committed is True
+    assert state.last_failure_code == "TRANSIENT_ERROR"
 
 
 def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -142,6 +142,19 @@ class FakeLayoutRepository:
         )
         return True
 
+    def record_post_cutover_evidence(self, **kwargs: object) -> bool:
+        if self._should_fail("post_cutover_evidence"):
+            return False
+        if not self._owns(kwargs):
+            return False
+        self.events.append("evidence")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            data_plane_cutover_committed=True,
+        )
+        return True
+
     def begin_cutover(self, **kwargs: object) -> bool:
         if self._should_fail("begin"):
             return False
@@ -564,7 +577,9 @@ async def test_unknown_cutover_enters_manual_repair_and_stops_automation() -> No
 
 
 @pytest.mark.asyncio
-async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas() -> None:
+async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas() -> (
+    None
+):
     layouts = FakeLayoutRepository(
         claimed_state(
             phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
@@ -587,8 +602,57 @@ async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas
 
     assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
-    assert layouts.events == ["database"]
+    assert layouts.events == ["evidence", "database"]
     assert layouts.state.active_layout is SkillLayout.POOL
+
+
+@pytest.mark.asyncio
+async def test_committed_repair_transport_failure_records_forward_only_and_retries() -> (
+    None
+):
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.UNKNOWN,
+        evidence={"reason": "transport_response_unavailable"},
+    )
+
+    first = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert first.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert first.retryable is True
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_stage == "post_cutover_refresh"
+
+    runtime.events.clear()
+    layouts.events.clear()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+
+    retried = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "mapping", "verify"]
+    assert layouts.events == ["database"]
 
 
 @pytest.mark.asyncio
@@ -627,7 +691,67 @@ async def test_post_cutover_sync_pending_retries_finalization_before_mappings() 
 
     assert second.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
-    assert layouts.events == ["cutover", "database"]
+    assert layouts.events == ["evidence", "database"]
+
+
+@pytest.mark.asyncio
+async def test_committed_repair_invalid_refresh_stays_forward_only() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.INVALID,
+        evidence={"reason": "active_marker_identity_mismatch"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert result.retryable is False
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_stage == "post_cutover_refresh"
+
+
+@pytest.mark.asyncio
+async def test_finalizing_transport_failure_does_not_reenter_pre_cutover_cas() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="POST_CUTOVER_SYNC_PENDING",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.TRANSIENT_ERROR,
+        evidence={"reason": "adapter_temporarily_unreachable"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert result.retryable is True
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_stage == "post_cutover_refresh"
 
 
 @pytest.mark.asyncio
@@ -812,8 +936,7 @@ async def test_mixed_image_bots_reconcile_independently_in_one_environment() -> 
         def _owns(self, values: dict[str, object]) -> bool:
             return (
                 values["scope"] == self._current_scope
-                and values["migration_generation"]
-                == self.state.migration_generation
+                and values["migration_generation"] == self.state.migration_generation
                 and values["lease_owner"] == self.state.lease_owner
             )
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -184,8 +184,14 @@ class FakeLayoutRepository:
         if not self._owns(kwargs):
             return False
         self.events.append("post_failure")
+        refresh_pending = self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
         self.state = replace(
             self.state,
+            phase=(
+                SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+                if refresh_pending
+                else self.state.phase
+            ),
             last_failure_code=str(kwargs["failure_code"]),
             last_failure_stage=str(kwargs["failure_stage"]),
             last_failure_retryable=bool(kwargs["retryable"]),
@@ -633,7 +639,7 @@ async def test_committed_repair_transport_failure_records_forward_only_and_retri
     assert first.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
     assert first.retryable is True
     assert layouts.events == ["post_failure"]
-    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
     assert layouts.state.data_plane_cutover_committed is True
     assert layouts.state.last_failure_stage == "post_cutover_refresh"
 
@@ -651,8 +657,8 @@ async def test_committed_repair_transport_failure_records_forward_only_and_retri
     )
 
     assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
-    assert runtime.events == ["probe", "mapping", "verify"]
-    assert layouts.events == ["database"]
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["evidence", "database"]
 
 
 @pytest.mark.asyncio
@@ -719,7 +725,7 @@ async def test_committed_repair_invalid_refresh_stays_forward_only() -> None:
     assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
     assert result.retryable is False
     assert layouts.events == ["post_failure"]
-    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
     assert layouts.state.data_plane_cutover_committed is True
     assert layouts.state.last_failure_stage == "post_cutover_refresh"
 

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1198,6 +1198,10 @@ def test_cutover_retry_replays_residue_after_merge_failure(
     )
 
     assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert retry.evidence["quarantine"] == str(
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
+    )
+    assert retry.evidence["quarantine_cleanup_pending"] is True
     assert not legacy_local.exists()
     assert (
         pool_local / "created-before-merge-failure" / "SKILL.md"

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1150,6 +1150,10 @@ def _activate_pool(
             {
                 "active_marker": str(layout.active_marker),
                 "legacy_storage_entries_absent": True,
+                "quarantine": str(quarantine),
+                "quarantine_cleanup_pending": (
+                    quarantine.exists() or quarantine.is_symlink()
+                ),
             },
         )
 


### PR DESCRIPTION
## Summary

修复 Skills Pool 在数据面已经 committed 后的 repair/finalizing 重入状态机，避免 transport 异常被错误写入 pre-cutover CAS 并产生 `state_race_lost`。

## Changes

- 已 committed 的 runtime refresh 失败统一记录 forward-only failure，不再进入 pre-cutover failure 或重复 cutover commit
- 新增 post-cutover evidence reconciliation，只补齐 marker/quarantine 证据
- finalizing 在跨越不可逆边界时同步登记 quarantine，后续 ALREADY_COMMITTED 幂等收敛
- 覆盖 transport UNKNOWN、INVALID、finalizing transient、ALREADY_COMMITTED 与最终 POOL_ACTIVE 回归

## Test Plan

- `uv run pytest tests/community/core/skills_pool tests/community/di/test_skills_pool_wiring.py tests/community/endpoints/test_skills_pool_ops.py tests/community/adapters/http/test_skills_pool_ops_router.py -q`（198 passed）
- changed files Ruff lint/format passed