### PR TITLE
fix(bcs): defer IM collaboration initial run

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -168,6 +168,7 @@ pub async fn create_group(
     uri: Uri,
     Json(req): Json<CreateGroupRequest>,
 ) -> Result<Json<Value>, HttpAdapterError> {
+    let start_initial_run = req.start_initial_run.unwrap_or(true);
     let caller_actor_id = resolve_group_create_caller(&state, &headers, &uri).await?;
     let collaboration_definition_yaml = req.collaboration_definition_yaml.clone();
     let auto_start_on_service_invocation = req.auto_start_on_service_invocation.unwrap_or(false);
@@ -323,7 +324,9 @@ pub async fn create_group(
             })
             .await
             .map_err(collaboration_runtime_error_to_http)?;
-        if result.group_strategy == bcs_service_api::GroupStrategy::StateMachine {
+        if start_initial_run
+            && result.group_strategy == bcs_service_api::GroupStrategy::StateMachine
+        {
             let authenticated_human = optional_authenticated_human(&state, &headers, &uri).await;
             if let Some(run_id) = start_initial_state_machine_run_for_group(
                 &state,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -920,6 +920,65 @@ runtime:
 }
 
 #[tokio::test]
+async fn post_groups_can_defer_initial_state_machine_run() {
+    let (app, _recorder, collaboration_runtime, _temp_dir) =
+        test_app_with_collaboration_runtime().await;
+    let definition_yaml = r#"
+api_version: bcs.collaboration/v1
+name: Deferred Initial Run
+participants:
+  writer:
+    required: true
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      answer:
+        kind: bot_task
+        display_name: Answer
+        assignee:
+          type: bot_binding
+          binding: writer
+        instruction: Answer.
+        final_output: true
+"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/groups")
+                .header("authorization", "Bearer driver-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "id": "group-deferred-initial-run",
+                        "driver_bot": "driver-bot",
+                        "group_strategy": "state_machine",
+                        "start_initial_run": false,
+                        "participant_bindings": {
+                            "writer": {
+                                "source": "manual",
+                                "bot_ids": ["driver-bot"]
+                            }
+                        },
+                        "collaboration_definition_yaml": definition_yaml
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(collaboration_runtime.configure_calls.lock().await.len(), 1);
+    assert!(collaboration_runtime.start_commands.lock().await.is_empty());
+}
+
+#[tokio::test]
 async fn post_groups_with_state_machine_yaml_rejects_judge_when_llm_disabled() {
     let (app, recorder, collaboration_runtime, _temp_dir) =
         test_app_with_collaboration_runtime().await;

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/groups.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/groups.rs
@@ -113,6 +113,12 @@ pub struct CreateGroupRequest {
     /// binding when `collaboration_definition_yaml` is provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_start_on_service_invocation: Option<bool>,
+    /// Whether group creation should immediately start the initial
+    /// service-invocation run. Defaults to true for backward compatibility.
+    /// Clients that must provision group-scoped runtime resources first can
+    /// set this to false and explicitly start the returned `session_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_initial_run: Option<bool>,
     /// Group visibility: "public" or "private" (default). Public groups allow
     /// any actor to create sessions.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -2940,8 +2940,6 @@ impl CollaborationRuntimeService for CollaborationRuntime {
         })?;
         reject_explicit_participant_roles(&definition)?;
         let compiled = validate_definition(definition)?;
-        self.validate_human_input_channel_for_group(&cmd.group_id, &compiled)
-            .await?;
         let candidate_ref = CollaborationDefinitionRef {
             id: compiled.definition.id.clone(),
             version: compiled.definition.version,
@@ -3032,10 +3030,8 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                     cmd.target_definition.id.clone(),
                     cmd.target_definition.version,
                 )
-            })?;
+        })?;
         let compiled = validate_definition(definition)?;
-        self.validate_human_input_channel_for_group(&cmd.group_id, &compiled)
-            .await?;
         let final_participant_bindings = cmd
             .participant_bindings
             .unwrap_or_else(|| binding.participant_bindings.clone());
@@ -3090,8 +3086,6 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 .map_err(|error| CollaborationRuntimeError::InvalidDefinition(error.to_string()))?;
             reject_explicit_participant_roles(&definition)?;
             let compiled = validate_definition(definition)?;
-            self.validate_human_input_channel_for_group(&cmd.group_id, &compiled)
-                .await?;
             let definition_ref = CollaborationDefinitionRef {
                 id: compiled.definition.id.clone(),
                 version: compiled.definition.version,
@@ -3106,8 +3100,6 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 .map_err(|error| CollaborationRuntimeError::InvalidDefinition(error.to_string()))?;
             reject_explicit_participant_roles(&definition)?;
             let compiled = validate_definition(definition)?;
-            self.validate_human_input_channel_for_group(&cmd.group_id, &compiled)
-                .await?;
             let definition_ref = CollaborationDefinitionRef {
                 id: compiled.definition.id.clone(),
                 version: compiled.definition.version,
@@ -3127,8 +3119,6 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                     )
                 })?;
             let compiled = validate_definition(definition)?;
-            self.validate_human_input_channel_for_group(&cmd.group_id, &compiled)
-                .await?;
             definition_for_validation = Some(compiled.definition);
             Some(definition_ref)
         } else {

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -100,10 +100,30 @@ fn test_sessions() -> Arc<SessionManagementServiceImpl> {
 #[derive(Default)]
 struct RecordingSessionChannelOutbound {
     events: Mutex<Vec<HumanInputReadyEvent>>,
+    validation_calls: Mutex<Vec<(String, String)>>,
+    validation_error: Mutex<Option<String>>,
 }
 
 #[async_trait]
 impl SessionChannelOutboundPort for RecordingSessionChannelOutbound {
+    async fn validate_human_input_channel(
+        &self,
+        group_id: &str,
+        channel_type: &str,
+    ) -> ServiceResult<SessionChannelDeliveryOutcome> {
+        self.validation_calls
+            .lock()
+            .await
+            .push((group_id.to_string(), channel_type.to_string()));
+        if let Some(message) = self.validation_error.lock().await.clone() {
+            return Err(ServiceError::InvalidOperation {
+                message,
+                request_id: None,
+            });
+        }
+        Ok(SessionChannelDeliveryOutcome::NotApplicable)
+    }
+
     async fn publish_human_input_ready(
         &self,
         event: HumanInputReadyEvent,
@@ -1916,6 +1936,63 @@ async fn start_run_uses_group_default_definition_binding() {
 
     assert_eq!(started.view.run.definition_id, "single_node");
     assert_eq!(delivery.commands.lock().await.len(), 1);
+}
+
+#[tokio::test]
+async fn configure_im_definition_defers_channel_validation_until_run_start() {
+    let group = Arc::new(GroupStore::new());
+    group
+        .upsert(state_machine_test_group())
+        .await
+        .expect("seed group");
+    let sessions = test_sessions();
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let channel_outbound = Arc::new(RecordingSessionChannelOutbound::default());
+    *channel_outbound.validation_error.lock().await =
+        Some("no active dingtalk ChannelBinding exists".to_string());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        sessions,
+        Arc::new(RecordingDelivery::default()),
+        noop_judge(),
+    )
+    .with_session_channel_outbound(channel_outbound.clone());
+
+    runtime
+        .configure_group_runtime(ConfigureGroupRuntimeCommand {
+            group_id: "group-1".to_string(),
+            definition_yaml: Some(human_input_yaml()),
+            definition: None,
+            definition_ref: None,
+            participant_bindings: Default::default(),
+            auto_start_on_service_invocation: true,
+        })
+        .await
+        .expect("configuration must not require a binding that needs the group id");
+    assert!(channel_outbound.validation_calls.lock().await.is_empty());
+
+    let error = runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: None,
+            definition: None,
+            definition_ref: None,
+            input: Value::Null,
+            caller_id: None,
+            authenticated_human: None,
+        })
+        .await
+        .expect_err("run start must still enforce the active binding");
+    assert!(error.to_string().contains("no active dingtalk ChannelBinding"));
+    assert_eq!(
+        channel_outbound.validation_calls.lock().await.as_slice(),
+        &[("group-1".to_string(), "dingtalk".to_string())]
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -1598,6 +1598,7 @@ impl BcsClient {
             originator: Some(options.driver_bot),
             collaboration_definition_yaml: Some(options.definition_yaml),
             auto_start_on_service_invocation: Some(options.auto_start_on_service_invocation),
+            start_initial_run: None,
             visibility: None,
         };
         let response = self
@@ -1649,6 +1650,7 @@ impl BcsClient {
             originator: None,
             collaboration_definition_yaml: None,
             auto_start_on_service_invocation: None,
+            start_initial_run: None,
             visibility: None,
         };
 
@@ -1725,6 +1727,7 @@ impl BcsClient {
             originator: None,
             collaboration_definition_yaml: None,
             auto_start_on_service_invocation: None,
+            start_initial_run: None,
             visibility: None,
         };
 

--- a/src/bcs/docs/plans/2026-07-27-human-input-dingtalk-im.md
+++ b/src/bcs/docs/plans/2026-07-27-human-input-dingtalk-im.md
@@ -77,25 +77,25 @@ runtime:
             targets: []
 ```
 
-YAML 不填写 `channel_binding_id`、robotCode 或机器人凭证。definition 绑定到具体
-BCS group 时，根据 `group_id + channel_type` 查询 Active ChannelBinding：
+YAML 不填写 `channel_binding_id`、robotCode 或机器人凭证。启动绑定了
+definition 的 BCS group 时，根据 `group_id + channel_type` 查询 Active
+ChannelBinding：
 
-1. 没有匹配 binding：拒绝绑定或启动；
+1. 没有匹配 binding：允许保存 definition，但拒绝启动；
 2. 恰好一个 binding：解析并保存 binding id 与 robot account；
 3. 多于一个 binding：拒绝为 ambiguous，不选择最新或任意一个。
 
 纯 `/collaboration/definitions/validate` 没有 group 上下文，只做 YAML schema 和
-静态语义校验。将 definition 配置到已有 group 时做 ChannelBinding 校验；每次
-创建 HumanInputRequest 时再次确认解析出的 binding 仍为 Active，并把 binding
-与 YAML conversation 快照到 request。
+静态语义校验。将 definition 配置到已有 group 时不做 ChannelBinding
+存在性校验；启动 run 和每次创建 HumanInputRequest 时确认解析出的 binding
+仍为 Active，并把 binding 与 YAML conversation 快照到 request。
 
 新建 group 时，ChannelBinding 只有在 group 存在后才能创建。因此 IM-enabled
 collaboration 必须按以下顺序编排：
 
 ```text
-创建 BCS group（不启动初始 run）
+创建 BCS group 并保存 collaboration YAML（不启动初始 run）
   -> 创建钉钉 ChannelBinding
-  -> 提交/绑定 collaboration YAML
   -> 校验唯一 Active ChannelBinding
   -> 启动 State Machine run
 ```


### PR DESCRIPTION
## Summary

- Add an optional `start_initial_run` group-creation flag that defaults to `true` for backward compatibility.
- Allow IM-enabled collaboration YAML to be persisted before a group-scoped ChannelBinding exists.
- Keep the unique Active ChannelBinding check at state-machine run start.
- Return and reuse the initial service-invocation `session_id`, so clients can create the group, bind DingTalk, and then explicitly start that original session.
- Update the implementation plan and add HTTP/runtime regression coverage.

## Why

A DingTalk ChannelBinding targets an existing BCS group, but IM-enabled group creation previously validated the binding and auto-started the run before the group could be bound. This created a provisioning deadlock.

## Impact

Existing structured-collaboration clients are unchanged because omitting `start_initial_run` preserves immediate startup. Only clients that explicitly pass `false` defer the initial run. Frontend-only HumanInput definitions continue to work without a channel, while IM HumanInput runs still fail closed when no unique Active binding exists.

## Validation

- `cargo test -p bcs-http --test groups_contract` — 32 passed
- `cargo test --offline -p bcs-collaboration-runtime --test runtime_progression` — 32 passed
- `git diff --check origin/dev...HEAD`

Commit and push hooks were intentionally skipped with `--no-verify` as requested.