### PR TITLE
docs: MCP and Passport walkthroughs

### DIFF
--- a/src/backend/docs/mcp/README.md
+++ b/src/backend/docs/mcp/README.md
@@ -387,11 +387,96 @@ The GET counterpart never returns the stored key:
 
 ## 6. Walkthrough B — a bot's toolset changes
 
-Saving a credential is the small path. The bigger one runs when a skill set is
-activated/deactivated, i.e. when the *set* of servers a bot may use changes.
-That is `MCPSyncService.refresh_mcp_scope`, and it does two distinct things.
+Saving a credential (Walkthrough A) is the small path: one server, one
+credential. The complicated one runs when the **set of servers a bot may use**
+changes — a user activates a skill set, or adds a new MCP to one. This section
+takes that path apart.
 
-### 6.1 Declare the allow-list to the device
+### 6.0 First, two concepts: scope and detail
+
+The thing that makes this code hard to read is not noticing that the system
+syncs **two independent things**. By analogy with a building's access control:
+
+- **scope** = the door whitelist. Answers "which servers is this bot *allowed*
+  to use".
+- **detail** = each door's address and key. Answers "what is this server's URL,
+  and what credential and headers connect to it".
+
+You need both, and the symptoms of missing either are quite different. Whitelist
+without detail: the bot is allowed to use a server but has no idea where to
+connect. Detail without whitelist: the config sits on the device but is filtered
+out, and the tool never appears.
+
+Two different sets of methods own them, and they are **always called in pairs**:
+
+| Concept | Question it answers | Where it lands | Method |
+| --- | --- | --- | --- |
+| scope | Which servers may this bot use | Device `filter-servers` whitelist **+** passport | `refresh_mcp_scope` |
+| detail | A server's URL / credential / headers | Device `mcporter.json` entry | `sync_mcp_detail` (one) / `sync_mcp_details` (all) |
+
+The service-layer docstring states the split plainly:
+
+```python
+        """刷新MCP授权范围（异步方法）。
+
+        向设备声明filter-servers白名单，并更新passport的MCP codes列表。
+        不包含MCP详细配置的推送——那是 sync_mcp_details / sync_mcp_detail 的职责。
+        """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py:1844`
+— "declares the filter-servers whitelist to the device and updates passport's MCP
+code list. It does **not** push MCP detail config — that is
+`sync_mcp_details` / `sync_mcp_detail`'s job."</sub>
+
+### 6.1 What triggers it
+
+No single endpoint owns this path; four classes of event do. Note the pairing —
+and that two of them run the pair in the opposite order:
+
+| Scenario | Call order | Location |
+| --- | --- | --- |
+| Add an MCP to a skill set | push that one detail, then refresh scope | `skill_set_service.py:1360` → `:1378` |
+| Remove an MCP from a skill set | remove that one from the device, then refresh scope | `skill_set_service.py:1442` → `:1459` |
+| Switch / activate a skill set | refresh scope, then push the active set's details | `skill_set_service.py:2265` → `:2274` |
+| Device comes back online | refresh scope, then push every detail | `device_service.py:1502` → `:1513` |
+
+Why does the order flip? **Adding an MCP** pushes its config to the device
+first, then whitelists it — so by the time the whitelist opens, the config is
+already there. **A device coming online** has no "one" server to speak of; it
+has to rebuild the whole state, so it declares the whitelist first and returns
+early on failure, skipping an entire round of detail pushes:
+
+```python
+                async def _do_sync() -> tuple[dict, dict | None]:
+                    # 1. 先声明白名单（scope），失败则直接返回，不必继续推送详细配置
+                    scope_result = await self._mcp_sync.refresh_mcp_scope(...)
+                    if not scope_result.get("success"):
+                        return scope_result, None
+
+                    # 2. 再推送详细配置
+                    detail_result = await self._mcp_sync.sync_mcp_details(...)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/devices/services/device_service.py:1500`
+(elided for length)</sub>
+
+One more detail in the "add" case — the association has just been written to the
+DB, and a failed push undoes it. Same hand-written compensation as Walkthrough A:
+
+```python
+        if not push_result.get("success"):
+            error = push_result.get("error", "Unknown error")
+            logger.error(f"[add_mcp_to_skill_set] Device sync failed: {error}")
+            self.skill_set_repo.remove_mcp_from_set(skill_set_id, server_code)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py:1366`</sub>
+
+### 6.2 Inside `refresh_mcp_scope` — two destinations
+
+Refreshing scope means writing "the currently allowed server list" to two places
+— device first, passport second:
 
 ```python
         # 先向设备声明白名单：即使 active_mcps 为空也会调用，防止设备残留旧白名单。
@@ -405,8 +490,30 @@ That is `MCPSyncService.refresh_mcp_scope`, and it does two distinct things.
 
 <sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:378`</sub>
 
-The list itself comes from `skill_center`, not from the `mcp` module — the `mcp`
-module only knows the `BotMCPProvider` protocol:
+The order is deliberate: **the device enforces, passport declares.** If the
+device write fails the method returns early and passport is never touched —
+better that both sides stay on the old state than have passport advertise a
+scope the device never took.
+
+### 6.3 Why an empty list must still be pushed
+
+The easiest phrase to skim past in that comment is "called even when
+`active_mcps` is empty". That isn't defensive coding, it's a security property:
+
+Suppose a user deactivates their last skill set. The allowed list becomes empty.
+If the call were skipped because "there's nothing to declare", the device's old
+whitelist would sit there untouched — and the bot would still be able to call
+tools it is no longer entitled to. **Revocation is exactly the empty-list case,
+and exactly the case most likely to be optimised away.**
+
+This is also why the engine side needs a sentinel for "allow nothing" — an empty
+string is indistinguishable from "no argument" on a command line (see
+`__EMPTY_FILTER_DISABLE_ALL__` in §7).
+
+### 6.4 Where the list comes from
+
+The `mcp` module does not know what a skill set is. It knows one Protocol, which
+`skill_center` implements:
 
 ```python
 @runtime_checkable
@@ -421,8 +528,94 @@ class BotMCPProvider(Protocol):
 
 <sub>`src/backend/src/agentclaw/community/core/mcp/services/repositories.py:11`</sub>
 
-Detail pushes are concurrent but throttled, because the target is a single
-container:
+Two of that Protocol's methods are easy to confuse; the difference is whether
+"active" filters:
+
+- `collect_bot_active_mcps` — only MCPs from **currently active** skill sets
+  (plus the engine defaults). Scope declaration uses this one
+  (`sync_service.py:588`): a whitelist should only ever contain what is live now.
+- `collect_bot_mcps` — **every** MCP associated with the bot, inactive included.
+
+Detail pushes switch between them with the `active_only` flag:
+
+```python
+            active_only: 为 True 时只推送当前**激活** skill sets 中的 MCP；
+                为 False 时推送该 bot 关联的**全部** MCP（含 inactive）。
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:177`
+— "True pushes only MCPs from currently **active** skill sets; False pushes
+**every** MCP associated with the bot, inactive included."</sub>
+
+Why would you ever push inactive ones? Because a detail is just config sitting in
+`mcporter.json` — the whitelist is what decides usability. Loading every detail
+when a device comes online means a later skill-set activation only has to change
+the whitelist, with no config push at all.
+
+### 6.5 Passport is an overwrite snapshot — hence the CLI read-back
+
+This is the least obvious part of the section, and the most worth understanding.
+Passport's `resourceManifest` is a **whole-object overwrite**: what you submit is
+what it becomes. And a bot's manifest carries CLI grants *as well as* MCP grants.
+
+The consequence: a sync that only cares about MCP would, by submitting only the
+MCP list, **silently erase that bot's CLI grants.** So the code reads the current
+CLI scope back, merges it with the engine defaults, and submits both together:
+
+```python
+        # MCP 同步触发 resourceManifest 更新时，要回填当前 CLI，避免覆盖式更新丢失 CLI 授权。
+        try:
+            current_cli_items = self.passport_update.query_passport_clis(
+                bot_id, user_id
+            )
+        ...
+        default_cli_items = get_default_cli_items(engine_type, template_type)
+        cli_items = _merge_cli_items(current_cli_items, default_cli_items)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:888`</sub>
+
+```python
+            # resource_scope 是完整快照：MCP 来自同步结果，CLI 来自当前许可证 + 引擎默认 CLI。
+            self.passport_update.update_passport(
+                bot_id=bot_id,
+                user_id=user_id,
+                resource_scope={
+                    "mcp_codes": synced_server_codes,
+                    "cli_items": cli_items,
+                },
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:913`</sub>
+
+Existing values win on merge, and there's a timing trap to guard against too — a
+freshly created bot may momentarily read back an empty CLI list, and taking that
+at face value would let one MCP sync flatten the defaults:
+
+```python
+    """Merge passport CLI scope with default CLI items, de-duped by cli_code.
+
+    The passport update API treats resourceManifest as an overwrite. During MCP
+    sync we must send the complete CLI scope as well as MCPs. If the passport
+    service returns a temporarily-empty CLI list right after bot creation,
+    preserving the engine defaults here prevents a later MCP sync from clearing
+    them. Existing passport values win on duplicate cli_code so user/provider
+    metadata is not overwritten by static defaults.
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:46`</sub>
+
+Same reasoning: if reading the bot's metadata fails, the passport update aborts
+outright rather than write a partial snapshot (`sync_service.py:884`).
+
+**The rule to carry away: anything writing passport must submit a complete
+snapshot, never a delta.**
+
+### 6.6 Detail pushes — concurrent, but throttled
+
+Scope is one call; details are N. They go out concurrently, with a deliberate cap,
+because the target is a single container:
 
 ```python
         # 3. 并发推送，但限制并发数为 5，防止一次性向设备发太多 HTTP 请求把引擎压垮。
@@ -431,7 +624,11 @@ container:
 
 <sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:681`</sub>
 
-### 6.2 Two delivery shapes, one plugin boundary
+One failure doesn't abort the rest (`asyncio.gather(..., return_exceptions=True)`),
+and results come back split into successes and failures — but `CancelledError` is
+re-raised rather than swallowed as an ordinary failure.
+
+### 6.7 One plugin boundary, two delivery shapes
 
 The backend does not branch on container type. It resolves a per-bot
 `DeviceSyncPlugin` and calls four methods; each implementation decides *how*:
@@ -455,17 +652,26 @@ The backend does not branch on container type. It resolves a per-bot
 
 <sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:89`</sub>
 
-The comment above those methods names the two delivery styles:
+Those four methods (declare whitelist / push one / remove one / probe presence)
+are exactly the actions in §6.1's table. The comment above them names the two
+delivery styles:
 
 > Per impl: arca/baas push per-MCP over `/api/mcp`; teclaw delivers the whole
 > composed artifact; local is no-op.
 
 <sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:81`</sub>
 
+The difference is more than transport. For a whole-artifact container like teclaw,
+*any* change means recomposing and delivering the entire manifest — so
+`sync_single_mcp` and `sync_all_mcp_servers` do the same work there, just
+idempotently repeated.
+
 In this (community) repository the local implementation is a no-op —
 `LocalDeviceSyncPlugin.sync_single_mcp` simply returns `True`
 (`plugins/local/device_sync.py:338`). The corp/arca implementations that do the
 real HTTP push are not part of this repo.
+
+### 6.8 Credentials are inlined in plaintext at compose time
 
 For the whole-artifact style, the manifest is composed **in the backend** and the
 credential is inlined into it — this is the clearest statement of the credential
@@ -509,11 +715,12 @@ TECLAW_MCP_NETWORK_PRIORITY = ("OFFICE", "INTERNET", "INTRANET")
 
 <sub>`src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py:53`</sub>
 
-### 6.3 Passport — the declared scope, minus local servers
+### 6.9 The passport scope excludes LOCAL servers
 
-Alongside the device push, the bot's scope is declared to the passport / Agent
-Principal service. `stdio`/LOCAL servers are deliberately excluded, because
-they're runtime-local capabilities nobody grants permission for:
+Back to §6.2's second destination. The list sent to passport is not the list sent
+to the device: `stdio`/LOCAL servers are stripped out, because they're
+runtime-local capabilities no permission system grants — but the device still
+needs their config:
 
 ```python
 def passport_mcp_items_from_entries(
@@ -536,8 +743,20 @@ def passport_mcp_items_from_entries(
 That `owner`/`caller` value is the `ac_bot_mcp_call_config` decision from §3.3,
 surfacing at the point where scope is published.
 
----
+### Recap
 
+One toolset change lands in three places:
+
+1. **The device whitelist** — what's allowed (pushed even when empty).
+2. **The device's `mcporter.json` entries** — how to reach each server, with what
+   credential.
+3. **The passport snapshot** — the declared scope, LOCAL excluded, identity mode
+   attached, and CLI grants read back in.
+
+The first two decide what the bot *can actually do*; the third is the *declaration*
+of that authority to the rest of the system.
+
+---
 ## 7. What happens on the device
 
 The engine exposes its own `/api/mcp` and dispatches everything to an
@@ -727,8 +946,10 @@ If you want to trace one thread end to end, read in this order:
 2. `adapters/http/mcp/router.py:237` — the write endpoint, all five steps.
 3. `core/mcp/services/config_service.py` — the merge rules.
 4. `core/mcp/services/sync_service.py:439` — the fan-out.
-5. `plugin_api/device_sync.py:81` — the delivery boundary.
-6. `src/engine/.../plugins/openclaw/_mcp.py` — what a device actually does.
+5. `core/mcp/services/sync_service.py:324` — `refresh_mcp_scope`, the scope path
+   (§6), and `:849` for the passport snapshot it writes.
+6. `plugin_api/device_sync.py:81` — the delivery boundary.
+7. `src/engine/.../plugins/openclaw/_mcp.py` — what a device actually does.
 
 Tests worth reading as executable documentation:
 

--- a/src/backend/docs/mcp/README.md
+++ b/src/backend/docs/mcp/README.md
@@ -1,5 +1,7 @@
 # How MCP works in Avernet
 
+**English** | [简体中文](README.zh-CN.md)
+
 A walkthrough of the Model Context Protocol (MCP) subsystem: what it is, which
 tables and services own it, how a user's credential travels from an HTTP request
 to a tool call inside a running bot, and where the in-flight tenant-isolation

--- a/src/backend/docs/mcp/README.md
+++ b/src/backend/docs/mcp/README.md
@@ -1,0 +1,748 @@
+# How MCP works in Avernet
+
+A walkthrough of the Model Context Protocol (MCP) subsystem: what it is, which
+tables and services own it, how a user's credential travels from an HTTP request
+to a tool call inside a running bot, and where the in-flight tenant-isolation
+work (Track A Stage 5, PR #564) plugs in.
+
+Every code block below is quoted verbatim from this repository, with a
+`path:line` reference you can click through.
+
+---
+
+## 1. What MCP is, in one paragraph
+
+MCP is a standard way for an AI agent to call external tools. An **MCP server**
+is a process or HTTP endpoint that advertises a list of tools (`tools/list`) and
+executes them on request (`tools/call`). The agent's runtime holds a list of MCP
+servers it is allowed to talk to, plus the credentials for each one. When the
+model decides to use a tool, the runtime opens a connection to the right MCP
+server and forwards the call.
+
+So a working MCP integration needs three things:
+
+1. **A catalog** — which MCP servers exist, what tools they expose, at which URL.
+2. **A credential + a scope** — which servers *this* user/bot may use, and with
+   what API key or header.
+3. **Delivery to the runtime** — the agent process needs both of the above
+   written somewhere it will read at tool-call time.
+
+Avernet splits those three responsibilities across three components, and most of
+the confusion when reading the code disappears once you know which is which:
+
+| Concern | Owner | Notes |
+| --- | --- | --- |
+| Catalog | **MCP Center** (external service), behind `MCPCenterPlugin` | Avernet stores no server metadata table |
+| Credential + scope | **backend** (`ac_user_mcp_config`, skill sets) | This is what Avernet actually persists |
+| Delivery + execution | **engine** on the device (`mcporter.json`) | Backend pushes; engine executes |
+
+---
+
+## 2. The map
+
+```mermaid
+flowchart TB
+    subgraph FE["Caller"]
+        UI["Workbench UI / API client"]
+    end
+
+    subgraph BE["Backend (src/backend)"]
+        R["adapters/http/mcp/router.py<br/>/api/mcp/*"]
+        MS["MCPMarketService<br/>(catalog reads)"]
+        AS["MCPAuthService<br/>(permission)"]
+        CS["MCPConfigService<br/>(credentials, merge)"]
+        SS["MCPSyncService<br/>(orchestration)"]
+        DB[("ac_user_mcp_config<br/>ac_skill_set_mcp<br/>ac_bot_mcp_call_config")]
+    end
+
+    MCPC["MCP Center<br/>(external catalog + permission)"]
+    PP["Passport / Agent Principal<br/>(declared scope)"]
+
+    subgraph DEV["Device (src/engine)"]
+        EAPI["engine api/mcp/router.py<br/>/api/mcp/*"]
+        MJ["mcporter.json"]
+        SRV["MCP servers<br/>(HTTP / SSE / stdio)"]
+    end
+
+    UI --> R
+    R --> MS & AS & CS & SS
+    MS --> MCPC
+    AS --> MCPC
+    CS --> DB
+    SS --> DB
+    SS --> PP
+    SS -->|DeviceSyncPlugin| EAPI
+    EAPI --> MJ
+    MJ -->|mcporter| SRV
+```
+
+Two HTTP surfaces are both called `/api/mcp` and they are **not** the same API:
+
+- `src/backend/.../adapters/http/mcp/router.py` — the user-facing backend API
+  (marketplace, permissions, "save my API key").
+- `src/engine/.../api/mcp/router.py` — the device-side API the backend *calls*
+  to install/remove an MCP server inside a running bot.
+
+---
+
+## 3. What Avernet actually stores
+
+### 3.1 `ac_user_mcp_config` — the caller's credential per server
+
+This is the single most important table in the subsystem. One row = "user X's
+settings for MCP server Y in environment Z".
+
+```python
+class UserMCPConfig(Base):
+    """User-specific MCP Server configuration (API keys, etc.).
+
+    Note: We store server_code directly instead of using a foreign key
+    to ac_mcp_server table, as MCP server data is managed by MCP Center.
+    """
+    __tablename__ = "ac_user_mcp_config"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(100), nullable=False, index=True)  # 用户工号
+    server_code = Column(String(256), nullable=False, index=True)  # MCP server code
+    api_key = Column(String(500), nullable=True)  # LING_XI类型需要的API Key (向后兼容)
+    custom_headers = Column(Text, nullable=True)  # JSON: 用户自定义Headers
+    extra_config = Column(Text, nullable=True)  # JSON: 其他配置项
+    env = Column(String(50), nullable=True)  # 环境标识: dev/pre/prod
+```
+
+<sub>`src/backend/src/agentclaw/community/core/models/mcp.py:56`</sub>
+
+Two things to internalise:
+
+- **There is no foreign key to a server table** — `server_code` is an opaque
+  string resolved against MCP Center. Avernet never owns the catalog.
+- **The live payload lives in `extra_config` (JSON)**, not in the flat columns.
+  `api_key`/`custom_headers` are legacy back-compat. The accessor spells out the
+  real shape:
+
+```python
+    def get_unified_config(self) -> dict:
+        """获取统一的配置（从 extra_config 中解析）
+
+        Returns:
+            {
+                "api_key": str or None,           # API Key（授权格式）
+                "headers": dict,                   # 自定义 Headers
+                "endpoint_env": str,              # 环境选择：PROD/PRE
+            }
+        """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/models/mcp.py:100`</sub>
+
+The uniqueness key is `(user_id, server_code, env)` — note it says nothing about
+*which tenant* the `user_id` belongs to. That gap is exactly what PR #564 is
+about; see §8.
+
+### 3.2 `ac_skill_set_mcp` — which servers a skill set brings
+
+A **skill set** is a bundle of capabilities a bot can activate. Attaching an MCP
+server to a skill set is what makes it reachable by a bot at all:
+
+```python
+class SkillSetMCPServer(Base):
+    """Association table between SkillSet and MCP Server.
+    ...
+    """
+    __tablename__ = "ac_skill_set_mcp"
+```
+
+<sub>`src/backend/src/agentclaw/community/core/models/mcp.py:14`</sub>
+
+Ownership is split on purpose: `UserMCPConfig` belongs to the `mcp` module,
+`SkillSetMCPServer` belongs to `skill_center` (the file header says so).
+
+### 3.3 `ac_bot_mcp_call_config` — whose identity the call runs as
+
+When a bot invokes a tool, does it authenticate as the bot's **owner** or as the
+**caller** who is chatting with it? The default is owner; only overrides get a
+row (a sparse table):
+
+```python
+class BotMcpCallConfigModel(Base):
+    """Sparse Caller overrides; Owner is represented by a missing row."""
+
+    __tablename__ = "ac_bot_mcp_call_config"
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    bot_pk = Column(BigInteger, nullable=False, comment="ac_bots.id")
+    server_code = Column(String(256), nullable=False)
+    engine_type = Column(String(64), nullable=False)
+    call_type = Column(String(16), nullable=False)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/caller_identity/models.py:30`</sub>
+
+### 3.4 Defaults — servers every bot gets for free
+
+Some MCP servers are attached to every bot of a given engine type, without
+anyone configuring anything:
+
+```python
+_DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
+    "openclaw": [
+        {"server_code": "mcp.ant.antprocessai.anttaskmcp"},
+        {"server_code": "mcp.ant.arkai.dimamcpserver"},
+        ...
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/_defaults.py:27`</sub>
+
+---
+
+## 4. The four backend services
+
+All four live in `core/mcp/services/` and are bound as singletons in one DI
+module:
+
+```python
+        binder.bind(MCPMarketService, to=MCPMarketService, scope=singleton)
+        binder.bind(MCPAuthService, to=MCPAuthService, scope=singleton)
+        binder.bind(MCPConfigService, to=MCPConfigService, scope=singleton)
+```
+
+<sub>`src/backend/src/agentclaw/community/di/modules/mcp_module.py:70`</sub>
+
+| Service | Responsibility | Talks to |
+| --- | --- | --- |
+| `MCPMarketService` | Read the catalog (list / detail / tenants) | `MCPCenterPlugin` |
+| `MCPAuthService` | "May this user use this server?" + apply for access | `MCPAuthPlugin` + `MCPCenterPlugin` |
+| `MCPConfigService` | CRUD the caller's credential, and **merge** it with defaults | `UserMCPConfigRepository` |
+| `MCPSyncService` | Orchestrate: collect → merge → push to devices → update scope | everything |
+
+The division that matters: **`MCPConfigService` never makes an HTTP call to a
+device.** Its own docstring pins that boundary down:
+
+```python
+class MCPConfigService:
+    """管理用户级 MCP 配置（CRUD + 负载构建）。
+
+    **不**向设备发送 HTTP 请求 —— 该职责由 ``MCPSyncService`` /
+    ``DeviceMCPSyncPlugin`` 承担。
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/config_service.py:17`</sub>
+
+`MCPSyncService` is wired by an explicit provider rather than plain `@inject`,
+because MCP delivery sits in the middle of a dependency cycle:
+
+```python
+        return MCPSyncService(
+            ...
+            resolver_provider=lambda: injector.get(DeviceContextResolver),
+            device_sync_dispatcher_provider=lambda: injector.get(DeviceSyncDispatcher),
+        )
+```
+
+<sub>`src/backend/src/agentclaw/community/di/modules/mcp_module.py:133` — the
+docstring above it names the cycle: `MCPSyncService → DeviceContextResolver →
+ArcaConnInfoBuilder → DeviceService → BotService → SkillSetServiceFactory →
+MCPSyncService`.</sub>
+
+---
+
+## 5. Walkthrough A — a user saves an API key
+
+This is the write path, end to end. Entry point: `POST /api/mcp/user/config`.
+
+### Step 0 — validate before touching anything
+
+```python
+    # 校验 endpoint_env
+    if request.endpoint_env is not None and request.endpoint_env not in ("PROD", "PRE"):
+        raise HTTPException(status_code=400, detail="endpoint_env must be PROD or PRE")
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/mcp/router.py:250`</sub>
+
+### Steps 1–3 — external check, then DB, then push, with rollback
+
+The ordering here is deliberate and is the single most instructive block in the
+subsystem:
+
+```python
+        # 步骤1：校验 MCP 存在性（外部依赖先校验，避免写库后再回滚）
+        mcp_data = market_service.get_mcp_detail(request.server_code)
+        if not mcp_data:
+            raise HTTPException(status_code=404, detail=f"MCP server {request.server_code} not found")
+
+        # 步骤2：写库，保留旧配置供回滚
+        old_config = config_service.update_user_unified_config(
+            user_id=user.staffId,
+            server_code=request.server_code,
+            ...
+        )
+
+        # 步骤3：推送到该用户/实体下的所有设备
+        result = await sync_service.sync_mcp_detail_to_all_bots(...)
+
+        if not result["success"]:
+            config_service.rollback_unified_config(
+                user_id=user.staffId,
+                server_code=request.server_code,
+                old_config=old_config,
+            )
+            raise HTTPException(status_code=500, detail=result.get("error", "Failed to sync to all devices"))
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/mcp/router.py:271` (elided
+for length)</sub>
+
+Read that as: *the database is not the source of truth on its own — a config the
+devices never received is rolled back.* There is no background reconciler that
+would repair a divergence later, which is why the write is compensated by hand.
+
+### The merge rule — how a partial update behaves
+
+`None` means "leave it alone", not "clear it":
+
+```python
+        if existing:
+            # 合并策略：入参为 None 表示不修改，沿用旧值
+            old_extra = old_config or {}
+            extra_config = {
+                "api_key": api_key if api_key is not None else old_extra.get("api_key"),
+                "headers": headers if headers is not None else old_extra.get("headers", {}),
+                ...
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/config_service.py:120`</sub>
+
+### The other merge rule — user headers over engine defaults
+
+When a config is turned into a payload for a device, defaults form the base and
+the user's values win. There is also one genuinely surprising special case:
+
+```python
+        # 当 api_key 是 x-ling-auth 格式时，需要把默认 headers 里的同名 key 删掉，
+        # 否则设备端会收到两个冲突的 authorization header。
+        if _api_key and "=" in _api_key:
+            key_name, _ = _api_key.split("=", 1)
+            if key_name.lower() == "x-ling-auth":
+                config_headers = {
+                    k: v for k, v in config_headers.items() if k.lower() != "x-ling-auth"
+                }
+
+        # 合并策略：默认 headers 作为基底，用户 headers 覆盖同名键。
+        merged_headers = {**config_headers, **user_headers}
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/config_service.py:233`</sub>
+
+Note the `api_key` format: it is **not** a bare token, it is `"name=value"` —
+the name decides whether the credential becomes a header or a query parameter
+(see §6.2).
+
+### The fan-out — push to every bot that has the server
+
+```python
+        for bot_id in bot_ids:
+            ...
+            has_mcp = await asyncio.to_thread(plugin.has_mcp, server_code)
+            if not has_mcp:
+                logger.warning(
+                    "[MCPSyncService] bot=%s 设备上未找到 MCP %s", bot_id, server_code
+                )
+                sync_results.append({
+                    "bot_id": bot_id, "synced": False, "reason": "设备上未找到该 MCP",
+                })
+                continue
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:478`</sub>
+
+And the failure rule — a device that doesn't have the server, or has no device
+binding at all, is *not* a failure:
+
+```python
+        # 只有"确实有该 MCP 的设备全部失败"时才整体报错；
+        # 如果设备上没有该 MCP 或者根本没有设备，不算失败。
+        if has_mcp_devices > 0 and not any_success:
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:538`</sub>
+
+### Reads mask the secret
+
+The GET counterpart never returns the stored key:
+
+```python
+    api_key = config.get("api_key")
+    masked_key = None
+    if api_key:
+        masked_key = api_key[:4] + "****" + api_key[-4:] if len(api_key) > 8 else "****"
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/mcp/router.py:370`</sub>
+
+---
+
+## 6. Walkthrough B — a bot's toolset changes
+
+Saving a credential is the small path. The bigger one runs when a skill set is
+activated/deactivated, i.e. when the *set* of servers a bot may use changes.
+That is `MCPSyncService.refresh_mcp_scope`, and it does two distinct things.
+
+### 6.1 Declare the allow-list to the device
+
+```python
+        # 先向设备声明白名单：即使 active_mcps 为空也会调用，防止设备残留旧白名单。
+        scope_result = await self._declare_mcp_scope(...)
+        if not scope_result.get("success"):
+            return scope_result
+
+        # 白名单声明成功后，再更新 passport 供前端权限校验使用。
+        passport_result = await self._update_passport(...)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:378`</sub>
+
+The list itself comes from `skill_center`, not from the `mcp` module — the `mcp`
+module only knows the `BotMCPProvider` protocol:
+
+```python
+@runtime_checkable
+class BotMCPProvider(Protocol):
+    """Interface for fetching a bot's MCP list from skill_center.
+
+    Implemented by ``SkillSetService``.  MCPSyncService depends only on
+    this protocol so that the mcp module does not need to import
+    skill_center internals.
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/repositories.py:11`</sub>
+
+Detail pushes are concurrent but throttled, because the target is a single
+container:
+
+```python
+        # 3. 并发推送，但限制并发数为 5，防止一次性向设备发太多 HTTP 请求把引擎压垮。
+        semaphore = asyncio.Semaphore(5)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:681`</sub>
+
+### 6.2 Two delivery shapes, one plugin boundary
+
+The backend does not branch on container type. It resolves a per-bot
+`DeviceSyncPlugin` and calls four methods; each implementation decides *how*:
+
+```python
+    def sync_all_mcp_servers(self, mcp_servers: list[dict[str, Any]]) -> bool:
+        """Declare the full set of allowed MCP servers to the device
+        (filter-servers). Returns ``True`` on success."""
+        ...
+
+    def sync_single_mcp(
+        self,
+        mcp_data: dict[str, Any],
+        *,
+        api_key: Optional[str] = None,
+        custom_headers: Optional[dict[str, str]] = None,
+        endpoint_env: str = "PROD",
+        transport_protocol: Optional[str] = None,
+    ) -> bool:
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:89`</sub>
+
+The comment above those methods names the two delivery styles:
+
+> Per impl: arca/baas push per-MCP over `/api/mcp`; teclaw delivers the whole
+> composed artifact; local is no-op.
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:81`</sub>
+
+In this (community) repository the local implementation is a no-op —
+`LocalDeviceSyncPlugin.sync_single_mcp` simply returns `True`
+(`plugins/local/device_sync.py:338`). The corp/arca implementations that do the
+real HTTP push are not part of this repo.
+
+For the whole-artifact style, the manifest is composed **in the backend** and the
+credential is inlined into it — this is the clearest statement of the credential
+format anywhere in the codebase:
+
+```python
+        """Inline the resolved credential, mirroring ``convert_to_device_format``.
+
+        ``api_key`` is ``"name=value"``. ``authorization`` is appended to the
+        endpoint URL query; ``x-ling-auth`` becomes a header; any other name is
+        ignored (device-path parity).
+        """
+        merged_headers: dict[str, str] = {}
+
+        if api_key and "=" in api_key:
+            key_name, key_value = api_key.split("=", 1)
+            lowered = key_name.lower()
+            if lowered == "authorization" and endpoint:
+                separator = "&" if "?" in endpoint else "?"
+                endpoint = f"{endpoint}{separator}{key_name}={key_value}"
+            elif lowered == "x-ling-auth":
+                merged_headers[key_name] = key_value
+```
+
+<sub>`src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py:125`</sub>
+
+**Secrets are inlined in plaintext at compose time** — there is no secret broker
+or by-reference indirection on the device. The module docstring says so
+explicitly, and it is why a failed device push rolls the DB write back: changing
+an `api_key` changes the artifact bytes, and a stale container would keep serving
+the old credential.
+
+The same file also holds the endpoint-selection rule (which URL out of the
+catalog's several):
+
+```python
+# Teclaw containers reach networks in this order; an endpoint on an earlier
+# network always wins over a later one (network is the primary sort key).
+TECLAW_MCP_NETWORK_PRIORITY = ("OFFICE", "INTERNET", "INTRANET")
+```
+
+<sub>`src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py:53`</sub>
+
+### 6.3 Passport — the declared scope, minus local servers
+
+Alongside the device push, the bot's scope is declared to the passport / Agent
+Principal service. `stdio`/LOCAL servers are deliberately excluded, because
+they're runtime-local capabilities nobody grants permission for:
+
+```python
+def passport_mcp_items_from_entries(
+    mcps: Iterable[Mapping[str, Any]],
+    *,
+    identity_modes: Mapping[str, object],
+    local_registry: LocalMCPRegistry | None = None,
+) -> list[McpScopeItem]:
+    """Build the complete non-local MCP identity scope for Agent Principal."""
+    ...
+        raw_mode = identity_modes.get(code, "owner")
+        mode = getattr(raw_mode, "value", raw_mode)
+        normalized_mode = str(mode).strip().lower()
+        if normalized_mode not in {"owner", "caller"}:
+            raise ValueError("identity mode must be owner or caller")
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/passport_scope.py:44`</sub>
+
+That `owner`/`caller` value is the `ac_bot_mcp_call_config` decision from §3.3,
+surfacing at the point where scope is published.
+
+---
+
+## 7. What happens on the device
+
+The engine exposes its own `/api/mcp` and dispatches everything to an
+engine-specific plugin:
+
+```python
+"""MCP router — dispatches every endpoint through ``EngineManager.mcp``.
+
+Engine-specific behaviour (mcporter file edits, ``mcporter`` CLI shell-out)
+lives in ``engines/openclaw/mcp.OpenClawMCPService``; AiCoding ships its own
+plugin proxying to teamclaw-aicoding-relay. The router only marshals
+HTTP↔Plugin types and applies capability guards.
+"""
+```
+
+<sub>`src/engine/src/engine/community/api/mcp/router.py:1`</sub>
+
+For the OpenClaw engine, "installing an MCP server" literally means editing a
+JSON file:
+
+```python
+    def _mcp_load(self) -> "tuple[dict[str, Any], str, dict[str, Any]]":
+        """Load mcporter.json; return (root, servers_key, servers_dict)."""
+```
+
+<sub>`src/engine/src/engine/community/plugins/openclaw/_mcp.py:24`</sub>
+
+…and the allow-list is applied by shelling out to the `mcporter` CLI. Note the
+sentinel for "allow nothing", which is why an empty list is still pushed:
+
+```python
+        csv_codes = (
+            ",".join(normalized) if normalized else "__EMPTY_FILTER_DISABLE_ALL__"
+        )
+        command = ["mcporter", "filter-servers", csv_codes]
+```
+
+<sub>`src/engine/src/engine/community/plugins/openclaw/_mcp.py:260`</sub>
+
+Tool execution is the same shape:
+
+```python
+        cmd = ["mcporter", "call", tool]
+        for key, value in (args or {}).items():
+            cmd.append(f"{key}={value}")
+```
+
+<sub>`src/engine/src/engine/community/plugins/openclaw/_mcp.py:209`</sub>
+
+The engine's transport model is a small dataclass set, and it is where the
+`stdio` vs `http` vs `sse` distinction finally becomes concrete:
+
+```python
+@dataclass
+class MCPServerConfig:
+    """Declared configuration for an MCP server.
+
+    `server_code` is the stable identifier used to look up the server.
+    Transport-dependent fields:
+      - HTTP / SSE: `url` (and optional `headers`)
+      - stdio: `command` + `args` (and optional `env`)
+    """
+```
+
+<sub>`src/engine/src/engine/community/core/mcp/models.py:31`</sub>
+
+Not every engine supports every operation; the router guards each one with a
+capability check (`check_capability(Capability.MCP_CREATE)` etc.) and answers
+`501` when an engine doesn't implement it — see
+`src/engine/src/engine/community/api/mcp/router.py:145`.
+
+---
+
+## 8. Where PR #564 fits — tenant isolation
+
+Everything above assumes one tenant. `ac_user_mcp_config` is keyed by
+`(user_id, server_code, env)` — a user id alone is only meaningful *inside* a
+tenant, and nothing on the row records which tenant that is.
+
+That is fine today, because all data belongs to the internal tenant. It stops
+being fine the moment `/openapi/v1` is opened to external tenants — those routes
+already exist as stubs:
+
+```python
+@router.get(
+    "/servers/{server_code}/config",
+    response_model=Envelope[McpConfig],
+)
+async def get_mcp_config(
+    server_code: str, principal: PrincipalDep
+) -> Envelope[McpConfig]:
+    """Read the caller's unified config for an MCP server."""
+    raise NotImplementedError
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py:72`</sub>
+
+The public-API programme is split into two tracks, and the rule is that a
+category's endpoints must not be implemented before its data is isolated
+(`src/backend/docs/openapi-v1/README.md`):
+
+- **Track A** — add tenant scoping to a data category. Implements no endpoint.
+- **Track B** — implement that category's `/openapi/v1` endpoints.
+
+The mechanism was built and proved on bots in Track A Stage 1 (PR #456) and is
+reused unchanged: a per-request tenant carrier, plus two SQLAlchemy guards
+registered on the model —
+
+> - `do_orm_execute` **read guard** on the `Session` class →
+>   `with_loader_criteria(...)`. Also constrains `Query.update()`/`Query.delete()`,
+>   so writes need no filter.
+> - `before_insert` **insert guard** → stamp when unset, raise
+>   `CrossTenantInsertError` on an explicit conflicting tenant.
+
+<sub>`src/backend/docs/openapi-v1/README.md:168`</sub>
+
+**PR #564 is Track A Stage 5: apply that mechanism to MCP configuration.** It is
+currently the spec document only (`src/backend/specs/2026-07-29-tenant-isolation-mcp/spec.md`);
+plan, tasks and implementation follow. In concrete terms it means adding an
+`avernet_tenant` column plus the two guards to:
+
+1. `UserMCPConfig` (§3.1) — the API keys and headers, the most sensitive data in
+   the category.
+2. `BotMcpCallConfigModel` (§3.3) — flagged in the PR as a judgement call. Its
+   rows hang off a bot, so Stage 1's bot isolation already covers anything
+   reached *through* a bot; but its aggregate reads query by `bot_pk` without
+   ever touching a bot record, so the guard doesn't reach them.
+
+Four of the six `mcp` endpoints (marketplace, tenants, server detail,
+permissions) need no Stage 5 work at all — they are served by MCP Center, and as
+§1 established, Avernet stores nothing for them.
+
+---
+
+## 9. Deployment profiles — why an "external" service isn't a hard dependency
+
+The catalog is reached only through a Protocol:
+
+```python
+@runtime_checkable
+class MCPCenterPlugin(Plugin, Protocol):
+    """Read-only queries against MCP Center API."""
+
+    def get_mcp_detail(self, server_code: str) -> dict[str, Any] | None:
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/mcp_center.py:13`</sub>
+
+Under `DEPLOY_PROFILE=community` that Protocol is satisfied by a config-file
+catalog with allow-all permissions, so the whole subsystem resolves with no
+internal MCP-Center service:
+
+```python
+class CommunityMCPCenter(MCPCenterPlugin):
+    """Config-file-backed MCP catalog with allow-all permission + default tenant."""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/mcp_center.py:31`</sub>
+
+Its module docstring makes the key point about why an empty catalog is still a
+working system:
+
+> The bot-run path uses bring-your-own MCP configs (`ac_user_mcp_config`) and
+> skill-set references, which sync to devices regardless of this catalog — so an
+> empty catalog never blocks a configured MCP server from working.
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/mcp_center.py:19`</sub>
+
+Servers declared in `configs/local-mcp-servers.yaml` are loaded by
+`LocalMCPRegistry` and normalised into MCP-Center-shaped dicts
+(`core/mcp/services/local_mcp_registry.py:18`), which is why the rest of the code
+can treat both sources identically.
+
+One useful escape hatch: when the caller presents an IAM token, server detail is
+fetched **live** from the MCP server (a real `initialize` → `tools/list`
+JSON-RPC exchange in `core/mcp/services/mcp_live_fetcher.py:14`) instead of
+trusting possibly-stale catalog metadata — falling back to catalog data on any
+failure (`adapters/http/mcp/router.py:144`).
+
+---
+
+## 10. Reading order & test map
+
+If you want to trace one thread end to end, read in this order:
+
+1. `core/models/mcp.py` — what's stored (117 lines).
+2. `adapters/http/mcp/router.py:237` — the write endpoint, all five steps.
+3. `core/mcp/services/config_service.py` — the merge rules.
+4. `core/mcp/services/sync_service.py:439` — the fan-out.
+5. `plugin_api/device_sync.py:81` — the delivery boundary.
+6. `src/engine/.../plugins/openclaw/_mcp.py` — what a device actually does.
+
+Tests worth reading as executable documentation:
+
+| Test | Covers |
+| --- | --- |
+| `src/backend/tests/community/api/mcp/routers/test_mcp.py` | Backend router behaviour |
+| `src/backend/tests/community/endpoints/test_mcp_device_sync.py` | Device-sync orchestration |
+| `src/backend/tests/community/_flows/mcp/api_lifecycle.py` | Full config lifecycle flow |
+| `src/backend/tests/community/contracts/test_mcp_center.py` | `MCPCenterPlugin` conformance |
+| `src/engine/.../api/tests/test_mcp_router.py` | Engine-side router |
+| `src/engine/.../plugins/openclaw/tests/test_mcp_port.py` | `mcporter.json` editing |
+
+Related docs:
+
+- `src/backend/src/agentclaw/community/core/mcp/README.md` — the module's
+  machine-checked context boundary.
+- `src/backend/docs/openapi-v1/README.md` — the Track A / Track B handoff board.
+- `src/engine/docs/heterogeneous-engine-architecture.md` §6.2 — engine-side MCP
+  model.

--- a/src/backend/docs/mcp/README.md
+++ b/src/backend/docs/mcp/README.md
@@ -495,6 +495,10 @@ device write fails the method returns early and passport is never touched —
 better that both sides stay on the old state than have passport advertise a
 scope the device never took.
 
+> **New to Passport?** It's the bot's identity credential — who the bot is, and
+> what it's authorized to reach. [`docs/passport/README.md`](../passport/README.md)
+> explains it end to end; §7 there maps every point where MCP touches it.
+
 ### 6.3 Why an empty list must still be pushed
 
 The easiest phrase to skim past in that comment is "called even when
@@ -964,6 +968,8 @@ Tests worth reading as executable documentation:
 
 Related docs:
 
+- [`src/backend/docs/passport/README.md`](../passport/README.md) — Passport, the
+  bot identity credential this doc writes to in §6.2/§6.5/§6.9.
 - `src/backend/src/agentclaw/community/core/mcp/README.md` — the module's
   machine-checked context boundary.
 - `src/backend/docs/openapi-v1/README.md` — the Track A / Track B handoff board.

--- a/src/backend/docs/mcp/README.zh-CN.md
+++ b/src/backend/docs/mcp/README.zh-CN.md
@@ -1,0 +1,718 @@
+# Avernet 中的 MCP 是如何工作的
+
+[English](README.md) | **简体中文**
+
+一份关于 Model Context Protocol（MCP）子系统的走查：它是什么、哪些表和服务持有它、
+一份用户凭据如何从一个 HTTP 请求一路走到运行中的 bot 内部的一次工具调用，以及正在进行中的
+租户隔离工作（Track A Stage 5，PR #564）接在什么位置。
+
+下文每一段代码都逐字引自本仓库，并附带可点击的 `path:line` 引用。
+
+---
+
+## 1. 一段话讲清 MCP 是什么
+
+MCP 是让 AI agent 调用外部工具的一套标准。一个 **MCP server** 是一个进程或 HTTP
+端点，它对外声明自己有哪些工具（`tools/list`），并按请求执行它们（`tools/call`）。
+agent 的运行时持有一份"允许与之通信的 MCP server 列表"，以及每一个 server 对应的凭据。
+当模型决定要用某个工具时，运行时就与对应的 MCP server 建立连接并把调用转发过去。
+
+所以一套能跑起来的 MCP 集成需要三样东西：
+
+1. **一份目录（catalog）** —— 有哪些 MCP server、各自暴露什么工具、URL 是什么。
+2. **一份凭据 + 一个授权范围（scope）** —— *这个*用户/bot 可以用哪些 server，以及用什么
+   API key 或 header。
+3. **投递到运行时** —— agent 进程需要在工具调用时能读到上面两样东西，因此它们必须被写到
+   进程读得到的地方。
+
+Avernet 把这三件事拆给了三个组件。一旦你分清了谁是谁，读代码时的大部分困惑就消失了：
+
+| 关注点 | 归属 | 说明 |
+| --- | --- | --- |
+| 目录 | **MCP Center**（外部服务），位于 `MCPCenterPlugin` 之后 | Avernet 不存任何 server 元数据表 |
+| 凭据 + 范围 | **backend**（`ac_user_mcp_config`、skill set） | 这才是 Avernet 真正持久化的东西 |
+| 投递 + 执行 | 设备上的 **engine**（`mcporter.json`） | backend 负责推送；engine 负责执行 |
+
+---
+
+## 2. 全局地图
+
+```mermaid
+flowchart TB
+    subgraph FE["调用方"]
+        UI["Workbench UI / API 客户端"]
+    end
+
+    subgraph BE["Backend (src/backend)"]
+        R["adapters/http/mcp/router.py<br/>/api/mcp/*"]
+        MS["MCPMarketService<br/>(目录读取)"]
+        AS["MCPAuthService<br/>(权限)"]
+        CS["MCPConfigService<br/>(凭据、合并)"]
+        SS["MCPSyncService<br/>(编排)"]
+        DB[("ac_user_mcp_config<br/>ac_skill_set_mcp<br/>ac_bot_mcp_call_config")]
+    end
+
+    MCPC["MCP Center<br/>(外部目录 + 权限)"]
+    PP["Passport / Agent Principal<br/>(已声明的 scope)"]
+
+    subgraph DEV["设备 (src/engine)"]
+        EAPI["engine api/mcp/router.py<br/>/api/mcp/*"]
+        MJ["mcporter.json"]
+        SRV["MCP servers<br/>(HTTP / SSE / stdio)"]
+    end
+
+    UI --> R
+    R --> MS & AS & CS & SS
+    MS --> MCPC
+    AS --> MCPC
+    CS --> DB
+    SS --> DB
+    SS --> PP
+    SS -->|DeviceSyncPlugin| EAPI
+    EAPI --> MJ
+    MJ -->|mcporter| SRV
+```
+
+有两个 HTTP 接口都叫 `/api/mcp`，但它们**不是**同一套 API：
+
+- `src/backend/.../adapters/http/mcp/router.py` —— 面向用户的 backend API（市场、权限、
+  "保存我的 API key"）。
+- `src/engine/.../api/mcp/router.py` —— 设备侧 API，backend *调用*它来在运行中的 bot 里
+  安装/移除 MCP server。
+
+---
+
+## 3. Avernet 究竟存了什么
+
+### 3.1 `ac_user_mcp_config` —— 调用方在每个 server 上的凭据
+
+这是整个子系统里最重要的一张表。一行 = "用户 X 在环境 Z 下针对 MCP server Y 的设置"。
+
+```python
+class UserMCPConfig(Base):
+    """User-specific MCP Server configuration (API keys, etc.).
+
+    Note: We store server_code directly instead of using a foreign key
+    to ac_mcp_server table, as MCP server data is managed by MCP Center.
+    """
+    __tablename__ = "ac_user_mcp_config"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(100), nullable=False, index=True)  # 用户工号
+    server_code = Column(String(256), nullable=False, index=True)  # MCP server code
+    api_key = Column(String(500), nullable=True)  # LING_XI类型需要的API Key (向后兼容)
+    custom_headers = Column(Text, nullable=True)  # JSON: 用户自定义Headers
+    extra_config = Column(Text, nullable=True)  # JSON: 其他配置项
+    env = Column(String(50), nullable=True)  # 环境标识: dev/pre/prod
+```
+
+<sub>`src/backend/src/agentclaw/community/core/models/mcp.py:56`</sub>
+
+有两点需要先记住：
+
+- **没有指向 server 表的外键** —— `server_code` 是一个不透明字符串，靠 MCP Center 解析。
+  Avernet 从不拥有这份目录。
+- **真正生效的负载放在 `extra_config`（JSON）里**，而不是那几个扁平列。
+  `api_key`/`custom_headers` 属于遗留的向后兼容字段。访问器把真实结构写得很清楚：
+
+```python
+    def get_unified_config(self) -> dict:
+        """获取统一的配置（从 extra_config 中解析）
+
+        Returns:
+            {
+                "api_key": str or None,           # API Key（授权格式）
+                "headers": dict,                   # 自定义 Headers
+                "endpoint_env": str,              # 环境选择：PROD/PRE
+            }
+        """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/models/mcp.py:100`</sub>
+
+唯一键是 `(user_id, server_code, env)` —— 注意它完全没有提及这个 `user_id`
+*属于哪个租户*。这个缺口正是 PR #564 要解决的问题，见 §8。
+
+### 3.2 `ac_skill_set_mcp` —— 一个 skill set 带来哪些 server
+
+**skill set** 是一组 bot 可以激活的能力包。把一个 MCP server 挂到某个 skill set 上，
+才是让 bot 能够触达它的前提：
+
+```python
+class SkillSetMCPServer(Base):
+    """Association table between SkillSet and MCP Server.
+    ...
+    """
+    __tablename__ = "ac_skill_set_mcp"
+```
+
+<sub>`src/backend/src/agentclaw/community/core/models/mcp.py:14`</sub>
+
+归属是有意拆开的：`UserMCPConfig` 属于 `mcp` 模块，`SkillSetMCPServer` 属于
+`skill_center`（文件头注释里写明了这一点）。
+
+### 3.3 `ac_bot_mcp_call_config` —— 这次调用以谁的身份执行
+
+当一个 bot 发起工具调用时，它是以 bot 的**拥有者（owner）**身份、还是以正在与它对话的
+**调用者（caller）**身份去做鉴权？默认是 owner；只有覆盖项才会写一行（稀疏表）：
+
+```python
+class BotMcpCallConfigModel(Base):
+    """Sparse Caller overrides; Owner is represented by a missing row."""
+
+    __tablename__ = "ac_bot_mcp_call_config"
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    bot_pk = Column(BigInteger, nullable=False, comment="ac_bots.id")
+    server_code = Column(String(256), nullable=False)
+    engine_type = Column(String(64), nullable=False)
+    call_type = Column(String(16), nullable=False)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/caller_identity/models.py:30`</sub>
+
+### 3.4 默认值 —— 每个 bot 白拿的 server
+
+有一些 MCP server 会挂到某个引擎类型下的每一个 bot 上，不需要任何人做任何配置：
+
+```python
+_DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
+    "openclaw": [
+        {"server_code": "mcp.ant.antprocessai.anttaskmcp"},
+        {"server_code": "mcp.ant.arkai.dimamcpserver"},
+        ...
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/_defaults.py:27`</sub>
+
+---
+
+## 4. backend 的四个服务
+
+四个服务都位于 `core/mcp/services/`，并在同一个 DI 模块里绑定为单例：
+
+```python
+        binder.bind(MCPMarketService, to=MCPMarketService, scope=singleton)
+        binder.bind(MCPAuthService, to=MCPAuthService, scope=singleton)
+        binder.bind(MCPConfigService, to=MCPConfigService, scope=singleton)
+```
+
+<sub>`src/backend/src/agentclaw/community/di/modules/mcp_module.py:70`</sub>
+
+| 服务 | 职责 | 依赖 |
+| --- | --- | --- |
+| `MCPMarketService` | 读目录（list / detail / tenants） | `MCPCenterPlugin` |
+| `MCPAuthService` | "这个用户能用这个 server 吗？" + 申请权限 | `MCPAuthPlugin` + `MCPCenterPlugin` |
+| `MCPConfigService` | 增删改查调用方的凭据，并与默认值做**合并** | `UserMCPConfigRepository` |
+| `MCPSyncService` | 编排：收集 → 合并 → 推送到设备 → 更新 scope | 以上全部 |
+
+真正关键的一条分工：**`MCPConfigService` 从不向设备发 HTTP 请求。** 它自己的
+docstring 就把这条边界钉死了：
+
+```python
+class MCPConfigService:
+    """管理用户级 MCP 配置（CRUD + 负载构建）。
+
+    **不**向设备发送 HTTP 请求 —— 该职责由 ``MCPSyncService`` /
+    ``DeviceMCPSyncPlugin`` 承担。
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/config_service.py:17`</sub>
+
+`MCPSyncService` 是用显式 provider 装配的，而不是普通的 `@inject`，因为 MCP 投递正好
+卡在一个依赖环的中间：
+
+```python
+        return MCPSyncService(
+            ...
+            resolver_provider=lambda: injector.get(DeviceContextResolver),
+            device_sync_dispatcher_provider=lambda: injector.get(DeviceSyncDispatcher),
+        )
+```
+
+<sub>`src/backend/src/agentclaw/community/di/modules/mcp_module.py:133` —— 它上方的
+docstring 点名了这个环：`MCPSyncService → DeviceContextResolver → ArcaConnInfoBuilder
+→ DeviceService → BotService → SkillSetServiceFactory → MCPSyncService`。</sub>
+
+---
+
+## 5. 走查 A —— 用户保存一个 API key
+
+这是端到端的写入路径。入口：`POST /api/mcp/user/config`。
+
+### 第 0 步 —— 在动任何东西之前先校验
+
+```python
+    # 校验 endpoint_env
+    if request.endpoint_env is not None and request.endpoint_env not in ("PROD", "PRE"):
+        raise HTTPException(status_code=400, detail="endpoint_env must be PROD or PRE")
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/mcp/router.py:250`</sub>
+
+### 第 1–3 步 —— 先查外部依赖，再写库，再推送，失败则回滚
+
+这里的顺序是刻意安排的，也是整个子系统里最有启发性的一段：
+
+```python
+        # 步骤1：校验 MCP 存在性（外部依赖先校验，避免写库后再回滚）
+        mcp_data = market_service.get_mcp_detail(request.server_code)
+        if not mcp_data:
+            raise HTTPException(status_code=404, detail=f"MCP server {request.server_code} not found")
+
+        # 步骤2：写库，保留旧配置供回滚
+        old_config = config_service.update_user_unified_config(
+            user_id=user.staffId,
+            server_code=request.server_code,
+            ...
+        )
+
+        # 步骤3：推送到该用户/实体下的所有设备
+        result = await sync_service.sync_mcp_detail_to_all_bots(...)
+
+        if not result["success"]:
+            config_service.rollback_unified_config(
+                user_id=user.staffId,
+                server_code=request.server_code,
+                old_config=old_config,
+            )
+            raise HTTPException(status_code=500, detail=result.get("error", "Failed to sync to all devices"))
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/mcp/router.py:271`（为篇幅做了省略）</sub>
+
+这段应该这样理解：*数据库本身并不是唯一事实来源 —— 一份设备从未收到的配置会被回滚。*
+系统里没有后台对账任务去事后修复这种不一致，所以这次写入只能靠手写的补偿逻辑来兜底。
+
+### 合并规则之一 —— 部分更新的语义
+
+`None` 表示"别动它"，而不是"清空它"：
+
+```python
+        if existing:
+            # 合并策略：入参为 None 表示不修改，沿用旧值
+            old_extra = old_config or {}
+            extra_config = {
+                "api_key": api_key if api_key is not None else old_extra.get("api_key"),
+                "headers": headers if headers is not None else old_extra.get("headers", {}),
+                ...
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/config_service.py:120`</sub>
+
+### 合并规则之二 —— 用户 header 盖过引擎默认值
+
+当一份配置要被转成推给设备的负载时，默认值作为基底，用户的值优先。这里还有一个真的很容易
+踩坑的特例：
+
+```python
+        # 当 api_key 是 x-ling-auth 格式时，需要把默认 headers 里的同名 key 删掉，
+        # 否则设备端会收到两个冲突的 authorization header。
+        if _api_key and "=" in _api_key:
+            key_name, _ = _api_key.split("=", 1)
+            if key_name.lower() == "x-ling-auth":
+                config_headers = {
+                    k: v for k, v in config_headers.items() if k.lower() != "x-ling-auth"
+                }
+
+        # 合并策略：默认 headers 作为基底，用户 headers 覆盖同名键。
+        merged_headers = {**config_headers, **user_headers}
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/config_service.py:233`</sub>
+
+注意 `api_key` 的格式：它**不是**一个裸 token，而是 `"name=value"` —— 其中的 name
+决定了这份凭据最终变成一个 header 还是一个 query 参数（见 §6.2）。
+
+### 扇出 —— 推给每一个装了该 server 的 bot
+
+```python
+        for bot_id in bot_ids:
+            ...
+            has_mcp = await asyncio.to_thread(plugin.has_mcp, server_code)
+            if not has_mcp:
+                logger.warning(
+                    "[MCPSyncService] bot=%s 设备上未找到 MCP %s", bot_id, server_code
+                )
+                sync_results.append({
+                    "bot_id": bot_id, "synced": False, "reason": "设备上未找到该 MCP",
+                })
+                continue
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:478`</sub>
+
+以及失败判定规则 —— 设备上没有这个 server、或者压根没有设备绑定，*都不算*失败：
+
+```python
+        # 只有"确实有该 MCP 的设备全部失败"时才整体报错；
+        # 如果设备上没有该 MCP 或者根本没有设备，不算失败。
+        if has_mcp_devices > 0 and not any_success:
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:538`</sub>
+
+### 读取时会做掩码
+
+对应的 GET 接口从不返回已存储的 key：
+
+```python
+    api_key = config.get("api_key")
+    masked_key = None
+    if api_key:
+        masked_key = api_key[:4] + "****" + api_key[-4:] if len(api_key) > 8 else "****"
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/mcp/router.py:370`</sub>
+
+---
+
+## 6. 走查 B —— 一个 bot 的工具集发生变化
+
+保存凭据是小路径。更大的那条路径在 skill set 被激活/取消激活时触发，也就是当一个 bot
+可用的 server *集合*发生变化时。这条路径是 `MCPSyncService.refresh_mcp_scope`，
+它做了两件互相独立的事。
+
+### 6.1 向设备声明白名单
+
+```python
+        # 先向设备声明白名单：即使 active_mcps 为空也会调用，防止设备残留旧白名单。
+        scope_result = await self._declare_mcp_scope(...)
+        if not scope_result.get("success"):
+            return scope_result
+
+        # 白名单声明成功后，再更新 passport 供前端权限校验使用。
+        passport_result = await self._update_passport(...)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:378`</sub>
+
+这份列表来自 `skill_center`，而不是 `mcp` 模块 —— `mcp` 模块只认识 `BotMCPProvider`
+这个 Protocol：
+
+```python
+@runtime_checkable
+class BotMCPProvider(Protocol):
+    """Interface for fetching a bot's MCP list from skill_center.
+
+    Implemented by ``SkillSetService``.  MCPSyncService depends only on
+    this protocol so that the mcp module does not need to import
+    skill_center internals.
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/repositories.py:11`</sub>
+
+详情推送是并发的，但做了限流，因为目标是同一个容器：
+
+```python
+        # 3. 并发推送，但限制并发数为 5，防止一次性向设备发太多 HTTP 请求把引擎压垮。
+        semaphore = asyncio.Semaphore(5)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:681`</sub>
+
+### 6.2 两种投递形态，同一个插件边界
+
+backend 不按容器类型做分支。它解析出 per-bot 的 `DeviceSyncPlugin` 并调用四个方法；
+*怎么投递*由各实现自己决定：
+
+```python
+    def sync_all_mcp_servers(self, mcp_servers: list[dict[str, Any]]) -> bool:
+        """Declare the full set of allowed MCP servers to the device
+        (filter-servers). Returns ``True`` on success."""
+        ...
+
+    def sync_single_mcp(
+        self,
+        mcp_data: dict[str, Any],
+        *,
+        api_key: Optional[str] = None,
+        custom_headers: Optional[dict[str, str]] = None,
+        endpoint_env: str = "PROD",
+        transport_protocol: Optional[str] = None,
+    ) -> bool:
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:89`</sub>
+
+这些方法上方的注释点明了两种投递风格：
+
+> Per impl: arca/baas push per-MCP over `/api/mcp`; teclaw delivers the whole
+> composed artifact; local is no-op.
+>
+> （各实现：arca/baas 逐个 MCP 走 `/api/mcp` 推送；teclaw 投递整份组装好的产物；
+> local 是 no-op。）
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:81`</sub>
+
+在本（community）仓库里，local 实现是 no-op —— `LocalDeviceSyncPlugin.sync_single_mcp`
+直接返回 `True`（`plugins/local/device_sync.py:338`）。真正做 HTTP 推送的 corp/arca
+实现不在本仓库内。
+
+对于"整份产物"这种形态，manifest 是在 **backend 侧**组装的，凭据被内联进去 ——
+这段代码是全仓对凭据格式说得最清楚的地方：
+
+```python
+        """Inline the resolved credential, mirroring ``convert_to_device_format``.
+
+        ``api_key`` is ``"name=value"``. ``authorization`` is appended to the
+        endpoint URL query; ``x-ling-auth`` becomes a header; any other name is
+        ignored (device-path parity).
+        """
+        merged_headers: dict[str, str] = {}
+
+        if api_key and "=" in api_key:
+            key_name, key_value = api_key.split("=", 1)
+            lowered = key_name.lower()
+            if lowered == "authorization" and endpoint:
+                separator = "&" if "?" in endpoint else "?"
+                endpoint = f"{endpoint}{separator}{key_name}={key_value}"
+            elif lowered == "x-ling-auth":
+                merged_headers[key_name] = key_value
+```
+
+<sub>`src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py:125`</sub>
+
+**凭据是在组装时以明文内联进去的** —— 设备侧没有 secret broker，也没有按引用间接解析的
+机制。模块 docstring 明确写了这一点；这也正是设备推送失败时要回滚数据库写入的原因：改
+`api_key` 就是改产物的字节，而一个过期的容器会继续用旧凭据对外发请求。
+
+同一个文件里还放着 endpoint 选择规则（从目录给出的若干 URL 里挑哪一个）：
+
+```python
+# Teclaw containers reach networks in this order; an endpoint on an earlier
+# network always wins over a later one (network is the primary sort key).
+TECLAW_MCP_NETWORK_PRIORITY = ("OFFICE", "INTERNET", "INTRANET")
+```
+
+<sub>`src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py:53`</sub>
+
+### 6.3 Passport —— 已声明的 scope，排除掉 local server
+
+在推送设备的同时，bot 的 scope 也会被声明给 passport / Agent Principal 服务。
+`stdio`/LOCAL 类型的 server 被有意排除，因为它们是运行时本地能力，没人需要为它们授权：
+
+```python
+def passport_mcp_items_from_entries(
+    mcps: Iterable[Mapping[str, Any]],
+    *,
+    identity_modes: Mapping[str, object],
+    local_registry: LocalMCPRegistry | None = None,
+) -> list[McpScopeItem]:
+    """Build the complete non-local MCP identity scope for Agent Principal."""
+    ...
+        raw_mode = identity_modes.get(code, "owner")
+        mode = getattr(raw_mode, "value", raw_mode)
+        normalized_mode = str(mode).strip().lower()
+        if normalized_mode not in {"owner", "caller"}:
+            raise ValueError("identity mode must be owner or caller")
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/passport_scope.py:44`</sub>
+
+这里的 `owner`/`caller` 值，就是 §3.3 里 `ac_bot_mcp_call_config` 所做的决定，在
+scope 被发布出去的这一刻浮出水面。
+
+---
+
+## 7. 设备上发生了什么
+
+engine 暴露了它自己的 `/api/mcp`，并把所有端点都转发给一个 engine 专属的插件：
+
+```python
+"""MCP router — dispatches every endpoint through ``EngineManager.mcp``.
+
+Engine-specific behaviour (mcporter file edits, ``mcporter`` CLI shell-out)
+lives in ``engines/openclaw/mcp.OpenClawMCPService``; AiCoding ships its own
+plugin proxying to teamclaw-aicoding-relay. The router only marshals
+HTTP↔Plugin types and applies capability guards.
+"""
+```
+
+<sub>`src/engine/src/engine/community/api/mcp/router.py:1`</sub>
+
+对 OpenClaw 引擎来说，"安装一个 MCP server"字面意思就是改一个 JSON 文件：
+
+```python
+    def _mcp_load(self) -> "tuple[dict[str, Any], str, dict[str, Any]]":
+        """Load mcporter.json; return (root, servers_key, servers_dict)."""
+```
+
+<sub>`src/engine/src/engine/community/plugins/openclaw/_mcp.py:24`</sub>
+
+……而白名单是通过 shell 调用 `mcporter` CLI 来生效的。注意"什么都不允许"的哨兵值 ——
+这也解释了为什么空列表仍然要推送一次：
+
+```python
+        csv_codes = (
+            ",".join(normalized) if normalized else "__EMPTY_FILTER_DISABLE_ALL__"
+        )
+        command = ["mcporter", "filter-servers", csv_codes]
+```
+
+<sub>`src/engine/src/engine/community/plugins/openclaw/_mcp.py:260`</sub>
+
+工具执行也是同样的形态：
+
+```python
+        cmd = ["mcporter", "call", tool]
+        for key, value in (args or {}).items():
+            cmd.append(f"{key}={value}")
+```
+
+<sub>`src/engine/src/engine/community/plugins/openclaw/_mcp.py:209`</sub>
+
+engine 的传输模型是一小组 dataclass，也正是在这里，`stdio` / `http` / `sse` 的区别
+才终于变得具体：
+
+```python
+@dataclass
+class MCPServerConfig:
+    """Declared configuration for an MCP server.
+
+    `server_code` is the stable identifier used to look up the server.
+    Transport-dependent fields:
+      - HTTP / SSE: `url` (and optional `headers`)
+      - stdio: `command` + `args` (and optional `env`)
+    """
+```
+
+<sub>`src/engine/src/engine/community/core/mcp/models.py:31`</sub>
+
+并不是每个引擎都支持每个操作；router 用能力检查（`check_capability(Capability.MCP_CREATE)`
+等）逐个把关，引擎没实现时返回 `501` —— 见
+`src/engine/src/engine/community/api/mcp/router.py:145`。
+
+---
+
+## 8. PR #564 接在哪里 —— 租户隔离
+
+上面所有内容都默认只有一个租户。`ac_user_mcp_config` 的键是
+`(user_id, server_code, env)` —— 一个 user id 只在*某个租户内部*才有意义，而这一行上
+没有任何字段记录它属于哪个租户。
+
+今天这没问题，因为所有数据都属于内部租户。但一旦 `/openapi/v1` 对外部租户开放，它就不再
+成立了 —— 那些路由已经以桩的形式存在了：
+
+```python
+@router.get(
+    "/servers/{server_code}/config",
+    response_model=Envelope[McpConfig],
+)
+async def get_mcp_config(
+    server_code: str, principal: PrincipalDep
+) -> Envelope[McpConfig]:
+    """Read the caller's unified config for an MCP server."""
+    raise NotImplementedError
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py:72`</sub>
+
+公共 API 这项工作被拆成两条 Track，规则是：某个类别的数据没有完成隔离之前，不得实现它的
+端点（见 `src/backend/docs/openapi-v1/README.zh-CN.md`）：
+
+- **Track A** —— 给某个数据类别加上租户隔离。不实现任何端点。
+- **Track B** —— 实现该类别的 `/openapi/v1` 端点。
+
+这套机制已经在 Track A Stage 1（PR #456）里于 bots 上建成并验证过，后续原样复用：一个
+按请求维度的租户载体，加上注册在模型上的两个 SQLAlchemy guard ——
+
+> - 在 `Session` 类上的 `do_orm_execute` **读 guard** →
+>   `with_loader_criteria(...)`。它同时约束 `Query.update()`/`Query.delete()`，
+>   所以写路径不需要额外加过滤条件。
+> - `before_insert` **插入 guard** → 未设置时自动打标；显式传入冲突租户时抛
+>   `CrossTenantInsertError`。
+
+<sub>`src/backend/docs/openapi-v1/README.md:168`</sub>
+
+**PR #564 就是 Track A Stage 5：把这套机制套用到 MCP 配置上。** 它目前只包含 spec 文档
+（`src/backend/specs/2026-07-29-tenant-isolation-mcp/spec.md`），plan、tasks 和实现
+随后跟进。具体来说，就是给下面两者加上 `avernet_tenant` 列以及那两个 guard：
+
+1. `UserMCPConfig`（§3.1）—— 也就是 API key 和 header，这个类别里最敏感的数据。
+2. `BotMcpCallConfigModel`（§3.3）—— PR 里把它标为一个需要判断的点。它的行挂在 bot 之下，
+   所以 Stage 1 的 bots 隔离已经覆盖了*通过 bot* 触达的一切；但它的聚合查询是直接按
+   `bot_pk` 查的，全程不碰任何 bot 记录，因此 guard 覆盖不到这些读。
+
+`mcp` 的六个端点里有四个完全不需要 Stage 5 做任何事（市场、租户列表、server 详情、权限）
+—— 它们由 MCP Center 提供服务，而正如 §1 所确立的，我们对它们什么都不存。
+
+---
+
+## 9. 部署 profile —— 为什么"外部服务"不是硬依赖
+
+目录只通过一个 Protocol 访问：
+
+```python
+@runtime_checkable
+class MCPCenterPlugin(Plugin, Protocol):
+    """Read-only queries against MCP Center API."""
+
+    def get_mcp_detail(self, server_code: str) -> dict[str, Any] | None:
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/mcp_center.py:13`</sub>
+
+在 `DEPLOY_PROFILE=community` 下，这个 Protocol 由一个基于配置文件、权限全放开的目录实现
+来满足，因此整个子系统在没有内部 MCP-Center 服务的情况下也能装配起来：
+
+```python
+class CommunityMCPCenter(MCPCenterPlugin):
+    """Config-file-backed MCP catalog with allow-all permission + default tenant."""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/mcp_center.py:31`</sub>
+
+它的模块 docstring 讲清了"为什么空目录依然是一套能用的系统"这个关键点：
+
+> The bot-run path uses bring-your-own MCP configs (`ac_user_mcp_config`) and
+> skill-set references, which sync to devices regardless of this catalog — so an
+> empty catalog never blocks a configured MCP server from working.
+>
+> （bot 运行路径使用自带的 MCP 配置（`ac_user_mcp_config`）和 skill set 引用，
+> 它们与这份目录无关地同步到设备 —— 所以空目录永远不会挡住一个已配置好的 MCP server
+> 正常工作。）
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/mcp_center.py:19`</sub>
+
+在 `configs/local-mcp-servers.yaml` 里声明的 server 由 `LocalMCPRegistry` 加载，并被
+规整成 MCP-Center 形状的 dict（`core/mcp/services/local_mcp_registry.py:18`），这就是
+为什么其余代码可以对两种来源一视同仁。
+
+还有一个有用的逃生口：当调用方带上 IAM token 时，server 详情会**实时**从 MCP server 本身
+拉取（`core/mcp/services/mcp_live_fetcher.py:14` 里是一次真实的 `initialize` →
+`tools/list` JSON-RPC 交互），而不是相信可能已经过期的目录元数据；任何一步失败都会退回到
+目录数据（`adapters/http/mcp/router.py:144`）。
+
+---
+
+## 10. 阅读顺序与测试地图
+
+如果你想端到端地跟一条线，建议按这个顺序读：
+
+1. `core/models/mcp.py` —— 存了什么（117 行）。
+2. `adapters/http/mcp/router.py:237` —— 写入端点，完整五步。
+3. `core/mcp/services/config_service.py` —— 合并规则。
+4. `core/mcp/services/sync_service.py:439` —— 扇出。
+5. `plugin_api/device_sync.py:81` —— 投递边界。
+6. `src/engine/.../plugins/openclaw/_mcp.py` —— 设备实际做的事。
+
+值得当作可执行文档来读的测试：
+
+| 测试 | 覆盖 |
+| --- | --- |
+| `src/backend/tests/community/api/mcp/routers/test_mcp.py` | backend router 行为 |
+| `src/backend/tests/community/endpoints/test_mcp_device_sync.py` | 设备同步编排 |
+| `src/backend/tests/community/_flows/mcp/api_lifecycle.py` | 完整配置生命周期流程 |
+| `src/backend/tests/community/contracts/test_mcp_center.py` | `MCPCenterPlugin` 一致性 |
+| `src/engine/.../api/tests/test_mcp_router.py` | engine 侧 router |
+| `src/engine/.../plugins/openclaw/tests/test_mcp_port.py` | `mcporter.json` 编辑 |
+
+相关文档：
+
+- `src/backend/src/agentclaw/community/core/mcp/README.md` —— 本模块受机器校验的
+  context boundary。
+- `src/backend/docs/openapi-v1/README.zh-CN.md` —— Track A / Track B 交接看板。
+- `src/engine/docs/heterogeneous-engine-architecture.md` §6.2 —— engine 侧 MCP 模型。

--- a/src/backend/docs/mcp/README.zh-CN.md
+++ b/src/backend/docs/mcp/README.zh-CN.md
@@ -370,11 +370,85 @@ docstring 点名了这个环：`MCPSyncService → DeviceContextResolver → Arc
 
 ## 6. 走查 B —— 一个 bot 的工具集发生变化
 
-保存凭据是小路径。更大的那条路径在 skill set 被激活/取消激活时触发，也就是当一个 bot
-可用的 server *集合*发生变化时。这条路径是 `MCPSyncService.refresh_mcp_scope`，
-它做了两件互相独立的事。
+保存凭据（走查 A）是小路径：一个 server、一份凭据。真正复杂的是当一个 bot **可用的
+server 集合本身**发生变化时 —— 用户激活了一个 skill set，或者往 skill set 里加了一个
+新的 MCP。这一节把这条路径拆开讲。
 
-### 6.1 向设备声明白名单
+### 6.0 先分清两个概念：scope（范围）与 detail（详情）
+
+读这段代码最容易卡住的地方，是没有意识到系统在同步**两种彼此独立的东西**。用一个门禁的
+比方：
+
+- **scope（范围）** = 门禁白名单。回答"这个 bot *被允许*使用哪些 server"。
+- **detail（详情）** = 每扇门的地址和钥匙。回答"某个 server 的 URL 是什么、用什么凭据和
+  header 连上去"。
+
+两者缺一不可，而且缺失时的症状完全不同：只有白名单没有详情，bot 知道自己被允许用某个
+server，却不知道往哪连；只有详情没有白名单，配置躺在设备上，但会被过滤掉，工具根本不出现。
+
+它们由两组不同的方法负责，**总是成对被调用**：
+
+| 概念 | 回答的问题 | 落到哪里 | 负责的方法 |
+| --- | --- | --- | --- |
+| scope | 这个 bot 允许用哪些 server | 设备的 `filter-servers` 白名单 **+** passport | `refresh_mcp_scope` |
+| detail | 某个 server 的 URL / 凭据 / header | 设备的 `mcporter.json` 条目 | `sync_mcp_detail`（单条）/ `sync_mcp_details`（全量） |
+
+服务层的 docstring 把这条分工写得很直白：
+
+```python
+        """刷新MCP授权范围（异步方法）。
+
+        向设备声明filter-servers白名单，并更新passport的MCP codes列表。
+        不包含MCP详细配置的推送——那是 sync_mcp_details / sync_mcp_detail 的职责。
+        """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py:1844`</sub>
+
+### 6.1 什么时候会触发
+
+这条路径不是由某一个端点触发的，而是由四类事件触发。注意**成对调用**的模式，以及两种事件
+下顺序是相反的：
+
+| 场景 | 调用顺序 | 代码位置 |
+| --- | --- | --- |
+| 往 skill set 里加一个 MCP | 先推该条 detail，再刷新 scope | `skill_set_service.py:1360` → `:1378` |
+| 从 skill set 移除一个 MCP | 先从设备移除该条，再刷新 scope | `skill_set_service.py:1442` → `:1459` |
+| 切换 / 激活 skill set | 先刷新 scope，再推激活集合的 details | `skill_set_service.py:2265` → `:2274` |
+| 设备重新上线 | 先刷新 scope，再推全部 details | `device_service.py:1502` → `:1513` |
+
+顺序为什么会反过来？**加一个 MCP 时**，先把它的配置推到设备上，再把它放进白名单 —— 这样
+白名单一放行，配置就已经在那儿了。**设备上线时**没有"某一条"可言，需要重建整个状态，于是
+先声明白名单，失败就直接返回，省掉后面一整轮详情推送：
+
+```python
+                async def _do_sync() -> tuple[dict, dict | None]:
+                    # 1. 先声明白名单（scope），失败则直接返回，不必继续推送详细配置
+                    scope_result = await self._mcp_sync.refresh_mcp_scope(...)
+                    if not scope_result.get("success"):
+                        return scope_result, None
+
+                    # 2. 再推送详细配置
+                    detail_result = await self._mcp_sync.sync_mcp_details(...)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/devices/services/device_service.py:1500`（为篇幅做了省略）</sub>
+
+另外注意"加 MCP"这个场景里的一个细节 —— 关联刚写进库，如果推送失败会被撤销，和走查 A
+里的回滚是同一种手写补偿：
+
+```python
+        if not push_result.get("success"):
+            error = push_result.get("error", "Unknown error")
+            logger.error(f"[add_mcp_to_skill_set] Device sync failed: {error}")
+            self.skill_set_repo.remove_mcp_from_set(skill_set_id, server_code)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py:1366`</sub>
+
+### 6.2 `refresh_mcp_scope` 内部：两个目的地
+
+刷新 scope 就是把"当前允许的 server 列表"同时写到两个地方 —— 先设备，后 passport：
 
 ```python
         # 先向设备声明白名单：即使 active_mcps 为空也会调用，防止设备残留旧白名单。
@@ -388,8 +462,24 @@ docstring 点名了这个环：`MCPSyncService → DeviceContextResolver → Arc
 
 <sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:378`</sub>
 
-这份列表来自 `skill_center`，而不是 `mcp` 模块 —— `mcp` 模块只认识 `BotMCPProvider`
-这个 Protocol：
+顺序是有意的：**设备是执行方，passport 是对外的声明。** 设备没改成功就提前返回，
+passport 完全不动 —— 宁可两边都停在旧状态，也不要 passport 宣称一份设备并未生效的范围。
+
+### 6.3 为什么"空列表也必须推"
+
+上面那句注释里最容易被读过去的，是"即使 `active_mcps` 为空也会调用"。这不是防御性编程，
+而是一条安全属性：
+
+设想用户取消激活了最后一个 skill set。此时允许列表变成空。如果因为"没什么可声明的"就跳过
+这次调用，设备上的旧白名单会原封不动地留着 —— bot 依然能调用它已经不该拥有的工具。**收回
+权限恰恰是列表为空的那一刻，也正是最容易被跳过的那一刻。**
+
+引擎侧因此需要一个"什么都不允许"的哨兵值，因为空字符串在命令行上无法与"没传参数"区分
+（见 §7 的 `__EMPTY_FILTER_DISABLE_ALL__`）。
+
+### 6.4 这份名单从哪来
+
+`mcp` 模块并不知道 skill set 是什么。它只认识一个 Protocol，实现方在 `skill_center`：
 
 ```python
 @runtime_checkable
@@ -404,7 +494,84 @@ class BotMCPProvider(Protocol):
 
 <sub>`src/backend/src/agentclaw/community/core/mcp/services/repositories.py:11`</sub>
 
-详情推送是并发的，但做了限流，因为目标是同一个容器：
+这个 Protocol 上有两个容易混淆的方法，区别在于是否只要"激活的"：
+
+- `collect_bot_active_mcps` —— 只取**当前激活**的 skill set 里的 MCP（外加引擎默认值）。
+  scope 声明用的就是它（`sync_service.py:588`）：白名单当然只该包含此刻生效的。
+- `collect_bot_mcps` —— 取该 bot 关联的**全部** MCP，包含未激活的。
+
+详情推送则用 `active_only` 参数在两者之间切换：
+
+```python
+            active_only: 为 True 时只推送当前**激活** skill sets 中的 MCP；
+                为 False 时推送该 bot 关联的**全部** MCP（含 inactive）。
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:177`</sub>
+
+为什么要有"把未激活的也推下去"这种模式？因为详情只是躺在 `mcporter.json` 里的配置，真正
+决定能不能用的是白名单。设备重新上线时把全部详情灌下去，之后再激活某个 skill set 就只需要
+改白名单，不必重新推配置。
+
+### 6.5 passport 是覆盖式快照 —— 所以必须回填 CLI
+
+这是本节里最不直观、也最值得理解的一段。passport 的 `resourceManifest` 是**整体覆盖**的：
+你提交什么，它就变成什么。而一个 bot 的 manifest 里同时装着 MCP 授权**和** CLI 授权。
+
+后果是：一次只关心 MCP 的同步，如果只提交 MCP 列表，会把这个 bot 的 CLI 授权**静默抹掉**。
+代码因此先把当前 CLI 读回来，与引擎默认值合并，再连同 MCP 一起提交：
+
+```python
+        # MCP 同步触发 resourceManifest 更新时，要回填当前 CLI，避免覆盖式更新丢失 CLI 授权。
+        try:
+            current_cli_items = self.passport_update.query_passport_clis(
+                bot_id, user_id
+            )
+        ...
+        default_cli_items = get_default_cli_items(engine_type, template_type)
+        cli_items = _merge_cli_items(current_cli_items, default_cli_items)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:888`</sub>
+
+```python
+            # resource_scope 是完整快照：MCP 来自同步结果，CLI 来自当前许可证 + 引擎默认 CLI。
+            self.passport_update.update_passport(
+                bot_id=bot_id,
+                user_id=user_id,
+                resource_scope={
+                    "mcp_codes": synced_server_codes,
+                    "cli_items": cli_items,
+                },
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:913`</sub>
+
+合并时"已有值优先"，而且还要防住一个时序陷阱 —— bot 刚创建时 passport 可能暂时返回空
+CLI 列表，此时若直接采信，一次 MCP 同步就会把默认 CLI 抹平：
+
+```python
+    """Merge passport CLI scope with default CLI items, de-duped by cli_code.
+
+    The passport update API treats resourceManifest as an overwrite. During MCP
+    sync we must send the complete CLI scope as well as MCPs. If the passport
+    service returns a temporarily-empty CLI list right after bot creation,
+    preserving the engine defaults here prevents a later MCP sync from clearing
+    them. Existing passport values win on duplicate cli_code so user/provider
+    metadata is not overwritten by static defaults.
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:46`</sub>
+
+同样的道理，读 bot 元数据失败时这次 passport 更新会直接中止 —— 宁可不更新，也不要写进一份
+不完整的快照（`sync_service.py:884`）。
+
+**一句话记住：任何写 passport 的地方，都必须提交完整快照，而不是增量。**
+
+### 6.6 详情推送：并发，但限流
+
+scope 是一次调用；详情是 N 次。推送是并发的，但刻意限了并发数，因为目标是同一个容器：
 
 ```python
         # 3. 并发推送，但限制并发数为 5，防止一次性向设备发太多 HTTP 请求把引擎压垮。
@@ -413,7 +580,10 @@ class BotMCPProvider(Protocol):
 
 <sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:681`</sub>
 
-### 6.2 两种投递形态，同一个插件边界
+单条失败不会中断其余（`asyncio.gather(..., return_exceptions=True)`），最终按成功/失败
+两组返回；但 `CancelledError` 必须继续向上抛，不能被当成普通失败吞掉。
+
+### 6.7 一个插件边界，两种投递形态
 
 backend 不按容器类型做分支。它解析出 per-bot 的 `DeviceSyncPlugin` 并调用四个方法；
 *怎么投递*由各实现自己决定：
@@ -437,7 +607,8 @@ backend 不按容器类型做分支。它解析出 per-bot 的 `DeviceSyncPlugin
 
 <sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:89`</sub>
 
-这些方法上方的注释点明了两种投递风格：
+这四个方法（声明白名单 / 推单条 / 移除单条 / 探测是否已装）正好覆盖了 §6.1 那张表里的所有
+动作。它们上方的注释点明了两种投递风格：
 
 > Per impl: arca/baas push per-MCP over `/api/mcp`; teclaw delivers the whole
 > composed artifact; local is no-op.
@@ -447,9 +618,15 @@ backend 不按容器类型做分支。它解析出 per-bot 的 `DeviceSyncPlugin
 
 <sub>`src/backend/src/agentclaw/community/plugin_api/device_sync.py:81`</sub>
 
+差别不只是传输方式。对 teclaw 这种"整份产物"的容器，*任何一次*改动都意味着重新组装并投递
+整个 manifest —— 所以对它而言 `sync_single_mcp` 和 `sync_all_mcp_servers` 实际做的是
+同一件事，只是幂等地重复投递。
+
 在本（community）仓库里，local 实现是 no-op —— `LocalDeviceSyncPlugin.sync_single_mcp`
 直接返回 `True`（`plugins/local/device_sync.py:338`）。真正做 HTTP 推送的 corp/arca
 实现不在本仓库内。
+
+### 6.8 凭据在组装时以明文内联
 
 对于"整份产物"这种形态，manifest 是在 **backend 侧**组装的，凭据被内联进去 ——
 这段代码是全仓对凭据格式说得最清楚的地方：
@@ -489,10 +666,11 @@ TECLAW_MCP_NETWORK_PRIORITY = ("OFFICE", "INTERNET", "INTRANET")
 
 <sub>`src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py:53`</sub>
 
-### 6.3 Passport —— 已声明的 scope，排除掉 local server
+### 6.9 passport scope 里排除 LOCAL server
 
-在推送设备的同时，bot 的 scope 也会被声明给 passport / Agent Principal 服务。
-`stdio`/LOCAL 类型的 server 被有意排除，因为它们是运行时本地能力，没人需要为它们授权：
+回到 §6.2 的第二个目的地。发给 passport 的列表并不等于发给设备的列表：`stdio`/LOCAL
+类型的 server 会被剔除，因为它们是运行时本地能力，没有哪个权限系统需要为它们授权 ——
+但设备仍然需要它们的配置：
 
 ```python
 def passport_mcp_items_from_entries(
@@ -515,8 +693,17 @@ def passport_mcp_items_from_entries(
 这里的 `owner`/`caller` 值，就是 §3.3 里 `ac_bot_mcp_call_config` 所做的决定，在
 scope 被发布出去的这一刻浮出水面。
 
----
+### 小结
 
+一次工具集变更，最终落在三个地方：
+
+1. **设备白名单** —— 允许哪些（空列表也必须推）。
+2. **设备 `mcporter.json` 条目** —— 每个 server 怎么连、用什么凭据。
+3. **passport 快照** —— 对外声明的范围，排除 LOCAL，带上身份模式，且必须回填 CLI。
+
+前两者决定 bot *实际能做什么*，第三个是这份权限对系统其余部分*的声明*。
+
+---
 ## 7. 设备上发生了什么
 
 engine 暴露了它自己的 `/api/mcp`，并把所有端点都转发给一个 engine 专属的插件：
@@ -696,8 +883,10 @@ class CommunityMCPCenter(MCPCenterPlugin):
 2. `adapters/http/mcp/router.py:237` —— 写入端点，完整五步。
 3. `core/mcp/services/config_service.py` —— 合并规则。
 4. `core/mcp/services/sync_service.py:439` —— 扇出。
-5. `plugin_api/device_sync.py:81` —— 投递边界。
-6. `src/engine/.../plugins/openclaw/_mcp.py` —— 设备实际做的事。
+5. `core/mcp/services/sync_service.py:324` —— `refresh_mcp_scope`，即 scope 路径
+   （§6）；以及 `:849`，它写出的 passport 快照。
+6. `plugin_api/device_sync.py:81` —— 投递边界。
+7. `src/engine/.../plugins/openclaw/_mcp.py` —— 设备实际做的事。
 
 值得当作可执行文档来读的测试：
 

--- a/src/backend/docs/mcp/README.zh-CN.md
+++ b/src/backend/docs/mcp/README.zh-CN.md
@@ -465,6 +465,10 @@ server，却不知道往哪连；只有详情没有白名单，配置躺在设�
 顺序是有意的：**设备是执行方，passport 是对外的声明。** 设备没改成功就提前返回，
 passport 完全不动 —— 宁可两边都停在旧状态，也不要 passport 宣称一份设备并未生效的范围。
 
+> **不熟悉 Passport？** 它是 bot 的身份凭证 —— 这个 bot 是谁、被授权触达什么。
+> [`docs/passport/README.zh-CN.md`](../passport/README.zh-CN.md) 有完整讲解，
+> 其中 §7 列出了 MCP 与它的每一处交集。
+
 ### 6.3 为什么"空列表也必须推"
 
 上面那句注释里最容易被读过去的，是"即使 `active_mcps` 为空也会调用"。这不是防御性编程，
@@ -901,6 +905,8 @@ class CommunityMCPCenter(MCPCenterPlugin):
 
 相关文档：
 
+- [`src/backend/docs/passport/README.zh-CN.md`](../passport/README.zh-CN.md) —— Passport，
+  即本文 §6.2/§6.5/§6.9 写入的那份 bot 身份凭证。
 - `src/backend/src/agentclaw/community/core/mcp/README.md` —— 本模块受机器校验的
   context boundary。
 - `src/backend/docs/openapi-v1/README.zh-CN.md` —— Track A / Track B 交接看板。

--- a/src/backend/docs/passport/README.md
+++ b/src/backend/docs/passport/README.md
@@ -1,0 +1,508 @@
+# Passport — a bot's identity credential
+
+**English** | [简体中文](README.zh-CN.md)
+
+What Passport is, what it holds, how a bot gets one and loses one, and the one
+rule about updating it that everything else defends against. Written as a
+companion to [`docs/mcp/README.md`](../mcp/README.md) — MCP sync writes to
+Passport, and §7 below maps the two together — but Passport is its own thing and
+this doc stands alone.
+
+Every code block is quoted verbatim from this repository, with a `path:line`
+reference you can click through.
+
+---
+
+## 1. The one-sentence version
+
+**A Passport is a bot's identity document.** It answers "who is this bot" with a
+credential the bot can present to services, and "what is this bot allowed to
+reach" with a list of grants.
+
+The name is the analogy, and it holds up well:
+
+| A person's passport | A bot's Passport |
+| --- | --- |
+| Identity page — your name, your number | `agent_id`, `agent_code`, `credential_id` |
+| The document itself, presented at a border | `token` — handed to the device, sent with outbound calls |
+| Visas — which countries you may enter | `resourceManifest` — which MCP servers and CLIs this bot may use |
+| Valid / expired / revoked | `PENDING` → `ISSUED` → frozen → destroyed |
+
+The reason a bot needs its own document rather than borrowing its owner's: a bot
+acts on its own, on a schedule, in a container, long after the human who created
+it has closed the tab. Something has to be able to say "this request came from
+bot X, which is authorized for Y" without a human session behind it.
+
+Externally the service is called **AgentPass / tcauthmng**; in this codebase it
+sits behind one Protocol:
+
+```python
+@runtime_checkable
+class PassportPlugin(Plugin, Protocol):
+    """Plugin for passport lifecycle management (tcauthmng facade)."""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:117`</sub>
+
+---
+
+## 2. What a Passport actually holds
+
+The clearest picture is the shape returned when you read one back. This is the
+schema snapshot the gateway contract test locks:
+
+```json
+{
+  "access_mode": {"type": "string"},
+  "agent_code": {"type": "string"},
+  "agent_id": {"type": "string"},
+  "certificate_url": {"type": "string"},
+  "credential_id": {"type": "string"},
+  "expire_at": {"type": "string"},
+  "mcps": {"type": "array", "items": {"...": "mcp_code / mcp_name / mcp_desc"}}
+}
+```
+
+<sub>`src/backend/tests/community/contracts/gateway/schema_snapshots/response_data/rule01_GET_api_bots_id_passport.json`
+(abridged)</sub>
+
+Three groups, and it's worth keeping them separate in your head:
+
+**1. Identity.** `agent_id` / `agent_code` / `credential_id` / `certificate_url`
+/ `expire_at`, plus the `token` you fetch separately. This is the "who".
+
+**2. Scope — the `resourceManifest`.** Two resource types today, MCP servers and
+CLIs, each a typed item:
+
+```python
+class CliItem(TypedDict, total=False):
+    """CLI scope item supplied by AgentPass query responses."""
+
+    cli_code: str | None
+    cli_name: str | None
+    cli_desc: str | None
+
+
+class McpScopeItem(TypedDict, total=False):
+    """Provider-neutral MCP resource item for Agent Principal updates."""
+
+    mcp_code: str
+    mcp_name: str | None
+    mcp_desc: str | None
+    identity_mode: str
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:41`</sub>
+
+**3. State.** `PENDING` while approval is outstanding, `ISSUED` once granted,
+frozen when the bot goes dormant, gone when the bot is deleted. §4 walks that.
+
+---
+
+## 3. The rule that matters most: updates are overwrites
+
+If you remember one thing from this document, this is it.
+
+`updatePassport` **replaces** each resource list rather than merging into it.
+Submit `{mcp_codes: [...]}` alone and the bot's CLI grants are gone — not
+rejected, not merged, *silently replaced with nothing*. The type that models the
+call says so in its docstring:
+
+```python
+class PassportResourceScope(TypedDict, total=False):
+    """Complete resourceManifest scope for overwrite-style updatePassport calls.
+
+    AgentPass/tcauthmng treats each resource list in updatePassport as a full
+    replacement. Callers that update MCP or CLI scope must pass both lists here
+    so one resource type does not accidentally clear the other.
+    """
+
+    mcp_codes: list[str]
+    mcp_items: list[McpScopeItem]
+    cli_items: list[CliItem]
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:58`</sub>
+
+Two consequences shape the calling code everywhere:
+
+**A. Anyone updating scope must first read back what they aren't changing.**
+This is why MCP sync — which cares only about MCP — queries the bot's *CLI*
+scope before writing (`docs/mcp/README.md` §6.5):
+
+```python
+            # resource_scope 是完整快照：MCP 来自同步结果，CLI 来自当前许可证 + 引擎默认 CLI。
+            self.passport_update.update_passport(
+                bot_id=bot_id,
+                user_id=user_id,
+                resource_scope={
+                    "mcp_codes": synced_server_codes,
+                    "cli_items": cli_items,
+                },
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:913`
+— "resource_scope is a complete snapshot: MCP from the sync result, CLI from the
+current licence plus the engine defaults."</sub>
+
+**B. Omitting `resource_scope` entirely is the way to say "don't touch the
+grants".** A metadata-only update (rename the bot, change its admins) passes
+nothing, and the helper that unpacks the field encodes that as a deliberate
+`None`:
+
+```python
+def unpack_resource_scope(
+    resource_scope: PassportResourceScope | None,
+) -> tuple[list[McpScopeItem] | None, list[CliItem] | None]:
+    """Return DTO-ready MCP/CLI lists, or None pair for non-resource updates.
+
+    Non-resource updates, such as admins or metadata, intentionally omit
+    resource_scope so existing MCP/CLI grants are left untouched.
+    """
+    if resource_scope is None:
+        return None, None
+    try:
+        cli_items = resource_scope["cli_items"]
+    except KeyError as e:
+        raise ValueError(
+            "resource_scope must include mcp_codes and cli_items"
+        ) from e
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:90`</sub>
+
+Note the `KeyError → ValueError`: pass a *partial* scope and it fails loudly.
+The only safe states are "complete snapshot" and "nothing at all"; the dangerous
+middle is rejected at the boundary. The community implementation calls this
+unpacking even though it has no external registry to notify, purely to keep that
+check alive in every deployment:
+
+```python
+        # No external registry to notify — scope/admin changes are a no-op.
+        # ``unpack_resource_scope`` is still called so a malformed scope raises
+        # the same ValueError the corp impl would, keeping callers honest.
+        unpack_resource_scope(resource_scope)
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:53`</sub>
+
+---
+
+## 4. The lifecycle
+
+### 4.1 Apply — at bot creation
+
+A bot's Passport is applied for as part of creating the bot, and the very first
+bot a user creates takes a different call than subsequent ones (first-time
+application involves an approval the user has not yet given):
+
+```python
+    apply = (
+        passport_plugin.apply_first_agent_passport
+        if is_first_bot
+        else passport_plugin.apply_agent_passport
+    )
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_management/create_flow.py:204`</sub>
+
+Note what is passed in: `mcp_codes` and `cli_items` are arguments *to the
+application*. A bot's initial scope is declared at birth, not bolted on
+afterwards.
+
+The resulting `agent_code` is persisted onto the bot record so later code doesn't
+have to re-query for it:
+
+```python
+def _build_ext(
+    *, avatar_url: str | None, agent_code: str | None, issued: bool = False
+) -> dict[str, Any] | None:
+    """Assemble the bot's ``ext`` payload; ``None`` when there is nothing to store."""
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_management/create_flow.py:227`</sub>
+
+### 4.2 The consent step — why creation is sometimes two-phase
+
+For desktop bots the application may come back needing a human to approve it.
+Creation therefore splits in two: apply, return "needs authorization" with a URL
+for the user, then poll:
+
+```python
+        # 桌面版两段式：先返回 need_authorization，前端授权后再调 auth-status
+        if result.get("need_authorization"):
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/desktop/router.py:120`
+— "desktop two-phase: return need_authorization first; the frontend calls
+auth-status after authorizing."</sub>
+
+```python
+        status = auth_status.get("status")
+
+        if status == "PENDING":
+            return {
+                "success": True,
+                "data": {"status": "PENDING", "message": "授权处理中"},
+            }
+
+        if status == "ISSUED":
+            result = service.create_after_authorization(
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/desktop/router.py:190`</sub>
+
+`PENDING` → keep waiting; `ISSUED` → the credential exists and the bot can
+finish being created. This is the clearest place in the codebase to see that a
+Passport is *granted*, not merely allocated.
+
+### 4.3 Use — the token reaches the device
+
+The credential only matters once the running bot holds it. At publish/bootstrap
+the backend fetches the token and passes it down to the device:
+
+```python
+            agent_pass_token = self._passport_plugin.query_token(bot_id, owner_id) or ""
+```
+
+<sub>`src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py:493`</sub>
+
+The comment above that line is worth noting: `查询 passport token（非阻塞，失败不影响
+发布）` — "non-blocking, a failure does not block the release". Publishing is not
+gated on the credential being fetchable.
+
+### 4.4 Update — scope changes over the bot's life
+
+Covered in §3. Triggered whenever the bot's grants change: MCP sync
+(`docs/mcp/README.md` §6.2), skill-set CLI changes
+(`adapters/http/skill_center/skillsets.py:1481`), admin or metadata edits.
+
+### 4.5 Freeze / unfreeze — dormancy
+
+A bot that goes dormant has its credential frozen rather than destroyed, so
+reactivation restores it. Freezing is deliberately best-effort — the device is
+already released by that point, so a failure is a billing concern, not a
+correctness one:
+
+```python
+        try:
+            self._passport_plugin.freeze_agent_passport(
+                bot_id=candidate.bot_id,
+                owner_workno=candidate.owner_id,
+                reason="dormant recycle",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[DormantBotService._execute_recycle] passport freeze failed "
+                "bot_id=%s: %s — continuing (recycle considered complete)",
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_dormant/service.py:373`</sub>
+
+Unfreeze is the opposite — strict, with a postcondition, because a bot cannot
+boot without a usable token:
+
+```python
+        """Bring the credential online and make a runtime token queryable.
+
+        Implementations must return only after ``query_token`` can provide the
+        token required by device bootstrap, or raise when that postcondition
+        cannot be established.
+        """
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:237`</sub>
+
+That asymmetry is the design: **losing a credential you're no longer using is
+tolerable; claiming to have restored one that isn't actually usable is not.**
+
+### 4.6 Destroy — bot deletion
+
+```python
+                self._passport_plugin.destroy_passport(bot_id, user_id)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py:3195`</sub>
+
+---
+
+## 5. Agent Principal and identity mode
+
+There is a second, narrower write path alongside `update_passport`:
+
+```python
+    def update_mcp_identity_to_agent_principal(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        mcp_items: list[McpScopeItem],
+    ) -> None:
+        """Replace the Agent Principal MCP scope while preserving other resources."""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:140`</sub>
+
+The distinction from §3's blanket overwrite is in the docstring: this one
+replaces the MCP scope **while preserving other resources**. It exists because
+`McpScopeItem` carries a field the plain code list cannot — `identity_mode`,
+which is `owner` or `caller`:
+
+- **owner** — the bot calls the MCP server as whoever owns the bot.
+- **caller** — the bot calls as whichever user is talking to it right now.
+
+That per-server choice is stored in `ac_bot_mcp_call_config` (see
+`docs/mcp/README.md` §3.3) and published here. Validation is strict on the way
+out, in the plugin itself:
+
+```python
+        if any(
+            not item.get("mcp_code")
+            or item.get("identity_mode") not in {"owner", "caller"}
+            for item in mcp_items
+        ):
+            raise ValueError("invalid MCP identity scope")
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:170`</sub>
+
+"Caller" mode is what makes a shared service bot possible: it acts with *your*
+authority when you talk to it, rather than silently borrowing its owner's.
+
+---
+
+## 6. What Passport is *not*
+
+Three clarifications that save a lot of confusion:
+
+**Passport does not enforce anything at tool-call time.** It is a declaration. On
+the MCP path, the thing that actually stops a bot from calling a server is the
+whitelist pushed to the device (`filter-servers`) — see `docs/mcp/README.md`
+§6.2, where the device write happens *first* and passport is only updated after
+it succeeds. Passport is the record of authority; the device is the enforcement
+point.
+
+**Passport does not hold MCP credentials.** API keys and headers for MCP servers
+live in `ac_user_mcp_config` and are inlined into the device artifact. Passport
+holds the bot's *own* credential and the *list* of servers it may use — never the
+keys for reaching them.
+
+**A Passport belongs to a bot, not to a user.** It's keyed by `bot_id` with the
+owner (`owner_workno`) alongside for authorization. One user with ten bots has
+ten Passports.
+
+---
+
+## 7. Where MCP touches Passport
+
+For readers arriving from the MCP walkthrough, the full intersection:
+
+| MCP doc | What it does with Passport | Call |
+| --- | --- | --- |
+| §6.2 | After the device whitelist lands, publishes the new MCP code list | `update_passport(resource_scope=...)` |
+| §6.5 | Reads CLI scope back so the MCP write doesn't erase it | `query_passport_clis` |
+| §6.9 | Strips LOCAL/stdio servers — no permission system grants those | `passport_mcp_items_from_entries` |
+| §3.3 | Publishes owner-vs-caller identity per server | `update_mcp_identity_to_agent_principal` |
+
+The filter in §6.9 is worth restating from the Passport side, because it explains
+*why* the two lists differ:
+
+```python
+def filter_passport_mcp_codes(
+    mcp_codes: Iterable[str],
+    *,
+    local_registry: LocalMCPRegistry | None = None,
+) -> list[str]:
+    """Return MCP codes that should be declared to the passport service.
+
+    LOCAL/stdio MCP servers are runtime-local capabilities. They still need to
+    be synced to the device, but the passport service does not own their permission scope.
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/passport_scope.py:11`</sub>
+
+The device list and the Passport list are deliberately not the same list. A
+stdio server running inside the bot's own container isn't something an external
+authority grants.
+
+---
+
+## 8. Deployment profiles
+
+Same pattern as the rest of the codebase — one Protocol, three implementations:
+
+| Profile | Implementation | Behaviour |
+| --- | --- | --- |
+| corp | `ProdPassportPlugin` (not in this repo) | Real tcauthmng / AgentPass calls |
+| community | `SelfIssuedPassportPlugin` | Self-issues a deterministic token; scope updates are no-ops |
+| local / test | `LocalPassportPlugin` | Mock seam; logs writes, returns a mock token |
+
+The community implementation is the interesting one, because it explains what
+Passport is *for* by describing what happens when there's nobody to ask:
+
+```python
+"""SelfIssuedPassportPlugin — community bot-credential broker.
+
+The corp ``PassportPlugin`` brokers per-bot "agent passport" credentials through
+tcauthmng/AgentPass. A community deployment is the sole authority over its own
+bots, so it **self-issues** those credentials locally: a deterministic, stateless
+function of ``bot_id`` — no external approval system, no consent step, no I/O.
+"""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:1`</sub>
+
+```python
+def _token_for(bot_id: str) -> str:
+    return f"community-passport-{bot_id}"
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:34`</sub>
+
+A community deployment is its own authority, so consent is vacuous and the token
+is an inert bearer placeholder. Everything above still runs — the calls, the
+snapshot discipline, the validation — it just resolves locally. The local/test
+plugin is explicit that it proves nothing about the real integration:
+
+```python
+    """Local Mock 实现 —— 不代表 AgentPass 真集成。
+
+    所有写操作仅打日志、apply_*/query_* 返回 mock token，**不**向 tcauthmng/AgentPass
+    发任何请求。本地无法验证 AgentPass 端真实写入/生效；admin 同步的真实回执只能 prod 验证。
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/local/passport.py:32`
+— "Local mock — not a real AgentPass integration. All writes only log; `apply_*`
+/ `query_*` return a mock token and send nothing to tcauthmng/AgentPass. Real
+write-through cannot be verified locally."</sub>
+
+---
+
+## 9. Reading order & test map
+
+1. `plugin_api/passport.py` — the whole contract in one file (283 lines). Read
+   the four types at the top before the Protocol.
+2. `plugin_api/passport.py:90` — `unpack_resource_scope`, i.e. §3's rule as code.
+3. `plugins/community/passport.py` — a complete implementation, small enough to
+   read end to end.
+4. `core/bot_management/create_flow.py:204` — where a Passport is born.
+5. `core/mcp/services/sync_service.py:849` — the most careful caller of
+   `update_passport` in the repo, and a good template for writing another one.
+
+| Test | Covers |
+| --- | --- |
+| `src/backend/tests/community/contracts/test_passport.py` | `PassportPlugin` conformance |
+| `src/backend/tests/community/plugins/community/test_passport.py` | Self-issued implementation |
+| `src/backend/tests/community/plugins/test_passport_save_sub_resources.py` | Second-level resource sync |
+| `src/backend/tests/community/services/test_bot_passport.py` | Bot-lifecycle integration |
+| `src/backend/tests/community/core/mcp/services/test_caller_identity_principal_sync.py` | Agent Principal identity scope |
+| `src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py` | Repair path for missing Passports |
+
+Related docs:
+
+- [`src/backend/docs/mcp/README.md`](../mcp/README.md) — the MCP walkthrough this
+  one accompanies.
+- `src/backend/specs/2026-07-10-dormant-unfreeze-passport-one/` — the freeze /
+  unfreeze postcondition, specified.

--- a/src/backend/docs/passport/README.zh-CN.md
+++ b/src/backend/docs/passport/README.zh-CN.md
@@ -1,0 +1,473 @@
+# Passport —— bot 的身份凭证
+
+[English](README.md) | **简体中文**
+
+Passport 是什么、它装了些什么、一个 bot 如何获得它又如何失去它，以及关于"更新它"的那条
+最重要的规则 —— 其余所有代码都在防它。本文是
+[`docs/mcp/README.zh-CN.md`](../mcp/README.zh-CN.md) 的配套：MCP 同步会写 Passport，
+§7 把两者对照起来。但 Passport 本身是独立的一件事，这篇文档可以单独读。
+
+下文每一段代码都逐字引自本仓库，并附带可点击的 `path:line` 引用。
+
+---
+
+## 1. 一句话版本
+
+**Passport 是一个 bot 的身份证件。** 它用一份凭证回答"这个 bot 是谁"，让 bot 能向各类
+服务出示；又用一份授权清单回答"这个 bot 被允许触达什么"。
+
+这个名字本身就是最好的比方，而且相当贴切：
+
+| 人的护照 | bot 的 Passport |
+| --- | --- |
+| 资料页 —— 姓名、证件号 | `agent_id`、`agent_code`、`credential_id` |
+| 证件本身，过关时出示 | `token` —— 下发给设备，随出站调用一起带上 |
+| 签证 —— 可以进哪些国家 | `resourceManifest` —— 可以用哪些 MCP server 和 CLI |
+| 有效 / 过期 / 吊销 | `PENDING` → `ISSUED` → 冻结 → 销毁 |
+
+为什么 bot 需要自己的证件，而不是借用它主人的：bot 是自己在跑的 —— 按计划任务、在容器里，
+在创建它的那个人早就关掉页面之后很久。总得有某个东西能说明"这个请求来自 bot X，它被授权做
+Y"，而这句话背后没有任何人的登录会话。
+
+对外这个服务叫 **AgentPass / tcauthmng**；在本仓库里它藏在一个 Protocol 之后：
+
+```python
+@runtime_checkable
+class PassportPlugin(Plugin, Protocol):
+    """Plugin for passport lifecycle management (tcauthmng facade)."""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:117`</sub>
+
+---
+
+## 2. 一份 Passport 究竟装了什么
+
+看它被读回来时的结构最直观。下面是 gateway 契约测试锁定的 schema 快照：
+
+```json
+{
+  "access_mode": {"type": "string"},
+  "agent_code": {"type": "string"},
+  "agent_id": {"type": "string"},
+  "certificate_url": {"type": "string"},
+  "credential_id": {"type": "string"},
+  "expire_at": {"type": "string"},
+  "mcps": {"type": "array", "items": {"...": "mcp_code / mcp_name / mcp_desc"}}
+}
+```
+
+<sub>`src/backend/tests/community/contracts/gateway/schema_snapshots/response_data/rule01_GET_api_bots_id_passport.json`
+（有删减）</sub>
+
+三组内容，在脑子里分开放会省很多事：
+
+**1. 身份。** `agent_id` / `agent_code` / `credential_id` / `certificate_url` /
+`expire_at`，外加需要单独去取的 `token`。这部分回答"是谁"。
+
+**2. 范围 —— 即 `resourceManifest`。** 目前有两种资源类型，MCP server 和 CLI，各自是一个
+带类型的条目：
+
+```python
+class CliItem(TypedDict, total=False):
+    """CLI scope item supplied by AgentPass query responses."""
+
+    cli_code: str | None
+    cli_name: str | None
+    cli_desc: str | None
+
+
+class McpScopeItem(TypedDict, total=False):
+    """Provider-neutral MCP resource item for Agent Principal updates."""
+
+    mcp_code: str
+    mcp_name: str | None
+    mcp_desc: str | None
+    identity_mode: str
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:41`</sub>
+
+**3. 状态。** 审批未完成时是 `PENDING`，授予后是 `ISSUED`，bot 休眠时被冻结，bot 删除
+时消失。§4 会走一遍。
+
+---
+
+## 3. 最重要的一条规则：更新是覆盖，不是合并
+
+如果这篇文档你只记住一件事，就记这条。
+
+`updatePassport` 对每一类资源列表都是**整体替换**，而不是并入。只提交
+`{mcp_codes: [...]}`，这个 bot 的 CLI 授权就没了 —— 不是被拒绝，不是被合并，而是*被悄无
+声息地替换成空*。建模这次调用的类型在 docstring 里写明了这一点：
+
+```python
+class PassportResourceScope(TypedDict, total=False):
+    """Complete resourceManifest scope for overwrite-style updatePassport calls.
+
+    AgentPass/tcauthmng treats each resource list in updatePassport as a full
+    replacement. Callers that update MCP or CLI scope must pass both lists here
+    so one resource type does not accidentally clear the other.
+    """
+
+    mcp_codes: list[str]
+    mcp_items: list[McpScopeItem]
+    cli_items: list[CliItem]
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:58`</sub>
+
+由此产生两条推论，塑造了各处调用方的写法：
+
+**A. 任何要改范围的人，必须先把自己不改的那部分读回来。** 这就是为什么只关心 MCP 的同步
+逻辑，在写入前要去查这个 bot 的 **CLI** 范围（见 `docs/mcp/README.zh-CN.md` §6.5）：
+
+```python
+            # resource_scope 是完整快照：MCP 来自同步结果，CLI 来自当前许可证 + 引擎默认 CLI。
+            self.passport_update.update_passport(
+                bot_id=bot_id,
+                user_id=user_id,
+                resource_scope={
+                    "mcp_codes": synced_server_codes,
+                    "cli_items": cli_items,
+                },
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/sync_service.py:913`</sub>
+
+**B. 完全不传 `resource_scope`，才是"别动授权"的表达方式。** 只改元数据的更新（改名、
+改管理员）什么范围都不传；负责解包这个字段的 helper 把这种情况显式编码成 `None`：
+
+```python
+def unpack_resource_scope(
+    resource_scope: PassportResourceScope | None,
+) -> tuple[list[McpScopeItem] | None, list[CliItem] | None]:
+    """Return DTO-ready MCP/CLI lists, or None pair for non-resource updates.
+
+    Non-resource updates, such as admins or metadata, intentionally omit
+    resource_scope so existing MCP/CLI grants are left untouched.
+    """
+    if resource_scope is None:
+        return None, None
+    try:
+        cli_items = resource_scope["cli_items"]
+    except KeyError as e:
+        raise ValueError(
+            "resource_scope must include mcp_codes and cli_items"
+        ) from e
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:90`</sub>
+
+注意那个 `KeyError → ValueError`：传一份**残缺的**范围会直接报错。安全的状态只有两个 ——
+"完整快照"和"什么都不传"；危险的中间态在边界上就被挡掉了。community 实现明明没有外部注册
+中心要通知，却依然调用这次解包，就是为了让这道校验在每种部署形态下都活着：
+
+```python
+        # No external registry to notify — scope/admin changes are a no-op.
+        # ``unpack_resource_scope`` is still called so a malformed scope raises
+        # the same ValueError the corp impl would, keeping callers honest.
+        unpack_resource_scope(resource_scope)
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:53`</sub>
+
+---
+
+## 4. 生命周期
+
+### 4.1 申请 —— 在 bot 创建时
+
+bot 的 Passport 是作为创建流程的一部分申请下来的；而且用户创建的**第一个** bot 走的是另一个
+调用（首次申请涉及一次用户尚未给出的授权）：
+
+```python
+    apply = (
+        passport_plugin.apply_first_agent_passport
+        if is_first_bot
+        else passport_plugin.apply_agent_passport
+    )
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_management/create_flow.py:204`</sub>
+
+注意传进去的东西：`mcp_codes` 和 `cli_items` 是**申请的入参**。一个 bot 的初始范围是在它
+出生时就声明的，不是事后补挂上去的。
+
+拿到的 `agent_code` 会持久化到 bot 记录上，省得后面的代码再去查一次：
+
+```python
+def _build_ext(
+    *, avatar_url: str | None, agent_code: str | None, issued: bool = False
+) -> dict[str, Any] | None:
+    """Assemble the bot's ``ext`` payload; ``None`` when there is nothing to store."""
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_management/create_flow.py:227`</sub>
+
+### 4.2 授权步骤 —— 为什么创建有时是两段式
+
+对桌面版 bot，申请可能返回"需要人来批"。于是创建被拆成两段：先申请、返回"需要授权"并给出
+一个链接，然后轮询：
+
+```python
+        # 桌面版两段式：先返回 need_authorization，前端授权后再调 auth-status
+        if result.get("need_authorization"):
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/desktop/router.py:120`</sub>
+
+```python
+        status = auth_status.get("status")
+
+        if status == "PENDING":
+            return {
+                "success": True,
+                "data": {"status": "PENDING", "message": "授权处理中"},
+            }
+
+        if status == "ISSUED":
+            result = service.create_after_authorization(
+```
+
+<sub>`src/backend/src/agentclaw/community/adapters/http/desktop/router.py:190`</sub>
+
+`PENDING` → 继续等；`ISSUED` → 凭证已存在，bot 可以完成创建。这是全仓最能直观看出"Passport
+是被**授予**的，而不只是被分配的"的地方。
+
+### 4.3 使用 —— token 抵达设备
+
+凭证只有在运行中的 bot 手里才有意义。发布 / 启动时，backend 取出 token 并下发给设备：
+
+```python
+            agent_pass_token = self._passport_plugin.query_token(bot_id, owner_id) or ""
+```
+
+<sub>`src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py:493`</sub>
+
+这一行上方的注释值得留意：`查询 passport token（非阻塞，失败不影响发布）`。发布并不以
+"能取到凭证"为前置条件。
+
+### 4.4 更新 —— 范围在 bot 生命周期里的变化
+
+见 §3。凡是 bot 的授权发生变化就会触发：MCP 同步（`docs/mcp/README.zh-CN.md` §6.2）、
+skill set 的 CLI 变更（`adapters/http/skill_center/skillsets.py:1481`）、管理员或元
+数据修改。
+
+### 4.5 冻结 / 解冻 —— 休眠
+
+进入休眠的 bot，凭证是被**冻结**而不是销毁的，这样重新激活时能恢复。冻结是刻意做成
+best-effort 的 —— 走到这一步设备早已释放，失败最多是计费上的浪费，不影响正确性：
+
+```python
+        try:
+            self._passport_plugin.freeze_agent_passport(
+                bot_id=candidate.bot_id,
+                owner_workno=candidate.owner_id,
+                reason="dormant recycle",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[DormantBotService._execute_recycle] passport freeze failed "
+                "bot_id=%s: %s — continuing (recycle considered complete)",
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_dormant/service.py:373`</sub>
+
+解冻恰好相反 —— 严格，并且带后置条件，因为 bot 没有可用 token 就起不来：
+
+```python
+        """Bring the credential online and make a runtime token queryable.
+
+        Implementations must return only after ``query_token`` can provide the
+        token required by device bootstrap, or raise when that postcondition
+        cannot be established.
+        """
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:237`
+—— "必须在 `query_token` 能提供设备启动所需的 token 之后才返回；无法建立该后置条件时必须
+抛错。"</sub>
+
+这种不对称正是设计本身：**丢掉一份你已经不用的凭证是可以接受的；声称恢复了一份其实不可用的
+凭证则不可以。**
+
+### 4.6 销毁 —— bot 删除
+
+```python
+                self._passport_plugin.destroy_passport(bot_id, user_id)
+```
+
+<sub>`src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py:3195`</sub>
+
+---
+
+## 5. Agent Principal 与身份模式
+
+除了 `update_passport`，还有一条更窄的写入路径：
+
+```python
+    def update_mcp_identity_to_agent_principal(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        mcp_items: list[McpScopeItem],
+    ) -> None:
+        """Replace the Agent Principal MCP scope while preserving other resources."""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugin_api/passport.py:140`</sub>
+
+它与 §3 那种全量覆盖的差别就写在 docstring 里：这一个替换 MCP 范围，但**保留其他资源**。
+它之所以存在，是因为 `McpScopeItem` 带着一个纯 code 列表装不下的字段 —— `identity_mode`，
+取值 `owner` 或 `caller`：
+
+- **owner** —— bot 以"谁拥有这个 bot"的身份去调 MCP server。
+- **caller** —— bot 以"此刻正在跟它说话的那个用户"的身份去调。
+
+这个"每个 server 一个选择"存在 `ac_bot_mcp_call_config`（见
+`docs/mcp/README.zh-CN.md` §3.3），并在这里发布出去。发布时校验很严，就在插件内部：
+
+```python
+        if any(
+            not item.get("mcp_code")
+            or item.get("identity_mode") not in {"owner", "caller"}
+            for item in mcp_items
+        ):
+            raise ValueError("invalid MCP identity scope")
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:170`</sub>
+
+`caller` 模式正是"共享的服务型 bot"能够成立的前提：你跟它说话时它用*你的*权限办事，而不是
+默默借用它主人的。
+
+---
+
+## 6. Passport **不是**什么
+
+三点澄清，能省掉很多困惑：
+
+**Passport 在工具调用时不做任何强制。** 它是一份声明。在 MCP 这条路径上，真正阻止 bot 调用
+某个 server 的，是推到设备上的白名单（`filter-servers`）—— 见 `docs/mcp/README.zh-CN.md`
+§6.2：设备写入在**前**，passport 只在设备成功之后才更新。**Passport 是权限的记录，设备才是
+执行点。**
+
+**Passport 不保存 MCP 凭据。** MCP server 的 API key 和 header 存在
+`ac_user_mcp_config` 里，并被内联进设备产物。Passport 保存的是 bot *自己的*凭证，以及它可用
+server 的*名单* —— 从不保存连上这些 server 所需的钥匙。
+
+**Passport 属于 bot，不属于用户。** 它以 `bot_id` 为键，`owner_workno`（拥有者）只是用于
+鉴权。一个用户有十个 bot，就有十份 Passport。
+
+---
+
+## 7. MCP 在哪些地方碰到 Passport
+
+给从 MCP 走查过来的读者，这是完整的交集：
+
+| MCP 文档 | 对 Passport 做了什么 | 调用 |
+| --- | --- | --- |
+| §6.2 | 设备白名单落地后，发布新的 MCP code 列表 | `update_passport(resource_scope=...)` |
+| §6.5 | 把 CLI 范围读回来，避免这次 MCP 写入把它抹掉 | `query_passport_clis` |
+| §6.9 | 剔除 LOCAL/stdio server —— 没有权限系统会为它们授权 | `passport_mcp_items_from_entries` |
+| §3.3 | 按 server 发布 owner / caller 身份 | `update_mcp_identity_to_agent_principal` |
+
+§6.9 的那道过滤值得从 Passport 这一侧再说一遍，因为它解释了两份列表*为什么*不一样：
+
+```python
+def filter_passport_mcp_codes(
+    mcp_codes: Iterable[str],
+    *,
+    local_registry: LocalMCPRegistry | None = None,
+) -> list[str]:
+    """Return MCP codes that should be declared to the passport service.
+
+    LOCAL/stdio MCP servers are runtime-local capabilities. They still need to
+    be synced to the device, but the passport service does not own their permission scope.
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/core/mcp/services/passport_scope.py:11`</sub>
+
+发给设备的列表和发给 Passport 的列表，是刻意不相同的。一个跑在 bot 自己容器里的 stdio
+server，本来就不是外部权威能"授予"的东西。
+
+---
+
+## 8. 部署形态
+
+和仓库其余部分同一个套路 —— 一个 Protocol，三种实现：
+
+| 形态 | 实现 | 行为 |
+| --- | --- | --- |
+| corp | `ProdPassportPlugin`（不在本仓库） | 真实调用 tcauthmng / AgentPass |
+| community | `SelfIssuedPassportPlugin` | 本地自签一个确定性 token；范围更新是 no-op |
+| local / test | `LocalPassportPlugin` | Mock seam；写操作只打日志，返回 mock token |
+
+community 实现最有意思，因为它用"没有人可问时会发生什么"反过来说明了 Passport 是**干什么
+用的**：
+
+```python
+"""SelfIssuedPassportPlugin — community bot-credential broker.
+
+The corp ``PassportPlugin`` brokers per-bot "agent passport" credentials through
+tcauthmng/AgentPass. A community deployment is the sole authority over its own
+bots, so it **self-issues** those credentials locally: a deterministic, stateless
+function of ``bot_id`` — no external approval system, no consent step, no I/O.
+"""
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:1`
+—— "community 部署对自己的 bot 就是唯一权威，因此在本地**自签**这些凭证：一个由 `bot_id`
+决定的确定性无状态函数 —— 没有外部审批系统，没有授权步骤，没有 I/O。"</sub>
+
+```python
+def _token_for(bot_id: str) -> str:
+    return f"community-passport-{bot_id}"
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/community/passport.py:34`</sub>
+
+community 部署自己就是权威，所以"授权"这一步是空的，token 也只是一个惰性的 bearer 占位符。
+但上面讲的一切仍然照常运行 —— 调用、快照纪律、校验，只是就地解析掉了。local/test 插件则明确
+声明它证明不了真集成的任何事：
+
+```python
+    """Local Mock 实现 —— 不代表 AgentPass 真集成。
+
+    所有写操作仅打日志、apply_*/query_* 返回 mock token，**不**向 tcauthmng/AgentPass
+    发任何请求。本地无法验证 AgentPass 端真实写入/生效；admin 同步的真实回执只能 prod 验证。
+    """
+```
+
+<sub>`src/backend/src/agentclaw/community/plugins/local/passport.py:32`</sub>
+
+---
+
+## 9. 阅读顺序与测试地图
+
+1. `plugin_api/passport.py` —— 整份契约就在这一个文件里（283 行）。先看顶部那四个类型，
+   再看 Protocol。
+2. `plugin_api/passport.py:90` —— `unpack_resource_scope`，也就是 §3 那条规则的代码形态。
+3. `plugins/community/passport.py` —— 一份完整实现，小到可以从头读到尾。
+4. `core/bot_management/create_flow.py:204` —— Passport 诞生的地方。
+5. `core/mcp/services/sync_service.py:849` —— 全仓对 `update_passport` 最谨慎的调用方，
+   也是你要再写一个调用方时最好的模板。
+
+| 测试 | 覆盖 |
+| --- | --- |
+| `src/backend/tests/community/contracts/test_passport.py` | `PassportPlugin` 一致性 |
+| `src/backend/tests/community/plugins/community/test_passport.py` | 自签实现 |
+| `src/backend/tests/community/plugins/test_passport_save_sub_resources.py` | 二级资源同步 |
+| `src/backend/tests/community/services/test_bot_passport.py` | bot 生命周期集成 |
+| `src/backend/tests/community/core/mcp/services/test_caller_identity_principal_sync.py` | Agent Principal 身份范围 |
+| `src/backend/tests/community/core/bot_management/services/test_default_bot_passport_repair_service.py` | Passport 缺失时的修复路径 |
+
+相关文档：
+
+- [`src/backend/docs/mcp/README.zh-CN.md`](../mcp/README.zh-CN.md) —— 本文配套的
+  MCP 走查。
+- `src/backend/specs/2026-07-10-dormant-unfreeze-passport-one/` —— 冻结 / 解冻后置条件的
+  规格文档。

--- a/src/backend/src/agentclaw/community/core/mcp/README.md
+++ b/src/backend/src/agentclaw/community/core/mcp/README.md
@@ -3,7 +3,8 @@
 MCP (Model Context Protocol) domain — config, auth, and sync for MCP servers bound to bots/devices.
 
 For an end-to-end walkthrough of how MCP works across backend, device, and
-engine, see [`src/backend/docs/mcp/README.md`](../../../../../docs/mcp/README.md).
+engine, see [`src/backend/docs/mcp/README.md`](../../../../../docs/mcp/README.md)
+([简体中文](../../../../../docs/mcp/README.zh-CN.md)).
 
 ## Context Boundary
 

--- a/src/backend/src/agentclaw/community/core/mcp/README.md
+++ b/src/backend/src/agentclaw/community/core/mcp/README.md
@@ -2,6 +2,9 @@
 
 MCP (Model Context Protocol) domain — config, auth, and sync for MCP servers bound to bots/devices.
 
+For an end-to-end walkthrough of how MCP works across backend, device, and
+engine, see [`src/backend/docs/mcp/README.md`](../../../../../docs/mcp/README.md).
+
 ## Context Boundary
 
 ```yaml


### PR DESCRIPTION
Two subsystem walkthroughs, each in English and Simplified Chinese, aimed at someone who has never worked with these and needs to understand how ours are built. Both use the language-switcher convention the `openapi-v1` docs already use, and every code block is quoted verbatim with a `path:line` reference.

- `src/backend/docs/mcp/README.md` (+ `README.zh-CN.md`)
- `src/backend/docs/passport/README.md` (+ `README.zh-CN.md`)

The `mcp` module already has a README, but that is the machine-checked Context Boundary (Rule 22) — it lists `provides`/`consumes` for the arch test and explains nothing about how the thing works. Nothing in the repo traced either path.

## MCP walkthrough

Organised around one framing: an MCP integration needs a **catalog**, a **credential + scope**, and **delivery to the runtime** — and Avernet owns exactly one of the three.

| Concern | Owner |
| --- | --- |
| Catalog | MCP Center (external), behind `MCPCenterPlugin` — no local table |
| Credential + scope | backend — `ac_user_mcp_config`, skill sets, `ac_bot_mcp_call_config` |
| Delivery + execution | engine on the device — `mcporter.json` |

Sections:

1. What MCP is, and the three-way split above.
2. A map, including the fact that `/api/mcp` names **two** different APIs (backend user-facing vs engine device-side).
3. What we actually store — the three tables, plus the per-engine default server lists.
4. The four services (`Market` / `Auth` / `Config` / `Sync`), their DI wiring, and the construction cycle `MCPSyncService` breaks with lazy thunks.
5. **Walkthrough A — a user saves an API key.** The validate → external-check → DB-write → device-push → rollback ordering, the `None`-means-unchanged merge rule, the `x-ling-auth` collision rule, and why a device that lacks the server isn't a failure.
6. **Walkthrough B — a bot's toolset changes.** Opens with the distinction the rest of the path depends on: the system syncs **scope** (which servers are allowed → device whitelist + passport) and **detail** (how to reach each one → `mcporter.json`) as two independent things, always pushed in pairs. Then: the four events that trigger the path and why two of them run the pair in the opposite order; why an empty allow-list must still be pushed (revocation is exactly that case); active-vs-all collection behind `BotMCPProvider`; the passport read-back that stops an MCP sync from silently erasing a bot's CLI grants; the throttled fan-out; the `DeviceSyncPlugin` boundary and its two delivery shapes; plaintext credential inlining; and owner-vs-caller identity at publish time.
7. What happens on the device — `mcporter.json` edits, the `__EMPTY_FILTER_DISABLE_ALL__` sentinel, `mcporter call`, transport model, capability guards.
8. **Where PR #564 fits** — why `(user_id, server_code, env)` is not tenant-safe, the Track A / Track B rule, the Stage 1 guard mechanism, and which two models Stage 5 touches (including why `ac_bot_mcp_call_config` is the judgement call). Notes that 4 of the 6 `mcp` endpoints need no Stage 5 work because MCP Center backs them.
9. Deploy profiles — why the community build works with an empty catalog, and the live `tools/list` fetch path.
10. Reading order and a test map.

## Passport walkthrough

The MCP doc leans on Passport in three places (§6.2, §6.5, §6.9) without ever saying what it is. Passport is bigger than that intersection — it's the bot's identity credential across creation, publish, dormancy and deletion — so it gets its own doc rather than distorting the MCP one. Both are cross-linked in both editions.

1. The one-sentence version, via the analogy the name implies: identity page (`agent_code` / `token`), visas (`resourceManifest` of MCP + CLI), validity (`PENDING` → `ISSUED` → frozen → destroyed). Plus why a bot needs its own document rather than borrowing its owner's.
2. What a Passport holds, read off the gateway contract snapshot.
3. **Updates are overwrites** — the rule everything else defends against. `updatePassport` replaces each resource list, so a caller touching MCP must read CLI back first, and omitting `resource_scope` entirely is how you say "don't touch the grants". A partial scope raises.
4. The lifecycle: apply at creation (first-bot vs not), the two-phase consent step for desktop bots, `query_token` reaching the device at publish, scope updates, freeze/unfreeze on dormancy — including why freeze is best-effort and unfreeze has a strict postcondition — and destroy on deletion.
5. Agent Principal and `identity_mode` — owner vs caller, and why "caller" is what makes a shared service bot possible.
6. **What Passport is not:** not an enforcement point (the device whitelist is), not where MCP credentials live, and per-bot rather than per-user.
7. Where MCP touches Passport — a table mapping to the MCP doc's sections.
8. Deployment profiles — corp / community self-issued / local mock.
9. Reading order and a test map.

## Also changed

`core/mcp/README.md` gets a two-line pointer to both MCP editions, above the `## Context Boundary` section so the arch-test parser is unaffected.

## On the Chinese editions

Same sections, same quoted snippets, same `path:line` refs — code blocks are left verbatim so neither edition drifts from the source. Where a quoted English docstring is itself the point being made, the translation follows it inline rather than replacing it. Cross-links point at the `zh-CN` edition of a sibling doc where one exists.

## Testing

Docs only — no code, no schema, no endpoint. Verified: every quoted snippet matches its cited `path:line`, every referenced file and test path exists, all relative cross-links resolve, and each doc's two editions match on heading count, code-fence count, and reference count. CI green on all 7 checks as of the previous commit.