### PR TITLE
fix(bcs): exclude deleted friends from /bots/{id}/friends

### DIFF
--- a/src/bcs/crates/services/bcs-friend/src/application/friends.rs
+++ b/src/bcs/crates/services/bcs-friend/src/application/friends.rs
@@ -204,7 +204,16 @@ impl FriendService for Friend {
                 let is_online = self.registry.is_effectively_online(&uuid).await;
                 (bot.capabilities.name, bot.capabilities.summary, is_online)
             } else {
-                (None, None, false)
+                // The friend bot is deleted or no longer registered.
+                // `BotRegistryCoreService::get` returns `None` for soft-deleted bots
+                // (bcs_bots.is_deleted = 1) and for unknown ids, so a missing entry
+                // means the friendship should not be surfaced. Exclude it instead of
+                // returning a null-named stub entry.
+                tracing::debug!(
+                    friend_uuid = %uuid,
+                    "skipping friend that is deleted or no longer registered"
+                );
+                continue;
             };
             let dynamic_status = DynamicStatusResponse {
                 status: if is_online { "active" } else { "offline" }.to_string(),

--- a/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
+++ b/src/bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs
@@ -8,7 +8,8 @@ use bcs_friend::{
 use bcs_service_api::{
     ActorKind, ActorStatus, AgentCredentials, BotCapabilities, BotDynamicStatus,
     BotRegistryCoreService, FriendCoreService, FriendRequestCoreService, FriendRequestDirection,
-    FriendRequestRepoPort, FriendRequestStatus, RegisteredBot, ServiceError, ServiceResult,
+    FriendRequestRepoPort, FriendRequestStatus, FriendService, ListFriendsCommand, RegisteredBot,
+    ServiceError, ServiceResult,
 };
 use bcs_test_support::{
     NoopBotRegistryCoreService, NoopFriendCoreService, NoopFriendRequestCoreService,
@@ -180,6 +181,55 @@ async fn friend_use_case_passes_application_contract() {
     );
 
     bcs_test_support::contract::application::friend_service_contract_tests(&svc).await;
+}
+
+#[tokio::test]
+async fn list_friends_excludes_deleted_or_unregistered_peers() {
+    // alice is friends with bob (live) and carol (deleted / no longer registered).
+    // `StaticRegistry` only knows alice and bob, so `get("carol")` returns `None`,
+    // which is exactly how the listing path observes a soft-deleted friend.
+    let friend_repo = Arc::new(MemoryFriendRepo::new());
+    let friend_core = Arc::new(FriendCore::with_repo(friend_repo));
+    friend_core
+        .add_friendship("alice", "bob")
+        .await
+        .expect("add alice-bob friendship");
+    friend_core
+        .add_friendship("alice", "carol")
+        .await
+        .expect("add alice-carol friendship");
+
+    let svc = Friend::new(
+        Arc::new(StaticRegistry::new(&[
+            ("alice", "protected", ActorKind::Bot),
+            ("bob", "protected", ActorKind::Bot),
+            // carol is intentionally omitted: it simulates a deleted friend.
+        ])),
+        friend_core,
+        Arc::new(NoopFriendRequestCoreService),
+        Arc::new(NoopRelationCoreService),
+    );
+
+    // Caller == target short-circuits the ownership check, so the only thing
+    // exercising the filter is the enrichment loop in `list_friends`.
+    let friends = svc
+        .list_friends(ListFriendsCommand {
+            caller_actor_id: "alice".to_string(),
+            target_actor_id: "alice".to_string(),
+        })
+        .await
+        .expect("list friends for alice");
+
+    assert_eq!(
+        friends.len(),
+        1,
+        "deleted/unregistered friends must be excluded from the list"
+    );
+    assert_eq!(friends[0].bot_uuid, "bob");
+    assert!(
+        friends.iter().all(|entry| entry.bot_uuid != "carol"),
+        "carol (deleted) must not appear in the friend list"
+    );
 }
 
 fn core_fixture(


### PR DESCRIPTION
## Summary

`GET /bots/{botId}/friends` returned friend relations that included **already-deleted friends**. When a bot is deleted, BCS soft-deletes its `bcs_bots` row (`is_deleted = 1`) but never cleans up its `bcs_friendships` rows, so those entries survive the deletion. The listing path then enriches each peer via `BotRegistryCoreService::get`, which returns `None` for deleted bots — and the `None` branch emitted a null-named stub (`name=null, is_online=false`) instead of excluding the friend. As a result, deleted friends leaked into the response as null-named entries.

Fixes #577.

## Root cause

- `bcs_friendships` has **no** lifecycle/status column, so a row only means "friends". There is no single-pair "unfriend"; the only removal is `remove_all_friendships` (hard `DELETE` of all of a bot's friendships), and that cleanup is **not** wired into the bot-deletion flow. So a soft-deleted bot's friendship rows are never removed.
- `DbFriendStore::list_friends` SELECTs all friendship rows (env-scoped only) and the application service enriches each peer via `BotRegistryCoreService::get(&uuid)`. For a soft-deleted peer, `get` returns `None` (it filters `is_deleted = 0`).
- In the `None` branch the code still pushed a stub entry instead of skipping it:
  ```rust
  } else {
      (None, None, false)   // deleted/gone friend still included as a null-named stub
  };
  ```

## Change

In the `list_friends` enrichment loop (`src/bcs/crates/services/bcs-friend/src/application/friends.rs`), when `get(&uuid)` returns `None`, **skip** the peer (`continue`) instead of emitting a stub.

Why this layer:
- Matches the existing curation rule in the same loop, which already skips `ActorKind::Human`.
- Keeps the friend store decoupled from `bcs_bots` — layering forbids joining `is_deleted` inside the `list_friends` SQL.
- Covers both the bot and `human_` target branches since they share the enrichment loop.

```rust
} else {
    // The friend bot is deleted or no longer registered.
    tracing::debug!(friend_uuid = %uuid, "skipping friend that is deleted or no longer registered");
    continue;
};
```

## Verification

- New regression test `list_friends_excludes_deleted_or_unregistered_peers` in `bcs/crates/services/bcs-friend/tests/conformance_friend_services.rs`, using the existing `StaticRegistry` stub (returns `None` for unregistered/deleted bots).
- Confirmed the test **fails without the fix** (`len == 2` — deleted `carol` leaks) and **passes with it** (`len == 1` — only `bob`).
- Full `bcs-friend` suite: **8/8 pass**.
- `bcs-http` friends route contract tests: **4/4 pass**; the entire consumer chain (`bcs-bot`, `bcs-group`, `bcs-callback`, `bcs-services-container`, `bcs-test-support`) compiled cleanly.

## Out of scope (noted in #577)

Stale `bcs_friendships` rows for deleted bots still linger on disk after this fix — the listing no longer surfaces them, but a deeper cleanup would wire `remove_all_friendships` / `cancel_pending_requests` into the bot-deletion flow. That is a separate change and not required to satisfy the endpoint guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)