### PR TITLE
fix(bcs): thread content_type through session file prepare + CLI upload PUT

### DIFF
--- a/src/bcs/crates/plugins/bcs-storage-baas/src/lib.rs
+++ b/src/bcs/crates/plugins/bcs-storage-baas/src/lib.rs
@@ -213,6 +213,7 @@ impl StoragePlugin for BaasStoragePlugin {
         let base = self.base_for_session(session_id);
         let body = serde_json::json!({
             "filename": req.file_name,
+            "content_type": req.mime_type,
             "file_size": req.size,
             "expire_seconds": req.ttl_secs,
             "staging_subdir": serde_json::Value::Null,

--- a/src/bcs/crates/plugins/bcs-storage-baas/tests/prepare.rs
+++ b/src/bcs/crates/plugins/bcs-storage-baas/tests/prepare.rs
@@ -33,7 +33,7 @@ async fn prepare_single_returns_direct_url_and_transfer_id() {
     Mock::given(method("POST"))
         .and(path("/api/v1/sessions/teamclaw/sid/files/upload-url"))
         .and(body_partial_json(
-            json!({"filename":"f","file_size":5,"staging_subdir":null}),
+            json!({"filename":"f","file_size":5,"content_type":"application/octet-stream","staging_subdir":null}),
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "code":0,"message":"success","data":{
@@ -152,7 +152,7 @@ async fn prepare_passes_caller_as_operator() {
     Mock::given(method("POST"))
         .and(path("/api/v1/sessions/teamclaw/sid/files/upload-url"))
         .and(body_partial_json(
-            json!({"operator": "human:human_123"}),
+            json!({"operator": "human:human_123", "content_type": "application/octet-stream"}),
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "code":0,"message":"success","data":{
@@ -170,4 +170,23 @@ async fn prepare_passes_caller_as_operator() {
     });
     let r = p.prepare_upload(req(5), caller).await.unwrap();
     assert_eq!(r.handle.backend_handle["transfer_id"], "t-operator");
+}
+
+#[tokio::test]
+async fn prepare_passes_request_mime_type_as_content_type() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/sessions/teamclaw/sid/files/upload-url"))
+        .and(body_partial_json(json!({"content_type": "image/png"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code":0,"data":{"upload_url":"https://oss/img","transfer_id":"t-png","http_method":"PUT","expires_at":"2026-07-23T12:00:00Z","type":"SINGLE"}
+        })))
+        .mount(&server)
+        .await;
+
+    let p = plugin(server.uri());
+    let mut r = req(5);
+    r.mime_type = "image/png".into();
+    let res = p.prepare_upload(r, None).await.unwrap();
+    assert_eq!(res.handle.backend_handle["transfer_id"], "t-png");
 }

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -2830,14 +2830,24 @@ impl BcsClient {
 
     /// PUT bytes to an upload_url. If the upload_url host != BCS base_url
     /// host, do NOT attach Authorization (backend presigned URL self-authenticates).
-    pub async fn put_session_file_bytes(&self, upload_url: &str, bytes: reqwest::Body) -> Result<()> {
+    /// `content_type` is the MIME type negotiated at prepare time so the blob is
+    /// stored with the same content type the backend reserved at `upload-url`.
+    pub async fn put_session_file_bytes(
+        &self,
+        upload_url: &str,
+        bytes: reqwest::Body,
+        content_type: &str,
+    ) -> Result<()> {
         let bcs_host = reqwest::Url::parse(&self.base_url).ok().and_then(|u| u.host_str().map(String::from));
         let target_host = reqwest::Url::parse(upload_url).ok().and_then(|u| u.host_str().map(String::from));
         let cross_host = match (bcs_host.as_deref(), target_host.as_deref()) {
             (Some(a), Some(b)) => a != b,
             _ => false,
         };
-        let mut req = self.http_client.put(upload_url).body(bytes);
+        let mut req = self.http_client
+            .put(upload_url)
+            .header(reqwest::header::CONTENT_TYPE, content_type)
+            .body(bytes);
         if !cross_host {
             req = self.add_auth(req);
         }
@@ -2870,7 +2880,7 @@ impl BcsClient {
             "single" => {
                 let url = prepared["upload_url"].as_str().context("missing upload_url")?.to_string();
                 let file = tokio::fs::File::open(path).await?;
-                self.put_session_file_bytes(&url, reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(file))).await?;
+                self.put_session_file_bytes(&url, reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(file)), &mime).await?;
             }
             "multipart" => {
                 let part_size = prepared["part_size"].as_u64().context("missing part_size")? as usize;
@@ -2881,7 +2891,7 @@ impl BcsClient {
                     use tokio::io::{AsyncReadExt as _, AsyncSeekExt as _};
                     f.seek(std::io::SeekFrom::Start((i as u64) * part_size as u64)).await?;
                     let take = f.take(part_size as u64);
-                    self.put_session_file_bytes(&url, reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(take))).await?;
+                    self.put_session_file_bytes(&url, reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(take)), &mime).await?;
                 }
             }
             _ => return Err(anyhow!("unknown mode {}", mode)),
@@ -3748,7 +3758,7 @@ mod tests {
         );
         let upload_url = format!("http://127.0.0.1:{}/put", addr.port());
         let body = reqwest::Body::from("test-body");
-        let result = client.put_session_file_bytes(&upload_url, body).await;
+        let result = client.put_session_file_bytes(&upload_url, body, "application/octet-stream").await;
 
         server.join().unwrap();
         assert!(result.is_ok(), "PUT should succeed: {:?}", result.err());
@@ -3757,6 +3767,11 @@ mod tests {
         assert!(
             !request_lower.contains("authorization:"),
             "Authorization header MUST NOT be sent cross-host, but was:\n{}",
+            request
+        );
+        assert!(
+            request_lower.contains("content-type: application/octet-stream"),
+            "Content-Type must match the prepared upload content type, but the request was:\n{}",
             request
         );
     }


### PR DESCRIPTION
## What
Make session-file uploads keep the declared MIME type end-to-end: baas `prepare_upload` sends the MIME in the `upload-url` request, and the CLI sets the same `Content-Type` when PUTting bytes to the returned upload URL.

## Why
- `bcs-storage-baas` `prepare_upload` built the `POST /upload-url` body without the file MIME, so baas never received the content type the file would be stored/typed with.
- The CLI's `put_session_file_bytes` PUT to the presigned `upload_url` sent no `Content-Type` header, so the stored blob could be typed differently from what was reserved at prepare.

Both gaps mean the uploaded object's content type was inconsistent / unspecified.

## Changes
- `bcs-storage-baas/src/lib.rs`: add `"content_type": req.mime_type` to the `upload-url` prepare body.
- `bcs-cli/src/client.rs`: `put_session_file_bytes` takes a `content_type` arg and sets `Content-Type` on the PUT; `upload_session_file` passes the locally-negotiated `mime` for both single and multipart uploads.
- Tests:
  - `prepare.rs`: assert `content_type` in existing single/operator tests; add `prepare_passes_request_mime_type_as_content_type` (uses `image/png` to prove the value comes from `mime_type`, not hardcoded).
  - `client.rs`: `cross_host_put_omits_authorization` now also asserts `content-type: application/octet-stream` is sent.

## Verification
- `cargo test -p bcs-storage-baas --test prepare`: 5 passed (incl. new case).
- `cargo test -p bcs-cli --lib cross_host_put_omits_authorization`: passed (incl. new Content-Type assertion).
- `cargo test -p bcs-storage-baas` (full): delete/complete/presign/health/factory/error_map all pass — no regression.

## Notes
- `mime` is already established in `upload_session_file` before both `prepare_session_file` and the PUT, so it flows from the CLI command line (`--mime` or extension-derived default) to baas prepare → upload PUT without needing the prepare response to echo it back.
- Cross-host `Authorization` omission for presigned URLs is preserved.
