### PR TITLE
feat(backend): add require_operator gate to governance admin router

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/economy/admin_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/economy/admin_router.py
@@ -30,6 +30,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from agentclaw.community.adapters.http.auth.dependencies import require_operator
 from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
 from agentclaw.community.adapters.http.economy.schemas import (
     ApiResponse,
@@ -60,6 +61,7 @@ log = logging.getLogger(__name__)
 admin_router = APIRouter(
     prefix="/api/economy/governance",
     tags=["economy-governance-admin"],
+    dependencies=[Depends(require_operator)],
 )
 
 _AdminSvc = GovernanceAdminServiceProtocol
@@ -386,7 +388,7 @@ async def trigger_scan(
     summary="扫描+投递通知 (可指定收件人, 可 dry-run)",
 )
 async def scan_and_deliver(
-    ctx: RequestContext = None,  # TODO: revert — temporarily disabled auth for dev testing
+    ctx: RequestContext = Depends(get_request_context),
     override_recipient: str = Query(
         ...,
         pattern=r"^\d{4,10}$",

--- a/src/backend/tests/community/endpoints/test_governance_admin_endpoints.py
+++ b/src/backend/tests/community/endpoints/test_governance_admin_endpoints.py
@@ -48,6 +48,7 @@ from tests.community.framework import CaseInput, ExpectError, ExpectSuccess, end
 
 
 _USER_HEADER = {"x-user-id": "88888"}
+_NON_OP_USER_HEADER = {"x-user-id": "99999"}
 
 
 # ---------------------------------------------------------------------------
@@ -1348,3 +1349,95 @@ def tickets_delete_cascade_error_missing_reason():
 )
 def tickets_delete_cascade_no_auth():
     """Error path: 无鉴权 → 401。"""
+
+
+# ---------------------------------------------------------------------------
+# 17. Non-operator 403 Forbidden (require_operator router-level gate)
+# ---------------------------------------------------------------------------
+
+
+def _seed_non_operator(world) -> None:
+    """Patch LocalAuth.is_operator_allowed to return False for non-operator tests.
+
+    The router-level ``dependencies=[Depends(require_operator)]`` gate calls
+    ``auth_plugin.is_operator_allowed(staff_id)``. In local mode LocalAuth
+    always returns True; this seed patches it to return False so the 403
+    path is exercised.
+    """
+    from unittest.mock import patch
+
+    patch(
+        "agentclaw.community.plugins.local.auth.LocalAuth.is_operator_allowed",
+        return_value=False,
+    ).start()
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/economy/governance/admin/tickets:offline-renew",
+    scenario="forbidden_non_operator",
+    input=CaseInput(
+        headers=_NON_OP_USER_HEADER,
+        json_body={
+            "owner_id": "owner-x",
+            "bot_id": "bot-x",
+            "governance_decision": "actionable",
+            "dt_version": "20260710",
+        },
+    ),
+    seed=_seed_non_operator,
+    expect=ExpectError(status=403),
+)
+def tickets_offline_renew_forbidden():
+    """Non-operator gets 403 on offline-renew."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/economy/governance/admin/tickets:deliver",
+    scenario="forbidden_non_operator",
+    input=CaseInput(
+        headers=_NON_OP_USER_HEADER,
+        json_body={
+            "worker_id": "owner-dl:bot-dl",
+            "dry_run": True,
+        },
+    ),
+    seed=_seed_non_operator,
+    expect=ExpectError(status=403),
+)
+def tickets_deliver_forbidden():
+    """Non-operator gets 403 on deliver."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/economy/governance/admin/brake",
+    scenario="forbidden_non_operator",
+    input=CaseInput(
+        headers=_NON_OP_USER_HEADER,
+        json_body={"enabled": True, "reason": "unauthorized attempt"},
+    ),
+    seed=_seed_non_operator,
+    expect=ExpectError(status=403),
+)
+def brake_toggle_forbidden():
+    """Non-operator gets 403 on brake toggle."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/economy/governance/admin/whitelist:delete",
+    scenario="forbidden_non_operator",
+    input=CaseInput(
+        headers=_NON_OP_USER_HEADER,
+        json_body={
+            "bot_owner_pairs": [{"bot_id": "b1", "owner_id": "o1"}],
+            "reason": "unauthorized",
+        },
+    ),
+    seed=_seed_non_operator,
+    expect=ExpectError(status=403),
+)
+def whitelist_delete_forbidden():
+    """Non-operator gets 403 on whitelist delete."""


### PR DESCRIPTION
## Summary

Adds a router-level `require_operator` dependency to the governance admin router, enforcing operator authorization on all admin endpoints. Previously, any authenticated user could invoke admin-only endpoints including `tickets:offline-renew`, which force-renews tickets for arbitrary workers.

## Changes

- Add `dependencies=[Depends(require_operator)]` to `admin_router` APIRouter constructor (router-level gate covers all 11 admin endpoints)
- Import `require_operator` from `auth/dependencies`
- Restore proper `Depends(get_request_context)` on `scan_and_deliver` endpoint (was `ctx=None` with TODO comment — completely unauthenticated)
- Add 4 endpoint test cases for non-operator 403 Forbidden: `tickets:offline-renew`, `tickets:deliver`, `brake_toggle`, `whitelist:delete`

## Security Impact

| Before | After |
|--------|-------|
| Any authenticated user can invoke admin endpoints | Only operator-role users can invoke admin endpoints |
| `scan-and-deliver` has no auth at all (`ctx=None`) | Router-level gate enforces auth + operator check |
| Non-operator gets 200 on admin operations | Non-operator gets 403 Forbidden |

## Testing

- Compile check: PASSED
- Lint (ruff): PASSED
- Governance endpoint tests: 93 passed (including 4 new 403 tests)
- Auth dependency tests: 6 passed
- Privacy scan: clean — no internal identifiers or credentials in changed files