### PR TITLE
fix: harden committed skills pool reconciliation

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -25,6 +25,7 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 
 
 LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+CUTOVER_EVIDENCE_CONTRACT_VERSION = "quarantine-v1"
 
 
 class RuntimeLayoutProbeStatus(str, Enum):
@@ -304,6 +305,7 @@ OpenClawPoolLayout = RuntimePoolLayout
 __all__ = [
     "CurrentRuntimeLayoutProbeService",
     "LAYOUT_CONTRACT_VERSION",
+    "CUTOVER_EVIDENCE_CONTRACT_VERSION",
     "OpenClawPoolLayout",
     "RuntimePoolLayout",
     "RuntimeLayoutProbeResult",

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -64,9 +64,12 @@ Engine Layout Descriptor 仍不在本期范围内。
   声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
   未声明该能力的旧 runtime 时，只释放 `POOL_PREPARING/POOL_READY` claim
   并保持 Legacy；`POOL_ACTIVATING_PRE_CUTOVER` 已属于结果不确定区，必须继续
-  幂等调用 cutover 探明事实。对于已跨界重试，允许旧响应复用 DB 中既有
-  quarantine 身份。两边都缺少身份时记录可重试的 runtime 升级要求，不由
-  Backend 推导引擎物理路径。
+  幂等调用 cutover 探明事实，READY probe 不得把它降回可释放阶段。认领后的
+  Bot 引擎若发生漂移，只允许释放尚在 PREPARING/READY 的 claim；切换开始后
+  保持 fail closed。对于已跨界重试，允许旧响应复用 DB 中既有 quarantine
+  身份；runtime 返回的身份与持久化身份冲突时记录不可重试的数据一致性错误。
+  两边都缺少身份时记录可重试的 runtime 升级要求，不由 Backend 推导引擎
+  物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -64,12 +64,13 @@ Engine Layout Descriptor 仍不在本期范围内。
   声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
   未声明该能力的旧 runtime 时，只释放 `POOL_PREPARING/POOL_READY` claim
   并保持 Legacy；`POOL_ACTIVATING_PRE_CUTOVER` 已属于结果不确定区，必须继续
-  幂等调用 cutover 探明事实，READY probe 不得把它降回可释放阶段。认领后的
-  Bot 引擎若发生漂移，只允许释放尚在 PREPARING/READY 的 claim；切换开始后
-  保持 fail closed。对于已跨界重试，允许旧响应复用 DB 中既有 quarantine
-  身份；runtime 返回的身份与持久化身份冲突时记录不可重试的数据一致性错误。
-  两边都缺少身份时记录可重试的 runtime 升级要求，不由 Backend 推导引擎
-  物理路径。
+  幂等调用 cutover 探明事实，READY probe 不得把它降回可释放阶段；probe
+  返回的 preparation identity 必须与进入 ACTIVATING 时持久化的 identity
+  一致，否则在调用 runtime 前转人工修复。认领后的 Bot 引擎若发生漂移，只
+  允许释放尚在 PREPARING/READY 的 claim；切换开始后保持 fail closed。对于
+  已跨界重试，允许旧响应复用 DB 中既有 quarantine 身份；runtime 返回的身份
+  与持久化身份冲突时记录不可重试的数据一致性错误。两边都缺少身份时记录
+  可重试的 runtime 升级要求，不由 Backend 推导引擎物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -60,6 +60,11 @@ Engine Layout Descriptor 仍不在本期范围内。
   与 `POOL_ACTIVE`，不恢复隔离副本。已提交状态的 runtime 重入只补齐
   quarantine/marker 证据，不重复执行数据面 commit CAS；transport 或校验失败
   只记录 forward-only failure。
+- runtime probe 通过 `cutover_evidence_contract_version=quarantine-v1`
+  声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
+  未声明该能力的旧 runtime 时只释放尚未切换的 claim 并保持 Legacy；对于
+  已跨界重试，允许旧响应复用 DB 中既有 quarantine 身份。两边都缺少身份时
+  记录可重试的 runtime 升级要求，不由 Backend 推导引擎物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -57,7 +57,9 @@ Engine Layout Descriptor 仍不在本期范围内。
   附带操作者、备注和已核验的数据面事实，之后才会重新入队同一 generation。
 - bridge 已提交后的 `POST_CUTOVER_SYNC_PENDING`、mapping 与数据库失败均
   持久化阶段、错误码、可重试性、证据和时间；重试只补齐 mapping、locator
-  与 `POOL_ACTIVE`，不恢复隔离副本。
+  与 `POOL_ACTIVE`，不恢复隔离副本。已提交状态的 runtime 重入只补齐
+  quarantine/marker 证据，不重复执行数据面 commit CAS；transport 或校验失败
+  只记录 forward-only failure。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -62,9 +62,11 @@ Engine Layout Descriptor 仍不在本期范围内。
   只记录 forward-only failure。
 - runtime probe 通过 `cutover_evidence_contract_version=quarantine-v1`
   声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
-  未声明该能力的旧 runtime 时只释放尚未切换的 claim 并保持 Legacy；对于
-  已跨界重试，允许旧响应复用 DB 中既有 quarantine 身份。两边都缺少身份时
-  记录可重试的 runtime 升级要求，不由 Backend 推导引擎物理路径。
+  未声明该能力的旧 runtime 时，只释放 `POOL_PREPARING/POOL_READY` claim
+  并保持 Legacy；`POOL_ACTIVATING_PRE_CUTOVER` 已属于结果不确定区，必须继续
+  幂等调用 cutover 探明事实。对于已跨界重试，允许旧响应复用 DB 中既有
+  quarantine 身份。两边都缺少身份时记录可重试的 runtime 升级要求，不由
+  Backend 推导引擎物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -111,6 +111,7 @@ class SkillsPoolReconcileService:
         if state.lease_owner != lease_owner:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.LEASE_NOT_HELD)
 
+        generation = state.migration_generation
         bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
         if bot is None:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_NOT_FOUND)
@@ -121,7 +122,33 @@ class SkillsPoolReconcileService:
             state.rollout_evidence is not None
             and state.rollout_evidence.engine_type != engine
         ):
-            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
+            evidence = {
+                "reason": "bot_engine_changed",
+                "claimed_engine": state.rollout_evidence.engine_type,
+                "current_engine": engine,
+            }
+            if (
+                state.phase
+                in {
+                    SkillLayoutPhase.POOL_PREPARING,
+                    SkillLayoutPhase.POOL_READY,
+                }
+                and not state.data_plane_cutover_committed
+            ):
+                if not self._layouts.release_changed_engine_claim(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    evidence=evidence,
+                ):
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        evidence=evidence,
+                    )
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.BOT_CHANGED,
+                evidence=evidence,
+            )
         try:
             paths = pool_paths_for_engine(engine)
         except ValueError:
@@ -131,7 +158,6 @@ class SkillsPoolReconcileService:
         if not isinstance(owner_id, (str, int)) or isinstance(owner_id, bool):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         user_id = str(owner_id)
-        generation = state.migration_generation
         if not self._layouts.holds_lease(
             scope=scope,
             migration_generation=generation,
@@ -280,23 +306,31 @@ class SkillsPoolReconcileService:
             or repair_evidence_refresh
         ):
             if not state.data_plane_cutover_committed:
-                recorded = self._layouts.record_ready_probe(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    preparation_id=probe.preparation_id,
-                    evidence=probe.evidence,
-                )
-                if not recorded:
-                    return SkillsPoolReconcileResult(
-                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                if state.phase in {
+                    SkillLayoutPhase.POOL_PREPARING,
+                    SkillLayoutPhase.POOL_READY,
+                }:
+                    recorded = self._layouts.record_ready_probe(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                        evidence=probe.evidence,
                     )
-                if not self._layouts.begin_cutover(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    preparation_id=probe.preparation_id,
-                ):
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                        )
+                    if not self._layouts.begin_cutover(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                    ):
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                        )
+                elif state.phase is not SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER:
                     return SkillsPoolReconcileResult(
                         SkillsPoolReconcileOutcome.STATE_RACE_LOST
                     )
@@ -406,8 +440,54 @@ class SkillsPoolReconcileService:
                     preparation_id=probe.preparation_id,
                     evidence=cutover.to_dict(),
                 )
+            quarantine_path = cutover.evidence.get("quarantine")
+            if (
+                isinstance(quarantine_path, str)
+                and quarantine_path
+                and self._layouts.quarantine_identity_conflicts(
+                    scope=scope,
+                    migration_generation=generation,
+                    engine=engine,
+                    path=quarantine_path,
+                )
+            ):
+                conflict_evidence = {
+                    **cutover.to_dict(),
+                    "reason": "quarantine_identity_conflict",
+                }
+                if state.data_plane_cutover_committed:
+                    recorded = self._layouts.record_post_cutover_failure(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code="QUARANTINE_IDENTITY_CONFLICT",
+                        failure_stage="post_cutover_evidence",
+                        retryable=False,
+                        evidence=conflict_evidence,
+                    )
+                    outcome = SkillsPoolReconcileOutcome.INVALID
+                else:
+                    recorded = self._layouts.mark_repair_required(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code="QUARANTINE_IDENTITY_CONFLICT",
+                        failure_stage="cutover_identity",
+                        evidence=conflict_evidence,
+                    )
+                    outcome = SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED
+                if not recorded:
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        preparation_id=probe.preparation_id,
+                    )
+                return SkillsPoolReconcileResult(
+                    outcome,
+                    preparation_id=probe.preparation_id,
+                    evidence=conflict_evidence,
+                    retryable=False,
+                )
             if state.data_plane_cutover_committed:
-                quarantine_path = cutover.evidence.get("quarantine")
                 if (
                     not isinstance(quarantine_path, str) or not quarantine_path
                 ) and not self._layouts.has_quarantine_identity(
@@ -442,7 +522,6 @@ class SkillsPoolReconcileService:
                         preparation_id=probe.preparation_id,
                     )
             else:
-                quarantine_path = cutover.evidence.get("quarantine")
                 if (
                     not isinstance(quarantine_path, str) or not quarantine_path
                 ) and not self._layouts.has_quarantine_identity(

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -117,6 +117,11 @@ class SkillsPoolReconcileService:
         engine = bot.get("active_engine")
         if bot.get("env") != scope.env or not isinstance(engine, str):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
+        if (
+            state.rollout_evidence is not None
+            and state.rollout_evidence.engine_type != engine
+        ):
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         try:
             paths = pool_paths_for_engine(engine)
         except ValueError:
@@ -202,6 +207,11 @@ class SkillsPoolReconcileService:
 
         if (
             not state.data_plane_cutover_committed
+            and state.phase
+            in {
+                SkillLayoutPhase.POOL_PREPARING,
+                SkillLayoutPhase.POOL_READY,
+            }
             and probe.evidence.get("cutover_evidence_contract_version")
             != CUTOVER_EVIDENCE_CONTRACT_VERSION
         ):
@@ -210,23 +220,12 @@ class SkillsPoolReconcileService:
                 "reason": "cutover_evidence_contract_not_supported",
                 "required_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
             }
-            if state.phase is SkillLayoutPhase.POOL_PREPARING:
-                recorded = self._layouts.release_not_capable_claim(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    evidence=compatibility_evidence,
-                )
-            else:
-                recorded = self._layouts.record_pre_cutover_failure(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    failure_code="NOT_CAPABLE",
-                    failure_stage="runtime_contract",
-                    retryable=False,
-                    evidence=compatibility_evidence,
-                )
+            recorded = self._layouts.release_not_capable_claim(
+                scope=scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                evidence=compatibility_evidence,
+            )
             if not recorded:
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.STATE_RACE_LOST
@@ -443,6 +442,35 @@ class SkillsPoolReconcileService:
                         preparation_id=probe.preparation_id,
                     )
             else:
+                quarantine_path = cutover.evidence.get("quarantine")
+                if (
+                    not isinstance(quarantine_path, str) or not quarantine_path
+                ) and not self._layouts.has_quarantine_identity(
+                    scope=scope,
+                    migration_generation=generation,
+                ):
+                    contract_evidence = {
+                        **cutover.to_dict(),
+                        "reason": ("quarantine_identity_missing_from_runtime_and_db"),
+                        "required_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+                    }
+                    if not self._layouts.record_cutover_finalizing(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                        evidence=contract_evidence,
+                    ):
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            preparation_id=probe.preparation_id,
+                        )
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.TRANSIENT_ERROR,
+                        preparation_id=probe.preparation_id,
+                        evidence=contract_evidence,
+                        retryable=True,
+                    )
                 if not self._layouts.record_cutover_committed(
                     scope=scope,
                     migration_generation=generation,

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -230,6 +230,34 @@ class SkillsPoolReconcileService:
                 evidence=probe.evidence,
                 retryable=False,
             )
+        if (
+            state.phase is SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER
+            and state.preparation_id != probe.preparation_id
+        ):
+            identity_evidence = {
+                **probe.evidence,
+                "reason": "preparation_identity_changed_during_cutover",
+                "persisted_preparation_id": state.preparation_id,
+                "observed_preparation_id": probe.preparation_id,
+            }
+            if not self._layouts.mark_repair_required(
+                scope=scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                failure_code="PREPARATION_IDENTITY_CHANGED",
+                failure_stage="runtime_probe",
+                evidence=identity_evidence,
+            ):
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                    preparation_id=probe.preparation_id,
+                )
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED,
+                preparation_id=probe.preparation_id,
+                evidence=identity_evidence,
+                retryable=False,
+            )
 
         if (
             not state.data_plane_cutover_committed

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -273,6 +273,30 @@ class SkillsPoolReconcileService:
             )
             if not cutover.committed:
                 evidence = cutover.to_dict()
+                if state.data_plane_cutover_committed:
+                    outcome, stage, retryable = (
+                        self._post_commit_cutover_failure_profile(cutover.status)
+                    )
+                    recorded = self._layouts.record_post_cutover_failure(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code=cutover.status.value,
+                        failure_stage=stage,
+                        retryable=retryable,
+                        evidence=evidence,
+                    )
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            preparation_id=probe.preparation_id,
+                        )
+                    return SkillsPoolReconcileResult(
+                        outcome,
+                        preparation_id=probe.preparation_id,
+                        evidence=evidence,
+                        retryable=retryable,
+                    )
                 if (
                     cutover.status is PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING
                     or cutover_finalizing
@@ -344,9 +368,19 @@ class SkillsPoolReconcileService:
                     preparation_id=probe.preparation_id,
                     evidence=cutover.to_dict(),
                 )
-            if not (
-                state.data_plane_cutover_committed and repair_evidence_refresh
-            ):
+            if state.data_plane_cutover_committed:
+                if not self._layouts.record_post_cutover_evidence(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    preparation_id=probe.preparation_id,
+                    evidence=cutover.to_dict(),
+                ):
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        preparation_id=probe.preparation_id,
+                    )
+            else:
                 if not self._layouts.record_cutover_committed(
                     scope=scope,
                     migration_generation=generation,
@@ -582,6 +616,33 @@ class SkillsPoolReconcileService:
                 True,
             ),
         }.get(status)
+
+    @classmethod
+    def _post_commit_cutover_failure_profile(
+        cls,
+        status: PoolCutoverStatus,
+    ) -> tuple[SkillsPoolReconcileOutcome, str, bool]:
+        """Classify refresh failures after the irreversible boundary is known."""
+
+        if status in {
+            PoolCutoverStatus.UNKNOWN,
+            PoolCutoverStatus.TRANSIENT_ERROR,
+            PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING,
+        }:
+            return (
+                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+                "post_cutover_refresh",
+                True,
+            )
+        profile = cls._cutover_failure_profile(status)
+        if profile is not None:
+            outcome, _, retryable = profile
+            return outcome, "post_cutover_refresh", retryable
+        return (
+            SkillsPoolReconcileOutcome.CUTOVER_FAILED,
+            "post_cutover_refresh",
+            False,
+        )
 
     @staticmethod
     def _source_tail(git_path: str, prefix: str) -> PurePosixPath:

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.bot_management.repository.protocol import (
     BotRepository,
 )
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    CUTOVER_EVIDENCE_CONTRACT_VERSION,
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skills_pool.models import (
@@ -199,6 +200,44 @@ class SkillsPoolReconcileService:
                 retryable=False,
             )
 
+        if (
+            not state.data_plane_cutover_committed
+            and probe.evidence.get("cutover_evidence_contract_version")
+            != CUTOVER_EVIDENCE_CONTRACT_VERSION
+        ):
+            compatibility_evidence = {
+                **probe.evidence,
+                "reason": "cutover_evidence_contract_not_supported",
+                "required_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+            }
+            if state.phase is SkillLayoutPhase.POOL_PREPARING:
+                recorded = self._layouts.release_not_capable_claim(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    evidence=compatibility_evidence,
+                )
+            else:
+                recorded = self._layouts.record_pre_cutover_failure(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    failure_code="NOT_CAPABLE",
+                    failure_stage="runtime_contract",
+                    retryable=False,
+                    evidence=compatibility_evidence,
+                )
+            if not recorded:
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                )
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.NOT_CAPABLE,
+                preparation_id=probe.preparation_id,
+                evidence=compatibility_evidence,
+                retryable=False,
+            )
+
         local_assets = self._skills.list_bot_local_assets(
             env=scope.env,
             bot_id=scope.bot_id,
@@ -369,6 +408,29 @@ class SkillsPoolReconcileService:
                     evidence=cutover.to_dict(),
                 )
             if state.data_plane_cutover_committed:
+                quarantine_path = cutover.evidence.get("quarantine")
+                if (
+                    not isinstance(quarantine_path, str) or not quarantine_path
+                ) and not self._layouts.has_quarantine_identity(
+                    scope=scope,
+                    migration_generation=generation,
+                ):
+                    return self._record_post_cutover_failure(
+                        scope=scope,
+                        generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                        outcome=SkillsPoolReconcileOutcome.TRANSIENT_ERROR,
+                        failure_code="RUNTIME_CONTRACT_UPGRADE_REQUIRED",
+                        failure_stage="post_cutover_evidence",
+                        evidence={
+                            **cutover.to_dict(),
+                            "reason": (
+                                "quarantine_identity_missing_from_runtime_and_db"
+                            ),
+                            "required_version": (CUTOVER_EVIDENCE_CONTRACT_VERSION),
+                        },
+                    )
                 if not self._layouts.record_post_cutover_evidence(
                     scope=scope,
                     migration_generation=generation,

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -110,6 +110,18 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """记录不可逆的数据面切换已经完成。"""
         ...
 
+    def record_post_cutover_evidence(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """在边界已提交时补齐运行时证据，不重复提交数据面边界。"""
+        ...
+
     def record_cutover_finalizing(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -122,6 +122,15 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """在边界已提交时补齐运行时证据，不重复提交数据面边界。"""
         ...
 
+    def has_quarantine_identity(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+    ) -> bool:
+        """确认该 generation 已持久化 quarantine 身份。"""
+        ...
+
     def record_cutover_finalizing(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -98,6 +98,17 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """记录旧运行时证据，并原子释放尚处于准备阶段的迁移认领。"""
         ...
 
+    def release_changed_engine_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录引擎身份漂移，并原子释放尚未开始切换的迁移认领。"""
+        ...
+
     def record_cutover_committed(
         self,
         *,
@@ -129,6 +140,17 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         migration_generation: str,
     ) -> bool:
         """确认该 generation 已持久化 quarantine 身份。"""
+        ...
+
+    def quarantine_identity_conflicts(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        engine: str,
+        path: str,
+    ) -> bool:
+        """判断运行时身份是否与该 generation 已持久化身份冲突。"""
         ...
 
     def record_cutover_finalizing(

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
@@ -29,7 +29,7 @@ class SkillsPoolCapabilityRepositoryMixin:
         lease_owner: str,
         evidence: dict[str, object],
     ) -> bool:
-        """Persist old-runtime evidence and release only a preparing claim."""
+        """Persist old-runtime evidence and release a provably pre-cutover claim."""
 
         evidence_json = json.dumps(evidence, ensure_ascii=False)
         with self._database.transactional_orm_session() as session:
@@ -39,12 +39,14 @@ class SkillsPoolCapabilityRepositoryMixin:
                     BotSkillLayoutStateModel.env == scope.env,
                     BotSkillLayoutStateModel.entity_id == scope.entity_id,
                     BotSkillLayoutStateModel.bot_id == scope.bot_id,
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase
-                    == SkillLayoutPhase.POOL_PREPARING.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_PREPARING.value,
+                            SkillLayoutPhase.POOL_READY.value,
+                        )
+                    ),
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
@@ -21,15 +21,16 @@ class SkillsPoolCapabilityRepositoryMixin:
 
     _database: object
 
-    def release_not_capable_claim(
+    def _release_pre_cutover_claim(
         self,
         *,
         scope: BotSkillLayoutScope,
         migration_generation: str,
         lease_owner: str,
+        result: str,
         evidence: dict[str, object],
     ) -> bool:
-        """Persist old-runtime evidence and release a provably pre-cutover claim."""
+        """Persist evidence and release a provably pre-cutover claim."""
 
         evidence_json = json.dumps(evidence, ensure_ascii=False)
         with self._database.transactional_orm_session() as session:
@@ -61,7 +62,7 @@ class SkillsPoolCapabilityRepositoryMixin:
                         ),
                         BotSkillLayoutStateModel.migration_generation: None,
                         BotSkillLayoutStateModel.preparation_id: None,
-                        BotSkillLayoutStateModel.last_probe_result: "NOT_CAPABLE",
+                        BotSkillLayoutStateModel.last_probe_result: result,
                         BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
                         BotSkillLayoutStateModel.last_failure_code: None,
                         BotSkillLayoutStateModel.last_failure_stage: None,
@@ -75,3 +76,39 @@ class SkillsPoolCapabilityRepositoryMixin:
                 )
             )
         return affected == 1
+
+    def release_not_capable_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Persist old-runtime evidence and release a safe claim."""
+
+        return self._release_pre_cutover_claim(
+            scope=scope,
+            migration_generation=migration_generation,
+            lease_owner=lease_owner,
+            result="NOT_CAPABLE",
+            evidence=evidence,
+        )
+
+    def release_changed_engine_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Release a safe claim whose immutable engine identity changed."""
+
+        return self._release_pre_cutover_claim(
+            scope=scope,
+            migration_generation=migration_generation,
+            lease_owner=lease_owner,
+            result="BOT_CHANGED",
+            evidence=evidence,
+        )

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -26,14 +26,22 @@ from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
     log_missing_quarantine_path,
 )
-from agentclaw.community.plugins.skills_pool_capability_repository import SkillsPoolCapabilityRepositoryMixin
-from agentclaw.community.plugins.skills_pool_operational_repository import SkillsPoolOperationalRepositoryMixin
+from agentclaw.community.plugins.skills_pool_capability_repository import (
+    SkillsPoolCapabilityRepositoryMixin,
+)
+from agentclaw.community.plugins.skills_pool_operational_repository import (
+    SkillsPoolOperationalRepositoryMixin,
+)
 from agentclaw.community.plugins.skills_pool_quarantine_repository import (
     SkillsPoolQuarantineRepositoryMixin,
 )
 
 
-class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPoolOperationalRepositoryMixin, SkillsPoolQuarantineRepositoryMixin):
+class SkillsPoolLayoutRepository(
+    SkillsPoolCapabilityRepositoryMixin,
+    SkillsPoolOperationalRepositoryMixin,
+    SkillsPoolQuarantineRepositoryMixin,
+):
     @inject
     def __init__(self, database: DatabasePlugin) -> None:
         self._database = database
@@ -188,8 +196,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     *self._scope_filter(scope),
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     or_(
                         BotSkillLayoutStateModel.lease_expires_at.is_(None),
                         BotSkillLayoutStateModel.lease_expires_at <= func.now(),
@@ -248,10 +255,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_PREPARING.value,
@@ -299,10 +304,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
@@ -351,15 +354,19 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
         evidence: dict[str, object],
     ) -> bool:
         evidence_json = json.dumps(evidence, ensure_ascii=False)
+        runtime_evidence = evidence.get("evidence")
+        quarantine_path = (
+            runtime_evidence.get("quarantine")
+            if isinstance(runtime_evidence, dict)
+            else None
+        )
         with self._database.transactional_orm_session() as session:
-            affected = (
+            row = (
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
@@ -372,28 +379,96 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     BotSkillLayoutStateModel.lease_owner == lease_owner,
                     BotSkillLayoutStateModel.lease_expires_at > func.now(),
                 )
-                .update(
-                    {
-                        BotSkillLayoutStateModel.phase: (
-                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
-                        ),
-                        BotSkillLayoutStateModel.data_plane_cutover_committed: 1,
-                        BotSkillLayoutStateModel.last_failure_code: (
-                            "POST_CUTOVER_SYNC_PENDING"
-                        ),
-                        BotSkillLayoutStateModel.last_failure_stage: (
-                            "post_cutover_sync"
-                        ),
-                        BotSkillLayoutStateModel.last_failure_retryable: 1,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
-                        BotSkillLayoutStateModel.last_failure_at: func.now(),
-                    },
-                    synchronize_session=False,
-                )
+                .with_for_update()
+                .one_or_none()
             )
-        return affected == 1
+            if row is None or row.rollout_evidence is None:
+                return False
+            engine = json.loads(row.rollout_evidence).get("engine_type")
+            if not isinstance(engine, str) or not engine:
+                return False
+            if not isinstance(quarantine_path, str) or not quarantine_path:
+                log_missing_quarantine_path(scope, migration_generation)
+                return False
+            if not self._upsert_quarantine(
+                session,
+                scope=scope,
+                migration_generation=migration_generation,
+                engine=engine,
+                path=quarantine_path,
+                evidence_json=evidence_json,
+            ):
+                return False
+            row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
+            row.data_plane_cutover_committed = 1
+            row.last_failure_code = "POST_CUTOVER_SYNC_PENDING"
+            row.last_failure_stage = "post_cutover_sync"
+            row.last_failure_retryable = 1
+            row.last_failure_evidence = evidence_json
+            row.last_failure_at = func.now()
+        return True
+
+    def record_post_cutover_evidence(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Reconcile runtime evidence without re-crossing the cutover boundary."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        runtime_evidence = evidence.get("evidence")
+        quarantine_path = (
+            runtime_evidence.get("quarantine")
+            if isinstance(runtime_evidence, dict)
+            else None
+        )
+        with self._database.transactional_orm_session() as session:
+            row = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if row is None or row.rollout_evidence is None:
+                return False
+            engine = json.loads(row.rollout_evidence).get("engine_type")
+            if not isinstance(engine, str) or not engine:
+                return False
+            if not isinstance(quarantine_path, str) or not quarantine_path:
+                log_missing_quarantine_path(scope, migration_generation)
+                return False
+            if not self._upsert_quarantine(
+                session,
+                scope=scope,
+                migration_generation=migration_generation,
+                engine=engine,
+                path=quarantine_path,
+                evidence_json=evidence_json,
+            ):
+                return False
+            row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
+            row.last_probe_evidence = evidence_json
+        return True
 
     def begin_cutover(
         self,
@@ -410,12 +485,9 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase
-                    == SkillLayoutPhase.POOL_READY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase == SkillLayoutPhase.POOL_READY.value,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
                     BotSkillLayoutStateModel.preparation_id == preparation_id,
@@ -452,10 +524,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.POOL_PREPARING.value,
@@ -472,15 +542,9 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 .update(
                     {
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
-                        BotSkillLayoutStateModel.last_failure_stage: (
-                            failure_stage
-                        ),
-                        BotSkillLayoutStateModel.last_failure_retryable: int(
-                            retryable
-                        ),
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_stage: (failure_stage),
+                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -507,12 +571,14 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase
-                    == SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                        )
+                    ),
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
@@ -523,12 +589,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     {
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
                         BotSkillLayoutStateModel.last_failure_stage: failure_stage,
-                        BotSkillLayoutStateModel.last_failure_retryable: int(
-                            retryable
-                        ),
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -554,10 +616,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER.value,
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
@@ -574,9 +634,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
                         BotSkillLayoutStateModel.last_failure_stage: failure_stage,
                         BotSkillLayoutStateModel.last_failure_retryable: 0,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                         BotSkillLayoutStateModel.lease_owner: None,
                         BotSkillLayoutStateModel.lease_expires_at: None,
@@ -607,10 +665,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.NEEDS_MANUAL_REPAIR.value,
                     BotSkillLayoutStateModel.migration_generation
@@ -658,8 +714,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
 
         pool_prefixes = local_locator_prefixes(pool=True)
         if any(
-            not isinstance(skill_id, int)
-            or not locator.startswith(pool_prefixes)
+            not isinstance(skill_id, int) or not locator.startswith(pool_prefixes)
             for skill_id, locator in local_locators.items()
         ):
             return False
@@ -682,10 +737,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
@@ -745,8 +798,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
                     BotSkillLayoutStateModel.target_layout.is_(None),
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.POOL_ACTIVE.value,
@@ -772,9 +824,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                             "rollback_requested"
                         ),
                         BotSkillLayoutStateModel.last_failure_retryable: None,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -798,10 +848,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
@@ -822,9 +870,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                         BotSkillLayoutStateModel.last_failure_code: None,
                         BotSkillLayoutStateModel.last_failure_stage: None,
                         BotSkillLayoutStateModel.last_failure_retryable: None,
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: None,
                     },
                     synchronize_session=False,
@@ -847,10 +893,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
@@ -896,10 +940,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase.in_(
                         (
                             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING.value,
@@ -915,12 +957,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                     {
                         BotSkillLayoutStateModel.last_failure_code: failure_code,
                         BotSkillLayoutStateModel.last_failure_stage: failure_stage,
-                        BotSkillLayoutStateModel.last_failure_retryable: int(
-                            retryable
-                        ),
-                        BotSkillLayoutStateModel.last_failure_evidence: (
-                            evidence_json
-                        ),
+                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
+                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
                         BotSkillLayoutStateModel.last_failure_at: func.now(),
                     },
                     synchronize_session=False,
@@ -940,8 +978,7 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
 
         legacy_prefixes = local_locator_prefixes(pool=False)
         if any(
-            not isinstance(skill_id, int)
-            or not locator.startswith(legacy_prefixes)
+            not isinstance(skill_id, int) or not locator.startswith(legacy_prefixes)
             for skill_id, locator in local_locators.items()
         ):
             return False
@@ -964,10 +1001,8 @@ class SkillsPoolLayoutRepository(SkillsPoolCapabilityRepositoryMixin, SkillsPool
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.LEGACY.value,
                     BotSkillLayoutStateModel.phase
                     == SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED.value,
                     BotSkillLayoutStateModel.migration_generation

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -387,18 +387,19 @@ class SkillsPoolLayoutRepository(
             engine = json.loads(row.rollout_evidence).get("engine_type")
             if not isinstance(engine, str) or not engine:
                 return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
-            if not self._upsert_quarantine(
-                session,
-                scope=scope,
-                migration_generation=migration_generation,
-                engine=engine,
-                path=quarantine_path,
-                evidence_json=evidence_json,
-            ):
-                return False
+            # Some post-boundary Engine failures cannot yet report the
+            # quarantine path. Persist the irreversible boundary first and
+            # keep FINALIZING until a later successful refresh supplies it.
+            if isinstance(quarantine_path, str) and quarantine_path:
+                if not self._upsert_quarantine(
+                    session,
+                    scope=scope,
+                    migration_generation=migration_generation,
+                    engine=engine,
+                    path=quarantine_path,
+                    evidence_json=evidence_json,
+                ):
+                    return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
             row.data_plane_cutover_committed = 1
             row.last_failure_code = "POST_CUTOVER_SYNC_PENDING"
@@ -567,7 +568,7 @@ class SkillsPoolLayoutRepository(
 
         evidence_json = json.dumps(evidence, ensure_ascii=False)
         with self._database.transactional_orm_session() as session:
-            affected = (
+            row = (
                 session.query(BotSkillLayoutStateModel)
                 .filter(
                     *self._scope_filter(scope),
@@ -585,18 +586,22 @@ class SkillsPoolLayoutRepository(
                     BotSkillLayoutStateModel.lease_owner == lease_owner,
                     BotSkillLayoutStateModel.lease_expires_at > func.now(),
                 )
-                .update(
-                    {
-                        BotSkillLayoutStateModel.last_failure_code: failure_code,
-                        BotSkillLayoutStateModel.last_failure_stage: failure_stage,
-                        BotSkillLayoutStateModel.last_failure_retryable: int(retryable),
-                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
-                        BotSkillLayoutStateModel.last_failure_at: func.now(),
-                    },
-                    synchronize_session=False,
-                )
+                .with_for_update()
+                .one_or_none()
             )
-        return affected == 1
+            if row is None:
+                return False
+            # Older Backend versions used this failure code as the durable
+            # "runtime evidence still missing" signal. Move that signal into
+            # the phase before replacing the code with the latest failure.
+            if row.last_failure_code == "MANUAL_REPAIR_RESOLVED":
+                row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
+            row.last_failure_code = failure_code
+            row.last_failure_stage = failure_stage
+            row.last_failure_retryable = int(retryable)
+            row.last_failure_evidence = evidence_json
+            row.last_failure_at = func.now()
+        return True
 
     def mark_repair_required(
         self,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -331,9 +331,6 @@ class SkillsPoolLayoutRepository(
             engine = json.loads(row.rollout_evidence).get("engine_type")
             if not isinstance(engine, str) or not engine:
                 return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
             if not self._upsert_quarantine(
                 session,
                 scope=scope,
@@ -342,6 +339,8 @@ class SkillsPoolLayoutRepository(
                 path=quarantine_path,
                 evidence_json=evidence_json,
             ):
+                if not isinstance(quarantine_path, str) or not quarantine_path:
+                    log_missing_quarantine_path(scope, migration_generation)
                 return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
             row.data_plane_cutover_committed = 1

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -32,6 +32,9 @@ from agentclaw.community.plugins.skills_pool_capability_repository import (
 from agentclaw.community.plugins.skills_pool_operational_repository import (
     SkillsPoolOperationalRepositoryMixin,
 )
+from agentclaw.community.plugins.skills_pool_post_cutover_repository import (
+    SkillsPoolPostCutoverRepositoryMixin,
+)
 from agentclaw.community.plugins.skills_pool_quarantine_repository import (
     SkillsPoolQuarantineRepositoryMixin,
 )
@@ -40,6 +43,7 @@ from agentclaw.community.plugins.skills_pool_quarantine_repository import (
 class SkillsPoolLayoutRepository(
     SkillsPoolCapabilityRepositoryMixin,
     SkillsPoolOperationalRepositoryMixin,
+    SkillsPoolPostCutoverRepositoryMixin,
     SkillsPoolQuarantineRepositoryMixin,
 ):
     @inject
@@ -407,68 +411,6 @@ class SkillsPoolLayoutRepository(
             row.last_failure_retryable = 1
             row.last_failure_evidence = evidence_json
             row.last_failure_at = func.now()
-        return True
-
-    def record_post_cutover_evidence(
-        self,
-        *,
-        scope: BotSkillLayoutScope,
-        migration_generation: str,
-        lease_owner: str,
-        preparation_id: str,
-        evidence: dict[str, object],
-    ) -> bool:
-        """Reconcile runtime evidence without re-crossing the cutover boundary."""
-
-        evidence_json = json.dumps(evidence, ensure_ascii=False)
-        runtime_evidence = evidence.get("evidence")
-        quarantine_path = (
-            runtime_evidence.get("quarantine")
-            if isinstance(runtime_evidence, dict)
-            else None
-        )
-        with self._database.transactional_orm_session() as session:
-            row = (
-                session.query(BotSkillLayoutStateModel)
-                .filter(
-                    *self._scope_filter(scope),
-                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase.in_(
-                        (
-                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
-                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
-                        )
-                    ),
-                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
-                    BotSkillLayoutStateModel.migration_generation
-                    == migration_generation,
-                    BotSkillLayoutStateModel.preparation_id == preparation_id,
-                    BotSkillLayoutStateModel.lease_owner == lease_owner,
-                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
-                )
-                .with_for_update()
-                .one_or_none()
-            )
-            if row is None or row.rollout_evidence is None:
-                return False
-            engine = json.loads(row.rollout_evidence).get("engine_type")
-            if not isinstance(engine, str) or not engine:
-                return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
-            if not self._upsert_quarantine(
-                session,
-                scope=scope,
-                migration_generation=migration_generation,
-                engine=engine,
-                path=quarantine_path,
-                evidence_json=evidence_json,
-            ):
-                return False
-            row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
-            row.last_probe_evidence = evidence_json
         return True
 
     def begin_cutover(

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -533,10 +533,23 @@ class SkillsPoolLayoutRepository(
             )
             if row is None:
                 return False
+            try:
+                last_probe_evidence = (
+                    json.loads(row.last_probe_evidence)
+                    if row.last_probe_evidence
+                    else {}
+                )
+            except (TypeError, ValueError):
+                last_probe_evidence = {}
             # Older Backend versions used this failure code as the durable
-            # "runtime evidence still missing" signal. Move that signal into
-            # the phase before replacing the code with the latest failure.
-            if row.last_failure_code == "MANUAL_REPAIR_RESOLVED":
+            # "runtime evidence still missing" signal. Once refreshed,
+            # last_probe_evidence carries an explicit durable success marker,
+            # so downstream failures must not reopen runtime finalization.
+            if (
+                row.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+                and last_probe_evidence.get("post_cutover_evidence_recorded")
+                is not True
+            ):
                 row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
             row.last_failure_code = failure_code
             row.last_failure_stage = failure_stage

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy import func
 
 from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
+    SkillMigrationQuarantineModel,
 )
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
@@ -24,6 +25,28 @@ class SkillsPoolPostCutoverRepositoryMixin:
 
     _database: object
 
+    def has_quarantine_identity(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+    ) -> bool:
+        """Check whether an older runtime may reuse persisted quarantine identity."""
+
+        with self._database.transactional_orm_session() as session:
+            return (
+                session.query(SkillMigrationQuarantineModel)
+                .filter(
+                    SkillMigrationQuarantineModel.env == scope.env,
+                    SkillMigrationQuarantineModel.entity_id == scope.entity_id,
+                    SkillMigrationQuarantineModel.bot_id == scope.bot_id,
+                    SkillMigrationQuarantineModel.migration_generation
+                    == migration_generation,
+                )
+                .one_or_none()
+                is not None
+            )
+
     def record_post_cutover_evidence(
         self,
         *,
@@ -35,7 +58,11 @@ class SkillsPoolPostCutoverRepositoryMixin:
     ) -> bool:
         """Reconcile runtime evidence without re-crossing the cutover boundary."""
 
-        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        persisted_evidence = {
+            **evidence,
+            "post_cutover_evidence_recorded": True,
+        }
+        evidence_json = json.dumps(persisted_evidence, ensure_ascii=False)
         runtime_evidence = evidence.get("evidence")
         quarantine_path = (
             runtime_evidence.get("quarantine")
@@ -70,9 +97,6 @@ class SkillsPoolPostCutoverRepositoryMixin:
             engine = json.loads(row.rollout_evidence).get("engine_type")
             if not isinstance(engine, str) or not engine:
                 return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
             if not self._upsert_quarantine(
                 session,
                 scope=scope,
@@ -81,6 +105,8 @@ class SkillsPoolPostCutoverRepositoryMixin:
                 path=quarantine_path,
                 evidence_json=evidence_json,
             ):
+                if not isinstance(quarantine_path, str) or not quarantine_path:
+                    log_missing_quarantine_path(scope, migration_generation)
                 return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
             row.last_probe_evidence = evidence_json

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
@@ -1,0 +1,87 @@
+"""Post-cutover runtime evidence persistence for Skills Pool migrations."""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import func
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    BotSkillLayoutStateModel,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
+    log_missing_quarantine_path,
+)
+
+
+class SkillsPoolPostCutoverRepositoryMixin:
+    """Reconcile runtime evidence after the irreversible cutover boundary."""
+
+    _database: object
+
+    def record_post_cutover_evidence(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        preparation_id: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Reconcile runtime evidence without re-crossing the cutover boundary."""
+
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        runtime_evidence = evidence.get("evidence")
+        quarantine_path = (
+            runtime_evidence.get("quarantine")
+            if isinstance(runtime_evidence, dict)
+            else None
+        )
+        with self._database.transactional_orm_session() as session:
+            row = (
+                session.query(BotSkillLayoutStateModel)
+                .filter(
+                    *self._scope_filter(scope),
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value,
+                            SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value,
+                        )
+                    ),
+                    BotSkillLayoutStateModel.data_plane_cutover_committed == 1,
+                    BotSkillLayoutStateModel.migration_generation
+                    == migration_generation,
+                    BotSkillLayoutStateModel.preparation_id == preparation_id,
+                    BotSkillLayoutStateModel.lease_owner == lease_owner,
+                    BotSkillLayoutStateModel.lease_expires_at > func.now(),
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if row is None or row.rollout_evidence is None:
+                return False
+            engine = json.loads(row.rollout_evidence).get("engine_type")
+            if not isinstance(engine, str) or not engine:
+                return False
+            if not isinstance(quarantine_path, str) or not quarantine_path:
+                log_missing_quarantine_path(scope, migration_generation)
+                return False
+            if not self._upsert_quarantine(
+                session,
+                scope=scope,
+                migration_generation=migration_generation,
+                engine=engine,
+                path=quarantine_path,
+                evidence_json=evidence_json,
+            ):
+                return False
+            row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
+            row.last_probe_evidence = evidence_json
+        return True

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
@@ -82,7 +82,7 @@ class SkillsPoolQuarantineRepositoryMixin:
         )
         if existing is not None:
             return existing.engine == engine and (
-                not isinstance(path, str) or existing.path == path
+                not isinstance(path, str) or not path or existing.path == path
             )
         if not isinstance(path, str) or not path:
             return False

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
@@ -27,6 +27,32 @@ class SkillsPoolQuarantineRepositoryMixin:
 
     _database: object
 
+    def quarantine_identity_conflicts(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        engine: str,
+        path: str,
+    ) -> bool:
+        """Return whether a runtime identity contradicts durable evidence."""
+
+        with self._database.transactional_orm_session() as session:
+            existing = (
+                session.query(SkillMigrationQuarantineModel)
+                .filter(
+                    SkillMigrationQuarantineModel.env == scope.env,
+                    SkillMigrationQuarantineModel.entity_id == scope.entity_id,
+                    SkillMigrationQuarantineModel.bot_id == scope.bot_id,
+                    SkillMigrationQuarantineModel.migration_generation
+                    == migration_generation,
+                )
+                .one_or_none()
+            )
+            return existing is not None and (
+                existing.engine != engine or existing.path != path
+            )
+
     @staticmethod
     def _cleanup_lease_deadline(session, seconds: int):
         if session.bind.dialect.name == "sqlite":

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -709,6 +709,57 @@ def test_unknown_cutover_is_fenced_for_manual_repair() -> None:
     assert state.last_failure_evidence == {"reason": "response_lost"}
 
 
+def test_cutover_finalizing_persists_quarantine_at_irreversible_boundary() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    quarantine_path = (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+
+    assert repository.record_cutover_finalizing(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": False,
+            "status": "POST_CUTOVER_SYNC_PENDING",
+            "evidence": {"quarantine": quarantine_path},
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert state.data_plane_cutover_committed is True
+    with database.transactional_orm_session() as session:
+        quarantine = session.query(SkillMigrationQuarantineModel).one()
+        assert quarantine.path == quarantine_path
+        assert quarantine.pool_activated_at is None
+
+
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -769,7 +820,7 @@ def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
         lease_owner="worker-2",
         lease_seconds=60,
     )
-    assert repository.record_cutover_committed(
+    assert repository.record_post_cutover_evidence(
         scope=scope,
         migration_generation="generation-1",
         lease_owner="worker-2",

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -347,6 +347,48 @@ def test_not_capable_probe_releases_ready_claim_before_cutover() -> None:
     assert state.preparation_id is None
 
 
+def test_changed_engine_releases_ready_claim_before_cutover() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+
+    assert repository.release_changed_engine_claim(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        evidence={
+            "reason": "bot_engine_changed",
+            "claimed_engine": "openclaw",
+            "current_engine": "claude_code",
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert state.target_layout is None
+    assert state.migration_generation is None
+    assert state.last_probe_result == "BOT_CHANGED"
+    assert state.last_probe_evidence == {
+        "reason": "bot_engine_changed",
+        "claimed_engine": "openclaw",
+        "current_engine": "claude_code",
+    }
+
+
 def test_claim_updates_an_existing_unclaimed_legacy_row() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -882,6 +924,24 @@ def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
     assert repository.has_quarantine_identity(
         scope=scope,
         migration_generation="generation-1",
+    )
+    assert not repository.quarantine_identity_conflicts(
+        scope=scope,
+        migration_generation="generation-1",
+        engine="openclaw",
+        path=quarantine_path,
+    )
+    assert repository.quarantine_identity_conflicts(
+        scope=scope,
+        migration_generation="generation-1",
+        engine="openclaw",
+        path=f"{quarantine_path}-other",
+    )
+    assert repository.quarantine_identity_conflicts(
+        scope=scope,
+        migration_generation="generation-1",
+        engine="claude_code",
+        path=quarantine_path,
     )
     assert repository.record_post_cutover_evidence(
         scope=scope,

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -314,6 +314,39 @@ def test_not_capable_probe_releases_preparing_claim_and_preserves_evidence() -> 
     assert state.data_plane_cutover_committed is False
 
 
+def test_not_capable_probe_releases_ready_claim_before_cutover() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+
+    assert repository.release_not_capable_claim(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        evidence={"reason": "runtime_contract_missing"},
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert state.target_layout is None
+    assert state.migration_generation is None
+    assert state.preparation_id is None
+
+
 def test_claim_updates_an_existing_unclaimed_legacy_row() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -868,6 +901,62 @@ def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
     with database.transactional_orm_session() as session:
         quarantine = session.query(SkillMigrationQuarantineModel).one()
         assert quarantine.path == quarantine_path
+
+
+def test_cutover_commit_reuses_quarantine_from_pending_response() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    quarantine_path = (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+    assert repository.record_cutover_finalizing(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "status": "POST_CUTOVER_SYNC_PENDING",
+            "evidence": {"quarantine": quarantine_path},
+        },
+    )
+
+    assert repository.record_cutover_committed(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "ALREADY_COMMITTED",
+            "evidence": {"active_marker": "same-generation"},
+        },
+    )
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert state.data_plane_cutover_committed is True
 
 
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -760,6 +760,51 @@ def test_cutover_finalizing_persists_quarantine_at_irreversible_boundary() -> No
         assert quarantine.pool_activated_at is None
 
 
+def test_cutover_finalizing_accepts_pending_evidence_without_quarantine() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+
+    assert repository.record_cutover_finalizing(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": False,
+            "status": "POST_CUTOVER_SYNC_PENDING",
+            "evidence": {"reason": "post_cutover_sync_failed"},
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert state.data_plane_cutover_committed is True
+    with database.transactional_orm_session() as session:
+        assert session.query(SkillMigrationQuarantineModel).count() == 0
+
+
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -864,6 +909,68 @@ def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     assert active.last_failure_evidence["previous_failure"] == {
         "reason": "response_lost"
     }
+
+
+def test_legacy_committed_repair_refresh_failure_keeps_refresh_phase() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    assert repository.mark_repair_required(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        failure_code="UNKNOWN",
+        failure_stage="cutover_outcome_unknown",
+        evidence={"reason": "response_lost"},
+    )
+    assert repository.resolve_repair(
+        scope=scope,
+        migration_generation="generation-1",
+        operator="oncall-1",
+        note="legacy backend resolved this row as committed",
+        cutover_committed=True,
+    )
+    assert repository.try_acquire_lease(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-2",
+        lease_seconds=60,
+    )
+    assert repository.record_post_cutover_failure(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-2",
+        failure_code="TRANSIENT_ERROR",
+        failure_stage="post_cutover_refresh",
+        retryable=True,
+        evidence={"reason": "adapter_temporarily_unreachable"},
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert state.data_plane_cutover_committed is True
+    assert state.last_failure_code == "TRANSIENT_ERROR"
 
 
 def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -954,6 +954,20 @@ def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
             "evidence": {"active_marker": "same-generation"},
         },
     )
+    assert repository.record_post_cutover_evidence(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "ALREADY_COMMITTED",
+            "evidence": {
+                "active_marker": "same-generation",
+                "quarantine": "",
+            },
+        },
+    )
 
     state = repository.get(scope)
     assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -805,6 +805,71 @@ def test_cutover_finalizing_accepts_pending_evidence_without_quarantine() -> Non
         assert session.query(SkillMigrationQuarantineModel).count() == 0
 
 
+def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    quarantine_path = (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+    assert repository.record_cutover_committed(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "COMMITTED",
+            "evidence": {"quarantine": quarantine_path},
+        },
+    )
+
+    assert repository.has_quarantine_identity(
+        scope=scope,
+        migration_generation="generation-1",
+    )
+    assert repository.record_post_cutover_evidence(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "ALREADY_COMMITTED",
+            "evidence": {"active_marker": "same-generation"},
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert state.last_probe_evidence["post_cutover_evidence_recorded"] is True
+    with database.transactional_orm_session() as session:
+        quarantine = session.query(SkillMigrationQuarantineModel).one()
+        assert quarantine.path == quarantine_path
+
+
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -540,6 +540,40 @@ async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_activating_generation_rejects_changed_preparation_identity() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            preparation_id="persisted-preparation",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        preparation_id="regenerated-preparation",
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED
+    assert result.retryable is False
+    assert runtime.events == ["probe"]
+    assert layouts.events == ["manual_repair"]
+    assert layouts.state.phase is SkillLayoutPhase.NEEDS_MANUAL_REPAIR
+    assert layouts.state.last_failure_code == "PREPARATION_IDENTITY_CHANGED"
+    assert layouts.state.last_failure_evidence == {
+        "marker": "valid",
+        "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+        "reason": "preparation_identity_changed_during_cutover",
+        "persisted_preparation_id": "persisted-preparation",
+        "observed_preparation_id": "regenerated-preparation",
+    }
+
+
+@pytest.mark.asyncio
 async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> None:
     layouts = FakeLayoutRepository(
         claimed_state(

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -142,6 +142,19 @@ class FakeLayoutRepository:
         )
         return True
 
+    def record_post_cutover_evidence(self, **kwargs: object) -> bool:
+        if self._should_fail("post_cutover_evidence"):
+            return False
+        if not self._owns(kwargs):
+            return False
+        self.events.append("evidence")
+        self.state = replace(
+            self.state,
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            data_plane_cutover_committed=True,
+        )
+        return True
+
     def begin_cutover(self, **kwargs: object) -> bool:
         if self._should_fail("begin"):
             return False
@@ -564,7 +577,9 @@ async def test_unknown_cutover_enters_manual_repair_and_stops_automation() -> No
 
 
 @pytest.mark.asyncio
-async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas() -> None:
+async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas() -> (
+    None
+):
     layouts = FakeLayoutRepository(
         claimed_state(
             phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
@@ -587,8 +602,57 @@ async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas
 
     assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
-    assert layouts.events == ["database"]
+    assert layouts.events == ["evidence", "database"]
     assert layouts.state.active_layout is SkillLayout.POOL
+
+
+@pytest.mark.asyncio
+async def test_committed_repair_transport_failure_records_forward_only_and_retries() -> (
+    None
+):
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.UNKNOWN,
+        evidence={"reason": "transport_response_unavailable"},
+    )
+
+    first = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert first.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert first.retryable is True
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_stage == "post_cutover_refresh"
+
+    runtime.events.clear()
+    layouts.events.clear()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+
+    retried = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "mapping", "verify"]
+    assert layouts.events == ["database"]
 
 
 @pytest.mark.asyncio
@@ -627,7 +691,67 @@ async def test_post_cutover_sync_pending_retries_finalization_before_mappings() 
 
     assert second.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
-    assert layouts.events == ["cutover", "database"]
+    assert layouts.events == ["evidence", "database"]
+
+
+@pytest.mark.asyncio
+async def test_committed_repair_invalid_refresh_stays_forward_only() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.INVALID,
+        evidence={"reason": "active_marker_identity_mismatch"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert result.retryable is False
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_stage == "post_cutover_refresh"
+
+
+@pytest.mark.asyncio
+async def test_finalizing_transport_failure_does_not_reenter_pre_cutover_cas() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="POST_CUTOVER_SYNC_PENDING",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.TRANSIENT_ERROR,
+        evidence={"reason": "adapter_temporarily_unreachable"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert result.retryable is True
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_stage == "post_cutover_refresh"
 
 
 @pytest.mark.asyncio
@@ -812,8 +936,7 @@ async def test_mixed_image_bots_reconcile_independently_in_one_environment() -> 
         def _owns(self, values: dict[str, object]) -> bool:
             return (
                 values["scope"] == self._current_scope
-                and values["migration_generation"]
-                == self.state.migration_generation
+                and values["migration_generation"] == self.state.migration_generation
                 and values["lease_owner"] == self.state.lease_owner
             )
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -184,8 +184,14 @@ class FakeLayoutRepository:
         if not self._owns(kwargs):
             return False
         self.events.append("post_failure")
+        refresh_pending = self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
         self.state = replace(
             self.state,
+            phase=(
+                SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+                if refresh_pending
+                else self.state.phase
+            ),
             last_failure_code=str(kwargs["failure_code"]),
             last_failure_stage=str(kwargs["failure_stage"]),
             last_failure_retryable=bool(kwargs["retryable"]),
@@ -633,7 +639,7 @@ async def test_committed_repair_transport_failure_records_forward_only_and_retri
     assert first.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
     assert first.retryable is True
     assert layouts.events == ["post_failure"]
-    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
     assert layouts.state.data_plane_cutover_committed is True
     assert layouts.state.last_failure_stage == "post_cutover_refresh"
 
@@ -651,8 +657,8 @@ async def test_committed_repair_transport_failure_records_forward_only_and_retri
     )
 
     assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
-    assert runtime.events == ["probe", "mapping", "verify"]
-    assert layouts.events == ["database"]
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["evidence", "database"]
 
 
 @pytest.mark.asyncio
@@ -719,7 +725,7 @@ async def test_committed_repair_invalid_refresh_stays_forward_only() -> None:
     assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
     assert result.retryable is False
     assert layouts.events == ["post_failure"]
-    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
     assert layouts.state.data_plane_cutover_committed is True
     assert layouts.state.last_failure_stage == "post_cutover_refresh"
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    CUTOVER_EVIDENCE_CONTRACT_VERSION,
     LAYOUT_CONTRACT_VERSION,
     RuntimeLayoutProbeResult,
     RuntimeLayoutProbeStatus,
@@ -82,6 +83,7 @@ class FakeLayoutRepository:
         self.committed_locators: dict[int, str] | None = None
         self.lease_valid = True
         self.fail_once_at: str | None = None
+        self.quarantine_identity = True
 
     def _should_fail(self, stage: str) -> bool:
         if self.fail_once_at != stage:
@@ -142,6 +144,13 @@ class FakeLayoutRepository:
         )
         return True
 
+    def has_quarantine_identity(self, **kwargs: object) -> bool:
+        return (
+            kwargs["scope"] == SCOPE
+            and kwargs["migration_generation"] == GENERATION
+            and self.quarantine_identity
+        )
+
     def record_post_cutover_evidence(self, **kwargs: object) -> bool:
         if self._should_fail("post_cutover_evidence"):
             return False
@@ -152,6 +161,7 @@ class FakeLayoutRepository:
             self.state,
             phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
             data_plane_cutover_committed=True,
+            last_probe_evidence={"post_cutover_evidence_recorded": True},
         )
         return True
 
@@ -184,7 +194,13 @@ class FakeLayoutRepository:
         if not self._owns(kwargs):
             return False
         self.events.append("post_failure")
-        refresh_pending = self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+        refresh_pending = (
+            self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+            and (self.state.last_probe_evidence or {}).get(
+                "post_cutover_evidence_recorded"
+            )
+            is not True
+        )
         self.state = replace(
             self.state,
             phase=(
@@ -339,7 +355,12 @@ class FakeRuntime:
             engine=engine,
             layout_contract_version="skills-pool-p3-v1",
             preparation_id=PREPARATION_ID,
-            evidence={"marker": "valid"},
+            evidence={
+                "marker": "valid",
+                "cutover_evidence_contract_version": (
+                    CUTOVER_EVIDENCE_CONTRACT_VERSION
+                ),
+            },
         )
 
     async def probe(self, **kwargs: object) -> RuntimeLayoutProbeResult:
@@ -407,6 +428,31 @@ async def test_ready_claimed_bot_completes_pool_activation() -> None:
             "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-b"
         ),
     }
+
+
+@pytest.mark.asyncio
+async def test_pre_upgrade_runtime_stays_legacy_before_cutover() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={"marker": "valid"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.NOT_CAPABLE
+    assert result.evidence == {
+        "marker": "valid",
+        "reason": "cutover_evidence_contract_not_supported",
+        "required_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+    }
+    assert runtime.events == ["probe"]
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert layouts.state.data_plane_cutover_committed is False
 
 
 @pytest.mark.asyncio
@@ -478,10 +524,11 @@ async def test_hermes_h0_ready_uses_its_own_pool_paths_for_full_activation() -> 
     runtime.probe_result = replace(
         runtime.probe_result,
         evidence={
+            "cutover_evidence_contract_version": (CUTOVER_EVIDENCE_CONTRACT_VERSION),
             "checks": {
                 "legacy_local_bridge_valid": True,
                 "stable_repo_bridge_valid": True,
-            }
+            },
         },
     )
 
@@ -610,6 +657,76 @@ async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
     assert layouts.events == ["evidence", "database"]
     assert layouts.state.active_layout is SkillLayout.POOL
+
+
+@pytest.mark.asyncio
+async def test_committed_old_runtime_without_quarantine_waits_for_upgrade() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    layouts.quarantine_identity = False
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.TRANSIENT_ERROR
+    assert result.retryable is True
+    assert runtime.events == ["probe", "cutover"]
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.last_failure_code == "RUNTIME_CONTRACT_UPGRADE_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_mapping_failure_after_repair_evidence_does_not_reopen_cutover() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+    runtime.publish_success = False
+
+    first = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert first.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.last_failure_code == "MAPPING_PUBLISH_FAILED"
+
+    runtime.publish_success = True
+    runtime.events.clear()
+    layouts.events.clear()
+    retried = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "mapping", "verify"]
+    assert layouts.events == ["database"]
 
 
 @pytest.mark.asyncio
@@ -1146,7 +1263,10 @@ async def test_pool_active_reconciliation_probes_current_runtime() -> None:
     )
 
     assert result.outcome is SkillsPoolReconcileOutcome.ALREADY_ACTIVE
-    assert result.evidence == {"marker": "valid"}
+    assert result.evidence == {
+        "marker": "valid",
+        "cutover_evidence_contract_version": (CUTOVER_EVIDENCE_CONTRACT_VERSION),
+    }
     assert runtime.events == ["probe"]
 
 
@@ -1287,7 +1407,10 @@ def test_real_reconciliation_retry_resumes_same_generation_without_repeating_cut
         engine="openclaw",
         layout_contract_version=LAYOUT_CONTRACT_VERSION,
         preparation_id=PREPARATION_ID,
-        evidence={"marker": "valid"},
+        evidence={
+            "marker": "valid",
+            "cutover_evidence_contract_version": (CUTOVER_EVIDENCE_CONTRACT_VERSION),
+        },
     )
     runtime.cutover_result = PoolCutoverResult(
         committed=True,
@@ -1363,7 +1486,12 @@ class ReadyProbeService:
             engine="openclaw",
             layout_contract_version=LAYOUT_CONTRACT_VERSION,
             preparation_id=PREPARATION_ID,
-            evidence={"marker": "valid"},
+            evidence={
+                "marker": "valid",
+                "cutover_evidence_contract_version": (
+                    CUTOVER_EVIDENCE_CONTRACT_VERSION
+                ),
+            },
         )
 
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -85,6 +85,7 @@ class FakeLayoutRepository:
         self.lease_valid = True
         self.fail_once_at: str | None = None
         self.quarantine_identity = True
+        self.quarantine_conflict = False
 
     def _should_fail(self, stage: str) -> bool:
         if self.fail_once_at != stage:
@@ -129,6 +130,25 @@ class FakeLayoutRepository:
         )
         return True
 
+    def release_changed_engine_claim(self, **kwargs: object) -> bool:
+        if self._should_fail("changed_engine_release"):
+            return False
+        if not self._owns(kwargs):
+            return False
+        self.events.append("changed_engine_release")
+        self.state = replace(
+            self.state,
+            target_layout=None,
+            phase=SkillLayoutPhase.LEGACY_ACTIVE,
+            migration_generation=None,
+            preparation_id=None,
+            last_probe_result="BOT_CHANGED",
+            last_probe_evidence=dict(kwargs["evidence"]),
+            lease_owner=None,
+            lease_expires_at=None,
+        )
+        return True
+
     def holds_lease(self, **kwargs: object) -> bool:
         return self.lease_valid and self._owns(kwargs)
 
@@ -150,6 +170,13 @@ class FakeLayoutRepository:
             kwargs["scope"] == SCOPE
             and kwargs["migration_generation"] == GENERATION
             and self.quarantine_identity
+        )
+
+    def quarantine_identity_conflicts(self, **kwargs: object) -> bool:
+        return (
+            kwargs["scope"] == SCOPE
+            and kwargs["migration_generation"] == GENERATION
+            and self.quarantine_conflict
         )
 
     def record_post_cutover_evidence(self, **kwargs: object) -> bool:
@@ -508,7 +535,7 @@ async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
 
     assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
-    assert layouts.events == ["ready", "begin", "cutover", "database"]
+    assert layouts.events == ["cutover", "database"]
     assert "not_capable_release" not in layouts.events
 
 
@@ -540,7 +567,7 @@ async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> No
     assert result.outcome is SkillsPoolReconcileOutcome.TRANSIENT_ERROR
     assert result.retryable is True
     assert runtime.events == ["probe", "cutover"]
-    assert layouts.events == ["ready", "begin", "finalizing"]
+    assert layouts.events == ["finalizing"]
     assert "not_capable_release" not in layouts.events
     assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
     assert layouts.state.data_plane_cutover_committed is True
@@ -573,7 +600,73 @@ async def test_changed_engine_is_rejected_before_runtime_access() -> None:
 
     assert result.outcome is SkillsPoolReconcileOutcome.BOT_CHANGED
     assert runtime.events == []
+    assert layouts.events == ["changed_engine_release"]
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert layouts.state.migration_generation is None
+    assert layouts.state.last_probe_result == "BOT_CHANGED"
+
+
+@pytest.mark.asyncio
+async def test_changed_engine_keeps_activating_generation_fail_closed() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            rollout_evidence=RolloutEvidence(
+                env=SCOPE.env,
+                config_id=12,
+                config_version="revision-1",
+                batch_id="openclaw-batch",
+                engine_type="openclaw",
+                decision_reason="whitelist",
+            ),
+        )
+    )
+    runtime = FakeRuntime(engine="claude_code")
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="claude_code",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.BOT_CHANGED
+    assert runtime.events == []
     assert layouts.events == []
+    assert layouts.state.phase is SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER
+    assert layouts.state.migration_generation == GENERATION
+
+
+@pytest.mark.asyncio
+async def test_committed_quarantine_identity_conflict_is_not_retried() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    layouts.quarantine_conflict = True
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"quarantine": "/runtime/quarantine/conflicting/skills-local"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert runtime.events == ["probe", "cutover"]
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.last_failure_code == "QUARANTINE_IDENTITY_CONFLICT"
+    assert layouts.state.last_failure_retryable is False
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -34,6 +34,7 @@ from agentclaw.community.core.skills_pool.reconcile_task import (
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
+    RolloutEvidence,
     SkillLayout,
     SkillLayoutPhase,
 )
@@ -453,6 +454,126 @@ async def test_pre_upgrade_runtime_stays_legacy_before_cutover() -> None:
     assert runtime.events == ["probe"]
     assert layouts.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
     assert layouts.state.data_plane_cutover_committed is False
+
+
+@pytest.mark.asyncio
+async def test_pre_upgrade_runtime_releases_ready_claim_safely() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_READY,
+            preparation_id=PREPARATION_ID,
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={"marker": "valid"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.NOT_CAPABLE
+    assert runtime.events == ["probe"]
+    assert layouts.events == ["not_capable_release"]
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert layouts.state.migration_generation is None
+
+
+@pytest.mark.asyncio
+async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            preparation_id=PREPARATION_ID,
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={"marker": "valid"},
+    )
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"quarantine": "/runtime/quarantine/generation-1/skills-local"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["ready", "begin", "cutover", "database"]
+    assert "not_capable_release" not in layouts.events
+
+
+@pytest.mark.asyncio
+async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            preparation_id=PREPARATION_ID,
+        )
+    )
+    layouts.quarantine_identity = False
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={"marker": "valid"},
+    )
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.TRANSIENT_ERROR
+    assert result.retryable is True
+    assert runtime.events == ["probe", "cutover"]
+    assert layouts.events == ["ready", "begin", "finalizing"]
+    assert "not_capable_release" not in layouts.events
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+
+
+@pytest.mark.asyncio
+async def test_changed_engine_is_rejected_before_runtime_access() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            rollout_evidence=RolloutEvidence(
+                env=SCOPE.env,
+                config_id=12,
+                config_version="revision-1",
+                batch_id="openclaw-batch",
+                engine_type="openclaw",
+                decision_reason="whitelist",
+            )
+        )
+    )
+    runtime = FakeRuntime(engine="claude_code")
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="claude_code",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.BOT_CHANGED
+    assert runtime.events == []
+    assert layouts.events == []
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1198,6 +1198,10 @@ def test_cutover_retry_replays_residue_after_merge_failure(
     )
 
     assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert retry.evidence["quarantine"] == str(
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
+    )
+    assert retry.evidence["quarantine_cleanup_pending"] is True
     assert not legacy_local.exists()
     assert (
         pool_local / "created-before-merge-failure" / "SKILL.md"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1583,6 +1583,41 @@ def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
     assert retry.status is PoolActivationStatus.COMMITTED
 
 
+def test_committed_cleanup_failure_keeps_quarantine_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import layout_activation
+
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def fail_after_compatibility_bridge(**_kwargs: object) -> None:
+        legacy_local.symlink_to(pool_local, target_is_directory=True)
+        raise OSError(5, "injected post-cutover cleanup failure")
+
+    monkeypatch.setattr(
+        layout_activation,
+        "_finalize_active_root",
+        fail_after_compatibility_bridge,
+    )
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    quarantine = (
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
+    )
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert result.evidence["reason"] == "post_cutover_cleanup_failed"
+    assert result.evidence["quarantine"] == str(quarantine)
+    assert result.evidence["quarantine_cleanup_pending"] is True
+
+
 def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:
     home, legacy_local, pool_local, _pool_repo = _prepared_home(tmp_path)
     valid_source = pool_local / "handmade"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1618,6 +1618,46 @@ def test_committed_cleanup_failure_keeps_quarantine_evidence(
     assert result.evidence["quarantine_cleanup_pending"] is True
 
 
+def test_already_committed_evidence_does_not_reprobe_quarantine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, _legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    first = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert first.status is PoolActivationStatus.COMMITTED
+
+    quarantine = (
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
+    )
+    real_exists = Path.exists
+
+    def fail_quarantine_probe(path: Path) -> bool:
+        if path == quarantine:
+            raise OSError(5, "injected quarantine probe failure")
+        return real_exists(path)
+
+    monkeypatch.setattr(Path, "exists", fail_quarantine_probe)
+    replay = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert replay.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert replay.evidence["quarantine"] == str(quarantine)
+    assert replay.evidence["quarantine_cleanup_pending"] is True
+
+
 def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:
     home, legacy_local, pool_local, _pool_repo = _prepared_home(tmp_path)
     valid_source = pool_local / "handmade"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from engine.community.plugins.openclaw.layout_probe import (
+    CUTOVER_EVIDENCE_CONTRACT_VERSION,
     LAYOUT_CONTRACT_VERSION,
     RuntimeLayoutInspectionStatus,
     inspect_runtime_layout,
@@ -65,6 +66,10 @@ def test_ready_requires_real_bridge_mount_and_readable_repo(tmp_path):
 
     assert result.status is RuntimeLayoutInspectionStatus.READY
     assert result.preparation_id == "2a958f59-8cf4-4413-a267-7d56d3382f23"
+    assert (
+        result.evidence["cutover_evidence_contract_version"]
+        == CUTOVER_EVIDENCE_CONTRACT_VERSION
+    )
     assert result.evidence["checks"]["pool_repo_mounted"] is True
     assert result.evidence["checks"]["legacy_repo_bridge_valid"] is True
 
@@ -100,6 +105,10 @@ def test_active_marker_requires_direct_pool_mappings_and_absent_storage_entries(
 
     assert result.status is RuntimeLayoutInspectionStatus.READY
     assert result.evidence["activation_state"] == "active"
+    assert (
+        result.evidence["cutover_evidence_contract_version"]
+        == CUTOVER_EVIDENCE_CONTRACT_VERSION
+    )
     assert result.evidence["checks"]["legacy_storage_entries_absent"] is True
 
 
@@ -171,13 +180,7 @@ def test_active_marker_allows_normal_skill_activation(tmp_path):
 
 
 def _active_marker_path(home: Path) -> Path:
-    return (
-        home
-        / ".openclaw"
-        / "workspace"
-        / "skills-pool"
-        / ".pool-active"
-    )
+    return home / ".openclaw" / "workspace" / "skills-pool" / ".pool-active"
 
 
 def _write_active_marker(
@@ -196,9 +199,7 @@ def _write_active_marker(
     }
     if activation_state == "finalizing" or mappings is not None:
         marker["mappings"] = [] if mappings is None else mappings
-    marker_path.write_text(
-        json.dumps(marker)
-    )
+    marker_path.write_text(json.dumps(marker))
     return marker_path
 
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1151,9 +1151,11 @@ def _activate_pool(
                 "active_marker": str(layout.active_marker),
                 "legacy_storage_entries_absent": True,
                 "quarantine": str(quarantine),
-                "quarantine_cleanup_pending": (
-                    quarantine.exists() or quarantine.is_symlink()
-                ),
+                # Finalization has already crossed the irreversible boundary.
+                # Keep cleanup evidence conservative and deterministic instead
+                # of probing persistent storage again while building the
+                # ALREADY_COMMITTED response.
+                "quarantine_cleanup_pending": True,
             },
         )
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1150,6 +1150,10 @@ def _activate_pool(
             {
                 "active_marker": str(layout.active_marker),
                 "legacy_storage_entries_absent": True,
+                "quarantine": str(quarantine),
+                "quarantine_cleanup_pending": (
+                    quarantine.exists() or quarantine.is_symlink()
+                ),
             },
         )
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1436,21 +1436,31 @@ def _activate_pool(
         committed = layout.legacy_local.is_symlink() and _lexical_target(
             layout.legacy_local
         ) == Path(os.path.abspath(layout.pool_local))
+        evidence: dict[str, object] = {
+            "reason": (
+                "post_cutover_cleanup_failed"
+                if committed
+                else "filesystem_operation_failed"
+            ),
+            "error_type": type(error).__name__,
+            "errno": error.errno,
+        }
+        if committed:
+            evidence.update(
+                {
+                    "quarantine": str(quarantine),
+                    "quarantine_cleanup_pending": (
+                        quarantine.exists() or quarantine.is_symlink()
+                    ),
+                }
+            )
         return PoolActivationResult(
             (
                 PoolActivationStatus.COMMITTED
                 if committed
                 else PoolActivationStatus.TRANSIENT_ERROR
             ),
-            {
-                "reason": (
-                    "post_cutover_cleanup_failed"
-                    if committed
-                    else "filesystem_operation_failed"
-                ),
-                "error_type": type(error).__name__,
-                "errno": error.errno,
-            },
+            evidence,
         )
 
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1449,9 +1449,11 @@ def _activate_pool(
             evidence.update(
                 {
                     "quarantine": str(quarantine),
-                    "quarantine_cleanup_pending": (
-                        quarantine.exists() or quarantine.is_symlink()
-                    ),
+                    # We are already handling an I/O failure after the
+                    # irreversible cutover. Do not probe the filesystem again
+                    # while constructing the COMMITTED response: Python 3.12
+                    # may re-raise permission/I/O errors from Path predicates.
+                    "quarantine_cleanup_pending": True,
                 }
             )
         return PoolActivationResult(

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 
 LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+CUTOVER_EVIDENCE_CONTRACT_VERSION = "quarantine-v1"
 
 
 class RuntimeLayoutInspectionStatus(str, Enum):
@@ -400,8 +401,7 @@ def _active_entries_valid(layout: _FilesystemPoolLayout) -> bool:
     """Validate mutable managed entries without freezing an old mapping set."""
 
     pool_roots = tuple(
-        Path(os.path.abspath(root))
-        for root in (layout.pool_local, layout.pool_repo)
+        Path(os.path.abspath(root)) for root in (layout.pool_local, layout.pool_repo)
     )
     retired_roots = tuple(
         Path(os.path.abspath(root))
@@ -745,6 +745,9 @@ def inspect_runtime_layout(
                 "active_marker": str(layout.active_marker),
                 "prepared_at": marker["prepared_at"],
                 "activation_state": active_marker["activation_state"],
+                "cutover_evidence_contract_version": (
+                    CUTOVER_EVIDENCE_CONTRACT_VERSION
+                ),
                 "checks": {
                     "marker_valid": True,
                     "active_marker_valid": True,
@@ -755,9 +758,7 @@ def inspect_runtime_layout(
                     "legacy_storage_entries_absent": (
                         active_marker["activation_state"] == "active"
                     ),
-                    "stable_repo_bridge_valid": (
-                        engine in {"aicoding", "hermes"}
-                    ),
+                    "stable_repo_bridge_valid": (engine in {"aicoding", "hermes"}),
                 },
             },
         )
@@ -850,6 +851,7 @@ def inspect_runtime_layout(
         evidence={
             "marker": str(layout.marker),
             "prepared_at": marker["prepared_at"],
+            "cutover_evidence_contract_version": (CUTOVER_EVIDENCE_CONTRACT_VERSION),
             "checks": checks,
         },
     )
@@ -857,6 +859,7 @@ def inspect_runtime_layout(
 
 __all__ = [
     "LAYOUT_CONTRACT_VERSION",
+    "CUTOVER_EVIDENCE_CONTRACT_VERSION",
     "RuntimeLayoutInspection",
     "RuntimeLayoutInspectionStatus",
     "inspect_runtime_layout",


### PR DESCRIPTION
## Summary

修复 Skills Pool 在数据面已经 committed 后的 repair/finalizing 重入状态机，避免 transport 异常被错误写入 pre-cutover CAS 并产生 `state_race_lost`。

## Changes

- 已 committed 的 runtime refresh 失败统一记录 forward-only failure，不再进入 pre-cutover failure 或重复 cutover commit
- 新增 post-cutover evidence reconciliation，只补齐 marker/quarantine 证据
- finalizing 在跨越不可逆边界时同步登记 quarantine，后续 ALREADY_COMMITTED 幂等收敛
- 覆盖 transport UNKNOWN、INVALID、finalizing transient、ALREADY_COMMITTED 与最终 POOL_ACTIVE 回归

## Test Plan

- `uv run pytest tests/community/core/skills_pool tests/community/di/test_skills_pool_wiring.py tests/community/endpoints/test_skills_pool_ops.py tests/community/adapters/http/test_skills_pool_ops_router.py -q`（198 passed）
- changed files Ruff lint/format passed