### PR TITLE
fix: negotiate pool cutover evidence contract

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -25,6 +25,7 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 
 LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
 MAPPING_CONTRACT_VERSION = "skills-pool-mapping-v2"
+CUTOVER_EVIDENCE_CONTRACT_VERSION = "quarantine-v1"
 
 
 class RuntimeLayoutProbeStatus(str, Enum):
@@ -259,6 +260,7 @@ __all__ = [
     "CurrentRuntimeLayoutProbeService",
     "LAYOUT_CONTRACT_VERSION",
     "MAPPING_CONTRACT_VERSION",
+    "CUTOVER_EVIDENCE_CONTRACT_VERSION",
     "RuntimeLayoutProbeResult",
     "RuntimeLayoutProbeStatus",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -69,6 +69,11 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   与 `POOL_ACTIVE`，不恢复隔离副本。已提交状态的 runtime 重入只补齐
   quarantine/marker 证据，不重复执行数据面 commit CAS；transport 或校验失败
   只记录 forward-only failure。
+- runtime probe 通过 `cutover_evidence_contract_version=quarantine-v1`
+  声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
+  未声明该能力的旧 runtime 时只释放尚未切换的 claim 并保持 Legacy；对于
+  已跨界重试，允许旧响应复用 DB 中既有 quarantine 身份。两边都缺少身份时
+  记录可重试的 runtime 升级要求，不由 Backend 推导引擎物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -73,9 +73,12 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
   未声明该能力的旧 runtime 时，只释放 `POOL_PREPARING/POOL_READY` claim
   并保持 Legacy；`POOL_ACTIVATING_PRE_CUTOVER` 已属于结果不确定区，必须继续
-  幂等调用 cutover 探明事实。对于已跨界重试，允许旧响应复用 DB 中既有
-  quarantine 身份。两边都缺少身份时记录可重试的 runtime 升级要求，不由
-  Backend 推导引擎物理路径。
+  幂等调用 cutover 探明事实，READY probe 不得把它降回可释放阶段。认领后的
+  Bot 引擎若发生漂移，只允许释放尚在 PREPARING/READY 的 claim；切换开始后
+  保持 fail closed。对于已跨界重试，允许旧响应复用 DB 中既有 quarantine
+  身份；runtime 返回的身份与持久化身份冲突时记录不可重试的数据一致性错误。
+  两边都缺少身份时记录可重试的 runtime 升级要求，不由 Backend 推导引擎
+  物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -73,12 +73,13 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
   未声明该能力的旧 runtime 时，只释放 `POOL_PREPARING/POOL_READY` claim
   并保持 Legacy；`POOL_ACTIVATING_PRE_CUTOVER` 已属于结果不确定区，必须继续
-  幂等调用 cutover 探明事实，READY probe 不得把它降回可释放阶段。认领后的
-  Bot 引擎若发生漂移，只允许释放尚在 PREPARING/READY 的 claim；切换开始后
-  保持 fail closed。对于已跨界重试，允许旧响应复用 DB 中既有 quarantine
-  身份；runtime 返回的身份与持久化身份冲突时记录不可重试的数据一致性错误。
-  两边都缺少身份时记录可重试的 runtime 升级要求，不由 Backend 推导引擎
-  物理路径。
+  幂等调用 cutover 探明事实，READY probe 不得把它降回可释放阶段；probe
+  返回的 preparation identity 必须与进入 ACTIVATING 时持久化的 identity
+  一致，否则在调用 runtime 前转人工修复。认领后的 Bot 引擎若发生漂移，只
+  允许释放尚在 PREPARING/READY 的 claim；切换开始后保持 fail closed。对于
+  已跨界重试，允许旧响应复用 DB 中既有 quarantine 身份；runtime 返回的身份
+  与持久化身份冲突时记录不可重试的数据一致性错误。两边都缺少身份时记录
+  可重试的 runtime 升级要求，不由 Backend 推导引擎物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -71,9 +71,11 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   只记录 forward-only failure。
 - runtime probe 通过 `cutover_evidence_contract_version=quarantine-v1`
   声明激活响应能够返回 generation-scoped quarantine 证据。新 Backend 遇到
-  未声明该能力的旧 runtime 时只释放尚未切换的 claim 并保持 Legacy；对于
-  已跨界重试，允许旧响应复用 DB 中既有 quarantine 身份。两边都缺少身份时
-  记录可重试的 runtime 升级要求，不由 Backend 推导引擎物理路径。
+  未声明该能力的旧 runtime 时，只释放 `POOL_PREPARING/POOL_READY` claim
+  并保持 Legacy；`POOL_ACTIVATING_PRE_CUTOVER` 已属于结果不确定区，必须继续
+  幂等调用 cutover 探明事实。对于已跨界重试，允许旧响应复用 DB 中既有
+  quarantine 身份。两边都缺少身份时记录可重试的 runtime 升级要求，不由
+  Backend 推导引擎物理路径。
 - 在递归版 OpenClaw 发布前的 Pool 独立 rollout 窗口，显式回滚先持久化
   `LEGACY_ROLLBACK_PREPARING` 作为 Bot 级编辑暂停状态，
   再从当前 Pool 全量重建新的 Legacy local 并提交切换。切换后即使 mapping

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -228,6 +228,34 @@ class SkillsPoolReconcileService:
                 evidence=probe.evidence,
                 retryable=False,
             )
+        if (
+            state.phase is SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER
+            and state.preparation_id != probe.preparation_id
+        ):
+            identity_evidence = {
+                **probe.evidence,
+                "reason": "preparation_identity_changed_during_cutover",
+                "persisted_preparation_id": state.preparation_id,
+                "observed_preparation_id": probe.preparation_id,
+            }
+            if not self._layouts.mark_repair_required(
+                scope=scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                failure_code="PREPARATION_IDENTITY_CHANGED",
+                failure_stage="runtime_probe",
+                evidence=identity_evidence,
+            ):
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                    preparation_id=probe.preparation_id,
+                )
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED,
+                preparation_id=probe.preparation_id,
+                evidence=identity_evidence,
+                retryable=False,
+            )
 
         if (
             not state.data_plane_cutover_committed

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -111,6 +111,7 @@ class SkillsPoolReconcileService:
         if state.lease_owner != lease_owner:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.LEASE_NOT_HELD)
 
+        generation = state.migration_generation
         bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
         if bot is None:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_NOT_FOUND)
@@ -121,7 +122,33 @@ class SkillsPoolReconcileService:
             state.rollout_evidence is not None
             and state.rollout_evidence.engine_type != engine
         ):
-            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
+            evidence = {
+                "reason": "bot_engine_changed",
+                "claimed_engine": state.rollout_evidence.engine_type,
+                "current_engine": engine,
+            }
+            if (
+                state.phase
+                in {
+                    SkillLayoutPhase.POOL_PREPARING,
+                    SkillLayoutPhase.POOL_READY,
+                }
+                and not state.data_plane_cutover_committed
+            ):
+                if not self._layouts.release_changed_engine_claim(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    evidence=evidence,
+                ):
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        evidence=evidence,
+                    )
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.BOT_CHANGED,
+                evidence=evidence,
+            )
         if engine not in FILESYSTEM_POOL_ENGINES:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
 
@@ -129,7 +156,6 @@ class SkillsPoolReconcileService:
         if not isinstance(owner_id, (str, int)) or isinstance(owner_id, bool):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         user_id = str(owner_id)
-        generation = state.migration_generation
         if not self._layouts.holds_lease(
             scope=scope,
             migration_generation=generation,
@@ -279,23 +305,31 @@ class SkillsPoolReconcileService:
             or repair_evidence_refresh
         ):
             if not state.data_plane_cutover_committed:
-                recorded = self._layouts.record_ready_probe(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    preparation_id=probe.preparation_id,
-                    evidence=probe.evidence,
-                )
-                if not recorded:
-                    return SkillsPoolReconcileResult(
-                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                if state.phase in {
+                    SkillLayoutPhase.POOL_PREPARING,
+                    SkillLayoutPhase.POOL_READY,
+                }:
+                    recorded = self._layouts.record_ready_probe(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                        evidence=probe.evidence,
                     )
-                if not self._layouts.begin_cutover(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    preparation_id=probe.preparation_id,
-                ):
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                        )
+                    if not self._layouts.begin_cutover(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                    ):
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                        )
+                elif state.phase is not SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER:
                     return SkillsPoolReconcileResult(
                         SkillsPoolReconcileOutcome.STATE_RACE_LOST
                     )
@@ -405,8 +439,54 @@ class SkillsPoolReconcileService:
                     preparation_id=probe.preparation_id,
                     evidence=cutover.to_dict(),
                 )
+            quarantine_path = cutover.evidence.get("quarantine")
+            if (
+                isinstance(quarantine_path, str)
+                and quarantine_path
+                and self._layouts.quarantine_identity_conflicts(
+                    scope=scope,
+                    migration_generation=generation,
+                    engine=engine,
+                    path=quarantine_path,
+                )
+            ):
+                conflict_evidence = {
+                    **cutover.to_dict(),
+                    "reason": "quarantine_identity_conflict",
+                }
+                if state.data_plane_cutover_committed:
+                    recorded = self._layouts.record_post_cutover_failure(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code="QUARANTINE_IDENTITY_CONFLICT",
+                        failure_stage="post_cutover_evidence",
+                        retryable=False,
+                        evidence=conflict_evidence,
+                    )
+                    outcome = SkillsPoolReconcileOutcome.INVALID
+                else:
+                    recorded = self._layouts.mark_repair_required(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code="QUARANTINE_IDENTITY_CONFLICT",
+                        failure_stage="cutover_identity",
+                        evidence=conflict_evidence,
+                    )
+                    outcome = SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED
+                if not recorded:
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        preparation_id=probe.preparation_id,
+                    )
+                return SkillsPoolReconcileResult(
+                    outcome,
+                    preparation_id=probe.preparation_id,
+                    evidence=conflict_evidence,
+                    retryable=False,
+                )
             if state.data_plane_cutover_committed:
-                quarantine_path = cutover.evidence.get("quarantine")
                 if (
                     not isinstance(quarantine_path, str) or not quarantine_path
                 ) and not self._layouts.has_quarantine_identity(
@@ -441,7 +521,6 @@ class SkillsPoolReconcileService:
                         preparation_id=probe.preparation_id,
                     )
             else:
-                quarantine_path = cutover.evidence.get("quarantine")
                 if (
                     not isinstance(quarantine_path, str) or not quarantine_path
                 ) and not self._layouts.has_quarantine_identity(

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.bot_management.repository.protocol import (
     BotRepository,
 )
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    CUTOVER_EVIDENCE_CONTRACT_VERSION,
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skills_pool.models import (
@@ -197,6 +198,44 @@ class SkillsPoolReconcileService:
                 retryable=False,
             )
 
+        if (
+            not state.data_plane_cutover_committed
+            and probe.evidence.get("cutover_evidence_contract_version")
+            != CUTOVER_EVIDENCE_CONTRACT_VERSION
+        ):
+            compatibility_evidence = {
+                **probe.evidence,
+                "reason": "cutover_evidence_contract_not_supported",
+                "required_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+            }
+            if state.phase is SkillLayoutPhase.POOL_PREPARING:
+                recorded = self._layouts.release_not_capable_claim(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    evidence=compatibility_evidence,
+                )
+            else:
+                recorded = self._layouts.record_pre_cutover_failure(
+                    scope=scope,
+                    migration_generation=generation,
+                    lease_owner=lease_owner,
+                    failure_code="NOT_CAPABLE",
+                    failure_stage="runtime_contract",
+                    retryable=False,
+                    evidence=compatibility_evidence,
+                )
+            if not recorded:
+                return SkillsPoolReconcileResult(
+                    SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                )
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.NOT_CAPABLE,
+                preparation_id=probe.preparation_id,
+                evidence=compatibility_evidence,
+                retryable=False,
+            )
+
         local_assets = self._skills.list_bot_local_assets(
             env=scope.env,
             bot_id=scope.bot_id,
@@ -368,6 +407,29 @@ class SkillsPoolReconcileService:
                     evidence=cutover.to_dict(),
                 )
             if state.data_plane_cutover_committed:
+                quarantine_path = cutover.evidence.get("quarantine")
+                if (
+                    not isinstance(quarantine_path, str) or not quarantine_path
+                ) and not self._layouts.has_quarantine_identity(
+                    scope=scope,
+                    migration_generation=generation,
+                ):
+                    return self._record_post_cutover_failure(
+                        scope=scope,
+                        generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                        outcome=SkillsPoolReconcileOutcome.TRANSIENT_ERROR,
+                        failure_code="RUNTIME_CONTRACT_UPGRADE_REQUIRED",
+                        failure_stage="post_cutover_evidence",
+                        evidence={
+                            **cutover.to_dict(),
+                            "reason": (
+                                "quarantine_identity_missing_from_runtime_and_db"
+                            ),
+                            "required_version": (CUTOVER_EVIDENCE_CONTRACT_VERSION),
+                        },
+                    )
                 if not self._layouts.record_post_cutover_evidence(
                     scope=scope,
                     migration_generation=generation,

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -117,6 +117,11 @@ class SkillsPoolReconcileService:
         engine = bot.get("active_engine")
         if bot.get("env") != scope.env or not isinstance(engine, str):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
+        if (
+            state.rollout_evidence is not None
+            and state.rollout_evidence.engine_type != engine
+        ):
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         if engine not in FILESYSTEM_POOL_ENGINES:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
 
@@ -200,6 +205,11 @@ class SkillsPoolReconcileService:
 
         if (
             not state.data_plane_cutover_committed
+            and state.phase
+            in {
+                SkillLayoutPhase.POOL_PREPARING,
+                SkillLayoutPhase.POOL_READY,
+            }
             and probe.evidence.get("cutover_evidence_contract_version")
             != CUTOVER_EVIDENCE_CONTRACT_VERSION
         ):
@@ -208,23 +218,12 @@ class SkillsPoolReconcileService:
                 "reason": "cutover_evidence_contract_not_supported",
                 "required_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
             }
-            if state.phase is SkillLayoutPhase.POOL_PREPARING:
-                recorded = self._layouts.release_not_capable_claim(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    evidence=compatibility_evidence,
-                )
-            else:
-                recorded = self._layouts.record_pre_cutover_failure(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    failure_code="NOT_CAPABLE",
-                    failure_stage="runtime_contract",
-                    retryable=False,
-                    evidence=compatibility_evidence,
-                )
+            recorded = self._layouts.release_not_capable_claim(
+                scope=scope,
+                migration_generation=generation,
+                lease_owner=lease_owner,
+                evidence=compatibility_evidence,
+            )
             if not recorded:
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.STATE_RACE_LOST
@@ -442,6 +441,35 @@ class SkillsPoolReconcileService:
                         preparation_id=probe.preparation_id,
                     )
             else:
+                quarantine_path = cutover.evidence.get("quarantine")
+                if (
+                    not isinstance(quarantine_path, str) or not quarantine_path
+                ) and not self._layouts.has_quarantine_identity(
+                    scope=scope,
+                    migration_generation=generation,
+                ):
+                    contract_evidence = {
+                        **cutover.to_dict(),
+                        "reason": ("quarantine_identity_missing_from_runtime_and_db"),
+                        "required_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+                    }
+                    if not self._layouts.record_cutover_finalizing(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        preparation_id=probe.preparation_id,
+                        evidence=contract_evidence,
+                    ):
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            preparation_id=probe.preparation_id,
+                        )
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.TRANSIENT_ERROR,
+                        preparation_id=probe.preparation_id,
+                        evidence=contract_evidence,
+                        retryable=True,
+                    )
                 if not self._layouts.record_cutover_committed(
                     scope=scope,
                     migration_generation=generation,

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -118,37 +118,15 @@ class SkillsPoolReconcileService:
         engine = bot.get("active_engine")
         if bot.get("env") != scope.env or not isinstance(engine, str):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
-        if (
-            state.rollout_evidence is not None
-            and state.rollout_evidence.engine_type != engine
-        ):
-            evidence = {
-                "reason": "bot_engine_changed",
-                "claimed_engine": state.rollout_evidence.engine_type,
-                "current_engine": engine,
-            }
-            if (
-                state.phase
-                in {
-                    SkillLayoutPhase.POOL_PREPARING,
-                    SkillLayoutPhase.POOL_READY,
-                }
-                and not state.data_plane_cutover_committed
-            ):
-                if not self._layouts.release_changed_engine_claim(
-                    scope=scope,
-                    migration_generation=generation,
-                    lease_owner=lease_owner,
-                    evidence=evidence,
-                ):
-                    return SkillsPoolReconcileResult(
-                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
-                        evidence=evidence,
-                    )
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.BOT_CHANGED,
-                evidence=evidence,
-            )
+        engine_drift = self._handle_engine_drift(
+            scope=scope,
+            state=state,
+            current_engine=engine,
+            generation=generation,
+            lease_owner=lease_owner,
+        )
+        if engine_drift is not None:
+            return engine_drift
         if engine not in FILESYSTEM_POOL_ENGINES:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
 
@@ -864,6 +842,51 @@ class SkillsPoolReconcileService:
             return None
         evidence = cutover.get("evidence")
         return evidence if isinstance(evidence, dict) else None
+
+    def _handle_engine_drift(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        state: BotSkillLayoutState,
+        current_engine: str,
+        generation: str,
+        lease_owner: str,
+    ) -> SkillsPoolReconcileResult | None:
+        claimed_engine = (
+            state.rollout_evidence.engine_type
+            if state.rollout_evidence is not None
+            else None
+        )
+        if claimed_engine is None or claimed_engine == current_engine:
+            return None
+
+        evidence = {
+            "reason": "bot_engine_changed",
+            "claimed_engine": claimed_engine,
+            "current_engine": current_engine,
+        }
+        claim_is_releasable = (
+            state.phase
+            in {
+                SkillLayoutPhase.POOL_PREPARING,
+                SkillLayoutPhase.POOL_READY,
+            }
+            and not state.data_plane_cutover_committed
+        )
+        if claim_is_releasable and not self._layouts.release_changed_engine_claim(
+            scope=scope,
+            migration_generation=generation,
+            lease_owner=lease_owner,
+            evidence=evidence,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                evidence=evidence,
+            )
+        return SkillsPoolReconcileResult(
+            SkillsPoolReconcileOutcome.BOT_CHANGED,
+            evidence=evidence,
+        )
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -122,6 +122,15 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """在边界已提交时补齐运行时证据，不重复提交数据面边界。"""
         ...
 
+    def has_quarantine_identity(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+    ) -> bool:
+        """确认该 generation 已持久化 quarantine 身份。"""
+        ...
+
     def record_cutover_finalizing(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -98,6 +98,17 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         """记录旧运行时证据，并原子释放尚处于准备阶段的迁移认领。"""
         ...
 
+    def release_changed_engine_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """记录引擎身份漂移，并原子释放尚未开始切换的迁移认领。"""
+        ...
+
     def record_cutover_committed(
         self,
         *,
@@ -129,6 +140,17 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         migration_generation: str,
     ) -> bool:
         """确认该 generation 已持久化 quarantine 身份。"""
+        ...
+
+    def quarantine_identity_conflicts(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        engine: str,
+        path: str,
+    ) -> bool:
+        """判断运行时身份是否与该 generation 已持久化身份冲突。"""
         ...
 
     def record_cutover_finalizing(

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
@@ -29,7 +29,7 @@ class SkillsPoolCapabilityRepositoryMixin:
         lease_owner: str,
         evidence: dict[str, object],
     ) -> bool:
-        """Persist old-runtime evidence and release only a preparing claim."""
+        """Persist old-runtime evidence and release a provably pre-cutover claim."""
 
         evidence_json = json.dumps(evidence, ensure_ascii=False)
         with self._database.transactional_orm_session() as session:
@@ -39,12 +39,14 @@ class SkillsPoolCapabilityRepositoryMixin:
                     BotSkillLayoutStateModel.env == scope.env,
                     BotSkillLayoutStateModel.entity_id == scope.entity_id,
                     BotSkillLayoutStateModel.bot_id == scope.bot_id,
-                    BotSkillLayoutStateModel.active_layout
-                    == SkillLayout.LEGACY.value,
-                    BotSkillLayoutStateModel.target_layout
-                    == SkillLayout.POOL.value,
-                    BotSkillLayoutStateModel.phase
-                    == SkillLayoutPhase.POOL_PREPARING.value,
+                    BotSkillLayoutStateModel.active_layout == SkillLayout.LEGACY.value,
+                    BotSkillLayoutStateModel.target_layout == SkillLayout.POOL.value,
+                    BotSkillLayoutStateModel.phase.in_(
+                        (
+                            SkillLayoutPhase.POOL_PREPARING.value,
+                            SkillLayoutPhase.POOL_READY.value,
+                        )
+                    ),
                     BotSkillLayoutStateModel.data_plane_cutover_committed == 0,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_capability_repository.py
@@ -21,15 +21,16 @@ class SkillsPoolCapabilityRepositoryMixin:
 
     _database: object
 
-    def release_not_capable_claim(
+    def _release_pre_cutover_claim(
         self,
         *,
         scope: BotSkillLayoutScope,
         migration_generation: str,
         lease_owner: str,
+        result: str,
         evidence: dict[str, object],
     ) -> bool:
-        """Persist old-runtime evidence and release a provably pre-cutover claim."""
+        """Persist evidence and release a provably pre-cutover claim."""
 
         evidence_json = json.dumps(evidence, ensure_ascii=False)
         with self._database.transactional_orm_session() as session:
@@ -61,7 +62,7 @@ class SkillsPoolCapabilityRepositoryMixin:
                         ),
                         BotSkillLayoutStateModel.migration_generation: None,
                         BotSkillLayoutStateModel.preparation_id: None,
-                        BotSkillLayoutStateModel.last_probe_result: "NOT_CAPABLE",
+                        BotSkillLayoutStateModel.last_probe_result: result,
                         BotSkillLayoutStateModel.last_probe_evidence: evidence_json,
                         BotSkillLayoutStateModel.last_failure_code: None,
                         BotSkillLayoutStateModel.last_failure_stage: None,
@@ -75,3 +76,39 @@ class SkillsPoolCapabilityRepositoryMixin:
                 )
             )
         return affected == 1
+
+    def release_not_capable_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Persist old-runtime evidence and release a safe claim."""
+
+        return self._release_pre_cutover_claim(
+            scope=scope,
+            migration_generation=migration_generation,
+            lease_owner=lease_owner,
+            result="NOT_CAPABLE",
+            evidence=evidence,
+        )
+
+    def release_changed_engine_claim(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        lease_owner: str,
+        evidence: dict[str, object],
+    ) -> bool:
+        """Release a safe claim whose immutable engine identity changed."""
+
+        return self._release_pre_cutover_claim(
+            scope=scope,
+            migration_generation=migration_generation,
+            lease_owner=lease_owner,
+            result="BOT_CHANGED",
+            evidence=evidence,
+        )

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -528,10 +528,23 @@ class SkillsPoolLayoutRepository(
             )
             if row is None:
                 return False
+            try:
+                last_probe_evidence = (
+                    json.loads(row.last_probe_evidence)
+                    if row.last_probe_evidence
+                    else {}
+                )
+            except (TypeError, ValueError):
+                last_probe_evidence = {}
             # Older Backend versions used this failure code as the durable
-            # "runtime evidence still missing" signal. Move that signal into
-            # the phase before replacing the code with the latest failure.
-            if row.last_failure_code == "MANUAL_REPAIR_RESOLVED":
+            # "runtime evidence still missing" signal. Once refreshed,
+            # last_probe_evidence carries an explicit durable success marker,
+            # so downstream failures must not reopen runtime finalization.
+            if (
+                row.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+                and last_probe_evidence.get("post_cutover_evidence_recorded")
+                is not True
+            ):
                 row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
             row.last_failure_code = failure_code
             row.last_failure_stage = failure_stage

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -539,10 +539,14 @@ class SkillsPoolLayoutRepository(
             # "runtime evidence still missing" signal. Once refreshed,
             # last_probe_evidence carries an explicit durable success marker,
             # so downstream failures must not reopen runtime finalization.
+            cutover_evidence = last_probe_evidence.get("cutover")
             if (
                 row.last_failure_code == "MANUAL_REPAIR_RESOLVED"
-                and last_probe_evidence.get("post_cutover_evidence_recorded")
-                is not True
+                and (
+                    not isinstance(cutover_evidence, dict)
+                    or cutover_evidence.get("post_cutover_evidence_recorded")
+                    is not True
+                )
             ):
                 row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
             row.last_failure_code = failure_code

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -535,18 +535,16 @@ class SkillsPoolLayoutRepository(
                 )
             except (TypeError, ValueError):
                 last_probe_evidence = {}
-            # Older Backend versions used this failure code as the durable
-            # "runtime evidence still missing" signal. Once refreshed,
+            # Once runtime evidence is refreshed,
             # last_probe_evidence carries an explicit durable success marker,
             # so downstream failures must not reopen runtime finalization.
             cutover_evidence = last_probe_evidence.get("cutover")
+            evidence_refreshed = isinstance(
+                cutover_evidence, dict
+            ) and cutover_evidence.get("post_cutover_evidence_recorded") is True
             if (
                 row.last_failure_code == "MANUAL_REPAIR_RESOLVED"
-                and (
-                    not isinstance(cutover_evidence, dict)
-                    or cutover_evidence.get("post_cutover_evidence_recorded")
-                    is not True
-                )
+                and not evidence_refreshed
             ):
                 row.phase = SkillLayoutPhase.POOL_CUTOVER_FINALIZING.value
             row.last_failure_code = failure_code

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -322,9 +322,6 @@ class SkillsPoolLayoutRepository(
             engine = json.loads(row.rollout_evidence).get("engine_type")
             if not isinstance(engine, str) or not engine:
                 return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
             if not self._upsert_quarantine(
                 session,
                 scope=scope,
@@ -333,6 +330,8 @@ class SkillsPoolLayoutRepository(
                 path=quarantine_path,
                 evidence_json=evidence_json,
             ):
+                if not isinstance(quarantine_path, str) or not quarantine_path:
+                    log_missing_quarantine_path(scope, migration_generation)
                 return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
             row.data_plane_cutover_committed = 1

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy import func
 
 from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
+    SkillMigrationQuarantineModel,
 )
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
@@ -24,6 +25,28 @@ class SkillsPoolPostCutoverRepositoryMixin:
 
     _database: object
 
+    def has_quarantine_identity(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+    ) -> bool:
+        """Check whether an older runtime may reuse persisted quarantine identity."""
+
+        with self._database.transactional_orm_session() as session:
+            return (
+                session.query(SkillMigrationQuarantineModel)
+                .filter(
+                    SkillMigrationQuarantineModel.env == scope.env,
+                    SkillMigrationQuarantineModel.entity_id == scope.entity_id,
+                    SkillMigrationQuarantineModel.bot_id == scope.bot_id,
+                    SkillMigrationQuarantineModel.migration_generation
+                    == migration_generation,
+                )
+                .one_or_none()
+                is not None
+            )
+
     def record_post_cutover_evidence(
         self,
         *,
@@ -35,7 +58,11 @@ class SkillsPoolPostCutoverRepositoryMixin:
     ) -> bool:
         """Reconcile runtime evidence without re-crossing the cutover boundary."""
 
-        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        persisted_evidence = {
+            **evidence,
+            "post_cutover_evidence_recorded": True,
+        }
+        evidence_json = json.dumps(persisted_evidence, ensure_ascii=False)
         runtime_evidence = evidence.get("evidence")
         quarantine_path = (
             runtime_evidence.get("quarantine")
@@ -70,9 +97,6 @@ class SkillsPoolPostCutoverRepositoryMixin:
             engine = json.loads(row.rollout_evidence).get("engine_type")
             if not isinstance(engine, str) or not engine:
                 return False
-            if not isinstance(quarantine_path, str) or not quarantine_path:
-                log_missing_quarantine_path(scope, migration_generation)
-                return False
             if not self._upsert_quarantine(
                 session,
                 scope=scope,
@@ -81,6 +105,8 @@ class SkillsPoolPostCutoverRepositoryMixin:
                 path=quarantine_path,
                 evidence_json=evidence_json,
             ):
+                if not isinstance(quarantine_path, str) or not quarantine_path:
+                    log_missing_quarantine_path(scope, migration_generation)
                 return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
             row.last_probe_evidence = evidence_json

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_post_cutover_repository.py
@@ -18,6 +18,9 @@ from agentclaw.community.core.skills_pool.types import (
 from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
     log_missing_quarantine_path,
 )
+from agentclaw.community.plugins.skills_pool_layout_persistence import (
+    encode_stage_evidence,
+)
 
 
 class SkillsPoolPostCutoverRepositoryMixin:
@@ -109,5 +112,9 @@ class SkillsPoolPostCutoverRepositoryMixin:
                     log_missing_quarantine_path(scope, migration_generation)
                 return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
-            row.last_probe_evidence = evidence_json
+            row.last_probe_evidence = encode_stage_evidence(
+                row.last_probe_evidence,
+                stage="cutover",
+                evidence=persisted_evidence,
+            )
         return True

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
@@ -82,7 +82,7 @@ class SkillsPoolQuarantineRepositoryMixin:
         )
         if existing is not None:
             return existing.engine == engine and (
-                not isinstance(path, str) or existing.path == path
+                not isinstance(path, str) or not path or existing.path == path
             )
         if not isinstance(path, str) or not path:
             return False

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
@@ -27,6 +27,32 @@ class SkillsPoolQuarantineRepositoryMixin:
 
     _database: object
 
+    def quarantine_identity_conflicts(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        migration_generation: str,
+        engine: str,
+        path: str,
+    ) -> bool:
+        """Return whether a runtime identity contradicts durable evidence."""
+
+        with self._database.transactional_orm_session() as session:
+            existing = (
+                session.query(SkillMigrationQuarantineModel)
+                .filter(
+                    SkillMigrationQuarantineModel.env == scope.env,
+                    SkillMigrationQuarantineModel.entity_id == scope.entity_id,
+                    SkillMigrationQuarantineModel.bot_id == scope.bot_id,
+                    SkillMigrationQuarantineModel.migration_generation
+                    == migration_generation,
+                )
+                .one_or_none()
+            )
+            return existing is not None and (
+                existing.engine != engine or existing.path != path
+            )
+
     @staticmethod
     def _cleanup_lease_deadline(session, seconds: int):
         if session.bind.dialect.name == "sqlite":

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -347,6 +347,48 @@ def test_not_capable_probe_releases_ready_claim_before_cutover() -> None:
     assert state.preparation_id is None
 
 
+def test_changed_engine_releases_ready_claim_before_cutover() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+
+    assert repository.release_changed_engine_claim(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        evidence={
+            "reason": "bot_engine_changed",
+            "claimed_engine": "openclaw",
+            "current_engine": "claude_code",
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert state.target_layout is None
+    assert state.migration_generation is None
+    assert state.last_probe_result == "BOT_CHANGED"
+    assert state.last_probe_evidence == {
+        "reason": "bot_engine_changed",
+        "claimed_engine": "openclaw",
+        "current_engine": "claude_code",
+    }
+
+
 def test_claim_updates_an_existing_unclaimed_legacy_row() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -882,6 +924,24 @@ def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
     assert repository.has_quarantine_identity(
         scope=scope,
         migration_generation="generation-1",
+    )
+    assert not repository.quarantine_identity_conflicts(
+        scope=scope,
+        migration_generation="generation-1",
+        engine="openclaw",
+        path=quarantine_path,
+    )
+    assert repository.quarantine_identity_conflicts(
+        scope=scope,
+        migration_generation="generation-1",
+        engine="openclaw",
+        path=f"{quarantine_path}-other",
+    )
+    assert repository.quarantine_identity_conflicts(
+        scope=scope,
+        migration_generation="generation-1",
+        engine="claude_code",
+        path=quarantine_path,
     )
     assert repository.record_post_cutover_evidence(
         scope=scope,

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -971,7 +971,14 @@ def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
 
     state = repository.get(scope)
     assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
-    assert state.last_probe_evidence["post_cutover_evidence_recorded"] is True
+    assert (
+        state.last_probe_evidence["cutover"]["post_cutover_evidence_recorded"]
+        is True
+    )
+    assert state.last_probe_evidence["cutover"]["evidence"] == {
+        "active_marker": "same-generation",
+        "quarantine": "",
+    }
     with database.transactional_orm_session() as session:
         quarantine = session.query(SkillMigrationQuarantineModel).one()
         assert quarantine.path == quarantine_path

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -314,6 +314,39 @@ def test_not_capable_probe_releases_preparing_claim_and_preserves_evidence() -> 
     assert state.data_plane_cutover_committed is False
 
 
+def test_not_capable_probe_releases_ready_claim_before_cutover() -> None:
+    repository = SkillsPoolLayoutRepository(InMemorySqliteDB())
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+
+    assert repository.release_not_capable_claim(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        evidence={"reason": "runtime_contract_missing"},
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert state.target_layout is None
+    assert state.migration_generation is None
+    assert state.preparation_id is None
+
+
 def test_claim_updates_an_existing_unclaimed_legacy_row() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -868,6 +901,62 @@ def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
     with database.transactional_orm_session() as session:
         quarantine = session.query(SkillMigrationQuarantineModel).one()
         assert quarantine.path == quarantine_path
+
+
+def test_cutover_commit_reuses_quarantine_from_pending_response() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    quarantine_path = (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+    assert repository.record_cutover_finalizing(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "status": "POST_CUTOVER_SYNC_PENDING",
+            "evidence": {"quarantine": quarantine_path},
+        },
+    )
+
+    assert repository.record_cutover_committed(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "ALREADY_COMMITTED",
+            "evidence": {"active_marker": "same-generation"},
+        },
+    )
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert state.data_plane_cutover_committed is True
 
 
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -954,6 +954,20 @@ def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
             "evidence": {"active_marker": "same-generation"},
         },
     )
+    assert repository.record_post_cutover_evidence(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "ALREADY_COMMITTED",
+            "evidence": {
+                "active_marker": "same-generation",
+                "quarantine": "",
+            },
+        },
+    )
 
     state = repository.get(scope)
     assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -805,6 +805,71 @@ def test_cutover_finalizing_accepts_pending_evidence_without_quarantine() -> Non
         assert session.query(SkillMigrationQuarantineModel).count() == 0
 
 
+def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    quarantine_path = (
+        "/home/admin/.openclaw/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+    assert repository.record_cutover_committed(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "COMMITTED",
+            "evidence": {"quarantine": quarantine_path},
+        },
+    )
+
+    assert repository.has_quarantine_identity(
+        scope=scope,
+        migration_generation="generation-1",
+    )
+    assert repository.record_post_cutover_evidence(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "ALREADY_COMMITTED",
+            "evidence": {"active_marker": "same-generation"},
+        },
+    )
+
+    state = repository.get(scope)
+    assert state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert state.last_probe_evidence["post_cutover_evidence_recorded"] is True
+    with database.transactional_orm_session() as session:
+        quarantine = session.query(SkillMigrationQuarantineModel).one()
+        assert quarantine.path == quarantine_path
+
+
 def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -32,6 +32,7 @@ from agentclaw.community.core.skills_pool.reconcile_task import (
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
+    RolloutEvidence,
     SkillLayout,
     SkillLayoutPhase,
 )
@@ -544,6 +545,126 @@ async def test_conflicting_same_name_sources_fail_before_cutover() -> None:
     assert runtime.physical_cutovers == 0
     assert layouts.events == ["failure"]
     assert layouts.state.data_plane_cutover_committed is False
+
+
+@pytest.mark.asyncio
+async def test_pre_upgrade_runtime_releases_ready_claim_safely() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_READY,
+            preparation_id=PREPARATION_ID,
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={"marker": "valid"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.NOT_CAPABLE
+    assert runtime.events == ["probe"]
+    assert layouts.events == ["not_capable_release"]
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert layouts.state.migration_generation is None
+
+
+@pytest.mark.asyncio
+async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            preparation_id=PREPARATION_ID,
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={"marker": "valid"},
+    )
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"quarantine": "/runtime/quarantine/generation-1/skills-local"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["ready", "begin", "cutover", "database"]
+    assert "not_capable_release" not in layouts.events
+
+
+@pytest.mark.asyncio
+async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            preparation_id=PREPARATION_ID,
+        )
+    )
+    layouts.quarantine_identity = False
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        evidence={"marker": "valid"},
+    )
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.TRANSIENT_ERROR
+    assert result.retryable is True
+    assert runtime.events == ["probe", "cutover"]
+    assert layouts.events == ["ready", "begin", "finalizing"]
+    assert "not_capable_release" not in layouts.events
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+
+
+@pytest.mark.asyncio
+async def test_changed_engine_is_rejected_before_runtime_access() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            rollout_evidence=RolloutEvidence(
+                env=SCOPE.env,
+                config_id=12,
+                config_version="revision-1",
+                batch_id="openclaw-batch",
+                engine_type="openclaw",
+                decision_reason="whitelist",
+            )
+        )
+    )
+    runtime = FakeRuntime(engine="claude_code")
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="claude_code",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.BOT_CHANGED
+    assert runtime.events == []
+    assert layouts.events == []
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -192,6 +192,13 @@ class FakeLayoutRepository:
             self.state,
             phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
             data_plane_cutover_committed=True,
+            last_probe_evidence={
+                **(self.state.last_probe_evidence or {}),
+                "cutover": {
+                    **dict(kwargs["evidence"]),
+                    "post_cutover_evidence_recorded": True,
+                },
+            },
         )
         return True
 
@@ -224,7 +231,15 @@ class FakeLayoutRepository:
         if not self._owns(kwargs):
             return False
         self.events.append("post_failure")
-        refresh_pending = self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+        cutover_evidence = (self.state.last_probe_evidence or {}).get("cutover")
+        refresh_pending = (
+            self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+            and (
+                not isinstance(cutover_evidence, dict)
+                or cutover_evidence.get("post_cutover_evidence_recorded")
+                is not True
+            )
+        )
         self.state = replace(
             self.state,
             phase=(
@@ -1010,6 +1025,51 @@ async def test_resolved_pool_committed_repair_skips_duplicate_cutover_ledger_cas
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
     assert layouts.events == ["evidence", "database"]
     assert layouts.state.active_layout is SkillLayout.POOL
+
+
+@pytest.mark.asyncio
+async def test_repair_refresh_mapping_failure_reuses_persisted_locator_evidence() -> (
+    None
+):
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="MANUAL_REPAIR_RESOLVED",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_marker": "same-generation"},
+    )
+    runtime.publish_success = False
+
+    first = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert first.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
+    assert layouts.state.last_probe_evidence["cutover"]["evidence"][
+        "local_locators"
+    ]["local-a"].endswith("/local-a")
+
+    runtime.events.clear()
+    layouts.events.clear()
+    runtime.publish_success = True
+
+    retried = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert retried.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "mapping", "verify"]
+    assert layouts.events == ["database"]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -638,6 +638,40 @@ async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_activating_generation_rejects_changed_preparation_identity() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            preparation_id="persisted-preparation",
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        preparation_id="regenerated-preparation",
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.MANUAL_REPAIR_REQUIRED
+    assert result.retryable is False
+    assert runtime.events == ["probe"]
+    assert layouts.events == ["manual_repair"]
+    assert layouts.state.phase is SkillLayoutPhase.NEEDS_MANUAL_REPAIR
+    assert layouts.state.last_failure_code == "PREPARATION_IDENTITY_CHANGED"
+    assert layouts.state.last_failure_evidence == {
+        "marker": "valid",
+        "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+        "reason": "preparation_identity_changed_during_cutover",
+        "persisted_preparation_id": "persisted-preparation",
+        "observed_preparation_id": "regenerated-preparation",
+    }
+
+
+@pytest.mark.asyncio
 async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> None:
     layouts = FakeLayoutRepository(
         claimed_state(

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    CUTOVER_EVIDENCE_CONTRACT_VERSION,
     LAYOUT_CONTRACT_VERSION,
     RuntimeLayoutProbeResult,
     RuntimeLayoutProbeStatus,
@@ -403,6 +404,7 @@ class FakeRuntime:
             preparation_id=PREPARATION_ID,
             evidence={
                 "marker": "valid",
+                "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
                 "resolved_layout": {
                     "active_root": "/runtime/skills",
                     "local_root": self.pool_local,
@@ -618,7 +620,7 @@ async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
     runtime = FakeRuntime()
     runtime.probe_result = replace(
         runtime.probe_result,
-        evidence={"marker": "valid"},
+        evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
     )
     runtime.cutover_result = PoolCutoverResult(
         committed=True,
@@ -664,6 +666,11 @@ async def test_activating_generation_rejects_changed_preparation_identity() -> N
     assert layouts.state.last_failure_code == "PREPARATION_IDENTITY_CHANGED"
     assert layouts.state.last_failure_evidence == {
         "marker": "valid",
+        "resolved_layout": {
+            "active_root": "/runtime/skills",
+            "local_root": "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+            "repo_root": "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+        },
         "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
         "reason": "preparation_identity_changed_during_cutover",
         "persisted_preparation_id": "persisted-preparation",
@@ -683,7 +690,7 @@ async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> No
     runtime = FakeRuntime()
     runtime.probe_result = replace(
         runtime.probe_result,
-        evidence={"marker": "valid"},
+        evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
     )
     runtime.cutover_result = PoolCutoverResult(
         committed=True,
@@ -869,12 +876,13 @@ async def test_hermes_h0_ready_uses_its_own_pool_paths_for_full_activation() -> 
     )
     runtime.probe_result = replace(
         runtime.probe_result,
-        evidence={
-            "checks": {
-                "legacy_local_bridge_valid": True,
-                "stable_repo_bridge_valid": True,
-            }
-        },
+            evidence={
+                "checks": {
+                    "legacy_local_bridge_valid": True,
+                    "stable_repo_bridge_valid": True,
+                },
+                "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+            },
     )
 
     result = await build_service(
@@ -1682,7 +1690,7 @@ def test_real_reconciliation_retry_resumes_same_generation_without_repeating_cut
         engine="openclaw",
         layout_contract_version=LAYOUT_CONTRACT_VERSION,
         preparation_id=PREPARATION_ID,
-        evidence={"marker": "valid"},
+        evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
     )
     runtime.cutover_result = PoolCutoverResult(
         committed=True,
@@ -1769,7 +1777,7 @@ class ReadyProbeService:
             engine="openclaw",
             layout_contract_version=LAYOUT_CONTRACT_VERSION,
             preparation_id=PREPARATION_ID,
-            evidence={"marker": "valid"},
+            evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
         )
 
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -82,6 +82,8 @@ class FakeLayoutRepository:
         self.committed_locators: dict[int, str] | None = None
         self.lease_valid = True
         self.fail_once_at: str | None = None
+        self.quarantine_identity = True
+        self.quarantine_conflict = False
 
     def _should_fail(self, stage: str) -> bool:
         if self.fail_once_at != stage:
@@ -127,6 +129,25 @@ class FakeLayoutRepository:
         )
         return True
 
+    def release_changed_engine_claim(self, **kwargs: object) -> bool:
+        if self._should_fail("changed_engine_release"):
+            return False
+        if not self._owns(kwargs):
+            return False
+        self.events.append("changed_engine_release")
+        self.state = replace(
+            self.state,
+            target_layout=None,
+            phase=SkillLayoutPhase.LEGACY_ACTIVE,
+            migration_generation=None,
+            preparation_id=None,
+            last_probe_result="BOT_CHANGED",
+            last_probe_evidence=dict(kwargs["evidence"]),
+            lease_owner=None,
+            lease_expires_at=None,
+        )
+        return True
+
     def holds_lease(self, **kwargs: object) -> bool:
         return self.lease_valid and self._owns(kwargs)
 
@@ -147,6 +168,19 @@ class FakeLayoutRepository:
         )
         return True
 
+    def has_quarantine_identity(self, **kwargs: object) -> bool:
+        return (
+            kwargs["scope"] == SCOPE
+            and kwargs["migration_generation"] == GENERATION
+            and self.quarantine_identity
+        )
+
+    def quarantine_identity_conflicts(self, **kwargs: object) -> bool:
+        return (
+            kwargs["scope"] == SCOPE
+            and kwargs["migration_generation"] == GENERATION
+            and self.quarantine_conflict
+        )
     def record_post_cutover_evidence(self, **kwargs: object) -> bool:
         if self._should_fail("post_cutover_evidence"):
             return False
@@ -599,7 +633,7 @@ async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
 
     assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert runtime.events == ["probe", "cutover", "mapping", "verify"]
-    assert layouts.events == ["ready", "begin", "cutover", "database"]
+    assert layouts.events == ["cutover", "database"]
     assert "not_capable_release" not in layouts.events
 
 
@@ -631,7 +665,7 @@ async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> No
     assert result.outcome is SkillsPoolReconcileOutcome.TRANSIENT_ERROR
     assert result.retryable is True
     assert runtime.events == ["probe", "cutover"]
-    assert layouts.events == ["ready", "begin", "finalizing"]
+    assert layouts.events == ["finalizing"]
     assert "not_capable_release" not in layouts.events
     assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
     assert layouts.state.data_plane_cutover_committed is True
@@ -664,7 +698,73 @@ async def test_changed_engine_is_rejected_before_runtime_access() -> None:
 
     assert result.outcome is SkillsPoolReconcileOutcome.BOT_CHANGED
     assert runtime.events == []
+    assert layouts.events == ["changed_engine_release"]
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+    assert layouts.state.migration_generation is None
+    assert layouts.state.last_probe_result == "BOT_CHANGED"
+
+
+@pytest.mark.asyncio
+async def test_changed_engine_keeps_activating_generation_fail_closed() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+            rollout_evidence=RolloutEvidence(
+                env=SCOPE.env,
+                config_id=12,
+                config_version="revision-1",
+                batch_id="openclaw-batch",
+                engine_type="openclaw",
+                decision_reason="whitelist",
+            ),
+        )
+    )
+    runtime = FakeRuntime(engine="claude_code")
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="claude_code",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.BOT_CHANGED
+    assert runtime.events == []
     assert layouts.events == []
+    assert layouts.state.phase is SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER
+    assert layouts.state.migration_generation == GENERATION
+
+
+@pytest.mark.asyncio
+async def test_committed_quarantine_identity_conflict_is_not_retried() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    layouts.quarantine_conflict = True
+    runtime = FakeRuntime()
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"quarantine": "/runtime/quarantine/conflicting/skills-local"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert runtime.events == ["probe", "cutover"]
+    assert layouts.events == ["post_failure"]
+    assert layouts.state.last_failure_code == "QUARANTINE_IDENTITY_CONFLICT"
+    assert layouts.state.last_failure_retryable is False
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1687,6 +1687,46 @@ def test_committed_cleanup_failure_keeps_quarantine_evidence(
     assert result.evidence["quarantine_cleanup_pending"] is True
 
 
+def test_already_committed_evidence_does_not_reprobe_quarantine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, _legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    first = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert first.status is PoolActivationStatus.COMMITTED
+
+    quarantine = (
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
+    )
+    real_exists = Path.exists
+
+    def fail_quarantine_probe(path: Path) -> bool:
+        if path == quarantine:
+            raise OSError(5, "injected quarantine probe failure")
+        return real_exists(path)
+
+    monkeypatch.setattr(Path, "exists", fail_quarantine_probe)
+    replay = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert replay.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert replay.evidence["quarantine"] == str(quarantine)
+    assert replay.evidence["quarantine_cleanup_pending"] is True
+
+
 def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:
     home, legacy_local, pool_local, _pool_repo = _prepared_home(tmp_path)
     valid_source = pool_local / "handmade"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -1652,6 +1652,41 @@ def test_cutover_reports_transient_filesystem_failure(tmp_path: Path) -> None:
     assert retry.status is PoolActivationStatus.COMMITTED
 
 
+def test_committed_cleanup_failure_keeps_quarantine_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import layout_activation
+
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+
+    def fail_after_compatibility_bridge(**_kwargs: object) -> None:
+        legacy_local.symlink_to(pool_local, target_is_directory=True)
+        raise OSError(5, "injected post-cutover cleanup failure")
+
+    monkeypatch.setattr(
+        layout_activation,
+        "_finalize_active_root",
+        fail_after_compatibility_bridge,
+    )
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    quarantine = (
+        pool_local.parent / ".migration-quarantine" / "generation-1" / "skills-local"
+    )
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert result.evidence["reason"] == "post_cutover_cleanup_failed"
+    assert result.evidence["quarantine"] == str(quarantine)
+    assert result.evidence["quarantine_cleanup_pending"] is True
+
+
 def test_mapping_verifier_reports_each_drift_class(tmp_path: Path) -> None:
     home, legacy_local, pool_local, _pool_repo = _prepared_home(tmp_path)
     valid_source = pool_local / "handmade"

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1137,9 +1137,11 @@ def _activate_pool(
                 "active_marker": str(layout.active_marker),
                 "legacy_storage_entries_absent": True,
                 "quarantine": str(quarantine),
-                "quarantine_cleanup_pending": (
-                    quarantine.exists() or quarantine.is_symlink()
-                ),
+                # Finalization has already crossed the irreversible boundary.
+                # Keep cleanup evidence conservative and deterministic instead
+                # of probing persistent storage again while building the
+                # ALREADY_COMMITTED response.
+                "quarantine_cleanup_pending": True,
             },
         )
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1410,21 +1410,31 @@ def _activate_pool(
         committed = layout.legacy_local.is_symlink() and _lexical_target(
             layout.legacy_local
         ) == Path(os.path.abspath(layout.pool_local))
+        evidence: dict[str, object] = {
+            "reason": (
+                "post_cutover_cleanup_failed"
+                if committed
+                else "filesystem_operation_failed"
+            ),
+            "error_type": type(error).__name__,
+            "errno": error.errno,
+        }
+        if committed:
+            evidence.update(
+                {
+                    "quarantine": str(quarantine),
+                    "quarantine_cleanup_pending": (
+                        quarantine.exists() or quarantine.is_symlink()
+                    ),
+                }
+            )
         return PoolActivationResult(
             (
                 PoolActivationStatus.COMMITTED
                 if committed
                 else PoolActivationStatus.TRANSIENT_ERROR
             ),
-            {
-                "reason": (
-                    "post_cutover_cleanup_failed"
-                    if committed
-                    else "filesystem_operation_failed"
-                ),
-                "error_type": type(error).__name__,
-                "errno": error.errno,
-            },
+            evidence,
         )
 
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1423,9 +1423,11 @@ def _activate_pool(
             evidence.update(
                 {
                     "quarantine": str(quarantine),
-                    "quarantine_cleanup_pending": (
-                        quarantine.exists() or quarantine.is_symlink()
-                    ),
+                    # We are already handling an I/O failure after the
+                    # irreversible cutover. Do not probe the filesystem again
+                    # while constructing the COMMITTED response: Python 3.12
+                    # may re-raise permission/I/O errors from Path predicates.
+                    "quarantine_cleanup_pending": True,
                 }
             )
         return PoolActivationResult(

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -62,6 +62,7 @@ def _ready_evidence(
     evidence: dict[str, Any] = {
         "marker": str(layout.marker),
         "prepared_at": marker["prepared_at"],
+        "cutover_evidence_contract_version": "quarantine-v1",
         "checks": checks,
     }
     if activation_state is not None:


### PR DESCRIPTION
## Summary

- negotiate a versioned runtime quarantine evidence contract before cutover
- keep pre-upgrade runtimes on Legacy and reuse persisted quarantine identity for committed retries
- prevent downstream mapping failures from reopening completed evidence finalization
- preserve operator repair audit while recording durable evidence-refresh success

## Validation

- Backend Skills Pool suite: 190 passed
- Engine layout probe/activation: 89 passed
- Ruff and diff checks passed

## Context

Follow-up hotfix for the review findings discovered after #570 had already merged into REL20260730.