### PR TITLE
refactor(engine): centralize Skills layout planning

### DIFF
--- a/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
+++ b/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
@@ -304,8 +304,8 @@ SC 接入后，`skills-center` 作为 `skills-pool` 下与 `skills-repo`、`skil
                      │       Engine Runtime               │
                      │ EngineSkillLayoutDescriptor        │
                      │  - active / legacy / pool roots    │
-                     │  - mount targets / compatibility   │
-                     │  - prepare / verify rules          │
+                     │  - structural compatibility links  │
+                     │  - filesystem / artifact kind      │
                      │ EngineSkillLayoutResolver           │
                      └──────────────┬────────────────────┘
                                     │ 统一解析接口
@@ -318,18 +318,58 @@ SC 接入后，`skills-center` 作为 `skills-pool` 下与 `skills-repo`、`skil
                                     v
                        各引擎真实目录、挂载和激活入口
 
- Backend ── 仅下发逻辑布局意图与 Skill 激活意图 ──> Engine Runtime
+ Backend ── 仅下发逻辑状态与 Skill 激活意图 ──> Engine Runtime
 ```
 
-Descriptor 至少覆盖 active 入口、Legacy/Pool 的 local 和 repo 根目录、兼容桥、挂载目标、准备与校验规则，以及 Teclaw 的显式 no-op/artifact 行为。未知引擎或未知布局契约必须失败关闭，不能默认回退为 OpenClaw。
+Descriptor 至少覆盖 active 入口、Legacy/Pool 的 local 和 repo 根目录、兼容桥，以及 Teclaw 的显式 artifact 行为。未知引擎或未知布局契约必须失败关闭，不能默认回退为 OpenClaw。
 
-Backend 的布局相关输入仅包含 `engine_type`、`layout_state` 和 `layout_contract_version`；Skill 激活本身继续以逻辑来源表达，不携带物理路径：
+Resolver 使用 Engine 持久化的逻辑引擎身份和当前运行时 home 解析拓扑：
+
+```text
+LayoutIdentity {
+  engine_type
+  layout_contract_version
+}
+
+RuntimeLayoutContext {
+  home
+}
+
+ResolvedSkillLayout {
+  engine_type
+  layout_contract_version
+  capability
+  active_root
+  legacy_local
+  legacy_repo
+  pool_root
+  pool_local
+  pool_repo
+  ready_marker
+  active_marker
+  structural_bridges
+}
+```
+
+一次解析同时返回 Legacy 与 Pool 的完整拓扑。Resolver 不读取 marker、Backend
+状态或 rollout 配置，不执行文件操作，也不选择当前权威布局。preparation、
+probe、activate、mapping、rollback 和 cleanup 根据各自协议消费命名路径；
+Backend 状态机负责决定 CRUD、mapping 和 locator 当前使用 Legacy 还是 Pool。
+
+repo 的挂载或下载属于 provider 的交付方式，不改变引擎目录身份，也不进入
+Resolver 输入。Cloud 与 Desktop 对同一逻辑引擎解析得到相同 descriptor，差异
+只存在于内容如何到达这些路径以及文件操作由谁执行。
+
+`aicoding` 与 `claude_code` 是不同的逻辑布局身份。两者共用
+`~/.claude/skills` 作为 CLI active 入口，但分别使用 `~/.aicoding` 与
+`~/.claude_code` 存储 Legacy/Pool 内容。既有 Skills Service 继续负责 physical
+路径转换和 CLI 兼容桥；Resolver 不用实现别名归一化替代 Bot 的逻辑身份。
+
+Skill 激活本身继续以逻辑来源表达，不携带物理路径：
 
 ```text
 {
-  engine_type: "claude_code",
-  layout_state: "pool",
-  layout_contract_version: 1,
+  source_layout: "pool",
   desired_skills: [
     {
       link_name: "risk-review",

--- a/src/engine/src/engine/community/core/skills/layout_planner.py
+++ b/src/engine/src/engine/community/core/skills/layout_planner.py
@@ -1,0 +1,289 @@
+"""Engine-owned Skills layout descriptors and resolver.
+
+This module is intentionally pure and stdlib-only. It resolves an Engine's
+logical layout identity into both Legacy and Pool topology. Callers choose the
+authoritative topology for their operation; the resolver does not inspect
+runtime state, rollout configuration, markers, or delivery mechanisms.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+
+
+class SkillLayoutCapability(StrEnum):
+    FILESYSTEM = "filesystem"
+    ARTIFACT = "artifact"
+
+
+class SkillLayoutResolutionError(ValueError):
+    """Logical layout identity cannot be resolved safely."""
+
+
+class UnsupportedLayoutContractError(SkillLayoutResolutionError):
+    pass
+
+
+class UnsupportedRuntimeLayoutError(SkillLayoutResolutionError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutIdentity:
+    engine_type: str
+    layout_contract_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeLayoutContext:
+    home: Path = Path("/home/admin")
+
+
+@dataclass(frozen=True, slots=True)
+class _FilesystemTemplate:
+    active_root: str
+    legacy_local: str
+    legacy_repo: str
+    pool_root: str
+    local_bridge: str
+    repo_bridge: str
+
+    def resolve(
+        self,
+        *,
+        identity: LayoutIdentity,
+        context: RuntimeLayoutContext,
+    ) -> ResolvedFilesystemLayoutPlan:
+        home = context.home
+
+        def path(relative: str) -> Path:
+            return home / relative
+
+        pool_root = path(self.pool_root)
+        return ResolvedFilesystemLayoutPlan(
+            engine_type=identity.engine_type,
+            layout_contract_version=identity.layout_contract_version,
+            active_root=path(self.active_root),
+            legacy_local=path(self.legacy_local),
+            legacy_repo=path(self.legacy_repo),
+            pool_root=pool_root,
+            pool_local=pool_root / "skills-local",
+            pool_repo=pool_root / "skills-repo",
+            ready_marker=pool_root / ".pool-ready",
+            active_marker=pool_root / ".pool-active",
+            local_bridge=path(self.local_bridge),
+            repo_bridge=path(self.repo_bridge),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EngineSkillLayoutDescriptor:
+    engine_type: str
+    capability: SkillLayoutCapability
+    filesystem: _FilesystemTemplate | None = None
+
+    def resolve(
+        self,
+        *,
+        identity: LayoutIdentity,
+        context: RuntimeLayoutContext,
+    ) -> ResolvedSkillLayoutPlan:
+        if identity.engine_type != self.engine_type:
+            raise SkillLayoutResolutionError(
+                "descriptor engine does not match layout identity"
+            )
+        if identity.layout_contract_version != LAYOUT_CONTRACT_VERSION:
+            raise UnsupportedLayoutContractError(
+                "unsupported Skills layout contract: "
+                f"{identity.layout_contract_version}"
+            )
+        if self.capability is SkillLayoutCapability.ARTIFACT:
+            return ResolvedArtifactLayoutPlan(
+                engine_type=self.engine_type,
+                layout_contract_version=identity.layout_contract_version,
+            )
+        template = self.filesystem
+        if template is None:
+            raise UnsupportedRuntimeLayoutError(
+                f"{self.engine_type} has no filesystem Skills layout"
+            )
+        return template.resolve(identity=identity, context=context)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedArtifactLayoutPlan:
+    engine_type: str
+    layout_contract_version: str
+    capability: SkillLayoutCapability = SkillLayoutCapability.ARTIFACT
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedFilesystemLayoutPlan:
+    engine_type: str
+    layout_contract_version: str
+    active_root: Path
+    legacy_local: Path
+    legacy_repo: Path
+    pool_root: Path
+    pool_local: Path
+    pool_repo: Path
+    ready_marker: Path
+    active_marker: Path
+    local_bridge: Path
+    repo_bridge: Path
+    capability: SkillLayoutCapability = SkillLayoutCapability.FILESYSTEM
+
+    @property
+    def marker(self) -> Path:
+        """Compatibility name used by the existing runtime probe."""
+
+        return self.ready_marker
+
+    @classmethod
+    def for_engine(
+        cls,
+        engine: str,
+        home: Path,
+    ) -> ResolvedFilesystemLayoutPlan:
+        """Compatibility constructor for existing Engine Pool consumers."""
+
+        return resolve_filesystem_skill_layout(
+            LayoutIdentity(
+                engine_type=engine,
+                layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            ),
+            RuntimeLayoutContext(home=home),
+        )
+
+    @classmethod
+    def for_home(cls, home: Path) -> ResolvedFilesystemLayoutPlan:
+        return cls.for_engine("openclaw", home)
+
+
+ResolvedSkillLayoutPlan = ResolvedFilesystemLayoutPlan | ResolvedArtifactLayoutPlan
+
+
+def _filesystem_template(
+    *,
+    engine_home: str,
+    active_root: str,
+    legacy_local: str,
+    legacy_repo: str,
+    local_bridge: str,
+    repo_bridge: str,
+) -> _FilesystemTemplate:
+    return _FilesystemTemplate(
+        active_root=active_root,
+        legacy_local=legacy_local,
+        legacy_repo=legacy_repo,
+        pool_root=f"{engine_home}/workspace/skills-pool",
+        local_bridge=local_bridge,
+        repo_bridge=repo_bridge,
+    )
+
+
+_OPENCLAW_FILESYSTEM = _filesystem_template(
+    engine_home=".openclaw",
+    active_root=".openclaw/workspace/skills",
+    legacy_local=".openclaw/workspace/skills/skills-local",
+    legacy_repo=".openclaw/workspace/skills/skills-repo",
+    local_bridge=".openclaw/workspace/skills/skills-local",
+    repo_bridge=".openclaw/workspace/skills/skills-repo",
+)
+_CLAUDE_FILESYSTEM = _filesystem_template(
+    engine_home=".claude_code",
+    active_root=".claude/skills",
+    legacy_local=".claude_code/workspace/skills/skills-local",
+    legacy_repo=".claude_code/skills-repo",
+    local_bridge=".claude/skills/skills-local",
+    repo_bridge=".claude/skills/skills-repo",
+)
+_AICODING_FILESYSTEM = _filesystem_template(
+    engine_home=".aicoding",
+    active_root=".claude/skills",
+    legacy_local=".aicoding/workspace/skills/skills-local",
+    legacy_repo=".aicoding/skills-repo",
+    local_bridge=".claude/skills/skills-local",
+    repo_bridge=".aicoding/skills-repo",
+)
+_HERMES_FILESYSTEM = _filesystem_template(
+    engine_home=".hermes",
+    active_root=".hermes/skills",
+    legacy_local=".hermes/workspace/skills/skills-local",
+    legacy_repo=".hermes/skills-repo",
+    local_bridge=".hermes/skills/skills-local",
+    repo_bridge=".hermes/skills-repo",
+)
+
+DESCRIPTORS: dict[str, EngineSkillLayoutDescriptor] = {
+    "openclaw": EngineSkillLayoutDescriptor(
+        engine_type="openclaw",
+        capability=SkillLayoutCapability.FILESYSTEM,
+        filesystem=_OPENCLAW_FILESYSTEM,
+    ),
+    "claude_code": EngineSkillLayoutDescriptor(
+        engine_type="claude_code",
+        capability=SkillLayoutCapability.FILESYSTEM,
+        filesystem=_CLAUDE_FILESYSTEM,
+    ),
+    "aicoding": EngineSkillLayoutDescriptor(
+        engine_type="aicoding",
+        capability=SkillLayoutCapability.FILESYSTEM,
+        filesystem=_AICODING_FILESYSTEM,
+    ),
+    "hermes": EngineSkillLayoutDescriptor(
+        engine_type="hermes",
+        capability=SkillLayoutCapability.FILESYSTEM,
+        filesystem=_HERMES_FILESYSTEM,
+    ),
+    "teclaw": EngineSkillLayoutDescriptor(
+        engine_type="teclaw",
+        capability=SkillLayoutCapability.ARTIFACT,
+    ),
+}
+
+
+def resolve_skill_layout(
+    identity: LayoutIdentity,
+    context: RuntimeLayoutContext,
+) -> ResolvedSkillLayoutPlan:
+    descriptor = DESCRIPTORS.get(identity.engine_type)
+    if descriptor is None:
+        raise SkillLayoutResolutionError(
+            f"unknown engine Skills layout: {identity.engine_type}"
+        )
+    return descriptor.resolve(identity=identity, context=context)
+
+
+def resolve_filesystem_skill_layout(
+    identity: LayoutIdentity,
+    context: RuntimeLayoutContext,
+) -> ResolvedFilesystemLayoutPlan:
+    plan = resolve_skill_layout(identity, context)
+    if not isinstance(plan, ResolvedFilesystemLayoutPlan):
+        raise UnsupportedRuntimeLayoutError(
+            f"{identity.engine_type} has no filesystem Skills layout"
+        )
+    return plan
+
+
+__all__ = [
+    "DESCRIPTORS",
+    "LAYOUT_CONTRACT_VERSION",
+    "EngineSkillLayoutDescriptor",
+    "LayoutIdentity",
+    "ResolvedArtifactLayoutPlan",
+    "ResolvedFilesystemLayoutPlan",
+    "ResolvedSkillLayoutPlan",
+    "RuntimeLayoutContext",
+    "SkillLayoutCapability",
+    "SkillLayoutResolutionError",
+    "UnsupportedLayoutContractError",
+    "UnsupportedRuntimeLayoutError",
+    "resolve_filesystem_skill_layout",
+    "resolve_skill_layout",
+]

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import json
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Callable
 from uuid import uuid4
 
+from engine.community.core.skills.layout_planner import (
+    ResolvedFilesystemLayoutPlan as _Layout,
+)
 from engine.community.plugins.skills_pool.layout_atomic import (
     atomic_exchange_paths,
 )
@@ -89,92 +92,6 @@ class MappingPublishResult:
 
     def to_data(self) -> dict[str, object]:
         return {"published": self.published, "evidence": self.evidence}
-
-
-@dataclass(frozen=True, slots=True)
-class _Layout:
-    legacy_root: Path
-    legacy_local: Path
-    pool_root: Path
-    pool_local: Path
-    pool_repo: Path
-    legacy_repo: Path
-    local_bridge: Path
-    repo_bridge: Path
-    active_marker: Path
-
-    @classmethod
-    def for_home(cls, home: Path) -> "_Layout":
-        return cls.for_engine("openclaw", home)
-
-    @classmethod
-    def for_engine(cls, engine: str, home: Path) -> "_Layout":
-        if engine == "hermes":
-            workspace = home / ".hermes" / "workspace"
-            legacy_root = home / ".hermes" / "skills"
-            legacy_local = workspace / "skills" / "skills-local"
-            pool_root = workspace / "skills-pool"
-            return cls(
-                legacy_root=legacy_root,
-                legacy_local=legacy_local,
-                pool_root=pool_root,
-                pool_local=pool_root / "skills-local",
-                pool_repo=pool_root / "skills-repo",
-                legacy_repo=home / ".hermes" / "skills-repo",
-                local_bridge=legacy_root / "skills-local",
-                repo_bridge=home / ".hermes" / "skills-repo",
-                active_marker=pool_root / ".pool-active",
-            )
-        if engine == "aicoding":
-            workspace = home / ".aicoding" / "workspace"
-            legacy_root = home / ".claude" / "skills"
-            legacy_local = workspace / "skills" / "skills-local"
-            pool_root = workspace / "skills-pool"
-            return cls(
-                legacy_root=legacy_root,
-                legacy_local=legacy_local,
-                pool_root=pool_root,
-                pool_local=pool_root / "skills-local",
-                pool_repo=pool_root / "skills-repo",
-                legacy_repo=home / ".aicoding" / "skills-repo",
-                local_bridge=legacy_root / "skills-local",
-                repo_bridge=home / ".aicoding" / "skills-repo",
-                active_marker=pool_root / ".pool-active",
-            )
-        if engine == "claude_code":
-            workspace = home / ".claude_code" / "workspace"
-            legacy_root = home / ".claude" / "skills"
-            legacy_local = workspace / "skills" / "skills-local"
-            pool_root = workspace / "skills-pool"
-            return cls(
-                legacy_root=legacy_root,
-                legacy_local=legacy_local,
-                pool_root=pool_root,
-                pool_local=pool_root / "skills-local",
-                pool_repo=pool_root / "skills-repo",
-                legacy_repo=home / ".claude_code" / "skills-repo",
-                local_bridge=legacy_root / "skills-local",
-                repo_bridge=legacy_root / "skills-repo",
-                active_marker=pool_root / ".pool-active",
-            )
-        if engine != "openclaw":
-            raise ValueError(f"unsupported filesystem Pool engine: {engine}")
-        workspace = home / ".openclaw" / "workspace"
-        legacy_root = workspace / "skills"
-        pool_root = workspace / "skills-pool"
-        legacy_local = legacy_root / "skills-local"
-        legacy_repo = legacy_root / "skills-repo"
-        return cls(
-            legacy_root=legacy_root,
-            legacy_local=legacy_local,
-            pool_root=pool_root,
-            pool_local=pool_root / "skills-local",
-            pool_repo=pool_root / "skills-repo",
-            legacy_repo=legacy_repo,
-            local_bridge=legacy_local,
-            repo_bridge=legacy_repo,
-            active_marker=pool_root / ".pool-active",
-        )
 
 
 def mapping_sources_use_pool(
@@ -576,7 +493,7 @@ def _active_entry_inventory(
     external: list[Path] = []
     occupied: list[Path] = []
     reserved = {layout.local_bridge, layout.repo_bridge}
-    for entry in sorted(layout.legacy_root.iterdir(), key=lambda path: path.name):
+    for entry in sorted(layout.active_root.iterdir(), key=lambda path: path.name):
         if entry in reserved or entry.name.startswith(".skills-local.pool-cutover-"):
             continue
         if not entry.is_symlink():
@@ -621,7 +538,7 @@ def _mapping_plan(
             )
         if not reason and (
             not target.is_absolute()
-            or target.parent != layout.legacy_root
+            or target.parent != layout.active_root
             or target
             in {
                 layout.legacy_local,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -5,15 +5,20 @@ from __future__ import annotations
 import json
 import os
 import stat
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from uuid import UUID
 
-
-LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
+)
+from engine.community.core.skills.layout_planner import (
+    ResolvedFilesystemLayoutPlan as _FilesystemPoolLayout,
+)
 
 
 class RuntimeLayoutInspectionStatus(str, Enum):
@@ -39,100 +44,6 @@ class RuntimeLayoutInspection:
             "preparation_id": self.preparation_id,
             "evidence": self.evidence,
         }
-
-
-@dataclass(frozen=True)
-class _FilesystemPoolLayout:
-    legacy_root: Path
-    legacy_local: Path
-    legacy_repo: Path
-    pool_root: Path
-    pool_local: Path
-    pool_repo: Path
-    marker: Path
-    active_marker: Path
-    local_bridge: Path
-    repo_bridge: Path
-
-    @classmethod
-    def for_home(cls, home: Path) -> "_FilesystemPoolLayout":
-        return cls.for_engine("openclaw", home)
-
-    @classmethod
-    def for_engine(cls, engine: str, home: Path) -> "_FilesystemPoolLayout":
-        if engine == "hermes":
-            workspace = home / ".hermes" / "workspace"
-            legacy_root = home / ".hermes" / "skills"
-            legacy_local = workspace / "skills" / "skills-local"
-            legacy_repo = home / ".hermes" / "skills-repo"
-            pool_root = workspace / "skills-pool"
-            return cls(
-                legacy_root=legacy_root,
-                legacy_local=legacy_local,
-                legacy_repo=legacy_repo,
-                pool_root=pool_root,
-                pool_local=pool_root / "skills-local",
-                pool_repo=pool_root / "skills-repo",
-                marker=pool_root / ".pool-ready",
-                active_marker=pool_root / ".pool-active",
-                local_bridge=legacy_root / "skills-local",
-                repo_bridge=legacy_repo,
-            )
-        if engine == "aicoding":
-            workspace = home / ".aicoding" / "workspace"
-            legacy_root = home / ".claude" / "skills"
-            legacy_local = workspace / "skills" / "skills-local"
-            legacy_repo = home / ".aicoding" / "skills-repo"
-            pool_root = workspace / "skills-pool"
-            return cls(
-                legacy_root=legacy_root,
-                legacy_local=legacy_local,
-                legacy_repo=legacy_repo,
-                pool_root=pool_root,
-                pool_local=pool_root / "skills-local",
-                pool_repo=pool_root / "skills-repo",
-                marker=pool_root / ".pool-ready",
-                active_marker=pool_root / ".pool-active",
-                local_bridge=legacy_root / "skills-local",
-                repo_bridge=legacy_repo,
-            )
-        if engine == "claude_code":
-            workspace = home / ".claude_code" / "workspace"
-            legacy_root = home / ".claude" / "skills"
-            legacy_local = workspace / "skills" / "skills-local"
-            legacy_repo = home / ".claude_code" / "skills-repo"
-            pool_root = workspace / "skills-pool"
-            return cls(
-                legacy_root=legacy_root,
-                legacy_local=legacy_local,
-                legacy_repo=legacy_repo,
-                pool_root=pool_root,
-                pool_local=pool_root / "skills-local",
-                pool_repo=pool_root / "skills-repo",
-                marker=pool_root / ".pool-ready",
-                active_marker=pool_root / ".pool-active",
-                local_bridge=legacy_root / "skills-local",
-                repo_bridge=legacy_root / "skills-repo",
-            )
-        if engine != "openclaw":
-            raise ValueError(f"unsupported filesystem Pool engine: {engine}")
-        workspace = home / ".openclaw" / "workspace"
-        legacy_root = workspace / "skills"
-        pool_root = workspace / "skills-pool"
-        legacy_local = legacy_root / "skills-local"
-        legacy_repo = legacy_root / "skills-repo"
-        return cls(
-            legacy_root=legacy_root,
-            legacy_local=legacy_local,
-            legacy_repo=legacy_repo,
-            pool_root=pool_root,
-            pool_local=pool_root / "skills-local",
-            pool_repo=pool_root / "skills-repo",
-            marker=pool_root / ".pool-ready",
-            active_marker=pool_root / ".pool-active",
-            local_bridge=legacy_local,
-            repo_bridge=legacy_repo,
-        )
 
 
 def _not_capable(
@@ -206,7 +117,7 @@ def _valid_timestamp(value: object) -> bool:
     if not isinstance(value, str):
         return False
     try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(value)
     except ValueError:
         return False
     return parsed.tzinfo is not None
@@ -325,17 +236,16 @@ def _managed_entries_valid(
     marker: dict[str, Any],
     layout: _FilesystemPoolLayout,
 ) -> bool:
-    entries = layout.legacy_root.iterdir()
+    entries = layout.active_root.iterdir()
     for entry in entries:
         if entry in (layout.local_bridge, layout.repo_bridge):
             continue
         record = _managed_entry_record(entry, layout)
-        if record is not None:
-            if record["valid"] is not True:
-                return False
+        if record is not None and record["valid"] is not True:
+            return False
 
     declared = marker["validation_summary"]["managed_active_entries"]
-    if any(
+    return not any(
         not isinstance(record, dict)
         or record.get("source") not in {"local", "repo"}
         or not isinstance(record.get("path"), str)
@@ -343,9 +253,7 @@ def _managed_entries_valid(
         or not isinstance(record.get("pool_target"), str)
         or record.get("valid") is not True
         for record in declared
-    ):
-        return False
-    return True
+    )
 
 
 def _active_marker_valid(
@@ -387,7 +295,7 @@ def _active_marker_valid(
         ):
             return False
         if (
-            target.parent != Path(os.path.abspath(layout.legacy_root))
+            target.parent != Path(os.path.abspath(layout.active_root))
             or target in {layout.local_bridge, layout.repo_bridge}
             or target in seen_targets
         ):
@@ -400,8 +308,7 @@ def _active_entries_valid(layout: _FilesystemPoolLayout) -> bool:
     """Validate mutable managed entries without freezing an old mapping set."""
 
     pool_roots = tuple(
-        Path(os.path.abspath(root))
-        for root in (layout.pool_local, layout.pool_repo)
+        Path(os.path.abspath(root)) for root in (layout.pool_local, layout.pool_repo)
     )
     retired_roots = tuple(
         Path(os.path.abspath(root))
@@ -412,7 +319,7 @@ def _active_entries_valid(layout: _FilesystemPoolLayout) -> bool:
             layout.repo_bridge,
         )
     )
-    for entry in layout.legacy_root.iterdir():
+    for entry in layout.active_root.iterdir():
         if not entry.is_symlink():
             continue
         target = _lexical_symlink_target(entry)
@@ -755,9 +662,7 @@ def inspect_runtime_layout(
                     "legacy_storage_entries_absent": (
                         active_marker["activation_state"] == "active"
                     ),
-                    "stable_repo_bridge_valid": (
-                        engine in {"aicoding", "hermes"}
-                    ),
+                    "stable_repo_bridge_valid": (engine in {"aicoding", "hermes"}),
                 },
             },
         )

--- a/src/engine/src/engine/community/tests/core/skills/test_layout_planner.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_layout_planner.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+import pytest
+
+from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
+    LayoutIdentity,
+    ResolvedArtifactLayoutPlan,
+    ResolvedFilesystemLayoutPlan,
+    RuntimeLayoutContext,
+    SkillLayoutResolutionError,
+    UnsupportedLayoutContractError,
+    resolve_skill_layout,
+)
+
+HOME = Path("/runtime")
+
+
+def _resolve(engine: str):
+    return resolve_skill_layout(
+        LayoutIdentity(
+            engine_type=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        ),
+        RuntimeLayoutContext(home=HOME),
+    )
+
+
+def test_resolver_identity_returns_both_layouts_without_selecting_authority() -> None:
+    plan = resolve_skill_layout(
+        LayoutIdentity(
+            engine_type="aicoding",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        ),
+        RuntimeLayoutContext(home=HOME),
+    )
+
+    assert isinstance(plan, ResolvedFilesystemLayoutPlan)
+    assert plan.active_root == HOME / ".claude/skills"
+    assert plan.legacy_local == HOME / ".aicoding/workspace/skills/skills-local"
+    assert plan.pool_local == HOME / ".aicoding/workspace/skills-pool/skills-local"
+    assert not hasattr(plan, "layout_state")
+    assert not hasattr(plan, "repo_delivery")
+    assert not hasattr(plan, "local_root")
+    assert not hasattr(plan, "repo_root")
+
+
+@pytest.mark.parametrize(
+    ("engine", "expected"),
+    [
+        (
+            "openclaw",
+            (
+                ".openclaw/workspace/skills",
+                ".openclaw/workspace/skills/skills-local",
+                ".openclaw/workspace/skills/skills-repo",
+                ".openclaw/workspace/skills-pool",
+                ".openclaw/workspace/skills/skills-local",
+                ".openclaw/workspace/skills/skills-repo",
+            ),
+        ),
+        (
+            "claude_code",
+            (
+                ".claude/skills",
+                ".claude_code/workspace/skills/skills-local",
+                ".claude_code/skills-repo",
+                ".claude_code/workspace/skills-pool",
+                ".claude/skills/skills-local",
+                ".claude/skills/skills-repo",
+            ),
+        ),
+        (
+            "aicoding",
+            (
+                ".claude/skills",
+                ".aicoding/workspace/skills/skills-local",
+                ".aicoding/skills-repo",
+                ".aicoding/workspace/skills-pool",
+                ".claude/skills/skills-local",
+                ".aicoding/skills-repo",
+            ),
+        ),
+        (
+            "hermes",
+            (
+                ".hermes/skills",
+                ".hermes/workspace/skills/skills-local",
+                ".hermes/skills-repo",
+                ".hermes/workspace/skills-pool",
+                ".hermes/skills/skills-local",
+                ".hermes/skills-repo",
+            ),
+        ),
+    ],
+)
+def test_filesystem_descriptor_snapshot(
+    engine: str,
+    expected: tuple[str, str, str, str, str, str],
+) -> None:
+    plan = _resolve(engine)
+    assert isinstance(plan, ResolvedFilesystemLayoutPlan)
+    assert (
+        str(plan.active_root.relative_to(HOME)),
+        str(plan.legacy_local.relative_to(HOME)),
+        str(plan.legacy_repo.relative_to(HOME)),
+        str(plan.pool_root.relative_to(HOME)),
+        str(plan.local_bridge.relative_to(HOME)),
+        str(plan.repo_bridge.relative_to(HOME)),
+    ) == expected
+    assert plan.ready_marker == plan.pool_root / ".pool-ready"
+    assert plan.marker == plan.ready_marker
+    assert plan.active_marker == plan.pool_root / ".pool-active"
+
+
+def test_teclaw_is_explicit_artifact_layout() -> None:
+    plan = _resolve("teclaw")
+    assert isinstance(plan, ResolvedArtifactLayoutPlan)
+    assert plan.capability.value == "artifact"
+
+
+def test_unknown_engine_never_falls_back_to_openclaw() -> None:
+    with pytest.raises(SkillLayoutResolutionError):
+        _resolve("future_engine")
+
+
+def test_unknown_contract_fails_closed() -> None:
+    with pytest.raises(UnsupportedLayoutContractError):
+        resolve_skill_layout(
+            LayoutIdentity(
+                engine_type="openclaw",
+                layout_contract_version="skills-pool-future-v2",
+            ),
+            RuntimeLayoutContext(home=HOME),
+        )


### PR DESCRIPTION
## Summary

First delivery step for #455 on `REL20260730`.

- centralize OpenClaw, Claude Code, AICoding, and Hermes Skills filesystem topology in an Engine-owned pure planner
- resolve both Legacy and Pool roots from `engine_type`, `layout_contract_version`, and runtime `home`
- keep the authoritative-layout choice in existing state-machine callers
- keep Teclaw explicit as artifact/no-filesystem
- fail closed for unknown engines and contract versions

The planner does not inspect Desktop/Cloud, repo delivery, rollout state, markers, or mapping source layout. It introduces no lock, lease, snapshot protocol, migration state, or rollout change.

Validation on this exact release-line commit: Engine 2111 passed (5 repository-defined deselections); pre-push SAST and diff-check passed.

This PR remains Draft and is the base of the ordered #455 stack.