### PR TITLE
feat(skills): resolve logical pool mappings (#455 PR2)

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from pathlib import Path
 from typing import Any, Literal
 
 from injector import inject
@@ -25,6 +24,7 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 
 
 LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+MAPPING_CONTRACT_VERSION = "skills-pool-mapping-v2"
 
 
 class RuntimeLayoutProbeStatus(str, Enum):
@@ -32,36 +32,6 @@ class RuntimeLayoutProbeStatus(str, Enum):
     NOT_CAPABLE = "NOT_CAPABLE"
     TRANSIENT_ERROR = "TRANSIENT_ERROR"
     INVALID = "INVALID"
-
-
-@dataclass(frozen=True)
-class RuntimePoolLayout:
-    pool_root: Path
-    marker: Path
-
-    @classmethod
-    def for_home(cls, home: str | Path = "/home/admin") -> "RuntimePoolLayout":
-        pool_root = Path(home) / ".openclaw" / "workspace" / "skills-pool"
-        return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
-
-    @classmethod
-    def for_engine(
-        cls,
-        engine: str,
-        home: str | Path = "/home/admin",
-    ) -> "RuntimePoolLayout":
-        if engine == "openclaw":
-            return cls.for_home(home)
-        if engine == "claude_code":
-            pool_root = Path(home) / ".claude_code" / "workspace" / "skills-pool"
-            return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
-        if engine == "aicoding":
-            pool_root = Path(home) / ".aicoding" / "workspace" / "skills-pool"
-            return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
-        if engine == "hermes":
-            pool_root = Path(home) / ".hermes" / "workspace" / "skills-pool"
-            return cls(pool_root=pool_root, marker=pool_root / ".pool-ready")
-        raise ValueError(f"engine Pool layout not implemented: {engine}")
 
 
 @dataclass(frozen=True)
@@ -107,7 +77,6 @@ class CurrentRuntimeLayoutProbeService:
         bot_id: str,
         user_id: str,
         engine: str,
-        layout: RuntimePoolLayout | None = None,
     ) -> RuntimeLayoutProbeResult:
         if engine == "teclaw":
             return self._not_capable(
@@ -116,8 +85,6 @@ class CurrentRuntimeLayoutProbeService:
             )
         if engine not in {"openclaw", "claude_code", "aicoding", "hermes"}:
             return self._not_capable(engine, "engine_pool_probe_not_implemented")
-        layout = layout or RuntimePoolLayout.for_engine(engine)
-
         try:
             context = self._resolver.resolve_for_bot(bot_id, user_id)
             response = await self._transport.invoke(
@@ -135,7 +102,6 @@ class CurrentRuntimeLayoutProbeService:
         except UnknownProviderError as error:
             return self._invalid_control_plane(
                 engine,
-                layout,
                 "current_runtime_provider_invalid",
                 error,
             )
@@ -143,25 +109,22 @@ class CurrentRuntimeLayoutProbeService:
             return await self._confirm_runtime_without_probe_endpoint(
                 conn_info=context.conn_info,
                 engine=engine,
-                layout=layout,
             )
         except DeviceAdapterHTTPStatusError as error:
             return self._classify_http_status_error(
                 engine=engine,
-                layout=layout,
                 error=error,
             )
         except Exception as error:
-            return self._transient(engine, layout, error)
+            return self._transient(engine, error)
 
-        return self._parse_response(response, engine=engine, layout=layout)
+        return self._parse_response(response, engine=engine)
 
     async def _confirm_runtime_without_probe_endpoint(
         self,
         *,
         conn_info: dict[str, Any],
         engine: str,
-        layout: RuntimePoolLayout,
     ) -> RuntimeLayoutProbeResult:
         """Treat 404 as old-image capability only after adapter liveness succeeds."""
         try:
@@ -174,11 +137,10 @@ class CurrentRuntimeLayoutProbeService:
         except DeviceAdapterHTTPStatusError as error:
             return self._classify_http_status_error(
                 engine=engine,
-                layout=layout,
                 error=error,
             )
         except Exception as error:
-            return self._transient(engine, layout, error)
+            return self._transient(engine, error)
         return self._not_capable(
             engine,
             "runtime_layout_probe_endpoint_absent",
@@ -188,18 +150,15 @@ class CurrentRuntimeLayoutProbeService:
     def _classify_http_status_error(
         *,
         engine: str,
-        layout: RuntimePoolLayout,
         error: DeviceAdapterHTTPStatusError,
     ) -> RuntimeLayoutProbeResult:
         if error.status_code >= 500 or error.status_code in {408, 425, 429}:
             return CurrentRuntimeLayoutProbeService._transient(
                 engine,
-                layout,
                 error,
             )
         return CurrentRuntimeLayoutProbeService._invalid_control_plane(
             engine,
-            layout,
             "runtime_probe_rejected",
             error,
         )
@@ -209,12 +168,11 @@ class CurrentRuntimeLayoutProbeService:
         response: dict[str, Any],
         *,
         engine: str,
-        layout: RuntimePoolLayout,
     ) -> RuntimeLayoutProbeResult:
         try:
             envelope = _RuntimeLayoutProbeEnvelope.model_validate(response)
         except ValidationError:
-            return CurrentRuntimeLayoutProbeService._invalid_response(engine, layout)
+            return CurrentRuntimeLayoutProbeService._invalid_response(engine)
         data = envelope.data
         if (
             data.engine != engine
@@ -224,7 +182,16 @@ class CurrentRuntimeLayoutProbeService:
                 and not isinstance(data.preparation_id, str)
             )
         ):
-            return CurrentRuntimeLayoutProbeService._invalid_response(engine, layout)
+            return CurrentRuntimeLayoutProbeService._invalid_response(engine)
+        if (
+            data.status is RuntimeLayoutProbeStatus.READY
+            and data.evidence.get("mapping_contract_version")
+            != MAPPING_CONTRACT_VERSION
+        ):
+            return CurrentRuntimeLayoutProbeService._not_capable(
+                engine,
+                "logical_mapping_contract_not_supported",
+            )
         return RuntimeLayoutProbeResult(
             status=data.status,
             engine=engine,
@@ -236,7 +203,6 @@ class CurrentRuntimeLayoutProbeService:
     @staticmethod
     def _invalid_control_plane(
         engine: str,
-        layout: RuntimePoolLayout,
         reason: str,
         error: Exception,
     ) -> RuntimeLayoutProbeResult:
@@ -247,7 +213,6 @@ class CurrentRuntimeLayoutProbeService:
             preparation_id=None,
             evidence={
                 "reason": reason,
-                "marker": str(layout.marker),
                 "error_type": type(error).__name__,
             },
         )
@@ -263,24 +228,18 @@ class CurrentRuntimeLayoutProbeService:
         )
 
     @staticmethod
-    def _invalid_response(
-        engine: str, layout: RuntimePoolLayout
-    ) -> RuntimeLayoutProbeResult:
+    def _invalid_response(engine: str) -> RuntimeLayoutProbeResult:
         return RuntimeLayoutProbeResult(
             status=RuntimeLayoutProbeStatus.INVALID,
             engine=engine,
             layout_contract_version=LAYOUT_CONTRACT_VERSION,
             preparation_id=None,
-            evidence={
-                "reason": "invalid_runtime_probe_response",
-                "marker": str(layout.marker),
-            },
+            evidence={"reason": "invalid_runtime_probe_response"},
         )
 
     @staticmethod
     def _transient(
         engine: str,
-        layout: RuntimePoolLayout,
         error: Exception,
     ) -> RuntimeLayoutProbeResult:
         return RuntimeLayoutProbeResult(
@@ -290,22 +249,16 @@ class CurrentRuntimeLayoutProbeService:
             preparation_id=None,
             evidence={
                 "reason": "runtime_probe_failed",
-                "marker": str(layout.marker),
                 "error_type": type(error).__name__,
                 "error": str(error),
             },
         )
 
 
-# Compatibility for callers introduced by the initial OpenClaw rollout.
-OpenClawPoolLayout = RuntimePoolLayout
-
-
 __all__ = [
     "CurrentRuntimeLayoutProbeService",
     "LAYOUT_CONTRACT_VERSION",
-    "OpenClawPoolLayout",
-    "RuntimePoolLayout",
+    "MAPPING_CONTRACT_VERSION",
     "RuntimeLayoutProbeResult",
     "RuntimeLayoutProbeStatus",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -4,8 +4,7 @@ Skills Pool 控制面的 Bot 级布局状态、首次迁移认领和激活编排
 容器目录准备由镜像负责；本模块通过当前 runtime adapter 完成 probe、
 受支持文件型引擎的原子数据面切换与 Pool mapping，并在最后事务性提交
 locator 和 `POOL_ACTIVE`。当前已接入 OpenClaw、Claude Code、AICoding 与
-Hermes；完整多引擎
-Engine Layout Descriptor 仍不在本期范围内。
+Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
 
 ## 核心语义
 
@@ -39,7 +38,17 @@ Engine Layout Descriptor 仍不在本期范围内。
   无效结构持久化失败证据并阻断；重复任务通过 generation/lease 收敛。
 - 激活只处理当前仍可编辑、已经认领、引擎已显式接入且由当前 worker 持有
   lease 的 Bot；每次执行都重新读取 Bot 和当前 provider binding，并重新
-  probe 对应引擎 marker。未知引擎不回退到 OpenClaw。
+  probe 对应引擎 marker。只有 probe evidence 明确声明
+  `skills-pool-mapping-v2` 后才发送 logical mapping；旧或缺失 capability
+  作为 `NOT_CAPABLE` 释放认领并保持 Legacy。OpenClaw、Claude Code 内置
+  consumer 直接广告 v2；AICoding、Hermes 只有在具体 composition root
+  已接入同一 resolver 后才显式广告，旧 consumer 继续保持
+  `NOT_CAPABLE`/Legacy。未知引擎不回退到 OpenClaw。
+- Backend 发送的 v2 mapping 只包含
+  `(corpus, relative_path, link_name)`；Engine 使用本地 runtime context 和
+  descriptor 投影 source/active target，并返回 locator evidence。Backend
+  只校验并持久化 evidence，不按引擎重建 activation/publish/verify/reconcile
+  的物理路径。
 - 容器内先把 Legacy local 以 generation-scoped rename 移入隔离区，再执行
   best-effort 后置合并；随后发布并验证直接指向 canonical Pool 的 active
   mapping。持久化 `.pool-active` 的 `finalizing → active` 后，active root
@@ -67,7 +76,9 @@ Engine Layout Descriptor 仍不在本期范围内。
   lease 过期后的新 worker 接管并继续提交 Legacy mapping 和 locator。
 - Backend 上传、删除和显式回滚共用 Bot 级互斥锁；回滚阶段内的新 local
   编辑 fail closed。mapping 请求同时声明 `source_layout`：激活缺省为
-  `pool`，显式回滚前后使用 `legacy`。
+  `pool`，显式回滚前后使用 `legacy`。显式回滚也必须在第一次 logical
+  mapping 请求前重新 probe 当前 binding；若运行时已降级或缺少 v2
+  capability，则不发送 v2、不执行文件系统切换，并记录可重试失败。
 - 显式回滚不会读取迁移隔离副本，Pool 激活后产生的 local 新增和修改会被
   带入新的 Legacy；Pool 本身保留用于证据和后续恢复。
 - local 后置合并采用 best-effort、无覆盖的文件级收敛：一般的切换前修改、
@@ -131,6 +142,7 @@ provides:
   - "RuntimeQuarantineCleanupResult"
   - "PoolCutoverStatus"
   - "PoolCutoverResult"
+  - "PoolSkillMapping logical intent"
   - "BotSkillLayoutState and migration enums"
 consumes:
   - "BotRepository"
@@ -139,6 +151,7 @@ consumes:
   - "DatabasePlugin (through Skills Pool layout, operational and rollout repositories)"
   - "SkillsPoolRuntimeProtocol"
   - "SkillsPoolSkillRepositoryProtocol"
+  - "skills-pool-mapping-v2 capability and Engine locator evidence"
   - "DeviceBindingRepository"
   - "TaskQueueService and HandlerRegistry"
 internal_dependencies:
@@ -160,4 +173,4 @@ internal_dependencies:
 
 状态机或激活顺序变化会同时影响迁移 Worker、Bot locator 事务和运行时
 mapping/bridge 实现；端口变化还必须同步 Backend runtime、skill
-repository 实现及相应测试。
+repository 实现、Engine `SkillsService` consumers 及相应 contract tests。

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -1,0 +1,103 @@
+"""Build logical mapping intent and validate Engine resolution evidence."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+)
+
+
+def _source_tail(git_path: str, prefix: str) -> PurePosixPath:
+    raw = git_path[len(prefix) :]
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or raw.strip() != raw
+        or (prefix == "git://" and path.is_absolute())
+        or path.name in {"", ".", ".."}
+        or ".." in path.parts
+        or path.as_posix() != raw
+    ):
+        raise ValueError(f"invalid skill locator: {git_path}")
+    return path
+
+
+def local_skill_name(asset: RegisteredSkillAsset) -> str:
+    if not asset.git_path.startswith("local://"):
+        raise ValueError(f"skill {asset.skill_id} is not local")
+    return _source_tail(asset.git_path, "local://").name
+
+
+def build_logical_skill_mappings(
+    assets: list[RegisteredSkillAsset],
+) -> list[PoolSkillMapping]:
+    mappings: list[PoolSkillMapping] = []
+    targets: dict[str, str] = {}
+    for asset in assets:
+        if asset.git_path.startswith("local://"):
+            relative = PurePosixPath(local_skill_name(asset))
+            corpus = "local"
+        elif asset.git_path.startswith("git://"):
+            relative = _source_tail(asset.git_path, "git://")
+            corpus = "repo"
+        else:
+            continue
+        link_name = relative.name
+        identity = f"{corpus}:{relative.as_posix()}"
+        if targets.get(link_name) == identity:
+            continue
+        if link_name in targets:
+            raise ValueError(f"duplicate managed target: {link_name}")
+        targets[link_name] = identity
+        mappings.append(
+            PoolSkillMapping(
+                corpus=corpus,
+                relative_path=relative.as_posix(),
+                link_name=link_name,
+            )
+        )
+    return mappings
+
+
+def local_locators_from_evidence(
+    assets: list[RegisteredSkillAsset],
+    names: list[str],
+    evidence: dict[str, object] | None,
+) -> dict[int, str]:
+    raw_locators = (
+        evidence.get("local_locators")
+        if isinstance(evidence, dict)
+        else None
+    )
+    if not isinstance(raw_locators, dict) or set(raw_locators) != set(names):
+        raise ValueError(
+            "Engine locator evidence does not match registered local Skills"
+        )
+    locators: dict[int, str] = {}
+    for asset, name in zip(assets, names, strict=True):
+        locator = raw_locators.get(name)
+        if not isinstance(locator, str) or not locator.startswith("local:///"):
+            raise ValueError(
+                f"Engine returned an invalid local locator for {name}"
+            )
+        path = PurePosixPath(locator[len("local://") :])
+        if (
+            not path.is_absolute()
+            or ".." in path.parts
+            or path.as_posix() != locator[len("local://") :]
+        ):
+            raise ValueError(
+                f"Engine returned an invalid local locator for {name}"
+            )
+        locators[asset.skill_id] = locator
+    return locators
+
+
+__all__ = [
+    "build_logical_skill_mappings",
+    "local_locators_from_evidence",
+    "local_skill_name",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -91,13 +91,18 @@ class RegisteredSkillAsset:
 
 @dataclass(frozen=True, slots=True)
 class PoolSkillMapping:
-    """显式以声明 source layout 构造的运行时 mapping。"""
+    """Backend-owned logical intent; Engine resolves filesystem paths."""
 
-    source: str
-    target: str
+    corpus: str
+    relative_path: str
+    link_name: str
 
     def to_dict(self) -> dict[str, str]:
-        return {"source": self.source, "target": self.target}
+        return {
+            "corpus": self.corpus,
+            "relative_path": self.relative_path,
+            "link_name": self.link_name,
+        }
 
 
 class SkillMappingSourceLayout(StrEnum):

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import PurePosixPath
-
 from injector import inject
 
 from agentclaw.community.core.bot_management.repository.protocol import (
@@ -19,11 +17,13 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skills_pool.models import (
-    PoolPaths,
+    FILESYSTEM_POOL_ENGINES,
     PoolCutoverStatus,
-    PoolSkillMapping,
-    RegisteredSkillAsset,
-    pool_paths_for_engine,
+)
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+    local_locators_from_evidence,
+    local_skill_name,
 )
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
@@ -116,9 +116,7 @@ class SkillsPoolReconcileService:
         engine = bot.get("active_engine")
         if bot.get("env") != scope.env or not isinstance(engine, str):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
-        try:
-            paths = pool_paths_for_engine(engine)
-        except ValueError:
+        if engine not in FILESYSTEM_POOL_ENGINES:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
 
         owner_id = bot.get("owner_id")
@@ -210,8 +208,8 @@ class SkillsPoolReconcileService:
             engine=engine,
         )
         try:
-            local_names = [self._local_name(asset) for asset in local_assets]
-            mappings = self._build_pool_mappings(active_assets, paths=paths)
+            local_names = [local_skill_name(asset) for asset in local_assets]
+            mappings = build_logical_skill_mappings(active_assets)
         except ValueError as error:
             evidence = {"reason": str(error)}
             recorded = self._record_failure_for_boundary(
@@ -236,6 +234,7 @@ class SkillsPoolReconcileService:
 
         cutover_finalizing = state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
         repair_evidence_refresh = state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+        locator_evidence = self._persisted_cutover_evidence(state)
         if (
             not state.data_plane_cutover_committed
             or cutover_finalizing
@@ -392,6 +391,7 @@ class SkillsPoolReconcileService:
                         SkillsPoolReconcileOutcome.STATE_RACE_LOST,
                         preparation_id=probe.preparation_id,
                     )
+            locator_evidence = cutover.evidence
 
         if not self._layouts.holds_lease(
             scope=scope,
@@ -433,10 +433,23 @@ class SkillsPoolReconcileService:
                 evidence={"mapping_count": len(mappings)},
             )
 
-        local_locators = {
-            asset.skill_id: f"local://{paths.pool_local}/{name}"
-            for asset, name in zip(local_assets, local_names, strict=True)
-        }
+        try:
+            local_locators = local_locators_from_evidence(
+                local_assets,
+                local_names,
+                locator_evidence,
+            )
+        except ValueError as error:
+            return self._record_post_cutover_failure(
+                scope=scope,
+                generation=generation,
+                lease_owner=lease_owner,
+                preparation_id=probe.preparation_id,
+                outcome=SkillsPoolReconcileOutcome.DATABASE_COMMIT_FAILED,
+                failure_code="LOCATOR_EVIDENCE_INVALID",
+                failure_stage="control_plane_commit",
+                evidence={"reason": str(error)},
+            )
         if not self._layouts.commit_pool_active(
             scope=scope,
             migration_generation=generation,
@@ -533,9 +546,7 @@ class SkillsPoolReconcileService:
         engine = bot.get("active_engine")
         if bot.get("env") != scope.env or not isinstance(engine, str):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
-        try:
-            pool_paths_for_engine(engine)
-        except ValueError:
+        if engine not in FILESYSTEM_POOL_ENGINES:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         owner_id = bot.get("owner_id")
         if not isinstance(owner_id, (str, int)) or isinstance(owner_id, bool):
@@ -645,43 +656,17 @@ class SkillsPoolReconcileService:
         )
 
     @staticmethod
-    def _source_tail(git_path: str, prefix: str) -> PurePosixPath:
-        raw = git_path[len(prefix) :]
-        path = PurePosixPath(raw)
-        if not raw or path.name in {"", ".", ".."}:
-            raise ValueError(f"invalid skill locator: {git_path}")
-        return path
-
-    def _local_name(self, asset: RegisteredSkillAsset) -> str:
-        if not asset.git_path.startswith("local://"):
-            raise ValueError(f"skill {asset.skill_id} is not local")
-        return self._source_tail(asset.git_path, "local://").name
-
-    def _build_pool_mappings(
-        self,
-        assets: list[RegisteredSkillAsset],
-        *,
-        paths: PoolPaths,
-    ) -> list[PoolSkillMapping]:
-        mappings: list[PoolSkillMapping] = []
-        targets: dict[str, str] = {}
-        for asset in assets:
-            if asset.git_path.startswith("local://"):
-                relative = PurePosixPath(self._local_name(asset))
-                source = PurePosixPath(paths.pool_local) / relative
-            elif asset.git_path.startswith("git://"):
-                relative = self._source_tail(asset.git_path, "git://")
-                source = PurePosixPath(paths.pool_repo) / relative
-            else:
-                continue
-            target = str(PurePosixPath(paths.active) / relative.name)
-            if targets.get(target) == str(source):
-                continue
-            if target in targets:
-                raise ValueError(f"duplicate managed target: {target}")
-            targets[target] = str(source)
-            mappings.append(PoolSkillMapping(source=str(source), target=target))
-        return mappings
+    def _persisted_cutover_evidence(
+        state: BotSkillLayoutState,
+    ) -> dict[str, object] | None:
+        probe_evidence = state.last_probe_evidence
+        if not isinstance(probe_evidence, dict):
+            return None
+        cutover = probe_evidence.get("cutover")
+        if not isinstance(cutover, dict):
+            return None
+        evidence = cutover.get("evidence")
+        return evidence if isinstance(evidence, dict) else None
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -4,20 +4,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import PurePosixPath
-
 from injector import inject
 
 from agentclaw.community.core.bot_management.repository.protocol import (
     BotRepository,
 )
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeStatus,
+)
 from agentclaw.community.core.skills_pool.models import (
+    FILESYSTEM_POOL_ENGINES,
     PoolCutoverStatus,
-    PoolPaths,
     PoolSkillMapping,
-    RegisteredSkillAsset,
     SkillMappingSourceLayout,
-    pool_paths_for_engine,
+)
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+    local_locators_from_evidence,
+    local_skill_name,
 )
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.ports import (
@@ -312,9 +316,7 @@ class SkillsPoolRollbackService:
                 retryable=False,
                 evidence={"reason": "bot_engine_or_owner_invalid"},
             )
-        try:
-            paths = pool_paths_for_engine(engine)
-        except ValueError as error:
+        if engine not in FILESYSTEM_POOL_ENGINES:
             return self._failure(
                 scope=scope,
                 rollback_generation=rollback_generation,
@@ -323,9 +325,32 @@ class SkillsPoolRollbackService:
                 code="ROLLBACK_ENGINE_UNSUPPORTED",
                 stage="rollback_bot_validation",
                 retryable=False,
-                evidence={"reason": str(error)},
+                evidence={
+                    "reason": f"engine Pool layout not implemented: {engine}"
+                },
             )
         user_id = str(owner_id)
+
+        probe = await self._runtime.probe(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            engine=engine,
+        )
+        if probe.status is not RuntimeLayoutProbeStatus.READY:
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.ROLLBACK_FAILED,
+                code=f"ROLLBACK_RUNTIME_{probe.status.value}",
+                stage="runtime_probe",
+                retryable=probe.status
+                in {
+                    RuntimeLayoutProbeStatus.NOT_CAPABLE,
+                    RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
+                },
+                evidence=probe.evidence,
+            )
 
         local_assets = self._skills.list_bot_local_assets(
             env=scope.env,
@@ -338,8 +363,8 @@ class SkillsPoolRollbackService:
             engine=engine,
         )
         try:
-            local_names = [self._local_name(asset) for asset in local_assets]
-            mappings = self._build_legacy_mappings(active_assets, paths=paths)
+            local_names = [local_skill_name(asset) for asset in local_assets]
+            mappings = build_logical_skill_mappings(active_assets)
         except ValueError as error:
             return self._failure(
                 scope=scope,
@@ -352,6 +377,9 @@ class SkillsPoolRollbackService:
                 evidence={"reason": str(error)},
             )
 
+        locator_evidence = self._persisted_rollback_evidence(
+            state.last_probe_evidence
+        )
         if state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING:
             pre_cutover_mapping = await self._publish_and_verify_mappings(
                 scope=scope,
@@ -395,6 +423,7 @@ class SkillsPoolRollbackService:
                 return SkillsPoolRollbackResult(
                     SkillsPoolRollbackOutcome.STATE_RACE_LOST
                 )
+            locator_evidence = cutover.evidence
 
         # Re-publish after the atomic exchange as an idempotent confirmation.
         # A process that resumes from LEGACY_ROLLBACK_COMMITTED starts here.
@@ -408,10 +437,23 @@ class SkillsPoolRollbackService:
         if post_cutover_mapping is not None:
             return post_cutover_mapping
 
-        local_locators = {
-            asset.skill_id: f"local://{paths.legacy_local}/{name}"
-            for asset, name in zip(local_assets, local_names, strict=True)
-        }
+        try:
+            local_locators = local_locators_from_evidence(
+                local_assets,
+                local_names,
+                locator_evidence,
+            )
+        except ValueError as error:
+            return self._failure(
+                scope=scope,
+                rollback_generation=rollback_generation,
+                lease_owner=lease_owner,
+                outcome=SkillsPoolRollbackOutcome.DATABASE_COMMIT_FAILED,
+                code="ROLLBACK_LOCATOR_EVIDENCE_INVALID",
+                stage="control_plane_commit",
+                retryable=True,
+                evidence={"reason": str(error)},
+            )
         if not self._layouts.commit_legacy_active(
             scope=scope,
             rollback_generation=rollback_generation,
@@ -506,45 +548,16 @@ class SkillsPoolRollbackService:
         )
 
     @staticmethod
-    def _source_tail(git_path: str, prefix: str) -> PurePosixPath:
-        raw = git_path[len(prefix) :]
-        path = PurePosixPath(raw)
-        if not raw or path.name in {"", ".", ".."}:
-            raise ValueError(f"invalid skill locator: {git_path}")
-        return path
-
-    @classmethod
-    def _local_name(cls, asset: RegisteredSkillAsset) -> str:
-        if not asset.git_path.startswith("local://"):
-            raise ValueError(f"skill {asset.skill_id} is not local")
-        return cls._source_tail(asset.git_path, "local://").name
-
-    @classmethod
-    def _build_legacy_mappings(
-        cls,
-        assets: list[RegisteredSkillAsset],
-        *,
-        paths: PoolPaths,
-    ) -> list[PoolSkillMapping]:
-        mappings: list[PoolSkillMapping] = []
-        targets: dict[str, str] = {}
-        for asset in assets:
-            if asset.git_path.startswith("local://"):
-                relative = PurePosixPath(cls._local_name(asset))
-                source = PurePosixPath(paths.legacy_local) / relative
-            elif asset.git_path.startswith("git://"):
-                relative = cls._source_tail(asset.git_path, "git://")
-                source = PurePosixPath(paths.legacy_repo) / relative
-            else:
-                continue
-            target = str(PurePosixPath(paths.active) / relative.name)
-            if targets.get(target) == str(source):
-                continue
-            if target in targets:
-                raise ValueError(f"duplicate managed target: {target}")
-            targets[target] = str(source)
-            mappings.append(PoolSkillMapping(source=str(source), target=target))
-        return mappings
+    def _persisted_rollback_evidence(
+        stored: dict[str, object] | None,
+    ) -> dict[str, object] | None:
+        if not isinstance(stored, dict):
+            return None
+        rollback = stored.get("rollback")
+        if not isinstance(rollback, dict):
+            return None
+        evidence = rollback.get("evidence")
+        return evidence if isinstance(evidence, dict) else None
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_persistence.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_persistence.py
@@ -1,0 +1,59 @@
+"""Pure persistence helpers for the Skills Pool layout repository."""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+
+from sqlalchemy import func, text
+from sqlalchemy.sql.elements import ColumnElement
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    BotSkillLayoutStateModel,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+
+
+def scope_filter(scope: BotSkillLayoutScope) -> tuple[ColumnElement, ...]:
+    return (
+        BotSkillLayoutStateModel.env == scope.env,
+        BotSkillLayoutStateModel.entity_id == scope.entity_id,
+        BotSkillLayoutStateModel.bot_id == scope.bot_id,
+    )
+
+
+def lease_expiry(session, seconds: int) -> ColumnElement:
+    if seconds <= 0:
+        raise ValueError("lease_seconds must be positive")
+    if session.bind.dialect.name == "sqlite":
+        return func.datetime(func.now(), text(f"'+{seconds} seconds'"))
+    return func.date_add(func.now(), text(f"INTERVAL {seconds} SECOND"))
+
+
+def is_runtime_local_locator(value: object) -> bool:
+    """Accept an opaque absolute ``local://`` locator without engine tables."""
+
+    if not isinstance(value, str) or not value.startswith("local:///"):
+        return False
+    raw_path = value[len("local://") :]
+    path = PurePosixPath(raw_path)
+    return (
+        path.is_absolute()
+        and ".." not in path.parts
+        and path.as_posix() == raw_path
+    )
+
+
+def encode_stage_evidence(
+    encoded_evidence: str | None,
+    *,
+    stage: str,
+    evidence: dict[str, object],
+) -> str:
+    """Merge one transition result into the persisted probe evidence."""
+
+    stored = json.loads(encoded_evidence) if encoded_evidence else {}
+    if not isinstance(stored, dict):
+        stored = {}
+    stored[stage] = evidence
+    return json.dumps(stored, ensure_ascii=False)

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_layout_repository.py
@@ -6,15 +6,13 @@ import json
 from dataclasses import asdict
 
 from injector import inject
-from sqlalchemy import func, or_, text
+from sqlalchemy import func, or_
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.elements import ColumnElement
 
 from agentclaw.community.core.skills_pool.repository.models import (
     BotSkillLayoutStateModel,
 )
 from agentclaw.community.core.models.skill import Skill
-from agentclaw.community.core.skills_pool.models import local_locator_prefixes
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
@@ -28,6 +26,12 @@ from agentclaw.community.plugins.skills_pool_cutover_diagnostics import (
 )
 from agentclaw.community.plugins.skills_pool_capability_repository import (
     SkillsPoolCapabilityRepositoryMixin,
+)
+from agentclaw.community.plugins.skills_pool_layout_persistence import (
+    encode_stage_evidence,
+    is_runtime_local_locator,
+    lease_expiry,
+    scope_filter,
 )
 from agentclaw.community.plugins.skills_pool_operational_repository import (
     SkillsPoolOperationalRepositoryMixin,
@@ -46,25 +50,12 @@ class SkillsPoolLayoutRepository(
     SkillsPoolPostCutoverRepositoryMixin,
     SkillsPoolQuarantineRepositoryMixin,
 ):
+    _scope_filter = staticmethod(scope_filter)
+    _now_plus = staticmethod(lease_expiry)
+
     @inject
     def __init__(self, database: DatabasePlugin) -> None:
         self._database = database
-
-    @staticmethod
-    def _scope_filter(scope: BotSkillLayoutScope):
-        return (
-            BotSkillLayoutStateModel.env == scope.env,
-            BotSkillLayoutStateModel.entity_id == scope.entity_id,
-            BotSkillLayoutStateModel.bot_id == scope.bot_id,
-        )
-
-    @staticmethod
-    def _now_plus(session, seconds: int) -> ColumnElement:
-        if seconds <= 0:
-            raise ValueError("lease_seconds must be positive")
-        if session.bind.dialect.name == "sqlite":
-            return func.datetime(func.now(), text(f"'+{seconds} seconds'"))
-        return func.date_add(func.now(), text(f"INTERVAL {seconds} SECOND"))
 
     def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
         with self._database.transactional_orm_session() as session:
@@ -345,7 +336,11 @@ class SkillsPoolLayoutRepository(
                 return False
             row.phase = SkillLayoutPhase.POOL_CUTOVER_COMMITTED.value
             row.data_plane_cutover_committed = 1
-            row.last_probe_evidence = evidence_json
+            row.last_probe_evidence = encode_stage_evidence(
+                row.last_probe_evidence,
+                stage="cutover",
+                evidence=evidence,
+            )
         return True
 
     def record_cutover_finalizing(
@@ -659,9 +654,9 @@ class SkillsPoolLayoutRepository(
     ) -> bool:
         """原子提交精确 Bot 范围内的全部 local locator 和布局状态。"""
 
-        pool_prefixes = local_locator_prefixes(pool=True)
         if any(
-            not isinstance(skill_id, int) or not locator.startswith(pool_prefixes)
+            not isinstance(skill_id, int)
+            or not is_runtime_local_locator(locator)
             for skill_id, locator in local_locators.items()
         ):
             return False
@@ -817,7 +812,16 @@ class SkillsPoolLayoutRepository(
                         BotSkillLayoutStateModel.last_failure_code: None,
                         BotSkillLayoutStateModel.last_failure_stage: None,
                         BotSkillLayoutStateModel.last_failure_retryable: None,
-                        BotSkillLayoutStateModel.last_failure_evidence: (evidence_json),
+                        BotSkillLayoutStateModel.last_failure_evidence: (
+                            evidence_json
+                        ),
+                        BotSkillLayoutStateModel.last_probe_evidence: (
+                            encode_stage_evidence(
+                                None,
+                                stage="rollback",
+                                evidence=evidence,
+                            )
+                        ),
                         BotSkillLayoutStateModel.last_failure_at: None,
                     },
                     synchronize_session=False,
@@ -923,9 +927,9 @@ class SkillsPoolLayoutRepository(
     ) -> bool:
         """同事务恢复全部 local locator 与 ``LEGACY_ACTIVE``。"""
 
-        legacy_prefixes = local_locator_prefixes(pool=False)
         if any(
-            not isinstance(skill_id, int) or not locator.startswith(legacy_prefixes)
+            not isinstance(skill_id, int)
+            or not is_runtime_local_locator(locator)
             for skill_id, locator in local_locators.items()
         ):
             return False

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.devices.services.device_context_resolver import (
 )
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     CurrentRuntimeLayoutProbeService,
+    MAPPING_CONTRACT_VERSION,
     RuntimeLayoutProbeResult,
 )
 from agentclaw.community.core.skills_pool.models import (
@@ -78,6 +79,7 @@ class SkillsPoolRuntime:
                     "migration_generation": migration_generation,
                     "preparation_id": preparation_id,
                     "registered_local_names": registered_local_names,
+                    "mapping_contract_version": MAPPING_CONTRACT_VERSION,
                     "mappings": [mapping.to_dict() for mapping in mappings],
                 },
             )
@@ -137,6 +139,7 @@ class SkillsPoolRuntime:
                 user_id=user_id,
                 path="/api/skills/layout/mappings/publish",
                 body={
+                    "mapping_contract_version": MAPPING_CONTRACT_VERSION,
                     "mappings": [mapping.to_dict() for mapping in mappings],
                     "source_layout": source_layout.value,
                 },
@@ -276,6 +279,7 @@ class SkillsPoolRuntime:
                 user_id=user_id,
                 path="/api/skills/layout/mappings/verify",
                 body={
+                    "mapping_contract_version": MAPPING_CONTRACT_VERSION,
                     "mappings": [mapping.to_dict() for mapping in mappings],
                     "source_layout": source_layout.value,
                 },

--- a/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
@@ -7,7 +7,6 @@ import pytest
 
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     CurrentRuntimeLayoutProbeService,
-    OpenClawPoolLayout,
     RuntimeLayoutProbeResult,
     RuntimeLayoutProbeStatus,
 )
@@ -47,6 +46,7 @@ def _service(
                     "layout_contract_version": "skills-pool-p3-v1",
                     "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
                     "evidence": {
+                        "mapping_contract_version": "skills-pool-mapping-v2",
                         "checks": {
                             "pool_repo_mounted": True,
                             "legacy_repo_bridge_valid": True,
@@ -98,6 +98,7 @@ async def test_claude_code_ready_uses_current_runtime_probe():
                 "layout_contract_version": "skills-pool-p3-v1",
                 "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
                 "evidence": {
+                    "mapping_contract_version": "skills-pool-mapping-v2",
                     "checks": {
                         "stable_local_bridge_valid": True,
                         "stable_repo_bridge_valid": True,
@@ -139,6 +140,7 @@ async def test_aicoding_ready_uses_current_runtime_probe():
                 "layout_contract_version": "skills-pool-p3-v1",
                 "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
                 "evidence": {
+                    "mapping_contract_version": "skills-pool-mapping-v2",
                     "checks": {
                         "stable_local_bridge_valid": True,
                         "stable_repo_bridge_valid": True,
@@ -180,6 +182,7 @@ async def test_hermes_ready_requires_current_runtime_h0_evidence():
                 "layout_contract_version": "skills-pool-p3-v1",
                 "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
                 "evidence": {
+                    "mapping_contract_version": "skills-pool-mapping-v2",
                     "checks": {
                         "legacy_local_bridge_valid": True,
                         "stable_repo_bridge_valid": True,
@@ -234,6 +237,33 @@ async def test_new_runtime_without_marker_is_not_capable():
 
     assert result.status is RuntimeLayoutProbeStatus.NOT_CAPABLE
     assert result.evidence["reason"] == "pool_ready_marker_absent"
+
+
+@pytest.mark.asyncio
+async def test_ready_runtime_without_mapping_v2_is_not_capable():
+    service, *_ = _service(
+        response={
+            "success": True,
+            "data": {
+                "status": "READY",
+                "engine": "openclaw",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
+                "evidence": {"checks": {"pool_repo_mounted": True}},
+            },
+        }
+    )
+
+    result = await service.probe_bot(
+        bot_id="bot-1",
+        user_id="user-1",
+        engine="openclaw",
+    )
+
+    assert result.status is RuntimeLayoutProbeStatus.NOT_CAPABLE
+    assert result.evidence == {
+        "reason": "logical_mapping_contract_not_supported"
+    }
 
 
 @pytest.mark.asyncio
@@ -421,7 +451,6 @@ async def test_teclaw_is_noop_without_resolving_runtime():
         bot_id="bot-1",
         user_id="user-1",
         engine="teclaw",
-        layout=OpenClawPoolLayout.for_home("/not-used"),
     )
 
     assert result == RuntimeLayoutProbeResult(
@@ -450,7 +479,10 @@ def test_real_engine_response_schema_is_accepted(monkeypatch):
             engine="openclaw",
             layout_contract_version="skills-pool-p3-v1",
             preparation_id="2a958f59-8cf4-4413-a267-7d56d3382f23",
-            evidence={"checks": {"pool_repo_mounted": True}},
+            evidence={
+                "mapping_contract_version": "skills-pool-mapping-v2",
+                "checks": {"pool_repo_mounted": True},
+            },
         ),
         message="运行时 Skills Pool 布局探测完成",
     )
@@ -458,7 +490,6 @@ def test_real_engine_response_schema_is_accepted(monkeypatch):
     result = CurrentRuntimeLayoutProbeService._parse_response(
         engine_response.model_dump(mode="json"),
         engine="openclaw",
-        layout=OpenClawPoolLayout.for_home(),
     )
 
     assert result.status is RuntimeLayoutProbeStatus.READY

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -1062,14 +1062,8 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
         lease_owner="worker-1",
         preparation_id="preparation-1",
         local_locators={
-            1: (
-                "local:///home/admin/.openclaw/workspace/"
-                "skills-pool/skills-local/local-a"
-            ),
-            2: (
-                "local:///home/admin/.openclaw/workspace/"
-                "skills-pool/skills-local/local-b"
-            ),
+            1: "local:///runtime/vendor-x/pool/local-a",
+            2: "local:///runtime/vendor-x/pool/local-b",
         },
     )
 
@@ -1185,8 +1179,8 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
             for row in session.query(Skill).order_by(Skill.id).all()
         }
     assert paths == {
-        1: ("local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-a"),
-        2: ("local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-b"),
+        1: "local:///runtime/vendor-x/pool/local-a",
+        2: "local:///runtime/vendor-x/pool/local-b",
         3: "git://business/repo",
         4: "local:///legacy/other-bot",
         5: "local:///legacy/other-env",

--- a/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
+++ b/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
@@ -1,0 +1,153 @@
+import pytest
+
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+    local_locators_from_evidence,
+)
+from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+
+def test_builds_logical_intent_without_engine_paths() -> None:
+    mappings = build_logical_skill_mappings(
+        [
+            RegisteredSkillAsset(
+                skill_id=1,
+                name="writer",
+                git_path="local:///legacy/engine-specific/writer",
+            ),
+            RegisteredSkillAsset(
+                skill_id=2,
+                name="reviewer",
+                git_path="git://business/reviewer",
+            ),
+        ]
+    )
+
+    assert [mapping.to_dict() for mapping in mappings] == [
+        {
+            "corpus": "local",
+            "relative_path": "writer",
+            "link_name": "writer",
+        },
+        {
+            "corpus": "repo",
+            "relative_path": "business/reviewer",
+            "link_name": "reviewer",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "git_path",
+    [
+        "git:///absolute",
+        "git://../escape",
+        "git://business/../escape",
+        "git://business//reviewer",
+        "git://business/./reviewer",
+        "git://business/reviewer/",
+    ],
+)
+def test_rejects_invalid_logical_relative_path(git_path: str) -> None:
+    with pytest.raises(ValueError, match="invalid skill locator"):
+        build_logical_skill_mappings(
+            [
+                RegisteredSkillAsset(
+                    skill_id=1,
+                    name="reviewer",
+                    git_path=git_path,
+                )
+            ]
+        )
+
+
+def test_rejects_duplicate_active_target() -> None:
+    with pytest.raises(ValueError, match="duplicate managed target"):
+        build_logical_skill_mappings(
+            [
+                RegisteredSkillAsset(
+                    skill_id=1,
+                    name="writer",
+                    git_path="local:///legacy/writer",
+                ),
+                RegisteredSkillAsset(
+                    skill_id=2,
+                    name="writer",
+                    git_path="git://business/writer",
+                ),
+            ]
+        )
+
+
+def test_validates_and_keys_engine_returned_locator_evidence() -> None:
+    assets = [
+        RegisteredSkillAsset(
+            skill_id=7,
+            name="writer",
+            git_path="local:///legacy/writer",
+        )
+    ]
+
+    assert local_locators_from_evidence(
+        assets,
+        ["writer"],
+        {"local_locators": {"writer": "local:///runtime/pool/writer"}},
+    ) == {7: "local:///runtime/pool/writer"}
+
+
+def test_reuses_one_engine_locator_for_historical_skill_versions() -> None:
+    assets = [
+        RegisteredSkillAsset(
+            skill_id=7,
+            name="writer",
+            git_path="local:///legacy/v1/writer",
+        ),
+        RegisteredSkillAsset(
+            skill_id=8,
+            name="writer",
+            git_path="local:///legacy/v2/writer",
+        ),
+    ]
+
+    assert local_locators_from_evidence(
+        assets,
+        ["writer", "writer"],
+        {"local_locators": {"writer": "local:///runtime/pool/writer"}},
+    ) == {
+        7: "local:///runtime/pool/writer",
+        8: "local:///runtime/pool/writer",
+    }
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        None,
+        {},
+        {"local_locators": {}},
+        {"local_locators": {"writer": "git://writer"}},
+        {"local_locators": {"writer": "local://relative/writer"}},
+        {"local_locators": {"writer": "local:///runtime/../escape"}},
+        {
+            "local_locators": {
+                "writer": "local:///runtime/pool/writer",
+                "extra": "local:///runtime/pool/extra",
+            }
+        },
+    ],
+)
+def test_rejects_invalid_or_mismatched_locator_evidence(
+    evidence: dict[str, object] | None,
+) -> None:
+    with pytest.raises(ValueError, match="Engine"):
+        local_locators_from_evidence(
+            [
+                RegisteredSkillAsset(
+                    skill_id=7,
+                    name="writer",
+                    git_path="local:///legacy/writer",
+                )
+            ],
+            ["writer"],
+            evidence,
+        )

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -20,7 +20,6 @@ from agentclaw.community.core.skills_pool.models import (
     PoolCutoverResult,
     PoolCutoverStatus,
     RegisteredSkillAsset,
-    pool_paths_for_engine,
 )
 from agentclaw.community.core.skills_pool.reconcile_service import (
     SkillsPoolReconcileOutcome,
@@ -104,6 +103,7 @@ class FakeLayoutRepository:
             phase=SkillLayoutPhase.POOL_READY,
             preparation_id=str(kwargs["preparation_id"]),
             last_probe_result="READY",
+            last_probe_evidence=dict(kwargs["evidence"]),
         )
         return True
 
@@ -139,6 +139,10 @@ class FakeLayoutRepository:
             self.state,
             phase=SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
             data_plane_cutover_committed=True,
+            last_probe_evidence={
+                **(self.state.last_probe_evidence or {}),
+                "cutover": dict(kwargs["evidence"]),
+            },
         )
         return True
 
@@ -315,14 +319,33 @@ class FakeRuntime:
         pool_local: str | None = None,
         pool_repo: str | None = None,
     ) -> None:
-        paths = pool_paths_for_engine(engine)
         self.engine = engine
-        self.pool_local = pool_local or paths.pool_local
-        self.pool_repo = pool_repo or paths.pool_repo
+        defaults = {
+            "openclaw": (
+                "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+                "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+            ),
+            "claude_code": (
+                "/home/admin/.claude_code/workspace/skills-pool/skills-local",
+                "/home/admin/.claude_code/workspace/skills-pool/skills-repo",
+            ),
+            "aicoding": (
+                "/home/admin/.aicoding/workspace/skills-pool/skills-local",
+                "/home/admin/.aicoding/workspace/skills-pool/skills-repo",
+            ),
+            "hermes": (
+                "/home/admin/.hermes/workspace/skills-pool/skills-local",
+                "/home/admin/.hermes/workspace/skills-pool/skills-repo",
+            ),
+        }
+        default_local, default_repo = defaults[engine]
+        self.pool_local = pool_local or default_local
+        self.pool_repo = pool_repo or default_repo
         self.events: list[str] = []
         self.publish_success = True
         self.verify_success = True
         self.physical_cutovers = 0
+        self.expected_registered_local_names = ["local-a", "local-b"]
         self.cutover_result = PoolCutoverResult(
             committed=True,
             status=PoolCutoverStatus.COMMITTED,
@@ -331,7 +354,11 @@ class FakeRuntime:
                     "registered": 2,
                     "unregistered": 1,
                     "total": 3,
-                }
+                },
+                "local_locators": {
+                    "local-a": f"local://{self.pool_local}/local-a",
+                    "local-b": f"local://{self.pool_local}/local-b",
+                },
             },
         )
         self.probe_result = RuntimeLayoutProbeResult(
@@ -339,7 +366,14 @@ class FakeRuntime:
             engine=engine,
             layout_contract_version="skills-pool-p3-v1",
             preparation_id=PREPARATION_ID,
-            evidence={"marker": "valid"},
+            evidence={
+                "marker": "valid",
+                "resolved_layout": {
+                    "active_root": "/runtime/skills",
+                    "local_root": self.pool_local,
+                    "repo_root": self.pool_repo,
+                },
+            },
         )
 
     async def probe(self, **kwargs: object) -> RuntimeLayoutProbeResult:
@@ -349,18 +383,44 @@ class FakeRuntime:
 
     async def cutover(self, **kwargs: object) -> PoolCutoverResult:
         self.events.append("cutover")
-        assert kwargs["registered_local_names"] == ["local-a", "local-b"]
+        assert (
+            kwargs["registered_local_names"]
+            == self.expected_registered_local_names
+        )
         mappings = kwargs["mappings"]
-        assert [mapping.source for mapping in mappings] == [
-            f"{self.pool_local}/local-a",
-            f"{self.pool_local}/local-b",
-            f"{self.pool_repo}/business/repo-skill",
+        assert [mapping.to_dict() for mapping in mappings] == [
+            {
+                "corpus": "local",
+                "relative_path": "local-a",
+                "link_name": "local-a",
+            },
+            {
+                "corpus": "local",
+                "relative_path": "local-b",
+                "link_name": "local-b",
+            },
+            {
+                "corpus": "repo",
+                "relative_path": "business/repo-skill",
+                "link_name": "repo-skill",
+            },
         ]
         if (
             self.cutover_result.committed
             and self.cutover_result.status is PoolCutoverStatus.COMMITTED
         ):
             self.physical_cutovers += 1
+        if self.cutover_result.committed:
+            return replace(
+                self.cutover_result,
+                evidence={
+                    **self.cutover_result.evidence,
+                    "local_locators": {
+                        "local-a": f"local://{self.pool_local}/local-a",
+                        "local-b": f"local://{self.pool_local}/local-b",
+                    },
+                },
+            )
         return self.cutover_result
 
     async def publish_mappings(self, **kwargs: object) -> bool:
@@ -377,11 +437,12 @@ def build_service(
     runtime: FakeRuntime,
     *,
     engine: str = "openclaw",
+    skills: FakeSkillRepository | None = None,
 ) -> SkillsPoolReconcileService:
     return SkillsPoolReconcileService(
         bot_repository=FakeBotRepository(engine),
         layout_repository=layouts,
-        skill_repository=FakeSkillRepository(engine),
+        skill_repository=skills or FakeSkillRepository(engine),
         runtime=runtime,
     )
 
@@ -407,6 +468,82 @@ async def test_ready_claimed_bot_completes_pool_activation() -> None:
             "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-b"
         ),
     }
+
+
+@pytest.mark.asyncio
+async def test_historical_local_versions_share_engine_locator_on_commit() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    runtime.expected_registered_local_names = [
+        "local-a",
+        "local-b",
+        "local-a",
+    ]
+    skills = FakeSkillRepository()
+    skills.registered.append(
+        RegisteredSkillAsset(
+            skill_id=13,
+            name="local-a",
+            git_path="local:///legacy/older-version/local-a",
+        )
+    )
+
+    result = await build_service(
+        layouts,
+        runtime,
+        skills=skills,
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert layouts.committed_locators == {
+        11: (
+            "local:///home/admin/.openclaw/workspace/skills-pool/"
+            "skills-local/local-a"
+        ),
+        12: (
+            "local:///home/admin/.openclaw/workspace/skills-pool/"
+            "skills-local/local-b"
+        ),
+        13: (
+            "local:///home/admin/.openclaw/workspace/skills-pool/"
+            "skills-local/local-a"
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_conflicting_same_name_sources_fail_before_cutover() -> None:
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime()
+    skills = FakeSkillRepository()
+    skills.active.append(
+        RegisteredSkillAsset(
+            skill_id=22,
+            name="local-a",
+            git_path="git://business/local-a",
+        )
+    )
+
+    result = await build_service(
+        layouts,
+        runtime,
+        skills=skills,
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.evidence == {
+        "reason": "duplicate managed target: local-a"
+    }
+    assert runtime.events == ["probe"]
+    assert runtime.physical_cutovers == 0
+    assert layouts.events == ["failure"]
+    assert layouts.state.data_plane_cutover_committed is False
 
 
 @pytest.mark.asyncio
@@ -1146,7 +1283,10 @@ async def test_pool_active_reconciliation_probes_current_runtime() -> None:
     )
 
     assert result.outcome is SkillsPoolReconcileOutcome.ALREADY_ACTIVE
-    assert result.evidence == {"marker": "valid"}
+    assert result.evidence["marker"] == "valid"
+    assert result.evidence["resolved_layout"]["local_root"] == (
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+    )
     assert runtime.events == ["probe"]
 
 
@@ -1348,7 +1488,18 @@ class RecordingTransport:
                 "data": {
                     "committed": True,
                     "status": "COMMITTED",
-                    "evidence": {},
+                    "evidence": {
+                        "local_locators": {
+                            "local-a": (
+                                "local:///home/admin/.openclaw/workspace/"
+                                "skills-pool/skills-local/local-a"
+                            ),
+                            "local-b": (
+                                "local:///home/admin/.openclaw/workspace/"
+                                "skills-pool/skills-local/local-b"
+                            ),
+                        },
+                    },
                 },
             }
         if path.endswith("/publish"):

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
@@ -375,6 +375,21 @@ def _payload(
     )
 
 
+def test_ineligible_unclaimed_bot_never_probes_or_reconciles_runtime() -> None:
+    legacy = BotSkillLayoutState.legacy_default(SCOPE)
+    handler, claims, _, reconcile = _handler(
+        claim_results=[
+            MigrationClaimResult(MigrationClaimOutcome.INELIGIBLE, legacy)
+        ],
+        reconcile_results=[],
+        state=legacy,
+    )
+
+    assert handler.handle(_payload()) == Complete()
+    assert len(claims.calls) == 1
+    assert reconcile.calls == []
+
+
 def test_unclaimed_task_claims_then_reconciles_same_generation() -> None:
     state = _claimed_state()
     handler, claims, _, reconcile = _handler(

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -6,6 +6,12 @@ from dataclasses import replace
 
 import pytest
 
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+    MAPPING_CONTRACT_VERSION,
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
 from agentclaw.community.core.skills_pool.recovery_service import (
     ManualRepairResolution,
     SkillsPoolRollbackOutcome,
@@ -233,6 +239,7 @@ class _RollbackLayouts:
             self.state,
             phase=SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
             data_plane_cutover_committed=False,
+            last_probe_evidence={"rollback": dict(kwargs["evidence"])},
         )
         return True
 
@@ -320,28 +327,74 @@ class _Skills:
         return self.active
 
 
+class _HistoricalSkills(_Skills):
+    local = [
+        *_Skills.local,
+        RegisteredSkillAsset(
+            skill_id=12,
+            name="local-a",
+            git_path=(
+                "local:///home/admin/.openclaw/workspace/"
+                "skills-pool/older-version/local-a"
+            ),
+        ),
+    ]
+    active = _Skills.active
+
+
 class _RollbackRuntime:
     def __init__(self) -> None:
         self.events: list[str] = []
         self.publish_results = [True, False]
         self.mapping_layouts: list[SkillMappingSourceLayout] = []
+        self.expected_registered_local_names = ["local-a"]
+        self.probe_result = RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.READY,
+            engine="openclaw",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id="preparation-1",
+            evidence={"mapping_contract_version": MAPPING_CONTRACT_VERSION},
+        )
+
+    async def probe(self, **kwargs: object) -> RuntimeLayoutProbeResult:
+        self.events.append("probe")
+        return self.probe_result
 
     async def rollback_to_legacy(self, **kwargs: object) -> PoolCutoverResult:
         self.events.append("rollback")
-        assert kwargs["registered_local_names"] == ["local-a"]
+        assert (
+            kwargs["registered_local_names"]
+            == self.expected_registered_local_names
+        )
         return PoolCutoverResult(
             committed=True,
             status=PoolCutoverStatus.COMMITTED,
-            evidence={"source": "current_pool"},
+            evidence={
+                "source": "current_pool",
+                "local_locators": {
+                    "local-a": (
+                        "local:///home/admin/.openclaw/workspace/"
+                        "skills/skills-local/local-a"
+                    ),
+                },
+            },
         )
 
     async def publish_mappings(self, **kwargs: object) -> bool:
         self.events.append("mapping")
         self.mapping_layouts.append(kwargs["source_layout"])
         mappings = kwargs["mappings"]
-        assert [item.source for item in mappings] == [
-            "/home/admin/.openclaw/workspace/skills/skills-local/local-a",
-            "/home/admin/.openclaw/workspace/skills/skills-repo/business/repo-a",
+        assert [item.to_dict() for item in mappings] == [
+            {
+                "corpus": "local",
+                "relative_path": "local-a",
+                "link_name": "local-a",
+            },
+            {
+                "corpus": "repo",
+                "relative_path": "business/repo-a",
+                "link_name": "repo-a",
+            },
         ]
         return self.publish_results.pop(0)
 
@@ -383,6 +436,7 @@ async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() 
     assert layouts.state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED
     assert layouts.events == ["begin", "cutover", "failure"]
     assert runtime.events == [
+        "probe",
         "mapping",
         "verify",
         "rollback",
@@ -407,7 +461,7 @@ async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() 
     )
 
     assert second.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
-    assert runtime.events == ["mapping", "verify"]
+    assert runtime.events == ["probe", "mapping", "verify"]
     assert layouts.events == ["database"]
     assert layouts.locators == {
         11: (
@@ -415,6 +469,36 @@ async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() 
             "skills/skills-local/local-a"
         )
     }
+
+
+@pytest.mark.asyncio
+async def test_rollback_updates_all_historical_local_versions() -> None:
+    layouts = _RollbackLayouts()
+    runtime = _RollbackRuntime()
+    runtime.publish_results = [True, True]
+    runtime.expected_registered_local_names = ["local-a", "local-a"]
+    service = SkillsPoolRollbackService(
+        bot_repository=_Bots(),
+        layout_repository=layouts,
+        skill_repository=_HistoricalSkills(),
+        runtime=runtime,
+        edit_guard=_EditGuard(),
+    )
+
+    result = await service.rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="rollback all versions",
+    )
+
+    locator = (
+        "local:///home/admin/.openclaw/workspace/"
+        "skills/skills-local/local-a"
+    )
+    assert result.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
+    assert layouts.locators == {11: locator, 12: locator}
 
 
 @pytest.mark.asyncio
@@ -437,3 +521,40 @@ async def test_rollback_bot_validation_failure_is_persisted() -> None:
     assert result.outcome is SkillsPoolRollbackOutcome.BOT_CHANGED
     assert layouts.events == ["begin", "failure"]
     assert layouts.state.last_failure_stage == "rollback_bot_validation"
+
+
+@pytest.mark.asyncio
+async def test_rollback_old_runtime_is_fenced_before_v2_mapping_request() -> None:
+    layouts = _RollbackLayouts()
+    runtime = _RollbackRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        preparation_id=None,
+        evidence={"reason": "logical_mapping_contract_not_supported"},
+    )
+    service = SkillsPoolRollbackService(
+        bot_repository=_Bots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=runtime,
+        edit_guard=_EditGuard(),
+    )
+
+    result = await service.rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="old runtime must not receive mapping v2",
+    )
+
+    assert result.outcome is SkillsPoolRollbackOutcome.ROLLBACK_FAILED
+    assert result.retryable is True
+    assert result.evidence == {
+        "reason": "logical_mapping_contract_not_supported"
+    }
+    assert runtime.events == ["probe"]
+    assert layouts.events == ["begin", "failure"]
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING
+    assert layouts.state.last_failure_stage == "runtime_probe"

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -117,8 +117,9 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
     )
     mappings = [
         PoolSkillMapping(
-            source=("/home/admin/.openclaw/workspace/skills-pool/skills-local/a"),
-            target="/home/admin/.openclaw/workspace/skills/a",
+            corpus="local",
+            relative_path="a",
+            link_name="a",
         )
     ]
 
@@ -165,6 +166,17 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
         "/api/skills/layout/mappings/publish",
         "/api/skills/layout/mappings/verify",
     ]
+    logical_mapping = {
+        "corpus": "local",
+        "relative_path": "a",
+        "link_name": "a",
+    }
+    for index in (0, 2, 3):
+        assert (
+            transport.calls[index]["body"]["mapping_contract_version"]
+            == "skills-pool-mapping-v2"
+        )
+        assert transport.calls[index]["body"]["mappings"] == [logical_mapping]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/services/test_skill_set_service_engine_type.py
+++ b/src/backend/tests/community/services/test_skill_set_service_engine_type.py
@@ -92,6 +92,31 @@ class TestSkillSetServiceEngineTypeThreading:
         call_kwargs = mock_skill_set_repo.get_all_active_skill_sets.call_args.kwargs
         assert call_kwargs.get("engine_type") == "claude-code"
 
+    async def test_get_symlink_mappings_keeps_known_legacy_moltis_paths(
+        self, skill_set_service
+    ):
+        skill_set_service.engine_type = "moltis"
+        skill_set_service.is_desktop = True
+        skill_set_service.get_active_skills = MagicMock(
+            return_value=[
+                {"name": "reviewer", "git_path": "git://business/reviewer"}
+            ]
+        )
+
+        mappings = skill_set_service.get_symlink_mappings()
+
+        assert [mapping.to_dict() for mapping in mappings] == [
+            {
+                "source": (
+                    "/home/admin/.moltis/skills/"
+                    "skills-repo/business/reviewer"
+                ),
+                "target": "/home/admin/.moltis/skills/reviewer",
+                "skill_uuid": None,
+                "version": None,
+            }
+        ]
+
     def test_get_all_skill_sets_with_skills_passes_engine_type(self, skill_set_service, mock_skill_set_repo):
         """get_all_skill_sets_with_skills should pass engine_type to repo.list_all."""
         mock_skill_set_repo.list_all.return_value = []

--- a/src/engine/docs/heterogeneous-engine-architecture.md
+++ b/src/engine/docs/heterogeneous-engine-architecture.md
@@ -1073,6 +1073,61 @@ class SkillExecutionResult:
     duration_ms: int = 0
 ```
 
+### 7.3 Skills Pool mapping wire contract
+
+`SkillsService` 的 Pool activation、publish、verify 使用显式版本协商。当前
+新契约版本为 `skills-pool-mapping-v2`：
+
+```json
+{
+  "mapping_contract_version": "skills-pool-mapping-v2",
+  "mappings": [
+    {
+      "corpus": "local",
+      "relative_path": "writer",
+      "link_name": "writer"
+    },
+    {
+      "corpus": "repo",
+      "relative_path": "business/reviewer",
+      "link_name": "reviewer"
+    }
+  ]
+}
+```
+
+- `corpus` 只允许 `local` 或 `repo`；`relative_path` 必须是规范化的相对
+  POSIX 路径；`link_name` 必须是单个规范化路径段。绝对路径、路径逃逸、
+  重复 target、未知 corpus 和额外/混合字段全部 fail closed。
+- Backend 不发送 engine-specific source/target。Engine 的
+  `layout_planner.py` 使用当前 engine、layout state、repo delivery 与本地
+  home 投影物理 source/active target；publish/verify 返回
+  `resolved_mappings`，activation/rollback 返回 `local_locators`。这些路径是
+  Engine evidence，Backend 只能校验和持久化，不能按 engine 重建。
+- 新 Backend 只有在 `/api/skills/layout/probe` 的 READY evidence 明确包含
+  `"mapping_contract_version": "skills-pool-mapping-v2"` 后，才会在已通过
+  rollout gate 且 migration claim 成功的 reconcile 中发送 v2。缺失或旧
+  capability 归类为 `NOT_CAPABLE`，保持 Legacy；probe 本身不能触发
+  claim/cutover。已处于 Pool 的 Bot 发起显式 rollback 时也会重新 probe
+  当前 binding；若 runtime 已降级或缺少 capability，则 Backend 在首个 v2
+  mapping 请求和文件系统 rollback 前停止，保留现状并返回可重试失败。
+- 兼容窗口内，新 Engine 仍接受不带 `mapping_contract_version` 的 legacy
+  physical item：`{"source": "...", "target": "..."}`。无版本 logical
+  payload、带 v2 的 physical payload、logical/physical 混合 payload 和未知
+  version 均在任何文件系统 mutation 前拒绝。
+- 消费者包括 Backend `SkillsPoolRuntimeProtocol`/
+  `SkillsPoolReconcileService`、Engine `/api/skills` router 与
+  `SkillsService`，以及 OpenClaw、Claude Code、AICoding、Hermes 的
+  filesystem composition roots。OpenClaw/Claude Code 内置 consumer
+  直接广告 v2；AICoding/Hermes 由具体 composition root 在接入同一 resolver
+  后显式广告。旧 composition root 不广告，混部期间保持
+  `NOT_CAPABLE`/Legacy。四个 consumer 使用相同 contract tests；Teclaw
+  保持 artifact delivery，不消费文件系统 mapping。
+- v2 在混部期间不替换 legacy wire form；旧 Backend→新 Engine 可继续使用
+  无版本 physical payload，新 Backend→旧 Engine 经 probe capability gate
+  停留在 Legacy。移除 legacy form 需要独立版本与全量 runtime 升级证据，
+  不属于当前迁移。
+
 ---
 
 ## 8. Approval 抽象层

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -21,12 +21,18 @@ from engine.community.api.skills.schemas import (
     PoolLayoutActivateRequest,
     PoolLayoutActivateResponse,
     PoolLayoutRollbackRequest,
-    PoolQuarantineCleanupRequest,
     PoolMappingVerifyRequest,
+    PoolQuarantineCleanupRequest,
     RuntimeLayoutProbeApiResponse,
     RuntimeLayoutProbeRequest,
     RuntimeLayoutProbeResponse,
     SyncSymlinkRequest,
+)
+from engine.community.api.skills.schemas import (
+    PoolPhysicalMapping as PoolPhysicalMappingSchema,
+)
+from engine.community.api.skills.schemas import (
+    PoolSkillMappingIntent as PoolSkillMappingIntentSchema,
 )
 from engine.community.core.engine.capability import Capability
 from engine.community.core.engine.exceptions import CapabilityNotSupportedError
@@ -34,14 +40,23 @@ from engine.community.core.skills.models import (
     CenterEnsureItem,
     CenterEnsureRequest,
     CleanSymlinksRequest,
-    PoolLayoutActivateRequest as PoolLayoutActivateCommand,
-    PoolLayoutRollbackRequest as PoolLayoutRollbackCommand,
-    PoolLayoutProbeRequest as PoolLayoutProbeCommand,
     PoolMappingSourceLayout,
-    PoolQuarantineCleanupRequest as PoolQuarantineCleanupCommand,
+    PoolSkillMappingIntent,
     SymlinkItem,
     SyncBindPathsRequest,
     SyncSymlinksRequest,
+)
+from engine.community.core.skills.models import (
+    PoolLayoutActivateRequest as PoolLayoutActivateCommand,
+)
+from engine.community.core.skills.models import (
+    PoolLayoutProbeRequest as PoolLayoutProbeCommand,
+)
+from engine.community.core.skills.models import (
+    PoolLayoutRollbackRequest as PoolLayoutRollbackCommand,
+)
+from engine.community.core.skills.models import (
+    PoolQuarantineCleanupRequest as PoolQuarantineCleanupCommand,
 )
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
@@ -51,6 +66,21 @@ log = logging.getLogger("api-skills")
 def _skills_plugin():
     from engine.community.manager import EngineManager
     return EngineManager.get_instance().skills
+
+
+def _mapping_command(
+    item: PoolSkillMappingIntentSchema | PoolPhysicalMappingSchema,
+) -> PoolSkillMappingIntent | SymlinkItem:
+    if isinstance(item, PoolSkillMappingIntentSchema):
+        return PoolSkillMappingIntent(
+            corpus=item.corpus,
+            relative_path=item.relative_path,
+            link_name=item.link_name,
+        )
+    return SymlinkItem(
+        source=item.source,
+        target=item.target,
+    )
 
 
 @router.post("/layout/probe", response_model=RuntimeLayoutProbeApiResponse)
@@ -91,10 +121,8 @@ async def activate_runtime_skills_layout(
                 migration_generation=body.migration_generation,
                 preparation_id=body.preparation_id,
                 registered_local_names=body.registered_local_names,
-                mappings=[
-                    SymlinkItem(source=item.source, target=item.target)
-                    for item in body.mappings
-                ],
+                mappings=[_mapping_command(item) for item in body.mappings],
+                mapping_contract_version=body.mapping_contract_version,
             )
         )
     except CapabilityNotSupportedError as error:
@@ -173,12 +201,13 @@ async def verify_runtime_skill_mappings(
         if body.source_layout == PoolMappingSourceLayout.LEGACY.value
         else {}
     )
+    if body.mapping_contract_version is not None:
+        layout_kwargs["mapping_contract_version"] = (
+            body.mapping_contract_version
+        )
     try:
         result = await plugin.verify_pool_mappings(
-            [
-                SymlinkItem(source=item.source, target=item.target)
-                for item in body.mappings
-            ],
+            [_mapping_command(item) for item in body.mappings],
             **layout_kwargs,
         )
     except CapabilityNotSupportedError as error:
@@ -202,12 +231,13 @@ async def publish_runtime_skill_mappings(
         if body.source_layout == PoolMappingSourceLayout.LEGACY.value
         else {}
     )
+    if body.mapping_contract_version is not None:
+        layout_kwargs["mapping_contract_version"] = (
+            body.mapping_contract_version
+        )
     try:
         result = await plugin.publish_pool_mappings(
-            [
-                SymlinkItem(source=item.source, target=item.target)
-                for item in body.mappings
-            ],
+            [_mapping_command(item) for item in body.mappings],
             **layout_kwargs,
         )
     except CapabilityNotSupportedError as error:

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -1,9 +1,9 @@
 """Skills router HTTP schemas."""
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from engine.community.api.response import ApiResponse
 
@@ -13,8 +13,27 @@ class SymlinkItem(BaseModel):
     target: str
 
 
+class PoolPhysicalMapping(BaseModel):
+    """Strict legacy physical mapping shape for Pool endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    target: str
+
+
+class PoolSkillMappingIntent(BaseModel):
+    """Strict mapping-v2 logical shape."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    corpus: Literal["local", "repo"]
+    relative_path: str
+    link_name: str
+
+
 class SyncSymlinkRequest(BaseModel):
-    symlinks: Optional[list[SymlinkItem]] = None
+    symlinks: list[SymlinkItem] | None = None
 
 
 class CleanSymlinkRequest(BaseModel):
@@ -72,7 +91,8 @@ class PoolLayoutActivateRequest(BaseModel):
     migration_generation: str
     preparation_id: str
     registered_local_names: list[str]
-    mappings: list[SymlinkItem]
+    mapping_contract_version: str | None = None
+    mappings: list[PoolSkillMappingIntent | PoolPhysicalMapping]
 
 
 class PoolLayoutRollbackRequest(BaseModel):
@@ -105,7 +125,8 @@ class PoolLayoutActivateApiResponse(ApiResponse):
 
 
 class PoolMappingVerifyRequest(BaseModel):
-    mappings: list[SymlinkItem]
+    mapping_contract_version: str | None = None
+    mappings: list[PoolSkillMappingIntent | PoolPhysicalMapping]
     source_layout: Literal["pool", "legacy"] = "pool"
 
 
@@ -122,10 +143,12 @@ __all__ = [
     "PoolLayoutActivateResponse",
     "PoolLayoutRollbackRequest",
     "PoolMappingVerifyRequest",
+    "PoolPhysicalMapping",
+    "PoolQuarantineCleanupRequest",
+    "PoolSkillMappingIntent",
     "RuntimeLayoutProbeApiResponse",
     "RuntimeLayoutProbeRequest",
     "RuntimeLayoutProbeResponse",
-    "PoolQuarantineCleanupRequest",
     "SymlinkItem",
     "SyncSymlinkRequest",
 ]

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -30,6 +30,7 @@ from engine.community.core.skills.models import (
     PoolMappingSourceLayout,
     PoolMappingVerificationResult,
     PoolQuarantineCleanupResult,
+    PoolSkillMappingIntent,
     SymlinkItem,
     SyncSymlinksResult,
 )
@@ -344,6 +345,75 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
             SymlinkItem(source="/pool/a", target="/skills/a"),
         ],
         source_layout=PoolMappingSourceLayout.LEGACY,
+    )
+
+
+def test_pool_mapping_routes_propagate_logical_v2_contract(
+    client, rich_manager
+):
+    plugin = MagicMock()
+    plugin.activate_pool_layout = AsyncMock(
+        return_value=PoolLayoutActivationResult(
+            committed=True,
+            status=PoolLayoutActivationStatus.COMMITTED,
+            evidence={},
+        ),
+    )
+    plugin.publish_pool_mappings = AsyncMock(
+        return_value=PoolMappingPublishResult(published=True, evidence={}),
+    )
+    plugin.verify_pool_mappings = AsyncMock(
+        return_value=PoolMappingVerificationResult(valid=True, evidence={}),
+    )
+    rich_manager._active_engine._skills = plugin
+    mapping = {
+        "corpus": "repo",
+        "relative_path": "business/reviewer",
+        "link_name": "reviewer",
+    }
+    version = "skills-pool-mapping-v2"
+
+    activation = client.post(
+        "/api/skills/layout/activate",
+        json={
+            "migration_generation": "generation-1",
+            "preparation_id": "preparation-1",
+            "registered_local_names": [],
+            "mapping_contract_version": version,
+            "mappings": [mapping],
+        },
+    )
+    published = client.post(
+        "/api/skills/layout/mappings/publish",
+        json={
+            "mapping_contract_version": version,
+            "mappings": [mapping],
+        },
+    )
+    verified = client.post(
+        "/api/skills/layout/mappings/verify",
+        json={
+            "mapping_contract_version": version,
+            "mappings": [mapping],
+        },
+    )
+
+    assert activation.status_code == published.status_code == verified.status_code == 200
+    intent = PoolSkillMappingIntent(
+        corpus="repo",
+        relative_path="business/reviewer",
+        link_name="reviewer",
+    )
+    request = plugin.activate_pool_layout.await_args.args[0]
+    assert request.mapping_contract_version == version
+    assert request.mappings == [intent]
+    plugin.publish_pool_mappings.assert_awaited_once_with(
+        [intent],
+        mapping_contract_version=version,
+    )
+    plugin.verify_pool_mappings.assert_awaited_once_with(
+        [intent],
+        mapping_contract_version=version,
     )
 
 

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -47,11 +47,12 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeResult,
     PoolLayoutProbeStatus,
     PoolLayoutRollbackRequest,
-    PoolQuarantineCleanupRequest,
-    PoolQuarantineCleanupResult,
     PoolMappingPublishResult,
     PoolMappingSourceLayout,
     PoolMappingVerificationResult,
+    PoolQuarantineCleanupRequest,
+    PoolQuarantineCleanupResult,
+    PoolSkillMappingIntent,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
@@ -67,6 +68,18 @@ from engine.community.core.skills.protocol import SkillsService
 from engine.community.plugin_api.claude_code.skills import ClaudeCodeSkillsPort
 
 log = logging.getLogger("claude-code-skills-adapter")
+
+
+def _serialize_pool_mapping(
+    item: PoolSkillMappingIntent | SymlinkItem,
+) -> dict[str, str]:
+    if isinstance(item, PoolSkillMappingIntent):
+        return {
+            "corpus": item.corpus,
+            "relative_path": item.relative_path,
+            "link_name": item.link_name,
+        }
+    return {"source": item.source, "target": item.target}
 
 
 # ── Dict → DTO helpers (relocated from engines/claude_code/skills.py) ─────────
@@ -340,17 +353,15 @@ class ClaudeCodeSkillsAdapter(SkillsService):
         request: PoolLayoutActivateRequest,
         auth: AuthContext | None = None,
     ) -> PoolLayoutActivationResult:
-        raw = await self._port.activate_pool_layout(
-            {
-                "migration_generation": request.migration_generation,
-                "preparation_id": request.preparation_id,
-                "registered_local_names": request.registered_local_names,
-                "mappings": [
-                    {"source": item.source, "target": item.target}
-                    for item in request.mappings
-                ],
-            }
-        )
+        payload: dict[str, object] = {
+            "migration_generation": request.migration_generation,
+            "preparation_id": request.preparation_id,
+            "registered_local_names": request.registered_local_names,
+            "mappings": [_serialize_pool_mapping(item) for item in request.mappings],
+        }
+        if request.mapping_contract_version is not None:
+            payload["mapping_contract_version"] = request.mapping_contract_version
+        raw = await self._port.activate_pool_layout(payload)
         raw_status = str(raw.get("status", ""))
         try:
             status = PoolLayoutActivationStatus(raw_status)
@@ -439,19 +450,19 @@ class ClaudeCodeSkillsAdapter(SkillsService):
 
     async def publish_pool_mappings(
         self,
-        mappings: list[SymlinkItem],
+        mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
+        mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
     ) -> PoolMappingPublishResult:
-        raw = await self._port.publish_pool_mappings(
-            {
-                "mappings": [
-                    {"source": item.source, "target": item.target} for item in mappings
-                ],
-                "source_layout": source_layout.value,
-            }
-        )
+        payload: dict[str, object] = {
+            "mappings": [_serialize_pool_mapping(item) for item in mappings],
+            "source_layout": source_layout.value,
+        }
+        if mapping_contract_version is not None:
+            payload["mapping_contract_version"] = mapping_contract_version
+        raw = await self._port.publish_pool_mappings(payload)
         return PoolMappingPublishResult(
             published=raw.get("published") is True,
             evidence=dict(raw.get("evidence") or {}),
@@ -459,19 +470,19 @@ class ClaudeCodeSkillsAdapter(SkillsService):
 
     async def verify_pool_mappings(
         self,
-        mappings: list[SymlinkItem],
+        mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
+        mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
     ) -> PoolMappingVerificationResult:
-        raw = await self._port.verify_pool_mappings(
-            {
-                "mappings": [
-                    {"source": item.source, "target": item.target} for item in mappings
-                ],
-                "source_layout": source_layout.value,
-            }
-        )
+        payload: dict[str, object] = {
+            "mappings": [_serialize_pool_mapping(item) for item in mappings],
+            "source_layout": source_layout.value,
+        }
+        if mapping_contract_version is not None:
+            payload["mapping_contract_version"] = mapping_contract_version
+        raw = await self._port.verify_pool_mappings(payload)
         return PoolMappingVerificationResult(
             valid=raw.get("valid") is True,
             evidence=dict(raw.get("evidence") or {}),

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -38,11 +38,12 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeResult,
     PoolLayoutProbeStatus,
     PoolLayoutRollbackRequest,
-    PoolQuarantineCleanupRequest,
-    PoolQuarantineCleanupResult,
     PoolMappingPublishResult,
     PoolMappingSourceLayout,
     PoolMappingVerificationResult,
+    PoolQuarantineCleanupRequest,
+    PoolQuarantineCleanupResult,
+    PoolSkillMappingIntent,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
@@ -54,6 +55,18 @@ from engine.community.core.skills.models import (
 )
 from engine.community.core.skills.protocol import SkillsService
 from engine.community.plugin_api.openclaw.skills import OpenClawSkillsPort
+
+
+def _serialize_pool_mapping(
+    item: PoolSkillMappingIntent | SymlinkItem,
+) -> dict[str, str]:
+    if isinstance(item, PoolSkillMappingIntent):
+        return {
+            "corpus": item.corpus,
+            "relative_path": item.relative_path,
+            "link_name": item.link_name,
+        }
+    return {"source": item.source, "target": item.target}
 
 
 class OpenClawSkillsAdapter(SkillsService):
@@ -150,17 +163,15 @@ class OpenClawSkillsAdapter(SkillsService):
         request: PoolLayoutActivateRequest,
         auth: AuthContext | None = None,
     ) -> PoolLayoutActivationResult:
-        raw = await self._port.activate_pool_layout(
-            {
-                "migration_generation": request.migration_generation,
-                "preparation_id": request.preparation_id,
-                "registered_local_names": request.registered_local_names,
-                "mappings": [
-                    {"source": item.source, "target": item.target}
-                    for item in request.mappings
-                ],
-            }
-        )
+        payload: dict[str, object] = {
+            "migration_generation": request.migration_generation,
+            "preparation_id": request.preparation_id,
+            "registered_local_names": request.registered_local_names,
+            "mappings": [_serialize_pool_mapping(item) for item in request.mappings],
+        }
+        if request.mapping_contract_version is not None:
+            payload["mapping_contract_version"] = request.mapping_contract_version
+        raw = await self._port.activate_pool_layout(payload)
         raw_status = str(raw.get("status", ""))
         try:
             status = PoolLayoutActivationStatus(raw_status)
@@ -253,20 +264,19 @@ class OpenClawSkillsAdapter(SkillsService):
 
     async def publish_pool_mappings(
         self,
-        mappings: list[SymlinkItem],
+        mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
+        mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
     ) -> PoolMappingPublishResult:
-        raw = await self._port.publish_pool_mappings(
-            {
-                "mappings": [
-                    {"source": item.source, "target": item.target}
-                    for item in mappings
-                ],
-                "source_layout": source_layout.value,
-            }
-        )
+        payload: dict[str, object] = {
+            "mappings": [_serialize_pool_mapping(item) for item in mappings],
+            "source_layout": source_layout.value,
+        }
+        if mapping_contract_version is not None:
+            payload["mapping_contract_version"] = mapping_contract_version
+        raw = await self._port.publish_pool_mappings(payload)
         return PoolMappingPublishResult(
             published=raw.get("published") is True,
             evidence=dict(raw.get("evidence") or {}),
@@ -274,20 +284,19 @@ class OpenClawSkillsAdapter(SkillsService):
 
     async def verify_pool_mappings(
         self,
-        mappings: list[SymlinkItem],
+        mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
+        mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
     ) -> PoolMappingVerificationResult:
-        raw = await self._port.verify_pool_mappings(
-            {
-                "mappings": [
-                    {"source": item.source, "target": item.target}
-                    for item in mappings
-                ],
-                "source_layout": source_layout.value,
-            }
-        )
+        payload: dict[str, object] = {
+            "mappings": [_serialize_pool_mapping(item) for item in mappings],
+            "source_layout": source_layout.value,
+        }
+        if mapping_contract_version is not None:
+            payload["mapping_contract_version"] = mapping_contract_version
+        raw = await self._port.verify_pool_mappings(payload)
         return PoolMappingVerificationResult(
             valid=raw.get("valid") is True,
             evidence=dict(raw.get("evidence") or {}),

--- a/src/engine/src/engine/community/core/skills/layout_planner.py
+++ b/src/engine/src/engine/community/core/skills/layout_planner.py
@@ -10,14 +10,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
+MAPPING_CONTRACT_VERSION = "skills-pool-mapping-v2"
 
 
 class SkillLayoutCapability(StrEnum):
     FILESYSTEM = "filesystem"
     ARTIFACT = "artifact"
+
+
+class SkillCorpus(StrEnum):
+    """Logical source collection named by the Backend wire contract."""
+
+    LOCAL = "local"
+    REPO = "repo"
 
 
 class SkillLayoutResolutionError(ValueError):
@@ -41,6 +49,27 @@ class LayoutIdentity:
 @dataclass(frozen=True, slots=True)
 class RuntimeLayoutContext:
     home: Path = Path("/home/admin")
+
+
+@dataclass(frozen=True, slots=True)
+class LogicalSkillMapping:
+    """Engine-independent declaration of one active Skill."""
+
+    corpus: SkillCorpus
+    relative_path: str
+    link_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSkillMapping:
+    """Engine-local projection and locator evidence for one active Skill."""
+
+    corpus: SkillCorpus
+    relative_path: str
+    link_name: str
+    source: Path
+    target: Path
+    resolved_locator: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -167,6 +196,115 @@ class ResolvedFilesystemLayoutPlan:
 ResolvedSkillLayoutPlan = ResolvedFilesystemLayoutPlan | ResolvedArtifactLayoutPlan
 
 
+def _normalize_relative_path(raw: str, *, field: str) -> str:
+    value = raw.strip()
+    path = PurePosixPath(value)
+    if (
+        not value
+        or raw != value
+        or "\x00" in raw
+        or path.is_absolute()
+        or not path.parts
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or path.as_posix() != value
+    ):
+        raise SkillLayoutResolutionError(
+            f"{field} must be a normalized relative POSIX path: {raw!r}"
+        )
+    return path.as_posix()
+
+
+def _normalize_link_name(raw: str) -> str:
+    value = _normalize_relative_path(raw, field="link_name")
+    if len(PurePosixPath(value).parts) != 1:
+        raise SkillLayoutResolutionError(
+            f"link_name must contain exactly one path segment: {raw!r}"
+        )
+    return value
+
+
+def resolve_skill_mappings(
+    *,
+    active_root: Path,
+    local_root: Path,
+    repo_root: Path,
+    mappings: list[LogicalSkillMapping],
+) -> list[ResolvedSkillMapping]:
+    """Resolve mappings from roots selected by the operation's protocol."""
+
+    resolved: list[ResolvedSkillMapping] = []
+    seen_targets: set[Path] = set()
+    for mapping in mappings:
+        relative_path = _normalize_relative_path(
+            mapping.relative_path,
+            field="relative_path",
+        )
+        link_name = _normalize_link_name(mapping.link_name)
+        if mapping.corpus is SkillCorpus.LOCAL:
+            source_root = local_root
+            locator_scheme = "local"
+        elif mapping.corpus is SkillCorpus.REPO:
+            source_root = repo_root
+            locator_scheme = "git"
+        else:
+            raise SkillLayoutResolutionError(
+                f"unknown Skill corpus: {mapping.corpus!r}"
+            )
+
+        source = source_root / relative_path
+        target = active_root / link_name
+        if target in seen_targets:
+            raise SkillLayoutResolutionError(
+                f"duplicate active Skill target: {link_name}"
+            )
+        seen_targets.add(target)
+        locator_value = (
+            str(source)
+            if mapping.corpus is SkillCorpus.LOCAL
+            else relative_path
+        )
+        resolved.append(
+            ResolvedSkillMapping(
+                corpus=mapping.corpus,
+                relative_path=relative_path,
+                link_name=link_name,
+                source=source,
+                target=target,
+                resolved_locator=f"{locator_scheme}://{locator_value}",
+            )
+        )
+    return resolved
+
+
+def resolved_filesystem_layout_evidence(
+    plan: ResolvedFilesystemLayoutPlan,
+    *,
+    local_root: Path,
+    repo_root: Path,
+) -> dict[str, str]:
+    """Return the roots selected by the caller as Backend evidence."""
+
+    return {
+        "active_root": str(plan.active_root),
+        "local_root": str(local_root),
+        "repo_root": str(repo_root),
+    }
+
+
+def resolve_local_skill_locators(
+    local_root: Path,
+    names: list[str],
+) -> dict[str, str]:
+    """Resolve registered local Skill names into persistence locators."""
+
+    resolved: dict[str, str] = {}
+    for raw_name in names:
+        name = _normalize_link_name(raw_name)
+        if name not in resolved:
+            resolved[name] = f"local://{local_root / name}"
+    return resolved
+
+
 def _filesystem_template(
     *,
     engine_home: str,
@@ -274,16 +412,23 @@ def resolve_filesystem_skill_layout(
 __all__ = [
     "DESCRIPTORS",
     "LAYOUT_CONTRACT_VERSION",
+    "MAPPING_CONTRACT_VERSION",
     "EngineSkillLayoutDescriptor",
     "LayoutIdentity",
+    "LogicalSkillMapping",
     "ResolvedArtifactLayoutPlan",
     "ResolvedFilesystemLayoutPlan",
     "ResolvedSkillLayoutPlan",
+    "ResolvedSkillMapping",
     "RuntimeLayoutContext",
+    "SkillCorpus",
     "SkillLayoutCapability",
     "SkillLayoutResolutionError",
     "UnsupportedLayoutContractError",
     "UnsupportedRuntimeLayoutError",
     "resolve_filesystem_skill_layout",
+    "resolve_local_skill_locators",
     "resolve_skill_layout",
+    "resolve_skill_mappings",
+    "resolved_filesystem_layout_evidence",
 ]

--- a/src/engine/src/engine/community/core/skills/models.py
+++ b/src/engine/src/engine/community/core/skills/models.py
@@ -95,6 +95,15 @@ class SymlinkItem:
     target: str
 
 
+@dataclass(frozen=True, slots=True)
+class PoolSkillMappingIntent:
+    """Path-agnostic mapping resolved by the active Engine implementation."""
+
+    corpus: str
+    relative_path: str
+    link_name: str
+
+
 @dataclass
 class SyncSymlinksRequest:
     """Bulk-sync request for relative-path symlinks under a base dir."""
@@ -185,7 +194,10 @@ class PoolLayoutActivateRequest:
     migration_generation: str
     preparation_id: str
     registered_local_names: list[str] = field(default_factory=list)
-    mappings: list[SymlinkItem] = field(default_factory=list)
+    mappings: list[PoolSkillMappingIntent | SymlinkItem] = field(
+        default_factory=list
+    )
+    mapping_contract_version: str | None = None
 
 
 @dataclass
@@ -250,7 +262,7 @@ class PoolLayoutActivationResult:
     """Pool 数据面切换结果。"""
 
     committed: bool
-    status: "PoolLayoutActivationStatus"
+    status: PoolLayoutActivationStatus
     evidence: dict[str, Any] = field(default_factory=dict)
 
     def to_data(self) -> dict[str, Any]:
@@ -312,8 +324,6 @@ __all__ = [
     "CleanSymlinksRequest",
     "CleanSymlinksResult",
     "PoolLayoutActivateRequest",
-    "PoolQuarantineCleanupRequest",
-    "PoolQuarantineCleanupResult",
     "PoolLayoutActivationResult",
     "PoolLayoutActivationStatus",
     "PoolLayoutProbeRequest",
@@ -323,6 +333,9 @@ __all__ = [
     "PoolMappingPublishResult",
     "PoolMappingSourceLayout",
     "PoolMappingVerificationResult",
+    "PoolQuarantineCleanupRequest",
+    "PoolQuarantineCleanupResult",
+    "PoolSkillMappingIntent",
     "Skill",
     "SkillConfig",
     "SkillExecutionRequest",

--- a/src/engine/src/engine/community/core/skills/protocol.py
+++ b/src/engine/src/engine/community/core/skills/protocol.py
@@ -13,11 +13,17 @@ The Protocol carries two parallel surfaces:
 * **bulk-symlink** ops (`sync_symlinks`, `sync_bindpaths`, `clean_symlinks`)
   — used by engines that materialise skills as filesystem symlinks and
   reconcile the whole directory in one call (current OpenClaw deployment).
+* **Pool layout** ops (`probe_pool_layout`, `activate_pool_layout`,
+  `publish_pool_mappings`, `verify_pool_mappings`) — implemented by the
+  OpenClaw and Claude Code adapters/ports in this repository. Corp AICoding
+  and Hermes composition roots consume the same Protocol, mapping contract,
+  and shared Engine-owned layout planner.
 
 Engines implement only the surface they need; the unsupported methods
 should raise :class:`CapabilityNotSupportedError`.
 
-See src/engine/docs/heterogeneous-engine-architecture.md §7.1.
+The versioned Pool mapping wire contract and compatibility rules are recorded
+in ``src/engine/docs/heterogeneous-engine-architecture.md`` §7.3.
 """
 from __future__ import annotations
 
@@ -31,14 +37,15 @@ from engine.community.core.skills.models import (
     CleanSymlinksResult,
     PoolLayoutActivateRequest,
     PoolLayoutActivationResult,
-    PoolQuarantineCleanupRequest,
-    PoolQuarantineCleanupResult,
     PoolLayoutProbeRequest,
     PoolLayoutProbeResult,
     PoolLayoutRollbackRequest,
     PoolMappingPublishResult,
     PoolMappingSourceLayout,
     PoolMappingVerificationResult,
+    PoolQuarantineCleanupRequest,
+    PoolQuarantineCleanupResult,
+    PoolSkillMappingIntent,
     Skill,
     SkillConfig,
     SkillExecutionRequest,
@@ -205,22 +212,28 @@ class SkillsService(Protocol):
 
     async def publish_pool_mappings(
         self,
-        mappings: list[SymlinkItem],
+        mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
+        mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
     ) -> PoolMappingPublishResult:
-        """发布目标 Pool layout 的完整受管 mapping。"""
+        """Publish a complete mapping set.
+
+        ``skills-pool-mapping-v2`` carries logical intents. An omitted version
+        is the compatibility form for legacy physical ``SymlinkItem`` values.
+        """
         ...
 
     async def verify_pool_mappings(
         self,
-        mappings: list[SymlinkItem],
+        mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
+        mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
     ) -> PoolMappingVerificationResult:
-        """验证当前受管入口精确指向请求中的 Pool source。"""
+        """Verify mappings using the same versioned contract as publication."""
         ...
 
 

--- a/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingPublishResult,
@@ -33,12 +33,14 @@ from engine.community.plugins.skills_pool.layout_probe import (
 def inspect_aicoding_runtime_layout(
     *,
     expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
+    mapping_contract_version: str | None = None,
     home: Path = Path("/home/admin"),
     repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
 ) -> RuntimeLayoutInspection:
     return inspect_runtime_layout(
         engine="aicoding",
         expected_contract_version=expected_contract_version,
+        mapping_contract_version=mapping_contract_version,
         home=home,
         repo_is_mounted=repo_is_mounted,
 )

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from engine.community.core.skills.layout_planner import (
+    MAPPING_CONTRACT_VERSION,
+)
 from engine.community.plugins.aicoding.layout_pool import (
     PoolActivationStatus,
     RuntimeLayoutInspectionStatus,
@@ -89,6 +92,7 @@ def test_aicoding_probe_uses_own_pool_and_stable_bridges(tmp_path: Path) -> None
 
     ready = inspect_aicoding_runtime_layout(
         home=home,
+        mapping_contract_version=MAPPING_CONTRACT_VERSION,
         repo_is_mounted=lambda path: path == pool_repo,
     )
 
@@ -97,6 +101,19 @@ def test_aicoding_probe_uses_own_pool_and_stable_bridges(tmp_path: Path) -> None
     assert ready.preparation_id == PREPARATION_ID
     assert ready.evidence["checks"]["stable_local_bridge_valid"] is True
     assert ready.evidence["checks"]["stable_repo_bridge_valid"] is True
+    assert (
+        ready.evidence["mapping_contract_version"]
+        == MAPPING_CONTRACT_VERSION
+    )
+    assert ready.evidence["resolved_layout"]["active_root"] == str(
+        home / ".claude/skills"
+    )
+
+    legacy_consumer = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert "mapping_contract_version" not in legacy_consumer.evidence
 
     repo_bridge.unlink()
     repo_bridge.symlink_to(home / "wrong", target_is_directory=True)

--- a/src/engine/src/engine/community/plugins/claude_code/_skills.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_skills.py
@@ -15,9 +15,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from engine.community.core.skills.layout_planner import (
+    MAPPING_CONTRACT_VERSION,
+)
 from engine.community.plugins.claude_code.layout_pool import (
     MappingSourceLayout,
-    SkillMapping,
     activate_claude_code_pool,
     inspect_claude_code_runtime_layout,
     publish_claude_code_pool_mappings,
@@ -25,6 +27,10 @@ from engine.community.plugins.claude_code.layout_pool import (
     verify_claude_code_pool_mappings,
 )
 from engine.community.plugins.skills_pool.layout_quarantine import cleanup_quarantine
+from engine.community.plugins.skills_pool.mapping_contract import (
+    ResolvedMappingPayload,
+    resolve_mapping_payload,
+)
 
 log = logging.getLogger("claude-code-community-port")
 
@@ -48,11 +54,17 @@ class _SkillsPortMixin:
     ensure_center}."""
 
     @staticmethod
-    def _pool_mappings(params: dict[str, Any]) -> list[SkillMapping]:
-        return [
-            SkillMapping(source=item["source"], target=item["target"])
-            for item in params.get("mappings", [])
-        ]
+    def _pool_mappings(
+        params: dict[str, Any],
+        *,
+        source_layout: MappingSourceLayout,
+    ) -> ResolvedMappingPayload:
+        return resolve_mapping_payload(
+            engine="claude_code",
+            source_layout=source_layout,
+            payload=params.get("mappings", []),
+            mapping_contract_version=params.get("mapping_contract_version"),
+        )
 
     async def activate_pool_layout(
         self,
@@ -63,7 +75,12 @@ class _SkillsPortMixin:
             migration_generation=params["migration_generation"],
             preparation_id=params["preparation_id"],
             registered_local_names=list(params.get("registered_local_names", [])),
-            mappings=self._pool_mappings(params),
+            mappings=list(
+                self._pool_mappings(
+                    params,
+                    source_layout=MappingSourceLayout.POOL,
+                ).mappings
+            ),
         )
         return result.to_data()
 
@@ -99,6 +116,7 @@ class _SkillsPortMixin:
         result = await asyncio.to_thread(
             inspect_claude_code_runtime_layout,
             expected_contract_version=params["layout_contract_version"],
+            mapping_contract_version=MAPPING_CONTRACT_VERSION,
         )
         return result.to_data()
 
@@ -106,27 +124,55 @@ class _SkillsPortMixin:
         self,
         params: dict[str, Any],
     ) -> dict[str, Any]:
+        resolved = self._pool_mappings(
+            params,
+            source_layout=MappingSourceLayout(
+                params.get(
+                    "source_layout",
+                    MappingSourceLayout.POOL.value,
+                )
+            ),
+        )
         result = await asyncio.to_thread(
             publish_claude_code_pool_mappings,
-            mappings=self._pool_mappings(params),
+            mappings=list(resolved.mappings),
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
         )
-        return result.to_data()
+        data = result.to_data()
+        if result.published and resolved.resolved_locators:
+            data["evidence"]["resolved_mappings"] = list(
+                resolved.resolved_locators
+            )
+        return data
 
     async def verify_pool_mappings(
         self,
         params: dict[str, Any],
     ) -> dict[str, Any]:
+        resolved = self._pool_mappings(
+            params,
+            source_layout=MappingSourceLayout(
+                params.get(
+                    "source_layout",
+                    MappingSourceLayout.POOL.value,
+                )
+            ),
+        )
         result = await asyncio.to_thread(
             verify_claude_code_pool_mappings,
-            mappings=self._pool_mappings(params),
+            mappings=list(resolved.mappings),
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
         )
-        return result.to_data()
+        data = result.to_data()
+        if result.valid and resolved.resolved_locators:
+            data["evidence"]["resolved_mappings"] = list(
+                resolved.resolved_locators
+            )
+        return data
 
     async def skills_list(self, token: str | None = None) -> list[dict]:
         resp = await (await self._relay()).send_request("skills.list", {})

--- a/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
@@ -8,8 +8,8 @@ engine-view seam to its plugin.
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingPublishResult,
@@ -38,12 +38,14 @@ from engine.community.plugins.skills_pool.layout_probe import (
 def inspect_claude_code_runtime_layout(
     *,
     expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
+    mapping_contract_version: str | None = None,
     home: Path = Path("/home/admin"),
     repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
 ) -> RuntimeLayoutInspection:
     return inspect_runtime_layout(
         engine="claude_code",
         expected_contract_version=expected_contract_version,
+        mapping_contract_version=mapping_contract_version,
         home=home,
         repo_is_mounted=repo_is_mounted,
     )

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from engine.community.core.skills.layout_planner import MAPPING_CONTRACT_VERSION
 from engine.community.plugins.claude_code.layout_pool import (
     LAYOUT_CONTRACT_VERSION,
     MappingPublishResult,
@@ -294,6 +295,7 @@ async def test_claude_code_port_runs_pool_filesystem_operations_off_loop(
     }
     assert received[1] == {
         "expected_contract_version": LAYOUT_CONTRACT_VERSION,
+        "mapping_contract_version": MAPPING_CONTRACT_VERSION,
     }
     assert received[2] == received[3] == {
         "mappings": [

--- a/src/engine/src/engine/community/plugins/hermes/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/hermes/layout_pool.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingPublishResult,
@@ -33,12 +33,14 @@ from engine.community.plugins.skills_pool.layout_probe import (
 def inspect_hermes_runtime_layout(
     *,
     expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
+    mapping_contract_version: str | None = None,
     home: Path = Path("/home/admin"),
     repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
 ) -> RuntimeLayoutInspection:
     return inspect_runtime_layout(
         engine="hermes",
         expected_contract_version=expected_contract_version,
+        mapping_contract_version=mapping_contract_version,
         home=home,
         repo_is_mounted=repo_is_mounted,
     )

--- a/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/hermes/tests/test_pool_layout.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from engine.community.core.skills.layout_planner import (
+    MAPPING_CONTRACT_VERSION,
+)
 from engine.community.plugins.hermes.layout_pool import (
     PoolActivationStatus,
     RuntimeLayoutInspectionStatus,
@@ -73,12 +76,26 @@ def test_probe_requires_verified_hermes_legacy_bridge(tmp_path: Path) -> None:
 
     result = inspect_hermes_runtime_layout(
         home=home,
+        mapping_contract_version=MAPPING_CONTRACT_VERSION,
         repo_is_mounted=lambda path: path == pool_repo,
     )
 
     assert result.status is RuntimeLayoutInspectionStatus.READY
     assert result.engine == "hermes"
     assert result.evidence["checks"]["legacy_local_bridge_valid"] is True
+    assert (
+        result.evidence["mapping_contract_version"]
+        == MAPPING_CONTRACT_VERSION
+    )
+    assert result.evidence["resolved_layout"]["active_root"] == str(
+        home / ".hermes/skills"
+    )
+
+    legacy_consumer = inspect_hermes_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert "mapping_contract_version" not in legacy_consumer.evidence
 
     marker_path = pool_root / ".pool-ready"
     marker = json.loads(marker_path.read_text())

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -10,6 +10,9 @@ import os
 from pathlib import Path
 from typing import Any
 
+from engine.community.core.skills.layout_planner import (
+    MAPPING_CONTRACT_VERSION,
+)
 from engine.community.plugin_api.openclaw.skills import (
     PoolLayoutActivationPortResult,
 )
@@ -17,16 +20,19 @@ from engine.community.plugin_api.workspace_root import workspace_root
 from engine.community.plugins.openclaw._file import _convert_path
 from engine.community.plugins.openclaw.layout_activation import (
     MappingSourceLayout,
-    SkillMapping,
     activate_openclaw_pool,
     publish_pool_mappings,
     rollback_openclaw_pool,
     verify_skill_mappings,
 )
+from engine.community.plugins.openclaw.layout_probe import inspect_runtime_layout
 from engine.community.plugins.skills_pool.layout_quarantine import (
     cleanup_quarantine,
 )
-from engine.community.plugins.openclaw.layout_probe import inspect_runtime_layout
+from engine.community.plugins.skills_pool.mapping_contract import (
+    ResolvedMappingPayload,
+    resolve_mapping_payload,
+)
 
 log = logging.getLogger("openclaw-port")
 
@@ -53,11 +59,17 @@ class _SkillsPortMixin:
     )
 
     @staticmethod
-    def _pool_mappings(params: dict[str, Any]) -> list[SkillMapping]:
-        return [
-            SkillMapping(source=item["source"], target=item["target"])
-            for item in params.get("mappings", [])
-        ]
+    def _pool_mappings(
+        params: dict[str, Any],
+        *,
+        source_layout: MappingSourceLayout,
+    ) -> ResolvedMappingPayload:
+        return resolve_mapping_payload(
+            engine="openclaw",
+            source_layout=source_layout,
+            payload=params.get("mappings", []),
+            mapping_contract_version=params.get("mapping_contract_version"),
+        )
 
     async def activate_pool_layout(
         self, params: dict[str, Any]
@@ -69,7 +81,12 @@ class _SkillsPortMixin:
             registered_local_names=list(
                 params.get("registered_local_names", [])
             ),
-            mappings=self._pool_mappings(params),
+            mappings=list(
+                self._pool_mappings(
+                    params,
+                    source_layout=MappingSourceLayout.POOL,
+                ).mappings
+            ),
         )
         return PoolLayoutActivationPortResult(**result.to_data())
 
@@ -103,32 +120,61 @@ class _SkillsPortMixin:
             inspect_runtime_layout,
             engine=params["engine"],
             expected_contract_version=params["layout_contract_version"],
+            mapping_contract_version=MAPPING_CONTRACT_VERSION,
         )
         return result.to_data()
 
     async def publish_pool_mappings(
         self, params: dict[str, Any]
     ) -> dict[str, Any]:
+        resolved = self._pool_mappings(
+            params,
+            source_layout=MappingSourceLayout(
+                params.get(
+                    "source_layout",
+                    MappingSourceLayout.POOL.value,
+                )
+            ),
+        )
         result = await asyncio.to_thread(
             publish_pool_mappings,
-            mappings=self._pool_mappings(params),
+            mappings=list(resolved.mappings),
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
         )
-        return result.to_data()
+        data = result.to_data()
+        if result.published and resolved.resolved_locators:
+            data["evidence"]["resolved_mappings"] = list(
+                resolved.resolved_locators
+            )
+        return data
 
     async def verify_pool_mappings(
         self, params: dict[str, Any]
     ) -> dict[str, Any]:
+        resolved = self._pool_mappings(
+            params,
+            source_layout=MappingSourceLayout(
+                params.get(
+                    "source_layout",
+                    MappingSourceLayout.POOL.value,
+                )
+            ),
+        )
         result = await asyncio.to_thread(
             verify_skill_mappings,
-            mappings=self._pool_mappings(params),
+            mappings=list(resolved.mappings),
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
         )
-        return result.to_data()
+        data = result.to_data()
+        if result.valid and resolved.resolved_locators:
+            data["evidence"]["resolved_mappings"] = list(
+                resolved.resolved_locators
+            )
+        return data
 
     def _skills_resolve_base_dir(self) -> Path:
         """Resolve SKILLS_LINK_BASE_DIR from env, or default.
@@ -145,11 +191,11 @@ class _SkillsPortMixin:
 
     # Per-key asyncio locks (in-process; single-process deployment, isolated per bot).
     @classmethod
-    def _get_ensure_lock(cls, key: str) -> "Any":
-        import asyncio as _asyncio  # noqa: PLC0415
-        from collections import defaultdict  # noqa: PLC0415
+    def _get_ensure_lock(cls, key: str) -> Any:
+        import asyncio as _asyncio
+        from collections import defaultdict
         if not hasattr(cls, "_skills_ensure_locks_store"):
-            cls._skills_ensure_locks_store: "dict[str, Any]" = defaultdict(
+            cls._skills_ensure_locks_store: dict[str, Any] = defaultdict(
                 _asyncio.Lock
             )
         return cls._skills_ensure_locks_store[key]
@@ -212,13 +258,14 @@ class _SkillsPortMixin:
         Relocated intact from
         ``engines/openclaw/skills.py:OpenClawSkillsService._rsync_dir``.
         """
-        import subprocess as _sp  # noqa: PLC0415
+        import subprocess as _sp
 
         result = _sp.run(
             ["rsync", "-rltD", "--delete", f"{src}/", f"{dst}/"],
             capture_output=True,
             text=True,
             timeout=120,
+            check=False,
         )
         if result.returncode != 0:
             raise _SkillsEnsureError(
@@ -254,7 +301,7 @@ class _SkillsPortMixin:
         operating on plain dicts.  Raises ``RuntimeError`` on NAS-source-
         missing or rsync failure.
         """
-        import asyncio as _asyncio  # noqa: PLC0415
+        import asyncio as _asyncio
 
         skill_uuid = item["skill_uuid"]
         version_dir_name = str(item["version"])

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -6,11 +6,16 @@ import json
 import os
 import shutil
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from engine.community.core.adapters.openclaw.skills import OpenClawSkillsAdapter
+from engine.community.core.skills.layout_planner import (
+    MAPPING_CONTRACT_VERSION,
+    SkillLayoutResolutionError,
+)
 from engine.community.core.skills.models import (
     PoolLayoutActivateRequest,
     PoolLayoutProbeRequest,
@@ -41,6 +46,9 @@ from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
 from engine.community.plugins.skills_pool import layout_atomic
 from engine.community.plugins.skills_pool.layout_activation import (
     mapping_sources_use_pool,
+)
+from engine.community.plugins.skills_pool.mapping_contract import (
+    resolve_mapping_payload,
 )
 
 PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
@@ -196,6 +204,14 @@ def test_registered_local_cutover_syncs_latest_content_and_retires_bridges(
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
+    assert result.evidence["resolved_layout"] == {
+        "active_root": str(home / ".openclaw/workspace/skills"),
+        "local_root": str(pool_local),
+        "repo_root": str(pool_repo),
+    }
+    assert result.evidence["local_locators"] == {
+        "handmade": f"local://{pool_local / 'handmade'}"
+    }
     assert not legacy_local.exists()
     assert not legacy_local.is_symlink()
     assert (pool_local / "handmade" / "SKILL.md").read_text() == "latest"
@@ -236,6 +252,59 @@ def test_registered_local_cutover_syncs_latest_content_and_retires_bridges(
         repo_is_mounted=lambda path: path == pool_repo,
     )
     assert repeated.status is PoolActivationStatus.ALREADY_COMMITTED
+
+
+def test_invalid_registered_name_is_rejected_before_cutover(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    invalid_name = " handmade"
+    (legacy_local / "handmade").rename(legacy_local / invalid_name)
+
+    result = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[invalid_name],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == "registered_local_name_invalid"
+    assert (legacy_local / invalid_name / "SKILL.md").read_text() == "latest"
+    assert not legacy_local.is_symlink()
+    assert (legacy_local.parent / "skills-repo").is_symlink()
+    assert not (pool_local.parent / ".pool-active").exists()
+
+
+def test_invalid_registered_name_is_rejected_before_rollback(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, pool_local, pool_repo = _prepared_home(tmp_path)
+    activated = activate_openclaw_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    invalid_name = " handmade"
+    (pool_local / "handmade").rename(pool_local / invalid_name)
+
+    result = rollback_openclaw_pool(
+        rollback_generation="rollback-1",
+        registered_local_names=[invalid_name],
+        home=home,
+    )
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == "registered_local_name_invalid"
+    assert (pool_local / invalid_name / "SKILL.md").read_text() == "latest"
+    assert not legacy_local.exists()
+    assert (pool_local.parent / ".pool-active").exists()
 
 
 def test_explicit_rollback_rebuilds_legacy_from_current_pool_content(
@@ -1289,7 +1358,7 @@ def test_atomic_exchange_treats_einval_as_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class FakeRenameAt2:
-        argtypes: list[object] = []
+        argtypes: ClassVar[list[object]] = []
         restype: object | None = None
 
         def __call__(self, *_args: object) -> int:
@@ -1786,3 +1855,124 @@ async def test_openclaw_port_runs_pool_filesystem_operations_off_loop(
     )["status"] == "READY"
     assert (await port.publish_pool_mappings(params))["published"] is True
     assert (await port.verify_pool_mappings(params))["valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_openclaw_port_resolves_logical_mapping_and_returns_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.openclaw import _skills
+
+    received: dict[str, object] = {}
+
+    def publish(**kwargs):
+        received.update(kwargs)
+        return MappingPublishResult(True, {"total": 1})
+
+    monkeypatch.setattr(_skills, "publish_pool_mappings", publish)
+    result = await OpenClawPluginImpl().publish_pool_mappings(
+        {
+            "mapping_contract_version": MAPPING_CONTRACT_VERSION,
+            "mappings": [
+                {
+                    "corpus": "repo",
+                    "relative_path": "business/reviewer",
+                    "link_name": "reviewer",
+                }
+            ],
+            "source_layout": "pool",
+        }
+    )
+
+    assert received["mappings"] == [
+        SkillMapping(
+            source=(
+                "/home/admin/.openclaw/workspace/skills-pool/"
+                "skills-repo/business/reviewer"
+            ),
+            target="/home/admin/.openclaw/workspace/skills/reviewer",
+        ),
+    ]
+    assert result["evidence"]["resolved_mappings"] == [
+        {
+            "corpus": "repo",
+            "relative_path": "business/reviewer",
+            "link_name": "reviewer",
+            "resolved_locator": "git://business/reviewer",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mappings",
+    [
+        [
+            {
+                "corpus": "local",
+                "relative_path": "writer\x00draft",
+                "link_name": "writer",
+            }
+        ],
+        [
+            {
+                "corpus": "local",
+                "relative_path": "writer",
+                "link_name": "writer",
+            },
+            {
+                "corpus": "repo",
+                "relative_path": "reviewer",
+                "link_name": "reviewer\x00draft",
+            },
+        ],
+    ],
+)
+async def test_openclaw_port_rejects_nul_before_publish(
+    monkeypatch: pytest.MonkeyPatch,
+    mappings: list[dict[str, str]],
+) -> None:
+    from engine.community.plugins.openclaw import _skills
+
+    publish = MagicMock()
+    monkeypatch.setattr(_skills, "publish_pool_mappings", publish)
+
+    with pytest.raises(SkillLayoutResolutionError):
+        await OpenClawPluginImpl().publish_pool_mappings(
+            {
+                "mapping_contract_version": MAPPING_CONTRACT_VERSION,
+                "mappings": mappings,
+                "source_layout": "pool",
+            }
+        )
+
+    publish.assert_not_called()
+
+
+def test_logical_dot_mapping_is_rejected_before_active_tree_mutation(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, _pool_local, _pool_repo = _prepared_home(tmp_path)
+    active_target = legacy_local.parent / "all-skills"
+
+    with pytest.raises(SkillLayoutResolutionError):
+        resolved = resolve_mapping_payload(
+            engine="openclaw",
+            source_layout=MappingSourceLayout.POOL,
+            payload=[
+                {
+                    "corpus": "local",
+                    "relative_path": ".",
+                    "link_name": "all-skills",
+                }
+            ],
+            mapping_contract_version=MAPPING_CONTRACT_VERSION,
+            home=home,
+        )
+        publish_pool_mappings(
+            mappings=list(resolved.mappings),
+            home=home,
+        )
+
+    assert not active_target.exists()
+    assert not active_target.is_symlink()

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -65,6 +65,19 @@ def test_ready_requires_real_bridge_mount_and_readable_repo(tmp_path):
 
     assert result.status is RuntimeLayoutInspectionStatus.READY
     assert result.preparation_id == "2a958f59-8cf4-4413-a267-7d56d3382f23"
+    assert (
+        result.evidence["mapping_contract_version"]
+        == "skills-pool-mapping-v2"
+    )
+    assert result.evidence["resolved_layout"] == {
+        "active_root": str(home / ".openclaw/workspace/skills"),
+        "local_root": str(
+            home / ".openclaw/workspace/skills-pool/skills-local"
+        ),
+        "repo_root": str(
+            home / ".openclaw/workspace/skills-pool/skills-repo"
+        ),
+    }
     assert result.evidence["checks"]["pool_repo_mounted"] is True
     assert result.evidence["checks"]["legacy_repo_bridge_valid"] is True
 
@@ -100,6 +113,10 @@ def test_active_marker_requires_direct_pool_mappings_and_absent_storage_entries(
 
     assert result.status is RuntimeLayoutInspectionStatus.READY
     assert result.evidence["activation_state"] == "active"
+    assert result.evidence["mapping_contract_version"] == (
+        "skills-pool-mapping-v2"
+    )
+    assert result.evidence["resolved_layout"]["local_root"] == str(pool_local)
     assert result.evidence["checks"]["legacy_storage_entries_absent"] is True
 
 
@@ -126,6 +143,10 @@ def test_active_marker_allows_normal_skill_deactivation(tmp_path):
     )
 
     assert result.status is RuntimeLayoutInspectionStatus.READY
+    assert result.evidence["mapping_contract_version"] == (
+        "skills-pool-mapping-v2"
+    )
+    assert result.evidence["resolved_layout"]["local_root"] == str(pool_local)
 
 
 def test_finalizing_marker_allows_concurrent_skill_deactivation(tmp_path):

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -13,6 +13,14 @@ from pathlib import Path
 from uuid import uuid4
 
 from engine.community.core.skills.layout_planner import (
+    LayoutIdentity,
+    RuntimeLayoutContext,
+    SkillLayoutResolutionError,
+    resolve_filesystem_skill_layout,
+    resolve_local_skill_locators,
+    resolved_filesystem_layout_evidence,
+)
+from engine.community.core.skills.layout_planner import (
     ResolvedFilesystemLayoutPlan as _Layout,
 )
 from engine.community.plugins.skills_pool.layout_atomic import (
@@ -203,6 +211,55 @@ class _PostCutoverFinalization:
     post_sync: dict[str, object]
     cleanup_pending: bool
     failure: PoolActivationResult | None = None
+
+
+def _with_resolution_evidence(
+    result_factory: Callable[[], PoolActivationResult],
+    *,
+    engine: str,
+    source_layout: MappingSourceLayout,
+    registered_local_names: list[str],
+    home: str | Path,
+) -> PoolActivationResult:
+    try:
+        plan = resolve_filesystem_skill_layout(
+            LayoutIdentity(
+                engine_type=engine,
+                layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            ),
+            RuntimeLayoutContext(home=Path(home)),
+        )
+        local_root = (
+            plan.pool_local
+            if source_layout is MappingSourceLayout.POOL
+            else plan.legacy_local
+        )
+        repo_root = (
+            plan.pool_repo
+            if source_layout is MappingSourceLayout.POOL
+            else plan.legacy_repo
+        )
+        local_locators = resolve_local_skill_locators(
+            local_root,
+            registered_local_names,
+        )
+    except SkillLayoutResolutionError as error:
+        return _invalid("registered_local_name_invalid", error=str(error))
+    result = result_factory()
+    if not result.committed:
+        return result
+    return PoolActivationResult(
+        result.status,
+        {
+            **result.evidence,
+            "resolved_layout": resolved_filesystem_layout_evidence(
+                plan,
+                local_root=local_root,
+                repo_root=repo_root,
+            ),
+            "local_locators": local_locators,
+        },
+    )
 
 
 def _read_active_marker(path: Path) -> dict[str, object] | None:
@@ -991,6 +1048,18 @@ def _activate_pool(
     layout = _Layout.for_engine(engine, home_path)
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", migration_generation):
         return _invalid("migration_generation_invalid")
+    try:
+        normalized_names = list(
+            resolve_local_skill_locators(
+                layout.pool_local,
+                registered_local_names,
+            )
+        )
+    except SkillLayoutResolutionError as error:
+        return _invalid(
+            "registered_local_name_invalid",
+            error=str(error),
+        )
 
     inspection = inspect_runtime_layout(
         engine=engine,
@@ -1074,18 +1143,6 @@ def _activate_pool(
             },
         )
 
-    normalized_names: list[str] = []
-    for name in registered_local_names:
-        path = Path(name)
-        if (
-            not name
-            or path.is_absolute()
-            or len(path.parts) != 1
-            or name in {".", ".."}
-        ):
-            return _invalid("registered_local_name_invalid", name=name)
-        if name not in normalized_names:
-            normalized_names.append(name)
     try:
         if layout.legacy_local.is_symlink():
             if _lexical_target(layout.legacy_local) != Path(
@@ -1387,17 +1444,23 @@ def activate_openclaw_pool(
     # Deprecated compatibility seam for existing in-process callers. Forward
     # activation no longer depends on atomic exchange.
     del exchange_paths
-    return _activate_pool(
+    return _with_resolution_evidence(
+        lambda: _activate_pool(
+            engine="openclaw",
+            migration_generation=migration_generation,
+            preparation_id=preparation_id,
+            registered_local_names=registered_local_names,
+            mappings=mappings,
+            home=home,
+            repo_is_mounted=repo_is_mounted,
+            retire_path=retire_path,
+            before_legacy_retire=before_legacy_retire,
+            before_post_sync=before_post_sync,
+        ),
         engine="openclaw",
-        migration_generation=migration_generation,
-        preparation_id=preparation_id,
+        source_layout=MappingSourceLayout.POOL,
         registered_local_names=registered_local_names,
-        mappings=mappings,
         home=home,
-        repo_is_mounted=repo_is_mounted,
-        retire_path=retire_path,
-        before_legacy_retire=before_legacy_retire,
-        before_post_sync=before_post_sync,
     )
 
 
@@ -1415,17 +1478,23 @@ def activate_claude_code_pool(
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
     del exchange_paths
-    return _activate_pool(
+    return _with_resolution_evidence(
+        lambda: _activate_pool(
+            engine="claude_code",
+            migration_generation=migration_generation,
+            preparation_id=preparation_id,
+            registered_local_names=registered_local_names,
+            mappings=mappings,
+            home=home,
+            repo_is_mounted=repo_is_mounted,
+            retire_path=retire_path,
+            before_legacy_retire=before_legacy_retire,
+            before_post_sync=before_post_sync,
+        ),
         engine="claude_code",
-        migration_generation=migration_generation,
-        preparation_id=preparation_id,
+        source_layout=MappingSourceLayout.POOL,
         registered_local_names=registered_local_names,
-        mappings=mappings,
         home=home,
-        repo_is_mounted=repo_is_mounted,
-        retire_path=retire_path,
-        before_legacy_retire=before_legacy_retire,
-        before_post_sync=before_post_sync,
     )
 
 
@@ -1443,17 +1512,23 @@ def activate_aicoding_pool(
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
     del exchange_paths
-    return _activate_pool(
+    return _with_resolution_evidence(
+        lambda: _activate_pool(
+            engine="aicoding",
+            migration_generation=migration_generation,
+            preparation_id=preparation_id,
+            registered_local_names=registered_local_names,
+            mappings=mappings,
+            home=home,
+            repo_is_mounted=repo_is_mounted,
+            retire_path=retire_path,
+            before_legacy_retire=before_legacy_retire,
+            before_post_sync=before_post_sync,
+        ),
         engine="aicoding",
-        migration_generation=migration_generation,
-        preparation_id=preparation_id,
+        source_layout=MappingSourceLayout.POOL,
         registered_local_names=registered_local_names,
-        mappings=mappings,
         home=home,
-        repo_is_mounted=repo_is_mounted,
-        retire_path=retire_path,
-        before_legacy_retire=before_legacy_retire,
-        before_post_sync=before_post_sync,
     )
 
 
@@ -1471,17 +1546,23 @@ def activate_hermes_pool(
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
     del exchange_paths
-    return _activate_pool(
+    return _with_resolution_evidence(
+        lambda: _activate_pool(
+            engine="hermes",
+            migration_generation=migration_generation,
+            preparation_id=preparation_id,
+            registered_local_names=registered_local_names,
+            mappings=mappings,
+            home=home,
+            repo_is_mounted=repo_is_mounted,
+            retire_path=retire_path,
+            before_legacy_retire=before_legacy_retire,
+            before_post_sync=before_post_sync,
+        ),
         engine="hermes",
-        migration_generation=migration_generation,
-        preparation_id=preparation_id,
+        source_layout=MappingSourceLayout.POOL,
         registered_local_names=registered_local_names,
-        mappings=mappings,
         home=home,
-        repo_is_mounted=repo_is_mounted,
-        retire_path=retire_path,
-        before_legacy_retire=before_legacy_retire,
-        before_post_sync=before_post_sync,
     )
 
 
@@ -1498,18 +1579,18 @@ def _rollback_pool(
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", rollback_generation):
         return _invalid("rollback_generation_invalid")
     layout = _Layout.for_engine(engine, Path(home))
-    normalized_names: list[str] = []
-    for name in registered_local_names:
-        path = Path(name)
-        if (
-            not name
-            or path.is_absolute()
-            or len(path.parts) != 1
-            or name in {".", ".."}
-        ):
-            return _invalid("registered_local_name_invalid", name=name)
-        if name not in normalized_names:
-            normalized_names.append(name)
+    try:
+        normalized_names = list(
+            resolve_local_skill_locators(
+                layout.legacy_local,
+                registered_local_names,
+            )
+        )
+    except SkillLayoutResolutionError as error:
+        return _invalid(
+            "registered_local_name_invalid",
+            error=str(error),
+        )
 
     rebuild = layout.legacy_local.parent / (
         f".skills-local.pool-rollback-{rollback_generation}"
@@ -1632,12 +1713,18 @@ def rollback_openclaw_pool(
     home: str | Path = "/home/admin",
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
 ) -> PoolActivationResult:
-    return _rollback_pool(
+    return _with_resolution_evidence(
+        lambda: _rollback_pool(
+            engine="openclaw",
+            rollback_generation=rollback_generation,
+            registered_local_names=registered_local_names,
+            home=home,
+            exchange_paths=exchange_paths,
+        ),
         engine="openclaw",
-        rollback_generation=rollback_generation,
+        source_layout=MappingSourceLayout.LEGACY,
         registered_local_names=registered_local_names,
         home=home,
-        exchange_paths=exchange_paths,
     )
 
 
@@ -1648,12 +1735,18 @@ def rollback_claude_code_pool(
     home: str | Path = "/home/admin",
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
 ) -> PoolActivationResult:
-    return _rollback_pool(
+    return _with_resolution_evidence(
+        lambda: _rollback_pool(
+            engine="claude_code",
+            rollback_generation=rollback_generation,
+            registered_local_names=registered_local_names,
+            home=home,
+            exchange_paths=exchange_paths,
+        ),
         engine="claude_code",
-        rollback_generation=rollback_generation,
+        source_layout=MappingSourceLayout.LEGACY,
         registered_local_names=registered_local_names,
         home=home,
-        exchange_paths=exchange_paths,
     )
 
 
@@ -1664,12 +1757,18 @@ def rollback_aicoding_pool(
     home: str | Path = "/home/admin",
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
 ) -> PoolActivationResult:
-    return _rollback_pool(
+    return _with_resolution_evidence(
+        lambda: _rollback_pool(
+            engine="aicoding",
+            rollback_generation=rollback_generation,
+            registered_local_names=registered_local_names,
+            home=home,
+            exchange_paths=exchange_paths,
+        ),
         engine="aicoding",
-        rollback_generation=rollback_generation,
+        source_layout=MappingSourceLayout.LEGACY,
         registered_local_names=registered_local_names,
         home=home,
-        exchange_paths=exchange_paths,
     )
 
 
@@ -1680,12 +1779,18 @@ def rollback_hermes_pool(
     home: str | Path = "/home/admin",
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
 ) -> PoolActivationResult:
-    return _rollback_pool(
+    return _with_resolution_evidence(
+        lambda: _rollback_pool(
+            engine="hermes",
+            rollback_generation=rollback_generation,
+            registered_local_names=registered_local_names,
+            home=home,
+            exchange_paths=exchange_paths,
+        ),
         engine="hermes",
-        rollback_generation=rollback_generation,
+        source_layout=MappingSourceLayout.LEGACY,
         registered_local_names=registered_local_names,
         home=home,
-        exchange_paths=exchange_paths,
     )
 
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -15,6 +15,11 @@ from uuid import UUID
 
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
+    MAPPING_CONTRACT_VERSION,
+    LayoutIdentity,
+    RuntimeLayoutContext,
+    resolve_filesystem_skill_layout,
+    resolved_filesystem_layout_evidence,
 )
 from engine.community.core.skills.layout_planner import (
     ResolvedFilesystemLayoutPlan as _FilesystemPoolLayout,
@@ -44,6 +49,40 @@ class RuntimeLayoutInspection:
             "preparation_id": self.preparation_id,
             "evidence": self.evidence,
         }
+
+
+def _ready_evidence(
+    *,
+    layout: _FilesystemPoolLayout,
+    marker: dict[str, Any],
+    checks: dict[str, bool],
+    mapping_contract_version: str | None,
+    activation_state: str | None = None,
+) -> dict[str, Any]:
+    evidence: dict[str, Any] = {
+        "marker": str(layout.marker),
+        "prepared_at": marker["prepared_at"],
+        "checks": checks,
+    }
+    if activation_state is not None:
+        evidence.update(
+            {
+                "active_marker": str(layout.active_marker),
+                "activation_state": activation_state,
+            }
+        )
+    if mapping_contract_version is not None:
+        evidence.update(
+            {
+                "mapping_contract_version": mapping_contract_version,
+                "resolved_layout": resolved_filesystem_layout_evidence(
+                    layout,
+                    local_root=layout.pool_local,
+                    repo_root=layout.pool_repo,
+                ),
+            }
+        )
+    return evidence
 
 
 def _not_capable(
@@ -341,6 +380,7 @@ def inspect_runtime_layout(
     *,
     engine: str,
     expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
+    mapping_contract_version: str | None = MAPPING_CONTRACT_VERSION,
     home: Path = Path("/home/admin"),
     repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
 ) -> RuntimeLayoutInspection:
@@ -358,7 +398,13 @@ def inspect_runtime_layout(
             "engine_pool_probe_not_implemented",
         )
 
-    layout = _FilesystemPoolLayout.for_engine(engine, home)
+    layout = resolve_filesystem_skill_layout(
+        LayoutIdentity(
+            engine_type=engine,
+            layout_contract_version=expected_contract_version,
+        ),
+        RuntimeLayoutContext(home=home),
+    )
     try:
         marker_stat = layout.marker.stat()
     except (FileNotFoundError, NotADirectoryError):
@@ -647,12 +693,12 @@ def inspect_runtime_layout(
             engine=engine,
             layout_contract_version=expected_contract_version,
             preparation_id=preparation_id,
-            evidence={
-                "marker": str(layout.marker),
-                "active_marker": str(layout.active_marker),
-                "prepared_at": marker["prepared_at"],
-                "activation_state": active_marker["activation_state"],
-                "checks": {
+            evidence=_ready_evidence(
+                layout=layout,
+                marker=marker,
+                activation_state=active_marker["activation_state"],
+                mapping_contract_version=mapping_contract_version,
+                checks={
                     "marker_valid": True,
                     "active_marker_valid": True,
                     "pool_local_valid": True,
@@ -664,7 +710,7 @@ def inspect_runtime_layout(
                     ),
                     "stable_repo_bridge_valid": (engine in {"aicoding", "hermes"}),
                 },
-            },
+            ),
         )
     required_bridges = [("legacy_repo", layout.repo_bridge, layout.pool_repo)]
     if engine != "openclaw":
@@ -752,11 +798,12 @@ def inspect_runtime_layout(
         engine=engine,
         layout_contract_version=expected_contract_version,
         preparation_id=preparation_id,
-        evidence={
-            "marker": str(layout.marker),
-            "prepared_at": marker["prepared_at"],
-            "checks": checks,
-        },
+        evidence=_ready_evidence(
+            layout=layout,
+            marker=marker,
+            mapping_contract_version=mapping_contract_version,
+            checks=checks,
+        ),
     )
 
 

--- a/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
@@ -1,0 +1,152 @@
+"""Resolve the versioned Backend mapping payload into Engine-local paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
+    MAPPING_CONTRACT_VERSION,
+    LayoutIdentity,
+    LogicalSkillMapping,
+    RuntimeLayoutContext,
+    SkillCorpus,
+    resolve_filesystem_skill_layout,
+    resolve_skill_mappings,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
+    MappingSourceLayout,
+    SkillMapping,
+)
+
+_LEGACY_PHYSICAL_FIELDS = frozenset({"source", "target"})
+_LOGICAL_V2_FIELDS = frozenset({"corpus", "relative_path", "link_name"})
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedMappingPayload:
+    mappings: tuple[SkillMapping, ...]
+    resolved_locators: tuple[dict[str, str], ...] = ()
+
+
+def _require_mapping_fields(
+    item: object,
+    *,
+    expected: frozenset[str],
+    contract_name: str,
+) -> dict[str, object]:
+    if not isinstance(item, dict):
+        raise TypeError(f"each {contract_name} mapping must be an object")
+    if frozenset(item) != expected:
+        raise TypeError(
+            f"{contract_name} mapping must contain exactly "
+            f"{', '.join(sorted(expected))}"
+        )
+    return item
+
+
+def resolve_mapping_payload(
+    *,
+    engine: str,
+    source_layout: MappingSourceLayout,
+    payload: object,
+    mapping_contract_version: str | None = None,
+    home: Path = Path("/home/admin"),
+) -> ResolvedMappingPayload:
+    """Resolve logical v2 or legacy unversioned physical mappings.
+
+    Version and shape validation finishes before any Engine filesystem
+    publication can begin. A versioned request is exclusively logical; only
+    an unversioned request may use the legacy physical pair.
+    """
+
+    if not isinstance(payload, list):
+        raise TypeError("mappings must be an array")
+    if mapping_contract_version is None:
+        physical: list[SkillMapping] = []
+        for raw_item in payload:
+            item = _require_mapping_fields(
+                raw_item,
+                expected=_LEGACY_PHYSICAL_FIELDS,
+                contract_name="legacy",
+            )
+            source = item["source"]
+            target = item["target"]
+            if not isinstance(source, str) or not isinstance(target, str):
+                raise TypeError("legacy mapping source and target must be strings")
+            physical.append(SkillMapping(source=source, target=target))
+        return ResolvedMappingPayload(tuple(physical))
+    if mapping_contract_version != MAPPING_CONTRACT_VERSION:
+        raise ValueError(
+            f"unsupported mapping contract: {mapping_contract_version}"
+        )
+
+    logical: list[LogicalSkillMapping] = []
+    for raw_item in payload:
+        item = _require_mapping_fields(
+            raw_item,
+            expected=_LOGICAL_V2_FIELDS,
+            contract_name="logical",
+        )
+        corpus = item["corpus"]
+        relative_path = item["relative_path"]
+        link_name = item["link_name"]
+        if (
+            not isinstance(corpus, str)
+            or not isinstance(relative_path, str)
+            or not isinstance(link_name, str)
+        ):
+            raise TypeError(
+                "logical mapping corpus, relative_path and link_name "
+                "must be strings"
+            )
+        logical.append(
+            LogicalSkillMapping(
+                corpus=SkillCorpus(corpus),
+                relative_path=relative_path,
+                link_name=link_name,
+            )
+        )
+
+    plan = resolve_filesystem_skill_layout(
+        LayoutIdentity(
+            engine_type=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        ),
+        RuntimeLayoutContext(home=home),
+    )
+    local_root = (
+        plan.pool_local
+        if source_layout is MappingSourceLayout.POOL
+        else plan.legacy_local
+    )
+    repo_root = (
+        plan.pool_repo
+        if source_layout is MappingSourceLayout.POOL
+        else plan.legacy_repo
+    )
+    resolved = resolve_skill_mappings(
+        active_root=plan.active_root,
+        local_root=local_root,
+        repo_root=repo_root,
+        mappings=logical,
+    )
+    return ResolvedMappingPayload(
+        mappings=tuple(
+            SkillMapping(source=str(mapping.source), target=str(mapping.target))
+            for mapping in resolved
+        ),
+        resolved_locators=tuple(
+            {
+                "corpus": mapping.corpus.value,
+                "relative_path": mapping.relative_path,
+                "link_name": mapping.link_name,
+                "resolved_locator": mapping.resolved_locator,
+            }
+            for mapping in resolved
+        ),
+    )
+
+
+__all__ = ["ResolvedMappingPayload", "resolve_mapping_payload"]

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -15,6 +15,7 @@ from engine.community.core.skills.models import (
     PoolLayoutProbeStatus,
     PoolLayoutRollbackRequest,
     PoolQuarantineCleanupRequest,
+    PoolSkillMappingIntent,
     SymlinkItem,
 )
 
@@ -154,6 +155,54 @@ async def test_claude_code_adapter_exposes_complete_pool_runtime_contract() -> N
             "source_layout": "pool",
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_claude_code_adapter_propagates_logical_mapping_version() -> None:
+    port = _port()
+    adapter = ClaudeCodeSkillsAdapter(port)
+    mapping = PoolSkillMappingIntent(
+        corpus="repo",
+        relative_path="business/reviewer",
+        link_name="reviewer",
+    )
+    version = "skills-pool-mapping-v2"
+
+    await adapter.activate_pool_layout(
+        PoolLayoutActivateRequest(
+            migration_generation="generation-1",
+            preparation_id="prep-1",
+            mappings=[mapping],
+            mapping_contract_version=version,
+        )
+    )
+    await adapter.publish_pool_mappings(
+        [mapping],
+        mapping_contract_version=version,
+    )
+    await adapter.verify_pool_mappings(
+        [mapping],
+        mapping_contract_version=version,
+    )
+
+    expected_mapping = {
+        "corpus": "repo",
+        "relative_path": "business/reviewer",
+        "link_name": "reviewer",
+    }
+    activation = port.activate_pool_layout.await_args.args[0]
+    assert activation["mapping_contract_version"] == version
+    assert activation["mappings"] == [expected_mapping]
+    assert port.publish_pool_mappings.await_args.args[0] == {
+        "mapping_contract_version": version,
+        "mappings": [expected_mapping],
+        "source_layout": "pool",
+    }
+    assert port.verify_pool_mappings.await_args.args[0] == {
+        "mapping_contract_version": version,
+        "mappings": [expected_mapping],
+        "source_layout": "pool",
+    }
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -12,6 +12,8 @@ from engine.community.core.skills.models import (
     PoolLayoutActivationStatus,
     PoolLayoutRollbackRequest,
     PoolQuarantineCleanupRequest,
+    PoolSkillMappingIntent,
+    SymlinkItem,
 )
 
 
@@ -161,3 +163,93 @@ async def test_quarantine_cleanup_contract_forwards_exact_generation() -> None:
     port.cleanup_pool_quarantine.assert_awaited_once_with(
         {"migration_generation": "generation-1"}
     )
+
+
+@pytest.mark.asyncio
+async def test_openclaw_adapter_propagates_logical_mapping_version() -> None:
+    port = MagicMock()
+    port.activate_pool_layout = AsyncMock(
+        return_value={
+            "committed": True,
+            "status": "COMMITTED",
+            "evidence": {},
+        }
+    )
+    port.publish_pool_mappings = AsyncMock(
+        return_value={"published": True, "evidence": {}}
+    )
+    port.verify_pool_mappings = AsyncMock(
+        return_value={"valid": True, "evidence": {}}
+    )
+    adapter = OpenClawSkillsAdapter(port)
+    mapping = PoolSkillMappingIntent(
+        corpus="repo",
+        relative_path="business/reviewer",
+        link_name="reviewer",
+    )
+    version = "skills-pool-mapping-v2"
+
+    await adapter.activate_pool_layout(
+        PoolLayoutActivateRequest(
+            migration_generation="generation-1",
+            preparation_id="preparation-1",
+            mappings=[mapping],
+            mapping_contract_version=version,
+        )
+    )
+    await adapter.publish_pool_mappings(
+        [mapping],
+        mapping_contract_version=version,
+    )
+    await adapter.verify_pool_mappings(
+        [mapping],
+        mapping_contract_version=version,
+    )
+
+    expected_mapping = {
+        "corpus": "repo",
+        "relative_path": "business/reviewer",
+        "link_name": "reviewer",
+    }
+    assert port.activate_pool_layout.await_args.args[0] == {
+        "migration_generation": "generation-1",
+        "preparation_id": "preparation-1",
+        "registered_local_names": [],
+        "mapping_contract_version": version,
+        "mappings": [expected_mapping],
+    }
+    assert port.publish_pool_mappings.await_args.args[0] == {
+        "mapping_contract_version": version,
+        "mappings": [expected_mapping],
+        "source_layout": "pool",
+    }
+    assert port.verify_pool_mappings.await_args.args[0] == {
+        "mapping_contract_version": version,
+        "mappings": [expected_mapping],
+        "source_layout": "pool",
+    }
+
+
+@pytest.mark.asyncio
+async def test_openclaw_adapter_keeps_unversioned_physical_mapping() -> None:
+    port = MagicMock()
+    port.publish_pool_mappings = AsyncMock(
+        return_value={"published": True, "evidence": {}}
+    )
+    port.verify_pool_mappings = AsyncMock(
+        return_value={"valid": True, "evidence": {}}
+    )
+    adapter = OpenClawSkillsAdapter(port)
+    mapping = SymlinkItem(source="/pool/writer", target="/active/writer")
+
+    await adapter.publish_pool_mappings([mapping])
+    await adapter.verify_pool_mappings([mapping])
+
+    expected = {
+        "mappings": [
+            {"source": "/pool/writer", "target": "/active/writer"}
+        ],
+        "source_layout": "pool",
+    }
+    port.publish_pool_mappings.assert_awaited_once_with(expected)
+    port.verify_pool_mappings.assert_awaited_once_with(expected)

--- a/src/engine/src/engine/community/tests/core/skills/test_logical_mapping_planner.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_logical_mapping_planner.py
@@ -1,0 +1,231 @@
+from pathlib import Path
+
+import pytest
+
+from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
+    LayoutIdentity,
+    LogicalSkillMapping,
+    ResolvedFilesystemLayoutPlan,
+    RuntimeLayoutContext,
+    SkillCorpus,
+    SkillLayoutResolutionError,
+    UnsupportedRuntimeLayoutError,
+    resolve_filesystem_skill_layout,
+    resolve_skill_mappings,
+)
+
+
+def _plan(engine: str = "openclaw") -> ResolvedFilesystemLayoutPlan:
+    return resolve_filesystem_skill_layout(
+        LayoutIdentity(
+            engine_type=engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        ),
+        RuntimeLayoutContext(home=Path("/runtime")),
+    )
+
+
+def _resolve_pool_mappings(
+    plan: ResolvedFilesystemLayoutPlan,
+    mappings: list[LogicalSkillMapping],
+):
+    return resolve_skill_mappings(
+        active_root=plan.active_root,
+        local_root=plan.pool_local,
+        repo_root=plan.pool_repo,
+        mappings=mappings,
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_layout", "expected_source"),
+    [
+        (
+            "legacy",
+            "/runtime/.openclaw/workspace/skills/skills-repo/business/reviewer",
+        ),
+        (
+            "pool",
+            (
+                "/runtime/.openclaw/workspace/skills-pool/"
+                "skills-repo/business/reviewer"
+            ),
+        ),
+    ],
+)
+def test_logical_mapping_uses_selected_corpus_without_changing_active_target(
+    source_layout: str,
+    expected_source: str,
+) -> None:
+    plan = _plan()
+    local_root = (
+        plan.pool_local if source_layout == "pool" else plan.legacy_local
+    )
+    repo_root = (
+        plan.pool_repo if source_layout == "pool" else plan.legacy_repo
+    )
+
+    resolved = resolve_skill_mappings(
+        active_root=plan.active_root,
+        local_root=local_root,
+        repo_root=repo_root,
+        mappings=[
+            LogicalSkillMapping(
+                corpus=SkillCorpus.REPO,
+                relative_path="business/reviewer",
+                link_name="reviewer",
+            )
+        ],
+    )
+
+    assert resolved[0].source == Path(expected_source)
+    assert resolved[0].target == Path(
+        "/runtime/.openclaw/workspace/skills/reviewer"
+    )
+    assert resolved[0].resolved_locator == "git://business/reviewer"
+
+
+@pytest.mark.parametrize(
+    ("engine", "expected_active", "expected_local", "expected_repo"),
+    [
+        (
+            "openclaw",
+            ".openclaw/workspace/skills",
+            ".openclaw/workspace/skills-pool/skills-local/writer",
+            ".openclaw/workspace/skills-pool/skills-repo/business/reviewer",
+        ),
+        (
+            "claude_code",
+            ".claude/skills",
+            ".claude_code/workspace/skills-pool/skills-local/writer",
+            ".claude_code/workspace/skills-pool/skills-repo/business/reviewer",
+        ),
+        (
+            "aicoding",
+            ".claude/skills",
+            ".aicoding/workspace/skills-pool/skills-local/writer",
+            ".aicoding/workspace/skills-pool/skills-repo/business/reviewer",
+        ),
+        (
+            "hermes",
+            ".hermes/skills",
+            ".hermes/workspace/skills-pool/skills-local/writer",
+            ".hermes/workspace/skills-pool/skills-repo/business/reviewer",
+        ),
+    ],
+)
+def test_logical_mapping_preserves_four_engine_projection_snapshot(
+    engine: str,
+    expected_active: str,
+    expected_local: str,
+    expected_repo: str,
+) -> None:
+    plan = _plan(engine)
+
+    resolved = _resolve_pool_mappings(
+        plan,
+        [
+            LogicalSkillMapping(SkillCorpus.LOCAL, "writer", "writer"),
+            LogicalSkillMapping(
+                SkillCorpus.REPO,
+                "business/reviewer",
+                "reviewer",
+            ),
+        ],
+    )
+
+    assert resolved[0].source.relative_to(Path("/runtime")).as_posix() == (
+        expected_local
+    )
+    assert resolved[1].source.relative_to(Path("/runtime")).as_posix() == (
+        expected_repo
+    )
+    assert resolved[0].target.relative_to(Path("/runtime")).as_posix() == (
+        f"{expected_active}/writer"
+    )
+    assert resolved[1].target.relative_to(Path("/runtime")).as_posix() == (
+        f"{expected_active}/reviewer"
+    )
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "link_name"),
+    [
+        (".", "writer"),
+        ("../writer", "writer"),
+        ("/absolute/writer", "writer"),
+        ("business//writer", "writer"),
+        ("business/./writer", "writer"),
+        (" writer", "writer"),
+        ("writer\x00draft", "writer"),
+        ("writer", "../writer"),
+        ("writer", "nested/writer"),
+        ("writer", "/writer"),
+        ("writer", "writer\x00draft"),
+    ],
+)
+def test_logical_mapping_rejects_noncanonical_paths(
+    relative_path: str,
+    link_name: str,
+) -> None:
+    plan = _plan()
+
+    with pytest.raises(SkillLayoutResolutionError):
+        _resolve_pool_mappings(
+            plan,
+            [
+                LogicalSkillMapping(
+                    SkillCorpus.LOCAL,
+                    relative_path,
+                    link_name,
+                )
+            ],
+        )
+
+
+def test_logical_mapping_rejects_unknown_corpus() -> None:
+    plan = _plan()
+
+    with pytest.raises(SkillLayoutResolutionError, match="unknown Skill corpus"):
+        _resolve_pool_mappings(
+            plan,
+            [
+                LogicalSkillMapping(
+                    "future",  # type: ignore[arg-type]
+                    "writer",
+                    "writer",
+                )
+            ],
+        )
+
+
+def test_logical_mapping_rejects_duplicate_active_target() -> None:
+    plan = _plan()
+
+    with pytest.raises(
+        SkillLayoutResolutionError,
+        match="duplicate active Skill target",
+    ):
+        _resolve_pool_mappings(
+            plan,
+            [
+                LogicalSkillMapping(SkillCorpus.LOCAL, "writer", "same"),
+                LogicalSkillMapping(
+                    SkillCorpus.REPO,
+                    "business/writer",
+                    "same",
+                ),
+            ],
+        )
+
+
+def test_teclaw_artifact_plan_rejects_logical_filesystem_mapping() -> None:
+    with pytest.raises(UnsupportedRuntimeLayoutError):
+        resolve_filesystem_skill_layout(
+            LayoutIdentity(
+                engine_type="teclaw",
+                layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            ),
+            RuntimeLayoutContext(home=Path("/runtime")),
+        )

--- a/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
@@ -1,0 +1,183 @@
+from pathlib import Path
+
+import pytest
+
+from engine.community.core.skills.layout_planner import (
+    MAPPING_CONTRACT_VERSION,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
+    MappingSourceLayout,
+)
+from engine.community.plugins.skills_pool.mapping_contract import (
+    resolve_mapping_payload,
+)
+
+
+def _snapshot(root: Path) -> list[Path]:
+    return sorted(path.relative_to(root) for path in root.rglob("*"))
+
+
+def test_logical_mapping_projects_desktop_claude_paths_and_locator_evidence(
+    tmp_path: Path,
+) -> None:
+    resolved = resolve_mapping_payload(
+        engine="claude_code",
+        source_layout=MappingSourceLayout.POOL,
+        mapping_contract_version=MAPPING_CONTRACT_VERSION,
+        payload=[
+            {
+                "corpus": "local",
+                "relative_path": "writer",
+                "link_name": "writer",
+            },
+            {
+                "corpus": "repo",
+                "relative_path": "business/reviewer",
+                "link_name": "reviewer",
+            },
+        ],
+        home=tmp_path,
+    )
+
+    assert resolved.mappings[0].source == str(
+        tmp_path / ".claude_code/workspace/skills-pool/skills-local/writer"
+    )
+    assert resolved.mappings[1].target == str(
+        tmp_path / ".claude/skills/reviewer"
+    )
+    assert resolved.resolved_locators == (
+        {
+            "corpus": "local",
+            "relative_path": "writer",
+            "link_name": "writer",
+            "resolved_locator": (
+                f"local://{tmp_path}/"
+                ".claude_code/workspace/skills-pool/skills-local/writer"
+            ),
+        },
+        {
+            "corpus": "repo",
+            "relative_path": "business/reviewer",
+            "link_name": "reviewer",
+            "resolved_locator": "git://business/reviewer",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("engine", "active_root"),
+    [
+        ("openclaw", ".openclaw/workspace/skills"),
+        ("claude_code", ".claude/skills"),
+        ("aicoding", ".claude/skills"),
+        ("hermes", ".hermes/skills"),
+    ],
+)
+def test_mapping_v2_resolves_for_every_filesystem_engine(
+    tmp_path: Path,
+    engine: str,
+    active_root: str,
+) -> None:
+    resolved = resolve_mapping_payload(
+        engine=engine,
+        source_layout=MappingSourceLayout.POOL,
+        mapping_contract_version=MAPPING_CONTRACT_VERSION,
+        payload=[
+            {
+                "corpus": "repo",
+                "relative_path": "business/reviewer",
+                "link_name": "reviewer",
+            }
+        ],
+        home=tmp_path,
+    )
+
+    assert resolved.mappings[0].target == str(
+        tmp_path / active_root / "reviewer"
+    )
+    assert (
+        resolved.resolved_locators[0]["resolved_locator"]
+        == "git://business/reviewer"
+    )
+
+
+@pytest.mark.parametrize(
+    ("version", "payload", "message"),
+    [
+        (
+            "skills-pool-mapping-future-v3",
+            [
+                {
+                    "corpus": "local",
+                    "relative_path": "writer",
+                    "link_name": "writer",
+                }
+            ],
+            "unsupported mapping contract",
+        ),
+        (
+            None,
+            [
+                {
+                    "corpus": "local",
+                    "relative_path": "writer",
+                    "link_name": "writer",
+                }
+            ],
+            "legacy mapping",
+        ),
+        (
+            MAPPING_CONTRACT_VERSION,
+            [{"source": "/pool/writer", "target": "/active/writer"}],
+            "logical mapping",
+        ),
+        (
+            MAPPING_CONTRACT_VERSION,
+            [
+                {
+                    "corpus": "local",
+                    "relative_path": "writer",
+                    "link_name": "writer",
+                    "source": "/pool/writer",
+                    "target": "/active/writer",
+                }
+            ],
+            "logical mapping",
+        ),
+    ],
+)
+def test_invalid_contract_shape_has_no_filesystem_side_effect(
+    tmp_path: Path,
+    version: str | None,
+    payload: list[dict[str, str]],
+    message: str,
+) -> None:
+    before = _snapshot(tmp_path)
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        resolve_mapping_payload(
+            engine="openclaw",
+            source_layout=MappingSourceLayout.POOL,
+            mapping_contract_version=version,
+            payload=payload,
+            home=tmp_path,
+        )
+
+    assert _snapshot(tmp_path) == before
+
+
+def test_legacy_no_version_physical_payload_remains_compatible(
+    tmp_path: Path,
+) -> None:
+    resolved = resolve_mapping_payload(
+        engine="openclaw",
+        source_layout=MappingSourceLayout.POOL,
+        mapping_contract_version=None,
+        payload=[{"source": "/pool/writer", "target": "/active/writer"}],
+        home=tmp_path,
+    )
+
+    assert resolved.mappings[0].source == "/pool/writer"
+    assert resolved.mappings[0].target == "/active/writer"
+    assert resolved.resolved_locators == ()
+    assert _snapshot(tmp_path) == []


### PR DESCRIPTION
## Summary

Part of #455. Based on merged PR #586, this PR adds the versioned logical Skills mapping contract.

- Backend sends logical intent: `corpus`, `relative_path`, and `link_name`
- Engine selects Legacy or Pool roots from explicit `source_layout`, resolves engine-local paths, performs the filesystem operation, and returns locator evidence
- the existing unversioned physical `{source,target}` form remains accepted for mixed deployment
- malformed, escaping, duplicate, or unsupported payloads fail before mutation

AICoding and Hermes planner projections are present here; their corp service consumers land with the downstream OCB integration.

Validation ran on the pre-restack source tree at `759f0e9661ea4d515ea078086dfcaf26f0853dce`: Engine 2111 passed (5 deselected), Backend 9288 passed; SAST, Ruff and diff-check passed.

After #586 merged as `640a28c438917a92f3b3a138924893238e2191b6`, this branch was mechanically rebased to `ca435ffe1c5ee83de8215f8842877c55409c75a1`. The old and new PR2 commits have the same tree `d1e8f800b6c0237f7e76c98600a10e4b2bce21f0`; diff-check passed, no code content changed, and the full suites were not rerun.

This PR remains Draft for manual review.