### PR TITLE
fix(backend): preserve template config on bot restart

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -23,7 +23,7 @@ from ..provisioning import BotProvisioningContext, EngineProvisioningStrategy
 # set with template keys.
 CODING_TEMPLATE_TYPES = frozenset({"applicationCoding", "personalCoding"})
 TEMPLATE_CONFIG_CONSUMING_ENGINES = frozenset({"aicoding", "claude_code"})
-BOT_TYPE_ENV_MAP = {
+LEGACY_BOT_TYPE_ENV_MAP = {
     "personalCoding": "personal",
     "applicationCoding": "application",
 }
@@ -54,15 +54,19 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         template_config: dict[str, Any] | None = None,
     ) -> bool:
         # Keep historical/built-in template types working even where legacy call
-        # sites only know template_type.  For user-created AC templates, do not
-        # require backend enum updates: as long as the bot is a coding engine and
-        # carries a template-factory config snapshot, consume it.
+        # sites only know template_type.  For non-legacy template types, the
+        # active engine must be a template-config-consuming engine and the saved
+        # snapshot must carry full template identity (template_key and template_uid).
+        # This prevents arbitrary plain dicts from being treated as governed template
+        # config while still allowing normalCC / architect / user-created / future
+        # template types to consume their resolved snapshot without backend enum
+        # updates.
         if template_type in CODING_TEMPLATE_TYPES:
             return True
-        return (
-            active_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES
-            and cls.has_template_factory_config(template_config)
+        has_template_identity = isinstance(template_config, dict) and bool(
+            template_config.get("template_key") and template_config.get("template_uid")
         )
+        return active_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES and has_template_identity
 
     def build_extra_envs(self, ctx: BotProvisioningContext) -> Dict[str, str] | None:
         template_type = ctx.template_type
@@ -75,9 +79,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             return None
         envs: Dict[str, str] = {}
 
-        bot_type = BOT_TYPE_ENV_MAP.get(template_type or "")
-        if bot_type:
-            envs["BOT_TYPE"] = bot_type
+        # Historical template types expose stable legacy bot-type values, while
+        # template-factory templates expose their template_type verbatim so new
+        # template types do not require backend enum/map changes.
+        if template_type:
+            envs["BOT_TYPE"] = LEGACY_BOT_TYPE_ENV_MAP.get(
+                template_type, template_type
+            )
 
         devflow_workflow = template_config.get("devflow_workflow", "")
         if isinstance(devflow_workflow, dict):

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3912,14 +3912,11 @@ class BotService:
         )
 
         # resolved_template_config 已在 BCN 能力门控前读取，后续 BaaS restart 复用同一快照。
-        # 与 _allocate_device_async（create / arca-restart 路径）同口径构造 extra_envs
-        # 与 template_config，让 BaaS 原地重启也消费 BOT_TYPE / RELAY_DEFAULT_MODEL /
-        # RELAY_DEFAULT_RUNTIME / AIX_DEVFLOW_INFO / GIT_ADDRESSES 及 sandbox overrides。
-        # 不补这段则 applicationCoding bot 走 baas 重启后 upgrade 不带 envs，容器拿不到
-        # BOT_TYPE=model/runtime 即便在 update_bot 改过也不生效。引擎口径与 create_bot
-        # 对齐（claude_code + aicoding），门控不命中时 extra_envs/template_config 保持
-        # None，upgrade 行为与改动前完全一致（envs 退化为 AGENTCLAW_ENGINE 单值）。
-        device_template_config: Optional[Dict[str, Any]] = None
+        # 与 _allocate_device_async（create / arca-restart 路径）同口径构造
+        # extra_envs，并独立透传 template_config。extra_envs 提供引擎策略
+        # 变量（BOT_TYPE / RELAY_DEFAULT_* / AIX_DEVFLOW_INFO / GIT_ADDRESSES），
+        # template_config 提供沙箱覆写（envs / image / resource_spec）。两者
+        # 不能互相门控。
         extra_envs: Optional[Dict[str, Any]] = self._build_engine_extra_envs(
             bot_id=str(bot_id),
             owner_id=user_id,
@@ -3929,25 +3926,26 @@ class BotService:
             template_config=resolved_template_config,
             log_context="bot_service._restart_bot_baas",
         )
-        if extra_envs:
-            # 与 _allocate_device_async 对齐：附加 template_uid 上下文给 BaaS device 层。
-            # 解析失败仅记 warning 不阻断（_attach_template_uid_context 内部已兜底）。
-            try:
-                device_template_config = self._attach_template_uid_context(
-                    bot_id=str(bot_id),
-                    user_id=user_id,
-                    bot_type=bot.get("bot_type", ""),
-                    engine_type=active_engine,
-                    template_type=bot_template_type,
-                    template_config=resolved_template_config,
-                )
-            except Exception as e:
-                logger.warning(
-                    "[bot_service._restart_bot_baas] Failed to attach template uid context for bot %s: %s",
-                    bot_id, e,
-                )
-                device_template_config = resolved_template_config
-
+        # 与 _allocate_device_async 对齐：BaaS 原地重启也必须透传模板快照。
+        # template_config.envs / image / resource_spec 是独立的沙箱覆写能力，
+        # 不能被 extra_envs（引擎策略环境变量）是否命中门控影响。否则非
+        # coding 模板或仅配置 envs/image/spec 的模板在 restart -> /update 时会
+        # 退化成默认 envs，丢失创建 Bot 时使用的沙箱覆写。
+        try:
+            device_template_config = self._attach_template_uid_context(
+                bot_id=str(bot_id),
+                user_id=user_id,
+                bot_type=bot.get("bot_type", ""),
+                engine_type=active_engine,
+                template_type=bot_template_type,
+                template_config=resolved_template_config,
+            )
+        except Exception as e:
+            logger.warning(
+                "[bot_service._restart_bot_baas] Failed to attach template uid context for bot %s: %s",
+                bot_id, e,
+            )
+            device_template_config = resolved_template_config
 
         import uuid as _uuid
         request_id = _uuid.uuid4().hex
@@ -3965,8 +3963,8 @@ class BotService:
             "migration_path": mig,
             # 个人 Bot / 服务 Bot 草稿的普通重启不走发布产物迁移，但仍按 NAS home 目录运行。
             "mount_home_dir_storage": True,
-            # 门控命中时透传 envs / template_config，让容器拿到 BOT_TYPE / RELAY_DEFAULT_*
-            # 及 sandbox overrides；门控不命中保持 None，upgrade 行为与改动前一致。
+            # extra_envs 可能因引擎策略门控为 None；template_config 仍需透传，
+            # 以保留创建 Bot 时使用的 envs / image / resource_spec 沙箱覆写。
             "extra_envs": extra_envs,
             "template_config": device_template_config,
         }

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -2,8 +2,9 @@
 
 覆盖本分支修复点：applicationCoding / personalCoding + (claude_code | aicoding) 引擎
 门控命中时，``upgrade_bot`` 必须收到带 ``BOT_TYPE`` / ``RELAY_DEFAULT_MODEL`` /
-``RELAY_DEFAULT_RUNTIME`` 的 ``extra_envs``，以及 ``template_config``（含
-template_uid 上下文）；门控不命中时两者保持 None，行为与改动前一致。
+``RELAY_DEFAULT_RUNTIME`` 的 ``extra_envs``；无论该门控是否命中，
+``template_config``（含 template_uid 上下文）都必须透传，确保 envs/image/resource_spec
+沙箱覆写在重启时不丢失。
 
 门控口径与 ``_allocate_device_async``（create / arca-restart）严格对齐：
 - ``active_engine ∈ {claude_code, aicoding}``
@@ -260,12 +261,71 @@ class TestRestartBaasEnvInjection:
         assert envs["RELAY_DEFAULT_MODEL"] == "m-claude"
         assert envs["RELAY_DEFAULT_RUNTIME"] == "node"
 
-    def test_non_coding_engine_no_envs(self):
-        """非 claude_code/aicoding 引擎门控不命中 → extra_envs / template_config 为 None，
-        upgrade 行为与改动前完全一致。"""
+
+    def test_claude_code_other_template_type_consumes_template_config(self):
+        """claude_code + 其它 template_type 也要消费 template_config。
+
+        这类模板可能不是 applicationCoding/personalCoding，但必须带
+        template_key/template_uid 模板身份；重启时应把 model/runtime 注入
+        extra_envs，并继续透传 template_config 给 BaaS 沙箱覆写。
+        """
+        template_config = {
+            "template_key": "customCC",
+            "template_uid": "tpl-custom-cc",
+            "model": "  antchat/custom  ",
+            "runtime": "  codefuse-antcc  ",
+            "envs": {"FOO": "bar"},
+            "image": "registry.example.com/custom:latest",
+            "resource_spec": {"cpu": 4, "memory": 8192},
+        }
+        svc, baas, _ = _make_service(
+            active_engine="claude_code",
+            template_config=template_config,
+        )
+        bot = _make_bot(active_engine="claude_code", template_type="customCC")
+
+        svc._restart_bot_baas(bot_id="bot001", user_id="user001", binding_id=42, bot=bot)
+
+        kwargs = baas.upgrade_bot.call_args.kwargs
+        envs = kwargs["extra_envs"]
+        assert envs is not None
+        assert envs["BOT_TYPE"] == "customCC"
+        assert envs["RELAY_DEFAULT_MODEL"] == "antchat/custom"
+        assert envs["RELAY_DEFAULT_RUNTIME"] == "codefuse-antcc"
+        assert kwargs["template_config"] == template_config
+
+    def test_claude_code_other_template_type_without_template_identity_does_not_consume_envs(self):
+        """claude_code + 其它 template_type 缺 template_key/template_uid 时不消费 env 策略。"""
+        template_config = {
+            "model": "antchat/custom",
+            "runtime": "codefuse-antcc",
+            "envs": {"FOO": "bar"},
+        }
+        svc, baas, _ = _make_service(
+            active_engine="claude_code",
+            template_config=template_config,
+        )
+        bot = _make_bot(active_engine="claude_code", template_type="customCC")
+
+        svc._restart_bot_baas(bot_id="bot001", user_id="user001", binding_id=42, bot=bot)
+
+        kwargs = baas.upgrade_bot.call_args.kwargs
+        assert kwargs["extra_envs"] is None
+        # 沙箱覆写仍按重启链路透传；只是引擎策略不消费 model/runtime/token。
+        assert kwargs["template_config"] == template_config
+
+    def test_non_coding_engine_keeps_template_config_overrides(self):
+        """非 claude_code/aicoding 引擎门控不命中 → extra_envs=None，
+        但 template_config.envs/image/resource_spec 仍要透传给 BaaS /update。"""
+        sandbox_overrides = {
+            "model": "m1",  # 不应被 extra_envs 消费
+            "envs": {"FOO": "bar"},
+            "image": "registry.example.com/custom:latest",
+            "resource_spec": {"cpu": 4, "memory": 8},
+        }
         svc, baas, _ = _make_service(
             active_engine="moltis",
-            template_config={"model": "m1"},  # 不应被消费
+            template_config=sandbox_overrides,
         )
         bot = _make_bot(active_engine="moltis", template_type="applicationCoding")
 
@@ -273,7 +333,7 @@ class TestRestartBaasEnvInjection:
 
         kwargs = baas.upgrade_bot.call_args.kwargs
         assert kwargs["extra_envs"] is None
-        assert kwargs["template_config"] is None
+        assert kwargs["template_config"] == sandbox_overrides
 
     def test_non_coding_template_type_no_envs(self):
         """非 applicationCoding/personalCoding 的 template_type 门控不命中。"""
@@ -287,6 +347,7 @@ class TestRestartBaasEnvInjection:
 
         kwargs = baas.upgrade_bot.call_args.kwargs
         assert kwargs["extra_envs"] is None
+        assert kwargs["template_config"] == {"model": "m1"}
 
     def test_missing_model_runtime_still_injects_bot_type(self):
         """applicationCoding + 无 model/runtime → 仍注入 BOT_TYPE，不写 RELAY_DEFAULT_*。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -335,6 +335,26 @@ class TestRestartBaasEnvInjection:
         assert kwargs["extra_envs"] is None
         assert kwargs["template_config"] == sandbox_overrides
 
+    def test_template_uid_context_failure_keeps_template_config_overrides(self):
+        """template_uid 上下文解析异常不应阻断 BaaS 重启或丢失沙箱覆写。"""
+        sandbox_overrides = {
+            "envs": {"FOO": "bar"},
+            "image": "registry.example.com/custom:latest",
+            "resource_spec": {"cpu": 4, "memory": 8},
+        }
+        svc, baas, _ = _make_service(
+            active_engine="moltis",
+            template_config=sandbox_overrides,
+        )
+        svc._attach_template_uid_context = MagicMock(side_effect=RuntimeError("resolver down"))
+        bot = _make_bot(active_engine="moltis", template_type="applicationCoding")
+
+        svc._restart_bot_baas(bot_id="bot001", user_id="user001", binding_id=42, bot=bot)
+
+        kwargs = baas.upgrade_bot.call_args.kwargs
+        assert kwargs["extra_envs"] is None
+        assert kwargs["template_config"] == sandbox_overrides
+
     def test_non_coding_template_type_no_envs(self):
         """非 applicationCoding/personalCoding 的 template_type 门控不命中。"""
         svc, baas, _ = _make_service(

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -812,6 +812,7 @@ class TestRestartGuardOrchestration:
             template_uuid="TEMPLATE-claude-code",
             source="system_config",
         )
+        resolver.resolve_template_uid.return_value = "claude_code_bot_template"
         template_config = {"image": "reg.example/custom:latest"}
         svc = _make_service(
             repo,
@@ -847,10 +848,23 @@ class TestRestartGuardOrchestration:
             template_type="normalCC",
             template_config=template_config,
         )
-        resolver.resolve_template_uid.assert_not_called()
+        resolver.resolve_template_uid.assert_called_once_with(
+            bot_id="bot001",
+            user_id="user001",
+            env=get_current_env(),
+            bot_type="service",
+            engine_type="claude_code",
+            template_type="normalCC",
+            template_config=template_config,
+        )
         resolver.resolve_template_uuid.assert_not_called()
-        assert baas.upgrade_bot.call_args.kwargs["template_uuid"] == "TEMPLATE-claude-code"
-        assert baas.upgrade_bot.call_args.kwargs["migration_path"] is None
+        upgrade_kwargs = baas.upgrade_bot.call_args.kwargs
+        assert upgrade_kwargs["template_uuid"] == "TEMPLATE-claude-code"
+        assert upgrade_kwargs["template_config"] == {
+            "image": "reg.example/custom:latest",
+            "template_uid": "claude_code_bot_template",
+        }
+        assert upgrade_kwargs["migration_path"] is None
         publish_repo.get_by_publish_bot_id.assert_not_called()
 
     def test_restart_baas_service_does_not_require_published_version(self):

--- a/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
+++ b/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
@@ -221,7 +221,7 @@ def test_template_factory_normal_cc_consumes_model_runtime_repos_and_token():
         "https://code/repo1",
         "https://code/repo2",
     ]
-    assert "BOT_TYPE" not in envs
+    assert envs["BOT_TYPE"] == "normalCC"
     assert strategy.should_encrypt_template_token(ctx) is True
     assert strategy.extract_runtime_token(ctx) == "tok-normal"
 
@@ -275,9 +275,60 @@ def test_user_created_template_factory_config_consumed_without_backend_template_
     assert envs["RELAY_DEFAULT_MODEL"] == "custom-model"
     assert envs["RELAY_DEFAULT_RUNTIME"] == "codefuse-antcc"
     assert json.loads(envs["GIT_ADDRESSES"]) == ["https://code/custom-repo"]
-    assert "BOT_TYPE" not in envs
+    assert envs["BOT_TYPE"] == "userCustomTemplate"
     assert strategy.should_encrypt_template_token(ctx) is True
     assert strategy.extract_runtime_token(ctx) == "tok-custom"
+
+
+def test_claude_code_other_template_type_consumes_identified_template_config():
+    """claude_code + 非 legacy template_type 需有 template_key/template_uid 才消费。"""
+    strategy = AicodingProvisioningStrategy("claude_code")
+    ctx = BotProvisioningContext(
+        active_engine="claude_code",
+        template_type="customCC",
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="personal",
+        template_config={
+            "template_key": "customCC",
+            "template_uid": "tpl-custom-cc",
+            "model": "  custom-model  ",
+            "runtime": "  codefuse-antcc  ",
+            "token": "tok-custom",
+            "repos": ["https://code/custom-repo"],
+        },
+    )
+
+    envs = strategy.build_extra_envs(ctx)
+    assert envs is not None
+    assert envs["BOT_TYPE"] == "customCC"
+    assert envs["RELAY_DEFAULT_MODEL"] == "custom-model"
+    assert envs["RELAY_DEFAULT_RUNTIME"] == "codefuse-antcc"
+    assert json.loads(envs["GIT_ADDRESSES"]) == ["https://code/custom-repo"]
+    assert strategy.should_encrypt_template_token(ctx) is True
+    assert strategy.extract_runtime_token(ctx) == "tok-custom"
+
+
+def test_claude_code_other_template_type_ignores_incomplete_template_identity():
+    """缺 template_key 或 template_uid 的普通 dict 不能触发非 legacy 模板消费。"""
+    strategy = AicodingProvisioningStrategy("claude_code")
+    for template_config in (
+        {"model": "custom-model", "runtime": "codefuse-antcc", "token": "tok-custom"},
+        {"template_key": "customCC", "model": "custom-model", "token": "tok-custom"},
+        {"template_uid": "tpl-custom-cc", "model": "custom-model", "token": "tok-custom"},
+    ):
+        ctx = BotProvisioningContext(
+            active_engine="claude_code",
+            template_type="customCC",
+            bot_id="b1",
+            owner_id="u1",
+            bot_type="personal",
+            template_config=template_config,
+        )
+
+        assert strategy.build_extra_envs(ctx) is None
+        assert strategy.should_encrypt_template_token(ctx) is False
+        assert strategy.extract_runtime_token(ctx) is None
 
 
 def test_non_coding_engine_does_not_consume_user_template_factory_config():


### PR DESCRIPTION
## Summary
- Preserve template_config when restarting BaaS bots so envs/image/resource_spec are not lost
- Allow identified claude_code template configs to provide engine envs
- Add restart/provisioning tests for template_config passthrough and gating

## Tests
- uv run python -m py_compile src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py src/agentclaw/community/core/bot_management/services/bot_service.py tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py tests/community/core/bot_management/test_engine_provisioning_strategy.py
- Direct invocation of test_engine_provisioning_strategy.py test functions passed
- Full pytest not run: local pytest initialization segfaults while importing readline