### PR TITLE
feat(workspace): exclude clawbench_* files in openclaw rsync

### DIFF
--- a/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
@@ -25,6 +25,7 @@ _OPENCLAW_RSYNC_EXCLUDES = [
     "workspace/skills/skills-center",
     "workspace/skills-pool/skills-repo",
     "workspace/skills-pool/.skills-repo*",
+    "workspace/clawbench_*",
     "skills/*/.git/",
     "memory/",
     "logs/",

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -245,6 +245,14 @@ class TestOpenClawIsRsyncExcluded:
         provider = OpenClawSandboxProvider(workspace=_workspace())
         assert provider._is_rsync_excluded("workspace/README.md") is False
 
+    def test_clawbench_wildcard_excludes_dir_and_descendants(self):
+        # ``workspace/clawbench_*`` excludes clawbench-prefixed items and descendants.
+        provider = OpenClawSandboxProvider(workspace=_workspace())
+        assert provider._is_rsync_excluded("workspace/clawbench_test") is True
+        assert provider._is_rsync_excluded("workspace/clawbench_test/sub/file") is True
+        assert provider._is_rsync_excluded("workspace/clawbench_123.json") is True
+        assert provider._is_rsync_excluded("workspace/clawbench-foo") is False
+
 
 @pytest.mark.unit
 class TestOpenClawListDirectorySandbox:


### PR DESCRIPTION
Add `workspace/clawbench_*` to rsync excludes to filter out clawbench-prefixed files/directories during workspace sync.