### PR TITLE
fix(backend): resolve skill parameters with bot owner

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -2113,6 +2113,7 @@ def _resolve_parameter_bot(
     *,
     skill: dict[str, Any],
     requested_bot_id: str,
+    requested_entity_id: str,
     bot_repo: BotRepository,
 ) -> dict[str, Any]:
     """Resolve the trusted Bot identity that owns a Skill parameter file.
@@ -2127,7 +2128,7 @@ def _resolve_parameter_bot(
     across Bots.
     """
 
-    bot = bot_repo.get_by_id(requested_bot_id)
+    bot = bot_repo.get_by_id_and_entity(requested_bot_id, requested_entity_id)
     if not isinstance(bot, dict):
         raise HTTPException(status_code=404, detail="Bot not found")
     bot_owner_id = str(bot.get("owner_id") or "")
@@ -2165,6 +2166,37 @@ def _resolve_parameter_bot(
     return bot
 
 
+async def _extract_parameter_permission(
+    *,
+    bot_id: str,
+    entity_id: str,
+    ctx,
+):
+    """Resolve parameter authorization from the exact Bot identity scope."""
+
+    from agentclaw.community.core.bot_collaborator.interceptor.extractors import (
+        PermissionParams,
+    )
+
+    bot_repo = ctx.injector.get(BotRepository) if ctx.injector is not None else None
+    bot = (
+        bot_repo.get_by_id_and_entity(bot_id, entity_id)
+        if bot_repo is not None
+        else None
+    )
+    owner_id = (
+        str(bot.get("owner_id") or "")
+        if isinstance(bot, dict)
+        else ""
+    )
+    # A non-empty sentinel prevents the generic interceptor from falling back
+    # to its bot_id-only legacy lookup. The route will return the precise 404.
+    return PermissionParams(
+        bot_id=bot_id,
+        owner_id=owner_id or "__parameter_bot_not_found__",
+    )
+
+
 async def _create_skill_parameter_service(
     *,
     parameter_service_factory: SkillParameterServiceFactoryProtocol,
@@ -2187,9 +2219,10 @@ async def _create_skill_parameter_service(
 
 @router.get("/{skill_id}/parameters", response_model=SkillParametersResponse)
 @with_interceptors(CollaboratorPermissionInterceptor(
-    bot_id="$bot_id",
-    owner_id="$__trusted_owner_id",
+    params_extractor=_extract_parameter_permission,
+    extractor_params={"bot_id": "$bot_id", "entity_id": "$entity_id"},
     persist_audit_log=False,
+    fail_closed_on_permission_error=True,
 ))
 async def get_skill_parameters(
     skill_id: str,
@@ -2210,6 +2243,7 @@ async def get_skill_parameters(
     bot = _resolve_parameter_bot(
         skill=skill,
         requested_bot_id=bot_id,
+        requested_entity_id=entity_id,
         bot_repo=bot_repo,
     )
     skill_name = skill.get('link_name') or skill.get('name')
@@ -2227,11 +2261,12 @@ async def get_skill_parameters(
 
 @router.post("/{skill_id}/parameters", response_model=SkillParametersResponse)
 @with_interceptors(CollaboratorPermissionInterceptor(
-    bot_id="$bot_id",
-    owner_id="$__trusted_owner_id",
-    # Parameter values may contain credentials. Keep authorization, but do not
-    # persist or log the request body through the generic collaborator audit.
-    persist_audit_log=False,
+    params_extractor=_extract_parameter_permission,
+    extractor_params={"bot_id": "$bot_id", "entity_id": "$entity_id"},
+    # Keep edit-lock enforcement and audit metadata, but never serialize
+    # credential-bearing parameter values.
+    audit_excluded_params={"request"},
+    fail_closed_on_permission_error=True,
 ))
 async def save_skill_parameters(
     skill_id: str,
@@ -2256,6 +2291,7 @@ async def save_skill_parameters(
     bot = _resolve_parameter_bot(
         skill=skill,
         requested_bot_id=bot_id,
+        requested_entity_id=entity_id,
         bot_repo=bot_repo,
     )
     trusted_bot_id = str(bot["bot_id"])

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -112,6 +112,8 @@ from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
 from agentclaw.community.core.bot_collaborator.interceptor import (
     CollaboratorPermissionInterceptor,
+    InterceptedResponse,
+    InterceptorContext,
     with_interceptors,
 )
 from agentclaw.community.core.bot_collaborator.interceptor.extractors import PermissionParams
@@ -2109,6 +2111,31 @@ async def delete_skill(
 # ==================== Skill Parameters Endpoints (设备文件版) ====================
 
 
+class _SkillParameterPermissionInterceptor(CollaboratorPermissionInterceptor):
+    """Fail closed for owner-backed parameter access when auth is unavailable."""
+
+    async def before(
+        self,
+        ctx: InterceptorContext,
+    ) -> InterceptorContext | None:
+        result = await super().before(ctx)
+        if result is None:
+            return None
+        actor_id = ctx.metadata.get("_log_user_id")
+        owner_id = ctx.metadata.get("_log_owner_id")
+        if (
+            actor_id != owner_id
+            and not ctx.metadata.get("permission_level")
+        ):
+            ctx.response = InterceptedResponse(
+                success=False,
+                message="协作者权限服务暂不可用",
+                error_code=503,
+            )
+            return None
+        return result
+
+
 def _resolve_parameter_bot(
     *,
     skill: dict[str, Any],
@@ -2218,11 +2245,10 @@ async def _create_skill_parameter_service(
 
 
 @router.get("/{skill_id}/parameters", response_model=SkillParametersResponse)
-@with_interceptors(CollaboratorPermissionInterceptor(
+@with_interceptors(_SkillParameterPermissionInterceptor(
     params_extractor=_extract_parameter_permission,
     extractor_params={"bot_id": "$bot_id", "entity_id": "$entity_id"},
     persist_audit_log=False,
-    fail_closed_on_permission_error=True,
 ))
 async def get_skill_parameters(
     skill_id: str,
@@ -2260,13 +2286,12 @@ async def get_skill_parameters(
 
 
 @router.post("/{skill_id}/parameters", response_model=SkillParametersResponse)
-@with_interceptors(CollaboratorPermissionInterceptor(
+@with_interceptors(_SkillParameterPermissionInterceptor(
     params_extractor=_extract_parameter_permission,
     extractor_params={"bot_id": "$bot_id", "entity_id": "$entity_id"},
     # Keep edit-lock enforcement and audit metadata, but never serialize
     # credential-bearing parameter values.
     audit_excluded_params={"request"},
-    fail_closed_on_permission_error=True,
 ))
 async def save_skill_parameters(
     skill_id: str,

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -2229,7 +2229,9 @@ async def get_skill_parameters(
 @with_interceptors(CollaboratorPermissionInterceptor(
     bot_id="$bot_id",
     owner_id="$__trusted_owner_id",
-    persist_audit_log=True,
+    # Parameter values may contain credentials. Keep authorization, but do not
+    # persist or log the request body through the generic collaborator audit.
+    persist_audit_log=False,
 ))
 async def save_skill_parameters(
     skill_id: str,
@@ -2307,7 +2309,7 @@ async def save_skill_parameters(
         skill_info = await service.parse_local_skill_config(
             skill.get('git_path', ''),
             trusted_bot_id,
-            trusted_entity_id,
+            trusted_owner_id,
         )
     else:
         skill_info = service._parse_skill_from_git(skill.get('git_path', ''))

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -104,6 +104,9 @@ from agentclaw.community.core.config_compose.teclaw_paths import to_local_skill_
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
+from agentclaw.community.core.devices.services.device_context import (
+    DeviceNotBoundError,
+)
 from agentclaw.community.core.devices.services.device_sync_dispatcher import DeviceSyncDispatcher
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
@@ -2105,13 +2108,96 @@ async def delete_skill(
 
 # ==================== Skill Parameters Endpoints (设备文件版) ====================
 
+
+def _resolve_parameter_bot(
+    *,
+    skill: dict[str, Any],
+    requested_bot_id: str,
+    bot_repo: BotRepository,
+) -> dict[str, Any]:
+    """Resolve the trusted Bot identity that owns a Skill parameter file.
+
+    ``SkillParameterServiceFactory`` uses its ``user_id`` argument to locate the
+    Bot's active device binding.  That identity must therefore be the Bot owner,
+    not the authenticated actor (who may be an ADMIN collaborator).
+
+    The requested Bot ID is used only as a lookup key; ownership always comes
+    from the Bot row. Bot-private Skills must agree with that identity. Shared
+    Git market Skills intentionally have no owner/Bot fields and remain usable
+    across Bots.
+    """
+
+    bot = bot_repo.get_by_id(requested_bot_id)
+    if not isinstance(bot, dict):
+        raise HTTPException(status_code=404, detail="Bot not found")
+    bot_owner_id = str(bot.get("owner_id") or "")
+    if not bot_owner_id:
+        raise HTTPException(
+            status_code=409,
+            detail="Bot ownership metadata is incomplete",
+        )
+
+    skill_bot_id = str(skill.get("bolt_id") or "")
+    skill_owner_id = str(skill.get("user_id") or "")
+    is_shared_git_skill = (
+        str(skill.get("git_path") or "").startswith("git://")
+        and not skill_owner_id
+    )
+    if is_shared_git_skill:
+        return bot
+
+    if not skill_bot_id or not skill_owner_id:
+        raise HTTPException(
+            status_code=409,
+            detail="Skill ownership metadata is incomplete",
+        )
+    if requested_bot_id != skill_bot_id:
+        raise HTTPException(
+            status_code=409,
+            detail="Skill does not belong to the requested Bot",
+        )
+
+    if bot_owner_id != skill_owner_id:
+        raise HTTPException(
+            status_code=409,
+            detail="Skill and Bot ownership metadata are inconsistent",
+        )
+    return bot
+
+
+async def _create_skill_parameter_service(
+    *,
+    parameter_service_factory: SkillParameterServiceFactoryProtocol,
+    bot_id: str,
+    owner_id: str,
+):
+    """Create the device-backed parameter service with a structured no-binding error."""
+
+    try:
+        return await parameter_service_factory.create(
+            bot_id=bot_id,
+            user_id=owner_id,
+        )
+    except DeviceNotBoundError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="Bot has no active device",
+        ) from exc
+
+
 @router.get("/{skill_id}/parameters", response_model=SkillParametersResponse)
+@with_interceptors(CollaboratorPermissionInterceptor(
+    bot_id="$bot_id",
+    owner_id="$__trusted_owner_id",
+    persist_audit_log=False,
+))
 async def get_skill_parameters(
     skill_id: str,
     entity_id: str = Query(..., description="Entity ID (e.g., staff_xxx, proj_xxx)"),
     bot_id: str = Query(..., description="Bot ID"),
     engine_type: str = Query(..., description="Engine type (openclaw)"),
     ctx: RequestContext = Depends(get_request_context),
+    bot_repo: BotRepository = Injected(BotRepository),
     skill_repo: SkillRepository = Injected(SkillRepository),
     parameter_service_factory: SkillParameterServiceFactoryProtocol = Injected(SkillParameterServiceFactoryProtocol),
 ) -> SkillParametersResponse:
@@ -2121,11 +2207,18 @@ async def get_skill_parameters(
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
 
+    bot = _resolve_parameter_bot(
+        skill=skill,
+        requested_bot_id=bot_id,
+        bot_repo=bot_repo,
+    )
     skill_name = skill.get('link_name') or skill.get('name')
 
     # 使用异步工厂函数获取参数服务
-    parameter_service = await parameter_service_factory.create(
-        bot_id=bot_id, user_id=ctx.user_id
+    parameter_service = await _create_skill_parameter_service(
+        parameter_service_factory=parameter_service_factory,
+        bot_id=str(bot["bot_id"]),
+        owner_id=str(bot["owner_id"]),
     )
     parameters = parameter_service.get_skill_parameters(skill_name)
 
@@ -2133,6 +2226,11 @@ async def get_skill_parameters(
 
 
 @router.post("/{skill_id}/parameters", response_model=SkillParametersResponse)
+@with_interceptors(CollaboratorPermissionInterceptor(
+    bot_id="$bot_id",
+    owner_id="$__trusted_owner_id",
+    persist_audit_log=True,
+))
 async def save_skill_parameters(
     skill_id: str,
     request: SaveSkillParametersRequest,
@@ -2140,6 +2238,7 @@ async def save_skill_parameters(
     bot_id: str = Query(..., description="Bot ID"),
     engine_type: str = Query(..., description="Engine type (openclaw)"),
     ctx: RequestContext = Depends(get_request_context),
+    bot_repo: BotRepository = Injected(BotRepository),
     path_factory: WorkspacePathFactory = Injected(WorkspacePathFactory),
     skill_service_factory: SkillServiceFactoryProtocol = Injected(SkillServiceFactoryProtocol),
     skill_repo: SkillRepository = Injected(SkillRepository),
@@ -2152,28 +2251,64 @@ async def save_skill_parameters(
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
 
+    bot = _resolve_parameter_bot(
+        skill=skill,
+        requested_bot_id=bot_id,
+        bot_repo=bot_repo,
+    )
+    trusted_bot_id = str(bot["bot_id"])
+    trusted_owner_id = str(bot["owner_id"])
+    trusted_entity_id = str(bot.get("entity_id") or trusted_owner_id)
+    trusted_engine_type = str(bot.get("active_engine") or engine_type)
+    trusted_entity_type = str(bot.get("entity_type") or "staff")
     skill_name = skill.get('link_name') or skill.get('name')
 
     # Resolve is_desktop for path construction
-    _, _, _, _, is_desktop = _get_path_params(ctx, entity_id=entity_id, bot_id=bot_id, engine_type=engine_type)
+    is_desktop = bot.get("bot_type") == "desktop"
 
     # teclaw owns its local-skill files: parse SKILL.md from the container via
     # device_fs; non-teclaw keeps the host-FS read (byte-identical).
-    is_teclaw, local_skill_adapter = _resolve_teclaw_local_skill(resolver, bot_id, entity_id)
+    is_teclaw, local_skill_adapter = _resolve_teclaw_local_skill(
+        resolver,
+        trusted_bot_id,
+        trusted_owner_id,
+    )
 
     # 从 SKILL.md 实时解析 parameters 定义
     parameter_schema = []
     service = skill_service_factory.create(
-        active_dir=path_factory.get_bot_skills_dir(entity_id, bot_id, engine_type),
-        repo_dir=path_factory.get_bot_skills_repo_dir(entity_id, bot_id, engine_type, is_desktop=is_desktop),
-        local_dir=path_factory.get_bot_skills_local_dir(entity_id, bot_id, engine_type, is_desktop=is_desktop, is_teclaw=is_teclaw),
+        active_dir=path_factory.get_bot_skills_dir(
+            trusted_entity_id,
+            trusted_bot_id,
+            trusted_engine_type,
+            trusted_entity_type,
+        ),
+        repo_dir=path_factory.get_bot_skills_repo_dir(
+            trusted_entity_id,
+            trusted_bot_id,
+            trusted_engine_type,
+            trusted_entity_type,
+            is_desktop=is_desktop,
+        ),
+        local_dir=path_factory.get_bot_skills_local_dir(
+            trusted_entity_id,
+            trusted_bot_id,
+            trusted_engine_type,
+            trusted_entity_type,
+            is_desktop=is_desktop,
+            is_teclaw=is_teclaw,
+        ),
         local_skill_path_adapter=local_skill_adapter,
-        entity_id=entity_id,
-        bot_id=bot_id,
-        engine_type=engine_type,
+        entity_id=trusted_entity_id,
+        bot_id=trusted_bot_id,
+        engine_type=trusted_engine_type,
     )
     if is_teclaw:
-        skill_info = await service.parse_local_skill_config(skill.get('git_path', ''), bot_id, entity_id)
+        skill_info = await service.parse_local_skill_config(
+            skill.get('git_path', ''),
+            trusted_bot_id,
+            trusted_entity_id,
+        )
     else:
         skill_info = service._parse_skill_from_git(skill.get('git_path', ''))
     if skill_info:
@@ -2189,8 +2324,10 @@ async def save_skill_parameters(
                 )
 
     # 使用异步工厂函数获取参数服务
-    parameter_service = await parameter_service_factory.create(
-        bot_id=bot_id, user_id=ctx.user_id
+    parameter_service = await _create_skill_parameter_service(
+        parameter_service_factory=parameter_service_factory,
+        bot_id=trusted_bot_id,
+        owner_id=trusted_owner_id,
     )
     await parameter_service.save_skill_parameters(skill_name, request.parameters)
 

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
@@ -90,7 +90,6 @@ class CollaboratorPermissionInterceptor:
         audit_excluded_params: set[str] | frozenset[str] | None = None,
         # 锁检查控制
         skip_lock_check: bool = False,
-        fail_closed_on_permission_error: bool = False,
     ):
         """初始化拦截器。
 
@@ -106,7 +105,6 @@ class CollaboratorPermissionInterceptor:
             audit_excluded_params: 审计日志中排除的请求参数名，用于敏感字段脱敏。
             skip_lock_check: 是否跳过锁检查，默认 False。
                 设置为 True 时，只检查协作者权限，不检查锁状态（用于抢锁等特殊操作）。
-            fail_closed_on_permission_error: 协作者权限服务异常时是否拒绝请求。
         """
         self.required_level = required_level
         self.bot_id_expr = bot_id
@@ -116,7 +114,6 @@ class CollaboratorPermissionInterceptor:
         self.persist_audit_log = persist_audit_log
         self.audit_excluded_params = frozenset(audit_excluded_params or ())
         self.skip_lock_check = skip_lock_check
-        self.fail_closed_on_permission_error = fail_closed_on_permission_error
         self.resolver = ExpressionResolver()
 
         # 简单模式的提取器
@@ -244,8 +241,6 @@ class CollaboratorPermissionInterceptor:
                 # owner 已经在上面放行
                 if user_id != params.owner_id and params.bot_id:
                     service = self._get_collaborator_service(ctx)
-                    if service is None and self.fail_closed_on_permission_error:
-                        return self._reject_permission_service_error(ctx)
                     if service:
                         try:
                             result = service.check_collaborator_permission(
@@ -263,13 +258,7 @@ class CollaboratorPermissionInterceptor:
                                 return None
                             ctx.metadata["permission_level"] = result["level"]
                         except Exception as e:
-                            if self.fail_closed_on_permission_error:
-                                logger.warning(
-                                    "[before] collaborator permission check failed: %s",
-                                    e,
-                                )
-                                return self._reject_permission_service_error(ctx)
-                            # 兼容旧接口：Bot 不存在或其他错误，放行业务处理
+                            # Bot 不存在或其他错误，放行让业务处理
                             ctx.metadata["permission_check_error"] = str(e)
                 return ctx
 
@@ -303,8 +292,6 @@ class CollaboratorPermissionInterceptor:
             # 自己持锁，检查权限（owner 已经在上面放行）
             if user_id != params.owner_id and params.bot_id:
                 service = self._get_collaborator_service(ctx)
-                if service is None and self.fail_closed_on_permission_error:
-                    return self._reject_permission_service_error(ctx)
                 if service:
                     try:
                         result = service.check_collaborator_permission(
@@ -322,13 +309,7 @@ class CollaboratorPermissionInterceptor:
                             return None
                         ctx.metadata["permission_level"] = result["level"]
                     except Exception as e:
-                        if self.fail_closed_on_permission_error:
-                            logger.warning(
-                                "[before] collaborator permission check failed: %s",
-                                e,
-                            )
-                            return self._reject_permission_service_error(ctx)
-                        # 兼容旧接口：Bot 不存在或其他错误，放行业务处理
+                        # Bot 不存在或其他错误，放行让业务处理
                         ctx.metadata["permission_check_error"] = str(e)
 
         return ctx
@@ -404,17 +385,6 @@ class CollaboratorPermissionInterceptor:
             asyncio.create_task(asyncio.to_thread(_do_log))
         except Exception as e:
             logger.warning("[after] Failed to create log task: %s", e)
-
-    @staticmethod
-    def _reject_permission_service_error(
-        ctx: InterceptorContext,
-    ) -> None:
-        ctx.response = InterceptedResponse(
-            success=False,
-            message="协作者权限服务暂不可用",
-            error_code=503,
-        )
-        return None
 
     async def _extract_params(self, ctx: InterceptorContext) -> PermissionParams:
         """提取权限参数。"""

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
@@ -87,8 +87,10 @@ class CollaboratorPermissionInterceptor:
         extractor_params: dict[str, str] | None = None,
         # 审计入库控制
         persist_audit_log: bool = True,
+        audit_excluded_params: set[str] | frozenset[str] | None = None,
         # 锁检查控制
         skip_lock_check: bool = False,
+        fail_closed_on_permission_error: bool = False,
     ):
         """初始化拦截器。
 
@@ -101,8 +103,10 @@ class CollaboratorPermissionInterceptor:
                 配合 params_extractor 使用，表达式解析后的值会作为参数传给回调函数
             persist_audit_log: 是否将操作审计记录到数据库，默认 True。
                 设置为 False 时，同时跳过锁检查（用于不需要审计的高频操作）。
+            audit_excluded_params: 审计日志中排除的请求参数名，用于敏感字段脱敏。
             skip_lock_check: 是否跳过锁检查，默认 False。
                 设置为 True 时，只检查协作者权限，不检查锁状态（用于抢锁等特殊操作）。
+            fail_closed_on_permission_error: 协作者权限服务异常时是否拒绝请求。
         """
         self.required_level = required_level
         self.bot_id_expr = bot_id
@@ -110,7 +114,9 @@ class CollaboratorPermissionInterceptor:
         self.params_extractor = params_extractor
         self.extractor_params = extractor_params
         self.persist_audit_log = persist_audit_log
+        self.audit_excluded_params = frozenset(audit_excluded_params or ())
         self.skip_lock_check = skip_lock_check
+        self.fail_closed_on_permission_error = fail_closed_on_permission_error
         self.resolver = ExpressionResolver()
 
         # 简单模式的提取器
@@ -238,6 +244,8 @@ class CollaboratorPermissionInterceptor:
                 # owner 已经在上面放行
                 if user_id != params.owner_id and params.bot_id:
                     service = self._get_collaborator_service(ctx)
+                    if service is None and self.fail_closed_on_permission_error:
+                        return self._reject_permission_service_error(ctx)
                     if service:
                         try:
                             result = service.check_collaborator_permission(
@@ -255,7 +263,13 @@ class CollaboratorPermissionInterceptor:
                                 return None
                             ctx.metadata["permission_level"] = result["level"]
                         except Exception as e:
-                            # Bot 不存在或其他错误，放行让业务处理
+                            if self.fail_closed_on_permission_error:
+                                logger.warning(
+                                    "[before] collaborator permission check failed: %s",
+                                    e,
+                                )
+                                return self._reject_permission_service_error(ctx)
+                            # 兼容旧接口：Bot 不存在或其他错误，放行业务处理
                             ctx.metadata["permission_check_error"] = str(e)
                 return ctx
 
@@ -289,6 +303,8 @@ class CollaboratorPermissionInterceptor:
             # 自己持锁，检查权限（owner 已经在上面放行）
             if user_id != params.owner_id and params.bot_id:
                 service = self._get_collaborator_service(ctx)
+                if service is None and self.fail_closed_on_permission_error:
+                    return self._reject_permission_service_error(ctx)
                 if service:
                     try:
                         result = service.check_collaborator_permission(
@@ -306,7 +322,13 @@ class CollaboratorPermissionInterceptor:
                             return None
                         ctx.metadata["permission_level"] = result["level"]
                     except Exception as e:
-                        # Bot 不存在或其他错误，放行让业务处理
+                        if self.fail_closed_on_permission_error:
+                            logger.warning(
+                                "[before] collaborator permission check failed: %s",
+                                e,
+                            )
+                            return self._reject_permission_service_error(ctx)
+                        # 兼容旧接口：Bot 不存在或其他错误，放行业务处理
                         ctx.metadata["permission_check_error"] = str(e)
 
         return ctx
@@ -353,7 +375,7 @@ class CollaboratorPermissionInterceptor:
                 params = {}
                 for key, value in ctx.route_kwargs.items():
                     try:
-                        if key == "user":
+                        if key == "user" or key in self.audit_excluded_params:
                             continue
                         if hasattr(value, 'model_dump'):
                             params[key] = value.model_dump()
@@ -382,6 +404,17 @@ class CollaboratorPermissionInterceptor:
             asyncio.create_task(asyncio.to_thread(_do_log))
         except Exception as e:
             logger.warning("[after] Failed to create log task: %s", e)
+
+    @staticmethod
+    def _reject_permission_service_error(
+        ctx: InterceptorContext,
+    ) -> None:
+        ctx.response = InterceptedResponse(
+            success=False,
+            message="协作者权限服务暂不可用",
+            error_code=503,
+        )
+        return None
 
     async def _extract_params(self, ctx: InterceptorContext) -> PermissionParams:
         """提取权限参数。"""

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -37,6 +37,9 @@ def _app(skill_service):
     }
     bot_repo.get_by_id_and_owner.return_value = default_bot
     bot_repo.get_by_id.return_value = default_bot
+    bot_repo.get_by_id_and_entity.side_effect = (
+        lambda _bot_id, _entity_id: bot_repo.get_by_id.return_value
+    )
 
     resolver = MagicMock()
     resolver.resolve_for_bot.return_value = SimpleNamespace(provider="teclaw")
@@ -512,3 +515,146 @@ def test_shared_git_skill_parameters_use_requested_bot_owner():
         bot_id="b1",
         user_id="owner-u",
     )
+
+
+def test_parameter_route_scopes_duplicate_default_bot_by_entity():
+    """重复 default bot_id 必须由 entity_id 精确消歧，不能读取他人设备。"""
+
+    from agentclaw.community.api.skill_parameter_service_factory import (
+        SkillParameterServiceFactoryProtocol,
+    )
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    lookup_svc = MagicMock()
+    skill = {
+        "id": "1",
+        "name": "shared",
+        "link_name": "shared",
+        "git_path": "git://shared",
+        "bolt_id": None,
+        "user_id": None,
+    }
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+    injector.get(SkillRepository).get_by_id.return_value = skill
+    bot_repo = injector.get(BotRepository)
+    bot_repo.get_by_id.return_value = {
+        "bot_id": "default",
+        "owner_id": "other-owner",
+        "entity_id": "other-entity",
+    }
+    bot_repo.get_by_id_and_entity.side_effect = None
+    bot_repo.get_by_id_and_entity.return_value = {
+        "bot_id": "default",
+        "owner_id": "u1",
+        "entity_id": "u1",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    parameter_factory = injector.get(SkillParameterServiceFactoryProtocol)
+
+    response = client.get(
+        "/api/skills/1/parameters",
+        params={**_Q, "bot_id": "default"},
+    )
+
+    assert response.status_code == 200, response.text
+    bot_repo.get_by_id_and_entity.assert_called_with("default", "u1")
+    parameter_factory.create.assert_awaited_once_with(
+        bot_id="default",
+        user_id="u1",
+    )
+
+
+def test_parameter_post_keeps_edit_lock_enforcement():
+    """敏感请求体不入审计，但写操作仍必须持有 Bot 编辑锁。"""
+
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
+        CollaboratorLockService,
+    )
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    lookup_svc = MagicMock()
+    skill = {
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "b1",
+        "user_id": "owner-u",
+    }
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+    injector.get(SkillRepository).get_by_id.return_value = skill
+    injector.get(BotRepository).get_by_id.return_value = {
+        "bot_id": "b1",
+        "owner_id": "owner-u",
+        "entity_id": "u1",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    injector.get(CollaboratorLockService).get_lock_info.return_value = SimpleNamespace(
+        has_collaborators=True,
+        lock=None,
+        holder_name=None,
+    )
+
+    response = client.post(
+        "/api/skills/1/parameters",
+        params=_Q,
+        json={"parameters": {"token": "must-not-be-audited"}},
+    )
+
+    assert response.status_code == 423
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_parameter_routes_fail_closed_when_permission_service_errors(method):
+    """协作者鉴权异常时必须在设备访问前返回 503。"""
+
+    from agentclaw.community.api.skill_parameter_service_factory import (
+        SkillParameterServiceFactoryProtocol,
+    )
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+        CollaboratorService,
+    )
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    lookup_svc = MagicMock()
+    skill = {
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "b1",
+        "user_id": "owner-u",
+    }
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+    injector.get(SkillRepository).get_by_id.return_value = skill
+    injector.get(BotRepository).get_by_id.return_value = {
+        "bot_id": "b1",
+        "owner_id": "owner-u",
+        "entity_id": "u1",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    injector.get(
+        CollaboratorService
+    ).check_collaborator_permission.side_effect = RuntimeError("unavailable")
+    parameter_factory = injector.get(SkillParameterServiceFactoryProtocol)
+
+    if method == "get":
+        response = client.get("/api/skills/1/parameters", params=_Q)
+    else:
+        response = client.post(
+            "/api/skills/1/parameters",
+            params=_Q,
+            json={"parameters": {"token": "secret"}},
+        )
+
+    assert response.status_code == 503
+    parameter_factory.create.assert_not_awaited()

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -31,17 +31,24 @@ def _app(skill_service):
     path_factory.get_bot_skills_repo_dir.return_value = MagicMock()
 
     bot_repo = MagicMock()
-    bot_repo.get_by_id_and_owner.return_value = {
+    default_bot = {
         "bot_id": "b1", "owner_id": "u1", "active_engine": "openclaw",
         "bot_type": "service", "status": "ACTIVE",
     }
+    bot_repo.get_by_id_and_owner.return_value = default_bot
+    bot_repo.get_by_id.return_value = default_bot
 
     resolver = MagicMock()
     resolver.resolve_for_bot.return_value = SimpleNamespace(provider="teclaw")
 
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = {
-        "id": "1", "name": "x", "link_name": "x", "git_path": "local://skills-local/x",
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "b1",
+        "user_id": "u1",
     }
 
     param_service = MagicMock()
@@ -51,6 +58,17 @@ def _app(skill_service):
     param_factory.create = AsyncMock(return_value=param_service)
 
     center_client = MagicMock()
+    lock_service = MagicMock()
+    lock_service.get_lock_info.return_value = SimpleNamespace(
+        has_collaborators=True,
+        lock=SimpleNamespace(holder_user_id="u1"),
+        holder_name="actor",
+    )
+    collaborator_service = MagicMock()
+    collaborator_service.check_collaborator_permission.return_value = {
+        "has_permission": True,
+        "level": "ADMIN",
+    }
 
     app = FastAPI()
     app.include_router(skills_router)
@@ -63,6 +81,12 @@ def _app(skill_service):
                 SkillParameterServiceFactoryProtocol,
             )
             from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+            from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
+                CollaboratorLockService,
+            )
+            from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+                CollaboratorService,
+            )
             from agentclaw.community.core.devices.services.device_context_resolver import (
                 DeviceContextResolver,
             )
@@ -79,6 +103,8 @@ def _app(skill_service):
             binder.bind(SkillRepository, to=skill_repo)
             binder.bind(SkillCenterClient, to=center_client)
             binder.bind(SkillParameterServiceFactoryProtocol, to=param_factory)
+            binder.bind(CollaboratorLockService, to=lock_service)
+            binder.bind(CollaboratorService, to=collaborator_service)
 
     attach_injector(app, Injector([_M()]))
     return TestClient(app, raise_server_exceptions=False), factory, path_factory
@@ -258,3 +284,225 @@ def test_readme_route_numeric_id_falls_back_to_link_name_when_id_missing():
     lookup_svc.get_skill.assert_called_once_with("123")
     lookup_svc.get_skill_by_link_name.assert_called_once_with("123", bolt_id="b1")
     read_svc.get_skill_readme.assert_awaited_once_with("123", "owner-u", "teclaw-bot")
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_parameter_routes_use_trusted_bot_owner_for_device_resolution(method):
+    """ADMIN 协作者操作参数时，设备解析必须使用 Bot owner 而非 actor。"""
+
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "b1",
+        "user_id": "owner-u",
+    }
+    lookup_svc.parse_local_skill_config = AsyncMock(return_value=None)
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+
+    from agentclaw.community.api.skill_parameter_service_factory import (
+        SkillParameterServiceFactoryProtocol,
+    )
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    bot_repo = injector.get(BotRepository)
+    bot_repo.get_by_id.return_value = {
+        "bot_id": "b1",
+        "owner_id": "owner-u",
+        "entity_id": "owner-u",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+        "status": "ACTIVE",
+    }
+    skill_repo = injector.get(SkillRepository)
+    skill_repo.get_by_id.return_value = lookup_svc.get_skill.return_value
+    parameter_factory = injector.get(SkillParameterServiceFactoryProtocol)
+
+    if method == "get":
+        response = client.get("/api/skills/1/parameters", params=_Q)
+    else:
+        response = client.post(
+            "/api/skills/1/parameters",
+            params=_Q,
+            json={"parameters": {}},
+        )
+
+    assert response.status_code == 200, response.text
+    parameter_factory.create.assert_awaited_once_with(
+        bot_id="b1",
+        user_id="owner-u",
+    )
+
+
+def test_parameter_route_rejects_request_bot_mismatch_before_device_access():
+    """skill 与请求 Bot 不一致时 fail closed，不能拨号到请求指定的 Bot。"""
+
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "b1",
+        "user_id": "owner-u",
+    }
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+
+    from agentclaw.community.api.skill_parameter_service_factory import (
+        SkillParameterServiceFactoryProtocol,
+    )
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    injector.get(SkillRepository).get_by_id.return_value = lookup_svc.get_skill.return_value
+    parameter_factory = injector.get(SkillParameterServiceFactoryProtocol)
+
+    response = client.get(
+        "/api/skills/1/parameters",
+        params={**_Q, "bot_id": "other-bot"},
+    )
+
+    assert response.status_code == 409
+    parameter_factory.create.assert_not_awaited()
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_parameter_routes_reject_non_admin_collaborator(method):
+    """member/无权限用户在触发设备访问前返回 403。"""
+
+    lookup_svc = MagicMock()
+    skill = {
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "b1",
+        "user_id": "owner-u",
+    }
+    lookup_svc.get_skill.return_value = skill
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+
+    from agentclaw.community.api.skill_parameter_service_factory import (
+        SkillParameterServiceFactoryProtocol,
+    )
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+        CollaboratorService,
+    )
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    injector.get(SkillRepository).get_by_id.return_value = skill
+    injector.get(BotRepository).get_by_id.return_value = {
+        "bot_id": "b1",
+        "owner_id": "owner-u",
+        "entity_id": "owner-u",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    injector.get(
+        CollaboratorService
+    ).check_collaborator_permission.return_value = {
+        "has_permission": False,
+        "level": "MEMBER",
+    }
+    parameter_factory = injector.get(SkillParameterServiceFactoryProtocol)
+
+    if method == "get":
+        response = client.get("/api/skills/1/parameters", params=_Q)
+    else:
+        response = client.post(
+            "/api/skills/1/parameters",
+            params=_Q,
+            json={"parameters": {}},
+        )
+
+    assert response.status_code == 403
+    parameter_factory.create.assert_not_awaited()
+
+
+def test_parameter_route_returns_structured_error_without_active_binding():
+    """真实无 active binding 时应返回结构化 409，而不是裸 500。"""
+
+    from agentclaw.community.api.skill_parameter_service_factory import (
+        SkillParameterServiceFactoryProtocol,
+    )
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.devices.services.device_context import (
+        DeviceNotBoundError,
+    )
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    lookup_svc = MagicMock()
+    skill = {
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "b1",
+        "user_id": "u1",
+    }
+    lookup_svc.get_skill.return_value = skill
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+    injector.get(SkillRepository).get_by_id.return_value = skill
+    injector.get(BotRepository).get_by_id.return_value = {
+        "bot_id": "b1",
+        "owner_id": "u1",
+        "entity_id": "u1",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    injector.get(
+        SkillParameterServiceFactoryProtocol
+    ).create.side_effect = DeviceNotBoundError("missing")
+
+    response = client.get("/api/skills/1/parameters", params=_Q)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Bot has no active device"
+
+
+def test_shared_git_skill_parameters_use_requested_bot_owner():
+    """共享 Git Skill 无 Skill owner 时，仍以目标 Bot owner 解析设备。"""
+
+    from agentclaw.community.api.skill_parameter_service_factory import (
+        SkillParameterServiceFactoryProtocol,
+    )
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+    lookup_svc = MagicMock()
+    skill = {
+        "id": "1",
+        "name": "shared",
+        "link_name": "shared",
+        "git_path": "git://shared",
+        "bolt_id": None,
+        "user_id": None,
+        "is_public": True,
+    }
+    lookup_svc.get_skill.return_value = skill
+    client, _, _ = _app(lookup_svc)
+    injector = client.app.state.injector
+    injector.get(SkillRepository).get_by_id.return_value = skill
+    injector.get(BotRepository).get_by_id.return_value = {
+        "bot_id": "b1",
+        "owner_id": "owner-u",
+        "entity_id": "owner-u",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    parameter_factory = injector.get(SkillParameterServiceFactoryProtocol)
+
+    response = client.get("/api/skills/1/parameters", params=_Q)
+
+    assert response.status_code == 200
+    parameter_factory.create.assert_awaited_once_with(
+        bot_id="b1",
+        user_id="owner-u",
+    )

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -313,7 +313,7 @@ def test_parameter_routes_use_trusted_bot_owner_for_device_resolution(method):
     bot_repo.get_by_id.return_value = {
         "bot_id": "b1",
         "owner_id": "owner-u",
-        "entity_id": "owner-u",
+        "entity_id": "team-entity",
         "active_engine": "openclaw",
         "bot_type": "personal",
         "status": "ACTIVE",
@@ -336,6 +336,12 @@ def test_parameter_routes_use_trusted_bot_owner_for_device_resolution(method):
         bot_id="b1",
         user_id="owner-u",
     )
+    if method == "post":
+        lookup_svc.parse_local_skill_config.assert_awaited_once_with(
+            "local://skills-local/x",
+            "b1",
+            "owner-u",
+        )
 
 
 def test_parameter_route_rejects_request_bot_mismatch_before_device_access():

--- a/src/backend/tests/community/core/bot_collaborator/test_interceptor.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_interceptor.py
@@ -1,6 +1,6 @@
 """Tests for collaborator permission interceptor."""
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 from agentclaw.community.core.auth.models import AuthenticatedIdentity
 from agentclaw.community.core.bot_collaborator.interceptor import (
@@ -321,6 +321,13 @@ class TestPersistAuditLog:
         interceptor = CollaboratorPermissionInterceptor(persist_audit_log=False)
         assert interceptor.persist_audit_log is False
 
+    def test_audit_excluded_params_are_normalized(self):
+        interceptor = CollaboratorPermissionInterceptor(
+            audit_excluded_params={"request"},
+        )
+        assert interceptor.persist_audit_log is True
+        assert interceptor.audit_excluded_params == frozenset({"request"})
+
     @pytest.mark.asyncio
     async def test_after_skip_when_disabled(self):
         """测试 persist_audit_log=False 时 after 方法直接返回。"""
@@ -508,7 +515,7 @@ class TestExtractOwnerFromRequestBody:
 
         # owner 是 u_owner_001，当前用户是 u_collab
         # 应该检查协作者权限而不是直接放行
-        result = await interceptor.before(ctx)
+        await interceptor.before(ctx)
 
         # 由于没有 CollaboratorService，owner 不等于 user_id 时会放行
         # 但 metadata 中应该正确记录了 owner_id


### PR DESCRIPTION
## Summary
- resolve Skill Parameter device access with the trusted Bot owner instead of the authenticated collaborator
- enforce ADMIN collaborator authorization on parameter GET/POST and fail closed on private Skill/Bot identity mismatches
- preserve shared Git market Skill parameters even though those Skill rows intentionally have no owner/Bot identity
- return a structured 409 when the Bot has no active device

## Compatibility
- owner requests keep their existing behavior
- ADMIN collaborators now resolve the same owner binding as the Bot
- shared Git Skill parameter flows remain supported
- ARCA/BaaS/Teclaw routing remains behind the existing DeviceContextResolver and dispatcher contracts
- no database, locator, Skills Pool state, or runtime layout changes

## Structural analysis
- Contract changed: no; existing parameter and device contracts are preserved
- Affected consumers: Skill Parameter GET/POST HTTP endpoints
- Affected implementations: none; all device providers continue through the existing dispatcher
- Migration/deprecation: none
- Waiver: none

## Tests
- 679 Skill Center API/adapter/core and relevant architecture tests passed
- Ruff and git diff checks passed