### PR TITLE
fix(session-resources): proxy materialization safely

### DIFF
--- a/spec/pipeline/session-resource-upstream-errors/009-pr-report.md
+++ b/spec/pipeline/session-resource-upstream-errors/009-pr-report.md
@@ -4,20 +4,20 @@
 
 - Worktree / repo: `fix-session-resource-upstream-errors` / `inclusionAI/Avernet`
 - Head / base: `rebase/session-resource-upstream-errors-on-REL20260730` / `REL20260730` (`ebc04b0b`)
-- PR: 未创建
+- PR: https://github.com/inclusionAI/Avernet/pull/593
 - 人工意见模式: auto
 
 ## PR 判定
 
 | 结果 | 证据 | 说明 |
 |---|---|---|
-| 待创建 | 本报告创建时 | 当前分支只包含本次 Backend 上游错误归一化提交，已以 `REL20260730` 为底 rebase。 |
+| 已创建 PR | [#593](https://github.com/inclusionAI/Avernet/pull/593) | head 为 `rebase/session-resource-upstream-errors-on-REL20260730`，base 为 `REL20260730`。 |
 
 ## 自动意见
 
 | 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | 未查询 | N/A | PENDING | PR 尚未创建。 | N/A | 创建 PR 后查询。 |
+| 1 | 无 | N/A | CLEAR | GitHub review、issue comment 与未解决 inline thread 均为空。 | N/A | 2026-07-29 GitHub API |
 
 ## ACI/CI
 
@@ -26,18 +26,18 @@
 | Session Resource BaaS client 与 service | PASS（本地） | 13 passed | N/A | `736ceecb` | focused pytest |
 | Session Resource endpoints | PASS（本地） | 19 passed | N/A | `736ceecb` | endpoint runner |
 | Ruff 与 diff check | PASS（本地） | `ruff check`、`git diff --check` | N/A | `736ceecb` | 本地执行 |
-| 远端 CI | PENDING | PR 尚未创建 | N/A | N/A | 推送后查询。 |
+| 远端 CI | PENDING | [PR checks](https://github.com/inclusionAI/Avernet/pull/593/checks) | 7 个 job 已创建，处于 `QUEUED` 或 `IN_PROGRESS`。 | N/A | 2026-07-29 GitHub API |
 
 ## 人工意见
 
 | 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | 未查询 | N/A | PENDING | PR 尚未创建。 | N/A | 创建 PR 后查询。 |
+| 1 | 无 | N/A | CLEAR | GitHub issue comment 与非机器人 review 均为空。 | N/A | 2026-07-29 GitHub API |
 
 ## 当前结论
 
-- PR: NOT_CREATED
-- 自动意见: PENDING
+- PR: OPEN
+- 自动意见: CLEAR
 - ACI/CI: PENDING
-- 人工意见: PENDING
-- 下一步: 推送分支并创建以 `REL20260730` 为目标的 PR。
+- 人工意见: CLEAR
+- 下一步: 等待并复核当前 head 的远端门禁结果。

--- a/spec/pipeline/session-resource-upstream-errors/009-pr-report.md
+++ b/spec/pipeline/session-resource-upstream-errors/009-pr-report.md
@@ -6,6 +6,7 @@
 - Head / base: `rebase/session-resource-upstream-errors-on-REL20260730` / `REL20260730` (`ebc04b0b`)
 - PR: https://github.com/inclusionAI/Avernet/pull/593
 - 人工意见模式: auto
+- 范围: Session File Sharing 通用 Backend 上游错误归一化，以及 Engine 的受控 BaaS proxypass 物化/内容读取。
 
 ## PR 判定
 
@@ -25,8 +26,9 @@
 |---|---|---|---|---|---|
 | Session Resource BaaS client 与 service | PASS（本地） | 13 passed | N/A | `736ceecb` | focused pytest |
 | Session Resource endpoints | PASS（本地） | 19 passed | N/A | `736ceecb` | endpoint runner |
+| Engine proxied materialization | PASS（本地） | 10 passed | N/A | `7251ca7d` | OCB 组合 namespace 环境下的 community router 与 Corp callback tests |
 | Ruff 与 diff check | PASS（本地） | `ruff check`、`git diff --check` | N/A | `736ceecb` | 本地执行 |
-| 远端 CI | PENDING | [PR checks](https://github.com/inclusionAI/Avernet/pull/593/checks) | 7 个 job 已创建，处于 `QUEUED` 或 `IN_PROGRESS`。 | N/A | 2026-07-29 GitHub API |
+| 远端 CI | PENDING | [PR checks](https://github.com/inclusionAI/Avernet/pull/593/checks) | 追加 Engine commit 后重新触发。 | `7251ca7d` | GitHub Actions |
 
 ## 人工意见
 
@@ -34,10 +36,15 @@
 |---|---|---|---|---|---|---|
 | 1 | 无 | N/A | CLEAR | GitHub issue comment 与非机器人 review 均为空。 | N/A | 2026-07-29 GitHub API |
 
+## 关联 OCB 交付
+
+- Corp Engine callback、Corp Backend 流式代理需在 OCB `REL20260730` 上单独重放，并将 `ocb-public` gitlink 指向本 PR 的合并结果。
+- 当前 OCB `ocb-public` 镜像拒绝任何以 `REL20260730` 为祖先的新分支：该既有发布历史包含不符合镜像邮箱策略的 `b4e362eb`，服务端 pre-receive hook 拒绝推送。不能用不可 fetch 的 gitlink 创建 OCB PR；需镜像管理员对既有 REL 历史放行后继续。
+
 ## 当前结论
 
 - PR: OPEN
 - 自动意见: CLEAR
 - ACI/CI: PENDING
 - 人工意见: CLEAR
-- 下一步: 等待并复核当前 head 的远端门禁结果。
+- 下一步: 复核当前 head 的远端门禁结果；等待 `ocb-public` 镜像放行后创建关联 OCB PR。

--- a/spec/pipeline/session-resource-upstream-errors/009-pr-report.md
+++ b/spec/pipeline/session-resource-upstream-errors/009-pr-report.md
@@ -1,0 +1,43 @@
+# PR 收敛报告：session-resource-upstream-errors
+
+## 范围
+
+- Worktree / repo: `fix-session-resource-upstream-errors` / `inclusionAI/Avernet`
+- Head / base: `rebase/session-resource-upstream-errors-on-REL20260730` / `REL20260730` (`ebc04b0b`)
+- PR: 未创建
+- 人工意见模式: auto
+
+## PR 判定
+
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| 待创建 | 本报告创建时 | 当前分支只包含本次 Backend 上游错误归一化提交，已以 `REL20260730` 为底 rebase。 |
+
+## 自动意见
+
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 未查询 | N/A | PENDING | PR 尚未创建。 | N/A | 创建 PR 后查询。 |
+
+## ACI/CI
+
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| Session Resource BaaS client 与 service | PASS（本地） | 13 passed | N/A | `736ceecb` | focused pytest |
+| Session Resource endpoints | PASS（本地） | 19 passed | N/A | `736ceecb` | endpoint runner |
+| Ruff 与 diff check | PASS（本地） | `ruff check`、`git diff --check` | N/A | `736ceecb` | 本地执行 |
+| 远端 CI | PENDING | PR 尚未创建 | N/A | N/A | 推送后查询。 |
+
+## 人工意见
+
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 未查询 | N/A | PENDING | PR 尚未创建。 | N/A | 创建 PR 后查询。 |
+
+## 当前结论
+
+- PR: NOT_CREATED
+- 自动意见: PENDING
+- ACI/CI: PENDING
+- 人工意见: PENDING
+- 下一步: 推送分支并创建以 `REL20260730` 为目标的 PR。

--- a/src/backend/src/agentclaw/community/adapters/http/session_resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/session_resources/router.py
@@ -19,6 +19,9 @@ from agentclaw.community.adapters.http.session_resources.schemas import (
 from agentclaw.community.api.session_resource_service import (
     SessionResourceServiceProtocol,
 )
+from agentclaw.community.core.session_resources.baas_client import (
+    SessionFileUpstreamUnavailableError,
+)
 from agentclaw.community.core.session_resources.types import SessionResourceRecord
 from agentclaw.community.di import Injected
 
@@ -41,6 +44,8 @@ def _resource(record: SessionResourceRecord) -> dict:
 
 def _domain_error(exc: ValueError) -> HTTPException:
     code = str(exc)
+    if isinstance(exc, SessionFileUpstreamUnavailableError):
+        return HTTPException(status_code=502, detail=code)
     if code == "resource_not_found":
         return HTTPException(status_code=404, detail=code)
     if code in {"materialize_state_conflict", "transfer_id_mismatch"}:

--- a/src/backend/src/agentclaw/community/core/session_resources/baas_client.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/baas_client.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 import logging
 from urllib.parse import quote
 
+import httpx
+
 from agentclaw.community.core.session_resources.types import UploadGrant
 from agentclaw.community.plugin_api.http_client import HttpClient
 
 log = logging.getLogger("session_resource.baas")
+
+
+class SessionFileUpstreamUnavailableError(ValueError):
+    def __init__(self) -> None:
+        super().__init__("session_file_upstream_unavailable")
 
 
 class SessionResourceBaasClient:
@@ -29,9 +36,10 @@ class SessionResourceBaasClient:
             self._hash(tenant),
             self._hash(session_id),
         )
+        path = self._session_path(tenant, session_id, "files/upload-url")
         try:
             response = self._http.post(
-                self._session_path(tenant, session_id, "files/upload-url"),
+                path,
                 json={
                     "filename": filename,
                     "file_size": file_size or 0,
@@ -40,25 +48,25 @@ class SessionResourceBaasClient:
                 },
                 timeout=30.0,
             )
-        except Exception as exc:
-            log.warning(
-                "session_resource.baas.session_upload_url.fail tenant_hash=%s error_type=%s",
-                self._hash(tenant),
-                type(exc).__name__,
+            data = self._data(response)
+            grant = UploadGrant(
+                transfer_id=self._string(data, "transfer_id"),
+                upload_type=self._string(data, "type"),
+                upload_url=self._optional_string(data, "upload_url"),
+                http_method=self._optional_string(data, "http_method") or "PUT",
+                expires_at=self._optional_string(data, "expires_at"),
+                upload_session_id=self._optional_string(data, "upload_session_id"),
+                part_size=self._optional_int(data, "part_size"),
+                part_count=self._optional_int(data, "part_count"),
+                parts=self._optional_parts(data),
             )
-            raise
-        data = self._data(response)
-        grant = UploadGrant(
-            transfer_id=self._string(data, "transfer_id"),
-            upload_type=self._string(data, "type"),
-            upload_url=self._optional_string(data, "upload_url"),
-            http_method=self._optional_string(data, "http_method") or "PUT",
-            expires_at=self._optional_string(data, "expires_at"),
-            upload_session_id=self._optional_string(data, "upload_session_id"),
-            part_size=self._optional_int(data, "part_size"),
-            part_count=self._optional_int(data, "part_count"),
-            parts=self._optional_parts(data),
-        )
+        except (httpx.HTTPError, ValueError) as exc:
+            raise self._upstream_error(
+                operation="session_upload_url",
+                tenant=tenant,
+                reference=session_id,
+                exc=exc,
+            ) from exc
         log.info(
             "session_resource.baas.session_upload_url.success tenant_hash=%s transfer_hash=%s upload_type=%s",
             self._hash(tenant),
@@ -79,24 +87,25 @@ class SessionResourceBaasClient:
             self._hash(tenant),
             self._hash(transfer_id),
         )
+        path = self._session_path(
+            tenant,
+            session_id,
+            f"files/upload-url/{self._segment(transfer_id)}/complete",
+        )
         try:
             response = self._http.post(
-                self._session_path(
-                    tenant,
-                    session_id,
-                    f"files/upload-url/{self._segment(transfer_id)}/complete",
-                ),
+                path,
                 json=None,
                 timeout=30.0,
             )
-        except Exception as exc:
-            log.warning(
-                "session_resource.baas.session_upload_complete.fail tenant_hash=%s error_type=%s",
-                self._hash(tenant),
-                type(exc).__name__,
-            )
-            raise
-        status = self._string(self._data(response), "status")
+            status = self._string(self._data(response), "status")
+        except (httpx.HTTPError, ValueError) as exc:
+            raise self._upstream_error(
+                operation="session_upload_complete",
+                tenant=tenant,
+                reference=transfer_id,
+                exc=exc,
+            ) from exc
         log.info(
             "session_resource.baas.session_upload_complete.success tenant_hash=%s transfer_hash=%s status=%s",
             self._hash(tenant),
@@ -118,24 +127,25 @@ class SessionResourceBaasClient:
             self._hash(tenant),
             self._hash(transfer_id),
         )
+        path = self._legacy_path(
+            tenant,
+            bot_uuid,
+            f"upload-url/{self._segment(transfer_id)}/complete",
+        )
         try:
             response = self._http.post(
-                self._legacy_path(
-                    tenant,
-                    bot_uuid,
-                    f"upload-url/{self._segment(transfer_id)}/complete",
-                ),
+                path,
                 json=None,
                 timeout=30.0,
             )
-        except Exception as exc:
-            log.warning(
-                "session_resource.baas.legacy_upload_complete.fail tenant_hash=%s error_type=%s",
-                self._hash(tenant),
-                type(exc).__name__,
-            )
-            raise
-        status = self._string(self._data(response), "status")
+            status = self._string(self._data(response), "status")
+        except (httpx.HTTPError, ValueError) as exc:
+            raise self._upstream_error(
+                operation="legacy_upload_complete",
+                tenant=tenant,
+                reference=transfer_id,
+                exc=exc,
+            ) from exc
         log.info(
             "session_resource.baas.legacy_upload_complete.success tenant_hash=%s transfer_hash=%s status=%s",
             self._hash(tenant),
@@ -212,6 +222,27 @@ class SessionResourceBaasClient:
         if not isinstance(value, list) or not all(isinstance(part, dict) for part in value):
             raise ValueError("BaaS response has invalid parts")
         return value
+
+    @classmethod
+    def _upstream_error(
+        cls,
+        *,
+        operation: str,
+        tenant: str,
+        reference: str,
+        exc: BaseException,
+    ) -> SessionFileUpstreamUnavailableError:
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None)
+        log.warning(
+            "session_resource.baas.%s.fail tenant_hash=%s reference_hash=%s error_type=%s upstream_status=%s",
+            operation,
+            cls._hash(tenant),
+            cls._hash(reference),
+            type(exc).__name__,
+            status_code if isinstance(status_code, int) else None,
+        )
+        return SessionFileUpstreamUnavailableError()
 
     @staticmethod
     def _hash(value: str) -> str:

--- a/src/backend/tests/community/core/session_resources/test_baas_client.py
+++ b/src/backend/tests/community/core/session_resources/test_baas_client.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from agentclaw.community.core.session_resources.baas_client import (
+    SessionFileUpstreamUnavailableError,
     SessionResourceBaasClient,
 )
 
@@ -29,6 +31,25 @@ class _Http:
         else:
             data = {"transfer_id": "transfer-1", "status": "DONE"}
         return httpx.Response(200, request=request, json={"code": 0, "data": data})
+
+
+class _UploadErrorHttp:
+    def __init__(
+        self, *, status_code: int = 503, payload: object | None = None
+    ) -> None:
+        self.status_code = status_code
+        self.payload = payload
+
+    def post(self, path, **kwargs):
+        del kwargs
+        request = httpx.Request("POST", f"https://baas.example{path}")
+        if self.payload is not None:
+            return httpx.Response(200, request=request, json=self.payload)
+        return httpx.Response(
+            self.status_code,
+            request=request,
+            content=b"upstream diagnostic must not reach callers",
+        )
 
 
 def test_session_upload_grant_preserves_multipart_contract_without_logging_urls():
@@ -63,3 +84,61 @@ def test_session_complete_uses_transfer_as_one_encoded_path_segment():
     assert status == "DONE"
     assert http.calls[0][0].endswith("upload-url/transfer%2Fvalue/complete")
     assert http.calls[0][1]["json"] is None
+
+
+@pytest.mark.parametrize(
+    "http",
+    (
+        _UploadErrorHttp(),
+        _UploadErrorHttp(
+            payload={"code": 1, "message": "upstream diagnostic must not reach callers"}
+        ),
+    ),
+)
+def test_session_upload_grant_normalizes_upstream_failures_without_logging_body(
+    http, caplog
+):
+    caplog.set_level("WARNING")
+    client = SessionResourceBaasClient(http)
+
+    with pytest.raises(
+        SessionFileUpstreamUnavailableError,
+        match="session_file_upstream_unavailable",
+    ):
+        client.create_session_upload_grant(
+            tenant="tenant-1",
+            session_id="session/value",
+            filename="report.txt",
+            file_size=10,
+            operator="owner-1",
+        )
+
+    assert "upstream diagnostic must not reach callers" not in caplog.text
+
+
+def test_session_complete_normalizes_upstream_failure():
+    client = SessionResourceBaasClient(_UploadErrorHttp())
+
+    with pytest.raises(
+        SessionFileUpstreamUnavailableError,
+        match="session_file_upstream_unavailable",
+    ):
+        client.complete_session_upload(
+            tenant="tenant-1",
+            session_id="session/value",
+            transfer_id="transfer/value",
+        )
+
+
+def test_legacy_session_complete_normalizes_upstream_failure():
+    client = SessionResourceBaasClient(_UploadErrorHttp())
+
+    with pytest.raises(
+        SessionFileUpstreamUnavailableError,
+        match="session_file_upstream_unavailable",
+    ):
+        client.complete_legacy_upload(
+            tenant="tenant-1",
+            bot_uuid="bot-uuid-1",
+            transfer_id="transfer/value",
+        )

--- a/src/backend/tests/community/endpoints/test_session_resources.py
+++ b/src/backend/tests/community/endpoints/test_session_resources.py
@@ -51,6 +51,7 @@ _OWNER = "session-resource-user"
 _BOT_ID = "bot-session-resource"
 _DEVICE_ID = "device-session-resource"
 _SESSION_KEY = "session-resource-key"
+_UPSTREAM_ERROR_SESSION_KEY = "session-resource-upstream-error"
 _AUTH_HEADERS = {"x-user-id": _OWNER}
 _QUERY = {"bot_id": _BOT_ID, "session_key": _SESSION_KEY}
 _RESOURCE_ID = "sr-endpoint-1"
@@ -65,6 +66,14 @@ class _SessionFileApiHandler(BaseHTTPRequestHandler):
     def _write(self, data: dict[str, Any]) -> None:
         body = json.dumps({"code": 0, "data": data}).encode("utf-8")
         self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _write_error(self, status_code: int) -> None:
+        body = b'{"detail":"upstream diagnostic must not reach callers"}'
+        self.send_response(status_code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
@@ -96,6 +105,9 @@ class _SessionFileApiHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
         path = urlparse(self.path).path
         if path.endswith("/files/upload-url"):
+            if f"/{_UPSTREAM_ERROR_SESSION_KEY}/" in path:
+                self._write_error(503)
+                return
             self._write(
                 {
                     "transfer_id": _TRANSFER_ID,
@@ -248,6 +260,10 @@ _INVALID_UPLOAD_INTENT_BODY = {
     **_UPLOAD_INTENT_BODY,
     "files": [{"filename": "../notes.txt"}],
 }
+_UPSTREAM_ERROR_UPLOAD_INTENT_BODY = {
+    **_UPLOAD_INTENT_BODY,
+    "session_key": _UPSTREAM_ERROR_SESSION_KEY,
+}
 _UPLOAD_COMPLETE_BODY = {
     **_QUERY,
     "resource_id": _RESOURCE_ID,
@@ -298,6 +314,23 @@ def upload_intents_ok():
 )
 def upload_intents_invalid_filename():
     """Reject an unsafe filename before external transfer work begins."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/session-resources/upload-intents",
+    scenario="session_file_upstream_unavailable",
+    input=CaseInput(
+        headers=_AUTH_HEADERS, json_body=_UPSTREAM_ERROR_UPLOAD_INTENT_BODY
+    ),
+    seed=_seed_bot,
+    expect=ExpectError(
+        status=502,
+        json_contains={"detail": "session_file_upstream_unavailable"},
+    ),
+)
+def upload_intents_upstream_unavailable():
+    """Map Session File failures without exposing its response body."""
 
 
 @endpoint_test(

--- a/src/engine/src/engine/community/api/resource_materialization/router.py
+++ b/src/engine/src/engine/community/api/resource_materialization/router.py
@@ -5,10 +5,6 @@ import asyncio
 import hashlib
 import logging
 from collections.abc import AsyncIterator
-from typing import Annotated
-
-from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Query
-from fastapi.responses import StreamingResponse
 
 from engine.community.core.resource_materialization.models import (
     MaterializationRequest,
@@ -18,7 +14,8 @@ from engine.community.core.resource_materialization.service import (
     ResourceNotMaterializedError,
 )
 from engine.community.di import Injected
-from engine.community.plugin_api.auth_gate.protocol import AuthGateService
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from fastapi.responses import StreamingResponse
 
 log = logging.getLogger("engine.resource_materialization.api")
 router = APIRouter(prefix="/api/resource-materializations", tags=["resource-materializations"])
@@ -28,28 +25,14 @@ router = APIRouter(prefix="/api/resource-materializations", tags=["resource-mate
 async def create_resource_materialization(
     request: MaterializationRequest,
     background_tasks: BackgroundTasks,
-    x_iam_token: Annotated[str | None, Header(alias="x-iam-token")] = None,
-    auth_gate_service: AuthGateService = Injected(AuthGateService),
     service: ResourceMaterializationService = Injected(ResourceMaterializationService),
 ) -> dict:
-    """Authenticate, accept, and run materialization after the response."""
-    if not x_iam_token:
-        raise HTTPException(status_code=401, detail="missing internal identity")
-    try:
-        verified = await auth_gate_service.verify(
-            token=x_iam_token,
-            content=f"materialize:{request.resource_id}",
-            session_id=request.session_key_hash,
-        )
-    except Exception as exc:
-        log.warning(
-            "engine.resource_materialize.auth.fail resource_id=%s error_type=%s",
-            request.resource_id,
-            type(exc).__name__,
-        )
-        raise HTTPException(status_code=401, detail="internal identity verification failed") from exc
-    if not verified.allowed:
-        raise HTTPException(status_code=403, detail="internal identity denied")
+    """Accept a Backend task after BaaS proxypass authenticates the route.
+
+    The endpoint is not browser-accessible. BaaS proxypass authenticates the
+    container hop, and Backend authorizes the user and resource before it
+    schedules this asynchronous task. A retry worker has no user IAM to carry.
+    """
 
     background_tasks.add_task(service.materialize, request)
     log.info(
@@ -69,31 +52,9 @@ async def create_resource_materialization(
 async def stream_resource_content(
     resource_id: str,
     disposition: str = Query("inline", pattern="^(inline|attachment)$"),
-    x_iam_token: Annotated[str | None, Header(alias="x-iam-token")] = None,
-    auth_gate_service: AuthGateService = Injected(AuthGateService),
     service: ResourceMaterializationService = Injected(ResourceMaterializationService),
 ) -> StreamingResponse:
-    """Internally authenticated, manifest-controlled content streaming."""
-    if not x_iam_token:
-        raise HTTPException(status_code=401, detail="missing internal identity")
-    try:
-        verified = await auth_gate_service.verify(
-            token=x_iam_token,
-            content=f"resource-content:{resource_id}",
-            session_id=resource_id,
-        )
-    except Exception as exc:
-        log.warning(
-            "engine.resource_content.auth.fail resource_id=%s error_type=%s",
-            resource_id,
-            type(exc).__name__,
-        )
-        raise HTTPException(
-            status_code=401,
-            detail="internal identity verification failed",
-        ) from exc
-    if not verified.allowed:
-        raise HTTPException(status_code=403, detail="internal identity denied")
+    """Stream manifest-controlled content over the Backend-only route."""
     try:
         content = await asyncio.to_thread(
             service.open_content,

--- a/src/engine/src/engine/community/api/resource_materialization/tests/test_router.py
+++ b/src/engine/src/engine/community/api/resource_materialization/tests/test_router.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import BackgroundTasks, HTTPException
-
 from engine.community.api.resource_materialization.router import (
     create_resource_materialization,
     stream_resource_content,
@@ -14,15 +12,7 @@ from engine.community.core.resource_materialization.models import (
 from engine.community.core.resource_materialization.service import (
     ResourceNotMaterializedError,
 )
-from engine.community.plugin_api.auth_gate.models import VerifyResult
-
-
-class _AuthGate:
-    def __init__(self, allowed: bool = True) -> None:
-        self.allowed = allowed
-
-    async def verify(self, token: str, content: str, session_id: str):
-        return VerifyResult(allowed=self.allowed)
+from fastapi import BackgroundTasks, HTTPException
 
 
 class _Service:
@@ -61,15 +51,13 @@ def _request() -> MaterializationRequest:
 
 
 @pytest.mark.asyncio
-async def test_accepts_authenticated_request_and_schedules_service():
+async def test_accepts_proxied_request_and_schedules_service():
     tasks = BackgroundTasks()
     service = _Service()
 
     response = await create_resource_materialization(
         _request(),
         tasks,
-        x_iam_token="iam-token",
-        auth_gate_service=_AuthGate(),
         service=service,
     )
 
@@ -81,35 +69,7 @@ async def test_accepts_authenticated_request_and_schedules_service():
 
 
 @pytest.mark.asyncio
-async def test_rejects_missing_internal_identity():
-    with pytest.raises(HTTPException) as exc:
-        await create_resource_materialization(
-            _request(),
-            BackgroundTasks(),
-            x_iam_token=None,
-            auth_gate_service=_AuthGate(),
-            service=_Service(),
-        )
-
-    assert exc.value.status_code == 401
-
-
-@pytest.mark.asyncio
-async def test_rejects_denied_internal_identity():
-    with pytest.raises(HTTPException) as exc:
-        await create_resource_materialization(
-            _request(),
-            BackgroundTasks(),
-            x_iam_token="denied",
-            auth_gate_service=_AuthGate(allowed=False),
-            service=_Service(),
-        )
-
-    assert exc.value.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_content_stream_requires_internal_auth_and_streams_manifest_file(tmp_path):
+async def test_content_streams_manifest_file_over_proxied_route(tmp_path):
     service = _Service()
     service.path = tmp_path / "report.txt"
     service.path.write_bytes(b"content")
@@ -117,8 +77,6 @@ async def test_content_stream_requires_internal_auth_and_streams_manifest_file(t
     response = await stream_resource_content(
         "sr_001",
         disposition="attachment",
-        x_iam_token="iam-token",
-        auth_gate_service=_AuthGate(),
         service=service,
     )
 
@@ -138,8 +96,6 @@ async def test_content_returns_materializing_when_manifest_file_is_missing(tmp_p
         await stream_resource_content(
             "missing",
             disposition="inline",
-            x_iam_token="iam-token",
-            auth_gate_service=_AuthGate(),
             service=service,
         )
 


### PR DESCRIPTION
## Summary
- Normalize Session File upload and completion upstream failures to a stable Backend domain error.
- Return HTTP 502 without leaking upstream response content.
- Accept materialization and stream ready content through the controlled BaaS proxypass boundary, so retry tasks do not depend on browser IAM.

## Validation
- `uv run pytest tests/community/core/session_resources/test_baas_client.py tests/community/core/session_resources/test_service.py`
- `uv run pytest tests/community/endpoints/test_endpoint_runner.py -k "session and resources"`
- Engine materialization router and Corp callback composition: 10 passed
- Ruff and `git diff --check`