### PR TITLE
chore(dev-ops): update Codex review instructions and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ src/bcs/.agent
 *.claude
 *.codex
 CLAUDE.local.md
+CODE_REVIEW.md
 .planning
 .dev
 .private_docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,3 +274,10 @@ activation, read
 - Treat a `center://` source as a governed, versioned content source. A source
   prefix alone is not evidence that publication, distribution, and activation
   have completed.
+
+# Code Review
+1. **Code Review Standards Integration**:
+   - Check if a file named `CODE_REVIEW.md` exists in the current directory
+   - If `CODE_REVIEW.md` exists, you MUST strictly read and follow all rules, scope restrictions, and guidelines defined in `CODE_REVIEW.md` for evaluating this PR.
+   - If `CODE_REVIEW.md` does NOT exist, skip applying these custom review standards and perform normal processing.
+

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -1,6 +1,0 @@
-# Agent Directives
-
-1. **Code Review Standards Integration**:
-   - Check if a file named `CODE_REVIEW.md` exists in the current directory
-   - If `CODE_REVIEW.md` exists, you MUST strictly read and follow all rules, scope restrictions, and guidelines defined in `CODE_REVIEW.md` for evaluating this PR.
-   - If `CODE_REVIEW.md` does NOT exist, skip applying these custom review standards and perform normal processing.

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Directives
+
+1. **Code Review Standards Integration**:
+   - Check if a file named `CODE_REVIEW.md` exists in the current directory
+   - If `CODE_REVIEW.md` exists, you MUST strictly read and follow all rules, scope restrictions, and guidelines defined in `CODE_REVIEW.md` for evaluating this PR.
+   - If `CODE_REVIEW.md` does NOT exist, skip applying these custom review standards and perform normal processing.


### PR DESCRIPTION
## 变更内容

- 将仓库级 Codex review instructions 放到顶层 `AGENTS.md`
- 更新 `.gitignore`，支持云端 Codex 环境
- 补充 backend 目录下的 `AGENTS.md`

## 验证

- 已基于最新 `origin/dev` rebase
- 当前分支无未提交改动
