### PR TITLE
fix: fence committed pool probe failures

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -39,6 +39,10 @@ from agentclaw.community.core.skills_pool.ports import (
     SkillsPoolRuntimeProtocol,
     SkillsPoolSkillRepositoryProtocol,
 )
+from agentclaw.community.log import get_logger
+
+
+logger = get_logger()
 
 
 class SkillsPoolReconcileOutcome(StrEnum):
@@ -146,8 +150,42 @@ class SkillsPoolReconcileService:
             user_id=user_id,
             engine=engine,
         )
+        logger.info(
+            "[skills_pool.reconcile] runtime probe bot_id=%s generation=%s "
+            "phase=%s committed=%s status=%s",
+            scope.bot_id,
+            generation,
+            state.phase.value,
+            state.data_plane_cutover_committed,
+            probe.status.value,
+        )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
             if probe.status is RuntimeLayoutProbeStatus.NOT_CAPABLE:
+                if state.data_plane_cutover_committed:
+                    recorded = self._layouts.record_post_cutover_failure(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code=probe.status.value,
+                        failure_stage="runtime_probe",
+                        retryable=False,
+                        evidence=probe.evidence,
+                    )
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            evidence={
+                                **probe.evidence,
+                                "state_race_stage": (
+                                    "record_committed_not_capable_probe"
+                                ),
+                            },
+                        )
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.INVALID,
+                        evidence=probe.evidence,
+                        retryable=False,
+                    )
                 released = self._layouts.release_not_capable_claim(
                     scope=scope,
                     migration_generation=generation,
@@ -156,7 +194,11 @@ class SkillsPoolReconcileService:
                 )
                 if not released:
                     return SkillsPoolReconcileResult(
-                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        evidence={
+                            **probe.evidence,
+                            "state_race_stage": "release_not_capable_claim",
+                        },
                     )
             elif probe.status in {
                 RuntimeLayoutProbeStatus.INVALID,
@@ -305,6 +347,16 @@ class SkillsPoolReconcileService:
         cutover_finalizing = state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
         repair_evidence_refresh = state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
         locator_evidence = self._persisted_cutover_evidence(state)
+        logger.info(
+            "[skills_pool.reconcile] mapping intent ready bot_id=%s generation=%s "
+            "phase=%s committed=%s local_count=%s mapping_count=%s",
+            scope.bot_id,
+            generation,
+            state.phase.value,
+            state.data_plane_cutover_committed,
+            len(local_names),
+            len(mappings),
+        )
         if (
             not state.data_plane_cutover_committed
             or cutover_finalizing

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -880,6 +880,81 @@ def test_cutover_finalizing_accepts_pending_evidence_without_quarantine() -> Non
         assert session.query(SkillMigrationQuarantineModel).count() == 0
 
 
+def test_finalizing_without_quarantine_accepts_runtime_identity_and_commits() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    repository.claim_pool_migration(
+        scope=scope,
+        layout_contract_version="skills-pool-p3-v1",
+        migration_generation="generation-1",
+        rollout_evidence=rollout_evidence(),
+        lease_owner="worker-1",
+        lease_seconds=60,
+    )
+    assert repository.record_ready_probe(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={"marker": "valid"},
+    )
+    assert repository.begin_cutover(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+    )
+    assert repository.record_cutover_finalizing(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": False,
+            "status": "POST_CUTOVER_SYNC_PENDING",
+            "evidence": {"reason": "transport_response_unavailable"},
+        },
+    )
+    with database.transactional_orm_session() as session:
+        assert session.query(SkillMigrationQuarantineModel).count() == 0
+
+    quarantine_path = (
+        "/home/admin/.aicoding/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+    assert repository.record_post_cutover_evidence(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        evidence={
+            "committed": True,
+            "status": "ALREADY_COMMITTED",
+            "evidence": {
+                "active_marker": "same-generation",
+                "quarantine": quarantine_path,
+                "quarantine_cleanup_pending": True,
+            },
+        },
+    )
+    assert repository.has_quarantine_identity(
+        scope=scope,
+        migration_generation="generation-1",
+    )
+    assert repository.commit_pool_active(
+        scope=scope,
+        migration_generation="generation-1",
+        lease_owner="worker-1",
+        preparation_id="preparation-1",
+        local_locators={},
+    )
+
+    state = repository.get(scope)
+    assert state.active_layout is SkillLayout.POOL
+    assert state.phase is SkillLayoutPhase.POOL_ACTIVE
+
+
 def test_post_cutover_evidence_reuses_existing_quarantine_identity() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -1170,6 +1170,47 @@ async def test_post_cutover_sync_pending_retries_finalization_before_mappings() 
 
 
 @pytest.mark.asyncio
+async def test_finalizing_without_persisted_quarantine_uses_runtime_identity() -> None:
+    quarantine = (
+        "/home/admin/.aicoding/workspace/skills-pool/"
+        ".migration-quarantine/generation-1/skills-local"
+    )
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="POST_CUTOVER_SYNC_PENDING",
+        )
+    )
+    layouts.quarantine_identity = False
+    runtime = FakeRuntime(engine="aicoding")
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={
+            "active_marker": "same-generation",
+            "quarantine": quarantine,
+            "quarantine_cleanup_pending": True,
+        },
+    )
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="aicoding",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["evidence", "database"]
+    assert layouts.state.active_layout is SkillLayout.POOL
+
+
+@pytest.mark.asyncio
 async def test_committed_repair_invalid_refresh_stays_forward_only() -> None:
     layouts = FakeLayoutRepository(
         claimed_state(

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -234,6 +234,8 @@ class FakeLayoutRepository:
         return True
 
     def record_post_cutover_failure(self, **kwargs: object) -> bool:
+        if self._should_fail("post_failure"):
+            return False
         if not self._owns(kwargs):
             return False
         self.events.append("post_failure")
@@ -1326,6 +1328,70 @@ async def test_non_ready_runtime_keeps_legacy_without_data_plane_changes() -> No
 
 
 @pytest.mark.asyncio
+async def test_not_capable_after_committed_cutover_is_not_released() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        preparation_id=None,
+        evidence={"reason": "logical_mapping_contract_not_supported"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert layouts.events == ["post_failure"]
+    assert "not_capable_release" not in layouts.events
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_code == "NOT_CAPABLE"
+    assert layouts.state.last_failure_stage == "runtime_probe"
+
+
+@pytest.mark.asyncio
+async def test_not_capable_after_committed_cutover_reports_cas_stage() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    layouts.fail_once_at = "post_failure"
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        preparation_id=None,
+        evidence={"reason": "logical_mapping_contract_not_supported"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.STATE_RACE_LOST
+    assert result.evidence == {
+        "reason": "logical_mapping_contract_not_supported",
+        "state_race_stage": "record_committed_not_capable_probe",
+    }
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+
+
+@pytest.mark.asyncio
 async def test_not_capable_release_race_is_not_reported_as_complete() -> None:
     layouts = FakeLayoutRepository()
     layouts.fail_once_at = "not_capable_release"
@@ -1343,6 +1409,10 @@ async def test_not_capable_release_race_is_not_reported_as_complete() -> None:
     )
 
     assert result.outcome is SkillsPoolReconcileOutcome.STATE_RACE_LOST
+    assert result.evidence == {
+        "reason": "pool_marker_missing",
+        "state_race_stage": "release_not_capable_claim",
+    }
     assert layouts.state.phase is SkillLayoutPhase.POOL_PREPARING
     assert layouts.state.migration_generation == GENERATION
 


### PR DESCRIPTION
## Summary

- keep a post-cutover `NOT_CAPABLE` probe inside the forward-only failure path instead of attempting the pre-cutover claim release CAS
- preserve the committed/finalizing identity and fail closed as `INVALID`
- add stage-safe reconcile logs around runtime probe and logical mapping construction so deployment/version drift and residual CAS failures are observable

## Root cause

The pre-cutover `NOT_CAPABLE` path was reused after `data_plane_cutover_committed=1`. Its claim-release CAS cannot legally match a committed/finalizing row, so the actual runtime condition was flattened into `state_race_lost` and could retry indefinitely.

The new commit also changes the Avernet gitlink target, forcing the OCB Backend image build to consume a fresh community tree instead of relying on a potentially stale cached submodule checkout.

## Compatibility

- pre-cutover and ordinary Legacy `NOT_CAPABLE` behavior is unchanged: release the claim and remain Legacy
- committed migrations never roll back or release their generation
- no rollout, schema, locator, or runtime filesystem behavior changes

## Validation

- `uv run ruff check src/agentclaw/community/core/skills_pool/reconcile_service.py tests/community/core/skills_pool/test_reconcile_service.py`
- `uv run pytest tests/community/core/skills_pool/test_reconcile_service.py -q` — 53 passed
