### PR TITLE
fix: fence committed pool probe failures

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -38,6 +38,10 @@ from agentclaw.community.core.skills_pool.ports import (
     SkillsPoolRuntimeProtocol,
     SkillsPoolSkillRepositoryProtocol,
 )
+from agentclaw.community.log import get_logger
+
+
+logger = get_logger()
 
 
 class SkillsPoolReconcileOutcome(StrEnum):
@@ -138,8 +142,42 @@ class SkillsPoolReconcileService:
             user_id=user_id,
             engine=engine,
         )
+        logger.info(
+            "[skills_pool.reconcile] runtime probe bot_id=%s generation=%s "
+            "phase=%s committed=%s status=%s",
+            scope.bot_id,
+            generation,
+            state.phase.value,
+            state.data_plane_cutover_committed,
+            probe.status.value,
+        )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
             if probe.status is RuntimeLayoutProbeStatus.NOT_CAPABLE:
+                if state.data_plane_cutover_committed:
+                    recorded = self._layouts.record_post_cutover_failure(
+                        scope=scope,
+                        migration_generation=generation,
+                        lease_owner=lease_owner,
+                        failure_code=probe.status.value,
+                        failure_stage="runtime_probe",
+                        retryable=False,
+                        evidence=probe.evidence,
+                    )
+                    if not recorded:
+                        return SkillsPoolReconcileResult(
+                            SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                            evidence={
+                                **probe.evidence,
+                                "state_race_stage": (
+                                    "record_committed_not_capable_probe"
+                                ),
+                            },
+                        )
+                    return SkillsPoolReconcileResult(
+                        SkillsPoolReconcileOutcome.INVALID,
+                        evidence=probe.evidence,
+                        retryable=False,
+                    )
                 released = self._layouts.release_not_capable_claim(
                     scope=scope,
                     migration_generation=generation,
@@ -148,7 +186,11 @@ class SkillsPoolReconcileService:
                 )
                 if not released:
                     return SkillsPoolReconcileResult(
-                        SkillsPoolReconcileOutcome.STATE_RACE_LOST
+                        SkillsPoolReconcileOutcome.STATE_RACE_LOST,
+                        evidence={
+                            **probe.evidence,
+                            "state_race_stage": "release_not_capable_claim",
+                        },
                     )
             elif probe.status in {
                 RuntimeLayoutProbeStatus.INVALID,
@@ -236,6 +278,16 @@ class SkillsPoolReconcileService:
 
         cutover_finalizing = state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
         repair_evidence_refresh = state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
+        logger.info(
+            "[skills_pool.reconcile] mapping intent ready bot_id=%s generation=%s "
+            "phase=%s committed=%s local_count=%s mapping_count=%s",
+            scope.bot_id,
+            generation,
+            state.phase.value,
+            state.data_plane_cutover_committed,
+            len(local_names),
+            len(mappings),
+        )
         if (
             not state.data_plane_cutover_committed
             or cutover_finalizing

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -168,6 +168,8 @@ class FakeLayoutRepository:
         return True
 
     def record_post_cutover_failure(self, **kwargs: object) -> bool:
+        if self._should_fail("post_failure"):
+            return False
         if not self._owns(kwargs):
             return False
         self.events.append("post_failure")
@@ -729,6 +731,70 @@ async def test_non_ready_runtime_keeps_legacy_without_data_plane_changes() -> No
 
 
 @pytest.mark.asyncio
+async def test_not_capable_after_committed_cutover_is_not_released() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        preparation_id=None,
+        evidence={"reason": "logical_mapping_contract_not_supported"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert layouts.events == ["post_failure"]
+    assert "not_capable_release" not in layouts.events
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+    assert layouts.state.last_failure_code == "NOT_CAPABLE"
+    assert layouts.state.last_failure_stage == "runtime_probe"
+
+
+@pytest.mark.asyncio
+async def test_not_capable_after_committed_cutover_reports_cas_stage() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    layouts.fail_once_at = "post_failure"
+    runtime = FakeRuntime()
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+        preparation_id=None,
+        evidence={"reason": "logical_mapping_contract_not_supported"},
+    )
+
+    result = await build_service(layouts, runtime).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.STATE_RACE_LOST
+    assert result.evidence == {
+        "reason": "logical_mapping_contract_not_supported",
+        "state_race_stage": "record_committed_not_capable_probe",
+    }
+    assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+    assert layouts.state.data_plane_cutover_committed is True
+
+
+@pytest.mark.asyncio
 async def test_not_capable_release_race_is_not_reported_as_complete() -> None:
     layouts = FakeLayoutRepository()
     layouts.fail_once_at = "not_capable_release"
@@ -746,6 +812,10 @@ async def test_not_capable_release_race_is_not_reported_as_complete() -> None:
     )
 
     assert result.outcome is SkillsPoolReconcileOutcome.STATE_RACE_LOST
+    assert result.evidence == {
+        "reason": "pool_marker_missing",
+        "state_race_stage": "release_not_capable_claim",
+    }
     assert layouts.state.phase is SkillLayoutPhase.POOL_PREPARING
     assert layouts.state.migration_generation == GENERATION
 


### PR DESCRIPTION
## Summary

- keep committed Skills Pool migrations in the post-cutover failure boundary when runtime probe returns NOT_CAPABLE
- preserve finalizing/committed identity instead of running the pre-cutover claim release CAS
- add stage-specific reconciliation logs and state-race evidence

## Tests

- `uv run ruff check src/agentclaw/community/core/skills_pool/reconcile_service.py tests/community/core/skills_pool/test_reconcile_service.py`
- `uv run pytest tests/community/core/skills_pool/test_reconcile_service.py -q` (36 passed)

Forward-port of #595 to dev.