### PR TITLE
Enable template-based member management for bot collaborators

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
@@ -26,6 +26,9 @@ from agentclaw.community.core.bot_collaborator.services.collaborator_lock_servic
 from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
     CollaboratorService,
 )
+from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
+    is_member_management_enabled_bot,
+)
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -487,8 +490,9 @@ class CollaboratorPermissionInterceptor:
         """判断目标 Bot 是否为 coding 应用。
 
         coding 应用：``active_engine == "claude_code"`` 且
-        ``template_type == "applicationCoding"``。失败时保守返回 False
-        （即按 Service Bot 原逻辑走 bot 级锁）。
+        ``template_type == "applicationCoding"``；或模板显式开启
+        ``ac_templates.ext.bot_template_config.advanced_config.member_management == true``。
+        失败时保守返回 False（即按 Service Bot 原逻辑走 bot 级锁）。
         """
         if not bot_id or not owner_id or ctx.injector is None:
             return False
@@ -499,10 +503,7 @@ class CollaboratorPermissionInterceptor:
 
             bot_service = ctx.injector.get(BotServiceProtocol)
             bot = bot_service.get_bot(bot_id, owner_id)
-            return bool(bot) and (
-                bot.get("active_engine") == "claude_code"
-                and bot.get("template_type") == "applicationCoding"
-            )
+            return is_member_management_enabled_bot(bot)
         except Exception as e:
             logger.warning("[_is_coding_app] check failed: %s", e)
             return False

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
@@ -489,9 +489,10 @@ class CollaboratorPermissionInterceptor:
     ) -> bool:
         """判断目标 Bot 是否使用应用/成员管理语义。
 
-        具体规则通过 ``MemberManagementCapabilityService`` 协调：通用模板开关
-        加各引擎自己的 capability 实现。失败时保守返回 False（即按 Service Bot
-        原逻辑走 bot 级锁）。
+        具体规则通过 ``MemberManagementCapabilityService`` 协调：通用层只
+        依赖 engine capability interface，不解释任何引擎私有 schema；各引擎
+        的定制判断放在各自目录的 capability 实现中。失败时保守返回 False
+        （即按 Service Bot 原逻辑走 bot 级锁）。
         """
         if not bot_id or not owner_id or ctx.injector is None:
             return False

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/collaborator.py
@@ -26,8 +26,8 @@ from agentclaw.community.core.bot_collaborator.services.collaborator_lock_servic
 from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
     CollaboratorService,
 )
-from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
-    is_member_management_enabled_bot,
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
 )
 from agentclaw.community.log import get_logger
 
@@ -487,12 +487,11 @@ class CollaboratorPermissionInterceptor:
     def _is_coding_app(
         self, ctx: InterceptorContext, bot_id: str | None, owner_id: str | None
     ) -> bool:
-        """判断目标 Bot 是否为 coding 应用。
+        """判断目标 Bot 是否使用应用/成员管理语义。
 
-        coding 应用：``active_engine == "claude_code"`` 且
-        ``template_type == "applicationCoding"``；或模板显式开启
-        ``ac_templates.ext.bot_template_config.advanced_config.member_management == true``。
-        失败时保守返回 False（即按 Service Bot 原逻辑走 bot 级锁）。
+        具体规则通过 ``MemberManagementCapabilityService`` 协调：通用模板开关
+        加各引擎自己的 capability 实现。失败时保守返回 False（即按 Service Bot
+        原逻辑走 bot 级锁）。
         """
         if not bot_id or not owner_id or ctx.injector is None:
             return False
@@ -503,7 +502,8 @@ class CollaboratorPermissionInterceptor:
 
             bot_service = ctx.injector.get(BotServiceProtocol)
             bot = bot_service.get_bot(bot_id, owner_id)
-            return is_member_management_enabled_bot(bot)
+            capability_service = ctx.injector.get(MemberManagementCapabilityService)
+            return capability_service.uses_member_management_semantics(bot, bot_id)
         except Exception as e:
             logger.warning("[_is_coding_app] check failed: %s", e)
             return False

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/__init__.py
@@ -1,0 +1,1 @@
+"""AICoding helpers for bot collaborator services."""

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/member_management_capability.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/member_management_capability.py
@@ -1,0 +1,19 @@
+"""AICoding member-management capability implementation."""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+class AICodingMemberManagementCapability:
+    """AICoding-specific member-management rules."""
+
+    def is_member_management_enabled(
+        self,
+        bot: Mapping[str, Any],
+        template_ext: Optional[Mapping[str, Any]],
+    ) -> bool:
+        """Application Coding bots use member-management semantics."""
+        return (
+            bot.get("active_engine") == "claude_code"
+            and bot.get("template_type") == "applicationCoding"
+        )

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/member_management_capability.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/member_management_capability.py
@@ -1,19 +1,95 @@
 """AICoding member-management capability implementation."""
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
+
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+def has_member_management_enabled(template_ext: object) -> bool:
+    """Whether AICoding template ext explicitly enables member management.
+
+    Expected shape on the AICoding template record::
+
+        ac_templates.ext.bot_template_config.advanced_config.member_management == true
+
+    Only the boolean value ``True`` enables the capability; missing/malformed
+    ext or truthy strings such as ``"true"`` stay disabled to avoid
+    accidentally expanding collaborator management.
+    """
+    if not isinstance(template_ext, Mapping):
+        return False
+    bot_template_config = template_ext.get("bot_template_config")
+    if not isinstance(bot_template_config, Mapping):
+        return False
+    advanced_config = bot_template_config.get("advanced_config")
+    if not isinstance(advanced_config, Mapping):
+        return False
+    return advanced_config.get("member_management") is True
+
+
+def get_template_ext(template_service: Any, bot_id: str) -> Optional[Dict[str, Any]]:
+    """Read AICoding template ext through TemplateService.
+
+    This helper lives in the AICoding capability because the ext schema is an
+    AICoding-owned opt-in mechanism, not a generic collaborator concept.
+    Query failures conservatively return ``None`` so member management is not
+    accidentally expanded.
+    """
+    if template_service is None:
+        return None
+    try:
+        get_template_config = getattr(template_service, "get_template_config", None)
+        if callable(get_template_config):
+            config = get_template_config(bot_id)
+            return config if isinstance(config, dict) else None
+
+        get_template = getattr(template_service, "get_template", None)
+        if callable(get_template):
+            template = get_template(bot_id)
+            if isinstance(template, dict):
+                ext = template.get("ext")
+                return ext if isinstance(ext, dict) else None
+    except Exception as e:
+        logger.warning(
+            "[AICodingMemberManagementCapability] failed to get template for bot %s: %s",
+            bot_id,
+            e,
+        )
+    return None
 
 
 class AICodingMemberManagementCapability:
     """AICoding-specific member-management rules."""
 
+    def __init__(self, template_service: Any = None) -> None:
+        self._template_service = template_service
+
     def is_member_management_enabled(
         self,
         bot: Mapping[str, Any],
-        template_ext: Optional[Mapping[str, Any]],
+        bot_id: str | None = None,
     ) -> bool:
-        """Application Coding bots use member-management semantics."""
+        """AICoding app bots or opted-in AICoding templates use member management."""
+        if self._has_template_switch_enabled(bot, bot_id):
+            return True
         return (
             bot.get("active_engine") == "claude_code"
             and bot.get("template_type") == "applicationCoding"
         )
+
+    def _has_template_switch_enabled(
+        self,
+        bot: Mapping[str, Any],
+        bot_id: str | None,
+    ) -> bool:
+        template_config = bot.get("template_config")
+        if isinstance(template_config, Mapping):
+            return has_member_management_enabled(template_config)
+        if bot_id:
+            return has_member_management_enabled(
+                get_template_ext(self._template_service, bot_id)
+            )
+        return False

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for AICoding collaborator/member management."""

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
@@ -1,0 +1,77 @@
+"""AICoding member-management capability helpers."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+def is_coding_app_bot(bot: object) -> bool:
+    """Return whether the bot is an application coding bot."""
+    return isinstance(bot, dict) and (
+        bot.get("active_engine") == "claude_code"
+        and bot.get("template_type") == "applicationCoding"
+    )
+
+
+def has_member_management_enabled(template_ext: object) -> bool:
+    """Whether ``ac_templates.ext`` explicitly enables member management.
+
+    Expected shape on the template record::
+
+        ac_templates.ext.bot_template_config.advanced_config.member_management == true
+
+    Only the boolean value ``True`` enables the capability; missing/malformed
+    ext or truthy strings such as ``"true"`` stay disabled to avoid
+    accidentally expanding collaborator management.
+    """
+    if not isinstance(template_ext, dict):
+        return False
+    bot_template_config = template_ext.get("bot_template_config")
+    if not isinstance(bot_template_config, dict):
+        return False
+    advanced_config = bot_template_config.get("advanced_config")
+    if not isinstance(advanced_config, dict):
+        return False
+    return advanced_config.get("member_management") is True
+
+
+def get_template_ext(template_service: Any, bot_id: str) -> Optional[Dict[str, Any]]:
+    """Read ``ac_templates.ext`` through TemplateService.
+
+    Some call sites only have the ``ac_bots`` record and therefore do not carry
+    template ext. Query failures conservatively return ``None`` so member
+    management is not accidentally expanded.
+    """
+    if template_service is None:
+        return None
+    try:
+        get_template_config = getattr(template_service, "get_template_config", None)
+        if callable(get_template_config):
+            config = get_template_config(bot_id)
+            return config if isinstance(config, dict) else None
+
+        get_template = getattr(template_service, "get_template", None)
+        if callable(get_template):
+            template = get_template(bot_id)
+            if isinstance(template, dict):
+                ext = template.get("ext")
+                return ext if isinstance(ext, dict) else None
+    except Exception as e:
+        logger.warning("[get_template_ext] Failed to get template for bot %s: %s", bot_id, e)
+    return None
+
+
+def is_member_management_enabled_bot(bot: object) -> bool:
+    """Return true when a bot should use application/member management semantics.
+
+    The member-management switch lives in ``ac_templates.ext``. ``BotService.get_bot``
+    exposes that field as ``bot["template_config"]``.
+    """
+    if not isinstance(bot, dict):
+        return False
+    if is_coding_app_bot(bot):
+        return True
+    return has_member_management_enabled(bot.get("template_config"))

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
@@ -1,77 +1,30 @@
-"""AICoding member-management capability helpers."""
+"""Compatibility helpers for AICoding member-management capability tests/callers."""
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
-
-from agentclaw.community.log import get_logger
-
-logger = get_logger()
+from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
+    AICodingMemberManagementCapability,
+)
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
+    get_template_ext,
+    has_template_member_management_enabled,
+)
 
 
 def is_coding_app_bot(bot: object) -> bool:
-    """Return whether the bot is an application coding bot."""
-    return isinstance(bot, dict) and (
-        bot.get("active_engine") == "claude_code"
-        and bot.get("template_type") == "applicationCoding"
-    )
+    """Return whether the bot matches AICoding application-coding semantics."""
+    if not isinstance(bot, dict):
+        return False
+    return AICodingMemberManagementCapability().is_member_management_enabled(bot, None)
 
 
 def has_member_management_enabled(template_ext: object) -> bool:
-    """Whether ``ac_templates.ext`` explicitly enables member management.
-
-    Expected shape on the template record::
-
-        ac_templates.ext.bot_template_config.advanced_config.member_management == true
-
-    Only the boolean value ``True`` enables the capability; missing/malformed
-    ext or truthy strings such as ``"true"`` stay disabled to avoid
-    accidentally expanding collaborator management.
-    """
-    if not isinstance(template_ext, dict):
-        return False
-    bot_template_config = template_ext.get("bot_template_config")
-    if not isinstance(bot_template_config, dict):
-        return False
-    advanced_config = bot_template_config.get("advanced_config")
-    if not isinstance(advanced_config, dict):
-        return False
-    return advanced_config.get("member_management") is True
-
-
-def get_template_ext(template_service: Any, bot_id: str) -> Optional[Dict[str, Any]]:
-    """Read ``ac_templates.ext`` through TemplateService.
-
-    Some call sites only have the ``ac_bots`` record and therefore do not carry
-    template ext. Query failures conservatively return ``None`` so member
-    management is not accidentally expanded.
-    """
-    if template_service is None:
-        return None
-    try:
-        get_template_config = getattr(template_service, "get_template_config", None)
-        if callable(get_template_config):
-            config = get_template_config(bot_id)
-            return config if isinstance(config, dict) else None
-
-        get_template = getattr(template_service, "get_template", None)
-        if callable(get_template):
-            template = get_template(bot_id)
-            if isinstance(template, dict):
-                ext = template.get("ext")
-                return ext if isinstance(ext, dict) else None
-    except Exception as e:
-        logger.warning("[get_template_ext] Failed to get template for bot %s: %s", bot_id, e)
-    return None
+    """Backward-compatible alias for the generic template-ext switch."""
+    return has_template_member_management_enabled(template_ext)
 
 
 def is_member_management_enabled_bot(bot: object) -> bool:
-    """Return true when a bot should use application/member management semantics.
-
-    The member-management switch lives in ``ac_templates.ext``. ``BotService.get_bot``
-    exposes that field as ``bot["template_config"]``.
-    """
-    if not isinstance(bot, dict):
-        return False
-    if is_coding_app_bot(bot):
-        return True
-    return has_member_management_enabled(bot.get("template_config"))
+    """Backward-compatible helper backed by the generic capability coordinator."""
+    return MemberManagementCapabilityService(
+        engine_capabilities=(AICodingMemberManagementCapability(),),
+    ).uses_member_management_semantics(bot)

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/aicoding/utils/member_management.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
     AICodingMemberManagementCapability,
+    get_template_ext,
+    has_member_management_enabled,
 )
 from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
     MemberManagementCapabilityService,
-    get_template_ext,
-    has_template_member_management_enabled,
 )
 
 
@@ -15,12 +15,10 @@ def is_coding_app_bot(bot: object) -> bool:
     """Return whether the bot matches AICoding application-coding semantics."""
     if not isinstance(bot, dict):
         return False
-    return AICodingMemberManagementCapability().is_member_management_enabled(bot, None)
-
-
-def has_member_management_enabled(template_ext: object) -> bool:
-    """Backward-compatible alias for the generic template-ext switch."""
-    return has_template_member_management_enabled(template_ext)
+    return (
+        bot.get("active_engine") == "claude_code"
+        and bot.get("template_type") == "applicationCoding"
+    )
 
 
 def is_member_management_enabled_bot(bot: object) -> bool:

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
@@ -12,6 +12,11 @@ from agentclaw.community.core.bot_collaborator.models import (
     PermissionLevel,
 )
 from agentclaw.community.core.bot_collaborator.repository.protocol import CollaboratorRepositoryProtocol
+from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
+    get_template_ext,
+    has_member_management_enabled,
+    is_coding_app_bot,
+)
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
@@ -145,6 +150,7 @@ class CollaboratorService:
         passport_plugin: PassportPlugin,
         resolver_provider: "Callable[[], DeviceContextResolver]",
         device_fs_dispatcher_provider: "Callable[[], DeviceFilesystemDispatcher]",
+        template_service: Any = None,
     ) -> None:
         """初始化服务。
 
@@ -157,12 +163,14 @@ class CollaboratorService:
                 （device 图反向依赖 ``BotService``）。
             device_fs_dispatcher_provider: 惰性 thunk，返回 ``DeviceFilesystemDispatcher``
                 （按 ``DeviceContext`` 派发 per-bot 文件读写插件）。
+            template_service: 模板服务，用于读取 ``ac_templates.ext``。
         """
         self._collaborator_repo = collaborator_repo
         self._bot_repo = bot_repo
         self._passport_plugin = passport_plugin
         self._resolver_provider = resolver_provider
         self._device_fs_dispatcher_provider = device_fs_dispatcher_provider
+        self._template_service = template_service
 
     # ========================================================================
     # 权限检查
@@ -275,12 +283,19 @@ class CollaboratorService:
         #    - service：Service Bot 协作者，走原逻辑。
         #    - coding 应用（active_engine == "claude_code" 且 template_type ==
         #      "applicationCoding"）：作为"应用成员"复用同一套协作者流程，放行。
-        is_coding_app = (
-            bot.get("active_engine") == "claude_code"
-            and bot.get("template_type") == "applicationCoding"
-        )
-        if bot.get("bot_type") != "service" and not is_coding_app:
-            raise BotNotServiceTypeError(f"Bot 不是服务型且非 coding 应用: bot_id={bot_id}")
+        #    - 模板显式打开成员管理：
+        #      ac_templates.ext.bot_template_config.advanced_config.member_management
+        #      == true 时，不强绑定 bot_type / engine / template_type，也放行。
+        is_service_bot = bot.get("bot_type") == "service"
+        is_coding_app = is_coding_app_bot(bot)
+        has_member_management = False
+        if not is_service_bot and not is_coding_app:
+            template_ext = get_template_ext(self._template_service, bot_id)
+            has_member_management = has_member_management_enabled(template_ext)
+        if not is_service_bot and not is_coding_app and not has_member_management:
+            raise BotNotServiceTypeError(
+                f"Bot 不是服务型、非 coding 应用且未开启成员管理: bot_id={bot_id}"
+            )
 
         bot_pk = bot["id"]
         owner_id_from_bot = bot["owner_id"]

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
@@ -12,10 +12,8 @@ from agentclaw.community.core.bot_collaborator.models import (
     PermissionLevel,
 )
 from agentclaw.community.core.bot_collaborator.repository.protocol import CollaboratorRepositoryProtocol
-from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
-    get_template_ext,
-    has_member_management_enabled,
-    is_coding_app_bot,
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
 )
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
@@ -150,7 +148,7 @@ class CollaboratorService:
         passport_plugin: PassportPlugin,
         resolver_provider: "Callable[[], DeviceContextResolver]",
         device_fs_dispatcher_provider: "Callable[[], DeviceFilesystemDispatcher]",
-        template_service: Any = None,
+        member_management_capability_service: MemberManagementCapabilityService | None = None,
     ) -> None:
         """初始化服务。
 
@@ -163,14 +161,16 @@ class CollaboratorService:
                 （device 图反向依赖 ``BotService``）。
             device_fs_dispatcher_provider: 惰性 thunk，返回 ``DeviceFilesystemDispatcher``
                 （按 ``DeviceContext`` 派发 per-bot 文件读写插件）。
-            template_service: 模板服务，用于读取 ``ac_templates.ext``。
+            member_management_capability_service: 成员管理能力服务，用于协调通用能力与各引擎定制逻辑。
         """
         self._collaborator_repo = collaborator_repo
         self._bot_repo = bot_repo
         self._passport_plugin = passport_plugin
         self._resolver_provider = resolver_provider
         self._device_fs_dispatcher_provider = device_fs_dispatcher_provider
-        self._template_service = template_service
+        self._member_management_capability_service = (
+            member_management_capability_service or MemberManagementCapabilityService()
+        )
 
     # ========================================================================
     # 权限检查
@@ -279,22 +279,14 @@ class CollaboratorService:
         if not bot:
             raise BotNotFoundError(f"Bot 不存在: bot_id={bot_id}, owner_id={owner_id}")
 
-        # 2. 检查 Bot 类型
-        #    - service：Service Bot 协作者，走原逻辑。
-        #    - coding 应用（active_engine == "claude_code" 且 template_type ==
-        #      "applicationCoding"）：作为"应用成员"复用同一套协作者流程，放行。
-        #    - 模板显式打开成员管理：
-        #      ac_templates.ext.bot_template_config.advanced_config.member_management
-        #      == true 时，不强绑定 bot_type / engine / template_type，也放行。
-        is_service_bot = bot.get("bot_type") == "service"
-        is_coding_app = is_coding_app_bot(bot)
-        has_member_management = False
-        if not is_service_bot and not is_coding_app:
-            template_ext = get_template_ext(self._template_service, bot_id)
-            has_member_management = has_member_management_enabled(template_ext)
-        if not is_service_bot and not is_coding_app and not has_member_management:
+        # 2. 检查 Bot 类型 / 成员管理能力
+        #    CollaboratorService 是 engine-agnostic 服务：
+        #    - service：Service Bot 协作者，走原逻辑；
+        #    - 非 service：通过 MemberManagementCapabilityService 协调模板开关和
+        #      各引擎自己的能力实现，避免在这里直接依赖某个 engine 的定制逻辑。
+        if not self._member_management_capability_service.can_manage_collaborators(bot, bot_id):
             raise BotNotServiceTypeError(
-                f"Bot 不是服务型、非 coding 应用且未开启成员管理: bot_id={bot_id}"
+                f"Bot 不是服务型且未开启成员管理: bot_id={bot_id}"
             )
 
         bot_pk = bot["id"]

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/member_management_capability.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/member_management_capability.py
@@ -7,7 +7,7 @@ wired by DI/registry code, instead of being called directly from
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Optional, Protocol, Sequence
+from typing import Any, Mapping, Protocol, Sequence
 
 from agentclaw.community.log import get_logger
 
@@ -20,75 +20,32 @@ class EngineMemberManagementCapability(Protocol):
     def is_member_management_enabled(
         self,
         bot: Mapping[str, Any],
-        template_ext: Optional[Mapping[str, Any]],
+        bot_id: str | None = None,
     ) -> bool:
         """Return whether this engine enables member-management semantics."""
 
 
-def has_template_member_management_enabled(template_ext: object) -> bool:
-    """Whether ``ac_templates.ext`` explicitly enables member management.
-
-    Expected shape on the template record::
-
-        ac_templates.ext.bot_template_config.advanced_config.member_management == true
-
-    Only the boolean value ``True`` enables the capability; missing/malformed
-    ext or truthy strings such as ``"true"`` stay disabled to avoid
-    accidentally expanding collaborator management.
-    """
-    if not isinstance(template_ext, Mapping):
-        return False
-    bot_template_config = template_ext.get("bot_template_config")
-    if not isinstance(bot_template_config, Mapping):
-        return False
-    advanced_config = bot_template_config.get("advanced_config")
-    if not isinstance(advanced_config, Mapping):
-        return False
-    return advanced_config.get("member_management") is True
-
-
-def get_template_ext(template_service: Any, bot_id: str) -> Optional[Dict[str, Any]]:
-    """Read ``ac_templates.ext`` through TemplateService.
-
-    Some call sites only have the ``ac_bots`` record and therefore do not carry
-    template ext. Query failures conservatively return ``None`` so member
-    management is not accidentally expanded.
-    """
-    if template_service is None:
-        return None
-    try:
-        get_template_config = getattr(template_service, "get_template_config", None)
-        if callable(get_template_config):
-            config = get_template_config(bot_id)
-            return config if isinstance(config, dict) else None
-
-        get_template = getattr(template_service, "get_template", None)
-        if callable(get_template):
-            template = get_template(bot_id)
-            if isinstance(template, dict):
-                ext = template.get("ext")
-                return ext if isinstance(ext, dict) else None
-    except Exception as e:
-        logger.warning("[get_template_ext] Failed to get template for bot %s: %s", bot_id, e)
-    return None
-
-
 class MemberManagementCapabilityService:
-    """Engine-agnostic coordinator for collaborator/member-management support."""
+    """Engine-agnostic coordinator for collaborator/member-management support.
+
+    This coordinator deliberately does not interpret engine-owned bot fields or
+    template schemas. It only keeps the original service-bot behavior and
+    delegates non-service member-management decisions to registered engine
+    capabilities.
+    """
 
     def __init__(
         self,
-        template_service: Any = None,
         engine_capabilities: Sequence[EngineMemberManagementCapability] | None = None,
     ) -> None:
-        self._template_service = template_service
         self._engine_capabilities = tuple(engine_capabilities or ())
 
     def can_manage_collaborators(self, bot: object, bot_id: str) -> bool:
         """Return whether collaborator/member management is allowed for ``bot``.
 
         Service bots keep the original collaborator behavior. Non-service bots
-        can opt in through template ext or an engine-specific capability hook.
+        must be enabled by one of the registered engine-specific capability
+        hooks.
         """
         if not isinstance(bot, Mapping):
             return False
@@ -105,12 +62,9 @@ class MemberManagementCapabilityService:
         """
         if not isinstance(bot, Mapping):
             return False
-        template_ext = self._resolve_template_ext(bot, bot_id)
-        if has_template_member_management_enabled(template_ext):
-            return True
         for capability in self._engine_capabilities:
             try:
-                if capability.is_member_management_enabled(bot, template_ext):
+                if capability.is_member_management_enabled(bot, bot_id):
                     return True
             except Exception as e:  # noqa: BLE001 - fail closed per capability
                 logger.warning(
@@ -119,15 +73,3 @@ class MemberManagementCapabilityService:
                     e,
                 )
         return False
-
-    def _resolve_template_ext(
-        self,
-        bot: Mapping[str, Any],
-        bot_id: str | None,
-    ) -> Optional[Mapping[str, Any]]:
-        template_config = bot.get("template_config")
-        if isinstance(template_config, Mapping):
-            return template_config
-        if bot_id:
-            return get_template_ext(self._template_service, bot_id)
-        return None

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/member_management_capability.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/member_management_capability.py
@@ -1,0 +1,133 @@
+"""Member-management capability extension points for bot collaborators.
+
+This module is engine agnostic. Engine-specific rules should implement
+``EngineMemberManagementCapability`` in their own engine directories and be
+wired by DI/registry code, instead of being called directly from
+``CollaboratorService``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional, Protocol, Sequence
+
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+class EngineMemberManagementCapability(Protocol):
+    """Engine-specific member-management capability hook."""
+
+    def is_member_management_enabled(
+        self,
+        bot: Mapping[str, Any],
+        template_ext: Optional[Mapping[str, Any]],
+    ) -> bool:
+        """Return whether this engine enables member-management semantics."""
+
+
+def has_template_member_management_enabled(template_ext: object) -> bool:
+    """Whether ``ac_templates.ext`` explicitly enables member management.
+
+    Expected shape on the template record::
+
+        ac_templates.ext.bot_template_config.advanced_config.member_management == true
+
+    Only the boolean value ``True`` enables the capability; missing/malformed
+    ext or truthy strings such as ``"true"`` stay disabled to avoid
+    accidentally expanding collaborator management.
+    """
+    if not isinstance(template_ext, Mapping):
+        return False
+    bot_template_config = template_ext.get("bot_template_config")
+    if not isinstance(bot_template_config, Mapping):
+        return False
+    advanced_config = bot_template_config.get("advanced_config")
+    if not isinstance(advanced_config, Mapping):
+        return False
+    return advanced_config.get("member_management") is True
+
+
+def get_template_ext(template_service: Any, bot_id: str) -> Optional[Dict[str, Any]]:
+    """Read ``ac_templates.ext`` through TemplateService.
+
+    Some call sites only have the ``ac_bots`` record and therefore do not carry
+    template ext. Query failures conservatively return ``None`` so member
+    management is not accidentally expanded.
+    """
+    if template_service is None:
+        return None
+    try:
+        get_template_config = getattr(template_service, "get_template_config", None)
+        if callable(get_template_config):
+            config = get_template_config(bot_id)
+            return config if isinstance(config, dict) else None
+
+        get_template = getattr(template_service, "get_template", None)
+        if callable(get_template):
+            template = get_template(bot_id)
+            if isinstance(template, dict):
+                ext = template.get("ext")
+                return ext if isinstance(ext, dict) else None
+    except Exception as e:
+        logger.warning("[get_template_ext] Failed to get template for bot %s: %s", bot_id, e)
+    return None
+
+
+class MemberManagementCapabilityService:
+    """Engine-agnostic coordinator for collaborator/member-management support."""
+
+    def __init__(
+        self,
+        template_service: Any = None,
+        engine_capabilities: Sequence[EngineMemberManagementCapability] | None = None,
+    ) -> None:
+        self._template_service = template_service
+        self._engine_capabilities = tuple(engine_capabilities or ())
+
+    def can_manage_collaborators(self, bot: object, bot_id: str) -> bool:
+        """Return whether collaborator/member management is allowed for ``bot``.
+
+        Service bots keep the original collaborator behavior. Non-service bots
+        can opt in through template ext or an engine-specific capability hook.
+        """
+        if not isinstance(bot, Mapping):
+            return False
+        if bot.get("bot_type") == "service":
+            return True
+        return self.uses_member_management_semantics(bot, bot_id)
+
+    def uses_member_management_semantics(self, bot: object, bot_id: str | None = None) -> bool:
+        """Return whether ``bot`` should use member-management semantics.
+
+        This excludes the original service-bot collaborator behavior and is used
+        by lock/interceptor paths that need to distinguish application/member
+        management from bot-level service collaboration.
+        """
+        if not isinstance(bot, Mapping):
+            return False
+        template_ext = self._resolve_template_ext(bot, bot_id)
+        if has_template_member_management_enabled(template_ext):
+            return True
+        for capability in self._engine_capabilities:
+            try:
+                if capability.is_member_management_enabled(bot, template_ext):
+                    return True
+            except Exception as e:  # noqa: BLE001 - fail closed per capability
+                logger.warning(
+                    "[MemberManagementCapabilityService] capability %s failed: %s",
+                    capability.__class__.__name__,
+                    e,
+                )
+        return False
+
+    def _resolve_template_ext(
+        self,
+        bot: Mapping[str, Any],
+        bot_id: str | None,
+    ) -> Optional[Mapping[str, Any]]:
+        template_config = bot.get("template_config")
+        if isinstance(template_config, Mapping):
+            return template_config
+        if bot_id:
+            return get_template_ext(self._template_service, bot_id)
+        return None

--- a/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
@@ -30,6 +30,7 @@ from agentclaw.community.core.bot_collaborator.repository.protocol import (
 from agentclaw.community.core.bot_collaborator.services.collaborator_service import CollaboratorService
 from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import CollaboratorLockService
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.devices.services.device_context_resolver import DeviceContextResolver
 from agentclaw.community.di.modules.skill_center_module import DeviceFilesystemDispatcher
 from agentclaw.community.plugin_api.passport import PassportPlugin
@@ -83,6 +84,7 @@ class BotCollaboratorModule(Module):
         collaborator_repo: CollaboratorRepositoryProtocol,
         bot_repo: BotRepository,
         passport_plugin: PassportPlugin,
+        template_service: TemplateService,
         injector: Injector,
     ) -> CollaboratorService:
         """Construct ``CollaboratorService``.
@@ -97,6 +99,7 @@ class BotCollaboratorModule(Module):
             passport_plugin=passport_plugin,
             resolver_provider=lambda: injector.get(DeviceContextResolver),
             device_fs_dispatcher_provider=lambda: injector.get(DeviceFilesystemDispatcher),
+            template_service=template_service,
         )
 
     # ── Core Protocol aliases (for core layer internal use) ───────────────

--- a/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
@@ -28,6 +28,12 @@ from agentclaw.community.core.bot_collaborator.repository.protocol import (
     BotCollabLockRepositoryProtocol,
 )
 from agentclaw.community.core.bot_collaborator.services.collaborator_service import CollaboratorService
+from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
+    AICodingMemberManagementCapability,
+)
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
+)
 from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import CollaboratorLockService
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
@@ -79,12 +85,25 @@ class BotCollaboratorModule(Module):
     @singleton
     @provider
     @inject
+    def member_management_capability_service(
+        self,
+        template_service: TemplateService,
+    ) -> MemberManagementCapabilityService:
+        """Construct engine-agnostic member-management capability coordinator."""
+        return MemberManagementCapabilityService(
+            template_service=template_service,
+            engine_capabilities=(AICodingMemberManagementCapability(),),
+        )
+
+    @singleton
+    @provider
+    @inject
     def collaborator_service(
         self,
         collaborator_repo: CollaboratorRepositoryProtocol,
         bot_repo: BotRepository,
         passport_plugin: PassportPlugin,
-        template_service: TemplateService,
+        member_management_capability_service: MemberManagementCapabilityService,
         injector: Injector,
     ) -> CollaboratorService:
         """Construct ``CollaboratorService``.
@@ -99,7 +118,7 @@ class BotCollaboratorModule(Module):
             passport_plugin=passport_plugin,
             resolver_provider=lambda: injector.get(DeviceContextResolver),
             device_fs_dispatcher_provider=lambda: injector.get(DeviceFilesystemDispatcher),
-            template_service=template_service,
+            member_management_capability_service=member_management_capability_service,
         )
 
     # ── Core Protocol aliases (for core layer internal use) ───────────────

--- a/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
@@ -91,8 +91,7 @@ class BotCollaboratorModule(Module):
     ) -> MemberManagementCapabilityService:
         """Construct engine-agnostic member-management capability coordinator."""
         return MemberManagementCapabilityService(
-            template_service=template_service,
-            engine_capabilities=(AICodingMemberManagementCapability(),),
+            engine_capabilities=(AICodingMemberManagementCapability(template_service),),
         )
 
     @singleton

--- a/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_live.py
+++ b/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_live.py
@@ -1,0 +1,128 @@
+"""Live singlebox coverage for template-ext member management."""
+from __future__ import annotations
+
+import json
+import time
+from uuid import uuid4
+
+import httpx
+import pytest
+
+
+def _fresh_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:12]}"
+
+
+def _execute_local_sql(client: httpx.Client, statements: list[dict]) -> dict:
+    last_response: httpx.Response | None = None
+    for attempt in range(5):
+        response = client.post("/local/sql/execute", json={"statements": statements})
+        if response.status_code == 200:
+            return response.json()
+        last_response = response
+        if "SQL statements in progress" not in response.text:
+            break
+        time.sleep(0.2 * (attempt + 1))
+    assert last_response is not None
+    assert last_response.status_code == 200, last_response.text
+    return last_response.json()
+
+
+def _seed_member_managed_bot(
+    client: httpx.Client,
+    *,
+    owner_id: str,
+    bot_id: str,
+) -> None:
+    """Seed a non-service, non-applicationCoding bot with ac_templates.ext enabled."""
+    _execute_local_sql(
+        client,
+        [
+            {
+                "sql": (
+                    "INSERT INTO ac_bots ("
+                    "bot_id, bot_name, bot_desc, entity_id, entity_type, creator_id, owner_id, "
+                    "owner_name, engine_types, active_engine, status, binding_id, device_id, "
+                    "gmt_create, gmt_modified, is_delete, public, ext, env, bot_type, template_type, "
+                    "call_type, caller_config_revision"
+                    ") VALUES ("
+                    ":bot_id, :bot_name, :bot_desc, :owner_id, 'staff', :owner_id, :owner_id, "
+                    ":owner_id, :engine_types, 'openclaw', 'ACTIVE', NULL, NULL, "
+                    "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0, '0', :bot_ext, 'dev', 'personal', 'chat', "
+                    "'owner', 0"
+                    ")"
+                ),
+                "params": {
+                    "bot_id": bot_id,
+                    "bot_name": f"Member managed {bot_id}",
+                    "bot_desc": "singlebox member-management template-ext seed",
+                    "owner_id": owner_id,
+                    "engine_types": json.dumps(["openclaw"]),
+                    "bot_ext": json.dumps({"member_management": False}),
+                },
+            },
+            {
+                "sql": (
+                    "INSERT INTO ac_templates (bot_id, ext, gmt_create, gmt_modified) "
+                    "VALUES (:bot_id, :template_ext, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                ),
+                "params": {
+                    "bot_id": bot_id,
+                    "template_ext": json.dumps(
+                        {
+                            "bot_template_config": {
+                                "advanced_config": {"member_management": True}
+                            }
+                        }
+                    ),
+                },
+            },
+        ],
+    )
+
+
+@pytest.mark.acceptance
+def test_template_ext_member_management_allows_live_collaborator_add(live_backend):
+    """A live API add uses ac_templates.ext to allow Bot member management."""
+    owner_id = _fresh_id("collab_owner")
+    bot_id = _fresh_id("collab_member_mgmt")
+    member_id = _fresh_id("collab_member")
+
+    with httpx.Client(
+        base_url=live_backend,
+        headers={"x-user-id": owner_id},
+        timeout=60.0,
+    ) as client:
+        _seed_member_managed_bot(client, owner_id=owner_id, bot_id=bot_id)
+
+        add_response = client.post(
+            "/api/bot/collaborator/add",
+            json={
+                "bot_id": bot_id,
+                "owner_id": owner_id,
+                "user_id": member_id,
+                "user_name": "Singlebox Member",
+                "role": "member",
+            },
+        )
+        assert add_response.status_code == 200, add_response.text
+        add_body = add_response.json()
+        assert add_body["success"] is True, add_body
+        assert add_body["data"]["bot_id"] == bot_id
+        assert add_body["data"]["user_id"] == member_id
+        assert add_body["data"]["role"] == "member"
+
+        permission = client.post(
+            "/api/bot/collaborator/check_permission",
+            json={
+                "bot_id": bot_id,
+                "owner_id": owner_id,
+                "user_id": member_id,
+                "required_level": "MEMBER",
+            },
+        )
+        assert permission.status_code == 200, permission.text
+        permission_body = permission.json()
+        assert permission_body["success"] is True, permission_body
+        assert permission_body["data"]["has_permission"] is True
+        assert permission_body["data"]["level"] == "MEMBER"

--- a/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_utils_acceptance.py
+++ b/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_utils_acceptance.py
@@ -5,11 +5,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
+from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
+    AICodingMemberManagementCapability,
+)
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
     get_template_ext,
-    has_member_management_enabled,
-    is_coding_app_bot,
-    is_member_management_enabled_bot,
+    has_template_member_management_enabled,
 )
 
 
@@ -17,16 +19,20 @@ def _enabled_template_ext() -> dict:
     return {"bot_template_config": {"advanced_config": {"member_management": True}}}
 
 
+def _capability_service() -> MemberManagementCapabilityService:
+    return MemberManagementCapabilityService(
+        engine_capabilities=(AICodingMemberManagementCapability(),),
+    )
+
+
 @pytest.mark.acceptance
 def test_member_management_acceptance_allows_coding_app_bot_or_template_switch():
     """Member-management semantics allow coding-app bots and template-ext switch bots."""
-    assert is_coding_app_bot(
+    service = _capability_service()
+    assert service.uses_member_management_semantics(
         {"active_engine": "claude_code", "template_type": "applicationCoding"}
     ) is True
-    assert is_member_management_enabled_bot(
-        {"active_engine": "claude_code", "template_type": "applicationCoding"}
-    ) is True
-    assert is_member_management_enabled_bot(
+    assert service.uses_member_management_semantics(
         {
             "active_engine": "openclaw",
             "template_type": "chat",
@@ -38,20 +44,20 @@ def test_member_management_acceptance_allows_coding_app_bot_or_template_switch()
 @pytest.mark.acceptance
 def test_member_management_acceptance_rejects_malformed_or_truthy_values():
     """Only ac_templates.ext boolean True enables collaborator member management."""
-    assert is_coding_app_bot(None) is False
-    assert is_member_management_enabled_bot(None) is False
-    assert is_coding_app_bot(
+    service = _capability_service()
+    assert service.uses_member_management_semantics(None) is False
+    assert service.uses_member_management_semantics(
         {"active_engine": "claude_code", "template_type": "chat"}
     ) is False
-    assert has_member_management_enabled(None) is False
-    assert has_member_management_enabled({"bot_template_config": None}) is False
-    assert has_member_management_enabled(
+    assert has_template_member_management_enabled(None) is False
+    assert has_template_member_management_enabled({"bot_template_config": None}) is False
+    assert has_template_member_management_enabled(
         {"bot_template_config": {"advanced_config": None}}
     ) is False
-    assert has_member_management_enabled(
+    assert has_template_member_management_enabled(
         {"bot_template_config": {"advanced_config": {"member_management": "true"}}}
     ) is False
-    assert is_member_management_enabled_bot(
+    assert service.uses_member_management_semantics(
         {
             "active_engine": "openclaw",
             "template_type": "chat",

--- a/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_utils_acceptance.py
+++ b/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_utils_acceptance.py
@@ -7,11 +7,11 @@ import pytest
 
 from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
     AICodingMemberManagementCapability,
+    get_template_ext,
+    has_member_management_enabled,
 )
 from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
     MemberManagementCapabilityService,
-    get_template_ext,
-    has_template_member_management_enabled,
 )
 
 
@@ -49,12 +49,12 @@ def test_member_management_acceptance_rejects_malformed_or_truthy_values():
     assert service.uses_member_management_semantics(
         {"active_engine": "claude_code", "template_type": "chat"}
     ) is False
-    assert has_template_member_management_enabled(None) is False
-    assert has_template_member_management_enabled({"bot_template_config": None}) is False
-    assert has_template_member_management_enabled(
+    assert has_member_management_enabled(None) is False
+    assert has_member_management_enabled({"bot_template_config": None}) is False
+    assert has_member_management_enabled(
         {"bot_template_config": {"advanced_config": None}}
     ) is False
-    assert has_template_member_management_enabled(
+    assert has_member_management_enabled(
         {"bot_template_config": {"advanced_config": {"member_management": "true"}}}
     ) is False
     assert service.uses_member_management_semantics(

--- a/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_utils_acceptance.py
+++ b/src/backend/tests/community/acceptance/bot_collaborator/test_member_management_utils_acceptance.py
@@ -1,0 +1,98 @@
+"""Acceptance coverage for bot collaborator member-management helpers."""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
+    get_template_ext,
+    has_member_management_enabled,
+    is_coding_app_bot,
+    is_member_management_enabled_bot,
+)
+
+
+def _enabled_template_ext() -> dict:
+    return {"bot_template_config": {"advanced_config": {"member_management": True}}}
+
+
+@pytest.mark.acceptance
+def test_member_management_acceptance_allows_coding_app_bot_or_template_switch():
+    """Member-management semantics allow coding-app bots and template-ext switch bots."""
+    assert is_coding_app_bot(
+        {"active_engine": "claude_code", "template_type": "applicationCoding"}
+    ) is True
+    assert is_member_management_enabled_bot(
+        {"active_engine": "claude_code", "template_type": "applicationCoding"}
+    ) is True
+    assert is_member_management_enabled_bot(
+        {
+            "active_engine": "openclaw",
+            "template_type": "chat",
+            "template_config": _enabled_template_ext(),
+        }
+    ) is True
+
+
+@pytest.mark.acceptance
+def test_member_management_acceptance_rejects_malformed_or_truthy_values():
+    """Only ac_templates.ext boolean True enables collaborator member management."""
+    assert is_coding_app_bot(None) is False
+    assert is_member_management_enabled_bot(None) is False
+    assert is_coding_app_bot(
+        {"active_engine": "claude_code", "template_type": "chat"}
+    ) is False
+    assert has_member_management_enabled(None) is False
+    assert has_member_management_enabled({"bot_template_config": None}) is False
+    assert has_member_management_enabled(
+        {"bot_template_config": {"advanced_config": None}}
+    ) is False
+    assert has_member_management_enabled(
+        {"bot_template_config": {"advanced_config": {"member_management": "true"}}}
+    ) is False
+    assert is_member_management_enabled_bot(
+        {
+            "active_engine": "openclaw",
+            "template_type": "chat",
+            "template_config": {
+                "bot_template_config": {
+                    "advanced_config": {"member_management": "true"}
+                }
+            },
+        }
+    ) is False
+
+
+@pytest.mark.acceptance
+def test_template_ext_acceptance_reads_ac_templates_ext_from_template_service():
+    """Service path reads template ext/config instead of relying on ac_bots.ext."""
+    template_service = Mock()
+    template_service.get_template_config.return_value = _enabled_template_ext()
+
+    assert get_template_ext(template_service, "bot-123") == _enabled_template_ext()
+    template_service.get_template_config.assert_called_once_with("bot-123")
+
+
+@pytest.mark.acceptance
+def test_template_ext_acceptance_fallback_and_safe_failures():
+    """Template ext lookup safely falls back and fails closed."""
+
+    class TemplateServiceWithoutConfig:
+        def get_template(self, bot_id: str) -> dict:
+            assert bot_id == "bot-123"
+            return {"ext": _enabled_template_ext()}
+
+    assert (
+        get_template_ext(TemplateServiceWithoutConfig(), "bot-123")
+        == _enabled_template_ext()
+    )
+    assert get_template_ext(None, "bot-123") is None
+
+    non_dict_config_service = Mock()
+    non_dict_config_service.get_template_config.return_value = "not-a-dict"
+    assert get_template_ext(non_dict_config_service, "bot-123") is None
+
+    failing_service = Mock()
+    failing_service.get_template_config.side_effect = RuntimeError("db down")
+    assert get_template_ext(failing_service, "bot-123") is None

--- a/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
@@ -17,6 +17,12 @@ from agentclaw.community.core.bot_collaborator.models import (
     CollaboratorRecord,
     CollaboratorRole,
 )
+from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
+    AICodingMemberManagementCapability,
+)
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
+)
 
 
 OWNER = "owner-001"
@@ -51,7 +57,10 @@ def service(collaborator_repo, bot_repo, template_service):
         passport_plugin=Mock(),
         resolver_provider=lambda: Mock(),
         device_fs_dispatcher_provider=lambda: Mock(),
-        template_service=template_service,
+        member_management_capability_service=MemberManagementCapabilityService(
+            template_service=template_service,
+            engine_capabilities=(AICodingMemberManagementCapability(),),
+        ),
     )
     # 隔离协作变更回调副作用（会反查协作者列表 / AgentPass），聚焦类型判断分支
     svc.on_collaboration_changed = Mock()

--- a/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
@@ -37,13 +37,21 @@ def bot_repo():
 
 
 @pytest.fixture
-def service(collaborator_repo, bot_repo):
+def template_service():
+    svc = Mock()
+    svc.get_template_config.return_value = None
+    return svc
+
+
+@pytest.fixture
+def service(collaborator_repo, bot_repo, template_service):
     svc = CollaboratorService(
         collaborator_repo=collaborator_repo,
         bot_repo=bot_repo,
         passport_plugin=Mock(),
         resolver_provider=lambda: Mock(),
         device_fs_dispatcher_provider=lambda: Mock(),
+        template_service=template_service,
     )
     # 隔离协作变更回调副作用（会反查协作者列表 / AgentPass），聚焦类型判断分支
     svc.on_collaboration_changed = Mock()
@@ -85,6 +93,40 @@ def test_add_collaborator_coding_app_allowed(service, bot_repo, collaborator_rep
 
     assert record is collaborator_repo.insert.return_value
     collaborator_repo.insert.assert_called_once()
+
+
+def test_add_collaborator_member_management_flag_allowed(
+    service, bot_repo, collaborator_repo, template_service
+):
+    """模板 advanced_config.member_management=true -> 非 service / 非 coding 也放行。"""
+    bot_repo.get_by_id_and_owner.return_value = _bot(
+        bot_type="personal",
+        active_engine="openclaw",
+        template_type="chat",
+    )
+    template_service.get_template_config.return_value = {
+        "bot_template_config": {"advanced_config": {"member_management": True}}
+    }
+
+    record = _add(service)
+
+    assert record is collaborator_repo.insert.return_value
+    collaborator_repo.insert.assert_called_once()
+
+
+def test_add_collaborator_member_management_requires_boolean_true(service, bot_repo, template_service):
+    """member_management 只有布尔 True 放行，字符串等 truthy 值不扩权。"""
+    bot_repo.get_by_id_and_owner.return_value = _bot(
+        bot_type="personal",
+        active_engine="openclaw",
+        template_type="chat",
+    )
+    template_service.get_template_config.return_value = {
+        "bot_template_config": {"advanced_config": {"member_management": "true"}}
+    }
+
+    with pytest.raises(BotNotServiceTypeError):
+        _add(service)
 
 
 def test_add_collaborator_service_type_still_allowed(service, bot_repo, collaborator_repo):

--- a/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
@@ -58,8 +58,7 @@ def service(collaborator_repo, bot_repo, template_service):
         resolver_provider=lambda: Mock(),
         device_fs_dispatcher_provider=lambda: Mock(),
         member_management_capability_service=MemberManagementCapabilityService(
-            template_service=template_service,
-            engine_capabilities=(AICodingMemberManagementCapability(),),
+            engine_capabilities=(AICodingMemberManagementCapability(template_service),),
         ),
     )
     # 隔离协作变更回调副作用（会反查协作者列表 / AgentPass），聚焦类型判断分支

--- a/src/backend/tests/community/core/bot_collaborator/test_interceptor_coding_app.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_interceptor_coding_app.py
@@ -1,7 +1,7 @@
 """Tests for CollaboratorPermissionInterceptor coding-app logic.
 
 Covers two changes from the session-lock feature branch:
-1. ``_is_coding_app()`` — detects coding applications by active_engine + template_type.
+1. ``_is_coding_app()`` — legacy helper name; delegates to engine-specific member-management capability.
 2. The ``skip_lock`` branch in ``before()`` — coding apps with collaborators skip
    bot-level lock enforcement (session-level locks are used instead), but
    collaborator permission is still checked.

--- a/src/backend/tests/community/core/bot_collaborator/test_interceptor_coding_app.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_interceptor_coding_app.py
@@ -15,7 +15,31 @@ from agentclaw.community.core.bot_collaborator.interceptor import (
     InterceptorContext,
 )
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.bot_collaborator.protocols import BotServiceProtocol
+from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
+    AICodingMemberManagementCapability,
+)
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
+)
 
+
+
+
+def _wire_member_management_injector(mock_injector, mock_bot_service):
+    capability_service = MemberManagementCapabilityService(
+        engine_capabilities=(AICodingMemberManagementCapability(),),
+    )
+
+    def _get(dep):
+        if dep is BotServiceProtocol:
+            return mock_bot_service
+        if dep is MemberManagementCapabilityService:
+            return capability_service
+        return mock_bot_service
+
+    mock_injector.get.side_effect = _get
+    return capability_service
 
 # ============================================================================
 # _is_coding_app unit tests
@@ -37,7 +61,7 @@ class TestIsCodingApp:
             "active_engine": "claude_code",
             "template_type": "applicationCoding",
         }
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -56,7 +80,7 @@ class TestIsCodingApp:
                 "bot_template_config": {"advanced_config": {"member_management": True}}
             },
         }
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -74,7 +98,7 @@ class TestIsCodingApp:
                 "bot_template_config": {"advanced_config": {"member_management": "true"}}
             },
         }
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -89,7 +113,7 @@ class TestIsCodingApp:
             "active_engine": "openai",
             "template_type": "service",
         }
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -104,7 +128,7 @@ class TestIsCodingApp:
             "active_engine": "claude_code",
             "template_type": "chat",  # not applicationCoding
         }
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -119,7 +143,7 @@ class TestIsCodingApp:
             "active_engine": "openai",
             "template_type": "applicationCoding",
         }
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -131,7 +155,7 @@ class TestIsCodingApp:
         mock_injector = MagicMock()
         mock_bot_service = MagicMock()
         mock_bot_service.get_bot.return_value = None
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -171,7 +195,7 @@ class TestIsCodingApp:
         mock_injector = MagicMock()
         mock_bot_service = MagicMock()
         mock_bot_service.get_bot.side_effect = RuntimeError("db error")
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
@@ -457,7 +481,7 @@ class TestCodingAppSkipLock:
         mock_injector = MagicMock()
         mock_bot_service = MagicMock()
         mock_bot_service.get_bot.side_effect = RuntimeError("db error")
-        mock_injector.get.return_value = mock_bot_service
+        _wire_member_management_injector(mock_injector, mock_bot_service)
         ctx.injector = mock_injector
 
         mock_lock_info = MagicMock()

--- a/src/backend/tests/community/core/bot_collaborator/test_interceptor_coding_app.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_interceptor_coding_app.py
@@ -44,6 +44,42 @@ class TestIsCodingApp:
         assert result is True
         mock_bot_service.get_bot.assert_called_once_with("bot_123", "owner_001")
 
+    def test_member_management_flag_return_true(self):
+        """advanced_config.member_management=true -> True even when not coding app."""
+        ctx = InterceptorContext(user=None, route_kwargs={})
+        mock_injector = MagicMock()
+        mock_bot_service = MagicMock()
+        mock_bot_service.get_bot.return_value = {
+            "active_engine": "openclaw",
+            "template_type": "chat",
+            "template_config": {
+                "bot_template_config": {"advanced_config": {"member_management": True}}
+            },
+        }
+        mock_injector.get.return_value = mock_bot_service
+        ctx.injector = mock_injector
+
+        result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
+        assert result is True
+
+    def test_member_management_flag_requires_boolean_true(self):
+        """member_management 字符串 true 不放行。"""
+        ctx = InterceptorContext(user=None, route_kwargs={})
+        mock_injector = MagicMock()
+        mock_bot_service = MagicMock()
+        mock_bot_service.get_bot.return_value = {
+            "active_engine": "openclaw",
+            "template_type": "chat",
+            "template_config": {
+                "bot_template_config": {"advanced_config": {"member_management": "true"}}
+            },
+        }
+        mock_injector.get.return_value = mock_bot_service
+        ctx.injector = mock_injector
+
+        result = self.interceptor._is_coding_app(ctx, "bot_123", "owner_001")
+        assert result is False
+
     def test_service_bot_return_false(self):
         """Service Bot (not claude_code) -> False."""
         ctx = InterceptorContext(user=None, route_kwargs={})

--- a/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
@@ -1,37 +1,49 @@
-"""Tests for AICoding collaborator/member-management utility helpers."""
+"""Tests for member-management capability extension points."""
 from unittest.mock import Mock
 
-from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
+from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
+    AICodingMemberManagementCapability,
+)
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
     get_template_ext,
-    has_member_management_enabled,
-    is_coding_app_bot,
-    is_member_management_enabled_bot,
+    has_template_member_management_enabled,
 )
 
 
-def test_is_coding_app_bot_matches_only_application_coding():
-    assert is_coding_app_bot(
-        {"active_engine": "claude_code", "template_type": "applicationCoding"}
+def _capability_service(template_service=None):
+    return MemberManagementCapabilityService(
+        template_service=template_service,
+        engine_capabilities=(AICodingMemberManagementCapability(),),
+    )
+
+
+def test_aicoding_capability_matches_only_application_coding():
+    capability = AICodingMemberManagementCapability()
+
+    assert capability.is_member_management_enabled(
+        {"active_engine": "claude_code", "template_type": "applicationCoding"}, None
     ) is True
-    assert is_coding_app_bot(
-        {"active_engine": "claude_code", "template_type": "chat"}
+    assert capability.is_member_management_enabled(
+        {"active_engine": "claude_code", "template_type": "chat"}, None
     ) is False
-    assert is_coding_app_bot(None) is False
 
 
-def test_has_member_management_enabled_requires_boolean_true():
-    assert has_member_management_enabled(
+def test_has_template_member_management_enabled_requires_boolean_true():
+    assert has_template_member_management_enabled(
         {"bot_template_config": {"advanced_config": {"member_management": True}}}
     ) is True
-    assert has_member_management_enabled(
+    assert has_template_member_management_enabled(
         {"bot_template_config": {"advanced_config": {"member_management": "true"}}}
     ) is False
 
 
-def test_has_member_management_enabled_handles_malformed_template_ext():
-    assert has_member_management_enabled(None) is False
-    assert has_member_management_enabled({"bot_template_config": None}) is False
-    assert has_member_management_enabled({"bot_template_config": {"advanced_config": None}}) is False
+def test_has_template_member_management_enabled_handles_malformed_template_ext():
+    assert has_template_member_management_enabled(None) is False
+    assert has_template_member_management_enabled({"bot_template_config": None}) is False
+    assert has_template_member_management_enabled(
+        {"bot_template_config": {"advanced_config": None}}
+    ) is False
 
 
 def test_get_template_ext_returns_config_from_get_template_config():
@@ -67,12 +79,14 @@ def test_get_template_ext_handles_missing_service_and_query_failure():
     assert get_template_ext(template_service, "bot-123") is None
 
 
-def test_is_member_management_enabled_bot_uses_coding_or_template_config():
-    assert is_member_management_enabled_bot(None) is False
-    assert is_member_management_enabled_bot(
+def test_capability_service_uses_engine_or_template_config():
+    service = _capability_service()
+
+    assert service.uses_member_management_semantics(None) is False
+    assert service.uses_member_management_semantics(
         {"active_engine": "claude_code", "template_type": "applicationCoding"}
     ) is True
-    assert is_member_management_enabled_bot(
+    assert service.uses_member_management_semantics(
         {
             "active_engine": "openclaw",
             "template_type": "chat",
@@ -81,7 +95,7 @@ def test_is_member_management_enabled_bot_uses_coding_or_template_config():
             },
         }
     ) is True
-    assert is_member_management_enabled_bot(
+    assert service.uses_member_management_semantics(
         {
             "active_engine": "openclaw",
             "template_type": "chat",
@@ -90,3 +104,18 @@ def test_is_member_management_enabled_bot_uses_coding_or_template_config():
             },
         }
     ) is False
+
+
+def test_capability_service_can_manage_collaborators_keeps_service_bot_behavior():
+    service = _capability_service()
+
+    assert service.can_manage_collaborators({"bot_type": "service"}, "bot-123") is True
+    assert service.can_manage_collaborators(
+        {
+            "bot_type": "personal",
+            "active_engine": "claude_code",
+            "template_type": "applicationCoding",
+        },
+        "bot-123",
+    ) is True
+    assert service.can_manage_collaborators({"bot_type": "personal"}, "bot-123") is False

--- a/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
@@ -3,18 +3,17 @@ from unittest.mock import Mock
 
 from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
     AICodingMemberManagementCapability,
+    get_template_ext,
+    has_member_management_enabled,
 )
 from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
     MemberManagementCapabilityService,
-    get_template_ext,
-    has_template_member_management_enabled,
 )
 
 
 def _capability_service(template_service=None):
     return MemberManagementCapabilityService(
-        template_service=template_service,
-        engine_capabilities=(AICodingMemberManagementCapability(),),
+        engine_capabilities=(AICodingMemberManagementCapability(template_service),),
     )
 
 
@@ -29,19 +28,19 @@ def test_aicoding_capability_matches_only_application_coding():
     ) is False
 
 
-def test_has_template_member_management_enabled_requires_boolean_true():
-    assert has_template_member_management_enabled(
+def test_has_member_management_enabled_requires_boolean_true():
+    assert has_member_management_enabled(
         {"bot_template_config": {"advanced_config": {"member_management": True}}}
     ) is True
-    assert has_template_member_management_enabled(
+    assert has_member_management_enabled(
         {"bot_template_config": {"advanced_config": {"member_management": "true"}}}
     ) is False
 
 
-def test_has_template_member_management_enabled_handles_malformed_template_ext():
-    assert has_template_member_management_enabled(None) is False
-    assert has_template_member_management_enabled({"bot_template_config": None}) is False
-    assert has_template_member_management_enabled(
+def test_has_member_management_enabled_handles_malformed_template_ext():
+    assert has_member_management_enabled(None) is False
+    assert has_member_management_enabled({"bot_template_config": None}) is False
+    assert has_member_management_enabled(
         {"bot_template_config": {"advanced_config": None}}
     ) is False
 

--- a/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_member_management_utils.py
@@ -1,0 +1,92 @@
+"""Tests for AICoding collaborator/member-management utility helpers."""
+from unittest.mock import Mock
+
+from agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management import (
+    get_template_ext,
+    has_member_management_enabled,
+    is_coding_app_bot,
+    is_member_management_enabled_bot,
+)
+
+
+def test_is_coding_app_bot_matches_only_application_coding():
+    assert is_coding_app_bot(
+        {"active_engine": "claude_code", "template_type": "applicationCoding"}
+    ) is True
+    assert is_coding_app_bot(
+        {"active_engine": "claude_code", "template_type": "chat"}
+    ) is False
+    assert is_coding_app_bot(None) is False
+
+
+def test_has_member_management_enabled_requires_boolean_true():
+    assert has_member_management_enabled(
+        {"bot_template_config": {"advanced_config": {"member_management": True}}}
+    ) is True
+    assert has_member_management_enabled(
+        {"bot_template_config": {"advanced_config": {"member_management": "true"}}}
+    ) is False
+
+
+def test_has_member_management_enabled_handles_malformed_template_ext():
+    assert has_member_management_enabled(None) is False
+    assert has_member_management_enabled({"bot_template_config": None}) is False
+    assert has_member_management_enabled({"bot_template_config": {"advanced_config": None}}) is False
+
+
+def test_get_template_ext_returns_config_from_get_template_config():
+    template_service = Mock()
+    template_service.get_template_config.return_value = {"foo": "bar"}
+
+    assert get_template_ext(template_service, "bot-123") == {"foo": "bar"}
+    template_service.get_template_config.assert_called_once_with("bot-123")
+
+
+def test_get_template_ext_ignores_non_dict_config():
+    template_service = Mock()
+    template_service.get_template_config.return_value = "not-a-dict"
+
+    assert get_template_ext(template_service, "bot-123") is None
+
+
+def test_get_template_ext_falls_back_to_get_template_ext_field():
+    class TemplateServiceWithoutConfig:
+        def get_template(self, bot_id):
+            assert bot_id == "bot-123"
+            return {"ext": {"foo": "bar"}}
+
+    assert get_template_ext(TemplateServiceWithoutConfig(), "bot-123") == {"foo": "bar"}
+
+
+def test_get_template_ext_handles_missing_service_and_query_failure():
+    assert get_template_ext(None, "bot-123") is None
+
+    template_service = Mock()
+    template_service.get_template_config.side_effect = RuntimeError("db down")
+
+    assert get_template_ext(template_service, "bot-123") is None
+
+
+def test_is_member_management_enabled_bot_uses_coding_or_template_config():
+    assert is_member_management_enabled_bot(None) is False
+    assert is_member_management_enabled_bot(
+        {"active_engine": "claude_code", "template_type": "applicationCoding"}
+    ) is True
+    assert is_member_management_enabled_bot(
+        {
+            "active_engine": "openclaw",
+            "template_type": "chat",
+            "template_config": {
+                "bot_template_config": {"advanced_config": {"member_management": True}}
+            },
+        }
+    ) is True
+    assert is_member_management_enabled_bot(
+        {
+            "active_engine": "openclaw",
+            "template_type": "chat",
+            "template_config": {
+                "bot_template_config": {"advanced_config": {"member_management": "true"}}
+            },
+        }
+    ) is False


### PR DESCRIPTION
## Summary
- Allow bot collaborator/member management when the template config explicitly enables member management.
- Read the flag from ac_templates.ext via template_config instead of ac_bots.ext.
- Extract AICoding member-management helpers into services/aicoding/utils.
- Add unit tests for collaborator service, interceptor behavior, and utility helper branches.

## Tests
- uv run pytest -q tests/community/core/bot_collaborator/test_member_management_utils.py tests/community/core/bot_collaborator/test_collaborator_service_coding.py tests/community/core/bot_collaborator/test_interceptor_coding_app.py
- uv run pytest -q tests/community/core/bot_collaborator/test_member_management_utils.py --cov=agentclaw.community.core.bot_collaborator.services.aicoding.utils.member_management --cov-report=term-missing