### PR TITLE
fix(backend): keep bot chat relation labels consistent (#572)

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
@@ -187,7 +187,12 @@ def enrich_group_labels(
             row.group_id, row.session_kind = label
 
 
-def enrich_task_labels(session: Any, rows: list[Any]) -> None:
+def enrich_task_labels(
+    session: Any,
+    rows: list[Any],
+    preferred_biz_scene: str | None = None,
+    preferred_biz_task_id: str | None = None,
+) -> None:
     """Batch-fill missing task labels using indexed runtime-ID relations."""
     candidate_rows: dict[tuple[str, str], list[Any]] = {}
     digests_by_type: dict[str, set[str]] = {}
@@ -198,6 +203,8 @@ def enrich_task_labels(session: Any, rows: list[Any]) -> None:
             ("session_key", "session_key"),
         ):
             ref_value = getattr(row, attribute, None)
+            if ref_type == "trace_id" and not ref_value:
+                ref_value = getattr(row, "id", None)
             if not ref_value:
                 continue
             candidate_rows.setdefault((ref_type, ref_value), []).append(row)
@@ -223,19 +230,38 @@ def enrich_task_labels(session: Any, rows: list[Any]) -> None:
         )
         .all()
     )
-    enriched_rows: set[int] = set()
+    relations_by_row: dict[int, list[Any]] = {}
     for relation in relations:
+        relation_type = getattr(relation, "ref_type", None)
+        relation_value = getattr(relation, "ref_value", None)
+        if not relation_type or not relation_value:
+            continue
         for row in candidate_rows.get(
-            (relation.ref_type, relation.ref_value), ()
+            (relation_type, relation_value), ()
         ):
-            row_identity = id(row)
-            if row_identity in enriched_rows:
+            relations_by_row.setdefault(id(row), []).append(relation)
+
+    for row in rows:
+        scene = getattr(row, "biz_scene", None)
+        task_id = getattr(row, "biz_task_id", None)
+        if scene and task_id:
+            continue
+        if (
+            preferred_biz_scene
+            and preferred_biz_task_id
+            and "biz_ref" in (getattr(row, "match_sources", None) or ())
+        ):
+            row.biz_scene = preferred_biz_scene
+            row.biz_task_id = preferred_biz_task_id
+            continue
+        for relation in relations_by_row.get(id(row), ()):
+            if scene and relation.biz_scene != scene:
                 continue
-            if not getattr(row, "biz_scene", None):
-                row.biz_scene = relation.biz_scene
-            if not getattr(row, "biz_task_id", None):
-                row.biz_task_id = relation.biz_task_id
-            enriched_rows.add(row_identity)
+            if task_id and relation.biz_task_id != task_id:
+                continue
+            row.biz_scene = relation.biz_scene
+            row.biz_task_id = relation.biz_task_id
+            break
 
 
 def load_bot_names(session: Any, bot_ids: set[str]) -> dict[str, str]:
@@ -270,9 +296,10 @@ def load_bot_names(session: Any, bot_ids: set[str]) -> dict[str, str]:
 
 
 def enrich_trace_labels(session: Any, row: Any) -> Any:
-    """Attach optional Bot and group labels to a detached trace row."""
+    """Attach optional Bot, group, and task labels to one detached trace row."""
     if row.bot_id:
         row.bot_name = load_bot_names(session, {row.bot_id}).get(row.bot_id)
+    enrich_task_labels(session, [row])
     session_key = row.session_key
     if not session_key:
         return row

--- a/src/backend/src/agentclaw/community/core/bot_chat/repository.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/repository.py
@@ -447,27 +447,21 @@ class BotChatDbRepository:
         """Check if user_id is either owner or collaborator of bot_id."""
         return self.is_bot_owner(user_id, bot_id) or self.is_bot_collaborator(user_id, bot_id)
 
-    def get_bot_name(self, bot_id: str | None) -> str | None:
-        if not bot_id:
-            return None
+    def enrich_labels(
+        self,
+        rows: list[Any],
+        preferred_biz_scene: str | None = None,
+        preferred_biz_task_id: str | None = None,
+    ) -> None:
+        """Batch-fill display labels for one final response page."""
         with self._db.orm_session() as session:
-            return load_bot_names(session, {bot_id}).get(bot_id)
-
-    def get_group_labels(
-        self, session_key: str | None
-    ) -> tuple[str | None, str | None]:
-        if not session_key:
-            return None, None
-        probe = SimpleNamespace(
-            bot_id=None,
-            bot_name=None,
-            session_key=session_key,
-            group_id=None,
-            session_kind=None,
-        )
-        with self._db.orm_session() as session:
-            enriched = enrich_trace_labels(session, probe)
-        return enriched.group_id, enriched.session_kind
+            enrich_group_labels(session, rows)
+            enrich_task_labels(
+                session, rows, preferred_biz_scene, preferred_biz_task_id
+            )
+            names = load_bot_names(session, {row.bot_id for row in rows if row.bot_id})
+            for row in rows:
+                row.bot_name = names.get(row.bot_id)
 
     def list_traces(
         self,
@@ -583,7 +577,6 @@ class BotChatDbRepository:
 
             detached = [self._detach_trace_row(row) for row in rows]
             enrich_group_labels(session, detached, group_id, group_sessions)
-            enrich_task_labels(session, detached)
             bot_names = load_bot_names(
                 session, {row.bot_id for row in detached if row.bot_id}
             )
@@ -591,6 +584,7 @@ class BotChatDbRepository:
                 row.bot_name = bot_names.get(row.bot_id)
                 if biz_scene or biz_task_id:
                     row.match_sources = ["biz_ref"]
+            enrich_task_labels(session, detached, biz_scene, biz_task_id)
             sessions = [self._row_to_session(row) for row in detached]
             return sessions, total
 
@@ -709,7 +703,7 @@ class BotChatDbRepository:
                 ):
                     sources.append("biz_ref")
                 row.match_sources = sources
-            enrich_task_labels(session, detached)
+            enrich_task_labels(session, detached, biz_scene, biz_task_id)
             sessions = [
                 self._row_to_session(row)
                 for row in detached

--- a/src/backend/src/agentclaw/community/core/bot_chat/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/service.py
@@ -625,6 +625,7 @@ class BotChatService(OpenBotChatServiceMixin):
             match_mode=match_mode,
             include_output_match=include_output_match,
         )
+        self._db_repo.enrich_labels(sessions)
 
         filtered_total = len(sessions)
         has_more = (page * limit) < total
@@ -768,6 +769,7 @@ class BotChatService(OpenBotChatServiceMixin):
         start_idx = (page - 1) * limit
         end_idx = start_idx + limit
         paginated_sessions = matched_sessions[start_idx:end_idx]
+        self._db_repo.enrich_labels(paginated_sessions)
 
         has_more = (page * limit < len(matched_sessions)) or (scanned_count < total_items)
 
@@ -879,9 +881,7 @@ class BotChatService(OpenBotChatServiceMixin):
             or attributes.get("gen_ai.conversation.id")
         )
         bot_id = attributes.get("identity.bot_id")
-        group_id, session_kind = self._db_repo.get_group_labels(session_key)
-
-        return ConversationDetail(
+        detail = ConversationDetail(
             id=trace_data.get("id", ""),
             biz_task_id=(
                 trace_data.get("biz_task_id")
@@ -896,9 +896,9 @@ class BotChatService(OpenBotChatServiceMixin):
             session_id=session_id,
             session_key=session_key,
             bot_id=bot_id,
-            bot_name=self._db_repo.get_bot_name(bot_id),
-            group_id=group_id,
-            session_kind=session_kind,
+            bot_name=None,
+            group_id=None,
+            session_kind=None,
             name=trace_data.get("name") or "未命名会话",
             input=trace_data.get("input"),
             output=trace_data.get("output"),
@@ -911,6 +911,8 @@ class BotChatService(OpenBotChatServiceMixin):
             total_tokens=int(usage.get("totalTokens") or 0),
             observations=observations,
         )
+        self._db_repo.enrich_labels([detail])
+        return detail
 
     async def _fetch_observations_from_langfuse(
         self, trace_id: str

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
@@ -301,6 +301,13 @@ def test_group_query_normalizes_session_key_and_returns_optional_labels():
                 env=get_current_env(),
             )
         )
+    repo.upsert_biz_refs(
+        {
+            "biz_scene": "scene_fixture",
+            "biz_task_id": "task_fixture",
+            "refs": [{"ref_type": "trace_id", "ref_value": "trace_group"}],
+        }
+    )
 
     rows, total = repo.list_ocb_traces(
         owner_id="user_fixture",
@@ -324,6 +331,8 @@ def test_group_query_normalizes_session_key_and_returns_optional_labels():
     assert detail_row.group_id == "group_fixture"
     assert detail_row.session_kind == "chat"
     assert detail_row.bot_name == "Fixture Bot"
+    assert detail_row.biz_scene == "scene_fixture"
+    assert detail_row.biz_task_id == "task_fixture"
 
 
 def test_group_query_supports_multiple_sessions_and_existing_agent_prefix():
@@ -509,6 +518,141 @@ def test_task_label_enrichment_preserves_direct_trace_values():
     assert total == 1
     assert rows[0].biz_scene == "direct_scene"
     assert rows[0].biz_task_id == "direct_task"
+
+
+@pytest.mark.parametrize(
+    ("stored_scene", "stored_task", "expected_scene", "expected_task"),
+    [
+        ("shared_scene", None, "shared_scene", "compatible_task"),
+        (None, "shared_task", "compatible_scene", "shared_task"),
+    ],
+)
+def test_partial_task_fields_only_use_a_compatible_relation(
+    stored_scene, stored_task, expected_scene, expected_task
+):
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    refs = [{"ref_type": "trace_id", "ref_value": "trace_partial"}]
+    compatible = (
+        ("shared_scene", "compatible_task")
+        if stored_scene
+        else ("compatible_scene", "shared_task")
+    )
+    for scene, task in (compatible, ("conflicting_scene", "conflicting_task")):
+        repo.upsert_biz_refs(
+            {"biz_scene": scene, "biz_task_id": task, "refs": refs}
+        )
+    row = SimpleNamespace(
+        id="trace_partial",
+        trace_id="trace_partial",
+        session_id=None,
+        session_key=None,
+        biz_scene=stored_scene,
+        biz_task_id=stored_task,
+        match_sources=[],
+    )
+
+    with db.orm_session() as session:
+        enrich_task_labels(session, [row])
+
+    assert (row.biz_scene, row.biz_task_id) == (expected_scene, expected_task)
+
+
+def test_partial_task_fields_do_not_mix_with_a_conflicting_relation():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    repo.upsert_biz_refs(
+        {
+            "biz_scene": "other_scene",
+            "biz_task_id": "other_task",
+            "refs": [{"ref_type": "trace_id", "ref_value": "trace_conflict"}],
+        }
+    )
+    row = SimpleNamespace(
+        id="trace_conflict",
+        trace_id="trace_conflict",
+        session_id=None,
+        session_key=None,
+        biz_scene="stored_scene",
+        biz_task_id=None,
+        match_sources=[],
+    )
+
+    with db.orm_session() as session:
+        enrich_task_labels(session, [row])
+
+    assert (row.biz_scene, row.biz_task_id) == ("stored_scene", None)
+
+
+def test_preferred_biz_ref_replaces_a_conflicting_partial_task():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    repo.upsert_biz_refs(
+        {
+            "biz_scene": "requested_scene",
+            "biz_task_id": "requested_task",
+            "refs": [{"ref_type": "trace_id", "ref_value": "trace_preferred"}],
+        }
+    )
+    row = SimpleNamespace(
+        id="trace_preferred",
+        trace_id="trace_preferred",
+        session_id=None,
+        session_key=None,
+        biz_scene="stale_scene",
+        biz_task_id=None,
+        match_sources=["biz_ref"],
+    )
+
+    with db.orm_session() as session:
+        enrich_task_labels(
+            session,
+            [row],
+            preferred_biz_scene="requested_scene",
+            preferred_biz_task_id="requested_task",
+        )
+
+    assert (row.biz_scene, row.biz_task_id) == (
+        "requested_scene",
+        "requested_task",
+    )
+
+
+def test_task_query_prefers_the_relation_named_by_the_request():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    _write_trace(
+        repo,
+        trace_id="trace_multi_task",
+        session_id="session_multi_task",
+        session_key="agent:main:session_multi_task",
+    )
+    for scene, task in (
+        ("requested_scene", "requested_task"),
+        ("newer_scene", "newer_task"),
+    ):
+        repo.upsert_biz_refs(
+            {
+                "biz_scene": scene,
+                "biz_task_id": task,
+                "refs": [{"ref_type": "trace_id", "ref_value": "trace_multi_task"}],
+            }
+        )
+
+    rows, total = repo.list_ocb_traces(
+        owner_id="user_fixture",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        biz_scene="requested_scene",
+        biz_task_id="requested_task",
+    )
+
+    assert total == 1
+    assert rows[0].biz_scene == "requested_scene"
+    assert rows[0].biz_task_id == "requested_task"
+    assert rows[0].match_sources == ["biz_ref"]
 
 
 def test_group_query_supports_legacy_trace_storage():

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
@@ -632,6 +632,35 @@ class TestBotChatServiceListSessions:
             assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
+    async def test_list_sessions_langfuse_enriches_only_the_response_page(
+        self, service
+    ):
+        trace = {
+            "id": "trace-labels",
+            "name": "Session",
+            "timestamp": "2025-01-15T10:00:00Z",
+            "metadata": {"attributes": {}},
+        }
+        service._fetch_traces_from_langfuse = AsyncMock(return_value=([trace], 1))
+        service._db_repo = MagicMock()
+
+        def enrich(rows):
+            rows[0].group_id = "group_fixture"
+            rows[0].biz_scene = "scene_fixture"
+            rows[0].biz_task_id = "task_fixture"
+
+        service._db_repo.enrich_labels.side_effect = enrich
+
+        result = await service.list_sessions(
+            owner_id="user1", log_source="langfuse"
+        )
+
+        assert result.sessions[0].group_id == "group_fixture"
+        assert result.sessions[0].biz_scene == "scene_fixture"
+        assert result.sessions[0].biz_task_id == "task_fixture"
+        service._db_repo.enrich_labels.assert_called_once_with(result.sessions)
+
+    @pytest.mark.asyncio
     async def test_list_sessions_with_query_filter(self, service):
         mock_response = AsyncMock()
         mock_response.status = 200
@@ -1612,12 +1641,14 @@ class TestBotChatServiceGetSession:
         mock_aiohttp_session.get = mock_get
         mock_aiohttp_session.__aenter__ = AsyncMock(return_value=mock_aiohttp_session)
         mock_aiohttp_session.__aexit__ = AsyncMock(return_value=False)
+        service._db_repo = MagicMock()
 
         with patch("agentclaw.community.core.bot_chat.service.aiohttp.ClientSession", return_value=mock_aiohttp_session):
             result = await service.get_session(trace_id="trace-1", owner_id="user1", log_source="langfuse")
 
         assert result.id == "trace-1"
         assert result.user_id == "user1"
+        service._db_repo.enrich_labels.assert_called_once_with([result])
 
     @pytest.mark.asyncio
     async def test_get_session_langfuse_non_default_bot_unauthorized(self, service):


### PR DESCRIPTION
# Bot Chat 关联信息一致性修复设计


## 1. 修复目标

本次修复解决同一条 Trace 在列表与详情、用户态接口与 OpenAPI、DB 与
Langfuse 数据源之间返回的关联信息不一致问题。

需要保持一致的字段为：

```text
biz_scene
biz_task_id
group_id
session_kind
bot_id
bot_name
```

不改变现有查询权限、分页、时间范围、Task direct + biz-ref 联合查询、
OTel/legacy fallback 和 observation 树结构。

## 2. 影响接口与当前问题

| 接口/场景 | 当前问题 | 修复要求 |
| --- | --- | --- |
| `GET /api/v1/bot-chats`，默认 DB | 已支持 Group/Biz 批量回填 | 保持现状 | | `GET /api/v1/bot-chats/{trace_id}`，默认 DB | Group 已反查，但没有从 `ac_otel_log_biz_ref` 回填 Biz | 详情补齐 Biz |
| `GET /api/v1/open/bot-chats?session_key=...` | 复用 DB 列表，字段已回填 | 保持现状 | | `GET /api/v1/open/bot-chats?biz_scene=...&biz_task_id=...` | 一个 Trace 关联多个 Task 时，可能返回其他最新 Task | 优先返回本次查询命中的 Task |
| `GET /api/v1/open/bot-chats?group_id=...` | 复用 DB 列表，字段已回填 | 保持现状 | | `GET /api/v1/open/bot-chats/{trace_id}` | 复用 DB 详情，因此同样缺少 Biz 回填 | 随 DB 详情一起修复 |
| 用户态列表显式指定 `log_source=langfuse` | 只映射 Langfuse Trace 自身字段，不批量反查 Group/Biz | 补齐批量回填 |
| 用户态详情显式指定 `log_source=langfuse` | 已反查 Group，但不反查 `ac_otel_log_biz_ref` | 补齐 Biz 回填 |
| `POST /api/bot-chat/log-relations` | 写入逻辑正常 | 不修改 |

## 3. 数据来源与优先级

### 3.1 业务场景和业务任务

业务信息有两个来源：

1. Trace 直存字段或 metadata：

```text
trace.biz_scene
trace.biz_task_id
metadata.attributes["agentic.biz_scene"]
metadata.attributes["identity.biz_scene"]
metadata.attributes["agentic.biz_task_id"]
metadata.attributes["identity.biz_task_id"]
```

2. 关联表 `ac_otel_log_biz_ref`：

```text
ref_type = trace_id | session_id | session_key
ref_value = Trace 对应标识
```

回填优先级：

1. Trace 直存的 `biz_scene + biz_task_id` 都存在时，完整保留原值；
2. 两个字段都为空时，从同一条 relation 成对回填；
3. 只有 `biz_scene` 时，只允许使用相同 scene 的 relation 补 Task ID；
4. 只有 `biz_task_id` 时，只允许使用相同 Task ID 的 relation 补 scene；
5. 没有兼容 relation 时保留缺失值，禁止拼接出不存在的 Task；
6. Task 条件查询由 biz-ref 命中且 Trace 只有部分 Task 字段时，成对返回请求中的 `biz_scene + biz_task_id`；
7. 无 Task 查询条件的普通列表、Session、Group 和详情查询，使用最新兼容 biz-ref；
8. 最新记录按 `gmt_modified DESC, gmt_create DESC, id DESC` 确定；
9. `ref_digest` 命中后必须再比较 `ref_value`，避免摘要碰撞造成错误关联。

### 3.2 群聊信息

群聊信息以 `bcs_group_sessions` 为唯一来源：

```text
bcs_group_sessions.group_id
bcs_group_sessions.session_kind
bcs_group_sessions.session_id
```

匹配 Trace `session_key` 时同时尝试：

```text
完整 session_key
去掉 agent:main: 前缀后的值
```

如果 `bcs_group_sessions` 中不存在对应关系，返回：

```json
{
  "group_id": null,
  "session_kind": null
}
```

不得根据 Task 关系或 Session Key 文本推测群 ID。

## 4. 修复方案

### 4.1 DB 详情统一回填

调整单条 Trace enrichment，使 OTel 和 legacy 详情都执行：

```text
Bot 名称回填
Task 关联回填
Group 关联回填
```

调用链：

```text
GET /api/v1/bot-chats/{trace_id}
  -> BotChatService._get_session_db()
  -> repository.get_ocb_trace() / get_trace()
  -> enrich_trace_labels()
  -> enrich_task_labels(session, [row])
  -> ConversationDetail
```

Open Trace 详情复用 `_get_session_db(trace_id, owner_id=None)`，不单独复制逻辑。

### 4.2 Task 条件查询返回匹配任务

为 Task enrichment 增加可选的优先关联：

```python
enrich_task_labels(
    session,
    rows,
    preferred_biz_scene=biz_scene,
    preferred_biz_task_id=biz_task_id,
)
```

仅当列表请求明确传入 `biz_scene + biz_task_id` 时使用优先关联。这样一个 Trace 即使同时属于多个 Task，Task B 查询结果也不会展示为 Task A。

`match_sources` 必须在展示字段回填前，基于 Trace 原始字段和查询命中来源计算：

```text
direct
biz_ref
direct + biz_ref
```

回填后的字段不得把原本仅由 biz-ref 命中的 Trace 误标为 direct。

### 4.3 Langfuse 列表批量回填

Langfuse 列表完成映射和最终分页后，对当前响应页执行一次批量关联查询：

```text
批量回填 Bot 名称
批量回填 Group
批量回填 Biz
```

不得在扫描 Langfuse 每一页时逐条查询数据库。对于 exhaustive scan，应在完成 过滤和最终分页后，仅回填最终返回的最多 100 条记录。

### 4.4 Langfuse 详情回填

Langfuse 详情保留现有远程 Trace 和 observation 获取逻辑。完成 Trace 映射后， 使用 `trace_id/session_id/session_key` 查询 biz-ref，并保留现有 Group 反查。

Langfuse Trace 自身已有 Biz 字段时优先保留，biz-ref 仅作为 fallback。

## 5. 性能设计

### 5.1 Task 关联

每页最多 100 条 Trace，每条最多产生三种候选标识：

```text
trace_id
session_id
session_key
```

后端计算：

```text
ref_digest = "sha256:" + sha256(ref_value)
```

使用现有索引一次批量查询：

```sql
KEY idx_ac_otel_log_biz_ref_ref (ref_type, ref_digest)
```

查询结果再按 `ref_type + ref_value` 映射到 Trace。禁止按 Trace 循环执行 SQL。

现有索引足够，不增加 `varchar(1024)` 的 `ref_value` 索引，不需要 DDL 变更。

### 5.2 Group 关联

普通列表按当前页全部 `session_key` 一次查询 `bcs_group_sessions`。Group 条件查询 沿用先解析群内全部 Session、再查询 Trace 的逻辑。

### 5.3 查询次数

| 场景 | 额外查询上限 |
| --- | --- |
| DB 列表 Biz 回填 | 每页 1 次 |
| DB 列表 Group 回填 | 每页 1 次 |
| DB 详情 Biz 回填 | 1 次 |
| DB 详情 Group 回填 | 1 次 |
| Langfuse 列表 Biz/Group 回填 | 最终响应页各 1 次 |
| Langfuse 详情 Biz/Group 回填 | 各 1 次 |

## 6. 兼容性

| 项目 | 结论 |
| --- | --- |
| 路由与请求参数 | 不变 |
| 响应 Schema | 不变，只将原有 null 字段补为关联值 |
| Owner/Bot 权限 | 用户态接口保持原限制；OpenAPI 保持跨 owner 精确查询 | | OTel/legacy fallback | 不变 |
| 分页和 total | 不变，enrichment 在查询和分页之后执行 |
| `match_sources` | 保持原始命中语义 |
| relation 写入 | 不变 |
| 数据库表与索引 | 不变 |

## 7. 测试与验收

必须使用本地内存数据库和 Mock Langfuse 数据，不写入真实用户、Bot、Session、 群 ID 或内部凭据。

### 7.1 DB 路径

- OTel 详情通过 `trace_id` biz-ref 返回 Biz；
- legacy 详情通过 `session_id/session_key` biz-ref 返回 Biz；
- 同一详情同时返回 Group 和 Biz；
- Trace 直存 Biz 不被关联表覆盖；
- 无群聊关系时 Group 字段保持 null；
- 一个 Trace 关联多个 Task 时，Task 条件查询返回当前请求 Task；
- 普通列表无 Task 条件时返回最新关联；
- `match_sources` 不因回填而从 `biz_ref` 误变为 `direct`。

### 7.2 OpenAPI

- Open Session 列表返回 Group/Biz；
- Open Task 列表返回查询中的 Task；
- Open Group 列表返回 Group/Biz；
- Open Trace 详情返回 Group/Biz；
- OpenAPI 不增加 owner 或 Bot 过滤。

### 7.3 Langfuse

- 普通 Langfuse 列表最终页批量返回 Group/Biz；
- exhaustive scan 只回填最终分页结果；
- Langfuse 详情返回 Group/Biz；
- Langfuse 自带 Biz 字段优先于 biz-ref；
- 关联表无记录时保持 null，不影响原始 Trace 返回。

### 7.4 性能

- 100 条 Trace 的 Biz 回填只执行一次 biz-ref 查询；
- 100 条 Trace 的 Group 回填只执行一次群聊关系查询；
- 查询使用 `idx_ac_otel_log_biz_ref_ref`；
- 不出现 N+1；
- `repository.py` 保持低于仓库 1000 行限制。

## 8. 实施状态

| 项目 | 状态 |
| --- | --- |
| DB 详情 Biz 回填 | 已实现，待提交 |
| DB 详情同时返回 Group/Biz 的测试 | 已实现并通过 |
| Task 条件查询优先返回当前任务 | 已实现并通过 |
| Langfuse 列表批量回填 Group/Biz | 已实现并通过 |
| Langfuse 详情回填 Biz | 已实现并通过 |
| OpenAPI 完整关联字段回归测试 | 已通过现有 OpenAPI 端点与 DB 复用链路测试 |