### PR TITLE
feat(bcs-cli): infer session file upload mime from extension

### DIFF
--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -2934,6 +2934,41 @@ impl BcsClient {
         Self::ensure_success(resp, "complete session file").await
     }
 
+    /// Infer a MIME type from a file name's extension. Covers common upload
+    /// types (text, JSON/HTML/XML, PDF, images, audio/video, archives); unknown
+    /// or missing extensions return `None` so callers fall back to the generic
+    /// `application/octet-stream`.
+    fn guess_mime_from_extension(file_name: &str) -> Option<String> {
+        let ext = std::path::Path::new(file_name)
+            .extension()?
+            .to_str()?
+            .to_ascii_lowercase();
+        Some(match ext.as_str() {
+            "txt" => "text/plain",
+            "md" => "text/markdown",
+            "csv" => "text/csv",
+            "json" => "application/json",
+            "xml" => "application/xml",
+            "pdf" => "application/pdf",
+            "zip" => "application/zip",
+            "gz" => "application/gzip",
+            "tar" => "application/x-tar",
+            "html" | "htm" => "text/html",
+            "css" => "text/css",
+            "js" => "text/javascript",
+            "png" => "image/png",
+            "jpg" | "jpeg" => "image/jpeg",
+            "gif" => "image/gif",
+            "webp" => "image/webp",
+            "svg" => "image/svg+xml",
+            "wav" => "audio/wav",
+            "mp3" => "audio/mpeg",
+            "mp4" => "video/mp4",
+            "bin" => "application/octet-stream",
+            _ => return None,
+        }.to_string())
+    }
+
     /// High-level three-stage upload: prepare -> PUT (single or multipart) -> complete.
     /// Serial multipart PUTs (no parallelism for v1). Best-effort delete on failure.
     pub async fn upload_session_file(
@@ -2943,7 +2978,11 @@ impl BcsClient {
             .unwrap_or_else(|| std::path::Path::new(path).file_name().and_then(|n| n.to_str()).unwrap_or("file").to_string());
         let metadata = tokio::fs::metadata(path).await?;
         let size = metadata.len();
-        let mime = mime.unwrap_or("application/octet-stream").to_string();
+        let mime = match mime {
+            Some(m) => m.to_string(),
+            None => Self::guess_mime_from_extension(&file_name)
+                .unwrap_or_else(|| "application/octet-stream".to_string()),
+        };
         let prepared = self.prepare_session_file(sid, &file_name, size, &mime).await?;
         let mode = prepared["mode"].as_str().unwrap_or("single");
         let file_id = prepared["file_id"].as_str().context("missing file_id")?.to_string();
@@ -3073,6 +3112,26 @@ impl BcsClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn guess_mime_from_extension_known_types() {
+        assert_eq!(BcsClient::guess_mime_from_extension("report.pdf"), Some("application/pdf".into()));
+        assert_eq!(BcsClient::guess_mime_from_extension("DATA.CSV"), Some("text/csv".into()));
+        assert_eq!(BcsClient::guess_mime_from_extension("pic.jpeg"), Some("image/jpeg".into()));
+        assert_eq!(BcsClient::guess_mime_from_extension("pic.jpg"), Some("image/jpeg".into()));
+        assert_eq!(BcsClient::guess_mime_from_extension("notes.md"), Some("text/markdown".into()));
+        assert_eq!(BcsClient::guess_mime_from_extension("data.json"), Some("application/json".into()));
+        assert_eq!(BcsClient::guess_mime_from_extension("archive.zip"), Some("application/zip".into()));
+        assert_eq!(BcsClient::guess_mime_from_extension("model.bin"), Some("application/octet-stream".into()));
+    }
+
+    #[test]
+    fn guess_mime_from_extension_unknown_returns_none() {
+        assert_eq!(BcsClient::guess_mime_from_extension("file.xyz"), None);
+        assert_eq!(BcsClient::guess_mime_from_extension("noext"), None);
+        assert_eq!(BcsClient::guess_mime_from_extension(""), None);
+        assert_eq!(BcsClient::guess_mime_from_extension(".hidden"), None);
+    }
 
     #[test]
     #[allow(unsafe_code)]


### PR DESCRIPTION
## What
When `bcs session file upload` is called without `--mime`, infer the MIME type from the file extension instead of always falling back to `application/octet-stream`.

## Why
The CLI hardcoded `application/octet-stream` whenever `--mime` was omitted, so common upload types (PDF, CSV, images, …) were stored with a generic type. The session-file skill doc already describes this as 「不指定时从扩展名推测」, but the implementation never matched — this closes that gap.

## Changes
- `bcs-cli/src/client.rs`: add `guess_mime_from_extension(file_name) -> Option<String>` covering common upload types (text/csv/json/xml/html, markdown, pdf, images png/jpg/gif/webp/svg, audio wav/mp3, video mp4, archives zip/gz/tar, bin). Extension matching is case-insensitive; unknown/missing extensions return `None`.
- `upload_session_file`: when `--mime` is absent, run the guesser on the effective file name (`--name` override or path basename) and fall back to `application/octet-stream` only if the guess is `None`. Explicit `--mime` still takes priority.
- Tests: `guess_mime_from_extension_known_types` (incl. `.CSV` uppercase, `.jpeg`/`.jpg`) and `guess_mime_from_extension_unknown_returns_none` (`.xyz`, no-ext, empty, `.hidden`).

## Verification
- `cargo test -p bcs-cli --lib guess_mime`: 2 passed.
- `cargo test -p bcs-cli --lib` (full): 44 passed — no regression (incl. cross-host PUT content-type test from the prior upload-type work).

## Notes
- No new crate dependency: a small built-in extension→MIME map, not `mime_guess`. Unknown extensions still default to `application/octet-stream`, preserving existing behavior for binaries.
- Guessing uses the effective file name so prepare (`content_type` in upload-url body) and the later PUT (`Content-Type` header) agree.
