### PR TITLE
fix(engine): harden fresh Desktop Skills Pool rollout

### DIFF
--- a/src/engine/docs/heterogeneous-engine-architecture.md
+++ b/src/engine/docs/heterogeneous-engine-architecture.md
@@ -1104,6 +1104,12 @@ class SkillExecutionResult:
   home 投影物理 source/active target；publish/verify 返回
   `resolved_mappings`，activation/rollback 返回 `local_locators`。这些路径是
   Engine evidence，Backend 只能校验和持久化，不能按 engine 重建。
+- READY Probe 已进入 cutover evidence（存在 active marker）后，
+  `checks.stable_repo_bridge_valid` 只在 AICoding/Hermes 已进入 `active`
+  且稳定 repo bridge 已实际校验时存在并为 `true`。OpenClaw/Claude Code
+  的 active layout 以及仍为 `finalizing` 的恢复窗口不适用或尚未完成该
+  检查，必须省略此 key，不能用 `false` 或未经校验的 `true` 代替；
+  preparation/Legacy evidence 仍按各 Engine 拓扑报告其必需 bridge 检查。
 - 新 Backend 只有在 `/api/skills/layout/probe` 的 READY evidence 明确包含
   `"mapping_contract_version": "skills-pool-mapping-v2"` 后，才会在已通过
   rollout gate 且 migration claim 成功的 reconcile 中发送 v2。缺失或旧
@@ -1114,7 +1120,9 @@ class SkillExecutionResult:
 - 兼容窗口内，新 Engine 仍接受不带 `mapping_contract_version` 的 legacy
   physical item：`{"source": "...", "target": "..."}`。无版本 logical
   payload、带 v2 的 physical payload、logical/physical 混合 payload 和未知
-  version 均在任何文件系统 mutation 前拒绝。
+  version 均在任何文件系统 mutation 前以
+  `InvalidPoolMappingRequestError` 拒绝，HTTP delivery adapter 固定映射为
+  `400`；Engine layout descriptor/invariant 异常不归入该输入错误。
 - 消费者包括 Backend `SkillsPoolRuntimeProtocol`/
   `SkillsPoolReconcileService`、Engine `/api/skills` router 与
   `SkillsService`，以及 OpenClaw、Claude Code、AICoding、Hermes 的

--- a/src/engine/docs/heterogeneous-engine-architecture.md
+++ b/src/engine/docs/heterogeneous-engine-architecture.md
@@ -1122,7 +1122,9 @@ class SkillExecutionResult:
   payload、带 v2 的 physical payload、logical/physical 混合 payload 和未知
   version 均在任何文件系统 mutation 前以
   `InvalidPoolMappingRequestError` 拒绝，HTTP delivery adapter 固定映射为
-  `400`；Engine layout descriptor/invariant 异常不归入该输入错误。
+  `400`；Engine layout descriptor/invariant 异常不归入该输入错误。未知
+  corpus 等不满足 HTTP schema 的结构错误由 FastAPI 在进入 Skills Service
+  前以 `422` 拒绝，同样不能触发 plugin 调用或文件系统 mutation。
 - 消费者包括 Backend `SkillsPoolRuntimeProtocol`/
   `SkillsPoolReconcileService`、Engine `/api/skills` router 与
   `SkillsService`，以及 OpenClaw、Claude Code、AICoding、Hermes 的

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -34,8 +34,8 @@ from engine.community.api.skills.schemas import (
 )
 from engine.community.core.engine.capability import Capability
 from engine.community.core.engine.exceptions import CapabilityNotSupportedError
-from engine.community.core.skills.layout_planner import (
-    SkillLayoutResolutionError,
+from engine.community.core.skills.exceptions import (
+    InvalidPoolMappingRequestError,
 )
 from engine.community.core.skills.models import (
     CenterEnsureItem,
@@ -100,8 +100,6 @@ async def probe_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
-    except SkillLayoutResolutionError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
     return RuntimeLayoutProbeApiResponse(
         success=True,
         data=RuntimeLayoutProbeResponse.model_validate(result.to_data()),
@@ -131,7 +129,7 @@ async def activate_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
-    except SkillLayoutResolutionError as error:
+    except InvalidPoolMappingRequestError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return PoolLayoutActivateApiResponse(
         success=result.committed,
@@ -163,8 +161,6 @@ async def rollback_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
-    except SkillLayoutResolutionError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
     return PoolLayoutActivateApiResponse(
         success=result.committed,
         data=PoolLayoutActivateResponse.model_validate(result.to_data()),
@@ -220,7 +216,7 @@ async def verify_runtime_skill_mappings(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
-    except SkillLayoutResolutionError as error:
+    except InvalidPoolMappingRequestError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return ApiResponse(
         success=result.valid,
@@ -252,7 +248,7 @@ async def publish_runtime_skill_mappings(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
-    except SkillLayoutResolutionError as error:
+    except InvalidPoolMappingRequestError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return ApiResponse(
         success=result.published,

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
-
 from engine.community.api.caps import check_capability
 from engine.community.api.response import ApiResponse
 from engine.community.api.skills.schemas import (
@@ -36,6 +34,9 @@ from engine.community.api.skills.schemas import (
 )
 from engine.community.core.engine.capability import Capability
 from engine.community.core.engine.exceptions import CapabilityNotSupportedError
+from engine.community.core.skills.layout_planner import (
+    SkillLayoutResolutionError,
+)
 from engine.community.core.skills.models import (
     CenterEnsureItem,
     CenterEnsureRequest,
@@ -58,6 +59,7 @@ from engine.community.core.skills.models import (
 from engine.community.core.skills.models import (
     PoolQuarantineCleanupRequest as PoolQuarantineCleanupCommand,
 )
+from fastapi import APIRouter, HTTPException
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 log = logging.getLogger("api-skills")
@@ -98,6 +100,8 @@ async def probe_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
+    except SkillLayoutResolutionError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
     return RuntimeLayoutProbeApiResponse(
         success=True,
         data=RuntimeLayoutProbeResponse.model_validate(result.to_data()),
@@ -127,6 +131,8 @@ async def activate_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
+    except SkillLayoutResolutionError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
     return PoolLayoutActivateApiResponse(
         success=result.committed,
         data=PoolLayoutActivateResponse.model_validate(result.to_data()),
@@ -157,6 +163,8 @@ async def rollback_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
+    except SkillLayoutResolutionError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
     return PoolLayoutActivateApiResponse(
         success=result.committed,
         data=PoolLayoutActivateResponse.model_validate(result.to_data()),
@@ -212,6 +220,8 @@ async def verify_runtime_skill_mappings(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
+    except SkillLayoutResolutionError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
     return ApiResponse(
         success=result.valid,
         data=result.to_data(),
@@ -242,6 +252,8 @@ async def publish_runtime_skill_mappings(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
+    except SkillLayoutResolutionError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
     return ApiResponse(
         success=result.published,
         data=result.to_data(),

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -530,6 +530,73 @@ def test_pool_mapping_routes_reject_v2_physical_shape_via_real_adapter(
     ("method", "path", "payload"),
     [
         (
+            "activate_pool_layout",
+            "/api/skills/layout/activate",
+            {
+                "migration_generation": "generation-1",
+                "preparation_id": "preparation-1",
+                "registered_local_names": [],
+                "mapping_contract_version": "skills-pool-mapping-v2",
+                "mappings": [
+                    {
+                        "corpus": "unknown",
+                        "relative_path": "writer",
+                        "link_name": "writer",
+                    }
+                ],
+            },
+        ),
+        (
+            "publish_pool_mappings",
+            "/api/skills/layout/mappings/publish",
+            {
+                "mapping_contract_version": "skills-pool-mapping-v2",
+                "mappings": [
+                    {
+                        "corpus": "unknown",
+                        "relative_path": "writer",
+                        "link_name": "writer",
+                    }
+                ],
+            },
+        ),
+        (
+            "verify_pool_mappings",
+            "/api/skills/layout/mappings/verify",
+            {
+                "mapping_contract_version": "skills-pool-mapping-v2",
+                "mappings": [
+                    {
+                        "corpus": "unknown",
+                        "relative_path": "writer",
+                        "link_name": "writer",
+                    }
+                ],
+            },
+        ),
+    ],
+)
+def test_pool_mapping_routes_reject_unknown_corpus_at_schema_boundary(
+    client,
+    rich_manager,
+    method: str,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    plugin = MagicMock()
+    setattr(plugin, method, AsyncMock())
+    rich_manager._active_engine._skills = plugin
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 422
+    getattr(plugin, method).assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        (
             "probe_pool_layout",
             "/api/skills/layout/probe",
             {

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -11,14 +11,17 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from engine.community.api.skills.router import router as skills_router
+from engine.community.core.adapters.openclaw.skills import (
+    OpenClawSkillsAdapter,
+)
 from engine.community.core.engine.base import BaseEngine
 from engine.community.core.engine.capability import Capability, EngineCapabilities
 from engine.community.core.engine.exceptions import (
     CapabilityNotSupportedError,
 )
 from engine.community.core.engine.registry import EngineRegistry
-from engine.community.core.skills.layout_planner import (
-    SkillLayoutResolutionError,
+from engine.community.core.skills.exceptions import (
+    InvalidPoolMappingRequestError,
 )
 from engine.community.core.skills.models import (
     CleanSymlinksResult,
@@ -35,6 +38,7 @@ from engine.community.core.skills.models import (
     SyncSymlinksResult,
 )
 from engine.community.manager import EngineManager
+from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -444,7 +448,7 @@ def test_pool_mapping_routes_propagate_logical_v2_contract(
         ),
     ],
 )
-def test_pool_mapping_routes_map_layout_resolution_errors_to_400(
+def test_pool_mapping_routes_map_invalid_request_errors_to_400(
     client,
     rich_manager,
     method: str,
@@ -456,7 +460,7 @@ def test_pool_mapping_routes_map_layout_resolution_errors_to_400(
         plugin,
         method,
         AsyncMock(
-            side_effect=SkillLayoutResolutionError(
+            side_effect=InvalidPoolMappingRequestError(
                 "mapping_contract_version is unsupported"
             )
         ),
@@ -469,6 +473,57 @@ def test_pool_mapping_routes_map_layout_resolution_errors_to_400(
     assert response.json()["detail"] == (
         "mapping_contract_version is unsupported"
     )
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/api/skills/layout/activate",
+            {
+                "migration_generation": "generation-1",
+                "preparation_id": "preparation-1",
+                "registered_local_names": [],
+                "mapping_contract_version": "skills-pool-mapping-v2",
+                "mappings": [
+                    {"source": "/pool/a", "target": "/active/a"}
+                ],
+            },
+        ),
+        (
+            "/api/skills/layout/mappings/publish",
+            {
+                "mapping_contract_version": "skills-pool-mapping-v2",
+                "mappings": [
+                    {"source": "/pool/a", "target": "/active/a"}
+                ],
+            },
+        ),
+        (
+            "/api/skills/layout/mappings/verify",
+            {
+                "mapping_contract_version": "skills-pool-mapping-v2",
+                "mappings": [
+                    {"source": "/pool/a", "target": "/active/a"}
+                ],
+            },
+        ),
+    ],
+)
+def test_pool_mapping_routes_reject_v2_physical_shape_via_real_adapter(
+    client,
+    rich_manager,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    rich_manager._active_engine._skills = OpenClawSkillsAdapter(
+        OpenClawPluginImpl()
+    )
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 400
+    assert "logical mapping" in response.json()["detail"]
 
 
 @pytest.mark.parametrize(

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -10,9 +10,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
 from engine.community.api.skills.router import router as skills_router
 from engine.community.core.engine.base import BaseEngine
 from engine.community.core.engine.capability import Capability, EngineCapabilities
@@ -20,6 +17,9 @@ from engine.community.core.engine.exceptions import (
     CapabilityNotSupportedError,
 )
 from engine.community.core.engine.registry import EngineRegistry
+from engine.community.core.skills.layout_planner import (
+    SkillLayoutResolutionError,
+)
 from engine.community.core.skills.models import (
     CleanSymlinksResult,
     PoolLayoutActivationResult,
@@ -35,6 +35,8 @@ from engine.community.core.skills.models import (
     SyncSymlinksResult,
 )
 from engine.community.manager import EngineManager
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 class _EngineWithSkills(BaseEngine):
@@ -414,6 +416,58 @@ def test_pool_mapping_routes_propagate_logical_v2_contract(
     plugin.verify_pool_mappings.assert_awaited_once_with(
         [intent],
         mapping_contract_version=version,
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        (
+            "activate_pool_layout",
+            "/api/skills/layout/activate",
+            {
+                "migration_generation": "generation-1",
+                "preparation_id": "preparation-1",
+                "registered_local_names": [],
+                "mappings": [],
+            },
+        ),
+        (
+            "publish_pool_mappings",
+            "/api/skills/layout/mappings/publish",
+            {"mappings": []},
+        ),
+        (
+            "verify_pool_mappings",
+            "/api/skills/layout/mappings/verify",
+            {"mappings": []},
+        ),
+    ],
+)
+def test_pool_mapping_routes_map_layout_resolution_errors_to_400(
+    client,
+    rich_manager,
+    method: str,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    plugin = MagicMock()
+    setattr(
+        plugin,
+        method,
+        AsyncMock(
+            side_effect=SkillLayoutResolutionError(
+                "mapping_contract_version is unsupported"
+            )
+        ),
+    )
+    rich_manager._active_engine._skills = plugin
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "mapping_contract_version is unsupported"
     )
 
 

--- a/src/engine/src/engine/community/core/skills/exceptions.py
+++ b/src/engine/src/engine/community/core/skills/exceptions.py
@@ -1,0 +1,8 @@
+"""Stable domain errors exposed by the Skills service contract."""
+
+
+class InvalidPoolMappingRequestError(ValueError):
+    """A Pool mapping request is invalid and safe to reject without mutation."""
+
+
+__all__ = ["InvalidPoolMappingRequestError"]

--- a/src/engine/src/engine/community/core/skills/protocol.py
+++ b/src/engine/src/engine/community/core/skills/protocol.py
@@ -30,6 +30,9 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 from engine.community.core.engine.context import AuthContext
+from engine.community.core.skills.exceptions import (
+    InvalidPoolMappingRequestError,
+)
 from engine.community.core.skills.models import (
     CenterEnsureRequest,
     CenterEnsureResult,
@@ -183,7 +186,12 @@ class SkillsService(Protocol):
         request: PoolLayoutActivateRequest,
         auth: AuthContext | None = None,
     ) -> PoolLayoutActivationResult:
-        """核对登记事实、同步完整 local 并原子提交 Legacy→Pool bridge。"""
+        """核对登记事实、同步完整 local 并原子提交 Legacy→Pool bridge。
+
+        Raises:
+            InvalidPoolMappingRequestError: The versioned mapping request is
+                invalid and no filesystem mutation has started.
+        """
         ...
 
     async def rollback_pool_layout(
@@ -222,6 +230,10 @@ class SkillsService(Protocol):
 
         ``skills-pool-mapping-v2`` carries logical intents. An omitted version
         is the compatibility form for legacy physical ``SymlinkItem`` values.
+
+        Raises:
+            InvalidPoolMappingRequestError: The version, wire shape, or
+                logical mapping is invalid before filesystem publication.
         """
         ...
 
@@ -233,8 +245,13 @@ class SkillsService(Protocol):
         mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
     ) -> PoolMappingVerificationResult:
-        """Verify mappings using the same versioned contract as publication."""
+        """Verify mappings using the same versioned contract as publication.
+
+        Raises:
+            InvalidPoolMappingRequestError: The version, wire shape, or
+                logical mapping is invalid before filesystem inspection.
+        """
         ...
 
 
-__all__ = ["SkillsService"]
+__all__ = ["InvalidPoolMappingRequestError", "SkillsService"]

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -10,11 +10,12 @@ from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from engine.community.core.adapters.openclaw.skills import OpenClawSkillsAdapter
+from engine.community.core.skills.exceptions import (
+    InvalidPoolMappingRequestError,
+)
 from engine.community.core.skills.layout_planner import (
     MAPPING_CONTRACT_VERSION,
-    SkillLayoutResolutionError,
 )
 from engine.community.core.skills.models import (
     PoolLayoutActivateRequest,
@@ -2012,7 +2013,7 @@ async def test_openclaw_port_rejects_nul_before_publish(
     publish = MagicMock()
     monkeypatch.setattr(_skills, "publish_pool_mappings", publish)
 
-    with pytest.raises(SkillLayoutResolutionError):
+    with pytest.raises(InvalidPoolMappingRequestError):
         await OpenClawPluginImpl().publish_pool_mappings(
             {
                 "mapping_contract_version": MAPPING_CONTRACT_VERSION,
@@ -2030,7 +2031,7 @@ def test_logical_dot_mapping_is_rejected_before_active_tree_mutation(
     home, legacy_local, _pool_local, _pool_repo = _prepared_home(tmp_path)
     active_target = legacy_local.parent / "all-skills"
 
-    with pytest.raises(SkillLayoutResolutionError):
+    with pytest.raises(InvalidPoolMappingRequestError):
         resolved = resolve_mapping_payload(
             engine="openclaw",
             source_layout=MappingSourceLayout.POOL,

--- a/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
@@ -224,7 +224,12 @@ def prepare_desktop_pool(
         ):
             raise OSError(f"Pool local is not a directory: {layout.pool_local}")
         layout.pool_local.mkdir(exist_ok=True)
-        if not layout.legacy_local.is_dir() or layout.legacy_local.is_symlink():
+        if layout.legacy_local.is_symlink():
+            raise OSError(
+                f"Legacy local is not a directory: {layout.legacy_local}"
+            )
+        layout.legacy_local.mkdir(parents=True, exist_ok=True)
+        if not layout.legacy_local.is_dir():
             raise OSError(
                 f"Legacy local is not a directory: {layout.legacy_local}"
             )

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -768,6 +768,23 @@ def inspect_runtime_layout(
                     reason="active_managed_entry_invalid",
                     preparation_id=preparation_id,
                 )
+        active_checks = {
+            "marker_valid": True,
+            "active_marker_valid": True,
+            "pool_local_valid": True,
+            (
+                "pool_repo_mounted"
+                if effective_repo_delivery is RepoDelivery.MOUNT
+                else "pool_repo_downloaded"
+            ): True,
+            "pool_repo_readable": True,
+            "pool_mappings_valid": True,
+            "legacy_storage_entries_absent": (
+                active_marker["activation_state"] == "active"
+            ),
+        }
+        if engine in {"aicoding", "hermes"}:
+            active_checks["stable_repo_bridge_valid"] = True
         return RuntimeLayoutInspection(
             status=RuntimeLayoutInspectionStatus.READY,
             engine=engine,
@@ -778,22 +795,7 @@ def inspect_runtime_layout(
                 marker=marker,
                 activation_state=active_marker["activation_state"],
                 mapping_contract_version=mapping_contract_version,
-                checks={
-                    "marker_valid": True,
-                    "active_marker_valid": True,
-                    "pool_local_valid": True,
-                    (
-                        "pool_repo_mounted"
-                        if effective_repo_delivery is RepoDelivery.MOUNT
-                        else "pool_repo_downloaded"
-                    ): True,
-                    "pool_repo_readable": True,
-                    "pool_mappings_valid": True,
-                    "legacy_storage_entries_absent": (
-                        active_marker["activation_state"] == "active"
-                    ),
-                    "stable_repo_bridge_valid": (engine in {"aicoding", "hermes"}),
-                },
+                checks=active_checks,
             ),
         )
     if effective_repo_delivery is RepoDelivery.DOWNLOAD:

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -783,7 +783,10 @@ def inspect_runtime_layout(
                 active_marker["activation_state"] == "active"
             ),
         }
-        if engine in {"aicoding", "hermes"}:
+        if (
+            engine in {"aicoding", "hermes"}
+            and active_marker["activation_state"] == "active"
+        ):
             active_checks["stable_repo_bridge_valid"] = True
         return RuntimeLayoutInspection(
             status=RuntimeLayoutInspectionStatus.READY,

--- a/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
@@ -12,6 +12,7 @@ from engine.community.core.skills.layout_planner import (
     LogicalSkillMapping,
     RuntimeLayoutContext,
     SkillCorpus,
+    SkillLayoutResolutionError,
     resolve_filesystem_skill_layout,
     resolve_skill_mappings,
 )
@@ -78,7 +79,7 @@ def resolve_mapping_payload(
             physical.append(SkillMapping(source=source, target=target))
         return ResolvedMappingPayload(tuple(physical))
     if mapping_contract_version != MAPPING_CONTRACT_VERSION:
-        raise ValueError(
+        raise SkillLayoutResolutionError(
             f"unsupported mapping contract: {mapping_contract_version}"
         )
 

--- a/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from engine.community.core.skills.exceptions import (
+    InvalidPoolMappingRequestError,
+)
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
     MAPPING_CONTRACT_VERSION,
@@ -38,9 +41,11 @@ def _require_mapping_fields(
     contract_name: str,
 ) -> dict[str, object]:
     if not isinstance(item, dict):
-        raise TypeError(f"each {contract_name} mapping must be an object")
+        raise InvalidPoolMappingRequestError(
+            f"each {contract_name} mapping must be an object"
+        )
     if frozenset(item) != expected:
-        raise TypeError(
+        raise InvalidPoolMappingRequestError(
             f"{contract_name} mapping must contain exactly "
             f"{', '.join(sorted(expected))}"
         )
@@ -63,7 +68,7 @@ def resolve_mapping_payload(
     """
 
     if not isinstance(payload, list):
-        raise TypeError("mappings must be an array")
+        raise InvalidPoolMappingRequestError("mappings must be an array")
     if mapping_contract_version is None:
         physical: list[SkillMapping] = []
         for raw_item in payload:
@@ -75,11 +80,13 @@ def resolve_mapping_payload(
             source = item["source"]
             target = item["target"]
             if not isinstance(source, str) or not isinstance(target, str):
-                raise TypeError("legacy mapping source and target must be strings")
+                raise InvalidPoolMappingRequestError(
+                    "legacy mapping source and target must be strings"
+                )
             physical.append(SkillMapping(source=source, target=target))
         return ResolvedMappingPayload(tuple(physical))
     if mapping_contract_version != MAPPING_CONTRACT_VERSION:
-        raise SkillLayoutResolutionError(
+        raise InvalidPoolMappingRequestError(
             f"unsupported mapping contract: {mapping_contract_version}"
         )
 
@@ -98,13 +105,19 @@ def resolve_mapping_payload(
             or not isinstance(relative_path, str)
             or not isinstance(link_name, str)
         ):
-            raise TypeError(
+            raise InvalidPoolMappingRequestError(
                 "logical mapping corpus, relative_path and link_name "
                 "must be strings"
             )
+        try:
+            resolved_corpus = SkillCorpus(corpus)
+        except ValueError as error:
+            raise InvalidPoolMappingRequestError(
+                f"unknown Skill corpus: {corpus!r}"
+            ) from error
         logical.append(
             LogicalSkillMapping(
-                corpus=SkillCorpus(corpus),
+                corpus=resolved_corpus,
                 relative_path=relative_path,
                 link_name=link_name,
             )
@@ -127,12 +140,15 @@ def resolve_mapping_payload(
         if source_layout is MappingSourceLayout.POOL
         else plan.legacy_repo
     )
-    resolved = resolve_skill_mappings(
-        active_root=plan.active_root,
-        local_root=local_root,
-        repo_root=repo_root,
-        mappings=logical,
-    )
+    try:
+        resolved = resolve_skill_mappings(
+            active_root=plan.active_root,
+            local_root=local_root,
+            repo_root=repo_root,
+            mappings=logical,
+        )
+    except SkillLayoutResolutionError as error:
+        raise InvalidPoolMappingRequestError(str(error)) from error
     return ResolvedMappingPayload(
         mappings=tuple(
             SkillMapping(source=str(mapping.source), target=str(mapping.target))

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from engine.community.core.adapters.openclaw.skills import OpenClawSkillsAdapter
+from engine.community.core.skills.exceptions import (
+    InvalidPoolMappingRequestError,
+)
 from engine.community.core.skills.models import (
     PoolLayoutActivateRequest,
     PoolLayoutActivationStatus,
@@ -253,3 +255,24 @@ async def test_openclaw_adapter_keeps_unversioned_physical_mapping() -> None:
     }
     port.publish_pool_mappings.assert_awaited_once_with(expected)
     port.verify_pool_mappings.assert_awaited_once_with(expected)
+
+
+@pytest.mark.asyncio
+async def test_openclaw_adapter_preserves_invalid_mapping_request_contract() -> None:
+    error = InvalidPoolMappingRequestError("invalid mapping payload")
+    port = MagicMock()
+    port.activate_pool_layout = AsyncMock(side_effect=error)
+    port.publish_pool_mappings = AsyncMock(side_effect=error)
+    port.verify_pool_mappings = AsyncMock(side_effect=error)
+    adapter = OpenClawSkillsAdapter(port)
+    request = PoolLayoutActivateRequest(
+        migration_generation="generation-1",
+        preparation_id="preparation-1",
+    )
+
+    with pytest.raises(InvalidPoolMappingRequestError):
+        await adapter.activate_pool_layout(request)
+    with pytest.raises(InvalidPoolMappingRequestError):
+        await adapter.publish_pool_mappings([])
+    with pytest.raises(InvalidPoolMappingRequestError):
+        await adapter.verify_pool_mappings([])

--- a/src/engine/src/engine/community/tests/contracts/test_skills_pool_probe_evidence.py
+++ b/src/engine/src/engine/community/tests/contracts/test_skills_pool_probe_evidence.py
@@ -1,0 +1,120 @@
+"""Cross-engine wire contract for READY Skills Pool Probe evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from engine.community.config import RepoDelivery
+from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
+    LayoutIdentity,
+    RuntimeLayoutContext,
+    resolve_filesystem_skill_layout,
+)
+from engine.community.plugins.skills_pool.desktop_preparation import (
+    DesktopPreparationStatus,
+    prepare_desktop_pool,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
+    PoolActivationStatus,
+    activate_aicoding_pool,
+    activate_claude_code_pool,
+    activate_hermes_pool,
+    activate_openclaw_pool,
+)
+from engine.community.plugins.skills_pool.layout_probe import (
+    RuntimeLayoutInspectionStatus,
+    inspect_runtime_layout,
+)
+
+_ACTIVATE = {
+    "openclaw": activate_openclaw_pool,
+    "claude_code": activate_claude_code_pool,
+    "aicoding": activate_aicoding_pool,
+    "hermes": activate_hermes_pool,
+}
+
+
+def _active_desktop_layout(home: Path, engine: str):
+    layout = resolve_filesystem_skill_layout(
+        LayoutIdentity(engine, LAYOUT_CONTRACT_VERSION),
+        RuntimeLayoutContext(home=home),
+    )
+    layout.legacy_local.mkdir(parents=True)
+    repo_source = home / ".desktop-skills-repo"
+    repo_source.mkdir()
+    layout.active_root.mkdir(parents=True, exist_ok=True)
+    if layout.local_bridge != layout.legacy_local:
+        layout.local_bridge.symlink_to(
+            layout.legacy_local,
+            target_is_directory=True,
+        )
+    if layout.legacy_repo != repo_source:
+        layout.legacy_repo.parent.mkdir(parents=True, exist_ok=True)
+        layout.legacy_repo.symlink_to(
+            repo_source,
+            target_is_directory=True,
+        )
+    if (
+        layout.repo_bridge != layout.legacy_repo
+        and not layout.repo_bridge.exists()
+        and not layout.repo_bridge.is_symlink()
+    ):
+        layout.repo_bridge.symlink_to(
+            layout.legacy_repo,
+            target_is_directory=True,
+        )
+    prepared = prepare_desktop_pool(
+        engine=engine,
+        repo_source=repo_source,
+        home=home,
+    )
+    assert prepared.status is DesktopPreparationStatus.PREPARED
+    activated = _ACTIVATE[engine](
+        migration_generation="generation-1",
+        preparation_id=str(prepared.preparation_id),
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+    )
+    assert activated.status is PoolActivationStatus.COMMITTED
+    return layout
+
+
+@pytest.mark.parametrize(
+    "engine",
+    ("openclaw", "claude_code", "aicoding", "hermes"),
+)
+def test_stable_repo_bridge_check_is_conditional_and_verified(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    engine: str,
+) -> None:
+    monkeypatch.setenv("MAC_CONTAINER", "true")
+    home = tmp_path / "home/admin"
+    layout = _active_desktop_layout(home, engine)
+
+    active = inspect_runtime_layout(
+        engine=engine,
+        home=home,
+        repo_delivery=RepoDelivery.DOWNLOAD,
+    )
+    assert active.status is RuntimeLayoutInspectionStatus.READY
+    checks = active.evidence["checks"]
+    if engine in {"aicoding", "hermes"}:
+        assert checks["stable_repo_bridge_valid"] is True
+    else:
+        assert "stable_repo_bridge_valid" not in checks
+
+    marker = json.loads(layout.active_marker.read_text())
+    marker["activation_state"] = "finalizing"
+    layout.active_marker.write_text(json.dumps(marker))
+    finalizing = inspect_runtime_layout(
+        engine=engine,
+        home=home,
+        repo_delivery=RepoDelivery.DOWNLOAD,
+    )
+    assert finalizing.status is RuntimeLayoutInspectionStatus.READY
+    assert "stable_repo_bridge_valid" not in finalizing.evidence["checks"]

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -139,6 +140,19 @@ def test_desktop_download_layout_uses_public_cutover_and_rollback(
         assert active.evidence["checks"]["stable_repo_bridge_valid"] is True
     else:
         assert "stable_repo_bridge_valid" not in active.evidence["checks"]
+
+    active_marker = json.loads(layout.active_marker.read_text())
+    active_marker["activation_state"] = "finalizing"
+    layout.active_marker.write_text(json.dumps(active_marker))
+    finalizing = inspect_runtime_layout(
+        engine=engine,
+        home=home,
+        repo_delivery=RepoDelivery.DOWNLOAD,
+    )
+    assert finalizing.status is RuntimeLayoutInspectionStatus.READY
+    assert "stable_repo_bridge_valid" not in finalizing.evidence["checks"]
+    active_marker["activation_state"] = "active"
+    layout.active_marker.write_text(json.dumps(active_marker))
 
     (layout.pool_local / "handmade/SKILL.md").write_text("pool")
     rolled_back = ROLLBACK[engine](

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 
 import pytest
-
 from engine.community.config import RepoDelivery
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
@@ -136,6 +135,10 @@ def test_desktop_download_layout_uses_public_cutover_and_rollback(
         repo_delivery=RepoDelivery.DOWNLOAD,
     )
     assert active.status is RuntimeLayoutInspectionStatus.READY
+    if engine in {"aicoding", "hermes"}:
+        assert active.evidence["checks"]["stable_repo_bridge_valid"] is True
+    else:
+        assert "stable_repo_bridge_valid" not in active.evidence["checks"]
 
     (layout.pool_local / "handmade/SKILL.md").write_text("pool")
     rolled_back = ROLLBACK[engine](

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
@@ -85,6 +85,82 @@ def _legacy_runtime(home: Path, engine: str):
     return layout, repo_source, managed, external
 
 
+def _fresh_legacy_runtime(home: Path, engine: str):
+    layout = _layout(home, engine)
+    repo_source = home / ".openclaw/workspace/skills/skills-repo"
+    repo_source.mkdir(parents=True)
+
+    layout.active_root.mkdir(parents=True, exist_ok=True)
+    if layout.local_bridge != layout.legacy_local:
+        layout.local_bridge.symlink_to(
+            layout.legacy_local,
+            target_is_directory=True,
+        )
+    if layout.legacy_repo != repo_source:
+        layout.legacy_repo.parent.mkdir(parents=True, exist_ok=True)
+        layout.legacy_repo.symlink_to(repo_source, target_is_directory=True)
+    if (
+        layout.repo_bridge != layout.legacy_repo
+        and not layout.repo_bridge.exists()
+        and not layout.repo_bridge.is_symlink()
+    ):
+        layout.repo_bridge.symlink_to(
+            layout.legacy_repo,
+            target_is_directory=True,
+        )
+    return layout, repo_source
+
+
+@pytest.mark.parametrize("engine", FILESYSTEM_ENGINES)
+def test_preparation_creates_empty_legacy_local_for_fresh_desktop_runtime(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout, repo_source = _fresh_legacy_runtime(home, engine)
+    assert not layout.legacy_local.exists()
+    assert not layout.legacy_local.is_symlink()
+
+    result = prepare_desktop_pool(
+        engine=engine,
+        repo_source=repo_source,
+        home=home,
+    )
+
+    assert result.status is DesktopPreparationStatus.PREPARED
+    assert layout.legacy_local.is_dir()
+    assert not layout.legacy_local.is_symlink()
+    assert layout.pool_local.is_dir()
+    probe = inspect_runtime_layout(
+        engine=engine,
+        home=home,
+        repo_delivery=RepoDelivery.DOWNLOAD,
+    )
+    assert probe.status is RuntimeLayoutInspectionStatus.READY
+    assert probe.preparation_id == result.preparation_id
+
+
+def test_preparation_does_not_replace_missing_legacy_local_symlink(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout, repo_source = _fresh_legacy_runtime(home, "openclaw")
+    wrong = home / "wrong-local"
+    layout.legacy_local.symlink_to(wrong, target_is_directory=True)
+
+    result = prepare_desktop_pool(
+        engine="openclaw",
+        repo_source=repo_source,
+        home=home,
+    )
+
+    assert result.status is DesktopPreparationStatus.FAILED
+    assert layout.legacy_local.is_symlink()
+    assert _target(layout.legacy_local) == wrong
+    assert not wrong.exists()
+    assert not layout.ready_marker.exists()
+
+
 @pytest.mark.parametrize("engine", FILESYSTEM_ENGINES)
 def test_preparation_reuses_downloaded_repo_and_preserves_legacy_layout(
     tmp_path: Path,

--- a/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 
 import pytest
-
+from engine.community.core.skills.exceptions import (
+    InvalidPoolMappingRequestError,
+)
 from engine.community.core.skills.layout_planner import (
     MAPPING_CONTRACT_VERSION,
+    SkillLayoutResolutionError,
 )
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingSourceLayout,
@@ -154,7 +157,7 @@ def test_invalid_contract_shape_has_no_filesystem_side_effect(
 ) -> None:
     before = _snapshot(tmp_path)
 
-    with pytest.raises((TypeError, ValueError), match=message):
+    with pytest.raises(InvalidPoolMappingRequestError, match=message):
         resolve_mapping_payload(
             engine="openclaw",
             source_layout=MappingSourceLayout.POOL,
@@ -164,6 +167,36 @@ def test_invalid_contract_shape_has_no_filesystem_side_effect(
         )
 
     assert _snapshot(tmp_path) == before
+
+
+def test_internal_layout_resolution_error_is_not_reclassified(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from engine.community.plugins.skills_pool import mapping_contract
+
+    def fail_layout_resolution(*args: object, **kwargs: object) -> None:
+        raise SkillLayoutResolutionError("descriptor invariant failed")
+
+    monkeypatch.setattr(
+        mapping_contract,
+        "resolve_filesystem_skill_layout",
+        fail_layout_resolution,
+    )
+
+    with pytest.raises(
+        SkillLayoutResolutionError,
+        match="descriptor invariant failed",
+    ) as error:
+        resolve_mapping_payload(
+            engine="openclaw",
+            source_layout=MappingSourceLayout.POOL,
+            mapping_contract_version=MAPPING_CONTRACT_VERSION,
+            payload=[],
+            home=tmp_path,
+        )
+
+    assert not isinstance(error.value, InvalidPoolMappingRequestError)
 
 
 def test_legacy_no_version_physical_payload_remains_compatible(


### PR DESCRIPTION
## What changed

- Treat a completely absent Desktop Legacy `skills-local` root as the valid empty-local-skills state and create it before Pool preparation.
- Continue to fail closed when the Legacy local path is a symlink or another invalid filesystem entry.
- Report `stable_repo_bridge_valid` only when that bridge is applicable and was actually verified: AICoding/Hermes in `active`; omit it for OpenClaw/Claude Code active layouts and all `finalizing` recovery windows.
- Introduce the public `InvalidPoolMappingRequestError` service contract and map only that request error to HTTP 400.
- Normalize invalid logical paths, incompatible logical/physical wire shapes, and unsupported mapping contract versions before filesystem mutation while leaving internal layout invariant errors as server failures.
- Keep transport-schema failures explicit: unknown corpus values are rejected by FastAPI with HTTP 422 before the Skills Service/plugin is invoked.
- Add implementation, Service API contract, HTTP integration, and four-engine Probe evidence coverage.

## Why

A fresh Desktop rootfs creates the workspace and downloads `skills-repo`, but it does not create `skills-local`. Pool preparation previously required that directory to exist, so a newly created Desktop Bot stayed `FAILED` and never published `.pool-ready` unless a local skill directory had already been created by another flow.

Real rootfs validation also found control-plane quality issues: OpenClaw exposed an inapplicable bridge check as `false`, deterministic invalid mapping requests surfaced as HTTP 500, and `finalizing` AICoding/Hermes evidence could claim a stable repo bridge had been verified before that verification ran.

## Impact

Fresh Desktop Bots with no local skills can now reach READY without changing active Legacy mappings. Existing local content and invalid/ambiguous filesystem states retain their previous behavior. Backend receives deterministic 400 responses for well-shaped but invalid mapping contracts, shapes, and paths without masking internal Engine invariants as client errors; malformed HTTP schema input fails before plugin invocation with 422.

## Validation

- 273 targeted Engine tests passed across Desktop preparation, repo download, Probe, activation/rollback, four filesystem engines, mapping contract/router, Service API contracts, fault injection, race recovery, and the HTTP schema boundary.
- Local AgentBox rootfs validation passed fresh prepare, cutover, mapping verify, restart persistence, idempotent replay, rollback, invalid preparation, missing/unreadable local data, active-entry conflict, post-cutover mapping failure and same-generation recovery, response loss and replay, rollback I/O failure and retry, and concurrent Pool/quarantine writes.
- Final rootfs validation confirmed v2 physical mappings, unversioned logical mappings, unknown versions, and path traversal all return HTTP 400 with active mappings and `.pool-active` byte-identical before/after.
- Unknown corpus payloads on activate/publish/verify return HTTP 422 before the corresponding plugin method is invoked.
- Ruff passed for the newly changed Python test; `git diff --check` passed.