### PR TITLE
fix: resolve current runtime binding for skills pool

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
@@ -103,6 +103,53 @@ class DeviceContextResolver:
             bot_type=bot_type,
         )
 
+    def resolve_current_runtime_for_bot(
+        self,
+        bot_id: str,
+        user_id: str,
+        *,
+        device_uuid: str | None = None,
+    ) -> DeviceContext:
+        """Resolve the Bot's currently active runtime.
+
+        A restart can replace ``ac_bots.device_id`` before every legacy caller
+        has converged ``ac_bots.binding_id``. Runtime mutations must therefore
+        resolve the current device identity, not follow a historical binding
+        primary key. Only an ACTIVE binding is accepted so a released, failed,
+        or still-starting instance can never receive a cutover mutation.
+        """
+        bot = self._bot_repository.get_by_id_and_owner(bot_id, user_id)
+        device_id = str((bot or {}).get("device_id") or "").strip()
+        if not device_id:
+            raise DeviceNotBoundError(
+                f"DeviceContextResolver: no current runtime device for bot={bot_id}"
+            )
+
+        binding = self._binding_repository.get_by_device_id(device_id)
+        if binding is None or binding.status != "ACTIVE":
+            raise DeviceNotBoundError(
+                f"DeviceContextResolver: no active runtime binding for bot={bot_id}"
+            )
+
+        provider = binding.device_provider
+        if provider not in self._builders:
+            raise UnknownProviderError(
+                f"DeviceContextResolver: unknown provider={provider!r} for bot={bot_id}"
+            )
+
+        builder = self._builders[provider]
+        raw_conn_info = builder.build(binding, user_id, device_uuid=device_uuid)
+        conn_info = self._normalize_schema(raw_conn_info, provider)
+
+        return DeviceContext(
+            provider=provider,
+            conn_info=conn_info,
+            binding_id=binding.id,
+            bot_id=bot_id,
+            user_id=user_id,
+            bot_type=(bot or {}).get("bot_type") or "",
+        )
+
     def resolve_for_binding(
         self, binding_id: int, operator_id: str, *, bot_id: str,
         device_uuid: str | None = None,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -87,7 +87,10 @@ class CurrentRuntimeLayoutProbeService:
         if engine not in {"openclaw", "claude_code", "aicoding", "hermes"}:
             return self._not_capable(engine, "engine_pool_probe_not_implemented")
         try:
-            context = self._resolver.resolve_for_bot(bot_id, user_id)
+            context = self._resolver.resolve_current_runtime_for_bot(
+                bot_id,
+                user_id,
+            )
             response = await self._transport.invoke(
                 context.conn_info,
                 "POST",

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
@@ -305,7 +305,7 @@ class SkillsPoolRuntime:
         path: str,
         body: dict[str, Any],
     ) -> dict[str, Any]:
-        context = self._resolver.resolve_for_bot(bot_id, user_id)
+        context = self._resolver.resolve_current_runtime_for_bot(bot_id, user_id)
         return await self._transport.invoke(
             context.conn_info,
             "POST",

--- a/src/backend/tests/community/core/devices/services/test_device_context_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context_resolver.py
@@ -58,11 +58,12 @@ def resolver(fake_binding_repo, fake_bot_repo, builders):
     )
 
 
-def _mock_binding(bid: int, provider: str):
+def _mock_binding(bid: int, provider: str, *, status: str = "ACTIVE"):
     b = MagicMock()
     b.id = bid
     b.device_provider = provider
     b.device_id = f"device-{bid}"
+    b.status = status
     return b
 
 
@@ -109,6 +110,62 @@ def test_bot_no_active_binding_raises_device_not_bound(resolver, fake_binding_re
     fake_binding_repo.get_active_by_bot_and_owner.return_value = None
     with pytest.raises(DeviceNotBoundError):
         resolver.resolve_for_bot("non-existent", "user-1")
+
+
+def test_current_runtime_uses_bot_device_id_instead_of_stale_binding_id(
+    resolver,
+    fake_binding_repo,
+    fake_bot_repo,
+    builders,
+):
+    """重启后 bot.binding_id 可能仍指向 RELEASED 历史记录。
+
+    当前运行时解析必须以 Bot 当前 device_id 为准，不能复用历史 binding_id。
+    """
+    fake_bot_repo.get_by_id_and_owner.return_value = {
+        "bot_type": "personal",
+        "binding_id": 10,
+        "device_id": "device-20",
+    }
+    fake_binding_repo.get_active_by_bot_and_owner.return_value = _mock_binding(
+        10,
+        "arca",
+        status="RELEASED",
+    )
+    current = _mock_binding(20, "arca")
+    current.device_id = "device-20"
+    fake_binding_repo.get_by_device_id.return_value = current
+
+    ctx = resolver.resolve_current_runtime_for_bot("bot-1", "owner-1")
+
+    assert ctx.binding_id == 20
+    assert ctx.conn_info["_provider_mark"] == "arca-built"
+    fake_binding_repo.get_by_device_id.assert_called_once_with("device-20")
+    fake_binding_repo.get_active_by_bot_and_owner.assert_not_called()
+    builders["arca"].build.assert_called_once_with(
+        current,
+        "owner-1",
+        device_uuid=None,
+    )
+
+
+@pytest.mark.parametrize("status", ["PENDING", "FAILED", "RELEASED", "STOPPED"])
+def test_current_runtime_rejects_non_active_binding(
+    resolver,
+    fake_binding_repo,
+    fake_bot_repo,
+    status,
+):
+    fake_bot_repo.get_by_id_and_owner.return_value = {
+        "bot_type": "personal",
+        "device_id": "device-20",
+    }
+    current = _mock_binding(20, "arca", status=status)
+    current.device_id = "device-20"
+    fake_binding_repo.get_by_device_id.return_value = current
+
+    with pytest.raises(DeviceNotBoundError, match="no active runtime binding"):
+        resolver.resolve_current_runtime_for_bot("bot-1", "owner-1")
 
 
 def test_unknown_provider_raises_unknown_provider_error(resolver, fake_binding_repo):

--- a/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
@@ -29,9 +29,9 @@ def _service(
     context = Mock(conn_info={"url": "http://current-runtime"})
     resolver = Mock()
     if resolver_error is not None:
-        resolver.resolve_for_bot.side_effect = resolver_error
+        resolver.resolve_current_runtime_for_bot.side_effect = resolver_error
     else:
-        resolver.resolve_for_bot.return_value = context
+        resolver.resolve_current_runtime_for_bot.return_value = context
     transport = Mock()
     if transport_error is not None:
         transport.invoke = AsyncMock(side_effect=transport_error)
@@ -74,7 +74,10 @@ async def test_ready_is_taken_from_current_runtime_inspection():
 
     assert result.status is RuntimeLayoutProbeStatus.READY
     assert result.preparation_id == "2a958f59-8cf4-4413-a267-7d56d3382f23"
-    resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
+    resolver.resolve_current_runtime_for_bot.assert_called_once_with(
+        "bot-1",
+        "user-1",
+    )
     transport.invoke.assert_awaited_once_with(
         context.conn_info,
         "POST",
@@ -116,7 +119,10 @@ async def test_claude_code_ready_uses_current_runtime_probe():
 
     assert result.status is RuntimeLayoutProbeStatus.READY
     assert result.engine == "claude_code"
-    resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
+    resolver.resolve_current_runtime_for_bot.assert_called_once_with(
+        "bot-1",
+        "user-1",
+    )
     transport.invoke.assert_awaited_once_with(
         context.conn_info,
         "POST",
@@ -158,7 +164,10 @@ async def test_aicoding_ready_uses_current_runtime_probe():
 
     assert result.status is RuntimeLayoutProbeStatus.READY
     assert result.engine == "aicoding"
-    resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
+    resolver.resolve_current_runtime_for_bot.assert_called_once_with(
+        "bot-1",
+        "user-1",
+    )
     transport.invoke.assert_awaited_once_with(
         context.conn_info,
         "POST",
@@ -201,7 +210,10 @@ async def test_hermes_ready_requires_current_runtime_h0_evidence():
     assert result.status is RuntimeLayoutProbeStatus.READY
     assert result.engine == "hermes"
     assert result.evidence["checks"]["legacy_local_bridge_valid"] is True
-    resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
+    resolver.resolve_current_runtime_for_bot.assert_called_once_with(
+        "bot-1",
+        "user-1",
+    )
     transport.invoke.assert_awaited_once_with(
         context.conn_info,
         "POST",
@@ -460,7 +472,7 @@ async def test_teclaw_is_noop_without_resolving_runtime():
         preparation_id=None,
         evidence={"reason": "engine_has_no_filesystem_pool_layout"},
     )
-    resolver.resolve_for_bot.assert_not_called()
+    resolver.resolve_current_runtime_for_bot.assert_not_called()
     transport.invoke.assert_not_awaited()
 
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -2014,7 +2014,7 @@ class CurrentBindingResolver:
         self.current_binding = "binding-new"
         self.calls: list[tuple[str, str]] = []
 
-    def resolve_for_bot(self, bot_id: str, user_id: str):
+    def resolve_current_runtime_for_bot(self, bot_id: str, user_id: str):
         self.calls.append((bot_id, user_id))
         return SimpleNamespace(
             conn_info={"binding": self.current_binding},

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -20,7 +20,7 @@ class FakeResolver:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
 
-    def resolve_for_bot(self, bot_id: str, user_id: str):
+    def resolve_current_runtime_for_bot(self, bot_id: str, user_id: str):
         self.calls.append((bot_id, user_id))
         return SimpleNamespace(conn_info={"binding": len(self.calls)})
 


### PR DESCRIPTION
## Summary

- add a Skills Pool-specific current-runtime resolver that follows `ac_bots.device_id`
- require the resolved runtime binding to be `ACTIVE`
- route runtime probe, cutover, mapping publish and verification through that resolver
- preserve the legacy `resolve_for_bot` behavior for unrelated device flows

## Root cause

After an ARCA restart, `ac_bots.device_id` can already identify the new active runtime while the legacy `ac_bots.binding_id` still references the released historical binding. Skills Pool resolved through that stale primary key and sent cutover requests to a released sandbox.

## Safety

The change is deliberately scoped to Skills Pool runtime inspection and mutation. Non-Skills-Pool device consumers keep their existing resolver behavior. Missing, pending, failed, stopped or released current runtimes fail closed.

## Validation

- focused red/green reproduction for stale `binding_id` plus current `device_id`
- Skills Pool, runtime probe, resolver and device repository suite: 332 passed
- Ruff: passed
- `git diff --check`: passed
