### PR TITLE
feat(baas): record provider_device_id into baas_publish_record.extra_config

### DIFF
--- a/src/baas/src/secbaas/community/core/repository/publish_record/__init__.py
+++ b/src/baas/src/secbaas/community/core/repository/publish_record/__init__.py
@@ -3,9 +3,10 @@
 from ._orm_model import PublishRecordModel
 from ._orm_repository import OrmPublishRecordRepository
 from ._protocol import PublishRecordRepository
-from ._record import PublishRecordRecord
+from ._record import PublishRecordExtraConfig, PublishRecordRecord
 
 __all__ = [
+    "PublishRecordExtraConfig",
     "PublishRecordRecord",
     "PublishRecordRepository",
     "OrmPublishRecordRepository",

--- a/src/baas/src/secbaas/community/core/repository/publish_record/_record.py
+++ b/src/baas/src/secbaas/community/core/repository/publish_record/_record.py
@@ -9,6 +9,19 @@ from typing import Any
 
 
 @dataclass(slots=True)
+class PublishRecordExtraConfig:
+    """Typed model for baas_publish_record.extra_config.
+
+    Captures device identity metadata at record creation time so the
+    device's provider identity is preserved even after the source
+    baas_device record is overwritten by subsequent publishes.
+    """
+
+    device_uuid: str | None = None
+    provider_device_id: str | None = None
+
+
+@dataclass(slots=True)
 class PublishRecordRecord:
     """Database record for baas_publish_record table.
 

--- a/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
+++ b/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
@@ -7,6 +7,7 @@ with approval gates and rolling updates. Per D-01, D-01a, D-07.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -66,6 +67,7 @@ from secbaas.community.core.repository.publish_batch import (
     PublishBatchRepository,
 )
 from secbaas.community.core.repository.publish_record import (
+    PublishRecordExtraConfig,
     PublishRecordRecord,
     PublishRecordRepository,
 )
@@ -1135,6 +1137,18 @@ class DefaultPublishService(PublishService):
             device_idx += batch_cap
 
             for device in batch_devices:
+                extra_config_dict = dataclasses.asdict(
+                    PublishRecordExtraConfig(
+                        device_uuid=device.device_uuid,
+                        provider_device_id=device.provider_device_id,
+                    )
+                )
+                extra_config = (
+                    extra_config_dict
+                    if extra_config_dict.get("device_uuid") is not None
+                    or extra_config_dict.get("provider_device_id") is not None
+                    else None
+                )
                 record_repo.insert_record(
                     tenant=tenant,
                     env=env,
@@ -1148,6 +1162,7 @@ class DefaultPublishService(PublishService):
                     result_message=None,
                     creator=operator,
                     modifier=operator,
+                    extra_config=extra_config,
                 )
 
         logger.info(

--- a/src/baas/tests/unit/core/repository/publish_record/test_orm_publish_record_repository.py
+++ b/src/baas/tests/unit/core/repository/publish_record/test_orm_publish_record_repository.py
@@ -955,6 +955,61 @@ class TestGetLatestCreatedRecordByDevice:
         mock_session.query.return_value.filter.return_value.order_by.return_value.first.assert_called_once()
 
 
+# ==================== PublishRecordExtraConfig ====================
+
+
+class TestPublishRecordExtraConfig:
+    def test_creates_with_both_fields(self):
+        from dataclasses import asdict
+
+        from secbaas.community.core.repository.publish_record import (
+            PublishRecordExtraConfig,
+        )
+
+        cfg = PublishRecordExtraConfig(
+            device_uuid="dev-abc", provider_device_id="container-xyz"
+        )
+        assert cfg.device_uuid == "dev-abc"
+        assert cfg.provider_device_id == "container-xyz"
+
+        d = asdict(cfg)
+        assert d == {"device_uuid": "dev-abc", "provider_device_id": "container-xyz"}
+
+    def test_defaults_to_none(self):
+        from dataclasses import asdict
+
+        from secbaas.community.core.repository.publish_record import (
+            PublishRecordExtraConfig,
+        )
+
+        cfg = PublishRecordExtraConfig()
+        assert cfg.device_uuid is None
+        assert cfg.provider_device_id is None
+
+        d = asdict(cfg)
+        assert d == {"device_uuid": None, "provider_device_id": None}
+
+    def test_provider_device_id_none(self):
+        from dataclasses import asdict
+
+        from secbaas.community.core.repository.publish_record import (
+            PublishRecordExtraConfig,
+        )
+
+        cfg = PublishRecordExtraConfig(device_uuid="dev-1", provider_device_id=None)
+        d = asdict(cfg)
+        assert d == {"device_uuid": "dev-1", "provider_device_id": None}
+
+    def test_slots_enforced(self):
+        from secbaas.community.core.repository.publish_record import (
+            PublishRecordExtraConfig,
+        )
+
+        cfg = PublishRecordExtraConfig(device_uuid="d1")
+        with pytest.raises(AttributeError):
+            cfg.nonexistent_field = "value"
+
+
 # ==================== constructor ====================
 
 

--- a/src/baas/tests/unit/core/service/publish_manage/test_publish_service_coverage.py
+++ b/src/baas/tests/unit/core/service/publish_manage/test_publish_service_coverage.py
@@ -982,6 +982,100 @@ class TestCreateDeviceRecordsForPublish:
                     operator="op",
                 )
 
+    def test_insert_record_includes_provider_device_id_in_extra_config(self):
+        """Verify extra_config captures device_uuid + provider_device_id on insert."""
+        import dataclasses
+
+        from secbaas.community.core.repository.publish_record import (
+            PublishRecordExtraConfig,
+        )
+
+        svc = _make_service()
+        bot = _make_bot_record()
+        svc._device_repo.list_by_bot_id.return_value = [
+            _make_device(
+                id=1, device_uuid="uuid-abc", provider_device_id="provider-xyz"
+            ),
+        ]
+        batch = _make_batch_record(batch_capacity=1)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            svc._create_device_records_for_publish(
+                tenant="t",
+                env="test",
+                publish_id=1,
+                publish_type=PublishType.CREATE,
+                bot_record=bot,
+                batch_records=[batch],
+                operator="op",
+            )
+
+        svc._publish_record_repo.insert_record.assert_called_once()
+        call_kwargs = svc._publish_record_repo.insert_record.call_args.kwargs
+        assert "extra_config" in call_kwargs
+        assert call_kwargs["extra_config"] == {
+            "device_uuid": "uuid-abc",
+            "provider_device_id": "provider-xyz",
+        }
+
+    def test_insert_record_extra_config_with_provider_none(self):
+        """Verify extra_config still captures device_uuid when provider_device_id is None."""
+        svc = _make_service()
+        bot = _make_bot_record()
+        svc._device_repo.list_by_bot_id.return_value = [
+            _make_device(id=1, device_uuid="uuid-abc", provider_device_id=None),
+        ]
+        batch = _make_batch_record(batch_capacity=1)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            svc._create_device_records_for_publish(
+                tenant="t",
+                env="test",
+                publish_id=1,
+                publish_type=PublishType.CREATE,
+                bot_record=bot,
+                batch_records=[batch],
+                operator="op",
+            )
+
+        call_kwargs = svc._publish_record_repo.insert_record.call_args.kwargs
+        assert call_kwargs["extra_config"] == {
+            "device_uuid": "uuid-abc",
+            "provider_device_id": None,
+        }
+
+    def test_insert_record_extra_config_both_none_is_omitted(self):
+        """Verify extra_config is None when both fields are None."""
+        svc = _make_service()
+        bot = _make_bot_record()
+        svc._device_repo.list_by_bot_id.return_value = [
+            _make_device(id=1, device_uuid=None, provider_device_id=None),
+        ]
+        batch = _make_batch_record(batch_capacity=1)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            svc._create_device_records_for_publish(
+                tenant="t",
+                env="test",
+                publish_id=1,
+                publish_type=PublishType.CREATE,
+                bot_record=bot,
+                batch_records=[batch],
+                operator="op",
+            )
+
+        call_kwargs = svc._publish_record_repo.insert_record.call_args.kwargs
+        assert call_kwargs["extra_config"] is None
+
 
 # ====================================================================
 # _get_current_stage / _get_pending_batches / _check_all_batches_complete


### PR DESCRIPTION
## Summary

Capture `provider_device_id` and `device_uuid` into `baas_publish_record.extra_config` at record creation time, preventing permanent data loss when devices are re-provisioned.

## Problem

When a device is re-provisioned through PaaS (UPDATE, RESTART, etc.), the old `provider_device_id` is overwritten on `baas_device`. The `baas_publish_record` table — our audit trail — stores `extra_config` as `null`, making post-mortem forensics impossible.

See: #607 for full failure scenario.

## Changes

- **New `PublishRecordExtraConfig` dataclass** (`_record.py`): typed model for `extra_config` with `device_uuid` and `provider_device_id` fields
- **Capture at insert time** (`_publish_service.py`): `_create_device_records_for_publish()` now constructs and passes `extra_config` to every `insert_record()` call
- **All 8 publish types covered**: CREATE, UPDATE, RESTART, SCALE_UP, SCALE_DOWN, DESTROY, STOP, UPDATE_DEVICE — single loop handles all
- **Backward compatible**: existing records with `null` or legacy `extra_config` continue to deserialize correctly
- **548 tests pass**: 4 new `PublishRecordExtraConfig` tests + 3 new capture verification tests

## Impact

- No database schema changes (`extra_config` is already a JSON text column)
- No API changes
- ~50-100 bytes additional storage per record (negligible)