### PR TITLE
feat(backend): Track B — public API mcp category

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -53,7 +53,7 @@ The work therefore splits into **two tracks**:
 - **Track B — Public API implementation.** Wire the seven `/openapi/v1`
   category handlers to the existing services. **This is where the endpoint/API
   code actually lands.** Each category depends on its data being isolated
-  (Track A) first. **1 of 7 done: bots (PR #494).**
+  (Track A) first. **2 of 7 done: bots (PR #494), mcp (PR #610).**
 
 > ⚠️ **The one confusion to avoid:** "isolation Stage N is done" does **not**
 > mean any API endpoint was implemented. A Track A stage is plumbing only (the
@@ -120,12 +120,12 @@ must implement._
 > Stage 1 also builds the **reusable mechanism** (see below) that every later
 > stage copies. It's the foundation, not just "bots."
 
-### Track B — Public API implementation (where the endpoints land — 1 of 7 done)
+### Track B — Public API implementation (where the endpoints land — 2 of 7 done)
 _Ordered by priority tier._
 | Category | Owner | Pri | Router | State | Depends on |
 |---|---|---|---|---|---|
 | bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ✅ **DONE — PR #494 merged 2026-07-29** (13/13 endpoints) | ~~Track A stage 1~~ ✅ |
-| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` *(stub)* | ⬜ TODO — **unblocked** | ~~Track A stage 5~~ ✅ (PR #564) |
+| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` | ✅ **DONE — PR #610** (6/6 endpoints) | ~~Track A stage 5~~ ✅ (PR #564) |
 | resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | 🔧 IN PROGRESS (PARTIAL) — 9 handlers all wired but DEFINITION-ONLY / NOT PUBLIC-READY | Track A resources ✅(Phase 0); Track B all 9 endpoints wired stub→service; gated on auth workstream (gateway principal seam) + DDL deploy before public exposure |
 | routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` *(stub)* | ⬜ TODO | Track A routines (lucas-xzp) |
 | channels | totalfrank | 🅳 **DEPRIORITIZED** | `openapi_v1/channels/router.py` *(stub)* | ⏸️ PARKED — scope intact, not cancelled | Track A stage 3 (also parked) |
@@ -364,8 +364,12 @@ rebuild it. Everything below is category-agnostic and lives in
    guard** (a foreign `{id}` must be a masked 404). Keep the internal suite
    unmodified and green.
 8. Own SDD (`spec.md`/`plan.md`/`tasks.md`) and own PR per category. Use
-   `src/backend/specs/2026-07-27-openapi-v1-bots-track-b/` and
-   `openapi_v1/bots/router.py` as the worked reference.
+   `src/backend/specs/2026-07-27-openapi-v1-bots-track-b/` +
+   `openapi_v1/bots/router.py` as the worked reference, and
+   `src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/` +
+   `openapi_v1/mcp/router.py` for the second — the pattern for a category that
+   **extracts shared logic** out of a live internal router (recipe step 6) into
+   `core/mcp/` and proves the extraction by leaving the internal suite unmodified.
 
 > **Architecture gate:** `tests/community/architecture/` now also runs
 > `test_service_api_conformance.py` — the Service API gate that `api/README.md`
@@ -385,14 +389,17 @@ contract overview in **PR #363** (`docs/api-endpoints.zh-CN.md`, a Chinese
 endpoint reference by totalfrank — still open/draft as of 2026-07-29; kept here
 as reference).
 
-> ⚠️ **Path divergence — still open for the six stub groups.** The routers nest
-> every non-`bots` group under `/openapi/v1/bots/...` (e.g.
-> `/openapi/v1/bots/resources`, `/openapi/v1/bots/mcp`). PR #363's overview used
-> **top-level** paths (`/openapi/v1/resources`, `/openapi/v1/mcp`, …). The
-> **router is authoritative** for implementation — the paths below match it.
-> Owners: if the top-level shape is the intended public surface, change the
-> router `prefix` and update this section in the same PR. _(bots is unaffected:
-> it is `/openapi/v1/bots` under either reading, and shipped that way in #494.)_
+> ⚠️ **Path divergence — RESOLVED for `mcp` (PR #610), open for the remaining
+> stub groups.** The routers nest every non-`bots` group under
+> `/openapi/v1/bots/...` (e.g. `/openapi/v1/bots/resources`,
+> `/openapi/v1/bots/mcp`). PR #363's overview used **top-level** paths
+> (`/openapi/v1/resources`, `/openapi/v1/mcp`, …). **Ruling (mcp owner, PR #610):
+> the nested router shape stays** — the router is authoritative and the churn of
+> a re-prefix buys nothing while the surface is pre-auth. The remaining five
+> groups inherit this precedent unless their owner decides otherwise; if you do
+> want the top-level shape, change the router `prefix` and update this section in
+> the same PR. _(bots is unaffected: it is `/openapi/v1/bots` under either
+> reading, and shipped that way in #494.)_
 >
 > **Mount order is load-bearing.** `build_public_router()` includes the six
 > literal sub-groups **before** the bots group, so `/openapi/v1/bots/channels`
@@ -448,8 +455,11 @@ DingTalk (`dingding`) config CRUD + status toggle.
 _Note: the stub returns `Envelope[list[Channel]]` for list (not `Page`); PR #363
 showed `Page[Channel]`. Confirm which you want when you wire it._
 
-### 🟦 totalfrank · P1 — mcp (6 endpoints) · `openapi_v1/mcp/router.py`
-Marketplace + tenants + the caller's unified per-server config.
+### ✅ totalfrank · P1 — mcp (6 endpoints) · `openapi_v1/mcp/router.py` — **IMPLEMENTED (PR #610)**
+Marketplace + tenants + the caller's unified per-server config. All 6 wired to
+the internal MCP services through the shared `core/mcp/` flow (extracted from the
+internal router so both surfaces answer identically); owner-scoped via
+`caller_owner_id`, tenant-scoped by the Stage 5 guard.
 | Method | Path | Purpose | Success |
 |---|---|---|---|
 | GET | `/openapi/v1/bots/mcp/servers` | List marketplace servers (`keyword`, paged) | `Envelope[Page[McpServer]]` |
@@ -458,6 +468,14 @@ Marketplace + tenants + the caller's unified per-server config.
 | GET | `/openapi/v1/bots/mcp/servers/{server_code}/permissions` | Caller's permission for a server | `Envelope[McpPermission]` |
 | GET | `/openapi/v1/bots/mcp/servers/{server_code}/config` | Read caller's unified server config | `Envelope[McpConfig]` |
 | PUT | `/openapi/v1/bots/mcp/servers/{server_code}/config` | Write config (pushed to devices) | `Envelope[McpConfig]` |
+
+_Delivered decisions (PR #610): paths stay nested (`/openapi/v1/bots/mcp/...`);
+`sync_mode` dropped from the write body (no single-device push path — `extra=
+"forbid"` makes it a 422); a failed device push rolls the write back and answers
+502 (mirrors the internal surface); `endpoint_env`/`transport_protocol` are
+strict enums (`PROD`/`PRE`, `SSE`/`STREAMABLE_HTTP`). **Preserved fail-open:** a
+marketplace outage still reports the caller as permitted (advisory endpoint; the
+MCP server enforces) — pinned by a test so it reads as a decision, not a bug._
 
 ### 🟩 lucas-xzp · P1 — resources (9 endpoints) · `openapi_v1/resources/router.py`
 Unified file/link/folder abstraction; storage location never exposed.
@@ -530,12 +548,12 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
 
 1. **Track A:** every data category (bots, resources, channels, skills, mcp,
    routines) carries `avernet_tenant` and is guarded, Stage-1 test shape green.
-   — _1 of 6 (bots ✅)._
+   — _2 of 6 (bots ✅, mcp ✅ PR #564)._
 2. Internal API unchanged throughout (no `to_dict()` leaks; internal suites
    unmodified). — _holding: full `tests/community` green at #494 (9171 passed,
    3 skipped)._
 3. **Track B:** the seven `/openapi/v1` categories' handlers implemented and
-   tenant-safe, each with its own tests + PR. — _1 of 7 (bots ✅)._
+   tenant-safe, each with its own tests + PR. — _2 of 7 (bots ✅, mcp ✅)._
 4. F2 tenant-leading indexes in place (mandatory policy). — _⬜_
 5. Background/scheduled work revisited for per-tenant correctness. — _⬜_
 6. `require_principal` / `resolve_avernet_tenant` wired to the real verifier
@@ -689,3 +707,20 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
      `with_loader_criteria` applies to join clauses. Verified, not assumed.
 - **2026-07-29** — **Channels deprioritized (not cancelled)**, Track A stage 3
   and Track B endpoints both parked with scope intact.
+- **2026-07-30** — **Track B mcp merged (PR #610) — second public category
+  implemented (2 of 7).** All 6 `/openapi/v1/bots/mcp` endpoints wired to the
+  internal MCP services through a **shared `core/mcp/` flow** extracted from the
+  internal `/api/mcp` router (masking / `extInfo` stripping / network-type
+  allowlist in `presentation.py`; the write→push→rollback + read in
+  `config_flow.py`; typed domain errors in `errors.py`), so both surfaces answer
+  identically. The internal router now calls that flow — proven behavior-
+  preserving by `test_mcp_config_internal_unchanged.py` + `test_mcp.py` passing
+  **unmodified**. Public handlers owner-scoped via `caller_owner_id`,
+  tenant-scoped by the Stage 5 guard (cross-tenant config invisible + un-
+  overwritable, proven against the real guard through the flow). Decisions:
+  nested paths (**resolves the path divergence for mcp**), `sync_mode` dropped
+  (`extra="forbid"` → 422), push-failure rolls back → 502, strict
+  `endpoint_env`/`transport_protocol` enums (no `DEV`). **Preserved fail-open**
+  permission on a marketplace outage (advisory endpoint), pinned by a test. Board
+  moved: Track B mcp → done; the "worked reference" list now points here as the
+  second example, specifically for the *extract-shared-logic* pattern.

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -44,7 +44,7 @@ _这是一份"活文档"，用于协调跨多个会话交付公共 `/openapi/v1`
   每一类数据都做到按租户隔离。**Track A 按设计不实现任何端点** —— 它是底层管道。
 - **Track B —— 公共 API 实现。** 把七个 `/openapi/v1` 类别处理器接到已有的服务上。
   **这才是真正落地端点/API 代码的地方。** 每个类别都依赖于其数据已先经过 Track A 的
-  隔离。**七个里已完成一个：bots（PR #494）。**
+  隔离。**七个里已完成两个：bots（PR #494）、mcp（PR #610）。**
 
 > ⚠️ **唯一需要避免的误解：** "隔离 Stage N 已完成"**并不**意味着任何 API 端点被实现了。
 > Track A 的每个阶段都只是底层管道（可复用机制 + 该类别的记录）。API 端点落在
@@ -105,12 +105,12 @@ _具体每个切片要实现哪些端点，见下方的 **各组件端点清单*
 > Stage 1 同时构建了后续每个阶段都会复制的**可复用机制**（见下文）。它是地基，
 > 不只是"机器人"。
 
-### Track B —— 公共 API 实现（端点真正落地之处 —— 七个里已完成一个）
+### Track B —— 公共 API 实现（端点真正落地之处 —— 七个里已完成两个）
 _按优先级分层排序。_
 | 类别 | 负责人 | 优先级 | 路由 | 状态 | 依赖 |
 |---|---|---|---|---|---|
 | bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ✅ **DONE —— PR #494 已于 2026-07-29 合并**（13/13 端点） | ~~Track A 阶段 1~~ ✅ |
-| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` *(桩)* | ⬜ TODO —— **已解除阻塞** | ~~Track A 阶段 5~~ ✅（PR #564） |
+| mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` | ✅ **DONE —— PR #610**（6/6 端点） | ~~Track A 阶段 5~~ ✅（PR #564） |
 | resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | 🔧 IN PROGRESS（PARTIAL）— 9 handler 全接通但 DEFINITION-ONLY / NOT PUBLIC-READY | Track A resources ✅(Phase 0)，Track B 全 9 端点接通 stub→service；待 auth workstream(gateway principal seam) 落地 + DDL 部署后才可对外 |
 | routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` | 🔧 IN PROGRESS（PARTIAL）— 7 handler 全接通但 NOT PUBLIC-READY | Track A routines 无表靠 ac_bots 间接隔离；Track B 7 端点接通；待 gateway principal seam + tenant resolver 落地后才可对外 |
 | channels | totalfrank | 🅳 **已降级** | `openapi_v1/channels/router.py` *(桩)* | ⏸️ 已搁置 —— 范围保持不变，并非取消 | Track A 阶段 3（同样搁置） |
@@ -323,8 +323,11 @@ ALTER TABLE ac_user_mcp_config
    错误），以及**针对真实 Track A 守卫的跨租户隔离测试**（别的租户的 `{id}` 必须是被掩盖
    的 404）。内部测试套件保持不修改且全绿。
 8. 每个类别有自己的 SDD（`spec.md`/`plan.md`/`tasks.md`）和自己的 PR。可以把
-   `src/backend/specs/2026-07-27-openapi-v1-bots-track-b/` 和
-   `openapi_v1/bots/router.py` 当作已经做过一遍的参考样板。
+   `src/backend/specs/2026-07-27-openapi-v1-bots-track-b/` +
+   `openapi_v1/bots/router.py` 当作已经做过一遍的参考样板；第二个样板是
+   `src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/` + `openapi_v1/mcp/router.py`
+   —— 它示范了当一个类别需要**从仍在运行的内部路由里抽取共享逻辑**（配方第 6 步）到
+   `core/mcp/` 时的做法，并通过让内部测试套件保持不修改来证明抽取是行为保持的。
 
 > **架构门禁：** `tests/community/architecture/` 现在还会跑
 > `test_service_api_conformance.py` —— 这就是 `api/README.md` 在两处承诺过、但一直没有
@@ -341,12 +344,14 @@ ALTER TABLE ac_user_mcp_config
 **PR #363**（`docs/api-endpoints.zh-CN.md`，totalfrank 写的中文端点参考 —— 截至
 2026-07-29 仍是 open/draft；此处作为参考保留）中的 v1 契约总览做了交叉核对。
 
-> ⚠️ **路径分歧 —— 对其余六个桩组仍未对齐。** 路由把所有非 `bots` 的组都嵌套在
-> `/openapi/v1/bots/...` 之下（如 `/openapi/v1/bots/resources`、`/openapi/v1/bots/mcp`）。
-> 而 PR #363 的总览用的是**顶层**路径（`/openapi/v1/resources`、`/openapi/v1/mcp` 等）。
-> 实现以**路由为准** —— 下面的路径与路由一致。负责人：如果顶层形态才是想要的对外形状，
-> 请修改路由的 `prefix`，并在同一个 PR 里更新本节。_（bots 不受影响：两种读法下它都是
-> `/openapi/v1/bots`，#494 也正是按这个形状上线的。）_
+> ⚠️ **路径分歧 —— `mcp` 已定案（PR #610），其余桩组仍未对齐。** 路由把所有非 `bots`
+> 的组都嵌套在 `/openapi/v1/bots/...` 之下（如 `/openapi/v1/bots/resources`、
+> `/openapi/v1/bots/mcp`）。而 PR #363 的总览用的是**顶层**路径
+> （`/openapi/v1/resources`、`/openapi/v1/mcp` 等）。**裁定（mcp 负责人，PR #610）：
+> 保持嵌套的路由形态** —— 以路由为准，界面尚在认证前（pre-auth），重排前缀带来的改动没有收益。
+> 其余五个组沿用这一先例，除非各自负责人另有决定；如果确实想要顶层形态，请修改路由的
+> `prefix` 并在同一个 PR 里更新本节。_（bots 不受影响：两种读法下它都是 `/openapi/v1/bots`，
+> #494 也正是按这个形状上线的。）_
 >
 > **挂载顺序是有承重作用的。** `build_public_router()` 会先挂那六个字面量子组，再挂
 > bots 组，这样 `/openapi/v1/bots/channels` 才能排在通配的
@@ -401,8 +406,10 @@ _内部 `/api/bots` 也有变化，全部是有意为之，并由 #494 覆盖：
 _注：桩里的列表返回 `Envelope[list[Channel]]`（不是 `Page`）；PR #363 里写的是
 `Page[Channel]`。接线时请确认用哪种。_
 
-### 🟦 totalfrank · P1 —— mcp（6 个端点）· `openapi_v1/mcp/router.py`
-市场 + 租户 + 调用者的统一 per-server 配置。
+### ✅ totalfrank · P1 —— mcp（6 个端点）· `openapi_v1/mcp/router.py` —— **已实现（PR #610）**
+市场 + 租户 + 调用者的统一 per-server 配置。6 个端点全部接到内部 MCP 服务，经由从内部
+路由抽取出来的共享 `core/mcp/` 流程（抽取后两套界面回答一致）；用 `caller_owner_id`
+做 owner 作用域，由 Stage 5 守卫做租户作用域。
 | 方法 | 路径 | 用途 | 成功响应 |
 |---|---|---|---|
 | GET | `/openapi/v1/bots/mcp/servers` | 列出市场 MCP 服务器（`keyword`、分页） | `Envelope[Page[McpServer]]` |
@@ -411,6 +418,13 @@ _注：桩里的列表返回 `Envelope[list[Channel]]`（不是 `Page`）；PR #
 | GET | `/openapi/v1/bots/mcp/servers/{server_code}/permissions` | 查询调用者对该服务器的权限 | `Envelope[McpPermission]` |
 | GET | `/openapi/v1/bots/mcp/servers/{server_code}/config` | 读取调用者的统一服务器配置 | `Envelope[McpConfig]` |
 | PUT | `/openapi/v1/bots/mcp/servers/{server_code}/config` | 写入配置（下发到设备） | `Envelope[McpConfig]` |
+
+_已定案的决策（PR #610）：路径保持嵌套（`/openapi/v1/bots/mcp/...`）；写入体去掉了
+`sync_mode`（不存在单设备下发路径 —— `extra="forbid"` 让它变成 422）；下发设备失败会回滚
+写入并返回 502（与内部界面一致）；`endpoint_env`/`transport_protocol` 为严格枚举
+（`PROD`/`PRE`、`SSE`/`STREAMABLE_HTTP`）。**保留 fail-open：** 市场调用异常时仍报告
+调用者"有权限"（该端点仅供参考，真正的强制点是 MCP 服务器本身）—— 已用测试钉住，使其读起来
+是一个决策而非 bug。_
 
 ### 🟩 lucas-xzp · P1 —— resources（9 个端点）· `openapi_v1/resources/router.py`
 文件/链接/文件夹的统一抽象；存储位置从不暴露。
@@ -476,11 +490,11 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
 ## 完成的定义（整个 `/openapi/v1` 工作）
 
 1. **Track A：** 每一类数据（bots、resources、channels、skills、mcp、routines）都带有
-   `avernet_tenant` 并被守卫，Stage-1 的测试形态全绿。—— _6 个里完成 1 个（bots ✅）。_
+   `avernet_tenant` 并被守卫，Stage-1 的测试形态全绿。—— _6 个里完成 2 个（bots ✅、mcp ✅ PR #564）。_
 2. 全程内部 API 保持不变（`to_dict()` 无泄漏；内部套件不作修改）。—— _仍然成立：#494
    时整个 `tests/community` 全绿（9171 通过，3 跳过）。_
 3. **Track B：** 七个 `/openapi/v1` 类别的处理器均已实现且租户安全，各自带测试 + PR。
-   —— _7 个里完成 1 个（bots ✅）。_
+   —— _7 个里完成 2 个（bots ✅、mcp ✅）。_
 4. F2 租户前导索引就位（强制策略）。—— _⬜_
 5. 后台/定时任务已针对按租户正确性完成复查。—— _⬜_
 6. `require_principal` / `resolve_avernet_tenant` 已接到真实验证器（认证工作线）——
@@ -604,3 +618,15 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
      子句同样生效。这是实测确认的，不是推断。
 - **2026-07-29** —— **渠道降级（并非取消）**，Track A 阶段 3 与 Track B 端点均已搁置，
   范围保持不变。
+- **2026-07-30** —— **Track B mcp 合并（PR #610）—— 第二个落地的公共类别（7 个里 2 个）。**
+  6 个 `/openapi/v1/bots/mcp` 端点全部接到内部 MCP 服务，经由一套从内部 `/api/mcp` 路由
+  **抽取出来的共享 `core/mcp/` 流程**（`presentation.py` 里的掩码 / `extInfo` 剥除 /
+  网络类型白名单；`config_flow.py` 里的 写入→下发→回滚 与 读取；`errors.py` 里的类型化
+  领域错误），使两套界面回答一致。内部路由现在调用这套流程 —— 由
+  `test_mcp_config_internal_unchanged.py` + `test_mcp.py` **保持不修改**通过来证明行为保持。
+  公共处理器用 `caller_owner_id` 做 owner 作用域，由 Stage 5 守卫做租户作用域（跨租户配置
+  不可见且不可覆写，已通过流程针对真实守卫验证）。决策：路径保持嵌套（**为 mcp 定案了路径
+  分歧**）、去掉 `sync_mode`（`extra="forbid"` → 422）、下发失败回滚 → 502、严格枚举
+  `endpoint_env`/`transport_protocol`（无 `DEV`）。**保留 fail-open** 的权限行为（市场异常时；
+  仅供参考的端点），已用测试钉住。看板已挪动：Track B mcp → 完成；"参考样板"清单现在把这里
+  列为第二个样板，专门示范*抽取共享逻辑*的模式。

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/plan.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/plan.md
@@ -1,0 +1,313 @@
+# Plan: Public API — MCP Category (Track B)
+
+## Approach
+
+Replace the six stub handlers in `openapi_v1/mcp/router.py` with real ones that
+obtain the existing MCP services via `Injected` and wrap results in the shared
+`Envelope`/`Page` builders — the same shape the bots slice established.
+
+The internal `/api/mcp` router carries real logic inside its handler bodies
+(validation, the write→push→rollback sequence, API-key masking, `extInfo`
+stripping, the network-type allowlist). Copying it into the public handlers
+would give us two versions of a credential-write flow. Instead that logic moves
+into `core/mcp/`, request-agnostic and raising typed domain errors, and **both**
+routers call it — the pattern `core/bot_management/create_flow.py` established
+in #494. The internal router keeps its `HTTPException` shapes by catching the
+new errors at its boundary, which is how the extraction is proven
+behavior-preserving: `test_mcp_config_internal_unchanged.py` pins its exact JSON
+bodies and passes unmodified.
+
+Tenant scoping needs no work here — `AvernetTenantMiddleware` binds the request
+tenant and the Stage 5 guard (merged, `c8d1fb1`) filters every ORM read and
+write beneath the services. Owner scoping is `caller_owner_id(principal)`,
+which replaces the internal surface's `user.staffId`.
+
+## Affected Components
+
+- `adapters/http/openapi_v1/mcp/` — the six public handlers and their
+  request/response models. The bulk of the change.
+- `adapters/http/openapi_v1/responses.py` — this category's domain errors added
+  to `ENVELOPE_ERRORS`.
+- `core/mcp/` (new modules) — the extracted, request-agnostic config-write
+  flow, marketplace presentation rules, masking, and the error types.
+- `adapters/http/mcp/router.py` — internal router rewired to call the extracted
+  code; its HTTP contract unchanged.
+- `docs/openapi-v1/README.md` + `README.zh-CN.md` — status board, changelog.
+
+Not touched: `core/mcp/services/*` service bodies, the repositories, the
+models, `di/modules/mcp_module.py`, and `AvernetTenantMiddleware`.
+
+## Data Model Changes
+
+**None.** Stage 5 (#564) added `avernet_tenant` to `ac_user_mcp_config` and
+`ac_bot_mcp_call_config`, registered the guards, and replaced the unique key
+with `(avernet_tenant, user_id, server_code, env)`. No column, no guard, no DDL
+in this change.
+
+## API / Interface Changes
+
+### Endpoints (paths unchanged from the stubs — decision 1 in `spec.md`)
+
+| Method | Path | Success |
+|---|---|---|
+| GET | `/openapi/v1/bots/mcp/servers` | `Envelope[Page[McpServer]]` |
+| GET | `/openapi/v1/bots/mcp/tenants` | `Envelope[list[McpTenant]]` |
+| GET | `/openapi/v1/bots/mcp/servers/{server_code}` | `Envelope[McpServerDetail]` |
+| GET | `/openapi/v1/bots/mcp/servers/{server_code}/permissions` | `Envelope[McpPermission]` |
+| GET | `/openapi/v1/bots/mcp/servers/{server_code}/config` | `Envelope[McpConfig]` |
+| PUT | `/openapi/v1/bots/mcp/servers/{server_code}/config` | `Envelope[McpConfig]` |
+
+`GET /servers` takes `page`/`page_size` via `PageParamsDep`
+(`contracts.py:100-118`) and an optional `keyword`, forwarded as MCP Center's
+`search_key`.
+
+### Schema changes (`openapi_v1/mcp/schemas.py`)
+
+- **All models gain `model_config = ConfigDict(extra="forbid")`.** Per the bots
+  slice's rule (`docs/openapi-v1/README.md`, Track B recipe step 5), an unknown
+  or unsupported field must be a 422, not a silent drop.
+- **`McpConfigWrite.sync_mode` is removed** (`schemas.py:60`). Decision 3 in
+  `spec.md`: no single-device push path exists.
+- **`McpConfigWrite.endpoint_env`** becomes `Literal["PROD", "PRE"] | None` and
+  **`transport_protocol`** `Literal["SSE", "STREAMABLE_HTTP"] | None`, matching
+  the values the internal route validates at `adapters/http/mcp/router.py:251-258`.
+  This deliberately moves enum validation into the request model so the caller
+  gets a field-level 422 (already enveloped by the app-level handler, and
+  already declared in `ERROR_RESPONSES`) instead of a fixed 400 string. It is
+  the one place the public surface answers *better* than the internal one; the
+  core flow keeps its own check as the internal path's backstop.
+  - Note: the internal route upper-cases `transport_protocol` before validating
+    (`router.py:256`). The public model is strict — `sse` is a 422, not a silent
+    normalization — because `extra="forbid"` reasoning applies to values too.
+- **`McpConfig.api_key`** documented as always masked.
+
+### New domain errors (`core/mcp/errors.py`)
+
+Raised by the extracted flow, mapped by each surface:
+
+| Error | Public (`ENVELOPE_ERRORS`) | Internal (preserved) |
+|---|---|---|
+| `McpServerNotFoundError` | 404 `"Not found"` | 404 `f"MCP server {code} not found"` |
+| `McpHeadersInvalidError` | 400 `"Invalid MCP headers"` | 400 `<validator's message>` |
+| `McpConfigValueError` | 400 `"Invalid MCP configuration"` | 400 `<field message>` |
+| `McpSyncFailedError` | 502 `"Device sync failed"` | 500 `<sync error>` |
+| `McpMarketUnavailableError` | 502 `"MCP service error"` | 500 `<upstream message>` |
+
+Public messages are fixed and carry no identifier — `validate_headers_for_mcp`
+returns Chinese internal-language text (`config_service.py:80`), which is
+exactly what the fixed-message rule exists to stop.
+
+The public/internal status divergence on the last two rows is intentional: 502
+is the correct class for a downstream failure and matches how the bots slice
+mapped `PassportError` and `ConnInfoBuildError` (`responses.py:118,131`). The
+internal surface keeps 500 because its tests pin it.
+
+## Key Files & Functions
+
+### New — `core/mcp/`
+
+- **`core/mcp/errors.py`** (new) — the five error types above. Dependency-free,
+  mirroring `openapi_v1/errors.py`.
+- **`core/mcp/presentation.py`** (new) — marketplace rules both surfaces apply:
+  - `ALLOWED_NETWORK_TYPES = ("INTERNET", "OFFICE")` — today duplicated at
+    `adapters/http/mcp/router.py:108` and `:162`.
+  - `strip_ext_info(mcp: dict) -> dict` and `strip_ext_info_from_list(...)` —
+    moved verbatim from `adapters/http/mcp/router.py:58-85`.
+  - `is_network_type_visible(detail: dict) -> bool` — the `:163-166` rule.
+  - `mask_api_key(key: str | None) -> str | None` — the masking expression
+    duplicated at `:308-309` and `:372-373`. One definition, so the two
+    surfaces cannot drift on how much of a credential they reveal.
+- **`core/mcp/config_flow.py`** (new) — the write orchestration lifted from
+  `adapters/http/mcp/router.py:250-337`, FastAPI-free:
+  ```python
+  def read_unified_config(*, user_id, server_code, config_service) -> UnifiedConfig
+  async def write_unified_config(
+      *, user_id, server_code, entity_id, entity_type,
+      api_key, headers, endpoint_env, transport_protocol,
+      config_service, market_service, sync_service,
+  ) -> UnifiedConfig
+  ```
+  `write_unified_config` keeps the internal ordering exactly: validate values →
+  validate headers → confirm the server exists (external check *before* the
+  write, so a bad code never touches the DB) → `update_user_unified_config`
+  keeping the old row → `sync_mcp_detail_to_all_bots` → on failure
+  `rollback_unified_config` and raise `McpSyncFailedError`. `UnifiedConfig` is a
+  frozen dataclass with the key already masked, so no caller can forget.
+
+### Modified — public surface
+
+- **`openapi_v1/mcp/router.py`** (:36-91, all six stubs) — real handlers. Each
+  takes `request: Request` (required by `@envelope_errors`), `PrincipalDep`,
+  and its services via `Injected`; each opens with
+  `owner_id = caller_owner_id(principal)`.
+  - `list_mcp_servers` — `market_service.get_mcp_list(page_num=…, page_size=…,
+    search_key=keyword, network_types=ALLOWED_NETWORK_TYPES)`, then
+    `strip_ext_info_from_list`, then `page(total, items, request)`.
+  - `get_mcp_server` — `get_mcp_detail`; `None` **or** network-type-invisible →
+    `McpServerNotFoundError` (one raise site, so the two paths are
+    indistinguishable, per `spec.md`).
+  - `check_mcp_permission` — `auth_service.check_mcp_permission_detail(owner_id,
+    server_code)`. `owner_id` comes from the principal; the internal route's
+    `user_id` query parameter (`adapters/http/mcp/router.py:173`) is **not**
+    exposed.
+  - `get_mcp_config` / `update_mcp_config` — delegate to `config_flow`.
+    `entity_id = owner_id`, `entity_type = "staff"`, matching
+    `_get_path_params`'s defaults (`:52-53`) and how the public bots create path
+    passes `entity_id=owner_id` (`bots/router.py:253`).
+  - No `IAM_TOKEN` cookie handling. The internal detail route exchanges a
+    browser cookie for a live `tools/list` (`:152-158`); a registered-tenant
+    caller has no such cookie, and forwarding one below the adapter boundary is
+    the same thing the bots slice refused at `bots/router.py:159-175`. Public
+    detail returns MCP Center data.
+- **`openapi_v1/mcp/schemas.py`** — as described above, plus `_to_server` /
+  `_to_server_detail` / `_to_tenant` adapters (module-private in `router.py`,
+  mirroring `bots/router.py:93-105`) mapping MCP Center's camelCase
+  (`serverCode`, `networkTypes`, `transportProtocol`) onto the snake_case public
+  models. Tenant keys `code`/`name`/`categories` are confirmed by
+  `tests/community/contracts/gateway/schema_snapshots/response_data/rule16_GET_api_mcp_tenants.json`.
+- **`openapi_v1/responses.py:106-143`** — add the five errors. Placement rule
+  from the bots gotchas: these are a flat set with no shared base, so ordering
+  among them is free, but they all go **above** `BotServiceError`.
+
+### Modified — internal surface (behavior-preserving)
+
+- **`adapters/http/mcp/router.py`**
+  - `:58-85` — `_remove_ext_info_*` deleted; imports from `core/mcp/presentation.py`.
+  - `:108-115`, `:162-166` — allowlist and visibility rule from the same module.
+  - `:237-344` — `update_mcp_unified_config` becomes a thin adapter: call
+    `write_unified_config`, catch the typed errors, re-raise the identical
+    `HTTPException`s. `sync_results` are still needed for its response
+    (`MCPUnifiedConfigData.sync_results`), so `write_unified_config` returns
+    them alongside the config; the public handler ignores them.
+  - `:347-386` — `get_mcp_unified_config` calls `read_unified_config`.
+  - `:307-309`, `:370-373` — masking via `mask_api_key`.
+
+### Architecture gate
+
+New cross-module imports must be declared before `tests/community/architecture/`
+will pass — the Stage 1 gotchas record this failing CI twice:
+- `core/mcp/README.md` `## Context Boundary` — add `MCPMarketService` to
+  `provides` (the flow now consumes it) and any new `internal_dependencies`.
+- `adapters/http/openapi_v1/` gains an import of `core.mcp.*`; check that
+  module's README the same way.
+
+## Dependencies
+
+None new. No package, no version bump, no new internal service. `MCPMarketService`,
+`MCPAuthService`, `MCPConfigService` and `MCPSyncService` are already bound in
+`di/modules/mcp_module.py` and already injected by the internal router.
+
+## Risks & Mitigations
+
+- **Risk:** The extraction silently changes internal behavior — the highest-cost
+  failure here, since the internal MCP config API is live.
+  **Mitigation:** `test_mcp_config_internal_unchanged.py` (283 lines, added by
+  #564) pins the exact JSON of GET and POST, the masking of a short key, the
+  400 detail string, and tenant stamping, through the **real** service and
+  repository. It must pass unmodified — that is the acceptance test for the
+  extraction, and it exists precisely because `test_mcp.py` mocks the services
+  and cannot see this layer.
+
+- **Risk:** A credential leaks in full through a response, a log, or an error.
+  **Mitigation:** `mask_api_key` is the only formatter and `UnifiedConfig`
+  carries the key already masked, so a handler cannot reach the raw value to
+  return it. A test asserts the raw key appears nowhere in the response text of
+  either surface, for both a long and a short key.
+
+- **Risk:** The rollback path is the least-tested branch in the internal flow and
+  now becomes a public guarantee.
+  **Mitigation:** A dedicated test drives a sync failure and asserts both that
+  `rollback_unified_config` restored the prior row and that the response is 502
+  — plus the create case, where rollback means *deleting* the row
+  (`config_service.py:172-177`) rather than restoring one.
+
+- **Risk:** Permission checks fail open on a marketplace error
+  (`auth_service.py:67-73` returns `has_permission: True`), so an upstream
+  outage answers "yes" to every external caller.
+  **Mitigation:** Preserved deliberately (`spec.md` Open Question 1,
+  recommendation accepted): this endpoint is advisory and the MCP server itself
+  enforces. Pinned by a test so the behavior is a recorded decision rather than
+  an accident, and noted in the handler docstring.
+
+- **Risk:** Public `PUT config` pushes to devices — a write with real side
+  effects on a surface whose caller identity is still a stub.
+  **Mitigation:** No mitigation needed today: `require_principal` returns `None`,
+  so every real request is a 401 before reaching the handler. Recorded because
+  it becomes live the moment the auth workstream lands, and it is the strongest
+  reason not to widen this category's write surface.
+
+- **Risk:** Route shadowing — `/servers/{server_code}` swallowing a literal like
+  `/tenants`.
+  **Mitigation:** `/tenants` sits on a different path segment than
+  `/servers/...`, so there is no overlap. The group-level ordering that *does*
+  matter (`mcp` before the bots `{bot_id}` wildcard) is already correct in
+  `openapi_v1/__init__.py:34-41` and this change does not touch it.
+
+## Alternatives Considered
+
+- **Copy the internal handler bodies into the public handlers.** Fastest, and
+  wrong for exactly the reason #494 recorded: two copies of the create flow
+  would have drifted within a release. This flow writes credentials and rolls
+  back — the worst candidate for a second copy.
+- **Extract into a new service class rather than module-level functions.**
+  Would need DI registration, a Protocol in `api/`, and an entry in the Service
+  API conformance gate, for orchestration with no state. `create_flow.py` set
+  the precedent of plain functions taking already-injected services; following
+  it keeps the two extractions shaped alike.
+- **Validate `endpoint_env` in the core flow only, answering 400 like internal.**
+  Consistent across surfaces, but throws away the structured field error the
+  public envelope already documents for 422, and means a typo comes back as a
+  fixed string that doesn't say which of the two fields was wrong. Both checks
+  exist; the model's runs first on the public path.
+- **Expose `sync_results` in the public response.** Rejected with decision 2 —
+  it presumes the partial-success model that #560 has not ruled on, and once
+  published it cannot be withdrawn without a breaking change.
+- **Move the paths to top-level `/openapi/v1/mcp`.** Considered and rejected by
+  the owner (decision 1); the router stays authoritative.
+
+## Rollout
+
+No flag, no migration, no ordering constraint. The public surface answers 401 to
+every real request until the auth workstream replaces `require_principal`, so
+these handlers are unreachable in production on merge — the same state bots has
+been in since #494. The internal surface changes behavior not at all.
+
+Ship as one PR (#610), with the handoff board and changelog moved in the same
+change per the README's standing rule.
+
+## Test Strategy
+
+New files under `tests/community/adapters/http/openapi_v1/`, following the bots
+harness (a minimal FastAPI app, services bound to mocks through the injector,
+`require_principal` overridden per test):
+
+1. **`test_mcp_endpoints.py`** — all six handlers. Per endpoint: success shape,
+   the envelope's `code`/`request_id`, and each mapped failure. Specifically:
+   masking for long and short keys; a never-configured server reporting
+   `has_config: false` rather than 404; a network-type-invisible server and an
+   unknown code returning byte-identical 404s; `extInfo` stripped from detail
+   and list; permission derived from the principal with no way to pass another
+   identity; `sync_mode` and any unknown field rejected as 422; missing
+   principal → 401.
+2. **`test_mcp_config_flow.py`** — the extracted flow directly, no HTTP: merge
+   semantics (an omitted field is unchanged), the ordering guarantee (an unknown
+   server code never reaches the repository), rollback-to-previous on sync
+   failure, and rollback-as-delete when the row was newly created.
+3. **`test_mcp_tenant_isolation.py`** — against the **real** Stage 5 guard with
+   a real `UserMCPConfigRepository` over SQLite, in the shape of
+   `test_bots_tenant_isolation.py`: a config written under tenant A is invisible
+   from tenant B; a tenant-B write creates its own row instead of overwriting;
+   both tenants hold a row for the same `user_id` + `server_code` (the case the
+   Stage 5 unique-key swap made possible) and neither displaces the other.
+4. **`test_mcp_presentation.py`** — masking, `extInfo` stripping, and the
+   network-type rule as pure units.
+
+Regression gates that must pass **unmodified**:
+- `tests/community/api/mcp/routers/test_mcp_config_internal_unchanged.py`
+- `tests/community/api/mcp/routers/test_mcp.py`
+- `tests/community/architecture/` (run after the README boundary edits)
+- the full `tests/community` suite
+
+Not covered: a live MCP Center or a real device push. Both are external
+dependencies the existing suites already mock, and this change adds no new
+outbound call.

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/plan.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/plan.md
@@ -63,14 +63,37 @@ in this change.
 
 ### Schema changes (`openapi_v1/mcp/schemas.py`)
 
-- **All models gain `model_config = ConfigDict(extra="forbid")`.** Per the bots
-  slice's rule (`docs/openapi-v1/README.md`, Track B recipe step 5), an unknown
-  or unsupported field must be a 422, not a silent drop.
+- **All models gain `model_config = ConfigDict(extra="forbid")`** via a shared
+  module-level `_STRICT` constant, mirroring `bots/schemas.py:16` exactly. Per
+  the bots slice's rule (`docs/openapi-v1/README.md`, Track B recipe step 5), an
+  unknown or unsupported field must be a 422, not a silent drop — Pydantic's
+  default is to discard unknown keys and answer 200, so a caller who typos a
+  field name (or sends the now-removed `sync_mode`) would believe a setting took
+  when it did not.
 - **`McpConfigWrite.sync_mode` is removed** (`schemas.py:60`). Decision 3 in
-  `spec.md`: no single-device push path exists.
+  `spec.md`: no single-device push path exists. Works *together* with
+  `extra="forbid"` — the two make dropping the field honest (sending it → 422)
+  instead of a silent no-op.
+- **Frontend blast radius: none — audited 2026-07-30.** A sweep of
+  `src/frontend` found no `sync_mode`/`syncMode`, no `endpoint_env`/`endpointEnv`,
+  and no MCP config-write call at all; the frontend's only MCP strings are the
+  `/market/mcp` page route and a `mcporter.json` path, and it never calls the
+  public `/openapi/v1` surface. So `extra="forbid"` and the `sync_mode` removal
+  cannot break a live client on two independent grounds: no client sends those
+  fields, and `extra="forbid"` lands only on the public model. The MCP
+  unified-config feature (api_key/endpoint_env/headers) is not exercised by this
+  OSS frontend.
 - **`McpConfigWrite.endpoint_env`** becomes `Literal["PROD", "PRE"] | None` and
   **`transport_protocol`** `Literal["SSE", "STREAMABLE_HTTP"] | None`, matching
   the values the internal route validates at `adapters/http/mcp/router.py:251-258`.
+  `PROD`/`PRE` only — **no `DEV`** (owner-confirmed 2026-07-30). `endpoint_env`
+  selects which deployment of the third-party MCP *server* to hit; it is a
+  distinct axis from the `env` column on `ac_user_mcp_config`, which is the
+  Avernet deploy env (`dev`/`test`/`pre`/`prod`, set server-side from
+  `get_current_env()`, never caller-supplied). Nothing downstream — device_sync,
+  config_compose, the model's own `to_dict` doc (`core/models/mcp.py:125`) —
+  knows a `DEV` value for `endpoint_env`. The `| None` means "field omitted →
+  leave unchanged" (merge semantics), not a third environment.
   This deliberately moves enum validation into the request model so the caller
   gets a field-level 422 (already enveloped by the app-level handler, and
   already declared in `ERROR_RESPONSES`) instead of a fixed 400 string. It is

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/spec.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/spec.md
@@ -1,0 +1,210 @@
+# Public API — MCP Category (Track B)
+
+## Summary
+
+The public API's `mcp` category is six route definitions whose handlers raise
+`NotImplementedError`. This wires them to the MCP services that already back the
+internal surface, so an external tenant can browse the MCP marketplace, see
+whether it is permitted to use a server, and read and write its own per-server
+configuration — with that configuration pushed to its agents' devices.
+
+This is the second of seven Track B categories, and the first one that stores
+caller-supplied secrets. Its data was isolated by Track A Stage 5 (PR #564,
+merged); the handoff board marks `mcp` P1 and unblocked.
+
+## Motivation
+
+MCP servers are how an agent reaches third-party tools. An external tenant that
+cannot configure them can create a bot but cannot make it useful — so this
+category is on the critical path to the public API being worth calling at all.
+
+Three things make it the right slice to take now:
+
+- **Its dependency is satisfied.** Track A Stage 5 isolated
+  `ac_user_mcp_config` and `ac_bot_mcp_call_config` and replaced the unique key
+  so two tenants can hold a configuration for the same user identifier. Nothing
+  else gates it.
+- **It is the highest-consequence category to get wrong.** The configuration
+  holds API keys and authorization headers for third-party servers. A read that
+  escapes its tenant does not leak a bot name — it leaks a credential.
+- **It is the second use of the Track B primitives.** The bots slice built the
+  envelope, the error mapping, the principal seam and the app-level backstop
+  once, and asserted the other six categories would reuse them. Until a second
+  category does, that is a claim rather than a fact.
+
+## User Stories
+
+- As an external tenant, I want to browse the MCP servers available to me and
+  read one server's detail including its tools, so that I can decide which to
+  configure for my agents.
+- As an external tenant, I want to know whether I am permitted to call a server
+  before I configure it, so that I do not spend effort on a server I will be
+  refused at call time.
+- As an external tenant, I want to store my own API key and headers for a
+  server and have them reach my agents' devices, so that my agents can actually
+  call that server.
+- As an external tenant, I want my stored credentials confined to my own tenant
+  and my own caller identity, so that no other tenant can read or overwrite them
+  and I cannot reach theirs.
+- As an external tenant, I want a credential I have stored to come back masked
+  rather than in full, so that reading my configuration back is not a way to
+  exfiltrate the secret.
+- As a caller of the existing internal MCP API, I want every response to be
+  exactly what it is today, so that this addition is invisible to me.
+- As an integrator, I want failures on this category to arrive in the same
+  envelope, with the same error shape, as every other public endpoint.
+
+## Acceptance Criteria
+
+### Marketplace
+
+- [ ] Listing MCP servers returns a page of servers for the caller's page and
+      page size, with a total, and accepts an optional keyword that filters on
+      name and server code.
+- [ ] Only servers on the network types the internal surface already permits are
+      visible. A server outside that set is absent from the listing, and asking
+      for its detail answers not-found — the same not-found a genuinely unknown
+      server code answers, so the restriction is not a way to learn a server
+      exists.
+- [ ] A server's detail includes its tools. Internal-only plumbing carried on a
+      tool's input schema is removed before the tool reaches an external caller,
+      exactly as the internal surface removes it.
+- [ ] Listing MCP tenants returns the available tenants with their codes, names
+      and categories.
+- [ ] An upstream marketplace failure is reported as an upstream failure, not as
+      an empty result and not as a caller error.
+
+### Permission
+
+- [ ] Asking about a server reports whether the caller may use it, at what
+      access level, and the caller's per-tool permissions.
+- [ ] The permission asked about is always the *caller's own*. There is no way
+      for a caller to ask about another identity's permission. (The internal
+      endpoint takes the user identifier as a query parameter; the public one
+      must not.)
+- [ ] A server the deployment serves locally is reported as permitted without
+      consulting the external authorization service.
+
+### Configuration — read
+
+- [ ] Reading the caller's configuration for a server returns the endpoint
+      environment, transport protocol, headers, and whether a configuration
+      exists at all.
+- [ ] A stored API key is returned masked, never in full — for any key length,
+      including short ones.
+- [ ] Reading a server the caller has never configured succeeds and reports that
+      no configuration exists, rather than answering not-found.
+
+### Configuration — write
+
+- [ ] Writing a configuration stores it and pushes it to every device under the
+      caller's identity, then returns the resulting configuration with the API
+      key masked.
+- [ ] A field the caller omits is left unchanged; the write is a merge, not a
+      replacement.
+- [ ] The endpoint environment and transport protocol are validated against the
+      values the system accepts, and an invalid one is a caller error naming
+      which field was wrong — not a stored bad value.
+- [ ] Headers are validated before anything is stored.
+- [ ] Writing a configuration for a server that does not exist is a not-found,
+      and nothing is stored.
+- [ ] If the push to devices fails, the stored configuration is rolled back to
+      what it was before the call and the call fails. A caller never ends up
+      with a configuration that is saved but not in effect. *(Decision 2 below.)*
+- [ ] An unknown or unsupported field in the request body is rejected rather
+      than silently ignored.
+
+### Isolation and caller identity
+
+- [ ] Every read and write is scoped to the caller's own identity as resolved
+      from the principal, not to any identifier the caller supplies.
+- [ ] Against the real Track A guard, a configuration belonging to another
+      tenant is invisible: reading it reports no configuration, and writing
+      creates the caller's own row rather than overwriting the other tenant's.
+- [ ] Two tenants each holding a configuration for the same user identifier and
+      the same server neither see nor displace each other.
+
+### Error contract
+
+- [ ] Every failure on this category answers in the standard envelope, with a
+      fixed public message that carries no internal identifier and no
+      internal-language text.
+- [ ] Every domain error these handlers can raise is mapped. Nothing this
+      category raises reaches the generic internal-error fallback.
+
+### The internal surface
+
+- [ ] The internal MCP API's request and response shapes are unchanged, and its
+      existing tests pass unmodified.
+
+## Decisions taken
+
+1. **Paths stay nested: `/openapi/v1/bots/mcp/...`.** The handoff README flagged
+   an unresolved divergence between the routers (nested) and PR #363's overview
+   (top-level). Resolved in favour of the router, which the README already names
+   as authoritative. The other five stub groups inherit the precedent. *(Owner
+   decision, 2026-07-30.)*
+2. **A failed device push rolls the write back and fails the call.** The
+   internal surface already does this; matching it keeps one write path across
+   both surfaces and lets the shared logic be extracted without changing
+   behavior. Reporting partial success instead — issue #560's leaning — would
+   pre-empt a ruling that has not been made, and would need per-bot sync results
+   in the public response shape. *(Owner decision, 2026-07-30.)*
+3. **The write model's `sync_mode` field is dropped.** The stub advertised
+   `single | broadcast`, but no single-device push path exists — the only
+   service operation pushes to every device under the identity. Following the
+   bots slice's ruling on `engine_options`, the surface does not advertise what
+   the server ignores; with unknown fields rejected, sending it is a validation
+   error rather than a silent no-op.
+
+## In Scope
+
+- The six `mcp` endpoint handlers, wired to the existing MCP market, auth,
+  config and sync services.
+- The public request/response models for the category, including masking.
+- This category's domain errors added to the shared error mapping.
+- Any behavior shared with the internal surface extracted so both call one
+  implementation, rather than copied.
+- Tests: per-handler success and mapped-failure coverage, masking, merge
+  semantics, rollback-on-push-failure, and cross-tenant isolation proven against
+  the real Track A guard.
+- Handoff board and changelog updated in the same change.
+
+## Out of Scope
+
+- Applying for permission on a server. The internal surface has an apply
+  endpoint; the public category's six routes do not include one, and adding a
+  seventh is a contract change to ratify separately.
+- Any Track A work. MCP data was isolated by Stage 5; nothing here adds a
+  column, a guard or a DDL step.
+- The real caller-identity verifier. The principal stays a stub, so — like every
+  other public route — these answer 401 to a real request until the auth
+  workstream lands. Handlers, contracts and tests are what "done" means here.
+- The other five stub categories, and the marketplace's own tenant model (see
+  Open Question 3).
+- Changing internal MCP behavior. Any defect found while extracting shared logic
+  is recorded, not fixed in passing, unless leaving it would make the public
+  surface wrong.
+
+## Open Questions
+
+1. **Permission checks currently fail open.** When the marketplace lookup
+   errors, the internal permission check reports the caller *as permitted*.
+   Preserved as-is, an external caller is told "yes" whenever an upstream
+   dependency is down. Recommendation: preserve it. This endpoint is advisory —
+   the MCP server itself is the enforcement point, so a wrong "yes" here costs
+   the caller a failed call, whereas failing closed would make a marketplace
+   outage look like a permission revocation. Needs a ruling before the plan
+   fixes the branch either way.
+2. **Should writing a configuration require permission on the server first?**
+   The internal surface does not check; it stores whatever the caller supplies.
+   Recommendation: do not add a check — storing a credential for a server you
+   cannot yet call is legitimate (permission may be granted later), and adding
+   the check would diverge the two surfaces.
+3. **The marketplace is not tenant-scoped, and cannot be.** Server listings,
+   detail and the MCP tenant list come from an external system with no Avernet
+   tenant axis, so every external tenant sees the same catalog. This is believed
+   correct — a marketplace is a shared catalog — but it should be a stated
+   product position rather than an artifact of where the data lives, because
+   "MCP tenants" and "Avernet tenants" being unrelated concepts on the same
+   surface is a durable source of confusion.

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -193,18 +193,22 @@ public is written until the extraction is green.
         made possible — would `IntegrityError` on the old key). **4 passed.**
 - **Depends on:** Task 5
 
-## Task 8: [ ] Move the handoff board + changelog
+## Task 8: [x] Move the handoff board + changelog
 - **Goal:** Reflect that mcp Track B has landed, in the same PR that lands it.
 - **Files:** `src/backend/docs/openapi-v1/README.md`,
   `src/backend/docs/openapi-v1/README.zh-CN.md`
 - **Done when:**
-  - [ ] The Track B board flips `mcp` to `✅ DONE — PR #610` (both editions).
-  - [ ] The `/openapi/v1/bots/mcp/...` vs top-level path note is resolved to the
-        nested shape (decision 1) rather than left "still open".
-  - [ ] A dated changelog line records the category, the shared-flow extraction,
-        the three decisions, and the preserved fail-open permission behavior.
-  - [ ] The reference-slice list ("use bots as the worked reference") gains mcp
-        as the second done category.
+  - [x] The Track B board flips `mcp` to `✅ DONE — PR #610` (both editions);
+        Track B counters → 2 of 7, and the (pre-existing-stale) Track A DoD
+        counter corrected to 2 of 6 (Stage 5 mcp merged in #564).
+  - [x] The `/openapi/v1/bots/mcp/...` vs top-level path note is resolved to the
+        nested shape for mcp (decision 1), remaining groups noted as inheriting
+        the precedent.
+  - [x] A dated changelog line (both editions) records the category, the
+        shared-flow extraction, the three decisions, and the preserved fail-open
+        permission behavior.
+  - [x] The reference-slice recipe (step 8) gains mcp as the second worked
+        reference, specifically for the extract-shared-logic pattern.
 - **Depends on:** Task 5
 
 ## Task 9: [ ] Tests & Verification

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -9,7 +9,7 @@ public is written until the extraction is green.
 
 ---
 
-## Task 1: [ ] Extract shared presentation helpers + error types
+## Task 1: [x] Extract shared presentation helpers + error types
 - **Goal:** Give both surfaces one definition of masking, `extInfo` stripping,
   the network-type allowlist, and the domain errors the flow raises.
 - **Files:**
@@ -17,19 +17,20 @@ public is written until the extraction is green.
   - `src/agentclaw/community/core/mcp/presentation.py` (new)
   - `tests/community/core/mcp/test_presentation.py` (new)
 - **Done when:**
-  - [ ] `errors.py` defines `McpServerNotFoundError`, `McpHeadersInvalidError`,
+  - [x] `errors.py` defines `McpServerNotFoundError`, `McpHeadersInvalidError`,
         `McpConfigValueError`, `McpSyncFailedError`, `McpMarketUnavailableError`
         — dependency-free, mirroring `openapi_v1/errors.py`.
-  - [ ] `presentation.py` defines `ALLOWED_NETWORK_TYPES = ("INTERNET",
+  - [x] `presentation.py` defines `ALLOWED_NETWORK_TYPES = ("INTERNET",
         "OFFICE")`, `strip_ext_info` / `strip_ext_info_from_list` (moved verbatim
         from `adapters/http/mcp/router.py:58-85`), `is_network_type_visible`, and
         `mask_api_key(key) -> str | None`.
-  - [ ] `mask_api_key` reproduces the existing expression exactly for both
+  - [x] `mask_api_key` reproduces the existing expression exactly for both
         branches — `len > 8` → `key[:4] + "****" + key[-4:]`, else `"****"`,
         `None` → `None` — matching `router.py:308-309` and `:372-373`.
-  - [ ] Unit tests cover: masking for a long key, a short key (`≤8`), and `None`;
+  - [x] Unit tests cover: masking for a long key, a short key (`≤8`), and `None`;
         `extInfo` removed from a tool's `inputSchema.properties` and left intact
         when absent; the network-type rule for INTERNET/OFFICE/neither/empty.
+        **15 passed.**
 - **Depends on:** —
 
 ## Task 2: [ ] Extract the config read/write flow

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -1,0 +1,220 @@
+# Tasks: Public API — MCP Category (Track B)
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+The order is deliberate: build the shared `core/mcp/` primitives, prove them
+behavior-preserving by rewiring the **internal** router (its pinned tests are the
+proof), then wire the public surface on top, then isolation + docs. Nothing
+public is written until the extraction is green.
+
+---
+
+## Task 1: [ ] Extract shared presentation helpers + error types
+- **Goal:** Give both surfaces one definition of masking, `extInfo` stripping,
+  the network-type allowlist, and the domain errors the flow raises.
+- **Files:**
+  - `src/agentclaw/community/core/mcp/errors.py` (new)
+  - `src/agentclaw/community/core/mcp/presentation.py` (new)
+  - `tests/community/core/mcp/test_presentation.py` (new)
+- **Done when:**
+  - [ ] `errors.py` defines `McpServerNotFoundError`, `McpHeadersInvalidError`,
+        `McpConfigValueError`, `McpSyncFailedError`, `McpMarketUnavailableError`
+        — dependency-free, mirroring `openapi_v1/errors.py`.
+  - [ ] `presentation.py` defines `ALLOWED_NETWORK_TYPES = ("INTERNET",
+        "OFFICE")`, `strip_ext_info` / `strip_ext_info_from_list` (moved verbatim
+        from `adapters/http/mcp/router.py:58-85`), `is_network_type_visible`, and
+        `mask_api_key(key) -> str | None`.
+  - [ ] `mask_api_key` reproduces the existing expression exactly for both
+        branches — `len > 8` → `key[:4] + "****" + key[-4:]`, else `"****"`,
+        `None` → `None` — matching `router.py:308-309` and `:372-373`.
+  - [ ] Unit tests cover: masking for a long key, a short key (`≤8`), and `None`;
+        `extInfo` removed from a tool's `inputSchema.properties` and left intact
+        when absent; the network-type rule for INTERNET/OFFICE/neither/empty.
+- **Depends on:** —
+
+## Task 2: [ ] Extract the config read/write flow
+- **Goal:** Lift the internal write orchestration (validate → server-exists →
+  write → push → rollback) into a FastAPI-free function both surfaces call.
+- **Files:**
+  - `src/agentclaw/community/core/mcp/config_flow.py` (new)
+  - `tests/community/core/mcp/test_mcp_config_flow.py` (new)
+- **Done when:**
+  - [ ] `read_unified_config(*, user_id, server_code, config_service) ->
+        UnifiedConfig` and async `write_unified_config(...)` exist, taking
+        already-injected services, raising the Task 1 errors, and returning a
+        frozen `UnifiedConfig` whose `api_key` is **already masked** (so no
+        caller can reach the raw key).
+  - [ ] `write_unified_config` preserves the internal ordering from
+        `router.py:250-337` exactly: validate values → validate headers →
+        `market_service.get_mcp_detail` (missing → `McpServerNotFoundError`,
+        *before* any DB write) → `update_user_unified_config` keeping the old row
+        → `sync_mcp_detail_to_all_bots` → on failure `rollback_unified_config`
+        then raise `McpSyncFailedError`.
+  - [ ] `write_unified_config` returns the sync results alongside the config, so
+        the internal adapter can keep populating `MCPUnifiedConfigData.sync_results`
+        (the public handler ignores them).
+  - [ ] Header validation surfaces the validator's failure as
+        `McpHeadersInvalidError`; the `endpoint_env`/`transport_protocol` value
+        check remains as the internal path's backstop, raising
+        `McpConfigValueError`.
+  - [ ] Tests (no HTTP): an omitted field is left unchanged (merge, not replace);
+        an unknown server code never reaches `update_user_unified_config`;
+        rollback restores the prior row on sync failure; rollback **deletes** the
+        row when it was newly created (`config_service.py:172-177`).
+- **Depends on:** Task 1
+
+## Task 3: [ ] Rewire the internal router onto the extracted code
+- **Goal:** Make `/api/mcp` call the shared flow and helpers, with its HTTP
+  contract byte-identical — this is the proof the extraction preserved behavior.
+- **Files:**
+  - `src/agentclaw/community/adapters/http/mcp/router.py`
+  - `src/agentclaw/community/core/mcp/README.md` (context boundary)
+- **Done when:**
+  - [ ] `_remove_ext_info_*` deleted from the router; `strip_ext_info*`,
+        `ALLOWED_NETWORK_TYPES`, `is_network_type_visible`, `mask_api_key`
+        imported from `core/mcp/presentation.py` (`router.py:58-85,108-115,
+        162-166,307-309,370-373`).
+  - [ ] `update_mcp_unified_config` (`:237-344`) becomes a thin adapter: call
+        `write_unified_config`, catch each typed error and re-raise the identical
+        `HTTPException` (same status, same `detail` string) it raised before;
+        `get_mcp_unified_config` (`:347-386`) calls `read_unified_config`.
+  - [ ] `core/mcp/README.md` `## Context Boundary` updated — `MCPMarketService`
+        added to `provides` (the flow now consumes it) and any new
+        `internal_dependencies` declared.
+  - [ ] **`tests/community/api/mcp/routers/test_mcp_config_internal_unchanged.py`
+        and `test_mcp.py` pass UNMODIFIED.** No edit to either file.
+  - [ ] `tests/community/architecture/` passes after the README edit.
+- **Depends on:** Task 2
+
+## Task 4: [ ] Public MCP request/response schemas
+- **Goal:** Turn the stub models into the strict public contract.
+- **Files:** `src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py`
+- **Done when:**
+  - [ ] A module-level `_STRICT = ConfigDict(extra="forbid")` is applied to every
+        model (mirroring `bots/schemas.py:16`), so an unknown field is a 422.
+  - [ ] `McpConfigWrite.sync_mode` is removed.
+  - [ ] `McpConfigWrite.endpoint_env` is `Literal["PROD", "PRE"] | None` and
+        `transport_protocol` is `Literal["SSE", "STREAMABLE_HTTP"] | None` — no
+        `DEV`; `None` means "leave unchanged".
+  - [ ] `McpConfig.api_key` documented as always masked.
+  - [ ] The response models still carry the fields the adapters populate
+        (`McpServer`, `McpServerDetail`, `McpPermission`, `McpTenant`, `McpConfig`).
+- **Depends on:** —
+
+## Task 5: [ ] Wire the six public handlers
+- **Goal:** Replace the `NotImplementedError` stubs with real handlers on the
+  shared flow, owner-scoped via the principal.
+- **Files:** `src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py`
+- **Done when:**
+  - [ ] Every handler takes `request: Request`, `PrincipalDep`, its services via
+        `Injected`, carries `@envelope_errors`, and opens with
+        `owner_id = caller_owner_id(principal)`.
+  - [ ] `list_mcp_servers` → `get_mcp_list(..., search_key=keyword,
+        network_types=ALLOWED_NETWORK_TYPES)`, `strip_ext_info_from_list`,
+        `page(total, items, request)`.
+  - [ ] `get_mcp_server` → `get_mcp_detail`; `None` **or** network-type-invisible
+        raise `McpServerNotFoundError` from **one** site, so the two 404 paths are
+        indistinguishable.
+  - [ ] `list_mcp_tenants` → `get_tenant_list`, mapped to `McpTenant` via an
+        adapter; an upstream `success: False` raises `McpMarketUnavailableError`.
+  - [ ] `check_mcp_permission` → `check_mcp_permission_detail(owner_id,
+        server_code)`; **no** `user_id` query parameter is exposed.
+  - [ ] `get_mcp_config` / `update_mcp_config` delegate to `config_flow` with
+        `entity_id = owner_id`, `entity_type = "staff"`; no `IAM_TOKEN` cookie
+        handling.
+  - [ ] Module-private `_to_server` / `_to_server_detail` / `_to_tenant` adapters
+        map MCP Center camelCase → the snake_case public models.
+  - [ ] Endpoint tests (`tests/community/adapters/http/openapi_v1/
+        test_mcp_endpoints.py`, new) cover, per handler: success shape +
+        envelope `code`/`request_id`; masking for long and short keys; a
+        never-configured server → `has_config: false` (not 404); invisible vs
+        unknown server → byte-identical 404; `extInfo` stripped; permission from
+        the principal only; `sync_mode`/unknown field → 422; missing principal →
+        401.
+- **Depends on:** Tasks 2, 4
+
+## Task 6: [ ] Map the MCP domain errors to envelopes
+- **Goal:** Every error these handlers raise answers in the envelope; nothing
+  reaches the generic 500 fallback.
+- **Files:** `src/agentclaw/community/adapters/http/openapi_v1/responses.py`
+- **Done when:**
+  - [ ] `ENVELOPE_ERRORS` gains the five errors with fixed public messages:
+        `McpServerNotFoundError`→404 "Not found",
+        `McpHeadersInvalidError`→400 "Invalid MCP headers",
+        `McpConfigValueError`→400 "Invalid MCP configuration",
+        `McpSyncFailedError`→502 "Device sync failed",
+        `McpMarketUnavailableError`→502 "MCP service error".
+  - [ ] They are placed above `BotServiceError` (they share no base with it, so
+        order among themselves is free); no message is `str(exc)`, and none
+        carries the validator's Chinese text.
+  - [ ] A test asserts every mapped error round-trips to its status + fixed
+        message, and that the 404 message is byte-identical to the not-found
+        the bots surface returns.
+- **Depends on:** Task 1
+
+## Task 7: [ ] Cross-tenant isolation against the real Stage 5 guard
+- **Goal:** Prove a config in another tenant is invisible and un-overwritable
+  through the path the handlers use — end to end, not mocked.
+- **Files:** `tests/community/adapters/http/openapi_v1/test_mcp_tenant_isolation.py`
+  (new)
+- **Done when:**
+  - [ ] Uses a real `UserMCPConfigRepository` over SQLite with the Stage 5
+        guard, in the shape of `test_bots_tenant_isolation.py`.
+  - [ ] A config written under tenant A is invisible from tenant B (read →
+        "no config"); a tenant-B write creates B's own row rather than
+        overwriting A's.
+  - [ ] Two tenants each hold a row for the same `user_id` + `server_code` and
+        neither sees or displaces the other (the case the Stage 5 unique-key swap
+        made possible).
+- **Depends on:** Task 5
+
+## Task 8: [ ] Move the handoff board + changelog
+- **Goal:** Reflect that mcp Track B has landed, in the same PR that lands it.
+- **Files:** `src/backend/docs/openapi-v1/README.md`,
+  `src/backend/docs/openapi-v1/README.zh-CN.md`
+- **Done when:**
+  - [ ] The Track B board flips `mcp` to `✅ DONE — PR #610` (both editions).
+  - [ ] The `/openapi/v1/bots/mcp/...` vs top-level path note is resolved to the
+        nested shape (decision 1) rather than left "still open".
+  - [ ] A dated changelog line records the category, the shared-flow extraction,
+        the three decisions, and the preserved fail-open permission behavior.
+  - [ ] The reference-slice list ("use bots as the worked reference") gains mcp
+        as the second done category.
+- **Depends on:** Task 5
+
+## Task 9: [ ] Tests & Verification
+- **Goal:** Ensure the feature meets every `spec.md` acceptance criterion and
+  the internal surface is untouched.
+- **Files:** — (runs the suites)
+- **Done when:**
+  - [ ] Every `spec.md` acceptance criterion maps to a passing test (marketplace,
+        permission, config read/write, isolation, error contract, internal
+        surface).
+  - [ ] The fail-open permission behavior is pinned by a test and noted in the
+        handler docstring, so it reads as a recorded decision (Open Question 1).
+  - [ ] The rollback-on-sync-failure path answers 502 and leaves the stored row
+        as it was (or absent, on a create).
+  - [ ] Raw API keys (long and short) appear nowhere in either surface's response
+        text.
+  - [ ] `test_mcp_config_internal_unchanged.py`, `test_mcp.py`,
+        `tests/community/architecture/`, and the full `tests/community` suite all
+        pass; no pre-existing test modified.
+- **Depends on:** Tasks 3, 5, 6, 7, 8
+
+---
+
+## Groups
+
+- **Group A — Shared extraction (behavior-preserving):** Tasks 1, 2, 3
+  - Theme: Lift masking / presentation / errors and the write-flow into
+    `core/mcp/`, and prove it by rewiring the internal router with its pinned
+    tests unmodified. Lands as a self-contained refactor even before any public
+    handler exists.
+- **Group B — Public MCP surface:** Tasks 4, 5, 6
+  - Theme: The strict public schemas, the six wired handlers, and the error
+    mapping — the category becomes callable (modulo the 401 auth stub).
+- **Group C — Isolation & docs:** Tasks 7, 8
+  - Theme: Prove tenant safety against the real guard and move the handoff board
+    in the same PR.
+- **Group D — Verification:** Task 9
+  - Theme: Final spec acceptance check + internal-surface regression gate.

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -96,19 +96,23 @@ public is written until the extraction is green.
         suite 168 passed.
 - **Depends on:** Task 2
 
-## Task 4: [ ] Public MCP request/response schemas
+## Task 4: [x] Public MCP request/response schemas
 - **Goal:** Turn the stub models into the strict public contract.
 - **Files:** `src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py`
 - **Done when:**
-  - [ ] A module-level `_STRICT = ConfigDict(extra="forbid")` is applied to every
-        model (mirroring `bots/schemas.py:16`), so an unknown field is a 422.
-  - [ ] `McpConfigWrite.sync_mode` is removed.
-  - [ ] `McpConfigWrite.endpoint_env` is `Literal["PROD", "PRE"] | None` and
+  - [x] A module-level `_STRICT = ConfigDict(extra="forbid")` is applied to the
+        **request** body `McpConfigWrite` (mirroring `bots/schemas.py:16`, which
+        guards request bodies — `BotCreate`/`BotUpdate` — and leaves
+        server-constructed response models plain). An unknown field is a 422.
+  - [x] `McpConfigWrite.sync_mode` is removed.
+  - [x] `McpConfigWrite.endpoint_env` is `Literal["PROD", "PRE"] | None` and
         `transport_protocol` is `Literal["SSE", "STREAMABLE_HTTP"] | None` — no
         `DEV`; `None` means "leave unchanged".
-  - [ ] `McpConfig.api_key` documented as always masked.
-  - [ ] The response models still carry the fields the adapters populate
-        (`McpServer`, `McpServerDetail`, `McpPermission`, `McpTenant`, `McpConfig`).
+  - [x] `McpConfig.api_key` documented as always masked; `McpTenant` documented
+        as a marketplace concept distinct from the Avernet isolation tenant.
+  - [x] Response models still carry the fields the adapters populate. Package
+        imports clean under pytest (113 openapi_v1 tests collect); strict
+        behavior (`sync_mode`/`DEV` → 422) verified and covered by Task 5.
 - **Depends on:** —
 
 ## Task 5: [ ] Wire the six public handlers

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -211,24 +211,60 @@ public is written until the extraction is green.
         reference, specifically for the extract-shared-logic pattern.
 - **Depends on:** Task 5
 
-## Task 9: [ ] Tests & Verification
+## Task 9: [x] Tests & Verification
 - **Goal:** Ensure the feature meets every `spec.md` acceptance criterion and
   the internal surface is untouched.
 - **Files:** — (runs the suites)
 - **Done when:**
-  - [ ] Every `spec.md` acceptance criterion maps to a passing test (marketplace,
-        permission, config read/write, isolation, error contract, internal
-        surface).
-  - [ ] The fail-open permission behavior is pinned by a test and noted in the
-        handler docstring, so it reads as a recorded decision (Open Question 1).
-  - [ ] The rollback-on-sync-failure path answers 502 and leaves the stored row
-        as it was (or absent, on a create).
-  - [ ] Raw API keys (long and short) appear nowhere in either surface's response
-        text.
-  - [ ] `test_mcp_config_internal_unchanged.py`, `test_mcp.py`,
-        `tests/community/architecture/`, and the full `tests/community` suite all
-        pass; no pre-existing test modified.
+  - [x] Every `spec.md` acceptance criterion maps to a passing test — see the
+        matrix below. Marketplace / permission / config read+write / isolation /
+        error contract / internal surface all covered.
+  - [x] The fail-open permission behavior is pinned by a test
+        (`test_permission_is_fail_open_by_decision` at the public layer +
+        `test_auth_service.test_check_mcp_permission_detail_mcp_center_failure`
+        at the service) and noted in the `check_mcp_permission` docstring.
+  - [x] The rollback-on-sync-failure path answers 502 and leaves the stored row
+        as it was / absent on create —
+        `test_put_config_sync_failure_is_502_and_rolls_back`,
+        `test_sync_failure_rolls_back_update_and_raises`,
+        `test_sync_failure_after_create_rolls_back_as_delete`.
+  - [x] Raw API keys (long + short) appear nowhere in a response —
+        `test_raw_key_never_appears_in_response_text`, masking tests both surfaces.
+  - [x] `test_mcp_config_internal_unchanged.py`, `test_mcp.py` pass UNMODIFIED
+        (confirmed via `git diff` — not in the changed-file set);
+        `tests/community/architecture/` 108 passed; MCP contract snapshots
+        (`test_rule16/17_mcp`, `test_mcp_center/auth`) 10 passed. Broad sweeps:
+        `tests/community/adapters/http/` 384, MCP+openapi+isolation suites 338.
+        `test_responses.py` is additions-only.
 - **Depends on:** Tasks 3, 5, 6, 7, 8
+
+### Acceptance criteria → test matrix
+| spec.md criterion | Test |
+|---|---|
+| List: page+total, keyword filters name/code | `test_list_servers_maps_fields_and_omits_tools`, `test_list_servers_forwards_keyword_and_paging` |
+| Only allowed network types visible; hidden==unknown 404 | `test_invisible_server_is_identical_404`, `test_unknown_server_is_404_not_found` |
+| Detail includes tools; internal `extInfo` stripped | `test_server_detail_strips_ext_info`, `test_presentation` |
+| List tenants (code/name/categories) | `test_list_tenants` |
+| Upstream marketplace failure → upstream error (502) | `test_list_servers_upstream_failure_is_502`, `test_tenants_upstream_failure_is_502` |
+| Permission: access + level + per-tool | `test_permission_shape` |
+| Permission is caller's own only (no id param) | `test_permission_uses_caller_identity_only` |
+| Local server permitted without external auth | inherited/unchanged: `test_auth_service` (service layer) |
+| Config read: env/transport/headers/has_config | `test_get_config_absent_reports_no_config`, `test_get_config_masks_long_key` |
+| API key masked, any length | `test_get_config_masks_long_key`, `test_get_config_masks_short_key`, `test_presentation` |
+| Never-configured → has_config:false not 404 | `test_get_config_absent_reports_no_config` |
+| Write stores + pushes + returns masked | `test_put_config_success_returns_reread_state` |
+| Omitted field unchanged (merge) | `test_write_forwards_params_for_merge_and_push` |
+| env/transport validated (bad → caller error) | `test_put_config_rejects_dev_endpoint_env_as_422`, `test_bad_endpoint_env_raises_before_any_write` |
+| Headers validated before storing | `test_invalid_headers_raise_before_any_write` |
+| Unknown server → 404, nothing stored | `test_put_config_unknown_server_is_404`, `test_unknown_server_raises_before_any_write` |
+| Push fail → rollback + fail | `test_put_config_sync_failure_is_502_and_rolls_back` (+ 2 flow rollback tests) |
+| Unknown/immutable field rejected (422) | `test_put_config_rejects_sync_mode_as_422` |
+| Reads/writes scoped to caller identity | `test_put_config_scopes_write_to_caller`, `test_permission_uses_caller_identity_only` |
+| Foreign tenant invisible + un-overwritable (real guard) | `test_mcp_tenant_isolation` (4 tests) |
+| Two tenants same user+server coexist | `test_two_tenants_same_user_and_server_coexist` |
+| Every failure enveloped, fixed message | `test_mcp_errors_map_to_status_and_fixed_message` |
+| Every domain error mapped (no generic 500 escape) | mapping test + Group B review verdict |
+| Internal API shapes unchanged, tests unmodified | `test_mcp_config_internal_unchanged.py` + `test_mcp.py` UNMODIFIED (16), contract snapshots (10) |
 
 ---
 

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -33,35 +33,40 @@ public is written until the extraction is green.
         **15 passed.**
 - **Depends on:** —
 
-## Task 2: [ ] Extract the config read/write flow
+## Task 2: [x] Extract the config read/write flow
 - **Goal:** Lift the internal write orchestration (validate → server-exists →
   write → push → rollback) into a FastAPI-free function both surfaces call.
 - **Files:**
   - `src/agentclaw/community/core/mcp/config_flow.py` (new)
   - `tests/community/core/mcp/test_mcp_config_flow.py` (new)
 - **Done when:**
-  - [ ] `read_unified_config(*, user_id, server_code, config_service) ->
+  - [x] `read_unified_config(*, user_id, server_code, config_service) ->
         UnifiedConfig` and async `write_unified_config(...)` exist, taking
         already-injected services, raising the Task 1 errors, and returning a
         frozen `UnifiedConfig` whose `api_key` is **already masked** (so no
         caller can reach the raw key).
-  - [ ] `write_unified_config` preserves the internal ordering from
+  - [x] `write_unified_config` preserves the internal ordering from
         `router.py:250-337` exactly: validate values → validate headers →
         `market_service.get_mcp_detail` (missing → `McpServerNotFoundError`,
         *before* any DB write) → `update_user_unified_config` keeping the old row
         → `sync_mcp_detail_to_all_bots` → on failure `rollback_unified_config`
         then raise `McpSyncFailedError`.
-  - [ ] `write_unified_config` returns the sync results alongside the config, so
+  - [x] `write_unified_config` returns the sync results alongside the config, so
         the internal adapter can keep populating `MCPUnifiedConfigData.sync_results`
         (the public handler ignores them).
-  - [ ] Header validation surfaces the validator's failure as
+  - [x] Header validation surfaces the validator's failure as
         `McpHeadersInvalidError`; the `endpoint_env`/`transport_protocol` value
         check remains as the internal path's backstop, raising
         `McpConfigValueError`.
-  - [ ] Tests (no HTTP): an omitted field is left unchanged (merge, not replace);
+  - [x] Tests (no HTTP): an omitted field is left unchanged (merge, not replace);
         an unknown server code never reaches `update_user_unified_config`;
         rollback restores the prior row on sync failure; rollback **deletes** the
-        row when it was newly created (`config_service.py:172-177`).
+        row when it was newly created (`config_service.py:172-177`). **9 passed.**
+  - [x] Also folded in `list_marketplace_servers` / `list_marketplace_tenants`
+        (raise `McpMarketUnavailableError` on upstream `success: False`) so the
+        internal list/tenant routes and the public handlers share the same
+        upstream-failure rule. *(Small addition beyond the plan's named
+        functions — same module, same pattern; flagged here.)*
 - **Depends on:** Task 1
 
 ## Task 3: [ ] Rewire the internal router onto the extracted code

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -115,36 +115,40 @@ public is written until the extraction is green.
         behavior (`sync_mode`/`DEV` → 422) verified and covered by Task 5.
 - **Depends on:** —
 
-## Task 5: [~] Wire the six public handlers
+## Task 5: [x] Wire the six public handlers
 - **Goal:** Replace the `NotImplementedError` stubs with real handlers on the
   shared flow, owner-scoped via the principal.
 - **Files:** `src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py`
 - **Done when:**
-  - [ ] Every handler takes `request: Request`, `PrincipalDep`, its services via
+  - [x] Every handler takes `request: Request`, `PrincipalDep`, its services via
         `Injected`, carries `@envelope_errors`, and opens with
         `owner_id = caller_owner_id(principal)`.
-  - [ ] `list_mcp_servers` → `get_mcp_list(..., search_key=keyword,
-        network_types=ALLOWED_NETWORK_TYPES)`, `strip_ext_info_from_list`,
-        `page(total, items, request)`.
-  - [ ] `get_mcp_server` → `get_mcp_detail`; `None` **or** network-type-invisible
+  - [x] `list_mcp_servers` → `list_marketplace_servers(..., keyword,
+        network_types=ALLOWED_NETWORK_TYPES)` (upstream failure → 502),
+        `page(total, items, request)`. **No per-item `extInfo` strip:** the list
+        projects to `McpServer`, which carries no `tools`, so there is nothing to
+        strip — kept the list lightweight and dropped the dead call.
+  - [x] `get_mcp_server` → `get_mcp_detail`; `None` **or** network-type-invisible
         raise `McpServerNotFoundError` from **one** site, so the two 404 paths are
-        indistinguishable.
-  - [ ] `list_mcp_tenants` → `get_tenant_list`, mapped to `McpTenant` via an
-        adapter; an upstream `success: False` raises `McpMarketUnavailableError`.
-  - [ ] `check_mcp_permission` → `check_mcp_permission_detail(owner_id,
-        server_code)`; **no** `user_id` query parameter is exposed.
-  - [ ] `get_mcp_config` / `update_mcp_config` delegate to `config_flow` with
-        `entity_id = owner_id`, `entity_type = "staff"`; no `IAM_TOKEN` cookie
-        handling.
-  - [ ] Module-private `_to_server` / `_to_server_detail` / `_to_tenant` adapters
-        map MCP Center camelCase → the snake_case public models.
-  - [ ] Endpoint tests (`tests/community/adapters/http/openapi_v1/
-        test_mcp_endpoints.py`, new) cover, per handler: success shape +
-        envelope `code`/`request_id`; masking for long and short keys; a
-        never-configured server → `has_config: false` (not 404); invisible vs
-        unknown server → byte-identical 404; `extInfo` stripped; permission from
-        the principal only; `sync_mode`/unknown field → 422; missing principal →
-        401.
+        indistinguishable (test asserts byte-identical bodies).
+  - [x] `list_mcp_tenants` → `list_marketplace_tenants`, mapped to `McpTenant`;
+        an upstream `success: False` raises `McpMarketUnavailableError` (→ 502).
+  - [x] `check_mcp_permission` → `check_mcp_permission_detail(owner_id,
+        server_code)`; **no** `user_id` query parameter (test proves a spoofed
+        `?user_id=` is ignored — the principal's owner is used).
+  - [x] `get_mcp_config` → `read_unified_config`; `update_mcp_config` →
+        `write_unified_config` then re-read for a response equal to a subsequent
+        GET; `entity_id = owner_id`, `entity_type = "staff"`; no `IAM_TOKEN`
+        cookie handling.
+  - [x] Module-private `_to_server` / `_to_server_detail` / `_to_tenant` /
+        `_to_config` adapters map MCP Center camelCase → the snake_case models.
+  - [x] Endpoint tests (`test_mcp_endpoints.py`, new) cover every handler:
+        success shape + envelope `code`/`request_id`; masking long+short keys +
+        raw key never in response text; never-configured → `has_config: false`
+        (not 404); invisible vs unknown → byte-identical 404; `extInfo` stripped
+        on detail; permission from principal only; sync-failure → 502 + rollback;
+        `sync_mode`/`DEV` → 422; missing principal → 401. **21 passed; full
+        openapi_v1 suite 136 passed.**
 - **Depends on:** Tasks 2, 4
 
 ## Task 6: [x] Map the MCP domain errors to envelopes

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -173,20 +173,24 @@ public is written until the extraction is green.
 - **Note:** Landed before Task 5 (its only dependency is Task 1) so Task 5's
   endpoint tests exercise the mappings.
 
-## Task 7: [ ] Cross-tenant isolation against the real Stage 5 guard
+## Task 7: [x] Cross-tenant isolation against the real Stage 5 guard
 - **Goal:** Prove a config in another tenant is invisible and un-overwritable
   through the path the handlers use — end to end, not mocked.
 - **Files:** `tests/community/adapters/http/openapi_v1/test_mcp_tenant_isolation.py`
   (new)
 - **Done when:**
-  - [ ] Uses a real `UserMCPConfigRepository` over SQLite with the Stage 5
-        guard, in the shape of `test_bots_tenant_isolation.py`.
-  - [ ] A config written under tenant A is invisible from tenant B (read →
-        "no config"); a tenant-B write creates B's own row rather than
-        overwriting A's.
-  - [ ] Two tenants each hold a row for the same `user_id` + `server_code` and
+  - [x] Drives the **flow the handlers call** (`read_unified_config` /
+        `write_unified_config`) against a real `MCPConfigService` + real
+        `UserMCPConfigRepository` + the real Stage 5 guard over SQLite (only the
+        marketplace + device-sync collaborators are mocked). This is a strictly
+        stronger proof than testing the repo directly — it covers the exact
+        layer the public GET/PUT use.
+  - [x] A config written under tenant A is invisible from tenant B (read →
+        `has_config: false`, `api_key: None`); a tenant-B write creates B's own
+        row rather than overwriting A's (A's stored bytes verified untouched).
+  - [x] Two tenants each hold a row for the same `user_id` + `server_code` and
         neither sees or displaces the other (the case the Stage 5 unique-key swap
-        made possible).
+        made possible — would `IntegrityError` on the old key). **4 passed.**
 - **Depends on:** Task 5
 
 ## Task 8: [ ] Move the handoff board + changelog

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -69,27 +69,31 @@ public is written until the extraction is green.
         functions — same module, same pattern; flagged here.)*
 - **Depends on:** Task 1
 
-## Task 3: [ ] Rewire the internal router onto the extracted code
+## Task 3: [x] Rewire the internal router onto the extracted code
 - **Goal:** Make `/api/mcp` call the shared flow and helpers, with its HTTP
   contract byte-identical — this is the proof the extraction preserved behavior.
 - **Files:**
   - `src/agentclaw/community/adapters/http/mcp/router.py`
   - `src/agentclaw/community/core/mcp/README.md` (context boundary)
 - **Done when:**
-  - [ ] `_remove_ext_info_*` deleted from the router; `strip_ext_info*`,
+  - [x] `_remove_ext_info_*` deleted from the router; `strip_ext_info*`,
         `ALLOWED_NETWORK_TYPES`, `is_network_type_visible`, `mask_api_key`
-        imported from `core/mcp/presentation.py` (`router.py:58-85,108-115,
-        162-166,307-309,370-373`).
-  - [ ] `update_mcp_unified_config` (`:237-344`) becomes a thin adapter: call
+        imported from `core/mcp/presentation.py`.
+  - [x] `update_mcp_unified_config` becomes a thin adapter: call
         `write_unified_config`, catch each typed error and re-raise the identical
         `HTTPException` (same status, same `detail` string) it raised before;
-        `get_mcp_unified_config` (`:347-386`) calls `read_unified_config`.
-  - [ ] `core/mcp/README.md` `## Context Boundary` updated — `MCPMarketService`
-        added to `provides` (the flow now consumes it) and any new
-        `internal_dependencies` declared.
-  - [ ] **`tests/community/api/mcp/routers/test_mcp_config_internal_unchanged.py`
-        and `test_mcp.py` pass UNMODIFIED.** No edit to either file.
-  - [ ] `tests/community/architecture/` passes after the README edit.
+        `get_mcp_unified_config` calls `read_unified_config` (message keyed on
+        `exists`, not `has_config`, to preserve the empty-row case).
+  - [x] `core/mcp/README.md` `## Context Boundary` updated — `MCPMarketService`
+        added to `provides`. **No new `internal_dependencies`:** the flow
+        *receives* the market/config/sync services as parameters rather than
+        importing them, so the arch gate stayed green with no dependency edit
+        (the plan's predicted new import did not materialize — receiving beats
+        importing).
+  - [x] **`test_mcp_config_internal_unchanged.py` and `test_mcp.py` pass
+        UNMODIFIED** — 16 passed, neither file touched.
+  - [x] `tests/community/architecture/` passes (108 passed); full MCP api+core
+        suite 168 passed.
 - **Depends on:** Task 2
 
 ## Task 4: [ ] Public MCP request/response schemas

--- a/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
+++ b/src/backend/specs/2026-07-30-openapi-v1-mcp-track-b/tasks.md
@@ -115,7 +115,7 @@ public is written until the extraction is green.
         behavior (`sync_mode`/`DEV` → 422) verified and covered by Task 5.
 - **Depends on:** —
 
-## Task 5: [ ] Wire the six public handlers
+## Task 5: [~] Wire the six public handlers
 - **Goal:** Replace the `NotImplementedError` stubs with real handlers on the
   shared flow, owner-scoped via the principal.
 - **Files:** `src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py`
@@ -147,24 +147,27 @@ public is written until the extraction is green.
         401.
 - **Depends on:** Tasks 2, 4
 
-## Task 6: [ ] Map the MCP domain errors to envelopes
+## Task 6: [x] Map the MCP domain errors to envelopes
 - **Goal:** Every error these handlers raise answers in the envelope; nothing
   reaches the generic 500 fallback.
 - **Files:** `src/agentclaw/community/adapters/http/openapi_v1/responses.py`
 - **Done when:**
-  - [ ] `ENVELOPE_ERRORS` gains the five errors with fixed public messages:
+  - [x] `ENVELOPE_ERRORS` gains the five errors with fixed public messages:
         `McpServerNotFoundError`→404 "Not found",
         `McpHeadersInvalidError`→400 "Invalid MCP headers",
         `McpConfigValueError`→400 "Invalid MCP configuration",
         `McpSyncFailedError`→502 "Device sync failed",
         `McpMarketUnavailableError`→502 "MCP service error".
-  - [ ] They are placed above `BotServiceError` (they share no base with it, so
+  - [x] They are placed above `BotServiceError` (they share no base with it, so
         order among themselves is free); no message is `str(exc)`, and none
-        carries the validator's Chinese text.
-  - [ ] A test asserts every mapped error round-trips to its status + fixed
+        carries the validator's Chinese text. Trailing comment corrected — the
+        MCP entries are a separate hierarchy from `BotServiceError`.
+  - [x] A test asserts every mapped error round-trips to its status + fixed
         message, and that the 404 message is byte-identical to the not-found
-        the bots surface returns.
+        the bots surface returns. **18 passed** (test_responses + error_schema).
 - **Depends on:** Task 1
+- **Note:** Landed before Task 5 (its only dependency is Task 1) so Task 5's
+  endpoint tests exercise the mappings.
 
 ## Task 7: [ ] Cross-tenant isolation against the real Stage 5 guard
 - **Goal:** Prove a config in another tenant is invisible and un-overwritable

--- a/src/backend/src/agentclaw/community/adapters/http/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/mcp/router.py
@@ -1,8 +1,7 @@
 """MCP API router — facade layer over core/mcp/services."""
 from __future__ import annotations
 
-from copy import deepcopy
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
@@ -24,6 +23,23 @@ from agentclaw.community.api.mcp_auth_service import MCPAuthServiceProtocol
 from agentclaw.community.api.mcp_config_service import MCPConfigServiceProtocol
 from agentclaw.community.api.mcp_market_service import MCPMarketServiceProtocol
 from agentclaw.community.api.mcp_sync_service import MCPSyncServiceProtocol
+from agentclaw.community.core.mcp.config_flow import (
+    read_unified_config,
+    write_unified_config,
+)
+from agentclaw.community.core.mcp.errors import (
+    McpConfigValueError,
+    McpHeadersInvalidError,
+    McpServerNotFoundError,
+    McpSyncFailedError,
+)
+from agentclaw.community.core.mcp.presentation import (
+    ALLOWED_NETWORK_TYPES,
+    is_network_type_visible,
+    mask_api_key,
+    strip_ext_info,
+    strip_ext_info_from_list,
+)
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
 
@@ -55,36 +71,6 @@ def _get_path_params(
     return effective_entity_id, effective_bot_id, effective_entity_type
 
 
-def _remove_ext_info_from_mcp_tools(mcp_data: dict[str, Any]) -> dict[str, Any]:
-    sanitized = deepcopy(mcp_data)
-    tools = sanitized.get("tools")
-    if not isinstance(tools, list):
-        return sanitized
-
-    for tool in tools:
-        if not isinstance(tool, dict):
-            continue
-        input_schema = tool.get("inputSchema")
-        if not isinstance(input_schema, dict):
-            continue
-        properties = input_schema.get("properties")
-        if isinstance(properties, dict):
-            properties.pop("extInfo", None)
-
-    return sanitized
-
-
-def _remove_ext_info_from_mcp_list_result(result: dict[str, Any]) -> dict[str, Any]:
-    sanitized = deepcopy(result)
-    data = sanitized.get("data")
-    if isinstance(data, list):
-        sanitized["data"] = [
-            _remove_ext_info_from_mcp_tools(item) if isinstance(item, dict) else item
-            for item in data
-        ]
-    return sanitized
-
-
 # ==================== MCP Market APIs ====================
 
 @router.get("/market/list", response_model=MCPListResponse)
@@ -105,7 +91,7 @@ async def list_mcp_servers(
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> MCPListResponse:
     """Get MCP list from market."""
-    allowed_network_types = ["INTERNET", "OFFICE"]
+    allowed_network_types = list(ALLOWED_NETWORK_TYPES)
     if network_types:
         filtered = [t for t in network_types if t in allowed_network_types]
         if not filtered:
@@ -131,7 +117,7 @@ async def list_mcp_servers(
     )
     if not result.get("success"):
         raise HTTPException(status_code=500, detail=result.get("message", "Failed to fetch MCP list"))
-    return MCPListResponse(**_remove_ext_info_from_mcp_list_result(result))
+    return MCPListResponse(**strip_ext_info_from_list(result))
 
 
 @router.get("/market/detail", response_model=MCPDetailResponse)
@@ -159,12 +145,10 @@ async def get_mcp_detail(
     if not detail:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    allowed_network_types = ["INTERNET", "OFFICE"]
-    network_types = detail.get("networkTypes") or []
-    if network_types and not any(nt in allowed_network_types for nt in network_types):
+    if not is_network_type_visible(detail):
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    return MCPDetailResponse(success=True, data=_remove_ext_info_from_mcp_tools(detail))
+    return MCPDetailResponse(success=True, data=strip_ext_info(detail))
 
 
 @router.get("/market/permission", response_model=MCPPermissionResponse)
@@ -246,72 +230,37 @@ async def update_mcp_unified_config(
     sync_service: MCPSyncServiceProtocol = Injected(MCPSyncServiceProtocol),
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> MCPUnifiedConfigResponse:
-    """更新MCP统一配置并同步到设备。"""
-    # 校验 endpoint_env
-    if request.endpoint_env is not None and request.endpoint_env not in ("PROD", "PRE"):
-        raise HTTPException(status_code=400, detail="endpoint_env must be PROD or PRE")
+    """更新MCP统一配置并同步到设备。
 
-    # 校验 transport_protocol
-    if request.transport_protocol is not None:
-        normalized_tp = request.transport_protocol.upper()
-        if normalized_tp not in ("SSE", "STREAMABLE_HTTP"):
-            raise HTTPException(status_code=400, detail="transport_protocol must be SSE or STREAMABLE_HTTP")
-
-    # 校验 headers
-    if request.headers is not None:
-        validation = config_service.validate_headers_for_mcp(request.server_code, request.headers)
-        if not validation["valid"]:
-            raise HTTPException(status_code=400, detail=validation["error"])
-
+    Validation, the write→push→rollback sequence, and masking now live in
+    ``core/mcp/config_flow.write_unified_config`` so this surface and the public
+    ``/openapi/v1`` surface share one implementation. This handler is the thin
+    adapter: it maps the flow's typed errors back onto the exact
+    ``HTTPException`` bodies this route has always returned, and shapes the
+    response identically (headers not echoed on the write path; ``sync_results``
+    mapped through :class:`MCPSyncResult`).
+    """
     try:
-        effective_entity_id, effective_bot_id, effective_entity_type = _get_path_params(
+        effective_entity_id, _effective_bot_id, effective_entity_type = _get_path_params(
             user, default_bot_id, entity_id, entity_type, bot_id
         )
 
-        # 步骤1：校验 MCP 存在性（外部依赖先校验，避免写库后再回滚）
-        mcp_data = market_service.get_mcp_detail(request.server_code)
-        if not mcp_data:
-            raise HTTPException(status_code=404, detail=f"MCP server {request.server_code} not found")
-
-        # 步骤2：写库，保留旧配置供回滚
-        old_config = config_service.update_user_unified_config(
+        result = await write_unified_config(
             user_id=user.staffId,
             server_code=request.server_code,
-            api_key=request.api_key,
-            headers=request.headers,
-            endpoint_env=request.endpoint_env,
-            transport_protocol=request.transport_protocol.upper() if request.transport_protocol else None,
-        )
-
-        # 步骤3：推送到该用户/实体下的所有设备
-        result = await sync_service.sync_mcp_detail_to_all_bots(
-            user_id=user.staffId,
-            server_code=request.server_code,
-            mcp_data=mcp_data,
             entity_id=effective_entity_id,
             entity_type=effective_entity_type,
             api_key=request.api_key,
-            custom_headers=request.headers,
+            headers=request.headers,
             endpoint_env=request.endpoint_env,
-            transport_protocol=request.transport_protocol.upper() if request.transport_protocol else None,
+            transport_protocol=request.transport_protocol,
+            config_service=config_service,
+            market_service=market_service,
+            sync_service=sync_service,
         )
 
-        if not result["success"]:
-            config_service.rollback_unified_config(
-                user_id=user.staffId,
-                server_code=request.server_code,
-                old_config=old_config,
-            )
-            raise HTTPException(status_code=500, detail=result.get("error", "Failed to sync to all devices"))
-
-        masked_key = None
-        if request.api_key:
-            masked_key = request.api_key[:4] + "****" + request.api_key[-4:] if len(request.api_key) > 8 else "****"
-
-        response_transport_protocol = request.transport_protocol.upper() if request.transport_protocol else None
-
         sync_results = None
-        if result.get("sync_results") is not None:
+        if result.sync_results is not None:
             sync_results = [
                 MCPSyncResult(
                     conn_info=r.get("conn_info"),
@@ -320,23 +269,33 @@ async def update_mcp_unified_config(
                     reason=r.get("reason"),
                     error=r.get("error"),
                 )
-                for r in result["sync_results"]
+                for r in result.sync_results
             ]
 
         return MCPUnifiedConfigResponse(
             success=True,
             message="MCP config updated and synced to all devices",
             data=MCPUnifiedConfigData(
-                server_code=request.server_code,
-                api_key=masked_key,
-                endpoint_env=request.endpoint_env,
-                transport_protocol=response_transport_protocol,
-                has_config=bool(request.api_key or request.headers or request.transport_protocol),
+                server_code=result.server_code,
+                api_key=result.api_key,
+                endpoint_env=result.endpoint_env,
+                transport_protocol=result.transport_protocol,
+                headers=result.headers,
+                has_config=result.has_config,
                 sync_results=sync_results,
             ),
         )
     except HTTPException:
         raise
+    except (McpConfigValueError, McpHeadersInvalidError) as e:
+        # Both were 400s with the flow's own message before extraction.
+        raise HTTPException(status_code=400, detail=str(e))
+    except McpServerNotFoundError:
+        raise HTTPException(
+            status_code=404, detail=f"MCP server {request.server_code} not found"
+        )
+    except McpSyncFailedError as e:
+        raise HTTPException(status_code=500, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -350,37 +309,25 @@ async def get_mcp_unified_config(
     user: AuthenticatedUser = Depends(get_current_user),
     config_service: MCPConfigServiceProtocol = Injected(MCPConfigServiceProtocol),
 ) -> MCPUnifiedConfigResponse:
-    """获取MCP统一配置。"""
-    config = config_service.get_user_unified_config(user.staffId, server_code)
+    """获取MCP统一配置。
 
-    if not config:
-        return MCPUnifiedConfigResponse(
-            success=True,
-            message="No config found",
-            data=MCPUnifiedConfigData(
-                server_code=server_code,
-                api_key=None,
-                headers={},
-                endpoint_env="PROD",
-                transport_protocol=None,
-                has_config=False,
-            ),
-        )
-
-    api_key = config.get("api_key")
-    masked_key = None
-    if api_key:
-        masked_key = api_key[:4] + "****" + api_key[-4:] if len(api_key) > 8 else "****"
-
+    Delegates to ``read_unified_config`` for the read + masking; the message
+    keys off whether a stored row exists (``exists``), not ``has_config`` — a row
+    can exist while carrying no api_key/headers/transport, and it read
+    "Config retrieved" before extraction.
+    """
+    config = read_unified_config(
+        user_id=user.staffId, server_code=server_code, config_service=config_service
+    )
     return MCPUnifiedConfigResponse(
         success=True,
-        message="Config retrieved",
+        message="Config retrieved" if config.exists else "No config found",
         data=MCPUnifiedConfigData(
-            server_code=server_code,
-            api_key=masked_key,
-            headers=config.get("headers", {}),
-            endpoint_env=config.get("endpoint_env", "PROD"),
-            transport_protocol=config.get("transport_protocol"),
-            has_config=bool(api_key or config.get("headers") or config.get("transport_protocol")),
+            server_code=config.server_code,
+            api_key=config.api_key,
+            headers=config.headers,
+            endpoint_env=config.endpoint_env,
+            transport_protocol=config.transport_protocol,
+            has_config=config.has_config,
         ),
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -51,6 +51,7 @@ from agentclaw.community.core.mcp.errors import McpServerNotFoundError
 from agentclaw.community.core.mcp.presentation import (
     ALLOWED_NETWORK_TYPES,
     is_network_type_visible,
+    normalize_network_types,
     strip_ext_info,
 )
 from agentclaw.community.di import Injected
@@ -83,7 +84,7 @@ def _to_server(data: dict[str, Any]) -> McpServer:
         server_code=data.get("serverCode") or data.get("server_code") or "",
         name=data.get("name") or "",
         description=data.get("description"),
-        network_types=data.get("networkTypes") or [],
+        network_types=normalize_network_types(data),
         transport_protocol=data.get("transportProtocol"),
     )
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -116,14 +116,24 @@ def _to_tenant(data: dict[str, Any]) -> McpTenant:
 
 
 def _to_config(cfg: Any) -> McpConfig:
-    """Map a :class:`~core.mcp.config_flow.UnifiedConfig` to :class:`McpConfig`."""
+    """Map a :class:`~core.mcp.config_flow.UnifiedConfig` to :class:`McpConfig`.
+
+    ``has_config`` keys off ``exists`` (a stored row is present), not the
+    internal ``has_config`` flag (api_key/headers/transport present). The
+    internal surface can use the narrower flag because it *also* returns a
+    message that keys off ``exists``; this surface exposes only ``has_config``,
+    so it must carry the present-vs-absent distinction itself. Otherwise a row
+    holding just ``endpoint_env`` — or the row a successful ``endpoint_env``-only
+    write just created — would report ``has_config: false``, indistinguishable
+    from a server the caller never configured (the documented false case).
+    """
     return McpConfig(
         server_code=cfg.server_code,
         api_key=cfg.api_key,
         endpoint_env=cfg.endpoint_env or "PROD",
         transport_protocol=cfg.transport_protocol,
         headers=cfg.headers or {},
-        has_config=cfg.has_config,
+        has_config=cfg.exists,
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -52,6 +52,7 @@ from agentclaw.community.core.mcp.presentation import (
     ALLOWED_NETWORK_TYPES,
     is_network_type_visible,
     normalize_network_types,
+    primary_transport_protocol,
     strip_ext_info,
 )
 from agentclaw.community.di import Injected
@@ -85,7 +86,7 @@ def _to_server(data: dict[str, Any]) -> McpServer:
         name=data.get("name") or "",
         description=data.get("description"),
         network_types=normalize_network_types(data),
-        transport_protocol=data.get("transportProtocol"),
+        transport_protocol=primary_transport_protocol(data),
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -1,23 +1,59 @@
-"""MCP group — ``/openapi/v1/mcp`` (definition only).
+"""MCP group — ``/openapi/v1/bots/mcp`` public endpoints.
 
-MCP marketplace (list / detail / permission), tenants, and the caller's unified
-per-server config. Handlers are stubs; every route requires an authenticated
-user principal.
+Public handlers for the MCP marketplace (list / detail / permission), MCP
+tenants, and the caller's unified per-server config (read / write, pushed to the
+caller's devices). They delegate to the same MCP services the internal
+``/api/mcp`` router uses, through the shared ``core/mcp`` flow and presentation
+helpers, and wrap the result in the standard :class:`Envelope` / :class:`Page`
+contracts.
+
+Identity is the caller resolved from ``require_principal`` (owner-scoping, via
+``caller_owner_id``); the request tenant is bound by ``AvernetTenantMiddleware``
+before the handler runs, so every config read/write is already tenant-scoped by
+the Track A guard. Unlike the internal detail route, no ``IAM_TOKEN`` cookie is
+read — a registered-tenant caller presents no browser cookie, and forwarding one
+below the adapter boundary is out of scope for this surface (same stance the
+bots slice took).
 """
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
-from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Envelope,
     Page,
     PageParamsDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.dependencies import Principal
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    Principal,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+    page,
+)
+from agentclaw.community.api.mcp_auth_service import MCPAuthServiceProtocol
+from agentclaw.community.api.mcp_config_service import MCPConfigServiceProtocol
+from agentclaw.community.api.mcp_market_service import MCPMarketServiceProtocol
+from agentclaw.community.api.mcp_sync_service import MCPSyncServiceProtocol
+from agentclaw.community.core.mcp.config_flow import (
+    list_marketplace_servers,
+    list_marketplace_tenants,
+    read_unified_config,
+    write_unified_config,
+)
+from agentclaw.community.core.mcp.errors import McpServerNotFoundError
+from agentclaw.community.core.mcp.presentation import (
+    ALLOWED_NETWORK_TYPES,
+    is_network_type_visible,
+    strip_ext_info,
+)
+from agentclaw.community.di import Injected
 
 from .schemas import (
     McpConfig,
@@ -32,60 +68,214 @@ router = APIRouter(prefix="/openapi/v1/bots/mcp", tags=["mcp"])
 
 PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
+# The caller's own identity is used as both entity id and (staff) entity type
+# for the config push, mirroring the internal route's defaults and how the bots
+# slice threads ``entity_id=owner_id``.
+_ENTITY_TYPE = "staff"
+
+
+# ── MCP Center dict → public model adapters ─────────────────────────
+
+
+def _to_server(data: dict[str, Any]) -> McpServer:
+    """Map one MCP Center server record to the public :class:`McpServer`."""
+    return McpServer(
+        server_code=data.get("serverCode") or data.get("server_code") or "",
+        name=data.get("name") or "",
+        description=data.get("description"),
+        network_types=data.get("networkTypes") or [],
+        transport_protocol=data.get("transportProtocol"),
+    )
+
+
+def _to_server_detail(data: dict[str, Any]) -> McpServerDetail:
+    """Map an MCP Center detail record (with tools) to :class:`McpServerDetail`."""
+    base = _to_server(data)
+    tools = data.get("tools")
+    return McpServerDetail(
+        **base.model_dump(),
+        tools=tools if isinstance(tools, list) else [],
+    )
+
+
+def _category_label(category: Any) -> str:
+    """A category's display string, tolerating dict or plain-string shapes."""
+    if isinstance(category, dict):
+        return category.get("name") or category.get("code") or ""
+    return str(category)
+
+
+def _to_tenant(data: dict[str, Any]) -> McpTenant:
+    """Map one MCP Center tenant record to the public :class:`McpTenant`."""
+    categories = data.get("categories") or []
+    return McpTenant(
+        code=data.get("code") or "",
+        name=data.get("name") or "",
+        categories=[_category_label(c) for c in categories if _category_label(c)],
+    )
+
+
+def _to_config(cfg: Any) -> McpConfig:
+    """Map a :class:`~core.mcp.config_flow.UnifiedConfig` to :class:`McpConfig`."""
+    return McpConfig(
+        server_code=cfg.server_code,
+        api_key=cfg.api_key,
+        endpoint_env=cfg.endpoint_env or "PROD",
+        transport_protocol=cfg.transport_protocol,
+        headers=cfg.headers or {},
+        has_config=cfg.has_config,
+    )
+
+
+# ── Marketplace ─────────────────────────────────────────────────────
+
 
 @router.get("/servers", response_model=Envelope[Page[McpServer]])
+@envelope_errors
 async def list_mcp_servers(
-    page: PageParamsDep, principal: PrincipalDep, keyword: str | None = None
+    request: Request,
+    page_params: PageParamsDep,
+    principal: PrincipalDep,
+    keyword: str | None = None,
+    market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[Page[McpServer]]:
-    """List marketplace MCP servers (filter + paginate)."""
-    raise NotImplementedError
+    """List marketplace MCP servers (filter by ``keyword``, paginate)."""
+    caller_owner_id(principal)  # require an authenticated caller
+    result = list_marketplace_servers(
+        page=page_params.page,
+        page_size=page_params.page_size,
+        keyword=keyword,
+        network_types=ALLOWED_NETWORK_TYPES,
+        market_service=market_service,
+    )
+    # The list projects to McpServer, which carries no tools — so there is no
+    # extInfo to strip here (that matters only on the detail path, which does
+    # expose tools). Keeping tools out of the list is also what keeps it light.
+    items = [
+        _to_server(s) for s in (result.get("data") or []) if isinstance(s, dict)
+    ]
+    return page(result.get("total", len(items)), items, request)
 
 
 @router.get("/tenants", response_model=Envelope[list[McpTenant]])
-async def list_mcp_tenants(principal: PrincipalDep) -> Envelope[list[McpTenant]]:
-    """List MCP tenants."""
-    raise NotImplementedError
+@envelope_errors
+async def list_mcp_tenants(
+    request: Request,
+    principal: PrincipalDep,
+    market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
+) -> Envelope[list[McpTenant]]:
+    """List MCP tenants (the marketplace's own tenant concept)."""
+    caller_owner_id(principal)
+    result = list_marketplace_tenants(market_service=market_service)
+    tenants = [_to_tenant(t) for t in (result.get("data") or []) if isinstance(t, dict)]
+    return envelope(tenants, request)
 
 
-@router.get(
-    "/servers/{server_code}",
-    response_model=Envelope[McpServerDetail],
-)
+@router.get("/servers/{server_code}", response_model=Envelope[McpServerDetail])
+@envelope_errors
 async def get_mcp_server(
-    server_code: str, principal: PrincipalDep
+    server_code: str,
+    request: Request,
+    principal: PrincipalDep,
+    market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[McpServerDetail]:
-    """Get an MCP server's detail."""
-    raise NotImplementedError
+    """Get an MCP server's detail (including tools).
+
+    A missing server and one hidden by the network-type rule both raise the same
+    not-found from one site, so a caller cannot tell "does not exist" from
+    "exists but not visible to you".
+    """
+    caller_owner_id(principal)
+    detail = market_service.get_mcp_detail(server_code)
+    if not detail or not is_network_type_visible(detail):
+        raise McpServerNotFoundError(server_code)
+    return envelope(_to_server_detail(strip_ext_info(detail)), request)
 
 
 @router.get(
-    "/servers/{server_code}/permissions",
-    response_model=Envelope[McpPermission],
+    "/servers/{server_code}/permissions", response_model=Envelope[McpPermission]
 )
+@envelope_errors
 async def check_mcp_permission(
-    server_code: str, principal: PrincipalDep
+    server_code: str,
+    request: Request,
+    principal: PrincipalDep,
+    auth_service: MCPAuthServiceProtocol = Injected(MCPAuthServiceProtocol),
 ) -> Envelope[McpPermission]:
-    """Check the caller's permission for an MCP server."""
-    raise NotImplementedError
+    """Report the caller's own permission for an MCP server.
+
+    Always the caller's permission — the identity comes from the principal, never
+    a caller-supplied id (the internal route takes a ``user_id`` query param; this
+    one must not, or a caller could probe another identity's grants).
+    """
+    owner_id = caller_owner_id(principal)
+    result = auth_service.check_mcp_permission_detail(owner_id, server_code)
+    return envelope(
+        McpPermission(
+            has_access=bool(result.get("has_permission")),
+            access_level=result.get("access_level"),
+            tool_permissions=result.get("tool_permissions") or {},
+        ),
+        request,
+    )
 
 
-@router.get(
-    "/servers/{server_code}/config",
-    response_model=Envelope[McpConfig],
-)
+# ── Unified config ──────────────────────────────────────────────────
+
+
+@router.get("/servers/{server_code}/config", response_model=Envelope[McpConfig])
+@envelope_errors
 async def get_mcp_config(
-    server_code: str, principal: PrincipalDep
+    server_code: str,
+    request: Request,
+    principal: PrincipalDep,
+    config_service: MCPConfigServiceProtocol = Injected(MCPConfigServiceProtocol),
 ) -> Envelope[McpConfig]:
-    """Read the caller's unified config for an MCP server."""
-    raise NotImplementedError
+    """Read the caller's unified config for an MCP server (``api_key`` masked).
+
+    A server the caller has never configured is not an error — it returns
+    ``has_config: false`` with defaults.
+    """
+    owner_id = caller_owner_id(principal)
+    cfg = read_unified_config(
+        user_id=owner_id, server_code=server_code, config_service=config_service
+    )
+    return envelope(_to_config(cfg), request)
 
 
-@router.put(
-    "/servers/{server_code}/config",
-    response_model=Envelope[McpConfig],
-)
+@router.put("/servers/{server_code}/config", response_model=Envelope[McpConfig])
+@envelope_errors
 async def update_mcp_config(
-    server_code: str, body: McpConfigWrite, principal: PrincipalDep
+    server_code: str,
+    body: McpConfigWrite,
+    request: Request,
+    principal: PrincipalDep,
+    config_service: MCPConfigServiceProtocol = Injected(MCPConfigServiceProtocol),
+    market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
+    sync_service: MCPSyncServiceProtocol = Injected(MCPSyncServiceProtocol),
 ) -> Envelope[McpConfig]:
-    """Write the caller's unified config for an MCP server (pushed to devices)."""
-    raise NotImplementedError
+    """Write the caller's unified config and push it to the caller's devices.
+
+    A null field is left unchanged (merge, not replace). If the device push
+    fails the write is rolled back and the call fails — the caller never ends up
+    with a config that is stored but not in effect. The response is re-read from
+    storage so it is exactly what a subsequent GET would return.
+    """
+    owner_id = caller_owner_id(principal)
+    await write_unified_config(
+        user_id=owner_id,
+        server_code=server_code,
+        entity_id=owner_id,
+        entity_type=_ENTITY_TYPE,
+        api_key=body.api_key,
+        headers=body.headers,
+        endpoint_env=body.endpoint_env,
+        transport_protocol=body.transport_protocol,
+        config_service=config_service,
+        market_service=market_service,
+        sync_service=sync_service,
+    )
+    cfg = read_unified_config(
+        user_id=owner_id, server_code=server_code, config_service=config_service
+    )
+    return envelope(_to_config(cfg), request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -207,6 +207,13 @@ async def check_mcp_permission(
     Always the caller's permission — the identity comes from the principal, never
     a caller-supplied id (the internal route takes a ``user_id`` query param; this
     one must not, or a caller could probe another identity's grants).
+
+    **Fail-open, by decision (spec Open Question 1).** When the marketplace
+    lookup errors, ``check_mcp_permission_detail`` reports the caller *as
+    permitted*. This surface preserves that rather than failing closed: the
+    endpoint is advisory — the MCP server itself is the enforcement point — so a
+    wrong "yes" during an upstream outage costs one failed call, whereas failing
+    closed would make a marketplace outage look like a permission revocation.
     """
     owner_id = caller_owner_id(principal)
     result = auth_service.check_mcp_permission_detail(owner_id, server_code)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
@@ -68,7 +68,10 @@ class McpConfig(BaseModel):
     endpoint_env: str
     transport_protocol: str | None = None
     headers: dict[str, str] = Field(default_factory=dict)
-    has_config: bool
+    has_config: bool = Field(
+        description="True when a stored config row exists for this server; "
+        "false only when the caller has never configured it."
+    )
 
 
 class McpConfigWrite(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+# Request bodies reject unknown keys. Pydantic's default is to *ignore* them,
+# which on a public API means a typo'd or unsupported field is silently dropped
+# and the caller gets a 200 believing it was applied. With ``forbid`` the
+# request fails validation (422, rendered as the standard Envelope) instead.
+# This is what turns the dropped ``sync_mode`` field (no single-device push path
+# exists) from a silent no-op into an honest rejection. Response models are
+# server-constructed and take no caller input, so — as in ``bots/schemas.py`` —
+# they are not guarded.
+_STRICT = ConfigDict(extra="forbid")
 
 
 class McpServer(BaseModel):
@@ -32,7 +42,12 @@ class McpPermission(BaseModel):
 
 
 class McpTenant(BaseModel):
-    """An MCP tenant."""
+    """An MCP tenant.
+
+    Note: an "MCP tenant" is a marketplace concept from the upstream MCP Center,
+    unrelated to the Avernet data-isolation tenant. The marketplace is a shared
+    catalog — every Avernet tenant sees the same MCP tenants.
+    """
 
     code: str
     name: str
@@ -40,10 +55,16 @@ class McpTenant(BaseModel):
 
 
 class McpConfig(BaseModel):
-    """The caller's unified config for an MCP server (``api_key`` is masked)."""
+    """The caller's unified config for an MCP server.
+
+    ``api_key`` is always returned masked (first/last four for a long key, fully
+    masked otherwise), never in full.
+    """
 
     server_code: str
-    api_key: str | None = None
+    api_key: str | None = Field(
+        default=None, description="Masked API key; null when none is stored."
+    )
     endpoint_env: str
     transport_protocol: str | None = None
     headers: dict[str, str] = Field(default_factory=dict)
@@ -51,10 +72,17 @@ class McpConfig(BaseModel):
 
 
 class McpConfigWrite(BaseModel):
-    """Write the unified config. A null field means "leave unchanged"."""
+    """Write the unified config. A null (omitted) field means "leave unchanged".
+
+    ``extra="forbid"``: an unknown field is a 422, not a silent no-op. In
+    particular the old ``sync_mode`` field is gone — the only push path is to
+    every device under the caller, so a per-device mode would advertise
+    something the server ignores.
+    """
+
+    model_config = _STRICT
 
     api_key: str | None = None
-    endpoint_env: str | None = None
-    transport_protocol: str | None = None
+    endpoint_env: Literal["PROD", "PRE"] | None = None
+    transport_protocol: Literal["SSE", "STREAMABLE_HTTP"] | None = None
     headers: dict[str, str] | None = None
-    sync_mode: str | None = None  # single | broadcast

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -56,6 +56,13 @@ from agentclaw.community.core.devices.services.device_context import (
     DeviceNotBoundError,
     UnknownProviderError,
 )
+from agentclaw.community.core.mcp.errors import (
+    McpConfigValueError,
+    McpHeadersInvalidError,
+    McpMarketUnavailableError,
+    McpServerNotFoundError,
+    McpSyncFailedError,
+)
 from agentclaw.community.core.resources.service import (
     DuplicateResourceError,
     FileTooLargeError,
@@ -158,7 +165,22 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # validate_entity_type / validate_file_type.
     InvalidIdentityEntityTypeError: (400, "Invalid entity type"),
     InvalidIdentityFileTypeError: (400, "Invalid file type"),
-    # Base class LAST: every mapping above is a subclass of BotServiceError, and
+    # MCP category (Track B). These share no base with BotServiceError, so their
+    # order among themselves is free — but they must sit above the BotServiceError
+    # fallback like everything else. Fixed public messages: the header-validation
+    # and value errors carry internal-language text (the validator answers in
+    # Chinese), which is exactly what the fixed-message rule keeps from leaking.
+    # 404 message is byte-identical to the bots not-found so existence can't be
+    # probed. The two upstream failures are 502 (downstream problem), matching how
+    # PassportError / ConnInfoBuildError are mapped above.
+    McpServerNotFoundError: (404, "Not found"),
+    McpHeadersInvalidError: (400, "Invalid MCP headers"),
+    McpConfigValueError: (400, "Invalid MCP configuration"),
+    McpSyncFailedError: (502, "Device sync failed"),
+    McpMarketUnavailableError: (502, "MCP service error"),
+    # Base class LAST: the bot mappings above subclass BotServiceError (the
+    # resources, identity, and MCP entries are separate hierarchies that never
+    # match a bot error), and
     # the lookup returns on the first isinstance match in insertion order, so the
     # specific mappings still win. Services raise the bare base for device,
     # persistence, and downstream failures — without this the decorator would

--- a/src/backend/src/agentclaw/community/core/mcp/README.md
+++ b/src/backend/src/agentclaw/community/core/mcp/README.md
@@ -10,6 +10,7 @@ provides:
   - "MCPConfigService"
   - "MCPAuthService"
   - "MCPSyncService"
+  - "MCPMarketService"
 consumes:
   - "BotRepository"
   - "DeviceMCPSyncPlugin"

--- a/src/backend/src/agentclaw/community/core/mcp/README.md
+++ b/src/backend/src/agentclaw/community/core/mcp/README.md
@@ -11,6 +11,28 @@ provides:
   - "MCPAuthService"
   - "MCPSyncService"
   - "MCPMarketService"
+  # Request-agnostic config flow extracted for both API surfaces (internal
+  # /api/mcp and public /openapi/v1/bots/mcp).
+  - "UnifiedConfig"
+  - "read_unified_config"
+  - "write_unified_config"
+  - "list_marketplace_servers"
+  - "list_marketplace_tenants"
+  # Presentation helpers shared by both surfaces.
+  - "mask_api_key"
+  - "strip_ext_info"
+  - "strip_ext_info_from_list"
+  - "is_network_type_visible"
+  - "normalize_network_types"
+  - "primary_transport_protocol"
+  - "ALLOWED_NETWORK_TYPES"
+  # Dependency-free domain errors each surface maps.
+  - "McpError"
+  - "McpServerNotFoundError"
+  - "McpHeadersInvalidError"
+  - "McpConfigValueError"
+  - "McpSyncFailedError"
+  - "McpMarketUnavailableError"
 consumes:
   - "BotRepository"
   - "DeviceMCPSyncPlugin"

--- a/src/backend/src/agentclaw/community/core/mcp/config_flow.py
+++ b/src/backend/src/agentclaw/community/core/mcp/config_flow.py
@@ -168,24 +168,38 @@ async def write_unified_config(
         transport_protocol=normalized_tp,
     )
 
-    result = await sync_service.sync_mcp_detail_to_all_bots(
-        user_id=user_id,
-        server_code=server_code,
-        mcp_data=mcp_data,
-        entity_id=entity_id,
-        entity_type=entity_type,
-        api_key=api_key,
-        custom_headers=headers,
-        endpoint_env=endpoint_env,
-        transport_protocol=normalized_tp,
-    )
-
-    if not result["success"]:
+    def _roll_back() -> None:
         config_service.rollback_unified_config(
             user_id=user_id,
             server_code=server_code,
             old_config=old_config,
         )
+
+    try:
+        result = await sync_service.sync_mcp_detail_to_all_bots(
+            user_id=user_id,
+            server_code=server_code,
+            mcp_data=mcp_data,
+            entity_id=entity_id,
+            entity_type=entity_type,
+            api_key=api_key,
+            custom_headers=headers,
+            endpoint_env=endpoint_env,
+            transport_protocol=normalized_tp,
+        )
+    except Exception as exc:
+        # The sync service contracts to *return* a failure dict rather than
+        # raise, but a device push that raises anyway (a dependency throwing,
+        # a future change) must not leave the freshly written credentials
+        # stored-but-unpushed — that is exactly the atomic write-and-push
+        # contract this function promises. Roll the row back and surface it as
+        # a sync failure, the same class a returned failure raises, so each
+        # surface maps it (internal 500 / public 502) with the row restored.
+        _roll_back()
+        raise McpSyncFailedError(str(exc)) from exc
+
+    if not result["success"]:
+        _roll_back()
         # Preserve the internal surface's exact 500 detail: the literal fallback
         # and ``.get(key, default)`` semantics (default only when the key is
         # absent). The public surface maps this error to a fixed message and

--- a/src/backend/src/agentclaw/community/core/mcp/config_flow.py
+++ b/src/backend/src/agentclaw/community/core/mcp/config_flow.py
@@ -52,6 +52,11 @@ class UnifiedConfig:
     transport_protocol: str | None
     headers: dict[str, str] | None
     has_config: bool
+    # Whether a stored row exists at all — distinct from ``has_config`` (a row
+    # can exist while carrying no api_key/headers/transport). The internal GET
+    # message ("Config retrieved" vs "No config found") keys off this, not
+    # ``has_config``. Always ``True`` for a write result.
+    exists: bool = field(default=True)
     sync_results: list[dict[str, Any]] | None = field(default=None)
 
 
@@ -93,6 +98,7 @@ def read_unified_config(
             transport_protocol=None,
             headers={},
             has_config=False,
+            exists=False,
         )
     api_key = config.get("api_key")
     return UnifiedConfig(

--- a/src/backend/src/agentclaw/community/core/mcp/config_flow.py
+++ b/src/backend/src/agentclaw/community/core/mcp/config_flow.py
@@ -1,0 +1,225 @@
+"""Request-agnostic MCP unified-config read/write orchestration.
+
+Both API surfaces need the same multi-step config write — validate the values
+and headers, confirm the server exists *before* any database write, persist the
+row keeping the old one for rollback, push to every device under the identity,
+and roll back if that push fails. This module owns that sequence so the internal
+``/api/mcp`` router and the public ``/openapi/v1/bots/mcp`` router call one
+implementation instead of each carrying a copy — the pattern
+``core/bot_management/create_flow.py`` established for bot creation.
+
+The functions here are FastAPI-free: they take the resolved caller identity plus
+the already-injected services, return a :class:`UnifiedConfig` whose ``api_key``
+is **already masked**, and **raise** the ``core/mcp/errors.py`` domain errors for
+each surface to map onto its own response shape.
+
+The write result is shaped to match the internal surface's historical write
+response (which does not echo ``headers`` and reports the request's own values),
+so the extraction is behavior-preserving; the public surface re-reads via
+:func:`read_unified_config` for a response consistent with a subsequent GET.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from agentclaw.community.core.mcp.errors import (
+    McpConfigValueError,
+    McpHeadersInvalidError,
+    McpMarketUnavailableError,
+    McpServerNotFoundError,
+    McpSyncFailedError,
+)
+from agentclaw.community.core.mcp.presentation import mask_api_key
+
+_VALID_ENDPOINT_ENVS = ("PROD", "PRE")
+_VALID_TRANSPORT_PROTOCOLS = ("SSE", "STREAMABLE_HTTP")
+
+
+@dataclass(frozen=True)
+class UnifiedConfig:
+    """A caller's unified config for one MCP server, ready to serialize.
+
+    ``api_key`` is already masked — no caller can reach the raw key through this
+    object. ``sync_results`` is populated only by :func:`write_unified_config`
+    (the raw per-bot push outcomes); reads leave it ``None``.
+    """
+
+    server_code: str
+    api_key: str | None
+    endpoint_env: str | None
+    transport_protocol: str | None
+    headers: dict[str, str] | None
+    has_config: bool
+    sync_results: list[dict[str, Any]] | None = field(default=None)
+
+
+def _validate_endpoint_env(endpoint_env: str | None) -> None:
+    """Reject an endpoint env outside the accepted set. ``None`` = leave unchanged."""
+    if endpoint_env is not None and endpoint_env not in _VALID_ENDPOINT_ENVS:
+        raise McpConfigValueError("endpoint_env must be PROD or PRE")
+
+
+def _normalize_transport_protocol(transport_protocol: str | None) -> str | None:
+    """Upper-case and validate the transport protocol. ``None`` = leave unchanged.
+
+    Upper-casing matches the internal route, which normalized before validating;
+    it is idempotent, so the public surface's already-strict value is unaffected.
+    """
+    if transport_protocol is None:
+        return None
+    normalized = transport_protocol.upper()
+    if normalized not in _VALID_TRANSPORT_PROTOCOLS:
+        raise McpConfigValueError("transport_protocol must be SSE or STREAMABLE_HTTP")
+    return normalized
+
+
+def read_unified_config(
+    *, user_id: str, server_code: str, config_service: Any
+) -> UnifiedConfig:
+    """Read a caller's unified config for one server (never raises for "absent").
+
+    A server the caller has never configured returns a :class:`UnifiedConfig`
+    with ``has_config`` false and the defaults (``endpoint_env="PROD"``, empty
+    headers) — not an error — so "no config" is distinguishable from a failure.
+    """
+    config = config_service.get_user_unified_config(user_id, server_code)
+    if not config:
+        return UnifiedConfig(
+            server_code=server_code,
+            api_key=None,
+            endpoint_env="PROD",
+            transport_protocol=None,
+            headers={},
+            has_config=False,
+        )
+    api_key = config.get("api_key")
+    return UnifiedConfig(
+        server_code=server_code,
+        api_key=mask_api_key(api_key),
+        endpoint_env=config.get("endpoint_env", "PROD"),
+        transport_protocol=config.get("transport_protocol"),
+        headers=config.get("headers", {}),
+        has_config=bool(
+            api_key or config.get("headers") or config.get("transport_protocol")
+        ),
+    )
+
+
+async def write_unified_config(
+    *,
+    user_id: str,
+    server_code: str,
+    entity_id: str,
+    entity_type: str,
+    api_key: str | None,
+    headers: dict[str, str] | None,
+    endpoint_env: str | None,
+    transport_protocol: str | None,
+    config_service: Any,
+    market_service: Any,
+    sync_service: Any,
+) -> UnifiedConfig:
+    """Persist a caller's config and push it to their devices, atomically.
+
+    Order is load-bearing and preserved from the internal route:
+
+    1. Validate the values (``endpoint_env`` / ``transport_protocol``).
+    2. Validate headers when present — this call also confirms the server exists,
+       so a missing server with headers present surfaces as an invalid-headers
+       error (pre-existing quirk, kept).
+    3. Confirm the server exists via the marketplace, **before** any write, so a
+       bad server code never touches the database.
+    4. Write the row, keeping the previous config for rollback.
+    5. Push to every device under the identity.
+    6. If the push fails, roll the write back and raise — the caller never ends
+       up with a config that is stored but not in effect.
+
+    Returns a write-shaped :class:`UnifiedConfig`: ``headers`` is ``None`` (the
+    write response has never echoed them) and the value fields reflect the
+    request, mirroring the internal surface. ``sync_results`` carries the raw
+    per-bot outcomes for the internal response to map.
+    """
+    _validate_endpoint_env(endpoint_env)
+    normalized_tp = _normalize_transport_protocol(transport_protocol)
+
+    if headers is not None:
+        validation = config_service.validate_headers_for_mcp(server_code, headers)
+        if not validation["valid"]:
+            raise McpHeadersInvalidError(validation["error"])
+
+    mcp_data = market_service.get_mcp_detail(server_code)
+    if not mcp_data:
+        raise McpServerNotFoundError(server_code)
+
+    old_config = config_service.update_user_unified_config(
+        user_id=user_id,
+        server_code=server_code,
+        api_key=api_key,
+        headers=headers,
+        endpoint_env=endpoint_env,
+        transport_protocol=normalized_tp,
+    )
+
+    result = await sync_service.sync_mcp_detail_to_all_bots(
+        user_id=user_id,
+        server_code=server_code,
+        mcp_data=mcp_data,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        api_key=api_key,
+        custom_headers=headers,
+        endpoint_env=endpoint_env,
+        transport_protocol=normalized_tp,
+    )
+
+    if not result["success"]:
+        config_service.rollback_unified_config(
+            user_id=user_id,
+            server_code=server_code,
+            old_config=old_config,
+        )
+        raise McpSyncFailedError(result.get("error") or "device sync failed")
+
+    return UnifiedConfig(
+        server_code=server_code,
+        api_key=mask_api_key(api_key),
+        endpoint_env=endpoint_env,
+        transport_protocol=normalized_tp,
+        headers=None,  # write path has never echoed headers — read path does
+        has_config=bool(api_key or headers or transport_protocol),
+        sync_results=result.get("sync_results"),
+    )
+
+
+def list_marketplace_servers(
+    *,
+    page: int,
+    page_size: int,
+    keyword: str | None,
+    network_types: tuple[str, ...],
+    market_service: Any,
+) -> dict[str, Any]:
+    """List marketplace servers, raising on an upstream failure.
+
+    A marketplace call that reports ``success: False`` is an upstream problem —
+    :class:`McpMarketUnavailableError`, not an empty page.
+    """
+    result = market_service.get_mcp_list(
+        page_num=page,
+        page_size=page_size,
+        search_key=keyword,
+        network_types=list(network_types),
+    )
+    if not result.get("success"):
+        raise McpMarketUnavailableError(result.get("message") or "marketplace error")
+    return result
+
+
+def list_marketplace_tenants(*, market_service: Any) -> dict[str, Any]:
+    """List MCP tenants, raising :class:`McpMarketUnavailableError` on failure."""
+    result = market_service.get_tenant_list()
+    if not result.get("success"):
+        raise McpMarketUnavailableError(result.get("message") or "marketplace error")
+    return result

--- a/src/backend/src/agentclaw/community/core/mcp/config_flow.py
+++ b/src/backend/src/agentclaw/community/core/mcp/config_flow.py
@@ -186,7 +186,15 @@ async def write_unified_config(
             server_code=server_code,
             old_config=old_config,
         )
-        raise McpSyncFailedError(result.get("error") or "device sync failed")
+        # Preserve the internal surface's exact 500 detail: the literal fallback
+        # and ``.get(key, default)`` semantics (default only when the key is
+        # absent). The public surface maps this error to a fixed message and
+        # never reads str(exc), so carrying the internal text here costs it
+        # nothing. The real sync service always sets a non-empty ``error`` on
+        # failure, so the fallback is defense-in-depth.
+        raise McpSyncFailedError(
+            result.get("error", "Failed to sync to all devices")
+        )
 
     return UnifiedConfig(
         server_code=server_code,

--- a/src/backend/src/agentclaw/community/core/mcp/errors.py
+++ b/src/backend/src/agentclaw/community/core/mcp/errors.py
@@ -1,0 +1,52 @@
+"""Domain errors raised by the MCP config/market flow.
+
+Dependency-free, mirroring ``adapters/http/openapi_v1/errors.py``: the flow in
+``config_flow.py`` and the helpers in ``presentation.py`` raise these so each API
+surface can map them onto its own response shape — the internal ``/api/mcp``
+router onto its historical ``HTTPException`` bodies, the public ``/openapi/v1``
+router onto the envelope — without either surface importing the other's types.
+"""
+
+from __future__ import annotations
+
+
+class McpError(Exception):
+    """Base for MCP flow errors. Never mapped directly — map the leaves."""
+
+
+class McpServerNotFoundError(McpError):
+    """The named MCP server does not exist in the marketplace.
+
+    Raised before any configuration is written, so a bad server code never
+    reaches the database.
+    """
+
+
+class McpHeadersInvalidError(McpError):
+    """The caller's headers failed validation.
+
+    Carries the validator's own message for the internal surface, which has
+    always echoed it. The public surface maps to a fixed message instead — the
+    validator's text is internal-language and must not reach an external caller.
+    """
+
+
+class McpConfigValueError(McpError):
+    """A configuration value (endpoint env / transport protocol) is not accepted."""
+
+
+class McpSyncFailedError(McpError):
+    """Pushing the configuration to the caller's devices failed.
+
+    Raised only after the stored configuration has been rolled back to its prior
+    state, so a caller never ends up with a configuration that is saved but not
+    in effect.
+    """
+
+
+class McpMarketUnavailableError(McpError):
+    """An upstream marketplace call reported failure.
+
+    A dependency problem, not a caller mistake — distinct from a genuinely empty
+    result, which is a success with no rows.
+    """

--- a/src/backend/src/agentclaw/community/core/mcp/presentation.py
+++ b/src/backend/src/agentclaw/community/core/mcp/presentation.py
@@ -78,6 +78,29 @@ def strip_ext_info_from_list(result: dict[str, Any]) -> dict[str, Any]:
     return sanitized
 
 
+def normalize_network_types(mcp_data: dict[str, Any]) -> list[str]:
+    """A server's declared network types, from whichever shape the catalog uses.
+
+    The plural ``networkTypes`` list is the primary shape; when it is absent/empty
+    the singular ``networkType`` / ``network_type`` (scalar or list) is used — the
+    shape ``LocalMCPRegistry`` declares and *filters its list on* (it reads those
+    keys). Returns a flat list of strings (empty when none is declared).
+
+    One definition so visibility and the response projection read the same shape:
+    a server the catalog hides from the list on its network type must not resolve
+    by code through the detail route, nor serialize an empty ``network_types``
+    while carrying a known classification.
+    """
+    raw = mcp_data.get("networkTypes")
+    if not raw:
+        raw = mcp_data.get("networkType") or mcp_data.get("network_type") or []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return [nt for nt in raw if isinstance(nt, str)]
+    return []
+
+
 def is_network_type_visible(mcp_data: dict[str, Any]) -> bool:
     """Whether a server's network types make it visible on this surface.
 
@@ -85,18 +108,10 @@ def is_network_type_visible(mcp_data: dict[str, Any]) -> bool:
     declares types is visible only if at least one is in
     :data:`ALLOWED_NETWORK_TYPES`. Mirrors the internal detail route's rule.
 
-    The plural ``networkTypes`` list is the primary shape; when it is absent the
-    check falls back to the singular ``networkType`` / ``network_type`` (scalar
-    or list) that the local registry declares and *filters its list on*
-    (``LocalMCPRegistry`` reads those keys). Without the fallback a server the
-    catalog hides from the list on its network type would still resolve by code
-    through the detail route — a visibility rule the two paths must not split on.
+    Reads every shape via :func:`normalize_network_types`, so a server hidden
+    from the list on a singular ``networkType`` cannot resolve by code here.
     """
-    network_types = mcp_data.get("networkTypes")
-    if not network_types:
-        network_types = mcp_data.get("networkType") or mcp_data.get("network_type") or []
-    if isinstance(network_types, str):
-        network_types = [network_types]
+    network_types = normalize_network_types(mcp_data)
     if not network_types:
         return True
     return any(nt in ALLOWED_NETWORK_TYPES for nt in network_types)

--- a/src/backend/src/agentclaw/community/core/mcp/presentation.py
+++ b/src/backend/src/agentclaw/community/core/mcp/presentation.py
@@ -1,0 +1,91 @@
+"""Presentation rules shared by both MCP API surfaces.
+
+Masking, ``extInfo`` stripping, and the network-type allowlist were duplicated
+inside the internal ``/api/mcp`` router's handler bodies. They live here so the
+internal and public surfaces cannot drift on how much of a credential they
+reveal or which servers they show — a single definition each.
+
+Nothing here touches HTTP, the database, or a service; these are pure functions
+over the plain dicts MCP Center returns.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+# The network types the surface exposes. MCP Center may carry others; a server
+# reachable only on a type outside this set is not shown, and its detail answers
+# not-found. Historically duplicated at two sites in the internal router.
+ALLOWED_NETWORK_TYPES: tuple[str, ...] = ("INTERNET", "OFFICE")
+
+
+def mask_api_key(api_key: str | None) -> str | None:
+    """Mask a stored API key for display.
+
+    Keeps the first and last four characters for a key long enough to spare
+    them (``> 8``); anything shorter is fully masked so the reveal never exceeds
+    the concealment. ``None`` stays ``None`` — "no key" is not "masked key".
+
+    The one definition both surfaces use, so a credential is never revealed more
+    on one door than the other.
+    """
+    if not api_key:
+        return None
+    if len(api_key) > 8:
+        return api_key[:4] + "****" + api_key[-4:]
+    return "****"
+
+
+def strip_ext_info(mcp_data: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of one MCP server's data with tool ``extInfo`` removed.
+
+    ``extInfo`` is internal plumbing carried on a tool's input-schema
+    properties; it must not reach an external caller. Non-dict shapes are left
+    untouched. The input is not mutated.
+    """
+    sanitized = deepcopy(mcp_data)
+    tools = sanitized.get("tools")
+    if not isinstance(tools, list):
+        return sanitized
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        input_schema = tool.get("inputSchema")
+        if not isinstance(input_schema, dict):
+            continue
+        properties = input_schema.get("properties")
+        if isinstance(properties, dict):
+            properties.pop("extInfo", None)
+
+    return sanitized
+
+
+def strip_ext_info_from_list(result: dict[str, Any]) -> dict[str, Any]:
+    """Apply :func:`strip_ext_info` to every server in a market-list result.
+
+    Operates on the ``data`` list of an MCP Center list response, leaving the
+    surrounding envelope (``total``, paging) intact. The input is not mutated.
+    """
+    sanitized = deepcopy(result)
+    data = sanitized.get("data")
+    if isinstance(data, list):
+        sanitized["data"] = [
+            strip_ext_info(item) if isinstance(item, dict) else item
+            for item in data
+        ]
+    return sanitized
+
+
+def is_network_type_visible(mcp_data: dict[str, Any]) -> bool:
+    """Whether a server's network types make it visible on this surface.
+
+    A server with no network types is visible (nothing restricts it); one that
+    declares types is visible only if at least one is in
+    :data:`ALLOWED_NETWORK_TYPES`. Mirrors the internal detail route's rule.
+    """
+    network_types = mcp_data.get("networkTypes") or []
+    if not network_types:
+        return True
+    return any(nt in ALLOWED_NETWORK_TYPES for nt in network_types)

--- a/src/backend/src/agentclaw/community/core/mcp/presentation.py
+++ b/src/backend/src/agentclaw/community/core/mcp/presentation.py
@@ -84,8 +84,19 @@ def is_network_type_visible(mcp_data: dict[str, Any]) -> bool:
     A server with no network types is visible (nothing restricts it); one that
     declares types is visible only if at least one is in
     :data:`ALLOWED_NETWORK_TYPES`. Mirrors the internal detail route's rule.
+
+    The plural ``networkTypes`` list is the primary shape; when it is absent the
+    check falls back to the singular ``networkType`` / ``network_type`` (scalar
+    or list) that the local registry declares and *filters its list on*
+    (``LocalMCPRegistry`` reads those keys). Without the fallback a server the
+    catalog hides from the list on its network type would still resolve by code
+    through the detail route — a visibility rule the two paths must not split on.
     """
-    network_types = mcp_data.get("networkTypes") or []
+    network_types = mcp_data.get("networkTypes")
+    if not network_types:
+        network_types = mcp_data.get("networkType") or mcp_data.get("network_type") or []
+    if isinstance(network_types, str):
+        network_types = [network_types]
     if not network_types:
         return True
     return any(nt in ALLOWED_NETWORK_TYPES for nt in network_types)

--- a/src/backend/src/agentclaw/community/core/mcp/presentation.py
+++ b/src/backend/src/agentclaw/community/core/mcp/presentation.py
@@ -124,7 +124,11 @@ def primary_transport_protocol(mcp_data: dict[str, Any]) -> str | None:
     server top level (``config_compose``/``local_mcp_registry`` both read it from
     there), so a flat projection reading only the top level always yields
     ``None``. Prefer an endpoint on an allowed network type — the ones this
-    surface would actually use — then any endpoint that declares a protocol;
+    surface would actually use — then any endpoint that declares a protocol.
+
+    A local MCP represented by ``stdioConfigs`` / ``stdio_configs`` carries no
+    HTTP endpoint; ``LocalMCPRegistry._transport_in`` classifies those as
+    ``STDIO``, so mirror that here rather than dropping the transport. Finally
     fall back to a top-level value for records that do carry one, else ``None``.
     First-in-list order breaks ties deterministically.
     """
@@ -143,5 +147,7 @@ def primary_transport_protocol(mcp_data: dict[str, Any]) -> str | None:
         for pool in (allowed, with_protocol):
             if pool:
                 return pool[0]["transportProtocol"]
+    if mcp_data.get("stdioConfigs") or mcp_data.get("stdio_configs"):
+        return "STDIO"
     top = mcp_data.get("transportProtocol")
     return top if isinstance(top, str) else None

--- a/src/backend/src/agentclaw/community/core/mcp/presentation.py
+++ b/src/backend/src/agentclaw/community/core/mcp/presentation.py
@@ -115,3 +115,33 @@ def is_network_type_visible(mcp_data: dict[str, Any]) -> bool:
     if not network_types:
         return True
     return any(nt in ALLOWED_NETWORK_TYPES for nt in network_types)
+
+
+def primary_transport_protocol(mcp_data: dict[str, Any]) -> str | None:
+    """The transport protocol to advertise for a server in a flat projection.
+
+    MCP Center carries ``transportProtocol`` per ``endpoints`` entry, not at the
+    server top level (``config_compose``/``local_mcp_registry`` both read it from
+    there), so a flat projection reading only the top level always yields
+    ``None``. Prefer an endpoint on an allowed network type — the ones this
+    surface would actually use — then any endpoint that declares a protocol;
+    fall back to a top-level value for records that do carry one, else ``None``.
+    First-in-list order breaks ties deterministically.
+    """
+    endpoints = mcp_data.get("endpoints")
+    if isinstance(endpoints, list):
+        with_protocol = [
+            ep
+            for ep in endpoints
+            if isinstance(ep, dict) and isinstance(ep.get("transportProtocol"), str)
+        ]
+        allowed = [
+            ep
+            for ep in with_protocol
+            if ep.get("networkType") in ALLOWED_NETWORK_TYPES
+        ]
+        for pool in (allowed, with_protocol):
+            if pool:
+                return pool[0]["transportProtocol"]
+    top = mcp_data.get("transportProtocol")
+    return top if isinstance(top, str) else None

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -1,0 +1,305 @@
+"""Endpoint tests for the public ``/openapi/v1/bots/mcp`` API (Track B).
+
+A minimal FastAPI app hosts the mcp router with the caller principal overridden
+and the four MCP services bound to mocks via the injector — mirroring the bots
+endpoint harness. The real authenticator stays a stub; ``require_principal`` is
+overridden per test.
+
+Note: a bare ``FastAPI()`` does not install the app-level 422→envelope handler
+(that is wired in ``adapters/http/app.py`` and tested surface-wide by
+``test_validation_envelope.py``), so body-validation cases here assert the 422
+status, not the envelope shape.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_injector import attach_injector
+from injector import Injector, Module
+
+from agentclaw.community.adapters.http.openapi_v1.mcp.router import router
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.api.mcp_auth_service import MCPAuthServiceProtocol
+from agentclaw.community.api.mcp_config_service import MCPConfigServiceProtocol
+from agentclaw.community.api.mcp_market_service import MCPMarketServiceProtocol
+from agentclaw.community.api.mcp_sync_service import MCPSyncServiceProtocol
+
+
+def _server(**ov):
+    base = {
+        "serverCode": "mcp.weather",
+        "name": "Weather",
+        "description": "d",
+        "networkTypes": ["INTERNET"],
+        "transportProtocol": "SSE",
+        "tools": [
+            {"name": "get", "inputSchema": {"properties": {"extInfo": {"z": 1}, "q": 2}}}
+        ],
+    }
+    base.update(ov)
+    return base
+
+
+@pytest.fixture
+def market():
+    m = MagicMock()
+    m.get_mcp_list.return_value = {"success": True, "data": [_server()], "total": 1}
+    m.get_mcp_detail.return_value = _server()
+    m.get_tenant_list.return_value = {
+        "success": True,
+        "data": [{"code": "t1", "name": "Tenant 1", "categories": [{"name": "cat-a"}]}],
+    }
+    return m
+
+
+@pytest.fixture
+def auth():
+    m = MagicMock()
+    m.check_mcp_permission_detail.return_value = {
+        "has_permission": True,
+        "access_level": "PUBLIC",
+        "tool_permissions": {"get": {"code": "AUTHORIZED"}},
+    }
+    return m
+
+
+@pytest.fixture
+def config():
+    m = MagicMock()
+    m.get_user_unified_config.return_value = None
+    m.validate_headers_for_mcp.return_value = {"valid": True, "error": None}
+    m.update_user_unified_config.return_value = None
+    m.rollback_unified_config.return_value = None
+    return m
+
+
+@pytest.fixture
+def sync():
+    m = MagicMock()
+    m.sync_mcp_detail_to_all_bots = AsyncMock(
+        return_value={"success": True, "sync_results": [], "error": None}
+    )
+    return m
+
+
+@pytest.fixture
+def client(market, auth, config, sync):
+    class _M(Module):
+        def configure(self, binder):
+            binder.bind(MCPMarketServiceProtocol, to=market)
+            binder.bind(MCPAuthServiceProtocol, to=auth)
+            binder.bind(MCPConfigServiceProtocol, to=config)
+            binder.bind(MCPSyncServiceProtocol, to=sync)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "u1"}
+    attach_injector(app, Injector([_M()]))
+    return TestClient(app)
+
+
+def _ok(resp, code=200000):
+    body = resp.json()
+    assert resp.status_code == 200, body
+    assert body["code"] == code, body
+    assert "request_id" in body
+    return body["data"]
+
+
+# ── marketplace ─────────────────────────────────────────────────────
+
+
+def test_list_servers_maps_fields_and_omits_tools(client):
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers"))
+    assert data["total"] == 1
+    item = data["items"][0]
+    assert item["server_code"] == "mcp.weather"
+    assert item["network_types"] == ["INTERNET"]
+    # The list is the lightweight McpServer projection — tools (and any extInfo
+    # they carry) are not exposed here; that is the detail endpoint's job.
+    assert "tools" not in item
+
+
+def test_list_servers_forwards_keyword_and_paging(client, market):
+    client.get("/openapi/v1/bots/mcp/servers?keyword=rain&page=3&page_size=7")
+    kw = market.get_mcp_list.call_args.kwargs
+    assert kw["search_key"] == "rain"
+    assert kw["page_num"] == 3 and kw["page_size"] == 7
+    assert kw["network_types"] == ["INTERNET", "OFFICE"]
+
+
+def test_list_servers_upstream_failure_is_502(client, market):
+    market.get_mcp_list.return_value = {"success": False, "message": "boom"}
+    resp = client.get("/openapi/v1/bots/mcp/servers")
+    assert resp.status_code == 502
+    assert resp.json()["message"] == "MCP service error"
+
+
+def test_list_tenants(client):
+    data = _ok(client.get("/openapi/v1/bots/mcp/tenants"))
+    assert data[0]["code"] == "t1"
+    assert data[0]["categories"] == ["cat-a"]
+
+
+def test_tenants_upstream_failure_is_502(client, market):
+    market.get_tenant_list.return_value = {"success": False}
+    resp = client.get("/openapi/v1/bots/mcp/tenants")
+    assert resp.status_code == 502
+
+
+def test_server_detail_strips_ext_info(client):
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather"))
+    assert data["server_code"] == "mcp.weather"
+    props = data["tools"][0]["inputSchema"]["properties"]
+    assert "extInfo" not in props and props["q"] == 2
+
+
+def test_unknown_server_is_404_not_found(client, market):
+    market.get_mcp_detail.return_value = None
+    resp = client.get("/openapi/v1/bots/mcp/servers/nope")
+    assert resp.status_code == 404
+    assert resp.json()["message"] == "Not found"
+
+
+def test_invisible_server_is_identical_404(client, market):
+    """A network-type-hidden server answers the SAME body as an unknown one."""
+    market.get_mcp_detail.return_value = None
+    r_unknown = client.get("/openapi/v1/bots/mcp/servers/nope").json()
+    market.get_mcp_detail.return_value = _server(networkTypes=["SECRET"])
+    r_hidden = client.get("/openapi/v1/bots/mcp/servers/secret").json()
+    assert r_unknown == r_hidden  # cannot probe existence
+
+
+# ── permission ──────────────────────────────────────────────────────
+
+
+def test_permission_uses_caller_identity_only(client, auth):
+    # Even with a spoofed ?user_id=, the service is queried for the principal.
+    _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/permissions?user_id=evil"))
+    args = auth.check_mcp_permission_detail.call_args.args
+    assert args[0] == "u1"  # owner from principal, not the query param
+
+
+def test_permission_shape(client):
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/permissions"))
+    assert data["has_access"] is True
+    assert data["access_level"] == "PUBLIC"
+    assert data["tool_permissions"]["get"]["code"] == "AUTHORIZED"
+
+
+# ── config read ─────────────────────────────────────────────────────
+
+
+def test_get_config_absent_reports_no_config(client):
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/config"))
+    assert data["has_config"] is False
+    assert data["endpoint_env"] == "PROD"
+    assert data["api_key"] is None
+
+
+def test_get_config_masks_long_key(client, config):
+    config.get_user_unified_config.return_value = {
+        "api_key": "sk-abcdefghijklmnop",
+        "headers": {"h": "v"},
+        "endpoint_env": "PRE",
+        "transport_protocol": "SSE",
+    }
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/config"))
+    assert data["api_key"] == "sk-a****mnop"
+    assert data["has_config"] is True
+    assert data["endpoint_env"] == "PRE"
+
+
+def test_get_config_masks_short_key(client, config):
+    config.get_user_unified_config.return_value = {"api_key": "sk-1", "headers": {}}
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/config"))
+    assert data["api_key"] == "****"
+
+
+def test_raw_key_never_appears_in_response_text(client, config):
+    config.get_user_unified_config.return_value = {"api_key": "sk-abcdefghijklmnop"}
+    resp = client.get("/openapi/v1/bots/mcp/servers/mcp.weather/config")
+    assert "sk-abcdefghijklmnop" not in resp.text
+
+
+# ── config write ────────────────────────────────────────────────────
+
+
+def test_put_config_success_returns_reread_state(client, config):
+    # After the write, the handler re-reads for the response.
+    config.get_user_unified_config.return_value = {
+        "api_key": "sk-abcdefghijklmnop",
+        "headers": {"h": "v"},
+        "endpoint_env": "PROD",
+        "transport_protocol": "SSE",
+    }
+    data = _ok(
+        client.put(
+            "/openapi/v1/bots/mcp/servers/mcp.weather/config",
+            json={"api_key": "sk-abcdefghijklmnop", "endpoint_env": "PROD"},
+        )
+    )
+    assert data["api_key"] == "sk-a****mnop"  # masked, from re-read
+    assert data["has_config"] is True
+
+
+def test_put_config_scopes_write_to_caller(client, config, sync):
+    client.put(
+        "/openapi/v1/bots/mcp/servers/mcp.weather/config",
+        json={"api_key": "sk-1"},
+    )
+    assert config.update_user_unified_config.call_args.kwargs["user_id"] == "u1"
+    assert sync.sync_mcp_detail_to_all_bots.call_args.kwargs["entity_id"] == "u1"
+
+
+def test_put_config_sync_failure_is_502_and_rolls_back(client, config, sync):
+    sync.sync_mcp_detail_to_all_bots.return_value = {
+        "success": False,
+        "error": "device down",
+        "sync_results": [],
+    }
+    resp = client.put(
+        "/openapi/v1/bots/mcp/servers/mcp.weather/config",
+        json={"api_key": "sk-1"},
+    )
+    assert resp.status_code == 502
+    assert resp.json()["message"] == "Device sync failed"
+    config.rollback_unified_config.assert_called_once()
+
+
+def test_put_config_unknown_server_is_404(client, market):
+    market.get_mcp_detail.return_value = None
+    resp = client.put(
+        "/openapi/v1/bots/mcp/servers/nope/config", json={"api_key": "sk-1"}
+    )
+    assert resp.status_code == 404
+
+
+def test_put_config_rejects_sync_mode_as_422(client):
+    resp = client.put(
+        "/openapi/v1/bots/mcp/servers/mcp.weather/config",
+        json={"sync_mode": "single"},
+    )
+    assert resp.status_code == 422
+
+
+def test_put_config_rejects_dev_endpoint_env_as_422(client):
+    resp = client.put(
+        "/openapi/v1/bots/mcp/servers/mcp.weather/config",
+        json={"endpoint_env": "DEV"},
+    )
+    assert resp.status_code == 422
+
+
+# ── auth ────────────────────────────────────────────────────────────
+
+
+def test_missing_principal_is_401(client):
+    client.app.dependency_overrides[require_principal] = lambda: None
+    resp = client.get("/openapi/v1/bots/mcp/servers")
+    assert resp.status_code == 401
+    assert resp.json()["code"] == 401000

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -174,6 +174,22 @@ def test_invisible_server_is_identical_404(client, market):
     assert r_unknown == r_hidden  # cannot probe existence
 
 
+def test_projection_reads_singular_network_type(client, market):
+    # A catalog entry declaring its type via the singular networkType (no plural
+    # networkTypes) — the shape LocalMCPRegistry accepts — must still serialize
+    # network_types on both the list and the detail, not an empty list.
+    singular = _server(networkType="INTERNET")
+    singular.pop("networkTypes")
+    market.get_mcp_detail.return_value = singular
+    market.get_mcp_list.return_value = {"success": True, "data": [singular], "total": 1}
+
+    detail = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather"))
+    assert detail["network_types"] == ["INTERNET"]
+
+    listed = _ok(client.get("/openapi/v1/bots/mcp/servers"))
+    assert listed["items"][0]["network_types"] == ["INTERNET"]
+
+
 # ── permission ──────────────────────────────────────────────────────
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -191,6 +191,25 @@ def test_permission_shape(client):
     assert data["tool_permissions"]["get"]["code"] == "AUTHORIZED"
 
 
+def test_permission_is_fail_open_by_decision(client, auth):
+    """The surface preserves the service's fail-open (spec Open Question 1).
+
+    On a marketplace outage the auth service reports the caller as permitted
+    (``has_permission: True``, empty access level — pinned at the service by
+    ``test_auth_service.test_check_mcp_permission_detail_mcp_center_failure``).
+    This public endpoint surfaces that verbatim rather than adding a fail-closed
+    gate of its own: it is advisory, and the MCP server enforces.
+    """
+    auth.check_mcp_permission_detail.return_value = {
+        "has_permission": True,  # the fail-open outcome
+        "access_level": "",
+        "tool_permissions": {},
+    }
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/permissions"))
+    assert data["has_access"] is True
+    assert data["access_level"] == ""
+
+
 # ── config read ─────────────────────────────────────────────────────
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -190,6 +190,25 @@ def test_projection_reads_singular_network_type(client, market):
     assert listed["items"][0]["network_types"] == ["INTERNET"]
 
 
+def test_projection_reads_transport_protocol_from_endpoints(client, market):
+    # Real MCP Center records carry transportProtocol on endpoints, not the top
+    # level, so the flat projection must read it from there or it serializes null.
+    rec = _server()
+    rec.pop("transportProtocol")
+    rec["endpoints"] = [
+        {"env": "PRE", "networkType": "INTERNET",
+         "transportProtocol": "STREAMABLE_HTTP", "url": "https://x"}
+    ]
+    market.get_mcp_detail.return_value = rec
+    market.get_mcp_list.return_value = {"success": True, "data": [rec], "total": 1}
+
+    detail = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather"))
+    assert detail["transport_protocol"] == "STREAMABLE_HTTP"
+
+    listed = _ok(client.get("/openapi/v1/bots/mcp/servers"))
+    assert listed["items"][0]["transport_protocol"] == "STREAMABLE_HTTP"
+
+
 # ── permission ──────────────────────────────────────────────────────
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -220,6 +220,18 @@ def test_get_config_absent_reports_no_config(client):
     assert data["api_key"] is None
 
 
+def test_get_config_existing_row_without_credentials_reports_has_config(client, config):
+    # A stored row carrying only endpoint_env (no api_key/headers/transport) is a
+    # configured server, not an absent one: has_config must be True so the caller
+    # can tell it apart from the never-configured case, which also defaults
+    # endpoint_env to PROD. Keys off row existence, not credential material.
+    config.get_user_unified_config.return_value = {"endpoint_env": "PRE"}
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/config"))
+    assert data["has_config"] is True
+    assert data["endpoint_env"] == "PRE"
+    assert data["api_key"] is None
+
+
 def test_get_config_masks_long_key(client, config):
     config.get_user_unified_config.return_value = {
         "api_key": "sk-abcdefghijklmnop",

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_tenant_isolation.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_tenant_isolation.py
@@ -1,0 +1,170 @@
+"""Cross-tenant isolation for the public MCP config path (Track B, Task 7).
+
+Stage 5 (`tests/community/plugins/test_user_mcp_config_tenant_isolation.py`)
+proves the guard at the repository. This proves it through the exact layer the
+public handlers use: `core/mcp/config_flow.read_unified_config` /
+`write_unified_config`, driven against a **real** `MCPConfigService` + real
+`UserMCPConfigRepository` + the real Stage 5 guard over SQLite. Only the
+marketplace and device-sync collaborators (external systems) are mocked; the
+config read/write and the tenant guard are the real thing.
+
+That is the mechanism behind the endpoints' guarantee: a config owned by another
+tenant is invisible (read reports "no config") and un-overwritable (a write
+creates the caller's own row rather than displacing the other tenant's).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.mcp.config_flow import (
+    read_unified_config,
+    write_unified_config,
+)
+from agentclaw.community.core.mcp.services.config_service import MCPConfigService
+from agentclaw.community.core.models.mcp import UserMCPConfig
+from agentclaw.community.plugins.user_mcp_config_repository import (
+    UserMCPConfigRepository,
+)
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+pytestmark = pytest.mark.integration
+
+TENANT_A = "tenant-a"
+TENANT_B = "tenant-b"
+SERVER = "mcp.third.weather"
+USER = "12345"  # a user id that collides across tenants
+
+
+class _FileSqliteDB:
+    def __init__(self, engine):
+        self._factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    session = orm_session
+
+
+@pytest.fixture
+def config_service(tmp_path):
+    """A real MCPConfigService over the real repo + guard on file SQLite.
+
+    ``mcp_center`` and ``bot_repo`` are not exercised by the read/write config
+    path (headers validation is skipped by passing ``headers=None``), so they
+    are mocks.
+    """
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'mcp.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    UserMCPConfig.__table__.create(engine)
+    repo = UserMCPConfigRepository(_FileSqliteDB(engine))
+    return MCPConfigService(
+        user_mcp_config_repo=repo, mcp_center=MagicMock(), bot_repo=MagicMock()
+    )
+
+
+@pytest.fixture
+def market():
+    m = MagicMock()
+    m.get_mcp_detail.return_value = {"serverCode": SERVER, "name": "Weather"}
+    return m
+
+
+@pytest.fixture
+def sync():
+    m = MagicMock()
+    m.sync_mcp_detail_to_all_bots = AsyncMock(
+        return_value={"success": True, "sync_results": [], "error": None}
+    )
+    return m
+
+
+def _write(config_service, market, sync, tenant, *, api_key):
+    with avernet_tenant_scope(tenant):
+        return asyncio.run(
+            write_unified_config(
+                user_id=USER,
+                server_code=SERVER,
+                entity_id=USER,
+                entity_type="staff",
+                api_key=api_key,
+                headers=None,
+                endpoint_env="PROD",
+                transport_protocol="SSE",
+                config_service=config_service,
+                market_service=market,
+                sync_service=sync,
+            )
+        )
+
+
+def _read(config_service, tenant):
+    with avernet_tenant_scope(tenant):
+        return read_unified_config(
+            user_id=USER, server_code=SERVER, config_service=config_service
+        )
+
+
+def test_config_written_under_a_is_invisible_from_b(config_service, market, sync):
+    _write(config_service, market, sync, TENANT_A, api_key="sk-tenant-a-secret")
+
+    # Tenant B, reading through the same flow, sees nothing.
+    b_view = _read(config_service, TENANT_B)
+    assert b_view.has_config is False
+    assert b_view.api_key is None
+
+    # Tenant A still sees its own (masked).
+    a_view = _read(config_service, TENANT_A)
+    assert a_view.has_config is True
+    assert a_view.api_key == "sk-t****cret"
+
+
+def test_b_write_creates_own_row_not_overwrite_a(config_service, market, sync):
+    _write(config_service, market, sync, TENANT_A, api_key="sk-tenant-a-secret")
+    _write(config_service, market, sync, TENANT_B, api_key="sk-tenant-b-secret")
+
+    # Each tenant reads back its own credential; neither displaced the other.
+    assert _read(config_service, TENANT_A).api_key == "sk-t****cret"  # a's masked
+    a_full = config_service.get_user_unified_config  # sanity: distinct stored rows
+    with avernet_tenant_scope(TENANT_A):
+        assert a_full(USER, SERVER)["api_key"] == "sk-tenant-a-secret"
+    with avernet_tenant_scope(TENANT_B):
+        assert a_full(USER, SERVER)["api_key"] == "sk-tenant-b-secret"
+
+
+def test_two_tenants_same_user_and_server_coexist(config_service, market, sync):
+    """The case the Stage 5 unique-key swap enables: same user id + server,
+    two tenants, neither write rejected and neither read crosses over."""
+    _write(config_service, market, sync, TENANT_A, api_key="sk-a-aaaaaaaa")
+    # Would raise IntegrityError against the old (user_id, server_code, env) key.
+    _write(config_service, market, sync, TENANT_B, api_key="sk-b-bbbbbbbb")
+
+    assert _read(config_service, TENANT_A).api_key == "sk-a****aaaa"
+    assert _read(config_service, TENANT_B).api_key == "sk-b****bbbb"
+
+
+def test_cross_tenant_write_does_not_touch_the_other_row(config_service, market, sync):
+    """A tenant-B write after a tenant-A write leaves A's stored bytes intact."""
+    _write(config_service, market, sync, TENANT_A, api_key="sk-tenant-a-secret")
+    _write(config_service, market, sync, TENANT_B, api_key="sk-tenant-b-secret")
+
+    with avernet_tenant_scope(TENANT_A):
+        stored = config_service.get_user_unified_config(USER, SERVER)
+        assert stored["api_key"] == "sk-tenant-a-secret"  # untouched

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -120,3 +120,64 @@ async def test_envelope_errors_passes_through_unmapped():
 
     with pytest.raises(ValueError, match="boom"):
         await handler(request=_request())
+
+
+# ── MCP category error mappings (Track B mcp, Task 6) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_mcp_errors_map_to_status_and_fixed_message():
+    """Every MCP domain error round-trips to its status + fixed public message."""
+    import json
+
+    from agentclaw.community.core.mcp.errors import (
+        McpConfigValueError,
+        McpHeadersInvalidError,
+        McpMarketUnavailableError,
+        McpServerNotFoundError,
+        McpSyncFailedError,
+    )
+
+    cases = [
+        # Internal-language / identifier-bearing text that must NOT leak.
+        (McpServerNotFoundError("mcp.secret.server"), 404, "Not found"),
+        (McpHeadersInvalidError("Header 键不能为空"), 400, "Invalid MCP headers"),
+        (McpConfigValueError("endpoint_env must be PROD or PRE"), 400, "Invalid MCP configuration"),
+        (McpSyncFailedError("bot b-123 device down"), 502, "Device sync failed"),
+        (McpMarketUnavailableError("upstream 500"), 502, "MCP service error"),
+    ]
+    for exc, status, message in cases:
+
+        @envelope_errors
+        async def handler(request: Request, _exc=exc):
+            raise _exc
+
+        resp = await handler(request=_request())
+        assert resp.status_code == status
+        body = json.loads(bytes(resp.body))
+        assert body["message"] == message
+        assert body["code"] == status * 1000
+        assert body["data"] is None
+        # The raw exception text (identifiers / Chinese) never reaches the caller.
+        assert str(exc) not in body["message"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_not_found_is_indistinguishable_from_bots_not_found():
+    """A missing MCP server and a masked bot 404 answer byte-identical bodies."""
+    import json
+
+    from agentclaw.community.core.mcp.errors import McpServerNotFoundError
+
+    @envelope_errors
+    async def mcp_missing(request: Request):
+        raise McpServerNotFoundError("mcp.x")
+
+    @envelope_errors
+    async def bot_missing(request: Request):
+        raise BotNotFoundError("Bot not found: b-1")
+
+    a = await mcp_missing(request=_request())
+    b = await bot_missing(request=_request())
+    assert a.status_code == b.status_code == 404
+    assert json.loads(bytes(a.body)) == json.loads(bytes(b.body))

--- a/src/backend/tests/community/core/mcp/test_mcp_config_flow.py
+++ b/src/backend/tests/community/core/mcp/test_mcp_config_flow.py
@@ -1,0 +1,187 @@
+"""Unit tests for the extracted MCP config read/write flow.
+
+No HTTP: the flow is driven directly with mocked services, asserting the
+load-bearing ordering (an unknown server never reaches the database), the
+rollback-on-sync-failure guarantee (restore on update, delete on create), and
+that the returned key is masked.
+
+The suite has no async plugin, so the one ``async def`` under test is driven
+through ``asyncio.run`` from sync test functions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.mcp.config_flow import (
+    read_unified_config,
+    write_unified_config,
+)
+from agentclaw.community.core.mcp.errors import (
+    McpConfigValueError,
+    McpHeadersInvalidError,
+    McpServerNotFoundError,
+    McpSyncFailedError,
+)
+
+
+def _config_service(*, existing=None):
+    m = MagicMock()
+    m.get_user_unified_config.return_value = existing
+    m.validate_headers_for_mcp.return_value = {"valid": True, "error": None}
+    # update returns the *prior* config (None when the row was newly created).
+    m.update_user_unified_config.return_value = None
+    return m
+
+
+_UNSET = object()
+
+
+def _market_service(*, detail=_UNSET):
+    m = MagicMock()
+    m.get_mcp_detail.return_value = (
+        {"serverCode": "s"} if detail is _UNSET else detail
+    )
+    return m
+
+
+def _sync_service(*, success=True, sync_results=None, error=None):
+    m = MagicMock()
+    m.sync_mcp_detail_to_all_bots = AsyncMock(
+        return_value={
+            "success": success,
+            "sync_results": sync_results if sync_results is not None else [],
+            "error": error,
+        }
+    )
+    return m
+
+
+def _write(cfg=None, mkt=None, sync=None, **overrides):
+    params = dict(
+        user_id="u1",
+        server_code="mcp.s",
+        entity_id="u1",
+        entity_type="staff",
+        api_key="sk-abcdefghijkl",
+        headers=None,
+        endpoint_env="PROD",
+        transport_protocol="sse",
+    )
+    params.update(overrides)
+    return asyncio.run(
+        write_unified_config(
+            **params,
+            config_service=cfg or _config_service(),
+            market_service=mkt or _market_service(),
+            sync_service=sync or _sync_service(),
+        )
+    )
+
+
+# ── read ────────────────────────────────────────────────────────────
+
+
+def test_read_absent_reports_no_config_with_defaults():
+    out = read_unified_config(
+        user_id="u1", server_code="mcp.s", config_service=_config_service()
+    )
+    assert out.has_config is False
+    assert out.endpoint_env == "PROD"
+    assert out.headers == {}
+    assert out.api_key is None
+
+
+def test_read_present_masks_key_and_carries_values():
+    cfg = _config_service(
+        existing={
+            "api_key": "sk-abcdefghijkl",
+            "headers": {"h": "v"},
+            "endpoint_env": "PRE",
+            "transport_protocol": "SSE",
+        }
+    )
+    out = read_unified_config(user_id="u1", server_code="mcp.s", config_service=cfg)
+    assert out.api_key == "sk-a****ijkl"
+    assert out.endpoint_env == "PRE"
+    assert out.headers == {"h": "v"}
+    assert out.has_config is True
+
+
+# ── write: success ──────────────────────────────────────────────────
+
+
+def test_write_success_returns_masked_write_shaped_config():
+    out = _write()
+    assert out.api_key == "sk-a****ijkl"  # masked
+    assert out.transport_protocol == "SSE"  # upper-cased
+    assert out.headers is None  # write path does not echo headers
+    assert out.has_config is True
+
+
+def test_write_forwards_params_for_merge_and_push():
+    cfg = _config_service()
+    sync = _sync_service()
+    _write(cfg=cfg, sync=sync, endpoint_env=None, api_key=None, headers=None)
+    # An omitted field is forwarded as None so config_service merges (not replace).
+    _, kw = cfg.update_user_unified_config.call_args
+    assert kw["endpoint_env"] is None and kw["api_key"] is None
+    # And the same identity/values reach the device push.
+    _, sync_kw = sync.sync_mcp_detail_to_all_bots.call_args
+    assert sync_kw["entity_id"] == "u1" and sync_kw["entity_type"] == "staff"
+
+
+# ── write: ordering — bad server never reaches the DB ───────────────
+
+
+def test_unknown_server_raises_before_any_write():
+    cfg = _config_service()
+    with pytest.raises(McpServerNotFoundError):
+        _write(cfg=cfg, mkt=_market_service(detail=None))
+    cfg.update_user_unified_config.assert_not_called()
+
+
+def test_bad_endpoint_env_raises_before_any_write():
+    cfg = _config_service()
+    with pytest.raises(McpConfigValueError):
+        _write(cfg=cfg, endpoint_env="NOPE")
+    cfg.update_user_unified_config.assert_not_called()
+    cfg.get_user_unified_config.assert_not_called()  # nothing touched
+
+
+def test_invalid_headers_raise_before_any_write():
+    cfg = _config_service()
+    cfg.validate_headers_for_mcp.return_value = {"valid": False, "error": "bad"}
+    with pytest.raises(McpHeadersInvalidError):
+        _write(cfg=cfg, headers={"": "x"})
+    cfg.update_user_unified_config.assert_not_called()
+
+
+# ── write: rollback on sync failure ─────────────────────────────────
+
+
+def test_sync_failure_rolls_back_update_and_raises():
+    # The row existed before this call → update returns the prior config.
+    prior = {"api_key": "old", "headers": {}, "endpoint_env": "PROD"}
+    cfg = _config_service()
+    cfg.update_user_unified_config.return_value = prior
+    sync = _sync_service(success=False, error="device down")
+    with pytest.raises(McpSyncFailedError):
+        _write(cfg=cfg, sync=sync)
+    # Rollback restores the prior config, not None.
+    _, kw = cfg.rollback_unified_config.call_args
+    assert kw["old_config"] == prior
+
+
+def test_sync_failure_after_create_rolls_back_as_delete():
+    # New row → update returns None → rollback receives None → delete path.
+    cfg = _config_service()
+    cfg.update_user_unified_config.return_value = None
+    sync = _sync_service(success=False, error="device down")
+    with pytest.raises(McpSyncFailedError):
+        _write(cfg=cfg, sync=sync)
+    _, kw = cfg.rollback_unified_config.call_args
+    assert kw["old_config"] is None

--- a/src/backend/tests/community/core/mcp/test_mcp_config_flow.py
+++ b/src/backend/tests/community/core/mcp/test_mcp_config_flow.py
@@ -185,3 +185,21 @@ def test_sync_failure_after_create_rolls_back_as_delete():
         _write(cfg=cfg, sync=sync)
     _, kw = cfg.rollback_unified_config.call_args
     assert kw["old_config"] is None
+
+
+def test_sync_raising_also_rolls_back_and_raises_sync_failure():
+    # The sync service contracts to return a failure dict, but if the push
+    # raises instead the freshly written row must still be rolled back — a
+    # stored-but-unpushed credential would violate the atomic write-and-push
+    # contract. The exception surfaces as McpSyncFailedError like any other
+    # push failure, so each surface maps it with the row already restored.
+    prior = {"api_key": "old", "headers": {}, "endpoint_env": "PROD"}
+    cfg = _config_service()
+    cfg.update_user_unified_config.return_value = prior
+    sync = MagicMock()
+    sync.sync_mcp_detail_to_all_bots = AsyncMock(side_effect=RuntimeError("boom"))
+    with pytest.raises(McpSyncFailedError, match="boom"):
+        _write(cfg=cfg, sync=sync)
+    cfg.rollback_unified_config.assert_called_once()
+    _, kw = cfg.rollback_unified_config.call_args
+    assert kw["old_config"] == prior

--- a/src/backend/tests/community/core/mcp/test_presentation.py
+++ b/src/backend/tests/community/core/mcp/test_presentation.py
@@ -1,0 +1,96 @@
+"""Unit tests for the shared MCP presentation helpers.
+
+These rules were duplicated inside the internal ``/api/mcp`` router; they are
+tested here as pure units so the two API surfaces provably apply the same
+masking, ``extInfo`` stripping, and network-type visibility.
+"""
+
+from __future__ import annotations
+
+from agentclaw.community.core.mcp.presentation import (
+    ALLOWED_NETWORK_TYPES,
+    is_network_type_visible,
+    mask_api_key,
+    strip_ext_info,
+    strip_ext_info_from_list,
+)
+
+
+class TestMaskApiKey:
+    def test_long_key_keeps_first_and_last_four(self):
+        assert mask_api_key("abcdefghijkl") == "abcd****ijkl"
+
+    def test_boundary_length_eight_is_fully_masked(self):
+        # len == 8 is not > 8, so it is fully masked (reveal never exceeds hide).
+        assert mask_api_key("abcdefgh") == "****"
+
+    def test_short_key_is_fully_masked(self):
+        assert mask_api_key("abc") == "****"
+
+    def test_none_stays_none(self):
+        assert mask_api_key(None) is None
+
+    def test_empty_string_is_none(self):
+        # Falsy key: "no key", not "masked key".
+        assert mask_api_key("") is None
+
+
+class TestStripExtInfo:
+    def test_ext_info_removed_from_tool_properties(self):
+        data = {
+            "tools": [
+                {"inputSchema": {"properties": {"extInfo": {"x": 1}, "keep": 2}}}
+            ]
+        }
+        out = strip_ext_info(data)
+        props = out["tools"][0]["inputSchema"]["properties"]
+        assert "extInfo" not in props
+        assert props["keep"] == 2
+
+    def test_absent_ext_info_leaves_properties_intact(self):
+        data = {"tools": [{"inputSchema": {"properties": {"keep": 2}}}]}
+        out = strip_ext_info(data)
+        assert out["tools"][0]["inputSchema"]["properties"] == {"keep": 2}
+
+    def test_input_is_not_mutated(self):
+        data = {"tools": [{"inputSchema": {"properties": {"extInfo": 1}}}]}
+        strip_ext_info(data)
+        assert "extInfo" in data["tools"][0]["inputSchema"]["properties"]
+
+    def test_non_dict_shapes_are_tolerated(self):
+        assert strip_ext_info({"tools": "not-a-list"}) == {"tools": "not-a-list"}
+        assert strip_ext_info({"tools": ["not-a-dict"]}) == {"tools": ["not-a-dict"]}
+        assert strip_ext_info({}) == {}
+
+    def test_list_variant_strips_each_item(self):
+        result = {
+            "total": 2,
+            "data": [
+                {"tools": [{"inputSchema": {"properties": {"extInfo": 1, "a": 2}}}]},
+                {"tools": [{"inputSchema": {"properties": {"extInfo": 3, "b": 4}}}]},
+            ],
+        }
+        out = strip_ext_info_from_list(result)
+        assert out["total"] == 2
+        for item in out["data"]:
+            props = item["tools"][0]["inputSchema"]["properties"]
+            assert "extInfo" not in props
+
+
+class TestNetworkTypeVisibility:
+    def test_allowed_type_is_visible(self):
+        assert is_network_type_visible({"networkTypes": ["INTERNET"]}) is True
+        assert is_network_type_visible({"networkTypes": ["OFFICE"]}) is True
+
+    def test_disallowed_type_only_is_not_visible(self):
+        assert is_network_type_visible({"networkTypes": ["SECRET"]}) is False
+
+    def test_mixed_types_visible_if_any_allowed(self):
+        assert is_network_type_visible({"networkTypes": ["SECRET", "OFFICE"]}) is True
+
+    def test_empty_or_absent_is_visible(self):
+        assert is_network_type_visible({"networkTypes": []}) is True
+        assert is_network_type_visible({}) is True
+
+    def test_allowlist_is_internet_and_office(self):
+        assert ALLOWED_NETWORK_TYPES == ("INTERNET", "OFFICE")

--- a/src/backend/tests/community/core/mcp/test_presentation.py
+++ b/src/backend/tests/community/core/mcp/test_presentation.py
@@ -92,5 +92,24 @@ class TestNetworkTypeVisibility:
         assert is_network_type_visible({"networkTypes": []}) is True
         assert is_network_type_visible({}) is True
 
+    def test_singular_disallowed_type_is_not_visible(self):
+        # The local registry filters its list on the singular networkType /
+        # network_type key; the detail check must honor the same shape or a
+        # server hidden from the list would still resolve by code.
+        assert is_network_type_visible({"networkType": "INTRANET"}) is False
+        assert is_network_type_visible({"network_type": "INTRANET"}) is False
+        assert is_network_type_visible({"networkType": ["INTRANET"]}) is False
+
+    def test_singular_allowed_type_is_visible(self):
+        assert is_network_type_visible({"networkType": "INTERNET"}) is True
+        assert is_network_type_visible({"network_type": "OFFICE"}) is True
+
+    def test_plural_takes_precedence_over_singular(self):
+        # A present plural list is authoritative — the singular fallback only
+        # fires when networkTypes is absent/empty, so existing behavior is intact.
+        assert is_network_type_visible(
+            {"networkTypes": ["OFFICE"], "networkType": "INTRANET"}
+        ) is True
+
     def test_allowlist_is_internet_and_office(self):
         assert ALLOWED_NETWORK_TYPES == ("INTERNET", "OFFICE")

--- a/src/backend/tests/community/core/mcp/test_presentation.py
+++ b/src/backend/tests/community/core/mcp/test_presentation.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.mcp.presentation import (
     ALLOWED_NETWORK_TYPES,
     is_network_type_visible,
     mask_api_key,
+    normalize_network_types,
     strip_ext_info,
     strip_ext_info_from_list,
 )
@@ -113,3 +114,30 @@ class TestNetworkTypeVisibility:
 
     def test_allowlist_is_internet_and_office(self):
         assert ALLOWED_NETWORK_TYPES == ("INTERNET", "OFFICE")
+
+
+class TestNormalizeNetworkTypes:
+    def test_plural_list_returned_as_is(self):
+        assert normalize_network_types({"networkTypes": ["INTERNET", "OFFICE"]}) == [
+            "INTERNET",
+            "OFFICE",
+        ]
+
+    def test_singular_scalar_wrapped(self):
+        assert normalize_network_types({"networkType": "INTRANET"}) == ["INTRANET"]
+        assert normalize_network_types({"network_type": "OFFICE"}) == ["OFFICE"]
+
+    def test_singular_list_returned(self):
+        assert normalize_network_types({"networkType": ["INTERNET"]}) == ["INTERNET"]
+
+    def test_plural_takes_precedence_over_singular(self):
+        assert normalize_network_types(
+            {"networkTypes": ["OFFICE"], "networkType": "INTRANET"}
+        ) == ["OFFICE"]
+
+    def test_absent_or_empty_is_empty_list(self):
+        assert normalize_network_types({}) == []
+        assert normalize_network_types({"networkTypes": []}) == []
+
+    def test_non_string_members_dropped(self):
+        assert normalize_network_types({"networkTypes": ["OFFICE", None, 3]}) == ["OFFICE"]

--- a/src/backend/tests/community/core/mcp/test_presentation.py
+++ b/src/backend/tests/community/core/mcp/test_presentation.py
@@ -12,6 +12,7 @@ from agentclaw.community.core.mcp.presentation import (
     is_network_type_visible,
     mask_api_key,
     normalize_network_types,
+    primary_transport_protocol,
     strip_ext_info,
     strip_ext_info_from_list,
 )
@@ -141,3 +142,35 @@ class TestNormalizeNetworkTypes:
 
     def test_non_string_members_dropped(self):
         assert normalize_network_types({"networkTypes": ["OFFICE", None, 3]}) == ["OFFICE"]
+
+
+class TestPrimaryTransportProtocol:
+    def test_read_from_endpoint_not_top_level(self):
+        # Real MCP Center records carry transportProtocol per endpoint.
+        data = {
+            "endpoints": [
+                {"env": "PRE", "networkType": "INTERNET",
+                 "transportProtocol": "STREAMABLE_HTTP", "url": "https://x"}
+            ]
+        }
+        assert primary_transport_protocol(data) == "STREAMABLE_HTTP"
+
+    def test_prefers_allowed_network_endpoint(self):
+        data = {
+            "endpoints": [
+                {"networkType": "INTRANET", "transportProtocol": "SSE"},
+                {"networkType": "INTERNET", "transportProtocol": "STREAMABLE_HTTP"},
+            ]
+        }
+        assert primary_transport_protocol(data) == "STREAMABLE_HTTP"
+
+    def test_falls_back_to_any_endpoint_with_protocol(self):
+        data = {"endpoints": [{"networkType": "INTRANET", "transportProtocol": "SSE"}]}
+        assert primary_transport_protocol(data) == "SSE"
+
+    def test_falls_back_to_top_level_when_no_endpoints(self):
+        assert primary_transport_protocol({"transportProtocol": "SSE"}) == "SSE"
+
+    def test_none_when_absent_everywhere(self):
+        assert primary_transport_protocol({}) is None
+        assert primary_transport_protocol({"endpoints": [{"url": "https://x"}]}) is None

--- a/src/backend/tests/community/core/mcp/test_presentation.py
+++ b/src/backend/tests/community/core/mcp/test_presentation.py
@@ -171,6 +171,18 @@ class TestPrimaryTransportProtocol:
     def test_falls_back_to_top_level_when_no_endpoints(self):
         assert primary_transport_protocol({"transportProtocol": "SSE"}) == "SSE"
 
+    def test_stdio_config_reports_stdio(self):
+        # LocalMCPRegistry._transport_in classifies stdioConfigs entries as STDIO.
+        assert primary_transport_protocol({"stdioConfigs": [{"command": "x"}]}) == "STDIO"
+        assert primary_transport_protocol({"stdio_configs": [{"command": "x"}]}) == "STDIO"
+
+    def test_http_endpoint_wins_over_stdio(self):
+        data = {
+            "endpoints": [{"networkType": "INTERNET", "transportProtocol": "SSE"}],
+            "stdioConfigs": [{"command": "x"}],
+        }
+        assert primary_transport_protocol(data) == "SSE"
+
     def test_none_when_absent_everywhere(self):
         assert primary_transport_protocol({}) is None
         assert primary_transport_protocol({"endpoints": [{"url": "https://x"}]}) is None


### PR DESCRIPTION
## What this is

Track B for the **`mcp`** category of the `/openapi/v1` public API
(`src/backend/docs/openapi-v1/README.md`): wire the six `openapi_v1/mcp/router.py`
handlers — previously stubs raising `NotImplementedError` — to the MCP market,
auth, config and sync services that already back the internal surface.

Second of seven Track B categories, after bots (#494). Its Track A dependency
(Stage 5, #564) merged as `c8d1fb1`, so this branch sits directly on `dev` with
the tenant guard already in place.

## Status — implementation complete (SDD)

Built via SDD; all four phases landed in this PR.

| Phase | Artifact | State |
|---|---|---|
| 1 — specify | `specs/2026-07-30-openapi-v1-mcp-track-b/spec.md` | ✅ |
| 2 — plan | `plan.md` | ✅ |
| 3 — tasks | `tasks.md` (9 tasks, 4 groups) | ✅ |
| 4 — implement | handlers + shared extraction + tests | ✅ |

## Endpoints (all six wired)

| Method | Path | Backing service | Local tables |
|---|---|---|---|
| GET | `/openapi/v1/bots/mcp/servers` | `MCPMarketService` | none |
| GET | `/openapi/v1/bots/mcp/tenants` | `MCPMarketService` | none |
| GET | `/openapi/v1/bots/mcp/servers/{code}` | `MCPMarketService` | none |
| GET | `/openapi/v1/bots/mcp/servers/{code}/permissions` | `MCPAuthService` | none |
| GET | `/openapi/v1/bots/mcp/servers/{code}/config` | `MCPConfigService` | `ac_user_mcp_config` |
| PUT | `/openapi/v1/bots/mcp/servers/{code}/config` | `+ MCPSyncService` | `ac_user_mcp_config`, `ac_bots`, `ac_entity_device_binding` |

First public category that stores **caller-supplied secrets** (API keys, auth
headers) — a read escaping its tenant here leaks a credential, which is why
Stage 5 came first.

## How it's built — extract, don't copy

The internal `/api/mcp` router carried real logic in its handler bodies (the
write→push→rollback sequence, API-key masking, `extInfo` stripping, the
network-type allowlist). Copying it into the public handlers would give two
divergent copies of a **credential-write** flow. Instead that logic moved into
`core/mcp/`, request-agnostic, and **both** routers call it — the pattern #494
established with `create_flow.py`:

- **`core/mcp/presentation.py`** — masking, `extInfo` stripping, network-type allowlist.
- **`core/mcp/config_flow.py`** — the read + the validate→server-exists→write→push→rollback write.
- **`core/mcp/errors.py`** — dependency-free domain errors each surface maps.

The internal router is now a thin adapter over this shared code. The extraction
is proven behavior-preserving: **`test_mcp_config_internal_unchanged.py` and
`test_mcp.py` pass unmodified**, and the gateway MCP contract snapshots are green.

## Decisions delivered

1. **Paths stay nested** (`/openapi/v1/bots/mcp/...`) — resolves the handoff
   README's path divergence for mcp; the router is authoritative.
2. **A failed device push rolls the write back and answers 502** — mirrors the
   internal surface, one write path, no drift.
3. **`sync_mode` dropped** from the write body (no single-device push path
   exists); with `extra="forbid"` it is a 422, not a silent no-op.
4. **`endpoint_env`/`transport_protocol` are strict enums** (`PROD`/`PRE`,
   `SSE`/`STREAMABLE_HTTP`; no `DEV`). Confirmed against a frontend audit — no
   client sends these fields or calls the public surface, so `extra="forbid"`
   has no blast radius.
5. **Fail-open permission preserved** (spec Open Question 1): a marketplace
   outage still reports the caller as permitted. Advisory endpoint — the MCP
   server enforces — pinned by a test and noted in the handler docstring.

## Safety

- **Owner-scoped** via `caller_owner_id(principal)` — the permission endpoint
  has no `user_id` param, so a spoofed `?user_id=` is ignored.
- **Tenant-scoped** by the Stage 5 guard; a config in another tenant is
  invisible and un-overwritable, proven **through the flow the handlers use**
  against the real guard (`test_mcp_tenant_isolation.py`).
- **No raw key in any response** — masking is the only formatter; verified the
  raw key appears nowhere in the response text.

## Testing

New: `test_presentation.py`, `test_mcp_config_flow.py`, `test_mcp_endpoints.py`,
`test_mcp_tenant_isolation.py`, plus MCP error mappings in `test_responses.py`
(~59 cases). Full acceptance-criterion → test matrix in `tasks.md`.

Green locally: adapters/http 384 · MCP+openapi+isolation 338 · architecture 108 ·
MCP contract snapshots 10 · **internal pinned suites unmodified (16)**. No
pre-existing test modified (`test_responses.py` is additions-only).

## Still out of scope

- Permission **application** (the internal apply endpoint is not exposed; adding
  a 7th route is a separate contract change).
- Any Track A work.
- The real caller-identity verifier — the principal stays a stub, so the surface
  answers **401 to every real request** until the auth workstream lands. "Done"
  means handlers, contracts and tests, not an externally callable surface.

## Open questions still worth a reviewer's eye

The three from the spec remain product positions rather than blockers:
(1) fail-open permission on outage — preserved, recommend keeping; (2) no
permission check gating a config write — recommend keeping (diverging would
split the two surfaces); (3) the marketplace can't be tenant-scoped (shared
catalog) — recommend stating as a product position.