### PR TITLE
fix(backend): scope bot chat names by trace owner

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/query_support.py
@@ -264,15 +264,34 @@ def enrich_task_labels(
             break
 
 
-def load_bot_names(session: Any, bot_ids: set[str]) -> dict[str, str]:
-    """Batch-load active Bot names, degrading to an empty map on read failure."""
-    if not bot_ids:
+def _bot_identity(row: Any) -> tuple[str, str] | None:
+    """Return the Trace-owned identity used to resolve a Bot display name."""
+    user_id = getattr(row, "user_id", None)
+    bot_id = getattr(row, "bot_id", None)
+    if not user_id or not bot_id:
+        return None
+    return str(user_id), str(bot_id)
+
+
+def load_bot_names(
+    session: Any,
+    bot_identities: set[tuple[str, str]],
+) -> dict[tuple[str, str], str]:
+    """Batch-load active Bot names by Trace owner and Bot ID."""
+    if not bot_identities:
         return {}
     try:
+        identity_conditions = [
+            and_(
+                BotModel.entity_id == user_id,
+                BotModel.bot_id == bot_id,
+            )
+            for user_id, bot_id in bot_identities
+        ]
         rows = (
             session.query(BotModel)
             .filter(
-                BotModel.bot_id.in_(bot_ids),
+                or_(*identity_conditions),
                 BotModel.is_delete == 0,
                 BotModel.env == get_current_env(),
             )
@@ -286,19 +305,37 @@ def load_bot_names(session: Any, bot_ids: set[str]) -> dict[str, str]:
         )
         return {}
 
-    result: dict[str, str] = {}
+    result: dict[tuple[str, str], str] = {}
     for row in rows:
+        entity_id = getattr(row, "entity_id", None)
         row_bot_id = getattr(row, "bot_id", None)
         bot_name = getattr(row, "bot_name", None)
-        if row_bot_id and row_bot_id not in result and bot_name:
-            result[row_bot_id] = bot_name
+        identity = (
+            (str(entity_id), str(row_bot_id))
+            if entity_id and row_bot_id
+            else None
+        )
+        if identity and identity not in result and bot_name:
+            result[identity] = bot_name
     return result
+
+
+def enrich_bot_names(session: Any, rows: list[Any]) -> None:
+    """Batch-attach owner-scoped Bot names to detached Trace rows."""
+    identities = {
+        identity
+        for row in rows
+        if (identity := _bot_identity(row)) is not None
+    }
+    names = load_bot_names(session, identities)
+    for row in rows:
+        identity = _bot_identity(row)
+        row.bot_name = names.get(identity) if identity else None
 
 
 def enrich_trace_labels(session: Any, row: Any) -> Any:
     """Attach optional Bot, group, and task labels to one detached trace row."""
-    if row.bot_id:
-        row.bot_name = load_bot_names(session, {row.bot_id}).get(row.bot_id)
+    enrich_bot_names(session, [row])
     enrich_task_labels(session, [row])
     session_key = row.session_key
     if not session_key:

--- a/src/backend/src/agentclaw/community/core/bot_chat/repository.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/repository.py
@@ -19,11 +19,11 @@ from agentclaw.community.core.bot_chat.models import (
 from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
 from agentclaw.community.core.bot_chat.query_support import (
     QueryScope,
+    enrich_bot_names,
     enrich_group_labels,
     enrich_task_labels,
     enrich_trace_labels,
     list_group_sessions,
-    load_bot_names,
     load_task_refs,
     match_column,
     task_trace_condition,
@@ -143,6 +143,16 @@ class BotChatDbRepository:
         value = attributes.get("identity.bot_id")
         return str(value) if value else None
 
+    def _metadata_owner_id(self, metadata_json: str | None) -> str | None:
+        metadata = self._safe_json_loads(metadata_json, {})
+        if not isinstance(metadata, dict):
+            return None
+        attributes = metadata.get("attributes") or {}
+        if not isinstance(attributes, dict):
+            return None
+        value = attributes.get("identity.owner_id") or attributes.get("user.id")
+        return str(value) if value else None
+
     def _ref_digest(self, ref_value: str) -> str:
         return f"sha256:{sha256(ref_value.encode('utf-8')).hexdigest()}"
 
@@ -159,7 +169,7 @@ class BotChatDbRepository:
             biz_scene=getattr(row, "biz_scene", None),
             session_id=row.session_id,
             session_key=row.session_id,
-            user_id=row.user_id,
+            user_id=row.user_id or self._metadata_owner_id(row.trace_metadata),
             trace_metadata=row.trace_metadata,
             latency=row.latency,
             total_cost=row.total_cost,
@@ -186,7 +196,7 @@ class BotChatDbRepository:
             biz_scene=row.biz_scene,
             session_id=row.session_id,
             session_key=row.session_key or row.session_id,
-            user_id=row.user_id,
+            user_id=row.user_id or self._metadata_owner_id(row.metadata_json),
             trace_metadata=row.metadata_json,
             latency=row.latency_ms,
             total_cost=row.total_cost,
@@ -459,9 +469,7 @@ class BotChatDbRepository:
             enrich_task_labels(
                 session, rows, preferred_biz_scene, preferred_biz_task_id
             )
-            names = load_bot_names(session, {row.bot_id for row in rows if row.bot_id})
-            for row in rows:
-                row.bot_name = names.get(row.bot_id)
+            enrich_bot_names(session, rows)
 
     def list_traces(
         self,
@@ -577,11 +585,8 @@ class BotChatDbRepository:
 
             detached = [self._detach_trace_row(row) for row in rows]
             enrich_group_labels(session, detached, group_id, group_sessions)
-            bot_names = load_bot_names(
-                session, {row.bot_id for row in detached if row.bot_id}
-            )
+            enrich_bot_names(session, detached)
             for row in detached:
-                row.bot_name = bot_names.get(row.bot_id)
                 if biz_scene or biz_task_id:
                     row.match_sources = ["biz_ref"]
             enrich_task_labels(session, detached, biz_scene, biz_task_id)
@@ -674,15 +679,11 @@ class BotChatDbRepository:
                 for row in rows
             ]
             enrich_group_labels(session, detached, group_id, group_sessions)
-            bot_names = load_bot_names(
-                session,
-                {row.bot_id for row in detached if row.bot_id},
-            )
+            enrich_bot_names(session, detached)
             ref_trace_ids = task_refs.get("trace_id", set())
             ref_session_ids = task_refs.get("session_id", set())
             ref_session_keys = task_refs.get("session_key", set())
             for row in detached:
-                row.bot_name = bot_names.get(row.bot_id)
                 sources = []
                 direct_scene = not biz_scene or (
                     biz_scene in (row.biz_scene or "")

--- a/src/backend/src/agentclaw/community/core/bot_chat/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/service.py
@@ -108,6 +108,10 @@ def _extract_user_input(trace_input: Any) -> str | None:
     return str(trace_input)
 
 
+def _trace_owner_id(trace: dict[str, Any], attributes: dict[str, Any]) -> Any:
+    return trace.get("userId") or attributes.get("identity.owner_id") or attributes.get("user.id")
+
+
 def _map_trace_to_session(trace: dict[str, Any]) -> ConversationSession:
     """Map a Langfuse trace dict to a ConversationSession."""
     metadata_raw = trace.get("metadata") or {}
@@ -146,7 +150,7 @@ def _map_trace_to_session(trace: dict[str, Any]) -> ConversationSession:
         ),
         status="FAILED" if trace.get("success") is False else "SUCCESS",
         timestamp=trace.get("timestamp", ""),
-        user_id=trace.get("userId"),
+        user_id=_trace_owner_id(trace, attributes),
         metadata=SessionMetadata(attributes=attributes),
         total_cost=float(trace.get("totalCost") or 0),
         latency_ms=float(trace.get("latency") or 0),
@@ -859,12 +863,13 @@ class BotChatService(OpenBotChatServiceMixin):
                 metadata_raw = trace_data.get("metadata") or {}
                 attributes = (metadata_raw.get("attributes") or {}) if isinstance(metadata_raw, dict) else {}
                 trace_bot_id = attributes.get("identity.bot_id")
+                trace_owner_id = _trace_owner_id(trace_data, attributes)
 
                 if (
                     trace_bot_id is None
                     or trace_bot_id == "default"
                 ):
-                    if trace_data.get("userId") != owner_id:
+                    if trace_owner_id != owner_id:
                         raise SessionNotFoundError(f"Trace {trace_id} not found or not accessible")
                 else:
                     if not self._db_repo.has_bot_access(owner_id, trace_bot_id):
@@ -904,7 +909,7 @@ class BotChatService(OpenBotChatServiceMixin):
             output=trace_data.get("output"),
             status="FAILED" if trace_data.get("success") is False else "SUCCESS",
             timestamp=trace_data.get("timestamp", ""),
-            user_id=trace_data.get("userId"),
+            user_id=_trace_owner_id(trace_data, attributes),
             metadata=SessionMetadata(attributes=attributes),
             total_cost=float(trace_data.get("totalCost") or 0),
             latency_ms=float(trace_data.get("latency") or 0),

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_product_queries.py
@@ -62,6 +62,7 @@ def _write_trace(
     biz_task_id: str | None = None,
     output: str = "synthetic output",
     user_id: str = "user_fixture",
+    bot_id: str = "bot_fixture",
 ) -> None:
     repo.upsert_ocb_trace(
         {
@@ -71,7 +72,7 @@ def _write_trace(
             "biz_scene": biz_scene,
             "biz_task_id": biz_task_id,
             "user_id": user_id,
-            "bot_id": "bot_fixture",
+            "bot_id": bot_id,
             "name": "Synthetic trace",
             "input": "synthetic input",
             "output": output,
@@ -268,6 +269,145 @@ def test_owner_scope_remains_the_default_for_session_queries():
     assert [row.id for row in owned] == ["trace_owned"]
     assert open_total == 2
     assert {row.id for row in opened} == {"trace_owned", "trace_other"}
+
+
+def test_session_group_and_detail_names_use_each_trace_owner():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    first_key = "agent:main:group_fixture:first"
+    second_key = "agent:main:group_fixture:second"
+    _write_trace(
+        repo,
+        trace_id="trace_first_owner",
+        session_id="shared_session",
+        session_key=first_key,
+        user_id="first_owner",
+        bot_id="default",
+    )
+    _write_trace(
+        repo,
+        trace_id="trace_second_owner",
+        session_id="shared_session",
+        session_key=second_key,
+        user_id="second_owner",
+        bot_id="default",
+    )
+    with db.orm_session() as session:
+        session.add_all(
+            [
+                BotModel(
+                    bot_id="default",
+                    bot_name="First Owner Bot",
+                    entity_id="first_owner",
+                    entity_type="staff",
+                    creator_id="first_owner",
+                    owner_id="first_owner",
+                    env=get_current_env(),
+                ),
+                BotModel(
+                    bot_id="default",
+                    bot_name="Second Owner Bot",
+                    entity_id="second_owner",
+                    entity_type="staff",
+                    creator_id="second_owner",
+                    owner_id="second_owner",
+                    env=get_current_env(),
+                ),
+                BcsGroupSession(
+                    session_id=first_key,
+                    group_id="group_fixture",
+                    env=get_current_env(),
+                ),
+                BcsGroupSession(
+                    session_id=second_key,
+                    group_id="group_fixture",
+                    env=get_current_env(),
+                ),
+            ]
+        )
+
+    by_session_id, session_total = repo.list_ocb_traces(
+        owner_id="first_owner",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        session_id="shared_session",
+    )
+    by_group, group_total = repo.list_ocb_traces(
+        owner_id=None,
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        group_id="group_fixture",
+        query_scope=QueryScope.OPEN,
+    )
+    by_session_key, session_key_total = repo.list_ocb_traces(
+        owner_id="second_owner",
+        from_ms=0,
+        to_ms=2_000,
+        page=1,
+        limit=20,
+        session_key=second_key,
+    )
+    detail = repo.get_ocb_trace("trace_second_owner")
+
+    assert session_total == 1
+    assert by_session_id[0].bot_name == "First Owner Bot"
+    assert session_key_total == 1
+    assert by_session_key[0].bot_name == "Second Owner Bot"
+    assert group_total == 2
+    assert {
+        (row.user_id, row.bot_name)
+        for row in by_group
+    } == {
+        ("first_owner", "First Owner Bot"),
+        ("second_owner", "Second Owner Bot"),
+    }
+    assert detail.user_id == "second_owner"
+    assert detail.bot_name == "Second Owner Bot"
+
+
+def test_bot_name_owner_falls_back_to_trace_metadata():
+    db = _LocalDb()
+    repo = BotChatDbRepository(db)
+    repo.upsert_ocb_trace(
+        {
+            "trace_id": "trace_metadata_owner",
+            "session_id": "session_metadata_owner",
+            "session_key": "agent:main:session_metadata_owner",
+            "user_id": None,
+            "bot_id": "default",
+            "name": "Synthetic trace",
+            "input": "synthetic input",
+            "output": "synthetic output",
+            "metadata": {
+                "attributes": {
+                    "identity.owner_id": "metadata_owner",
+                }
+            },
+            "start_time_ms": 1_000,
+            "usage": {},
+        }
+    )
+    with db.orm_session() as session:
+        session.add(
+            BotModel(
+                bot_id="default",
+                bot_name="Metadata Owner Bot",
+                entity_id="metadata_owner",
+                entity_type="staff",
+                creator_id="metadata_owner",
+                owner_id="metadata_owner",
+                env=get_current_env(),
+            )
+        )
+
+    detail = repo.get_ocb_trace("trace_metadata_owner")
+
+    assert detail.user_id == "metadata_owner"
+    assert detail.bot_name == "Metadata Owner Bot"
 
 
 def test_group_query_normalizes_session_key_and_returns_optional_labels():

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
@@ -1610,16 +1610,26 @@ class TestBotChatServiceGetSession:
                 await service.get_session(trace_id="trace-1", owner_id="user1", log_source="langfuse")
 
     @pytest.mark.asyncio
-    async def test_get_session_langfuse_default_bot_owner_match(self, service):
-        """Langfuse default-bot traces are accessible when userId matches owner_id."""
+    @pytest.mark.parametrize(
+        "owner_fields",
+        [
+            {"userId": "user1"},
+            {"metadata": {"attributes": {"identity.owner_id": "user1"}}},
+            {"metadata": {"attributes": {"user.id": "user1"}}},
+        ],
+    )
+    async def test_get_session_langfuse_default_bot_owner_match(
+        self, service, owner_fields
+    ):
+        """Default-bot traces accept every supported owner representation."""
         trace_response = AsyncMock()
         trace_response.status = 200
         trace_response.json = AsyncMock(return_value={
             "id": "trace-1",
             "name": "Session",
-            "userId": "user1",
             "timestamp": "2025-01-01T00:00:00Z",
             "success": True,
+            **owner_fields,
         })
         trace_response.__aenter__ = AsyncMock(return_value=trace_response)
         trace_response.__aexit__ = AsyncMock(return_value=False)


### PR DESCRIPTION
## 改动说明

  修复 Bot Chat 接口在不同用户使用相同 `bot_id` 时，可能返回错误 `bot_name` 的问题，主要影响 `bot_id=default` 的默认 Bot。

  ## 问题原因

  原实现仅根据 `bot_id` 查询 `ac_bots`：

  ```text
  bot_id → bot_name

  不同用户的默认 Bot 都可能使用 bot_id=default，因此接口可能取到其他用户最新创建的默认 Bot 名称。

  该问题涉及：

  - Trace 详情查询
  - Session ID 查询
  - Session Key 查询
  - Task 聚合查询
  - 群聊聚合查询
  - Open Bot Chat API
  - OTel 及 legacy/Langfuse 数据路径

  此外，Langfuse 详情接口的访问校验只读取 trace.userId。当 userId 缺失、owner 信息只存在于 metadata 时，请求会在名称回填前被错误拒绝。

  ## 修改内容

  - Bot 名称查询由单独使用 bot_id 改为使用 (Trace.user_id, Trace.bot_id) 联合键。
  - 使用 (ac_bots.entity_id, ac_bots.bot_id) 匹配对应 Bot。
  - Trace owner 按以下顺序解析：
      1. Trace user_id / Langfuse userId
      2. metadata.attributes["identity.owner_id"]
      3. metadata.attributes["user.id"]

  - Langfuse 详情鉴权与响应回填统一使用相同的 owner 解析逻辑。
  - 支持群聊及 Open API 同一页包含多个 owner 的 Default Bot，并分别返回正确名称。
  - 找不到 owner 对应的 Bot、Bot 已删除或 owner 信息缺失时，保持返回 bot_name=null。

  ## 兼容性

  本次不修改接口路径、请求参数和响应结构，现有调用方无需额外传递 owner_id。

  普通接口的请求 owner 信息仍用于访问范围控制；bot_name 则根据每条 Trace 自身记录的 owner 信息进行回填。

