### PR TITLE
fix(singlebox): mock IAM token endpoint

### DIFF
--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/caller_identity.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/caller_identity.py
@@ -1,0 +1,42 @@
+"""Singlebox-only Caller IAM token boundary."""
+
+from __future__ import annotations
+
+from injector import Binder, Module, singleton
+
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenOutcome,
+    CallerIdentityStage,
+)
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+
+
+class SingleboxCallerIamTokenService:
+    """Return an opaque token because singlebox has no corporate SSO cookie."""
+
+    async def get_iam_token(
+        self,
+        *,
+        iam_token: str,
+        auth_request: AuthRequestContext,
+        bot_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        is_test_exchange: bool,
+    ) -> CallerIamTokenOutcome:
+        return CallerIamTokenOutcome(iam_token="mock_iam_token")
+
+
+class SingleboxCallerIdentityModule(Module):
+    """Install the no-SSO Caller IAM boundary for the singlebox profile."""
+
+    def configure(self, binder: Binder) -> None:
+        binder.bind(
+            CallerIamTokenServiceProtocol,
+            to=SingleboxCallerIamTokenService,
+            scope=singleton,
+        )

--- a/src/backend/src/agentclaw/community/di/profile_modules.py
+++ b/src/backend/src/agentclaw/community/di/profile_modules.py
@@ -151,11 +151,18 @@ def modules_for(profile: DeployProfile) -> list[Module]:
             from agentclaw.community.di.modules.singlebox_access_module import (
                 SingleboxAccessModule,
             )
+            from agentclaw.community.di.modules.infrastructure.singlebox.caller_identity import (
+                SingleboxCallerIdentityModule,
+            )
             from agentclaw.community.di.modules.infrastructure.singlebox.devices import (
                 SingleboxDevicesModule,
             )
 
-            column.extend([SingleboxDevicesModule(), SingleboxAccessModule()])
+            column.extend([
+                SingleboxDevicesModule(),
+                SingleboxAccessModule(),
+                SingleboxCallerIdentityModule(),
+            ])
 
         return column
 

--- a/src/backend/tests/community/di/test_profile_and_modules_for.py
+++ b/src/backend/tests/community/di/test_profile_and_modules_for.py
@@ -12,6 +12,9 @@ import pytest
 from injector import Injector
 
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
 from agentclaw.community.core.bot_management.services.teclaw_publish_task_handler import (
     TeclawPublishTaskLifecycle,
 )
@@ -47,6 +50,8 @@ from agentclaw.community.plugin_api.http_client import (
     QUALIFIER_MASA_AGENT_EVAL,
     HttpClient,
 )
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+from agentclaw.community.core.caller_identity.contracts import CallerIdentityStage
 from agentclaw.community.plugins.http_client import HttpxClient
 from agentclaw.community.plugins.local.http_client import LocalHttpClient
 from agentclaw.community.plugins.local.policy_service import LocalPolicyService
@@ -189,7 +194,12 @@ def test_test_and_singlebox_have_explicit_access_and_http_bindings():
     assert legacy_access_module not in singlebox_names
 
     assert test_names - {"TestHttpClientModule", "TestDevicesModule"} == (
-        singlebox_names - {"SingleboxAccessModule", "SingleboxDevicesModule"}
+        singlebox_names
+        - {
+            "SingleboxAccessModule",
+            "SingleboxCallerIdentityModule",
+            "SingleboxDevicesModule",
+        }
     )
 
 
@@ -210,6 +220,24 @@ def test_singlebox_profile_resolves_local_policy_and_real_http_clients():
     assert all(
         isinstance(client, HttpxClient) for client in _resolve_http_clients(injector)
     )
+
+
+@pytest.mark.asyncio
+async def test_singlebox_profile_returns_mock_iam_token_without_cookie():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+
+    result = await injector.get(CallerIamTokenServiceProtocol).get_iam_token(
+        iam_token="",
+        auth_request=AuthRequestContext({}, {}, {}, "http://test/"),
+        bot_id=None,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    assert result.iam_token == "mock_iam_token"
 
 
 def test_singlebox_profile_resolves_baas_only_device_runtime():


### PR DESCRIPTION
## 背景
Singlebox 没有企业 SSO 的 `IAM_TOKEN` Cookie，但前端会请求 `/api/v1/token/iam`，此前因此返回 400 并干扰本地 Bot 初始化。

## 修复
仅在 `DEPLOY_PROFILE=singlebox` 的 DI 装配列注入 mock IAM token 服务；其他 profile 保持原有严格校验。

## 验证
- 36 个 profile / Caller Identity 测试通过
- 本地无 IAM_TOKEN Cookie 请求返回 200 和非空 mock token