### PR TITLE
fix(singlebox): validate bot configuration and mock IAM token

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -11,6 +11,7 @@ Provides CRUD operations for bots:
 Each bot is associated with an entity (staff, proj, team) and has its own device.
 """
 import asyncio
+import json
 from typing import Any, List, Literal, Optional
 
 from fastapi import APIRouter, Query, Request, Response, Depends, Path
@@ -2940,8 +2941,24 @@ async def update_engine_config(
                 data=None,
             )
 
-        # Get request body
-        config_data = await request.json()
+        # 引擎配置必须是一个 JSON 对象。显式转换解析/类型错误，避免无效内容
+        # 被通用异常处理为 500，或将数组、字符串等顶层值写进配置文件。
+        try:
+            config_data = await request.json()
+        except json.JSONDecodeError:
+            return ApiResponse(
+                success=False,
+                message="请求体不是有效的 JSON",
+                error_code=400,
+                data=None,
+            )
+        if not isinstance(config_data, dict):
+            return ApiResponse(
+                success=False,
+                message="引擎配置必须是 JSON 对象",
+                error_code=400,
+                data=None,
+            )
 
         effective_engine = engine_type or bot.get("active_engine") or DEFAULT_ENGINE_TYPE
 

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -2129,6 +2129,11 @@ async def update_bot(
         # Get cookie for potential memoryos API call (when yuque_kb_repos changes)
         cookie = request.headers.get("cookie", "")
 
+        # 兼容历史请求字段 name，统一走 bot_name 的校验和更新链路，避免旧客户端
+        # 传入空名称时被静默忽略并返回成功。
+        if "bot_name" not in data and "name" in data:
+            data["bot_name"] = data["name"]
+
         # bot_name 早校验（与 create_bot 对齐）：允许 None（本次不改名），非 None 时
         # 严格校验非法字符/长度，避免脏名落库及污染下游 passport / 同步链路。
         raw_bot_name = data.get("bot_name")

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/caller_identity.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/singlebox/caller_identity.py
@@ -1,0 +1,42 @@
+"""Singlebox-only Caller IAM token boundary."""
+
+from __future__ import annotations
+
+from injector import Binder, Module, singleton
+
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIamTokenOutcome,
+    CallerIdentityStage,
+)
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+
+
+class SingleboxCallerIamTokenService:
+    """Return an opaque token because singlebox has no corporate SSO cookie."""
+
+    async def get_iam_token(
+        self,
+        *,
+        iam_token: str,
+        auth_request: AuthRequestContext,
+        bot_id: str | None,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        is_test_exchange: bool,
+    ) -> CallerIamTokenOutcome:
+        return CallerIamTokenOutcome(iam_token="mock_iam_token")
+
+
+class SingleboxCallerIdentityModule(Module):
+    """Install the no-SSO Caller IAM boundary for the singlebox profile."""
+
+    def configure(self, binder: Binder) -> None:
+        binder.bind(
+            CallerIamTokenServiceProtocol,
+            to=SingleboxCallerIamTokenService,
+            scope=singleton,
+        )

--- a/src/backend/src/agentclaw/community/di/profile_modules.py
+++ b/src/backend/src/agentclaw/community/di/profile_modules.py
@@ -151,11 +151,18 @@ def modules_for(profile: DeployProfile) -> list[Module]:
             from agentclaw.community.di.modules.singlebox_access_module import (
                 SingleboxAccessModule,
             )
+            from agentclaw.community.di.modules.infrastructure.singlebox.caller_identity import (
+                SingleboxCallerIdentityModule,
+            )
             from agentclaw.community.di.modules.infrastructure.singlebox.devices import (
                 SingleboxDevicesModule,
             )
 
-            column.extend([SingleboxDevicesModule(), SingleboxAccessModule()])
+            column.extend([
+                SingleboxDevicesModule(),
+                SingleboxAccessModule(),
+                SingleboxCallerIdentityModule(),
+            ])
 
         return column
 

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -1890,6 +1890,26 @@ class TestUpdateEngineConfig:
         assert body["success"] is False
         assert body["error_code"] == 500
 
+    def test_invalid_json_rejected(self, engine_cfg_client):
+        tc, svc = engine_cfg_client
+        resp = tc.put(
+            "/api/bots/default/engine-config",
+            content="this is not valid json {{{",
+            headers={"content-type": "application/json"},
+        )
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error_code"] == 400
+        svc.write_bot_config.assert_not_awaited()
+
+    def test_non_object_json_rejected(self, engine_cfg_client):
+        tc, svc = engine_cfg_client
+        resp = tc.put("/api/bots/default/engine-config", json=["not", "an", "object"])
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error_code"] == 400
+        svc.write_bot_config.assert_not_awaited()
+
 
 class TestGetEngineConfig:
     """get_engine_config delegates to EngineConfigService.read_bot_config (provider-blind)."""

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -655,6 +655,16 @@ class TestUpdateBot:
         assert "不能为空" in body["message"]
         svc.update_bot.assert_not_called()
 
+    def test_legacy_name_empty_rejected(self, client):
+        # 兼容旧字段 name，不能静默忽略空名称并返回成功。
+        tc, svc, _ = client
+        resp = tc.put("/api/bots/default", json={"name": ""})
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error_code"] == 400
+        assert "不能为空" in body["message"]
+        svc.update_bot.assert_not_called()
+
     def test_invalid_name_too_long_rejected(self, client):
         tc, svc, _ = client
         resp = tc.put("/api/bots/default", json={"bot_name": "x" * 33})

--- a/src/backend/tests/community/di/test_profile_and_modules_for.py
+++ b/src/backend/tests/community/di/test_profile_and_modules_for.py
@@ -12,6 +12,9 @@ import pytest
 from injector import Injector
 
 from agentclaw.community.api.policy_service import PolicyServiceProtocol
+from agentclaw.community.api.caller_iam_token_service import (
+    CallerIamTokenServiceProtocol,
+)
 from agentclaw.community.core.bot_management.services.teclaw_publish_task_handler import (
     TeclawPublishTaskLifecycle,
 )
@@ -47,6 +50,8 @@ from agentclaw.community.plugin_api.http_client import (
     QUALIFIER_MASA_AGENT_EVAL,
     HttpClient,
 )
+from agentclaw.community.plugin_api.auth import AuthRequestContext
+from agentclaw.community.core.caller_identity.contracts import CallerIdentityStage
 from agentclaw.community.plugins.http_client import HttpxClient
 from agentclaw.community.plugins.local.http_client import LocalHttpClient
 from agentclaw.community.plugins.local.policy_service import LocalPolicyService
@@ -189,7 +194,12 @@ def test_test_and_singlebox_have_explicit_access_and_http_bindings():
     assert legacy_access_module not in singlebox_names
 
     assert test_names - {"TestHttpClientModule", "TestDevicesModule"} == (
-        singlebox_names - {"SingleboxAccessModule", "SingleboxDevicesModule"}
+        singlebox_names
+        - {
+            "SingleboxAccessModule",
+            "SingleboxCallerIdentityModule",
+            "SingleboxDevicesModule",
+        }
     )
 
 
@@ -210,6 +220,24 @@ def test_singlebox_profile_resolves_local_policy_and_real_http_clients():
     assert all(
         isinstance(client, HttpxClient) for client in _resolve_http_clients(injector)
     )
+
+
+@pytest.mark.asyncio
+async def test_singlebox_profile_returns_mock_iam_token_without_cookie():
+    injector = build_injector(profile=DeployProfile.SINGLEBOX)
+
+    result = await injector.get(CallerIamTokenServiceProtocol).get_iam_token(
+        iam_token="",
+        auth_request=AuthRequestContext({}, {}, {}, "http://test/"),
+        bot_id=None,
+        stage=CallerIdentityStage.DRAFT,
+        publish_id=None,
+        entity_id=None,
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    assert result.iam_token == "mock_iam_token"
 
 
 def test_singlebox_profile_resolves_baas_only_device_runtime():

--- a/src/engine/src/engine/community/plugins/openclaw/_default_config.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_default_config.py
@@ -18,11 +18,15 @@ class _DefaultConfigPortMixin:
         "/home/admin/agentclaw-daas-scripts/confs/openclaw/openclaw.json"
     )
     _CONFIG_PATH_ENV = "OPENCLAW_DEFAULT_CONFIG_PATH"
+    _MODEL_CONFIG_SOURCE_ENV = "OPENCLAW_MODEL_CONFIG_SOURCE"
 
     def _resolve_config_path(self) -> Path:
         """Resolve the default-config file path from env or fallback default."""
         return Path(
-            os.getenv(self._CONFIG_PATH_ENV, self._DEFAULT_CONFIG_PATH)
+            os.getenv(
+                self._CONFIG_PATH_ENV,
+                os.getenv(self._MODEL_CONFIG_SOURCE_ENV, self._DEFAULT_CONFIG_PATH),
+            )
         ).expanduser()
 
     async def get_default_config(self) -> dict[str, Any]:

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_default_config_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_default_config_port.py
@@ -14,6 +14,7 @@ import pytest
 from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
 
 _ENV = "OPENCLAW_DEFAULT_CONFIG_PATH"
+_MODEL_SOURCE_ENV = "OPENCLAW_MODEL_CONFIG_SOURCE"
 
 
 async def test_reads_and_returns_path_and_config(tmp_path, monkeypatch):
@@ -23,6 +24,19 @@ async def test_reads_and_returns_path_and_config(tmp_path, monkeypatch):
     out = await OpenClawPluginImpl().get_default_config()
     assert out["path"] == str(cfg)
     assert out["config"] == {"model": "gpt-4", "nested": {"a": 1}}
+
+
+async def test_uses_singlebox_model_config_source_when_default_path_is_unset(
+    tmp_path, monkeypatch
+):
+    cfg = tmp_path / "singlebox-openclaw.json"
+    cfg.write_text(json.dumps({"models": {"mode": "merge"}}), encoding="utf-8")
+    monkeypatch.delenv(_ENV, raising=False)
+    monkeypatch.setenv(_MODEL_SOURCE_ENV, str(cfg))
+
+    out = await OpenClawPluginImpl().get_default_config()
+
+    assert out == {"path": str(cfg), "config": {"models": {"mode": "merge"}}}
 
 
 async def test_missing_file_raises_filenotfound(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
修复 singlebox 下 Bot 默认配置读取、配置接口校验与本地 IAM Token 获取。

## 改动
- 使用 singlebox 模型默认配置，避免恢复默认引擎失败。
- 校验 Bot 名称不能为空。
- 校验引擎配置 payload 的 JSON 格式。
- 为 singlebox 注入 mock IAM Token，实现本地无 Cookie 场景下的鉴权接口返回。

## Test Plan
- [x] `DEPLOY_PROFILE=test uv run pytest tests/community/api/bot_management/test_router.py tests/community/di/test_profile_and_modules_for.py tests/community/core/caller_identity/test_iam_token_service.py -q`（178 passed）