### PR TITLE
fix(engine): prevent premature chat stream timeout for long-running tasks

### DIFF
--- a/src/engine/src/engine/community/openclaw/client/gateway_client.py
+++ b/src/engine/src/engine/community/openclaw/client/gateway_client.py
@@ -48,6 +48,8 @@ from engine.community.openclaw.config import OpenClawConfig, get_config
 log = logging.getLogger("openclaw-client")
 _DEBUG = os.getenv("OPENCLAW_DEBUG_EVENTS", "").lower() in {"1", "true", "yes", "on"}
 _DEFAULT_EARLY_FINAL_GRACE_SECONDS = 3.0
+# Long-running subagent workflows can be quiet while work continues upstream.
+_DEFAULT_CHAT_STREAM_TIMEOUT_SECONDS = 20 * 60
 
 
 def _summarize_attachments(attachments: Any) -> dict[str, Any]:
@@ -888,7 +890,11 @@ class OpenClawGatewayClient:
             if not run_id:
                 log.warning("chat.send response missing runId, falling back to unfiltered mode")
 
-            timeout = (timeout_ms / 1000) if timeout_ms else 300
+            timeout = (
+                timeout_ms / 1000
+                if timeout_ms
+                else _DEFAULT_CHAT_STREAM_TIMEOUT_SECONDS
+            )
             while True:
                 try:
                     wait_timeout = (

--- a/src/engine/src/engine/community/openclaw/client/tests/test_gateway_client.py
+++ b/src/engine/src/engine/community/openclaw/client/tests/test_gateway_client.py
@@ -387,6 +387,42 @@ async def test_chat_stream_does_not_hold_final_with_message(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_uses_twenty_minute_default_timeout(monkeypatch):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+    sent_params: Dict[str, Any] = {}
+    observed_timeouts: list[float] = []
+
+    async def fake_send_request(
+        method: str,
+        params: Optional[Dict[str, Any]] = None,
+        timeout: float = 30.0,
+    ) -> ResponseFrame:
+        sent_params.update(params or {})
+        return ResponseFrame.ok_response("rid", {"runId": "run-1"})
+
+    async def fake_wait_for(awaitable, timeout):
+        awaitable.close()
+        observed_timeouts.append(timeout)
+        raise asyncio.TimeoutError
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+
+    events = await _collect(
+        client.chat_stream(
+            session_key="sk-1",
+            message="hello",
+            idempotency_key="run-1",
+        )
+    )
+
+    assert "timeoutMs" not in sent_params
+    assert observed_timeouts == [20 * 60]
+    assert events[0]["errorMessage"] == "Chat stream timeout"
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_timeout_no_event_received(monkeypatch):
     """timeout reason = no_event_received_from_upstream：
     openclaw ack 了但始终不推 event。"""


### PR DESCRIPTION
## Summary

- Extend the default OpenClaw chat stream inactivity timeout from 5 minutes to 20 minutes.
- Preserve the existing behavior when callers explicitly provide `timeoutMs`.
- Add a regression test that verifies the 20-minute default and confirms no implicit `timeoutMs` is forwarded upstream.

## Root Cause

Long-running tasks, especially subagent workflows, can remain quiet while work is still progressing upstream. The adapter previously waited only 300 seconds for the next stream event and then returned `Chat stream timeout`, even though the task could still be running.

## Impact

The adapter now allows up to 20 minutes of stream inactivity by default. Callers that explicitly set `timeoutMs` are unaffected and continue to use their requested timeout.

## Validation

- `PYTHONPATH=src uv run python -m pytest src/engine/community/openclaw/client/tests/test_gateway_client.py -q` (`14 passed`)
- `uv run ruff check src/engine/src/engine/community/openclaw/client/gateway_client.py src/engine/src/engine/community/openclaw/client/tests/test_gateway_client.py`
- Changed production lines covered: 100%