### PR TITLE
fix: retire AICoding active repo corpus after pool cutover

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
@@ -31,4 +31,27 @@ def is_trusted_aicoding_repo_retirement_resume(
     )
 
 
-__all__ = ["is_trusted_aicoding_repo_retirement_resume"]
+def is_trusted_aicoding_repo_restoration_resume(
+    *,
+    state: BotSkillLayoutState,
+    engine: str,
+    probe: RuntimeLayoutProbeResult,
+) -> bool:
+    """Allow an identity-matched Legacy rollback to finish after restoration."""
+
+    return (
+        state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING
+        and probe.status is RuntimeLayoutProbeStatus.INVALID
+        and probe.engine == engine
+        and probe.layout_contract_version == state.layout_contract_version
+        and probe.preparation_id == state.preparation_id
+        and probe.evidence.get("reason") == "active_repo_corpus_present"
+        and probe.evidence.get("implementation_engine") == "aicoding"
+        and probe.evidence.get("physical_layout_engine") == "aicoding"
+    )
+
+
+__all__ = [
+    "is_trusted_aicoding_repo_restoration_resume",
+    "is_trusted_aicoding_repo_retirement_resume",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
@@ -1,0 +1,34 @@
+"""AICoding active-root corpus retirement resume policy."""
+
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutState,
+    SkillLayoutPhase,
+)
+
+
+def is_trusted_aicoding_repo_retirement_resume(
+    *,
+    state: BotSkillLayoutState,
+    engine: str,
+    probe: RuntimeLayoutProbeResult,
+) -> bool:
+    """Allow only the known, committed AICoding finalization to re-enter."""
+
+    return (
+        state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+        and state.data_plane_cutover_committed
+        and probe.status is RuntimeLayoutProbeStatus.INVALID
+        and probe.engine == engine
+        and probe.layout_contract_version == state.layout_contract_version
+        and probe.preparation_id == state.preparation_id
+        and probe.evidence.get("reason") == "active_repo_corpus_present"
+        and probe.evidence.get("implementation_engine") == "aicoding"
+        and probe.evidence.get("physical_layout_engine") == "aicoding"
+    )
+
+
+__all__ = ["is_trusted_aicoding_repo_retirement_resume"]

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -15,8 +15,10 @@ from agentclaw.community.core.bot_management.repository.protocol import (
 )
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     CUTOVER_EVIDENCE_CONTRACT_VERSION,
-    RuntimeLayoutProbeResult,
     RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skills_pool.aicoding_retirement import (
+    is_trusted_aicoding_repo_retirement_resume,
 )
 from agentclaw.community.core.skills_pool.models import (
     FILESYSTEM_POOL_ENGINES,
@@ -161,7 +163,7 @@ class SkillsPoolReconcileService:
             probe.status.value,
         )
         finalizing_repo_retirement_resume = (
-            self._is_trusted_aicoding_repo_retirement_resume(
+            is_trusted_aicoding_repo_retirement_resume(
                 state=state,
                 engine=engine,
                 probe=probe,
@@ -854,34 +856,6 @@ class SkillsPoolReconcileService:
             SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
             preparation_id=probe.preparation_id,
             evidence=probe.evidence,
-        )
-
-    @staticmethod
-    def _is_trusted_aicoding_repo_retirement_resume(
-        *,
-        state: BotSkillLayoutState,
-        engine: str,
-        probe: RuntimeLayoutProbeResult,
-    ) -> bool:
-        """Allow only the known, committed finalizing cleanup to re-enter.
-
-        The runtime probe remains INVALID so a Bot with the full repo in its
-        active root cannot be treated as business-ready. Reconciliation may
-        nevertheless call cutover again when the persisted identity and the
-        runtime's physical AICoding identity prove this is the same
-        forward-only finalization.
-        """
-
-        return (
-            state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
-            and state.data_plane_cutover_committed
-            and probe.status is RuntimeLayoutProbeStatus.INVALID
-            and probe.engine == engine
-            and probe.layout_contract_version == state.layout_contract_version
-            and probe.preparation_id == state.preparation_id
-            and probe.evidence.get("reason") == "active_repo_corpus_present"
-            and probe.evidence.get("implementation_engine") == "aicoding"
-            and probe.evidence.get("physical_layout_engine") == "aicoding"
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.bot_management.repository.protocol import (
 )
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     CUTOVER_EVIDENCE_CONTRACT_VERSION,
+    RuntimeLayoutProbeResult,
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skills_pool.models import (
@@ -159,7 +160,17 @@ class SkillsPoolReconcileService:
             state.data_plane_cutover_committed,
             probe.status.value,
         )
-        if probe.status is not RuntimeLayoutProbeStatus.READY:
+        finalizing_repo_retirement_resume = (
+            self._is_trusted_aicoding_repo_retirement_resume(
+                state=state,
+                engine=engine,
+                probe=probe,
+            )
+        )
+        if (
+            probe.status is not RuntimeLayoutProbeStatus.READY
+            and not finalizing_repo_retirement_resume
+        ):
             if probe.status is RuntimeLayoutProbeStatus.NOT_CAPABLE:
                 if state.data_plane_cutover_committed:
                     recorded = self._layouts.record_post_cutover_failure(
@@ -843,6 +854,34 @@ class SkillsPoolReconcileService:
             SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
             preparation_id=probe.preparation_id,
             evidence=probe.evidence,
+        )
+
+    @staticmethod
+    def _is_trusted_aicoding_repo_retirement_resume(
+        *,
+        state: BotSkillLayoutState,
+        engine: str,
+        probe: RuntimeLayoutProbeResult,
+    ) -> bool:
+        """Allow only the known, committed finalizing cleanup to re-enter.
+
+        The runtime probe remains INVALID so a Bot with the full repo in its
+        active root cannot be treated as business-ready. Reconciliation may
+        nevertheless call cutover again when the persisted identity and the
+        runtime's physical AICoding identity prove this is the same
+        forward-only finalization.
+        """
+
+        return (
+            state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
+            and state.data_plane_cutover_committed
+            and probe.status is RuntimeLayoutProbeStatus.INVALID
+            and probe.engine == engine
+            and probe.layout_contract_version == state.layout_contract_version
+            and probe.preparation_id == state.preparation_id
+            and probe.evidence.get("reason") == "active_repo_corpus_present"
+            and probe.evidence.get("implementation_engine") == "aicoding"
+            and probe.evidence.get("physical_layout_engine") == "aicoding"
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -18,6 +18,9 @@ from agentclaw.community.core.skills_pool.models import (
     PoolSkillMapping,
     SkillMappingSourceLayout,
 )
+from agentclaw.community.core.skills_pool.aicoding_retirement import (
+    is_trusted_aicoding_repo_restoration_resume,
+)
 from agentclaw.community.core.skills_pool.mapping_intent import (
     build_logical_skill_mappings,
     local_locators_from_evidence,
@@ -336,7 +339,15 @@ class SkillsPoolRollbackService:
             user_id=user_id,
             engine=engine,
         )
-        if probe.status is not RuntimeLayoutProbeStatus.READY:
+        restoration_resume = is_trusted_aicoding_repo_restoration_resume(
+            state=state,
+            engine=engine,
+            probe=probe,
+        )
+        if (
+            probe.status is not RuntimeLayoutProbeStatus.READY
+            and not restoration_resume
+        ):
             return self._failure(
                 scope=scope,
                 rollback_generation=rollback_generation,

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -409,6 +409,7 @@ class SkillsPoolRollbackService:
                     # is safe to retry rather than guess filesystem truth.
                     retryable=cutover.status
                     in {
+                        PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING,
                         PoolCutoverStatus.TRANSIENT_ERROR,
                         PoolCutoverStatus.UNKNOWN,
                     },

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -1170,6 +1170,83 @@ async def test_post_cutover_sync_pending_retries_finalization_before_mappings() 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("logical_engine", ["aicoding", "claude_code"])
+async def test_aicoding_finalizing_repo_retirement_invalid_probe_can_resume(
+    logical_engine: str,
+) -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            last_failure_code="POST_CUTOVER_SYNC_PENDING",
+        )
+    )
+    runtime = FakeRuntime(engine=logical_engine)
+    runtime.probe_result = RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.INVALID,
+        engine=logical_engine,
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id=PREPARATION_ID,
+        evidence={
+            "reason": "active_repo_corpus_present",
+            "implementation_engine": "aicoding",
+            "physical_layout_engine": "aicoding",
+        },
+    )
+    runtime.cutover_result = PoolCutoverResult(
+        committed=True,
+        status=PoolCutoverStatus.ALREADY_COMMITTED,
+        evidence={"active_repo_retired": True},
+    )
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine=logical_engine,
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.events == ["evidence", "database"]
+
+
+@pytest.mark.asyncio
+async def test_repo_retirement_invalid_probe_without_physical_identity_stops() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            phase=SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime(engine="aicoding")
+    runtime.probe_result = RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.INVALID,
+        engine="aicoding",
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id=PREPARATION_ID,
+        evidence={"reason": "active_repo_corpus_present"},
+    )
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="aicoding",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="worker-1",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert runtime.events == ["probe"]
+    assert layouts.events == ["post_failure"]
+
+
+@pytest.mark.asyncio
 async def test_finalizing_without_persisted_quarantine_uses_runtime_identity() -> None:
     quarantine = (
         "/home/admin/.aicoding/workspace/skills-pool/"

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -298,6 +298,14 @@ class _ChangedBots:
         return None
 
 
+class _AICodingBots(_Bots):
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> dict[str, object]:
+        value = super().get_by_id_and_entity(bot_id, entity_id)
+        return {**value, "active_engine": "aicoding"}
+
+
 class _Skills:
     local = [
         RegisteredSkillAsset(
@@ -592,3 +600,47 @@ async def test_rollback_post_cutover_sync_pending_is_retryable() -> None:
     assert result.retryable is True
     assert layouts.state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING
     assert layouts.state.last_failure_retryable is True
+
+
+@pytest.mark.asyncio
+async def test_aicoding_rollback_resumes_after_active_repo_restoration() -> None:
+    layouts = _RollbackLayouts()
+    runtime = _RollbackRuntime()
+    runtime.publish_results = [True, True]
+    runtime.probe_result = RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.INVALID,
+        engine="aicoding",
+        layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        preparation_id="preparation-1",
+        evidence={
+            "reason": "active_repo_corpus_present",
+            "implementation_engine": "aicoding",
+            "physical_layout_engine": "aicoding",
+            "mapping_contract_version": MAPPING_CONTRACT_VERSION,
+        },
+    )
+
+    result = await SkillsPoolRollbackService(
+        bot_repository=_AICodingBots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=runtime,
+        edit_guard=_EditGuard(),
+    ).rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="resume restored active repo",
+    )
+
+    assert result.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
+    assert runtime.events == [
+        "probe",
+        "mapping",
+        "verify",
+        "rollback",
+        "mapping",
+        "verify",
+    ]
+    assert layouts.events == ["begin", "cutover", "database"]

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -558,3 +558,37 @@ async def test_rollback_old_runtime_is_fenced_before_v2_mapping_request() -> Non
     assert layouts.events == ["begin", "failure"]
     assert layouts.state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING
     assert layouts.state.last_failure_stage == "runtime_probe"
+
+
+@pytest.mark.asyncio
+async def test_rollback_post_cutover_sync_pending_is_retryable() -> None:
+    class _PendingRollbackRuntime(_RollbackRuntime):
+        async def rollback_to_legacy(self, **kwargs: object) -> PoolCutoverResult:
+            self.events.append("rollback")
+            return PoolCutoverResult(
+                committed=False,
+                status=PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING,
+                evidence={"reason": "active_repo_restoration_required"},
+            )
+
+    layouts = _RollbackLayouts()
+    runtime = _PendingRollbackRuntime()
+    runtime.publish_results = [True]
+    result = await SkillsPoolRollbackService(
+        bot_repository=_Bots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=runtime,
+        edit_guard=_EditGuard(),
+    ).rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="runtime restoration pending",
+    )
+
+    assert result.outcome is SkillsPoolRollbackOutcome.ROLLBACK_FAILED
+    assert result.retryable is True
+    assert layouts.state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING
+    assert layouts.state.last_failure_retryable is True

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -530,6 +530,40 @@ def test_aicoding_rollback_rebuilds_legacy_from_current_pool(
     assert active_repo.is_dir()
 
 
+def test_aicoding_rollback_restoration_io_failure_stays_pending(
+    tmp_path: Path,
+) -> None:
+    home, _, _, _, _, pool_repo = _prepared_home(tmp_path)
+    activated = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+
+    def restore_active_repo(_generation: str, _preparation_id: str):
+        raise OSError(5, "mount failed")
+
+    rolled_back = rollback_aicoding_pool(
+        rollback_generation="rollback-1",
+        registered_local_names=["handmade"],
+        home=home,
+        restore_active_repo=restore_active_repo,
+    )
+
+    assert rolled_back.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert rolled_back.evidence["reason"] == "active_repo_restoration_failed"
+    assert rolled_back.evidence["restoration_reason"] == (
+        "active_repo_restoration_io_error"
+    )
+    assert (
+        home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active"
+    ).is_file()
+
+
 def test_aicoding_publishes_and_verifies_only_its_pool_sources(
     tmp_path: Path,
 ) -> None:

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -16,6 +16,10 @@ from engine.community.plugins.aicoding.layout_pool import (
     rollback_aicoding_pool,
     verify_aicoding_pool_mappings,
 )
+from engine.community.plugins.skills_pool.layout_activation import (
+    ActiveRepoRetirementError,
+    mapping_sources_use_pool,
+)
 
 PREPARATION_ID = "2a958f59-8cf4-4413-a267-7d56d3382f23"
 
@@ -126,6 +130,40 @@ def test_aicoding_probe_uses_own_pool_and_stable_bridges(tmp_path: Path) -> None
     assert invalid.evidence["reason"] == "stable_repo_bridge_invalid"
 
 
+def test_aicoding_stable_repo_authority_follows_active_marker(
+    tmp_path: Path,
+) -> None:
+    home, _, _, repo_bridge, _, _ = _prepared_home(tmp_path)
+    source = repo_bridge / "business" / "shared"
+
+    assert not mapping_sources_use_pool(
+        engine="aicoding",
+        sources=[source],
+        home=home,
+    )
+
+    active_marker = (
+        home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active"
+    )
+    active_marker.write_text(
+        json.dumps(
+            {
+                "engine": "aicoding",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "preparation_id": PREPARATION_ID,
+                "migration_generation": "generation-1",
+                "activation_state": "active",
+            }
+        )
+    )
+
+    assert mapping_sources_use_pool(
+        engine="aicoding",
+        sources=[source],
+        home=home,
+    )
+
+
 def test_aicoding_activation_switches_local_and_keeps_repo_namespace(
     tmp_path: Path,
 ) -> None:
@@ -172,6 +210,182 @@ def test_aicoding_activation_switches_local_and_keeps_repo_namespace(
     )
     assert ready.status is RuntimeLayoutInspectionStatus.READY
     assert ready.evidence["checks"]["stable_repo_bridge_valid"] is True
+
+
+def test_aicoding_activation_retires_full_corpus_from_active_root(
+    tmp_path: Path,
+) -> None:
+    (
+        home,
+        _,
+        local_bridge,
+        _,
+        pool_local,
+        pool_repo,
+    ) = _prepared_home(tmp_path)
+    active_repo = local_bridge.parent / "skills-repo"
+    (active_repo / "business" / "unactivated").mkdir(parents=True)
+    calls: list[tuple[str, str]] = []
+
+    def retire_active_repo(generation: str, preparation_id: str):
+        calls.append((generation, preparation_id))
+        marker = json.loads(
+            (
+                home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active"
+            ).read_text()
+        )
+        assert marker["activation_state"] == "finalizing"
+        (active_repo / "business" / "unactivated").rmdir()
+        (active_repo / "business").rmdir()
+        active_repo.rmdir()
+        return {"status": "retired"}
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(local_bridge.parent / "handmade"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=retire_active_repo,
+    )
+
+    assert result.status is PoolActivationStatus.COMMITTED
+    assert calls == [("generation-1", PREPARATION_ID)]
+    assert not active_repo.exists()
+
+
+def test_aicoding_activation_without_retirement_capability_stays_finalizing(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, _, pool_repo = _prepared_home(tmp_path)
+    active_repo = local_bridge.parent / "skills-repo"
+    active_repo.mkdir()
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert result.evidence["reason"] == "active_repo_retirement_required"
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "finalizing"
+
+
+def test_aicoding_retirement_failure_stays_retryable_finalizing(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, _, pool_repo = _prepared_home(tmp_path)
+    active_repo = local_bridge.parent / "skills-repo"
+    active_repo.mkdir()
+
+    def reject_retirement(_generation: str, _preparation_id: str):
+        raise ActiveRepoRetirementError(
+            "active_repo_unmount_failed",
+            error_type="BusyMount",
+        )
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=reject_retirement,
+    )
+
+    assert result.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert result.evidence["reason"] == "active_repo_retirement_failed"
+    assert result.evidence["retirement_reason"] == "active_repo_unmount_failed"
+    assert result.evidence["error_type"] == "BusyMount"
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "finalizing"
+
+
+def test_aicoding_finalizing_retry_retires_active_repo_and_commits(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, _, pool_repo = _prepared_home(tmp_path)
+    active_repo = local_bridge.parent / "skills-repo"
+    active_repo.mkdir()
+
+    def fail_once(_generation: str, _preparation_id: str):
+        raise ActiveRepoRetirementError("active_repo_unmount_failed")
+
+    first = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=fail_once,
+    )
+    assert first.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+
+    calls = 0
+
+    def retire_on_retry(_generation: str, _preparation_id: str):
+        nonlocal calls
+        calls += 1
+        active_repo.rmdir()
+        return {"status": "retired"}
+
+    retry = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=retire_on_retry,
+    )
+
+    assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert calls == 1
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "active"
+
+
+def test_aicoding_active_probe_rejects_full_corpus_in_active_root(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, _, pool_repo = _prepared_home(tmp_path)
+    activated = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    (local_bridge.parent / "skills-repo").mkdir()
+
+    inspection = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert inspection.status is RuntimeLayoutInspectionStatus.INVALID
+    assert inspection.evidence["reason"] == "active_repo_corpus_present"
 
 
 def test_aicoding_rollback_rebuilds_legacy_from_current_pool(

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -260,6 +260,34 @@ def test_aicoding_activation_retires_full_corpus_from_active_root(
     assert not active_repo.exists()
 
 
+def test_aicoding_activation_reserves_active_repo_corpus_name(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, local_bridge, _, pool_local, pool_repo = _prepared_home(
+        tmp_path
+    )
+    (legacy_local / "skills-repo").mkdir()
+    (legacy_local / "skills-repo" / "SKILL.md").write_text("reserved")
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["skills-repo"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "skills-repo"),
+                target=str(local_bridge.parent / "skills-repo"),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is PoolActivationStatus.INVALID
+    assert result.evidence["reason"] == "mapping_source_invalid"
+    assert result.evidence["failures"][0]["reason"] == "target_invalid"
+
+
 def test_aicoding_activation_without_retirement_capability_stays_finalizing(
     tmp_path: Path,
 ) -> None:
@@ -364,6 +392,75 @@ def test_aicoding_finalizing_retry_retires_active_repo_and_commits(
     assert marker["activation_state"] == "active"
 
 
+def test_aicoding_retirement_revalidates_stable_repo_before_commit(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, repo_bridge, _, pool_repo = _prepared_home(tmp_path)
+    active_repo = local_bridge.parent / "skills-repo"
+    active_repo.mkdir()
+
+    def retire_and_break_bridge(_generation: str, _preparation_id: str):
+        active_repo.rmdir()
+        repo_bridge.unlink()
+        return {"status": "retired"}
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=[],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=retire_and_break_bridge,
+    )
+
+    assert result.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert result.evidence["reason"] == "stable_repo_bridge_invalid"
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "finalizing"
+
+
+def test_aicoding_retirement_revalidates_active_mappings_before_commit(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, local_bridge, _, pool_local, pool_repo = _prepared_home(
+        tmp_path
+    )
+    active_repo = local_bridge.parent / "skills-repo"
+    active_repo.mkdir()
+    target = local_bridge.parent / "handmade"
+
+    def retire_and_repoint_mapping(_generation: str, _preparation_id: str):
+        active_repo.rmdir()
+        target.unlink()
+        target.symlink_to(legacy_local / "handmade", target_is_directory=True)
+        return {"status": "retired"}
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(pool_local / "handmade"),
+                target=str(target),
+            )
+        ],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=retire_and_repoint_mapping,
+    )
+
+    assert result.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert result.evidence["reason"] == "post_retirement_mapping_verify_failed"
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "finalizing"
+
+
 def test_aicoding_active_probe_rejects_full_corpus_in_active_root(
     tmp_path: Path,
 ) -> None:
@@ -404,11 +501,19 @@ def test_aicoding_rollback_rebuilds_legacy_from_current_pool(
     (pool_local / "handmade" / "SKILL.md").write_text("after-activation")
     (pool_local / "new-local").mkdir()
     (pool_local / "new-local" / "SKILL.md").write_text("new")
+    active_repo = home / ".claude" / "skills" / "skills-repo"
+    restore_calls: list[tuple[str, str]] = []
+
+    def restore_active_repo(generation: str, preparation_id: str):
+        restore_calls.append((generation, preparation_id))
+        active_repo.mkdir()
+        return {"restored": True}
 
     rolled_back = rollback_aicoding_pool(
         rollback_generation="rollback-1",
         registered_local_names=["handmade"],
         home=home,
+        restore_active_repo=restore_active_repo,
     )
 
     assert rolled_back.status is PoolActivationStatus.COMMITTED
@@ -421,6 +526,8 @@ def test_aicoding_rollback_rebuilds_legacy_from_current_pool(
     assert (pool_local / "handmade" / "SKILL.md").read_text() == (
         "after-activation"
     )
+    assert restore_calls == [("generation-1", PREPARATION_ID)]
+    assert active_repo.is_dir()
 
 
 def test_aicoding_publishes_and_verifies_only_its_pool_sources(

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -345,6 +345,36 @@ def test_aicoding_retirement_failure_stays_retryable_finalizing(
     assert marker["activation_state"] == "finalizing"
 
 
+def test_aicoding_retirement_io_failure_stays_retryable_finalizing(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, _, pool_repo = _prepared_home(tmp_path)
+    active_repo = local_bridge.parent / "skills-repo"
+    active_repo.mkdir()
+
+    def fail_retirement(_generation: str, _preparation_id: str):
+        raise OSError(16, "mount busy")
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=fail_retirement,
+    )
+
+    assert result.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert result.evidence["reason"] == "active_repo_retirement_failed"
+    assert result.evidence["retirement_reason"] == "active_repo_retirement_io_error"
+    assert result.evidence["errno"] == 16
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "finalizing"
+
+
 def test_aicoding_finalizing_retry_retires_active_repo_and_commits(
     tmp_path: Path,
 ) -> None:

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -476,6 +476,16 @@ def _finalize_active_root(
                     **error.evidence,
                 },
             )
+        except OSError as error:
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "active_repo_retirement_failed",
+                    "retirement_reason": "active_repo_retirement_io_error",
+                    "error_type": type(error).__name__,
+                    "errno": error.errno,
+                },
+            )
         if active_repo.exists() or active_repo.is_symlink():
             return PoolActivationResult(
                 PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -68,6 +68,15 @@ class ActiveRepoRetirementError(RuntimeError):
         self.evidence = evidence
 
 
+class ActiveRepoRestorationError(RuntimeError):
+    """A runtime-owned Legacy active-root corpus could not be restored."""
+
+    def __init__(self, reason: str, **evidence: object) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.evidence = evidence
+
+
 @dataclass(frozen=True, slots=True)
 class SkillMapping:
     source: str
@@ -516,6 +525,36 @@ def _finalize_active_root(
                 "paths": sorted(remaining_storage_entries),
             },
         )
+    if engine in {"aicoding", "hermes"}:
+        try:
+            stable_repo_bridge_valid = (
+                layout.repo_bridge.is_symlink()
+                and _lexical_target(layout.repo_bridge)
+                == Path(os.path.abspath(layout.pool_repo))
+            )
+        except OSError:
+            stable_repo_bridge_valid = False
+        if not stable_repo_bridge_valid:
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "stable_repo_bridge_invalid",
+                    "path": str(layout.repo_bridge),
+                },
+            )
+    final_verification = verify_skill_mappings(
+        mappings=mappings,
+        home=layout.pool_root.parents[2],
+        engine=engine,
+    )
+    if not final_verification.valid:
+        return PoolActivationResult(
+            PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+            {
+                "reason": "post_retirement_mapping_verify_failed",
+                "mapping": final_verification.evidence,
+            },
+        )
     _write_active_marker(
         layout=layout,
         engine=engine,
@@ -706,6 +745,10 @@ def _mapping_plan(
                 layout.local_bridge,
                 layout.repo_bridge,
             }
+            or (
+                layout.engine_type == "aicoding"
+                and target == layout.active_root / "skills-repo"
+            )
         ):
             reason = "target_invalid"
         elif not reason and target in desired and desired[target] != source:
@@ -1707,6 +1750,7 @@ def _rollback_pool(
     registered_local_names: list[str],
     home: str | Path = "/home/admin",
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    restore_active_repo: Callable[[str, str], dict[str, object]] | None = None,
 ) -> PoolActivationResult:
     """Rebuild Legacy from Pool for the pre-recursive-engine rollout window."""
 
@@ -1730,6 +1774,74 @@ def _rollback_pool(
         f".skills-local.pool-rollback-{rollback_generation}"
     )
     copy_staging = layout.pool_root / (f".rollback-copy-{rollback_generation}")
+
+    def finish_legacy_structure() -> PoolActivationResult | None:
+        _restore_legacy_repo_bridge(engine=engine, layout=layout)
+        active_repo = layout.active_root / "skills-repo"
+        if (
+            engine == "aicoding"
+            and current_repo_delivery() is RepoDelivery.MOUNT
+            and not (active_repo.exists() or active_repo.is_symlink())
+        ):
+            if restore_active_repo is None:
+                return PoolActivationResult(
+                    PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                    {
+                        "reason": "active_repo_restoration_required",
+                        "path": str(active_repo),
+                    },
+                )
+            try:
+                active_marker = _read_active_marker(layout.active_marker)
+                if active_marker is None:
+                    return PoolActivationResult(
+                        PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                        {"reason": "active_repo_restoration_identity_unavailable"},
+                    )
+                migration_generation = active_marker.get("migration_generation")
+                preparation_id = active_marker.get("preparation_id")
+                if not isinstance(migration_generation, str) or not isinstance(
+                    preparation_id, str
+                ):
+                    return PoolActivationResult(
+                        PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                        {"reason": "active_repo_restoration_identity_invalid"},
+                    )
+                restoration = restore_active_repo(
+                    migration_generation,
+                    preparation_id,
+                )
+            except ActiveRepoRestorationError as error:
+                return PoolActivationResult(
+                    PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                    {
+                        "reason": "active_repo_restoration_failed",
+                        "restoration_reason": error.reason,
+                        **error.evidence,
+                    },
+                )
+            if not active_repo.is_dir() or active_repo.is_symlink():
+                return PoolActivationResult(
+                    PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                    {
+                        "reason": "active_repo_restoration_unverified",
+                        "path": str(active_repo),
+                        "restoration": restoration,
+                    },
+                )
+        if layout.local_bridge != layout.legacy_local:
+            layout.local_bridge.parent.mkdir(parents=True, exist_ok=True)
+            if (
+                not layout.local_bridge.exists()
+                and not layout.local_bridge.is_symlink()
+            ):
+                layout.local_bridge.symlink_to(
+                    layout.legacy_local,
+                    target_is_directory=True,
+                )
+        layout.active_marker.unlink(missing_ok=True)
+        return None
+
     try:
         if layout.legacy_local.is_dir() and not layout.legacy_local.is_symlink():
             for name in normalized_names:
@@ -1740,6 +1852,9 @@ def _rollback_pool(
                         registered_name=name,
                         source=str(source),
                     )
+            structure_failure = finish_legacy_structure()
+            if structure_failure is not None:
+                return structure_failure
             return PoolActivationResult(
                 PoolActivationStatus.ALREADY_COMMITTED,
                 {
@@ -1789,18 +1904,9 @@ def _rollback_pool(
         # The displaced object is only the compatibility symlink. Pool content
         # itself remains intact for evidence and forward recovery.
         rebuild.unlink(missing_ok=True)
-        _restore_legacy_repo_bridge(engine=engine, layout=layout)
-        if layout.local_bridge != layout.legacy_local:
-            layout.local_bridge.parent.mkdir(parents=True, exist_ok=True)
-            if (
-                not layout.local_bridge.exists()
-                and not layout.local_bridge.is_symlink()
-            ):
-                layout.local_bridge.symlink_to(
-                    layout.legacy_local,
-                    target_is_directory=True,
-                )
-        layout.active_marker.unlink(missing_ok=True)
+        structure_failure = finish_legacy_structure()
+        if structure_failure is not None:
+            return structure_failure
         return PoolActivationResult(
             PoolActivationStatus.COMMITTED,
             {
@@ -1885,6 +1991,7 @@ def rollback_aicoding_pool(
     registered_local_names: list[str],
     home: str | Path = "/home/admin",
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
+    restore_active_repo: Callable[[str, str], dict[str, object]] | None = None,
 ) -> PoolActivationResult:
     return _with_resolution_evidence(
         lambda: _rollback_pool(
@@ -1893,6 +2000,7 @@ def rollback_aicoding_pool(
             registered_local_names=registered_local_names,
             home=home,
             exchange_paths=exchange_paths,
+            restore_active_repo=restore_active_repo,
         ),
         engine="aicoding",
         source_layout=MappingSourceLayout.LEGACY,
@@ -2042,6 +2150,7 @@ def publish_pool_mappings(
 
 
 __all__ = [
+    "ActiveRepoRestorationError",
     "MappingPublishResult",
     "MappingSourceLayout",
     "MappingVerificationResult",

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -1820,6 +1820,16 @@ def _rollback_pool(
                         **error.evidence,
                     },
                 )
+            except OSError as error:
+                return PoolActivationResult(
+                    PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                    {
+                        "reason": "active_repo_restoration_failed",
+                        "restoration_reason": "active_repo_restoration_io_error",
+                        "error_type": type(error).__name__,
+                        "errno": error.errno,
+                    },
+                )
             if not active_repo.is_dir() or active_repo.is_symlink():
                 return PoolActivationResult(
                     PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -59,6 +59,15 @@ class MappingSourceLayout(StrEnum):
     LEGACY = "legacy"
 
 
+class ActiveRepoRetirementError(RuntimeError):
+    """A runtime-owned active-root corpus could not be safely retired."""
+
+    def __init__(self, reason: str, **evidence: object) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.evidence = evidence
+
+
 @dataclass(frozen=True, slots=True)
 class SkillMapping:
     source: str
@@ -133,6 +142,11 @@ def mapping_sources_use_pool(
             layout.repo_bridge,
         )
     )
+    stable_repo_root = (
+        Path(os.path.abspath(layout.repo_bridge))
+        if engine in {"aicoding", "hermes"}
+        else None
+    )
     has_pool = False
     has_legacy = False
     for raw_source in sources:
@@ -142,6 +156,13 @@ def mapping_sources_use_pool(
         normalized = Path(os.path.abspath(source))
         if any(normalized.is_relative_to(root) for root in pool_roots):
             has_pool = True
+        elif stable_repo_root is not None and normalized.is_relative_to(
+            stable_repo_root
+        ):
+            if _active_marker_selects_pool(layout=layout, engine=engine):
+                has_pool = True
+            else:
+                has_legacy = True
         elif any(normalized.is_relative_to(root) for root in legacy_roots):
             has_legacy = True
     if has_pool and has_legacy:
@@ -194,6 +215,8 @@ def _retired_storage_entries(
     """
 
     entries = [layout.legacy_local, layout.local_bridge]
+    if engine == "aicoding":
+        entries.append(layout.active_root / "skills-repo")
     if engine in {"openclaw", "claude_code"} and not (
         engine == "openclaw"
         and current_repo_delivery() is RepoDelivery.DOWNLOAD
@@ -384,6 +407,7 @@ def _finalize_active_root(
     mappings: list[SkillMapping],
     quarantine: Path,
     retire_path: Callable[[Path, Path], None],
+    retire_active_repo: Callable[[str, str], dict[str, object]] | None,
 ) -> PoolActivationResult | None:
     published = publish_pool_mappings(
         mappings=mappings,
@@ -419,6 +443,39 @@ def _finalize_active_root(
         mappings=mappings,
         activation_state="finalizing",
     )
+    active_repo = layout.active_root / "skills-repo"
+    if engine == "aicoding" and (active_repo.exists() or active_repo.is_symlink()):
+        if retire_active_repo is None:
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "active_repo_retirement_required",
+                    "path": str(active_repo),
+                },
+            )
+        try:
+            retirement_evidence = retire_active_repo(
+                migration_generation,
+                preparation_id,
+            )
+        except ActiveRepoRetirementError as error:
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "active_repo_retirement_failed",
+                    "retirement_reason": error.reason,
+                    **error.evidence,
+                },
+            )
+        if active_repo.exists() or active_repo.is_symlink():
+            return PoolActivationResult(
+                PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+                {
+                    "reason": "active_repo_retirement_unverified",
+                    "path": str(active_repo),
+                    "retirement": retirement_evidence,
+                },
+            )
     _residue_evidence, residue_failure = _capture_recreated_legacy_local(
         layout=layout,
         quarantine=quarantine,
@@ -1077,6 +1134,7 @@ def _activate_pool(
     home: str | Path = "/home/admin",
     repo_is_mounted: Callable[[Path], bool] | None = None,
     retire_path: Callable[[Path, Path], None] = os.replace,
+    retire_active_repo: Callable[[str, str], dict[str, object]] | None = None,
     before_legacy_retire: Callable[[], None] | None = None,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
@@ -1107,16 +1165,35 @@ def _activate_pool(
             error=str(error),
         )
 
+    active_marker = _read_active_marker(layout.active_marker)
+    if active_marker is not None and (
+        active_marker.get("engine") != engine
+        or active_marker.get("layout_contract_version") != LAYOUT_CONTRACT_VERSION
+        or active_marker.get("preparation_id") != preparation_id
+        or active_marker.get("migration_generation") != migration_generation
+        or active_marker.get("activation_state") not in {"finalizing", "active"}
+    ):
+        return _invalid("active_marker_identity_mismatch")
+
     inspection = inspect_runtime_layout(
         engine=engine,
         expected_contract_version=LAYOUT_CONTRACT_VERSION,
         home=home_path,
         repo_is_mounted=repo_is_mounted or os.path.ismount,
     )
-    if (
-        inspection.status is not RuntimeLayoutInspectionStatus.READY
-        or inspection.preparation_id != preparation_id
-    ):
+    layout_ready = (
+        inspection.status is RuntimeLayoutInspectionStatus.READY
+        and inspection.preparation_id == preparation_id
+    )
+    trusted_finalizing_retirement_retry = (
+        engine == "aicoding"
+        and active_marker is not None
+        and active_marker.get("activation_state") == "finalizing"
+        and inspection.status is RuntimeLayoutInspectionStatus.INVALID
+        and inspection.preparation_id == preparation_id
+        and inspection.evidence.get("reason") == "active_repo_corpus_present"
+    )
+    if not layout_ready and not trusted_finalizing_retirement_retry:
         return _invalid(
             "runtime_layout_not_ready",
             probe_status=inspection.status.value,
@@ -1135,16 +1212,7 @@ def _activate_pool(
     baseline_path = layout.pool_root / (
         f".cutover-baseline-{migration_generation}.json"
     )
-    active_marker = _read_active_marker(layout.active_marker)
     if active_marker is not None:
-        if (
-            active_marker.get("engine") != engine
-            or active_marker.get("layout_contract_version") != LAYOUT_CONTRACT_VERSION
-            or active_marker.get("preparation_id") != preparation_id
-            or active_marker.get("migration_generation") != migration_generation
-            or active_marker.get("activation_state") not in {"finalizing", "active"}
-        ):
-            return _invalid("active_marker_identity_mismatch")
         if active_marker.get("activation_state") == "finalizing":
             ownership_failure = _ensure_quarantine_generation_owned(
                 quarantine=quarantine,
@@ -1164,6 +1232,7 @@ def _activate_pool(
                 mappings=mappings,
                 quarantine=quarantine,
                 retire_path=retire_path,
+                retire_active_repo=retire_active_repo,
             )
         except OSError as error:
             return PoolActivationResult(
@@ -1231,6 +1300,7 @@ def _activate_pool(
                 mappings=mappings,
                 quarantine=quarantine,
                 retire_path=retire_path,
+                retire_active_repo=retire_active_repo,
             )
             if completion_failure is not None:
                 return completion_failure
@@ -1299,6 +1369,7 @@ def _activate_pool(
                 mappings=mappings,
                 quarantine=quarantine,
                 retire_path=retire_path,
+                retire_active_repo=retire_active_repo,
             )
             if completion_failure is not None:
                 return completion_failure
@@ -1427,6 +1498,7 @@ def _activate_pool(
             mappings=mappings,
             quarantine=quarantine,
             retire_path=retire_path,
+            retire_active_repo=retire_active_repo,
         )
         if completion_failure is not None:
             return completion_failure
@@ -1568,6 +1640,7 @@ def activate_aicoding_pool(
     repo_is_mounted: Callable[[Path], bool] | None = None,
     exchange_paths: Callable[[Path, Path], bool] = atomic_exchange_paths,
     retire_path: Callable[[Path, Path], None] = os.replace,
+    retire_active_repo: Callable[[str, str], dict[str, object]] | None = None,
     before_legacy_retire: Callable[[], None] | None = None,
     before_post_sync: Callable[[], None] | None = None,
 ) -> PoolActivationResult:
@@ -1582,6 +1655,7 @@ def activate_aicoding_pool(
             home=home,
             repo_is_mounted=repo_is_mounted,
             retire_path=retire_path,
+            retire_active_repo=retire_active_repo,
             before_legacy_retire=before_legacy_retire,
             before_post_sync=before_post_sync,
         ),

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -707,6 +707,17 @@ def inspect_runtime_layout(
                 reason="active_marker_contract_mismatch",
                 preparation_id=preparation_id,
             )
+        active_repo_corpus = layout.active_root / "skills-repo"
+        if engine == "aicoding" and (
+            active_repo_corpus.exists() or active_repo_corpus.is_symlink()
+        ):
+            return _invalid(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="active_repo_corpus_present",
+                preparation_id=preparation_id,
+            )
         if active_marker["activation_state"] == "active":
             retired_bridges = [("local", layout.local_bridge)]
             if engine in {"openclaw", "claude_code"} and not (


### PR DESCRIPTION
## Summary

- retire the historical full-repo entry from the AICoding active Skills root only during trusted Pool finalization
- keep runtime probe fail-closed while allowing the same committed finalizing generation to retry safely
- classify the stable AICoding/Hermes repo namespace as Pool authority only when a valid active marker exists
- preserve Legacy and pure Claude Code behavior

## Contract and compatibility

- Legacy Bots keep their historical active-root repo delivery
- unknown marker identity, unknown objects, and ordinary INVALID probes remain blocked
- mixed logical claude_code + physical AICoding runtimes are admitted only with explicit physical identity evidence

## Tests

- Backend Skills Pool suite: 243 passed
- Engine community suite: 2146 passed, 5 skipped
- AICoding corp suite (in OCB companion): 681 passed
- targeted cross-engine suite: 116 passed
- ruff and git diff --check passed