### PR TITLE
fix(backend): confine the "default" bot_id to the default tenant (#556)

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -387,20 +387,18 @@ async def update_bot(
         owner_id,
         bot_name=bot_name,
         bot_desc=body.bot_desc,
-        # BCN sync is OFF on this surface until the coordination-network
-        # identity carries a tenant. ``_sync_bot_to_bcn`` builds it as
-        # ``f"{bot_id}:{owner_id}"``, and ``bot_id`` is only unique per owner —
-        # every owner's first bot is "default" — so two tenants sharing a
-        # principal resolve to ONE BCN record and either can overwrite the
-        # other's name and summary. Local rows stay isolated by the tenant
-        # guard; this identifier escapes it.
-        #
-        # A stale BCN name is a much smaller problem than a cross-tenant write,
-        # so this stays off until the BCN contract gains a tenant axis. One line
-        # to re-enable then. See the F49 thread on PR #494.
-        sync_to_bcn=False,
-        # Bearer token only — see _bcn_auth_headers. Kept so re-enabling the
-        # sync does not silently reintroduce the unauthenticated call F37 fixed.
+        # BCN sync is ON again (R14/F49 stopgap lifted). ``_sync_bot_to_bcn``
+        # keys on ``f"{bot_id}:{owner_id}"``, which used to collide across
+        # tenants because every owner's first bot was "default". It no longer
+        # can: ``generate_bot_id`` confines that shortcut to the default tenant,
+        # so any other tenant's bots carry a generated ``yyyymmdd_xxxxxxxx`` id
+        # and the composite is distinct even for one owner present in two
+        # tenants. The identity became unique instead of gaining a tenant field,
+        # but the cross-tenant write the stopgap guarded is gone either way.
+        # See #556.
+        # Bearer token only — see _bcn_auth_headers. Kept from the stopgap so
+        # the re-enabled sync cannot regress to the unauthenticated call F37
+        # fixed.
         request_headers=_bcn_auth_headers(request),
     )
     # Identity metadata lives in the Passport too; leaving it stale would make

--- a/src/backend/src/agentclaw/community/api/bot_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_service.py
@@ -38,6 +38,11 @@ class BotServiceProtocol(Protocol):
 
     def check_create_bot_preflight(self, *args: Any, **kwargs: Any) -> Any: ...
 
+    # Whether the owner has no bots yet. ``create_flow`` calls this on the
+    # injected service to choose the first-bot passport application, so it is
+    # part of the surface adapters depend on — not an internal helper.
+    def is_first_bot(self, *args: Any, **kwargs: Any) -> Any: ...
+
     # The ceiling creation actually enforces (per-user policy, falling back to
     # the configured allocation limit). Exposed so a surface that *reports* the
     # quota resolves it the same way, instead of re-deriving the precedence and

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -326,7 +326,14 @@ def create_bot_with_authorization(
     # Validate the name up front so an invalid one never reaches Passport or
     # create. An unset name stays unset — create_bot applies default naming.
     bot_name = validate_bot_name(spec.bot_name) if spec.bot_name is not None else None
-    is_first_bot = bot_id == "default"
+    # Ask the repository, not the id. ``bot_id == "default"`` was a proxy that
+    # held only while every owner's first bot was "default"; ``generate_bot_id``
+    # confines that shortcut to the default tenant, so elsewhere a genuinely
+    # first bot carries a generated id and the proxy would pick
+    # ``apply_agent_passport`` for an owner who has never had a Passport.
+    # Safe here because the new bot's row is not inserted until ``create_bot``,
+    # further down this flow.
+    is_first_bot = bot_service.is_first_bot(user_id)
 
     # Pre-flight before Passport, so a limit or a taken name is reported before
     # the user is sent through authorization and before an external Passport

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -65,7 +65,11 @@ from agentclaw.community.core.workspace.path_factory import (
 )
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
-from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
+from agentclaw.community.utils.avernet_tenant import (
+    DEFAULT_AVERNET_TENANT,
+    bind_current_avernet_tenant,
+    get_current_avernet_tenant,
+)
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.core.devices.errors import (
     DeviceNotFoundError,
@@ -245,8 +249,25 @@ def generate_bot_id(owner_id: str, bot_repository: BotRepository) -> str:
     Generate bot_id based on owner's bot history.
 
     Rules:
-    - If user has no bot with id "default", return "default"
+    - In the default tenant, if the user has no bot with id "default", return
+      "default"
     - Otherwise, return "yyyymmdd_{random_8_chars}"
+
+    The ``"default"`` shortcut is confined to the default tenant on purpose.
+    ``bot_id`` is unique only per owner *per tenant*, and the read below goes
+    through the ``BotModel`` tenant guard — so a second tenant asking "does this
+    owner already have a 'default' bot?" cannot see the first tenant's row and
+    correctly answers no. Both tenants would then mint ``bot_id="default"`` for
+    the same owner, and the identities we derive from it are handed to systems
+    that have no tenant field to tell them apart: the passport service's
+    principal, keyed on ``(bot_id, owner)``; the ``agent_code`` it issues for
+    that principal; and the coordination-network record keyed on
+    ``"{bot_id}:{owner_id}"``.
+
+    A generated ``yyyymmdd_xxxxxxxx`` id is unique on its own, so restricting
+    the shortcut keeps every external identity collision-free without changing
+    a single external contract. Existing bots are unaffected: they all belong to
+    the default tenant and keep ``"default"``.
 
     Args:
         owner_id: Owner user ID
@@ -256,7 +277,10 @@ def generate_bot_id(owner_id: str, bot_repository: BotRepository) -> str:
         Bot ID as string ("default" or "yyyymmdd_xxxx")
     """
     # Check if owner already has a bot with id "default"
-    if not bot_repository.exists_by_owner_and_bot_id(owner_id, "default"):
+    if (
+        get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT
+        and not bot_repository.exists_by_owner_and_bot_id(owner_id, "default")
+    ):
         logger.info(f"[bot_service.generate_bot_id] Owner {owner_id} has no 'default' bot, using 'default' as bot_id")
         return "default"
 
@@ -265,7 +289,11 @@ def generate_bot_id(owner_id: str, bot_repository: BotRepository) -> str:
     # Generate 8 random lowercase letters and digits
     random_part = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
     bot_id = f"{date_part}_{random_part}"
-    logger.info(f"[bot_service.generate_bot_id] Owner {owner_id} already has 'default' bot, using generated bot_id: {bot_id}")
+    logger.info(
+        f"[bot_service.generate_bot_id] Owner {owner_id} is not eligible for the "
+        f"'default' bot_id (tenant={get_current_avernet_tenant()}), "
+        f"using generated bot_id: {bot_id}"
+    )
     return bot_id
 
 
@@ -792,17 +820,27 @@ class BotService:
             logger.error(f"[get_bot_by_ip_and_user] Error querying bot by IP {ip} and user {user_id}: {e}")
             return None
 
-    def _is_first_bot(self, user_id: str) -> bool:
+    def is_first_bot(self, user_id: str) -> bool:
         """
-        Check if this is the user's first bot (user has no bot with id "default").
+        Check whether the user has no bots yet.
+
+        Asks the repository how many bots the owner has rather than testing for
+        a bot with id ``"default"``. The id test was a proxy that only held while
+        every owner's first bot was ``"default"``; ``generate_bot_id`` confines
+        that shortcut to the default tenant, so in any other tenant a genuinely
+        first bot carries a generated id and the proxy would answer False —
+        sending the create flow down the non-first-bot Passport branch.
+
+        Must be called before the new bot's row is inserted; both call sites
+        (:meth:`_resolve_bot_name` and ``create_flow``) run pre-insert.
 
         Args:
             user_id: User ID to check
 
         Returns:
-            True if user has no "default" bot, False otherwise
+            True if the user owns no bots, False otherwise
         """
-        return not self._repository.exists_by_owner_and_bot_id(user_id, "default")
+        return self._repository.count_by_owner(user_id) == 0
 
     def _check_bot_count_limit(self, owner_id: str) -> None:
         """Enforce the per-owner bot count limit.
@@ -1045,7 +1083,7 @@ class BotService:
             return bot_name.strip()
 
         # Check if this is the first bot for the user
-        is_first = self._is_first_bot(user_id)
+        is_first = self.is_first_bot(user_id)
 
         if is_first:
             # First bot: use nick_name (花名) as default

--- a/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
@@ -19,6 +19,10 @@ from agentclaw.community.core.skill_center.factories import SkillSetServiceFacto
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
 from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.utils.avernet_tenant import (
+    DEFAULT_AVERNET_TENANT,
+    get_current_avernet_tenant,
+)
 
 if TYPE_CHECKING:
     from agentclaw.community.core.bot_management.services.bot_service import BotService
@@ -73,6 +77,20 @@ class CreateBotForOthersService:
         cookie: str,
     ) -> dict[str, Any]:
         """Create or repair one target user's default bot serially."""
+        # This service writes ``bot_id="default"`` directly rather than going
+        # through ``generate_bot_id``, so it is the one path that can still mint
+        # a colliding id. ``generate_bot_id`` confines "default" to the default
+        # tenant precisely because the Passport principal and BCN record derived
+        # from it carry no tenant field; creating one here for another tenant
+        # would reintroduce that collision. Fail closed instead: a non-default
+        # tenant has no "default" bots by construction, so the operation has no
+        # meaning there.
+        tenant = get_current_avernet_tenant()
+        if tenant != DEFAULT_AVERNET_TENANT:
+            raise CreateBotForOthersError(
+                "create-for-others is only available in the default tenant",
+                error_code=400,
+            )
         with self._target_locks_guard:
             lock_entry = self._target_locks.get(target_user_id)
             if lock_entry is None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -811,16 +811,22 @@ def test_auth_status_defaulted_engine_passes_when_configured(client, svc, passpo
 # ----- round-14 review regressions ------------------------------------------
 
 
-def test_update_does_not_sync_to_bcn(client, svc):
-    """R14/F49: the BCN identity has no tenant axis, so this surface stays out.
+def test_update_syncs_to_bcn(client, svc):
+    """R14/F49 stopgap lifted: the BCN identity can no longer collide (#556).
 
-    ``_sync_bot_to_bcn`` keys on ``f"{bot_id}:{owner_id}"``; ``bot_id`` is only
-    unique per owner, so two tenants sharing a principal resolve to one BCN
-    record and either can overwrite the other's. Stopgap until the BCN contract
-    carries a tenant — a stale name beats a cross-tenant write.
+    ``_sync_bot_to_bcn`` keys on ``f"{bot_id}:{owner_id}"``. That collided while
+    every owner's first bot was ``"default"`` — two tenants sharing a principal
+    resolved to one BCN record and either could overwrite the other's name and
+    summary. ``generate_bot_id`` now confines the ``"default"`` shortcut to the
+    default tenant, so any other tenant's bots carry a generated id and the
+    composite is distinct even for one owner present in both.
+
+    Asserting the default rather than an explicit ``True``: the point is that
+    this surface no longer opts out, so a re-introduced ``sync_to_bcn=False``
+    fails here.
     """
     _ok(client.put("/openapi/v1/bots/b1", json={"bot_name": "Renamed"}))
-    assert svc.update_bot.call_args.kwargs["sync_to_bcn"] is False
+    assert svc.update_bot.call_args.kwargs.get("sync_to_bcn", True) is not False
 
 
 def test_update_still_carries_the_bearer_token(client, svc):

--- a/src/backend/tests/community/contracts/gateway/test_rule01_bot_management.py
+++ b/src/backend/tests/community/contracts/gateway/test_rule01_bot_management.py
@@ -59,6 +59,9 @@ def _bind_bot(app):
     svc.delete_bot.return_value = True
     svc.check_bot_name_exists.return_value = False
     svc.restart_bot.return_value = {"bot_id": "bot_test_001", "status": "RESTARTING"}
+    # create_flow asks the service whether this is the owner's first bot, and the
+    # response contract types passport.is_first_bot as a boolean.
+    svc.is_first_bot.return_value = True
     bind_mock_service(BotService, svc, app)
     return svc
 

--- a/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
@@ -531,3 +531,43 @@ def test_restart_wait_treats_naive_iso_string_as_utc(monkeypatch):
     )
 
     assert result == (10, 20)
+
+
+def test_execute_is_refused_outside_the_default_tenant():
+    """This service writes ``bot_id="default"`` directly, bypassing generate_bot_id.
+
+    ``generate_bot_id`` confines the ``"default"`` shortcut to the default tenant
+    because the Passport principal and BCN record derived from it carry no tenant
+    field. Minting one here for another tenant would reintroduce exactly that
+    collision, so the operation fails closed instead (issue #556).
+    """
+    from agentclaw.community.core.bot_management.errors import CreateBotForOthersError
+    from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+    service, repository, bot_service, passport, _, _ = _service()
+
+    with avernet_tenant_scope("acme"):
+        with pytest.raises(CreateBotForOthersError) as excinfo:
+            _execute(service)
+
+    assert excinfo.value.error_code == 400
+    # Fails before any lookup, Passport mint, or create.
+    repository.get_by_id_and_owner.assert_not_called()
+    passport.apply_first_agent_passport.assert_not_called()
+    bot_service.create_bot.assert_not_called()
+
+
+def test_execute_still_runs_in_the_default_tenant():
+    """The guard must not change existing behavior for the internal API path."""
+    from agentclaw.community.utils.avernet_tenant import (
+        DEFAULT_AVERNET_TENANT,
+        avernet_tenant_scope,
+    )
+
+    service, _, bot_service, _, _, _ = _service()
+
+    with avernet_tenant_scope(DEFAULT_AVERNET_TENANT):
+        result = _execute(service)
+
+    assert result["bot_id"] == "default"
+    bot_service.create_bot.assert_called_once()

--- a/src/backend/tests/community/core/bot_management/test_bot_id_tenant_uniqueness.py
+++ b/src/backend/tests/community/core/bot_management/test_bot_id_tenant_uniqueness.py
@@ -1,0 +1,141 @@
+"""``bot_id`` never collides across tenants, and "first bot" is a data question.
+
+``bot_id`` is unique only per owner *per tenant*, and the ``"default"`` shortcut
+in ``generate_bot_id`` reads through the ``BotModel`` tenant guard — so a second
+tenant asking "does this owner already have a 'default' bot?" cannot see the
+first tenant's row and correctly answers no. Both tenants would then mint
+``bot_id="default"`` for the same owner, and every identity derived from it is
+handed to a system with no tenant field to disambiguate it: the Passport /
+AgentPass principal keyed on ``(botId, ownerWorkno)``, the ``agent_code``
+AgentPass returns, and the BCN record keyed on ``"{bot_id}:{owner_id}"``.
+
+Confining the shortcut to the default tenant fixes all of them at the source,
+with no change to any external contract. Two properties have to hold together:
+
+1. Non-default tenants never mint ``"default"`` (the fix), **and**
+2. the default tenant's ids are byte-identical to before (no re-keying of
+   Passport principals or BCN records that already exist).
+
+Regression for issue #556.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotService,
+    generate_bot_id,
+)
+from agentclaw.community.utils.avernet_tenant import (
+    DEFAULT_AVERNET_TENANT,
+    avernet_tenant_scope,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def repo_without_default():
+    """An owner who has no ``"default"`` bot yet in the current tenant."""
+    repo = MagicMock()
+    repo.exists_by_owner_and_bot_id.return_value = False
+    return repo
+
+
+def _bare_service(repository) -> BotService:
+    """Only the slice ``is_first_bot`` touches."""
+    svc = BotService.__new__(BotService)
+    svc._repository = repository
+    return svc
+
+
+class TestDefaultTenantIsUnchanged:
+    """The fix must not re-key any identity that already exists."""
+
+    def test_default_tenant_still_mints_default(self, repo_without_default):
+        with avernet_tenant_scope(DEFAULT_AVERNET_TENANT):
+            assert generate_bot_id("85020", repo_without_default) == "default"
+
+    def test_outside_any_request_still_mints_default(self, repo_without_default):
+        # get_current_avernet_tenant() is total: background work and ad-hoc
+        # scripts run as the default tenant, and must keep the old behavior.
+        assert generate_bot_id("85020", repo_without_default) == "default"
+
+    def test_default_tenant_second_bot_is_generated(self):
+        repo = MagicMock()
+        repo.exists_by_owner_and_bot_id.return_value = True
+
+        with avernet_tenant_scope(DEFAULT_AVERNET_TENANT):
+            bot_id = generate_bot_id("85020", repo)
+
+        assert bot_id != "default"
+        assert len(bot_id) == 17  # yyyymmdd + "_" + 8 random chars
+
+
+class TestOtherTenantsNeverMintDefault:
+    """The collision itself: same owner, two tenants, distinct ids."""
+
+    def test_non_default_tenant_gets_generated_id(self, repo_without_default):
+        with avernet_tenant_scope("acme"):
+            bot_id = generate_bot_id("85020", repo_without_default)
+
+        assert bot_id != "default"
+        assert len(bot_id) == 17
+
+    def test_same_owner_across_tenants_does_not_collide(self, repo_without_default):
+        """The exact scenario in #556: every owner's first bot was "default"."""
+        with avernet_tenant_scope(DEFAULT_AVERNET_TENANT):
+            first = generate_bot_id("85020", repo_without_default)
+        with avernet_tenant_scope("acme"):
+            second = generate_bot_id("85020", repo_without_default)
+
+        assert first == "default"
+        assert second != first
+
+    def test_two_non_default_tenants_do_not_collide(self, repo_without_default):
+        with avernet_tenant_scope("acme"):
+            first = generate_bot_id("85020", repo_without_default)
+        with avernet_tenant_scope("globex"):
+            second = generate_bot_id("85020", repo_without_default)
+
+        assert first != "default"
+        assert second != "default"
+        assert first != second
+
+    def test_shortcut_read_is_skipped_entirely(self, repo_without_default):
+        """No point asking a tenant-scoped question whose answer cannot be used."""
+        with avernet_tenant_scope("acme"):
+            generate_bot_id("85020", repo_without_default)
+
+        repo_without_default.exists_by_owner_and_bot_id.assert_not_called()
+
+
+class TestIsFirstBotIsDataDriven:
+    """``is_first_bot`` must not infer "first" from the id being "default".
+
+    It selects ``apply_first_agent_passport`` vs ``apply_agent_passport`` in
+    ``create_flow``. Inferring it from the id string answers False for a
+    genuinely-first bot in any tenant that does not mint ``"default"``, which
+    would send a brand-new owner down the non-first-bot Passport branch.
+    """
+
+    def test_no_bots_is_first(self):
+        repo = MagicMock()
+        repo.count_by_owner.return_value = 0
+
+        assert _bare_service(repo).is_first_bot("85020") is True
+        repo.count_by_owner.assert_called_once_with("85020")
+
+    def test_existing_bots_is_not_first(self):
+        repo = MagicMock()
+        repo.count_by_owner.return_value = 1
+
+        assert _bare_service(repo).is_first_bot("85020") is False
+
+    def test_does_not_depend_on_a_default_bot_existing(self):
+        """An owner whose only bot has a generated id is not a first-bot owner."""
+        repo = MagicMock()
+        repo.count_by_owner.return_value = 1
+        # Would have answered "first bot" under the old id-based proxy.
+        repo.exists_by_owner_and_bot_id.return_value = False
+
+        assert _bare_service(repo).is_first_bot("85020") is False

--- a/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_management.create_flow import (
     BotCreateSpec,
     create_bot_with_authorization,
@@ -40,7 +41,11 @@ def _run(*, bot_id: str, is_first_bot: bool):
     passport.apply_first_agent_passport.return_value = {"token": "tok"}
     passport.apply_agent_passport.return_value = {"token": "tok"}
 
-    bot_service = MagicMock()
+    # Spec'd to the *protocol*, not the concrete class: both routers inject
+    # BotServiceProtocol, so anything create_flow calls on it has to be declared
+    # there. A bare MagicMock would happily answer an undeclared method and hide
+    # the AttributeError a conforming implementation would raise at runtime.
+    bot_service = MagicMock(spec=BotServiceProtocol)
     bot_service.is_first_bot.return_value = is_first_bot
 
     skill_set_factory = MagicMock()

--- a/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
@@ -1,0 +1,92 @@
+"""Which Passport apply the create flow calls is a data question, not a string one.
+
+``create_bot_with_authorization`` picks between ``apply_first_agent_passport``
+and ``apply_agent_passport``. It used to decide with ``bot_id == "default"``, a
+proxy that held only while every owner's first bot was ``"default"``.
+
+``generate_bot_id`` now confines that shortcut to the default tenant (issue
+#556), so in any other tenant a genuinely first bot carries a generated id. Under
+the old proxy that owner would be sent to ``apply_agent_passport`` — the
+non-first-bot branch — despite never having had a Passport.
+
+The flow therefore asks the repository. These tests pin both directions, since
+the two branches hit different tcauthmng facade methods.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.bot_management.create_flow import (
+    BotCreateSpec,
+    create_bot_with_authorization,
+)
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+pytestmark = pytest.mark.unit
+
+_SPEC = BotCreateSpec(
+    entity_id="85020",
+    engine_type="openclaw",
+    bot_type="personal",
+    bot_name="Bot",
+)
+
+
+def _run(*, bot_id: str, is_first_bot: bool):
+    passport = MagicMock()
+    passport.apply_first_agent_passport.return_value = {"token": "tok"}
+    passport.apply_agent_passport.return_value = {"token": "tok"}
+
+    bot_service = MagicMock()
+    bot_service.is_first_bot.return_value = is_first_bot
+
+    skill_set_factory = MagicMock()
+    skill_set_factory.create.return_value.get_bot_mcp_codes.return_value = []
+
+    create_bot_with_authorization(
+        user_id="85020",
+        nick_name="Alice",
+        bot_id=bot_id,
+        spec=_SPEC,
+        bot_service=bot_service,
+        passport_plugin=passport,
+        auth_rel_plugin=MagicMock(),
+        skill_set_factory=skill_set_factory,
+    )
+    return passport, bot_service
+
+
+def test_generated_id_still_takes_the_first_bot_branch():
+    """The case the id proxy got wrong: first bot, non-"default" id."""
+    passport, bot_service = _run(bot_id="20260730_ab12cd34", is_first_bot=True)
+
+    passport.apply_first_agent_passport.assert_called_once()
+    passport.apply_agent_passport.assert_not_called()
+    bot_service.is_first_bot.assert_called_once_with("85020")
+
+
+def test_default_id_takes_the_first_bot_branch():
+    """Unchanged for the default tenant, where a first bot is still "default"."""
+    passport, _ = _run(bot_id="default", is_first_bot=True)
+
+    passport.apply_first_agent_passport.assert_called_once()
+    passport.apply_agent_passport.assert_not_called()
+
+
+def test_owner_with_existing_bots_takes_the_non_first_branch():
+    passport, _ = _run(bot_id="20260730_ab12cd34", is_first_bot=False)
+
+    passport.apply_agent_passport.assert_called_once()
+    passport.apply_first_agent_passport.assert_not_called()
+
+
+def test_branch_is_not_inferred_from_the_id_in_another_tenant():
+    """A non-default tenant never mints "default", so the id must not decide."""
+    with avernet_tenant_scope("acme"):
+        passport, _ = _run(bot_id="20260730_ab12cd34", is_first_bot=True)
+
+    passport.apply_first_agent_passport.assert_called_once()
+    passport.apply_agent_passport.assert_not_called()

--- a/src/backend/tests/community/e2e/test_bot_creation_flow.py
+++ b/src/backend/tests/community/e2e/test_bot_creation_flow.py
@@ -339,6 +339,9 @@ class TestRouterLogic:
 
         mock_bot_service = MagicMock()
         mock_bot_service.check_create_bot_preflight.return_value = None
+        # The flow asks the service, not the bot_id, whether this is a first bot
+        # (see create_flow) — so the mock has to answer.
+        mock_bot_service.is_first_bot.return_value = True
         mock_bot_service.create_bot.return_value = {
             "bot_id": "default",
             "owner_id": "user_001",


### PR DESCRIPTION
Fixes the bot-identity collision in #556 at its source, and lifts the BCN stopgap that collision forced.

Rebased onto `dev` (`738cd2f`).

## The collision

`bot_id` is unique only per owner *per tenant*, and `generate_bot_id`'s `"default"` shortcut reads through the `BotModel` tenant guard:

```python
if not bot_repository.exists_by_owner_and_bot_id(owner_id, "default"):
    return "default"
```

A second tenant asking "does this owner already have a `default` bot?" cannot see the first tenant's row and correctly answers no — so both tenants mint `bot_id="default"` for the same owner. It is *because* the rows are isolated that the ids converge; this is deterministic, not a race.

Every external identity derived from that id then collides, in systems that have no tenant field to disambiguate them:

- the passport service's principal, keyed on `(bot_id, owner)`
- the `agent_code` it issues for that principal — which is also the auth-relationship key, since the relationship plugin only ever sees `agent_code`, never `bot_id`
- the coordination-network record keyed on `"{bot_id}:{owner_id}"`
- the caller execution credential, keyed on the same `(bot_id, owner)` pair

## The fix

Restrict the shortcut to the default tenant rather than namespacing each identity downstream. A generated `yyyymmdd_xxxxxxxx` id is unique on its own, so **every** external identity above becomes collision-free with **no change to any external contract** — in particular the corp `ProdPassportPlugin` and `ProdAuthRelationshipPlugin` need no change at all — and no already-minted identity is re-keyed.

Two properties are pinned by tests, and the second matters as much as the first:

1. Non-default tenants never mint `"default"`.
2. The default tenant's ids are byte-identical to before — no re-keying of passport principals or coordination-network records that already exist.

## First-bot inference

Two call sites inferred "is this the owner's first bot" from `bot_id == "default"`. That was never really the question being asked — it tests whether the owner lacks a bot *named* `"default"`, which coincided with "first bot" only because `generate_bot_id` gave every first bot that name. Confining the shortcut breaks the coincidence: in another tenant a genuinely-first bot carries a generated id, so the proxy answers False and sends a brand-new owner to `apply_agent_passport` instead of `apply_first_agent_passport`.

Both now ask the repository directly: `count_by_owner(user_id) == 0` — which the `BotModel` guard scopes to the current tenant, so it means "first bot for this owner *in this tenant*".

**This is a behavior change in the default tenant too, in one reachable case — and the new answer is the correct one.** `delete_bot` refuses to delete `"default"`, but two desktop paths have no such guard — `desktop_bot_service.py:216` (health check soft-deletes on orphan/`RELEASED`) and `:966` (explicit desktop delete) — and a desktop bot can *be* `"default"`, since `generate_bot_id` never looks at `bot_type`. So an owner whose first bot was a desktop bot can end up with live bots but no live `"default"`:

| on their next create | answer | consequence |
|---|---|---|
| old `not exists("default")` | `is_first = True` | applies the **first**-agent passport for a non-first bot; names it after the owner's nick name |
| `count_by_owner == 0` | `is_first = False` | correct |

So this corrects a latent default-tenant bug rather than preserving current behavior. An earlier revision of this description claimed the opposite ("`"default"` cannot be deleted, so the two are equivalent") — that was wrong, and the desktop soft-delete paths are why.

No existing test covered the non-first-bot branch, so `test_create_flow_first_bot.py` pins both directions.

## BCN sync re-enabled

PR #494 set `sync_to_bcn=False` on `/openapi/v1/bots` as a stopgap, with the note *"one line to re-enable"* once the identity stopped colliding. That precondition is now met — by the identity becoming unique rather than by the BCN contract gaining a tenant field, but the cross-tenant write the stopgap guarded is gone either way. Same owner in two tenants now yields `default:85020` and `20260730_ab12:85020`.

The bearer-token header the stopgap kept is retained, so the re-enabled sync cannot regress to the unauthenticated call F37 fixed. `test_update_does_not_sync_to_bcn` becomes `test_update_syncs_to_bcn`.

Worth noting the uniqueness is behavioral, not structural: `BotModel` carries **no** unique constraint, so `(bot_id, owner_id)` uniqueness is upheld by `generate_bot_id` rather than by the schema.

## Remaining mint path

`CreateBotForOthersService` writes `bot_id="default"` directly rather than going through `generate_bot_id`, so it was the one remaining path that could mint a colliding id. It now fails closed outside the default tenant, where a `"default"` bot has no meaning. Reachable today only via a non-`/openapi/v1/` route, which the middleware always resolves to the default tenant — so this is a guard against future exposure, not a live fix.

## Audit of the other `"default"` dependencies

12 further sites compare `bot_id` against `"default"`. All are branches that only fire *for* a `"default"` bot, so a tenant without one simply never takes them. Several are the permissive/fallback paths — `_check_bot_access` grants access unconditionally for `"default"`, and `file_router` / `collaborator` bypass the repository lookup — which makes the non-default-tenant path strictly *stricter*. `DefaultBotPassportRepairService` requires an existing live `"default"` bot and already 404s without one.

The entity-level endpoints in `core/services/identity.py` also hardcode `bot_id="default"`, but they are reachable only through the internal `/api/identity` router, which the middleware always resolves to the default tenant — so they keep working, and the `/openapi/v1/identity` surface is already bot-scoped with an explicit `{bot_id}`. (An earlier revision of this description listed them as a multi-tenancy precondition. That was wrong.)

Two intentional semantic differences in a non-default tenant, neither a correctness problem: a first bot is deletable (the `"default"`-is-permanent carve-out is keyed on the id), and its record is soft-deleted on device-allocation failure rather than kept for retry.

## Testing

Full backend suite: **9539 passed, 3 skipped, 0 failed**.

Three existing tests needed updating, all because a mock didn't stub the new `is_first_bot` call. Note `passport.is_first_bot` is part of the response contract and typed `boolean` — production returns a real bool (`count_by_owner(...) == 0`); the failures were `MagicMock` leaking into the payload.

The `python_sast_local.sh` gate exits 1, but byte-identically (1255 lines) on a clean tree — pre-existing, and none of the changed files are flagged.

## Out of scope, tracked separately

- **Per-owner create idempotency** — #631. Duplicate submissions inside the passport consent window mint two principals; already true for bots 2..N in the default tenant today.
- **Access-control policy tenant axis** — #643. `ac_access_control_policy` is keyed on `(entity_type, workno)` with no tenant, so admission and `bots_ceiling` are shared.
- **`ac_user_info` / compete-flow deprecation** — #644. Dormant table; deprecating it removes most of the shared-container-quota problem rather than giving it a tenant axis.

Refs #556