### PR TITLE
fix(backend): _compose_device_conn_info 优先使用 http_info 的 target

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/local_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/local_device_service.py
@@ -504,6 +504,9 @@ class LocalDeviceService(DeviceService):
             )
             url = http_info.http_url
             token = http_info.token
+            # http_info 返回的 target 是 3 段格式 LOCAL_{dev}@{tpl}:{port}，
+            # 与 token（JWT 中的 target claim）对齐。
+            target = http_info.target
         except Exception as e:
             logger.warning(
                 "[_compose_device_conn_info] http-info unavailable bind=%s: %s "
@@ -512,10 +515,11 @@ class LocalDeviceService(DeviceService):
             )
             url = ""
             token = ws_info.token
-
+            # 回退到 WS 链路的 target，与 ws_info.token 对齐。
+            target = ws_info.target
         return DeviceConnectionInfo(
             type=LOCAL_DEVICE_PROVIDER,
-            target=ws_info.target,
+            target=target,
             token=token,
             engine_type=device.device_props.get("engine", DEFAULT_ENGINE_TYPE),
             baas_base_url=ws_info.baas_base_url,

--- a/src/backend/tests/community/core/devices/services/test_local_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_local_device_service.py
@@ -128,6 +128,7 @@ def mock_baas():
     m.get_http_info.return_value = HttpConnectionInfo(
         http_url="http://10.0.0.1:20010",
         token="http-token-001",
+        target="LOCAL_bot-test-001--machine--user@2:20010",
     )
     return m
 
@@ -431,7 +432,9 @@ def test_do_release_approve_failure_does_not_block(local_device_service, mock_ba
 # ---------------------------------------------------------------------------
 
 
-def test_compose_conn_info_uses_baas_ws_info(local_device_service, mock_baas):
+def test_compose_conn_info_uses_http_info_when_available(
+    local_device_service, mock_baas
+):
     device = AllocatedDevice(
         device_id="bot-test-001",
         device_provider="local",
@@ -439,8 +442,10 @@ def test_compose_conn_info_uses_baas_ws_info(local_device_service, mock_baas):
     )
 
     conn = local_device_service._compose_device_conn_info(device=device)
-    assert conn.target == "127.0.0.1:18789"
-    # T07: http-info 成功时 token 由 http-info 覆盖（业务主走 HTTP）
+    # http-info 可用时，target/token/url 都来自 HTTP 链路（3 段 target），
+    # 与 JWT token 中的 target claim 对齐，proxy jwt_auth 才能校验通过。
+    assert conn.target == "LOCAL_bot-test-001--machine--user@2:20010"
+    # http-info 成功时 token 由 http-info 覆盖（业务主走 HTTP）
     assert conn.token == "http-token-001"
     assert conn.bot_uuid == "bot-test-001"
     mock_baas.get_ws_info.assert_called_once_with(


### PR DESCRIPTION
http_info.target 是 3 段格式 LOCAL_{dev}@{tpl}:{port}，与 JWT token 中 的 target claim 对齐；ws_info.target 是 4 段格式（含 :session_id 后缀）， proxy jwt_auth 校验时 session_id 后缀会导致 target 不匹配。

http-info 可用时优先取 HTTP 链路的 target/token/url，不可用时回退到 WS 链路。 同步更新测试用例以覆盖新行为。