### PR TITLE
fix(backend): make Skills Pool rollback resumable

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -250,6 +250,7 @@ class SkillsPoolRollbackService:
             )
 
         state = self._layouts.get(scope)
+        began_rollback = False
         if not state.persisted:
             return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.NOT_FOUND)
         if state.phase is SkillLayoutPhase.POOL_ACTIVE:
@@ -264,6 +265,7 @@ class SkillsPoolRollbackService:
                 return SkillsPoolRollbackResult(
                     SkillsPoolRollbackOutcome.STATE_RACE_LOST
                 )
+            began_rollback = True
             state = self._layouts.get(scope)
         elif state.phase not in {
             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
@@ -277,7 +279,7 @@ class SkillsPoolRollbackService:
             return SkillsPoolRollbackResult(
                 SkillsPoolRollbackOutcome.STALE_GENERATION
             )
-        if not self._layouts.try_acquire_rollback_lease(
+        if not began_rollback and not self._layouts.try_acquire_rollback_lease(
             scope=scope,
             rollback_generation=rollback_generation,
             lease_owner=lease_owner,
@@ -381,15 +383,8 @@ class SkillsPoolRollbackService:
             state.last_probe_evidence
         )
         if state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING:
-            pre_cutover_mapping = await self._publish_and_verify_mappings(
-                scope=scope,
-                user_id=user_id,
-                mappings=mappings,
-                rollback_generation=rollback_generation,
-                lease_owner=lease_owner,
-            )
-            if pre_cutover_mapping is not None:
-                return pre_cutover_mapping
+            # Pool cutover retires Legacy local storage, so Legacy mappings
+            # cannot be published until the runtime has rebuilt that corpus.
             cutover = await self._runtime.rollback_to_legacy(
                 bot_id=scope.bot_id,
                 user_id=user_id,

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -412,10 +412,48 @@ class _EditGuard:
         return True
 
 
+class _FreshRollbackLeaseLooksUnchanged(_RollbackLayouts):
+    """Model MySQL changed-row semantics for an immediate same-owner renewal."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lease_acquire_calls = 0
+
+    def try_acquire_rollback_lease(self, **kwargs: object) -> bool:
+        self.lease_acquire_calls += 1
+        return False
+
+
+@pytest.mark.asyncio
+async def test_new_rollback_uses_the_lease_acquired_by_begin() -> None:
+    layouts = _FreshRollbackLeaseLooksUnchanged()
+    runtime = _RollbackRuntime()
+    runtime.publish_results = [True, True]
+    service = SkillsPoolRollbackService(
+        bot_repository=_Bots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=runtime,
+        edit_guard=_EditGuard(),
+    )
+
+    result = await service.rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="fresh rollback already owns its lease",
+    )
+
+    assert result.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
+    assert layouts.lease_acquire_calls == 0
+
+
 @pytest.mark.asyncio
 async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() -> None:
     layouts = _RollbackLayouts()
     runtime = _RollbackRuntime()
+    runtime.publish_results = [False]
     service = SkillsPoolRollbackService(
         bot_repository=_Bots(),
         layout_repository=layouts,
@@ -437,14 +475,10 @@ async def test_explicit_rollback_only_moves_forward_and_preserves_pool_writes() 
     assert layouts.events == ["begin", "cutover", "failure"]
     assert runtime.events == [
         "probe",
-        "mapping",
-        "verify",
         "rollback",
         "mapping",
     ]
     assert runtime.mapping_layouts == [
-        SkillMappingSourceLayout.LEGACY,
-        SkillMappingSourceLayout.LEGACY,
         SkillMappingSourceLayout.LEGACY,
     ]
 


### PR DESCRIPTION
## What changed

- Reuse the rollback lease atomically acquired by `begin_legacy_rollback` instead of immediately renewing the same owner/expiry.
- Rebuild Legacy local storage through the Engine rollback endpoint before publishing and verifying Legacy logical mappings.
- Add regression coverage for MySQL changed-row semantics and post-cutover mapping failure/resume.

## Root cause

A fresh rollback immediately re-acquired its own lease. When MySQL treated that update as a no-op, the repository returned zero changed rows and the service reported `state_race_lost`.

After the lease expired, the next attempt published Legacy mappings before the Engine had rebuilt Legacy local storage. Desktop Pool cutover intentionally retires that directory, so any local Skill made the mapping request fail closed with `source_missing`.

## Impact

The rollback now follows the documented forward-only sequence: persist rollback intent and lease, rebuild Legacy from the authoritative Pool, record the data-plane commit, then publish/verify Legacy mappings and commit Legacy locators. A mapping or database failure after the filesystem exchange remains retryable from `LEGACY_ROLLBACK_COMMITTED`.

No Engine, layout planner, mapping contract, database schema, or rollout gate behavior changes.

## Validation

- 241 Backend Skills Pool core and operator endpoint tests passed.
- Ruff passed on both changed files.
- Local Python SAST block scan passed on both changed files.
- `git diff --check` passed.

The repository pre-push hook was intentionally skipped per delivery instruction because it is too slow; the push used `--no-verify`.