### PR TITLE
fix(backend): normalize Skills Pool runtime timestamps

### DIFF
--- a/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import calendar
 import json
-from datetime import datetime
+from datetime import UTC, datetime
+from decimal import Decimal
 
 from sqlalchemy import exists, func, or_, text
 
@@ -20,6 +22,29 @@ from agentclaw.community.core.skills_pool.types import (
     SkillLayout,
     SkillLayoutPhase,
 )
+
+
+def _database_timestamp(
+    value: datetime,
+    *,
+    dialect_name: str,
+) -> object:
+    """Express an aware instant in the database session timezone.
+
+    MySQL ``TIMESTAMP`` columns are projected in the session timezone. Passing
+    a UTC-aware value through PyMySQL drops the timezone without converting
+    the wall clock, so compare and persist through ``FROM_UNIXTIME`` instead.
+    SQLite's clock is UTC and accepts the equivalent UTC-naive value directly.
+    """
+
+    if value.tzinfo is None:
+        return value
+    utc_value = value.astimezone(UTC)
+    if dialect_name in {"mysql", "mariadb"}:
+        epoch_seconds = Decimal(calendar.timegm(utc_value.utctimetuple()))
+        epoch_seconds += Decimal(utc_value.microsecond) / Decimal(1_000_000)
+        return func.from_unixtime(epoch_seconds)
+    return utc_value.replace(tzinfo=None)
 
 
 class SkillsPoolQuarantineRepositoryMixin:
@@ -193,20 +218,27 @@ class SkillsPoolQuarantineRepositoryMixin:
         status: RuntimeReconciliationStatus,
         evidence: dict[str, object],
     ) -> bool:
-        observed_at = observed_at.replace(tzinfo=None)
-        timestamp_order = (
-            SkillMigrationQuarantineModel.runtime_reconciled_at <= observed_at
-            if status is RuntimeReconciliationStatus.FAILED
-            else or_(
-                SkillMigrationQuarantineModel.runtime_reconciled_at < observed_at,
-                (SkillMigrationQuarantineModel.runtime_reconciled_at == observed_at)
-                & (
-                    SkillMigrationQuarantineModel.runtime_reconciliation_status
-                    == RuntimeReconciliationStatus.READY.value
-                ),
-            )
-        )
         with self._database.transactional_orm_session() as session:
+            observed_at_db = _database_timestamp(
+                observed_at,
+                dialect_name=session.bind.dialect.name,
+            )
+            timestamp_order = (
+                SkillMigrationQuarantineModel.runtime_reconciled_at <= observed_at_db
+                if status is RuntimeReconciliationStatus.FAILED
+                else or_(
+                    SkillMigrationQuarantineModel.runtime_reconciled_at
+                    < observed_at_db,
+                    (
+                        SkillMigrationQuarantineModel.runtime_reconciled_at
+                        == observed_at_db
+                    )
+                    & (
+                        SkillMigrationQuarantineModel.runtime_reconciliation_status
+                        == RuntimeReconciliationStatus.READY.value
+                    ),
+                )
+            )
             current = (
                 session.query(BotSkillLayoutStateModel.id)
                 .filter(
@@ -218,7 +250,7 @@ class SkillsPoolQuarantineRepositoryMixin:
                     == SkillLayoutPhase.POOL_ACTIVE.value,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
-                    BotSkillLayoutStateModel.pool_activated_at < observed_at,
+                    BotSkillLayoutStateModel.pool_activated_at < observed_at_db,
                 )
                 .first()
             )
@@ -232,7 +264,7 @@ class SkillsPoolQuarantineRepositoryMixin:
                     SkillMigrationQuarantineModel.bot_id == scope.bot_id,
                     SkillMigrationQuarantineModel.migration_generation
                     == migration_generation,
-                    SkillMigrationQuarantineModel.pool_activated_at < observed_at,
+                    SkillMigrationQuarantineModel.pool_activated_at < observed_at_db,
                     SkillMigrationQuarantineModel.cleaned_at.is_(None),
                     SkillMigrationQuarantineModel.status != "cleaning",
                     or_(
@@ -242,7 +274,9 @@ class SkillsPoolQuarantineRepositoryMixin:
                 )
                 .update(
                     {
-                        SkillMigrationQuarantineModel.runtime_reconciled_at: observed_at,
+                        SkillMigrationQuarantineModel.runtime_reconciled_at: (
+                            observed_at_db
+                        ),
                         SkillMigrationQuarantineModel.runtime_reconciliation_status: (
                             status.value
                         ),
@@ -265,8 +299,11 @@ class SkillsPoolQuarantineRepositoryMixin:
         lease_seconds: int,
         eligible_before: datetime,
     ) -> bool:
-        eligible_before = eligible_before.replace(tzinfo=None)
         with self._database.transactional_orm_session() as session:
+            eligible_before_db = _database_timestamp(
+                eligible_before,
+                dialect_name=session.bind.dialect.name,
+            )
             current = (
                 session.query(BotSkillLayoutStateModel)
                 .filter(
@@ -293,7 +330,8 @@ class SkillsPoolQuarantineRepositoryMixin:
                     SkillMigrationQuarantineModel.migration_generation
                     == migration_generation,
                     SkillMigrationQuarantineModel.cleaned_at.is_(None),
-                    SkillMigrationQuarantineModel.pool_activated_at <= eligible_before,
+                    SkillMigrationQuarantineModel.pool_activated_at
+                    <= eligible_before_db,
                     SkillMigrationQuarantineModel.runtime_reconciled_at
                     > SkillMigrationQuarantineModel.pool_activated_at,
                     SkillMigrationQuarantineModel.runtime_reconciliation_status

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from threading import Barrier
 
-from sqlalchemy import create_engine, func, text
+from sqlalchemy import create_engine, func, select, text
 from sqlalchemy.dialects import mysql
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -38,6 +38,9 @@ from agentclaw.community.core.skills_pool.repository.protocol import (
 from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.plugins.skills_pool_layout_repository import (
     SkillsPoolLayoutRepository,
+)
+from agentclaw.community.plugins.skills_pool_quarantine_repository import (
+    _database_timestamp,
 )
 
 
@@ -102,6 +105,23 @@ def test_skills_pool_operational_tables_use_mysql_timestamp_contract() -> None:
     assert "EFFECTIVE_AT TIMESTAMP(6)" in audit_ddl
     assert "GMT_CREATE TIMESTAMP" in audit_ddl
     assert "GMT_MODIFY TIMESTAMP" in audit_ddl
+
+
+def test_aware_runtime_observation_uses_mysql_session_timestamp() -> None:
+    observed_at = datetime(2026, 7, 30, 12, 58, 13, 841734, tzinfo=UTC)
+
+    expression = _database_timestamp(observed_at, dialect_name="mysql")
+    compiled = str(
+        select(expression).compile(
+            dialect=mysql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    ).lower()
+
+    assert "from_unixtime(1785416293.841734)" in compiled
+    assert _database_timestamp(observed_at, dialect_name="sqlite") == (
+        observed_at.replace(tzinfo=None)
+    )
 
 
 def rollout_evidence() -> RolloutEvidence:

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -671,8 +671,6 @@ async def test_aicoding_rollback_resumes_after_active_repo_restoration() -> None
     assert result.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
     assert runtime.events == [
         "probe",
-        "mapping",
-        "verify",
         "rollback",
         "mapping",
         "verify",


### PR DESCRIPTION
## Summary

- normalize timezone-aware Skills Pool runtime observations through the database session timezone before comparing or persisting MySQL `TIMESTAMP` values
- apply the same conversion to quarantine retention cutoffs
- add a MySQL SQL-compilation regression test for the UTC observation path
- align the stale AICoding rollback test expectation with the safe rollback-before-mapping order introduced by #628

## Pre reproduction

A Desktop OpenClaw Bot reached `pool_active`, but the post-activation reconciliation task remained `PENDING` and repeatedly returned `skills pool runtime reconciliation evidence race lost`. The task observation was UTC while MySQL exposed `TIMESTAMP` values in the session timezone, so dropping `tzinfo` shifted the comparison by eight hours.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/core/skills_pool -q` — 247 passed
- Ruff check passed for all changed Python files
- `git diff --check` passed

Related to #455.