### PR TITLE
fix(community): prune skills-pool in aicoding file-tree

### DIFF
--- a/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
@@ -326,7 +326,7 @@ async def test_list_file_tree_prunes_mounts_and_returns_sorted_tree(
     assert "-maxdepth 3" in command
     assert "-name .git" in command
     assert "-name node_modules" in command
-    assert "-path './skills'" in command
+    assert "-path './skills-pool'" in command
     assert "-path './.repos'" in command
     assert "%s" not in command
     assert file_plugin.calls == []

--- a/src/engine/src/engine/community/core/aicoding/workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/workspace_service.py
@@ -56,7 +56,7 @@ DEFAULT_FILE_TREE_MAX_DEPTH = 3
 # explicit size metadata lookup per file.
 _FILE_TREE_FIND_EXPRESSION = (
     r"\( -type d \( -name .git -o -name node_modules "
-    r"-o -path './skills' -o -path './.repos' \) -prune \) "
+    r"-o -path './skills-pool' -o -path './.repos' \) -prune \) "
     r"-o -printf '%y\0%P\0'"
 )
 


### PR DESCRIPTION
## 背景

AICoding workspace 的文件树接口 `GET /file-tree`（`router.py` 的 `list_file_tree`，过滤逻辑在 `workspace_service.py` 的 `_FILE_TREE_FIND_EXPRESSION`）原本 prune 的是顶层 `./skills` 目录。

但 AICoding workspace 里实际的基础设施目录名是 `skills-pool`（与 engine 的 `workspace/skills-pool` pool_root 约定一致），原来的 `./skills` 是过时/错误的过滤目标，导致真实的 `skills-pool` 目录仍会出现在文件树里。

## 改动

将 find 表达式中的 `-path './skills'` 换成 `-path './skills-pool'`，其余 prune 项（`.git` / `node_modules` / `.repos`）保持不变。

- `-path './skills-pool'` 只 prune 顶层 `skills-pool`；
- 深层目录如 `project-fe/skills`（项目自带的 skills 文件夹）仍正常展示，不受影响。

## 影响文件

- `src/engine/src/engine/community/core/aicoding/workspace_service.py`
- `src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py`（同步更新断言）

## 验证

用 Python 3.12 直接 import 模块，确认生成的 find 命令含 `-path './skills-pool'`、不再含旧的 `-path './skills'`，其余 prune 项完整；测试断言已同步更新。