### PR TITLE
fix(engine): fail closed on invalid layout probes

### DIFF
--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -37,6 +37,12 @@ from engine.community.core.engine.exceptions import CapabilityNotSupportedError
 from engine.community.core.skills.exceptions import (
     InvalidPoolMappingRequestError,
 )
+from engine.community.core.skills.layout_planner import (
+    LayoutIdentity,
+    RuntimeLayoutContext,
+    SkillLayoutResolutionError,
+    resolve_skill_layout,
+)
 from engine.community.core.skills.models import (
     CenterEnsureItem,
     CenterEnsureRequest,
@@ -90,6 +96,30 @@ async def probe_runtime_skills_layout(
     body: RuntimeLayoutProbeRequest,
 ) -> RuntimeLayoutProbeApiResponse:
     """通过 Skills Service API 核验当前运行时事实。"""
+    try:
+        resolve_skill_layout(
+            LayoutIdentity(
+                engine_type=body.engine,
+                layout_contract_version=body.layout_contract_version,
+            ),
+            RuntimeLayoutContext(),
+        )
+    except SkillLayoutResolutionError as error:
+        return RuntimeLayoutProbeApiResponse(
+            success=True,
+            data=RuntimeLayoutProbeResponse(
+                status="INVALID",
+                engine=body.engine,
+                layout_contract_version=body.layout_contract_version,
+                preparation_id=None,
+                evidence={
+                    "reason": "layout_identity_invalid",
+                    "error_type": type(error).__name__,
+                },
+            ),
+            message="运行时 Skills Pool 布局探测完成",
+        )
+
     plugin = _skills_plugin()
     try:
         result = await plugin.probe_pool_layout(
@@ -100,6 +130,21 @@ async def probe_runtime_skills_layout(
         )
     except CapabilityNotSupportedError as error:
         raise HTTPException(status_code=501, detail=str(error)) from error
+    if result.engine != body.engine:
+        return RuntimeLayoutProbeApiResponse(
+            success=True,
+            data=RuntimeLayoutProbeResponse(
+                status="INVALID",
+                engine=body.engine,
+                layout_contract_version=body.layout_contract_version,
+                preparation_id=None,
+                evidence={
+                    "reason": "runtime_engine_mismatch",
+                    "actual_engine": result.engine,
+                },
+            ),
+            message="运行时 Skills Pool 布局探测完成",
+        )
     return RuntimeLayoutProbeApiResponse(
         success=True,
         data=RuntimeLayoutProbeResponse.model_validate(result.to_data()),

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -264,6 +264,101 @@ def test_runtime_layout_probe_has_no_engine_capability_dependency(
     plugin.probe_pool_layout.assert_awaited_once()
 
 
+def test_runtime_layout_probe_rejects_unknown_engine_before_dispatch(
+    client, rich_manager
+):
+    plugin = MagicMock()
+    plugin.probe_pool_layout = AsyncMock()
+    rich_manager._active_engine._skills = plugin
+
+    response = client.post(
+        "/api/skills/layout/probe",
+        json={
+            "engine": "unknown-engine",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "status": "INVALID",
+        "engine": "unknown-engine",
+        "layout_contract_version": "skills-pool-p3-v1",
+        "preparation_id": None,
+        "evidence": {
+            "reason": "layout_identity_invalid",
+            "error_type": "SkillLayoutResolutionError",
+        },
+    }
+    plugin.probe_pool_layout.assert_not_awaited()
+
+
+def test_runtime_layout_probe_rejects_unknown_contract_before_dispatch(
+    client, rich_manager
+):
+    plugin = MagicMock()
+    plugin.probe_pool_layout = AsyncMock()
+    rich_manager._active_engine._skills = plugin
+
+    response = client.post(
+        "/api/skills/layout/probe",
+        json={
+            "engine": "hermes",
+            "layout_contract_version": "skills-pool-p3-v999",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "status": "INVALID",
+        "engine": "hermes",
+        "layout_contract_version": "skills-pool-p3-v999",
+        "preparation_id": None,
+        "evidence": {
+            "reason": "layout_identity_invalid",
+            "error_type": "UnsupportedLayoutContractError",
+        },
+    }
+    plugin.probe_pool_layout.assert_not_awaited()
+
+
+def test_runtime_layout_probe_rejects_plugin_engine_mismatch(
+    client, rich_manager
+):
+    plugin = MagicMock()
+    plugin.probe_pool_layout = AsyncMock(
+        return_value=PoolLayoutProbeResult(
+            status=PoolLayoutProbeStatus.READY,
+            engine="hermes",
+            layout_contract_version="skills-pool-p3-v1",
+            preparation_id="prep-1",
+            evidence={"checks": {"marker_valid": True}},
+        )
+    )
+    rich_manager._active_engine._skills = plugin
+
+    response = client.post(
+        "/api/skills/layout/probe",
+        json={
+            "engine": "openclaw",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "status": "INVALID",
+        "engine": "openclaw",
+        "layout_contract_version": "skills-pool-p3-v1",
+        "preparation_id": None,
+        "evidence": {
+            "reason": "runtime_engine_mismatch",
+            "actual_engine": "hermes",
+        },
+    }
+    plugin.probe_pool_layout.assert_awaited_once()
+
+
 def test_pool_activation_and_mapping_routes_are_capability_independent(
     client, rich_manager
 ):


### PR DESCRIPTION
## What changed

- validate the requested Engine/layout-contract identity through the Engine-owned Layout Planner before dispatching a runtime probe
- return structured `INVALID` evidence for unknown engines and unsupported contract versions
- reject a plugin probe result whose runtime Engine does not match the requested Engine
- add HTTP contract coverage for all three fail-closed cases

## Why

Real Desktop Hermes validation for #455 showed that `engine=unknown-engine` was ignored and returned the active Hermes runtime as `READY`; an unsupported contract escaped as an unhandled exception. The probe boundary must fail closed before Backend can accept mismatched runtime evidence.

## Impact

This is a backward-compatible Engine Service API hardening. Valid probes are unchanged. Invalid identities now return the existing `INVALID` probe status instead of dispatching or raising.

## Validation

- Engine Skills router + Layout Planner: 37 passed
- focused router coverage: 29 passed; changed-line coverage 100% (7/7)
- Engine Python SAST block scan: passed
- `git diff --check`: passed

Refs #455