### PR TITLE
feat(skills): isolate Track A records by tenant

### DIFF
--- a/docs/skills-pool-p3-rollout-runbook.zh-CN.md
+++ b/docs/skills-pool-p3-rollout-runbook.zh-CN.md
@@ -7,7 +7,7 @@
 ## 发布前置
 
 生产环境不由 Backend 自动建表。发布新 Backend 前，必须先通过 OceanBase
-数据库变更流程创建 `ac_skill_migration_quarantine` 和
+数据库变更流程创建或升级 `ac_skill_migration_quarantine` 和
 `ac_skills_pool_rollout_audit`，并分别执行 `SELECT 1 ... LIMIT 1` 作为发布
 preflight；任一表不存在或不可读写时禁止开启 rollout。Avernet 仓库只维护
 ORM，数据库变更单需使用以下与 ORM 一致的 DDL：
@@ -16,6 +16,8 @@ ORM，数据库变更单需使用以下与 ORM 一致的 DDL：
 CREATE TABLE ac_skill_migration_quarantine (
   id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT
     COMMENT '自增主键',
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
+    COMMENT '数据隔离租户；既有内部数据归属 teamclaw',
   env VARCHAR(20) NOT NULL
     COMMENT '部署环境，如 pre、prod',
   entity_id VARCHAR(512) NOT NULL
@@ -54,8 +56,8 @@ CREATE TABLE ac_skill_migration_quarantine (
     ON UPDATE CURRENT_TIMESTAMP
     COMMENT '记录最后修改时间',
   PRIMARY KEY (id),
-  UNIQUE KEY uk_skill_migration_quarantine_scope_generation
-    (env, entity_id, bot_id, migration_generation) GLOBAL,
+  UNIQUE KEY uk_skill_migration_quarantine_tenant_scope_generation
+    (avernet_tenant, env, entity_id, bot_id, migration_generation) GLOBAL,
   KEY idx_skill_migration_quarantine_cleanup
     (env, status, pool_activated_at) GLOBAL
 ) DEFAULT CHARSET = utf8mb4
@@ -64,6 +66,8 @@ CREATE TABLE ac_skill_migration_quarantine (
 CREATE TABLE ac_skills_pool_rollout_audit (
   id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT
     COMMENT '自增主键',
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
+    COMMENT '数据隔离租户；既有内部数据归属 teamclaw',
   env VARCHAR(20) NOT NULL
     COMMENT 'Rollout 配置所属部署环境',
   config_id BIGINT(20) UNSIGNED NOT NULL
@@ -90,15 +94,42 @@ CREATE TABLE ac_skills_pool_rollout_audit (
     ON UPDATE CURRENT_TIMESTAMP
     COMMENT '审计记录的数据库修改时间',
   PRIMARY KEY (id),
-  UNIQUE KEY uk_skills_pool_rollout_audit_revision
-    (env, effective_config_version) GLOBAL,
+  UNIQUE KEY uk_skills_pool_rollout_audit_tenant_revision
+    (avernet_tenant, env, effective_config_version) GLOBAL,
   KEY idx_skills_pool_rollout_audit_batch
     (env, batch_id, id) GLOBAL
 ) DEFAULT CHARSET = utf8mb4
   COMMENT = 'Skills Pool 灰度配置变更追加式审计记录';
 
+-- 已存在上述两表的环境不得重复 CREATE。发布读取 avernet_tenant 的 Backend
+-- 前，按以下顺序升级：先加列，再建 tenant 前导唯一键，最后删除旧唯一键。
+ALTER TABLE ac_skill_migration_quarantine
+  ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
+    COMMENT '数据隔离租户；既有内部数据归属 teamclaw';
+ALTER TABLE ac_skills_pool_rollout_audit
+  ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
+    COMMENT '数据隔离租户；既有内部数据归属 teamclaw';
+
+ALTER TABLE ac_skill_migration_quarantine
+  ADD UNIQUE KEY uk_skill_migration_quarantine_tenant_scope_generation
+    (avernet_tenant, env, entity_id, bot_id, migration_generation) GLOBAL;
+ALTER TABLE ac_skills_pool_rollout_audit
+  ADD UNIQUE KEY uk_skills_pool_rollout_audit_tenant_revision
+    (avernet_tenant, env, effective_config_version) GLOBAL;
+
+ALTER TABLE ac_skill_migration_quarantine
+  DROP INDEX uk_skill_migration_quarantine_scope_generation;
+ALTER TABLE ac_skills_pool_rollout_audit
+  DROP INDEX uk_skills_pool_rollout_audit_revision;
+
 SELECT 1 FROM ac_skill_migration_quarantine LIMIT 1;
 SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
+SELECT COUNT(*) AS null_tenant_rows
+  FROM ac_skill_migration_quarantine WHERE avernet_tenant IS NULL;
+SELECT COUNT(*) AS null_tenant_rows
+  FROM ac_skills_pool_rollout_audit WHERE avernet_tenant IS NULL;
+SHOW INDEX FROM ac_skill_migration_quarantine;
+SHOW INDEX FROM ac_skills_pool_rollout_audit;
 ```
 
 数据库变更顺序固定为：建表并 preflight → 发布 Backend → 保持 feature disabled

--- a/docs/skills-pool-p3-rollout-runbook.zh-CN.md
+++ b/docs/skills-pool-p3-rollout-runbook.zh-CN.md
@@ -16,8 +16,6 @@ ORM，数据库变更单需使用以下与 ORM 一致的 DDL：
 CREATE TABLE ac_skill_migration_quarantine (
   id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT
     COMMENT '自增主键',
-  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
-    COMMENT '数据隔离租户；既有内部数据归属 teamclaw',
   env VARCHAR(20) NOT NULL
     COMMENT '部署环境，如 pre、prod',
   entity_id VARCHAR(512) NOT NULL
@@ -56,8 +54,8 @@ CREATE TABLE ac_skill_migration_quarantine (
     ON UPDATE CURRENT_TIMESTAMP
     COMMENT '记录最后修改时间',
   PRIMARY KEY (id),
-  UNIQUE KEY uk_skill_migration_quarantine_tenant_scope_generation
-    (avernet_tenant, env, entity_id, bot_id, migration_generation) GLOBAL,
+  UNIQUE KEY uk_skill_migration_quarantine_scope_generation
+    (env, entity_id, bot_id, migration_generation) GLOBAL,
   KEY idx_skill_migration_quarantine_cleanup
     (env, status, pool_activated_at) GLOBAL
 ) DEFAULT CHARSET = utf8mb4
@@ -101,31 +99,21 @@ CREATE TABLE ac_skills_pool_rollout_audit (
 ) DEFAULT CHARSET = utf8mb4
   COMMENT = 'Skills Pool 灰度配置变更追加式审计记录';
 
--- 已存在上述两表的环境不得重复 CREATE。发布读取 avernet_tenant 的 Backend
--- 前，按以下顺序升级：先加列，再建 tenant 前导唯一键，最后删除旧唯一键。
-ALTER TABLE ac_skill_migration_quarantine
-  ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
-    COMMENT '数据隔离租户；既有内部数据归属 teamclaw';
+-- 已存在上述两表的环境不得重复 CREATE。只有 rollout audit 是 tenant
+-- 隔离表：发布读取该列的 Backend 前，按以下顺序升级 audit 表。
 ALTER TABLE ac_skills_pool_rollout_audit
   ADD COLUMN avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw'
     COMMENT '数据隔离租户；既有内部数据归属 teamclaw';
 
-ALTER TABLE ac_skill_migration_quarantine
-  ADD UNIQUE KEY uk_skill_migration_quarantine_tenant_scope_generation
-    (avernet_tenant, env, entity_id, bot_id, migration_generation) GLOBAL;
 ALTER TABLE ac_skills_pool_rollout_audit
   ADD UNIQUE KEY uk_skills_pool_rollout_audit_tenant_revision
     (avernet_tenant, env, effective_config_version) GLOBAL;
 
-ALTER TABLE ac_skill_migration_quarantine
-  DROP INDEX uk_skill_migration_quarantine_scope_generation;
 ALTER TABLE ac_skills_pool_rollout_audit
   DROP INDEX uk_skills_pool_rollout_audit_revision;
 
 SELECT 1 FROM ac_skill_migration_quarantine LIMIT 1;
 SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
-SELECT COUNT(*) AS null_tenant_rows
-  FROM ac_skill_migration_quarantine WHERE avernet_tenant IS NULL;
 SELECT COUNT(*) AS null_tenant_rows
   FROM ac_skills_pool_rollout_audit WHERE avernet_tenant IS NULL;
 SHOW INDEX FROM ac_skill_migration_quarantine;

--- a/src/backend/specs/2026-07-31-openapi-v1-skills-track-a/spec.md
+++ b/src/backend/specs/2026-07-31-openapi-v1-skills-track-a/spec.md
@@ -17,12 +17,15 @@ or lifecycle workflow; that is Track B.
 
 ## Solution
 
-Apply the established tenant-isolation mechanism to the nine confirmed Skills
-tables. Each row records its tenant, reads and writes are enforced by the
-shared ORM tenant guard, and existing rows remain visible to the internal
-tenant through the database default. The production DDL, including all
-necessary unique-key replacements, is applied as one release gate before the
-application code that reads the new columns is deployed.
+Apply the established tenant-isolation mechanism to the seven tenant-scoped
+Skills tables. Each of those rows records its tenant, reads and writes are
+enforced by the shared ORM tenant guard, and existing rows remain visible to
+the internal tenant through the database default. `ac_bot_skill_layout_state`
+and `ac_skill_migration_quarantine` are instead globally identified by
+`(env, entity_id, bot_id)` because that Bot identity is globally unique across
+tenants. The production DDL, including all necessary unique-key replacements,
+is applied as one release gate before the application code that reads the new
+columns is deployed.
 
 An external tenant starts with an empty tenant-scoped skill catalog: it does
 not receive Git-market catalog entries automatically. Shared skill categories
@@ -44,7 +47,7 @@ remain outside this Track A boundary.
 
 4. As an external tenant, I want to use the same identifiers as another tenant
    where the business identity is tenant-local, so that another tenant's
-   exclusion, layout, audit, or quarantine record cannot block my write.
+   exclusion or audit record cannot block my write.
 
 5. As an engineer implementing Skills Track B, I want tenant scoping to be
    enforced below the HTTP handler, so that an endpoint cannot leak data merely
@@ -70,21 +73,30 @@ remain outside this Track A boundary.
   `ac_default_skillset_skill_exclusion`, `ac_bot_skill_layout_state`,
   `ac_skills_pool_rollout_audit`, and `ac_skill_migration_quarantine`.
 
-- Each scoped table receives a non-null `avernet_tenant` column with database
-  server default `teamclaw`. The mapped model declares the matching tenant
-  field and registers with the existing shared tenant guard. This reuses the
-  established single enforcement mechanism; it does not add model-specific
-  session listeners or endpoint-level filtering.
+- The seven tenant-scoped tables are `ac_skill`, `ac_skill_set`,
+  `ac_skill_set_skill`, `ac_skill_set_mcp`,
+  `ac_default_skillset_mcp_exclusion`,
+  `ac_default_skillset_skill_exclusion`, and
+  `ac_skills_pool_rollout_audit`. Each receives a non-null
+  `avernet_tenant` column with database server default `teamclaw`; its mapped
+  model registers with the shared tenant guard. This reuses the established
+  single enforcement mechanism and does not add endpoint-level filtering.
+
+- `ac_bot_skill_layout_state` and `ac_skill_migration_quarantine` deliberately
+  do not receive `avernet_tenant` and do not register with the tenant guard.
+  Their `(env, entity_id, bot_id)` identity is globally unique across tenants;
+  quarantine adds `migration_generation`. Bot ownership authorization remains
+  the responsibility of the Bot boundary, not these persistence tables.
 
 - The tenant field is persistence metadata, not API data. Existing serializers
   must not expose it and internal response shapes must remain unchanged.
 
 - The production schema change is out-of-band DDL and is one release gate. For
   each affected business unique key, create its tenant-leading replacement
-  first, then remove the legacy key. The five replacements are on
+  first, then remove the legacy key. The three replacements are on
   `ac_default_skillset_mcp_exclusion`,
-  `ac_default_skillset_skill_exclusion`, `ac_bot_skill_layout_state`,
-  `ac_skills_pool_rollout_audit`, and `ac_skill_migration_quarantine`.
+  `ac_default_skillset_skill_exclusion`, and
+  `ac_skills_pool_rollout_audit`.
 
 - The current production DDL is authoritative for key changes. Track A does
   not introduce a new business unique key for tables that do not currently
@@ -98,10 +110,10 @@ remain outside this Track A boundary.
   catalog-boundary decision only; the upload and activation workflow remains
   Track B.
 
-- Skills Pool audit and quarantine records are tenant-scoped now, despite the
-  current cutover being internal-only. Background and scheduled Skills Pool
-  jobs do not yet iterate tenants: this is acceptable only until a second
-  tenant holds real data, and becomes a release gate before that point.
+- Skills Pool rollout audit records are tenant-scoped. Layout state and
+  quarantine records are globally Bot-scoped, so their background scan,
+  reconciliation, cleanup, and recovery paths use the globally unique Bot
+  identity rather than tenant iteration.
 
 - Tenant-leading non-unique query indexes are deferred to the cross-cutting
   index work. They are required before opening sustained multi-tenant traffic,
@@ -112,14 +124,17 @@ remain outside this Track A boundary.
 
 ## Testing Decisions
 
-- Prove insert behavior: a request-scoped write stamps the current tenant, and
-  a raw write omitting the column receives the `teamclaw` server default.
+- Prove tenant-scoped insert behavior: a request-scoped write stamps the
+  current tenant, and a raw write omitting the column receives the `teamclaw`
+  server default.
 
-- For each scoped data set, prove tenant A can read and mutate its own rows,
-  while the same read, update, and delete against tenant B's rows behaves as if
-  the other rows do not exist.
+- For each tenant-scoped data set, prove tenant A can read and mutate its own
+  rows, while the same read, update, and delete against tenant B's rows behaves
+  as if the other rows do not exist. Prove the two globally Bot-scoped tables
+  have no tenant column and reject the same global Bot identity from any tenant
+  context.
 
-- Prove that each of the five replaced unique keys permits equivalent
+- Prove that each of the three replaced unique keys permits equivalent
   tenant-local records in two tenants and still rejects a duplicate within one
   tenant.
 
@@ -148,24 +163,19 @@ remain outside this Track A boundary.
 - Tenant-isolating `ac_skill_category`, legacy aliases, backup tables, and
   inactive historical skill tables excluded from the confirmed scope.
 
-- Refactoring background or scheduled Skills Pool jobs to enumerate tenants.
-  That work is deferred but must complete before a second tenant writes real
-  data.
-
 - Tenant-leading non-unique performance indexes, except where a replacement
   unique key requires the tenant-leading shape for correctness.
 
 ## Further Notes
 
 - The domain terms and catalog decision are recorded in `CONTEXT.md` and the
-  tenant-scoped catalog ADR. The one-gate DDL decision and the five affected
+  tenant-scoped catalog ADR. The one-gate DDL decision and the three affected
   keys are recorded in the DDL ADR.
 
 - The production DDL run needs platform review and an execution window. Its
   order is mandatory: add tenant columns, create tenant-leading unique keys,
   remove legacy unique keys, then deploy code that reads the new columns.
 
-- Background work resolving to `teamclaw` is a temporary compatibility state,
-  not a multi-tenant design. Before the first non-`teamclaw` tenant acquires
-  real Skills data, its scan, reconciliation, cleanup, and recovery paths must
-  have an explicit tenant-iteration design and test coverage.
+- Background work for the globally Bot-scoped layout and quarantine tables
+  resolves records by `(env, entity_id, bot_id)`, not tenant. The remaining
+  tenant-scoped catalog and audit paths continue to use the shared guard.

--- a/src/backend/specs/2026-07-31-openapi-v1-skills-track-a/spec.md
+++ b/src/backend/specs/2026-07-31-openapi-v1-skills-track-a/spec.md
@@ -1,0 +1,171 @@
+# OpenAPI v1 Skills — Track A Tenant Isolation
+
+## Problem Statement
+
+Skills data currently sits in a shared persistence domain. The public OpenAPI
+will eventually let an external tenant upload and use its own skills, but the
+current skill catalog, skill-set associations, exclusion state, and Skills Pool
+control records have no tenant boundary. Wiring any public Skills endpoint on
+top of that state would risk exposing `teamclaw` records, modifying another
+tenant's records, or rejecting valid writes because a legacy unique key is
+shared across tenants.
+
+This Track A slice establishes the data boundary only. It makes the existing
+Skills persistence safe for future public endpoints while keeping internal
+`teamclaw` behavior unchanged. It does not define the public upload, activation,
+or lifecycle workflow; that is Track B.
+
+## Solution
+
+Apply the established tenant-isolation mechanism to the nine confirmed Skills
+tables. Each row records its tenant, reads and writes are enforced by the
+shared ORM tenant guard, and existing rows remain visible to the internal
+tenant through the database default. The production DDL, including all
+necessary unique-key replacements, is applied as one release gate before the
+application code that reads the new columns is deployed.
+
+An external tenant starts with an empty tenant-scoped skill catalog: it does
+not receive Git-market catalog entries automatically. Shared skill categories
+remain outside this Track A boundary.
+
+## User Stories
+
+1. As a caller of the existing internal API, I want Skills responses and
+   behavior to remain unchanged, so that adding tenant isolation is invisible
+   to the current `teamclaw` tenant.
+
+2. As an external tenant, I want every skill catalog record I create or later
+   access through a public API to belong to my tenant, so that another tenant
+   cannot read, update, or delete it.
+
+3. As an external tenant, I want to start with no automatically provisioned
+   Git-market skill entries, so that my catalog contains only records added by
+   my own future public API workflow.
+
+4. As an external tenant, I want to use the same identifiers as another tenant
+   where the business identity is tenant-local, so that another tenant's
+   exclusion, layout, audit, or quarantine record cannot block my write.
+
+5. As an engineer implementing Skills Track B, I want tenant scoping to be
+   enforced below the HTTP handler, so that an endpoint cannot leak data merely
+   because its implementation omits a tenant predicate.
+
+6. As an operator, I want existing rows and writers that omit the tenant column
+   to resolve to `teamclaw` during this cutover, so that the current platform
+   continues to work while it is the only tenant with real data.
+
+7. As a reviewer, I want relation loading to preserve the same tenant boundary
+   as the parent query, so that a tenant-scoped Skill record cannot lazily
+   expose another tenant's association row.
+
+8. As a release owner, I want column additions and unique-key changes to land
+   together before the code release, so that there is no interval in which a
+   second tenant can write through an incomplete schema boundary.
+
+## Implementation Decisions
+
+- The Track A table scope is exactly:
+  `ac_skill`, `ac_skill_set`, `ac_skill_set_skill`, `ac_skill_set_mcp`,
+  `ac_default_skillset_mcp_exclusion`,
+  `ac_default_skillset_skill_exclusion`, `ac_bot_skill_layout_state`,
+  `ac_skills_pool_rollout_audit`, and `ac_skill_migration_quarantine`.
+
+- Each scoped table receives a non-null `avernet_tenant` column with database
+  server default `teamclaw`. The mapped model declares the matching tenant
+  field and registers with the existing shared tenant guard. This reuses the
+  established single enforcement mechanism; it does not add model-specific
+  session listeners or endpoint-level filtering.
+
+- The tenant field is persistence metadata, not API data. Existing serializers
+  must not expose it and internal response shapes must remain unchanged.
+
+- The production schema change is out-of-band DDL and is one release gate. For
+  each affected business unique key, create its tenant-leading replacement
+  first, then remove the legacy key. The five replacements are on
+  `ac_default_skillset_mcp_exclusion`,
+  `ac_default_skillset_skill_exclusion`, `ac_bot_skill_layout_state`,
+  `ac_skills_pool_rollout_audit`, and `ac_skill_migration_quarantine`.
+
+- The current production DDL is authoritative for key changes. Track A does
+  not introduce a new business unique key for tables that do not currently
+  have one merely because a source model declaration suggests one.
+
+- `ac_skill_category` is a shared classification hierarchy and is excluded.
+  The legacy, backup, and inactive skill-related tables confirmed outside the
+  scope remain unchanged.
+
+- External tenants receive no automatic Git-market catalog seeding. This is a
+  catalog-boundary decision only; the upload and activation workflow remains
+  Track B.
+
+- Skills Pool audit and quarantine records are tenant-scoped now, despite the
+  current cutover being internal-only. Background and scheduled Skills Pool
+  jobs do not yet iterate tenants: this is acceptable only until a second
+  tenant holds real data, and becomes a release gate before that point.
+
+- Tenant-leading non-unique query indexes are deferred to the cross-cutting
+  index work. They are required before opening sustained multi-tenant traffic,
+  but do not change the correctness boundary delivered by this slice.
+
+- Any architecture-boundary documentation affected by new dependency edges is
+  updated together with the implementation.
+
+## Testing Decisions
+
+- Prove insert behavior: a request-scoped write stamps the current tenant, and
+  a raw write omitting the column receives the `teamclaw` server default.
+
+- For each scoped data set, prove tenant A can read and mutate its own rows,
+  while the same read, update, and delete against tenant B's rows behaves as if
+  the other rows do not exist.
+
+- Prove that each of the five replaced unique keys permits equivalent
+  tenant-local records in two tenants and still rejects a duplicate within one
+  tenant.
+
+- Prove direct ORM queries are tenant-filtered and that lazy-loaded Skill
+  relationships retain the parent query's tenant criteria. The latter is a
+  shared-guard regression seam, already covered by a focused guard test.
+
+- Prove the tenant field is absent from serialized output and that existing
+  internal Skills tests continue to pass without response-contract changes.
+
+- Run the closest Skills, model, and shared-tenant-guard tests; run required
+  architecture checks for every changed boundary declaration. Record any
+  platform DDL validation separately because production schema execution is
+  not a repository migration.
+
+## Out of Scope
+
+- Implementing or changing the OpenAPI v1 Skills endpoints, including upload,
+  activation, patch, assignment, and deletion semantics. Those are Track B.
+
+- Defining public caller authentication or the source of a request tenant.
+
+- Automatically generating, seeding, sharing, or managing a Git skill market
+  for external tenants.
+
+- Tenant-isolating `ac_skill_category`, legacy aliases, backup tables, and
+  inactive historical skill tables excluded from the confirmed scope.
+
+- Refactoring background or scheduled Skills Pool jobs to enumerate tenants.
+  That work is deferred but must complete before a second tenant writes real
+  data.
+
+- Tenant-leading non-unique performance indexes, except where a replacement
+  unique key requires the tenant-leading shape for correctness.
+
+## Further Notes
+
+- The domain terms and catalog decision are recorded in `CONTEXT.md` and the
+  tenant-scoped catalog ADR. The one-gate DDL decision and the five affected
+  keys are recorded in the DDL ADR.
+
+- The production DDL run needs platform review and an execution window. Its
+  order is mandatory: add tenant columns, create tenant-leading unique keys,
+  remove legacy unique keys, then deploy code that reads the new columns.
+
+- Background work resolving to `teamclaw` is a temporary compatibility state,
+  not a multi-tenant design. Before the first non-`teamclaw` tenant acquires
+  real Skills data, its scan, reconciliation, cleanup, and recovery paths must
+  have an explicit tenant-iteration design and test coverage.

--- a/src/backend/src/agentclaw/community/core/models/mcp.py
+++ b/src/backend/src/agentclaw/community/core/models/mcp.py
@@ -28,6 +28,9 @@ class SkillSetMCPServer(Base):
     icon = Column(String(500), nullable=True)  # MCP server icon URL
     user_id = Column(String(100), nullable=True, index=True)  # 用户工号
     env = Column(String(50), nullable=True)  # 环境标识: dev/pre/prod
+    # The association is tenant-owned alongside its Skill Set. Keep the field
+    # out of to_dict() so existing Skills API payloads do not change.
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
     # DB-owned timestamps: prod ac_user_mcp_config is `timestamp NULL
     # DEFAULT CURRENT_TIMESTAMP [ON UPDATE CURRENT_TIMESTAMP]`. The repo
     # does not set these in Python (matches the prior prod twin's NOW()).
@@ -52,6 +55,11 @@ class SkillSetMCPServer(Base):
             "gmt_created": self.gmt_created.isoformat() if self.gmt_created else None,
             "gmt_modified": self.gmt_modified.isoformat() if self.gmt_modified else None,
         }
+
+
+# Register where the model is defined so every direct ORM path has the shared
+# read/write boundary without per-repository predicates or Session listeners.
+register_avernet_tenant_guard(SkillSetMCPServer)
 
 
 class UserMCPConfig(Base):

--- a/src/backend/src/agentclaw/community/core/models/skill.py
+++ b/src/backend/src/agentclaw/community/core/models/skill.py
@@ -3,6 +3,7 @@ Skill 相关 ORM 模型（迁移自 services/openclawserver/server/models/skill.
 """
 from agentclaw.community.core.base import Base
 from agentclaw.community.utils.env_utils import get_current_env
+from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
 from sqlalchemy import Column, String, Text, Boolean, DateTime, ForeignKey, UniqueConstraint, Integer, func
 from sqlalchemy.orm import relationship
 
@@ -23,6 +24,10 @@ class SkillSet(Base):
     env = Column(String(20), default=get_current_env, nullable=False)
     engine_type = Column(String(32), nullable=True, index=True, comment="引擎类型，如 openclaw/moltis/hermes/aicoding/claude_code；is_default 行由应用层保证非空")
     is_active = Column(Boolean, default=False, nullable=False, comment="当前激活的技能集")
+    # Persistence-only isolation metadata. The shared guard stamps ORM inserts
+    # from the current request tenant; the server default preserves existing
+    # internal rows and raw writers during the one-tenant cutover.
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
     # Relationships
     skills = relationship("SkillSetSkill", back_populates="skill_set", cascade="all, delete-orphan")
@@ -49,6 +54,9 @@ class SkillSet(Base):
             "engine_type": self.engine_type,
             "is_active": self.is_active if self.is_active is not None else False,
         }
+
+
+register_avernet_tenant_guard(SkillSet)
 
 
 class Skill(Base):
@@ -87,6 +95,9 @@ class Skill(Base):
     category_path = Column(String(256), nullable=True, comment="类目完整路径(ac_skill_category.code)")
     package_url = Column(String(1028), nullable=True, comment="上传到oss上的可访问的url")
     zip_url = Column(String(1028), nullable=True, comment="用户上传的url")
+    # Deliberately absent from to_dict(): tenant is persistence metadata, not
+    # part of the established internal Skills response contract.
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
     __table_args__ = (
         # uix_skill_link_name_env_version dropped along with the
@@ -142,6 +153,9 @@ class Skill(Base):
         }
 
 
+register_avernet_tenant_guard(Skill)
+
+
 class SkillSetSkill(Base):
     """Association table between SkillSet and Skill."""
     __tablename__ = "ac_skill_set_skill"
@@ -155,6 +169,7 @@ class SkillSetSkill(Base):
     gmt_created = Column(DateTime, default=func.now(), nullable=False)
     gmt_modified = Column(DateTime, default=func.now(), onupdate=func.now(), nullable=False)
     env = Column(String(20), default=get_current_env, nullable=False)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
     skill_set = relationship("SkillSet", back_populates="skills")
     skill = relationship("Skill", back_populates="skill_sets")
@@ -171,6 +186,9 @@ class SkillSetSkill(Base):
             "gmt_modified": self.gmt_modified.isoformat() if self.gmt_modified else None,
             "env": self.env,
         }
+
+
+register_avernet_tenant_guard(SkillSetSkill)
 
 
 class UserDefaultSkillSet(Base):

--- a/src/backend/src/agentclaw/community/core/models/skill.py
+++ b/src/backend/src/agentclaw/community/core/models/skill.py
@@ -33,10 +33,9 @@ class SkillSet(Base):
     skills = relationship("SkillSetSkill", back_populates="skill_set", cascade="all, delete-orphan")
     mcp_servers = relationship("SkillSetMCPServer", back_populates="skill_set", cascade="all, delete-orphan")
 
-    __table_args__ = (
-        UniqueConstraint("name", "user_id", "env", "bolt_id", name="uix_skill_set_name_user_env_bot"),
-        {"extend_existing": True},
-    )
+    # Production has no business unique key on ac_skill_set. Keep the local
+    # schema aligned so two tenants can hold the same legacy identity.
+    __table_args__ = {"extend_existing": True}
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -99,12 +98,10 @@ class Skill(Base):
     # part of the established internal Skills response contract.
     avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
-    __table_args__ = (
-        # uix_skill_link_name_env_version dropped along with the
-        # link_name column (2026-05-20) — prod DDL has neither.
-        UniqueConstraint("skill_uuid", "name", "env", "version", name="uix_skill_uuid_name_env_ver"),
-        {"extend_existing": True},
-    )
+    # uix_skill_link_name_env_version was dropped with link_name, and prod has
+    # no replacement unique key on these fields. Keep SQLite create_all aligned
+    # with that production DDL rather than inventing a source-only constraint.
+    __table_args__ = {"extend_existing": True}
 
     skill_sets = relationship("SkillSetSkill", back_populates="skill", cascade="all, delete-orphan")
 

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -50,6 +50,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.skill_repo_sync
   - agentclaw.community.plugin_api.skill_scanner
   - agentclaw.community.utils
+  - agentclaw.community.utils.avernet_tenant
   - agentclaw.community.utils.env_utils
 ```
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_cache.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_cache.py
@@ -16,6 +16,7 @@ from injector import inject
 
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.cache import CachePlugin
+from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 
 
 logger = get_logger()
@@ -26,10 +27,10 @@ logger = get_logger()
 # ============================================================================
 
 class MarketCache:
-    """全局市场技能缓存
+    """按环境和 tenant 分区的市场技能缓存
 
     优先使用 分布式缓存，失败时降级到内存缓存。
-    缓存键使用环境变量区分，全局共享。
+    缓存键按环境和当前 tenant 区分；同一 tenant 内共享。
     """
 
     # 缓存键前缀
@@ -60,9 +61,10 @@ class MarketCache:
             return "dev"
 
     def _build_key(self, base_key: str) -> str:
-        """构建全局缓存键"""
+        """构建环境和 tenant 隔离的缓存键。"""
         env = self._get_env()
-        return f"{self.CACHE_KEY_PREFIX}:{base_key}:{env}"
+        tenant = get_current_avernet_tenant()
+        return f"{self.CACHE_KEY_PREFIX}:{base_key}:{env}:{tenant}"
 
     def _check_zcache_available(self) -> bool:
         """检查 分布式缓存 是否可用（带 TTL 复检）。

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -618,7 +618,13 @@ class SkillSetService:
                 continue
 
             # Create association using repository
-            self.skill_set_repo.add_skill_to_set(skill_set_id, skill.get('id'))
+            if not self.skill_set_repo.add_skill_to_set(
+                skill_set_id, skill.get('id')
+            ):
+                results["failed"].append(
+                    {"skill_id": skill_id, "error": "Failed to add skill to skill set"}
+                )
+                continue
             results["success"].append({"skill_id": skill.get('id'), "name": skill.get('name')})
 
         # Update metadata file
@@ -1353,7 +1359,20 @@ class SkillSetService:
         # Create association (store server_code, name, description and icon)
         from agentclaw.community.utils.env_utils import get_current_env
         current_env = get_current_env()
-        self.skill_set_repo.add_mcp_to_set(skill_set_id, server_code, mcp_name, mcp_description, mcp_icon, user_id, env=current_env)
+        if not self.skill_set_repo.add_mcp_to_set(
+            skill_set_id,
+            server_code,
+            mcp_name,
+            mcp_description,
+            mcp_icon,
+            user_id,
+            env=current_env,
+        ):
+            return {
+                "success": False,
+                "error": "Failed to add MCP server to skill set",
+                "server_code": server_code,
+            }
 
         # Sync to device (blocking - must succeed for operation to be considered successful)
         # Note: API key is NOT passed during initial add, user should configure it separately

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -152,6 +152,7 @@ internal_dependencies:
   - agentclaw.community.log
   - agentclaw.community.plugin_api.database
   - agentclaw.community.core.skills_pool.ports
+  - agentclaw.community.utils.avernet_tenant_guard
 ```
 
 ### Change impact

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
@@ -31,6 +31,9 @@ from agentclaw.community.core.skills_pool.quarantine import (
     RuntimeReconciliationStatus,
 )
 from agentclaw.community.plugin_api.models import AutoIncrementBigInteger
+from agentclaw.community.utils.avernet_tenant_guard import (
+    register_avernet_tenant_guard,
+)
 
 
 def _operational_timestamp(*, fsp: int | None = None):
@@ -192,12 +195,17 @@ class SkillsPoolRolloutAuditModel(Base):
         server_default=func.now(),
         onupdate=func.now(),
     )
+    # Persistence-only isolation metadata. The server default preserves the
+    # internal/background compatibility tenant for non-ORM writers; the shared
+    # guard stamps request-scoped ORM writes and never exposes this field.
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
     __table_args__ = (
         UniqueConstraint(
+            "avernet_tenant",
             "env",
             "effective_config_version",
-            name="uk_skills_pool_rollout_audit_revision",
+            name="uk_skills_pool_rollout_audit_tenant_revision",
         ),
         Index(
             "idx_skills_pool_rollout_audit_batch",
@@ -256,14 +264,18 @@ class SkillMigrationQuarantineModel(Base):
         server_default=func.now(),
         onupdate=func.now(),
     )
+    # Persistence-only isolation metadata. See SkillsPoolRolloutAuditModel for
+    # why this is a server default rather than a Python-side default.
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
     __table_args__ = (
         UniqueConstraint(
+            "avernet_tenant",
             "env",
             "entity_id",
             "bot_id",
             "migration_generation",
-            name="uk_skill_migration_quarantine_scope_generation",
+            name="uk_skill_migration_quarantine_tenant_scope_generation",
         ),
         Index(
             "idx_skill_migration_quarantine_cleanup",
@@ -314,3 +326,10 @@ class SkillMigrationQuarantineModel(Base):
                 else None
             ),
         )
+
+
+# These records are control-plane data, but their identities become tenant-local
+# as soon as Skills has a second tenant. Reuse the single ORM enforcement point
+# rather than adding repository-specific predicates or listeners.
+register_avernet_tenant_guard(SkillsPoolRolloutAuditModel)
+register_avernet_tenant_guard(SkillMigrationQuarantineModel)

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
@@ -56,6 +56,7 @@ class BotSkillLayoutStateModel(Base):
     env = Column(String(20), nullable=False)
     entity_id = Column(String(512), nullable=False)
     bot_id = Column(String(128), nullable=False)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
     active_layout = Column(
         String(20),
         nullable=False,
@@ -96,6 +97,7 @@ class BotSkillLayoutStateModel(Base):
 
     __table_args__ = (
         UniqueConstraint(
+            "avernet_tenant",
             "env",
             "entity_id",
             "bot_id",
@@ -157,6 +159,9 @@ class BotSkillLayoutStateModel(Base):
             gmt_create=self.gmt_create,
             gmt_modified=self.gmt_modified,
         )
+
+
+register_avernet_tenant_guard(BotSkillLayoutStateModel)
 
 
 class SkillsPoolRolloutAuditModel(Base):

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/models.py
@@ -56,7 +56,6 @@ class BotSkillLayoutStateModel(Base):
     env = Column(String(20), nullable=False)
     entity_id = Column(String(512), nullable=False)
     bot_id = Column(String(128), nullable=False)
-    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
     active_layout = Column(
         String(20),
         nullable=False,
@@ -97,7 +96,6 @@ class BotSkillLayoutStateModel(Base):
 
     __table_args__ = (
         UniqueConstraint(
-            "avernet_tenant",
             "env",
             "entity_id",
             "bot_id",
@@ -159,9 +157,6 @@ class BotSkillLayoutStateModel(Base):
             gmt_create=self.gmt_create,
             gmt_modified=self.gmt_modified,
         )
-
-
-register_avernet_tenant_guard(BotSkillLayoutStateModel)
 
 
 class SkillsPoolRolloutAuditModel(Base):
@@ -269,18 +264,13 @@ class SkillMigrationQuarantineModel(Base):
         server_default=func.now(),
         onupdate=func.now(),
     )
-    # Persistence-only isolation metadata. See SkillsPoolRolloutAuditModel for
-    # why this is a server default rather than a Python-side default.
-    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
-
     __table_args__ = (
         UniqueConstraint(
-            "avernet_tenant",
             "env",
             "entity_id",
             "bot_id",
             "migration_generation",
-            name="uk_skill_migration_quarantine_tenant_scope_generation",
+            name="uk_skill_migration_quarantine_scope_generation",
         ),
         Index(
             "idx_skill_migration_quarantine_cleanup",
@@ -333,8 +323,7 @@ class SkillMigrationQuarantineModel(Base):
         )
 
 
-# These records are control-plane data, but their identities become tenant-local
-# as soon as Skills has a second tenant. Reuse the single ORM enforcement point
-# rather than adding repository-specific predicates or listeners.
+# Rollout audit records are tenant-local. Bot layout and quarantine records are
+# keyed globally by (env, entity_id, bot_id), so they deliberately do not use
+# the tenant guard.
 register_avernet_tenant_guard(SkillsPoolRolloutAuditModel)
-register_avernet_tenant_guard(SkillMigrationQuarantineModel)

--- a/src/backend/src/agentclaw/community/plugins/local/README.md
+++ b/src/backend/src/agentclaw/community/plugins/local/README.md
@@ -75,6 +75,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.tracer
   - agentclaw.community.plugins.prod.baas_service    # LocalBaasService inherits ProdBaasService to reuse httpx logic, override URL only
   - agentclaw.community.utils.env_utils
+  - agentclaw.community.utils.avernet_tenant_guard  # Shared tenant isolation for local SQLite ORM models
 ```
 
 ### Change impact

--- a/src/backend/src/agentclaw/community/plugins/local/sqlite_models.py
+++ b/src/backend/src/agentclaw/community/plugins/local/sqlite_models.py
@@ -7,6 +7,7 @@ The model is used in local development mode (DATABASE_MODE=sqlite).
 from sqlalchemy import Column, Integer, String, Text, DateTime, Index, func
 
 from agentclaw.community.core.base import Base
+from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
 
 
 class EntityDeviceBinding(Base):
@@ -85,12 +86,13 @@ class DefaultSkillsetMcpExclusion(Base):
     bot_id = Column(String(64), nullable=False, index=True)
     skill_set_id = Column(Integer, nullable=False, index=True)
     server_code = Column(String(255), nullable=False)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
     excluded_at = Column(DateTime, nullable=False, default=func.now())
     gmt_create = Column(DateTime, nullable=False, default=func.now())
     gmt_modified = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     __table_args__ = (
-        Index("uk_user_bot_skillset_mcp", "user_id", "bot_id", "skill_set_id", "server_code", unique=True),
+        Index("uk_user_bot_skillset_mcp", "avernet_tenant", "user_id", "bot_id", "skill_set_id", "server_code", unique=True),
         {"extend_existing": True},
     )
 
@@ -107,11 +109,16 @@ class DefaultSkillsetSkillExclusion(Base):
     bot_id = Column(String(64), nullable=False, index=True)
     skill_set_id = Column(Integer, nullable=False, index=True)
     skill_id = Column(Integer, nullable=False)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
     excluded_at = Column(DateTime, nullable=False, default=func.now())
     gmt_create = Column(DateTime, nullable=False, default=func.now())
     gmt_modified = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
 
     __table_args__ = (
-        Index("uk_user_bot_skillset_skill", "user_id", "bot_id", "skill_set_id", "skill_id", unique=True),
+        Index("uk_user_bot_skillset_skill", "avernet_tenant", "user_id", "bot_id", "skill_set_id", "skill_id", unique=True),
         {"extend_existing": True},
     )
+
+
+register_avernet_tenant_guard(DefaultSkillsetMcpExclusion)
+register_avernet_tenant_guard(DefaultSkillsetSkillExclusion)

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -52,6 +52,7 @@ from sqlalchemy import and_, func, or_
 
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 
 logger = get_logger()
@@ -1367,6 +1368,7 @@ class SkillSetRepository:
             dialect = db.get_bind().dialect.name
             table = DefaultSkillsetMcpExclusion.__table__
             values = {
+                "avernet_tenant": get_current_avernet_tenant(),
                 "user_id": user_id,
                 "bot_id": bot_id,
                 "skill_set_id": skill_set_id,
@@ -1385,6 +1387,7 @@ class SkillSetRepository:
                 )
                 stmt = stmt.on_conflict_do_update(
                     index_elements=[
+                        "avernet_tenant",
                         "user_id",
                         "bot_id",
                         "skill_set_id",
@@ -1503,6 +1506,7 @@ class SkillSetRepository:
             dialect = db.get_bind().dialect.name
             table = DefaultSkillsetSkillExclusion.__table__
             values = {
+                "avernet_tenant": get_current_avernet_tenant(),
                 "user_id": user_id,
                 "bot_id": bot_id,
                 "skill_set_id": skill_set_id,
@@ -1521,6 +1525,7 @@ class SkillSetRepository:
                 )
                 stmt = stmt.on_conflict_do_update(
                     index_elements=[
+                        "avernet_tenant",
                         "user_id",
                         "bot_id",
                         "skill_set_id",

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -851,12 +851,14 @@ class SkillSetRepository:
     @inject
     def __init__(self, db: DatabasePlugin):
         from agentclaw.community.core.models import (
+            Skill,
             SkillSet,
             SkillSetMCPServer,
             SkillSetSkill,
         )
 
         self._db = db
+        self.Skill = Skill
         self.SkillSet = SkillSet
         self.SkillSetSkill = SkillSetSkill
         self.SkillSetMCPServer = SkillSetMCPServer
@@ -1105,6 +1107,24 @@ class SkillSetRepository:
         user_id: Optional[str] = None,
     ) -> bool:
         with self._db.orm_session() as db:
+            skill_set = (
+                db.query(self.SkillSet)
+                .filter(
+                    self.SkillSet.id == int(skill_set_id),
+                    self.SkillSet.env == get_current_env(),
+                )
+                .one_or_none()
+            )
+            skill = (
+                db.query(self.Skill)
+                .filter(
+                    self.Skill.id == int(skill_id),
+                    self.Skill.env == get_current_env(),
+                )
+                .one_or_none()
+            )
+            if skill_set is None or skill is None:
+                return False
             db.add(
                 self.SkillSetSkill(
                     skill_set_id=int(skill_set_id),
@@ -1269,6 +1289,17 @@ class SkillSetRepository:
         env: Optional[str] = None,
     ) -> bool:
         with self._db.orm_session() as db:
+            target_env = env or get_current_env()
+            skill_set = (
+                db.query(self.SkillSet)
+                .filter(
+                    self.SkillSet.id == int(skill_set_id),
+                    self.SkillSet.env == target_env,
+                )
+                .one_or_none()
+            )
+            if skill_set is None:
+                return False
             db.add(
                 self.SkillSetMCPServer(
                     skill_set_id=int(skill_set_id),

--- a/src/backend/src/agentclaw/community/utils/avernet_tenant_guard.py
+++ b/src/backend/src/agentclaw/community/utils/avernet_tenant_guard.py
@@ -62,11 +62,11 @@ class CrossTenantInsertError(RuntimeError):
 def _read_guard(orm_execute_state: Any) -> None:
     """Confine every guarded model's SELECT/UPDATE/DELETE to the current tenant.
 
-    Column and relationship loads are skipped: they only reload an object that a
-    prior (already tenant-filtered) SELECT put in the session, so they carry no
-    new exposure. This holds while nothing maps a ``relationship()`` to a
-    guarded model; if one is ever added, a lazy load would emit an unfiltered
-    SELECT — revisit this skip then.
+    Column loads are skipped because they only reload an object that a prior
+    (already tenant-filtered) SELECT put in the session. Relationship loads
+    are skipped because ``with_loader_criteria`` from that parent SELECT
+    propagates to lazy loaders; the regression suite proves a parent cannot
+    lazy-load a cross-tenant child through a malformed association.
     """
     if orm_execute_state.is_column_load or orm_execute_state.is_relationship_load:
         return

--- a/src/backend/tests/community/contracts/test_cache.py
+++ b/src/backend/tests/community/contracts/test_cache.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from agentclaw.community.core.skill_center.services.skill_cache import MarketCache
 from agentclaw.community.plugin_api.cache import CachePlugin
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 
 def test_marketcache_set_then_get_round_trips_through_cache_plugin(world) -> None:
@@ -53,3 +54,17 @@ def test_marketcache_round_trips_through_community_cache(community_world) -> Non
     assert cache.get(full_key) is not None, (
         "community CachePlugin must surface the consumer's write"
     )
+
+
+def test_marketcache_partitions_persisted_skill_data_by_current_tenant(world) -> None:
+    mc = world.get(MarketCache)
+
+    with avernet_tenant_scope("tenant-a"):
+        mc.set("market_skills_list_default", {"skills": ["tenant-a"]})
+
+    with avernet_tenant_scope("tenant-b"):
+        assert mc.get("market_skills_list_default") is None
+        mc.set("market_skills_list_default", {"skills": ["tenant-b"]})
+
+    with avernet_tenant_scope("tenant-a"):
+        assert mc.get("market_skills_list_default") == {"skills": ["tenant-a"]}

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -827,6 +827,53 @@ class TestAddSkillsToSetExclusion:
         )
 
     @pytest.mark.asyncio
+    async def test_repository_rejection_is_reported_as_a_failed_skill_add(self):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = {
+            "id": "2", "name": "Custom", "is_default": False, "is_active": False
+        }
+        mock_repo.list_all.return_value = []
+        mock_repo.get_skills_in_set.return_value = []
+        mock_repo.add_skill_to_set.return_value = False
+        mock_skill_repo = MagicMock()
+        mock_skill_repo.get_by_id.return_value = {
+            "id": "42", "name": "catalog-skill", "bolt_id": "default"
+        }
+        svc = self._make_svc(mock_repo, mock_skill_repo)
+
+        with patch("agentclaw.community.core.skill_center.services.skill_set_service.SkillSetMetadataWriter"):
+            result = await svc.add_skills_to_set("2", ["42"], user_id="user1")
+
+        assert result["success"] == []
+        assert result["failed"] == [{
+            "skill_id": "42", "error": "Failed to add skill to skill set"
+        }]
+
+    @pytest.mark.asyncio
+    async def test_repository_rejection_skips_mcp_device_sync(self):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = {
+            "id": "2", "name": "Custom", "is_default": False
+        }
+        mock_repo.get_mcp_servers_in_set.return_value = []
+        mock_repo.add_mcp_to_set.return_value = False
+        svc = self._make_svc(mock_repo, MagicMock())
+        svc.entity_id = "user1"
+        svc.mcp_center.get_mcp_detail.return_value = {
+            "server_code": "mcp.example", "name": "Example MCP"
+        }
+        svc._mcp_sync_service = MagicMock()
+
+        result = await svc.add_mcp_to_skill_set("2", "mcp.example", user_id="user1")
+
+        assert result == {
+            "success": False,
+            "error": "Failed to add MCP server to skill set",
+            "server_code": "mcp.example",
+        }
+        svc._mcp_sync_service.sync_mcp_detail.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unexcluded_default_skill_still_blocks_normal_set(self):
         mock_repo = MagicMock()
         mock_repo.get_by_id.side_effect = lambda skill_set_id: {

--- a/src/backend/tests/community/plugins/test_avernet_tenant_guard.py
+++ b/src/backend/tests/community/plugins/test_avernet_tenant_guard.py
@@ -22,8 +22,8 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import Column, Integer, String, create_engine, event
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine, event
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 from agentclaw.community.utils.avernet_tenant_guard import (
@@ -54,6 +54,25 @@ class _Beta(_Base):
     avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
 
+class _Parent(_Base):
+    __tablename__ = "guard_parent"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(32), nullable=False)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    children = relationship("_Child", back_populates="parent")
+
+
+class _Child(_Base):
+    __tablename__ = "guard_child"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    parent_id = Column(Integer, ForeignKey("guard_parent.id"), nullable=False)
+    name = Column(String(32), nullable=False)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    parent = relationship("_Parent", back_populates="children")
+
+
 class _Unguarded(_Base):
     """Mapped, but declares no tenant column — must be refused registration."""
 
@@ -79,6 +98,8 @@ class _FakeTenantColumn(_Base):
 
 register_avernet_tenant_guard(_Alpha)
 register_avernet_tenant_guard(_Beta)
+register_avernet_tenant_guard(_Parent)
+register_avernet_tenant_guard(_Child)
 
 
 @pytest.fixture
@@ -223,6 +244,30 @@ def test_cross_tenant_write_is_a_noop_on_a_second_model(db):
     with avernet_tenant_scope("tenant-a"):
         with session() as s:
             assert [r.name for r in s.query(_Beta).all()] == ["b-own"]
+
+
+def test_lazy_loaded_relationship_is_tenant_filtered(db):
+    """A parent's relationship must not expose a child from another tenant."""
+    session, _ = db
+
+    with avernet_tenant_scope("tenant-a"):
+        with session() as s:
+            parent = _Parent(name="parent-a")
+            s.add(parent)
+            s.flush()
+            parent_id = parent.id
+            s.add(_Child(parent_id=parent_id, name="child-a"))
+
+    # This is a malformed cross-tenant association, but the ORM guard must
+    # still prevent it from becoming visible through a lazy relationship load.
+    with avernet_tenant_scope("tenant-b"):
+        with session() as s:
+            s.add(_Child(parent_id=parent_id, name="child-b"))
+
+    with avernet_tenant_scope("tenant-a"):
+        with session() as s:
+            parent = s.query(_Parent).filter_by(name="parent-a").one()
+            assert [child.name for child in parent.children] == ["child-a"]
 
 
 def test_unregistered_model_is_untouched(db):

--- a/src/backend/tests/community/plugins/test_skill_catalog_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_skill_catalog_tenant_isolation.py
@@ -1,0 +1,143 @@
+"""Tenant isolation for the Skills catalog and Skill Set association rows."""
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.models import Skill, SkillSet, SkillSetMCPServer, SkillSetSkill
+from agentclaw.community.utils.avernet_tenant import (
+    avernet_tenant_scope,
+)
+from agentclaw.community.utils.avernet_tenant_guard import CrossTenantInsertError
+
+
+MODELS = (Skill, SkillSet, SkillSetSkill, SkillSetMCPServer)
+UPDATE_VALUES = {
+    Skill: {"name": "changed"},
+    SkillSet: {"name": "changed"},
+    SkillSetSkill: {"skill_uuid": "changed"},
+    SkillSetMCPServer: {"name": "changed"},
+}
+
+
+class _SqliteDB:
+    def __init__(self, engine):
+        self._factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+@pytest.fixture
+def db(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'skill-catalog.db'}")
+    for model in MODELS:
+        model.__table__.create(engine)
+    return _SqliteDB(engine)
+
+
+def _seed_catalog(session_factory, tenant: str, suffix: str) -> tuple[int, int, int, int]:
+    with avernet_tenant_scope(tenant):
+        with session_factory.orm_session() as session:
+            skill = Skill(name=f"skill-{suffix}")
+            skill_set = SkillSet(name=f"set-{suffix}")
+            session.add_all((skill, skill_set))
+            session.flush()
+            association = SkillSetSkill(skill_set_id=skill_set.id, skill_id=skill.id)
+            mcp = SkillSetMCPServer(
+                skill_set_id=skill_set.id,
+                server_code=f"server-{suffix}",
+                name=f"MCP {suffix}",
+            )
+            session.add_all((association, mcp))
+            session.flush()
+            return skill.id, skill_set.id, association.id, mcp.id
+
+
+def test_catalog_models_stamp_current_tenant_and_keep_serializers_unchanged(db):
+    ids = _seed_catalog(db, "tenant-a", "a")
+
+    with avernet_tenant_scope("tenant-a"):
+        with db.orm_session() as session:
+            rows = [session.get(model, row_id) for model, row_id in zip(MODELS, ids)]
+            assert [row.avernet_tenant for row in rows] == ["tenant-a"] * len(MODELS)
+            assert all("avernet_tenant" not in row.to_dict() for row in rows)
+
+
+def test_catalog_models_filter_direct_queries_and_cross_tenant_writes(db):
+    own_ids = _seed_catalog(db, "tenant-a", "a")
+    _seed_catalog(db, "tenant-b", "b")
+
+    with avernet_tenant_scope("tenant-a"):
+        with db.orm_session() as session:
+            assert [session.query(model).count() for model in MODELS] == [1] * len(MODELS)
+
+    with avernet_tenant_scope("tenant-b"):
+        with db.orm_session() as session:
+            for model, row_id in zip(MODELS, own_ids):
+                assert session.query(model).filter(model.id == row_id).delete() == 0
+                assert (
+                    session.query(model)
+                    .filter(model.id == row_id)
+                    .update(UPDATE_VALUES[model])
+                    == 0
+                )
+
+    with avernet_tenant_scope("tenant-a"):
+        with db.orm_session() as session:
+            assert [session.get(model, row_id) is not None for model, row_id in zip(MODELS, own_ids)] == [True] * len(MODELS)
+            for model, row_id in zip(MODELS, own_ids):
+                assert (
+                    session.query(model)
+                    .filter(model.id == row_id)
+                    .update(UPDATE_VALUES[model])
+                    == 1
+                )
+            for model, row_id in zip(reversed(MODELS), reversed(own_ids)):
+                assert session.query(model).filter(model.id == row_id).delete() == 1
+
+
+@pytest.mark.parametrize("model, kwargs", [
+    (Skill, {"name": "conflicting-skill"}),
+    (SkillSet, {"name": "conflicting-set"}),
+    (SkillSetSkill, {"skill_set_id": 1, "skill_id": 1}),
+    (SkillSetMCPServer, {"skill_set_id": 1, "server_code": "conflicting", "name": "Conflicting"}),
+])
+def test_catalog_models_reject_explicit_cross_tenant_insert(db, model, kwargs):
+    with avernet_tenant_scope("tenant-a"):
+        with pytest.raises(CrossTenantInsertError):
+            with db.orm_session() as session:
+                session.add(model(**kwargs, avernet_tenant="tenant-b"))
+                session.flush()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "INSERT INTO ac_skill (name, env, is_public, is_builtin, gmt_created, gmt_modified) "
+        "VALUES ('raw-skill', 'dev', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        "INSERT INTO ac_skill_set (name, env, is_default, is_builtin, is_active, gmt_created, gmt_modified) "
+        "VALUES ('raw-set', 'dev', 0, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        "INSERT INTO ac_skill_set_skill (skill_set_id, skill_id, env, gmt_created, gmt_modified) "
+        "VALUES (99, 99, 'dev', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        "INSERT INTO ac_skill_set_mcp (skill_set_id, server_code, name) VALUES (99, 'raw-mcp', 'Raw MCP')",
+    ],
+)
+def test_catalog_raw_writers_receive_teamclaw_server_default(db, sql):
+    """Non-ORM cutover writers retain the internal tenant through DDL default."""
+    with db.orm_session() as session:
+        session.execute(text(sql))
+        table_name = sql.split(" ", 3)[2]
+        assert session.execute(
+            text(f"SELECT avernet_tenant FROM {table_name}")
+        ).scalar_one() == "teamclaw"

--- a/src/backend/tests/community/plugins/test_skill_catalog_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_skill_catalog_tenant_isolation.py
@@ -6,6 +6,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.models import Skill, SkillSet, SkillSetMCPServer, SkillSetSkill
+from agentclaw.community.plugins.skill_repository import SkillSetRepository
 from agentclaw.community.utils.avernet_tenant import (
     avernet_tenant_scope,
 )
@@ -141,3 +142,52 @@ def test_catalog_raw_writers_receive_teamclaw_server_default(db, sql):
         assert session.execute(
             text(f"SELECT avernet_tenant FROM {table_name}")
         ).scalar_one() == "teamclaw"
+
+
+def test_catalog_allows_the_same_legacy_identity_in_two_tenants(db):
+    for tenant in ("tenant-a", "tenant-b"):
+        with avernet_tenant_scope(tenant):
+            with db.orm_session() as session:
+                session.add_all(
+                    (
+                        Skill(
+                            name="shared-skill",
+                            skill_uuid="shared-skill-uuid",
+                            env="dev",
+                            version=1,
+                        ),
+                        SkillSet(
+                            name="shared-set",
+                            user_id="shared-user",
+                            env="dev",
+                            bolt_id="default",
+                        ),
+                    )
+                )
+                session.flush()
+
+
+def test_association_writes_reject_references_owned_by_another_tenant(db):
+    tenant_a_skill_id, tenant_a_set_id, _, _ = _seed_catalog(db, "tenant-a", "a")
+    tenant_b_skill_id, tenant_b_set_id, _, _ = _seed_catalog(db, "tenant-b", "b")
+    repository = SkillSetRepository(db)
+
+    with avernet_tenant_scope("tenant-a"):
+        assert repository.add_skill_to_set(tenant_a_set_id, tenant_a_skill_id) is True
+        assert (
+            repository.add_mcp_to_set(
+                tenant_a_set_id,
+                server_code="own-server",
+                name="Own MCP",
+            )
+            is True
+        )
+        assert repository.add_skill_to_set(tenant_b_set_id, tenant_b_skill_id) is False
+        assert (
+            repository.add_mcp_to_set(
+                tenant_b_set_id,
+                server_code="foreign-server",
+                name="Foreign MCP",
+            )
+            is False
+        )

--- a/src/backend/tests/community/plugins/test_skill_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_skill_repository_unified.py
@@ -114,20 +114,11 @@ def test_skill_create_is_plain_insert_not_upsert(skills):
     assert len(skills.list_skills()) == 2
 
 
-def test_skill_create_hits_sqlite_only_unique_constraint(skills):
-    """DOCUMENTED pre-existing divergence: the SQLite ``Skill`` model
-    declares UniqueConstraint(skill_uuid,name,env,version) that prod
-    ``ac_skill`` DDL does NOT have. ``create`` is a plain INSERT (prod
-    parity) — so a duplicate (skill_uuid,name,env,version) raises
-    IntegrityError on SQLite, whereas prod OceanBase would accept it.
-    Asserting the plain-INSERT shape here (NOT an upsert that would
-    silently update). Flagged in the DDL-parity doc + Pre check."""
-    import pytest as _pytest
-    from sqlalchemy.exc import IntegrityError
-
-    skills.create({"name": "d", "skill_uuid": "x", "version": 1})
-    with _pytest.raises(IntegrityError):
-        skills.create({"name": "d", "skill_uuid": "x", "version": 1})
+def test_skill_create_matches_prod_without_a_source_only_unique_constraint(skills):
+    """Prod accepts duplicate legacy skill identity fields; SQLite must too."""
+    first = skills.create({"name": "d", "skill_uuid": "x", "version": 1})
+    duplicate = skills.create({"name": "d", "skill_uuid": "x", "version": 1})
+    assert duplicate["id"] != first["id"]
 
 
 def test_skill_user_id_anonymous_coercion(skills):

--- a/src/backend/tests/community/plugins/test_skills_pool_control_plane_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_skills_pool_control_plane_tenant_isolation.py
@@ -1,0 +1,287 @@
+"""Tenant isolation for Skills Pool rollout audit and quarantine records."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import create_engine, insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    SkillMigrationQuarantineModel,
+    SkillsPoolRolloutAuditModel,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.plugins.skills_pool_rollout_repository import (
+    SkillsPoolRolloutRepository,
+)
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+from agentclaw.community.utils.avernet_tenant_guard import CrossTenantInsertError
+
+pytestmark = pytest.mark.integration
+
+
+class _SqliteDatabase:
+    def __init__(self, engine) -> None:
+        self._factory = sessionmaker(bind=engine, autoflush=False)
+
+    @contextmanager
+    def transactional_orm_session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+@pytest.fixture
+def database(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'skills-pool-control.db'}")
+    SkillsPoolRolloutAuditModel.__table__.create(engine)
+    SkillMigrationQuarantineModel.__table__.create(engine)
+    return _SqliteDatabase(engine)
+
+
+def _audit(revision: str = "revision-1") -> SkillsPoolRolloutAuditModel:
+    return SkillsPoolRolloutAuditModel(
+        env="pre",
+        config_id=1,
+        action="enable",
+        operator="operator",
+        reason="start canary",
+        effective_config_version=revision,
+    )
+
+
+def _quarantine(
+    generation: str = "generation-1",
+) -> SkillMigrationQuarantineModel:
+    return SkillMigrationQuarantineModel(
+        env="pre",
+        entity_id="owner-1",
+        bot_id="bot-1",
+        migration_generation=generation,
+        engine="openclaw",
+        path="/quarantine/generation-1",
+        source_evidence="{}",
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "factory", "identity_filter", "update_values"),
+    [
+        (
+            SkillsPoolRolloutAuditModel,
+            _audit,
+            lambda item: item.effective_config_version == "revision-1",
+            {"action": "disabled"},
+        ),
+        (
+            SkillMigrationQuarantineModel,
+            _quarantine,
+            lambda item: item.migration_generation == "generation-1",
+            {"status": "cleaned"},
+        ),
+    ],
+)
+def test_control_plane_records_are_stamped_and_direct_orm_reads_are_tenant_scoped(
+    database,
+    model,
+    factory,
+    identity_filter,
+    update_values,
+) -> None:
+    with avernet_tenant_scope("tenant-a"):
+        with database.transactional_orm_session() as session:
+            session.add(factory())
+
+    with avernet_tenant_scope("tenant-b"):
+        with database.transactional_orm_session() as session:
+            assert session.query(model).filter(identity_filter(model)).all() == []
+
+    with database.transactional_orm_session() as session:
+        row = (
+            session.query(model).execution_options(skip_avernet_tenant_guard=True).one()
+        )
+        assert row.avernet_tenant == "tenant-a"
+
+
+@pytest.mark.parametrize(
+    ("model", "factory", "identity_filter", "update_values"),
+    [
+        (
+            SkillsPoolRolloutAuditModel,
+            _audit,
+            lambda item: item.effective_config_version == "revision-1",
+            {"action": "disabled"},
+        ),
+        (
+            SkillMigrationQuarantineModel,
+            _quarantine,
+            lambda item: item.migration_generation == "generation-1",
+            {"status": "cleaned"},
+        ),
+    ],
+)
+def test_cross_tenant_control_plane_update_and_delete_are_noops(
+    database,
+    model,
+    factory,
+    identity_filter,
+    update_values,
+) -> None:
+    with avernet_tenant_scope("tenant-a"):
+        with database.transactional_orm_session() as session:
+            session.add(factory())
+
+    with avernet_tenant_scope("tenant-b"):
+        with database.transactional_orm_session() as session:
+            query = session.query(model).filter(identity_filter(model))
+            assert query.update(update_values, synchronize_session=False) == 0
+            assert query.delete(synchronize_session=False) == 0
+
+    with avernet_tenant_scope("tenant-a"):
+        with database.transactional_orm_session() as session:
+            assert session.query(model).filter(identity_filter(model)).count() == 1
+
+
+@pytest.mark.parametrize(
+    ("model", "factory", "identity_filter", "update_values"),
+    [
+        (
+            SkillsPoolRolloutAuditModel,
+            _audit,
+            lambda item: item.effective_config_version == "revision-1",
+            {"action": "disabled"},
+        ),
+        (
+            SkillMigrationQuarantineModel,
+            _quarantine,
+            lambda item: item.migration_generation == "generation-1",
+            {"status": "cleaned"},
+        ),
+    ],
+)
+def test_own_tenant_can_update_and_delete_control_plane_records(
+    database,
+    model,
+    factory,
+    identity_filter,
+    update_values,
+) -> None:
+    with avernet_tenant_scope("tenant-a"):
+        with database.transactional_orm_session() as session:
+            session.add(factory())
+
+        with database.transactional_orm_session() as session:
+            query = session.query(model).filter(identity_filter(model))
+            assert query.update(update_values, synchronize_session=False) == 1
+
+        with database.transactional_orm_session() as session:
+            query = session.query(model).filter(identity_filter(model))
+            assert query.delete(synchronize_session=False) == 1
+
+        with database.transactional_orm_session() as session:
+            assert session.query(model).filter(identity_filter(model)).count() == 0
+
+
+def test_audit_revision_is_unique_per_tenant_and_serialization_hides_tenant(
+    database,
+) -> None:
+    for tenant in ("tenant-a", "tenant-b"):
+        with avernet_tenant_scope(tenant):
+            with database.transactional_orm_session() as session:
+                session.add(_audit())
+
+    repository = SkillsPoolRolloutRepository(database)
+    with avernet_tenant_scope("tenant-a"):
+        events = repository.list_audit_events(env="pre")
+    assert [event["effective_config_version"] for event in events] == ["revision-1"]
+    assert "avernet_tenant" not in events[0]
+
+    with avernet_tenant_scope("tenant-a"):
+        with pytest.raises(IntegrityError):
+            with database.transactional_orm_session() as session:
+                session.add(_audit())
+                session.flush()
+
+
+def test_quarantine_identity_is_unique_per_tenant_and_serialization_hides_tenant(
+    database,
+) -> None:
+    for tenant in ("tenant-a", "tenant-b"):
+        with avernet_tenant_scope(tenant):
+            with database.transactional_orm_session() as session:
+                row = _quarantine()
+                row.pool_activated_at = datetime.now(UTC).replace(tzinfo=None)
+                session.add(row)
+
+    with avernet_tenant_scope("tenant-a"):
+        with database.transactional_orm_session() as session:
+            record = session.query(SkillMigrationQuarantineModel).one().to_record()
+    assert record.scope == BotSkillLayoutScope("pre", "owner-1", "bot-1")
+    assert not hasattr(record, "avernet_tenant")
+
+    with avernet_tenant_scope("tenant-a"):
+        with pytest.raises(IntegrityError):
+            with database.transactional_orm_session() as session:
+                session.add(_quarantine())
+                session.flush()
+
+
+@pytest.mark.parametrize(
+    ("model", "values"),
+    [
+        (
+            SkillsPoolRolloutAuditModel,
+            {
+                "env": "pre",
+                "config_id": 1,
+                "action": "enable",
+                "operator": "operator",
+                "reason": "default tenant",
+                "effective_config_version": "raw-default",
+            },
+        ),
+        (
+            SkillMigrationQuarantineModel,
+            {
+                "env": "pre",
+                "entity_id": "owner-raw",
+                "bot_id": "bot-raw",
+                "migration_generation": "raw-default",
+                "engine": "openclaw",
+                "path": "/quarantine/raw-default",
+                "source_evidence": "{}",
+            },
+        ),
+    ],
+)
+def test_raw_control_plane_inserts_default_to_teamclaw(database, model, values) -> None:
+    with database.transactional_orm_session() as session:
+        session.execute(insert(model).values(**values))
+        row = (
+            session.query(model).execution_options(skip_avernet_tenant_guard=True).one()
+        )
+        assert row.avernet_tenant == "teamclaw"
+
+
+@pytest.mark.parametrize("factory", [_audit, _quarantine])
+def test_control_plane_insert_rejects_an_explicit_conflicting_tenant(
+    database,
+    factory,
+) -> None:
+    with avernet_tenant_scope("tenant-a"):
+        with pytest.raises(CrossTenantInsertError):
+            with database.transactional_orm_session() as session:
+                row = factory()
+                row.avernet_tenant = "tenant-b"
+                session.add(row)
+                session.flush()

--- a/src/backend/tests/community/plugins/test_skills_pool_control_plane_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_skills_pool_control_plane_tenant_isolation.py
@@ -11,10 +11,15 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.skills_pool.repository.models import (
+    BotSkillLayoutStateModel,
     SkillMigrationQuarantineModel,
     SkillsPoolRolloutAuditModel,
 )
-from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    SkillLayout,
+    SkillLayoutPhase,
+)
 from agentclaw.community.plugins.skills_pool_rollout_repository import (
     SkillsPoolRolloutRepository,
 )
@@ -44,6 +49,7 @@ class _SqliteDatabase:
 @pytest.fixture
 def database(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'skills-pool-control.db'}")
+    BotSkillLayoutStateModel.__table__.create(engine)
     SkillsPoolRolloutAuditModel.__table__.create(engine)
     SkillMigrationQuarantineModel.__table__.create(engine)
     return _SqliteDatabase(engine)
@@ -74,122 +80,73 @@ def _quarantine(
     )
 
 
-@pytest.mark.parametrize(
-    ("model", "factory", "identity_filter", "update_values"),
-    [
-        (
-            SkillsPoolRolloutAuditModel,
-            _audit,
-            lambda item: item.effective_config_version == "revision-1",
-            {"action": "disabled"},
-        ),
-        (
-            SkillMigrationQuarantineModel,
-            _quarantine,
-            lambda item: item.migration_generation == "generation-1",
-            {"status": "cleaned"},
-        ),
-    ],
-)
-def test_control_plane_records_are_stamped_and_direct_orm_reads_are_tenant_scoped(
+def _layout() -> BotSkillLayoutStateModel:
+    return BotSkillLayoutStateModel(
+        env="pre",
+        entity_id="owner-1",
+        bot_id="bot-1",
+        active_layout=SkillLayout.LEGACY.value,
+        phase=SkillLayoutPhase.LEGACY_ACTIVE.value,
+    )
+
+
+def test_rollout_audit_is_stamped_and_direct_orm_reads_are_tenant_scoped(
     database,
-    model,
-    factory,
-    identity_filter,
-    update_values,
 ) -> None:
     with avernet_tenant_scope("tenant-a"):
         with database.transactional_orm_session() as session:
-            session.add(factory())
+            session.add(_audit())
 
     with avernet_tenant_scope("tenant-b"):
         with database.transactional_orm_session() as session:
-            assert session.query(model).filter(identity_filter(model)).all() == []
+            assert session.query(SkillsPoolRolloutAuditModel).all() == []
 
     with database.transactional_orm_session() as session:
         row = (
-            session.query(model).execution_options(skip_avernet_tenant_guard=True).one()
+            session.query(SkillsPoolRolloutAuditModel)
+            .execution_options(skip_avernet_tenant_guard=True)
+            .one()
         )
         assert row.avernet_tenant == "tenant-a"
 
 
-@pytest.mark.parametrize(
-    ("model", "factory", "identity_filter", "update_values"),
-    [
-        (
-            SkillsPoolRolloutAuditModel,
-            _audit,
-            lambda item: item.effective_config_version == "revision-1",
-            {"action": "disabled"},
-        ),
-        (
-            SkillMigrationQuarantineModel,
-            _quarantine,
-            lambda item: item.migration_generation == "generation-1",
-            {"status": "cleaned"},
-        ),
-    ],
-)
-def test_cross_tenant_control_plane_update_and_delete_are_noops(
-    database,
-    model,
-    factory,
-    identity_filter,
-    update_values,
-) -> None:
+def test_cross_tenant_rollout_audit_update_and_delete_are_noops(database) -> None:
     with avernet_tenant_scope("tenant-a"):
         with database.transactional_orm_session() as session:
-            session.add(factory())
+            session.add(_audit())
 
     with avernet_tenant_scope("tenant-b"):
         with database.transactional_orm_session() as session:
-            query = session.query(model).filter(identity_filter(model))
-            assert query.update(update_values, synchronize_session=False) == 0
+            query = session.query(SkillsPoolRolloutAuditModel).filter(
+                SkillsPoolRolloutAuditModel.effective_config_version == "revision-1"
+            )
+            assert query.update({"action": "disabled"}, synchronize_session=False) == 0
             assert query.delete(synchronize_session=False) == 0
 
     with avernet_tenant_scope("tenant-a"):
         with database.transactional_orm_session() as session:
-            assert session.query(model).filter(identity_filter(model)).count() == 1
+            assert session.query(SkillsPoolRolloutAuditModel).count() == 1
 
 
-@pytest.mark.parametrize(
-    ("model", "factory", "identity_filter", "update_values"),
-    [
-        (
-            SkillsPoolRolloutAuditModel,
-            _audit,
-            lambda item: item.effective_config_version == "revision-1",
-            {"action": "disabled"},
-        ),
-        (
-            SkillMigrationQuarantineModel,
-            _quarantine,
-            lambda item: item.migration_generation == "generation-1",
-            {"status": "cleaned"},
-        ),
-    ],
-)
-def test_own_tenant_can_update_and_delete_control_plane_records(
-    database,
-    model,
-    factory,
-    identity_filter,
-    update_values,
-) -> None:
+def test_own_tenant_can_update_and_delete_rollout_audit(database) -> None:
     with avernet_tenant_scope("tenant-a"):
         with database.transactional_orm_session() as session:
-            session.add(factory())
+            session.add(_audit())
 
         with database.transactional_orm_session() as session:
-            query = session.query(model).filter(identity_filter(model))
-            assert query.update(update_values, synchronize_session=False) == 1
+            query = session.query(SkillsPoolRolloutAuditModel).filter(
+                SkillsPoolRolloutAuditModel.effective_config_version == "revision-1"
+            )
+            assert query.update({"action": "disabled"}, synchronize_session=False) == 1
 
         with database.transactional_orm_session() as session:
-            query = session.query(model).filter(identity_filter(model))
+            query = session.query(SkillsPoolRolloutAuditModel).filter(
+                SkillsPoolRolloutAuditModel.effective_config_version == "revision-1"
+            )
             assert query.delete(synchronize_session=False) == 1
 
         with database.transactional_orm_session() as session:
-            assert session.query(model).filter(identity_filter(model)).count() == 0
+            assert session.query(SkillsPoolRolloutAuditModel).count() == 0
 
 
 def test_audit_revision_is_unique_per_tenant_and_serialization_hides_tenant(
@@ -213,75 +170,58 @@ def test_audit_revision_is_unique_per_tenant_and_serialization_hides_tenant(
                 session.flush()
 
 
-def test_quarantine_identity_is_unique_per_tenant_and_serialization_hides_tenant(
-    database,
-) -> None:
-    for tenant in ("tenant-a", "tenant-b"):
-        with avernet_tenant_scope(tenant):
-            with database.transactional_orm_session() as session:
-                row = _quarantine()
-                row.pool_activated_at = datetime.now(UTC).replace(tzinfo=None)
-                session.add(row)
-
-    with avernet_tenant_scope("tenant-a"):
-        with database.transactional_orm_session() as session:
-            record = session.query(SkillMigrationQuarantineModel).one().to_record()
-    assert record.scope == BotSkillLayoutScope("pre", "owner-1", "bot-1")
-    assert not hasattr(record, "avernet_tenant")
-
-    with avernet_tenant_scope("tenant-a"):
-        with pytest.raises(IntegrityError):
-            with database.transactional_orm_session() as session:
-                session.add(_quarantine())
-                session.flush()
-
-
 @pytest.mark.parametrize(
-    ("model", "values"),
+    ("model", "factory"),
     [
-        (
-            SkillsPoolRolloutAuditModel,
-            {
-                "env": "pre",
-                "config_id": 1,
-                "action": "enable",
-                "operator": "operator",
-                "reason": "default tenant",
-                "effective_config_version": "raw-default",
-            },
-        ),
-        (
-            SkillMigrationQuarantineModel,
-            {
-                "env": "pre",
-                "entity_id": "owner-raw",
-                "bot_id": "bot-raw",
-                "migration_generation": "raw-default",
-                "engine": "openclaw",
-                "path": "/quarantine/raw-default",
-                "source_evidence": "{}",
-            },
-        ),
+        (BotSkillLayoutStateModel, _layout),
+        (SkillMigrationQuarantineModel, _quarantine),
     ],
 )
-def test_raw_control_plane_inserts_default_to_teamclaw(database, model, values) -> None:
+def test_bot_scoped_control_records_are_global_and_have_no_tenant_column(
+    database,
+    model,
+    factory,
+) -> None:
+    assert "avernet_tenant" not in model.__table__.c
+
+    for tenant in ("tenant-a", "tenant-b"):
+        with avernet_tenant_scope(tenant):
+            if tenant == "tenant-a":
+                with database.transactional_orm_session() as session:
+                    row = factory()
+                    if isinstance(row, SkillMigrationQuarantineModel):
+                        row.pool_activated_at = datetime.now(UTC).replace(tzinfo=None)
+                    session.add(row)
+            else:
+                with pytest.raises(IntegrityError):
+                    with database.transactional_orm_session() as session:
+                        session.add(factory())
+                        session.flush()
+
+    if model is SkillMigrationQuarantineModel:
+        with database.transactional_orm_session() as session:
+            record = session.query(model).one().to_record()
+        assert record.scope == BotSkillLayoutScope("pre", "owner-1", "bot-1")
+
+def test_raw_rollout_audit_inserts_default_to_teamclaw(database) -> None:
     with database.transactional_orm_session() as session:
-        session.execute(insert(model).values(**values))
+        session.execute(insert(SkillsPoolRolloutAuditModel).values(
+            env="pre", config_id=1, action="enable", operator="operator",
+            reason="default tenant", effective_config_version="raw-default",
+        ))
         row = (
-            session.query(model).execution_options(skip_avernet_tenant_guard=True).one()
+            session.query(SkillsPoolRolloutAuditModel)
+            .execution_options(skip_avernet_tenant_guard=True)
+            .one()
         )
         assert row.avernet_tenant == "teamclaw"
 
 
-@pytest.mark.parametrize("factory", [_audit, _quarantine])
-def test_control_plane_insert_rejects_an_explicit_conflicting_tenant(
-    database,
-    factory,
-) -> None:
+def test_rollout_audit_insert_rejects_an_explicit_conflicting_tenant(database) -> None:
     with avernet_tenant_scope("tenant-a"):
         with pytest.raises(CrossTenantInsertError):
             with database.transactional_orm_session() as session:
-                row = factory()
+                row = _audit()
                 row.avernet_tenant = "tenant-b"
                 session.add(row)
                 session.flush()

--- a/src/backend/tests/community/plugins/test_skills_track_a_ticket_02_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_skills_track_a_ticket_02_tenant_isolation.py
@@ -1,4 +1,4 @@
-"""Tenant isolation for Skills Track A ticket 02 persistence records."""
+"""Tenant isolation for the tenant-scoped Skills Track A ticket 02 records."""
 from contextlib import contextmanager
 
 import pytest
@@ -19,6 +19,12 @@ from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 from agentclaw.community.utils.avernet_tenant_guard import CrossTenantInsertError
 
 pytestmark = pytest.mark.integration
+
+
+TENANT_SCOPED_MODELS = (
+    DefaultSkillsetMcpExclusion,
+    DefaultSkillsetSkillExclusion,
+)
 
 
 class _FileSqliteDB:
@@ -84,7 +90,7 @@ def _raw_insert_values(model):
 
 
 @pytest.mark.parametrize(
-    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+    "model", TENANT_SCOPED_MODELS,
 )
 def test_current_tenant_stamps_insert_and_rejects_conflicting_insert(db, model):
     with avernet_tenant_scope("tenant-a"):
@@ -107,7 +113,7 @@ def test_current_tenant_stamps_insert_and_rejects_conflicting_insert(db, model):
 
 
 @pytest.mark.parametrize(
-    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+    "model", TENANT_SCOPED_MODELS,
 )
 def test_raw_insert_omitting_tenant_uses_server_default(db, model):
     """Core inserts bypass ``before_insert`` and must retain compatibility."""
@@ -122,7 +128,7 @@ def test_raw_insert_omitting_tenant_uses_server_default(db, model):
 
 
 @pytest.mark.parametrize(
-    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+    "model", TENANT_SCOPED_MODELS,
 )
 def test_direct_orm_queries_and_mutations_are_tenant_scoped(db, model):
     with avernet_tenant_scope("tenant-a"):
@@ -161,7 +167,7 @@ def test_direct_orm_queries_and_mutations_are_tenant_scoped(db, model):
 
 
 @pytest.mark.parametrize(
-    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+    "model", TENANT_SCOPED_MODELS,
 )
 def test_tenant_local_business_identity_can_repeat_across_tenants(db, model):
     for tenant in ("tenant-a", "tenant-b"):

--- a/src/backend/tests/community/plugins/test_skills_track_a_ticket_02_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_skills_track_a_ticket_02_tenant_isolation.py
@@ -1,0 +1,203 @@
+"""Tenant isolation for Skills Track A ticket 02 persistence records."""
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine, func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.skills_pool.repository.models import (
+    BotSkillLayoutStateModel,
+)
+from agentclaw.community.core.skills_pool.types import SkillLayout
+from agentclaw.community.plugins.local.sqlite_models import (
+    DefaultSkillsetMcpExclusion,
+    DefaultSkillsetSkillExclusion,
+)
+from agentclaw.community.plugins.skill_repository import SkillSetRepository
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+from agentclaw.community.utils.avernet_tenant_guard import CrossTenantInsertError
+
+pytestmark = pytest.mark.integration
+
+
+class _FileSqliteDB:
+    def __init__(self, engine):
+        self._factory = sessionmaker(bind=engine, autoflush=False)
+
+    @contextmanager
+    def session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    orm_session = session
+
+
+@pytest.fixture
+def db(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'skills-ticket-02.db'}")
+    for model in (
+        DefaultSkillsetMcpExclusion,
+        DefaultSkillsetSkillExclusion,
+        BotSkillLayoutStateModel,
+    ):
+        model.__table__.create(engine)
+    return _FileSqliteDB(engine)
+
+
+def _new_row(model, *, suffix="shared"):
+    if model is DefaultSkillsetMcpExclusion:
+        return model(
+            user_id="user-1", bot_id="bot-1", skill_set_id=7,
+            server_code=f"mcp.{suffix}",
+        )
+    if model is DefaultSkillsetSkillExclusion:
+        return model(
+            user_id="user-1", bot_id="bot-1", skill_set_id=7, skill_id=42,
+        )
+    return model(env="pre", entity_id="entity-1", bot_id=f"bot-{suffix}")
+
+
+def _raw_insert_values(model):
+    if model is DefaultSkillsetMcpExclusion:
+        return {
+            "user_id": "user-1",
+            "bot_id": "bot-1",
+            "skill_set_id": 7,
+            "server_code": "mcp.raw",
+        }
+    if model is DefaultSkillsetSkillExclusion:
+        return {
+            "user_id": "user-1",
+            "bot_id": "bot-1",
+            "skill_set_id": 7,
+            "skill_id": 42,
+        }
+    return {"env": "pre", "entity_id": "entity-1", "bot_id": "bot-raw"}
+
+
+@pytest.mark.parametrize(
+    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+)
+def test_current_tenant_stamps_insert_and_rejects_conflicting_insert(db, model):
+    with avernet_tenant_scope("tenant-a"):
+        with db.session() as session:
+            session.add(_new_row(model))
+
+    with db.session() as session:
+        stored = session.query(model).execution_options(
+            skip_avernet_tenant_guard=True
+        ).one()
+        assert stored.avernet_tenant == "tenant-a"
+
+    with avernet_tenant_scope("tenant-b"):
+        with pytest.raises(CrossTenantInsertError, match=model.__name__):
+            with db.session() as session:
+                conflicting = _new_row(model, suffix="conflict")
+                conflicting.avernet_tenant = "tenant-a"
+                session.add(conflicting)
+                session.flush()
+
+
+@pytest.mark.parametrize(
+    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+)
+def test_raw_insert_omitting_tenant_uses_server_default(db, model):
+    """Core inserts bypass ``before_insert`` and must retain compatibility."""
+    with db.session() as session:
+        session.execute(model.__table__.insert().values(**_raw_insert_values(model)))
+
+    with db.session() as session:
+        stored = session.query(model).execution_options(
+            skip_avernet_tenant_guard=True
+        ).one()
+        assert stored.avernet_tenant == "teamclaw"
+
+
+@pytest.mark.parametrize(
+    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+)
+def test_direct_orm_queries_and_mutations_are_tenant_scoped(db, model):
+    with avernet_tenant_scope("tenant-a"):
+        with db.session() as session:
+            own = _new_row(model, suffix="a")
+            session.add(own)
+            session.flush()
+            own_id = own.id
+    with avernet_tenant_scope("tenant-b"):
+        with db.session() as session:
+            foreign = _new_row(model, suffix="b")
+            session.add(foreign)
+            session.flush()
+            foreign_id = foreign.id
+
+    with avernet_tenant_scope("tenant-a"):
+        with db.session() as session:
+            assert session.query(model).count() == 1
+            assert (
+                session.query(model)
+                .filter(model.id == foreign_id)
+                .update({model.gmt_modified: func.now()}, synchronize_session=False)
+                == 0
+            )
+            assert (
+                session.query(model)
+                .filter(model.id == foreign_id)
+                .delete(synchronize_session=False)
+                == 0
+            )
+            assert session.query(model).filter(model.id == own_id).count() == 1
+
+    with avernet_tenant_scope("tenant-b"):
+        with db.session() as session:
+            assert session.query(model).count() == 1
+
+
+@pytest.mark.parametrize(
+    "model", (DefaultSkillsetMcpExclusion, DefaultSkillsetSkillExclusion, BotSkillLayoutStateModel),
+)
+def test_tenant_local_business_identity_can_repeat_across_tenants(db, model):
+    for tenant in ("tenant-a", "tenant-b"):
+        with avernet_tenant_scope(tenant):
+            with db.session() as session:
+                session.add(_new_row(model))
+
+    with avernet_tenant_scope("tenant-a"):
+        with pytest.raises(IntegrityError):
+            with db.session() as session:
+                session.add(_new_row(model))
+                session.flush()
+
+
+def test_layout_state_value_object_does_not_serialize_tenant(db):
+    with avernet_tenant_scope("tenant-a"):
+        with db.session() as session:
+            session.add(_new_row(BotSkillLayoutStateModel))
+
+    with avernet_tenant_scope("tenant-a"):
+        with db.session() as session:
+            state = session.query(BotSkillLayoutStateModel).one().to_state()
+
+    assert state.active_layout is SkillLayout.LEGACY
+    assert not hasattr(state, "avernet_tenant")
+
+
+def test_default_exclusion_repository_upserts_by_current_tenant(db):
+    repository = SkillSetRepository(db)
+
+    for tenant in ("tenant-a", "tenant-b"):
+        with avernet_tenant_scope(tenant):
+            assert repository.add_default_mcp_exclusion("user-1", "bot-1", 7, "mcp.a")
+            assert repository.add_default_skill_exclusion("user-1", "bot-1", 7, 42)
+
+    for tenant in ("tenant-a", "tenant-b"):
+        with avernet_tenant_scope(tenant):
+            assert repository.get_excluded_mcps("user-1", "bot-1", 7) == ["mcp.a"]
+            assert repository.get_excluded_skills("user-1", "bot-1", 7) == [42]


### PR DESCRIPTION
## What changed

Implements the code and test portions of OpenAPI v1 Skills Track A tenant
isolation across the nine confirmed Skills tables:

- Skills catalog, Skill Set, and their association records
- default Skill Set exclusions and Bot Skills layout state
- Skills Pool rollout audit and migration quarantine control-plane records

Each scoped model now uses the shared tenant guard, stores a non-null tenant
with `teamclaw` as the server default, and keeps tenant metadata out of existing
serialization. Tenant-local uniqueness is represented by the five required
tenant-leading unique keys. The exclusion repository's Core upsert now supplies
the current tenant explicitly because that path bypasses ORM insert events.

## Why

Future public Skills endpoints must not read or mutate internal `teamclaw` data
or collide with an equivalent record from another tenant. This PR establishes
the persistence boundary only; it does not implement any OpenAPI Skills handler
or Skill lifecycle.

## Validation

- Catalog isolation, default exclusion/layout isolation, Skills Pool control
  plane isolation, shared guard, and architecture suites
- Existing affected Skills tests and repository tests
- `ruff` and architecture boundary checks
- Ticket-level full backend/community suites were run during implementation;
  the one discovered architecture-boundary failure was fixed by declaring the
  new dependency before the final focused re-run.

## Release gate / follow-up

This PR is intentionally draft. Production DDL is not a repository migration
and must be completed before application code that reads these columns is
deployed: add all tenant columns, create the five tenant-leading unique keys,
then remove the legacy keys. The corresponding platform execution and the
final bilingual handoff closeout remain Track A tickets 04 and 05.

The PR also does not make Skills public-ready: public endpoint implementation,
real principal resolution, tenant-leading performance indexes, and tenant-aware
background work remain separate gates.
