### PR TITLE
fix(community): filter notify polling by engine (#573)

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/notify_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/notify_router.py
@@ -1,8 +1,8 @@
 """
-Notify router — aggregates pending HITL interactions from all bots via Engine.
+Notify router — aggregates pending HITL interactions from notification-capable bots.
 
 GET /api/v1/notify:
-  1. Get user's active device bindings (bots with sandboxes)
+  1. List notification-capable bots with active device bindings.
   2. Parallel probe each bot's Engine /api/notify endpoint — routed by
      ``device_provider`` via ``DeviceContextResolver`` (same path chat / cron
      use), so BaaS (desktop + cloud), Arca, teclaw and local each reach their
@@ -281,7 +281,7 @@ async def get_notify_summary(
     transport: DeviceAdapterTransport = Injected(DeviceAdapterTransport),
 ):
     """
-    Get aggregated pending notifications from all user bots.
+    Get aggregated pending notifications from notification-capable user bots.
 
     Returns a list of bot summaries, each containing the pending HITL
     interactions from that bot's engine.

--- a/src/backend/src/agentclaw/community/core/notify/bot_lister.py
+++ b/src/backend/src/agentclaw/community/core/notify/bot_lister.py
@@ -8,7 +8,9 @@
   - ``status="ACTIVE"`` —— 只取活绑定
   - ``sandbox_id`` 回退到 ``binding.device_id`` —— 老版本绑定没写 device_props
 
-bot 名字仍然从 ``BotRepository`` 解析 (device_props.bolt_id → bot_id)。
+bot 名字和 ``active_engine`` 从 ``BotRepository`` / ``ac_bots`` 解析。只有
+``aicoding`` / ``claude_code`` 引擎支持 Engine ``/api/notify``，其他引擎
+在生成 ``NotifyTarget`` 前跳过，避免无效探测。
 
 协作者机器人：除 owner 自己的活绑定外，再查 ``CollaboratorRepository``,
 把当前用户作为协作者参与的 Bot 一并纳入通知列表（对齐
@@ -24,6 +26,7 @@ from agentclaw.community.core.bot_collaborator.repository.protocol import (
 )
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.core.notify.constants import NOTIFY_SUPPORTED_ENGINES
 from agentclaw.community.core.notify.protocol import NotifyTarget
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
@@ -67,7 +70,9 @@ class RepositoryNotifyBotLister:
             if not sandbox_id:
                 continue
             bot_id = str(props.get("bolt_id") or b.device_id)
-            bot_name = self._resolve_bot_name(bot_id, user_id)
+            bot_name = self._resolve_supported_bot_name(bot_id, user_id)
+            if bot_name is None:
+                continue
             result.append(NotifyTarget(
                 bot_id=bot_id, bot_name=bot_name,
                 owner_id=user_id, sandbox_id=str(sandbox_id),
@@ -93,22 +98,41 @@ class RepositoryNotifyBotLister:
     # ------------------------------------------------------------------
     # helpers
     # ------------------------------------------------------------------
-    def _resolve_bot_name(self, bot_id: str, owner_id: str) -> str:
-        """Resolve display name; fall back to bot_id on failure.
+    def _resolve_supported_bot_name(
+        self, bot_id: str, owner_id: str
+    ) -> str | None:
+        """Return the display name when the bot supports notification polling.
 
-        镜像原始实现：bot 名字优先从 ``BotRepository`` 取，查不到/报错时
-        回退到 ``bot_id``。
+        ``active_engine`` comes from ``ac_bots`` via ``BotRepository``. Missing
+        bot metadata, lookup failures, and unsupported engines all fail closed:
+        without a confirmed notification-capable engine we must not call the
+        Engine ``/api/notify`` endpoint.
         """
-        bot_name = bot_id
         try:
             bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
-            if bot:
-                bot_name = bot.get("bot_name") or bot_id
         except Exception as e:
             logger.warning(
-                f"[notify_bot_lister] bot lookup failed bot={bot_id}: {e}"
+                f"[notify_bot_lister] bot lookup failed bot={bot_id} "
+                f"owner={owner_id}: {e}"
             )
-        return bot_name
+            return None
+
+        if not bot:
+            logger.warning(
+                f"[notify_bot_lister] bot not found bot={bot_id} "
+                f"owner={owner_id}"
+            )
+            return None
+
+        active_engine = str(bot.get("active_engine") or "").strip().lower()
+        if active_engine not in NOTIFY_SUPPORTED_ENGINES:
+            logger.info(
+                f"[notify_bot_lister] skip unsupported engine bot={bot_id} "
+                f"owner={owner_id} active_engine={active_engine!r}"
+            )
+            return None
+
+        return str(bot.get("bot_name") or bot_id)
 
     def _list_collaborator_mappings(
         self,
@@ -139,7 +163,7 @@ class RepositoryNotifyBotLister:
             f"{len(collaborators)}"
         )
         # NOTE: each collaborator bot issues 2 DB calls (active binding +
-        # name lookup) → O(2N). Fine for typical collaborator counts; if
+        # bot metadata lookup) → O(2N). Fine for typical collaborator counts; if
         # /api/v1/notify polling load grows, add batch methods
         # (get_active_by_bots_and_owners / get_bots_by_ids_and_owners) to
         # DeviceBindingRepository / BotRepository and resolve in O(1).
@@ -167,7 +191,9 @@ class RepositoryNotifyBotLister:
             sandbox_id = props.get("sandbox_id") or binding.device_id
             if not sandbox_id:
                 continue
-            bot_name = self._resolve_bot_name(bot_id, owner_id)
+            bot_name = self._resolve_supported_bot_name(bot_id, owner_id)
+            if bot_name is None:
+                continue
             mappings.append(NotifyTarget(
                 bot_id=bot_id, bot_name=bot_name,
                 owner_id=owner_id, sandbox_id=str(sandbox_id),

--- a/src/backend/src/agentclaw/community/core/notify/constants.py
+++ b/src/backend/src/agentclaw/community/core/notify/constants.py
@@ -1,0 +1,5 @@
+"""Constants for notification-capable bot engines."""
+from __future__ import annotations
+
+
+NOTIFY_SUPPORTED_ENGINES = frozenset({"aicoding", "claude_code"})

--- a/src/backend/src/agentclaw/community/core/notify/local_bot_lister.py
+++ b/src/backend/src/agentclaw/community/core/notify/local_bot_lister.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.notify.constants import NOTIFY_SUPPORTED_ENGINES
 from agentclaw.community.core.notify.protocol import NotifyTarget
 
 
@@ -18,6 +19,9 @@ class LocalNotifyBotLister:
         )
         mappings: list[NotifyTarget] = []
         for bot in bots:
+            active_engine = str(bot.get("active_engine") or "").strip().lower()
+            if active_engine not in NOTIFY_SUPPORTED_ENGINES:
+                continue
             binding_id = bot.get("binding_id")
             if not binding_id:
                 continue

--- a/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
+++ b/src/backend/tests/community/core/notify/test_repository_notify_bot_lister.py
@@ -48,6 +48,10 @@ def _binding(
     )
 
 
+def _bot(bot_name: str | None, active_engine: str = "aicoding") -> dict:
+    return {"bot_name": bot_name, "active_engine": active_engine}
+
+
 def _collab(bot_id: str, owner_id: str, user_id: str = "u001") -> CollaboratorRecord:
     return CollaboratorRecord(
         bot_pk=0,
@@ -111,8 +115,8 @@ class TestRepositoryNotifyBotLister:
                 _binding(device_id="dev2", sandbox_id="sb2", bolt_id="bot2"),
             ],
             bot_lookup={
-                ("bot1", "u001"): {"bot_name": "Alpha"},
-                ("bot2", "u001"): {"bot_name": "Beta"},
+                ("bot1", "u001"): _bot("Alpha"),
+                ("bot2", "u001"): _bot("Beta", "claude_code"),
             },
             collaborator_records=None,  # collaborator repo not provided
         )
@@ -134,12 +138,43 @@ class TestRepositoryNotifyBotLister:
                 _binding(device_id="", sandbox_id=None, bolt_id="bot2"),
             ],
             bot_lookup={
-                ("bot1", "u001"): {"bot_name": "Alpha"},
+                ("bot1", "u001"): _bot("Alpha"),
             },
         )
         result = lister.list_bot_mappings("u001")
         # bot_id comes from device_props.bolt_id; sandbox falls back to device_id
         assert result == [NotifyTarget("bot1", "Alpha", "u001", "dev1")]
+
+    def test_owner_mappings_only_include_notify_supported_engines(self):
+        lister, _, _, _ = _make_lister(
+            bindings=[
+                _binding(device_id="dev1", sandbox_id="sb1", bolt_id="aicoding"),
+                _binding(device_id="dev2", sandbox_id="sb2", bolt_id="claude"),
+                _binding(device_id="dev3", sandbox_id="sb3", bolt_id="openclaw"),
+                _binding(device_id="dev4", sandbox_id="sb4", bolt_id="missing"),
+            ],
+            bot_lookup={
+                ("aicoding", "u001"): _bot("AI Coding", "aicoding"),
+                ("claude", "u001"): _bot("Claude", "claude_code"),
+                ("openclaw", "u001"): _bot("OpenClaw", "openclaw"),
+                ("missing", "u001"): {"bot_name": "Missing Engine"},
+            },
+        )
+
+        assert lister.list_bot_mappings("u001") == [
+            NotifyTarget("aicoding", "AI Coding", "u001", "sb1"),
+            NotifyTarget("claude", "Claude", "u001", "sb2"),
+        ]
+
+    def test_owner_bot_lookup_failure_is_skipped(self):
+        lister, _, bot_repo, _ = _make_lister(
+            bindings=[
+                _binding(device_id="dev1", sandbox_id="sb1", bolt_id="bot1"),
+            ],
+        )
+        bot_repo.get_by_id_and_owner.side_effect = RuntimeError("db down")
+
+        assert lister.list_bot_mappings("u001") == []
 
     # ------------------------------------------------------------------
     # Collaborator fold-in
@@ -151,8 +186,8 @@ class TestRepositoryNotifyBotLister:
                 _binding(device_id="dev1", sandbox_id="sb1", bolt_id="owned"),
             ],
             bot_lookup={
-                ("owned", "u001"): {"bot_name": "Mine"},
-                ("cobra", "ownerA"): {"bot_name": "Collab"},
+                ("owned", "u001"): _bot("Mine"),
+                ("cobra", "ownerA"): _bot("Collab", "claude_code"),
             },
             collaborator_records=[_collab("cobra", "ownerA")],
             binding_by_bot_owner={
@@ -176,6 +211,31 @@ class TestRepositoryNotifyBotLister:
         bot_repo.get_by_id_and_owner.assert_any_call("cobra", "ownerA")
         collab_repo.list_by_user.assert_called_once()
 
+    def test_collaborator_mappings_skip_unsupported_engines(self):
+        lister, _, _, _ = _make_lister(
+            bindings=[],
+            collaborator_records=[
+                _collab("coding", "ownerA"),
+                _collab("general", "ownerB"),
+            ],
+            bot_lookup={
+                ("coding", "ownerA"): _bot("Coding", "claude_code"),
+                ("general", "ownerB"): _bot("General", "openclaw"),
+            },
+            binding_by_bot_owner={
+                ("coding", "ownerA"): _binding(
+                    device_id="devA", sandbox_id="sbA", bolt_id="coding"
+                ),
+                ("general", "ownerB"): _binding(
+                    device_id="devB", sandbox_id="sbB", bolt_id="general"
+                ),
+            },
+        )
+
+        assert lister.list_bot_mappings("u001") == [
+            NotifyTarget("coding", "Coding", "ownerA", "sbA")
+        ]
+
     def test_collaborator_duplicate_with_owner_is_deduped(self):
         # bot "shared" is owned by u001 AND u001 is recorded as a collaborator →
         # must appear exactly once, coming from the owner path.
@@ -184,8 +244,8 @@ class TestRepositoryNotifyBotLister:
                 _binding(device_id="dev1", sandbox_id="sb1", bolt_id="shared"),
             ],
             bot_lookup={
-                ("shared", "u001"): {"bot_name": "Shared"},
-                ("shared", "ownerA"): {"bot_name": "SharedOwner"},
+                ("shared", "u001"): _bot("Shared"),
+                ("shared", "ownerA"): _bot("SharedOwner"),
             },
             collaborator_records=[_collab("shared", "ownerA")],
             binding_by_bot_owner={
@@ -209,6 +269,10 @@ class TestRepositoryNotifyBotLister:
                 _collab("cbot1", "ownerA"),
                 _collab("cbot2", "ownerB"),
             ],
+            bot_lookup={
+                ("cbot1", "ownerA"): _bot(None),
+                ("cbot2", "ownerB"): _bot(None),
+            },
             binding_by_bot_owner={
                 # cbot1 has an active binding, cbot2 does not
                 ("cbot1", "ownerA"): _binding(
@@ -232,6 +296,7 @@ class TestRepositoryNotifyBotLister:
                 _collab("cbot1", "ownerA"),
                 _collab("cbot_empty", ""),  # missing owner_id
             ],
+            bot_lookup={("cbot1", "ownerA"): _bot(None)},
             binding_by_bot_owner={
                 ("cbot1", "ownerA"): _binding(
                     device_id="devA", sandbox_id="sbA", bolt_id="cbot1"
@@ -252,7 +317,7 @@ class TestRepositoryNotifyBotLister:
         )
 
     def test_collaborator_bot_name_falls_back_to_bot_id(self):
-        # bot_repo raises / returns None → name falls back to bot_id
+        # Supported bot with an empty name falls back to bot_id.
         lister, binding_repo, bot_repo, _ = _make_lister(
             bindings=[],
             collaborator_records=[_collab("cbot1", "ownerA")],
@@ -262,7 +327,7 @@ class TestRepositoryNotifyBotLister:
                 ),
             },
         )
-        bot_repo.get_by_id_and_owner.return_value = None
+        bot_repo.get_by_id_and_owner.return_value = _bot(None)
 
         result = lister.list_bot_mappings("u001")
 
@@ -273,7 +338,7 @@ class TestRepositoryNotifyBotLister:
             bindings=[
                 _binding(device_id="dev1", sandbox_id="sb1", bolt_id="owned"),
             ],
-            bot_lookup={("owned", "u001"): {"bot_name": "Mine"}},
+            bot_lookup={("owned", "u001"): _bot("Mine")},
             collaborator_records=[],
         )
         collab_repo.list_by_user.side_effect = RuntimeError("db down")
@@ -290,6 +355,7 @@ class TestRepositoryNotifyBotLister:
                 _collab("cbot1", "ownerA"),
                 _collab("cbot2", "ownerB"),
             ],
+            bot_lookup={("cbot1", "ownerA"): _bot(None)},
             binding_by_bot_owner={
                 ("cbot1", "ownerA"): _binding(
                     device_id="devA", sandbox_id="sbA", bolt_id="cbot1"

--- a/src/backend/tests/community/plugins/local/test_notify_bot_lister.py
+++ b/src/backend/tests/community/plugins/local/test_notify_bot_lister.py
@@ -7,9 +7,15 @@ from agentclaw.community.core.notify.protocol import NotifyTarget
 def test_list_bot_mappings_uses_active_personal_bots_from_repository():
     bot_repo = MagicMock()
     bot_repo.list_active_bots_by_entity.return_value = [
-        {"bot_id": "bot1", "bot_name": "Alpha", "binding_id": 101},
-        {"bot_id": "bot2", "bot_name": "Beta", "binding_id": None},
-        {"bot_id": "bot3", "binding_id": 103},
+        {
+            "bot_id": "bot1", "bot_name": "Alpha", "binding_id": 101,
+            "active_engine": "aicoding",
+        },
+        {
+            "bot_id": "bot2", "bot_name": "Beta", "binding_id": None,
+            "active_engine": "claude_code",
+        },
+        {"bot_id": "bot3", "binding_id": 103, "active_engine": "claude_code"},
     ]
     lister = LocalNotifyBotLister(bot_repository=bot_repo)
 
@@ -28,8 +34,41 @@ def test_list_bot_mappings_skips_empty_bot_id():
     """Entries with falsy bot_id are filtered out."""
     bot_repo = MagicMock()
     bot_repo.list_active_bots_by_entity.return_value = [
-        {"bot_id": "", "bot_name": "Ghost", "binding_id": 200},
-        {"bot_id": "real", "bot_name": "OK", "binding_id": 201},
+        {
+            "bot_id": "", "bot_name": "Ghost", "binding_id": 200,
+            "active_engine": "aicoding",
+        },
+        {
+            "bot_id": "real", "bot_name": "OK", "binding_id": 201,
+            "active_engine": "claude_code",
+        },
     ]
     lister = LocalNotifyBotLister(bot_repository=bot_repo)
     assert lister.list_bot_mappings("u002") == [NotifyTarget("real", "OK", "u002", "201")]
+
+
+def test_list_bot_mappings_only_includes_notify_supported_engines():
+    bot_repo = MagicMock()
+    bot_repo.list_active_bots_by_entity.return_value = [
+        {
+            "bot_id": "aicoding", "bot_name": "AI Coding", "binding_id": 101,
+            "active_engine": "aicoding",
+        },
+        {
+            "bot_id": "claude", "bot_name": "Claude", "binding_id": 102,
+            "active_engine": "claude_code",
+        },
+        {
+            "bot_id": "openclaw", "bot_name": "OpenClaw", "binding_id": 103,
+            "active_engine": "openclaw",
+        },
+        {
+            "bot_id": "missing", "bot_name": "Missing", "binding_id": 104,
+        },
+    ]
+    lister = LocalNotifyBotLister(bot_repository=bot_repo)
+
+    assert lister.list_bot_mappings("u003") == [
+        NotifyTarget("aicoding", "AI Coding", "u003", "101"),
+        NotifyTarget("claude", "Claude", "u003", "102"),
+    ]


### PR DESCRIPTION
## Summary

- filter `/api/v1/notify` polling targets by `ac_bots.active_engine`
- only probe bots using `aicoding` or `claude_code`
- apply the same eligibility rule to owner, collaborator, and local/singlebox bot listings
- fail closed when bot metadata or `active_engine` cannot be resolved

## Testing

- `DEPLOY_PROFILE=test uv run pytest tests/community/core/notify/test_repository_notify_bot_lister.py tests/community/plugins/local/test_notify_bot_lister.py tests/community/api/aicoding/test_notify_router.py -q` (49 passed)
- `uv run ruff check` on all changed Python files
- repository pre-push Python SAST/lint gate