### PR TITLE
fix(engine): reject retired AICoding corpus links

### DIFF
--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -260,6 +260,70 @@ def test_aicoding_activation_retires_full_corpus_from_active_root(
     assert not active_repo.exists()
 
 
+def test_aicoding_activation_rejects_unmapped_link_through_retired_corpus(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, _, pool_repo = _prepared_home(tmp_path)
+    active_root = local_bridge.parent
+    active_repo = active_root / "skills-repo"
+    repo_skill = active_repo / "business" / "historical"
+    repo_skill.mkdir(parents=True)
+    (repo_skill / "SKILL.md").write_text("historical")
+    historical = active_root / "historical"
+    historical.symlink_to(repo_skill, target_is_directory=True)
+
+    def retire_active_repo(_generation: str, _preparation_id: str):
+        for path in sorted(active_repo.rglob("*"), reverse=True):
+            path.unlink() if path.is_file() else path.rmdir()
+        active_repo.rmdir()
+        return {"status": "retired"}
+
+    result = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=retire_active_repo,
+    )
+
+    assert result.status is PoolActivationStatus.POST_CUTOVER_SYNC_PENDING
+    assert result.evidence["reason"] == "post_retirement_layout_invalid"
+    assert (
+        result.evidence["probe"]["reason"]
+        == "retired_active_corpus_reference_present"
+    )
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "finalizing"
+    assert historical.is_symlink()
+    assert not historical.exists()
+
+    canonical_repo_skill = pool_repo / "business" / "historical"
+    canonical_repo_skill.mkdir(parents=True)
+    (canonical_repo_skill / "SKILL.md").write_text("historical")
+    historical.unlink()
+    historical.symlink_to(canonical_repo_skill, target_is_directory=True)
+
+    retry = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        retire_active_repo=retire_active_repo,
+    )
+
+    assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    marker = json.loads(
+        (home / ".aicoding" / "workspace" / "skills-pool" / ".pool-active").read_text()
+    )
+    assert marker["activation_state"] == "active"
+
+
 def test_aicoding_activation_reserves_active_repo_corpus_name(
     tmp_path: Path,
 ) -> None:

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -515,6 +515,40 @@ def test_aicoding_active_probe_rejects_full_corpus_in_active_root(
     assert inspection.evidence["reason"] == "active_repo_corpus_present"
 
 
+def test_aicoding_active_probe_rejects_skill_link_through_retired_corpus(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, _, _, pool_repo = _prepared_home(tmp_path)
+    activated = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[],
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    active_root = local_bridge.parent
+    retired_repo = active_root / "skills-repo"
+    indirect = active_root / "shared"
+    indirect.symlink_to(
+        retired_repo / "business/shared",
+        target_is_directory=True,
+    )
+    assert not indirect.exists()
+
+    inspection = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert inspection.status is RuntimeLayoutInspectionStatus.INVALID
+    assert (
+        inspection.evidence["reason"]
+        == "retired_active_corpus_reference_present"
+    )
+
+
 def test_aicoding_rollback_rebuilds_legacy_from_current_pool(
     tmp_path: Path,
 ) -> None:

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -12,6 +12,7 @@ from engine.community.plugins.openclaw.layout_probe import (
     RuntimeLayoutInspectionStatus,
     inspect_runtime_layout,
 )
+from engine.community.plugins.skills_pool import layout_probe as shared_layout_probe
 
 
 def _ready_home(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
@@ -171,6 +172,32 @@ def test_finalizing_marker_allows_concurrent_skill_deactivation(tmp_path):
     )
 
     assert result.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_finalizing_marker_rejects_unreadable_active_entries(
+    tmp_path, monkeypatch
+):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    _write_active_marker(home, activation_state="finalizing")
+
+    def raise_permission_error(*_args, **_kwargs):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(
+        shared_layout_probe,
+        "_active_entries_failure_reason",
+        raise_permission_error,
+    )
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.INVALID
+    assert result.evidence["reason"] == "active_managed_entry_invalid"
 
 
 def test_active_marker_allows_normal_skill_activation(tmp_path):

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -417,6 +417,7 @@ def _finalize_active_root(
     quarantine: Path,
     retire_path: Callable[[Path, Path], None],
     retire_active_repo: Callable[[str, str], dict[str, object]] | None,
+    repo_is_mounted: Callable[[Path], bool],
 ) -> PoolActivationResult | None:
     published = publish_pool_mappings(
         mappings=mappings,
@@ -563,6 +564,21 @@ def _finalize_active_root(
             {
                 "reason": "post_retirement_mapping_verify_failed",
                 "mapping": final_verification.evidence,
+            },
+        )
+    final_inspection = inspect_runtime_layout(
+        engine=engine,
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=layout.pool_root.parents[2],
+        repo_is_mounted=repo_is_mounted,
+    )
+    if final_inspection.status is not RuntimeLayoutInspectionStatus.READY:
+        return PoolActivationResult(
+            PoolActivationStatus.POST_CUTOVER_SYNC_PENDING,
+            {
+                "reason": "post_retirement_layout_invalid",
+                "probe_status": final_inspection.status.value,
+                "probe": final_inspection.evidence,
             },
         )
     _write_active_marker(
@@ -1203,6 +1219,7 @@ def _activate_pool(
 
     home_path = Path(home)
     layout = _Layout.for_engine(engine, home_path)
+    repo_mount_probe = repo_is_mounted or os.path.ismount
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", migration_generation):
         return _invalid("migration_generation_invalid")
     try:
@@ -1232,7 +1249,7 @@ def _activate_pool(
         engine=engine,
         expected_contract_version=LAYOUT_CONTRACT_VERSION,
         home=home_path,
-        repo_is_mounted=repo_is_mounted or os.path.ismount,
+        repo_is_mounted=repo_mount_probe,
     )
     layout_ready = (
         inspection.status is RuntimeLayoutInspectionStatus.READY
@@ -1286,6 +1303,7 @@ def _activate_pool(
                 quarantine=quarantine,
                 retire_path=retire_path,
                 retire_active_repo=retire_active_repo,
+                repo_is_mounted=repo_mount_probe,
             )
         except OSError as error:
             return PoolActivationResult(
@@ -1354,6 +1372,7 @@ def _activate_pool(
                 quarantine=quarantine,
                 retire_path=retire_path,
                 retire_active_repo=retire_active_repo,
+                repo_is_mounted=repo_mount_probe,
             )
             if completion_failure is not None:
                 return completion_failure
@@ -1423,6 +1442,7 @@ def _activate_pool(
                 quarantine=quarantine,
                 retire_path=retire_path,
                 retire_active_repo=retire_active_repo,
+                repo_is_mounted=repo_mount_probe,
             )
             if completion_failure is not None:
                 return completion_failure
@@ -1552,6 +1572,7 @@ def _activate_pool(
             quarantine=quarantine,
             retire_path=retire_path,
             retire_active_repo=retire_active_repo,
+            repo_is_mounted=repo_mount_probe,
         )
         if completion_failure is not None:
             return completion_failure

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -772,30 +772,30 @@ def inspect_runtime_layout(
                         reason="stable_repo_bridge_invalid",
                         preparation_id=preparation_id,
                     )
-            try:
-                active_entries_failure_reason = _active_entries_failure_reason(
-                    layout,
-                    engine=engine,
-                )
-            except PermissionError:
-                active_entries_failure_reason = "active_managed_entry_invalid"
-            except OSError as error:
-                return _transient(
-                    engine=engine,
-                    contract_version=expected_contract_version,
-                    layout=layout,
-                    reason="active_entries_temporarily_unavailable",
-                    error=error,
-                    preparation_id=preparation_id,
-                )
-            if active_entries_failure_reason is not None:
-                return _invalid(
-                    engine=engine,
-                    contract_version=expected_contract_version,
-                    layout=layout,
-                    reason=active_entries_failure_reason,
-                    preparation_id=preparation_id,
-                )
+        try:
+            active_entries_failure_reason = _active_entries_failure_reason(
+                layout,
+                engine=engine,
+            )
+        except PermissionError:
+            active_entries_failure_reason = "active_managed_entry_invalid"
+        except OSError as error:
+            return _transient(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="active_entries_temporarily_unavailable",
+                error=error,
+                preparation_id=preparation_id,
+            )
+        if active_entries_failure_reason is not None:
+            return _invalid(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason=active_entries_failure_reason,
+                preparation_id=preparation_id,
+            )
         active_checks = {
             "marker_valid": True,
             "active_marker_valid": True,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -394,7 +394,11 @@ def _active_marker_valid(
     return True
 
 
-def _active_entries_valid(layout: _FilesystemPoolLayout) -> bool:
+def _active_entries_failure_reason(
+    layout: _FilesystemPoolLayout,
+    *,
+    engine: str,
+) -> str | None:
     """Validate mutable managed entries without freezing an old mapping set."""
 
     pool_roots = tuple(
@@ -409,6 +413,14 @@ def _active_entries_valid(layout: _FilesystemPoolLayout) -> bool:
             layout.repo_bridge,
         )
     )
+    retired_active_corpus_roots = (
+        (
+            Path(os.path.abspath(layout.active_root / "skills-local")),
+            Path(os.path.abspath(layout.active_root / "skills-repo")),
+        )
+        if engine == "aicoding"
+        else ()
+    )
     for entry in layout.active_root.iterdir():
         if not entry.is_symlink():
             continue
@@ -417,14 +429,16 @@ def _active_entries_valid(layout: _FilesystemPoolLayout) -> bool:
             try:
                 target_stat = entry.stat()
             except (FileNotFoundError, NotADirectoryError):
-                return False
+                return "active_managed_entry_invalid"
             if not stat.S_ISDIR(target_stat.st_mode):
-                return False
+                return "active_managed_entry_invalid"
             continue
+        if any(target.is_relative_to(root) for root in retired_active_corpus_roots):
+            return "retired_active_corpus_reference_present"
         if any(target.is_relative_to(root) for root in retired_roots):
-            return False
+            return "active_managed_entry_invalid"
         # External active entries predate Pool and remain outside this migration.
-    return True
+    return None
 
 
 def inspect_runtime_layout(
@@ -759,9 +773,12 @@ def inspect_runtime_layout(
                         preparation_id=preparation_id,
                     )
             try:
-                active_entries_valid = _active_entries_valid(layout)
+                active_entries_failure_reason = _active_entries_failure_reason(
+                    layout,
+                    engine=engine,
+                )
             except PermissionError:
-                active_entries_valid = False
+                active_entries_failure_reason = "active_managed_entry_invalid"
             except OSError as error:
                 return _transient(
                     engine=engine,
@@ -771,12 +788,12 @@ def inspect_runtime_layout(
                     error=error,
                     preparation_id=preparation_id,
                 )
-            if not active_entries_valid:
+            if active_entries_failure_reason is not None:
                 return _invalid(
                     engine=engine,
                     contract_version=expected_contract_version,
                     layout=layout,
-                    reason="active_managed_entry_invalid",
+                    reason=active_entries_failure_reason,
                     preparation_id=preparation_id,
                 )
         active_checks = {


### PR DESCRIPTION
## Summary

- classify AICoding active-skill symlinks that still target retired `.claude/skills/skills-local` or `skills-repo` roots as invalid
- keep pure Claude Code and other engine probe semantics unchanged
- return a specific fail-closed reason so rollout cannot accept a partially retired active root

## Root cause

The Relay could retire the structural corpus bridge while historical direct skill links still referenced paths underneath it. Those links became dangling, but the runtime probe treated them as unrelated external links and incorrectly returned READY.

## Validation

- AICoding Pool layout tests: 16 passed
- AICoding + Claude Code + Hermes + OpenClaw targeted layout tests: 63 passed
- Engine full suite: 2156 passed, 5 skipped
- `git diff --check`