### PR TITLE
fix(skill): preserve collaborator author

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -446,7 +446,10 @@ async def upload_skill(
 
         logger.info(f"[skills.upload_skill] Calling service.upload_skill with {len(uploaded_files)} files")
 
-        # Use user_id from query param if provided, otherwise fall back to ctx.user_id
+        # ``user_id`` identifies the Bot owner for collaborator authorization and
+        # device access. Skill metadata belongs to the authenticated uploader;
+        # using the owner for both made collaborator-uploaded local Skills appear
+        # to have been authored by the Bot owner.
         effective_user_id = user_id or ctx.user_id
 
         # Call the service method (async)
@@ -461,6 +464,7 @@ async def upload_skill(
             skill = await service.upload_skill(
                 uploaded_files,
                 user_id=effective_user_id,
+                author_id=ctx.user_id,
                 bolt_id=effective_bot_id,
             )
         finally:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1784,6 +1784,7 @@ class SkillService:
         self,
         uploaded_files: list[dict[str, Any]],
         user_id: str | None = None,
+        author_id: str | None = None,
         bolt_id: str | None = None
     ):
         """
@@ -1794,7 +1795,8 @@ class SkillService:
                 - filename: 文件名
                 - content: 文件内容（bytes）
                 - relative_path: 相对路径（文件夹上传时使用）
-            user_id: 用户 ID
+            user_id: Bot owner ID，用于设备文件系统路由
+            author_id: 实际上传者 ID，用于 Skill 元数据；未提供时兼容为 user_id
             bolt_id: Bot ID，为空时默认使用 'default'
 
         Returns:
@@ -1803,9 +1805,10 @@ class SkillService:
         Raises:
             ValueError: 如果验证失败
         """
+        author_id = author_id or user_id
         logger.info(
             f"[SkillService.upload_skill] Start: file_count={len(uploaded_files)}, "
-            f"user_id={user_id}, bolt_id={bolt_id}"
+            f"user_id={user_id}, author_id={author_id}, bolt_id={bolt_id}"
         )
 
         if not uploaded_files:
@@ -1837,7 +1840,7 @@ class SkillService:
         existing_skill = self._skill_repo.get_bot_local_by_name(
             bot_id=bolt_id or "default",
             name=skill_name,
-            user_id=user_id,
+            user_id=author_id,
         )
         existing_locator = (
             str(existing_skill["git_path"])[len("local://") :]
@@ -1888,8 +1891,8 @@ class SkillService:
                     'git_path': skill_path,
                     'gmt_modified': datetime.utcnow()
                 }
-                if user_id:
-                    update_data['user_id'] = user_id
+                if author_id:
+                    update_data['user_id'] = author_id
                 updated = self._skill_repo.update(existing_skill['id'], update_data)
                 logger.info(
                     f"[SkillService.upload_skill] Updated existing skill: {skill_name} "
@@ -1905,7 +1908,7 @@ class SkillService:
                     category=skill_info.get("category", "general"),
                     tags=skill_info.get("tags", []),
                     is_public=False,  # 本地技能默认不公开
-                    user_id=user_id,
+                    user_id=author_id,
                     bolt_id=bolt_id
                 )
                 logger.info(f"[SkillService.upload_skill] Created new skill: {skill_name} (id: {skill.get('id')})")

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -302,6 +302,21 @@ class TestUploadSkillValidation:
             assert body["success"] is True
             assert mock_svc.upload_skill.await_count == 1
 
+    def test_upload_passes_authenticated_user_as_author(self, mock_ctx):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _, _):
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    ("files", ("SKILL.md", b"---\nname: a\ndescription: a\n---", "text/markdown"))
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            assert response.json()["success"] is True
+            mock_svc.upload_skill.assert_awaited_once()
+            assert mock_svc.upload_skill.await_args.kwargs["user_id"] == mock_ctx.user_id
+            assert mock_svc.upload_skill.await_args.kwargs["author_id"] == mock_ctx.user_id
+
     def test_upload_passes_bot_scope_to_layout_aware_factory(self, mock_ctx):
         with _upload_skill_di_app(
             mock_ctx,

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -62,6 +62,24 @@ async def test_teclaw_upload_adapts_path_and_stores_logical_git_path():
 
 
 @pytest.mark.asyncio
+async def test_upload_uses_author_id_for_skill_metadata():
+    fake_fs = MagicMock()
+    fake_fs.delete_tree = AsyncMock(return_value=True)
+    fake_fs.write_file = AsyncMock()
+    svc = _service(Path("skills-local"), to_local_skill_engine_path, fake_fs)
+
+    uploaded = [{"filename": "SKILL.md", "relative_path": "SKILL.md", "content": SKILL_MD}]
+    await svc.upload_skill(
+        uploaded,
+        user_id="bot-owner",
+        author_id="collaborator",
+        bolt_id="b1",
+    )
+
+    assert svc.create_skill.call_args.kwargs["user_id"] == "collaborator"
+
+
+@pytest.mark.asyncio
 async def test_non_teclaw_upload_passes_host_path_through_unchanged():
     fake_fs = MagicMock()
     fake_fs.delete_tree = AsyncMock(return_value=True)


### PR DESCRIPTION
## 变更

- 协作者上传私有 Skill 时，将实际认证用户写为 Skill 作者。
- 读取该 Skill 的 README 时，始终使用请求中解析的 Bot owner 定位设备与容器。

## 根因

上传接口此前将 Bot owner 同时用于设备访问和 Skill 作者字段，导致作者显示错误。拆分作者后，README 链路仍从 `skill.user_id` 解析设备；该字段已是协作者，因而无法定位服务 Bot 的活动设备。

## 修复

`SkillService.get_skill_readme()` 新增显式 `device_owner_id`，只用于设备文件系统路由；`skill.user_id` 仅保留作者含义。

## 验证

- `uv run pytest tests/community/api/skill_center/test_skills_routes_teclaw.py -q`（6 passed）
- `uv run pytest tests/community/core/skill_center/services/test_skill_service_readme.py -q`（24 passed）
- `uv run pytest tests/community/api/skill_center/test_skills_api_async_correctness.py -q`（21 passed）
- `uv run pytest tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py -q`（14 passed）