### PR TITLE
fix(mcp): pass --config to mcporter CLI invocations

### DIFF
--- a/src/engine/src/engine/community/claude_code_gateway/src/mcp/handlers.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/src/mcp/handlers.ts
@@ -241,7 +241,7 @@ export async function handleConfigDelete(
 // ---- Tools plane (phase-1 stub) ----
 
 export async function handleToolsList(
-  _store: McpStore,
+  store: McpStore,
   params: unknown,
 ): Promise<McpResult<{ tools: Array<{ name: string; description?: string }> }>> {
   const p = asObject(params);
@@ -261,7 +261,7 @@ export async function handleToolsList(
   try {
     const { stdout } = await new Promise<{ stdout: string; stderr: string }>(
       (resolve, reject) => {
-        runner.execFile('mcporter', [ 'list', serverCode, '--schema', '--json' ], {
+        runner.execFile('mcporter', [ 'list', serverCode, '--schema', '--json', '--config', store.configPath ], {
           timeout: 30000,
           maxBuffer: 10 * 1024 * 1024,
           env: { ...process.env, MCPORTER_USER_TOKEN: userToken ? `Bearer ${userToken}` : '' },
@@ -296,7 +296,7 @@ export async function handleToolsList(
 }
 
 export async function handleToolsCall(
-  _store: McpStore,
+  store: McpStore,
   params: unknown,
 ): Promise<McpResult<{
   serverCode: string;
@@ -343,7 +343,7 @@ export async function handleToolsCall(
       (resolve, reject) => {
         // mcporter `call` uses `--output json`, not `--json` — see
         // MCPORTER_CALL_OUTPUT_ARGS. Pinned by test/mcp-real-binary.test.ts.
-        runner.execFile('mcporter', [ 'call', selector, ...cmdArgs, ...MCPORTER_CALL_OUTPUT_ARGS ], {
+        runner.execFile('mcporter', [ 'call', selector, ...cmdArgs, ...MCPORTER_CALL_OUTPUT_ARGS, '--config', store.configPath ], {
           timeout: 60000,
           maxBuffer: 10 * 1024 * 1024,
           env: { ...process.env, ...mcporterEnv },

--- a/src/engine/src/engine/community/claude_code_gateway/src/mcp/store.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/src/mcp/store.ts
@@ -214,6 +214,11 @@ export class McpStore {
     await fsp.rename(tmp, this.filePath);
   }
 
+  /** Absolute path to the mcporter.json this store manages (for --config passthrough). */
+  get configPath(): string {
+    return this.filePath;
+  }
+
   /** Await any pending writes. Use on shutdown or from tests. */
   async flush(): Promise<void> {
     if (this.pendingTimer) {

--- a/src/engine/src/engine/community/claude_code_gateway/test/mcp.test.ts
+++ b/src/engine/src/engine/community/claude_code_gateway/test/mcp.test.ts
@@ -369,14 +369,17 @@ describe('mcp.tools.* handlers (phase-1 stubs)', () => {
 
   // Helper: create a stub execFile that returns a JSON response.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function stubExecFile(jsonResponse: unknown, capture?: { env?: Record<string, string> }): any {
+  function stubExecFile(jsonResponse: unknown, capture?: { env?: Record<string, string>; args?: string[] }): any {
     return (
       _cmd: string,
-      _args: string[],
+      args: string[],
       opts: { env?: Record<string, string> },
       cb: (err: Error | null, stdout: string, stderr: string) => void,
     ) => {
-      if (capture) capture.env = opts.env;
+      if (capture) {
+        capture.env = opts.env;
+        capture.args = args;
+      }
       cb(null, JSON.stringify(jsonResponse), '');
     };
   }
@@ -410,6 +413,21 @@ describe('mcp.tools.* handlers (phase-1 stubs)', () => {
       assert.ok(capture.env, 'env should be passed to execFile');
       assert.equal(capture.env!.MCPORTER_USER_TOKEN, 'Bearer sno-330429',
         'list should inject Bearer <userToken> into MCPORTER_USER_TOKEN (same as call)');
+    } finally {
+      _resetExecFileRunner();
+    }
+  });
+
+  it('list passes --config <store.configPath> in argv', async () => {
+    try {
+      const capture: { env?: Record<string, string>; args?: string[] } = {};
+      _setExecFileRunner(stubExecFile({ tools: [] }, capture));
+      await handleToolsList(store, { serverCode: 'test-srv' });
+      assert.ok(capture.args, 'args should be captured');
+      const configIdx = capture.args!.indexOf('--config');
+      assert.notEqual(configIdx, -1, 'argv must include --config');
+      assert.equal(capture.args![configIdx + 1], store.configPath,
+        '--config value must match store.configPath');
     } finally {
       _resetExecFileRunner();
     }
@@ -456,6 +474,21 @@ describe('mcp.tools.* handlers (phase-1 stubs)', () => {
       assert.ok(capture.env, 'env should always be passed to execFile');
       assert.equal(capture.env!.MCPORTER_USER_TOKEN, '',
         'empty userToken → empty MCPORTER_USER_TOKEN (zero-regression)');
+    } finally {
+      _resetExecFileRunner();
+    }
+  });
+
+  it('call passes --config <store.configPath> in argv', async () => {
+    try {
+      const capture: { env?: Record<string, string>; args?: string[] } = {};
+      _setExecFileRunner(stubExecFile({ ok: true, data: {} }, capture));
+      await handleToolsCall(store, { toolName: 'x', serverCode: 'srv', arguments: {} });
+      assert.ok(capture.args, 'args should be captured');
+      const configIdx = capture.args!.indexOf('--config');
+      assert.notEqual(configIdx, -1, 'argv must include --config');
+      assert.equal(capture.args![configIdx + 1], store.configPath,
+        '--config value must match store.configPath');
     } finally {
       _resetExecFileRunner();
     }

--- a/src/engine/src/engine/community/plugins/openclaw/_mcp.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_mcp.py
@@ -209,6 +209,7 @@ class _McpPortMixin:
         cmd = ["mcporter", "call", tool]
         for key, value in (args or {}).items():
             cmd.append(f"{key}={value}")
+        cmd.extend(["--config", str(self._mcporter_config_path())])
 
         timeout = 30
         try:
@@ -261,6 +262,7 @@ class _McpPortMixin:
             ",".join(normalized) if normalized else "__EMPTY_FILTER_DISABLE_ALL__"
         )
         command = ["mcporter", "filter-servers", csv_codes]
+        command.extend(["--config", str(self._mcporter_config_path())])
         try:
             proc = _sp.run(
                 command,

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_mcp_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_mcp_port.py
@@ -267,7 +267,7 @@ async def test_full_crud_lifecycle(impl, cfg_path):
 
 
 @pytest.mark.asyncio
-async def test_call_tool_builds_correct_argv(impl, monkeypatch):
+async def test_call_tool_builds_correct_argv(impl, cfg_path, monkeypatch):
     captured: dict = {}
 
     def fake_run(cmd, **kwargs):
@@ -280,7 +280,10 @@ async def test_call_tool_builds_correct_argv(impl, monkeypatch):
     import subprocess as _sp  # noqa: PLC0415
     monkeypatch.setattr(_sp, "run", fake_run)
     result = await impl.call_tool("my_tool", {"key": "val", "num": 42})
-    assert captured["cmd"] == ["mcporter", "call", "my_tool", "key=val", "num=42"]
+    assert captured["cmd"] == [
+        "mcporter", "call", "my_tool", "key=val", "num=42",
+        "--config", str(cfg_path),
+    ]
     assert result["tool_name"] == "my_tool"
     assert result["is_error"] is False
     assert result["content"] == [{"type": "text", "text": "tool_output"}]
@@ -314,7 +317,7 @@ async def test_call_tool_nonzero_exit_sets_is_error(impl, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_call_tool_no_args(impl, monkeypatch):
+async def test_call_tool_no_args(impl, cfg_path, monkeypatch):
     captured: dict = {}
 
     def fake_run(cmd, **kwargs):
@@ -324,7 +327,10 @@ async def test_call_tool_no_args(impl, monkeypatch):
     import subprocess as _sp  # noqa: PLC0415
     monkeypatch.setattr(_sp, "run", fake_run)
     await impl.call_tool("bare_tool", {})
-    assert captured["cmd"] == ["mcporter", "call", "bare_tool"]
+    assert captured["cmd"] == [
+        "mcporter", "call", "bare_tool",
+        "--config", str(cfg_path),
+    ]
 
 
 @pytest.mark.asyncio
@@ -355,7 +361,7 @@ async def test_call_tool_timeout_raises_timeout_error(impl, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_filter_servers_passes_csv_to_subprocess(impl, monkeypatch):
+async def test_filter_servers_passes_csv_to_subprocess(impl, cfg_path, monkeypatch):
     captured: dict = {}
 
     def fake_run(cmd, **kwargs):
@@ -366,7 +372,10 @@ async def test_filter_servers_passes_csv_to_subprocess(impl, monkeypatch):
     import subprocess as _sp  # noqa: PLC0415
     monkeypatch.setattr(_sp, "run", fake_run)
     result = await impl.filter_servers(["a", "b"], timeout=5)
-    assert captured["cmd"] == ["mcporter", "filter-servers", "a,b"]
+    assert captured["cmd"] == [
+        "mcporter", "filter-servers", "a,b",
+        "--config", str(cfg_path),
+    ]
     assert result["return_code"] == 0
     assert result["stdout"] == "out"
     assert result["server_codes"] == ["a", "b"]


### PR DESCRIPTION
## Summary

Pass the `McpStore`-managed config path (`mcporter.json`) through to every
`mcporter` CLI invocation so each call targets the correct configuration
file instead of relying on the default discovery path.

## Changes

- **`claude_code_gateway/src/mcp/store.ts`** — add a `configPath` getter that
  exposes the absolute path of the `mcporter.json` the store manages.
- **`claude_code_gateway/src/mcp/handlers.ts`** — forward `--config <path>` to
  the `mcporter list` (tools/list) and `mcporter call` (tools/call) execFile
  invocations; the previously unused `_store` parameter is now bound.
- **`plugins/openclaw/_mcp.py`** — append `--config` to the `mcporter call`
  and `mcporter filter-servers` commands in `_McpPortMixin`.
- **Tests** — extend `mcp.test.ts` and `test_mcp_port.py` to assert the
  `--config` flag is present in the spawned command lines.

## Why

Without `--config`, concurrent or multi-tenant gateways could pick up the
wrong `mcporter.json` from the default discovery path, leading to tools
being listed or called against an unintended server configuration. Binding
the config path explicitly makes each invocation deterministic.

## Verification

- `cd src/engine/src/engine/community/claude_code_gateway && npm run test-local`
- `cd src/engine && PYTHONPATH=src .venv/bin/python -m pytest src/engine/community/plugins/openclaw/tests/test_mcp_port.py -v`
- 348 tests run, 348 passed, 0 failed.
- Public-diff privacy scan: passed (no introduced secrets).
- Code review: clear (0 blocking findings).

## Notes

- `mcporter call --config` compatibility was checked against deployed
  versions (0.7.4-openclaw.4 / 0.9.0); the real-binary test pins this
  contract.
- OCB corp integration regression (`test_mcp_cwd.py`) is deferred to the
  post-mirror follow-up.