### PR TITLE
fix(engine): pin OpenClaw probe identity

### DIFF
--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -359,6 +359,35 @@ def test_runtime_layout_probe_rejects_plugin_engine_mismatch(
     plugin.probe_pool_layout.assert_awaited_once()
 
 
+def test_runtime_layout_probe_rejects_real_openclaw_plugin_engine_mismatch(
+    client,
+    rich_manager,
+) -> None:
+    rich_manager._active_engine._skills = OpenClawSkillsAdapter(
+        OpenClawPluginImpl()
+    )
+
+    response = client.post(
+        "/api/skills/layout/probe",
+        json={
+            "engine": "hermes",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "status": "INVALID",
+        "engine": "hermes",
+        "layout_contract_version": "skills-pool-p3-v1",
+        "preparation_id": None,
+        "evidence": {
+            "reason": "runtime_engine_mismatch",
+            "actual_engine": "openclaw",
+        },
+    }
+
+
 def test_pool_activation_and_mapping_routes_are_capability_independent(
     client, rich_manager
 ):

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -118,7 +118,7 @@ class _SkillsPortMixin:
     ) -> dict[str, Any]:
         result = await asyncio.to_thread(
             inspect_runtime_layout,
-            engine=params["engine"],
+            engine="openclaw",
             expected_contract_version=params["layout_contract_version"],
             mapping_contract_version=MAPPING_CONTRACT_VERSION,
         )


### PR DESCRIPTION
## What changed

- make the OpenClaw Skills Pool plugin report its actual `openclaw` runtime identity instead of echoing the caller-provided engine
- add an HTTP regression test wired through the real OpenClaw adapter and plugin

## Why

A real OpenClaw Desktop rootfs returned `NOT_CAPABLE` when `/api/skills/layout/probe` was called with `engine=hermes`. The router's fail-closed identity check could not detect the mismatch because the OpenClaw plugin passed the requested engine into layout inspection and returned the same value.

The plugin now supplies its implementation identity. The existing router converts a differing request/runtime identity into `INVALID` with `reason=runtime_engine_mismatch` before migration can proceed.

## Impact

This preserves valid OpenClaw probes and makes mismatched engine identity fail closed. No layout, mapping, cutover, or Backend contract changes are introduced.

## Validation

- red/green real adapter+plugin HTTP regression
- 107 focused Engine router, OpenClaw Skills Pool contract, and layout activation tests passed
- Python SAST block-rule scan on the changed files passed
- `git diff --check` passed

The pre-push hook was intentionally skipped as requested.