### PR TITLE
fix(session-files): support unicode filenames

### DIFF
--- a/src/backend/src/agentclaw/community/core/session_resources/service.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/service.py
@@ -30,7 +30,8 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 )
 
 log = logging.getLogger("session_resource.service")
-_SAFE_FILENAME = re.compile(r"^[A-Za-z0-9._ -]+$")
+_SAFE_FILENAME = re.compile(r"^[\w .-]+$", re.UNICODE)
+_MAX_FILENAME_UTF8_BYTES = 255
 
 
 class SessionResourceService:
@@ -438,7 +439,14 @@ class SessionResourceService:
     def _safe_filename(value: str) -> str:
         if Path(value).name != value or value in {".", ".."}:
             raise ValueError("invalid_filename")
-        if not _SAFE_FILENAME.fullmatch(value):
+        try:
+            filename_bytes = value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise ValueError("invalid_filename") from exc
+        if (
+            len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
+            or not _SAFE_FILENAME.fullmatch(value)
+        ):
             raise ValueError("invalid_filename")
         return value
 

--- a/src/backend/tests/community/core/session_resources/test_service.py
+++ b/src/backend/tests/community/core/session_resources/test_service.py
@@ -202,6 +202,39 @@ def test_upload_intent_uses_session_api_and_persists_encrypted_session_key():
     assert repo.value.transfer_api_version.value == "session_v2"
 
 
+def test_upload_intent_allows_unicode_filename_within_filesystem_limit():
+    service, repo, http = _service()
+
+    intent = service.create_upload_intent(
+        owner_id="owner-1",
+        bot_id="bot-1",
+        session_key="session/raw value",
+        scope_type="personal_bot_chat",
+        engine_type="openclaw",
+        filename="\u4e2d\u6587\u62a5\u544a 2026.txt",
+        size_bytes=4,
+    )
+
+    assert http.calls[0][1]["json"]["filename"] == "\u4e2d\u6587\u62a5\u544a 2026.txt"
+    assert repo.value.filename == "\u4e2d\u6587\u62a5\u544a 2026.txt"
+    assert intent.resource.workspace_relative_path.endswith("/\u4e2d\u6587\u62a5\u544a 2026.txt")
+
+
+def test_upload_intent_rejects_filename_exceeding_utf8_segment_limit():
+    service, _, _ = _service()
+
+    with pytest.raises(ValueError, match="invalid_filename"):
+        service.create_upload_intent(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            scope_type="personal_bot_chat",
+            engine_type="openclaw",
+            filename=f"{'\u4e2d' * 86}.txt",
+            size_bytes=4,
+        )
+
+
 def test_upload_complete_requires_baas_done_then_queues_identity_only():
     queue = _Queue()
     service, repo, http = _service(queue)

--- a/src/engine/src/engine/community/core/resource_materialization/service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/service.py
@@ -184,10 +184,11 @@ class ResourceMaterializationService:
                 result = await self._materialize_locked(request)
             except MaterializationSecurityError as exc:
                 log.warning(
-                    "engine.resource_materialize.path.reject resource_id=%s task_version=%s error_type=%s",
+                    "engine.resource_materialize.path.reject resource_id=%s task_version=%s error_type=%s reason=%s",
                     request.resource_id,
                     request.task_version,
                     type(exc).__name__,
+                    str(exc),
                 )
                 result = self._failure_result(request, "invalid_device_path")
             except Exception as exc:

--- a/src/engine/src/engine/community/core/resource_materialization/service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/service.py
@@ -28,7 +28,9 @@ from engine.community.plugin_api.resource_materialization import (
 from engine.community.plugin_api.workspace_root import workspace_root_strict
 
 log = logging.getLogger("engine.resource_materialization")
-_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+_SAFE_IDENTIFIER_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+_SAFE_FILENAME = re.compile(r"^[\w .-]+$", re.UNICODE)
+_MAX_FILENAME_UTF8_BYTES = 255
 
 
 class MaterializationSecurityError(ValueError):
@@ -150,7 +152,11 @@ class ResourceMaterializationService:
             # can never disclose a sibling or host path through the content API.
             self._assert_contained(root, target)
             canonical = target.resolve(strict=True)
-            if not canonical.is_file() or canonical.stat().st_size != entry.size_bytes:
+            if (
+                not canonical.is_file()
+                or canonical.stat().st_size != entry.size_bytes
+                or self._sha256(canonical) != entry.content_hash
+            ):
                 raise ResourceNotMaterializedError("resource_not_materialized")
             if self._sha256(canonical) != entry.content_hash:
                 raise ResourceNotMaterializedError("resource_not_materialized")
@@ -231,7 +237,9 @@ class ResourceMaterializationService:
         # COSEC: resolve the final parent after mkdir and enforce containment;
         # this rejects pre-existing symlinks that redirect writes outside Bot root.
         self._assert_contained(root, target)
-        temporary = target.with_name(f".{target.name}.part-{uuid.uuid4().hex}")
+        # Keep the temporary segment independent of the user filename: the final
+        # filename may already be close to the filesystem's per-segment limit.
+        temporary = target.with_name(f".part-{uuid.uuid4().hex}")
         log.info(
             "engine.resource_materialize.pull.start resource_id=%s task_version=%s path_hash=%s",
             request.resource_id,
@@ -298,13 +306,24 @@ class ResourceMaterializationService:
         root: Path,
         request: MaterializationRequest,
     ) -> tuple[Path, Path]:
-        segments = (
+        identifier_segments = (
             request.scope_key_hash,
             request.session_key_hash,
             request.resource_id,
-            request.filename,
         )
-        if any(not _SAFE_SEGMENT.fullmatch(segment) for segment in segments):
+        if any(
+            not _SAFE_IDENTIFIER_SEGMENT.fullmatch(segment)
+            for segment in identifier_segments
+        ):
+            raise MaterializationSecurityError("invalid controlled path segment")
+        try:
+            filename_bytes = request.filename.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise MaterializationSecurityError("invalid controlled path segment") from exc
+        if (
+            len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
+            or not _SAFE_FILENAME.fullmatch(request.filename)
+        ):
             raise MaterializationSecurityError("invalid controlled path segment")
         supplied_path = request.workspace_relative_path or request.device_path
         if supplied_path is None:

--- a/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
@@ -94,6 +94,93 @@ async def test_materialize_writes_atomic_file_manifest_and_callback(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_materialize_supports_filename_near_filesystem_segment_limit(
+    tmp_path: Path,
+):
+    content = b"long filename content"
+    filename = f"{'a' * 240}.txt"
+    service = ResourceMaterializationService(
+        pull_client=_PullClient(content),
+        callback_client=_CallbackClient(),
+        workspace_root_provider=lambda: tmp_path,
+    )
+    request = _request(
+        content,
+        filename=filename,
+        device_path=(
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
+            f"sr_001/{filename}"
+        ),
+    )
+
+    result = await service.materialize(request)
+
+    target = (
+        tmp_path
+        / ".teamclaw/session-files/scope_abc/session_abc/sr_001"
+        / filename
+    )
+    assert result.ready is True
+    assert target.read_bytes() == content
+    assert not list(target.parent.glob(".part-*"))
+
+
+@pytest.mark.asyncio
+async def test_materialize_supports_unicode_filename(tmp_path: Path):
+    content = b"unicode filename content"
+    filename = "\u4e2d\u6587\u62a5\u544a 2026.txt"
+    service = ResourceMaterializationService(
+        pull_client=_PullClient(content),
+        callback_client=_CallbackClient(),
+        workspace_root_provider=lambda: tmp_path,
+    )
+    request = _request(
+        content,
+        filename=filename,
+        device_path=(
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
+            f"sr_001/{filename}"
+        ),
+    )
+
+    result = await service.materialize(request)
+
+    target = (
+        tmp_path
+        / ".teamclaw/session-files/scope_abc/session_abc/sr_001"
+        / filename
+    )
+    assert result.ready is True
+    assert target.read_bytes() == content
+
+
+@pytest.mark.asyncio
+async def test_materialize_rejects_filename_exceeding_utf8_segment_limit(tmp_path: Path):
+    content = b"too long unicode filename"
+    filename = f"{'\u4e2d' * 86}.txt"
+    callback = _CallbackClient()
+    service = ResourceMaterializationService(
+        pull_client=_PullClient(content),
+        callback_client=callback,
+        workspace_root_provider=lambda: tmp_path,
+    )
+    request = _request(
+        content,
+        filename=filename,
+        device_path=(
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
+            f"sr_001/{filename}"
+        ),
+    )
+
+    result = await service.materialize(request)
+
+    assert result.ready is False
+    assert result.error_code == "invalid_device_path"
+    assert callback.results == [result]
+
+
+@pytest.mark.asyncio
 async def test_session_v2_materialization_never_persists_raw_session_id(tmp_path: Path):
     content = b"session v2 content"
     pull = _PullClient(content)

--- a/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
@@ -186,7 +186,7 @@ async def test_hash_mismatch_removes_partial_file_and_reports_failure(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_materialize_rejects_untrusted_device_path_escape(tmp_path: Path):
+async def test_materialize_rejects_untrusted_device_path_escape(tmp_path: Path, caplog):
     callback = _CallbackClient()
     service = ResourceMaterializationService(
         pull_client=_PullClient(b"x"),
@@ -204,6 +204,8 @@ async def test_materialize_rejects_untrusted_device_path_escape(tmp_path: Path):
     assert result.error_code == "invalid_device_path"
     assert callback.results == [result]
     assert not (tmp_path.parent / "outside/report.txt").exists()
+    assert "reason=device_path traversal is forbidden" in caplog.text
+    assert "../../outside/report.txt" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow Unicode filenames while retaining controlled-path and UTF-8 segment-length validation
- use filename-independent materialization temp files and verify SHA-256 before serving ready content
- add a stable, redacted materialization path-rejection reason

## Validation
- src/backend/.venv/bin/python -m pytest src/backend/tests/community/core/session_resources/test_service.py -q
- uv run --project src/engine --with pytest --with pytest-asyncio pytest src/engine/src/engine/community/core/resource_materialization/tests/test_service.py -q
- git diff --check origin/REL20260730...HEAD