### PR TITLE
fix(skill): route README through bot owner

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -1225,13 +1225,11 @@ async def get_skill_readme(
             logger.warning(f"[skills.get_skill_readme] SkillCenter file-content failed: {e}")
         raise HTTPException(status_code=404, detail="Skill or README not found")
 
-    # The DB row is the source of truth for the bot/owner that owns local files.
-    # Keep this explicit so README reads do not regress to request-context-only
-    # resolution after REL20260710 rebases.
-    # This is especially important for TEClaw requests whose HTTP context can be
-    # default/openclaw even though the local skill belongs to a TEClaw bot.
+    # The request's resolved entity identifies the Bot owner and therefore the
+    # device that owns local files. ``skill.user_id`` is the Skill author and can
+    # be a collaborator, so it must not be used for device routing.
     read_bot_id = (skill or {}).get("bolt_id") or effective_bot_id
-    read_owner_id = (skill or {}).get("user_id") or effective_entity_id
+    read_owner_id = effective_entity_id
     read_entity_type = effective_entity_type
     read_engine = resolve_engine_for_bot(
         bot_id=read_bot_id,
@@ -1293,7 +1291,12 @@ async def get_skill_readme(
         "skill_id=%s, user_id=%s, bot_id=%s",
         skill_id, read_owner_id, read_bot_id,
     )
-    readme = await read_service.get_skill_readme(skill_id, read_owner_id, read_bot_id)
+    readme = await read_service.get_skill_readme(
+        skill_id,
+        ctx.user_id,
+        read_bot_id,
+        device_owner_id=read_owner_id,
+    )
     if readme is None:
         raise HTTPException(status_code=404, detail="Skill or README not found")
     logger.info(f"[skills.get_skill_readme] Success: skill_id={skill_id}")

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1290,14 +1290,26 @@ class SkillService:
     # README 内容获取
     # ========================================================================
 
-    async def get_skill_readme(self, skill_id: str, user_id: str | None = None, bolt_id: str | None = None) -> str | None:
+    async def get_skill_readme(
+        self,
+        skill_id: str,
+        user_id: str | None = None,
+        bolt_id: str | None = None,
+        *,
+        device_owner_id: str | None = None,
+    ) -> str | None:
         """获取技能的 README/SKILL.md 内容
 
         通过 skill_id 查询数据库获取 skill 记录，然后使用记录中的 bolt_id 和 git_path
-        直接定位文件，不依赖前端传递的 bot_id。
+        直接定位文件，不依赖前端传递的 bot_id。``user_id`` 是当前操作者，
+        ``device_owner_id``（如传入）仅用于定位 Bot 的设备绑定。
         """
         try:
-            logger.info(f"[get_skill_readme] skill_id={skill_id}, user_id={user_id}, bolt_id={bolt_id}")
+            logger.info(
+                "[get_skill_readme] skill_id=%s, user_id=%s, bolt_id=%s, "
+                "device_owner_id=%s",
+                skill_id, user_id, bolt_id, device_owner_id,
+            )
             # 从数据库获取 skill 信息（优先用 ID 查询，其次用 link_name）
             skill = None
             if skill_id.isdigit():
@@ -1324,11 +1336,12 @@ class SkillService:
                 git_path = skill.get('git_path', '')
                 db_bolt_id = skill.get('bolt_id')
                 bolt_id = db_bolt_id or bolt_id
-                skill_user_id = skill.get('user_id') or user_id
+                skill_author_id = skill.get('user_id') or user_id
+                device_user_id = device_owner_id or skill_author_id
                 logger.info(
                     f"[get_skill_readme] DB found, git_path={git_path}, "
                     f"db_bolt_id={db_bolt_id}, effective_bolt_id={bolt_id}, "
-                    f"skill_user_id={skill_user_id}"
+                    f"skill_author_id={skill_author_id}, device_user_id={device_user_id}"
                 )
 
                 if git_path.startswith('local://'):
@@ -1338,7 +1351,7 @@ class SkillService:
                     logger.info(f"[get_skill_readme] Looking for local skill: {local_path}")
 
                     # 通过 DeviceFileSystem 读取，自动适配 local/arca/teclaw
-                    device_fs = self._device_fs_factory(bolt_id, skill_user_id)
+                    device_fs = self._device_fs_factory(bolt_id, device_user_id)
                     # teclaw: skills-local/<name> → workspace/skills-local/<name>;
                     # 非 teclaw: identity（主机路径原样）。
                     skill_base = self._local_skill_path_adapter(str(local_path))

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -97,7 +97,7 @@ def test_readme_route_teclaw_branch():
     assert path_factory.get_bot_skills_local_dir.call_args.kwargs["is_teclaw"] is True
 
 
-def test_readme_route_uses_skill_owner_context_for_teclaw():
+def test_readme_route_uses_request_owner_context_for_teclaw():
     lookup_svc = MagicMock()
     lookup_svc.get_skill.return_value = {
         "id": "1",
@@ -105,7 +105,7 @@ def test_readme_route_uses_skill_owner_context_for_teclaw():
         "link_name": "x",
         "git_path": "local://skills-local/x",
         "bolt_id": "teclaw-bot",
-        "user_id": "owner-u",
+        "user_id": "collaborator-u",
     }
     read_svc = MagicMock()
     read_svc.get_skill_readme = AsyncMock(return_value="# readme")
@@ -115,7 +115,7 @@ def test_readme_route_uses_skill_owner_context_for_teclaw():
 
     resp = client.get(
         "/api/skills/1/readme",
-        params={"entity_id": "viewer-u", "bot_id": "default", "engine_type": "openclaw"},
+        params={"entity_id": "owner-u", "bot_id": "default", "engine_type": "openclaw"},
     )
 
     assert resp.status_code == 200
@@ -129,7 +129,9 @@ def test_readme_route_uses_skill_owner_context_for_teclaw():
         "staff",
     )
     assert path_factory.get_bot_skills_local_dir.call_args.kwargs["is_teclaw"] is True
-    read_svc.get_skill_readme.assert_awaited_once_with("1", "owner-u", "teclaw-bot")
+    read_svc.get_skill_readme.assert_awaited_once_with(
+        "1", "u1", "teclaw-bot", device_owner_id="owner-u"
+    )
 
 
 def test_readme_route_link_name_falls_back_to_global_lookup():
@@ -143,7 +145,7 @@ def test_readme_route_link_name_falls_back_to_global_lookup():
             "link_name": "x",
             "git_path": "local://skills-local/x",
             "bolt_id": "teclaw-bot",
-            "user_id": "owner-u",
+            "user_id": "collaborator-u",
         },
     ]
     read_svc = MagicMock()
@@ -154,14 +156,16 @@ def test_readme_route_link_name_falls_back_to_global_lookup():
 
     resp = client.get(
         "/api/skills/x/readme",
-        params={"entity_id": "viewer-u", "bot_id": "default", "engine_type": "openclaw"},
+        params={"entity_id": "owner-u", "bot_id": "default", "engine_type": "openclaw"},
     )
 
     assert resp.status_code == 200
     lookup_svc.get_skill_by_link_name.assert_any_call("x", bolt_id="default")
     lookup_svc.get_skill_by_link_name.assert_any_call("x", bolt_id="b1")
     lookup_svc.get_skill_by_link_name.assert_any_call("x", bolt_id=None)
-    read_svc.get_skill_readme.assert_awaited_once_with("x", "owner-u", "teclaw-bot")
+    read_svc.get_skill_readme.assert_awaited_once_with(
+        "x", "u1", "teclaw-bot", device_owner_id="owner-u"
+    )
 
 
 def test_readme_route_handles_duplicate_link_name_scopes_and_desktop_bot():
@@ -232,7 +236,9 @@ def test_readme_route_falls_back_when_skill_not_found_and_bot_type_lookup_fails(
     resp = client.get("/api/skills/404/readme", params=_Q)
 
     assert resp.status_code == 200
-    read_svc.get_skill_readme.assert_awaited_once_with("404", "u1", "b1")
+    read_svc.get_skill_readme.assert_awaited_once_with(
+        "404", "u1", "b1", device_owner_id="u1"
+    )
 
 
 def test_readme_route_numeric_id_falls_back_to_link_name_when_id_missing():
@@ -244,7 +250,7 @@ def test_readme_route_numeric_id_falls_back_to_link_name_when_id_missing():
         "link_name": "123",
         "git_path": "local://skills-local/numeric-link",
         "bolt_id": "teclaw-bot",
-        "user_id": "owner-u",
+        "user_id": "collaborator-u",
     }
     read_svc = MagicMock()
     read_svc.get_skill_readme = AsyncMock(return_value="# numeric")
@@ -257,4 +263,6 @@ def test_readme_route_numeric_id_falls_back_to_link_name_when_id_missing():
     assert resp.status_code == 200
     lookup_svc.get_skill.assert_called_once_with("123")
     lookup_svc.get_skill_by_link_name.assert_called_once_with("123", bolt_id="b1")
-    read_svc.get_skill_readme.assert_awaited_once_with("123", "owner-u", "teclaw-bot")
+    read_svc.get_skill_readme.assert_awaited_once_with(
+        "123", "u1", "teclaw-bot", device_owner_id="u1"
+    )

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_readme.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_readme.py
@@ -206,6 +206,36 @@ class TestGetSkillReadmeEncoding:
         assert result == "# Caller Bot"
         factory.assert_called_once_with("route-bot", "owner1")
 
+    @pytest.mark.asyncio
+    async def test_local_readme_uses_explicit_device_owner_not_skill_author(self, skill_dirs, mock_skill_repo):
+        mock_skill_repo.get_by_id.return_value = {
+            "id": "107",
+            "git_path": "local://skills-local/my-skill",
+            "bolt_id": "service-bot",
+            "user_id": "collaborator",
+        }
+
+        device_fs = AsyncMock()
+        device_fs.read_file = AsyncMock(return_value=b"# Collaborator Skill")
+        factory = MagicMock(return_value=device_fs)
+        svc = _make_service(
+            mock_skill_repo,
+            skill_dirs["repo_dir"],
+            skill_dirs["local_dir"],
+            skill_dirs["active_dir"],
+            device_fs_factory=factory,
+        )
+
+        result = await svc.get_skill_readme(
+            "107",
+            user_id="collaborator",
+            bolt_id="service-bot",
+            device_owner_id="bot-owner",
+        )
+
+        assert result == "# Collaborator Skill"
+        factory.assert_called_once_with("service-bot", "bot-owner")
+
 
 class TestPrepareUploadPlanEncoding:
     """_prepare_upload_plan should handle GBK-encoded SKILL.md bytes."""
@@ -297,4 +327,3 @@ class TestIsIgnoredUploadPath:
         assert "pkg/helper.pyc" not in candidate_paths
         assert ".DS_Store" not in candidate_paths
         assert candidate_paths == {"SKILL.md", "pkg/helper.py"}
-


### PR DESCRIPTION
## 变更

协作者上传的私有 Skill 在读取 README 时，显式使用服务 Bot owner 解析设备文件系统，不再将 Skill 作者误用于设备路由。

## 根因

`skill.user_id` 已用于记录实际上传协作者；README 读取链路仍将它作为设备 owner，导致无法定位服务 Bot 的活动设备。

## 验证

- `uv run pytest tests/community/api/skill_center/test_skills_routes_teclaw.py -q`（6 passed）
- `uv run pytest tests/community/core/skill_center/services/test_skill_service_readme.py -q`（24 passed）
- `uv run pytest tests/community/api/skill_center/test_skills_api_async_correctness.py -q`（21 passed）
- `uv run pytest tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py -q`（14 passed）