### PR TITLE
feat(engine): prune top-level `./skills` from file-tree endpoint

### DIFF
--- a/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
@@ -328,6 +328,7 @@ async def test_list_file_tree_prunes_mounts_and_returns_sorted_tree(
     assert "-name node_modules" in command
     assert "-path './skills-pool'" in command
     assert "-path './.repos'" in command
+    assert "-path './skills'" in command
     assert "%s" not in command
     assert file_plugin.calls == []
 

--- a/src/engine/src/engine/community/core/aicoding/workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/workspace_service.py
@@ -56,7 +56,8 @@ DEFAULT_FILE_TREE_MAX_DEPTH = 3
 # explicit size metadata lookup per file.
 _FILE_TREE_FIND_EXPRESSION = (
     r"\( -type d \( -name .git -o -name node_modules "
-    r"-o -path './skills-pool' -o -path './.repos' \) -prune \) "
+    r"-o -path './skills-pool' -o -path './.repos' "
+    r"-o -path './skills' \) -prune \) "
     r"-o -printf '%y\0%P\0'"
 )
 


### PR DESCRIPTION
## What

Add the top-level `./skills` directory to the prune list of the AICoding `file-tree` find expression, so it no longer surfaces in the workspace tree.

`GET /api/aicoding/sessions/file-tree` (handler at `router.py:140`, logic in `WorkspaceService.list_file_tree`) previously pruned only `.git`, `node_modules`, `./skills-pool` and `./.repos`.

## Why

`./skills` holds shared skill assets that are not part of the user's workspace content and should be excluded from the file tree, consistent with the existing top-level-only pruning of `./skills-pool` and `./.repos`.

## Change

`_FILE_TREE_FIND_EXPRESSION` now also includes `-o -path './skills'`:

```bash
find -P . -ignore_readdir_race -mindepth 1 -maxdepth 3 \
  \( -type d \( -name .git -o -name node_modules \
       -o -path './skills-pool' -o -path './.repos' \
       -o -path './skills' \) -prune \) \
  -o -printf '%y\0%P\0'
```

Semantics match the existing top-level-only entries: only the workspace-root `skills/` is pruned; nested `skills/` dirs under individual projects (e.g. \`project-fe/skills\`) are unaffected.

## Test

- Updated \`test_list_file_tree_prunes_mounts_and_returns_sorted_tree\` to assert \`-path './skills'\` is present.
- Full \`test_workspace_service.py\` suite: **81 passed**.

Branch is based on the latest \`REL20260730\` (\`7707830f\`); the two touched files are unchanged between \`7707830f\` and the current GitHub \`REL20260730\` tip (\`07054442\`), so the PR diff is clean with no rebase needed.