### PR TITLE
feat(skills-pool): allow parallel engine promotion

### DIFF
--- a/docs/skills-pool-p3-rollout-runbook.zh-CN.md
+++ b/docs/skills-pool-p3-rollout-runbook.zh-CN.md
@@ -110,10 +110,12 @@ SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
    精确白名单和对照样本。
 2. 通过 `POST /rollout/feature` 启用 rollout。初始配置固定
    `enable_all=false`，不存在通配入口。
-3. 通过 `POST /rollout/promote` 按
-   OpenClaw、Claude Code、AICoding、Hermes 的顺序人工晋级引擎。
-   除首个 OpenClaw 外，请求必须携带上一引擎已通过验收的
-   `acceptance_batch_id`；Backend 只接受已冻结的批次验收记录。
+3. 通过 `POST /rollout/promote` 独立人工晋级 OpenClaw、Claude Code、
+   AICoding 或 Hermes；各引擎可并行建立精确白名单批次并执行 B0--B2。
+   `promoted_engines` 始终按该固定引擎顺序存储为唯一的规范子集，例如
+   `["openclaw", "aicoding"]` 合法。接口保留可选
+   `acceptance_batch_id` 以兼容既有调用方，但晋级不会读取、校验或审计其他
+   引擎的验收；它不是跨引擎门禁。
 4. 通过 `POST /rollout/controls` 为当前批次登记至少一个同环境、同引擎、
    未命中白名单的负对照，以及一个 Teclaw 对照。
 5. 通过 `POST /rollout/whitelist` 添加精确 `(owner_id, bot_id)` 条目和
@@ -125,12 +127,14 @@ SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
    `GET /batches/{batch_id}?engine=...` 生成批次验收报告。
 8. 只有批次报告 `promotion_ready=true` 且人工确认实际业务指标后，才调用
    `POST /rollout/batches/accept` 冻结该批次的验收报告。扩大批次时，新
-   `batch_id` 必须引用当前引擎最近的 `acceptance_batch_id`；晋级下一引擎
-   也必须引用上一引擎已验收批次。Backend 不会自动验收、扩大或晋级。
+   `batch_id` 必须引用当前引擎最近的 `acceptance_batch_id`。owner 全量和
+   环境全量仍要求各目标引擎已晋级、存在最近已验收批次且没有该引擎 open
+   batch；Backend 不会自动验收、扩大或晋级。
 9. 如需在当前环境内按员工覆盖其存量重启和未来新建 Bot，调用
    `POST /rollout/owners`，传入精确 `owner_id`、`engine`、`enabled` 和该
    引擎最近一次已验收的 `acceptance_batch_id`。规则按
-   `(owner_id, engine)` 隔离，不会越过引擎晋级顺序，也不会影响其他员工。
+   `(owner_id, engine)` 隔离，不会越过该引擎的晋级和验收门禁，也不会影响
+   其他员工。
    精确负对照优先于 owner 全量并保持 Legacy；关闭规则只阻止尚未认领的
    Bot，已认领 Bot 继续前滚。
 
@@ -203,7 +207,8 @@ SELECT 1 FROM ac_skills_pool_rollout_audit LIMIT 1;
 | 服务发布固定草稿布局并向容器传递 | `test_arca_snapshot_producer.py::test_pool_build_freezes_the_draft_layout_into_one_versioned_artifact` 与 `::test_release_translates_frozen_layout_into_container_env` |
 | 服务重启、回滚和扩容继承冻结制品布局 | `test_publish_flow_service.py::test_restart_and_recreate_preserve_frozen_pool_layout`、`::test_execute_rollback_with_config_artifact` 与 `::test_scale_bot_success_prefers_bot_ext_device_count` |
 | 批次必须有健康负对照、Teclaw 对照且无数据不一致 | `test_operational_query.py` |
-| 同一引擎扩大批次和跨引擎晋级都必须引用已冻结验收 | `test_operations.py::test_next_batch_requires_latest_persisted_acceptance` 与 `::test_next_engine_requires_and_audits_a_passing_batch` |
+| 各引擎可独立晋级；同一引擎扩大批次仍必须引用已冻结验收 | `test_operations.py::test_engine_promotion_audit_does_not_depend_on_another_engine_batch`、`::test_other_engine_can_promote_while_existing_engine_batch_is_open` 与 `::test_next_batch_requires_latest_persisted_acceptance` |
+| 非前缀多引擎环境全量仍逐一要求验收且无 open batch | `test_operations.py::test_environment_full_rollout_checks_every_non_prefix_promoted_engine` |
 
 镜像 preparation 脚本、Hermes H0 和各引擎 companion 的验收由对应镜像/引擎
 仓库 CI 承担；本 Backend 报告只读取已提交的控制面与运行时证据，不推断容器

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -109,9 +109,10 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   `POST /rollout/owners` 按 `(owner_id, engine)` 放开该员工全部未来认领；
   完成批次验收且无负对照后，可写入 `full_rollout_engines` 单独全量；
   所有已晋级引擎均满足条件后，可显式打开或关闭环境级 `enable_all`。
-  引擎按 OpenClaw、Claude Code、AICoding、Hermes 的固定
-  顺序人工晋级；每次扩大同引擎批次必须引用最近一次已冻结验收，除首个
-  引擎外，晋级还必须引用上一引擎已冻结的验收批次。配置写入使用完整旧值
+  OpenClaw、Claude Code、AICoding、Hermes 可独立人工晋级并并行测试；
+  `promoted_engines` 以该顺序保存唯一的规范子集。每次扩大同引擎批次必须
+  引用最近一次已冻结验收；晋级接口保留 `acceptance_batch_id` 参数以兼容旧
+  调用方，但不再将其作为跨引擎门禁或审计证据。配置写入使用完整旧值
   加逻辑 revision CAS，冲突 fail closed；缺少可选默认字段的旧配置按规范化
   语义参与 CAS，并在首次成功写入时原子升级为完整形状；配置和包含前后
   revision、原因及验收快照的独立审计事件在同一事务提交。

--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -237,6 +237,10 @@ class SkillsPoolRolloutOperations:
         reason: str,
         acceptance_batch_id: str | None = None,
     ) -> RolloutConfigSnapshot:
+        # Retain the established HTTP/service parameter for callers that still
+        # send it.  Engine promotion is now independent, so it must not
+        # validate or audit acceptance evidence from another engine.
+        del acceptance_batch_id
         self._validate_change(operator=operator, reason=reason)
         if engine not in ENGINE_PROMOTION_ORDER:
             raise RolloutOperationError(f"unsupported engine: {engine}")
@@ -247,46 +251,25 @@ class SkillsPoolRolloutOperations:
             raise RolloutOperationError(
                 "disable environment full rollout before promoting another engine"
             )
-        expected_previous = ENGINE_PROMOTION_ORDER[
-            : ENGINE_PROMOTION_ORDER.index(engine)
-        ]
-        if current.promoted_engines != expected_previous:
-            raise RolloutOperationError(
-                f"previous engine promotion is incomplete for {engine}"
-            )
-        previous_engine = expected_previous[-1] if expected_previous else None
-        acceptance = None
-        if previous_engine is not None:
-            acceptance = self._accepted_batch(
-                current,
-                engine=previous_engine,
-                batch_id=acceptance_batch_id,
-            )
-            if acceptance is None:
-                raise RolloutOperationError(
-                    f"an accepted {previous_engine} batch is required for {engine}"
-                )
-            if self._open_batches(
-                current,
-                env=env,
-                engine=previous_engine,
-            ):
-                raise RolloutOperationError(
-                    f"{previous_engine} still has an unaccepted batch"
-                )
+        promoted = {*current.promoted_engines, engine}
+        promoted_engines = tuple(
+            candidate
+            for candidate in ENGINE_PROMOTION_ORDER
+            if candidate in promoted
+        )
         return self._write(
             snapshot=RolloutConfigSnapshot(
                 **{
                     **self._snapshot_values(current),
-                    "promoted_engines": (*current.promoted_engines, engine),
+                    "promoted_engines": promoted_engines,
                 }
             ),
             expected_snapshot=current,
             enabled=current.enabled,
             operator=operator,
             reason=reason,
-            batch_id=acceptance.batch_id if acceptance else None,
-            evidence=acceptance.report if acceptance else None,
+            batch_id=None,
+            evidence=None,
             action=f"promote:{engine}",
         )
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/rollout_config.py
@@ -72,7 +72,16 @@ def is_valid_rollout_config_value(value: Any) -> bool:
     if not isinstance(engines, list):
         return False
     promoted_engines = tuple(engines)
-    if promoted_engines != ENGINE_PROMOTION_ORDER[: len(promoted_engines)]:
+    if (
+        len(set(promoted_engines)) != len(promoted_engines)
+        or any(engine not in ENGINE_PROMOTION_ORDER for engine in promoted_engines)
+        or promoted_engines
+        != tuple(
+            engine
+            for engine in ENGINE_PROMOTION_ORDER
+            if engine in promoted_engines
+        )
+    ):
         return False
     full_rollout_engines = value.get("full_rollout_engines", [])
     if (

--- a/src/backend/tests/community/core/skills_pool/test_operations.py
+++ b/src/backend/tests/community/core/skills_pool/test_operations.py
@@ -225,33 +225,47 @@ def test_enabling_missing_rollout_creates_safe_exact_bot_configuration() -> None
     }
 
 
-def test_engine_promotion_is_manual_ordered_and_idempotent() -> None:
-    operations, configs, _, _ = build_operations(config=rollout_config())
-
-    with pytest.raises(RolloutOperationError, match="previous engine"):
-        operations.promote_engine(
-            env=ENV,
-            engine="claude_code",
-            operator="freddie",
-            reason="advance",
+def test_engine_promotion_is_independent_canonical_and_idempotent() -> None:
+    operations, configs, _, _ = build_operations(
+        config=rollout_config(
+            promoted_engines=["openclaw"],
+            whitelist=[
+                {
+                    "owner_id": OWNER,
+                    "bot_id": BOT_ID,
+                    "batch_id": "openclaw-unaccepted",
+                }
+            ],
         )
+    )
 
-    promoted = operations.promote_engine(
+    hermes_promoted = operations.promote_engine(
         env=ENV,
-        engine="openclaw",
+        engine="hermes",
         operator="freddie",
-        reason="start first engine",
+        reason="test Hermes in parallel",
+    )
+    aicoding_promoted = operations.promote_engine(
+        env=ENV,
+        engine="aicoding",
+        operator="freddie",
+        reason="test AICoding in parallel",
     )
     repeated = operations.promote_engine(
         env=ENV,
-        engine="openclaw",
+        engine="hermes",
         operator="freddie",
         reason="idempotent retry",
     )
 
-    assert promoted.promoted_engines == ("openclaw",)
-    assert repeated.promoted_engines == ("openclaw",)
-    assert len(configs.upserts) == 1
+    assert hermes_promoted.promoted_engines == ("openclaw", "hermes")
+    assert aicoding_promoted.promoted_engines == (
+        "openclaw",
+        "aicoding",
+        "hermes",
+    )
+    assert repeated.promoted_engines == ("openclaw", "aicoding", "hermes")
+    assert len(configs.upserts) == 2
 
 
 def test_full_rollout_requires_accepted_promoted_engine_then_admits_environment() -> (
@@ -294,6 +308,34 @@ def test_full_rollout_requires_accepted_promoted_engine_then_admits_environment(
     assert configs.config is not None
     assert configs.config["param_value"]["enable_all"] is True
     assert snapshot.audit_log[-1].action == "full_rollout:environment:enable"
+
+
+def test_environment_full_rollout_checks_every_non_prefix_promoted_engine() -> None:
+    operations, _, _, _ = build_operations(
+        config=rollout_config(promoted_engines=["openclaw", "aicoding"])
+    )
+    operations.accept_batch(
+        env=ENV,
+        operator="freddie",
+        reason="openclaw canary passed",
+        acceptance=BatchPromotionEvidence(
+            engine="openclaw",
+            batch_id="openclaw-canary-1",
+            promotion_ready=True,
+            report={
+                "rollout_config_version": "2026-07-25T09:00:00+00:00",
+                "promotion_ready": True,
+            },
+        ),
+    )
+
+    with pytest.raises(RolloutOperationError, match="accepted aicoding batch"):
+        operations.set_full_rollout(
+            env=ENV,
+            enabled=True,
+            operator="freddie",
+            reason="aicoding still needs acceptance",
+        )
 
 
 def test_engine_full_rollout_does_not_admit_other_promoted_engine() -> None:
@@ -429,51 +471,32 @@ def test_full_rollout_can_be_disabled_without_reverting_claimed_bots() -> None:
     assert snapshot.promoted_engines == ("openclaw",)
 
 
-def test_next_engine_requires_and_audits_a_passing_batch() -> None:
+def test_engine_promotion_audit_does_not_depend_on_another_engine_batch() -> None:
     operations, _, _, _ = build_operations(
-        config=rollout_config(promoted_engines=["openclaw"])
-    )
-
-    with pytest.raises(RolloutOperationError, match="accepted openclaw batch"):
-        operations.promote_engine(
-            env=ENV,
-            engine="claude_code",
-            operator="freddie",
-            reason="advance",
+        config=rollout_config(
+            promoted_engines=["openclaw"],
+            whitelist=[
+                {
+                    "owner_id": OWNER,
+                    "bot_id": BOT_ID,
+                    "batch_id": "openclaw-unaccepted",
+                }
+            ],
         )
-
-    operations.accept_batch(
-        env=ENV,
-        operator="freddie",
-        reason="freeze openclaw acceptance",
-        acceptance=BatchPromotionEvidence(
-            engine="openclaw",
-            batch_id="openclaw-canary-1",
-            promotion_ready=True,
-            report={
-                "rollout_config_version": "2026-07-25T09:00:00+00:00",
-                "success_rate": 1.0,
-                "promotion_ready": True,
-            },
-        ),
     )
+
     promoted = operations.promote_engine(
         env=ENV,
         engine="claude_code",
         operator="freddie",
-        reason="openclaw batch accepted",
-        acceptance_batch_id="openclaw-canary-1",
+        reason="test Claude Code independently",
     )
 
     assert promoted.promoted_engines == ("openclaw", "claude_code")
     event = promoted.audit_log[-1]
-    assert event.reason == "openclaw batch accepted"
-    assert event.batch_id == "openclaw-canary-1"
-    assert event.evidence == {
-        "rollout_config_version": "2026-07-25T09:00:00+00:00",
-        "success_rate": 1.0,
-        "promotion_ready": True,
-    }
+    assert event.reason == "test Claude Code independently"
+    assert event.batch_id is None
+    assert event.evidence is None
     assert event.effective_config_version == promoted.config_revision
 
 
@@ -600,7 +623,7 @@ def test_claimed_batch_stays_open_after_whitelist_removal() -> None:
         )
 
 
-def test_next_engine_cannot_promote_while_previous_engine_batch_is_open() -> None:
+def test_other_engine_can_promote_while_existing_engine_batch_is_open() -> None:
     operations, _, _, _ = build_operations(
         config=rollout_config(promoted_engines=["openclaw"])
     )
@@ -628,14 +651,18 @@ def test_next_engine_cannot_promote_while_previous_engine_batch_is_open() -> Non
         reason="open second batch",
     )
 
-    with pytest.raises(RolloutOperationError, match="unaccepted batch"):
-        operations.promote_engine(
-            env=ENV,
-            engine="claude_code",
-            acceptance_batch_id="batch-1",
-            operator="freddie",
-            reason="must finish current engine",
-        )
+    promoted = operations.promote_engine(
+        env=ENV,
+        engine="claude_code",
+        acceptance_batch_id="obsolete-cross-engine-acceptance",
+        operator="freddie",
+        reason="test engines in parallel",
+    )
+
+    assert promoted.promoted_engines == ("openclaw", "claude_code")
+    assert promoted.whitelist[0].batch_id == "batch-2"
+    assert promoted.audit_log[-1].batch_id is None
+    assert promoted.audit_log[-1].evidence is None
 
 
 def test_stale_batch_report_cannot_be_accepted() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
+++ b/src/backend/tests/community/core/skills_pool/test_rollout_gate.py
@@ -49,6 +49,40 @@ def test_legacy_rollout_entries_are_normalized_to_canonical_shape() -> None:
     }
 
 
+def test_promoted_engines_accept_only_canonical_supported_subsets() -> None:
+    assert normalize_rollout_config_value(
+        {
+            "enable_all": False,
+            "promoted_engines": ["openclaw", "aicoding"],
+            "whitelist": [],
+        }
+    ) == {
+        "enable_all": False,
+        "full_rollout_engines": [],
+        "full_rollout_owners": [],
+        "promoted_engines": ["openclaw", "aicoding"],
+        "whitelist": [],
+        "negative_controls": [],
+        "teclaw_controls": [],
+    }
+
+    for promoted_engines in (
+        ["aicoding", "openclaw"],
+        ["openclaw", "openclaw"],
+        ["unsupported"],
+    ):
+        assert (
+            normalize_rollout_config_value(
+                {
+                    "enable_all": False,
+                    "promoted_engines": promoted_engines,
+                    "whitelist": [],
+                }
+            )
+            is None
+        )
+
+
 class FakeCommonConfigService:
     def __init__(
         self,


### PR DESCRIPTION
## 变更

移除 Skills Pool 跨引擎串行 promotion 门禁。OpenClaw、Claude Code、AICoding、Hermes 现在可独立 promote，并行建立各自精确白名单 batch 与执行 B0--B2。

`promoted_engines` 改为按 `ENGINE_PROMOTION_ORDER` 保存的唯一、受支持规范子集；因此 `['openclaw', 'aicoding']` 合法，倒序、重复和未知引擎 fail-closed。

## 安全边界

- 同一引擎的 open batch、latest accepted batch、controls、batch report、人工 accept 与 batch expansion 门禁未变。
- owner full rollout 仍要求目标引擎已 promoted、存在最新 accepted batch，且无该引擎 open batch。
- 环境 full rollout 仍遍历全部已 promoted 目标引擎，逐一要求 accepted batch 且无 open batch。
- 环境 full rollout 启用时仍禁止继续 promote。
- 未修改 DB schema、audit schema 或 rollout gate membership 语义。

## 兼容性

| 场景 | 行为 |
| --- | --- |
| 既有前缀配置 | 保持有效 |
| 非前缀规范子集 | 有效并按固定顺序持久化 |
| 倒序、重复、未知引擎 | 配置校验拒绝 |
| `acceptance_batch_id` | HTTP/服务参数保留；promotion 不读取、校验或审计其他引擎验收 |

## 验证

- `cd src/backend && uv run pytest tests/community/core/skills_pool tests/community/adapters/http/test_skills_pool_ops_router.py tests/community/endpoints/test_skills_pool_ops.py tests/community/plugins/test_skills_pool_rollout_repository.py tests/community/plugins/local/test_database_bootstrap_skills_pool.py tests/community/di/test_skills_pool_wiring.py -q`（268 passed）
- `cd src/backend && uv run ruff check src/agentclaw/community/core/skills_pool/operations.py src/agentclaw/community/core/skills_pool/rollout_config.py tests/community/core/skills_pool/test_operations.py tests/community/core/skills_pool/test_rollout_gate.py`（passed）
- `scripts/ci/python_sast_local.sh src/backend 1 --base github/REL20260730 --head HEAD`（passed）
- 已按请求使用 `git push --no-verify`；完整 Backend changed-line coverage 未作为推送前置条件。