### PR TITLE
feat(bcs): expose collaboration definition graph preview

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -14,6 +14,7 @@ use bcs_http::{
 use bcs_service_api::{
     ActorKind, BotCapabilities, BotGroupListCommand, BotRegistryCoreService,
     CancelStateMachineRunCommand, CollaborationDefinition,
+    CollaborationDefinitionGraphNode, CollaborationDefinitionGraphPreview,
     CollaborationDefinitionParticipantSlot, CollaborationDefinitionValidationOutcome,
     CollaborationDefinitionValidationSummary, CollaborationRuntimeError,
     CollaborationRuntimeService, ConfigureGroupRuntimeCommand, ConfigureGroupRuntimeOutcome,
@@ -30,8 +31,9 @@ use bcs_service_api::{
     RoutingPolicy, SessionHistoryResult, SessionStateMachinePermissionCommand,
     SessionStateMachinePermissionView, Skill, StartSessionStateMachineRunCommand,
     StartStateMachineRunCommand, StartStateMachineRunOutcome, StateMachineDeliveryCorrelation,
-    StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus,
-    StateMachineRunView, Workspace, ValidateCollaborationDefinitionYamlCommand,
+    StateMachineAssignee, StateMachineGraphMode, StateMachineNodeKind, StateMachineNodeRun,
+    StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus, StateMachineRunView, Workspace,
+    ValidateCollaborationDefinitionYamlCommand,
 };
 use bcs_service_api::{
     CreateOrReactivateCommand, NewSessionParams, SessionKind, SessionManagementService,
@@ -125,6 +127,20 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
                 required: true,
                 assigned: true,
             }],
+            graph: Some(CollaborationDefinitionGraphPreview {
+                graph_mode: StateMachineGraphMode::Acyclic,
+                nodes: vec![CollaborationDefinitionGraphNode {
+                    node_id: "answer".to_string(),
+                    display_name: "Answer".to_string(),
+                    kind: StateMachineNodeKind::BotTask,
+                    assignee: Some(StateMachineAssignee::BotBinding {
+                        binding: "writer".to_string(),
+                    }),
+                    final_output: true,
+                    judge: false,
+                }],
+                edges: Vec::new(),
+            }),
             definition: None,
         })
     }
@@ -677,6 +693,9 @@ async fn post_collaboration_definition_validate_delegates_to_runtime_service() {
     assert_eq!(json["valid"], true);
     assert_eq!(json["summary"]["nodes"], 1);
     assert_eq!(json["participants"][0]["binding"], "writer");
+    assert_eq!(json["graph"]["graph_mode"], "acyclic");
+    assert_eq!(json["graph"]["nodes"][0]["node_id"], "answer");
+    assert_eq!(json["graph"]["edges"], serde_json::json!([]));
     assert!(json.get("definition").is_none());
 
     let calls = collaboration_runtime.validation_calls.lock().await;

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
@@ -32,6 +32,8 @@ pub struct CollaborationDefinitionValidationOutcome {
     pub summary: CollaborationDefinitionValidationSummary,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub participants: Vec<CollaborationDefinitionParticipantSlot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph: Option<CollaborationDefinitionGraphPreview>,
     #[serde(skip_serializing)]
     pub definition: Option<CollaborationDefinition>,
 }
@@ -64,6 +66,31 @@ pub struct CollaborationDefinitionParticipantSlot {
     pub description: Option<String>,
     pub required: bool,
     pub assigned: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CollaborationDefinitionGraphPreview {
+    pub graph_mode: StateMachineGraphMode,
+    pub nodes: Vec<CollaborationDefinitionGraphNode>,
+    pub edges: Vec<CollaborationDefinitionGraphEdge>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CollaborationDefinitionGraphNode {
+    pub node_id: String,
+    pub display_name: String,
+    pub kind: StateMachineNodeKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<StateMachineAssignee>,
+    pub final_output: bool,
+    pub judge: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CollaborationDefinitionGraphEdge {
+    pub source: String,
+    pub target: String,
+    pub outcome: String,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -56,7 +56,8 @@ pub use application::session_files::{
 };
 pub use application::collaboration_runtime::{
     AuthenticatedHumanCaller, CancelStateMachineRunCommand,
-    CollaborationDefinitionParticipantSlot,
+    CollaborationDefinitionGraphEdge, CollaborationDefinitionGraphNode,
+    CollaborationDefinitionGraphPreview, CollaborationDefinitionParticipantSlot,
     CollaborationDefinitionValidationDiagnostic, CollaborationDefinitionValidationOutcome,
     CollaborationDefinitionValidationSummary, CollaborationRuntimeError,
     CollaborationRuntimeService, ConfigureGroupRuntimeCommand, ConfigureGroupRuntimeOutcome,

--- a/src/bcs/crates/service-api/bcs-service-api/tests/collaboration_runtime_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/collaboration_runtime_contract.rs
@@ -1,11 +1,13 @@
 use bcs_service_api::{
-    AuthenticatedHumanCaller, CollaborationDefinitionParticipantSlot,
+    AuthenticatedHumanCaller, CollaborationDefinitionGraphNode,
+    CollaborationDefinitionGraphPreview, CollaborationDefinitionParticipantSlot,
     CollaborationDefinitionValidationOutcome, CollaborationDefinitionValidationSummary,
     CollaborationRuntimeError, CollaborationRuntimeService, HumanResponseSource,
-    HumanRunAccessCommand, ListPendingHumanNodesCommand, RespondHumanNodeCommand,
-    ServiceResult, SessionStateMachinePermissionCommand, StartSessionStateMachineRunCommand,
-    StateMachineResultPublishCommand, StateMachineResultPublisherPort,
-    StateMachineRunAccessCommand, ValidateCollaborationDefinitionYamlCommand,
+    HumanRunAccessCommand, ListPendingHumanNodesCommand, RespondHumanNodeCommand, ServiceResult,
+    SessionStateMachinePermissionCommand, StartSessionStateMachineRunCommand, StateMachineAssignee,
+    StateMachineGraphMode, StateMachineNodeKind, StateMachineResultPublishCommand,
+    StateMachineResultPublisherPort, StateMachineRunAccessCommand,
+    ValidateCollaborationDefinitionYamlCommand,
 };
 use bcs_test_support::{
     NoopCollaborationRuntimeService,
@@ -220,15 +222,55 @@ fn validation_outcome_serializes_without_internal_definition() {
             required: true,
             assigned: true,
         }],
+        graph: Some(CollaborationDefinitionGraphPreview {
+            graph_mode: StateMachineGraphMode::Acyclic,
+            nodes: vec![CollaborationDefinitionGraphNode {
+                node_id: "answer".to_string(),
+                display_name: "Answer".to_string(),
+                kind: StateMachineNodeKind::BotTask,
+                assignee: Some(StateMachineAssignee::BotBinding {
+                    binding: "writer".to_string(),
+                }),
+                final_output: true,
+                judge: false,
+            }],
+            edges: Vec::new(),
+        }),
         definition: None,
     };
 
     let wire = serde_json::to_value(outcome).unwrap();
     assert_eq!(wire["valid"], true);
     assert_eq!(wire["participants"][0]["binding"], "writer");
+    assert_eq!(wire["graph"]["graph_mode"], "acyclic");
+    assert_eq!(wire["graph"]["nodes"][0]["node_id"], "answer");
     assert!(wire.get("definition").is_none());
     assert!(wire.get("errors").is_none());
     assert!(wire.get("warnings").is_none());
+}
+
+#[test]
+fn invalid_validation_outcome_omits_graph() {
+    let outcome = CollaborationDefinitionValidationOutcome {
+        valid: false,
+        errors: vec![
+            bcs_service_api::CollaborationDefinitionValidationDiagnostic {
+                code: "INVALID_DEFINITION".to_string(),
+                path: "$".to_string(),
+                message: "invalid definition".to_string(),
+                hint: None,
+            },
+        ],
+        warnings: Vec::new(),
+        summary: CollaborationDefinitionValidationSummary::default(),
+        participants: Vec::new(),
+        graph: None,
+        definition: None,
+    };
+
+    let wire = serde_json::to_value(outcome).unwrap();
+    assert_eq!(wire["valid"], false);
+    assert!(wire.get("graph").is_none());
 }
 
 #[derive(Default)]

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/definition.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/definition.rs
@@ -14,6 +14,70 @@ pub struct CompiledStateMachine {
     pub initial_nodes: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DefinitionGraphProjection {
+    pub graph_mode: StateMachineGraphMode,
+    pub nodes: Vec<DefinitionGraphNodeProjection>,
+    pub edges: Vec<DefinitionGraphEdgeProjection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DefinitionGraphNodeProjection {
+    pub node_id: String,
+    pub display_name: String,
+    pub kind: StateMachineNodeKind,
+    pub assignee: Option<StateMachineAssignee>,
+    pub final_output: bool,
+    pub judge: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DefinitionGraphEdgeProjection {
+    pub source: String,
+    pub target: String,
+    pub outcome: String,
+    pub guard: Option<String>,
+}
+
+pub(crate) fn project_definition_graph(
+    compiled: &CompiledStateMachine,
+) -> Result<DefinitionGraphProjection, CollaborationRuntimeError> {
+    let state_machine = match &compiled.definition.runtime {
+        CollaborationRuntimeDefinition::StateMachine(state_machine) => state_machine,
+        _ => return invalid("runtime.kind must be state_machine"),
+    };
+    let nodes = state_machine
+        .nodes
+        .iter()
+        .map(|(node_id, node)| DefinitionGraphNodeProjection {
+            node_id: node_id.clone(),
+            display_name: node.display_name.clone(),
+            kind: node.kind,
+            assignee: node.assignee.clone(),
+            final_output: node.final_output,
+            judge: node.judge.is_some(),
+        })
+        .collect();
+    let mut edges = Vec::new();
+    for (source, node) in &state_machine.nodes {
+        for (outcome, transition) in &node.transitions {
+            for target in &transition.targets {
+                edges.push(DefinitionGraphEdgeProjection {
+                    source: source.clone(),
+                    target: target.clone(),
+                    outcome: outcome.clone(),
+                    guard: transition.guard.clone(),
+                });
+            }
+        }
+    }
+    Ok(DefinitionGraphProjection {
+        graph_mode: state_machine.graph_mode,
+        nodes,
+        edges,
+    })
+}
+
 pub fn validate_definition(
     mut definition: CollaborationDefinition,
 ) -> Result<CompiledStateMachine, CollaborationRuntimeError> {

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -56,7 +56,8 @@ use uuid::Uuid;
 const RUNTIME_CLEANUP_SESSION_LIMIT: u64 = i64::MAX as u64;
 
 use crate::definition::{
-    CompiledStateMachine, reject_explicit_participant_roles, validate_definition,
+    CompiledStateMachine, project_definition_graph, reject_explicit_participant_roles,
+    validate_definition,
 };
 use crate::validation::validate_authoring_definition_yaml;
 
@@ -4293,16 +4294,17 @@ fn run_graph_view(
         .iter()
         .map(|node| (node.node_id.as_str(), node))
         .collect::<BTreeMap<_, _>>();
-    let nodes = state_machine
+    let projection = project_definition_graph(compiled)?;
+    let nodes = projection
         .nodes
-        .iter()
-        .map(|(node_id, node)| {
-            let run_node = node_runs_by_id.get(node_id.as_str()).copied();
+        .into_iter()
+        .map(|node| {
+            let run_node = node_runs_by_id.get(node.node_id.as_str()).copied();
             StateMachineGraphNodeView {
-                node_id: node_id.clone(),
-                display_name: node.display_name.clone(),
+                node_id: node.node_id,
+                display_name: node.display_name,
                 kind: node.kind,
-                assignee: node.assignee.clone(),
+                assignee: node.assignee,
                 final_output: node.final_output,
                 status: run_node.map(|node| node.status),
                 attempt: run_node.map(|node| node.attempt),
@@ -4313,19 +4315,16 @@ fn run_graph_view(
             }
         })
         .collect();
-    let mut edges = Vec::new();
-    for (source, node) in &state_machine.nodes {
-        for (outcome, transition) in &node.transitions {
-            for target in &transition.targets {
-                edges.push(StateMachineGraphEdgeView {
-                    source: source.clone(),
-                    outcome: outcome.clone(),
-                    target: target.clone(),
-                    guard: transition.guard.clone(),
-                });
-            }
-        }
-    }
+    let edges = projection
+        .edges
+        .into_iter()
+        .map(|edge| StateMachineGraphEdgeView {
+            source: edge.source,
+            outcome: edge.outcome,
+            target: edge.target,
+            guard: edge.guard,
+        })
+        .collect();
     Ok(StateMachineRunGraphView {
         run,
         definition: StateMachineGraphDefinitionView {

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/validation.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/validation.rs
@@ -2,12 +2,15 @@ use std::collections::BTreeSet;
 
 use bcs_domain::{CollaborationDefinition, CollaborationRuntimeDefinition, StateMachineAssignee};
 use bcs_service_api::{
-    CollaborationDefinitionParticipantSlot, CollaborationDefinitionValidationDiagnostic,
-    CollaborationDefinitionValidationOutcome, CollaborationDefinitionValidationSummary,
-    MAX_COLLABORATION_DEFINITION_YAML_BYTES, ValidateCollaborationDefinitionYamlCommand,
+    CollaborationDefinitionGraphEdge, CollaborationDefinitionGraphNode,
+    CollaborationDefinitionGraphPreview, CollaborationDefinitionParticipantSlot,
+    CollaborationDefinitionValidationDiagnostic, CollaborationDefinitionValidationOutcome,
+    CollaborationDefinitionValidationSummary, MAX_COLLABORATION_DEFINITION_YAML_BYTES,
+    ValidateCollaborationDefinitionYamlCommand,
 };
 use serde_yaml::{Mapping, Value};
 
+use crate::definition::{DefinitionGraphProjection, project_definition_graph};
 use crate::{CompiledStateMachine, reject_explicit_participant_roles, validate_definition};
 
 pub fn validate_authoring_definition_yaml(
@@ -100,7 +103,41 @@ pub fn validate_authoring_definition_yaml(
         outcome.definition = None;
         return outcome;
     }
+    let projection = match project_definition_graph(&compiled) {
+        Ok(projection) => projection,
+        Err(error) => {
+            return invalid_outcome(diagnostic("INVALID_DEFINITION", "$", error.to_string()));
+        }
+    };
+    outcome.graph = Some(graph_preview(projection));
     outcome
+}
+
+fn graph_preview(projection: DefinitionGraphProjection) -> CollaborationDefinitionGraphPreview {
+    CollaborationDefinitionGraphPreview {
+        graph_mode: projection.graph_mode,
+        nodes: projection
+            .nodes
+            .into_iter()
+            .map(|node| CollaborationDefinitionGraphNode {
+                node_id: node.node_id,
+                display_name: node.display_name,
+                kind: node.kind,
+                assignee: node.assignee,
+                final_output: node.final_output,
+                judge: node.judge,
+            })
+            .collect(),
+        edges: projection
+            .edges
+            .into_iter()
+            .map(|edge| CollaborationDefinitionGraphEdge {
+                source: edge.source,
+                target: edge.target,
+                outcome: edge.outcome,
+            })
+            .collect(),
+    }
 }
 
 fn valid_outcome(compiled: &CompiledStateMachine) -> CollaborationDefinitionValidationOutcome {
@@ -149,6 +186,7 @@ fn valid_outcome(compiled: &CompiledStateMachine) -> CollaborationDefinitionVali
             },
         },
         participants,
+        graph: None,
         definition: Some(compiled.definition.clone()),
     }
 }
@@ -162,6 +200,7 @@ fn invalid_outcome(
         warnings: Vec::new(),
         summary: CollaborationDefinitionValidationSummary::default(),
         participants: Vec::new(),
+        graph: None,
         definition: None,
     }
 }

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/definition_validation.rs
@@ -1,7 +1,10 @@
 use bcs_collaboration_runtime::{
     reject_explicit_participant_roles, validate_authoring_definition_yaml, validate_definition,
 };
-use bcs_domain::{CollaborationDefinition, CollaborationRuntimeDefinition, StateMachineGraphMode};
+use bcs_domain::{
+    CollaborationDefinition, CollaborationRuntimeDefinition, StateMachineGraphMode,
+    StateMachineNodeKind,
+};
 use bcs_service_api::ValidateCollaborationDefinitionYamlCommand;
 
 const AUTHORING_YAML: &str = r#"
@@ -72,6 +75,21 @@ fn authoring_validation_returns_binding_and_graph_summary() {
     assert_eq!(outcome.participants[0].binding, "writer");
     assert!(outcome.participants[0].required);
     assert!(outcome.participants[0].assigned);
+    let graph = outcome.graph.as_ref().expect("validated graph preview");
+    assert_eq!(graph.graph_mode, StateMachineGraphMode::Acyclic);
+    assert_eq!(graph.nodes.len(), 1);
+    assert_eq!(graph.nodes[0].node_id, "answer");
+    assert_eq!(graph.nodes[0].display_name, "Answer");
+    assert_eq!(graph.nodes[0].kind, StateMachineNodeKind::BotTask);
+    assert_eq!(
+        graph.nodes[0].assignee,
+        Some(bcs_domain::StateMachineAssignee::BotBinding {
+            binding: "writer".to_string(),
+        })
+    );
+    assert!(graph.nodes[0].final_output);
+    assert!(!graph.nodes[0].judge);
+    assert!(graph.edges.is_empty());
     assert!(outcome.definition.is_some());
 }
 
@@ -105,6 +123,15 @@ fn authoring_validation_accepts_direct_human_input_channel_without_binding_id() 
             .map(|channel| channel.channel_type.as_str()),
         Some("dingtalk")
     );
+    let graph = outcome.graph.expect("validated graph preview");
+    assert_eq!(graph.nodes[0].kind, StateMachineNodeKind::HumanInput);
+    assert_eq!(
+        graph.nodes[0].assignee,
+        Some(bcs_domain::StateMachineAssignee::RuntimeActor {
+            actor: "human_1001".to_string(),
+        })
+    );
+    assert!(!graph.nodes[0].final_output);
 }
 
 #[test]
@@ -147,17 +174,165 @@ fn authoring_validation_rejects_judge_when_server_has_no_judge_provider() {
 
     assert!(!outcome.valid);
     assert_eq!(outcome.errors[0].code, "UNAVAILABLE_FEATURE");
+    assert!(outcome.graph.is_none());
 }
 
 #[test]
 fn authoring_validation_accepts_judge_when_server_has_judge_provider() {
     let yaml = AUTHORING_YAML.replace(
         "        final_output: true",
-        "        judge:\n          type: llm\n          criteria: [quality]\n          outcomes: [approved]\n        transitions:\n          approved:\n            targets: [publish]\n      publish:\n        kind: bot_task\n        display_name: Publish\n        assignee:\n          type: bot_binding\n          binding: writer\n        instruction: Publish the answer.\n        final_output: true",
+        "        judge:\n          type: llm\n          criteria: [quality]\n          outcomes: [approved, revise]\n        transitions:\n          approved:\n            targets: [publish]\n          revise:\n            targets: [publish]\n      publish:\n        kind: bot_task\n        display_name: Publish\n        assignee:\n          type: bot_binding\n          binding: writer\n        instruction: Publish the answer.\n        final_output: true",
     );
     let outcome = validate_authoring(&yaml, true);
 
     assert!(outcome.valid, "{:?}", outcome.errors);
+    let graph = outcome.graph.expect("validated graph preview");
+    assert_eq!(
+        graph
+            .nodes
+            .iter()
+            .map(|node| node.node_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["answer", "publish"]
+    );
+    assert!(graph.nodes[0].judge);
+    assert!(!graph.nodes[1].judge);
+    assert_eq!(graph.edges.len(), 2);
+    assert_eq!(graph.edges[0].source, "answer");
+    assert_eq!(graph.edges[0].outcome, "approved");
+    assert_eq!(graph.edges[0].target, "publish");
+    assert_eq!(graph.edges[1].outcome, "revise");
+    assert_eq!(graph.edges[1].target, "publish");
+}
+
+#[test]
+fn authoring_graph_preview_preserves_deterministic_fan_out_target_order() {
+    let yaml = r#"
+name: Fan out and join
+participants:
+  writer:
+    display_name: Writer
+    required: true
+runtime:
+  kind: state_machine
+  state_machine:
+    graph_mode: acyclic
+    nodes:
+      start:
+        kind: bot_task
+        display_name: Start
+        assignee:
+          type: bot_binding
+          binding: writer
+        instruction: Start.
+        transitions:
+          complete:
+            targets: [beta, alpha]
+      alpha:
+        kind: bot_task
+        display_name: Alpha
+        assignee:
+          type: bot_binding
+          binding: writer
+        instruction: Alpha.
+        transitions:
+          complete:
+            targets: [finish]
+      beta:
+        kind: bot_task
+        display_name: Beta
+        assignee:
+          type: bot_binding
+          binding: writer
+        instruction: Beta.
+        transitions:
+          complete:
+            targets: [finish]
+      finish:
+        kind: bot_task
+        display_name: Finish
+        assignee:
+          type: bot_binding
+          binding: writer
+        instruction: Finish.
+        final_output: true
+"#;
+
+    let outcome = validate_authoring(yaml, false);
+
+    assert!(outcome.valid, "{:?}", outcome.errors);
+    let graph = outcome.graph.expect("validated graph preview");
+    assert_eq!(
+        graph
+            .nodes
+            .iter()
+            .map(|node| node.node_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "beta", "finish", "start"]
+    );
+    assert_eq!(
+        graph
+            .edges
+            .iter()
+            .map(|edge| {
+                (
+                    edge.source.as_str(),
+                    edge.outcome.as_str(),
+                    edge.target.as_str(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            ("alpha", "complete", "finish"),
+            ("beta", "complete", "finish"),
+            ("start", "complete", "beta"),
+            ("start", "complete", "alpha"),
+        ]
+    );
+}
+
+#[test]
+fn authoring_graph_preview_preserves_missing_human_input_assignee() {
+    let yaml = r#"
+name: Frontend human review
+participants:
+  writer:
+    display_name: Writer
+    required: true
+runtime:
+  kind: state_machine
+  state_machine:
+    graph_mode: acyclic
+    nodes:
+      draft:
+        kind: bot_task
+        display_name: Draft
+        assignee:
+          type: bot_binding
+          binding: writer
+        instruction: Draft.
+        transitions:
+          complete:
+            targets: [review]
+      review:
+        kind: human_input
+        display_name: Human review
+        instruction: Review.
+        node_timeout_ms: 60000
+"#;
+
+    let outcome = validate_authoring(yaml, false);
+
+    assert!(outcome.valid, "{:?}", outcome.errors);
+    let graph = outcome.graph.expect("validated graph preview");
+    let review = graph
+        .nodes
+        .iter()
+        .find(|node| node.node_id == "review")
+        .expect("human input node");
+    assert_eq!(review.kind, StateMachineNodeKind::HumanInput);
+    assert_eq!(review.assignee, None);
+    assert!(!review.final_output);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Expose a read-only graph projection in successful custom collaboration YAML validation responses.

## Changes

- Add graph preview DTOs to the BCS Service API.
- Return graph mode, nodes, and edges from definition validation.
- Include node ID, display name, kind, assignee, final-output flag, and derived Judge flag.
- Include edge source, target, and outcome.
- Preserve deterministic node and edge ordering.
- Keep instructions and guards out of the preview contract.
- Add Runtime, Service API, and HTTP contract coverage.
- Continue omitting the graph from invalid validation responses.

## Compatibility

The graph field is optional and additive. Existing clients can ignore it without changing their behavior.

## Verification

- `cargo test -p bcs-collaboration-runtime`
- `cargo test -p bcs-service-api`
- `cargo test -p bcs-http`