### PR TITLE
feat(bcs): add Anthropic LLM judge provider

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "bcs-judge",
  "bcs-jwt",
  "bcs-leader-election",
+ "bcs-llm-anthropic",
  "bcs-llm-api",
  "bcs-llm-openai-compatible",
  "bcs-message",
@@ -1048,6 +1049,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs-llm-anthropic"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bcs-config-api",
+ "bcs-llm-api",
+ "bcs-test-support",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "bcs-llm-api"
 version = "0.1.0"
 dependencies = [
@@ -1064,6 +1081,7 @@ dependencies = [
  "async-trait",
  "bcs-config-api",
  "bcs-llm-api",
+ "bcs-test-support",
  "reqwest",
  "secrecy",
  "serde",
@@ -1519,6 +1537,7 @@ dependencies = [
  "bcs-cache-api",
  "bcs-db-api",
  "bcs-domain",
+ "bcs-llm-api",
  "bcs-service-api",
  "bcs-session",
  "bcs-session-file",

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "crates/plugins/bcs-storage-local",
     "crates/plugins/bcs-db-local",
     "crates/plugins/bcs-db-mysql",
+    "crates/plugins/bcs-llm-anthropic",
     "crates/plugins/bcs-llm-openai-compatible",
     "crates/plugins/bcs-secret-local",
     "crates/plugins/bcs-security-gateway-local",
@@ -277,6 +278,7 @@ bcs-cache-local            = { path = "crates/plugins/bcs-cache-local" }
 bcs-cache-redis            = { path = "crates/plugins/bcs-cache-redis" }
 bcs-db-local               = { path = "crates/plugins/bcs-db-local" }
 bcs-db-mysql               = { path = "crates/plugins/bcs-db-mysql" }
+bcs-llm-anthropic          = { path = "crates/plugins/bcs-llm-anthropic" }
 bcs-llm-openai-compatible = { path = "crates/plugins/bcs-llm-openai-compatible" }
 bcs-secret-local           = { path = "crates/plugins/bcs-secret-local" }
 bcs-auth-session           = { path = "crates/plugins/bcs-auth-session" }

--- a/src/bcs/README.md
+++ b/src/bcs/README.md
@@ -133,6 +133,7 @@ crates/
 │   ├── bcs-cache-local/    # In-memory cache
 │   ├── bcs-db-local/       # SQLite / local persistence
 │   ├── bcs-secret-local/   # Local secret storage
+│   ├── bcs-llm-anthropic/  # Anthropic Messages API LLM plugin
 │   └── bcs-llm-openai-compatible/ # OpenAI-compatible LLM plugin
 ├── external-clients/
 │   └── bcs-fuse-client/            # Context fusion HTTP client
@@ -273,6 +274,29 @@ Key config fields:
 | `default_visibility` | `protected` | Default bot visibility (`public` or `protected`) |
 | `store_messages` | `false` | Persist chat messages to database |
 | `[cors].allowed_origins` | localhost origins | CORS allowed origins for frontend |
+
+To run state-machine LLM judge nodes through the Anthropic Messages API, set
+the API key in the process environment and select the native provider:
+
+```bash
+export ANTHROPIC_API_KEY="..."
+```
+
+```toml
+[llm]
+type = "anthropic"
+base_url = "https://api.anthropic.com"
+api_key_env = "ANTHROPIC_API_KEY"
+model = "claude-sonnet-4-6"
+timeout_ms = 120000
+max_tokens = 4096
+structured_output = "json_schema"
+```
+
+Anthropic supports `json_schema` and `tool_call` for judge output.
+`json_object` is rejected during provider initialization. The Anthropic client
+does not send `temperature`, because current Messages API models may reject
+non-default sampling parameters.
 
 ### Test organization admin-run callbacks locally
 

--- a/src/bcs/crates/bootstrap/bcs/Cargo.toml
+++ b/src/bcs/crates/bootstrap/bcs/Cargo.toml
@@ -149,6 +149,7 @@ bcs-collaboration-template = { workspace = true }
 bcs-collaboration-runtime = { workspace = true }
 bcs-collaboration-store = { workspace = true }
 bcs-judge = { workspace = true }
+bcs-llm-anthropic = { workspace = true }
 bcs-llm-openai-compatible = { workspace = true }
 
 # URL encoding

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -65,6 +65,7 @@ use bcs_http::{
 use bcs_judge::{LlmJudgeService, NoopJudgeEvaluator};
 use bcs_leader_election::StandaloneLeaderElection;
 use bcs_llm_api::LlmChatCompletionPort;
+use bcs_llm_anthropic::AnthropicLlmClient;
 use bcs_llm_openai_compatible::OpenAiCompatibleLlmClient;
 use bcs_message::MessageService;
 use bcs_message_flow::{A2aChat, BcsGroupFusion, BcsGroupMessageHistory, BcsMessageFlow};
@@ -1948,12 +1949,14 @@ fn create_interceptor_chain(config: &BcsConfig) -> crate::Result<Arc<Interceptor
 enum JudgeLlmProviderKind {
     None,
     OpenAiCompatible,
+    Anthropic,
 }
 
 fn select_judge_llm_provider(config: &BcsConfig) -> crate::Result<JudgeLlmProviderKind> {
     match &config.llm.provider_type {
         LlmProviderType::None => Ok(JudgeLlmProviderKind::None),
         LlmProviderType::OpenAiCompatible => Ok(JudgeLlmProviderKind::OpenAiCompatible),
+        LlmProviderType::Anthropic => Ok(JudgeLlmProviderKind::Anthropic),
         LlmProviderType::Other(provider) => Err(crate::BcsError::InvalidConfig(format!(
             "llm.type = '{}' is not available in this binary",
             provider
@@ -1975,6 +1978,22 @@ fn create_public_judge_evaluator(config: &BcsConfig) -> crate::Result<Arc<dyn Ju
                 base_url = %llm_config.base_url,
                 structured_output = ?llm_config.structured_output,
                 "OpenAI-compatible LLM judge enabled"
+            );
+            Ok(Arc::new(LlmJudgeService::new(
+                Arc::new(llm_client),
+                llm_config.model.clone(),
+            )))
+        }
+        JudgeLlmProviderKind::Anthropic => {
+            let llm_config = resolve_llm_config(config);
+            let llm_client = AnthropicLlmClient::new(llm_config.clone()).map_err(|error| {
+                crate::BcsError::InvalidConfig(format!("invalid llm config: {error}"))
+            })?;
+            info!(
+                model = %llm_config.model,
+                base_url = %llm_config.base_url,
+                structured_output = ?llm_config.structured_output,
+                "Anthropic LLM judge enabled"
             );
             Ok(Arc::new(LlmJudgeService::new(
                 Arc::new(llm_client),
@@ -2108,7 +2127,7 @@ mod judge_provider_tests {
     }
 
     #[test]
-    fn judge_llm_provider_selection_uses_openai_compatible_type() {
+    fn judge_llm_provider_selection_uses_public_provider_types() {
         let mut config = BcsConfig::default();
         config.llm.provider_type = LlmProviderType::OpenAiCompatible;
 
@@ -2116,6 +2135,40 @@ mod judge_provider_tests {
             select_judge_llm_provider(&config).unwrap(),
             JudgeLlmProviderKind::OpenAiCompatible
         );
+
+        config.llm.provider_type = LlmProviderType::Anthropic;
+        assert_eq!(
+            select_judge_llm_provider(&config).unwrap(),
+            JudgeLlmProviderKind::Anthropic
+        );
+    }
+
+    #[test]
+    fn anthropic_llm_provider_requires_api_key() {
+        let mut config = BcsConfig::default();
+        config.llm.provider_type = LlmProviderType::Anthropic;
+        config.llm.base_url = "https://api.anthropic.com/v1".to_string();
+        config.llm.api_key_env = None;
+        config.llm.api_key = None;
+
+        let error = match create_judge_evaluator(&config, &BcsServerExtensions::default()) {
+            Ok(_) => panic!("anthropic provider without an API key should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("anthropic api_key is required"));
+    }
+
+    #[test]
+    fn anthropic_llm_provider_builds_judge_evaluator() {
+        let mut config = BcsConfig::default();
+        config.llm.provider_type = LlmProviderType::Anthropic;
+        config.llm.base_url = "https://api.anthropic.com/v1".to_string();
+        config.llm.api_key_env = None;
+        config.llm.api_key = Some(Secret::new("anthropic-key".to_string()));
+
+        create_judge_evaluator(&config, &BcsServerExtensions::default())
+            .expect("valid anthropic provider should build a judge evaluator");
     }
 
     #[tokio::test]
@@ -4096,7 +4149,7 @@ mod tests {
     }
 
     #[test]
-    fn judge_llm_provider_selection_uses_openai_compatible_type() {
+    fn judge_llm_provider_selection_uses_public_provider_types() {
         let mut config = BcsConfig::default();
         assert_eq!(
             select_judge_llm_provider(&config).unwrap(),
@@ -4107,6 +4160,12 @@ mod tests {
         assert_eq!(
             select_judge_llm_provider(&config).unwrap(),
             JudgeLlmProviderKind::OpenAiCompatible
+        );
+
+        config.llm.provider_type = LlmProviderType::Anthropic;
+        assert_eq!(
+            select_judge_llm_provider(&config).unwrap(),
+            JudgeLlmProviderKind::Anthropic
         );
     }
 

--- a/src/bcs/crates/plugin-api/bcs-llm-api/src/lib.rs
+++ b/src/bcs/crates/plugin-api/bcs-llm-api/src/lib.rs
@@ -1,10 +1,17 @@
+//! Provider-neutral LLM completion contract.
+//!
+//! Every implementation must run
+//! `bcs_test_support::contract::plugin::llm_chat_completion_contract_tests`.
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LlmChatMessage {
+    /// Canonical role. Providers must support `system`, `user`, and `assistant`.
     pub role: String,
+    /// Provider-neutral message content. Judge requests currently use JSON strings.
     pub content: Value,
 }
 
@@ -12,6 +19,11 @@ pub struct LlmChatMessage {
 pub struct LlmChatCompletionRequest {
     pub model: String,
     pub messages: Vec<LlmChatMessage>,
+    /// Canonical BCS structured-output envelope.
+    ///
+    /// When present, the value uses
+    /// `{ "type": "json_schema", "json_schema": { "name", "strict", "schema" } }`.
+    /// Provider implementations translate this envelope to their native wire format.
     #[serde(default)]
     pub response_format: Option<Value>,
     #[serde(default)]

--- a/src/bcs/crates/plugins/README.md
+++ b/src/bcs/crates/plugins/README.md
@@ -15,6 +15,7 @@ BCS WebSocket protocol.
   and contract tests.
 - `bcs-secret-local`: local secret-store stub for development.
 - `bcs-auth-*`: OAuth provider plugins (github, google, alipay, wechat, local).
+- `bcs-llm-anthropic`: Anthropic Messages API LLM judge client.
 - `bcs-llm-openai-compatible`: optional OpenAI-compatible LLM judge client.
 - `openclaw-channel-bcn`: OpenClaw channel plugin package for connecting
   OpenClaw bot runtimes to BCS.

--- a/src/bcs/crates/plugins/bcs-llm-anthropic/Cargo.toml
+++ b/src/bcs/crates/plugins/bcs-llm-anthropic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "bcs-llm-openai-compatible"
-description = "OpenAI-compatible LLM plugin for BCS"
+name = "bcs-llm-anthropic"
+description = "Anthropic Messages API LLM plugin for BCS"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/bcs/crates/plugins/bcs-llm-anthropic/src/lib.rs
+++ b/src/bcs/crates/plugins/bcs-llm-anthropic/src/lib.rs
@@ -1,0 +1,464 @@
+use std::time::Instant;
+
+use async_trait::async_trait;
+use bcs_config_api::{LlmConfig, StructuredOutputMode};
+use bcs_llm_api::{
+    LlmChatCompletionPort, LlmChatCompletionRequest, LlmChatCompletionResponse, LlmError,
+};
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use secrecy::ExposeSecret;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::warn;
+
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const RESPONSE_LOG_LIMIT: usize = 2_048;
+const X_API_KEY: HeaderName = HeaderName::from_static("x-api-key");
+const ANTHROPIC_VERSION_HEADER: HeaderName = HeaderName::from_static("anthropic-version");
+
+#[derive(Clone)]
+pub struct AnthropicLlmClient {
+    config: LlmConfig,
+    client: reqwest::Client,
+}
+
+impl AnthropicLlmClient {
+    pub fn new(config: LlmConfig) -> Result<Self, LlmError> {
+        if config.base_url.trim().is_empty() {
+            return Err(LlmError::Config(
+                "anthropic base_url must not be empty".to_string(),
+            ));
+        }
+        let has_api_key = config
+            .api_key
+            .as_ref()
+            .is_some_and(|api_key| !api_key.expose_secret().trim().is_empty());
+        if !has_api_key {
+            return Err(LlmError::Config(
+                "anthropic api_key is required".to_string(),
+            ));
+        }
+        if config.structured_output == StructuredOutputMode::JsonObject {
+            return Err(LlmError::Config(
+                "anthropic does not support structured_output = \"json_object\"; use \"json_schema\" or \"tool_call\""
+                    .to_string(),
+            ));
+        }
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(config.timeout_ms))
+            .build()
+            .map_err(|error| LlmError::Config(error.to_string()))?;
+        Ok(Self { config, client })
+    }
+
+    pub fn build_http_request(
+        &self,
+        request: LlmChatCompletionRequest,
+    ) -> Result<reqwest::Request, LlmError> {
+        let LlmChatCompletionRequest {
+            model,
+            messages,
+            response_format,
+            stream,
+        } = request;
+        if stream {
+            return Err(LlmError::Config(
+                "anthropic streaming is not supported by this completion port".to_string(),
+            ));
+        }
+
+        let url = anthropic_messages_url(&self.config.base_url);
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(
+            ANTHROPIC_VERSION_HEADER,
+            HeaderValue::from_static(ANTHROPIC_VERSION),
+        );
+        let api_key = self
+            .config
+            .api_key
+            .as_ref()
+            .ok_or_else(|| LlmError::Config("anthropic api_key is required".to_string()))?;
+        let api_key_header = HeaderValue::from_str(api_key.expose_secret())
+            .map_err(|error| LlmError::Config(format!("invalid anthropic api_key header: {error}")))?;
+        headers.insert(X_API_KEY, api_key_header);
+
+        let (system, messages) = translate_messages(messages)?;
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+            "stream": false,
+            "max_tokens": self.config.max_tokens,
+        });
+        if let Some(system) = system {
+            body["system"] = Value::String(system);
+        }
+        apply_structured_output(&mut body, response_format, self.config.structured_output)?;
+
+        self.client
+            .post(url)
+            .headers(headers)
+            .json(&body)
+            .build()
+            .map_err(|error| LlmError::Request(error.to_string()))
+    }
+}
+
+#[async_trait]
+impl LlmChatCompletionPort for AnthropicLlmClient {
+    async fn complete(
+        &self,
+        request: LlmChatCompletionRequest,
+    ) -> Result<LlmChatCompletionResponse, LlmError> {
+        let model = request.model.clone();
+        let structured_output_requested = request.response_format.is_some();
+        let structured_output = structured_output_mode_name(self.config.structured_output);
+        let http_request = self.build_http_request(request)?;
+        let url = http_request.url().to_string();
+        let started_at = Instant::now();
+        let response = self.client.execute(http_request).await.map_err(|error| {
+            let elapsed_ms = elapsed_ms(started_at);
+            warn!(
+                provider = "anthropic",
+                model = %model,
+                url = %url,
+                elapsed_ms,
+                timeout = error.is_timeout(),
+                connect = error.is_connect(),
+                error = %error,
+                structured_output,
+                "anthropic: message request failed"
+            );
+            LlmError::Request(format!(
+                "anthropic request to {url} failed after {elapsed_ms}ms: {error}; timeout={}; connect={}; structured_output={structured_output}",
+                error.is_timeout(),
+                error.is_connect(),
+            ))
+        })?;
+        let status = response.status();
+        let request_id = response
+            .headers()
+            .get("request-id")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("none")
+            .to_string();
+        let body = response.text().await.map_err(|error| {
+            let elapsed_ms = elapsed_ms(started_at);
+            warn!(
+                provider = "anthropic",
+                model = %model,
+                url = %url,
+                status = %status,
+                request_id = %request_id,
+                elapsed_ms,
+                error = %error,
+                "anthropic: failed to read message response body"
+            );
+            LlmError::Response(format!(
+                "anthropic failed to read response body from {url} with status {status} after {elapsed_ms}ms: {error}; request_id={request_id}"
+            ))
+        })?;
+        let elapsed_ms = elapsed_ms(started_at);
+        let body_excerpt = response_excerpt(&body);
+        if !status.is_success() {
+            warn!(
+                provider = "anthropic",
+                model = %model,
+                url = %url,
+                status = %status,
+                request_id = %request_id,
+                elapsed_ms,
+                response_body_excerpt = %body_excerpt,
+                "anthropic: message request returned non-success status"
+            );
+            return Err(LlmError::Request(format!(
+                "anthropic returned {status} from {url} after {elapsed_ms}ms: {body_excerpt}; request_id={request_id}"
+            )));
+        }
+
+        let raw: Value = serde_json::from_str(&body).map_err(|error| {
+            warn!(
+                provider = "anthropic",
+                model = %model,
+                url = %url,
+                status = %status,
+                request_id = %request_id,
+                elapsed_ms,
+                response_body_excerpt = %body_excerpt,
+                error = %error,
+                "anthropic: message response is not valid JSON"
+            );
+            LlmError::Response(format!(
+                "anthropic response from {url} with status {status} is not valid JSON after {elapsed_ms}ms: {error}; body={body_excerpt}; request_id={request_id}"
+            ))
+        })?;
+        let parsed: AnthropicMessageResponse =
+            serde_json::from_value(raw.clone()).map_err(|error| {
+                warn!(
+                    provider = "anthropic",
+                    model = %model,
+                    url = %url,
+                    status = %status,
+                    request_id = %request_id,
+                    elapsed_ms,
+                    response_body_excerpt = %body_excerpt,
+                    error = %error,
+                    "anthropic: message response schema mismatch"
+                );
+                LlmError::Response(format!(
+                    "anthropic response schema mismatch from {url} with status {status} after {elapsed_ms}ms: {error}; body={body_excerpt}; request_id={request_id}"
+                ))
+            })?;
+
+        reject_incomplete_response(&parsed, &url, &request_id)?;
+        let content = match (structured_output_requested, self.config.structured_output) {
+            (false, _) | (true, StructuredOutputMode::JsonSchema) => {
+                text_content(parsed.content)
+            }
+            (true, StructuredOutputMode::ToolCall) => tool_use_content(parsed.content),
+            (true, StructuredOutputMode::JsonObject) => {
+                unreachable!("rejected during client construction")
+            }
+        }
+        .ok_or_else(|| {
+            LlmError::Response(format!(
+                "anthropic response from {url} is missing the expected {structured_output} content; request_id={request_id}"
+            ))
+        })?;
+
+        Ok(LlmChatCompletionResponse { content, raw })
+    }
+}
+
+fn anthropic_messages_url(base_url: &str) -> String {
+    let base_url = base_url.trim_end_matches('/');
+    if base_url.ends_with("/v1") {
+        format!("{base_url}/messages")
+    } else {
+        format!("{base_url}/v1/messages")
+    }
+}
+
+fn translate_messages(
+    messages: Vec<bcs_llm_api::LlmChatMessage>,
+) -> Result<(Option<String>, Vec<Value>), LlmError> {
+    let mut system_parts = Vec::new();
+    let mut translated = Vec::new();
+    for message in messages {
+        match message.role.as_str() {
+            "system" => system_parts.push(text_from_message_content(&message.content)?),
+            "user" | "assistant" => translated.push(json!({
+                "role": message.role,
+                "content": message.content,
+            })),
+            other => {
+                return Err(LlmError::Config(format!(
+                    "anthropic does not support LLM message role '{other}'"
+                )));
+            }
+        }
+    }
+    if translated.is_empty() {
+        return Err(LlmError::Config(
+            "anthropic requires at least one user or assistant message".to_string(),
+        ));
+    }
+    let system = if system_parts.is_empty() {
+        None
+    } else {
+        Some(system_parts.join("\n\n"))
+    };
+    Ok((system, translated))
+}
+
+fn text_from_message_content(content: &Value) -> Result<String, LlmError> {
+    if let Some(text) = content.as_str() {
+        return Ok(text.to_string());
+    }
+    let Some(blocks) = content.as_array() else {
+        return Err(LlmError::Config(
+            "anthropic system message content must be a string or text-block array".to_string(),
+        ));
+    };
+    let mut texts = Vec::new();
+    for block in blocks {
+        let is_text = block
+            .get("type")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value == "text");
+        let Some(text) = block.get("text").and_then(Value::as_str).filter(|_| is_text) else {
+            return Err(LlmError::Config(
+                "anthropic system message arrays may contain only text blocks".to_string(),
+            ));
+        };
+        texts.push(text);
+    }
+    Ok(texts.join("\n"))
+}
+
+fn apply_structured_output(
+    body: &mut Value,
+    response_format: Option<Value>,
+    mode: StructuredOutputMode,
+) -> Result<(), LlmError> {
+    let Some(response_format) = response_format else {
+        return Ok(());
+    };
+    let schema = parse_json_schema_envelope(response_format)?;
+    match mode {
+        StructuredOutputMode::JsonSchema => {
+            body["output_config"] = json!({
+                "format": {
+                    "type": "json_schema",
+                    "schema": schema.schema,
+                }
+            });
+        }
+        StructuredOutputMode::ToolCall => {
+            body["tools"] = json!([
+                {
+                    "name": schema.name,
+                    "description": "Return the structured judge response.",
+                    "input_schema": schema.schema,
+                    "strict": schema.strict,
+                }
+            ]);
+            body["tool_choice"] = json!({
+                "type": "tool",
+                "name": schema.name,
+            });
+        }
+        StructuredOutputMode::JsonObject => {
+            return Err(LlmError::Config(
+                "anthropic does not support structured_output = \"json_object\"".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+struct JsonSchemaEnvelope {
+    name: String,
+    strict: bool,
+    schema: Value,
+}
+
+fn parse_json_schema_envelope(response_format: Value) -> Result<JsonSchemaEnvelope, LlmError> {
+    if response_format.get("type").and_then(Value::as_str) != Some("json_schema") {
+        return Err(LlmError::Config(
+            "anthropic requires response_format.type = \"json_schema\"".to_string(),
+        ));
+    }
+    let json_schema = response_format
+        .get("json_schema")
+        .ok_or_else(|| LlmError::Config("json_schema response_format is missing json_schema".to_string()))?;
+    let name = json_schema
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| LlmError::Config("json_schema response_format requires a non-empty name".to_string()))?
+        .to_string();
+    let schema = json_schema
+        .get("schema")
+        .cloned()
+        .ok_or_else(|| LlmError::Config("json_schema response_format is missing schema".to_string()))?;
+    let strict = json_schema
+        .get("strict")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    Ok(JsonSchemaEnvelope {
+        name,
+        strict,
+        schema,
+    })
+}
+
+fn reject_incomplete_response(
+    response: &AnthropicMessageResponse,
+    url: &str,
+    request_id: &str,
+) -> Result<(), LlmError> {
+    match response.stop_reason.as_deref() {
+        Some("refusal") => Err(LlmError::Response(format!(
+            "anthropic refused the request to {url}; request_id={request_id}"
+        ))),
+        Some("max_tokens") => Err(LlmError::Response(format!(
+            "anthropic response from {url} reached max_tokens; request_id={request_id}"
+        ))),
+        Some("model_context_window_exceeded") => Err(LlmError::Response(format!(
+            "anthropic response from {url} exceeded the model context window; request_id={request_id}"
+        ))),
+        Some("pause_turn") => Err(LlmError::Response(format!(
+            "anthropic response from {url} paused before completing; request_id={request_id}"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+fn text_content(content: Vec<AnthropicContentBlock>) -> Option<String> {
+    let text = content
+        .into_iter()
+        .filter_map(|block| match block {
+            AnthropicContentBlock::Text { text } => Some(text),
+            _ => None,
+        })
+        .collect::<String>();
+    (!text.trim().is_empty()).then_some(text)
+}
+
+fn tool_use_content(content: Vec<AnthropicContentBlock>) -> Option<String> {
+    content.into_iter().find_map(|block| match block {
+        AnthropicContentBlock::ToolUse { input, .. } => serde_json::to_string(&input).ok(),
+        _ => None,
+    })
+}
+
+fn structured_output_mode_name(mode: StructuredOutputMode) -> &'static str {
+    match mode {
+        StructuredOutputMode::JsonSchema => "json_schema",
+        StructuredOutputMode::JsonObject => "json_object",
+        StructuredOutputMode::ToolCall => "tool_call",
+    }
+}
+
+fn response_excerpt(body: &str) -> String {
+    let body = body.trim();
+    let mut excerpt = String::new();
+    for (index, ch) in body.chars().enumerate() {
+        if index >= RESPONSE_LOG_LIMIT {
+            excerpt.push_str("...");
+            return excerpt;
+        }
+        excerpt.push(ch);
+    }
+    excerpt
+}
+
+fn elapsed_ms(started_at: Instant) -> u64 {
+    started_at
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicMessageResponse {
+    content: Vec<AnthropicContentBlock>,
+    stop_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum AnthropicContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        #[allow(dead_code)]
+        name: String,
+        input: Value,
+    },
+    #[serde(other)]
+    Other,
+}

--- a/src/bcs/crates/plugins/bcs-llm-anthropic/src/lib.rs
+++ b/src/bcs/crates/plugins/bcs-llm-anthropic/src/lib.rs
@@ -391,7 +391,10 @@ fn reject_incomplete_response(
         Some("pause_turn") => Err(LlmError::Response(format!(
             "anthropic response from {url} paused before completing; request_id={request_id}"
         ))),
-        _ => Ok(()),
+        None => Err(LlmError::Response(format!(
+            "anthropic response from {url} is missing stop_reason; request_id={request_id}"
+        ))),
+        Some(_) => Ok(()),
     }
 }
 

--- a/src/bcs/crates/plugins/bcs-llm-anthropic/tests/client.rs
+++ b/src/bcs/crates/plugins/bcs-llm-anthropic/tests/client.rs
@@ -1,0 +1,551 @@
+use bcs_config_api::{LlmConfig, LlmProviderType, StructuredOutputMode};
+use bcs_llm_anthropic::AnthropicLlmClient;
+use bcs_llm_api::{LlmChatCompletionPort, LlmChatCompletionRequest, LlmChatMessage};
+use secrecy::Secret;
+use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[test]
+fn builds_anthropic_json_schema_request() {
+    let client = AnthropicLlmClient::new(test_config(
+        "https://api.anthropic.com/",
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic client");
+
+    let request = client
+        .build_http_request(test_request(judge_response_format()))
+        .expect("http request");
+
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.anthropic.com/v1/messages"
+    );
+    assert_eq!(
+        request.headers()["x-api-key"]
+            .to_str()
+            .expect("api key header"),
+        "anthropic-key"
+    );
+    assert_eq!(
+        request.headers()["anthropic-version"]
+            .to_str()
+            .expect("version header"),
+        "2023-06-01"
+    );
+    assert!(request.headers().get("authorization").is_none());
+
+    let body = request_json_body(&request);
+    assert_eq!(body["model"], "claude-sonnet-4-6");
+    assert_eq!(body["max_tokens"], 4096);
+    assert_eq!(body["stream"], false);
+    assert!(body.get("temperature").is_none());
+    assert_eq!(body["system"], "Return JSON only.");
+    assert_eq!(body["messages"].as_array().map(Vec::len), Some(1));
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"], "Judge the candidate.");
+    assert_eq!(body["output_config"]["format"]["type"], "json_schema");
+    assert_eq!(
+        body["output_config"]["format"]["schema"]["properties"]["outcome"]["enum"],
+        json!(["approved", "rejected"])
+    );
+}
+
+#[test]
+fn accepts_base_url_that_already_contains_v1() {
+    let client = AnthropicLlmClient::new(test_config(
+        "https://api.anthropic.com/v1/",
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic client");
+
+    let request = client
+        .build_http_request(test_request(judge_response_format()))
+        .expect("http request");
+
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.anthropic.com/v1/messages"
+    );
+}
+
+#[test]
+fn builds_kimi_anthropic_compatible_messages_url() {
+    let client = AnthropicLlmClient::new(test_config(
+        "https://api.kimi.com/coding/",
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic-compatible client");
+
+    let request = client
+        .build_http_request(test_request(judge_response_format()))
+        .expect("http request");
+
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.kimi.com/coding/v1/messages"
+    );
+}
+
+#[test]
+fn builds_anthropic_forced_tool_call_request() {
+    let client = AnthropicLlmClient::new(test_config(
+        "https://api.anthropic.com/v1",
+        StructuredOutputMode::ToolCall,
+    ))
+    .expect("anthropic client");
+
+    let request = client
+        .build_http_request(test_request(judge_response_format()))
+        .expect("http request");
+    let body = request_json_body(&request);
+
+    assert!(body.get("output_config").is_none());
+    assert_eq!(body["tools"][0]["name"], "judge_response");
+    assert_eq!(body["tools"][0]["strict"], true);
+    assert_eq!(
+        body["tools"][0]["input_schema"]["properties"]["outcome"]["enum"],
+        json!(["approved", "rejected"])
+    );
+    assert_eq!(
+        body["tool_choice"],
+        json!({"type": "tool", "name": "judge_response"})
+    );
+}
+
+#[test]
+fn rejects_json_object_mode() {
+    let error = match AnthropicLlmClient::new(test_config(
+        "https://api.anthropic.com/v1",
+        StructuredOutputMode::JsonObject,
+    )) {
+        Ok(_) => panic!("json_object must be rejected"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("does not support"));
+}
+
+#[test]
+fn rejects_empty_base_url_and_streaming_requests() {
+    let error = match AnthropicLlmClient::new(test_config(" \t", StructuredOutputMode::JsonSchema))
+    {
+        Ok(_) => panic!("empty base URL must be rejected"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("base_url must not be empty"));
+
+    let client = AnthropicLlmClient::new(test_config(
+        "https://api.anthropic.com/v1",
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic client");
+    let mut request = test_request(judge_response_format());
+    request.stream = true;
+
+    let error = client
+        .build_http_request(request)
+        .expect_err("streaming must be rejected")
+        .to_string();
+    assert!(error.contains("streaming is not supported"), "{error}");
+}
+
+#[test]
+fn rejects_invalid_message_shapes() {
+    let client = AnthropicLlmClient::new(test_config(
+        "https://api.anthropic.com/v1",
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic client");
+
+    let cases = [
+        (
+            vec![LlmChatMessage {
+                role: "tool".to_string(),
+                content: json!("result"),
+            }],
+            "does not support LLM message role 'tool'",
+        ),
+        (
+            vec![LlmChatMessage {
+                role: "system".to_string(),
+                content: json!("instructions only"),
+            }],
+            "requires at least one user or assistant message",
+        ),
+        (
+            vec![
+                LlmChatMessage {
+                    role: "system".to_string(),
+                    content: json!({"type": "text", "text": "instructions"}),
+                },
+                LlmChatMessage {
+                    role: "user".to_string(),
+                    content: json!("question"),
+                },
+            ],
+            "system message content must be a string or text-block array",
+        ),
+        (
+            vec![
+                LlmChatMessage {
+                    role: "system".to_string(),
+                    content: json!([{"type": "image", "text": "not text"}]),
+                },
+                LlmChatMessage {
+                    role: "user".to_string(),
+                    content: json!("question"),
+                },
+            ],
+            "system message arrays may contain only text blocks",
+        ),
+    ];
+
+    for (messages, expected) in cases {
+        let mut request = test_request(judge_response_format());
+        request.messages = messages;
+        let error = client
+            .build_http_request(request)
+            .expect_err("invalid message shape must be rejected")
+            .to_string();
+        assert!(error.contains(expected), "{error}");
+    }
+}
+
+#[tokio::test]
+async fn parses_anthropic_text_response() {
+    let body = r#"{"content":[{"type":"text","text":"{\"outcome\":\"approved\"}"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}"#;
+    let base_url = spawn_anthropic_response(200, body, "req-text").await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+        .expect("anthropic client");
+
+    let response = client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect("completion response");
+
+    assert_eq!(response.content, "{\"outcome\":\"approved\"}");
+    assert_eq!(response.raw["usage"]["input_tokens"], 10);
+}
+
+#[tokio::test]
+async fn joins_all_anthropic_text_blocks_in_order() {
+    let body = r#"{"content":[{"type":"text","text":"{\"outcome\":"},{"type":"thinking","thinking":"hidden","signature":"sig"},{"type":"text","text":"\"approved\"}"}],"stop_reason":"end_turn"}"#;
+    let base_url = spawn_anthropic_response(200, body, "req-multi-text").await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+        .expect("anthropic client");
+
+    let response = client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect("completion response");
+
+    assert_eq!(response.content, "{\"outcome\":\"approved\"}");
+}
+
+#[tokio::test]
+async fn anthropic_passes_llm_chat_completion_contract() {
+    let body = r#"{"content":[{"type":"text","text":"{\"outcome\":\"complete\"}"}],"stop_reason":"end_turn"}"#;
+    let base_url = spawn_anthropic_response(200, body, "req-contract").await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+        .expect("anthropic client");
+
+    bcs_test_support::contract::plugin::llm_chat_completion_contract_tests(
+        &client,
+        "claude-sonnet-4-6",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn parses_anthropic_tool_use_response() {
+    let body = r#"{"content":[{"type":"tool_use","id":"toolu_1","name":"judge_response","input":{"outcome":"approved"}}],"stop_reason":"tool_use"}"#;
+    let base_url = spawn_anthropic_response(200, body, "req-tool").await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::ToolCall))
+        .expect("anthropic client");
+
+    let response = client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect("completion response");
+
+    assert_eq!(response.content, "{\"outcome\":\"approved\"}");
+}
+
+#[tokio::test]
+async fn tool_call_mode_parses_plain_text_without_response_format() {
+    let body = r#"{"content":[{"type":"text","text":"plain response"}],"stop_reason":"end_turn"}"#;
+    let base_url = spawn_anthropic_response(200, body, "req-plain").await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::ToolCall))
+        .expect("anthropic client");
+    let mut request = test_request(judge_response_format());
+    request.response_format = None;
+
+    let response = client
+        .complete(request)
+        .await
+        .expect("plain completion response");
+
+    assert_eq!(response.content, "plain response");
+}
+
+#[tokio::test]
+async fn request_transport_error_includes_diagnostics() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock server");
+    let addr = listener.local_addr().expect("mock server addr");
+    tokio::spawn(async move {
+        let (socket, _) = listener.accept().await.expect("accept mock request");
+        drop(socket);
+    });
+    let client = AnthropicLlmClient::new(test_config(
+        &format!("http://{addr}/v1"),
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic client");
+
+    let error = client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect_err("closed connection must fail")
+        .to_string();
+
+    assert!(error.contains("anthropic request to"), "{error}");
+    assert!(error.contains("structured_output=json_schema"), "{error}");
+    assert!(error.contains("connect="), "{error}");
+}
+
+#[tokio::test]
+async fn response_body_read_error_includes_request_context() {
+    let raw_response = "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nrequest-id: req-short\r\ncontent-length: 50\r\n\r\n{";
+    let base_url = spawn_raw_response(raw_response).await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+        .expect("anthropic client");
+
+    let error = client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect_err("truncated response body must fail")
+        .to_string();
+
+    assert!(error.contains("failed to read response body"), "{error}");
+    assert!(error.contains("req-short"), "{error}");
+}
+
+#[tokio::test]
+async fn rejects_invalid_json_and_schema_mismatch() {
+    let invalid_json_url = spawn_anthropic_response(200, "not-json", "req-json").await;
+    let invalid_json_client = AnthropicLlmClient::new(test_config(
+        &invalid_json_url,
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic client");
+    let error = invalid_json_client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect_err("invalid JSON must fail")
+        .to_string();
+    assert!(error.contains("not valid JSON"), "{error}");
+    assert!(error.contains("req-json"), "{error}");
+
+    let invalid_schema_url = spawn_anthropic_response(
+        200,
+        r#"{"content":"wrong","stop_reason":"end_turn"}"#,
+        "req-schema",
+    )
+    .await;
+    let invalid_schema_client = AnthropicLlmClient::new(test_config(
+        &invalid_schema_url,
+        StructuredOutputMode::JsonSchema,
+    ))
+    .expect("anthropic client");
+    let error = invalid_schema_client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect_err("schema mismatch must fail")
+        .to_string();
+    assert!(error.contains("schema mismatch"), "{error}");
+    assert!(error.contains("req-schema"), "{error}");
+}
+
+#[tokio::test]
+async fn rejects_missing_expected_content_and_incomplete_stop_reasons() {
+    let missing_url = spawn_anthropic_response(
+        200,
+        r#"{"content":[{"type":"thinking","thinking":"hidden"}],"stop_reason":"end_turn"}"#,
+        "req-missing",
+    )
+    .await;
+    let missing_client =
+        AnthropicLlmClient::new(test_config(&missing_url, StructuredOutputMode::JsonSchema))
+            .expect("anthropic client");
+    let error = missing_client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect_err("missing text content must fail")
+        .to_string();
+    assert!(
+        error.contains("missing the expected json_schema content"),
+        "{error}"
+    );
+    assert!(error.contains("req-missing"), "{error}");
+
+    for (stop_reason, expected) in [
+        ("max_tokens", "reached max_tokens"),
+        (
+            "model_context_window_exceeded",
+            "exceeded the model context window",
+        ),
+        ("pause_turn", "paused before completing"),
+    ] {
+        let body = format!(r#"{{"content":[],"stop_reason":"{stop_reason}"}}"#);
+        let base_url = spawn_anthropic_response(200, &body, "req-incomplete").await;
+        let client =
+            AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+                .expect("anthropic client");
+        let error = client
+            .complete(test_request(judge_response_format()))
+            .await
+            .expect_err("incomplete response must fail")
+            .to_string();
+        assert!(error.contains(expected), "{error}");
+    }
+}
+
+#[tokio::test]
+async fn rejects_refusal_stop_reason() {
+    let body = r#"{"content":[],"stop_reason":"refusal","stop_details":{"type":"refusal"}}"#;
+    let base_url = spawn_anthropic_response(200, body, "req-refusal").await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+        .expect("anthropic client");
+
+    let error = client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect_err("refusal should fail")
+        .to_string();
+
+    assert!(error.contains("refused"), "{error}");
+    assert!(error.contains("req-refusal"), "{error}");
+}
+
+#[tokio::test]
+async fn http_error_includes_status_body_and_request_id() {
+    let base_url =
+        spawn_anthropic_response(429, r#"{"error":{"message":"rate limited"}}"#, "req-rate").await;
+    let client = AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+        .expect("anthropic client");
+
+    let error = client
+        .complete(test_request(judge_response_format()))
+        .await
+        .expect_err("rate limit should fail")
+        .to_string();
+
+    assert!(error.contains("429 Too Many Requests"), "{error}");
+    assert!(error.contains("rate limited"), "{error}");
+    assert!(error.contains("req-rate"), "{error}");
+}
+
+fn test_config(base_url: &str, structured_output: StructuredOutputMode) -> LlmConfig {
+    LlmConfig {
+        provider_type: LlmProviderType::Anthropic,
+        base_url: base_url.to_string(),
+        api_key_env: None,
+        api_key: Some(Secret::new("anthropic-key".to_string())),
+        model: "claude-sonnet-4-6".to_string(),
+        timeout_ms: 10_000,
+        temperature: 0.0,
+        max_tokens: 4_096,
+        structured_output,
+    }
+}
+
+fn test_request(response_format: serde_json::Value) -> LlmChatCompletionRequest {
+    LlmChatCompletionRequest {
+        model: "claude-sonnet-4-6".to_string(),
+        messages: vec![
+            LlmChatMessage {
+                role: "system".to_string(),
+                content: json!("Return JSON only."),
+            },
+            LlmChatMessage {
+                role: "user".to_string(),
+                content: json!("Judge the candidate."),
+            },
+        ],
+        response_format: Some(response_format),
+        stream: false,
+    }
+}
+
+fn judge_response_format() -> serde_json::Value {
+    json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": "judge_response",
+            "strict": true,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "outcome": {"type": "string", "enum": ["approved", "rejected"]}
+                },
+                "required": ["outcome"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn request_json_body(request: &reqwest::Request) -> serde_json::Value {
+    let body = request
+        .body()
+        .and_then(|body| body.as_bytes())
+        .expect("json body");
+    serde_json::from_slice(body).expect("body json")
+}
+
+async fn spawn_anthropic_response(status: u16, body: &str, request_id: &str) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock server");
+    let addr = listener.local_addr().expect("mock server addr");
+    let reason = match status {
+        200 => "OK",
+        429 => "Too Many Requests",
+        _ => "Error",
+    };
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\nrequest-id: {request_id}\r\ncontent-length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept mock request");
+        let mut request = vec![0; 8_192];
+        let _ = socket.read(&mut request).await.expect("read mock request");
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write mock response");
+    });
+    format!("http://{addr}/v1")
+}
+
+async fn spawn_raw_response(response: &str) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock server");
+    let addr = listener.local_addr().expect("mock server addr");
+    let response = response.to_string();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept mock request");
+        let mut request = vec![0; 8_192];
+        let _ = socket.read(&mut request).await.expect("read mock request");
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write mock response");
+    });
+    format!("http://{addr}/v1")
+}

--- a/src/bcs/crates/plugins/bcs-llm-anthropic/tests/client.rs
+++ b/src/bcs/crates/plugins/bcs-llm-anthropic/tests/client.rs
@@ -41,9 +41,16 @@ fn builds_anthropic_json_schema_request() {
     assert_eq!(body["stream"], false);
     assert!(body.get("temperature").is_none());
     assert_eq!(body["system"], "Return JSON only.");
-    assert_eq!(body["messages"].as_array().map(Vec::len), Some(1));
+    assert_eq!(body["messages"].as_array().map(Vec::len), Some(3));
     assert_eq!(body["messages"][0]["role"], "user");
     assert_eq!(body["messages"][0]["content"], "Judge the candidate.");
+    assert_eq!(body["messages"][1]["role"], "assistant");
+    assert_eq!(
+        body["messages"][1]["content"],
+        "I will evaluate the candidate against the criteria."
+    );
+    assert_eq!(body["messages"][2]["role"], "user");
+    assert_eq!(body["messages"][2]["content"], "Return the final outcome now.");
     assert_eq!(body["output_config"]["format"]["type"], "json_schema");
     assert_eq!(
         body["output_config"]["format"]["schema"]["properties"]["outcome"]["enum"],
@@ -473,6 +480,14 @@ fn test_request(response_format: serde_json::Value) -> LlmChatCompletionRequest 
             LlmChatMessage {
                 role: "user".to_string(),
                 content: json!("Judge the candidate."),
+            },
+            LlmChatMessage {
+                role: "assistant".to_string(),
+                content: json!("I will evaluate the candidate against the criteria."),
+            },
+            LlmChatMessage {
+                role: "user".to_string(),
+                content: json!("Return the final outcome now."),
             },
         ],
         response_format: Some(response_format),

--- a/src/bcs/crates/plugins/bcs-llm-anthropic/tests/client.rs
+++ b/src/bcs/crates/plugins/bcs-llm-anthropic/tests/client.rs
@@ -398,6 +398,29 @@ async fn rejects_missing_expected_content_and_incomplete_stop_reasons() {
     );
     assert!(error.contains("req-missing"), "{error}");
 
+    for (body, request_id) in [
+        (
+            r#"{"content":[{"type":"text","text":"{\"outcome\":\"approved\"}"}]}"#,
+            "req-stop-missing",
+        ),
+        (
+            r#"{"content":[{"type":"text","text":"{\"outcome\":\"approved\"}"}],"stop_reason":null}"#,
+            "req-stop-null",
+        ),
+    ] {
+        let base_url = spawn_anthropic_response(200, body, request_id).await;
+        let client =
+            AnthropicLlmClient::new(test_config(&base_url, StructuredOutputMode::JsonSchema))
+                .expect("anthropic client");
+        let error = client
+            .complete(test_request(judge_response_format()))
+            .await
+            .expect_err("missing stop reason must fail")
+            .to_string();
+        assert!(error.contains("missing stop_reason"), "{error}");
+        assert!(error.contains(request_id), "{error}");
+    }
+
     for (stop_reason, expected) in [
         ("max_tokens", "reached max_tokens"),
         (

--- a/src/bcs/crates/plugins/bcs-llm-openai-compatible/tests/client.rs
+++ b/src/bcs/crates/plugins/bcs-llm-openai-compatible/tests/client.rs
@@ -132,6 +132,26 @@ async fn openai_compatible_success_response_parses_choice_content() {
 }
 
 #[tokio::test]
+async fn openai_compatible_passes_llm_chat_completion_contract() {
+    let body = r#"{"choices":[{"message":{"content":"{\"outcome\":\"complete\"}"}}]}"#;
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let base_url = spawn_openai_compatible_response(response).await;
+    let client = OpenAiCompatibleLlmClient::new(test_config(
+        &base_url,
+        StructuredOutputMode::JsonSchema,
+        10_000,
+    ))
+    .expect("openai-compatible client");
+
+    bcs_test_support::contract::plugin::llm_chat_completion_contract_tests(&client, "gpt-4.1-mini")
+        .await;
+}
+
+#[tokio::test]
 async fn openai_compatible_success_response_parses_tool_call_arguments() {
     let body = r#"{"choices":[{"message":{"content":null,"tool_calls":[{"function":{"arguments":"{\"outcome\":\"complete\"}"}}]}}],"usage":{"total_tokens":12}}"#;
     let response = format!(

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -871,6 +871,8 @@ pub enum LlmProviderType {
     None,
     /// OpenAI Chat Completions compatible HTTP API.
     OpenAiCompatible,
+    /// Anthropic Messages HTTP API.
+    Anthropic,
     /// A linked extension-provided LLM provider.
     Other(String),
 }
@@ -880,6 +882,7 @@ impl LlmProviderType {
         match self {
             Self::None => "none",
             Self::OpenAiCompatible => "openai_compatible",
+            Self::Anthropic => "anthropic",
             Self::Other(value) => value.as_str(),
         }
     }
@@ -903,6 +906,7 @@ impl<'de> Deserialize<'de> for LlmProviderType {
         Ok(match value.trim().to_ascii_lowercase().as_str() {
             "none" => Self::None,
             "openai_compatible" => Self::OpenAiCompatible,
+            "anthropic" => Self::Anthropic,
             _ => Self::Other(value),
         })
     }
@@ -918,11 +922,11 @@ impl Default for LlmProviderType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StructuredOutputMode {
-    /// Send OpenAI `response_format = { type = "json_schema", ... }`.
+    /// Use the provider's native JSON Schema constrained-output mechanism.
     JsonSchema,
-    /// Send OpenAI JSON mode and rely on local schema validation.
+    /// Use JSON-object mode and rely on local schema validation when supported.
     JsonObject,
-    /// Convert the schema to a forced OpenAI-compatible tool call.
+    /// Convert the schema to a provider-native forced tool call.
     ToolCall,
 }
 

--- a/src/bcs/crates/service-api/bcs-config-api/tests/llm_config.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/tests/llm_config.rs
@@ -66,3 +66,23 @@ model = "internal-model"
     assert!(config.is_enabled());
     assert_eq!(config.model, "internal-model");
 }
+
+#[test]
+fn llm_config_accepts_anthropic_provider_type() {
+    let config: LlmConfig = toml::from_str(
+        r#"
+type = "anthropic"
+base_url = "https://api.anthropic.com/v1"
+api_key_env = "ANTHROPIC_API_KEY"
+model = "claude-sonnet-4-6"
+structured_output = "json_schema"
+"#,
+    )
+    .expect("anthropic config should parse");
+
+    assert_eq!(config.provider_type, LlmProviderType::Anthropic);
+    assert_eq!(config.base_url, "https://api.anthropic.com/v1");
+    assert_eq!(config.api_key_env.as_deref(), Some("ANTHROPIC_API_KEY"));
+    assert_eq!(config.model, "claude-sonnet-4-6");
+    assert_eq!(config.structured_output, StructuredOutputMode::JsonSchema);
+}

--- a/src/bcs/crates/test-support/bcs-test-support/Cargo.toml
+++ b/src/bcs/crates/test-support/bcs-test-support/Cargo.toml
@@ -16,6 +16,7 @@ bcs-service-api = { workspace = true }
 bcs-auth-api    = { workspace = true }
 bcs-cache-api   = { workspace = true }
 bcs-db-api      = { workspace = true }
+bcs-llm-api     = { workspace = true }
 bcs-session     = { workspace = true }
 bcs-session-file = { workspace = true }
 axum            = { workspace = true }

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/plugin/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/plugin/mod.rs
@@ -48,7 +48,11 @@ where
                 },
                 LlmChatMessage {
                     role: "assistant".to_string(),
-                    content: json!("The result is "),
+                    content: json!("I will evaluate the candidate against the criteria."),
+                },
+                LlmChatMessage {
+                    role: "user".to_string(),
+                    content: json!("Return the final outcome now."),
                 },
             ],
             response_format: Some(json!({

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/plugin/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/plugin/mod.rs
@@ -2,7 +2,9 @@
 
 use bcs_cache_api::CachePlugin;
 use bcs_db_api::DbPlugin;
+use bcs_llm_api::{LlmChatCompletionPort, LlmChatCompletionRequest, LlmChatMessage};
 use bcs_service_api::port::secret::{SecretAccessPort, SecretRecord};
+use serde_json::json;
 
 pub async fn cache_plugin_contract_tests<P: CachePlugin>(plugin: &P) {
     crate::cache_plugin_contract_tests(plugin).await;
@@ -18,4 +20,63 @@ where
     F: FnOnce() -> SecretRecord,
 {
     crate::secret_access_contract_tests(plugin, seed).await;
+}
+
+/// Contract tests every LLM chat completion plugin must pass.
+///
+/// The provider fixture must return `{"outcome":"complete"}` for the canonical
+/// request constructed by this harness.
+#[allow(
+    clippy::expect_used,
+    reason = "test harness — panic on failure is the contract"
+)]
+pub async fn llm_chat_completion_contract_tests<P>(plugin: &P, model: &str)
+where
+    P: LlmChatCompletionPort,
+{
+    let response = plugin
+        .complete(LlmChatCompletionRequest {
+            model: model.to_string(),
+            messages: vec![
+                LlmChatMessage {
+                    role: "system".to_string(),
+                    content: json!("Return JSON only."),
+                },
+                LlmChatMessage {
+                    role: "user".to_string(),
+                    content: json!("Judge the candidate."),
+                },
+                LlmChatMessage {
+                    role: "assistant".to_string(),
+                    content: json!("The result is "),
+                },
+            ],
+            response_format: Some(json!({
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "judge_response",
+                    "strict": true,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "outcome": {
+                                "type": "string",
+                                "enum": ["complete", "retry"]
+                            }
+                        },
+                        "required": ["outcome"],
+                        "additionalProperties": false
+                    }
+                }
+            })),
+            stream: false,
+        })
+        .await
+        .expect("LLM provider must complete the canonical request");
+
+    assert_eq!(response.content, r#"{"outcome":"complete"}"#);
+    assert!(
+        response.raw.is_object(),
+        "LLM provider must preserve the raw provider response"
+    );
 }


### PR DESCRIPTION
## Summary

- Add a native Anthropic Messages API plugin for the BCS LLM judge.
- Support `llm.type = "anthropic"` and wire it into the BCS composition root.
- Translate shared system, user, and assistant messages into the Anthropic request format.
- Support `json_schema` and `tool_call` structured output modes.
- Resolve the Anthropic `/v1/messages` endpoint from configurable base URLs.
- Add detailed diagnostics for transport failures, invalid responses, schema mismatches, and incomplete stop reasons.
- Add client contract, configuration, and provider composition tests.

## Configuration

```toml
[llm]
type = "anthropic"
base_url = "https://api.anthropic.com"
api_key_env = "ANTHROPIC_API_KEY"
model = "claude-sonnet-4-6"
timeout_ms = 120000
max_tokens = 4096
structured_output = "json_schema"
```

The base URL above is resolved to:

```text
https://api.anthropic.com/v1/messages
```

No example or local configuration files were changed.

## Validation

- Anthropic client tests: 18 passed
- Judge provider tests: 6 passed
- Overall line coverage: 78.15% (`> 70%` required)
- Changed-line coverage: 93.95% (`>= 80%` required)