### PR TITLE
fix: resolve readme workspace from skill bot

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -107,6 +107,7 @@ from agentclaw.community.core.devices.services.device_context_resolver import (
 from agentclaw.community.core.devices.services.device_sync_dispatcher import DeviceSyncDispatcher
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
+from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.core.bot_collaborator.interceptor import (
     CollaboratorPermissionInterceptor,
     with_interceptors,
@@ -1231,9 +1232,29 @@ async def get_skill_readme(
     # ``skill.user_id`` is only the Skill author and can be a collaborator.
     read_bot_id = (skill or {}).get("bolt_id") or effective_bot_id
     target_bot = None
+    # ``default`` is shared by many owners.  Resolve an explicitly supplied
+    # owner against the server-side environment so a same-named default Bot
+    # can never select an arbitrary user's workspace.
+    owner_hint = entity_id or (ctx.user_id if read_bot_id == "default" else None)
     try:
-        target_bot = bot_repo.get_by_id(read_bot_id)
+        if owner_hint:
+            matches = bot_repo.get_live_by_id_owner_and_env(
+                bot_id=read_bot_id,
+                owner_id=owner_hint,
+                env=get_current_env(),
+            )
+            if len(matches) > 1:
+                raise HTTPException(status_code=409, detail="Skill's owning bot is ambiguous")
+            if matches:
+                target_bot = matches[0]
+
+        if not target_bot and read_bot_id != "default":
+            # Service Bot IDs are normally globally unique.  Fail closed if
+            # they are not, rather than using repository ``.first()``.
+            target_bot = bot_repo.get_unique_by_id(read_bot_id)
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise
         logger.warning(
             "[skills.get_skill_readme] target bot lookup failed for bot_id=%s: %s",
             read_bot_id,

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -1240,6 +1240,12 @@ async def get_skill_readme(
             e,
         )
 
+    # A persisted local Skill must always be read from the Bot that owns it.
+    # Do not fall back to the caller's workspace when that Bot has disappeared:
+    # doing so can turn a stale record into a read against an unrelated device.
+    if skill and skill.get("bolt_id") and not target_bot:
+        raise HTTPException(status_code=404, detail="Skill's owning bot was not found")
+
     read_owner_id = (target_bot or {}).get("owner_id") or effective_entity_id
     read_entity_type = (target_bot or {}).get("entity_type") or effective_entity_type
     # Do not honour a caller-provided engine override for a Skill owned by a
@@ -1249,6 +1255,19 @@ async def get_skill_readme(
         owner_id=read_owner_id,
         bot_repo=bot_repo,
     )
+    if target_bot and (
+        (entity_id and entity_id != read_owner_id)
+        or (bot_id and bot_id != read_bot_id)
+        or (engine_type and engine_type != read_engine)
+    ):
+        logger.warning(
+            "[skills.get_skill_readme] Ignoring mismatched caller context: "
+            "skill_id=%s target_bot_id=%s target_owner_id=%s target_engine=%s",
+            skill_id,
+            read_bot_id,
+            read_owner_id,
+            read_engine,
+        )
     read_is_desktop = False
     if target_bot:
         read_is_desktop = target_bot.get("bot_type") == "desktop"

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -1225,29 +1225,33 @@ async def get_skill_readme(
             logger.warning(f"[skills.get_skill_readme] SkillCenter file-content failed: {e}")
         raise HTTPException(status_code=404, detail="Skill or README not found")
 
-    # The request's resolved entity identifies the Bot owner and therefore the
-    # device that owns local files. ``skill.user_id`` is the Skill author and can
-    # be a collaborator, so it must not be used for device routing.
+    # A Skill may be read while the caller is operating another Bot.  Its DB
+    # ``bolt_id`` is the authoritative target; derive owner, entity type and
+    # engine from that Bot instead of trusting the caller's route parameters.
+    # ``skill.user_id`` is only the Skill author and can be a collaborator.
     read_bot_id = (skill or {}).get("bolt_id") or effective_bot_id
-    read_owner_id = effective_entity_id
-    read_entity_type = effective_entity_type
+    target_bot = None
+    try:
+        target_bot = bot_repo.get_by_id(read_bot_id)
+    except Exception as e:
+        logger.warning(
+            "[skills.get_skill_readme] target bot lookup failed for bot_id=%s: %s",
+            read_bot_id,
+            e,
+        )
+
+    read_owner_id = (target_bot or {}).get("owner_id") or effective_entity_id
+    read_entity_type = (target_bot or {}).get("entity_type") or effective_entity_type
+    # Do not honour a caller-provided engine override for a Skill owned by a
+    # different Bot: it points at a different on-device workspace.
     read_engine = resolve_engine_for_bot(
         bot_id=read_bot_id,
         owner_id=read_owner_id,
-        override=engine_type,
         bot_repo=bot_repo,
     )
     read_is_desktop = False
-    try:
-        bot = bot_repo.get_by_id_and_owner(read_bot_id, read_owner_id)
-        if bot and bot.get("bot_type") == "desktop":
-            read_is_desktop = True
-    except Exception as e:
-        logger.warning(
-            "[skills.get_skill_readme] bot_type lookup failed for bot_id=%s "
-            "owner=%s: %s — defaulting is_desktop=False",
-            read_bot_id, read_owner_id, e,
-        )
+    if target_bot:
+        read_is_desktop = target_bot.get("bot_type") == "desktop"
 
     read_is_teclaw, read_local_skill_adapter = _resolve_teclaw_local_skill(
         resolver, read_bot_id, read_owner_id

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -36,6 +36,10 @@ def _app(skill_service):
         "entity_type": "staff", "bot_type": "service", "status": "ACTIVE",
     }
     bot_repo.get_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
+    bot_repo.get_unique_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
+    bot_repo.get_live_by_id_owner_and_env.return_value = [
+        bot_repo.get_by_id_and_owner.return_value
+    ]
 
     resolver = MagicMock()
     resolver.resolve_for_bot.return_value = SimpleNamespace(provider="teclaw")
@@ -119,13 +123,15 @@ def test_readme_route_uses_skill_bot_context_not_request_context_for_teclaw():
             fromlist=["BotRepository"],
         ).BotRepository
     )
-    bot_repo.get_by_id.return_value = {
+    target_bot = {
         "bot_id": "teclaw-bot",
         "owner_id": "skill-owner-u",
         "entity_type": "staff",
         "active_engine": "openclaw",
         "bot_type": "service",
     }
+    bot_repo.get_unique_by_id.return_value = target_bot
+    bot_repo.get_live_by_id_owner_and_env.return_value = []
 
     resp = client.get(
         "/api/skills/1/readme",
@@ -173,13 +179,15 @@ def test_readme_route_link_name_falls_back_to_global_lookup():
             fromlist=["BotRepository"],
         ).BotRepository
     )
-    bot_repo.get_by_id.return_value = {
+    target_bot = {
         "bot_id": "teclaw-bot",
         "owner_id": "owner-u",
         "entity_type": "staff",
         "active_engine": "openclaw",
         "bot_type": "service",
     }
+    bot_repo.get_unique_by_id.return_value = target_bot
+    bot_repo.get_live_by_id_owner_and_env.return_value = []
 
     resp = client.get(
         "/api/skills/x/readme",
@@ -226,7 +234,8 @@ def test_readme_route_handles_duplicate_link_name_scopes_and_desktop_bot():
         "bot_type": "desktop",
         "status": "ACTIVE",
     }
-    bot_repo.get_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
+    bot_repo.get_unique_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
+    bot_repo.get_live_by_id_owner_and_env.return_value = []
 
     resp = client.get(
         "/api/skills/x/readme",
@@ -311,10 +320,53 @@ def test_readme_route_rejects_local_skill_when_owning_bot_is_missing():
             fromlist=["BotRepository"],
         ).BotRepository
     )
-    bot_repo.get_by_id.return_value = None
+    bot_repo.get_unique_by_id.return_value = None
+    bot_repo.get_live_by_id_owner_and_env.return_value = []
 
     resp = client.get("/api/skills/1/readme", params=_Q)
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Skill's owning bot was not found"
     assert factory.create.call_count == 1
+
+
+def test_readme_route_resolves_default_bot_by_env_owner_and_bot_id():
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "default",
+    }
+    read_svc = MagicMock()
+    read_svc.get_skill_readme = AsyncMock(return_value="# readme")
+    client, factory, _ = _app(lookup_svc)
+    factory.create.side_effect = [lookup_svc, read_svc]
+    bot_repo = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.core.bot_management.repository.protocol",
+            fromlist=["BotRepository"],
+        ).BotRepository
+    )
+    target_bot = {
+        "bot_id": "default",
+        "owner_id": "target-owner",
+        "entity_type": "staff",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    bot_repo.get_live_by_id_owner_and_env.return_value = [target_bot]
+
+    resp = client.get(
+        "/api/skills/1/readme",
+        params={"entity_id": "target-owner", "bot_id": "default"},
+    )
+
+    assert resp.status_code == 200
+    bot_repo.get_live_by_id_owner_and_env.assert_called_once()
+    assert bot_repo.get_live_by_id_owner_and_env.call_args.kwargs["bot_id"] == "default"
+    assert bot_repo.get_live_by_id_owner_and_env.call_args.kwargs["owner_id"] == "target-owner"
+    bot_repo.get_unique_by_id.assert_not_called()
+    read_svc.get_skill_readme.assert_awaited_once_with(
+        "1", "u1", "default", device_owner_id="target-owner"
+    )

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -294,3 +294,27 @@ def test_readme_route_numeric_id_falls_back_to_link_name_when_id_missing():
     read_svc.get_skill_readme.assert_awaited_once_with(
         "123", "u1", "teclaw-bot", device_owner_id="u1"
     )
+
+
+def test_readme_route_rejects_local_skill_when_owning_bot_is_missing():
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "deleted-bot",
+    }
+    client, factory, _ = _app(lookup_svc)
+    bot_repo = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.core.bot_management.repository.protocol",
+            fromlist=["BotRepository"],
+        ).BotRepository
+    )
+    bot_repo.get_by_id.return_value = None
+
+    resp = client.get("/api/skills/1/readme", params=_Q)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Skill's owning bot was not found"
+    assert factory.create.call_count == 1

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -33,8 +33,9 @@ def _app(skill_service):
     bot_repo = MagicMock()
     bot_repo.get_by_id_and_owner.return_value = {
         "bot_id": "b1", "owner_id": "u1", "active_engine": "openclaw",
-        "bot_type": "service", "status": "ACTIVE",
+        "entity_type": "staff", "bot_type": "service", "status": "ACTIVE",
     }
+    bot_repo.get_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
 
     resolver = MagicMock()
     resolver.resolve_for_bot.return_value = SimpleNamespace(provider="teclaw")
@@ -97,7 +98,7 @@ def test_readme_route_teclaw_branch():
     assert path_factory.get_bot_skills_local_dir.call_args.kwargs["is_teclaw"] is True
 
 
-def test_readme_route_uses_request_owner_context_for_teclaw():
+def test_readme_route_uses_skill_bot_context_not_request_context_for_teclaw():
     lookup_svc = MagicMock()
     lookup_svc.get_skill.return_value = {
         "id": "1",
@@ -112,10 +113,23 @@ def test_readme_route_uses_request_owner_context_for_teclaw():
 
     client, factory, path_factory = _app(lookup_svc)
     factory.create.side_effect = [lookup_svc, read_svc]
+    bot_repo = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.core.bot_management.repository.protocol",
+            fromlist=["BotRepository"],
+        ).BotRepository
+    )
+    bot_repo.get_by_id.return_value = {
+        "bot_id": "teclaw-bot",
+        "owner_id": "skill-owner-u",
+        "entity_type": "staff",
+        "active_engine": "openclaw",
+        "bot_type": "service",
+    }
 
     resp = client.get(
         "/api/skills/1/readme",
-        params={"entity_id": "owner-u", "bot_id": "default", "engine_type": "openclaw"},
+        params={"entity_id": "wrong-request-owner", "bot_id": "default", "engine_type": "hermes"},
     )
 
     assert resp.status_code == 200
@@ -123,14 +137,14 @@ def test_readme_route_uses_request_owner_context_for_teclaw():
     assert factory.create.call_count == 2
     assert factory.create.call_args.kwargs["local_skill_path_adapter"] is not None
     assert path_factory.get_bot_skills_local_dir.call_args.args[:4] == (
-        "owner-u",
+        "skill-owner-u",
         "teclaw-bot",
         "openclaw",
         "staff",
     )
     assert path_factory.get_bot_skills_local_dir.call_args.kwargs["is_teclaw"] is True
     read_svc.get_skill_readme.assert_awaited_once_with(
-        "1", "u1", "teclaw-bot", device_owner_id="owner-u"
+        "1", "u1", "teclaw-bot", device_owner_id="skill-owner-u"
     )
 
 
@@ -153,6 +167,19 @@ def test_readme_route_link_name_falls_back_to_global_lookup():
 
     client, factory, _ = _app(lookup_svc)
     factory.create.side_effect = [lookup_svc, read_svc]
+    bot_repo = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.core.bot_management.repository.protocol",
+            fromlist=["BotRepository"],
+        ).BotRepository
+    )
+    bot_repo.get_by_id.return_value = {
+        "bot_id": "teclaw-bot",
+        "owner_id": "owner-u",
+        "entity_type": "staff",
+        "active_engine": "openclaw",
+        "bot_type": "service",
+    }
 
     resp = client.get(
         "/api/skills/x/readme",
@@ -199,6 +226,7 @@ def test_readme_route_handles_duplicate_link_name_scopes_and_desktop_bot():
         "bot_type": "desktop",
         "status": "ACTIVE",
     }
+    bot_repo.get_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
 
     resp = client.get(
         "/api/skills/x/readme",

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -1,6 +1,7 @@
 """Endpoint coverage for the teclaw branches of the readme / delete / parameters
 routes — they resolve the provider and build the skill service with the teclaw
 path adapter. A teclaw-provider resolver drives those branches end-to-end."""
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,8 +11,13 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
-from agentclaw.community.adapters.http.skill_center.skills import router as skills_router
+from agentclaw.community.adapters.http.dependencies import (
+    RequestContext,
+    get_request_context,
+)
+from agentclaw.community.adapters.http.skill_center.skills import (
+    router as skills_router,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -32,8 +38,12 @@ def _app(skill_service):
 
     bot_repo = MagicMock()
     bot_repo.get_by_id_and_owner.return_value = {
-        "bot_id": "b1", "owner_id": "u1", "active_engine": "openclaw",
-        "entity_type": "staff", "bot_type": "service", "status": "ACTIVE",
+        "bot_id": "b1",
+        "owner_id": "u1",
+        "active_engine": "openclaw",
+        "entity_type": "staff",
+        "bot_type": "service",
+        "status": "ACTIVE",
     }
     bot_repo.get_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
     bot_repo.get_unique_by_id.return_value = bot_repo.get_by_id_and_owner.return_value
@@ -46,7 +56,10 @@ def _app(skill_service):
 
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = {
-        "id": "1", "name": "x", "link_name": "x", "git_path": "local://skills-local/x",
+        "id": "1",
+        "name": "x",
+        "link_name": "x",
+        "git_path": "local://skills-local/x",
     }
 
     param_service = MagicMock()
@@ -63,18 +76,30 @@ def _app(skill_service):
 
     class _M(Module):
         def configure(self, binder):
-            from agentclaw.community.api.skill_service_factory import SkillServiceFactoryProtocol
+            from agentclaw.community.api.skill_service_factory import (
+                SkillServiceFactoryProtocol,
+            )
             from agentclaw.community.api.skill_parameter_service_factory import (
                 SkillParameterServiceFactoryProtocol,
             )
-            from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+            from agentclaw.community.core.bot_management.repository.protocol import (
+                BotRepository,
+            )
             from agentclaw.community.core.devices.services.device_context_resolver import (
                 DeviceContextResolver,
             )
-            from agentclaw.community.core.skill_center.factories import SkillServiceFactory
-            from agentclaw.community.core.skill_center.services.repositories import SkillRepository
-            from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
-            from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
+            from agentclaw.community.core.skill_center.factories import (
+                SkillServiceFactory,
+            )
+            from agentclaw.community.core.skill_center.services.repositories import (
+                SkillRepository,
+            )
+            from agentclaw.community.core.workspace.path_factory import (
+                WorkspacePathFactory,
+            )
+            from agentclaw.community.plugin_api.skill_center_client import (
+                SkillCenterClient,
+            )
 
             binder.bind(SkillServiceFactory, to=factory)
             binder.bind(SkillServiceFactoryProtocol, to=factory)
@@ -135,7 +160,11 @@ def test_readme_route_uses_skill_bot_context_not_request_context_for_teclaw():
 
     resp = client.get(
         "/api/skills/1/readme",
-        params={"entity_id": "wrong-request-owner", "bot_id": "default", "engine_type": "hermes"},
+        params={
+            "entity_id": "wrong-request-owner",
+            "bot_id": "default",
+            "engine_type": "hermes",
+        },
     )
 
     assert resp.status_code == 200
@@ -365,8 +394,63 @@ def test_readme_route_resolves_default_bot_by_env_owner_and_bot_id():
     assert resp.status_code == 200
     bot_repo.get_live_by_id_owner_and_env.assert_called_once()
     assert bot_repo.get_live_by_id_owner_and_env.call_args.kwargs["bot_id"] == "default"
-    assert bot_repo.get_live_by_id_owner_and_env.call_args.kwargs["owner_id"] == "target-owner"
+    assert (
+        bot_repo.get_live_by_id_owner_and_env.call_args.kwargs["owner_id"]
+        == "target-owner"
+    )
     bot_repo.get_unique_by_id.assert_not_called()
     read_svc.get_skill_readme.assert_awaited_once_with(
         "1", "u1", "default", device_owner_id="target-owner"
     )
+
+
+def test_readme_route_rejects_ambiguous_default_bot_owner_scope():
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "default",
+    }
+    client, _, _ = _app(lookup_svc)
+    bot_repo = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.core.bot_management.repository.protocol",
+            fromlist=["BotRepository"],
+        ).BotRepository
+    )
+    bot_repo.get_live_by_id_owner_and_env.return_value = [
+        {"bot_id": "default", "owner_id": "u1"},
+        {"bot_id": "default", "owner_id": "u1"},
+    ]
+
+    resp = client.get(
+        "/api/skills/1/readme", params={"entity_id": "u1", "bot_id": "default"}
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Skill's owning bot is ambiguous"
+
+
+def test_readme_route_handles_target_bot_repository_failure(caplog):
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "x",
+        "git_path": "local://skills-local/x",
+        "bolt_id": "service-bot",
+    }
+    client, _, _ = _app(lookup_svc)
+    bot_repo = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.core.bot_management.repository.protocol",
+            fromlist=["BotRepository"],
+        ).BotRepository
+    )
+    bot_repo.get_live_by_id_owner_and_env.return_value = []
+    bot_repo.get_unique_by_id.side_effect = RuntimeError("database unavailable")
+
+    resp = client.get("/api/skills/1/readme", params=_Q)
+
+    assert resp.status_code == 404
+    assert "target bot lookup failed" in caplog.text


### PR DESCRIPTION
修复协作者查看本地 Skill README 时依赖调用方上下文的问题。

- 以 Skill 的 `bolt_id` 查询目标 Bot，并使用其 `owner_id`、`entity_type`、`active_engine` 定位设备工作区
- 不再使用调用方传入的 `entity_id` 或 `engine_type` 作为跨 Bot 本地 Skill 的读取路径
- 增加当前 Bot 与目标 Skill Bot 不同的回归覆盖

测试：`cd src/backend && uv run pytest tests/community/api/skill_center/test_skills_routes_teclaw.py tests/community/core/skill_center/services/test_skill_service_readme.py -q`（30 passed）