### PR TITLE
fix(backend): settle obsolete skills pool wakeups

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -128,7 +128,9 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   以“递归引擎 + Legacy corpus 入口”持续 serving。该门禁不能只加在 Backend
   adapter 的 `/readiness`，否则无法覆盖直接访问 Gateway 的流量。
 - 人工 wake/retry 通过持久化任务队列交接，repair/rollback 复用既有恢复
-  服务；所有写入口仅对 operator 开放。
+  服务；激活前观测或已被同 generation 更新证据覆盖的 runtime 任务直接安全
+  收敛，不写入或覆盖证据；缺失当前状态或 quarantine 时仍 fail closed 重试。
+  所有写入口仅对 operator 开放。
 
 ## Context Boundary
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/repository/protocol.py
@@ -249,7 +249,12 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         observed_at: datetime,
         evidence: dict[str, object],
     ) -> bool:
-        """Record a qualified post-activation runtime lifecycle signal."""
+        """Account for a runtime-ready signal.
+
+        ``True`` means the signal was persisted or is safely obsolete or
+        superseded. ``False`` means current state cannot account for it and the
+        caller must retry.
+        """
         ...
 
     def record_runtime_reconciliation_failure(
@@ -260,7 +265,7 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         observed_at: datetime,
         evidence: dict[str, object],
     ) -> bool:
-        """Invalidate older READY evidence with a newer unhealthy runtime fact."""
+        """Account for a runtime failure, invalidating older READY evidence."""
         ...
 
     def begin_legacy_rollback(

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_quarantine_repository.py
@@ -250,12 +250,38 @@ class SkillsPoolQuarantineRepositoryMixin:
                     == SkillLayoutPhase.POOL_ACTIVE.value,
                     BotSkillLayoutStateModel.migration_generation
                     == migration_generation,
-                    BotSkillLayoutStateModel.pool_activated_at < observed_at_db,
+                    BotSkillLayoutStateModel.pool_activated_at.isnot(None),
                 )
                 .first()
             )
             if current is None:
                 return False
+            quarantine = (
+                session.query(SkillMigrationQuarantineModel.id)
+                .filter(
+                    SkillMigrationQuarantineModel.env == scope.env,
+                    SkillMigrationQuarantineModel.entity_id == scope.entity_id,
+                    SkillMigrationQuarantineModel.bot_id == scope.bot_id,
+                    SkillMigrationQuarantineModel.migration_generation
+                    == migration_generation,
+                    SkillMigrationQuarantineModel.pool_activated_at.isnot(None),
+                    SkillMigrationQuarantineModel.cleaned_at.is_(None),
+                    SkillMigrationQuarantineModel.status != "cleaning",
+                )
+                .first()
+            )
+            if quarantine is None:
+                return False
+            post_activation = (
+                session.query(BotSkillLayoutStateModel.id)
+                .filter(
+                    BotSkillLayoutStateModel.id == current.id,
+                    BotSkillLayoutStateModel.pool_activated_at < observed_at_db,
+                )
+                .first()
+            )
+            if post_activation is None:
+                return True
             affected = (
                 session.query(SkillMigrationQuarantineModel)
                 .filter(
@@ -288,7 +314,25 @@ class SkillsPoolQuarantineRepositoryMixin:
                     synchronize_session=False,
                 )
             )
-        return affected == 1
+            if affected == 1:
+                return True
+            superseded = (
+                session.query(SkillMigrationQuarantineModel.id)
+                .filter(
+                    SkillMigrationQuarantineModel.env == scope.env,
+                    SkillMigrationQuarantineModel.entity_id == scope.entity_id,
+                    SkillMigrationQuarantineModel.bot_id == scope.bot_id,
+                    SkillMigrationQuarantineModel.migration_generation
+                    == migration_generation,
+                    SkillMigrationQuarantineModel.pool_activated_at < observed_at_db,
+                    SkillMigrationQuarantineModel.cleaned_at.is_(None),
+                    SkillMigrationQuarantineModel.status != "cleaning",
+                    SkillMigrationQuarantineModel.runtime_reconciled_at
+                    >= observed_at_db,
+                )
+                .first()
+            )
+            return superseded is not None
 
     def claim_cleanup(
         self,

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -141,6 +141,31 @@ def test_layout_repository_satisfies_public_protocol_shape() -> None:
     assert isinstance(repository, SkillsPoolLayoutRepositoryProtocol)
 
 
+def test_runtime_reconciliation_fails_closed_without_quarantine() -> None:
+    database = InMemorySqliteDB()
+    repository = SkillsPoolLayoutRepository(database)
+    scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+    with database.transactional_orm_session() as session:
+        session.add(
+            BotSkillLayoutStateModel(
+                env=scope.env,
+                entity_id=scope.entity_id,
+                bot_id=scope.bot_id,
+                active_layout=SkillLayout.POOL.value,
+                phase=SkillLayoutPhase.POOL_ACTIVE.value,
+                migration_generation="generation-1",
+                pool_activated_at=datetime.now(UTC).replace(tzinfo=None),
+            )
+        )
+
+    assert not repository.record_runtime_reconciliation(
+        scope=scope,
+        migration_generation="generation-1",
+        observed_at=datetime.now(UTC) - timedelta(days=1),
+        evidence={"source": "pre_activation_without_quarantine"},
+    )
+
+
 def test_cutover_commit_logs_missing_quarantine_path(caplog) -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
@@ -1408,6 +1433,23 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
     assert quarantine is not None
     assert quarantine.engine == "openclaw"
     assert quarantine.source_evidence["evidence"]["bridge"] == "valid"
+    assert not repository.record_runtime_reconciliation(
+        scope=scope,
+        migration_generation="missing-generation",
+        observed_at=datetime.now(UTC),
+        evidence={"source": "wrong_generation"},
+    )
+    pre_activation_observed_at = datetime.now(UTC) - timedelta(days=1)
+    assert repository.record_runtime_reconciliation(
+        scope=scope,
+        migration_generation="generation-1",
+        observed_at=pre_activation_observed_at,
+        evidence={"source": "concurrent_pre_activation_wakeup"},
+    )
+    quarantine = repository.get_quarantine(scope, "generation-1")
+    assert quarantine is not None
+    assert quarantine.runtime_reconciled_at is None
+    assert quarantine.runtime_evidence is None
     ready_observed_at = datetime.now(UTC) + timedelta(seconds=1)
     assert repository.record_runtime_reconciliation(
         scope=scope,
@@ -1430,12 +1472,18 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
     assert failed is not None
     assert failed.runtime_reconciliation_status is RuntimeReconciliationStatus.FAILED
     assert failed.runtime_evidence == {"outcome": "invalid"}
-    assert not repository.record_runtime_reconciliation(
+    assert repository.record_runtime_reconciliation(
         scope=scope,
         migration_generation="generation-1",
         observed_at=failed_observed_at,
         evidence={"source": "stale_retry"},
     )
+    superseded = repository.get_quarantine(scope, "generation-1")
+    assert superseded is not None
+    assert (
+        superseded.runtime_reconciliation_status is RuntimeReconciliationStatus.FAILED
+    )
+    assert superseded.runtime_evidence == {"outcome": "invalid"}
     assert not repository.claim_cleanup(
         scope=scope,
         migration_generation="generation-1",


### PR DESCRIPTION
## Summary

- settle persisted runtime wakeups whose observation predates Pool activation without writing runtime evidence
- treat equal or newer generation-scoped runtime evidence as safely superseding a stale retry, preserving the newer evidence
- keep missing layout state, activation timestamp, or quarantine fail-closed for retry

## Runtime evidence

During Avernet #455 Desktop Hermes acceptance, reconcile task 17061 carried an observation from before Pool activation. A later wakeup had already persisted READY evidence, but task 17061 continued retrying with `skills pool runtime reconciliation evidence race lost` until rollback removed the Pool state.

## Tests

- `DEPLOY_PROFILE=test uv run pytest tests/community/core/skills_pool -q` (250 passed)
- Ruff check on changed Python files
- `git diff --check`

## Scope

Backend-only persistence semantics. No API, schema, config, Engine, or Desktop image changes.