### PR TITLE
feat(gateway): resolve principal signing key via SecretResolver SPI

### DIFF
--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -32,12 +32,33 @@ user_config:
     forwarder: "httpx"
     schema_catalog: "file"
     cache: "stub"
+    auth: "stub"
+    # SecretResolver flavor. Community reads creds from env; enterprise overlays
+    # this with a corp/KMS-backed selector registered via the plugin_registry.
+    secret: "community"
     authn:
       app_token: "stub"
       tenant: "stub"
     database:
       plugin_database: "SQLITE_ORM"
       database_url: ""
+
+  # SecretResolver configuration. The community (env-backed) resolver reads
+  # ``{env_prefix}{NAME}_VALUE`` / ``_USER`` from the process environment.
+  # Enterprise overlays may swap the resolver implementation via the plugin
+  # registry (e.g. a corp secret store / KMS).
+  secret:
+    env_prefix: "AVERNET_SECRET_"
+
+  # PrincipalSigner (JWT client) config. The signing key is a secret and is
+  # resolved at runtime via the SecretResolver using ``secret_name``; the
+  # remaining fields are non-secret and live here. A missing/empty key falls
+  # back to a dev key (single-box/tests only — NOT for production).
+  principal_signer:
+    secret_name: "principal_signing_key"
+    kid: "bare"
+    issuer: "gateway"
+    ttl_seconds: 60
 
   # Values used to expand ${...} placeholders in upstreams.servers.*.base_url.
   upstream_vars:

--- a/src/gateway/src/gateway/community/bootstrap/__init__.py
+++ b/src/gateway/src/gateway/community/bootstrap/__init__.py
@@ -94,7 +94,10 @@ def bootstrap_app() -> BootstrapResult:
 
     authenticator = container.authenticator()
     forwarding = container.forwarding()
-    principal_signer = build_principal_signer()
+    principal_signer = build_principal_signer(
+        user_config=container.user_config(),
+        secret_resolver=container.plugins().secret_resolver(),
+    )
     db = container.plugins().database()
     access_key_issuer = build_access_key_issuer(db, principal_signer)
     app_registrar = build_app_registrar(db, principal_signer)

--- a/src/gateway/src/gateway/community/bootstrap/_principal_signer.py
+++ b/src/gateway/src/gateway/community/bootstrap/_principal_signer.py
@@ -1,18 +1,33 @@
 """Composition root for the PrincipalSigner (auth design §7.1).
 
-Builds the bare (HMAC) signer from env. The adapter receives the built signer
-via ``app.state.principal_signer`` and calls it at the forwarder seam.
+Builds the bare (HMAC) signer from typed config: non-secret parameters
+(``kid`` / ``issuer`` / ``ttl_seconds``) come from ``user_config.principal_signer``
+and the signing key is resolved via the :class:`SecretResolver` SPI. The
+``SecretResolver`` implementation is selected by the ``plugins.secret`` config
+selector (community = env-backed; enterprise may register a corp/KMS-backed
+option via ``plugin_registry``), so the resolver is resolved from the DI
+container and passed in — this module never constructs a concrete flavor. The
+adapter receives the built signer via ``app.state.principal_signer`` and calls
+it at the forwarder seam.
 """
 
 from __future__ import annotations
 
+from gateway.community.config import UserConfig
 from gateway.community.plugins.principal_signer.bare import (
     BarePrincipalSigner,
     load_signer_config,
 )
 from gateway.community.spi.principal_signer import PrincipalSigner
+from gateway.community.spi.secret_resolver import SecretResolver
 
 
-def build_principal_signer() -> PrincipalSigner:
-    """Build the PrincipalSigner from env (bare HMAC flavor)."""
-    return BarePrincipalSigner(load_signer_config())
+def build_principal_signer(
+    *,
+    user_config: UserConfig,
+    secret_resolver: SecretResolver,
+) -> PrincipalSigner:
+    """Build the PrincipalSigner from typed config + a resolved SecretResolver."""
+    return BarePrincipalSigner(
+        load_signer_config(user_config.principal_signer, secret_resolver)
+    )

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -12,6 +12,7 @@ from gateway.community.plugins.cache.in_memory import InMemoryCachePlugin
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
 from gateway.community.plugins.forwarder.httpx import HttpxForwarder
 from gateway.community.plugins.schema_catalog.file import FileSchemaCatalog
+from gateway.community.plugins.secret_resolver.community import CommunitySecretResolver
 
 
 def _default(value, fallback):
@@ -44,6 +45,17 @@ class PluginContainer(containers.DeclarativeContainer):
     auth = providers.Selector(
         config.plugins.auth,
         stub=providers.Singleton(StubAuthPlugin),
+    )
+
+    # SecretResolver — community flavor reads signing keys (and other creds)
+    # from the process environment. Enterprise registers a corp/KMS-backed
+    # option (e.g. "corp") via plugin_registry.register_plugin_option_provider
+    # and selects it with ``plugins.secret: "corp"`` in the config overlay.
+    secret_resolver = providers.Selector(
+        config.plugins.secret,
+        community=providers.Singleton(
+            CommunitySecretResolver, env_prefix=config.secret.env_prefix
+        ),
     )
 
     bot_registry = providers.Factory(BotRepository, db=database)

--- a/src/gateway/src/gateway/community/config/__init__.py
+++ b/src/gateway/src/gateway/community/config/__init__.py
@@ -12,6 +12,8 @@ from ._models import (
     LogConfig,
     ModuleConfig,
     PluginConfig,
+    PrincipalSignerPluginConfig,
+    SecretConfig,
     UserConfig,
     WebConfig,
 )
@@ -24,6 +26,8 @@ __all__ = [
     "LogConfig",
     "ModuleConfig",
     "PluginConfig",
+    "PrincipalSignerPluginConfig",
+    "SecretConfig",
     "UserConfig",
     "WebConfig",
     "get_config",

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -41,6 +41,34 @@ class DatabasePluginConfig(BaseSettings):
     database_url: str = ""
 
 
+class SecretConfig(BaseModel):
+    """SecretResolver configuration (mirrors backend ``CommunitySecretConfig``).
+
+    ``env_prefix`` is the prefix the community (env-backed) SecretResolver
+    prepends to ``{NAME}_VALUE`` / ``{NAME}_USER`` lookups. Enterprise overlays
+    may swap the resolver implementation entirely via the plugin registry.
+    """
+
+    model_config = {"extra": "allow"}
+    env_prefix: str = "AVERNET_SECRET_"
+
+
+class PrincipalSignerPluginConfig(BaseModel):
+    """Non-secret PrincipalSigner config — read from ``user_config.principal_signer``.
+
+    The signing key (a secret) is resolved at runtime via the
+    :class:`~gateway.community.spi.secret_resolver.SecretResolver` using
+    ``secret_name``; ``kid`` / ``issuer`` / ``ttl_seconds`` are non-secret and
+    live in the config file.
+    """
+
+    model_config = {"extra": "allow"}
+    secret_name: str = "principal_signing_key"
+    kid: str = "bare"
+    issuer: str = "gateway"
+    ttl_seconds: int = 60
+
+
 class PluginConfig(BaseSettings):
     """Plugin selection config for gateway DI container.
 
@@ -58,6 +86,7 @@ class PluginConfig(BaseSettings):
     schema_catalog: str = Field(default="file", min_length=1)
     cache: str = Field(default="stub", min_length=1)
     auth: str = Field(default="stub", min_length=1)
+    secret: str = Field(default="community", min_length=1)
     authn: AuthnPluginConfig = Field(default_factory=AuthnPluginConfig)
     database: DatabasePluginConfig = Field(default_factory=DatabasePluginConfig)
 
@@ -65,6 +94,10 @@ class PluginConfig(BaseSettings):
 class UserConfig(BaseModel):
     model_config = {"extra": "allow"}
     plugins: PluginConfig = Field(default_factory=PluginConfig)
+    secret: SecretConfig = Field(default_factory=SecretConfig)
+    principal_signer: PrincipalSignerPluginConfig = Field(
+        default_factory=PrincipalSignerPluginConfig
+    )
     upstream_vars: dict[str, str] = Field(default_factory=dict)
     identity_strategies: dict[str, list[str]] = Field(default_factory=dict)
     route_security: dict[str, dict[str, str]] = Field(default_factory=dict)

--- a/src/gateway/src/gateway/community/core/bot/_repository.py
+++ b/src/gateway/src/gateway/community/core/bot/_repository.py
@@ -33,3 +33,13 @@ class BotRepository(BotRegistry):
                 select(self.Model).where(self.Model.session_token == token)
             )
             return None if row is None else row.to_record()
+
+    async def find_bot_by_agent_code(self, agent_code: str) -> RegisteredBot | None:
+        """Resolve a bot by its ``agent_code`` column (soft miss on unknown)."""
+        if not agent_code:
+            return None
+        with self._db.orm_session() as session:
+            row = session.scalar(
+                select(self.Model).where(self.Model.agent_code == agent_code)
+            )
+            return None if row is None else row.to_record()

--- a/src/gateway/src/gateway/community/plugins/principal_signer/bare/_plugin.py
+++ b/src/gateway/src/gateway/community/plugins/principal_signer/bare/_plugin.py
@@ -4,22 +4,24 @@ Signs the resolved identity set as a short-lived JWT with ``iss/aud/iat/exp`` +
 a ``principals`` claim, keyed by a shared HMAC secret (kid in the JOSE header
 for rotation). NOT production-grade — sofa uses asymmetric signing + KMS
 (auth design §7.1).
+
+The signing key is resolved via the :class:`SecretResolver` SPI (community
+flavor reads it from the environment); ``kid`` / ``issuer`` / ``ttl_seconds``
+are non-secret and come from ``user_config.principal_signer``.
 """
 
 from __future__ import annotations
 
-import os
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
 import jwt
 
+from gateway.community.config import PrincipalSignerPluginConfig
 from gateway.community.spi.authn import Principal, PrincipalType
+from gateway.community.spi.secret_resolver import SecretResolver
 
-_KID_ENV = "AVERNET_PRINCIPAL_SIGNING_KID"
-_KEY_ENV = "AVERNET_PRINCIPAL_SIGNING_KEY"
-_TTL_ENV = "AVERNET_PRINCIPAL_SIGNING_TTL"
 _DEV_FALLBACK_KEY = "avernet-dev-signing-key-NOT-FOR-PROD"
 
 
@@ -67,26 +69,44 @@ class BarePrincipalSigner:
         )
 
 
-def load_signer_config(
-    env: Mapping[str, str] | None = None,
-) -> PrincipalSignerConfig:
-    """Build :class:`PrincipalSignerConfig` from env, with a dev fallback key.
+def _resolve_signing_key(
+    signer_cfg: PrincipalSignerPluginConfig,
+    secret_resolver: SecretResolver,
+) -> str:
+    """Resolve the HMAC signing key via the SecretResolver, with a dev fallback.
 
-    A missing ``AVERNET_PRINCIPAL_SIGNING_KEY`` falls back to a fixed dev secret
-    and logs a warning — fine for single-box/tests, NOT for production. sofa
-    (asymmetric + KMS) is a separate workstream and will require a real key.
+    A missing secret (resolver returns ``None`` or an empty value) falls back to
+    a fixed dev secret and logs a warning — fine for single-box/tests, NOT for
+    production. sofa (asymmetric + KMS) resolves a real key through the same
+    SecretResolver seam.
     """
-    env = os.environ if env is None else env
-    key = env.get(_KEY_ENV, "")
-    kid = env.get(_KID_ENV, "") or "bare"
-    ttl_raw = env.get(_TTL_ENV, "")
-    ttl = int(ttl_raw) if ttl_raw.isdigit() else 60
+    material = secret_resolver.get_secret(signer_cfg.secret_name)
+    key = getattr(material, "secret_value", "") or ""
     if not key:
         from gateway.community.logger import get_logger
 
         get_logger("principal_signer").warning(
-            "AVERNET_PRINCIPAL_SIGNING_KEY unset — using dev fallback key "
-            "(NOT for production)."
+            "Principal signing key not found via SecretResolver (secret_name=%r) "
+            "— using dev fallback key (NOT for production).",
+            signer_cfg.secret_name,
         )
         key = _DEV_FALLBACK_KEY
-    return PrincipalSignerConfig(signing_key=key, kid=kid, ttl_seconds=ttl)
+    return key
+
+
+def load_signer_config(
+    signer_cfg: PrincipalSignerPluginConfig,
+    secret_resolver: SecretResolver,
+) -> PrincipalSignerConfig:
+    """Build :class:`PrincipalSignerConfig` from typed config + SecretResolver.
+
+    Non-secret fields (``kid`` / ``issuer`` / ``ttl_seconds``) come from the
+    ``user_config.principal_signer`` block; the signing key is resolved via
+    ``secret_resolver`` using ``signer_cfg.secret_name``.
+    """
+    return PrincipalSignerConfig(
+        signing_key=_resolve_signing_key(signer_cfg, secret_resolver),
+        kid=signer_cfg.kid,
+        issuer=signer_cfg.issuer,
+        ttl_seconds=signer_cfg.ttl_seconds,
+    )

--- a/src/gateway/src/gateway/community/plugins/secret_resolver/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/secret_resolver/__init__.py
@@ -1,0 +1,3 @@
+"""SecretResolver plugins — community (env-backed) flavor."""
+
+__all__: list[str] = []

--- a/src/gateway/src/gateway/community/plugins/secret_resolver/community/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/secret_resolver/community/__init__.py
@@ -1,0 +1,3 @@
+from ._plugin import CommunitySecretResolver
+
+__all__ = ["CommunitySecretResolver"]

--- a/src/gateway/src/gateway/community/plugins/secret_resolver/community/_plugin.py
+++ b/src/gateway/src/gateway/community/plugins/secret_resolver/community/_plugin.py
@@ -1,0 +1,46 @@
+"""CommunitySecretResolver — community secret resolution from the environment.
+
+Mirrors the backend ``agentclaw.community.plugins.community.secret_resolver``
+implementation: a real, dependency-free resolver that reads two env vars per
+secret — ``{env_prefix}{NAME}_USER`` and ``{env_prefix}{NAME}_VALUE`` — and
+returns an object exposing ``.secret_user`` / ``.secret_value``. When the value
+var is unset the secret is absent and the lookup returns ``None``, preserving
+the Protocol's "absent ⇒ None" contract.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from gateway.community.spi.secret_resolver import SecretResolver
+
+
+@dataclass(frozen=True)
+class _EnvSecret:
+    """Resolved secret — the ``.secret_user`` / ``.secret_value`` surface
+    consumers read off the corp secret object."""
+
+    secret_user: str
+    secret_value: str
+
+
+class CommunitySecretResolver(SecretResolver):
+    """Resolve a named secret from two prefixed environment variables."""
+
+    def __init__(self, env_prefix: str) -> None:
+        self._prefix = env_prefix
+
+    def get_secret(self, secret_name: str) -> _EnvSecret | None:
+        norm = secret_name.upper().replace("-", "_")
+        value = os.environ.get(f"{self._prefix}{norm}_VALUE")
+        if value is None:
+            # Absent — the credential's value is unset, so the secret does not
+            # exist. Returning None (never a half-populated object with an empty
+            # value) preserves the Protocol's "absent ⇒ None" contract, so a
+            # consumer that branches on ``secret is not None`` falls back rather
+            # than running with an empty credential. ``_USER`` is secondary — a
+            # token-only secret (value set, no user) resolves with user="".
+            return None
+        user = os.environ.get(f"{self._prefix}{norm}_USER")
+        return _EnvSecret(secret_user=user or "", secret_value=value)

--- a/src/gateway/src/gateway/community/spi/bot/_ports.py
+++ b/src/gateway/src/gateway/community/spi/bot/_ports.py
@@ -36,3 +36,15 @@ class BotRegistry(Protocol):
     """
 
     async def find_bot_by_token(self, token: str) -> RegisteredBot | None: ...
+
+    async def find_bot_by_agent_code(
+        self, agent_code: str
+    ) -> RegisteredBot | None:
+        """Resolve a bot by its ``agent_code`` (Provider-facing agent/engine code).
+
+        Returns ``None`` for an unknown ``agent_code`` (soft miss — not
+        applicable); never raises on an unknown code. Used by the agentpass
+        agent_code fallback path to map an Agent Server SDK-resolved
+        ``agent_code`` to a registered bot.
+        """
+        ...

--- a/src/gateway/src/gateway/community/spi/secret_resolver/__init__.py
+++ b/src/gateway/src/gateway/community/spi/secret_resolver/__init__.py
@@ -1,0 +1,5 @@
+"""SecretResolver SPI package."""
+
+from ._protocols import SecretResolver
+
+__all__ = ["SecretResolver"]

--- a/src/gateway/src/gateway/community/spi/secret_resolver/_protocols.py
+++ b/src/gateway/src/gateway/community/spi/secret_resolver/_protocols.py
@@ -1,0 +1,28 @@
+"""SecretResolver SPI — abstract retrieval of a named secret from a credential backend.
+
+Mirrors the backend ``agentclaw.community.plugin_api.secret_resolver.SecretResolver``
+contract so the gateway can resolve signing keys (and other credentials) through
+the same abstraction. Implementations are selected by deploy profile: community
+reads from the process environment; enterprise may resolve from a corp secret
+store / KMS. The gateway Protocol is a plain ``Protocol`` (gateway SPI
+convention) rather than the backend ``Plugin`` base.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SecretResolver(Protocol):
+    """Resolve a named secret to its credential object.
+
+    Returns an object exposing ``.secret_user`` / ``.secret_value`` (duck-typed
+    shape every consumer reads), or ``None`` when the backend has no such
+    secret. Backend/transport errors are **not** swallowed — they propagate so
+    callers that need a fallback must wrap the call in ``try/except``.
+    """
+
+    def get_secret(self, secret_name: str) -> Any | None:
+        """Return the secret object for ``secret_name``, or ``None`` if absent."""
+        ...

--- a/src/gateway/tests/integration/test_forward_route.py
+++ b/src/gateway/tests/integration/test_forward_route.py
@@ -17,13 +17,27 @@ from fastapi.testclient import TestClient
 
 from gateway.community.adapters.web._forward import _ALL_METHODS, forward_request
 from gateway.community.bootstrap._principal_signer import build_principal_signer
+from gateway.community.config import ConfigLoader, UserConfig
 from gateway.community.core.forwarding import DomainMap
 from gateway.community.plugins.forwarder.httpx import HttpxForwarder
+from gateway.community.plugins.secret_resolver.community import CommunitySecretResolver
 from gateway.community.spi.auth import AuthError
 
 Scope = dict[str, Any]
 Receive = Callable[[], Awaitable[dict[str, Any]]]
 Send = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+def _load_user_config() -> UserConfig:
+    return ConfigLoader.load().user_config
+
+
+def _build_signer():
+    uc = _load_user_config()
+    return build_principal_signer(
+        user_config=uc,
+        secret_resolver=CommunitySecretResolver(env_prefix=uc.secret.env_prefix),
+    )
 
 
 async def _stub_upstream(scope: Scope, receive: Receive, send: Send) -> None:
@@ -105,7 +119,7 @@ def _build() -> tuple[FastAPI, _FakeAuth]:
     app.state.forwarder = HttpxForwarder(client=client)
     auth = _FakeAuth()
     app.state.authenticator = auth
-    app.state.principal_signer = build_principal_signer()
+    app.state.principal_signer = _build_signer()
     app.add_api_route("/{full_path:path}", forward_request, methods=_ALL_METHODS)
     return app, auth
 
@@ -233,7 +247,7 @@ def test_real_authenticator_admits_google_token_then_forwards() -> None:
     )
     app.state.forwarder = HttpxForwarder(client=client)
     app.state.authenticator = authenticator
-    app.state.principal_signer = build_principal_signer()
+    app.state.principal_signer = _build_signer()
     app.add_api_route("/{full_path:path}", forward_request, methods=_ALL_METHODS)
 
     with TestClient(app) as c:

--- a/src/gateway/tests/unit/plugins/test_bot_registry_db.py
+++ b/src/gateway/tests/unit/plugins/test_bot_registry_db.py
@@ -34,3 +34,22 @@ async def test_known_token_resolves_seeded_bot(registry: BotRepository) -> None:
 
 async def test_unknown_token_returns_none(registry: BotRepository) -> None:
     assert await registry.find_bot_by_token("nope") is None
+
+
+async def test_known_agent_code_resolves_seeded_bot(registry: BotRepository) -> None:
+    bot = await registry.find_bot_by_agent_code("agent-1")
+    assert bot == RegisteredBot(
+        bot_uuid="bot-7",
+        owner_id="owner-1",
+        app_id=-1,
+        agent_code="agent-1",
+        tenant="default",
+    )
+
+
+async def test_unknown_agent_code_returns_none(registry: BotRepository) -> None:
+    assert await registry.find_bot_by_agent_code("nope") is None
+
+
+async def test_empty_agent_code_returns_none(registry: BotRepository) -> None:
+    assert await registry.find_bot_by_agent_code("") is None

--- a/src/gateway/tests/unit/plugins/test_plugin_registry.py
+++ b/src/gateway/tests/unit/plugins/test_plugin_registry.py
@@ -215,3 +215,58 @@ class TestRegisterExtraAuthnStrategy:
         inject_into_plugin_container(container)
         pool = container.plugins().authn_strategies()
         assert "google" in pool
+
+
+class TestRegisterSecretResolverOption:
+    """Enterprise registers a corp/KMS SecretResolver alongside the community one."""
+
+    def test_inject_corp_secret_resolver_via_provider_factory(self) -> None:
+        from dependency_injector import providers
+
+        from gateway.community.bootstrap._configs import init_container_config
+        from gateway.community.bootstrap._container import ApplicationContainer
+        from gateway.community.plugin_registry import inject_into_plugin_container
+        from gateway.community.spi.secret_resolver import SecretResolver
+
+        class CorpSecretResolver(SecretResolver):
+            """Stand-in for an enterprise KMS/corp-store resolver."""
+
+            def __init__(self, kms_endpoint: str) -> None:
+                self.kms_endpoint = kms_endpoint
+
+            def get_secret(self, secret_name: str):  # type: ignore[no-untyped-def]
+                return None
+
+        def provider_factory(root):
+            # Enterprise can read loaded config off the root container, e.g. a
+            # corp endpoint declared in the config overlay.
+            return providers.Singleton(
+                CorpSecretResolver, kms_endpoint="https://kms.corp.local"
+            )
+
+        register_plugin_option_provider("secret_resolver", "corp", provider_factory)
+        assert has_enterprise_plugins() is True
+
+        container = ApplicationContainer()
+        init_container_config(container)
+        container.config.plugins.secret.override("corp")
+
+        inject_into_plugin_container(container)
+
+        resolver = container.plugins().secret_resolver()
+        assert isinstance(resolver, CorpSecretResolver)
+        assert resolver.kms_endpoint == "https://kms.corp.local"
+
+    def test_community_secret_resolver_is_default(self) -> None:
+        from gateway.community.bootstrap._configs import init_container_config
+        from gateway.community.bootstrap._container import ApplicationContainer
+        from gateway.community.plugins.secret_resolver.community import (
+            CommunitySecretResolver,
+        )
+
+        container = ApplicationContainer()
+        init_container_config(container)
+
+        assert isinstance(
+            container.plugins().secret_resolver(), CommunitySecretResolver
+        )

--- a/src/gateway/tests/unit/plugins/test_principal_signer.py
+++ b/src/gateway/tests/unit/plugins/test_principal_signer.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import time as _time
+from dataclasses import dataclass
 
 import jwt
 import pytest
 
+from gateway.community.config import PrincipalSignerPluginConfig
 from gateway.community.plugins.principal_signer.bare import (
     BarePrincipalSigner,
     PrincipalSignerConfig,
     load_signer_config,
 )
 from gateway.community.spi.authn import AppPrincipal, ThirdPartyApp
+from gateway.community.spi.secret_resolver import SecretResolver
 
 _PRINCIPAL_HEADER = "X-Avernet-Principal"  # noqa: F841  (documented contract)
 # Use the real wall clock so PyJWT's ``iat``/``exp`` validation (which checks
@@ -81,23 +84,49 @@ async def test_empty_principals_still_signs() -> None:
     assert decoded["principals"] == []
 
 
-def test_load_signer_config_reads_env() -> None:
+@dataclass(frozen=True)
+class _Secret:
+    secret_user: str
+    secret_value: str
+
+
+class _FakeResolver(SecretResolver):
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+
+    def get_secret(self, secret_name: str) -> _Secret | None:
+        if self._value is None:
+            return None
+        return _Secret(secret_user="", secret_value=self._value)
+
+
+def _block(
+    *,
+    secret_name: str = "principal_signing_key",
+    kid: str = "bare",
+    issuer: str = "gateway",
+    ttl_seconds: int = 60,
+) -> PrincipalSignerPluginConfig:
+    return PrincipalSignerPluginConfig(
+        secret_name=secret_name, kid=kid, issuer=issuer, ttl_seconds=ttl_seconds
+    )
+
+
+def test_load_signer_config_reads_key_from_resolver_and_params_from_config() -> None:
     cfg = load_signer_config(
-        {
-            "AVERNET_PRINCIPAL_SIGNING_KEY": "envk",
-            "AVERNET_PRINCIPAL_SIGNING_KID": "k7",
-            "AVERNET_PRINCIPAL_SIGNING_TTL": "30",
-        }
+        _block(kid="k7", issuer="gw", ttl_seconds=30), _FakeResolver("envk")
     )
     assert cfg.signing_key == "envk"
     assert cfg.kid == "k7"
+    assert cfg.issuer == "gw"
     assert cfg.ttl_seconds == 30
 
 
-def test_load_signer_config_dev_fallback_when_unset() -> None:
-    cfg = load_signer_config({})
+def test_load_signer_config_dev_fallback_when_secret_absent() -> None:
+    cfg = load_signer_config(_block(), _FakeResolver(None))
     assert cfg.signing_key  # dev fallback present
     assert cfg.kid == "bare"
+    assert cfg.issuer == "gateway"
     assert cfg.ttl_seconds == 60
 
 


### PR DESCRIPTION
 ## Summary

  把 gateway 的 PrincipalSigner（JWT client）配置从直接读 env 重构为通过
  `SecretResolver` SPI 获取，并打通 enterprise 实现的注入路径。设计上参考 backend
  `plugin_api/secret_resolver.SecretResolver`，落地时复用 gateway 既有的
  `plugin_registry` + `providers.Selector` 机制（与 `cache_plugin` 同构），而非 backend
  的 `injector` Module / `DEPLOY_PROFILE` 机制——两者是不同的 DI 框架。

  ## Changes

  **新增 SPI 与实现**
  - `spi/secret_resolver/_protocols.py`：`SecretResolver` Protocol
    （`get_secret(name) -> Any | None`），对齐 backend 同名接口，按 gateway 纯
    `Protocol` 约定（不继承 `Plugin`）。
  - `plugins/secret_resolver/community/_plugin.py`：`CommunitySecretResolver`，env-pair
    读取 `{prefix}{NAME}_VALUE` / `_USER`，返回 frozen `_EnvSecret`，镜像 backend
    `CommunitySecretResolver`。

  **接线 SecretResolver 到 DI**
  - `PluginContainer` 新增 `secret_resolver` `providers.Selector`，键为
    `config.plugins.secret`；社区选项注入 `env_prefix=config.secret.env_prefix`。
  - `PluginConfig` 新增 `secret` 选择器字段（默认 `"community"`），`application.yaml`
    的 `plugins` block 增加 `secret: "community"`。

  **改造 bare signer**
  - 删除 `_KID_ENV/_KEY_ENV/_TTL_ENV` 与 env 读取；`load_signer_config` 改签为
    `(PrincipalSignerPluginConfig, SecretResolver)`。
  - `signing_key` 经 `SecretResolver` 解析（缺失走 dev fallback + warning，保持 single-box
    /测试可用）；`kid` / `issuer` / `ttl_seconds` 来自 `user_config.principal_signer`。
  - `PrincipalSignerConfig` dataclass 不变。

  **合成根**
  - `build_principal_signer(*, user_config, secret_resolver)` 接收**已从容器解析的**
    resolver，不再自行构造；`bootstrap_app` 改为 `container.plugins().secret_resolver()`。
  - `config/_models.py` 新增 `SecretConfig`、`PrincipalSignerPluginConfig`，挂到
    `UserConfig`，并在 `application.yaml` 增加对应 block。

  ## Enterprise 注入方式

  enterprise 包在 import 时调用既有 `plugin_registry`：

  ```python
  register_plugin_option_provider(
      "secret_resolver", "corp",
      lambda root: providers.Singleton(CorpSecretResolver, kms_endpoint=...),
  )

  并在配置 overlay 里设 plugins.secret: "corp" 即可切换到 corp/KMS 实现——与
  cache_plugin → zcache 的注入路径完全一致。社区同名选项优先，enterprise 只新增选项。

  Config / 迁移

  - 旧行为：key 来自 AVERNET_PRINCIPAL_SIGNING_KEY。
  - 新行为：key 来自 {env_prefix}{secret_name}_VALUE，默认
  AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE；kid / issuer / ttl 来自 yaml。
  - 未设该 env 时仍走 dev fallback（single-box/测试可用，生产必须设置）。

  Tests

  - 新增 resolver 注入单测 + TestRegisterSecretResolverOption（注册 corp 工厂 →
  override plugins.secret="corp" → inject_into_plugin_container → 容器解析出
  CorpSecretResolver；另测社区默认）。
  - test_forward_route.py 改用 _build_signer() 工厂传 resolver。
  - test_principal_signer.py 的 env 测试改为 resolver 注入 + 配置字段测试。
  - 全量 475 passed；11 个失败均为预先存在、与本 PR 无关（spi/bot/_ports.py 的 ruff
  格式未触碰；10 个 e2e/live 健康检查需真实运行的服务器）。新增/改动文件
  ruff format --check 与 ruff check 全部通过。