### PR TITLE
docs(repo): define PR title and description conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Title format: <type>(<scope>): <concise outcome>
+  e.g. feat(backend): add whitelist observed state
+Types: feat | fix | refactor | docs | test | ci | build | chore
+The title becomes the commit message on squash merge, so make it self-contained.
+See "Pull Request Conventions" in AGENTS.md.
+Delete the optional sections that do not apply.
+-->
+
+## Problem
+
+<!-- The defect, gap, or requirement, and why it matters. -->
+
+## Solution
+
+<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->
+
+## Validation
+
+<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->
+
+## Compatibility and risk (optional)
+
+<!-- Contract, schema, config, or migration impact, and the rollback path. -->
+
+## Spec (optional)
+
+<!-- The contract or design document this change implements. -->
+
+## Related issues (optional)
+
+<!-- Issues this closes or relates to. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,67 @@ Changes should preserve or improve the gates described in
 Do not weaken these checks to make a change pass. If a check is wrong, fix the
 check and document why.
 
+## Pull Request Conventions
+
+A pull request is read by external contributors and reviewers who do not share
+your context, and its title becomes the commit message when the PR is squash
+merged. Both must carry meaning on their own.
+
+### Title
+
+Use `<type>(<scope>): <concise outcome>`:
+
+```text
+feat(backend): add whitelist observed state
+fix(bcs): reject routing updates for unknown bot ids
+docs(arch): document plugin protocol conformance shape
+```
+
+| Type | Use for |
+| --- | --- |
+| `feat` | New functionality |
+| `fix` | Bug fix |
+| `refactor` | Restructuring with no external behavior change |
+| `docs` | Documentation |
+| `test` | Tests |
+| `ci` | CI/CD |
+| `build` | Build system or dependencies |
+| `chore` | Other maintenance |
+
+The scope is the module or area you touched, such as `backend`, `baas`,
+`engine`, `bcs`, `frontend`, `gateway`, `arch`, or `ci`. The outcome describes
+what the change accomplishes, not which files moved.
+
+Do not use vague or context-free titles such as `fix bug`, `update code`,
+`sync`, a bare branch name, or an issue number with no summary.
+
+### Description
+
+Use these sections, in this order:
+
+```markdown
+## Problem
+## Solution
+## Validation
+## Compatibility and risk (optional)
+## Spec (optional)
+## Related issues (optional)
+```
+
+- **Problem** — the observed defect, gap, or requirement, and why it matters.
+- **Solution** — the approach taken, and the alternatives rejected when the
+  choice is not obvious.
+- **Validation** — the tests, gates, and manual checks you actually ran, with
+  their results. State explicitly what you could not run and why.
+- **Compatibility and risk** — contract, schema, config, or migration impact,
+  and the rollback path.
+- **Spec** — the contract or design document this change implements.
+- **Related issues** — issues this closes or relates to.
+
+`.github/pull_request_template.md` holds this skeleton. Fill in every required
+section; delete the optional sections that do not apply rather than leaving
+them empty.
+
 ## Pre-push Module Selection
 
 Install the repository hooks separately in every Git worktree:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,11 @@ for a persistent override or `AVERNET_PRE_PUSH_MERGE_TARGET` for one `git push`.
 The hook must fetch that target and use its merge base rather than a direct
 target-to-head diff.
 
+When opening a pull request, follow the `Pull Request Conventions` section in
+`AGENTS.md`: title the PR `<type>(<scope>): <concise outcome>` and write the
+description with the `Problem` / `Solution` / `Validation` sections from
+`.github/pull_request_template.md`.
+
 Before changing Git hooks, module CI entrypoints, Singlebox orchestration,
 acceptance E2E tests, coverage manifests, or coverage reporting, read the
 `Pre-push Module Selection` section in `AGENTS.md` and treat it together with


### PR DESCRIPTION
## Problem

PR titles and descriptions in this repository have no agreed shape. Vague
titles such as `fix bug` or a bare branch name give reviewers no context, and
because PRs are squash merged the title lands verbatim in the commit history,
so the log loses meaning too. Neither `AGENTS.md` nor `CLAUDE.md` documented a
convention, so AI coding agents had nothing to follow either, and `.github/`
had no pull request template.

## Solution

- `AGENTS.md`: new `Pull Request Conventions` section specifying the title
  format `type(scope): concise outcome` — for example
  `feat(backend): add whitelist observed state` — the allowed type table
  (`feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `build`, `chore`), scope
  guidance, explicit bad-title examples, and the required description sections
  (`Problem` / `Solution` / `Validation`, plus optional
  `Compatibility and risk` / `Spec` / `Related issues`).
- `CLAUDE.md`: one short pointer to that section, keeping the file small as the
  file itself instructs.
- `.github/pull_request_template.md`: new template carrying the same skeleton,
  so the convention is applied by default in the GitHub UI and picked up by
  coding agents that read repository templates.

## Validation

Documentation-only change — no code paths touched, so no module gates apply.
Verified that `.github/` previously had no pull request template and that no
existing doc defined a PR title or description convention. All 7 PR checks
pass. This PR's own title and body follow the convention being introduced.

## Compatibility and risk

None. No build, runtime, or CI behavior changes. Reverting the commit fully
removes the convention.