### PR TITLE
fix(session-files): harden upload identity and filename handling

### DIFF
--- a/spec/pipeline/session-file-sharing-dev-rebase/009-pr-report.md
+++ b/spec/pipeline/session-file-sharing-dev-rebase/009-pr-report.md
@@ -1,0 +1,43 @@
+# PR 收敛报告：session-file-sharing-dev-rebase
+
+## 范围
+
+- Worktree / repo: `rebase-session-files-on-dev-20260801` / `inclusionAI/Avernet`
+- Head / base: `rebase/session-files-on-dev-20260801` / `dev` (`339556a6`)
+- PR: 待创建
+- 人工意见模式: auto
+
+## PR 判定
+
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| 待创建 PR | 本地分支包含 5 条 Session File 提交 | 仅从旧发布线挑选 Session File 改动，未重放无关 Skills/AICoding 历史。 |
+
+## 自动意见
+
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | N/A | N/A | PENDING | PR 尚未创建。 | N/A | N/A |
+
+## ACI/CI
+
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| Backend Session Resources | PASS（本地） | focused pytest | N/A | `42b62715` | 31 passed |
+| Engine Session Files | PASS（本地） | focused pytest | N/A | `4fde2af7` | 34 passed |
+| Ruff / whitespace | PASS（本地） | focused lint + `git diff --check` | N/A | N/A | 无诊断 |
+| 远端门禁 | PENDING | PR 尚未创建 | N/A | N/A | 待推送后观察 |
+
+## 人工意见
+
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | N/A | N/A | PENDING | PR 尚未创建。 | N/A | N/A |
+
+## 当前结论
+
+- PR: NOT_CREATED
+- 自动意见: PENDING
+- ACI/CI: PENDING
+- 人工意见: PENDING
+- 下一步: 推送分支，创建指向 `dev` 的 PR，并观察远端检查。

--- a/spec/pipeline/session-file-sharing-dev-rebase/009-pr-report.md
+++ b/spec/pipeline/session-file-sharing-dev-rebase/009-pr-report.md
@@ -4,20 +4,20 @@
 
 - Worktree / repo: `rebase-session-files-on-dev-20260801` / `inclusionAI/Avernet`
 - Head / base: `rebase/session-files-on-dev-20260801` / `dev` (`339556a6`)
-- PR: 待创建
+- PR: https://github.com/inclusionAI/Avernet/pull/679
 - 人工意见模式: auto
 
 ## PR 判定
 
 | 结果 | 证据 | 说明 |
 |---|---|---|
-| 待创建 PR | 本地分支包含 5 条 Session File 提交 | 仅从旧发布线挑选 Session File 改动，未重放无关 Skills/AICoding 历史。 |
+| 已创建 PR | [#679](https://github.com/inclusionAI/Avernet/pull/679) | `rebase/session-files-on-dev-20260801` 指向 `dev`；仅从旧发布线挑选 Session File 改动，未重放无关 Skills/AICoding 历史。 |
 
 ## 自动意见
 
 | 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | N/A | N/A | PENDING | PR 尚未创建。 | N/A | N/A |
+| 1 | 无 | N/A | PENDING | 首次查询无 review 或普通评论。 | N/A | 等待远端检查稳定后复查。 |
 
 ## ACI/CI
 
@@ -26,17 +26,17 @@
 | Backend Session Resources | PASS（本地） | focused pytest | N/A | `42b62715` | 31 passed |
 | Engine Session Files | PASS（本地） | focused pytest | N/A | `4fde2af7` | 34 passed |
 | Ruff / whitespace | PASS（本地） | focused lint + `git diff --check` | N/A | N/A | 无诊断 |
-| 远端门禁 | PENDING | PR 尚未创建 | N/A | N/A | 待推送后观察 |
+| 远端门禁 | PENDING | [#679 checks](https://github.com/inclusionAI/Avernet/pull/679/checks) | 7 个工作流已创建，处于 queued 或 in progress。 | N/A | 等待当前 head 终态 |
 
 ## 人工意见
 
 | 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | N/A | N/A | PENDING | PR 尚未创建。 | N/A | N/A |
+| 1 | 无 | N/A | PENDING | 首次查询无 review 或普通评论。 | N/A | 等待远端检查稳定后复查。 |
 
 ## 当前结论
 
-- PR: NOT_CREATED
+- PR: OPEN
 - 自动意见: PENDING
 - ACI/CI: PENDING
 - 人工意见: PENDING

--- a/src/backend/src/agentclaw/community/core/session_resources/service.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/service.py
@@ -30,7 +30,8 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 )
 
 log = logging.getLogger("session_resource.service")
-_SAFE_FILENAME = re.compile(r"^[A-Za-z0-9._ -]+$")
+_SAFE_FILENAME = re.compile(r"^[\w .-]+$", re.UNICODE)
+_MAX_FILENAME_UTF8_BYTES = 255
 
 
 class SessionResourceService:
@@ -438,7 +439,14 @@ class SessionResourceService:
     def _safe_filename(value: str) -> str:
         if Path(value).name != value or value in {".", ".."}:
             raise ValueError("invalid_filename")
-        if not _SAFE_FILENAME.fullmatch(value):
+        try:
+            filename_bytes = value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise ValueError("invalid_filename") from exc
+        if (
+            len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
+            or not _SAFE_FILENAME.fullmatch(value)
+        ):
             raise ValueError("invalid_filename")
         return value
 

--- a/src/backend/src/agentclaw/community/core/session_resources/service.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/service.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import uuid
 from pathlib import Path
 
@@ -30,8 +29,9 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 )
 
 log = logging.getLogger("session_resource.service")
-_SAFE_FILENAME = re.compile(r"^[\w .-]+$", re.UNICODE)
+_WINDOWS_FORBIDDEN_FILENAME_CHARACTERS = frozenset('<>:"/\\|?*')
 _MAX_FILENAME_UTF8_BYTES = 255
+_DEFAULT_SESSION_FILE_TENANT = "team_claw"
 
 
 class SessionResourceService:
@@ -66,10 +66,38 @@ class SessionResourceService:
     ) -> SessionUploadIntent:
         safe_filename = self._safe_filename(filename)
         context = self._resolver.resolve_for_bot(bot_id, owner_id)
-        tenant = context.conn_info.get("tenant")
-        bot_uuid = context.conn_info.get("bot_uuid")
-        if not isinstance(tenant, str) or not isinstance(bot_uuid, str):
+        raw_tenant = context.conn_info.get("tenant")
+        raw_bot_uuid = context.conn_info.get("bot_uuid")
+        provider = (
+            context.provider
+            if isinstance(context.provider, str)
+            else type(context.provider).__name__
+        )
+        bot_uuid_present = isinstance(raw_bot_uuid, str) and bool(raw_bot_uuid)
+        if raw_tenant is None or raw_tenant == "":
+            tenant = _DEFAULT_SESSION_FILE_TENANT
+            tenant_source = "default"
+        elif isinstance(raw_tenant, str):
+            tenant = raw_tenant
+            tenant_source = "context"
+        else:
+            log.warning(
+                "session_resource.upload_intent.identity.reject provider=%s tenant_source=invalid bot_uuid_present=%s tenant_type=%s bot_uuid_type=%s",
+                provider,
+                bot_uuid_present,
+                type(raw_tenant).__name__,
+                type(raw_bot_uuid).__name__,
+            )
             raise ValueError("BaaS device identity is unavailable")
+        bot_uuid = raw_bot_uuid if bot_uuid_present else ""
+        log.info(
+            "session_resource.upload_intent.identity.resolved provider=%s tenant_source=%s bot_uuid_present=%s tenant_type=%s bot_uuid_type=%s",
+            provider,
+            tenant_source,
+            bot_uuid_present,
+            type(raw_tenant).__name__,
+            type(raw_bot_uuid).__name__,
+        )
         grant = self._baas.create_session_upload_grant(
             tenant=tenant,
             session_id=session_key,
@@ -94,6 +122,8 @@ class SessionResourceService:
                 session_key_hash=session_hash,
                 engine_type=engine_type,
                 tenant=tenant,
+                # Session v2 uses tenant + session ID. Empty bot_uuid marks the
+                # shared legacy column as inapplicable; BOT_DEVICE_V1 needs a real value.
                 bot_uuid=bot_uuid,
                 display_name=filename,
                 filename=safe_filename,
@@ -106,14 +136,6 @@ class SessionResourceService:
                 size_bytes=size_bytes,
                 client_content_hash=content_hash,
             )
-        )
-        log.info(
-            "session_resource.upload_intent.create resource_id=%s session_key_hash=%s file_ext=%s size_bytes=%s upload_type=%s",
-            resource_id,
-            session_hash[:16],
-            Path(safe_filename).suffix.lower(),
-            size_bytes,
-            grant.upload_type,
         )
         return SessionUploadIntent(resource=record, grant=grant)
 
@@ -444,8 +466,13 @@ class SessionResourceService:
         except UnicodeEncodeError as exc:
             raise ValueError("invalid_filename") from exc
         if (
-            len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
-            or not _SAFE_FILENAME.fullmatch(value)
+            not value
+            or len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
+            or any(
+                not character.isprintable()
+                or character in _WINDOWS_FORBIDDEN_FILENAME_CHARACTERS
+                for character in value
+            )
         ):
             raise ValueError("invalid_filename")
         return value

--- a/src/backend/tests/community/core/session_resources/test_materialization.py
+++ b/src/backend/tests/community/core/session_resources/test_materialization.py
@@ -16,11 +16,15 @@ from agentclaw.community.core.task_queue.types import Complete, Retry
 
 
 class _Resolver:
+    def __init__(self, conn_info=None, *, provider="baas") -> None:
+        self._conn_info = conn_info or {"target": "engine"}
+        self._provider = provider
+
     def resolve_for_bot(self, bot_id, owner_id):
         return type(
             "Context",
             (),
-            {"conn_info": {"target": "engine"}, "provider": "baas"},
+            {"conn_info": self._conn_info, "provider": self._provider},
         )()
 
 
@@ -94,6 +98,32 @@ def test_handler_reloads_decrypts_and_dispatches_to_shared_engine_endpoint():
     assert body["transfer_api_version"] == "session_v2"
     assert body["workspace_relative_path"].startswith(".teamclaw/")
     assert "owner_id" not in body
+
+
+def test_session_v2_empty_bot_uuid_uses_the_given_arca_proxypass_context():
+    vault = TokenVault(master_key="test-master-key")
+    arca_context = {
+        "url": "https://proxypass.example/proxypass/ARCA_test",
+        "headers": {"x-proxypass-token": "secret-token"},
+        "use_proxy": True,
+    }
+    transport = _Transport()
+    handler = SessionResourceMaterializeHandler(
+        _Resolver(arca_context, provider="arca"),
+        transport,
+        _Repo(replace(_record(vault), tenant="team_claw", bot_uuid="")),
+        vault,
+    )
+
+    result = handler.handle(_payload())
+
+    assert isinstance(result, Complete)
+    conn_info, method, path, body = transport.calls[0]
+    assert conn_info is arca_context
+    assert (method, path) == ("POST", "/api/resource-materializations")
+    assert body["tenant"] == "team_claw"
+    assert "bot_uuid" not in body
+    assert "bot_uuid" not in path
 
 
 def test_handler_ignores_stale_task_without_calling_engine():

--- a/src/backend/tests/community/core/session_resources/test_service.py
+++ b/src/backend/tests/community/core/session_resources/test_service.py
@@ -11,7 +11,10 @@ from agentclaw.community.core.session_resources.baas_client import (
     SessionResourceBaasClient,
 )
 from agentclaw.community.core.session_resources.service import SessionResourceService
-from agentclaw.community.core.session_resources.types import SessionResourceStatus
+from agentclaw.community.core.session_resources.types import (
+    SessionResourceStatus,
+    TransferApiVersion,
+)
 from agentclaw.community.plugin_api.device_adapter_transport import (
     DeviceAdapterStreamResponse,
 )
@@ -112,13 +115,20 @@ class _HttpClient:
 
 
 class _Resolver:
+    def __init__(self, *, provider="baas", conn_info=None) -> None:
+        self._provider = provider
+        self._conn_info = conn_info or {
+            "tenant": "tenant-1",
+            "bot_uuid": "bot-uuid-1",
+        }
+
     def resolve_for_bot(self, bot_id, owner_id):
         return type(
             "Context",
             (),
             {
-                "provider": "baas",
-                "conn_info": {"tenant": "tenant-1", "bot_uuid": "bot-uuid-1"},
+                "provider": self._provider,
+                "conn_info": self._conn_info,
             },
         )()
 
@@ -157,14 +167,14 @@ class _Transport:
         )
 
 
-def _service(queue=None, *, complete_status="DONE", transport=None):
+def _service(queue=None, *, complete_status="DONE", transport=None, resolver=None):
     repo = _Repo()
     http = _HttpClient(complete_status=complete_status)
     service = SessionResourceService(
         repository=repo,
         baas_client=SessionResourceBaasClient(http),
         task_queue=queue or _Queue(),
-        device_context_resolver=_Resolver(),
+        device_context_resolver=resolver or _Resolver(),
         token_vault=TokenVault(master_key="test-master-key"),
         adapter_transport=transport or _Transport(),
     )
@@ -202,8 +212,144 @@ def test_upload_intent_uses_session_api_and_persists_encrypted_session_key():
     assert repo.value.transfer_api_version.value == "session_v2"
 
 
+def test_upload_intent_defaults_missing_arca_identity_without_logging_raw_values(caplog):
+    caplog.set_level("INFO", logger="session_resource.service")
+    resolver = _Resolver(
+        provider="arca",
+        conn_info={
+            "proxypass_url": "https://proxypass.example/internal",
+            "x-proxypass-token": "secret-token",
+        },
+    )
+    service, repo, http = _service(resolver=resolver)
+
+    intent = _intent(service)
+
+    assert http.calls[0][0] == (
+        "/api/v1/sessions/team_claw/session%2Fraw%20value/files/upload-url"
+    )
+    assert intent.resource.tenant == "team_claw"
+    assert repo.value.bot_uuid == ""
+    assert "provider=arca" in caplog.text
+    assert "tenant_source=default" in caplog.text
+    assert "bot_uuid_present=False" in caplog.text
+    assert "tenant_type=NoneType" in caplog.text
+    assert "bot_uuid_type=NoneType" in caplog.text
+    for raw_value in (
+        "owner-1",
+        "bot-1",
+        "session/raw value",
+        "report.txt",
+        "secret-token",
+        "https://proxypass.example/internal",
+    ):
+        assert raw_value not in caplog.text
+    for forbidden_field in (
+        "resource_id=",
+        "session_key_hash=",
+        "file_ext=",
+        "size_bytes=",
+        "upload_type=",
+    ):
+        assert forbidden_field not in caplog.text
+
+
+def test_upload_intent_defaults_empty_tenant():
+    resolver = _Resolver(
+        provider="arca",
+        conn_info={"tenant": "", "bot_uuid": "upstream-bot-uuid"},
+    )
+    service, repo, http = _service(resolver=resolver)
+
+    intent = _intent(service)
+
+    assert http.calls[0][0] == (
+        "/api/v1/sessions/team_claw/session%2Fraw%20value/files/upload-url"
+    )
+    assert intent.resource.tenant == "team_claw"
+    assert repo.value.bot_uuid == "upstream-bot-uuid"
+
+
+def test_upload_intent_normalizes_nonstring_bot_uuid_without_leaking_value(caplog):
+    caplog.set_level("INFO", logger="session_resource.service")
+    resolver = _Resolver(
+        provider="arca",
+        conn_info={"tenant": "tenant-1", "bot_uuid": {"private": "value"}},
+    )
+    service, repo, _ = _service(resolver=resolver)
+
+    intent = _intent(service)
+
+    assert intent.resource.bot_uuid == ""
+    assert repo.value.bot_uuid == ""
+    assert "bot_uuid_present=False" in caplog.text
+    assert "bot_uuid_type=dict" in caplog.text
+    assert "private" not in caplog.text
+    assert "value" not in caplog.text
+
+
+def test_upload_intent_preserves_nonempty_upstream_identity():
+    resolver = _Resolver(
+        provider="arca",
+        conn_info={"tenant": "upstream-tenant", "bot_uuid": "upstream-bot-uuid"},
+    )
+    service, repo, http = _service(resolver=resolver)
+
+    intent = _intent(service)
+
+    assert http.calls[0][0].startswith("/api/v1/sessions/upstream-tenant/")
+    assert intent.resource.tenant == "upstream-tenant"
+    assert repo.value.bot_uuid == "upstream-bot-uuid"
+
+
+def test_upload_intent_rejects_nonstring_tenant_without_leaking_identity(caplog):
+    caplog.set_level("WARNING", logger="session_resource.service")
+    resolver = _Resolver(
+        provider="arca",
+        conn_info={"tenant": {"private-tenant": "hidden"}, "bot_uuid": "bot-uuid"},
+    )
+    service, repo, http = _service(resolver=resolver)
+
+    with pytest.raises(ValueError, match="BaaS device identity is unavailable"):
+        _intent(service)
+
+    assert repo.value is None
+    assert http.calls == []
+    assert "provider=arca" in caplog.text
+    assert "tenant_source=invalid" in caplog.text
+    assert "tenant_type=dict" in caplog.text
+    assert "bot_uuid_type=str" in caplog.text
+    assert "private-tenant" not in caplog.text
+    assert "hidden" not in caplog.text
+    assert "bot-uuid" not in caplog.text
+
+
+def test_legacy_complete_uses_the_recorded_bot_uuid():
+    service, repo, http = _service()
+    intent = _intent(service)
+    repo.value = replace(
+        intent.resource,
+        transfer_api_version=TransferApiVersion.BOT_DEVICE_V1,
+        bot_uuid="legacy-bot-uuid",
+    )
+
+    service.complete_upload(
+        owner_id="owner-1",
+        bot_id="bot-1",
+        session_key="session/raw value",
+        resource_id=intent.resource.resource_id,
+        transfer_id="transfer-1",
+    )
+
+    assert (
+        http.calls[1][0]
+        == "/api/v1/bots/tenant-1/legacy-bot-uuid/files/upload-url/transfer-1/complete"
+    )
+
+
 def test_upload_intent_allows_unicode_filename_within_filesystem_limit():
     service, repo, http = _service()
+    filename = "\u4e2d\u6587 \u62a5\u544a (final)\uff08\u5df2\u5ba1\uff09.txt"
 
     intent = service.create_upload_intent(
         owner_id="owner-1",
@@ -211,13 +357,13 @@ def test_upload_intent_allows_unicode_filename_within_filesystem_limit():
         session_key="session/raw value",
         scope_type="personal_bot_chat",
         engine_type="openclaw",
-        filename="\u4e2d\u6587\u62a5\u544a 2026.txt",
+        filename=filename,
         size_bytes=4,
     )
 
-    assert http.calls[0][1]["json"]["filename"] == "\u4e2d\u6587\u62a5\u544a 2026.txt"
-    assert repo.value.filename == "\u4e2d\u6587\u62a5\u544a 2026.txt"
-    assert intent.resource.workspace_relative_path.endswith("/\u4e2d\u6587\u62a5\u544a 2026.txt")
+    assert http.calls[0][1]["json"]["filename"] == filename
+    assert repo.value.filename == filename
+    assert intent.resource.workspace_relative_path.endswith(f"/{filename}")
 
 
 def test_upload_intent_rejects_filename_exceeding_utf8_segment_limit():
@@ -233,6 +379,27 @@ def test_upload_intent_rejects_filename_exceeding_utf8_segment_limit():
             filename=f"{'\u4e2d' * 86}.txt",
             size_bytes=4,
         )
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [".", "..", "folder/report.txt", r"folder\report.txt", "report?.txt", "report\n.txt"],
+)
+def test_upload_intent_rejects_unsafe_filename_characters(filename):
+    service, _, http = _service()
+
+    with pytest.raises(ValueError, match="invalid_filename"):
+        service.create_upload_intent(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            scope_type="personal_bot_chat",
+            engine_type="openclaw",
+            filename=filename,
+            size_bytes=4,
+        )
+
+    assert http.calls == []
 
 
 def test_upload_complete_requires_baas_done_then_queues_identity_only():

--- a/src/backend/tests/community/core/session_resources/test_service.py
+++ b/src/backend/tests/community/core/session_resources/test_service.py
@@ -202,6 +202,39 @@ def test_upload_intent_uses_session_api_and_persists_encrypted_session_key():
     assert repo.value.transfer_api_version.value == "session_v2"
 
 
+def test_upload_intent_allows_unicode_filename_within_filesystem_limit():
+    service, repo, http = _service()
+
+    intent = service.create_upload_intent(
+        owner_id="owner-1",
+        bot_id="bot-1",
+        session_key="session/raw value",
+        scope_type="personal_bot_chat",
+        engine_type="openclaw",
+        filename="\u4e2d\u6587\u62a5\u544a 2026.txt",
+        size_bytes=4,
+    )
+
+    assert http.calls[0][1]["json"]["filename"] == "\u4e2d\u6587\u62a5\u544a 2026.txt"
+    assert repo.value.filename == "\u4e2d\u6587\u62a5\u544a 2026.txt"
+    assert intent.resource.workspace_relative_path.endswith("/\u4e2d\u6587\u62a5\u544a 2026.txt")
+
+
+def test_upload_intent_rejects_filename_exceeding_utf8_segment_limit():
+    service, _, _ = _service()
+
+    with pytest.raises(ValueError, match="invalid_filename"):
+        service.create_upload_intent(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            scope_type="personal_bot_chat",
+            engine_type="openclaw",
+            filename=f"{'\u4e2d' * 86}.txt",
+            size_bytes=4,
+        )
+
+
 def test_upload_complete_requires_baas_done_then_queues_identity_only():
     queue = _Queue()
     service, repo, http = _service(queue)

--- a/src/backend/tests/community/core/session_resources/test_service.py
+++ b/src/backend/tests/community/core/session_resources/test_service.py
@@ -224,17 +224,22 @@ def test_upload_intent_defaults_missing_arca_identity_without_logging_raw_values
     service, repo, http = _service(resolver=resolver)
 
     intent = _intent(service)
+    service_logs = "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "session_resource.service"
+    )
 
     assert http.calls[0][0] == (
         "/api/v1/sessions/team_claw/session%2Fraw%20value/files/upload-url"
     )
     assert intent.resource.tenant == "team_claw"
     assert repo.value.bot_uuid == ""
-    assert "provider=arca" in caplog.text
-    assert "tenant_source=default" in caplog.text
-    assert "bot_uuid_present=False" in caplog.text
-    assert "tenant_type=NoneType" in caplog.text
-    assert "bot_uuid_type=NoneType" in caplog.text
+    assert "provider=arca" in service_logs
+    assert "tenant_source=default" in service_logs
+    assert "bot_uuid_present=False" in service_logs
+    assert "tenant_type=NoneType" in service_logs
+    assert "bot_uuid_type=NoneType" in service_logs
     for raw_value in (
         "owner-1",
         "bot-1",
@@ -243,7 +248,7 @@ def test_upload_intent_defaults_missing_arca_identity_without_logging_raw_values
         "secret-token",
         "https://proxypass.example/internal",
     ):
-        assert raw_value not in caplog.text
+        assert raw_value not in service_logs
     for forbidden_field in (
         "resource_id=",
         "session_key_hash=",
@@ -251,7 +256,7 @@ def test_upload_intent_defaults_missing_arca_identity_without_logging_raw_values
         "size_bytes=",
         "upload_type=",
     ):
-        assert forbidden_field not in caplog.text
+        assert forbidden_field not in service_logs
 
 
 def test_upload_intent_defaults_empty_tenant():

--- a/src/engine/src/engine/community/core/resource_materialization/service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/service.py
@@ -184,10 +184,11 @@ class ResourceMaterializationService:
                 result = await self._materialize_locked(request)
             except MaterializationSecurityError as exc:
                 log.warning(
-                    "engine.resource_materialize.path.reject resource_id=%s task_version=%s error_type=%s",
+                    "engine.resource_materialize.path.reject resource_id=%s task_version=%s error_type=%s reason=%s",
                     request.resource_id,
                     request.task_version,
                     type(exc).__name__,
+                    str(exc),
                 )
                 result = self._failure_result(request, "invalid_device_path")
             except Exception as exc:

--- a/src/engine/src/engine/community/core/resource_materialization/service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/service.py
@@ -29,7 +29,7 @@ from engine.community.plugin_api.workspace_root import workspace_root_strict
 
 log = logging.getLogger("engine.resource_materialization")
 _SAFE_IDENTIFIER_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
-_SAFE_FILENAME = re.compile(r"^[\w .-]+$", re.UNICODE)
+_WINDOWS_FORBIDDEN_FILENAME_CHARACTERS = frozenset('<>:"/\\|?*')
 _MAX_FILENAME_UTF8_BYTES = 255
 
 
@@ -321,8 +321,15 @@ class ResourceMaterializationService:
         except UnicodeEncodeError as exc:
             raise MaterializationSecurityError("invalid controlled path segment") from exc
         if (
-            len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
-            or not _SAFE_FILENAME.fullmatch(request.filename)
+            not request.filename
+            or Path(request.filename).name != request.filename
+            or request.filename in {".", ".."}
+            or len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
+            or any(
+                not character.isprintable()
+                or character in _WINDOWS_FORBIDDEN_FILENAME_CHARACTERS
+                for character in request.filename
+            )
         ):
             raise MaterializationSecurityError("invalid controlled path segment")
         supplied_path = request.workspace_relative_path or request.device_path

--- a/src/engine/src/engine/community/core/resource_materialization/service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/service.py
@@ -28,7 +28,9 @@ from engine.community.plugin_api.resource_materialization import (
 from engine.community.plugin_api.workspace_root import workspace_root_strict
 
 log = logging.getLogger("engine.resource_materialization")
-_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+_SAFE_IDENTIFIER_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+_SAFE_FILENAME = re.compile(r"^[\w .-]+$", re.UNICODE)
+_MAX_FILENAME_UTF8_BYTES = 255
 
 
 class MaterializationSecurityError(ValueError):
@@ -150,7 +152,11 @@ class ResourceMaterializationService:
             # can never disclose a sibling or host path through the content API.
             self._assert_contained(root, target)
             canonical = target.resolve(strict=True)
-            if not canonical.is_file() or canonical.stat().st_size != entry.size_bytes:
+            if (
+                not canonical.is_file()
+                or canonical.stat().st_size != entry.size_bytes
+                or self._sha256(canonical) != entry.content_hash
+            ):
                 raise ResourceNotMaterializedError("resource_not_materialized")
             if self._sha256(canonical) != entry.content_hash:
                 raise ResourceNotMaterializedError("resource_not_materialized")
@@ -231,7 +237,9 @@ class ResourceMaterializationService:
         # COSEC: resolve the final parent after mkdir and enforce containment;
         # this rejects pre-existing symlinks that redirect writes outside Bot root.
         self._assert_contained(root, target)
-        temporary = target.with_name(f".{target.name}.part-{uuid.uuid4().hex}")
+        # Keep the temporary segment independent of the user filename: the final
+        # filename may already be close to the filesystem's per-segment limit.
+        temporary = target.with_name(f".part-{uuid.uuid4().hex}")
         log.info(
             "engine.resource_materialize.pull.start resource_id=%s task_version=%s path_hash=%s",
             request.resource_id,
@@ -298,13 +306,24 @@ class ResourceMaterializationService:
         root: Path,
         request: MaterializationRequest,
     ) -> tuple[Path, Path]:
-        segments = (
+        identifier_segments = (
             request.scope_key_hash,
             request.session_key_hash,
             request.resource_id,
-            request.filename,
         )
-        if any(not _SAFE_SEGMENT.fullmatch(segment) for segment in segments):
+        if any(
+            not _SAFE_IDENTIFIER_SEGMENT.fullmatch(segment)
+            for segment in identifier_segments
+        ):
+            raise MaterializationSecurityError("invalid controlled path segment")
+        try:
+            filename_bytes = request.filename.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise MaterializationSecurityError("invalid controlled path segment") from exc
+        if (
+            len(filename_bytes) > _MAX_FILENAME_UTF8_BYTES
+            or not _SAFE_FILENAME.fullmatch(request.filename)
+        ):
             raise MaterializationSecurityError("invalid controlled path segment")
         supplied_path = request.workspace_relative_path or request.device_path
         if supplied_path is None:

--- a/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
@@ -94,6 +94,93 @@ async def test_materialize_writes_atomic_file_manifest_and_callback(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_materialize_supports_filename_near_filesystem_segment_limit(
+    tmp_path: Path,
+):
+    content = b"long filename content"
+    filename = f"{'a' * 240}.txt"
+    service = ResourceMaterializationService(
+        pull_client=_PullClient(content),
+        callback_client=_CallbackClient(),
+        workspace_root_provider=lambda: tmp_path,
+    )
+    request = _request(
+        content,
+        filename=filename,
+        device_path=(
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
+            f"sr_001/{filename}"
+        ),
+    )
+
+    result = await service.materialize(request)
+
+    target = (
+        tmp_path
+        / ".teamclaw/session-files/scope_abc/session_abc/sr_001"
+        / filename
+    )
+    assert result.ready is True
+    assert target.read_bytes() == content
+    assert not list(target.parent.glob(".part-*"))
+
+
+@pytest.mark.asyncio
+async def test_materialize_supports_unicode_filename(tmp_path: Path):
+    content = b"unicode filename content"
+    filename = "\u4e2d\u6587\u62a5\u544a 2026.txt"
+    service = ResourceMaterializationService(
+        pull_client=_PullClient(content),
+        callback_client=_CallbackClient(),
+        workspace_root_provider=lambda: tmp_path,
+    )
+    request = _request(
+        content,
+        filename=filename,
+        device_path=(
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
+            f"sr_001/{filename}"
+        ),
+    )
+
+    result = await service.materialize(request)
+
+    target = (
+        tmp_path
+        / ".teamclaw/session-files/scope_abc/session_abc/sr_001"
+        / filename
+    )
+    assert result.ready is True
+    assert target.read_bytes() == content
+
+
+@pytest.mark.asyncio
+async def test_materialize_rejects_filename_exceeding_utf8_segment_limit(tmp_path: Path):
+    content = b"too long unicode filename"
+    filename = f"{'\u4e2d' * 86}.txt"
+    callback = _CallbackClient()
+    service = ResourceMaterializationService(
+        pull_client=_PullClient(content),
+        callback_client=callback,
+        workspace_root_provider=lambda: tmp_path,
+    )
+    request = _request(
+        content,
+        filename=filename,
+        device_path=(
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
+            f"sr_001/{filename}"
+        ),
+    )
+
+    result = await service.materialize(request)
+
+    assert result.ready is False
+    assert result.error_code == "invalid_device_path"
+    assert callback.results == [result]
+
+
+@pytest.mark.asyncio
 async def test_session_v2_materialization_never_persists_raw_session_id(tmp_path: Path):
     content = b"session v2 content"
     pull = _PullClient(content)

--- a/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
@@ -186,7 +186,7 @@ async def test_hash_mismatch_removes_partial_file_and_reports_failure(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_materialize_rejects_untrusted_device_path_escape(tmp_path: Path):
+async def test_materialize_rejects_untrusted_device_path_escape(tmp_path: Path, caplog):
     callback = _CallbackClient()
     service = ResourceMaterializationService(
         pull_client=_PullClient(b"x"),
@@ -204,6 +204,8 @@ async def test_materialize_rejects_untrusted_device_path_escape(tmp_path: Path):
     assert result.error_code == "invalid_device_path"
     assert callback.results == [result]
     assert not (tmp_path.parent / "outside/report.txt").exists()
+    assert "reason=device_path traversal is forbidden" in caplog.text
+    assert "../../outside/report.txt" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
@@ -128,7 +128,7 @@ async def test_materialize_supports_filename_near_filesystem_segment_limit(
 @pytest.mark.asyncio
 async def test_materialize_supports_unicode_filename(tmp_path: Path):
     content = b"unicode filename content"
-    filename = "\u4e2d\u6587\u62a5\u544a 2026.txt"
+    filename = "\u4e2d\u6587 \u62a5\u544a (final)\uff08\u5df2\u5ba1\uff09.txt"
     service = ResourceMaterializationService(
         pull_client=_PullClient(content),
         callback_client=_CallbackClient(),
@@ -152,6 +152,38 @@ async def test_materialize_supports_unicode_filename(tmp_path: Path):
     )
     assert result.ready is True
     assert target.read_bytes() == content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filename",
+    [".", "..", "folder/report.txt", r"folder\report.txt", "report?.txt", "report\n.txt"],
+)
+async def test_materialize_rejects_unsafe_filename_characters(
+    tmp_path: Path,
+    filename: str,
+):
+    content = b"unsafe filename content"
+    callback = _CallbackClient()
+    service = ResourceMaterializationService(
+        pull_client=_PullClient(content),
+        callback_client=callback,
+        workspace_root_provider=lambda: tmp_path,
+    )
+    request = _request(
+        content,
+        filename=filename,
+        device_path=(
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
+            f"sr_001/{filename}"
+        ),
+    )
+
+    result = await service.materialize(request)
+
+    assert result.ready is False
+    assert result.error_code == "invalid_device_path"
+    assert callback.results == [result]
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/plugins/tests/test_resource_materialization.py
+++ b/src/engine/src/engine/community/plugins/tests/test_resource_materialization.py
@@ -22,7 +22,7 @@ def _request(**overrides) -> MaterializationRequest:
         "scope_key_hash": "scope_abc",
         "session_key_hash": "session_abc",
         "transfer_api_version": "session_v2",
-        "tenant": "tenant-1",
+        "tenant": "team_claw",
         "session_id": "session/value",
         "workspace_relative_path": (
             ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
@@ -43,6 +43,7 @@ async def test_session_pull_uses_share_link_and_never_forwards_control_headers(
         requests.append(request)
         if request.url.host == "baas.example":
             assert request.headers["x-control-token"] == "control-secret"
+            assert "/sessions/team_claw/" in request.url.path
             assert request.url.path.endswith("/transfers/transfer-001/share-link")
             return httpx.Response(
                 200,


### PR DESCRIPTION
## Problem

Session File uploads need a safe fallback when an ARCA connection does not expose tenant or bot UUID metadata. The materialization path also rejected ordinary cross-platform Unicode filenames such as names containing Chinese parentheses, and path-validation failures lacked a concise diagnostic reason.

## Solution

- Default missing tenant identity to the Session File tenant while preserving an empty optional bot UUID.
- Validate filenames structurally: allow printable Unicode while rejecting path segments, control characters, Windows-forbidden characters, and overlong UTF-8 names.
- Add focused materialization diagnostics and regression coverage for identity resolution, unsafe paths, and portable Unicode filenames.
- Keep the identity-log assertion scoped to its service logger so unrelated BaaS telemetry cannot cause a false failure.

## Validation

- `31 passed`: focused Backend Session Resource tests.
- `34 passed`: focused Engine materialization, references, Session File API, and plugin tests.
- Focused Ruff checks and `git diff --check` passed.

## Compatibility and risk

The change widens accepted filenames only for printable names that remain portable across common filesystems. Existing path traversal and length protections remain enforced.

## Spec

- `spec/pipeline/session-file-sharing-dev-rebase/009-pr-report.md`
