### PR TITLE
feat(openapi-v1): admit only callers that name an end user

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -41,14 +41,16 @@ with stub handlers**.
 > 🔒 **The surface is still not callable end-to-end, but no longer because of a
 > stub.** `require_principal` now really verifies the gateway's signed
 > `X-Avernet-Principal` token and `resolve_avernet_tenant` really reads the
-> tenant out of it (see **The auth seam** below). Two things upstream still stand
-> between an external tenant and a `200`: the gateway's signing PR
-> ([#599](https://github.com/inclusionAI/Avernet/pull/599)) is open, so on `dev`
-> nothing forwards the header yet; and the gateway's `route_security.yaml`
-> requires a `user` identity resolved by the Google chain, which an external
-> tenant presenting an access key cannot satisfy. Until both move, every real
-> request still answers `401` — now by denying rather than by stubbing. "bots is
-> done" still means handlers, contracts and tests are done.
+> tenant out of it (see **The auth seam** below). The gateway's signing PR
+> ([#599](https://github.com/inclusionAI/Avernet/pull/599)) **has merged**, so
+> `dev` does forward the header — a `user` caller now round-trips end to end
+> (verified against the real signer, 2026-08-02). What still stands between an
+> **external tenant** and a `200` is who may call: `route_security` requires a
+> `user` identity resolved by the Google chain, which a tenant presenting an
+> access key cannot satisfy, and since 2026-08-02 the backend independently
+> refuses any identity set that names no end user. Widening that is the
+> delegation workstream, not a config line. "bots is done" still means handlers,
+> contracts and tests are done.
 
 The catch: the internal `/api/...` surface and the public `/openapi/v1` surface
 share the **same tables, repositories, and services**. So a public endpoint
@@ -191,7 +193,9 @@ DDL. Full ruling and per-endpoint mapping in
 ### Cross-cutting (not per-stage)
 | Item | State | Note |
 |---|---|---|
-| Real caller-identity verifier (auth workstream) | ✅ **BACKEND HALF DONE — PR [#634](https://github.com/inclusionAI/Avernet/pull/634)** (gateway half: [#599](https://github.com/inclusionAI/Avernet/pull/599), open) | `require_principal` + `resolve_avernet_tenant` now verify the gateway's signed `X-Avernet-Principal` (HS256, `aud=backend`) and read tenant + owner from it. **The surface is still not callable end-to-end:** #599 must merge (until then nothing forwards the header) and the gateway's `route_security.yaml` must admit the public API's actual callers — see the two open questions below |
+| Real caller-identity verifier (auth workstream) | ✅ **DONE both halves** — backend PR [#634](https://github.com/inclusionAI/Avernet/pull/634), gateway PR [#599](https://github.com/inclusionAI/Avernet/pull/599) **merged** | `require_principal` + `resolve_avernet_tenant` verify the gateway's signed `X-Avernet-Principal` (HS256, `aud=backend`) and read tenant + owner from it. The wire contract was checked by round-tripping the **real** gateway signer into the **real** backend verifier (2026-08-02): user/bot/app/access_key shapes, secret non-projection, `aud`/`iss` refusal. **A `user` caller works end to end.** What remains is *which* callers are admitted — see the identity-admission row below |
+| **Identity admission: `user` only** | ✅ **DONE 2026-08-02** | `verify_principal_token` refuses an identity set naming no end user, so `bot` / `app` / `access_key` callers get `401` by design rather than by whether a handler asks for the owner. Widening it is delegation (auth design §15), not config. SDD: `specs/2026-08-02-public-api-user-only-principal/` |
+| **No cross-repo test pins the principal wire shape** | ⬜ TODO | Both sides are tested against their own hand-written idea of the payload (`test_verifier.py` builds dicts; the gateway tests its own models). Renaming a field on one side leaves both suites green and 401s production |
 | Tenant-leading indexes (F2, **MANDATORY** policy) | ⬜ TODO | before multi-tenant go-live |
 | Background/scheduled work revisit | ⬜ TODO | before a 2nd tenant holds real data |
 | **Bot identity keys collide across tenants** ([#556](https://github.com/inclusionAI/Avernet/issues/556)) | ⬜ TODO (totalfrank) | Passport, auth relationships, BCN, policy row are keyed on `bot_id`/`owner_id` with no tenant axis, and every owner's first bot is literally `"default"`. **Should gate enabling multi-tenancy.** Stopgapped in #494 by `sync_to_bcn=False` on the public update path |
@@ -371,20 +375,28 @@ route dependency        → require_principal(request)       ─┘  cache on sc
 - What gets rejected, all as an identical `401`: bad signature, `alg: none`, an
   `aud` for another upstream, wrong `iss`, expired, a missing required claim, an
   unknown `type` tag, a renamed contract field, an identity set that disagrees
-  about its tenant, and **a tenant claiming to be `teamclaw`** (that one would
-  hand an external caller every internal row).
+  about its tenant, **a tenant claiming to be `teamclaw`** (that one would
+  hand an external caller every internal row), and **an identity set naming no
+  end user** (see below).
 - The gateway's tenant id **is** the `avernet_tenant` value — no mapping table.
   So a real external tenant reads an empty dataset until it has data; that is
   isolation working, not a bug.
 
 **Two things you inherit if you own a Track B category:**
 
-1. **`app` and `access_key` callers currently 401.** Owner id is derived only from
-   a `user` or `bot` principal. The gateway's `app.owners` is free-text org
-   attribution and its access-key registry has no owner column, so neither names
-   a person to scope by — and guessing is a cross-account data bug. Since the
-   public API's callers are *external registered tenants*, this likely needs
-   settling before any category goes live.
+1. **Only a `user` caller is admitted — `bot`, `app` and `access_key` are refused
+   at verification.** _Decided 2026-08-02._ Owner id is derived only from a
+   `user` principal. `app.owners` is free-text org attribution and the
+   access-key registry has no owner column, so neither names a person to scope
+   by; `bot` does carry `owner_id`, but letting a bot act as its owner across
+   the whole public contract is a grant nobody made. **The refusal happens in
+   `verify_principal_token`, not in `caller_owner_id`** — that is the load-bearing
+   part. A per-handler refusal only covers handlers that ask for the owner, and
+   four in `resources/router.py` don't; refusing the identity set means an
+   unscopeable caller cannot reach *any* route, present or future. What an `app`
+   / `access_key` caller should own is still unsettled (auth design §14 Q4);
+   delegation (§15) is the designed way to widen this. SDD:
+   `src/backend/specs/2026-08-02-public-api-user-only-principal/`.
 2. **A mapped error raised in a dependency is now enveloped too.** `@envelope_errors`
    only wraps the handler, so the seam's 401 (raised in a dependency) escaped it;
    the lookup now lives in `responses.py::mapped_error_response` and the app's
@@ -703,8 +715,10 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
 6. `require_principal` / `resolve_avernet_tenant` wired to the real verifier
    (auth workstream) — the point at which a second tenant can safely hold real
    data, and the point at which the public surface stops answering 401.
-   — _🔧 backend half done; needs gateway [#599](https://github.com/inclusionAI/Avernet/pull/599) merged **and** a `route_security.yaml`
-   rule admitting this surface's real callers._
+   — _✅ both halves merged ([#634](https://github.com/inclusionAI/Avernet/pull/634), [#599](https://github.com/inclusionAI/Avernet/pull/599)); a `user` caller round-trips.
+   Admitting an **external tenant** is now a separate, deliberate step:
+   `route_security` must accept its credential **and** delegation must give that
+   credential an end user to scope by (auth design §15)._
 7. **Cross-tenant external identity settled ([#556](https://github.com/inclusionAI/Avernet/issues/556))** — Passport, auth
    relationships and BCN carry a tenant axis, so the BCN sync can be re-enabled
    on the public path. — _⬜ (added 2026-07-29; gates enabling multi-tenancy)._
@@ -727,12 +741,16 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   index's name to its columns; create before drop so there's no index-less
   window). Leave low-cardinality (`idx_status`, `idx_is_delete`) and
   unique-lookup (`idx_binding_id`) indexes alone.
-- ~~**Real caller-identity verifier.**~~ **DONE on the backend side** — see **The
-  auth seam** above. `caller_owner_id`'s tolerance of an object exposing
-  `user_id` is what let this land with zero handler changes, exactly as intended.
-  What remains is upstream: gateway [#599](https://github.com/inclusionAI/Avernet/pull/599)
-  merged, a `route_security.yaml` rule for this surface's callers, and the
-  owner-semantics question for `app` / `access_key` callers.
+- ~~**Real caller-identity verifier.**~~ **DONE, both halves** — see **The auth
+  seam** above. `caller_owner_id`'s tolerance of an object exposing `user_id` is
+  what let this land with zero handler changes, exactly as intended. Gateway
+  [#599](https://github.com/inclusionAI/Avernet/pull/599) has merged and the wire
+  shapes were verified by round-trip, so a `user` caller works end to end.
+- **Owner semantics for `app` / `access_key` callers.** Still open, and now
+  explicit: those callers are **refused at verification** (2026-08-02), not
+  silently unscoped. Settling what they own is the delegation workstream (auth
+  design §15); a `route_security` rule alone would not be enough, because a
+  credential that names no person still cannot be owner-scoped.
 - **Background/scheduled work.** Resolves to the default tenant now (correct
   while all data is `teamclaw`); revisit before a 2nd tenant holds real data
   (scheduled scans, pollers, sync loops in skill_center / governance / dormant /
@@ -964,3 +982,38 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   Full inventory, per-endpoint mapping and the ruling on every non-wrapped
   engine route: **[`engine-surface.md`](engine-surface.md)**. Board moved: Track
   C section added (0 of 6 groups), DoD item 8 added. **Owners still unassigned.**
+- **2026-08-02** — **Identity admission decided: `user` only.** `verify_principal_token`
+  now refuses an identity set that names no end user, so `bot` / `app` /
+  `access_key` callers answer `401` **by design** rather than as a side effect of
+  `caller_owner_id` raising on an empty owner. Four things worth knowing:
+  1. **The refusal moved because the old placement was skippable.** A 401 that
+     comes from `caller_owner_id` only covers handlers that call it — and four in
+     `resources/router.py` (`list_resources`, `create_resource`, `get_resource`,
+     `update_resource`) never do; they scope on a caller-supplied `bot_id`. An
+     unscopeable caller reached them and got data. Refusing the identity set
+     during verification makes the rule hold for every route, including ones not
+     written yet. An invariant every handler must remember is not an invariant.
+  2. **`bot` lost its owner fallback.** `VerifiedCaller.user_id` no longer falls
+     back to `bot.owner_id`. It was unreachable (no `route_security` rule
+     requires or accepts `bot`), but it was a standing grant — a bot acting as
+     its owner across the whole public contract — that nobody had decided to
+     make. A bot-facing surface should re-add it deliberately.
+  3. **A user *plus* other identities is still accepted.** The gateway forwards
+     the whole set it resolved, so a route declaring `user: required, app:
+     optional` yields two principals. The rule is "must contain a user", not
+     "must contain nothing else" — the strict form would refuse a request the
+     gateway considers valid.
+  4. **Auth is now attached at `build_public_router()`**, alongside
+     `ERROR_RESPONSES`, so a future route cannot omit it by construction rather
+     than by `test_public_routes_require_principal` catching it afterwards.
+     Zero behaviour change — every route already declared `PrincipalDep`, and
+     FastAPI caches the dependency, so it resolves once per request.
+
+  Also corrected on this board: gateway [#599](https://github.com/inclusionAI/Avernet/pull/599)
+  **has merged** (it was still recorded as open in three places), and the
+  principal wire contract was verified by round-tripping the real gateway signer
+  into the real backend verifier — the shapes match, forwarded secrets are not
+  projected, and `aud`/`iss` mismatches are refused. **Filed as still-open:** no
+  cross-repo test pins that contract, so a rename on either side leaves both
+  suites green and 401s production. Full suite 10204 passed / 3 skipped. SDD:
+  `src/backend/specs/2026-08-02-public-api-user-only-principal/`.

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -35,11 +35,12 @@ _这是一份"活文档"，用于协调跨多个会话交付公共 `/openapi/v1`
 > 🔒 **这套界面端到端仍不可被真正调用，但原因已不再是"桩"。**
 > `require_principal` 现在会真正校验网关签发的 `X-Avernet-Principal` 令牌，
 > `resolve_avernet_tenant` 也会真正从中读出租户（见下文**认证接缝**一节）。上游还有
-> 两件事挡在外部租户与 `200` 之间：网关的签发 PR
-> （[#599](https://github.com/inclusionAI/Avernet/pull/599)）尚未合并，因此 `dev` 上
-> 还没有任何东西会转发这个头；以及网关的 `route_security.yaml` 要求由 Google 链解析出
-> 的 `user` 身份，而持访问密钥（access key）的外部租户满足不了它。在这两件事推进之前，
-> 任何真实请求依然返回 `401` —— 只不过现在是**因为拒绝**，而不是因为打桩。
+> 网关的签发 PR（[#599](https://github.com/inclusionAI/Avernet/pull/599)）**已合并**，
+> 因此 `dev` 上确实会转发这个头 —— `user` 调用方现已端到端跑通（2026-08-02 对着真实
+> 签名器验证过）。仍挡在**外部租户**与 `200` 之间的是"谁可以调用"：网关的
+> `route_security` 要求由 Google 链解析出的 `user` 身份，而持访问密钥（access key）的
+> 租户满足不了它；且自 2026-08-02 起后端会独立拒绝任何不指向终端用户的身份集合。
+> 放宽它属于委托工作线，不是改一行配置。
 > "bots 做完了"的含义不变：处理器、契约和测试做完了。
 
 关键难点：内部的 `/api/...` 界面与公共的 `/openapi/v1` 界面**共享同一批表、仓储
@@ -168,7 +169,9 @@ _所有组只依赖 **bots 隔离（Stage 1 ✅）** —— 没有 Track A 阶�
 ### 横切事项（非按阶段划分）
 | 事项 | 状态 | 备注 |
 |---|---|---|
-| 真实的调用方身份验证器（认证工作线） | ✅ **后端这一半已完成 —— PR [#634](https://github.com/inclusionAI/Avernet/pull/634)**（网关那一半：[#599](https://github.com/inclusionAI/Avernet/pull/599)，未合并） | `require_principal` 与 `resolve_avernet_tenant` 现在会校验网关签发的 `X-Avernet-Principal`（HS256、`aud=backend`），并从中读出租户与 owner。**端到端仍不可调用**：#599 必须先合并（否则没有东西转发这个头），且网关的 `route_security.yaml` 必须允许本界面真实的调用方 —— 见下方两个待定问题 |
+| 真实的调用方身份验证器（认证工作线） | ✅ **两半均已完成** —— 后端 PR [#634](https://github.com/inclusionAI/Avernet/pull/634)、网关 PR [#599](https://github.com/inclusionAI/Avernet/pull/599) **已合并** | `require_principal` 与 `resolve_avernet_tenant` 会校验网关签发的 `X-Avernet-Principal`（HS256、`aud=backend`），并从中读出租户与 owner。线上契约已通过把**真实**网关签名器接进**真实**后端验证器做往返验证（2026-08-02）：user/bot/app/access_key 四种形状、机密不外投、`aud`/`iss` 不符即拒。**`user` 调用方已可端到端跑通。** 剩下的是*哪些*调用方被接纳 —— 见下一行 |
+| **身份接纳：仅 `user`** | ✅ **2026-08-02 完成** | `verify_principal_token` 拒绝任何不指向终端用户的身份集合，因此 `bot` / `app` / `access_key` 调用方是**按设计**返回 `401`，而不是取决于某个 handler 是否去取 owner。放宽它靠委托（认证设计 §15），不是改配置。SDD：`specs/2026-08-02-public-api-user-only-principal/` |
+| **没有跨仓测试钉住 principal 线上形状** | ⬜ TODO | 两侧各自对着自己手写的 payload 认知做测试（`test_verifier.py` 拼 dict；网关测自己的 model）。任一侧改个字段名，两边测试都还是绿的，线上却全 401 |
 | 租户前导索引（F2，**强制**策略） | ⬜ TODO | 多租户上线前必须完成 |
 | 后台/定时任务的复查 | ⬜ TODO | 在第二个租户持有真实数据之前完成 |
 | **Agent 身份标识在租户之间会撞车**（[#556](https://github.com/inclusionAI/Avernet/issues/556)） | ⬜ TODO（totalfrank） | Passport、授权关系、BCN、策略行都只用 `bot_id`/`owner_id` 作键，没有租户维度，而每个 owner 的第一个 bot 的 id 就是字符串 `"default"`。**应当成为开启多租户的前置闸口。** #494 里以公共更新路径上的 `sync_to_bcn=False` 做了临时止血 |
@@ -334,17 +337,23 @@ AvernetTenantMiddleware → resolve_avernet_tenant(request)  ─┐
     校验。
 - 会被拒绝的情形，全部返回**完全一致**的 `401`：签名错误、`alg: none`、`aud` 指向别的
   上游、`iss` 不对、已过期、缺少必需 claim、未知的 `type` tag、契约字段被改名、身份集合
-  内部租户不一致，以及**声称自己是 `teamclaw` 的租户**（后者会把全部内部数据交给外部
-  调用方）。
+  内部租户不一致、**声称自己是 `teamclaw` 的租户**（后者会把全部内部数据交给外部
+  调用方），以及**没有指向任何终端用户的身份集合**（见下）。
 - 网关的租户 id **就是** `avernet_tenant` 的值 —— 没有映射表。因此真实外部租户在拥有
   自己的数据之前读到的是空集；这是隔离在正常工作，不是 bug。
 
 **如果你负责某个 Track B 类别，有两件事会传导到你：**
 
-1. **`app` 与 `access_key` 调用方目前一律 401。** owner id 只从 `user` 或 `bot`
-   principal 推导。网关的 `app.owners` 是自由文本的组织归属，其访问密钥注册表根本没有
-   owner 列，两者都指不出一个可用于作用域的人 —— 而"猜"出来的就是跨账号数据 bug。鉴于
-   公共 API 的调用方本就是*外部注册租户*，这件事很可能要在任何类别对外开放之前定案。
+1. **只接纳 `user` 调用方 —— `bot` / `app` / `access_key` 在校验阶段即被拒绝。**
+   _2026-08-02 定案。_ owner id 只从 `user` principal 推导。网关的 `app.owners` 是
+   自由文本的组织归属，其访问密钥注册表根本没有 owner 列，两者都指不出一个可用于作用域
+   的人；`bot` 虽然带 `owner_id`，但让一个 bot 在整个公共契约上以其 owner 的身份行事，
+   是没有人做过的授权。**拒绝发生在 `verify_principal_token`，而不是
+   `caller_owner_id`** —— 这才是关键：放在 handler 里的拒绝只覆盖会去取 owner 的
+   handler，而 `resources/router.py` 里有四个并不取；拒绝整个身份集合，意味着无法作用域
+   的调用方**任何**路由都进不来（包括以后新增的）。`app` / `access_key` 究竟该拥有什么
+   仍未定（认证设计 §14 Q4）；委托（§15）才是放宽它的设计路径。SDD：
+   `src/backend/specs/2026-08-02-public-api-user-only-principal/`。
 2. **依赖（dependency）里抛出的已映射错误现在也会被套上信封。** `@envelope_errors`
    只包裹 handler，所以接缝的 401（在依赖里抛出）会绕过它；现在查表逻辑落在
    `responses.py::mapped_error_response`，应用的 catch-all 查的是同一张表。你新增的依赖
@@ -626,7 +635,9 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
 5. 后台/定时任务已针对按租户正确性完成复查。—— _⬜_
 6. `require_principal` / `resolve_avernet_tenant` 已接到真实验证器（认证工作线）——
    到此，第二个租户才能安全地持有真实数据，公共界面也才会停止一律返回 401。
-   —— _🔧 后端这一半已完成；还需网关 [#599](https://github.com/inclusionAI/Avernet/pull/599) 合并**并且** `route_security.yaml` 增加允许本界面真实调用方的规则。_
+   —— _✅ 两半均已合并（[#634](https://github.com/inclusionAI/Avernet/pull/634)、[#599](https://github.com/inclusionAI/Avernet/pull/599)），`user` 调用方已可往返。
+   接纳**外部租户**如今是一个独立且需要刻意为之的步骤：`route_security` 必须接受其凭证，
+   **并且**委托必须给这份凭证一个可用于作用域的终端用户（认证设计 §15）。_
 7. **跨租户的外部身份问题已定案（[#556](https://github.com/inclusionAI/Avernet/issues/556)）** —— Passport、授权关系与 BCN 都带上
    租户维度，从而可以在公共路径上重新打开 BCN 同步。—— _⬜（2026-07-29 新增；它是开启
    多租户的前置闸口）。_
@@ -645,11 +656,14 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
   `idx_entity`、搜索索引），采用**先建新、再删旧**（命名约定把索引名与其列绑定，因此先建后删，
   避免出现无索引的窗口）。低基数索引（`idx_status`、`idx_is_delete`）与唯一查找索引
   （`idx_binding_id`）保持不动。
-- ~~**真实的调用方身份验证器。**~~ **后端侧已完成** —— 见上文**认证接缝**一节。
-  `caller_owner_id` 本来就接受带 `user_id` 的对象，这正是它能零改动落地的原因。
-  剩下的都在上游：网关 [#599](https://github.com/inclusionAI/Avernet/pull/599) 合并、
-  `route_security.yaml` 为本界面的调用方加规则，以及 `app` / `access_key` 调用方的
-  owner 语义问题。
+- ~~**真实的调用方身份验证器。**~~ **两半均已完成** —— 见上文**认证接缝**一节。
+  `caller_owner_id` 本来就接受带 `user_id` 的对象，这正是它能零改动落地的原因。网关
+  [#599](https://github.com/inclusionAI/Avernet/pull/599) 已合并，线上形状也已通过往返
+  验证，`user` 调用方端到端可用。
+- **`app` / `access_key` 调用方的 owner 语义。** 仍未定，但现在是显式的：这类调用方在
+  校验阶段即被**拒绝**（2026-08-02），而不是悄悄地没有作用域。要定它属于委托工作线
+  （认证设计 §15）；只加一条 `route_security` 规则是不够的 —— 一个指不出人的凭证，
+  依然无法按 owner 作用域。
 - **后台/定时任务。** 现在都解析为默认租户（在全部数据都是 `teamclaw` 时是正确的）；在第二个
   租户持有真实数据之前需复查（skill_center / governance / dormant / 设备轮询器中的定时扫描、
   轮询器、同步循环）。
@@ -831,3 +845,30 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
   完整清单、逐端点映射，以及每一条未包装 engine 路由的裁定：
   **[`engine-surface.zh-CN.md`](engine-surface.zh-CN.md)**。看板变动：新增 Track C
   小节（6 组完成 0 组），新增 DoD 第 8 条。**负责人仍未分配。**
+- **2026-08-02** —— **身份接纳定案：仅 `user`。** `verify_principal_token` 现在会拒绝
+  任何不指向终端用户的身份集合，因此 `bot` / `app` / `access_key` 调用方是**按设计**
+  返回 `401`，而不是因为 `caller_owner_id` 拿到空 owner 才抛错。四点值得知道：
+  1. **拒绝之所以挪位置，是因为原来的位置可以被绕过。** 来自 `caller_owner_id` 的 401
+     只覆盖会调用它的 handler —— 而 `resources/router.py` 里有四个不调用
+     （`list_resources`、`create_resource`、`get_resource`、`update_resource`），它们按
+     调用方自带的 `bot_id` 作用域。无法作用域的调用方能进到这些 handler 并拿到数据。把
+     拒绝放到校验阶段，这条规则对所有路由都成立，包括还没写的。**每个 handler 都得记住
+     的不变量，不是不变量。**
+  2. **`bot` 失去了 owner 兜底。** `VerifiedCaller.user_id` 不再回退到 `bot.owner_id`。
+     它原本不可达（没有任何 `route_security` 规则要求或接受 `bot`），但那是一份没人决定
+     过的常设授权 —— 让 bot 在整个公共契约上以其 owner 的身份行事。要做面向 bot 的界面，
+     应当刻意重新加回来。
+  3. **user **加上**其他身份依然被接受。** 网关会转发它解析出的整个集合，因此声明
+     `user: required, app: optional` 的路由会产生两个 principal。规则是"必须含 user"，
+     不是"不能含别的" —— 后者会拒掉网关认为合法的请求。
+  4. **认证现在挂在 `build_public_router()`**，与 `ERROR_RESPONSES` 并列，因此以后新增
+     的路由**在构造上**无法遗漏，而不是靠 `test_public_routes_require_principal` 事后
+     抓到。行为零变化 —— 每个路由本就声明了 `PrincipalDep`，且 FastAPI 会缓存依赖，
+     每请求只解析一次。
+
+  本次同时更正了看板：网关 [#599](https://github.com/inclusionAI/Avernet/pull/599)
+  **已合并**（此前有三处仍记为未合并）；principal 线上契约已通过把真实网关签名器接进
+  真实后端验证器做往返验证 —— 形状一致、转发来的机密不外投、`aud`/`iss` 不符即拒。
+  **新记为待办：** 没有任何跨仓测试钉住这份契约，任一侧改字段名都会让两边测试保持绿色
+  而线上全 401。整套测试 10204 通过 / 3 跳过。SDD：
+  `src/backend/specs/2026-08-02-public-api-user-only-principal/`。

--- a/src/backend/specs/2026-08-02-public-api-user-only-principal/spec.md
+++ b/src/backend/specs/2026-08-02-public-api-user-only-principal/spec.md
@@ -1,0 +1,140 @@
+# Public API — Admit Only Callers That Name an End User
+
+## Summary
+
+The public `/openapi/v1` surface scopes every read and write to an owner, and
+only one of the gateway's four identity types names one. Today that constraint
+is enforced by accident: a caller whose identity set names no person reaches the
+handler, and the request fails only when that handler happens to ask for the
+owner. Handlers that never ask do not fail — they serve data.
+
+This makes the rule explicit and structural. Verification refuses an identity set
+that carries no `user` principal, so a caller the surface cannot scope is turned
+away at the boundary rather than at a lookup each handler has to remember to
+perform. `bot`, `app` and `access_key` callers are refused by design.
+
+## Motivation
+
+**The rule is real but unenforced.** `VerifiedCaller.user_id` returns `""` for an
+`app` or `access_key` caller, `caller_owner_id` raises on the empty string, and
+the request answers 401. That chain works only for handlers that call
+`caller_owner_id`. Four in `resources/router.py` — `list_resources`,
+`create_resource`, `get_resource`, `update_resource` — take the principal
+dependency but never derive an owner, scoping instead on a caller-supplied
+`bot_id`. For them the 401 never happens. The surface's own module docstring
+claims otherwise ("Owner/identity comes from `caller_owner_id(principal)`
+(fail-closed)"), which is how a gap like this stays invisible: the contract is
+stated in prose and enforced per call site.
+
+An invariant that every handler must remember is not an invariant. Moving it to
+the boundary makes it independent of handler discipline, and makes a future
+route safe by construction rather than by review.
+
+**A bot caller is admitted today, and should not be.** `user_id` falls back to a
+`bot` principal's `owner_id`, so a bot presenting its own token would be scoped
+as its owner across the entire public contract. No `route_security` rule
+currently requires or accepts `bot`, so this is unreachable rather than
+exploitable — but it is a capability nobody decided to grant, sitting one gateway
+config line away from being live.
+
+**The decision has been pending in three places.** The `/openapi/v1` handoff
+records that `app` and `access_key` callers 401 and that this "likely needs
+settling before any category goes live". The auth design leaves resource
+ownership granularity open (§14 Q4) and defers delegation entirely (§15). The
+code documents the *symptom* at length — `user_id`'s docstring explains why those
+callers yield no owner and says settling it "is a cross-team decision, not
+something to paper over here". Nothing records a decision. Narrowing the surface
+without writing one down invites the next reader to restore what that docstring
+describes.
+
+## User Stories
+
+- As an engineer implementing a public API category, I want a caller who cannot
+  be owner-scoped to be refused before my handler runs, so that forgetting an
+  owner lookup cannot expose another caller's data.
+- As a reviewer, I want the set of identity types this surface admits to be
+  stated in one place, so I can tell whether a change widens it without reading
+  every router.
+- As an operator reading logs, I want a refused caller to say it named no user
+  identity, so a misconfigured `route_security` rule is diagnosable as a policy
+  refusal rather than a missing field.
+- As the engineer who later implements delegation, I want the refusal to name
+  what would lift it, so widening the surface is an edit to one guard rather
+  than an archaeology exercise.
+- As an integrator, I want a refused request to be indistinguishable from any
+  other authentication failure, so that probing identity types reveals nothing.
+
+## Acceptance Criteria
+
+- [ ] An identity set carrying no `user` principal fails verification.
+- [ ] A `bot`-only, `app`-only, or `access_key`-only identity set is refused.
+- [ ] A set carrying a `user` principal alongside any other identity is
+      accepted, and the user remains the owner anchor.
+- [ ] A refused set yields the same fixed `401` response as every other
+      verification failure, with the specific reason logged and never returned.
+- [ ] Every route on the public surface requires an authenticated caller
+      structurally, not because its handler declares the dependency.
+- [ ] A new route added to any public group inherits that requirement without
+      its author doing anything.
+- [ ] `user_id` is derived only from a `user` principal; no other identity type
+      can supply an owner.
+- [ ] The internal `/api` surface is unchanged, and its test suite passes
+      unmodified.
+- [ ] Existing `user`-caller behaviour is byte-identical — same owner, same
+      tenant, same responses.
+
+## In Scope
+
+- The identity-set admission rule in gateway principal verification.
+- Removal of `bot` as an owner source.
+- Applying the caller requirement once at the public router's assembly point.
+- Tests covering each refused identity type, the mixed-set acceptance, and the
+  structural route requirement.
+- Recording the decision in the `/openapi/v1` handoff doc.
+
+## Out of Scope
+
+- **Owner scoping within a tenant.** The four `resources` handlers that scope on
+  a caller-supplied `bot_id` rather than the caller's owner are a separate
+  defect: this change stops a caller with *no* owner from reaching them, but a
+  `user` caller can still name another owner's `bot_id`. Owned by the resources
+  category owner; filed separately.
+- **Delegation (auth design §15).** A partner acting for a verified end user is
+  the designed way to admit third-party callers, and is what should lift this
+  restriction. Not built here.
+- **The gateway's `route_security` table.** It already requires `user` on both
+  rules that exist. This change makes the backend agree with it independently
+  rather than depending on it.
+- **An architecture gate asserting every public handler derives an owner.** The
+  right follow-up to the resources defect, and test-only; kept separate so it
+  can land red-or-exempted without blocking this.
+- **`app` / `access_key` ownership semantics.** Deliberately left unsettled —
+  this change records that they are refused, not what they would own.
+
+## Resolved Questions
+
+1. **Refuse the whole set, or only sets made *entirely* of non-user
+   identities?** *Resolved:* require a `user` principal to be present; ignore
+   any others. The gateway forwards every identity it resolved, so a route
+   declaring `user: required, app: optional` legitimately produces two
+   principals. Refusing a set that merely *contains* a non-user identity would
+   reject a request the gateway considers valid, and would break that rule shape
+   the first time anyone uses it.
+
+2. **Enforce in the verifier or in `caller_owner_id`?** *Resolved:* the
+   verifier. `caller_owner_id` runs per handler, which is the property that
+   made the rule skippable. The verifier runs once per request, before any
+   route, and already hosts the sibling policy that refuses the internal
+   tenant off the wire — so the admission rules for an identity set live
+   together.
+
+3. **Keep the `bot` owner fallback for a future bot-facing route?** *Resolved:*
+   remove it. It is unreachable today, and leaving a silent grant in place for a
+   route that does not exist means the grant is never reviewed when that route
+   is written. A bot-facing surface should re-add it deliberately, with its own
+   decision about what a bot may do as its owner.
+
+4. **Does refusing at the boundary change what a caller sees?** *Resolved:* no.
+   The response is the same fixed 401 envelope; only the log line differs. A
+   caller cannot tell a refused identity type from a bad signature, which is the
+   existing posture for every verification failure.

--- a/src/backend/specs/2026-08-02-public-api-user-only-principal/spec.md
+++ b/src/backend/specs/2026-08-02-public-api-user-only-principal/spec.md
@@ -68,6 +68,13 @@ describes.
 
 - [ ] An identity set carrying no `user` principal fails verification.
 - [ ] A `bot`-only, `app`-only, or `access_key`-only identity set is refused.
+- [ ] A `user` principal whose subject id is empty or whitespace-only is
+      refused: it names an owner no better than an access key does, and both
+      sides model the id as an unconstrained string, so a type check alone does
+      not establish that an owner exists.
+- [ ] The principal the admission check validates is the same one the owner is
+      derived from, so a set whose first `user` has a blank id cannot be
+      admitted on the strength of a second one.
 - [ ] A set carrying a `user` principal alongside any other identity is
       accepted, and the user remains the owner anchor.
 - [ ] A refused set yields the same fixed `401` response as every other
@@ -138,3 +145,13 @@ describes.
    The response is the same fixed 401 envelope; only the log line differs. A
    caller cannot tell a refused identity type from a bad signature, which is the
    existing posture for every verification failure.
+
+5. **Is "carries a `user` principal" the same as "has an owner"?** *Resolved:*
+   no, and conflating them reopens the gap this feature closes. Both sides model
+   the subject id as an unconstrained `str`, and the gateway's google strategy
+   reads `body["sub"]` — which raises on a *missing* claim but passes an empty
+   one straight through. A `user` principal with a blank id therefore verifies,
+   yields no owner, and reaches the handlers that never ask for one. The
+   admission rule is about a usable owner, not a type tag, so it checks the
+   value; and it checks it on the same principal the owner is derived from,
+   since a set may present more than one `user`.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -13,10 +13,11 @@ are mounted **before** the bots group so their literal path segments
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from .bots import router as bots_router
 from .contracts import ENGINE_RUNTIME_ERROR_RESPONSES, ERROR_RESPONSES
+from .dependencies import require_principal
 from .engine_runtime.approvals import router as engine_approvals_router
 from .engine_runtime.connection import router as engine_connection_router
 from .engine_runtime.engine import router as engine_engine_router
@@ -60,20 +61,41 @@ _ENGINE_RUNTIME_GROUPS = [
     engine_connection_router,
 ]
 
+# Authentication for the whole surface, declared once. Every handler already
+# takes ``principal: PrincipalDep``, so this changes nothing today — its value is
+# that a route added later cannot *omit* it. Verification is what refuses a
+# caller this surface cannot scope (``core/gateway_principal/verifier.py``
+# admits only identity sets naming an end user), and a route that never reaches
+# that check is a route the refusal does not cover.
+#
+# Declaring it in both places costs one call, not two: FastAPI caches a
+# dependency's result per request, so a handler's own ``PrincipalDep`` resolves
+# to this same invocation.
+_PUBLIC_AUTH = [Depends(require_principal)]
+
 
 def build_public_router() -> APIRouter:
     """Assemble the ``/openapi/v1/bots`` public router.
 
-    ``ERROR_RESPONSES`` is attached here rather than on each handler so the
-    published schema documents the envelope this surface actually returns on
-    failure — every group, every route, one declaration.
+    ``ERROR_RESPONSES`` and ``_PUBLIC_AUTH`` are attached here rather than on
+    each handler so the published schema documents the envelope this surface
+    actually returns on failure, and so every route requires an authenticated
+    caller — every group, every route, one declaration.
     """
     public = APIRouter()
     for router in _SUBGROUPS:
-        public.include_router(router, responses=ERROR_RESPONSES)
+        public.include_router(
+            router, responses=ERROR_RESPONSES, dependencies=_PUBLIC_AUTH
+        )
     for router in _ENGINE_RUNTIME_GROUPS:
-        public.include_router(router, responses=ENGINE_RUNTIME_ERROR_RESPONSES)
-    public.include_router(bots_router, responses=ERROR_RESPONSES)
+        public.include_router(
+            router,
+            responses=ENGINE_RUNTIME_ERROR_RESPONSES,
+            dependencies=_PUBLIC_AUTH,
+        )
+    public.include_router(
+        bots_router, responses=ERROR_RESPONSES, dependencies=_PUBLIC_AUTH
+    )
     return public
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
@@ -9,12 +9,16 @@ The owner id scopes reads/writes to the caller's own bots *within* the tenant
 
 The gateway verifier now supplies a
 :class:`~agentclaw.community.core.gateway_principal.VerifiedCaller`, whose
-``user_id`` is the owner anchor derived from the identity set — and which is
-empty for an ``app`` or ``access_key`` caller, because neither the gateway's
-``app.owners`` free-text field nor its owner-less access-key registry names a
-person. Such a caller lands on the "carries no user_id" branch below and gets a
-``401`` rather than a guessed owner. That tolerance of a bare string or a mapping
-is what let this helper survive the stub-to-real swap unchanged.
+``user_id`` is the ``user`` principal's subject id. A caller that names no end
+user — ``app``, ``access_key``, ``bot`` — never reaches here at all: verification
+refuses the identity set outright, so the ``401`` is answered before any route
+runs rather than at this lookup. That is deliberate, and it is what makes the
+rule independent of whether a given handler remembers to call this function.
+
+The "carries no user_id" branch below is therefore unreachable for a verified
+caller, and stays only as the fail-closed answer for a hand-constructed
+principal. The tolerance of a bare string or a mapping is what let this helper
+survive the stub-to-real swap unchanged.
 """
 
 from __future__ import annotations

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -106,11 +106,15 @@ class VerifiedCaller:
         against "whatever shape the auth workstream's verified principal takes",
         so satisfying it needs no change to any handler.
 
-        A ``user`` principal is the only source. It is also the only identity
-        type :func:`_require_user_principal` admits, so a caller reaching this
-        property always has one and the loop always finds it. The two facts are
-        the same decision seen from two sides: this surface scopes by an owner,
-        so it serves only callers that name one.
+        A ``user`` principal is the only source, and
+        :func:`_require_user_principal` admits no set that lacks one carrying a
+        usable id — so a caller reaching this property always has an owner. The
+        two facts are the same decision seen from two sides: this surface scopes
+        by an owner, so it serves only callers that name one.
+
+        Both read the set through :func:`_first_user_principal`, so the
+        admission check and this property cannot disagree about *which*
+        principal supplies the owner.
 
         The ``""`` fallback is unreachable through
         :func:`verify_principal_token`. It stays so that a hand-constructed
@@ -118,10 +122,8 @@ class VerifiedCaller:
         ``caller_owner_id`` turns into a ``401``, rather than raising something
         no caller-facing code is written to catch.
         """
-        for principal in self.principals:
-            if isinstance(principal, UserPrincipal):
-                return principal.subject.id
-        return ""
+        principal = _first_user_principal(self.principals)
+        return principal.subject.id if principal is not None else ""
 
 
 def verify_principal_token(
@@ -201,6 +203,29 @@ def _reject_contradictory_tenant(principals: tuple[GatewayPrincipal, ...]) -> No
         )
 
 
+def _first_user_principal(
+    principals: tuple[GatewayPrincipal, ...],
+) -> UserPrincipal | None:
+    """The user principal an owner is derived from, or ``None`` when there is none.
+
+    ``None`` is a real state of the contract here — "this identity set names no
+    end user" is exactly what :func:`_require_user_principal` exists to detect —
+    so the optional return is the state, not a widened type.
+
+    One function rather than two loops so the admission check and
+    :attr:`VerifiedCaller.user_id` cannot disagree about *which* principal
+    supplies the owner. That matters for a set carrying two user principals: the
+    gateway never produces one (it resolves at most a single identity per type),
+    but the ``principals`` claim is a list, so a token can present two. Checking
+    "some user has a usable id" while deriving the owner from "the first user"
+    would admit a set whose first user has a blank id and then scope by nothing.
+    """
+    for principal in principals:
+        if isinstance(principal, UserPrincipal):
+            return principal
+    return None
+
+
 def _require_user_principal(principals: tuple[GatewayPrincipal, ...]) -> None:
     """Refuse an identity set that names no end user.
 
@@ -233,14 +258,29 @@ def _require_user_principal(principals: tuple[GatewayPrincipal, ...]) -> None:
     name a person — is the designed way to widen this (§15). Lift the guard
     there, deliberately.
     """
-    if any(isinstance(principal, UserPrincipal) for principal in principals):
-        return
-    # The types are named for the operator reading the log, never for the
-    # caller: ``require_principal`` answers one fixed 401 for every verification
-    # failure, so a caller cannot tell a refused identity type from a bad
-    # signature.
-    carried = ", ".join(sorted({principal.type.value for principal in principals}))
-    raise PrincipalVerificationError(
-        f"principal token names no user identity (carries: {carried}); the "
-        "public surface admits only callers that name an end user"
-    )
+    user = _first_user_principal(principals)
+    if user is None:
+        # The types are named for the operator reading the log, never for the
+        # caller: ``require_principal`` answers one fixed 401 for every
+        # verification failure, so a caller cannot tell a refused identity type
+        # from a bad signature.
+        carried = ", ".join(sorted({principal.type.value for principal in principals}))
+        raise PrincipalVerificationError(
+            f"principal token names no user identity (carries: {carried}); the "
+            "public surface admits only callers that name an end user"
+        )
+    # A ``user`` principal with a blank subject id names an end user no better
+    # than an access key does — and the type check alone would admit it, because
+    # both sides model the id as an unconstrained ``str``. It is reachable: the
+    # gateway's google strategy reads ``body["sub"]``, which raises on a
+    # *missing* claim but passes an empty one straight through.
+    #
+    # Whitespace is stripped for the test rather than merely checked falsy (the
+    # empty-tenant guard above can be laxer because a tenant is compared, not
+    # used as a key): an id of ``"   "`` would be carried into owner-scoped
+    # queries as a real value.
+    if not user.subject.id.strip():
+        raise PrincipalVerificationError(
+            "principal token carries a user identity with a blank subject id, "
+            "which names no owner to scope by"
+        )

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -11,7 +11,8 @@ about earning the right to believe it:
 3. ``iss`` must be the gateway and ``exp`` must not have passed,
 4. the ``principals`` payload must parse onto :mod:`.models`,
 5. every principal in the set must agree on one tenant, and that tenant must not
-   be the internal one.
+   be the internal one,
+6. the set must name an end user — see :func:`_require_user_principal`.
 
 Any failure raises :class:`PrincipalVerificationError`. There is no partial
 success and no fallback: a token we cannot fully verify yields no caller, and the
@@ -34,7 +35,6 @@ from agentclaw.community.core.gateway_principal.errors import (
     PrincipalVerificationError,
 )
 from agentclaw.community.core.gateway_principal.models import (
-    BotPrincipal,
     GatewayPrincipal,
     UserPrincipal,
 )
@@ -99,34 +99,28 @@ class VerifiedCaller:
 
     @property
     def user_id(self) -> str:
-        """The owner id to scope data by, or ``""`` when none can be derived.
+        """The owner id to scope data by — a ``user`` principal's subject id.
 
         Named ``user_id`` because that is the attribute
         ``openapi_v1/principal.py::caller_owner_id`` looks for — it was written
         against "whatever shape the auth workstream's verified principal takes",
         so satisfying it needs no change to any handler.
 
-        Derivable for the two identities that name a person: a ``user``
-        principal's subject, and a ``bot`` principal's owner. **Not** derivable
-        for ``app`` or ``access_key``:
+        A ``user`` principal is the only source. It is also the only identity
+        type :func:`_require_user_principal` admits, so a caller reaching this
+        property always has one and the loop always finds it. The two facts are
+        the same decision seen from two sides: this surface scopes by an owner,
+        so it serves only callers that name one.
 
-        - the gateway's ``app.owners`` is a free-text "developer/org" field
-          (``varchar(1024)``, plural), not a user id — feeding it to an
-          owner-scoped query would either silently match nothing or, worse,
-          match somebody;
-        - its access-key registry has no owner column at all, so an access-key
-          caller identifies a tenant and nothing finer.
-
-        Returning ``""`` makes ``caller_owner_id`` raise, so such a caller gets
-        ``401`` instead of a guess. Settling what those callers should scope to
-        is a cross-team decision, not something to paper over here.
+        The ``""`` fallback is unreachable through
+        :func:`verify_principal_token`. It stays so that a hand-constructed
+        instance — a test fixture, say — degrades to "no owner", which
+        ``caller_owner_id`` turns into a ``401``, rather than raising something
+        no caller-facing code is written to catch.
         """
         for principal in self.principals:
             if isinstance(principal, UserPrincipal):
                 return principal.subject.id
-        for principal in self.principals:
-            if isinstance(principal, BotPrincipal):
-                return principal.bot.owner_id
         return ""
 
 
@@ -136,8 +130,8 @@ def verify_principal_token(
     """Verify ``token`` and return the caller it carries.
 
     Raises :class:`PrincipalVerificationError` on any failure — bad signature,
-    wrong audience, expired, unparseable payload, contradictory tenants, or no
-    signing key configured at all.
+    wrong audience, expired, unparseable payload, contradictory tenants, an
+    identity set that names no end user, or no signing key configured at all.
     """
     if not config.signing_key:
         # No key means we cannot tell a gateway token from a forged one. The
@@ -161,6 +155,7 @@ def verify_principal_token(
 
     principals = _parse_principals(claims.get("principals"))
     _reject_contradictory_tenant(principals)
+    _require_user_principal(principals)
     return VerifiedCaller(principals=principals)
 
 
@@ -204,3 +199,48 @@ def _reject_contradictory_tenant(principals: tuple[GatewayPrincipal, ...]) -> No
             "principal token names the internal tenant, which is not routable "
             "from the public surface"
         )
+
+
+def _require_user_principal(principals: tuple[GatewayPrincipal, ...]) -> None:
+    """Refuse an identity set that names no end user.
+
+    The public surface scopes every read and write to an owner, and a ``user``
+    principal is the only identity that names one. ``app.owners`` is free-text
+    "developer/org" attribution (``varchar(1024)``, plural), and the gateway's
+    access-key registry has no owner column at all — so neither identifies a
+    person, and guessing one is a cross-account data bug. A ``bot`` principal
+    does carry ``owner_id``, but a bot calling on its own behalf is not a caller
+    this API is defined for; admitting it would silently let a bot act as its
+    owner across the whole public contract.
+
+    Enforced **here** rather than at each handler's owner lookup, and that is the
+    point. Refusing in ``caller_owner_id`` only refuses handlers that call it —
+    the four in ``openapi_v1/resources/router.py`` that scope on a caller-supplied
+    ``bot_id`` never do, so an unscopeable caller reached them. A rule every
+    handler has to remember is not a rule. Refusing during verification makes it
+    hold for every route that exists and every route added later.
+
+    Sets carrying *extra* identities alongside the user are accepted, not
+    refused: the gateway forwards the whole set it resolved, so a route declaring
+    ``user: required, app: optional`` legitimately yields two principals.
+    Rejecting a set that merely *contains* a non-user identity would refuse a
+    request the gateway considers valid. The user is required; the rest are
+    ignored.
+
+    This is the narrow reading of an open question, not an answer to it. What an
+    ``app`` or ``access_key`` caller should own is still unsettled (auth design
+    §14 Q4); delegation — a partner acting for a verified end user, which *does*
+    name a person — is the designed way to widen this (§15). Lift the guard
+    there, deliberately.
+    """
+    if any(isinstance(principal, UserPrincipal) for principal in principals):
+        return
+    # The types are named for the operator reading the log, never for the
+    # caller: ``require_principal`` answers one fixed 401 for every verification
+    # failure, so a caller cannot tell a refused identity type from a bad
+    # signature.
+    carried = ", ".join(sorted({principal.type.value for principal in principals}))
+    raise PrincipalVerificationError(
+        f"principal token names no user identity (carries: {carried}); the "
+        "public surface admits only callers that name an end user"
+    )

--- a/src/backend/tests/community/core/gateway_principal/test_verifier.py
+++ b/src/backend/tests/community/core/gateway_principal/test_verifier.py
@@ -202,6 +202,44 @@ def test_the_refusal_names_the_types_carried_for_the_operator():
     assert "app" in str(exc_info.value)
 
 
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_a_user_with_a_blank_subject_id_is_refused(blank: str):
+    """A type check alone is not enough — both sides model the id as a bare ``str``.
+
+    Reachable rather than theoretical: the gateway's google strategy reads
+    ``body["sub"]``, which raises on a *missing* claim but passes an empty one
+    through. Such a caller names an owner no better than an access key does, and
+    the handlers that never call ``caller_owner_id`` would run for it.
+    """
+    with pytest.raises(PrincipalVerificationError, match="blank subject id"):
+        verify_principal_token(mint([user_principal(user_id=blank)]), CONFIG)
+
+
+def test_a_blank_first_user_is_refused_even_behind_a_usable_one():
+    """The admission check and ``user_id`` must agree on *which* user is the owner.
+
+    The gateway resolves at most one identity per type, but ``principals`` is a
+    list, so a token can present two users. Asking "does some user have an id?"
+    while deriving the owner from the *first* user would admit this set and then
+    scope by nothing at all.
+    """
+    token = mint([user_principal(user_id=""), user_principal(user_id="u-2")])
+
+    with pytest.raises(PrincipalVerificationError, match="blank subject id"):
+        verify_principal_token(token, CONFIG)
+
+
+def test_a_blank_subject_id_is_refused_distinctly_from_a_missing_user():
+    """Two different operator diagnoses, so two different messages."""
+    with pytest.raises(PrincipalVerificationError) as blank:
+        verify_principal_token(mint([user_principal(user_id="")]), CONFIG)
+    with pytest.raises(PrincipalVerificationError) as missing:
+        verify_principal_token(mint([app_principal()]), CONFIG)
+
+    assert "no user identity" not in str(blank.value)
+    assert "blank subject id" not in str(missing.value)
+
+
 def test_unknown_fields_do_not_break_verification():
     """The gateway must be able to add a field without taking this surface down."""
     payload = user_principal()

--- a/src/backend/tests/community/core/gateway_principal/test_verifier.py
+++ b/src/backend/tests/community/core/gateway_principal/test_verifier.py
@@ -129,44 +129,77 @@ def test_user_token_yields_tenant_and_owner():
     assert isinstance(caller.principals[0], UserPrincipal)
 
 
-def test_bot_token_scopes_to_the_bots_owner():
-    caller = verify_principal_token(mint([bot_principal()]), CONFIG)
-
-    assert isinstance(caller.principals[0], BotPrincipal)
-    assert caller.user_id == "owner-9"
-
-
 def test_user_wins_over_app_when_both_identities_are_present():
     """A route may require a user and also accept an app; the person is the owner."""
     caller = verify_principal_token(mint([app_principal(), user_principal()]), CONFIG)
 
     assert len(caller.principals) == 2
+    # The extra identity is carried, not dropped: admission requires a user, it
+    # does not strip everything else out of the set.
+    assert isinstance(caller.principals[0], AppPrincipal)
     assert caller.user_id == "u-1"
     assert caller.tenant == TENANT
 
 
 def test_user_wins_over_bot_when_both_identities_are_present():
+    """A bot alongside a user is carried, not refused — the person is the owner."""
     caller = verify_principal_token(mint([bot_principal(), user_principal()]), CONFIG)
 
+    assert len(caller.principals) == 2
+    assert isinstance(caller.principals[0], BotPrincipal)
     assert caller.user_id == "u-1"
 
 
-def test_app_only_caller_yields_no_owner():
-    """``app.owners`` is free-text org attribution, not a user id — never guessed."""
-    caller = verify_principal_token(mint([app_principal()]), CONFIG)
-
-    assert isinstance(caller.principals[0], AppPrincipal)
-    assert caller.tenant == TENANT
-    assert caller.user_id == ""
-
-
-def test_access_key_only_caller_yields_no_owner():
-    """The gateway's access-key registry has no owner column; nothing to scope to."""
-    caller = verify_principal_token(mint([access_key_principal()]), CONFIG)
+def test_access_key_alongside_a_user_is_carried():
+    """The gateway forwards every identity it resolved; only the user is required."""
+    caller = verify_principal_token(
+        mint([access_key_principal(), user_principal()]), CONFIG
+    )
 
     assert isinstance(caller.principals[0], AccessKeyPrincipal)
-    assert caller.tenant == TENANT
-    assert caller.user_id == ""
+    assert caller.user_id == "u-1"
+
+
+# ── identity-set admission (only callers that name an end user) ───────────────
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("app", app_principal()),
+        ("access_key", access_key_principal()),
+        ("bot", bot_principal()),
+    ],
+)
+def test_a_set_naming_no_end_user_is_refused(label: str, payload: dict):
+    """Refused at verification, so no handler can be reached with an unscopeable caller.
+
+    ``app.owners`` is free-text org attribution and the access-key registry has
+    no owner column, so neither names a person. ``bot`` does carry ``owner_id``,
+    but a bot acting as its own owner across the public contract is a grant
+    nobody made — see ``_require_user_principal``.
+    """
+    with pytest.raises(PrincipalVerificationError, match="no user identity"):
+        verify_principal_token(mint([payload]), CONFIG)
+
+
+def test_a_set_of_several_non_user_identities_is_refused():
+    """Two identities that each name no person still name no person."""
+    with pytest.raises(PrincipalVerificationError, match="no user identity"):
+        verify_principal_token(
+            mint([app_principal(), access_key_principal()]), CONFIG
+        )
+
+
+def test_the_refusal_names_the_types_carried_for_the_operator():
+    """The log line has to be diagnosable; the caller still sees one fixed 401."""
+    with pytest.raises(PrincipalVerificationError) as exc_info:
+        verify_principal_token(
+            mint([access_key_principal(), app_principal()]), CONFIG
+        )
+
+    assert "access_key" in str(exc_info.value)
+    assert "app" in str(exc_info.value)
 
 
 def test_unknown_fields_do_not_break_verification():
@@ -181,9 +214,18 @@ def test_unknown_fields_do_not_break_verification():
 
 
 def test_forwarded_secrets_are_not_projected():
-    """We are told the bot's session token and the access-key token; we drop both."""
-    bot_caller = verify_principal_token(mint([bot_principal()]), CONFIG)
-    key_caller = verify_principal_token(mint([access_key_principal()]), CONFIG)
+    """We are told the bot's session token and the access-key token; we drop both.
+
+    Each is minted alongside a user because a set naming no end user is now
+    refused before projection — the secrets still ride the wire, so dropping
+    them is still this module's job.
+    """
+    bot_caller = verify_principal_token(
+        mint([bot_principal(), user_principal()]), CONFIG
+    )
+    key_caller = verify_principal_token(
+        mint([access_key_principal(), user_principal()]), CONFIG
+    )
 
     assert not hasattr(bot_caller.principals[0].bot, "token")
     assert "SECRET" not in bot_caller.principals[0].bot.model_dump_json()


### PR DESCRIPTION
## Problem

The public `/openapi/v1` surface scopes every read and write to an owner, and only a `user` principal names one — `app.owners` is free-text org attribution and the gateway's access-key registry has no owner column.

That rule was enforced by accident. `VerifiedCaller.user_id` returns `""` for those callers, `caller_owner_id` raises on it, and the request answers 401 — **but only for handlers that call `caller_owner_id`.** Four in `resources/router.py` don't:

| Handler | Line | Scoping |
|---|---|---|
| `list_resources` | :130 | caller-supplied `bot_id` only |
| `create_resource` | :199 | caller-supplied `bot_id` only |
| `get_resource` | :291 | caller-supplied `bot_id` only |
| `update_resource` | :311 | caller-supplied `bot_id` only |

For those, the 401 never happened — an unscopeable caller reached the handler and got data. The module's own docstring claims otherwise ("Owner/identity comes from `caller_owner_id(principal)` (fail-closed)"), which is how a gap like this stays invisible: the contract is stated in prose and enforced per call site.

Separately, `user_id` fell back to a `bot` principal's `owner_id`. Unreachable today (no `route_security` rule requires or accepts `bot`), but a standing grant nobody decided to make: a bot acting as its owner across the whole public contract.

## Solution

Refuse the identity set **during verification**, so the rule holds for every route that exists and every route added later. An invariant every handler must remember is not an invariant.

- **`_require_user_principal`** in `verify_principal_token`, beside the existing internal-tenant refusal. Requires a user principal to be *present with a usable subject id*; identities carried alongside it are kept, not refused — the gateway forwards the whole set it resolved, so a route declaring `user: required, app: optional` legitimately yields two principals, and the strict form would reject a request the gateway considers valid.
- **`VerifiedCaller.user_id` drops the `bot.owner_id` fallback.** A bot-facing surface should re-add it deliberately, with its own decision about what a bot may do as its owner.
- **`build_public_router()` attaches `require_principal`** alongside `ERROR_RESPONSES`. No behaviour change — every route already declared `PrincipalDep`, and FastAPI caches the dependency so it resolves once per request. The value is that a future route cannot omit it *by construction*, rather than being caught afterwards by `test_public_routes_require_principal`.

Rejected: enforcing in `caller_owner_id`. That is exactly the placement that made the rule skippable.

### Second commit (29661bb) — a type check was not enough

Codex caught that the guard checked the principal's *type*, not whether it named an owner. Both sides model `subject.id` as an unconstrained `str`, so a `user` principal with `id == ""` passed the guard, produced no owner, and reached the same four handlers — reopening the exact path the guard closes. Reachable, not theoretical: the gateway's google strategy reads `body["sub"]`, which raises on a *missing* claim but passes an empty one through.

Fixed, plus a related defect the review did not raise: the gateway resolves at most one identity per type, but `principals` is a **list**, so a token can present two `user` entries. Checking "some user has a usable id" while deriving the owner from "the *first* user" would admit a set whose first user is blank and then scope by nothing. Both paths now read the set through one `_first_user_principal` helper, so the admission check and `user_id` cannot disagree about which principal supplies the owner.

Whitespace is stripped for the test rather than merely checked falsy — `"   "` would otherwise reach owner-scoped queries as a real value. (The neighbouring empty-tenant guard can be laxer: a tenant is compared, never used as a key.) The two refusals carry distinct messages, since "named no user" and "named a user with no id" are different operator diagnoses.

Out of scope, deliberately: **owner scoping within a tenant.** This stops a caller with *no* owner from reaching those four resources handlers, but a `user` caller can still name another owner's `bot_id`. That is a separate defect for the resources category owner — filing it next.

## Validation

- Full backend suite: **10209 passed, 3 skipped** (`tests/community`). Internal `/api` suite unmodified.
- `tests/community/architecture/` 112 passed, including `test_public_routes_require_principal`.
- `ruff check` clean on all changed files.
- Tests: each of `bot` / `app` / `access_key` refused alone; several non-user identities together refused; the refusal names the carried types for the operator; user-plus-extra sets accepted with the extra carried through; blank subject id refused for `""` / `"   "` / `"\t"`; a blank *first* user refused even behind a usable second one; the two refusal messages proven distinct.
- **Wire contract verified by round-trip** — the real `BarePrincipalSigner` from `src/gateway` signing into the real `verify_principal_token` from `src/backend`, in one process. Shapes match field for field across all four principal types; forwarded secrets (`Bot.token`, `AccessKey.access_key_token`) are not projected; `aud`/`iss` mismatches refused. A `user` caller round-trips end to end.

## Compatibility and risk

No schema, config, or migration impact. One behaviour change — a `bot`-only identity set now answers 401 instead of being scoped to the bot's owner — which is unreachable on current gateway config, so the practical blast radius is zero. Rollback is reverting the two commits.

**Also corrected on the handoff board** (stale, not caused by this change): gateway [#599](https://github.com/inclusionAI/Avernet/pull/599) **has merged** but was still recorded as open in three places, which materially misstates whether the surface is callable. Flagged here rather than folded in silently.

**Filed as newly open:** no cross-repo test pins the principal wire shape. Both sides test against their own hand-written idea of the payload (`test_verifier.py` builds dicts; the gateway tests its own models), so renaming a field on either side leaves both suites green and 401s production. The round-trip above is essentially that test and could be promoted, but it is the one check that legitimately imports both packages, so where it should live needs a call.

## Spec

`src/backend/specs/2026-08-02-public-api-user-only-principal/spec.md` — spec only, no plan/tasks, following `specs/2026-07-30-gateway-principal-verifier/`. The code is mechanical; the decision is not, and the code previously documented the opposite rationale at length.

## Related issues

Narrows an open question recorded in the `/openapi/v1` handoff and in auth design §14 Q4. Delegation (§15) is the designed way to widen it.