### PR TITLE
feat(bcs): enforce V1 gateway principal authorization

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -405,6 +405,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs-app-bot"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bcs-bot",
+ "bcs-bot-store",
+ "bcs-config",
+ "bcs-friend",
+ "bcs-service-api",
+ "bcs-test-support",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "bcs-app-group"
 version = "0.1.0"
 dependencies = [

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1389,6 +1389,7 @@ dependencies = [
  "strum",
  "syn 2.0.119",
  "thiserror 2.0.19",
+ "time",
  "tokio",
 ]
 

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -230,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,9 +400,11 @@ dependencies = [
  "async-trait",
  "axum",
  "bcs-service-api",
+ "jsonwebtoken",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -2019,6 +2027,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2046,33 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2171,10 +2218,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2229,6 +2335,22 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -2477,6 +2599,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2523,6 +2646,17 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -2619,6 +2753,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -2952,6 +3095,28 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "rand 0.8.7",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -3531,6 +3696,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,6 +3878,15 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4110,6 +4308,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,6 +4416,15 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -4315,6 +4532,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,6 +4577,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -5862,6 +6099,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/services/bcs-friend-store",
     "crates/services/bcs-group",
     "crates/application/v1/bcs-app-group",
+    "crates/application/v1/bcs-app-bot",
     "crates/services/bcs-group-store",
     "crates/services/bcs-message",
     "crates/services/bcs-message-flow",
@@ -227,6 +228,7 @@ bcs-collaboration-store = { path = "crates/services/bcs-collaboration-store" }
 bcs-judge = { path = "crates/services/bcs-judge" }
 bcs-jwt = { path = "crates/services/bcs-jwt" }
 bcs-group      = { path = "crates/services/bcs-group" }
+bcs-app-bot   = { path = "crates/application/v1/bcs-app-bot" }
 bcs-app-group   = { path = "crates/application/v1/bcs-app-group" }
 bcs-group-store = { path = "crates/services/bcs-group-store" }
 bcs-message = { path = "crates/services/bcs-message" }

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -151,6 +151,9 @@ futures     = "0.3"
 # HTTP client
 reqwest = { version = "0.12", features = ["http2", "json", "stream", "rustls-tls-native-roots"], default-features = false }
 
+# JWT verification
+jsonwebtoken = { version = "11.0.0", default-features = false, features = ["rust_crypto"] }
+
 # UUID
 uuid = { version = "1", features = ["v4"] }
 

--- a/src/bcs/api-contracts/README.md
+++ b/src/bcs/api-contracts/README.md
@@ -4,13 +4,23 @@
 models and resource path items live in separate YAML fragments so a domain can
 evolve without creating one monolithic file.
 
-The first implementation batch contains exactly five Group operations:
+The current contract contains 32 approved operations across Bot, Group,
+GroupParticipant, Session, SessionParticipant, Invitation, Friendship, and
+FriendRequest resources.
 
-- `GET /openapi/v1/bots/collaboration/{bot_uuid}/groups`
-- `POST /openapi/v1/groups`
-- `GET /openapi/v1/groups/{group_id}`
-- `PATCH /openapi/v1/groups/{group_id}`
-- `DELETE /openapi/v1/groups/{group_id}`
+The Human control-plane Bot batch contains exactly five operations:
+
+- `GET /openapi/v1/bots/{bot_id}/candidates`
+- `POST /openapi/v1/bots/query`
+- `GET /openapi/v1/bots/{bot_id}`
+- `PATCH /openapi/v1/bots/{bot_id}`
+- `GET /openapi/v1/bots/mine`
+
+These operations deliberately do not add generic `GET /bots`, legacy
+`/actors/**` aliases, runtime discovery, or a separate descriptor patch route.
+All five require a Human Principal. The Bot domain object is discriminated by
+`kind=bot|human`; omission of a `kind` query filter means both kinds rather
+than a synthetic `all` enum value.
 
 Validate the contract:
 
@@ -33,7 +43,7 @@ dependencies:
 
 ```bash
 uv run --with pytest --with pyyaml \
-  pytest src/bcs/tests/openapi/test_group_v1_contract.py -q
+  pytest src/bcs/tests/openapi -q
 ```
 
 Generated files are build artifacts and are not committed. The candidate YAML

--- a/src/bcs/api-contracts/v1/domain-models.yaml
+++ b/src/bcs/api-contracts/v1/domain-models.yaml
@@ -18,6 +18,364 @@ Actor:
     name:
       type: string
 
+# ---- Bot control-plane resources ------------------------------------------
+
+BotKind:
+  type: string
+  enum:
+    - bot
+    - human
+  description: >-
+    Persisted bcs_bots actor kind. Legacy rows without actor_kind are exposed
+    as bot.
+
+BotVisibility:
+  type: string
+  enum:
+    - public
+    - protected
+    - private
+  description: Discovery and collaboration visibility stored for the Bot.
+
+BotStatus:
+  type: string
+  enum:
+    - online
+    - hidden
+  description: >-
+    Raw persisted Bot status. This field does not express effective runtime
+    connectivity.
+
+BotReachability:
+  type: string
+  enum:
+    - reachable
+    - unreachable
+  description: >-
+    Effective runtime reachability computed with the existing BCN
+    online/downlink logic. It has no direct database column.
+
+BotSkill:
+  type: object
+  additionalProperties: false
+  required:
+    - name
+  properties:
+    name:
+      type: string
+      minLength: 1
+    description:
+      type: string
+  description: One non-sensitive capability declared by a physical Bot.
+
+BotDescriptor:
+  type: object
+  additionalProperties: false
+  required:
+    - summary
+    - domains
+    - skills
+    - scopes
+  properties:
+    summary:
+      type: string
+      description: Empty when no legacy summary was persisted.
+    domains:
+      type: array
+      description: Empty when no legacy domains were persisted.
+      items:
+        type: string
+    skills:
+      type: array
+      description: Empty when no legacy skills were persisted.
+      items:
+        $ref: "#/BotSkill"
+    scopes:
+      type: array
+      description: Empty when no legacy scopes were persisted.
+      items:
+        type: string
+  description: >-
+    Public capability description of a physical Bot. It contains no provider,
+    credential, endpoint, or internal routing configuration.
+
+BotProvider:
+  type: object
+  additionalProperties: false
+  required:
+    - provider_id
+    - name
+  properties:
+    provider_id:
+      type: string
+      minLength: 1
+    name:
+      type: string
+      minLength: 1
+  description: Optional non-sensitive Provider projection; no slug is exposed.
+
+PhysicalBot:
+  type: object
+  additionalProperties: false
+  required:
+    - bot_id
+    - kind
+    - name
+    - visibility
+    - status
+    - env
+    - descriptor
+    - reachability
+    - created_at
+    - updated_at
+  properties:
+    bot_id:
+      type: string
+      minLength: 1
+      description: Authoritative BCN identifier.
+    kind:
+      const: bot
+    name:
+      type: string
+      minLength: 1
+    visibility:
+      $ref: "#/BotVisibility"
+    status:
+      $ref: "#/BotStatus"
+    env:
+      type: string
+      minLength: 1
+      description: Persisted environment boundary; never inferred from kind.
+    created_by:
+      type: string
+      minLength: 1
+      description: >-
+        Immutable creator staff_no. Omitted when a legacy row has no creator.
+    descriptor:
+      $ref: "#/BotDescriptor"
+    reachability:
+      $ref: "#/BotReachability"
+    provider:
+      $ref: "#/BotProvider"
+    agent_code:
+      type: string
+      description: Optional read-only external Agent identity.
+    created_at:
+      type: integer
+      format: int64
+      minimum: 0
+      description: Unix milliseconds mapped from gmt_create.
+    updated_at:
+      type: integer
+      format: int64
+      minimum: 0
+      description: Unix milliseconds mapped from gmt_modified.
+  description: >-
+    A physical software Bot. descriptor and reachability are normalized even
+    when their legacy source columns are incomplete.
+
+HumanBot:
+  type: object
+  additionalProperties: false
+  required:
+    - bot_id
+    - kind
+    - name
+    - visibility
+    - status
+    - env
+    - created_at
+    - updated_at
+  properties:
+    bot_id:
+      type: string
+      minLength: 1
+      description: Authoritative BCN identifier.
+    kind:
+      const: human
+    name:
+      type: string
+      minLength: 1
+    visibility:
+      $ref: "#/BotVisibility"
+    status:
+      $ref: "#/BotStatus"
+    env:
+      type: string
+      minLength: 1
+      description: Persisted environment boundary; never inferred from kind.
+    created_by:
+      type: string
+      minLength: 1
+      description: >-
+        Immutable creator staff_no. Omitted when a legacy row has no creator.
+    created_at:
+      type: integer
+      format: int64
+      minimum: 0
+      description: Unix milliseconds mapped from gmt_create.
+    updated_at:
+      type: integer
+      format: int64
+      minimum: 0
+      description: Unix milliseconds mapped from gmt_modified.
+  description: >-
+    A Human row stored in bcs_bots. Human participates in groups and sessions
+    but has no descriptor, reachability, Provider projection, or agent_code.
+
+Bot:
+  oneOf:
+    - $ref: "#/PhysicalBot"
+    - $ref: "#/HumanBot"
+  discriminator:
+    propertyName: kind
+    mapping:
+      bot: "#/PhysicalBot"
+      human: "#/HumanBot"
+  description: BCN control-plane domain object for physical Bots and Humans.
+
+BotCandidate:
+  type: object
+  additionalProperties: false
+  required:
+    - bot
+    - is_friend
+  properties:
+    bot:
+      $ref: "#/PhysicalBot"
+    is_friend:
+      type: boolean
+      description: Whether the acting physical Bot has an accepted Friendship.
+
+BotPage:
+  type: object
+  additionalProperties: false
+  required:
+    - items
+    - total
+    - offset
+    - limit
+  properties:
+    items:
+      type: array
+      items:
+        $ref: "#/Bot"
+    total:
+      type: integer
+      minimum: 0
+    offset:
+      type: integer
+      minimum: 0
+    limit:
+      type: integer
+      minimum: 1
+
+BotCandidatePage:
+  type: object
+  additionalProperties: false
+  required:
+    - items
+    - total
+    - offset
+    - limit
+  properties:
+    items:
+      type: array
+      items:
+        $ref: "#/BotCandidate"
+    total:
+      type: integer
+      minimum: 0
+    offset:
+      type: integer
+      minimum: 0
+    limit:
+      type: integer
+      minimum: 1
+
+BotList:
+  type: object
+  additionalProperties: false
+  required:
+    - items
+  properties:
+    items:
+      type: array
+      items:
+        $ref: "#/Bot"
+
+BotEnvelope:
+  type: object
+  additionalProperties: false
+  required:
+    - code
+    - message
+    - data
+    - request_id
+  properties:
+    code:
+      const: 20000
+    message:
+      type: string
+    data:
+      $ref: "#/Bot"
+    request_id:
+      type: string
+
+BotPageEnvelope:
+  type: object
+  additionalProperties: false
+  required:
+    - code
+    - message
+    - data
+    - request_id
+  properties:
+    code:
+      const: 20000
+    message:
+      type: string
+    data:
+      $ref: "#/BotPage"
+    request_id:
+      type: string
+
+BotCandidatePageEnvelope:
+  type: object
+  additionalProperties: false
+  required:
+    - code
+    - message
+    - data
+    - request_id
+  properties:
+    code:
+      const: 20000
+    message:
+      type: string
+    data:
+      $ref: "#/BotCandidatePage"
+    request_id:
+      type: string
+
+BotListEnvelope:
+  type: object
+  additionalProperties: false
+  required:
+    - code
+    - message
+    - data
+    - request_id
+  properties:
+    code:
+      const: 20000
+    message:
+      type: string
+    data:
+      $ref: "#/BotList"
+    request_id:
+      type: string
+
 Participant:
   type: object
   additionalProperties: false

--- a/src/bcs/api-contracts/v1/gateway-principal/contract.md
+++ b/src/bcs/api-contracts/v1/gateway-principal/contract.md
@@ -1,0 +1,13 @@
+# Gateway Principal Contract for BCS V1
+
+`X-Avernet-Principal` carries one raw compact JWT. The verifier requires
+`alg=HS256`, `typ=JWT`, `kid=bare`, `iss=gateway`, `aud=bcs`, integer `iat` and
+`exp`, and a non-empty `principals` array. It allows one each of `user`, `bot`,
+`app`, and `access_key`; all must agree on one non-blank tenant.
+
+Known Principal types may add fields compatibly. Unknown Principal types,
+duplicate types, removed required fields, mixed tenants, invalid time claims,
+and invalid signatures fail the whole request. BCS never projects `bot.token`
+or `access_key_token` into its internal caller.
+
+This contract is preparatory: BCS V1 is not production-mounted by this change.

--- a/src/bcs/api-contracts/v1/gateway-principal/principal-set.json
+++ b/src/bcs/api-contracts/v1/gateway-principal/principal-set.json
@@ -1,0 +1,50 @@
+{
+  "issuer": "gateway",
+  "audience": "bcs",
+  "key_id": "bare",
+  "principals": [
+    {
+      "type": "user",
+      "tenant": "tenant-a",
+      "subject": {
+        "id": "user-1",
+        "username": "alice",
+        "display_name": "Alice",
+        "full_name": null,
+        "tenant_id": "tenant-a"
+      }
+    },
+    {
+      "type": "bot",
+      "tenant": "tenant-a",
+      "bot": {
+        "bot_uuid": "bot-1",
+        "owner_id": "user-1",
+        "token": "TEST_ONLY_BOT_TOKEN_MARKER",
+        "app_id": 7,
+        "agent_code": "agent-1",
+        "tenant": "tenant-a"
+      }
+    },
+    {
+      "type": "app",
+      "tenant": "tenant-a",
+      "app": {
+        "app_id": 7,
+        "app_name": "Contract App",
+        "owners": "contract-owner",
+        "tenant": "tenant-a",
+        "app_type": "THIRD_PARTY"
+      }
+    },
+    {
+      "type": "access_key",
+      "tenant": "tenant-a",
+      "access_key": {
+        "access_key": "ak-test-1",
+        "access_key_token": "TEST_ONLY_ACCESS_KEY_TOKEN_MARKER",
+        "expire_at": "2030-01-01T00:00:00Z"
+      }
+    }
+  ]
+}

--- a/src/bcs/api-contracts/v1/openapi.yaml
+++ b/src/bcs/api-contracts/v1/openapi.yaml
@@ -4,6 +4,14 @@ info:
   version: 1.0.0
   description: Versioned public contract for Bot Collaboration Network resources.
 paths:
+  /openapi/v1/bots/mine:
+    $ref: ./openapi/bots.yaml#/MyBotsPath
+  /openapi/v1/bots/query:
+    $ref: ./openapi/bots.yaml#/QueryBotsPath
+  /openapi/v1/bots/{bot_id}:
+    $ref: ./openapi/bots.yaml#/BotPath
+  /openapi/v1/bots/{bot_id}/candidates:
+    $ref: ./openapi/bots.yaml#/BotCandidatesPath
   /openapi/v1/bots/collaboration/{bot_uuid}/groups:
     $ref: ./openapi/groups.yaml#/ListBotGroupsPath
   /openapi/v1/bots/collaboration/{bot_uuid}/friendships:
@@ -44,6 +52,18 @@ paths:
     $ref: ./openapi/invitations.yaml#/AcceptInvitationPath
 components:
   schemas:
+    Bot:
+      $ref: ./domain-models.yaml#/Bot
+    PhysicalBot:
+      $ref: ./domain-models.yaml#/PhysicalBot
+    HumanBot:
+      $ref: ./domain-models.yaml#/HumanBot
+    BotDescriptor:
+      $ref: ./domain-models.yaml#/BotDescriptor
+    BotCandidate:
+      $ref: ./domain-models.yaml#/BotCandidate
+    BotPage:
+      $ref: ./domain-models.yaml#/BotPage
     GroupSummary:
       $ref: ./domain-models.yaml#/GroupSummary
     GroupDetail:

--- a/src/bcs/api-contracts/v1/openapi.yaml
+++ b/src/bcs/api-contracts/v1/openapi.yaml
@@ -12,8 +12,6 @@ paths:
     $ref: ./openapi/bots.yaml#/BotPath
   /openapi/v1/bots/{bot_id}/candidates:
     $ref: ./openapi/bots.yaml#/BotCandidatesPath
-  /openapi/v1/bots/collaboration/{bot_uuid}/groups:
-    $ref: ./openapi/groups.yaml#/ListBotGroupsPath
   /openapi/v1/bots/collaboration/{bot_uuid}/friendships:
     $ref: ./openapi/friendships.yaml#/ListFriendshipsPath
   /openapi/v1/bots/collaboration/{bot_uuid}/friendships/{friend_bot_uuid}:
@@ -25,7 +23,7 @@ paths:
   /openapi/v1/friend-requests/{request_id}/reject:
     $ref: ./openapi/friendships.yaml#/RejectFriendRequestPath
   /openapi/v1/groups:
-    $ref: ./openapi/groups.yaml#/CreateGroupPath
+    $ref: ./openapi/groups.yaml#/GroupsPath
   /openapi/v1/groups/{group_id}:
     $ref: ./openapi/groups.yaml#/GroupPath
   /openapi/v1/groups/{group_id}/participants:

--- a/src/bcs/api-contracts/v1/openapi/bots.yaml
+++ b/src/bcs/api-contracts/v1/openapi/bots.yaml
@@ -1,0 +1,445 @@
+BotCandidatesPath:
+  get:
+    operationId: list_bot_candidates
+    summary: List candidate physical Bots from a managed Bot's perspective.
+    description: >-
+      Human control-plane operation. The path bot_id must identify a physical
+      Bot managed by the current Human. Results stay in that Bot's environment,
+      exclude the acting Bot, Humans, deleted rows, and unonboarded rows. An
+      empty or whitespace-only name is treated as absent; otherwise matching is
+      a trimmed case-insensitive substring. Status and reachability do not
+      remove candidates.
+    x-avernet-security:
+      principal: human
+    x-avernet-behavior:
+      acting_bot: managed_physical_bot
+      result_kind: bot
+      environment: same_as_acting_bot
+      exclude_self: true
+      purpose_visibility:
+        discovery:
+          - public
+          - protected
+        collaboration:
+          - public
+          - friend
+      status_filter: none
+      reachability_filter: none
+      ordering:
+        - created_at_desc
+        - bot_id_asc
+    parameters:
+      - $ref: ../shared.yaml#/BotIdPath
+      - name: purpose
+        in: query
+        description: >-
+          discovery returns public and protected Bots. collaboration returns
+          public Bots plus accepted friends regardless of non-public visibility.
+        schema:
+          type: string
+          enum:
+            - discovery
+            - collaboration
+          default: discovery
+      - name: name
+        in: query
+        description: Optional trimmed, case-insensitive name substring.
+        schema:
+          type: string
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 20
+    responses:
+      "200":
+        description: >-
+          Candidate Bots ordered by created_at descending with bot_id ascending
+          as the deterministic tie-breaker, then paginated.
+        content:
+          application/json:
+            schema:
+              $ref: ../domain-models.yaml#/BotCandidatePageEnvelope
+      "400":
+        description: Invalid filter or the acting identity is not a physical Bot.
+        x-error-codes:
+          - invalid_request
+          - invalid_bot_kind
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "401":
+        description: Gateway Human Principal is missing or invalid.
+        x-error-codes:
+          - unauthenticated
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "403":
+        description: Current Human does not manage the acting physical Bot.
+        x-error-codes:
+          - forbidden
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "404":
+        description: Acting Bot is missing, deleted, or unonboarded.
+        x-error-codes:
+          - bot_not_found
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "500":
+        $ref: ../shared.yaml#/InternalErrorResponse
+
+QueryBotsPath:
+  post:
+    operationId: query_bots
+    summary: Query Bot domain objects by explicit identifiers.
+    description: >-
+      Human control-plane operation for deterministic explicit-ID hydration.
+      Both physical Bot and Human rows can be returned. The operation does not
+      apply ownership or visibility filtering. Duplicate IDs are collapsed at
+      their first occurrence; missing, deleted, and unonboarded rows are
+      silently omitted. An empty bot_ids array returns an empty items array.
+    x-avernet-security:
+      principal: human
+    x-avernet-behavior:
+      result_kinds:
+        - bot
+        - human
+      authorization_filter: none
+      visibility_filter: none
+      deduplicate: first_occurrence
+      ordering: request_order
+      missing: omit
+      deleted: omit
+      unonboarded: omit
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/QueryBotsRequest"
+    responses:
+      "200":
+        description: Bot objects in first-occurrence request order.
+        content:
+          application/json:
+            schema:
+              $ref: ../domain-models.yaml#/BotListEnvelope
+      "400":
+        description: Invalid JSON body, identifier, or batch size.
+        x-error-codes:
+          - invalid_request
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "401":
+        description: Gateway Human Principal is missing or invalid.
+        x-error-codes:
+          - unauthenticated
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "403":
+        description: Authenticated Principal is not a Human control-plane caller.
+        x-error-codes:
+          - forbidden
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "500":
+        $ref: ../shared.yaml#/InternalErrorResponse
+
+BotPath:
+  get:
+    operationId: get_bot
+    summary: Get one Bot domain object by exact identifier.
+    description: >-
+      Human control-plane exact-ID lookup for either a physical Bot or a Human
+      row. No acting Bot, ownership filter, or visibility filter is applied;
+      visibility controls directory discovery rather than explicit hydration.
+    x-avernet-security:
+      principal: human
+    x-avernet-behavior:
+      result_kinds:
+        - bot
+        - human
+      visibility_filter: none
+    parameters:
+      - $ref: ../shared.yaml#/BotIdPath
+    responses:
+      "200":
+        description: Full Bot domain object selected by kind.
+        content:
+          application/json:
+            schema:
+              $ref: ../domain-models.yaml#/BotEnvelope
+      "400":
+        description: Invalid Bot identifier encoding.
+        x-error-codes:
+          - invalid_request
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "401":
+        description: Gateway Human Principal is missing or invalid.
+        x-error-codes:
+          - unauthenticated
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "403":
+        description: Authenticated Principal is not a Human control-plane caller.
+        x-error-codes:
+          - forbidden
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "404":
+        description: Bot is missing, deleted, or unonboarded.
+        x-error-codes:
+          - bot_not_found
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "500":
+        $ref: ../shared.yaml#/InternalErrorResponse
+  patch:
+    operationId: update_bot
+    summary: Update the explicitly mutable Bot properties.
+    description: >-
+      Human control-plane owner update. The current Human staff_no must equal
+      the target row's created_by; a missing created_by is not special-cased and
+      is therefore forbidden. descriptor is a nested partial update available
+      only for a physical Bot. Descriptor arrays replace their complete stored
+      arrays. bot_id, kind, env, created_by, timestamps, reachability, provider,
+      and agent_code are immutable through this operation.
+    x-avernet-security:
+      principal: human
+    x-avernet-behavior:
+      authorization: created_by_matches_current_staff_no
+      missing_created_by: forbidden
+      descriptor_kind: bot_only
+      descriptor_arrays: replace
+    parameters:
+      - $ref: ../shared.yaml#/BotIdPath
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/UpdateBotRequest"
+    responses:
+      "200":
+        description: Updated full Bot domain object with refreshed updated_at.
+        content:
+          application/json:
+            schema:
+              $ref: ../domain-models.yaml#/BotEnvelope
+      "400":
+        description: >-
+          Empty or invalid patch, or a descriptor patch targeting a Human row.
+        x-error-codes:
+          - invalid_request
+          - invalid_bot_kind
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "401":
+        description: Gateway Human Principal is missing or invalid.
+        x-error-codes:
+          - unauthenticated
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "403":
+        description: Current Human is not the target row's created_by.
+        x-error-codes:
+          - forbidden
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "404":
+        description: Bot is missing, deleted, or unonboarded.
+        x-error-codes:
+          - bot_not_found
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "500":
+        $ref: ../shared.yaml#/InternalErrorResponse
+
+MyBotsPath:
+  get:
+    operationId: list_my_bots
+    summary: List Bot rows created by the current Human.
+    description: >-
+      Human control-plane operation. Ownership is selected by comparing the
+      current Human staff_no with created_by, without kind-specific handling.
+      Both physical Bot and Human rows can be returned. Omitting kind means all
+      kinds; reachability only matches physical Bots, so combining kind=human
+      with reachability produces an empty page.
+    x-avernet-security:
+      principal: human
+    x-avernet-behavior:
+      owner_field: created_by
+      owner_value: current_staff_no
+      omitted_kind: all
+      reachability_applies_to: bot
+      ordering:
+        - created_at_desc
+        - bot_id_asc
+    parameters:
+      - name: kind
+        in: query
+        description: Bot kind filter; omission returns both kinds.
+        schema:
+          type: string
+          enum:
+            - bot
+            - human
+      - name: name
+        in: query
+        description: >-
+          Optional trimmed, case-insensitive name substring; empty is absent.
+        schema:
+          type: string
+      - name: status
+        in: query
+        description: Raw persisted status filter.
+        schema:
+          $ref: ../domain-models.yaml#/BotStatus
+      - name: reachability
+        in: query
+        description: Computed reachability filter for physical Bots only.
+        schema:
+          $ref: ../domain-models.yaml#/BotReachability
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 20
+    responses:
+      "200":
+        description: >-
+          Owned rows ordered by created_at descending with bot_id ascending as
+          the deterministic tie-breaker, then paginated.
+        content:
+          application/json:
+            schema:
+              $ref: ../domain-models.yaml#/BotPageEnvelope
+      "400":
+        description: Invalid filter or pagination parameter.
+        x-error-codes:
+          - invalid_request
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "401":
+        description: Gateway Human Principal is missing or invalid.
+        x-error-codes:
+          - unauthenticated
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "403":
+        description: Authenticated Principal is not a Human control-plane caller.
+        x-error-codes:
+          - forbidden
+        content:
+          application/json:
+            schema:
+              $ref: ../shared.yaml#/ErrorEnvelope
+      "500":
+        $ref: ../shared.yaml#/InternalErrorResponse
+
+QueryBotsRequest:
+  type: object
+  additionalProperties: false
+  required:
+    - bot_ids
+  properties:
+    bot_ids:
+      type: array
+      maxItems: 100
+      description: >-
+        Explicit IDs. Duplicates are accepted and collapsed at their first
+        occurrence. An empty array is valid.
+      items:
+        type: string
+        minLength: 1
+
+UpdateBotDescriptor:
+  type: object
+  additionalProperties: false
+  minProperties: 1
+  properties:
+    summary:
+      type: string
+      description: New summary; omission keeps the stored value.
+    domains:
+      type: array
+      description: Complete replacement; an empty array clears the value.
+      items:
+        type: string
+    skills:
+      type: array
+      description: Complete replacement; an empty array clears the value.
+      items:
+        $ref: ../domain-models.yaml#/BotSkill
+    scopes:
+      type: array
+      description: Complete replacement; an empty array clears the value.
+      items:
+        type: string
+
+UpdateBotRequest:
+  type: object
+  additionalProperties: false
+  minProperties: 1
+  properties:
+    name:
+      type: string
+      minLength: 1
+    visibility:
+      $ref: ../domain-models.yaml#/BotVisibility
+    status:
+      $ref: ../domain-models.yaml#/BotStatus
+    descriptor:
+      $ref: "#/UpdateBotDescriptor"
+

--- a/src/bcs/api-contracts/v1/openapi/bots.yaml
+++ b/src/bcs/api-contracts/v1/openapi/bots.yaml
@@ -10,7 +10,7 @@ BotCandidatesPath:
       a trimmed case-insensitive substring. Status and reachability do not
       remove candidates.
     x-avernet-security:
-      principal: human
+      user: required
     x-avernet-behavior:
       acting_bot: managed_physical_bot
       result_kind: bot
@@ -115,7 +115,7 @@ QueryBotsPath:
       their first occurrence; missing, deleted, and unonboarded rows are
       silently omitted. An empty bot_ids array returns an empty items array.
     x-avernet-security:
-      principal: human
+      user: required
     x-avernet-behavior:
       result_kinds:
         - bot
@@ -176,7 +176,7 @@ BotPath:
       row. No acting Bot, ownership filter, or visibility filter is applied;
       visibility controls directory discovery rather than explicit hydration.
     x-avernet-security:
-      principal: human
+      user: required
     x-avernet-behavior:
       result_kinds:
         - bot
@@ -236,7 +236,7 @@ BotPath:
       arrays. bot_id, kind, env, created_by, timestamps, reachability, provider,
       and agent_code are immutable through this operation.
     x-avernet-security:
-      principal: human
+      user: required
     x-avernet-behavior:
       authorization: created_by_matches_current_staff_no
       missing_created_by: forbidden
@@ -305,7 +305,7 @@ MyBotsPath:
       kinds; reachability only matches physical Bots, so combining kind=human
       with reachability produces an empty page.
     x-avernet-security:
-      principal: human
+      user: required
     x-avernet-behavior:
       owner_field: created_by
       owner_value: current_staff_no
@@ -442,4 +442,3 @@ UpdateBotRequest:
       $ref: ../domain-models.yaml#/BotStatus
     descriptor:
       $ref: "#/UpdateBotDescriptor"
-

--- a/src/bcs/api-contracts/v1/openapi/friendships.yaml
+++ b/src/bcs/api-contracts/v1/openapi/friendships.yaml
@@ -12,7 +12,7 @@ ListFriendshipsPath:
     operationId: list_bot_friendships
     summary: List a Bot's friendships.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/BotUuidPath
       - name: offset
@@ -77,7 +77,7 @@ FriendshipPath:
     operationId: delete_bot_friendship
     summary: Remove a friendship symmetrically and idempotently.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/BotUuidPath
       - $ref: ../shared.yaml#/FriendBotUuidPath
@@ -128,7 +128,7 @@ BotFriendRequestsPath:
     operationId: create_bot_friend_request
     summary: Send a friend request from the path Bot to a target Bot.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/BotUuidPath
     requestBody:
@@ -194,7 +194,7 @@ BotFriendRequestsPath:
     operationId: list_bot_friend_requests
     summary: List friend requests sent by or received by a Bot.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/BotUuidPath
       - name: offset
@@ -267,7 +267,7 @@ AcceptFriendRequestPath:
     operationId: accept_friend_request
     summary: Accept a friend request as the receiver; idempotent after acceptance.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/FriendRequestIdPath
     responses:
@@ -326,7 +326,7 @@ RejectFriendRequestPath:
     operationId: reject_friend_request
     summary: Reject a friend request as the receiver; idempotent after rejection.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/FriendRequestIdPath
     responses:

--- a/src/bcs/api-contracts/v1/openapi/groups.yaml
+++ b/src/bcs/api-contracts/v1/openapi/groups.yaml
@@ -1,11 +1,11 @@
-ListBotGroupsPath:
+GroupsPath:
   get:
-    operationId: list_bot_groups
-    summary: List groups visible from a Bot collaboration identity.
+    operationId: list_groups
+    summary: List groups visible from the selected View Actor.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
-      - $ref: ../shared.yaml#/BotUuidPath
+      - $ref: ../shared.yaml#/ViewBotIdQuery
       - name: offset
         in: query
         schema:
@@ -53,8 +53,10 @@ ListBotGroupsPath:
       "200":
         description: >-
           Groups ordered by created_at descending (group_id ascending
-          tie-breaker) after relation/strategy/kind filtering and
-          deduplication, then paginated with offset/limit.
+          tie-breaker) after selected-Actor relation, strategy, kind, and
+          search filtering and deduplication, then paginated with offset/limit.
+          Both items and total are scoped before pagination. An authorized View
+          Actor with no matching Group relation receives an empty page.
         content:
           application/json:
             schema:
@@ -76,17 +78,11 @@ ListBotGroupsPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot manage the target Bot identity.
+        description: >-
+          The explicit View Actor is not the authenticated Human or a Bot
+          created by that Human.
         x-error-codes:
           - forbidden
-        content:
-          application/json:
-            schema:
-              $ref: ../shared.yaml#/ErrorEnvelope
-      "404":
-        description: Target Bot is missing.
-        x-error-codes:
-          - bot_not_found
         content:
           application/json:
             schema:
@@ -94,12 +90,11 @@ ListBotGroupsPath:
       "500":
         $ref: ../shared.yaml#/InternalErrorResponse
 
-CreateGroupPath:
   post:
     operationId: create_group
     summary: Create a collaboration group or direct-message group.
     x-avernet-security:
-      principal: required
+      user: required
     requestBody:
       required: true
       content:
@@ -175,7 +170,7 @@ GroupPath:
     operationId: get_group
     summary: Get target-independent group detail.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     responses:
@@ -202,7 +197,9 @@ GroupPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot read the group.
+        description: >-
+          Neither the authenticated User's Human Actor nor a Bot created by
+          that Human is a Group Participant.
         x-error-codes:
           - forbidden
         content:
@@ -231,7 +228,7 @@ GroupPath:
     operationId: update_group
     summary: Update the explicitly mutable group properties.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     requestBody:
@@ -296,7 +293,7 @@ GroupPath:
     operationId: delete_group
     summary: Delete a group using the authenticated Principal as caller.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     responses:
@@ -485,7 +482,7 @@ AddGroupParticipantPath:
     operationId: add_group_participant
     summary: Add a Human or Bot actor as a Group participant.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     requestBody:
@@ -554,7 +551,7 @@ GroupParticipantPath:
     operationId: update_group_participant
     summary: Update the mutable properties of a Group participant.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
       - $ref: ../shared.yaml#/ActorIdPath
@@ -619,7 +616,7 @@ GroupParticipantPath:
     operationId: remove_group_participant
     summary: Remove a participant or let an actor leave the group.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
       - $ref: ../shared.yaml#/ActorIdPath

--- a/src/bcs/api-contracts/v1/openapi/invitations.yaml
+++ b/src/bcs/api-contracts/v1/openapi/invitations.yaml
@@ -21,7 +21,7 @@ CreateGroupInvitationPath:
     operationId: create_group_invitation
     summary: Create an Invitation for a Group target.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     requestBody:
@@ -85,7 +85,7 @@ CreateSessionInvitationPath:
     operationId: create_session_invitation
     summary: Create an Invitation for a Session target.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     requestBody:
@@ -150,7 +150,7 @@ AcceptInvitationPath:
     operationId: accept_invitation
     summary: Accept an invitation and join its target resource.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/InvitationTokenPath
     requestBody:

--- a/src/bcs/api-contracts/v1/openapi/sessions.yaml
+++ b/src/bcs/api-contracts/v1/openapi/sessions.yaml
@@ -50,7 +50,7 @@ GroupSessionsPath:
     operationId: create_session
     summary: Create a Session under a Group.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     requestBody:
@@ -114,11 +114,12 @@ GroupSessionsPath:
 
   get:
     operationId: list_sessions
-    summary: List Sessions under a Group.
+    summary: List Sessions under a Group for the selected View Actor.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
+      - $ref: ../shared.yaml#/ViewBotIdQuery
       - name: offset
         in: query
         schema:
@@ -139,8 +140,11 @@ GroupSessionsPath:
     responses:
       "200":
         description: >-
-          Sessions ordered by created_at descending (session_id ascending
-          tie-breaker), then paginated with offset/limit.
+          Sessions in which the selected View Actor is a Participant, ordered
+          by created_at descending (session_id ascending tie-breaker), then
+          paginated with offset/limit. Both items and total are scoped before
+          pagination. An authorized View Actor with no matching Session returns
+          an empty page.
         content:
           application/json:
             schema:
@@ -162,7 +166,9 @@ GroupSessionsPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot read the group.
+        description: >-
+          The explicit View Actor is not the authenticated Human or a Bot
+          created by that Human.
         x-error-codes:
           - forbidden
         content:
@@ -185,7 +191,7 @@ SessionPath:
     operationId: get_session
     summary: Get session detail.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     responses:
@@ -212,7 +218,9 @@ SessionPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot read the session.
+        description: >-
+          Neither the authenticated User's Human Actor nor a Bot created by
+          that Human is a Session Participant.
         x-error-codes:
           - forbidden
         content:
@@ -233,7 +241,7 @@ SessionPath:
     operationId: update_session
     summary: Update the explicitly mutable session properties.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     requestBody:
@@ -295,7 +303,7 @@ SessionPath:
     operationId: delete_session
     summary: Delete a session using the authenticated Principal as caller.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     responses:
@@ -337,7 +345,7 @@ SessionCompletionPath:
     operationId: complete_session
     summary: Complete a running chat session; idempotent after completion.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     responses:
@@ -387,7 +395,7 @@ SessionMessagesPath:
     operationId: list_session_messages
     summary: List session message history (cursor-based).
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
       - name: before
@@ -408,21 +416,15 @@ SessionMessagesPath:
           minimum: 1
           maximum: 100
           default: 50
-      - name: view_bot_id
-        in: query
-        description: >-
-          Optional viewer identity for message history visibility scoping.
-          Bot callers: omit (defaults to self) or pass self bot_uuid.
-          Human callers: omit for full manager-view; pass "human_<staff_no>"
-          for own participant cutoff; or pass an owned Bot's UUID for that
-          Bot's perspective (ownership verified server-side).
-        schema:
-          type: string
+      - $ref: ../shared.yaml#/ViewBotIdQuery
     responses:
       "200":
         description: >-
-          Messages ordered by created_at descending, session_seq descending
-          (legacy behavior); cursor-based pagination.
+          Messages visible to the selected Session Participant, ordered by
+          created_at descending and session_seq descending (legacy behavior),
+          with cursor-based pagination. Omitting view_bot_id selects the
+          authenticated Human Participant; creator or manager status does not
+          create an implicit manager view.
         content:
           application/json:
             schema:
@@ -444,7 +446,9 @@ SessionMessagesPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot read the session.
+        description: >-
+          The View Actor is unauthorized or is not a Participant of the
+          requested Session.
         x-error-codes:
           - forbidden
         content:
@@ -467,7 +471,7 @@ AddSessionParticipantPath:
     operationId: add_session_participant
     summary: Add a Bot as a Session participant.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     requestBody:
@@ -534,7 +538,7 @@ SessionParticipantPath:
     operationId: update_session_participant
     summary: Update a Session participant mode.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
       - $ref: ../shared.yaml#/BotUuidPath
@@ -598,7 +602,7 @@ SessionParticipantPath:
     operationId: remove_session_participant
     summary: Remove a Session participant or let a Bot leave.
     x-avernet-security:
-      principal: required
+      user: required
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
       - $ref: ../shared.yaml#/BotUuidPath

--- a/src/bcs/api-contracts/v1/shared.yaml
+++ b/src/bcs/api-contracts/v1/shared.yaml
@@ -50,6 +50,14 @@ BotUuidPath:
     type: string
     minLength: 1
 
+BotIdPath:
+  name: bot_id
+  in: path
+  required: true
+  schema:
+    type: string
+    minLength: 1
+
 GroupIdPath:
   name: group_id
   in: path

--- a/src/bcs/api-contracts/v1/shared.yaml
+++ b/src/bcs/api-contracts/v1/shared.yaml
@@ -42,6 +42,21 @@ InternalErrorResponse:
       schema:
         $ref: "#/ErrorEnvelope"
 
+ViewBotIdQuery:
+  name: view_bot_id
+  in: query
+  required: false
+  description: >-
+    Selects the Actor whose collaboration relations or Participant visibility
+    scope the response. Omit to select the authenticated User's
+    `human_<subject.id>` Actor. An explicit Human Actor ID must identify that
+    same User. An explicit Bot UUID is allowed only when the Bot's `created_by`
+    equals the authenticated User ID. Selecting a Bot scopes returned data; it
+    does not change the Human caller or grant management authority.
+  schema:
+    type: string
+    minLength: 1
+
 BotUuidPath:
   name: bot_uuid
   in: path

--- a/src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md
+++ b/src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md
@@ -5,11 +5,14 @@
 - Versioned `/openapi/v1/**` and `/internal/v1/**` HTTP delivery boundaries.
 - Request/response DTO translation and the common response envelope.
 - An injectable Gateway Principal verification boundary.
+- A preparatory V1 Gateway wire projection and HS256 token verifier that
+  returns a complete, secret-free authenticated caller.
 
 ## Consumes
 
 - `bcs-service-api::application::v1` contracts.
 - HTTP framework crates such as `axum`.
+- JWT, time, and serialization utilities used only by the V1 delivery adapter.
 
 ## Allowed dependencies
 
@@ -26,15 +29,16 @@
 
 ## Configuration
 
-- Bootstrap injects V1 Application services and a Principal verifier.
+- Production bootstrap does not mount this crate yet.
 - The adapter must not read environment variables or select a production
   Principal trust mechanism.
 
 ## Runtime ownership
 
-This crate owns HTTP parsing, versioned wire DTOs, request IDs, envelopes, and
-HTTP error mapping. Resource authorization and business policy remain in V1
-Application services.
+This crate owns HTTP parsing, versioned wire DTOs, Gateway token verification,
+request IDs, envelopes, and HTTP error mapping. Header extraction, production
+trust selection, router mounting, resource authorization, Actor selection, and
+business policy remain outside this preparatory verifier slice.
 
 ## Tests
 

--- a/src/bcs/crates/adapters/http/bcs-api-http/Cargo.toml
+++ b/src/bcs/crates/adapters/http/bcs-api-http/Cargo.toml
@@ -14,9 +14,11 @@ workspace = true
 async-trait = { workspace = true }
 axum = { workspace = true }
 bcs-service-api = { workspace = true }
+jsonwebtoken = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true, features = ["parsing"] }
 tracing = { workspace = true }
 ulid = { workspace = true }
 

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/principal.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/principal.rs
@@ -3,7 +3,7 @@ use axum::extract::{Request, State};
 use axum::http::HeaderMap;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use bcs_service_api::application::v1::Principal;
+use bcs_service_api::application::v1::AuthenticatedCaller;
 
 use super::{ApiState, ErrorResponse, RequestId};
 
@@ -21,7 +21,10 @@ pub enum PrincipalVerificationError {
 /// not provide a verifier that trusts an unsigned Principal header.
 #[async_trait]
 pub trait PrincipalVerifier: Send + Sync {
-    async fn verify(&self, headers: &HeaderMap) -> Result<Principal, PrincipalVerificationError>;
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError>;
 }
 
 pub async fn verify_principal(
@@ -31,8 +34,8 @@ pub async fn verify_principal(
 ) -> Response {
     let request_id = RequestId::from_headers(request.headers());
     match state.principal_verifier.verify(request.headers()).await {
-        Ok(principal) => {
-            request.extensions_mut().insert(principal);
+        Ok(caller) => {
+            request.extensions_mut().insert(caller);
             request.extensions_mut().insert(request_id);
             next.run(request).await
         }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/state.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/state.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
 use bcs_service_api::application::v1::{
-    FriendshipService, GroupService, InvitationService, SessionMessageService, SessionService,
+    BotService, FriendshipService, GroupService, InvitationService, SessionMessageService,
+    SessionService,
 };
 
 use super::PrincipalVerifier;
 
 #[derive(Clone)]
 pub struct ApiState {
+    pub bot_service: Option<Arc<dyn BotService>>,
     pub group_service: Arc<dyn GroupService>,
     pub session_service: Arc<dyn SessionService>,
     pub message_service: Arc<dyn SessionMessageService>,
@@ -26,6 +28,7 @@ impl ApiState {
         principal_verifier: Arc<dyn PrincipalVerifier>,
     ) -> Self {
         Self {
+            bot_service: None,
             group_service,
             session_service,
             message_service,
@@ -33,5 +36,14 @@ impl ApiState {
             friendship_service,
             principal_verifier,
         }
+    }
+
+    /// Add the Bot control-plane V1 slice.
+    ///
+    /// The service remains optional until the production trusted-Principal
+    /// rollout mounts this adapter in the bootstrap composition root.
+    pub fn with_bot_service(mut self, bot_service: Arc<dyn BotService>) -> Self {
+        self.bot_service = Some(bot_service);
+        self
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/mod.rs
@@ -1,0 +1,10 @@
+mod verifier;
+mod wire;
+
+pub use verifier::{
+    GatewayPrincipalTokenVerifier, GatewayPrincipalTrust, GatewayPrincipalVerificationError,
+    GatewayPrincipalVerifierBuildError,
+};
+
+#[cfg(test)]
+mod tests;

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
@@ -9,7 +9,8 @@ use super::{
 };
 
 const NOW: u64 = 1_785_657_600;
-const TEST_KEY: &[u8] = b"TEST-ONLY-bcs-principal-contract-key-32-bytes";
+const TEST_KEY_TEXT: &str = "TEST-ONLY-bcs-principal-contract-key-32-bytes";
+const TEST_KEY: &[u8] = TEST_KEY_TEXT.as_bytes();
 
 #[derive(Deserialize)]
 struct ContractFixture {
@@ -19,12 +20,35 @@ struct ContractFixture {
     principals: Value,
 }
 
+fn must_ok<T, E>(result: Result<T, E>, context: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(_) => panic!("{context}"),
+    }
+}
+
+fn must_some<T>(value: Option<T>, context: &str) -> T {
+    match value {
+        Some(value) => value,
+        None => panic!("{context}"),
+    }
+}
+
+fn must_err<T, E>(result: Result<T, E>, context: &str) -> E {
+    match result {
+        Err(error) => error,
+        Ok(_) => panic!("{context}"),
+    }
+}
+
 fn fixture() -> ContractFixture {
-    serde_json::from_str(include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../../../api-contracts/v1/gateway-principal/principal-set.json"
-    )))
-    .expect("valid shared Principal fixture")
+    must_ok(
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../../api-contracts/v1/gateway-principal/principal-set.json"
+        ))),
+        "valid shared Principal fixture",
+    )
 }
 
 fn mint(fixture: &ContractFixture, principals: Value) -> String {
@@ -49,17 +73,25 @@ fn header(typ: &str, kid: &str) -> Header {
 }
 
 fn mint_with(header: Header, claims: &Value, signing_key: &[u8]) -> String {
-    encode(&header, claims, &EncodingKey::from_secret(signing_key)).expect("test token signs")
+    must_ok(
+        encode(&header, claims, &EncodingKey::from_secret(signing_key)),
+        "test token signs",
+    )
 }
 
 fn verifier_from(fixture: &ContractFixture) -> GatewayPrincipalTokenVerifier {
-    let trust = GatewayPrincipalTrust::new(
-        fixture.issuer.clone(),
-        fixture.audience.clone(),
-        fixture.key_id.clone(),
+    let trust = must_ok(
+        GatewayPrincipalTrust::new(
+            fixture.issuer.clone(),
+            fixture.audience.clone(),
+            fixture.key_id.clone(),
+        ),
+        "valid trust",
+    );
+    must_ok(
+        GatewayPrincipalTokenVerifier::new(TEST_KEY, trust),
+        "valid verifier",
     )
-    .expect("valid trust");
-    GatewayPrincipalTokenVerifier::new(TEST_KEY, trust).expect("valid verifier")
 }
 
 fn verifier() -> GatewayPrincipalTokenVerifier {
@@ -96,9 +128,7 @@ fn verify_principals(
 
 fn select_principals(principals: &Value, kinds: &[&str]) -> Value {
     Value::Array(
-        principals
-            .as_array()
-            .expect("fixture principals array")
+        must_some(principals.as_array(), "fixture principals array")
             .iter()
             .filter(|principal| {
                 principal["type"]
@@ -115,9 +145,10 @@ fn verifies_the_shared_all_identity_fixture_without_projecting_secrets() {
     let fixture = fixture();
     let token = mint(&fixture, fixture.principals.clone());
 
-    let caller = verifier_from(&fixture)
-        .verify_at(&token, NOW)
-        .expect("verified caller");
+    let caller = must_ok(
+        verifier_from(&fixture).verify_at(&token, NOW),
+        "verified caller",
+    );
 
     assert_eq!(caller.tenant, "tenant-a");
     assert_eq!(
@@ -149,12 +180,13 @@ fn accepts_user_only_bot_only_and_user_plus_bot() {
         (&["bot"][..], false, true),
         (&["user", "bot"][..], true, true),
     ] {
-        let caller = verifier_from(&fixture)
-            .verify_at(
+        let caller = must_ok(
+            verifier_from(&fixture).verify_at(
                 &mint(&fixture, select_principals(&fixture.principals, kinds)),
                 NOW,
-            )
-            .expect("valid identity combination");
+            ),
+            "valid identity combination",
+        );
         assert_eq!(caller.user.is_some(), expect_user);
         assert_eq!(caller.bot.is_some(), expect_bot);
     }
@@ -163,18 +195,16 @@ fn accepts_user_only_bot_only_and_user_plus_bot() {
 #[test]
 fn principal_order_does_not_change_the_normalized_caller() {
     let fixture = fixture();
-    let forward = verifier_from(&fixture)
-        .verify_at(&mint(&fixture, fixture.principals.clone()), NOW)
-        .expect("forward order");
-    let mut reversed = fixture
-        .principals
-        .as_array()
-        .expect("fixture principals array")
-        .clone();
+    let forward = must_ok(
+        verifier_from(&fixture).verify_at(&mint(&fixture, fixture.principals.clone()), NOW),
+        "forward order",
+    );
+    let mut reversed = must_some(fixture.principals.as_array(), "fixture principals array").clone();
     reversed.reverse();
-    let reverse = verifier_from(&fixture)
-        .verify_at(&mint(&fixture, Value::Array(reversed)), NOW)
-        .expect("reverse order");
+    let reverse = must_ok(
+        verifier_from(&fixture).verify_at(&mint(&fixture, Value::Array(reversed)), NOW),
+        "reverse order",
+    );
     assert_eq!(forward, reverse);
 }
 
@@ -214,7 +244,10 @@ fn rejects_untrusted_algorithm_token_type_and_key_id() {
 
 #[test]
 fn rejects_empty_trust_material() {
-    let valid = GatewayPrincipalTrust::new("gateway", "bcs", "bare").expect("valid trust");
+    let valid = must_ok(
+        GatewayPrincipalTrust::new("gateway", "bcs", "bare"),
+        "valid trust",
+    );
     assert_eq!(
         GatewayPrincipalTokenVerifier::new(b"", valid).err(),
         Some(GatewayPrincipalVerifierBuildError::EmptySigningKey),
@@ -270,7 +303,7 @@ fn rejects_wrong_signature_issuer_and_audience() {
 fn rejects_missing_required_claims_and_invalid_shapes() {
     for claim in ["iss", "aud", "iat", "exp", "principals"] {
         let mut claims = valid_claims();
-        claims.as_object_mut().expect("claims object").remove(claim);
+        must_some(claims.as_object_mut(), "claims object").remove(claim);
         let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
         assert_eq!(
             verifier().verify_at(&token, NOW),
@@ -340,10 +373,7 @@ fn rejects_empty_unknown_and_duplicate_principal_types() {
 
     let mut duplicate = fixture().principals;
     let repeated_user = duplicate[0].clone();
-    duplicate
-        .as_array_mut()
-        .expect("principals array")
-        .push(repeated_user);
+    must_some(duplicate.as_array_mut(), "principals array").push(repeated_user);
     assert_eq!(
         verify_principals(duplicate),
         Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
@@ -354,10 +384,7 @@ fn rejects_empty_unknown_and_duplicate_principal_types() {
 fn rejects_missing_required_known_principal_fields() {
     for (index, field) in [(0, "subject"), (1, "bot"), (2, "app"), (3, "access_key")] {
         let mut principals = fixture().principals;
-        principals[index]
-            .as_object_mut()
-            .expect("principal object")
-            .remove(field);
+        must_some(principals[index].as_object_mut(), "principal object").remove(field);
         assert_eq!(
             verify_principals(principals),
             Err(GatewayPrincipalVerificationError::InvalidClaims),
@@ -375,7 +402,7 @@ fn rejects_mixed_and_contradictory_tenants() {
         "/0/subject/tenant_id",
     ] {
         let mut principals = fixture().principals;
-        *principals.pointer_mut(pointer).expect("fixture pointer") = json!("tenant-b");
+        *must_some(principals.pointer_mut(pointer), "fixture pointer") = json!("tenant-b");
         assert_eq!(
             verify_principals(principals),
             Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
@@ -405,7 +432,7 @@ fn rejects_blank_stable_identities_and_invalid_access_key_time() {
         "/3/access_key/access_key",
     ] {
         let mut principals = fixture().principals;
-        *principals.pointer_mut(pointer).expect("fixture pointer") = json!("   ");
+        *must_some(principals.pointer_mut(pointer), "fixture pointer") = json!("   ");
         assert_eq!(
             verify_principals(principals),
             Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
@@ -440,15 +467,13 @@ fn verification_errors_do_not_expose_tokens_or_keys() {
     claims["principals"] = principals;
     let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
 
-    let error = verifier()
-        .verify_at(&token, NOW)
-        .expect_err("blank tenant must fail");
+    let error = must_err(verifier().verify_at(&token, NOW), "blank tenant must fail");
     let message = error.to_string();
     for forbidden in [
         "TEST_ONLY_BOT_TOKEN_MARKER",
         "TEST_ONLY_ACCESS_KEY_TOKEN_MARKER",
         token.as_str(),
-        std::str::from_utf8(TEST_KEY).expect("ASCII test key"),
+        TEST_KEY_TEXT,
     ] {
         assert!(!message.contains(forbidden));
     }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
@@ -1,0 +1,179 @@
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{
+    GatewayPrincipalTokenVerifier, GatewayPrincipalTrust, GatewayPrincipalVerificationError,
+};
+
+const NOW: u64 = 1_785_657_600;
+const TEST_KEY: &[u8] = b"TEST-ONLY-bcs-principal-contract-key-32-bytes";
+
+#[derive(Deserialize)]
+struct ContractFixture {
+    issuer: String,
+    audience: String,
+    key_id: String,
+    principals: Value,
+}
+
+fn fixture() -> ContractFixture {
+    serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../../api-contracts/v1/gateway-principal/principal-set.json"
+    )))
+    .expect("valid shared Principal fixture")
+}
+
+fn mint(fixture: &ContractFixture, principals: Value) -> String {
+    mint_with(
+        header("JWT", &fixture.key_id),
+        &json!({
+            "iss": fixture.issuer,
+            "aud": fixture.audience,
+            "iat": NOW,
+            "exp": NOW + 60,
+            "principals": principals,
+        }),
+        TEST_KEY,
+    )
+}
+
+fn header(typ: &str, kid: &str) -> Header {
+    let mut header = Header::new(Algorithm::HS256);
+    header.typ = Some(typ.into());
+    header.kid = Some(kid.into());
+    header
+}
+
+fn mint_with(header: Header, claims: &Value, signing_key: &[u8]) -> String {
+    encode(&header, claims, &EncodingKey::from_secret(signing_key)).expect("test token signs")
+}
+
+fn verifier_from(fixture: &ContractFixture) -> GatewayPrincipalTokenVerifier {
+    let trust = GatewayPrincipalTrust::new(
+        fixture.issuer.clone(),
+        fixture.audience.clone(),
+        fixture.key_id.clone(),
+    )
+    .expect("valid trust");
+    GatewayPrincipalTokenVerifier::new(TEST_KEY, trust).expect("valid verifier")
+}
+
+fn select_principals(principals: &Value, kinds: &[&str]) -> Value {
+    Value::Array(
+        principals
+            .as_array()
+            .expect("fixture principals array")
+            .iter()
+            .filter(|principal| {
+                principal["type"]
+                    .as_str()
+                    .is_some_and(|kind| kinds.contains(&kind))
+            })
+            .cloned()
+            .collect(),
+    )
+}
+
+#[test]
+fn verifies_the_shared_all_identity_fixture_without_projecting_secrets() {
+    let fixture = fixture();
+    let token = mint(&fixture, fixture.principals.clone());
+
+    let caller = verifier_from(&fixture)
+        .verify_at(&token, NOW)
+        .expect("verified caller");
+
+    assert_eq!(caller.tenant, "tenant-a");
+    assert_eq!(
+        caller.user.as_ref().map(|value| value.id.as_str()),
+        Some("user-1")
+    );
+    assert_eq!(
+        caller.bot.as_ref().map(|value| value.bot_uuid.as_str()),
+        Some("bot-1")
+    );
+    assert_eq!(caller.app.as_ref().map(|value| value.app_id), Some(7));
+    assert_eq!(
+        caller
+            .access_key
+            .as_ref()
+            .map(|value| value.access_key.as_str()),
+        Some("ak-test-1"),
+    );
+    let debug = format!("{caller:?}");
+    assert!(!debug.contains("TEST_ONLY_BOT_TOKEN_MARKER"));
+    assert!(!debug.contains("TEST_ONLY_ACCESS_KEY_TOKEN_MARKER"));
+}
+
+#[test]
+fn accepts_user_only_bot_only_and_user_plus_bot() {
+    let fixture = fixture();
+    for (kinds, expect_user, expect_bot) in [
+        (&["user"][..], true, false),
+        (&["bot"][..], false, true),
+        (&["user", "bot"][..], true, true),
+    ] {
+        let caller = verifier_from(&fixture)
+            .verify_at(
+                &mint(&fixture, select_principals(&fixture.principals, kinds)),
+                NOW,
+            )
+            .expect("valid identity combination");
+        assert_eq!(caller.user.is_some(), expect_user);
+        assert_eq!(caller.bot.is_some(), expect_bot);
+    }
+}
+
+#[test]
+fn principal_order_does_not_change_the_normalized_caller() {
+    let fixture = fixture();
+    let forward = verifier_from(&fixture)
+        .verify_at(&mint(&fixture, fixture.principals.clone()), NOW)
+        .expect("forward order");
+    let mut reversed = fixture
+        .principals
+        .as_array()
+        .expect("fixture principals array")
+        .clone();
+    reversed.reverse();
+    let reverse = verifier_from(&fixture)
+        .verify_at(&mint(&fixture, Value::Array(reversed)), NOW)
+        .expect("reverse order");
+    assert_eq!(forward, reverse);
+}
+
+#[test]
+fn rejects_untrusted_algorithm_token_type_and_key_id() {
+    let fixture = fixture();
+    let claims = json!({
+        "iss": fixture.issuer,
+        "aud": fixture.audience,
+        "iat": NOW,
+        "exp": NOW + 60,
+        "principals": fixture.principals,
+    });
+    let mut wrong_algorithm = header("JWT", "bare");
+    wrong_algorithm.alg = Algorithm::HS512;
+
+    for (token, expected) in [
+        (
+            mint_with(wrong_algorithm, &claims, TEST_KEY),
+            GatewayPrincipalVerificationError::UnsupportedAlgorithm,
+        ),
+        (
+            mint_with(header("NOT-JWT", "bare"), &claims, TEST_KEY),
+            GatewayPrincipalVerificationError::InvalidTokenType,
+        ),
+        (
+            mint_with(header("JWT", "rotated"), &claims, TEST_KEY),
+            GatewayPrincipalVerificationError::InvalidKeyId,
+        ),
+    ] {
+        assert_eq!(
+            verifier_from(&fixture).verify_at(&token, NOW),
+            Err(expected)
+        );
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
@@ -478,3 +478,11 @@ fn verification_errors_do_not_expose_tokens_or_keys() {
         assert!(!message.contains(forbidden));
     }
 }
+
+#[test]
+fn public_verify_uses_the_current_system_time() {
+    let now = jsonwebtoken::get_current_timestamp();
+    let token = token_with_times(now, now + 60);
+
+    assert!(verifier().verify(&token).is_ok());
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
@@ -1,9 +1,11 @@
+use bcs_service_api::application::v1::AuthenticatedCaller;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::{
     GatewayPrincipalTokenVerifier, GatewayPrincipalTrust, GatewayPrincipalVerificationError,
+    GatewayPrincipalVerifierBuildError,
 };
 
 const NOW: u64 = 1_785_657_600;
@@ -58,6 +60,38 @@ fn verifier_from(fixture: &ContractFixture) -> GatewayPrincipalTokenVerifier {
     )
     .expect("valid trust");
     GatewayPrincipalTokenVerifier::new(TEST_KEY, trust).expect("valid verifier")
+}
+
+fn verifier() -> GatewayPrincipalTokenVerifier {
+    let fixture = fixture();
+    verifier_from(&fixture)
+}
+
+fn valid_claims() -> Value {
+    let fixture = fixture();
+    json!({
+        "iss": fixture.issuer,
+        "aud": fixture.audience,
+        "iat": NOW,
+        "exp": NOW + 60,
+        "principals": fixture.principals,
+    })
+}
+
+fn token_with_times(iat: u64, exp: u64) -> String {
+    let mut claims = valid_claims();
+    claims["iat"] = json!(iat);
+    claims["exp"] = json!(exp);
+    mint_with(header("JWT", "bare"), &claims, TEST_KEY)
+}
+
+fn verify_principals(
+    principals: Value,
+) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
+    let mut claims = valid_claims();
+    claims["principals"] = principals;
+    let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
+    verifier().verify_at(&token, NOW)
 }
 
 fn select_principals(principals: &Value, kinds: &[&str]) -> Value {
@@ -175,5 +209,247 @@ fn rejects_untrusted_algorithm_token_type_and_key_id() {
             verifier_from(&fixture).verify_at(&token, NOW),
             Err(expected)
         );
+    }
+}
+
+#[test]
+fn rejects_empty_trust_material() {
+    let valid = GatewayPrincipalTrust::new("gateway", "bcs", "bare").expect("valid trust");
+    assert_eq!(
+        GatewayPrincipalTokenVerifier::new(b"", valid).err(),
+        Some(GatewayPrincipalVerifierBuildError::EmptySigningKey),
+    );
+    for values in [
+        ("", "bcs", "bare"),
+        ("gateway", "", "bare"),
+        ("gateway", "bcs", ""),
+        ("   ", "bcs", "bare"),
+    ] {
+        assert!(matches!(
+            GatewayPrincipalTrust::new(values.0, values.1, values.2),
+            Err(GatewayPrincipalVerifierBuildError::InvalidTrustConfiguration),
+        ));
+    }
+}
+
+#[test]
+fn rejects_empty_malformed_and_unsigned_tokens() {
+    let verifier = verifier();
+    assert_eq!(
+        verifier.verify_at("", NOW),
+        Err(GatewayPrincipalVerificationError::EmptyToken),
+    );
+    for token in ["not-a-jwt", "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30."] {
+        assert_eq!(
+            verifier.verify_at(token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidHeader),
+        );
+    }
+}
+
+#[test]
+fn rejects_wrong_signature_issuer_and_audience() {
+    let claims = valid_claims();
+    let wrong_key = mint_with(header("JWT", "bare"), &claims, b"different-test-key");
+    assert_eq!(
+        verifier().verify_at(&wrong_key, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidSignature),
+    );
+    for (claim, value) in [("iss", "other-gateway"), ("aud", "backend")] {
+        let mut claims = valid_claims();
+        claims[claim] = json!(value);
+        let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+        );
+    }
+}
+
+#[test]
+fn rejects_missing_required_claims_and_invalid_shapes() {
+    for claim in ["iss", "aud", "iat", "exp", "principals"] {
+        let mut claims = valid_claims();
+        claims.as_object_mut().expect("claims object").remove(claim);
+        let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+            "missing {claim}",
+        );
+    }
+
+    for (claim, value) in [
+        ("iat", json!("1785657600")),
+        ("exp", json!(null)),
+        ("principals", json!({})),
+    ] {
+        let mut claims = valid_claims();
+        claims[claim] = value;
+        let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+            "invalid shape for {claim}",
+        );
+    }
+}
+
+#[test]
+fn enforces_exact_five_second_clock_skew() {
+    let accepted_future = token_with_times(NOW + 5, NOW + 65);
+    let rejected_future = token_with_times(NOW + 6, NOW + 66);
+    let accepted_expired = token_with_times(NOW - 65, NOW - 4);
+    let rejected_expired = token_with_times(NOW - 66, NOW - 5);
+    assert!(verifier().verify_at(&accepted_future, NOW).is_ok());
+    assert_eq!(
+        verifier().verify_at(&rejected_future, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidClaims),
+    );
+    assert!(verifier().verify_at(&accepted_expired, NOW).is_ok());
+    assert_eq!(
+        verifier().verify_at(&rejected_expired, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidClaims),
+    );
+}
+
+#[test]
+fn rejects_non_positive_token_lifetime() {
+    for (iat, exp) in [(NOW, NOW), (NOW + 1, NOW)] {
+        let token = token_with_times(iat, exp);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+        );
+    }
+}
+
+#[test]
+fn rejects_empty_unknown_and_duplicate_principal_types() {
+    assert_eq!(
+        verify_principals(json!([])),
+        Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+    );
+
+    let mut unknown = fixture().principals;
+    unknown[0]["type"] = json!("future_identity");
+    assert_eq!(
+        verify_principals(unknown),
+        Err(GatewayPrincipalVerificationError::InvalidClaims),
+    );
+
+    let mut duplicate = fixture().principals;
+    let repeated_user = duplicate[0].clone();
+    duplicate
+        .as_array_mut()
+        .expect("principals array")
+        .push(repeated_user);
+    assert_eq!(
+        verify_principals(duplicate),
+        Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+    );
+}
+
+#[test]
+fn rejects_missing_required_known_principal_fields() {
+    for (index, field) in [(0, "subject"), (1, "bot"), (2, "app"), (3, "access_key")] {
+        let mut principals = fixture().principals;
+        principals[index]
+            .as_object_mut()
+            .expect("principal object")
+            .remove(field);
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+            "missing {field}",
+        );
+    }
+}
+
+#[test]
+fn rejects_mixed_and_contradictory_tenants() {
+    for pointer in [
+        "/1/tenant",
+        "/1/bot/tenant",
+        "/2/app/tenant",
+        "/0/subject/tenant_id",
+    ] {
+        let mut principals = fixture().principals;
+        *principals.pointer_mut(pointer).expect("fixture pointer") = json!("tenant-b");
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+            "tenant mutation at {pointer}",
+        );
+    }
+
+    for value in ["", "   "] {
+        let mut principals = fixture().principals;
+        principals[0]["subject"]["tenant_id"] = json!(value);
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+        );
+    }
+}
+
+#[test]
+fn rejects_blank_stable_identities_and_invalid_access_key_time() {
+    for pointer in [
+        "/0/tenant",
+        "/0/subject/id",
+        "/0/subject/username",
+        "/1/bot/bot_uuid",
+        "/1/bot/owner_id",
+        "/1/bot/agent_code",
+        "/3/access_key/access_key",
+    ] {
+        let mut principals = fixture().principals;
+        *principals.pointer_mut(pointer).expect("fixture pointer") = json!("   ");
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+            "blank identity at {pointer}",
+        );
+    }
+
+    let mut principals = fixture().principals;
+    principals[3]["access_key"]["expire_at"] = json!("not-rfc3339");
+    assert_eq!(
+        verify_principals(principals),
+        Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+    );
+}
+
+#[test]
+fn ignores_future_fields_within_known_principal_types() {
+    let mut principals = fixture().principals;
+    principals[0]["future_principal_field"] = json!(true);
+    principals[0]["subject"]["future_user_field"] = json!(1);
+    principals[1]["bot"]["future_bot_field"] = json!(2);
+    principals[2]["app"]["future_app_field"] = json!(3);
+    principals[3]["access_key"]["future_access_key_field"] = json!(4);
+    assert!(verify_principals(principals).is_ok());
+}
+
+#[test]
+fn verification_errors_do_not_expose_tokens_or_keys() {
+    let mut principals = fixture().principals;
+    principals[0]["tenant"] = json!("   ");
+    let mut claims = valid_claims();
+    claims["principals"] = principals;
+    let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
+
+    let error = verifier()
+        .verify_at(&token, NOW)
+        .expect_err("blank tenant must fail");
+    let message = error.to_string();
+    for forbidden in [
+        "TEST_ONLY_BOT_TOKEN_MARKER",
+        "TEST_ONLY_ACCESS_KEY_TOKEN_MARKER",
+        token.as_str(),
+        std::str::from_utf8(TEST_KEY).expect("ASCII test key"),
+    ] {
+        assert!(!message.contains(forbidden));
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
@@ -1,4 +1,5 @@
 use bcs_service_api::application::v1::AuthenticatedCaller;
+use axum::http::{HeaderMap, HeaderValue};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -7,6 +8,7 @@ use super::{
     GatewayPrincipalTokenVerifier, GatewayPrincipalTrust, GatewayPrincipalVerificationError,
     GatewayPrincipalVerifierBuildError,
 };
+use crate::v1::common::{PrincipalVerificationError, PrincipalVerifier};
 
 const NOW: u64 = 1_785_657_600;
 const TEST_KEY_TEXT: &str = "TEST-ONLY-bcs-principal-contract-key-32-bytes";
@@ -117,6 +119,23 @@ fn token_with_times(iat: u64, exp: u64) -> String {
     mint_with(header("JWT", "bare"), &claims, TEST_KEY)
 }
 
+fn current_token() -> String {
+    let fixture = fixture();
+    let now = u64::try_from(time::OffsetDateTime::now_utc().unix_timestamp())
+        .expect("current timestamp is positive");
+    mint_with(
+        header("JWT", &fixture.key_id),
+        &json!({
+            "iss": fixture.issuer,
+            "aud": fixture.audience,
+            "iat": now.saturating_sub(1),
+            "exp": now + 60,
+            "principals": fixture.principals,
+        }),
+        TEST_KEY,
+    )
+}
+
 fn verify_principals(
     principals: Value,
 ) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
@@ -170,6 +189,55 @@ fn verifies_the_shared_all_identity_fixture_without_projecting_secrets() {
     let debug = format!("{caller:?}");
     assert!(!debug.contains("TEST_ONLY_BOT_TOKEN_MARKER"));
     assert!(!debug.contains("TEST_ONLY_ACCESS_KEY_TOKEN_MARKER"));
+}
+
+#[tokio::test]
+async fn header_verifier_extracts_one_signed_gateway_principal_token() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-avernet-principal",
+        HeaderValue::from_str(&current_token()).expect("valid header value"),
+    );
+
+    let caller = PrincipalVerifier::verify(&verifier(), &headers)
+        .await
+        .expect("valid signed Gateway caller");
+
+    assert_eq!(caller.tenant, "tenant-a");
+    assert_eq!(caller.user.as_ref().map(|user| user.id.as_str()), Some("user-1"));
+    assert_eq!(caller.bot.as_ref().map(|bot| bot.bot_uuid.as_str()), Some("bot-1"));
+    assert!(caller.app.is_some());
+    assert!(caller.access_key.is_some());
+}
+
+#[tokio::test]
+async fn header_verifier_rejects_missing_duplicate_blank_and_non_utf8_values() {
+    let verifier = verifier();
+    assert!(matches!(
+        PrincipalVerifier::verify(&verifier, &HeaderMap::new()).await,
+        Err(PrincipalVerificationError::Missing)
+    ));
+
+    let mut duplicate = HeaderMap::new();
+    duplicate.append("x-avernet-principal", HeaderValue::from_static("one"));
+    duplicate.append("x-avernet-principal", HeaderValue::from_static("two"));
+    assert!(matches!(
+        PrincipalVerifier::verify(&verifier, &duplicate).await,
+        Err(PrincipalVerificationError::Invalid(_))
+    ));
+
+    for value in [
+        HeaderValue::from_static(""),
+        HeaderValue::from_static("   "),
+        HeaderValue::from_bytes(&[0xff]).expect("opaque non-UTF-8 header"),
+    ] {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-avernet-principal", value);
+        assert!(matches!(
+            PrincipalVerifier::verify(&verifier, &headers).await,
+            Err(PrincipalVerificationError::Invalid(_))
+        ));
+    }
 }
 
 #[test]

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+use axum::http::HeaderMap;
 use bcs_service_api::application::v1::{
     AuthenticatedAccessKeyIdentity, AuthenticatedAppIdentity, AuthenticatedBotIdentity,
     AuthenticatedCaller, AuthenticatedUserIdentity,
@@ -6,8 +8,10 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::wire::{GatewayClaims, GatewayPrincipal};
+use crate::v1::common::{PrincipalVerificationError, PrincipalVerifier};
 
 const CLOCK_SKEW_SECONDS: u64 = 5;
+const GATEWAY_PRINCIPAL_HEADER: &str = "x-avernet-principal";
 
 pub struct GatewayPrincipalTrust {
     issuer: String,
@@ -105,6 +109,35 @@ impl GatewayPrincipalTokenVerifier {
         validate_times(claims.iat, claims.exp, now)?;
 
         project_principals(claims.principals)
+    }
+}
+
+#[async_trait]
+impl PrincipalVerifier for GatewayPrincipalTokenVerifier {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError> {
+        let mut values = headers.get_all(GATEWAY_PRINCIPAL_HEADER).iter();
+        let value = values.next().ok_or(PrincipalVerificationError::Missing)?;
+        if values.next().is_some() {
+            return Err(PrincipalVerificationError::Invalid(
+                "Gateway Principal header must occur exactly once".into(),
+            ));
+        }
+        let token = value.to_str().map_err(|_| {
+            PrincipalVerificationError::Invalid(
+                "Gateway Principal header is not valid text".into(),
+            )
+        })?;
+        if token.is_empty() || token.trim() != token {
+            return Err(PrincipalVerificationError::Invalid(
+                "Gateway Principal header is empty or padded".into(),
+            ));
+        }
+        GatewayPrincipalTokenVerifier::verify(self, token).map_err(|_| {
+            PrincipalVerificationError::Invalid("Gateway Principal token is invalid".into())
+        })
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
@@ -1,0 +1,182 @@
+use bcs_service_api::application::v1::{
+    AuthenticatedAccessKeyIdentity, AuthenticatedAppIdentity, AuthenticatedBotIdentity,
+    AuthenticatedCaller, AuthenticatedUserIdentity,
+};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::wire::{GatewayClaims, GatewayPrincipal};
+
+pub struct GatewayPrincipalTrust {
+    issuer: String,
+    audience: String,
+    key_id: String,
+}
+
+impl GatewayPrincipalTrust {
+    pub fn new(
+        issuer: impl Into<String>,
+        audience: impl Into<String>,
+        key_id: impl Into<String>,
+    ) -> Result<Self, GatewayPrincipalVerifierBuildError> {
+        Ok(Self {
+            issuer: issuer.into(),
+            audience: audience.into(),
+            key_id: key_id.into(),
+        })
+    }
+}
+
+pub struct GatewayPrincipalTokenVerifier {
+    decoding_key: DecodingKey,
+    trust: GatewayPrincipalTrust,
+}
+
+impl GatewayPrincipalTokenVerifier {
+    pub fn new(
+        signing_key: &[u8],
+        trust: GatewayPrincipalTrust,
+    ) -> Result<Self, GatewayPrincipalVerifierBuildError> {
+        Ok(Self {
+            decoding_key: DecodingKey::from_secret(signing_key),
+            trust,
+        })
+    }
+
+    pub fn verify(
+        &self,
+        token: &str,
+    ) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
+        let now = u64::try_from(OffsetDateTime::now_utc().unix_timestamp())
+            .map_err(|_| GatewayPrincipalVerificationError::InvalidClaims)?;
+        self.verify_at(token, now)
+    }
+
+    pub(super) fn verify_at(
+        &self,
+        token: &str,
+        _now: u64,
+    ) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
+        let header =
+            decode_header(token).map_err(|_| GatewayPrincipalVerificationError::InvalidHeader)?;
+        if header.alg != Algorithm::HS256 {
+            return Err(GatewayPrincipalVerificationError::UnsupportedAlgorithm);
+        }
+        if header.typ.as_deref() != Some("JWT") {
+            return Err(GatewayPrincipalVerificationError::InvalidTokenType);
+        }
+        if header.kid.as_deref() != Some(self.trust.key_id.as_str()) {
+            return Err(GatewayPrincipalVerificationError::InvalidKeyId);
+        }
+
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.set_audience(&[&self.trust.audience]);
+        validation.set_issuer(&[&self.trust.issuer]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        validation.validate_exp = false;
+
+        let claims = decode::<GatewayClaims>(token, &self.decoding_key, &validation)
+            .map_err(|error| match error.kind() {
+                jsonwebtoken::errors::ErrorKind::InvalidSignature => {
+                    GatewayPrincipalVerificationError::InvalidSignature
+                }
+                _ => GatewayPrincipalVerificationError::InvalidClaims,
+            })?
+            .claims;
+
+        if claims.iss != self.trust.issuer
+            || claims.aud != self.trust.audience
+            || claims.iat >= claims.exp
+        {
+            return Err(GatewayPrincipalVerificationError::InvalidClaims);
+        }
+
+        project_principals(claims.principals)
+    }
+}
+
+fn project_principals(
+    principals: Vec<GatewayPrincipal>,
+) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
+    let mut caller = AuthenticatedCaller {
+        tenant: String::new(),
+        user: None,
+        bot: None,
+        app: None,
+        access_key: None,
+    };
+
+    for principal in principals {
+        match principal {
+            GatewayPrincipal::User { tenant, subject } => {
+                caller.tenant = tenant;
+                let _ = subject.tenant_id;
+                caller.user = Some(AuthenticatedUserIdentity {
+                    id: subject.id,
+                    username: subject.username,
+                    display_name: subject.display_name,
+                    full_name: subject.full_name,
+                });
+            }
+            GatewayPrincipal::Bot { tenant, bot } => {
+                caller.tenant = tenant;
+                let _ = bot.tenant;
+                caller.bot = Some(AuthenticatedBotIdentity {
+                    bot_uuid: bot.bot_uuid,
+                    owner_id: bot.owner_id,
+                    app_id: bot.app_id,
+                    agent_code: bot.agent_code,
+                });
+            }
+            GatewayPrincipal::App { tenant, app } => {
+                caller.tenant = tenant;
+                let _ = app.tenant;
+                caller.app = Some(AuthenticatedAppIdentity {
+                    app_id: app.app_id,
+                    app_name: app.app_name,
+                    owners: app.owners,
+                    app_type: app.app_type,
+                });
+            }
+            GatewayPrincipal::AccessKey { tenant, access_key } => {
+                caller.tenant = tenant;
+                let expire_at = OffsetDateTime::parse(&access_key.expire_at, &Rfc3339)
+                    .map_err(|_| GatewayPrincipalVerificationError::InvalidPrincipalSet)?;
+                caller.access_key = Some(AuthenticatedAccessKeyIdentity {
+                    access_key: access_key.access_key,
+                    expire_at,
+                });
+            }
+        }
+    }
+
+    Ok(caller)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum GatewayPrincipalVerifierBuildError {
+    #[error("Gateway Principal signing key is empty")]
+    EmptySigningKey,
+    #[error("Gateway Principal trust configuration is invalid")]
+    InvalidTrustConfiguration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum GatewayPrincipalVerificationError {
+    #[error("Gateway Principal token is empty")]
+    EmptyToken,
+    #[error("Gateway Principal token header is invalid")]
+    InvalidHeader,
+    #[error("Gateway Principal token algorithm is unsupported")]
+    UnsupportedAlgorithm,
+    #[error("Gateway Principal token type is invalid")]
+    InvalidTokenType,
+    #[error("Gateway Principal token key id is invalid")]
+    InvalidKeyId,
+    #[error("Gateway Principal token signature is invalid")]
+    InvalidSignature,
+    #[error("Gateway Principal token claims are invalid")]
+    InvalidClaims,
+    #[error("Gateway Principal set is invalid")]
+    InvalidPrincipalSet,
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
@@ -7,6 +7,8 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::wire::{GatewayClaims, GatewayPrincipal};
 
+const CLOCK_SKEW_SECONDS: u64 = 5;
+
 pub struct GatewayPrincipalTrust {
     issuer: String,
     audience: String,
@@ -19,10 +21,16 @@ impl GatewayPrincipalTrust {
         audience: impl Into<String>,
         key_id: impl Into<String>,
     ) -> Result<Self, GatewayPrincipalVerifierBuildError> {
+        let issuer = issuer.into();
+        let audience = audience.into();
+        let key_id = key_id.into();
+        if !is_non_blank(&issuer) || !is_non_blank(&audience) || !is_non_blank(&key_id) {
+            return Err(GatewayPrincipalVerifierBuildError::InvalidTrustConfiguration);
+        }
         Ok(Self {
-            issuer: issuer.into(),
-            audience: audience.into(),
-            key_id: key_id.into(),
+            issuer,
+            audience,
+            key_id,
         })
     }
 }
@@ -37,6 +45,9 @@ impl GatewayPrincipalTokenVerifier {
         signing_key: &[u8],
         trust: GatewayPrincipalTrust,
     ) -> Result<Self, GatewayPrincipalVerifierBuildError> {
+        if signing_key.is_empty() {
+            return Err(GatewayPrincipalVerifierBuildError::EmptySigningKey);
+        }
         Ok(Self {
             decoding_key: DecodingKey::from_secret(signing_key),
             trust,
@@ -55,8 +66,11 @@ impl GatewayPrincipalTokenVerifier {
     pub(super) fn verify_at(
         &self,
         token: &str,
-        _now: u64,
+        now: u64,
     ) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
+        if token.is_empty() {
+            return Err(GatewayPrincipalVerificationError::EmptyToken);
+        }
         let header =
             decode_header(token).map_err(|_| GatewayPrincipalVerificationError::InvalidHeader)?;
         if header.alg != Algorithm::HS256 {
@@ -84,65 +98,106 @@ impl GatewayPrincipalTokenVerifier {
             })?
             .claims;
 
-        if claims.iss != self.trust.issuer
-            || claims.aud != self.trust.audience
-            || claims.iat >= claims.exp
-        {
+        if claims.iss != self.trust.issuer || claims.aud != self.trust.audience {
             return Err(GatewayPrincipalVerificationError::InvalidClaims);
         }
+        validate_times(claims.iat, claims.exp, now)?;
 
         project_principals(claims.principals)
     }
 }
 
+fn validate_times(iat: u64, exp: u64, now: u64) -> Result<(), GatewayPrincipalVerificationError> {
+    let latest_allowed_iat = now.saturating_add(CLOCK_SKEW_SECONDS);
+    let expiration_with_skew = exp.saturating_add(CLOCK_SKEW_SECONDS);
+    if iat >= exp || iat > latest_allowed_iat || now >= expiration_with_skew {
+        return Err(GatewayPrincipalVerificationError::InvalidClaims);
+    }
+    Ok(())
+}
+
+fn is_non_blank(value: &str) -> bool {
+    !value.trim().is_empty()
+}
+
 fn project_principals(
     principals: Vec<GatewayPrincipal>,
 ) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
-    let mut caller = AuthenticatedCaller {
-        tenant: String::new(),
-        user: None,
-        bot: None,
-        app: None,
-        access_key: None,
-    };
+    let mut tenant = None;
+    let mut user = None;
+    let mut bot_identity = None;
+    let mut app_identity = None;
+    let mut access_key_identity = None;
 
     for principal in principals {
         match principal {
-            GatewayPrincipal::User { tenant, subject } => {
-                caller.tenant = tenant;
-                let _ = subject.tenant_id;
-                caller.user = Some(AuthenticatedUserIdentity {
+            GatewayPrincipal::User {
+                tenant: outer_tenant,
+                subject,
+            } => {
+                validate_tenant(&mut tenant, &outer_tenant)?;
+                if user.is_some()
+                    || !is_non_blank(&subject.id)
+                    || !is_non_blank(&subject.username)
+                    || subject.tenant_id.as_ref().is_some_and(|nested_tenant| {
+                        !is_non_blank(nested_tenant) || nested_tenant != &outer_tenant
+                    })
+                {
+                    return Err(GatewayPrincipalVerificationError::InvalidPrincipalSet);
+                }
+                user = Some(AuthenticatedUserIdentity {
                     id: subject.id,
                     username: subject.username,
                     display_name: subject.display_name,
                     full_name: subject.full_name,
                 });
             }
-            GatewayPrincipal::Bot { tenant, bot } => {
-                caller.tenant = tenant;
-                let _ = bot.tenant;
-                caller.bot = Some(AuthenticatedBotIdentity {
+            GatewayPrincipal::Bot {
+                tenant: outer_tenant,
+                bot,
+            } => {
+                validate_tenant(&mut tenant, &outer_tenant)?;
+                if bot_identity.is_some()
+                    || bot.tenant != outer_tenant
+                    || !is_non_blank(&bot.bot_uuid)
+                    || !is_non_blank(&bot.owner_id)
+                    || !is_non_blank(&bot.agent_code)
+                {
+                    return Err(GatewayPrincipalVerificationError::InvalidPrincipalSet);
+                }
+                bot_identity = Some(AuthenticatedBotIdentity {
                     bot_uuid: bot.bot_uuid,
                     owner_id: bot.owner_id,
                     app_id: bot.app_id,
                     agent_code: bot.agent_code,
                 });
             }
-            GatewayPrincipal::App { tenant, app } => {
-                caller.tenant = tenant;
-                let _ = app.tenant;
-                caller.app = Some(AuthenticatedAppIdentity {
+            GatewayPrincipal::App {
+                tenant: outer_tenant,
+                app,
+            } => {
+                validate_tenant(&mut tenant, &outer_tenant)?;
+                if app_identity.is_some() || app.tenant != outer_tenant {
+                    return Err(GatewayPrincipalVerificationError::InvalidPrincipalSet);
+                }
+                app_identity = Some(AuthenticatedAppIdentity {
                     app_id: app.app_id,
                     app_name: app.app_name,
                     owners: app.owners,
                     app_type: app.app_type,
                 });
             }
-            GatewayPrincipal::AccessKey { tenant, access_key } => {
-                caller.tenant = tenant;
+            GatewayPrincipal::AccessKey {
+                tenant: outer_tenant,
+                access_key,
+            } => {
+                validate_tenant(&mut tenant, &outer_tenant)?;
+                if access_key_identity.is_some() || !is_non_blank(&access_key.access_key) {
+                    return Err(GatewayPrincipalVerificationError::InvalidPrincipalSet);
+                }
                 let expire_at = OffsetDateTime::parse(&access_key.expire_at, &Rfc3339)
                     .map_err(|_| GatewayPrincipalVerificationError::InvalidPrincipalSet)?;
-                caller.access_key = Some(AuthenticatedAccessKeyIdentity {
+                access_key_identity = Some(AuthenticatedAccessKeyIdentity {
                     access_key: access_key.access_key,
                     expire_at,
                 });
@@ -150,7 +205,30 @@ fn project_principals(
         }
     }
 
-    Ok(caller)
+    Ok(AuthenticatedCaller {
+        tenant: tenant.ok_or(GatewayPrincipalVerificationError::InvalidPrincipalSet)?,
+        user,
+        bot: bot_identity,
+        app: app_identity,
+        access_key: access_key_identity,
+    })
+}
+
+fn validate_tenant(
+    normalized: &mut Option<String>,
+    candidate: &str,
+) -> Result<(), GatewayPrincipalVerificationError> {
+    if !is_non_blank(candidate)
+        || normalized
+            .as_ref()
+            .is_some_and(|expected| expected != candidate)
+    {
+        return Err(GatewayPrincipalVerificationError::InvalidPrincipalSet);
+    }
+    if normalized.is_none() {
+        *normalized = Some(candidate.to_owned());
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
@@ -87,6 +87,7 @@ impl GatewayPrincipalTokenVerifier {
         validation.set_audience(&[&self.trust.audience]);
         validation.set_issuer(&[&self.trust.issuer]);
         validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        validation.leeway = 0;
         validation.validate_exp = false;
 
         let claims = decode::<GatewayClaims>(token, &self.decoding_key, &validation)

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs
@@ -1,0 +1,64 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(super) struct GatewayClaims {
+    pub iss: String,
+    pub aud: String,
+    pub iat: u64,
+    pub exp: u64,
+    pub principals: Vec<GatewayPrincipal>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum GatewayPrincipal {
+    User {
+        tenant: String,
+        subject: GatewayUser,
+    },
+    Bot {
+        tenant: String,
+        bot: GatewayBot,
+    },
+    App {
+        tenant: String,
+        app: GatewayApp,
+    },
+    AccessKey {
+        tenant: String,
+        access_key: GatewayAccessKey,
+    },
+}
+
+#[derive(Deserialize)]
+pub(super) struct GatewayUser {
+    pub id: String,
+    pub username: String,
+    pub display_name: Option<String>,
+    pub full_name: Option<String>,
+    pub tenant_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GatewayBot {
+    pub bot_uuid: String,
+    pub owner_id: String,
+    pub app_id: i64,
+    pub agent_code: String,
+    pub tenant: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GatewayApp {
+    pub app_id: i64,
+    pub app_name: String,
+    pub owners: String,
+    pub tenant: String,
+    pub app_type: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GatewayAccessKey {
+    pub access_key: String,
+    pub expire_at: String,
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod gateway_principal;
 pub mod internal;
 pub mod openapi;
 

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/bot.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/bot.rs
@@ -1,0 +1,110 @@
+use bcs_service_api::application::v1::{
+    BotCandidatePurpose, BotDescriptorPatch, BotKind, BotPatch, BotReachability, BotSkill,
+    BotStatus, BotVisibility,
+};
+use serde::Deserialize;
+
+fn default_limit() -> u64 {
+    20
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CandidatePurposeQuery {
+    #[default]
+    Discovery,
+    Collaboration,
+}
+
+impl From<CandidatePurposeQuery> for BotCandidatePurpose {
+    fn from(value: CandidatePurposeQuery) -> Self {
+        match value {
+            CandidatePurposeQuery::Discovery => Self::Discovery,
+            CandidatePurposeQuery::Collaboration => Self::Collaboration,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListBotCandidatesQuery {
+    #[serde(default)]
+    pub purpose: CandidatePurposeQuery,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub offset: u64,
+    #[serde(default = "default_limit")]
+    pub limit: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueryBotsRequest {
+    pub bot_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateBotDescriptorRequest {
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub domains: Option<Vec<String>>,
+    #[serde(default)]
+    pub skills: Option<Vec<BotSkill>>,
+    #[serde(default)]
+    pub scopes: Option<Vec<String>>,
+}
+
+impl From<UpdateBotDescriptorRequest> for BotDescriptorPatch {
+    fn from(value: UpdateBotDescriptorRequest) -> Self {
+        Self {
+            summary: value.summary,
+            domains: value.domains,
+            skills: value.skills,
+            scopes: value.scopes,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateBotRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub visibility: Option<BotVisibility>,
+    #[serde(default)]
+    pub status: Option<BotStatus>,
+    #[serde(default)]
+    pub descriptor: Option<UpdateBotDescriptorRequest>,
+}
+
+impl From<UpdateBotRequest> for BotPatch {
+    fn from(value: UpdateBotRequest) -> Self {
+        Self {
+            name: value.name,
+            visibility: value.visibility,
+            status: value.status,
+            descriptor: value.descriptor.map(BotDescriptorPatch::from),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListMyBotsQuery {
+    #[serde(default)]
+    pub kind: Option<BotKind>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub status: Option<BotStatus>,
+    #[serde(default)]
+    pub reachability: Option<BotReachability>,
+    #[serde(default)]
+    pub offset: u64,
+    #[serde(default = "default_limit")]
+    pub limit: u64,
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/friendship.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/friendship.rs
@@ -1,5 +1,5 @@
 use bcs_service_api::application::v1::{
-    CreateBotFriendRequest, FriendRequestDirection, FriendRequestStatus, Principal,
+    AuthenticatedCaller, CreateBotFriendRequest, FriendRequestDirection, FriendRequestStatus,
 };
 use serde::Deserialize;
 
@@ -15,9 +15,13 @@ pub struct CreateFriendRequestRequest {
 }
 
 impl CreateFriendRequestRequest {
-    pub fn into_command(self, principal: Principal, bot_uuid: String) -> CreateBotFriendRequest {
+    pub fn into_command(
+        self,
+        caller: AuthenticatedCaller,
+        bot_uuid: String,
+    ) -> CreateBotFriendRequest {
         CreateBotFriendRequest {
-            principal,
+            caller,
             bot_uuid,
             to_bot_uuid: self.to_bot_uuid,
         }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/group.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/group.rs
@@ -44,6 +44,8 @@ impl Default for KindQuery {
 #[serde(deny_unknown_fields)]
 pub struct ListGroupsQuery {
     #[serde(default)]
+    pub view_bot_id: Option<String>,
+    #[serde(default)]
     pub offset: u64,
     #[serde(default = "default_limit")]
     pub limit: u64,

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/invitation.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/invitation.rs
@@ -1,5 +1,5 @@
 use bcs_service_api::application::v1::{
-    AcceptInvitation, CreateGroupInvitation, CreateSessionInvitation, Principal,
+    AcceptInvitation, AuthenticatedCaller, CreateGroupInvitation, CreateSessionInvitation,
 };
 use serde::Deserialize;
 
@@ -35,11 +35,11 @@ where
 impl CreateInvitationRequest {
     pub fn into_group_command(
         self,
-        principal: Principal,
+        caller: AuthenticatedCaller,
         group_id: String,
     ) -> CreateGroupInvitation {
         CreateGroupInvitation {
-            principal,
+            caller,
             group_id,
             expires_in_seconds: self.expires_in_seconds,
         }
@@ -47,11 +47,11 @@ impl CreateInvitationRequest {
 
     pub fn into_session_command(
         self,
-        principal: Principal,
+        caller: AuthenticatedCaller,
         session_id: String,
     ) -> CreateSessionInvitation {
         CreateSessionInvitation {
-            principal,
+            caller,
             session_id,
             expires_in_seconds: self.expires_in_seconds,
         }
@@ -60,18 +60,18 @@ impl CreateInvitationRequest {
 
 /// Request body for accepting an invitation token.
 ///
-/// The body is empty: only a Human Principal authenticated by the Gateway may
-/// accept, and the joining Human actor is derived from the Principal's
-/// `staff_no`. `deny_unknown_fields` rejects any supplied `bot_uuid` (legacy
+/// The body is empty: only a Caller with User identity may accept, and the
+/// joining Human actor is derived from the User subject id.
+/// `deny_unknown_fields` rejects any supplied `bot_uuid` (legacy
 /// V1 pre-pivot field, now removed) with a 400 `invalid_request`.
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AcceptInvitationRequest {}
 
 impl AcceptInvitationRequest {
-    pub fn into_command(self, principal: Principal, token: String) -> AcceptInvitation {
+    pub fn into_command(self, caller: AuthenticatedCaller, token: String) -> AcceptInvitation {
         AcceptInvitation {
-            principal,
+            caller,
             token,
         }
     }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/mod.rs
@@ -1,3 +1,4 @@
+pub mod bot;
 pub mod friendship;
 pub mod group;
 pub mod invitation;

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/session.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/session.rs
@@ -1,6 +1,6 @@
 use bcs_service_api::application::v1::{
-    BotParticipantMode, CreateSession, Principal, SessionInput, SessionParticipantInput as ServiceParticipantInput,
-    SessionStatus, UpdateSession,
+    AuthenticatedCaller, BotParticipantMode, CreateSession, SessionInput,
+    SessionParticipantInput as ServiceParticipantInput, SessionStatus, UpdateSession,
 };
 use serde::Deserialize;
 
@@ -61,9 +61,9 @@ pub struct CreateSessionRequest {
 }
 
 impl CreateSessionRequest {
-    pub fn into_command(self, principal: Principal, group_id: String) -> CreateSession {
+    pub fn into_command(self, caller: AuthenticatedCaller, group_id: String) -> CreateSession {
         CreateSession {
-            principal,
+            caller,
             group_id,
             driver_bot_uuid: self.driver_bot_uuid,
             title: self.title,
@@ -85,9 +85,9 @@ pub struct UpdateSessionRequest {
 }
 
 impl UpdateSessionRequest {
-    pub fn into_command(self, principal: Principal, session_id: String) -> UpdateSession {
+    pub fn into_command(self, caller: AuthenticatedCaller, session_id: String) -> UpdateSession {
         UpdateSession {
-            principal,
+            caller,
             session_id,
             title: self.title,
         }
@@ -103,6 +103,8 @@ pub struct UpdateSessionParticipantRequest {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListSessionsQuery {
+    #[serde(default)]
+    pub view_bot_id: Option<String>,
     #[serde(default)]
     pub offset: u64,
     #[serde(default = "default_limit")]
@@ -121,8 +123,7 @@ pub struct ListSessionMessagesQuery {
     pub before: Option<String>,
     #[serde(default = "default_messages_limit")]
     pub limit: u64,
-    /// Optional viewer identity for message history visibility scoping. The
-    /// V1 facade applies Principal-based authz; see `ListSessionMessages`.
+    /// Optional viewer identity for message history visibility scoping.
     #[serde(default)]
     pub view_bot_id: Option<String>,
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/mod.rs
@@ -6,7 +6,8 @@ use axum::Router;
 use super::common::ApiState;
 
 pub fn router() -> Router<ApiState> {
-    routes::group::router()
+    routes::bot::router()
+        .merge(routes::group::router())
         .merge(routes::session::router())
         .merge(routes::invitation::router())
         .merge(routes::friendship::router())

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::rejection::{JsonRejection, PathRejection, QueryRejection};
+use axum::extract::{Extension, Json, Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use bcs_service_api::application::v1::{
+    ApplicationError, BotList, BotService, GetBot, ListBotCandidates, ListMyBots, Principal,
+    QueryBots, UpdateBot,
+};
+
+use crate::v1::common::{
+    ApiState, Envelope, ErrorResponse, RequestId, application_error_response, invalid_request,
+};
+use crate::v1::openapi::dto::bot::{
+    ListBotCandidatesQuery, ListMyBotsQuery, QueryBotsRequest, UpdateBotRequest,
+};
+
+pub fn router() -> Router<ApiState> {
+    Router::new()
+        .route("/openapi/v1/bots/{bot_id}/candidates", get(list_candidates))
+        .route("/openapi/v1/bots/query", post(query_bots))
+        .route("/openapi/v1/bots/mine", get(list_mine))
+        .route("/openapi/v1/bots/{bot_id}", get(get_bot).patch(update_bot))
+}
+
+fn service(state: &ApiState, request_id: &RequestId) -> Result<Arc<dyn BotService>, ErrorResponse> {
+    state.bot_service.clone().ok_or_else(|| {
+        application_error_response(
+            request_id,
+            ApplicationError::internal("Bot V1 service is not configured"),
+        )
+    })
+}
+
+async fn list_candidates(
+    State(state): State<ApiState>,
+    Extension(principal): Extension<Principal>,
+    Extension(request_id): Extension<RequestId>,
+    path: Result<Path<String>, PathRejection>,
+    query: Result<Query<ListBotCandidatesQuery>, QueryRejection>,
+) -> Result<Response, ErrorResponse> {
+    let Path(bot_id) = path.map_err(|error| invalid_request(&request_id, error.body_text()))?;
+    let Query(query) = query.map_err(|error| invalid_request(&request_id, error.body_text()))?;
+    let result = service(&state, &request_id)?
+        .list_candidates(ListBotCandidates {
+            principal,
+            bot_id,
+            purpose: query.purpose.into(),
+            name: query.name,
+            offset: query.offset,
+            limit: query.limit,
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+    Ok((
+        StatusCode::OK,
+        Json(Envelope::success(20_000, "OK", result, request_id.0)),
+    )
+        .into_response())
+}
+
+async fn query_bots(
+    State(state): State<ApiState>,
+    Extension(principal): Extension<Principal>,
+    Extension(request_id): Extension<RequestId>,
+    body: Result<Json<QueryBotsRequest>, JsonRejection>,
+) -> Result<Response, ErrorResponse> {
+    let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
+    let items = service(&state, &request_id)?
+        .query(QueryBots {
+            principal,
+            bot_ids: body.bot_ids,
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+    Ok((
+        StatusCode::OK,
+        Json(Envelope::success(
+            20_000,
+            "OK",
+            BotList { items },
+            request_id.0,
+        )),
+    )
+        .into_response())
+}
+
+async fn get_bot(
+    State(state): State<ApiState>,
+    Extension(principal): Extension<Principal>,
+    Extension(request_id): Extension<RequestId>,
+    path: Result<Path<String>, PathRejection>,
+) -> Result<Response, ErrorResponse> {
+    let Path(bot_id) = path.map_err(|error| invalid_request(&request_id, error.body_text()))?;
+    let result = service(&state, &request_id)?
+        .get(GetBot { principal, bot_id })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+    Ok((
+        StatusCode::OK,
+        Json(Envelope::success(20_000, "OK", result, request_id.0)),
+    )
+        .into_response())
+}
+
+async fn update_bot(
+    State(state): State<ApiState>,
+    Extension(principal): Extension<Principal>,
+    Extension(request_id): Extension<RequestId>,
+    path: Result<Path<String>, PathRejection>,
+    body: Result<Json<UpdateBotRequest>, JsonRejection>,
+) -> Result<Response, ErrorResponse> {
+    let Path(bot_id) = path.map_err(|error| invalid_request(&request_id, error.body_text()))?;
+    let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
+    let result = service(&state, &request_id)?
+        .update(UpdateBot {
+            principal,
+            bot_id,
+            patch: body.into(),
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+    Ok((
+        StatusCode::OK,
+        Json(Envelope::success(20_000, "OK", result, request_id.0)),
+    )
+        .into_response())
+}
+
+async fn list_mine(
+    State(state): State<ApiState>,
+    Extension(principal): Extension<Principal>,
+    Extension(request_id): Extension<RequestId>,
+    query: Result<Query<ListMyBotsQuery>, QueryRejection>,
+) -> Result<Response, ErrorResponse> {
+    let Query(query) = query.map_err(|error| invalid_request(&request_id, error.body_text()))?;
+    let result = service(&state, &request_id)?
+        .list_mine(ListMyBots {
+            principal,
+            kind: query.kind,
+            name: query.name,
+            status: query.status,
+            reachability: query.reachability,
+            offset: query.offset,
+            limit: query.limit,
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+    Ok((
+        StatusCode::OK,
+        Json(Envelope::success(20_000, "OK", result, request_id.0)),
+    )
+        .into_response())
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs
@@ -7,8 +7,8 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use bcs_service_api::application::v1::{
-    ApplicationError, BotList, BotService, GetBot, ListBotCandidates, ListMyBots, Principal,
-    QueryBots, UpdateBot,
+    ApplicationError, AuthenticatedCaller, BotList, BotService, GetBot, ListBotCandidates,
+    ListMyBots, QueryBots, UpdateBot,
 };
 
 use crate::v1::common::{
@@ -37,7 +37,7 @@ fn service(state: &ApiState, request_id: &RequestId) -> Result<Arc<dyn BotServic
 
 async fn list_candidates(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     query: Result<Query<ListBotCandidatesQuery>, QueryRejection>,
@@ -46,7 +46,7 @@ async fn list_candidates(
     let Query(query) = query.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = service(&state, &request_id)?
         .list_candidates(ListBotCandidates {
-            principal,
+            caller,
             bot_id,
             purpose: query.purpose.into(),
             name: query.name,
@@ -64,14 +64,14 @@ async fn list_candidates(
 
 async fn query_bots(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     body: Result<Json<QueryBotsRequest>, JsonRejection>,
 ) -> Result<Response, ErrorResponse> {
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let items = service(&state, &request_id)?
         .query(QueryBots {
-            principal,
+            caller,
             bot_ids: body.bot_ids,
         })
         .await
@@ -90,13 +90,13 @@ async fn query_bots(
 
 async fn get_bot(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
     let Path(bot_id) = path.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = service(&state, &request_id)?
-        .get(GetBot { principal, bot_id })
+        .get(GetBot { caller, bot_id })
         .await
         .map_err(|error| application_error_response(&request_id, error))?;
     Ok((
@@ -108,7 +108,7 @@ async fn get_bot(
 
 async fn update_bot(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<UpdateBotRequest>, JsonRejection>,
@@ -117,7 +117,7 @@ async fn update_bot(
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = service(&state, &request_id)?
         .update(UpdateBot {
-            principal,
+            caller,
             bot_id,
             patch: body.into(),
         })
@@ -132,14 +132,14 @@ async fn update_bot(
 
 async fn list_mine(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     query: Result<Query<ListMyBotsQuery>, QueryRejection>,
 ) -> Result<Response, ErrorResponse> {
     let Query(query) = query.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = service(&state, &request_id)?
         .list_mine(ListMyBots {
-            principal,
+            caller,
             kind: query.kind,
             name: query.name,
             status: query.status,

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/friendship.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/friendship.rs
@@ -5,8 +5,8 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use bcs_service_api::application::v1::{
-    AcceptFriendRequest, DeleteBotFriendship, ListBotFriendRequests, ListBotFriendships,
-    Principal, RejectFriendRequest,
+    AcceptFriendRequest, AuthenticatedCaller, DeleteBotFriendship, ListBotFriendRequests,
+    ListBotFriendships, RejectFriendRequest,
 };
 
 use crate::v1::common::{
@@ -42,7 +42,7 @@ pub fn router() -> Router<ApiState> {
 
 async fn list_bot_friendships(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     query: Result<Query<ListFriendshipsQuery>, QueryRejection>,
@@ -52,7 +52,7 @@ async fn list_bot_friendships(
     let result = state
         .friendship_service
         .list_bot_friendships(ListBotFriendships {
-            principal,
+            caller,
             bot_uuid,
             offset: query.offset,
             limit: query.limit,
@@ -68,7 +68,7 @@ async fn list_bot_friendships(
 
 async fn delete_bot_friendship(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<(String, String)>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -77,7 +77,7 @@ async fn delete_bot_friendship(
     let result = state
         .friendship_service
         .delete_bot_friendship(DeleteBotFriendship {
-            principal,
+            caller,
             bot_uuid,
             friend_bot_uuid,
         })
@@ -92,7 +92,7 @@ async fn delete_bot_friendship(
 
 async fn create_bot_friend_request(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<CreateFriendRequestRequest>, JsonRejection>,
@@ -101,7 +101,7 @@ async fn create_bot_friend_request(
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = state
         .friendship_service
-        .create_bot_friend_request(body.into_command(principal, bot_uuid))
+        .create_bot_friend_request(body.into_command(caller, bot_uuid))
         .await
         .map_err(|error| application_error_response(&request_id, error))?;
     Ok((
@@ -113,7 +113,7 @@ async fn create_bot_friend_request(
 
 async fn list_bot_friend_requests(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     query: Result<Query<ListFriendRequestsQuery>, QueryRejection>,
@@ -123,7 +123,7 @@ async fn list_bot_friend_requests(
     let result = state
         .friendship_service
         .list_bot_friend_requests(ListBotFriendRequests {
-            principal,
+            caller,
             bot_uuid,
             direction: query.direction.unwrap_or_default(),
             status: query.status,
@@ -141,7 +141,7 @@ async fn list_bot_friend_requests(
 
 async fn accept_friend_request(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -150,7 +150,7 @@ async fn accept_friend_request(
     let result = state
         .friendship_service
         .accept_friend_request(AcceptFriendRequest {
-            principal,
+            caller,
             request_id: request_id_path,
         })
         .await
@@ -164,7 +164,7 @@ async fn accept_friend_request(
 
 async fn reject_friend_request(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -173,7 +173,7 @@ async fn reject_friend_request(
     let result = state
         .friendship_service
         .reject_friend_request(RejectFriendRequest {
-            principal,
+            caller,
             request_id: request_id_path,
         })
         .await

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/group.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/group.rs
@@ -5,8 +5,8 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
 use bcs_service_api::application::v1::{
-    AddGroupParticipant, CreateGroup, DeleteGroup, DeleteGroupParticipant, GetGroup, ListBotGroups,
-    Principal, UpdateGroup, UpdateGroupParticipant,
+    AddGroupParticipant, AuthenticatedCaller, CreateGroup, DeleteGroup, DeleteGroupParticipant,
+    GetGroup, ListGroups, UpdateGroup, UpdateGroupParticipant,
 };
 
 use crate::v1::common::{
@@ -19,11 +19,7 @@ use crate::v1::openapi::dto::group::{
 
 pub fn router() -> Router<ApiState> {
     Router::new()
-        .route(
-            "/openapi/v1/bots/collaboration/{bot_uuid}/groups",
-            get(list_bot_groups),
-        )
-        .route("/openapi/v1/groups", post(create_group))
+        .route("/openapi/v1/groups", get(list_groups).post(create_group))
         .route(
             "/openapi/v1/groups/{group_id}",
             get(get_group).patch(update_group).delete(delete_group),
@@ -38,22 +34,20 @@ pub fn router() -> Router<ApiState> {
         )
 }
 
-async fn list_bot_groups(
+async fn list_groups(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
-    path: Result<Path<String>, PathRejection>,
     query: Result<Query<ListGroupsQuery>, QueryRejection>,
 ) -> Result<Response, ErrorResponse> {
-    let Path(bot_uuid) = path.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let Query(query) = query.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let membership = query.membership_filter();
     let kind = query.kind_filter();
     let result = state
         .group_service
-        .list_bot_groups(ListBotGroups {
-            principal,
-            bot_uuid,
+        .list_groups(ListGroups {
+            caller,
+            view_bot_id: query.view_bot_id,
             offset: query.offset,
             limit: query.limit,
             q: query.q,
@@ -72,7 +66,7 @@ async fn list_bot_groups(
 
 async fn create_group(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     body: Result<Json<CreateGroupRequest>, JsonRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -80,7 +74,7 @@ async fn create_group(
     let result = state
         .group_service
         .create_with_outcome(CreateGroup {
-            principal,
+            caller,
             group: body.into(),
         })
         .await
@@ -99,7 +93,7 @@ async fn create_group(
 
 async fn get_group(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -107,7 +101,7 @@ async fn get_group(
     let result = state
         .group_service
         .get(GetGroup {
-            principal,
+            caller,
             group_id,
         })
         .await
@@ -121,7 +115,7 @@ async fn get_group(
 
 async fn update_group(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<UpdateGroupRequest>, JsonRejection>,
@@ -131,7 +125,7 @@ async fn update_group(
     let result = state
         .group_service
         .update(UpdateGroup {
-            principal,
+            caller,
             group_id,
             patch: body.into(),
         })
@@ -146,7 +140,7 @@ async fn update_group(
 
 async fn delete_group(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -154,7 +148,7 @@ async fn delete_group(
     let result = state
         .group_service
         .delete(DeleteGroup {
-            principal,
+            caller,
             group_id,
         })
         .await
@@ -168,7 +162,7 @@ async fn delete_group(
 
 async fn add_group_participant(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<AddParticipantRequest>, JsonRejection>,
@@ -178,7 +172,7 @@ async fn add_group_participant(
     let result = state
         .group_service
         .add_participant(AddGroupParticipant {
-            principal,
+            caller,
             group_id,
             actor_id: body.actor_id,
             role: body.role,
@@ -194,7 +188,7 @@ async fn add_group_participant(
 
 async fn update_group_participant(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<(String, String)>, PathRejection>,
     body: Result<Json<UpdateParticipantRequest>, JsonRejection>,
@@ -205,7 +199,7 @@ async fn update_group_participant(
     let result = state
         .group_service
         .update_participant(UpdateGroupParticipant {
-            principal,
+            caller,
             group_id,
             actor_id,
             mode: body.mode,
@@ -221,7 +215,7 @@ async fn update_group_participant(
 
 async fn remove_group_participant(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<(String, String)>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -230,7 +224,7 @@ async fn remove_group_participant(
     let result = state
         .group_service
         .delete_participant(DeleteGroupParticipant {
-            principal,
+            caller,
             group_id,
             actor_id,
         })

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/invitation.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/invitation.rs
@@ -4,7 +4,7 @@ use axum::extract::{Extension, Json, Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use bcs_service_api::application::v1::Principal;
+use bcs_service_api::application::v1::AuthenticatedCaller;
 
 use crate::v1::common::{
     ApiState, Envelope, ErrorResponse, RequestId, application_error_response, invalid_request,
@@ -29,7 +29,7 @@ pub fn router() -> Router<ApiState> {
 
 async fn create_group_invitation(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<CreateInvitationRequest>, JsonRejection>,
@@ -38,7 +38,7 @@ async fn create_group_invitation(
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = state
         .invitation_service
-        .create_group_invitation(body.into_group_command(principal, group_id))
+        .create_group_invitation(body.into_group_command(caller, group_id))
         .await
         .map_err(|error| application_error_response(&request_id, error))?;
     Ok((
@@ -50,7 +50,7 @@ async fn create_group_invitation(
 
 async fn create_session_invitation(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<CreateInvitationRequest>, JsonRejection>,
@@ -59,7 +59,7 @@ async fn create_session_invitation(
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = state
         .invitation_service
-        .create_session_invitation(body.into_session_command(principal, session_id))
+        .create_session_invitation(body.into_session_command(caller, session_id))
         .await
         .map_err(|error| application_error_response(&request_id, error))?;
     Ok((
@@ -71,7 +71,7 @@ async fn create_session_invitation(
 
 async fn accept_invitation(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<AcceptInvitationRequest>, JsonRejection>,
@@ -80,7 +80,7 @@ async fn accept_invitation(
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = state
         .invitation_service
-        .accept_invitation(body.into_command(principal, token))
+        .accept_invitation(body.into_command(caller, token))
         .await
         .map_err(|error| application_error_response(&request_id, error))?;
     Ok((

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod bot;
 pub mod friendship;
 pub mod group;
 pub mod invitation;

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/session.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/session.rs
@@ -5,8 +5,9 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
 use bcs_service_api::application::v1::{
-    AddSessionParticipant, CompleteSession, DeleteSession, DeleteSessionParticipant,
-    GetSession, ListSessionMessages, ListSessions, Principal, UpdateSessionParticipant,
+    AddSessionParticipant, AuthenticatedCaller, CompleteSession, DeleteSession,
+    DeleteSessionParticipant, GetSession, ListSessionMessages, ListSessions,
+    UpdateSessionParticipant,
 };
 
 use crate::v1::common::{
@@ -49,7 +50,7 @@ pub fn router() -> Router<ApiState> {
 
 async fn create_session(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<CreateSessionRequest>, JsonRejection>,
@@ -58,7 +59,7 @@ async fn create_session(
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = state
         .session_service
-        .create(body.into_command(principal, group_id))
+        .create(body.into_command(caller, group_id))
         .await
         .map_err(|error| application_error_response(&request_id, error))?;
     let (status, code, message) = if result.created {
@@ -75,7 +76,7 @@ async fn create_session(
 
 async fn list_sessions(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     query: Result<Query<ListSessionsQuery>, QueryRejection>,
@@ -85,8 +86,9 @@ async fn list_sessions(
     let result = state
         .session_service
         .list(ListSessions {
-            principal,
+            caller,
             group_id,
+            view_bot_id: query.view_bot_id,
             offset: query.offset,
             limit: query.limit,
             status: query.status,
@@ -102,7 +104,7 @@ async fn list_sessions(
 
 async fn get_session(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -110,7 +112,7 @@ async fn get_session(
     let result = state
         .session_service
         .get(GetSession {
-            principal,
+            caller,
             session_id,
         })
         .await
@@ -124,7 +126,7 @@ async fn get_session(
 
 async fn update_session(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<UpdateSessionRequest>, JsonRejection>,
@@ -133,7 +135,7 @@ async fn update_session(
     let Json(body) = body.map_err(|error| invalid_request(&request_id, error.body_text()))?;
     let result = state
         .session_service
-        .update(body.into_command(principal, session_id))
+        .update(body.into_command(caller, session_id))
         .await
         .map_err(|error| application_error_response(&request_id, error))?;
     Ok((
@@ -145,7 +147,7 @@ async fn update_session(
 
 async fn delete_session(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -153,7 +155,7 @@ async fn delete_session(
     let result = state
         .session_service
         .delete(DeleteSession {
-            principal,
+            caller,
             session_id,
         })
         .await
@@ -167,7 +169,7 @@ async fn delete_session(
 
 async fn complete_session(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -175,7 +177,7 @@ async fn complete_session(
     let result = state
         .session_service
         .complete(CompleteSession {
-            principal,
+            caller,
             session_id,
         })
         .await
@@ -189,7 +191,7 @@ async fn complete_session(
 
 async fn list_session_messages(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     query: Result<Query<ListSessionMessagesQuery>, QueryRejection>,
@@ -199,7 +201,7 @@ async fn list_session_messages(
     let result = state
         .message_service
         .list(ListSessionMessages {
-            principal,
+            caller,
             session_id,
             before: query.before,
             limit: query.limit,
@@ -216,7 +218,7 @@ async fn list_session_messages(
 
 async fn add_session_participant(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<String>, PathRejection>,
     body: Result<Json<SessionParticipantInput>, JsonRejection>,
@@ -226,7 +228,7 @@ async fn add_session_participant(
     let result = state
         .session_service
         .add_participant(AddSessionParticipant {
-            principal,
+            caller,
             session_id,
             bot_uuid: body.bot_uuid,
             mode: body.mode,
@@ -242,7 +244,7 @@ async fn add_session_participant(
 
 async fn update_session_participant(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<(String, String)>, PathRejection>,
     body: Result<Json<UpdateSessionParticipantRequest>, JsonRejection>,
@@ -253,7 +255,7 @@ async fn update_session_participant(
     let result = state
         .session_service
         .update_participant(UpdateSessionParticipant {
-            principal,
+            caller,
             session_id,
             bot_uuid,
             mode: body.mode,
@@ -269,7 +271,7 @@ async fn update_session_participant(
 
 async fn remove_session_participant(
     State(state): State<ApiState>,
-    Extension(principal): Extension<Principal>,
+    Extension(caller): Extension<AuthenticatedCaller>,
     Extension(request_id): Extension<RequestId>,
     path: Result<Path<(String, String)>, PathRejection>,
 ) -> Result<Response, ErrorResponse> {
@@ -278,7 +280,7 @@ async fn remove_session_participant(
     let result = state
         .session_service
         .delete_participant(DeleteSessionParticipant {
-            principal,
+            caller,
             session_id,
             bot_uuid,
         })

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
@@ -1,0 +1,465 @@
+#![allow(
+    clippy::expect_used,
+    reason = "test assertions intentionally fail fast"
+)]
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::body::{Body, to_bytes};
+use axum::http::{HeaderMap, Request, StatusCode};
+use bcs_api_http::{ApiState, PrincipalVerificationError, PrincipalVerifier, router};
+use bcs_service_api::application::v1::*;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+struct HeaderVerifier;
+
+#[async_trait]
+impl PrincipalVerifier for HeaderVerifier {
+    async fn verify(&self, headers: &HeaderMap) -> Result<Principal, PrincipalVerificationError> {
+        if headers
+            .get("x-test-auth")
+            .and_then(|value| value.to_str().ok())
+            == Some("yes")
+        {
+            Ok(Principal::human(
+                AuthenticatedUser {
+                    id: "staff-1".to_string(),
+                    username: "staff-1".to_string(),
+                    display_name: None,
+                    full_name: None,
+                },
+                "tenant-1",
+                BTreeSet::new(),
+            ))
+        } else {
+            Err(PrincipalVerificationError::Missing)
+        }
+    }
+}
+
+#[derive(Default)]
+struct FakeBotService {
+    candidates: Mutex<Option<ListBotCandidates>>,
+    query: Mutex<Option<QueryBots>>,
+    get: Mutex<Option<GetBot>>,
+    update: Mutex<Option<UpdateBot>>,
+    mine: Mutex<Option<ListMyBots>>,
+}
+
+#[async_trait]
+impl BotService for FakeBotService {
+    async fn list_candidates(
+        &self,
+        command: ListBotCandidates,
+    ) -> Result<Page<BotCandidate>, ApplicationError> {
+        *self.candidates.lock().expect("candidates lock") = Some(command);
+        Ok(Page {
+            items: vec![BotCandidate {
+                bot: physical_bot(),
+                is_friend: true,
+            }],
+            total: 1,
+            offset: 5,
+            limit: 10,
+        })
+    }
+
+    async fn query(&self, command: QueryBots) -> Result<Vec<Bot>, ApplicationError> {
+        *self.query.lock().expect("query lock") = Some(command);
+        Ok(vec![Bot::Physical(physical_bot())])
+    }
+
+    async fn get(&self, query: GetBot) -> Result<Bot, ApplicationError> {
+        *self.get.lock().expect("get lock") = Some(query);
+        Ok(Bot::Physical(physical_bot()))
+    }
+
+    async fn update(&self, command: UpdateBot) -> Result<Bot, ApplicationError> {
+        *self.update.lock().expect("update lock") = Some(command);
+        Ok(Bot::Physical(physical_bot()))
+    }
+
+    async fn list_mine(&self, command: ListMyBots) -> Result<Page<Bot>, ApplicationError> {
+        *self.mine.lock().expect("mine lock") = Some(command);
+        Ok(Page {
+            items: vec![Bot::Human(human_bot())],
+            total: 1,
+            offset: 2,
+            limit: 3,
+        })
+    }
+}
+
+struct NoopGroupService;
+
+#[async_trait]
+impl GroupService for NoopGroupService {
+    async fn list_bot_groups(
+        &self,
+        _: ListBotGroups,
+    ) -> Result<Page<GroupSummary>, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn create(&self, _: CreateGroup) -> Result<GroupDetail, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn get(&self, _: GetGroup) -> Result<GroupDetail, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn update(&self, _: UpdateGroup) -> Result<GroupDetail, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn delete(&self, _: DeleteGroup) -> Result<DeleteResult, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn add_participant(
+        &self,
+        _: AddGroupParticipant,
+    ) -> Result<Participant, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn update_participant(
+        &self,
+        _: UpdateGroupParticipant,
+    ) -> Result<Participant, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn delete_participant(
+        &self,
+        _: DeleteGroupParticipant,
+    ) -> Result<DeleteResult, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+}
+
+struct NoopSessionService;
+
+#[async_trait]
+impl SessionService for NoopSessionService {
+    async fn create(&self, _: CreateSession) -> Result<CreateSessionOutcome, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn list(&self, _: ListSessions) -> Result<Page<SessionSummary>, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn get(&self, _: GetSession) -> Result<SessionDetail, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn update(&self, _: UpdateSession) -> Result<SessionDetail, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn delete(&self, _: DeleteSession) -> Result<DeleteResult, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn complete(
+        &self,
+        _: CompleteSession,
+    ) -> Result<SessionCompletionResult, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn add_participant(
+        &self,
+        _: AddSessionParticipant,
+    ) -> Result<SessionParticipant, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn update_participant(
+        &self,
+        _: UpdateSessionParticipant,
+    ) -> Result<SessionParticipant, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn delete_participant(
+        &self,
+        _: DeleteSessionParticipant,
+    ) -> Result<DeleteResult, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+}
+
+struct NoopMessageService;
+
+#[async_trait]
+impl SessionMessageService for NoopMessageService {
+    async fn list(&self, _: ListSessionMessages) -> Result<SessionMessagePage, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+}
+
+struct NoopInvitationService;
+
+#[async_trait]
+impl InvitationService for NoopInvitationService {
+    async fn create_group_invitation(
+        &self,
+        _: CreateGroupInvitation,
+    ) -> Result<Invitation, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn create_session_invitation(
+        &self,
+        _: CreateSessionInvitation,
+    ) -> Result<Invitation, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn accept_invitation(
+        &self,
+        _: AcceptInvitation,
+    ) -> Result<InvitationAcceptResult, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+}
+
+struct NoopFriendshipService;
+
+#[async_trait]
+impl FriendshipService for NoopFriendshipService {
+    async fn list_bot_friendships(
+        &self,
+        _: ListBotFriendships,
+    ) -> Result<Page<Friendship>, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn delete_bot_friendship(
+        &self,
+        _: DeleteBotFriendship,
+    ) -> Result<DeleteResult, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn create_bot_friend_request(
+        &self,
+        _: CreateBotFriendRequest,
+    ) -> Result<FriendRequest, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn list_bot_friend_requests(
+        &self,
+        _: ListBotFriendRequests,
+    ) -> Result<Page<FriendRequest>, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn accept_friend_request(
+        &self,
+        _: AcceptFriendRequest,
+    ) -> Result<FriendRequest, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+    async fn reject_friend_request(
+        &self,
+        _: RejectFriendRequest,
+    ) -> Result<FriendRequest, ApplicationError> {
+        Err(ApplicationError::internal("not configured"))
+    }
+}
+
+fn test_router(service: Arc<FakeBotService>) -> axum::Router {
+    router(
+        ApiState::new(
+            Arc::new(NoopGroupService),
+            Arc::new(NoopSessionService),
+            Arc::new(NoopMessageService),
+            Arc::new(NoopInvitationService),
+            Arc::new(NoopFriendshipService),
+            Arc::new(HeaderVerifier),
+        )
+        .with_bot_service(service),
+    )
+}
+
+#[tokio::test]
+async fn all_five_bot_routes_forward_verified_human_and_contract_inputs() {
+    let service = Arc::new(FakeBotService::default());
+    let app = test_router(service.clone());
+
+    let candidates = app
+        .clone()
+        .oneshot(request(
+            "GET",
+            "/openapi/v1/bots/acting/candidates?purpose=collaboration&name=planner&offset=5&limit=10",
+            Value::Null,
+        ))
+        .await
+        .expect("candidates response");
+    assert_eq!(candidates.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(candidates).await["data"]["items"][0]["bot"]["kind"],
+        "bot"
+    );
+
+    let queried = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            "/openapi/v1/bots/query",
+            json!({"bot_ids": ["bot-2", "bot-1", "bot-2"]}),
+        ))
+        .await
+        .expect("query response");
+    assert_eq!(queried.status(), StatusCode::OK);
+
+    let got = app
+        .clone()
+        .oneshot(request("GET", "/openapi/v1/bots/bot-1", Value::Null))
+        .await
+        .expect("get response");
+    assert_eq!(got.status(), StatusCode::OK);
+
+    let updated = app
+        .clone()
+        .oneshot(request(
+            "PATCH",
+            "/openapi/v1/bots/bot-1",
+            json!({
+                "name": "Renamed",
+                "visibility": "protected",
+                "status": "hidden",
+                "descriptor": {"domains": [], "skills": [{"name": "plan"}]}
+            }),
+        ))
+        .await
+        .expect("update response");
+    assert_eq!(updated.status(), StatusCode::OK);
+
+    let mine = app
+        .oneshot(request(
+            "GET",
+            "/openapi/v1/bots/mine?kind=human&name=vin&status=online&reachability=unreachable&offset=2&limit=3",
+            Value::Null,
+        ))
+        .await
+        .expect("mine response");
+    assert_eq!(mine.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(mine).await["data"]["items"][0]["kind"],
+        "human"
+    );
+
+    let candidates = service.candidates.lock().expect("candidates lock");
+    let candidates = candidates.as_ref().expect("candidates command");
+    assert_eq!(
+        candidates
+            .principal
+            .authenticated_user()
+            .map(|user| user.id.as_str()),
+        Some("staff-1")
+    );
+    assert_eq!(candidates.bot_id, "acting");
+    assert_eq!(candidates.purpose, BotCandidatePurpose::Collaboration);
+    assert_eq!(candidates.name.as_deref(), Some("planner"));
+    assert_eq!((candidates.offset, candidates.limit), (5, 10));
+
+    assert_eq!(
+        service
+            .query
+            .lock()
+            .expect("query lock")
+            .as_ref()
+            .expect("query command")
+            .bot_ids,
+        vec!["bot-2", "bot-1", "bot-2"]
+    );
+    let update = service.update.lock().expect("update lock");
+    let update = update.as_ref().expect("update command");
+    assert_eq!(update.patch.visibility, Some(BotVisibility::Protected));
+    assert_eq!(update.patch.status, Some(BotStatus::Hidden));
+    assert_eq!(
+        update
+            .patch
+            .descriptor
+            .as_ref()
+            .and_then(|d| d.domains.as_ref()),
+        Some(&vec![])
+    );
+    let mine = service.mine.lock().expect("mine lock");
+    let mine = mine.as_ref().expect("mine command");
+    assert_eq!(mine.kind, Some(BotKind::Human));
+    assert_eq!(mine.reachability, Some(BotReachability::Unreachable));
+}
+
+#[tokio::test]
+async fn bot_routes_reject_unknown_request_fields_and_missing_principal() {
+    let app = test_router(Arc::new(FakeBotService::default()));
+    let unknown = app
+        .clone()
+        .oneshot(request(
+            "PATCH",
+            "/openapi/v1/bots/bot-1",
+            json!({"name": "Bot", "created_by": "forged"}),
+        ))
+        .await
+        .expect("unknown field response");
+    assert_eq!(unknown.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response_json(unknown).await["data"]["error_code"],
+        "invalid_request"
+    );
+
+    let missing = app
+        .oneshot(
+            Request::builder()
+                .uri("/openapi/v1/bots/bot-1")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("missing principal response");
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+}
+
+fn physical_bot() -> PhysicalBot {
+    PhysicalBot {
+        bot_id: "bot-1".to_string(),
+        kind: BotKind::Bot,
+        name: "Bot One".to_string(),
+        visibility: BotVisibility::Public,
+        status: BotStatus::Online,
+        env: "dev".to_string(),
+        created_by: Some("staff-1".to_string()),
+        descriptor: BotDescriptor {
+            summary: "summary".to_string(),
+            domains: vec![],
+            skills: vec![],
+            scopes: vec![],
+        },
+        reachability: BotReachability::Reachable,
+        provider: None,
+        agent_code: Some("agent-code".to_string()),
+        created_at: 1,
+        updated_at: 2,
+    }
+}
+
+fn human_bot() -> HumanBot {
+    HumanBot {
+        bot_id: "human_staff-1".to_string(),
+        kind: BotKind::Human,
+        name: "Human".to_string(),
+        visibility: BotVisibility::Protected,
+        status: BotStatus::Online,
+        env: "dev".to_string(),
+        created_by: Some("staff-1".to_string()),
+        created_at: 1,
+        updated_at: 2,
+    }
+}
+
+fn request(method: &str, uri: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("x-test-auth", "yes")
+        .header("x-request-id", "request-bot")
+        .body(Body::from(body.to_string()))
+        .expect("request")
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&bytes).expect("JSON response")
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
@@ -3,7 +3,6 @@
     reason = "test assertions intentionally fail fast"
 )]
 
-use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -18,22 +17,27 @@ struct HeaderVerifier;
 
 #[async_trait]
 impl PrincipalVerifier for HeaderVerifier {
-    async fn verify(&self, headers: &HeaderMap) -> Result<Principal, PrincipalVerificationError> {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError> {
         if headers
             .get("x-test-auth")
             .and_then(|value| value.to_str().ok())
             == Some("yes")
         {
-            Ok(Principal::human(
-                AuthenticatedUser {
+            Ok(AuthenticatedCaller {
+                tenant: "tenant-1".into(),
+                user: Some(AuthenticatedUserIdentity {
                     id: "staff-1".to_string(),
                     username: "staff-1".to_string(),
                     display_name: None,
                     full_name: None,
-                },
-                "tenant-1",
-                BTreeSet::new(),
-            ))
+                }),
+                bot: None,
+                app: None,
+                access_key: None,
+            })
         } else {
             Err(PrincipalVerificationError::Missing)
         }
@@ -97,9 +101,9 @@ struct NoopGroupService;
 
 #[async_trait]
 impl GroupService for NoopGroupService {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        _: ListBotGroups,
+        _: ListGroups,
     ) -> Result<Page<GroupSummary>, ApplicationError> {
         Err(ApplicationError::internal("not configured"))
     }
@@ -340,10 +344,7 @@ async fn all_five_bot_routes_forward_verified_human_and_contract_inputs() {
     let candidates = service.candidates.lock().expect("candidates lock");
     let candidates = candidates.as_ref().expect("candidates command");
     assert_eq!(
-        candidates
-            .principal
-            .authenticated_user()
-            .map(|user| user.id.as_str()),
+        candidates.caller.user.as_ref().map(|user| user.id.as_str()),
         Some("staff-1")
     );
     assert_eq!(candidates.bot_id, "acting");

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs
@@ -21,6 +21,7 @@ fn manifest_does_not_depend_on_legacy_or_concrete_bcs_crates() {
     for forbidden in [
         "bcs-protocol",
         "bcs-http",
+        "bcs-jwt",
         "bcs-group",
         "bcs-session",
         "bcs-friend",
@@ -35,6 +36,23 @@ fn manifest_does_not_depend_on_legacy_or_concrete_bcs_crates() {
             "versioned HTTP adapter must not depend on {forbidden}"
         );
     }
+}
+
+#[test]
+fn production_bootstrap_does_not_mount_the_versioned_http_adapter() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let bootstrap_manifest =
+        match fs::read_to_string(manifest_dir.join("../../../bootstrap/bcs/Cargo.toml")) {
+            Ok(source) => source,
+            Err(_) => panic!("read production bootstrap manifest"),
+        };
+
+    assert!(
+        !bootstrap_manifest
+            .lines()
+            .any(|line| { line.trim_start().starts_with("bcs-api-http ") }),
+        "production bootstrap must not mount bcs-api-http in this preparatory change"
+    );
 }
 
 #[test]

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs
@@ -12,6 +12,17 @@ fn rust_files_under(directory: &Path, files: &mut Vec<PathBuf>) {
     }
 }
 
+fn manifest_declares_dependency(manifest: &str, dependency: &str) -> bool {
+    manifest.lines().any(|line| {
+        let line = line.trim_start();
+        if line.starts_with('#') {
+            return false;
+        }
+        line.split_once('=')
+            .is_some_and(|(name, _)| name.trim().trim_matches('"') == dependency)
+    })
+}
+
 #[test]
 fn manifest_does_not_depend_on_legacy_or_concrete_bcs_crates() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -28,11 +39,8 @@ fn manifest_does_not_depend_on_legacy_or_concrete_bcs_crates() {
         "bcs-bot",
         "bcs-relation",
     ] {
-        let dependency_prefix = format!("{forbidden} ");
         assert!(
-            !manifest
-                .lines()
-                .any(|line| line.trim_start().starts_with(&dependency_prefix)),
+            !manifest_declares_dependency(&manifest, forbidden),
             "versioned HTTP adapter must not depend on {forbidden}"
         );
     }
@@ -48,9 +56,7 @@ fn production_bootstrap_does_not_mount_the_versioned_http_adapter() {
         };
 
     assert!(
-        !bootstrap_manifest
-            .lines()
-            .any(|line| { line.trim_start().starts_with("bcs-api-http ") }),
+        !manifest_declares_dependency(&bootstrap_manifest, "bcs-api-http"),
         "production bootstrap must not mount bcs-api-http in this preparatory change"
     );
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/friendship_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/friendship_routes.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -7,13 +6,15 @@ use axum::http::{HeaderMap, Request, StatusCode};
 use bcs_api_http::{ApiState, PrincipalVerificationError, PrincipalVerifier, router};
 use bcs_service_api::application::v1::{
     AcceptFriendRequest, AcceptInvitation, AddGroupParticipant, AddSessionParticipant,
-    ApplicationError, CompleteSession, CreateBotFriendRequest, CreateGroup, CreateGroupInvitation,
+    ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity, CompleteSession,
+    CreateBotFriendRequest, CreateGroup, CreateGroupInvitation,
     CreateSession, CreateSessionInvitation, CreateSessionOutcome, DeleteGroup,
     DeleteGroupParticipant, DeleteResult, DeleteSession, DeleteSessionParticipant, Friendship,
     FriendshipService, FriendRequest, FriendRequestDirection, FriendRequestStatus, GetGroup,
     GetSession, GroupDetail, GroupService, GroupSummary, Invitation, InvitationAcceptResult,
-    InvitationService, ListBotGroups, ListBotFriendRequests, ListBotFriendships, ListSessionMessages,
-    ListSessions, Page, Principal, RejectFriendRequest, DeleteBotFriendship, SessionCompletionResult,
+    InvitationService, ListGroups, ListBotFriendRequests, ListBotFriendships,
+    ListSessionMessages, ListSessions, Page, RejectFriendRequest, DeleteBotFriendship,
+    SessionCompletionResult,
     SessionDetail, SessionMessagePage, SessionMessageService, SessionParticipant, SessionService,
     SessionSummary, UpdateGroup, UpdateGroupParticipant, UpdateSession,
     UpdateSessionParticipant,
@@ -27,26 +28,44 @@ use tower::ServiceExt;
 // ---------------------------------------------------------------------------
 
 struct HeaderVerifier {
-    principal: Principal,
+    caller: AuthenticatedCaller,
 }
 
 #[async_trait]
 impl PrincipalVerifier for HeaderVerifier {
-    async fn verify(&self, headers: &HeaderMap) -> Result<Principal, PrincipalVerificationError> {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError> {
         if headers
             .get("x-test-auth")
             .and_then(|value| value.to_str().ok())
             == Some("yes")
         {
-            Ok(self.principal.clone())
+            Ok(self.caller.clone())
         } else {
             Err(PrincipalVerificationError::Missing)
         }
     }
 }
 
-fn principal() -> Principal {
-    Principal::bot("bot-1", "tenant-a", BTreeSet::new())
+fn caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn caller_user_id(caller: &AuthenticatedCaller) -> &str {
+    caller.user.as_ref().expect("User identity").id.as_str()
 }
 
 fn authenticated_request(method: &str, uri: &str, body: Value) -> Request<Body> {
@@ -76,9 +95,9 @@ struct NoopGroupService;
 
 #[async_trait]
 impl GroupService for NoopGroupService {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        _command: ListBotGroups,
+        _command: ListGroups,
     ) -> Result<Page<GroupSummary>, ApplicationError> {
         Err(ApplicationError::internal("group not configured"))
     }
@@ -360,7 +379,7 @@ fn test_router(service: Arc<FakeFriendshipService>) -> axum::Router {
         Arc::new(NoopInvitationService),
         service,
         Arc::new(HeaderVerifier {
-            principal: principal(),
+            caller: caller(),
         }),
     ))
 }
@@ -395,7 +414,7 @@ async fn list_friendships_returns_page_and_forwards_principal() {
     {
         let listed = service.listed_friendships.lock().expect("list friendships lock");
         let listed = listed.as_ref().expect("list friendships command");
-        assert_eq!(listed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&listed.caller), "staff-1");
         assert_eq!(listed.bot_uuid, "bot-1");
         assert_eq!(listed.offset, 5);
         assert_eq!(listed.limit, 10);
@@ -444,7 +463,7 @@ async fn remove_friendship_returns_deleted_and_forwards_principal() {
     {
         let removed = service.removed_friendship.lock().expect("remove friendship lock");
         let removed = removed.as_ref().expect("remove friendship command");
-        assert_eq!(removed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&removed.caller), "staff-1");
         assert_eq!(removed.bot_uuid, "bot-1");
         assert_eq!(removed.friend_bot_uuid, "bot-2");
     }
@@ -477,7 +496,7 @@ async fn create_friend_request_returns_created_and_forwards_principal() {
             .lock()
             .expect("create friend request lock");
         let created = created.as_ref().expect("create friend request command");
-        assert_eq!(created.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&created.caller), "staff-1");
         assert_eq!(created.bot_uuid, "bot-1");
         assert_eq!(created.to_bot_uuid, "bot-2");
     }
@@ -509,7 +528,7 @@ async fn list_friend_requests_returns_page_and_forwards_filters() {
             .lock()
             .expect("list friend requests lock");
         let listed = listed.as_ref().expect("list friend requests command");
-        assert_eq!(listed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&listed.caller), "staff-1");
         assert_eq!(listed.bot_uuid, "bot-1");
         assert_eq!(listed.direction, FriendRequestDirection::Sent);
         assert_eq!(listed.status, Some(FriendRequestStatus::Pending));
@@ -570,7 +589,7 @@ async fn accept_friend_request_returns_ok_and_forwards_principal() {
             .lock()
             .expect("accept friend request lock");
         let accepted = accepted.as_ref().expect("accept friend request command");
-        assert_eq!(accepted.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&accepted.caller), "staff-1");
         assert_eq!(accepted.request_id, "req-1");
     }
 }
@@ -599,7 +618,7 @@ async fn reject_friend_request_returns_ok_and_forwards_principal() {
             .lock()
             .expect("reject friend request lock");
         let rejected = rejected.as_ref().expect("reject friend request command");
-        assert_eq!(rejected.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&rejected.caller), "staff-1");
         assert_eq!(rejected.request_id, "req-1");
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/group_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/group_routes.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -7,11 +6,12 @@ use axum::body::{Body, to_bytes};
 use axum::http::{HeaderMap, Request, StatusCode};
 use bcs_api_http::{ApiState, PrincipalVerificationError, PrincipalVerifier, router};
 use bcs_service_api::application::v1::{
-    AddGroupParticipant, ApplicationError, BotFinalDelivery, ChatConfiguration,
-    CollaborationConfiguration, CollaborationGroupDetail, CreateGroup, CreateGroupOutcome,
+    AddGroupParticipant, ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity,
+    BotFinalDelivery, ChatConfiguration, CollaborationConfiguration, CollaborationGroupDetail,
+    CreateGroup, CreateGroupOutcome,
     DeleteGroup, DeleteGroupParticipant, DeleteResult, GetGroup, GroupDeliveryPolicy, GroupDetail,
-    GroupService, GroupStatus, GroupStrategy, GroupVisibility, ListBotGroups, Page, Participant,
-    Principal, UpdateGroup, UpdateGroupParticipant,
+    GroupService, GroupStatus, GroupStrategy, GroupVisibility, ListGroups, Page, Participant,
+    UpdateGroup, UpdateGroupParticipant,
 };
 use bcs_service_api::application::v1::{
     AddSessionParticipant, CompleteSession, CreateSession, CreateSessionOutcome,
@@ -31,18 +31,21 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 
 struct HeaderVerifier {
-    principal: Principal,
+    caller: AuthenticatedCaller,
 }
 
 #[async_trait]
 impl PrincipalVerifier for HeaderVerifier {
-    async fn verify(&self, headers: &HeaderMap) -> Result<Principal, PrincipalVerificationError> {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError> {
         if headers
             .get("x-test-auth")
             .and_then(|value| value.to_str().ok())
             == Some("yes")
         {
-            Ok(self.principal.clone())
+            Ok(self.caller.clone())
         } else {
             Err(PrincipalVerificationError::Missing)
         }
@@ -51,7 +54,7 @@ impl PrincipalVerifier for HeaderVerifier {
 
 #[derive(Default)]
 struct FakeGroupService {
-    list: Mutex<Option<ListBotGroups>>,
+    list: Mutex<Option<ListGroups>>,
     created: Mutex<Option<CreateGroup>>,
     reuse_dm: AtomicBool,
     get: Mutex<Option<GetGroup>>,
@@ -64,9 +67,9 @@ struct FakeGroupService {
 
 #[async_trait]
 impl GroupService for FakeGroupService {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        command: ListBotGroups,
+        command: ListGroups,
     ) -> Result<Page<bcs_service_api::application::v1::GroupSummary>, ApplicationError> {
         *self.list.lock().expect("list lock") = Some(command);
         Ok(Page::empty(0, 20))
@@ -289,8 +292,23 @@ impl FriendshipService for NoopFriendshipService {
     }
 }
 
-fn principal() -> Principal {
-    Principal::bot("bot-1", "tenant-a", BTreeSet::new())
+fn caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn caller_user_id(caller: &AuthenticatedCaller) -> &str {
+    caller.user.as_ref().expect("User identity").id.as_str()
 }
 
 fn group_detail() -> GroupDetail {
@@ -328,7 +346,7 @@ fn test_router(service: Arc<FakeGroupService>) -> axum::Router {
         Arc::new(NoopInvitationService),
         Arc::new(NoopFriendshipService),
         Arc::new(HeaderVerifier {
-            principal: principal(),
+            caller: caller(),
         }),
     ))
 }
@@ -352,7 +370,7 @@ fn authenticated_request(method: &str, uri: &str, body: Value) -> Request<Body> 
 }
 
 #[tokio::test]
-async fn all_five_group_routes_forward_the_verified_principal() {
+async fn group_routes_forward_the_verified_caller() {
     let service = Arc::new(FakeGroupService::default());
     let app = test_router(service.clone());
 
@@ -360,7 +378,7 @@ async fn all_five_group_routes_forward_the_verified_principal() {
         .clone()
         .oneshot(authenticated_request(
             "GET",
-            "/openapi/v1/bots/collaboration/bot-1/groups?offset=5&limit=10&membership=session_only&kind=all&strategy=state_machine",
+            "/openapi/v1/groups?view_bot_id=bot-1&offset=5&limit=10&membership=session_only&kind=all&strategy=state_machine",
             Value::Null,
         ))
         .await
@@ -373,7 +391,8 @@ async fn all_five_group_routes_forward_the_verified_principal() {
     {
         let list = service.list.lock().expect("list lock");
         let list = list.as_ref().expect("list command");
-        assert_eq!(list.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&list.caller), "staff-1");
+        assert_eq!(list.view_bot_id.as_deref(), Some("bot-1"));
         assert_eq!(list.offset, 5);
         assert_eq!(list.limit, 10);
         assert_eq!(list.strategy, Some(GroupStrategy::StateMachine));
@@ -410,9 +429,12 @@ async fn all_five_group_routes_forward_the_verified_principal() {
             .expect("create lock")
             .as_ref()
             .expect("create command")
-            .principal
-            .actor_id(),
-        "bot-1"
+            .caller
+            .user
+            .as_ref()
+            .expect("User identity")
+            .id,
+        "staff-1"
     );
 
     let get_response = app
@@ -469,7 +491,7 @@ async fn all_five_group_routes_forward_the_verified_principal() {
             .lock()
             .expect("add participant lock");
         let added = added.as_ref().expect("add participant command");
-        assert_eq!(added.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&added.caller), "staff-1");
         assert_eq!(added.group_id, "group-1");
         assert_eq!(added.actor_id, "bot-2");
         assert_eq!(added.role, ParticipantRole::Consultant);
@@ -491,7 +513,7 @@ async fn all_five_group_routes_forward_the_verified_principal() {
             .lock()
             .expect("update participant lock");
         let updated = updated.as_ref().expect("update participant command");
-        assert_eq!(updated.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&updated.caller), "staff-1");
         assert_eq!(updated.group_id, "group-1");
         assert_eq!(updated.actor_id, "bot-2");
         assert_eq!(updated.mode, ParticipantMode::Muted);
@@ -512,7 +534,7 @@ async fn all_five_group_routes_forward_the_verified_principal() {
             .lock()
             .expect("remove participant lock");
         let removed = removed.as_ref().expect("remove participant command");
-        assert_eq!(removed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&removed.caller), "staff-1");
         assert_eq!(removed.group_id, "group-1");
         assert_eq!(removed.actor_id, "bot-2");
     }
@@ -589,11 +611,6 @@ async fn malformed_percent_encoded_paths_use_the_common_error_envelope() {
     let app = test_router(service);
 
     for (method, uri, body) in [
-        (
-            "GET",
-            "/openapi/v1/bots/collaboration/%FF/groups",
-            Value::Null,
-        ),
         ("GET", "/openapi/v1/groups/%FF", Value::Null),
         (
             "PATCH",

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/invitation_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/invitation_routes.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -7,13 +6,15 @@ use axum::http::{HeaderMap, Request, StatusCode};
 use bcs_api_http::{ApiState, PrincipalVerificationError, PrincipalVerifier, router};
 use bcs_service_api::application::v1::{
     AcceptFriendRequest, AcceptInvitation, AddGroupParticipant, AddSessionParticipant,
-    ApplicationError, CompleteSession, CreateBotFriendRequest, CreateGroup, CreateGroupInvitation,
+    ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity, CompleteSession,
+    CreateBotFriendRequest, CreateGroup, CreateGroupInvitation,
     CreateSession, CreateSessionInvitation, CreateSessionOutcome, DeleteGroup,
     DeleteGroupParticipant, DeleteResult, DeleteSession, DeleteSessionParticipant,
     Friendship, FriendshipService, FriendRequest, GetGroup, GetSession, GroupDetail, GroupService,
     GroupSummary, Invitation, InvitationAcceptResult, InvitationService, InvitationState,
-    InvitationTargetType, ListBotGroups, ListBotFriendRequests, ListBotFriendships, ListSessionMessages,
-    ListSessions, Page, Principal, RejectFriendRequest, DeleteBotFriendship, SessionCompletionResult,
+    InvitationTargetType, ListGroups, ListBotFriendRequests, ListBotFriendships,
+    ListSessionMessages, ListSessions, Page, RejectFriendRequest, DeleteBotFriendship,
+    SessionCompletionResult,
     SessionDetail, SessionMessagePage, SessionMessageService, SessionParticipant, SessionService,
     SessionSummary, UpdateGroup, UpdateGroupParticipant, UpdateSession,
     UpdateSessionParticipant,
@@ -27,26 +28,44 @@ use tower::ServiceExt;
 // ---------------------------------------------------------------------------
 
 struct HeaderVerifier {
-    principal: Principal,
+    caller: AuthenticatedCaller,
 }
 
 #[async_trait]
 impl PrincipalVerifier for HeaderVerifier {
-    async fn verify(&self, headers: &HeaderMap) -> Result<Principal, PrincipalVerificationError> {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError> {
         if headers
             .get("x-test-auth")
             .and_then(|value| value.to_str().ok())
             == Some("yes")
         {
-            Ok(self.principal.clone())
+            Ok(self.caller.clone())
         } else {
             Err(PrincipalVerificationError::Missing)
         }
     }
 }
 
-fn principal() -> Principal {
-    Principal::bot("bot-1", "tenant-a", BTreeSet::new())
+fn caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn caller_user_id(caller: &AuthenticatedCaller) -> &str {
+    caller.user.as_ref().expect("User identity").id.as_str()
 }
 
 fn authenticated_request(method: &str, uri: &str, body: Value) -> Request<Body> {
@@ -76,9 +95,9 @@ struct NoopGroupService;
 
 #[async_trait]
 impl GroupService for NoopGroupService {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        _command: ListBotGroups,
+        _command: ListGroups,
     ) -> Result<Page<GroupSummary>, ApplicationError> {
         Err(ApplicationError::internal("group not configured"))
     }
@@ -308,7 +327,7 @@ fn test_router(service: Arc<FakeInvitationService>) -> axum::Router {
         service,
         Arc::new(NoopFriendshipService),
         Arc::new(HeaderVerifier {
-            principal: principal(),
+            caller: caller(),
         }),
     ))
 }
@@ -343,7 +362,7 @@ async fn create_group_invitation_returns_created_and_forwards_principal() {
     {
         let created = service.created_group.lock().expect("create group lock");
         let created = created.as_ref().expect("create group command");
-        assert_eq!(created.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&created.caller), "staff-1");
         assert_eq!(created.group_id, "group-1");
         assert_eq!(created.expires_in_seconds, Some(3600));
     }
@@ -442,7 +461,7 @@ async fn create_session_invitation_returns_created_and_forwards_principal() {
     {
         let created = service.created_session.lock().expect("create session lock");
         let created = created.as_ref().expect("create session command");
-        assert_eq!(created.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&created.caller), "staff-1");
         assert_eq!(created.session_id, "session-1");
     }
 }
@@ -470,7 +489,7 @@ async fn accept_invitation_returns_ok_and_forwards_principal() {
     {
         let accepted = service.accepted.lock().expect("accept lock");
         let accepted = accepted.as_ref().expect("accept command");
-        assert_eq!(accepted.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&accepted.caller), "staff-1");
         assert_eq!(accepted.token, "token-1");
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -7,11 +6,12 @@ use axum::body::{Body, to_bytes};
 use axum::http::{HeaderMap, Request, StatusCode};
 use bcs_api_http::{ApiState, PrincipalVerificationError, PrincipalVerifier, router};
 use bcs_service_api::application::v1::{
-    AddGroupParticipant, AddSessionParticipant, ApplicationError, BotParticipantMode,
-    CompleteSession, CreateGroup, CreateSession, CreateSessionOutcome,
+    AddGroupParticipant, AddSessionParticipant, ApplicationError, AuthenticatedCaller,
+    AuthenticatedUserIdentity, BotParticipantMode, CompleteSession, CreateGroup, CreateSession,
+    CreateSessionOutcome,
     DeleteGroup, DeleteGroupParticipant, DeleteResult, DeleteSession, DeleteSessionParticipant,
-    GetGroup, GetSession, GroupDetail, GroupService, GroupSummary, ListBotGroups,
-    ListSessionMessages, ListSessions, MessageSenderKind, Page, Principal, SessionCompletionResult,
+    GetGroup, GetSession, GroupDetail, GroupService, GroupSummary, ListGroups,
+    ListSessionMessages, ListSessions, MessageSenderKind, Page, SessionCompletionResult,
     SessionDetail, SessionMessage, SessionMessageKind, SessionMessagePage, SessionMessageService, SessionParticipant,
     SessionService, SessionStatus, SessionSummary, UpdateGroup, UpdateGroupParticipant,
     UpdateSession, UpdateSessionParticipant,
@@ -32,26 +32,44 @@ use tower::ServiceExt;
 // ---------------------------------------------------------------------------
 
 struct HeaderVerifier {
-    principal: Principal,
+    caller: AuthenticatedCaller,
 }
 
 #[async_trait]
 impl PrincipalVerifier for HeaderVerifier {
-    async fn verify(&self, headers: &HeaderMap) -> Result<Principal, PrincipalVerificationError> {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError> {
         if headers
             .get("x-test-auth")
             .and_then(|value| value.to_str().ok())
             == Some("yes")
         {
-            Ok(self.principal.clone())
+            Ok(self.caller.clone())
         } else {
             Err(PrincipalVerificationError::Missing)
         }
     }
 }
 
-fn principal() -> Principal {
-    Principal::bot("bot-1", "tenant-a", BTreeSet::new())
+fn caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn caller_user_id(caller: &AuthenticatedCaller) -> &str {
+    caller.user.as_ref().expect("User identity").id.as_str()
 }
 
 fn authenticated_request(method: &str, uri: &str, body: Value) -> Request<Body> {
@@ -80,9 +98,9 @@ struct NoopGroupService;
 
 #[async_trait]
 impl GroupService for NoopGroupService {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        _command: ListBotGroups,
+        _command: ListGroups,
     ) -> Result<Page<GroupSummary>, ApplicationError> {
         Err(ApplicationError::internal("group not configured"))
     }
@@ -418,7 +436,7 @@ fn test_session_router(
         Arc::new(NoopInvitationService),
         Arc::new(NoopFriendshipService),
         Arc::new(HeaderVerifier {
-            principal: principal(),
+            caller: caller(),
         }),
     ))
 }
@@ -459,7 +477,7 @@ async fn create_session_returns_created_and_forwards_principal() {
     {
         let created = session.created.lock().expect("create lock");
         let created = created.as_ref().expect("create command");
-        assert_eq!(created.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&created.caller), "staff-1");
         assert_eq!(created.group_id, "group-1");
         assert_eq!(created.driver_bot_uuid, "bot-1");
         assert_eq!(created.title.as_deref(), Some("Planning"));
@@ -505,7 +523,7 @@ async fn list_sessions_returns_page_and_forwards_filters() {
     let response = app
         .oneshot(authenticated_request(
             "GET",
-            "/openapi/v1/groups/group-1/sessions?offset=5&limit=10&status=running",
+            "/openapi/v1/groups/group-1/sessions?view_bot_id=bot-1&offset=5&limit=10&status=running",
             Value::Null,
         ))
         .await
@@ -521,7 +539,8 @@ async fn list_sessions_returns_page_and_forwards_filters() {
     {
         let listed = session.listed.lock().expect("list lock");
         let listed = listed.as_ref().expect("list command");
-        assert_eq!(listed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&listed.caller), "staff-1");
+        assert_eq!(listed.view_bot_id.as_deref(), Some("bot-1"));
         assert_eq!(listed.group_id, "group-1");
         assert_eq!(listed.offset, 5);
         assert_eq!(listed.limit, 10);
@@ -550,7 +569,7 @@ async fn get_session_returns_detail() {
     {
         let got = session.got.lock().expect("get lock");
         let got = got.as_ref().expect("get command");
-        assert_eq!(got.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&got.caller), "staff-1");
         assert_eq!(got.session_id, "session-1");
     }
 }
@@ -576,7 +595,7 @@ async fn update_session_returns_updated_detail() {
     {
         let updated = session.updated.lock().expect("update lock");
         let updated = updated.as_ref().expect("update command");
-        assert_eq!(updated.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&updated.caller), "staff-1");
         assert_eq!(updated.session_id, "session-1");
         assert_eq!(updated.title.as_deref(), Some("Renamed"));
     }
@@ -603,7 +622,7 @@ async fn delete_session_returns_deleted() {
     {
         let deleted = session.deleted.lock().expect("delete lock");
         let deleted = deleted.as_ref().expect("delete command");
-        assert_eq!(deleted.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&deleted.caller), "staff-1");
         assert_eq!(deleted.session_id, "session-1");
     }
 }
@@ -631,7 +650,7 @@ async fn complete_session_returns_completion_result() {
     {
         let completed = session.completed.lock().expect("complete lock");
         let completed = completed.as_ref().expect("complete command");
-        assert_eq!(completed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&completed.caller), "staff-1");
         assert_eq!(completed.session_id, "session-1");
     }
 }
@@ -659,7 +678,7 @@ async fn list_session_messages_returns_cursor_page() {
     {
         let listed = message.listed.lock().expect("list messages lock");
         let listed = listed.as_ref().expect("list messages command");
-        assert_eq!(listed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&listed.caller), "staff-1");
         assert_eq!(listed.session_id, "session-1");
         assert_eq!(listed.before, None);
         assert_eq!(listed.limit, 50);
@@ -778,7 +797,7 @@ async fn add_session_participant_returns_participant() {
     {
         let added = session.added_participant.lock().expect("add participant lock");
         let added = added.as_ref().expect("add participant command");
-        assert_eq!(added.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&added.caller), "staff-1");
         assert_eq!(added.session_id, "session-1");
         assert_eq!(added.bot_uuid, "bot-2");
         assert_eq!(added.mode, Some(BotParticipantMode::Muted));
@@ -806,7 +825,7 @@ async fn update_session_participant_returns_updated_mode() {
     {
         let updated = session.updated_participant.lock().expect("update participant lock");
         let updated = updated.as_ref().expect("update participant command");
-        assert_eq!(updated.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&updated.caller), "staff-1");
         assert_eq!(updated.session_id, "session-1");
         assert_eq!(updated.bot_uuid, "bot-2");
         assert_eq!(updated.mode, BotParticipantMode::Muted);
@@ -834,7 +853,7 @@ async fn remove_session_participant_returns_deleted() {
     {
         let removed = session.removed_participant.lock().expect("remove participant lock");
         let removed = removed.as_ref().expect("remove participant command");
-        assert_eq!(removed.principal.actor_id(), "bot-1");
+        assert_eq!(caller_user_id(&removed.caller), "staff-1");
         assert_eq!(removed.session_id, "session-1");
         assert_eq!(removed.bot_uuid, "bot-2");
     }

--- a/src/bcs/crates/application/v1/bcs-app-bot/CONTEXT.md
+++ b/src/bcs/crates/application/v1/bcs-app-bot/CONTEXT.md
@@ -1,0 +1,41 @@
+# bcs-app-bot Context
+
+## Provides
+
+- `BotServiceImpl`, the transport-agnostic implementation of the BCN V1 Bot
+  control-plane Service API.
+- Human-Principal authorization, Bot/Human projections, candidate visibility,
+  reachability computation, and owner-scoped updates.
+
+## Consumes
+
+- `bcs-service-api` application, core, and outbound-port contracts.
+- Pure utility crates for asynchronous traits and standard collections.
+
+## Allowed dependencies
+
+- `service-api/*`
+- Utility crates such as `async-trait`
+
+## Forbidden dependencies
+
+- `bootstrap/bcs`
+- `adapters/*`
+- Concrete `plugins/*`
+- Store or Legacy service implementations outside tests
+
+## Configuration
+
+- The composition root injects the environment and all contract
+  implementations.
+- This crate must not select implementations or inspect environment variables.
+
+## Runtime ownership
+
+This crate owns the V1 Bot control-plane use-case facade. The HTTP adapter may
+mount it only behind the trusted Human Principal verification boundary.
+
+## Tests
+
+- `cargo test --package bcs-app-bot --manifest-path src/bcs/Cargo.toml`
+- `cargo check --package bcs-app-bot --all-targets --manifest-path src/bcs/Cargo.toml`

--- a/src/bcs/crates/application/v1/bcs-app-bot/Cargo.toml
+++ b/src/bcs/crates/application/v1/bcs-app-bot/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bcs-app-bot"
+description = "Versioned Bot control-plane application facade for the BCN V1 API"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+bcs-service-api = { workspace = true }
+
+[dev-dependencies]
+bcs-bot = { workspace = true }
+bcs-bot-store = { workspace = true }
+bcs-config = { workspace = true }
+bcs-friend = { workspace = true }
+bcs-test-support = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
@@ -1,0 +1,484 @@
+//! Versioned Bot control-plane application facade for the BCN V1 API.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bcs_service_api::application::v1::{
+    ApplicationError, Bot, BotCandidate, BotCandidatePurpose, BotDescriptor, BotKind, BotProvider,
+    BotReachability, BotService, BotSkill, BotStatus, BotVisibility, GetBot, HumanBot,
+    ListBotCandidates, ListMyBots, Page, PhysicalBot, Principal, QueryBots, UpdateBot,
+};
+use bcs_service_api::{
+    ActorKind, ActorStatus, BotCandidateReadQuery, BotCandidateVisibility,
+    BotControlPlaneDescriptorPatch, BotControlPlaneOwnedQuery, BotControlPlanePatch,
+    BotControlPlaneRecord, BotControlPlaneRepoPort, BotRegistryCoreService, FriendCoreService,
+    ProviderBotBindingRepoPort, ProviderRepoPort, ServiceError,
+};
+
+#[derive(Debug, Clone)]
+pub struct BotServiceConfig {
+    pub env: String,
+}
+
+pub struct BotServiceImpl {
+    control_plane: Arc<dyn BotControlPlaneRepoPort>,
+    registry: Arc<dyn BotRegistryCoreService>,
+    friends: Arc<dyn FriendCoreService>,
+    providers: Arc<dyn ProviderRepoPort>,
+    provider_bindings: Arc<dyn ProviderBotBindingRepoPort>,
+    config: BotServiceConfig,
+}
+
+impl BotServiceImpl {
+    pub fn new(
+        control_plane: Arc<dyn BotControlPlaneRepoPort>,
+        registry: Arc<dyn BotRegistryCoreService>,
+        friends: Arc<dyn FriendCoreService>,
+        providers: Arc<dyn ProviderRepoPort>,
+        provider_bindings: Arc<dyn ProviderBotBindingRepoPort>,
+        config: BotServiceConfig,
+    ) -> Self {
+        Self {
+            control_plane,
+            registry,
+            friends,
+            providers,
+            provider_bindings,
+            config,
+        }
+    }
+
+    fn human_staff_no(principal: &Principal) -> Result<&str, ApplicationError> {
+        match principal {
+            Principal::Human(human) => Ok(&human.subject.id),
+            Principal::Bot(_) => Err(ApplicationError::forbidden(
+                "Bot control-plane operations require a Human Principal",
+            )),
+        }
+    }
+
+    fn validate_pagination(offset: u64, limit: u64) -> Result<(), ApplicationError> {
+        let _ = offset;
+        if (1..=100).contains(&limit) {
+            Ok(())
+        } else {
+            Err(ApplicationError::invalid(
+                "invalid_request",
+                "limit must be between 1 and 100",
+            ))
+        }
+    }
+
+    fn validate_bot_id(bot_id: &str) -> Result<(), ApplicationError> {
+        if bot_id.trim().is_empty() {
+            Err(ApplicationError::invalid(
+                "invalid_request",
+                "bot_id must not be empty",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn load_record(&self, bot_id: &str) -> Result<BotControlPlaneRecord, ApplicationError> {
+        self.control_plane
+            .get_control_plane(bot_id, &self.config.env)
+            .await
+            .map_err(map_service_error)?
+            .ok_or_else(|| {
+                ApplicationError::not_found(
+                    "bot_not_found",
+                    format!("Bot '{bot_id}' was not found"),
+                )
+            })
+    }
+
+    async fn project_records(
+        &self,
+        records: Vec<BotControlPlaneRecord>,
+    ) -> Result<Vec<Bot>, ApplicationError> {
+        let physical_ids = records
+            .iter()
+            .filter(|record| record.kind == ActorKind::Bot)
+            .map(|record| record.bot_id.clone())
+            .collect::<Vec<_>>();
+        let runtime_active = self
+            .registry
+            .list_runtime_active_bot_ids(&physical_ids)
+            .await
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        let bindings = self
+            .provider_bindings
+            .list_bindings_by_bot_uuids(&physical_ids)
+            .await
+            .map_err(map_service_error)?;
+        let provider_ids = bindings
+            .iter()
+            .map(|binding| binding.provider_id.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let providers = self
+            .providers
+            .list_providers_by_ids(&provider_ids)
+            .await
+            .map_err(map_service_error)?
+            .into_iter()
+            .map(|provider| (provider.provider_id.clone(), provider))
+            .collect::<HashMap<_, _>>();
+        let bindings = bindings
+            .into_iter()
+            .map(|binding| (binding.bot_uuid.clone(), binding))
+            .collect::<HashMap<_, _>>();
+
+        records
+            .into_iter()
+            .map(|record| {
+                let visibility = project_visibility(&record.visibility)?;
+                let status = project_status(record.status);
+                if record.kind == ActorKind::Human {
+                    return Ok(Bot::Human(HumanBot {
+                        bot_id: record.bot_id,
+                        kind: BotKind::Human,
+                        name: record.name,
+                        visibility,
+                        status,
+                        env: record.env,
+                        created_by: record.created_by,
+                        created_at: record.created_at,
+                        updated_at: record.updated_at,
+                    }));
+                }
+
+                let reachability = if record.status == ActorStatus::Online
+                    && runtime_active.contains(&record.bot_id)
+                {
+                    BotReachability::Reachable
+                } else {
+                    BotReachability::Unreachable
+                };
+                let provider = bindings
+                    .get(&record.bot_id)
+                    .and_then(|binding| providers.get(&binding.provider_id))
+                    .map(|provider| BotProvider {
+                        provider_id: provider.provider_id.clone(),
+                        name: provider.name.clone(),
+                    });
+                Ok(Bot::Physical(PhysicalBot {
+                    bot_id: record.bot_id,
+                    kind: BotKind::Bot,
+                    name: record.name,
+                    visibility,
+                    status,
+                    env: record.env,
+                    created_by: record.created_by,
+                    descriptor: BotDescriptor {
+                        summary: record.descriptor.summary,
+                        domains: record.descriptor.domains,
+                        skills: record
+                            .descriptor
+                            .skills
+                            .into_iter()
+                            .map(|skill| BotSkill {
+                                name: skill.name,
+                                description: skill.description,
+                            })
+                            .collect(),
+                        scopes: record.descriptor.scopes,
+                    },
+                    reachability,
+                    provider,
+                    agent_code: record.agent_code,
+                    created_at: record.created_at,
+                    updated_at: record.updated_at,
+                }))
+            })
+            .collect()
+    }
+
+    async fn project_one(&self, record: BotControlPlaneRecord) -> Result<Bot, ApplicationError> {
+        self.project_records(vec![record])
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ApplicationError::internal("Bot projection returned no record"))
+    }
+}
+
+#[async_trait]
+impl BotService for BotServiceImpl {
+    async fn list_candidates(
+        &self,
+        command: ListBotCandidates,
+    ) -> Result<Page<BotCandidate>, ApplicationError> {
+        let staff_no = Self::human_staff_no(&command.principal)?;
+        Self::validate_bot_id(&command.bot_id)?;
+        Self::validate_pagination(command.offset, command.limit)?;
+        let acting = self.load_record(&command.bot_id).await?;
+        if acting.kind != ActorKind::Bot {
+            return Err(ApplicationError::invalid(
+                "invalid_bot_kind",
+                "Candidate search requires a physical acting Bot",
+            ));
+        }
+        if acting.created_by.as_deref() != Some(staff_no) {
+            return Err(ApplicationError::forbidden(format!(
+                "Current Human does not manage Bot '{}'",
+                command.bot_id
+            )));
+        }
+
+        let friend_ids = self
+            .friends
+            .list_friends(&command.bot_id)
+            .await
+            .into_iter()
+            .collect();
+        let (records, total) = self
+            .control_plane
+            .list_control_plane_candidates(BotCandidateReadQuery {
+                acting_bot_id: command.bot_id,
+                env: acting.env,
+                visibility: match command.purpose {
+                    BotCandidatePurpose::Discovery => BotCandidateVisibility::Discovery,
+                    BotCandidatePurpose::Collaboration => BotCandidateVisibility::Collaboration,
+                },
+                friend_ids,
+                name: normalize_optional_name(command.name),
+                offset: command.offset,
+                limit: command.limit,
+            })
+            .await
+            .map_err(map_service_error)?;
+        let is_friend = records
+            .iter()
+            .map(|record| record.is_friend)
+            .collect::<Vec<_>>();
+        let bots = self
+            .project_records(records.into_iter().map(|record| record.bot).collect())
+            .await?;
+        let mut items = Vec::with_capacity(bots.len());
+        for (bot, is_friend) in bots.into_iter().zip(is_friend) {
+            let Bot::Physical(bot) = bot else {
+                return Err(ApplicationError::internal(
+                    "Candidate store returned a Human record",
+                ));
+            };
+            items.push(BotCandidate { bot, is_friend });
+        }
+        Ok(Page {
+            items,
+            total,
+            offset: command.offset,
+            limit: command.limit,
+        })
+    }
+
+    async fn query(&self, command: QueryBots) -> Result<Vec<Bot>, ApplicationError> {
+        Self::human_staff_no(&command.principal)?;
+        if command.bot_ids.len() > 100
+            || command
+                .bot_ids
+                .iter()
+                .any(|bot_id| bot_id.trim().is_empty())
+        {
+            return Err(ApplicationError::invalid(
+                "invalid_request",
+                "bot_ids must contain at most 100 non-empty identifiers",
+            ));
+        }
+        let records = self
+            .control_plane
+            .get_control_plane_by_ids(&command.bot_ids, &self.config.env)
+            .await
+            .map_err(map_service_error)?;
+        self.project_records(records).await
+    }
+
+    async fn get(&self, query: GetBot) -> Result<Bot, ApplicationError> {
+        Self::human_staff_no(&query.principal)?;
+        Self::validate_bot_id(&query.bot_id)?;
+        self.project_one(self.load_record(&query.bot_id).await?)
+            .await
+    }
+
+    async fn update(&self, command: UpdateBot) -> Result<Bot, ApplicationError> {
+        let staff_no = Self::human_staff_no(&command.principal)?;
+        Self::validate_bot_id(&command.bot_id)?;
+        if command.patch.is_empty() {
+            return Err(ApplicationError::invalid(
+                "invalid_request",
+                "Bot patch must contain at least one mutable field",
+            ));
+        }
+        if command
+            .patch
+            .descriptor
+            .as_ref()
+            .is_some_and(|descriptor| descriptor.is_empty())
+        {
+            return Err(ApplicationError::invalid(
+                "invalid_request",
+                "descriptor patch must contain at least one field",
+            ));
+        }
+        let record = self.load_record(&command.bot_id).await?;
+        if record.created_by.as_deref() != Some(staff_no) {
+            return Err(ApplicationError::forbidden(format!(
+                "Current Human does not own Bot '{}'",
+                command.bot_id
+            )));
+        }
+        if record.kind == ActorKind::Human && command.patch.descriptor.is_some() {
+            return Err(ApplicationError::invalid(
+                "invalid_bot_kind",
+                "Human rows do not have a descriptor",
+            ));
+        }
+
+        let name = command
+            .patch
+            .name
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_string);
+        if name.as_deref().is_some_and(str::is_empty) {
+            return Err(ApplicationError::invalid(
+                "invalid_request",
+                "name must not be empty",
+            ));
+        }
+        let descriptor = command
+            .patch
+            .descriptor
+            .map(|descriptor| {
+                let skills = descriptor.skills.map(|skills| {
+                    skills
+                        .into_iter()
+                        .map(|skill| {
+                            let name = skill.name.trim().to_string();
+                            if name.is_empty() {
+                                return Err(ApplicationError::invalid(
+                                    "invalid_request",
+                                    "descriptor skill name must not be empty",
+                                ));
+                            }
+                            Ok(bcs_service_api::Skill {
+                                name,
+                                description: skill.description,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                });
+                Ok(BotControlPlaneDescriptorPatch {
+                    summary: descriptor.summary,
+                    domains: descriptor.domains,
+                    skills: skills.transpose()?,
+                    scopes: descriptor.scopes,
+                })
+            })
+            .transpose()?;
+        let updated = self
+            .control_plane
+            .patch_control_plane(
+                &command.bot_id,
+                &self.config.env,
+                BotControlPlanePatch {
+                    name,
+                    visibility: command.patch.visibility.map(visibility_value),
+                    status: command.patch.status.map(domain_status),
+                    descriptor,
+                },
+            )
+            .await
+            .map_err(map_service_error)?
+            .ok_or_else(|| {
+                ApplicationError::not_found(
+                    "bot_not_found",
+                    format!("Bot '{}' was not found", command.bot_id),
+                )
+            })?;
+        self.project_one(updated).await
+    }
+
+    async fn list_mine(&self, command: ListMyBots) -> Result<Page<Bot>, ApplicationError> {
+        let staff_no = Self::human_staff_no(&command.principal)?;
+        Self::validate_pagination(command.offset, command.limit)?;
+        let records = self
+            .control_plane
+            .list_control_plane_by_creator(BotControlPlaneOwnedQuery {
+                created_by: staff_no.to_string(),
+                env: self.config.env.clone(),
+                kind: command.kind.map(|kind| match kind {
+                    BotKind::Bot => ActorKind::Bot,
+                    BotKind::Human => ActorKind::Human,
+                }),
+                name: normalize_optional_name(command.name),
+                status: command.status.map(domain_status),
+            })
+            .await
+            .map_err(map_service_error)?;
+        let mut bots = self.project_records(records).await?;
+        if let Some(reachability) = command.reachability {
+            bots.retain(|bot| {
+                matches!(bot, Bot::Physical(physical) if physical.reachability == reachability)
+            });
+        }
+        let total = bots.len() as u64;
+        let offset = usize::try_from(command.offset).unwrap_or(usize::MAX);
+        let limit = usize::try_from(command.limit).unwrap_or(usize::MAX);
+        let items = bots.into_iter().skip(offset).take(limit).collect();
+        Ok(Page {
+            items,
+            total,
+            offset: command.offset,
+            limit: command.limit,
+        })
+    }
+}
+
+fn normalize_optional_name(name: Option<String>) -> Option<String> {
+    name.map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+}
+
+fn project_visibility(value: &str) -> Result<BotVisibility, ApplicationError> {
+    match value {
+        "public" => Ok(BotVisibility::Public),
+        "protected" => Ok(BotVisibility::Protected),
+        "private" => Ok(BotVisibility::Private),
+        other => Err(ApplicationError::internal(format!(
+            "Bot has unsupported visibility '{other}'"
+        ))),
+    }
+}
+
+fn visibility_value(value: BotVisibility) -> String {
+    match value {
+        BotVisibility::Public => "public",
+        BotVisibility::Protected => "protected",
+        BotVisibility::Private => "private",
+    }
+    .to_string()
+}
+
+fn project_status(value: ActorStatus) -> BotStatus {
+    match value {
+        ActorStatus::Online => BotStatus::Online,
+        ActorStatus::Hidden => BotStatus::Hidden,
+    }
+}
+
+fn domain_status(value: BotStatus) -> ActorStatus {
+    match value {
+        BotStatus::Online => ActorStatus::Online,
+        BotStatus::Hidden => ActorStatus::Hidden,
+    }
+}
+
+fn map_service_error(error: ServiceError) -> ApplicationError {
+    ApplicationError::internal(error.to_string())
+}

--- a/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
@@ -7,7 +7,8 @@ use async_trait::async_trait;
 use bcs_service_api::application::v1::{
     ApplicationError, Bot, BotCandidate, BotCandidatePurpose, BotDescriptor, BotKind, BotProvider,
     BotReachability, BotService, BotSkill, BotStatus, BotVisibility, GetBot, HumanBot,
-    ListBotCandidates, ListMyBots, Page, PhysicalBot, Principal, QueryBots, UpdateBot,
+    ListBotCandidates, ListMyBots, Page, PhysicalBot, QueryBots, UpdateBot,
+    require_authenticated_user,
 };
 use bcs_service_api::{
     ActorKind, ActorStatus, BotCandidateReadQuery, BotCandidateVisibility,
@@ -49,13 +50,10 @@ impl BotServiceImpl {
         }
     }
 
-    fn human_staff_no(principal: &Principal) -> Result<&str, ApplicationError> {
-        match principal {
-            Principal::Human(human) => Ok(&human.subject.id),
-            Principal::Bot(_) => Err(ApplicationError::forbidden(
-                "Bot control-plane operations require a Human Principal",
-            )),
-        }
+    fn human_staff_no(
+        caller: &bcs_service_api::application::v1::AuthenticatedCaller,
+    ) -> Result<String, ApplicationError> {
+        Ok(require_authenticated_user(caller)?.id.clone())
     }
 
     fn validate_pagination(offset: u64, limit: u64) -> Result<(), ApplicationError> {
@@ -214,7 +212,7 @@ impl BotService for BotServiceImpl {
         &self,
         command: ListBotCandidates,
     ) -> Result<Page<BotCandidate>, ApplicationError> {
-        let staff_no = Self::human_staff_no(&command.principal)?;
+        let staff_no = Self::human_staff_no(&command.caller)?;
         Self::validate_bot_id(&command.bot_id)?;
         Self::validate_pagination(command.offset, command.limit)?;
         let acting = self.load_record(&command.bot_id).await?;
@@ -224,7 +222,7 @@ impl BotService for BotServiceImpl {
                 "Candidate search requires a physical acting Bot",
             ));
         }
-        if acting.created_by.as_deref() != Some(staff_no) {
+        if acting.created_by.as_deref() != Some(staff_no.as_str()) {
             return Err(ApplicationError::forbidden(format!(
                 "Current Human does not manage Bot '{}'",
                 command.bot_id
@@ -278,7 +276,7 @@ impl BotService for BotServiceImpl {
     }
 
     async fn query(&self, command: QueryBots) -> Result<Vec<Bot>, ApplicationError> {
-        Self::human_staff_no(&command.principal)?;
+        Self::human_staff_no(&command.caller)?;
         if command.bot_ids.len() > 100
             || command
                 .bot_ids
@@ -299,14 +297,14 @@ impl BotService for BotServiceImpl {
     }
 
     async fn get(&self, query: GetBot) -> Result<Bot, ApplicationError> {
-        Self::human_staff_no(&query.principal)?;
+        Self::human_staff_no(&query.caller)?;
         Self::validate_bot_id(&query.bot_id)?;
         self.project_one(self.load_record(&query.bot_id).await?)
             .await
     }
 
     async fn update(&self, command: UpdateBot) -> Result<Bot, ApplicationError> {
-        let staff_no = Self::human_staff_no(&command.principal)?;
+        let staff_no = Self::human_staff_no(&command.caller)?;
         Self::validate_bot_id(&command.bot_id)?;
         if command.patch.is_empty() {
             return Err(ApplicationError::invalid(
@@ -326,7 +324,7 @@ impl BotService for BotServiceImpl {
             ));
         }
         let record = self.load_record(&command.bot_id).await?;
-        if record.created_by.as_deref() != Some(staff_no) {
+        if record.created_by.as_deref() != Some(staff_no.as_str()) {
             return Err(ApplicationError::forbidden(format!(
                 "Current Human does not own Bot '{}'",
                 command.bot_id
@@ -405,12 +403,12 @@ impl BotService for BotServiceImpl {
     }
 
     async fn list_mine(&self, command: ListMyBots) -> Result<Page<Bot>, ApplicationError> {
-        let staff_no = Self::human_staff_no(&command.principal)?;
+        let staff_no = Self::human_staff_no(&command.caller)?;
         Self::validate_pagination(command.offset, command.limit)?;
         let records = self
             .control_plane
             .list_control_plane_by_creator(BotControlPlaneOwnedQuery {
-                created_by: staff_no.to_string(),
+                created_by: staff_no,
                 env: self.config.env.clone(),
                 kind: command.kind.map(|kind| match kind {
                     BotKind::Bot => ActorKind::Bot,

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/conformance_bot_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/conformance_bot_service.rs
@@ -1,0 +1,29 @@
+#![allow(
+    clippy::expect_used,
+    reason = "test assertions intentionally fail fast"
+)]
+
+use std::sync::Arc;
+
+use bcs_app_bot::{BotServiceConfig, BotServiceImpl};
+use bcs_bot_store::{MemoryBotRepo, MemoryProviderStore};
+use bcs_test_support::{NoopBotRegistryCoreService, NoopFriendCoreService};
+
+#[tokio::test]
+async fn bot_service_impl_passes_the_v1_bot_service_contract() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let repo = Arc::new(MemoryBotRepo::with_base_dir(temp.path().to_path_buf()));
+    let providers = Arc::new(MemoryProviderStore::new());
+    let service = BotServiceImpl::new(
+        repo,
+        Arc::new(NoopBotRegistryCoreService),
+        Arc::new(NoopFriendCoreService),
+        providers.clone(),
+        providers,
+        BotServiceConfig {
+            env: bcs_config::resolve_env_str(),
+        },
+    );
+
+    bcs_test_support::contract::application::bot_service_contract_tests(&service).await;
+}

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
@@ -1,0 +1,428 @@
+#![allow(
+    clippy::expect_used,
+    reason = "test assertions intentionally fail fast"
+)]
+
+use std::sync::Arc;
+
+use bcs_app_bot::{BotServiceConfig, BotServiceImpl};
+use bcs_bot::BotCore;
+use bcs_bot_store::{MemoryBotRepo, MemoryProviderStore};
+use bcs_friend::FriendCore;
+use bcs_service_api::application::v1::{
+    ApplicationError, Bot, BotCandidatePurpose, BotDescriptorPatch, BotKind, BotPatch,
+    BotReachability, BotService, BotStatus, BotVisibility, GetBot, ListBotCandidates, ListMyBots,
+    QueryBots, UpdateBot,
+};
+use bcs_service_api::{
+    ActorStatus, BotCapabilities, BotControlPlaneRepoPort, BotRegistryCoreService, BotRepoPort,
+    FriendCoreService, ProviderBotBinding, ProviderBotBindingRepoPort, ProviderRecord,
+    ProviderRepoPort, Skill,
+};
+
+#[test]
+fn v1_bot_commands_expose_the_approved_control_plane_surface() {
+    let principal = human_principal("staff-1");
+
+    let _ = ListBotCandidates {
+        principal: principal.clone(),
+        bot_id: "bot-1".to_string(),
+        purpose: Default::default(),
+        name: None,
+        offset: 0,
+        limit: 20,
+    };
+    let _ = QueryBots {
+        principal: principal.clone(),
+        bot_ids: vec!["bot-1".to_string()],
+    };
+    let _ = GetBot {
+        principal: principal.clone(),
+        bot_id: "bot-1".to_string(),
+    };
+    let _ = UpdateBot {
+        principal: principal.clone(),
+        bot_id: "bot-1".to_string(),
+        patch: BotPatch {
+            name: Some("Renamed".to_string()),
+            visibility: Some(BotVisibility::Protected),
+            status: Some(BotStatus::Online),
+            descriptor: Some(BotDescriptorPatch {
+                summary: Some("summary".to_string()),
+                domains: None,
+                skills: None,
+                scopes: None,
+            }),
+        },
+    };
+    let _ = ListMyBots {
+        principal,
+        kind: Some(BotKind::Bot),
+        name: None,
+        status: None,
+        reachability: Some(BotReachability::Reachable),
+        offset: 0,
+        limit: 20,
+    };
+
+    let _assert_object_safe: fn(&dyn BotService) = |_| {};
+}
+
+struct Fixture {
+    service: BotServiceImpl,
+    repo: Arc<MemoryBotRepo>,
+    friends: Arc<FriendCore>,
+    providers: Arc<MemoryProviderStore>,
+    _temp: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let repo = Arc::new(MemoryBotRepo::with_base_dir(temp.path().to_path_buf()));
+        let registry: Arc<dyn BotRegistryCoreService> = Arc::new(BotCore::with_repo(repo.clone()));
+        let control_plane: Arc<dyn BotControlPlaneRepoPort> = repo.clone();
+        let friends = Arc::new(FriendCore::memory());
+        let providers = Arc::new(MemoryProviderStore::new());
+        let provider_repo: Arc<dyn ProviderRepoPort> = providers.clone();
+        let provider_bindings: Arc<dyn ProviderBotBindingRepoPort> = providers.clone();
+        let env = bcs_config::resolve_env_str();
+        let service = BotServiceImpl::new(
+            control_plane,
+            registry,
+            friends.clone(),
+            provider_repo,
+            provider_bindings,
+            BotServiceConfig { env: env.clone() },
+        );
+        Self {
+            service,
+            repo,
+            friends,
+            providers,
+            _temp: temp,
+        }
+    }
+
+    async fn add_bot(&self, bot_id: &str, owner: &str, visibility: &str, status: ActorStatus) {
+        self.repo
+            .register_with_owner_and_token(
+                bot_id.to_string(),
+                BotCapabilities {
+                    name: Some(bot_id.to_string()),
+                    summary: Some(format!("summary-{bot_id}")),
+                    domains: vec!["planning".to_string()],
+                    skills: vec![Skill::with_description("plan", "Make a plan")],
+                    scopes: vec!["workspace".to_string()],
+                    visibility: visibility.to_string(),
+                    agent_code: Some(format!("agent-{bot_id}")),
+                    ..Default::default()
+                },
+                owner,
+                &format!("token-{bot_id}"),
+            )
+            .await
+            .expect("register bot");
+        self.repo
+            .update_actor_status(bot_id, status)
+            .await
+            .expect("update actor status");
+    }
+}
+
+#[tokio::test]
+async fn candidates_require_a_human_owner_and_a_physical_acting_bot() {
+    let fixture = Fixture::new();
+    fixture
+        .add_bot("acting", "staff-1", "private", ActorStatus::Online)
+        .await;
+    fixture
+        .repo
+        .ensure_human_actor("staff-1", "Human")
+        .await
+        .expect("ensure human");
+
+    let error = fixture
+        .service
+        .list_candidates(ListBotCandidates {
+            principal: human_principal("staff-2"),
+            bot_id: "acting".to_string(),
+            purpose: BotCandidatePurpose::Discovery,
+            name: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect_err("non-owner must fail");
+    assert_eq!(error.code(), "forbidden");
+
+    let error = fixture
+        .service
+        .list_candidates(ListBotCandidates {
+            principal: human_principal("staff-1"),
+            bot_id: "human_staff-1".to_string(),
+            purpose: BotCandidatePurpose::Discovery,
+            name: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect_err("human acting row must fail");
+    assert_eq!(error.code(), "invalid_bot_kind");
+}
+
+#[tokio::test]
+async fn collaboration_candidates_include_private_friends_without_status_filtering() {
+    let fixture = Fixture::new();
+    fixture
+        .add_bot("acting", "staff-1", "private", ActorStatus::Online)
+        .await;
+    fixture
+        .add_bot("private-friend", "staff-2", "private", ActorStatus::Hidden)
+        .await;
+    fixture
+        .friends
+        .add_friendship("acting", "private-friend")
+        .await
+        .expect("add friendship");
+
+    let page = fixture
+        .service
+        .list_candidates(ListBotCandidates {
+            principal: human_principal("staff-1"),
+            bot_id: "acting".to_string(),
+            purpose: BotCandidatePurpose::Collaboration,
+            name: Some(" FRIEND ".to_string()),
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("list candidates");
+    assert_eq!(page.total, 1);
+    assert_eq!(page.items[0].bot.bot_id, "private-friend");
+    assert_eq!(page.items[0].bot.status, BotStatus::Hidden);
+    assert_eq!(page.items[0].bot.reachability, BotReachability::Unreachable);
+    assert!(page.items[0].is_friend);
+}
+
+#[tokio::test]
+async fn query_preserves_first_occurrence_and_projects_both_kinds_provider_and_reachability() {
+    let fixture = Fixture::new();
+    fixture
+        .add_bot("physical", "staff-1", "private", ActorStatus::Online)
+        .await;
+    fixture
+        .repo
+        .ensure_human_actor("staff-1", "Human")
+        .await
+        .expect("ensure human");
+    fixture
+        .repo
+        .register_streaming_connection("physical".to_string())
+        .await
+        .expect("connect physical bot");
+    fixture
+        .providers
+        .insert_provider(ProviderRecord {
+            provider_id: "provider-1".to_string(),
+            name: "Provider One".to_string(),
+            config: "{}".to_string(),
+            created_by: "staff-1".to_string(),
+            owners: "[]".to_string(),
+            disabled: false,
+            created_at: 1,
+            updated_at: 1,
+        })
+        .await
+        .expect("insert provider");
+    fixture
+        .providers
+        .insert_binding(ProviderBotBinding {
+            bot_uuid: "physical".to_string(),
+            provider_id: "provider-1".to_string(),
+            provider_bot_ref: "secret-internal-ref".to_string(),
+            disabled: false,
+            created_at: 1,
+            updated_at: 1,
+        })
+        .await
+        .expect("insert binding");
+
+    let bots = fixture
+        .service
+        .query(QueryBots {
+            principal: human_principal("staff-2"),
+            bot_ids: vec![
+                "human_staff-1".to_string(),
+                "missing".to_string(),
+                "physical".to_string(),
+                "human_staff-1".to_string(),
+            ],
+        })
+        .await
+        .expect("query bots");
+    assert_eq!(
+        bots.iter().map(Bot::bot_id).collect::<Vec<_>>(),
+        vec!["human_staff-1", "physical"]
+    );
+    let Bot::Physical(physical) = &bots[1] else {
+        panic!("expected physical bot");
+    };
+    assert_eq!(physical.reachability, BotReachability::Reachable);
+    assert_eq!(
+        physical.provider.as_ref().map(|p| p.name.as_str()),
+        Some("Provider One")
+    );
+    assert_eq!(physical.agent_code.as_deref(), Some("agent-physical"));
+}
+
+#[tokio::test]
+async fn update_requires_created_by_and_rejects_descriptor_for_human() {
+    let fixture = Fixture::new();
+    fixture
+        .add_bot("owned", "staff-1", "public", ActorStatus::Online)
+        .await;
+    fixture
+        .repo
+        .ensure_human_actor("staff-1", "Human")
+        .await
+        .expect("ensure human");
+
+    let error = fixture
+        .service
+        .update(UpdateBot {
+            principal: human_principal("staff-2"),
+            bot_id: "owned".to_string(),
+            patch: BotPatch {
+                name: Some("Nope".to_string()),
+                ..Default::default()
+            },
+        })
+        .await
+        .expect_err("non-owner update");
+    assert_eq!(error.code(), "forbidden");
+
+    let error = fixture
+        .service
+        .update(UpdateBot {
+            principal: human_principal("staff-1"),
+            bot_id: "human_staff-1".to_string(),
+            patch: BotPatch {
+                descriptor: Some(BotDescriptorPatch {
+                    summary: Some("not allowed".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        })
+        .await
+        .expect_err("human descriptor update");
+    assert_eq!(error.code(), "invalid_bot_kind");
+
+    let updated = fixture
+        .service
+        .update(UpdateBot {
+            principal: human_principal("staff-1"),
+            bot_id: "owned".to_string(),
+            patch: BotPatch {
+                name: Some(" Renamed ".to_string()),
+                visibility: Some(BotVisibility::Protected),
+                status: Some(BotStatus::Hidden),
+                descriptor: Some(BotDescriptorPatch {
+                    domains: Some(vec![]),
+                    scopes: Some(vec!["new-scope".to_string()]),
+                    ..Default::default()
+                }),
+            },
+        })
+        .await
+        .expect("owner update");
+    let Bot::Physical(updated) = updated else {
+        panic!("expected physical bot");
+    };
+    assert_eq!(updated.name, "Renamed");
+    assert_eq!(updated.visibility, BotVisibility::Protected);
+    assert_eq!(updated.status, BotStatus::Hidden);
+    assert!(updated.descriptor.domains.is_empty());
+    assert_eq!(updated.descriptor.scopes, vec!["new-scope"]);
+}
+
+#[tokio::test]
+async fn mine_applies_reachability_before_pagination_and_bot_principals_are_forbidden() {
+    let fixture = Fixture::new();
+    fixture
+        .add_bot("reachable", "staff-1", "public", ActorStatus::Online)
+        .await;
+    fixture
+        .add_bot("unreachable", "staff-1", "public", ActorStatus::Online)
+        .await;
+    fixture
+        .repo
+        .register_streaming_connection("reachable".to_string())
+        .await
+        .expect("connect bot");
+    fixture
+        .repo
+        .ensure_human_actor("staff-1", "Human")
+        .await
+        .expect("ensure human");
+
+    let page = fixture
+        .service
+        .list_mine(ListMyBots {
+            principal: human_principal("staff-1"),
+            kind: None,
+            name: None,
+            status: None,
+            reachability: Some(BotReachability::Reachable),
+            offset: 0,
+            limit: 1,
+        })
+        .await
+        .expect("list mine");
+    assert_eq!(page.total, 1);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].bot_id(), "reachable");
+
+    let error = fixture
+        .service
+        .get(GetBot {
+            principal: bcs_service_api::application::v1::Principal::bot(
+                "reachable",
+                "tenant-1",
+                Default::default(),
+            ),
+            bot_id: "reachable".to_string(),
+        })
+        .await
+        .expect_err("Bot Principal must be rejected");
+    assert_eq!(error.code(), "forbidden");
+}
+
+#[tokio::test]
+async fn invalid_application_inputs_use_stable_codes() {
+    let fixture = Fixture::new();
+    let error = fixture
+        .service
+        .query(QueryBots {
+            principal: human_principal("staff-1"),
+            bot_ids: (0..101).map(|index| format!("bot-{index}")).collect(),
+        })
+        .await
+        .expect_err("oversized query must fail");
+    assert!(matches!(error, ApplicationError::InvalidInput { .. }));
+    assert_eq!(error.code(), "invalid_request");
+}
+
+fn human_principal(staff_no: &str) -> bcs_service_api::application::v1::Principal {
+    bcs_service_api::application::v1::Principal::human(
+        bcs_service_api::application::v1::AuthenticatedUser {
+            id: staff_no.to_string(),
+            username: staff_no.to_string(),
+            display_name: None,
+            full_name: None,
+        },
+        "tenant-1",
+        Default::default(),
+    )
+}

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
@@ -22,10 +22,10 @@ use bcs_service_api::{
 
 #[test]
 fn v1_bot_commands_expose_the_approved_control_plane_surface() {
-    let principal = human_principal("staff-1");
+    let caller = human_caller("staff-1");
 
     let _ = ListBotCandidates {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_id: "bot-1".to_string(),
         purpose: Default::default(),
         name: None,
@@ -33,15 +33,15 @@ fn v1_bot_commands_expose_the_approved_control_plane_surface() {
         limit: 20,
     };
     let _ = QueryBots {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_ids: vec!["bot-1".to_string()],
     };
     let _ = GetBot {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_id: "bot-1".to_string(),
     };
     let _ = UpdateBot {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_id: "bot-1".to_string(),
         patch: BotPatch {
             name: Some("Renamed".to_string()),
@@ -56,7 +56,7 @@ fn v1_bot_commands_expose_the_approved_control_plane_surface() {
         },
     };
     let _ = ListMyBots {
-        principal,
+        caller,
         kind: Some(BotKind::Bot),
         name: None,
         status: None,
@@ -145,7 +145,7 @@ async fn candidates_require_a_human_owner_and_a_physical_acting_bot() {
     let error = fixture
         .service
         .list_candidates(ListBotCandidates {
-            principal: human_principal("staff-2"),
+            caller: human_caller("staff-2"),
             bot_id: "acting".to_string(),
             purpose: BotCandidatePurpose::Discovery,
             name: None,
@@ -159,7 +159,7 @@ async fn candidates_require_a_human_owner_and_a_physical_acting_bot() {
     let error = fixture
         .service
         .list_candidates(ListBotCandidates {
-            principal: human_principal("staff-1"),
+            caller: human_caller("staff-1"),
             bot_id: "human_staff-1".to_string(),
             purpose: BotCandidatePurpose::Discovery,
             name: None,
@@ -189,7 +189,7 @@ async fn collaboration_candidates_include_private_friends_without_status_filteri
     let page = fixture
         .service
         .list_candidates(ListBotCandidates {
-            principal: human_principal("staff-1"),
+            caller: human_caller("staff-1"),
             bot_id: "acting".to_string(),
             purpose: BotCandidatePurpose::Collaboration,
             name: Some(" FRIEND ".to_string()),
@@ -251,7 +251,7 @@ async fn query_preserves_first_occurrence_and_projects_both_kinds_provider_and_r
     let bots = fixture
         .service
         .query(QueryBots {
-            principal: human_principal("staff-2"),
+            caller: human_caller("staff-2"),
             bot_ids: vec![
                 "human_staff-1".to_string(),
                 "missing".to_string(),
@@ -291,7 +291,7 @@ async fn update_requires_created_by_and_rejects_descriptor_for_human() {
     let error = fixture
         .service
         .update(UpdateBot {
-            principal: human_principal("staff-2"),
+            caller: human_caller("staff-2"),
             bot_id: "owned".to_string(),
             patch: BotPatch {
                 name: Some("Nope".to_string()),
@@ -305,7 +305,7 @@ async fn update_requires_created_by_and_rejects_descriptor_for_human() {
     let error = fixture
         .service
         .update(UpdateBot {
-            principal: human_principal("staff-1"),
+            caller: human_caller("staff-1"),
             bot_id: "human_staff-1".to_string(),
             patch: BotPatch {
                 descriptor: Some(BotDescriptorPatch {
@@ -322,7 +322,7 @@ async fn update_requires_created_by_and_rejects_descriptor_for_human() {
     let updated = fixture
         .service
         .update(UpdateBot {
-            principal: human_principal("staff-1"),
+            caller: human_caller("staff-1"),
             bot_id: "owned".to_string(),
             patch: BotPatch {
                 name: Some(" Renamed ".to_string()),
@@ -348,7 +348,7 @@ async fn update_requires_created_by_and_rejects_descriptor_for_human() {
 }
 
 #[tokio::test]
-async fn mine_applies_reachability_before_pagination_and_bot_principals_are_forbidden() {
+async fn mine_applies_reachability_before_pagination_and_callers_without_user_are_forbidden() {
     let fixture = Fixture::new();
     fixture
         .add_bot("reachable", "staff-1", "public", ActorStatus::Online)
@@ -370,7 +370,7 @@ async fn mine_applies_reachability_before_pagination_and_bot_principals_are_forb
     let page = fixture
         .service
         .list_mine(ListMyBots {
-            principal: human_principal("staff-1"),
+            caller: human_caller("staff-1"),
             kind: None,
             name: None,
             status: None,
@@ -387,15 +387,11 @@ async fn mine_applies_reachability_before_pagination_and_bot_principals_are_forb
     let error = fixture
         .service
         .get(GetBot {
-            principal: bcs_service_api::application::v1::Principal::bot(
-                "reachable",
-                "tenant-1",
-                Default::default(),
-            ),
+            caller: bot_only_caller("reachable"),
             bot_id: "reachable".to_string(),
         })
         .await
-        .expect_err("Bot Principal must be rejected");
+        .expect_err("caller without User must be rejected");
     assert_eq!(error.code(), "forbidden");
 }
 
@@ -405,7 +401,7 @@ async fn invalid_application_inputs_use_stable_codes() {
     let error = fixture
         .service
         .query(QueryBots {
-            principal: human_principal("staff-1"),
+            caller: human_caller("staff-1"),
             bot_ids: (0..101).map(|index| format!("bot-{index}")).collect(),
         })
         .await
@@ -414,15 +410,32 @@ async fn invalid_application_inputs_use_stable_codes() {
     assert_eq!(error.code(), "invalid_request");
 }
 
-fn human_principal(staff_no: &str) -> bcs_service_api::application::v1::Principal {
-    bcs_service_api::application::v1::Principal::human(
-        bcs_service_api::application::v1::AuthenticatedUser {
+fn human_caller(staff_no: &str) -> bcs_service_api::application::v1::AuthenticatedCaller {
+    bcs_service_api::application::v1::AuthenticatedCaller {
+        tenant: "tenant-1".into(),
+        user: Some(bcs_service_api::application::v1::AuthenticatedUserIdentity {
             id: staff_no.to_string(),
             username: staff_no.to_string(),
             display_name: None,
             full_name: None,
-        },
-        "tenant-1",
-        Default::default(),
-    )
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn bot_only_caller(bot_uuid: &str) -> bcs_service_api::application::v1::AuthenticatedCaller {
+    bcs_service_api::application::v1::AuthenticatedCaller {
+        tenant: "tenant-1".into(),
+        user: None,
+        bot: Some(bcs_service_api::application::v1::AuthenticatedBotIdentity {
+            bot_uuid: bot_uuid.into(),
+            owner_id: "staff-1".into(),
+            app_id: 1,
+            agent_code: "agent".into(),
+        }),
+        app: None,
+        access_key: None,
+    }
 }

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -10,10 +10,11 @@ use bcs_service_api::application::v1::{
     CreateDirectMessageGroup, CreateGroup, CreateGroupOutcome, CreateGroupSpec, CreateParticipant,
     DeleteGroup, DeleteGroupParticipant, DeleteResult, DirectMessageGroupDetail,
     DirectMessageGroupSummary, GetGroup, GroupDetail, GroupKindFilter, GroupService, GroupStatus,
-    GroupStrategy as V1GroupStrategy, GroupSummary, GroupVisibility, HumanPrincipal, ListBotGroups,
+    GroupStrategy as V1GroupStrategy, GroupSummary, GroupVisibility, HumanPrincipal, ListGroups,
     ManagerWorkerConfiguration, Membership, MembershipFilter, NormalGroupSummary, Page,
     Participant as V1Participant, Principal, StateMachineConfiguration, StateMachineDefinitionReference,
     StateMachineParticipantBinding, UpdateGroup, UpdateGroupParticipant,
+    require_authenticated_user, require_human,
 };
 use bcs_service_api::{
     ActorKind, ActorStatus, AuthenticatedHumanCaller, BotRegistryCoreService,
@@ -21,7 +22,7 @@ use bcs_service_api::{
     ConfigureGroupRuntimeCommand, DefaultDelivery, DmCreateCommand, FriendCoreService,
     Group as DomainGroup, GroupAddMemberCommand, GroupCoreService, GroupCreateCommand,
     GroupCreateParticipantCommand, GroupDeleteCommand, GroupKind, GroupManagementService,
-    GroupMutableFieldsPatch, GroupParticipantModeCommand, GroupParticipantView,
+    GroupMutableFieldsPatch, GroupParticipantView,
     GroupRemoveMemberCommand, GroupStrategy, GroupUseCaseError, ParticipantMode,
     RelationCoreService, RoutingMode, RoutingPolicy, RuntimeParticipantBinding, ServiceError,
     SessionManagementService, StartStateMachineRunCommand,
@@ -35,7 +36,7 @@ pub struct GroupServiceConfig {
 
 /// OpenAPI v1 Group facade.
 ///
-/// It owns Principal-based resource authorization and V1 projections while
+/// It owns authenticated-Caller resource authorization and V1 projections while
 /// delegating existing group creation/deletion side effects to the legacy-
 /// compatible application service. No HTTP type crosses this boundary.
 pub struct GroupServiceImpl {
@@ -96,37 +97,73 @@ impl GroupServiceImpl {
             })
     }
 
-    async fn authorize_bot_resource(
+    async fn resolve_view_actor(
         &self,
-        principal: &Principal,
-        bot_uuid: &str,
-    ) -> Result<(), ApplicationError> {
-        match principal {
-            Principal::Bot(bot) if bot.bot_uuid == bot_uuid => {
-                self.load_bot(bot_uuid).await?;
-                Ok(())
-            }
-            Principal::Bot(_) => Err(ApplicationError::forbidden(
-                "Bot Principal may query only its own bot_uuid",
-            )),
-            Principal::Human(human) => {
-                let bot = self.load_bot(bot_uuid).await?;
-                if bot.created_by.as_deref() == Some(human.subject.id.as_str()) {
-                    return Ok(());
-                }
-                let creator_edge = self
-                    .relation
-                    .get_edge(&principal.actor_id(), bot_uuid, &self.config.relation_env)
-                    .await
-                    .map_err(map_service_error)?;
-                if creator_edge.is_some_and(|edge| edge.is_creator) {
-                    return Ok(());
-                }
-                Err(ApplicationError::forbidden(format!(
-                    "Human Principal cannot manage Bot '{bot_uuid}'"
-                )))
-            }
+        caller: &bcs_service_api::application::v1::AuthenticatedCaller,
+        requested: Option<&str>,
+    ) -> Result<String, ApplicationError> {
+        let user = require_authenticated_user(caller)?;
+        let human_actor_id = format!("human_{}", user.id);
+        let Some(requested) = requested else {
+            return Ok(human_actor_id);
+        };
+        if requested == human_actor_id {
+            return Ok(human_actor_id);
         }
+        if requested.starts_with("human_") {
+            return Err(ApplicationError::forbidden(
+                "The explicit Human View Actor must identify the authenticated User",
+            ));
+        }
+        let bot = self.load_bot(requested).await.map_err(|error| match error {
+            ApplicationError::NotFound { .. } => {
+                ApplicationError::forbidden("The explicit View Actor is not authorized")
+            }
+            other => other,
+        })?;
+        if bot.actor_kind == ActorKind::Bot
+            && bot.created_by.as_deref() == Some(user.id.as_str())
+        {
+            Ok(requested.to_string())
+        } else {
+            Err(ApplicationError::forbidden(
+                "The explicit View Actor is not authorized",
+            ))
+        }
+    }
+
+    async fn can_read_group_detail(
+        &self,
+        caller: &bcs_service_api::application::v1::AuthenticatedCaller,
+        group: &DomainGroup,
+    ) -> Result<bool, ApplicationError> {
+        let user = require_authenticated_user(caller)?;
+        let human_actor_id = format!("human_{}", user.id);
+        if group
+            .participants
+            .iter()
+            .any(|participant| {
+                participant.actor_kind == ActorKind::Human
+                    && participant.bot_uuid == human_actor_id
+            })
+        {
+            return Ok(true);
+        }
+        let owned_bot_ids = self
+            .registry
+            .list_bots_by_creator(&user.id)
+            .await
+            .into_iter()
+            .filter(|bot| bot.actor_kind == ActorKind::Bot)
+            .map(|bot| bot.bot_uuid)
+            .collect::<HashSet<_>>();
+        Ok(group
+            .participants
+            .iter()
+            .any(|participant| {
+                participant.actor_kind == ActorKind::Bot
+                    && owned_bot_ids.contains(&participant.bot_uuid)
+            }))
     }
 
     async fn ensure_collaboration_eligible(
@@ -231,6 +268,30 @@ impl GroupServiceImpl {
         if !self.can_read_group(principal, &group).await? {
             return Err(ApplicationError::forbidden(
                 "Principal has no readable relation to this Group",
+            ));
+        }
+        Ok(group)
+    }
+
+    async fn load_group_detail_for_caller(
+        &self,
+        caller: &bcs_service_api::application::v1::AuthenticatedCaller,
+        group_id: &str,
+    ) -> Result<DomainGroup, ApplicationError> {
+        let group = self
+            .groups
+            .try_get(group_id)
+            .await
+            .map_err(map_service_error)?
+            .ok_or_else(|| {
+                ApplicationError::not_found(
+                    "group_not_found",
+                    format!("Group '{group_id}' was not found"),
+                )
+            })?;
+        if !self.can_read_group_detail(caller, &group).await? {
+            return Err(ApplicationError::forbidden(
+                "Neither the Human Actor nor an owned Bot is a Group Participant",
             ));
         }
         Ok(group)
@@ -477,12 +538,7 @@ impl GroupServiceImpl {
         }
 
         let principal_actor_id = principal.actor_id();
-        if let Principal::Human(human) = &principal
-            && request
-                .participants
-                .iter()
-                .any(|participant| participant.actor_id == principal_actor_id)
-        {
+        if let Principal::Human(human) = &principal {
             self.registry
                 .ensure_human_actor(&human.subject.id, &human_display_name(human))
                 .await
@@ -495,16 +551,7 @@ impl GroupServiceImpl {
             }),
             Principal::Bot(_) => None,
         };
-        let principal_is_participant = request
-            .participants
-            .iter()
-            .any(|participant| participant.actor_id == principal_actor_id)
-            || request.driver_bot_uuid == principal_actor_id;
-        let originator = if principal_is_participant {
-            principal_actor_id.clone()
-        } else {
-            request.driver_bot_uuid.clone()
-        };
+        let originator = principal_actor_id.clone();
         let (strategy, routing_policy, state_machine) =
             map_create_collaboration(request.collaboration.clone());
         let lead_role = strategy.lead_role();
@@ -876,11 +923,12 @@ impl GroupServiceImpl {
 
 #[async_trait]
 impl GroupService for GroupServiceImpl {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        command: ListBotGroups,
+        command: ListGroups,
     ) -> Result<Page<GroupSummary>, ApplicationError> {
-        self.authorize_bot_resource(&command.principal, &command.bot_uuid)
+        let view_actor_id = self
+            .resolve_view_actor(&command.caller, command.view_bot_id.as_deref())
             .await?;
         if command.limit == 0 || command.limit > 100 {
             return Err(ApplicationError::invalid(
@@ -897,7 +945,7 @@ impl GroupService for GroupServiceImpl {
 
         let direct = self
             .groups
-            .try_find_by_participant(&command.bot_uuid)
+            .try_find_by_participant(&view_actor_id)
             .await
             .map_err(map_service_error)?
             .into_iter()
@@ -905,7 +953,7 @@ impl GroupService for GroupServiceImpl {
             .collect::<HashMap<_, _>>();
         let session_group_ids = self
             .sessions
-            .list_group_ids_by_session_participant(&command.bot_uuid)
+            .list_group_ids_by_session_participant(&view_actor_id)
             .await
             .map_err(|error| ApplicationError::internal(error.to_string()))?;
         let mut related = direct;
@@ -973,7 +1021,7 @@ impl GroupService for GroupServiceImpl {
         let mut items = Vec::with_capacity(page.len());
         for (group, membership) in page {
             items.push(
-                self.project_summary(group, &command.bot_uuid, membership)
+                self.project_summary(group, &view_actor_id, membership)
                     .await?,
             );
         }
@@ -993,27 +1041,29 @@ impl GroupService for GroupServiceImpl {
         &self,
         command: CreateGroup,
     ) -> Result<CreateGroupOutcome, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         match command.group {
             CreateGroupSpec::Collaboration(request) => Ok(CreateGroupOutcome {
                 group: self
-                    .create_collaboration(command.principal, request)
+                    .create_collaboration(principal, request)
                     .await?,
                 created: true,
             }),
             CreateGroupSpec::DirectMessage(request) => {
-                self.create_dm(command.principal, request).await
+                self.create_dm(principal, request).await
             }
         }
     }
 
     async fn get(&self, query: GetGroup) -> Result<GroupDetail, ApplicationError> {
         let group = self
-            .load_readable_group(&query.principal, &query.group_id)
+            .load_group_detail_for_caller(&query.caller, &query.group_id)
             .await?;
         self.project_detail(group).await
     }
 
     async fn update(&self, command: UpdateGroup) -> Result<GroupDetail, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         if command.patch.is_empty() {
             return Err(ApplicationError::invalid(
                 "invalid_request",
@@ -1021,7 +1071,7 @@ impl GroupService for GroupServiceImpl {
             ));
         }
         let mut group = self
-            .load_manageable_group(&command.principal, &command.group_id)
+            .load_manageable_group(&principal, &command.group_id)
             .await?;
         if group.group_kind == GroupKind::Dm {
             if command.patch.delivery_policy.is_some()
@@ -1102,6 +1152,7 @@ impl GroupService for GroupServiceImpl {
     }
 
     async fn delete(&self, command: DeleteGroup) -> Result<DeleteResult, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let Some(group) = self
             .groups
             .try_get(&command.group_id)
@@ -1122,7 +1173,7 @@ impl GroupService for GroupServiceImpl {
                 deleted: false,
             });
         };
-        if !Self::can_manage_group(&command.principal, &group) {
+        if !Self::can_manage_group(&principal, &group) {
             return Err(ApplicationError::forbidden(
                 "Principal cannot delete the group",
             ));
@@ -1139,7 +1190,7 @@ impl GroupService for GroupServiceImpl {
         let result = self
             .management
             .delete_group(GroupDeleteCommand {
-                caller_actor_id: command.principal.actor_id(),
+                caller_actor_id: principal.actor_id(),
                 group_id: command.group_id,
             })
             .await
@@ -1163,10 +1214,11 @@ impl GroupService for GroupServiceImpl {
         &self,
         command: AddGroupParticipant,
     ) -> Result<V1Participant, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let group = self
-            .load_readable_group(&command.principal, &command.group_id)
+            .load_readable_group(&principal, &command.group_id)
             .await?;
-        if !Self::can_manage_group(&command.principal, &group) {
+        if !Self::can_manage_group(&principal, &group) {
             return Err(ApplicationError::forbidden(
                 "Principal cannot manage the group",
             ));
@@ -1191,7 +1243,7 @@ impl GroupService for GroupServiceImpl {
         let result = self
             .management
             .add_member(GroupAddMemberCommand {
-                caller_actor_id: Some(command.principal.actor_id()),
+                caller_actor_id: Some(principal.actor_id()),
                 human_actor_id,
                 group_id: command.group_id.clone(),
                 bot_id,
@@ -1206,26 +1258,32 @@ impl GroupService for GroupServiceImpl {
         &self,
         command: UpdateGroupParticipant,
     ) -> Result<V1Participant, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let group = self
-            .load_readable_group(&command.principal, &command.group_id)
+            .load_readable_group(&principal, &command.group_id)
             .await?;
         // Design §8.7: the target Actor may update its own participant mode
         // (self-service) in addition to the driver/originator/manager path.
-        let is_self = command.principal.actor_id() == command.actor_id;
-        if !is_self && !Self::can_manage_group(&command.principal, &group) {
+        let is_self = principal.actor_id() == command.actor_id;
+        if !is_self && !Self::can_manage_group(&principal, &group) {
             return Err(ApplicationError::forbidden(
                 "Principal cannot manage the group",
             ));
         }
-        self.management
-            .update_participant_mode(GroupParticipantModeCommand {
-                caller_actor_id: command.principal.actor_id(),
-                group_id: command.group_id.clone(),
-                actor_id: command.actor_id.clone(),
-                mode: command.mode,
-            })
+        let target = self.load_bot(&command.actor_id).await?;
+        if !command.mode.is_valid_for(target.actor_kind) {
+            return Err(ApplicationError::invalid(
+                "invalid_participant_mode",
+                format!(
+                    "Participant mode '{:?}' is invalid for actor kind '{:?}'",
+                    command.mode, target.actor_kind
+                ),
+            ));
+        }
+        self.groups
+            .update_participant_mode(&command.group_id, &command.actor_id, command.mode)
             .await
-            .map_err(map_group_error)?;
+            .map_err(map_service_error)?;
         // Reload the group and project the updated participant via the shared
         // domain Participant -> V1 Participant projection used by get/create.
         let group = self
@@ -1256,15 +1314,16 @@ impl GroupService for GroupServiceImpl {
         &self,
         command: DeleteGroupParticipant,
     ) -> Result<DeleteResult, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let group = self
-            .load_readable_group(&command.principal, &command.group_id)
+            .load_readable_group(&principal, &command.group_id)
             .await?;
         // Design §8.7: the target Actor may leave the group (self-service
         // delete) in addition to the driver/originator/manager path. The legacy
         // `remove_member` still rejects driver/originator removal, preserving
         // the role invariant; non-driver self-leave proceeds.
-        let is_self = command.principal.actor_id() == command.actor_id;
-        if !is_self && !Self::can_manage_group(&command.principal, &group) {
+        let is_self = principal.actor_id() == command.actor_id;
+        if !is_self && !Self::can_manage_group(&principal, &group) {
             return Err(ApplicationError::forbidden(
                 "Principal cannot manage the group",
             ));
@@ -1277,7 +1336,7 @@ impl GroupService for GroupServiceImpl {
         match self
             .management
             .remove_member(GroupRemoveMemberCommand {
-                caller_actor_id: Some(command.principal.actor_id()),
+                caller_actor_id: Some(principal.actor_id()),
                 group_id: command.group_id.clone(),
                 bot_id: command.actor_id.clone(),
             })

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
@@ -3,10 +3,8 @@
 //! The harness mirrors `tests/v1_group_service.rs`: it wires
 //! `GroupServiceImpl` with the in-memory real services (`GroupCore`,
 //! `BotCore`, `FriendCore`, `RelationCore`, `SessionManagementServiceImpl`,
-//! `GroupManagement`) and seeds a Chat group whose driver is `bot-driver`
-//! with a plain Consultant participant `bot-a`.
+//! `GroupManagement`) and seeds a Chat group managed by a Human originator.
 
-use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use bcs_bot::BotCore;
@@ -14,12 +12,12 @@ use bcs_friend::FriendCore;
 use bcs_group::{GroupConfig, GroupCore, GroupManagement, MemoryGroupRepo};
 use bcs_relation::RelationCore;
 use bcs_service_api::application::v1::{
-    AddGroupParticipant, ApplicationError, DeleteGroupParticipant, GroupService, ParticipantRole,
-    Principal, UpdateGroupParticipant,
+    AddGroupParticipant, ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity,
+    DeleteGroupParticipant, GroupService, ParticipantRole, UpdateGroupParticipant,
 };
 use bcs_service_api::{
     BotCapabilities, BotRegistryCoreService, Group, GroupCoreService, GroupStrategy, Participant,
-    ParticipantMode, RelationCoreService, RelationEdge, SystemMessageService,
+    ParticipantMode, SystemMessageService,
 };
 use bcs_session::SessionManagementServiceImpl;
 use bcs_session_store::MemorySessionRepo;
@@ -33,7 +31,6 @@ struct Fixture {
     service: GroupServiceImpl,
     groups: Arc<GroupCore>,
     bots: Arc<BotCore>,
-    relation: Arc<RelationCore>,
 }
 
 impl Fixture {
@@ -75,7 +72,6 @@ impl Fixture {
             service,
             groups,
             bots,
-            relation,
         }
     }
 
@@ -92,8 +88,19 @@ impl Fixture {
     }
 }
 
-fn bot_principal(bot_uuid: &str) -> Principal {
-    Principal::bot(bot_uuid, "tenant-a", BTreeSet::new())
+fn human_caller(staff_no: &str) -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: staff_no.into(),
+            username: staff_no.into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
 }
 
 fn normal_group(
@@ -111,57 +118,49 @@ fn normal_group(
     group
 }
 
-/// Build a fixture with a Chat group `GROUP_ID` whose driver is `bot-driver`
-/// and a plain Consultant participant `bot-a`. `bot-b` is registered as a
-/// public bot but is not yet a participant, so the add-participant path can
-/// target it. The driver is also seeded as a creator of `bot-a` so the legacy
-/// `update_participant_mode` actor-level authorization accepts the caller.
+/// Build a fixture with a Chat group `GROUP_ID` whose Human originator manages
+/// the Group. A second Human is a plain participant for self-service tests.
 async fn seed() -> Fixture {
     let fixture = Fixture::new().await;
     for bot in ["bot-driver", "bot-a", "bot-b"] {
         fixture.add_public_bot(bot).await;
     }
+    for staff_no in ["staff-manager", "staff-member"] {
+        fixture
+            .bots
+            .ensure_human_actor(staff_no, staff_no)
+            .await
+            .expect("register Human actor");
+    }
+    let mut group = normal_group(
+        GROUP_ID,
+        "bot-driver",
+        vec![
+            Participant::bot("bot-driver", ParticipantRole::Driver),
+            Participant::bot("bot-a", ParticipantRole::Consultant),
+            Participant::human("human_staff-manager", ParticipantRole::Observer),
+            Participant::human("human_staff-member", ParticipantRole::Observer),
+        ],
+        GroupStrategy::Chat,
+        1,
+    );
+    group.originator = Some("human_staff-manager".into());
     fixture
         .groups
-        .upsert(normal_group(
-            GROUP_ID,
-            "bot-driver",
-            vec![
-                Participant::bot("bot-driver", ParticipantRole::Driver),
-                Participant::bot("bot-a", ParticipantRole::Consultant),
-            ],
-            GroupStrategy::Chat,
-            1,
-        ))
+        .upsert(group)
         .await
         .expect("store group");
-    // Legacy `update_participant_mode` authorizes the caller as the actor
-    // itself or its creator; seed a creator edge driver -> bot-a so the
-    // driver-managed mode update is allowed.
-    fixture
-        .relation
-        .upsert_edge(RelationEdge {
-            from_id: "bot-driver".into(),
-            to_id: "bot-a".into(),
-            env: "dev".into(),
-            kinds: 0,
-            allow: 0,
-            deny: 0,
-            is_creator: true,
-        })
-        .await
-        .expect("seed creator edge");
     fixture
 }
 
 #[tokio::test]
-async fn driver_can_add_bot_participant() {
+async fn human_manager_can_add_bot_participant() {
     let fixture = seed().await;
-    let principal = bot_principal("bot-driver");
+    let caller = human_caller("staff-manager");
     let added = fixture
         .service
         .add_participant(AddGroupParticipant {
-            principal,
+            caller,
             group_id: GROUP_ID.into(),
             actor_id: "bot-b".into(),
             role: ParticipantRole::Consultant,
@@ -175,11 +174,11 @@ async fn driver_can_add_bot_participant() {
 #[tokio::test]
 async fn non_manager_cannot_add_participant() {
     let fixture = seed().await;
-    let principal = bot_principal("bot-a");
+    let caller = human_caller("staff-member");
     let err = fixture
         .service
         .add_participant(AddGroupParticipant {
-            principal,
+            caller,
             group_id: GROUP_ID.into(),
             actor_id: "bot-b".into(),
             role: ParticipantRole::Consultant,
@@ -192,11 +191,11 @@ async fn non_manager_cannot_add_participant() {
 #[tokio::test]
 async fn update_participant_mode_returns_participant() {
     let fixture = seed().await;
-    let principal = bot_principal("bot-driver");
+    let caller = human_caller("staff-manager");
     let updated = fixture
         .service
         .update_participant(UpdateGroupParticipant {
-            principal,
+            caller,
             group_id: GROUP_ID.into(),
             actor_id: "bot-a".into(),
             mode: ParticipantMode::Muted,
@@ -214,7 +213,7 @@ async fn delete_participant_is_idempotent_for_bot() {
     let first = fixture
         .service
         .delete_participant(DeleteGroupParticipant {
-            principal: bot_principal("bot-driver"),
+            caller: human_caller("staff-manager"),
             group_id: GROUP_ID.into(),
             actor_id: "bot-a".into(),
         })
@@ -228,7 +227,7 @@ async fn delete_participant_is_idempotent_for_bot() {
     let second = fixture
         .service
         .delete_participant(DeleteGroupParticipant {
-            principal: bot_principal("bot-driver"),
+            caller: human_caller("staff-manager"),
             group_id: GROUP_ID.into(),
             actor_id: "bot-a".into(),
         })
@@ -247,15 +246,15 @@ async fn participant_can_update_own_mode() {
     let updated = fixture
         .service
         .update_participant(UpdateGroupParticipant {
-            principal: bot_principal("bot-a"),
+            caller: human_caller("staff-member"),
             group_id: GROUP_ID.into(),
-            actor_id: "bot-a".into(),
-            mode: ParticipantMode::Muted,
+            actor_id: "human_staff-member".into(),
+            mode: ParticipantMode::Absent,
         })
         .await
         .expect("plain participant can update own mode");
-    assert_eq!(updated.actor_id, "bot-a");
-    assert_eq!(updated.mode, ParticipantMode::Muted);
+    assert_eq!(updated.actor_id, "human_staff-member");
+    assert_eq!(updated.mode, ParticipantMode::Absent);
 }
 
 #[tokio::test]
@@ -268,9 +267,9 @@ async fn participant_can_leave_via_delete() {
     let result = fixture
         .service
         .delete_participant(DeleteGroupParticipant {
-            principal: bot_principal("bot-a"),
+            caller: human_caller("staff-member"),
             group_id: GROUP_ID.into(),
-            actor_id: "bot-a".into(),
+            actor_id: "human_staff-member".into(),
         })
         .await
         .expect("plain participant can leave via delete");
@@ -287,8 +286,8 @@ async fn participant_can_leave_via_delete() {
         !group
             .participants
             .iter()
-            .any(|p| p.bot_uuid == "bot-a"),
-        "bot-a should have left the group"
+            .any(|p| p.bot_uuid == "human_staff-member"),
+        "the Human participant should have left the group"
     );
 }
 
@@ -301,7 +300,7 @@ async fn participant_cannot_update_others() {
     let err = fixture
         .service
         .update_participant(UpdateGroupParticipant {
-            principal: bot_principal("bot-a"),
+            caller: human_caller("staff-member"),
             group_id: GROUP_ID.into(),
             actor_id: "bot-driver".into(),
             mode: ParticipantMode::Muted,

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -15,11 +15,12 @@ use bcs_group::{GroupConfig, GroupCore, GroupManagement, MemoryGroupRepo};
 use bcs_group_store::MySqlGroupStore;
 use bcs_relation::RelationCore;
 use bcs_service_api::application::v1::{
-    ApplicationError, AuthenticatedUser, BotFinalDelivery, ChatConfiguration,
+    ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity, BotFinalDelivery,
+    ChatConfiguration,
     CollaborationConfiguration, CreateCollaborationGroup, CreateDirectMessageGroup, CreateGroup,
     CreateGroupSpec, CreateParticipant, DeleteGroup, GetGroup, GroupDeliveryPolicy, GroupDetail,
     GroupKindFilter, GroupPatch, GroupService, GroupStrategy as V1GroupStrategy, GroupSummary,
-    GroupVisibility, ListBotGroups, Membership, MembershipFilter, Principal, UpdateGroup,
+    GroupVisibility, ListGroups, Membership, MembershipFilter, UpdateGroup,
 };
 use bcs_service_api::{
     BotCapabilities, BotRegistryCoreService, CancelStateMachineRunCommand, CollaborationDefinition,
@@ -28,7 +29,8 @@ use bcs_service_api::{
     DefaultDelivery, DefinitionYamlSource, FriendCoreService, FriendRepoPort, Group,
     GroupCollaborationDefinitionView, GroupCoreService, GroupStrategy,
     HandleBotTerminalEventCommand, HandleBotTerminalEventOutcome, NewSessionParams, Participant,
-    ParticipantRole, RoutingMode, RoutingPolicy, ServiceError, ServiceResult, SessionHistoryResult,
+    ParticipantRole, RelationCoreService, RoutingMode, RoutingPolicy, ServiceError, ServiceResult,
+    SessionHistoryResult,
     SessionManagementService, StartStateMachineRunCommand, StartStateMachineRunOutcome,
     StateMachineDeliveryCorrelation, StateMachineRun, StateMachineRunStatus, StateMachineRunView,
     SystemMessageService,
@@ -44,6 +46,7 @@ struct Fixture {
     groups: Arc<GroupCore>,
     bots: Arc<BotCore>,
     friends: Arc<FriendCore>,
+    relation: Arc<RelationCore>,
     sessions: Arc<SessionManagementServiceImpl>,
 }
 
@@ -95,7 +98,7 @@ impl Fixture {
             groups.clone(),
             bots.clone(),
             friends.clone(),
-            relation,
+            relation.clone(),
             sessions.clone(),
             management,
             GroupServiceConfig {
@@ -107,6 +110,7 @@ impl Fixture {
             groups,
             bots,
             friends,
+            relation: relation.clone(),
             sessions,
         }
     }
@@ -141,7 +145,7 @@ impl Fixture {
             groups.clone(),
             bots.clone(),
             friends.clone(),
-            relation,
+            relation.clone(),
             sessions.clone(),
             management,
             GroupServiceConfig {
@@ -154,6 +158,7 @@ impl Fixture {
             groups,
             bots,
             friends,
+            relation,
             sessions,
         }
     }
@@ -190,7 +195,7 @@ impl Fixture {
             groups.clone(),
             bots.clone(),
             friends.clone(),
-            relation,
+            relation.clone(),
             sessions.clone(),
             management,
             GroupServiceConfig {
@@ -205,6 +210,7 @@ impl Fixture {
             groups,
             bots,
             friends,
+            relation,
             sessions,
         }
     }
@@ -219,6 +225,10 @@ impl Fixture {
             .register(bot_uuid.to_string(), capabilities)
             .await
             .expect("register bot");
+        self.bots
+            .save_created_by(bot_uuid, bot_uuid, true)
+            .await
+            .expect("assign test Bot owner");
     }
 
     async fn add_protected_bot(&self, bot_uuid: &str) {
@@ -231,6 +241,10 @@ impl Fixture {
             .register(bot_uuid.to_string(), capabilities)
             .await
             .expect("register bot");
+        self.bots
+            .save_created_by(bot_uuid, bot_uuid, true)
+            .await
+            .expect("assign test Bot owner");
     }
 }
 
@@ -537,12 +551,23 @@ impl CollaborationRuntimeService for RecordingRuntime {
     }
 }
 
-fn bot_principal(bot_uuid: &str) -> Principal {
-    Principal::bot(bot_uuid, "tenant-a", BTreeSet::new())
+fn bot_principal(bot_uuid: &str) -> AuthenticatedCaller {
+    human_principal_with_profile(bot_uuid, bot_uuid, None, None)
 }
 
-fn bot_principal_in_tenant(bot_uuid: &str, tenant: &str) -> Principal {
-    Principal::bot(bot_uuid, tenant, BTreeSet::new())
+fn bot_principal_in_tenant(bot_uuid: &str, tenant: &str) -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: tenant.to_string(),
+        user: Some(AuthenticatedUserIdentity {
+            id: bot_uuid.to_string(),
+            username: bot_uuid.to_string(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
 }
 
 fn human_principal_with_profile(
@@ -550,17 +575,19 @@ fn human_principal_with_profile(
     username: &str,
     display_name: Option<&str>,
     full_name: Option<&str>,
-) -> Principal {
-    Principal::human(
-        AuthenticatedUser {
+) -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
             id: subject_id.into(),
             username: username.into(),
             display_name: display_name.map(str::to_string),
             full_name: full_name.map(str::to_string),
-        },
-        "tenant-a",
-        BTreeSet::new(),
-    )
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
 }
 
 fn normal_group(
@@ -571,11 +598,11 @@ fn normal_group(
     updated_at: u64,
 ) -> Group {
     let mut group = Group::new(group_id, driver, participants);
-    group.originator = Some(driver.to_string());
+    group.originator = Some(format!("human_{driver}"));
     group.label = Some(group_id.to_string());
     group.group_strategy = strategy;
     group.updated_at = updated_at;
-    // V1 list_bot_groups sorts by `created_at DESC, group_id ASC`; pin both
+    // V1 list_groups sorts by `created_at DESC, group_id ASC`; pin both
     // timestamps to the same value so existing ordering assertions remain
     // deterministic under the new comparator.
     group.created_at = updated_at;
@@ -646,9 +673,9 @@ async fn list_filters_deduplicates_before_pagination_and_direct_wins() {
 
     let page = fixture
         .service
-        .list_bot_groups(ListBotGroups {
-            principal: bot_principal("target"),
-            bot_uuid: "target".into(),
+        .list_groups(ListGroups {
+            caller: bot_principal("target"),
+            view_bot_id: Some("target".into()),
             offset: 0,
             limit: 10,
             q: None,
@@ -678,9 +705,9 @@ async fn list_filters_deduplicates_before_pagination_and_direct_wins() {
 
     let session_only = fixture
         .service
-        .list_bot_groups(ListBotGroups {
-            principal: bot_principal("target"),
-            bot_uuid: "target".into(),
+        .list_groups(ListGroups {
+            caller: bot_principal("target"),
+            view_bot_id: Some("target".into()),
             offset: 0,
             limit: 1,
             q: None,
@@ -695,7 +722,168 @@ async fn list_filters_deduplicates_before_pagination_and_direct_wins() {
 }
 
 #[tokio::test]
-async fn list_bot_groups_sorts_by_created_at_desc_not_updated_at() {
+async fn list_defaults_to_the_authenticated_human_and_accepts_only_authorized_views() {
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("owned-by-someone-else").await;
+    fixture
+        .bots
+        .register(
+            "owned-by-alice".into(),
+            BotCapabilities {
+                visibility: "public".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("register Alice's Bot");
+    fixture
+        .bots
+        .save_created_by("owned-by-alice", "alice", true)
+        .await
+        .expect("assign Alice's Bot ownership");
+    for (group_id, actor_id) in [
+        ("human-group", "human_alice"),
+        ("owned-bot-group", "owned-by-alice"),
+    ] {
+        fixture
+            .groups
+            .upsert(normal_group(
+                group_id,
+                "owned-by-someone-else",
+                vec![Participant::bot(actor_id, ParticipantRole::Consultant)],
+                GroupStrategy::Chat,
+                1,
+            ))
+            .await
+            .expect("store Group");
+    }
+
+    let list = |view_bot_id| ListGroups {
+        caller: bot_principal("alice"),
+        view_bot_id,
+        offset: 0,
+        limit: 20,
+        q: None,
+        membership: MembershipFilter::All,
+        kind: GroupKindFilter::All,
+        strategy: None,
+    };
+
+    let default_view = fixture
+        .service
+        .list_groups(list(None))
+        .await
+        .expect("omission selects the Human Actor");
+    assert_eq!(default_view.total, 1);
+    let explicit_human = fixture
+        .service
+        .list_groups(list(Some("human_alice".into())))
+        .await
+        .expect("the caller's Human Actor is an explicit valid view");
+    assert_eq!(explicit_human.total, 1);
+    let owned_bot = fixture
+        .service
+        .list_groups(list(Some("owned-by-alice".into())))
+        .await
+        .expect("an exact-created_by Bot is an explicit valid view");
+    assert_eq!(owned_bot.total, 1);
+
+    for invalid_view in ["human_bob", "owned-by-someone-else", "unknown-bot"] {
+        let error = fixture
+            .service
+            .list_groups(list(Some(invalid_view.into())))
+            .await
+            .expect_err("unauthorized View Actor must not fall back");
+        assert!(matches!(error, ApplicationError::Forbidden(_)));
+    }
+}
+
+#[tokio::test]
+async fn group_detail_accepts_human_or_exact_owned_bot_participation_only() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "relation-only"] {
+        fixture.add_public_bot(bot).await;
+    }
+    fixture
+        .bots
+        .register(
+            "owned".into(),
+            BotCapabilities {
+                visibility: "public".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("register Alice's Bot");
+    fixture
+        .bots
+        .save_created_by("owned", "alice", true)
+        .await
+        .expect("assign Alice's Bot ownership");
+    fixture
+        .relation
+        .upsert_edge(bcs_service_api::RelationEdge {
+            from_id: "human_alice".into(),
+            to_id: "relation-only".into(),
+            env: "dev".into(),
+            kinds: 0,
+            allow: 0,
+            deny: 0,
+            is_creator: true,
+        })
+        .await
+        .expect("seed legacy creator relation");
+
+    for (group_id, participant) in [
+        (
+            "human-detail",
+            Participant::human("human_alice", ParticipantRole::Observer),
+        ),
+        (
+            "owned-detail",
+            Participant::bot("owned", ParticipantRole::Consultant),
+        ),
+        (
+            "relation-detail",
+            Participant::bot("relation-only", ParticipantRole::Consultant),
+        ),
+    ] {
+        fixture
+            .groups
+            .upsert(normal_group(
+                group_id,
+                "driver",
+                vec![participant],
+                GroupStrategy::Chat,
+                1,
+            ))
+            .await
+            .expect("store Group");
+    }
+
+    for group_id in ["human-detail", "owned-detail"] {
+        fixture
+            .service
+            .get(GetGroup {
+                caller: bot_principal("alice"),
+                group_id: group_id.into(),
+            })
+            .await
+            .expect("direct Human or exact owned Bot participation grants detail read");
+    }
+    let error = fixture
+        .service
+        .get(GetGroup {
+            caller: bot_principal("alice"),
+            group_id: "relation-detail".into(),
+        })
+        .await
+        .expect_err("creator relation alone is not Bot ownership");
+    assert!(matches!(error, ApplicationError::Forbidden(_)));
+}
+
+#[tokio::test]
+async fn list_groups_sorts_by_created_at_desc_not_updated_at() {
     // V1 contract declares `created_at DESC, group_id ASC`. The legacy
     // `updated_at DESC` ordering would put a recently-edited but older group
     // first, violating the contract. Seed three groups where the sort keys
@@ -751,9 +939,9 @@ async fn list_bot_groups_sorts_by_created_at_desc_not_updated_at() {
 
     let page = fixture
         .service
-        .list_bot_groups(ListBotGroups {
-            principal: bot_principal("target"),
-            bot_uuid: "target".into(),
+        .list_groups(ListGroups {
+            caller: bot_principal("target"),
+            view_bot_id: Some("target".into()),
             offset: 0,
             limit: 10,
             q: None,
@@ -780,7 +968,7 @@ async fn list_bot_groups_sorts_by_created_at_desc_not_updated_at() {
 }
 
 #[tokio::test]
-async fn create_derives_originator_after_driver_is_added_to_canonical_participants() {
+async fn create_uses_the_authenticated_human_as_originator() {
     let fixture = Fixture::new().await;
     for bot in ["requester", "driver", "helper"] {
         fixture.add_public_bot(bot).await;
@@ -789,7 +977,7 @@ async fn create_derives_originator_after_driver_is_added_to_canonical_participan
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("requester"),
+            caller: bot_principal("requester"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("Planning".into()),
                 context: Some("Plan the release".into()),
@@ -815,7 +1003,7 @@ async fn create_derives_originator_after_driver_is_added_to_canonical_participan
         panic!("expected collaboration detail");
     };
     assert_eq!(detail.driver_bot_uuid, "driver");
-    assert_eq!(detail.originator_actor_id, "driver");
+    assert_eq!(detail.originator_actor_id, "human_requester");
     assert!(
         detail
             .participants
@@ -838,7 +1026,7 @@ async fn human_participant_can_create_with_driver_reachable_protected_participan
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: human_principal_with_profile(
+            caller: human_principal_with_profile(
                 "staff-1",
                 "alice-login",
                 Some("Alice"),
@@ -892,7 +1080,7 @@ async fn dm_create_uses_target_actor_id_and_projects_two_symmetric_participants(
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("bot-a"),
+            caller: bot_principal("bot-a"),
             group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
                 name: Some("A and B".into()),
                 context: None,
@@ -906,7 +1094,12 @@ async fn dm_create_uses_target_actor_id_and_projects_two_symmetric_participants(
         panic!("expected DM detail");
     };
     assert_eq!(detail.participants.len(), 2);
-    assert!(detail.participants.iter().any(|p| p.actor_id == "bot-a"));
+    assert!(
+        detail
+            .participants
+            .iter()
+            .any(|p| p.actor_id == "human_bot-a")
+    );
     assert!(detail.participants.iter().any(|p| p.actor_id == "bot-b"));
     let json = serde_json::to_value(&detail).expect("serialize DM detail");
     assert!(json.get("driver_bot_uuid").is_none());
@@ -921,9 +1114,9 @@ async fn dm_kind_rejects_a_strategy_filter() {
 
     let result = fixture
         .service
-        .list_bot_groups(ListBotGroups {
-            principal: bot_principal("target"),
-            bot_uuid: "target".into(),
+        .list_groups(ListGroups {
+            caller: bot_principal("target"),
+            view_bot_id: Some("target".into()),
             offset: 0,
             limit: 20,
             q: None,
@@ -940,14 +1133,14 @@ async fn dm_kind_rejects_a_strategy_filter() {
 }
 
 #[tokio::test]
-async fn bot_principal_list_requires_the_target_bot_to_exist() {
+async fn explicit_view_requires_the_target_bot_to_exist_and_be_owned() {
     let fixture = Fixture::new().await;
 
     let result = fixture
         .service
-        .list_bot_groups(ListBotGroups {
-            principal: bot_principal("missing"),
-            bot_uuid: "missing".into(),
+        .list_groups(ListGroups {
+            caller: bot_principal("missing"),
+            view_bot_id: Some("missing".into()),
             offset: 0,
             limit: 20,
             q: None,
@@ -959,12 +1152,12 @@ async fn bot_principal_list_requires_the_target_bot_to_exist() {
 
     assert!(matches!(
         result,
-        Err(ApplicationError::NotFound { code, .. }) if code == "bot_not_found"
+        Err(ApplicationError::Forbidden(_))
     ));
 }
 
 #[tokio::test]
-async fn bot_principal_list_propagates_registry_database_failure() {
+async fn explicit_view_propagates_registry_database_failure() {
     let bots = Arc::new(BotCore::with_repo(Arc::new(
         PersistentBotRepo::with_plugins(
             Arc::new(InMemoryCachePlugin::new()),
@@ -975,9 +1168,9 @@ async fn bot_principal_list_propagates_registry_database_failure() {
 
     let result = fixture
         .service
-        .list_bot_groups(ListBotGroups {
-            principal: bot_principal("stored-bot"),
-            bot_uuid: "stored-bot".into(),
+        .list_groups(ListGroups {
+            caller: bot_principal("stored-bot"),
+            view_bot_id: Some("stored-bot".into()),
             offset: 0,
             limit: 20,
             q: None,
@@ -1002,7 +1195,7 @@ async fn create_group_propagates_quota_lookup_database_failure() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 driver_bot_uuid: "driver".into(),
                 name: Some("quota lookup failure".into()),
@@ -1038,7 +1231,7 @@ async fn create_group_propagates_non_driver_registry_database_failure() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 driver_bot_uuid: "driver".into(),
                 name: Some("registry failure".into()),
@@ -1077,7 +1270,7 @@ async fn bot_dm_propagates_caller_registry_failure_after_target_validation() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("caller"),
+            caller: bot_principal("caller"),
             group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
                 name: None,
                 context: None,
@@ -1105,7 +1298,7 @@ async fn bot_dm_propagates_friendship_failure_after_initial_validation() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("caller"),
+            caller: bot_principal("caller"),
             group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
                 name: None,
                 context: None,
@@ -1134,7 +1327,7 @@ async fn create_rejects_non_bot_driver_and_dm_target_with_declared_code() {
     let driver = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("requester"),
+            caller: bot_principal("requester"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: None,
                 context: None,
@@ -1159,7 +1352,7 @@ async fn create_rejects_non_bot_driver_and_dm_target_with_declared_code() {
     let target = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("requester"),
+            caller: bot_principal("requester"),
             group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
                 name: None,
                 context: None,
@@ -1184,7 +1377,7 @@ async fn state_machine_create_without_runtime_fails_before_persisting_group() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: None,
@@ -1228,7 +1421,7 @@ async fn state_machine_create_rejects_duplicate_participant_binding_names() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: None,
@@ -1283,7 +1476,7 @@ async fn state_machine_runtime_failure_rolls_back_created_group() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: None,
@@ -1325,7 +1518,7 @@ async fn state_machine_create_configures_runtime_and_returns_typed_detail() {
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: Some("Execute the workflow".into()),
@@ -1406,7 +1599,7 @@ async fn state_machine_create_configures_runtime_and_returns_typed_detail() {
     assert_eq!(started.len(), 1);
     assert_eq!(started[0].group_id, detail.group_id);
     assert!(started[0].session_id.is_some());
-    assert_eq!(started[0].caller_id.as_deref(), Some("driver"));
+    assert_eq!(started[0].caller_id.as_deref(), Some("human_driver"));
 }
 
 #[tokio::test]
@@ -1423,7 +1616,7 @@ async fn state_machine_create_defers_initial_run_until_required_channel_is_bound
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("Human review".into()),
                 context: None,
@@ -1467,7 +1660,7 @@ async fn state_machine_create_rejects_human_actors_in_bot_bindings() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: None,
@@ -1515,7 +1708,7 @@ async fn state_machine_create_preserves_authenticated_human_in_audit_and_start()
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: human_principal_with_profile("staff-1", "alice", Some("Alice"), None),
+            caller: human_principal_with_profile("staff-1", "alice", Some("Alice"), None),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: Some("Review the release".into()),
@@ -1542,7 +1735,7 @@ async fn state_machine_create_preserves_authenticated_human_in_audit_and_start()
     let GroupDetail::Collaboration(detail) = detail else {
         panic!("expected collaboration detail");
     };
-    assert_eq!(detail.originator_actor_id, "driver");
+    assert_eq!(detail.originator_actor_id, "human_staff-1");
 
     let sessions = fixture
         .sessions
@@ -1581,7 +1774,7 @@ async fn state_machine_create_does_not_reread_runtime_for_its_response() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: None,
@@ -1619,7 +1812,7 @@ async fn state_machine_start_failure_removes_runtime_session_and_group() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: None,
@@ -1684,7 +1877,7 @@ async fn deleting_state_machine_group_cancels_runs_and_removes_runtime_state() {
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("State machine".into()),
                 context: None,
@@ -1715,7 +1908,7 @@ async fn deleting_state_machine_group_cancels_runs_and_removes_runtime_state() {
     let deleted = fixture
         .service
         .delete(DeleteGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: detail.group_id.clone(),
         })
         .await
@@ -1761,7 +1954,7 @@ async fn failed_group_delete_does_not_cancel_runs_before_group_rollback() {
     let error = fixture
         .service
         .delete(DeleteGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "group-1".into(),
         })
         .await
@@ -1814,7 +2007,7 @@ async fn update_preserves_hidden_legacy_routing_fields() {
     let detail = fixture
         .service
         .update(UpdateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "group-1".into(),
             patch: GroupPatch {
                 name: Some("Renamed".into()),
@@ -1865,7 +2058,7 @@ async fn get_requires_a_group_relation_and_delete_is_idempotent() {
     let denied = fixture
         .service
         .get(GetGroup {
-            principal: bot_principal("outsider"),
+            caller: bot_principal("outsider"),
             group_id: "group-1".into(),
         })
         .await;
@@ -1877,7 +2070,7 @@ async fn get_requires_a_group_relation_and_delete_is_idempotent() {
     let first = fixture
         .service
         .delete(DeleteGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "group-1".into(),
         })
         .await
@@ -1887,7 +2080,7 @@ async fn get_requires_a_group_relation_and_delete_is_idempotent() {
     let second = fixture
         .service
         .delete(DeleteGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "group-1".into(),
         })
         .await
@@ -1905,7 +2098,7 @@ async fn tenant_metadata_does_not_restrict_bot_collaboration() {
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal_in_tenant("driver", "tenant-b"),
+            caller: bot_principal_in_tenant("driver", "tenant-b"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("Cross-tenant collaboration".into()),
                 context: None,
@@ -1929,7 +2122,7 @@ async fn tenant_metadata_does_not_restrict_bot_collaboration() {
 }
 
 #[tokio::test]
-async fn manager_worker_manager_can_update_and_delete_group() {
+async fn human_originator_can_update_and_delete_group() {
     let fixture = Fixture::new().await;
     for bot in ["driver", "manager", "worker"] {
         fixture.add_public_bot(bot).await;
@@ -1945,13 +2138,13 @@ async fn manager_worker_manager_can_update_and_delete_group() {
         GroupStrategy::ManagerWorker,
         1,
     );
-    group.originator = Some("driver".into());
+    group.originator = Some("human_manager".into());
     fixture.groups.upsert(group).await.expect("store group");
 
     fixture
         .service
         .update(UpdateGroup {
-            principal: bot_principal("manager"),
+            caller: bot_principal("manager"),
             group_id: "group-1".into(),
             patch: GroupPatch {
                 name: Some("Managed".into()),
@@ -1964,7 +2157,7 @@ async fn manager_worker_manager_can_update_and_delete_group() {
     let deleted = fixture
         .service
         .delete(DeleteGroup {
-            principal: bot_principal("manager"),
+            caller: bot_principal("manager"),
             group_id: "group-1".into(),
         })
         .await
@@ -1997,7 +2190,7 @@ async fn delete_group_unauthorized_principal_forbidden() {
     let err = fixture
         .service
         .delete(DeleteGroup {
-            principal: bot_principal("outsider"),
+            caller: bot_principal("outsider"),
             group_id: "group-1".into(),
         })
         .await
@@ -2019,7 +2212,7 @@ async fn state_machine_patch_failure_does_not_commit_requested_changes() {
     fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: Some("Before".into()),
                 context: None,
@@ -2060,7 +2253,7 @@ async fn state_machine_patch_failure_does_not_commit_requested_changes() {
     let result = fixture
         .service
         .update(UpdateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: group_id.clone(),
             patch: GroupPatch {
                 name: Some("After".into()),
@@ -2091,7 +2284,7 @@ async fn create_propagates_friendship_lookup_failure() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("requester"),
+            caller: bot_principal("requester"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: None,
                 context: None,
@@ -2123,7 +2316,7 @@ async fn create_propagates_protected_participant_friendship_lookup_failure() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: None,
                 context: None,
@@ -2173,7 +2366,7 @@ async fn update_rejects_delivery_policy_for_non_chat_strategy() {
     let result = fixture
         .service
         .update(UpdateGroup {
-            principal: bot_principal("manager"),
+            caller: bot_principal("manager"),
             group_id: "manager-worker".into(),
             patch: GroupPatch {
                 delivery_policy: Some(GroupDeliveryPolicy {
@@ -2200,7 +2393,7 @@ async fn create_rejects_duplicate_participant_actor_ids() {
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: None,
                 context: None,
@@ -2241,7 +2434,7 @@ async fn create_rejects_roles_that_do_not_match_the_strategy_lead() {
     let invalid_chat = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: None,
                 context: None,
@@ -2269,7 +2462,7 @@ async fn create_rejects_roles_that_do_not_match_the_strategy_lead() {
     let invalid_manager_worker = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: None,
                 context: None,
@@ -2323,7 +2516,7 @@ async fn human_principal_creates_legacy_actor_with_current_display_name_priority
         let detail = fixture
             .service
             .create(CreateGroup {
-                principal: human_principal_with_profile(
+                caller: human_principal_with_profile(
                     staff_no,
                     username,
                     display_name,
@@ -2371,7 +2564,7 @@ async fn human_principal_preserves_existing_legacy_actor_display_name() {
     fixture
         .service
         .create(CreateGroup {
-            principal: human_principal_with_profile(
+            caller: human_principal_with_profile(
                 "staff-1",
                 "alice-login",
                 Some("Changed Name"),
@@ -2400,7 +2593,7 @@ async fn dm_create_outcome_reports_when_the_existing_pair_is_reused() {
     fixture.add_public_bot("bot-a").await;
     fixture.add_public_bot("bot-b").await;
     let command = || CreateGroup {
-        principal: bot_principal("bot-a"),
+        caller: bot_principal("bot-a"),
         group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
             name: Some("A and B".into()),
             context: Some("original context".into()),
@@ -2441,26 +2634,10 @@ async fn client_caused_group_errors_map_to_documented_4xx_classes() {
         .await
         .expect("driver/protected friendship");
 
-    let self_dm = fixture
-        .service
-        .create(CreateGroup {
-            principal: bot_principal("driver"),
-            group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
-                name: None,
-                context: None,
-                target_actor_id: "driver".into(),
-            }),
-        })
-        .await;
-    assert!(matches!(
-        self_dm,
-        Err(ApplicationError::InvalidInput { code, .. }) if code == "invalid_request"
-    ));
-
     let public_with_protected = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 name: None,
                 context: None,
@@ -2487,14 +2664,14 @@ async fn client_caused_group_errors_map_to_documented_4xx_classes() {
 }
 
 #[tokio::test]
-async fn missing_bot_caller_uses_the_documented_bot_not_found_code() {
+async fn human_caller_does_not_require_a_same_named_bot() {
     let fixture = Fixture::new().await;
     fixture.add_public_bot("target").await;
 
     let result = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("missing-caller"),
+            caller: bot_principal("missing-caller"),
             group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
                 name: None,
                 context: None,
@@ -2503,10 +2680,7 @@ async fn missing_bot_caller_uses_the_documented_bot_not_found_code() {
         })
         .await;
 
-    assert!(matches!(
-        result,
-        Err(ApplicationError::NotFound { code, .. }) if code == "bot_not_found"
-    ));
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
@@ -2517,7 +2691,7 @@ async fn deleting_dm_maps_the_legacy_rejection_to_contract_conflict() {
     let detail = fixture
         .service
         .create(CreateGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group: CreateGroupSpec::DirectMessage(CreateDirectMessageGroup {
                 name: None,
                 context: None,
@@ -2533,7 +2707,7 @@ async fn deleting_dm_maps_the_legacy_rejection_to_contract_conflict() {
     let result = fixture
         .service
         .delete(DeleteGroup {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: detail.group_id,
         })
         .await;
@@ -2586,9 +2760,9 @@ async fn session_only_nonmember_dm_summary_omits_peer_actor() {
 
     let page = fixture
         .service
-        .list_bot_groups(ListBotGroups {
-            principal: bot_principal("target"),
-            bot_uuid: "target".into(),
+        .list_groups(ListGroups {
+            caller: bot_principal("target"),
+            view_bot_id: Some("target".into()),
             offset: 0,
             limit: 20,
             q: None,

--- a/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
@@ -1,7 +1,7 @@
 //! Versioned Invitation + Friendship application facade for the BCN V1 API.
 //!
 //! Implements both [`InvitationService`] and [`FriendshipService`]. The facade
-//! owns Principal-based resource authorization and V1 projections while
+//! owns Caller-based resource authorization and V1 projections while
 //! delegating friendship/friend-request side effects to the legacy
 //! [`FriendCoreService`] / [`FriendRequestCoreService`] cores and invitation
 //! accept-join side effects to the legacy [`InviteService`]
@@ -16,8 +16,8 @@
 //! - V1 `create_*_invitation` mirrors the legacy DM/active-group guards but
 //!   mints tokens directly (the legacy `create_*_invite_token` paths are not
 //!   reused because they emit legacy join URLs).
-//! - Accept pivots to the legacy Human-only join path. A Bot Principal is
-//!   rejected outright; a Human Principal's `staff_no` is forwarded to
+//! - Accept pivots to the legacy Human-only join path. A Caller without User
+//!   is rejected; the User's subject id is forwarded to
 //!   `InviteService::join_*_by_invite`, which `ensure_human`s the actor and
 //!   creates a Human Participant (Consultant role, Present mode). This matches
 //!   the legacy invite-link accept semantics exactly.
@@ -36,22 +36,18 @@ use bcs_service_api::application::v1::{
     CreateGroupInvitation, CreateSessionInvitation, DeleteBotFriendship, DeleteResult,
     FriendshipService, InvitationAcceptResult, InvitationService, InvitationTargetType,
     Invitation, ListBotFriendRequests, ListBotFriendships, Page, Principal,
-    RejectFriendRequest,
+    RejectFriendRequest, require_authenticated_user, require_human,
 };
 use bcs_service_api::{
     BotRegistryCoreService, FriendCoreService, FriendRequestCoreService,
     FriendRequest as DomainFriendRequest, FriendRequestDirection as DomainFriendRequestDirection,
     Friendship as DomainFriendship, Group as DomainGroup, GroupCoreService, GroupKind,
     GroupStatus, GroupStrategy, InviteService, InviteUseCaseError, JoinByInviteCommand,
-    ParticipantRole, RegisteredBot, RelationCoreService,
-    ServiceError, SessionManagementService, SessionUseCaseError,
+    ParticipantRole, RegisteredBot, ServiceError, SessionManagementService, SessionUseCaseError,
 };
 
 #[derive(Debug, Clone)]
 pub struct InvitationFriendshipServiceConfig {
-    /// Relation environment tag used for creator-edge authorization, mirroring
-    /// the sibling Group V1 facade's `relation_env`.
-    pub relation_env: String,
     /// Default invitation token lifetime in seconds when the caller does not
     /// supply `expires_in_seconds`.
     pub default_ttl_seconds: u64,
@@ -71,7 +67,6 @@ pub struct InvitationFriendshipServiceImpl {
     groups: Arc<dyn GroupCoreService>,
     sessions: Arc<dyn SessionManagementService>,
     registry: Arc<dyn BotRegistryCoreService>,
-    relation: Arc<dyn RelationCoreService>,
     invite: Arc<dyn InviteService>,
     token_secret: Vec<u8>,
     config: InvitationFriendshipServiceConfig,
@@ -85,7 +80,6 @@ impl InvitationFriendshipServiceImpl {
         groups: Arc<dyn GroupCoreService>,
         sessions: Arc<dyn SessionManagementService>,
         registry: Arc<dyn BotRegistryCoreService>,
-        relation: Arc<dyn RelationCoreService>,
         invite: Arc<dyn InviteService>,
         token_secret: Vec<u8>,
         config: InvitationFriendshipServiceConfig,
@@ -96,7 +90,6 @@ impl InvitationFriendshipServiceImpl {
             groups,
             sessions,
             registry,
-            relation,
             invite,
             token_secret,
             config,
@@ -118,43 +111,20 @@ impl InvitationFriendshipServiceImpl {
             })
     }
 
-    /// Principal must be the Bot itself or a Human that owns it (via
-    /// `created_by` or a creator relation edge). Mirrors
-    /// `bcs-app-group::authorize_bot_resource`.
+    /// The authenticated User must own the Bot through exact `created_by`.
     async fn authorize_bot_resource(
         &self,
-        principal: &Principal,
+        caller: &bcs_service_api::application::v1::AuthenticatedCaller,
         bot_uuid: &str,
     ) -> Result<(), ApplicationError> {
-        match principal {
-            Principal::Bot(bot) if bot.bot_uuid == bot_uuid => {
-                self.load_bot(bot_uuid).await?;
-                Ok(())
-            }
-            Principal::Bot(_) => Err(ApplicationError::forbidden(
-                "Bot Principal may act only on its own bot_uuid",
-            )),
-            Principal::Human(human) => {
-                let bot = self.load_bot(bot_uuid).await?;
-                if bot.created_by.as_deref() == Some(human.subject.id.as_str()) {
-                    return Ok(());
-                }
-                let creator_edge = self
-                    .relation
-                    .get_edge(
-                        &principal.actor_id(),
-                        bot_uuid,
-                        &self.config.relation_env,
-                    )
-                    .await
-                    .map_err(map_service_error)?;
-                if creator_edge.is_some_and(|edge| edge.is_creator) {
-                    return Ok(());
-                }
-                Err(ApplicationError::forbidden(format!(
-                    "Human Principal cannot manage Bot '{bot_uuid}'"
-                )))
-            }
+        let user = require_authenticated_user(caller)?;
+        let bot = self.load_bot(bot_uuid).await?;
+        if bot.created_by.as_deref() == Some(user.id.as_str()) {
+            Ok(())
+        } else {
+            Err(ApplicationError::forbidden(format!(
+                "Authenticated User cannot manage Bot '{bot_uuid}'"
+            )))
         }
     }
 
@@ -225,10 +195,10 @@ impl InvitationFriendshipServiceImpl {
 
     async fn ensure_bot_resource(
         &self,
-        principal: &Principal,
+        caller: &bcs_service_api::application::v1::AuthenticatedCaller,
         bot_uuid: &str,
     ) -> Result<(), ApplicationError> {
-        self.authorize_bot_resource(principal, bot_uuid).await
+        self.authorize_bot_resource(caller, bot_uuid).await
     }
 }
 
@@ -238,8 +208,9 @@ impl InvitationService for InvitationFriendshipServiceImpl {
         &self,
         command: CreateGroupInvitation,
     ) -> Result<Invitation, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let group = self
-            .load_manageable_group(&command.principal, &command.group_id)
+            .load_manageable_group(&principal, &command.group_id)
             .await?;
         // VaGQI: DM (DirectMessage) groups are pairwise (participant_count=2);
         // minting an invitation + accept would add a third participant. Mirror
@@ -269,6 +240,7 @@ impl InvitationService for InvitationFriendshipServiceImpl {
         &self,
         command: CreateSessionInvitation,
     ) -> Result<Invitation, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let session = self
             .sessions
             .get(&command.session_id)
@@ -293,7 +265,7 @@ impl InvitationService for InvitationFriendshipServiceImpl {
                     format!("Group '{}' was not found", session.group_id),
                 )
             })?;
-        if !Self::can_manage_group(&command.principal, &group) {
+        if !Self::can_manage_group(&principal, &group) {
             return Err(ApplicationError::forbidden(
                 "Only the Group originator, driver, or manager may manage Sessions",
             ));
@@ -335,36 +307,15 @@ impl InvitationService for InvitationFriendshipServiceImpl {
                 "legacy invitation token without target_type is not supported by V1",
             )
         })?;
-        // Vcj6H: pivot to legacy Human-only accept. A Bot Principal cannot
-        // accept invitations regardless of `bot_uuid` (which is no longer on
-        // the request). The legacy `join_*_by_invite` path enforces this via
-        // `ensure_actor_is_human`, which rejects Bot actors; the V1 facade
-        // mirrors that up-front so the Bot case never reaches the legacy path.
-        let (staff_no, nick_name) = match &command.principal {
-            Principal::Bot(_) => {
-                return Err(ApplicationError::forbidden(
-                    "Only Human Principals can accept invitations",
-                ));
-            }
-            Principal::Human(human) => {
-                let nick = human
-                    .subject
-                    .display_name
-                    .clone()
-                    .filter(|s| !s.is_empty())
-                    .or_else(|| {
-                        if human.subject.username.is_empty() {
-                            None
-                        } else {
-                            Some(human.subject.username.clone())
-                        }
-                    });
-                (human.subject.id.clone(), nick)
-            }
-        };
+        let user = require_authenticated_user(&command.caller)?;
+        let nick_name = user
+            .display_name
+            .clone()
+            .filter(|value| !value.is_empty())
+            .or_else(|| (!user.username.is_empty()).then(|| user.username.clone()));
         let join_command = JoinByInviteCommand {
             token: command.token.clone(),
-            staff_no,
+            staff_no: user.id.clone(),
             nick_name,
         };
         let result = match target_type {
@@ -395,7 +346,7 @@ impl FriendshipService for InvitationFriendshipServiceImpl {
         &self,
         command: ListBotFriendships,
     ) -> Result<Page<Friendship>, ApplicationError> {
-        self.ensure_bot_resource(&command.principal, &command.bot_uuid)
+        self.ensure_bot_resource(&command.caller, &command.bot_uuid)
             .await?;
         if command.limit == 0 || command.limit > 100 {
             return Err(ApplicationError::invalid(
@@ -425,12 +376,12 @@ impl FriendshipService for InvitationFriendshipServiceImpl {
         // deletion ("Principal cannot manage either friendship endpoint").
         // Try the primary bot_uuid first; fall back to the friend endpoint.
         match self
-            .ensure_bot_resource(&command.principal, &command.bot_uuid)
+            .ensure_bot_resource(&command.caller, &command.bot_uuid)
             .await
         {
             Ok(()) => {}
             Err(_) => {
-                self.ensure_bot_resource(&command.principal, &command.friend_bot_uuid)
+                self.ensure_bot_resource(&command.caller, &command.friend_bot_uuid)
                     .await?;
             }
         }
@@ -446,7 +397,7 @@ impl FriendshipService for InvitationFriendshipServiceImpl {
         &self,
         command: CreateBotFriendRequest,
     ) -> Result<FriendRequest, ApplicationError> {
-        self.ensure_bot_resource(&command.principal, &command.bot_uuid)
+        self.ensure_bot_resource(&command.caller, &command.bot_uuid)
             .await?;
         let request = self
             .friend_requests
@@ -460,7 +411,7 @@ impl FriendshipService for InvitationFriendshipServiceImpl {
         &self,
         command: ListBotFriendRequests,
     ) -> Result<Page<FriendRequest>, ApplicationError> {
-        self.ensure_bot_resource(&command.principal, &command.bot_uuid)
+        self.ensure_bot_resource(&command.caller, &command.bot_uuid)
             .await?;
         if command.limit == 0 || command.limit > 100 {
             return Err(ApplicationError::invalid(
@@ -513,7 +464,7 @@ impl FriendshipService for InvitationFriendshipServiceImpl {
             .map_err(map_service_error)?;
         // Only the receiver may accept; this also covers Human-owned bots via
         // `authorize_bot_resource`.
-        self.ensure_bot_resource(&command.principal, &request.to_bot)
+        self.ensure_bot_resource(&command.caller, &request.to_bot)
             .await?;
         self.friend_requests
             .accept_request(&command.request_id)
@@ -536,7 +487,7 @@ impl FriendshipService for InvitationFriendshipServiceImpl {
             .get_request(&command.request_id)
             .await
             .map_err(map_service_error)?;
-        self.ensure_bot_resource(&command.principal, &request.to_bot)
+        self.ensure_bot_resource(&command.caller, &request.to_bot)
             .await?;
         self.friend_requests
             .reject_request(&command.request_id)

--- a/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
@@ -5,7 +5,6 @@
 //! / FriendCore / FriendRequestCore / RelationCore), mirroring the sibling
 //! `bcs-app-group` / `bcs-app-session` test harnesses.
 
-use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -21,10 +20,11 @@ use bcs_relation::RelationCore;
 use bcs_service_api::application::invite::InviteService;
 use bcs_service_api::application::session::{CreateOrReactivateCommand, SessionManagementService};
 use bcs_service_api::application::v1::{
-    AcceptFriendRequest, AcceptInvitation, ApplicationError, AuthenticatedUser, CreateBotFriendRequest,
+    AcceptFriendRequest, AcceptInvitation, ApplicationError, AuthenticatedCaller,
+    AuthenticatedUserIdentity, CreateBotFriendRequest,
     CreateGroupInvitation, CreateSessionInvitation, DeleteResult, FriendshipService,
     FriendRequestDirection, FriendRequestStatus, Friendship, InvitationService,
-    InvitationState, InvitationTargetType, ListBotFriendRequests, ListBotFriendships, Page, Principal,
+    InvitationState, InvitationTargetType, ListBotFriendRequests, ListBotFriendships, Page,
     RejectFriendRequest, DeleteBotFriendship,
 };
 use bcs_service_api::port::repo::{GroupRepoPort, NewSessionParams, SessionRepoPort};
@@ -52,9 +52,7 @@ struct Fixture {
     groups: Arc<GroupCore>,
     bots: Arc<BotCore>,
     friends: Arc<FriendCore>,
-    friend_requests: Arc<FriendRequestCore>,
     sessions: Arc<SessionManagementServiceImpl>,
-    relation: Arc<RelationCore>,
     invite: Arc<dyn InviteService>,
 }
 
@@ -97,11 +95,9 @@ impl Fixture {
             groups.clone(),
             sessions.clone(),
             bots.clone(),
-            relation.clone(),
             invite.clone(),
             SECRET.to_vec(),
             InvitationFriendshipServiceConfig {
-                relation_env: "dev".to_string(),
                 default_ttl_seconds: 3600,
             },
         );
@@ -110,9 +106,7 @@ impl Fixture {
             groups,
             bots,
             friends,
-            friend_requests,
             sessions,
-            relation,
             invite,
         }
     }
@@ -131,11 +125,9 @@ impl Fixture {
             self.groups.clone(),
             self.sessions.clone(),
             self.bots.clone(),
-            self.relation.clone(),
             self.invite.clone(),
             SECRET.to_vec(),
             InvitationFriendshipServiceConfig {
-                relation_env: "dev".to_string(),
                 default_ttl_seconds: 3600,
             },
         )
@@ -153,6 +145,7 @@ impl Fixture {
     }
 
     async fn add_bot_with_visibility(&self, bot_uuid: &str, visibility: &str) {
+        let owner = Self::bot_owner(bot_uuid);
         self.bots
             .register(
                 bot_uuid.to_string(),
@@ -164,6 +157,10 @@ impl Fixture {
             )
             .await
             .expect("register bot");
+        self.bots
+            .save_created_by(bot_uuid, owner, true)
+            .await
+            .expect("assign test Bot owner");
     }
 
     async fn store_group(&self, group_id: &str, driver: &str) {
@@ -172,7 +169,7 @@ impl Fixture {
             driver,
             vec![Participant::bot(driver, ParticipantRole::Driver)],
         );
-        group.originator = Some(driver.to_string());
+        group.originator = Some(Self::human_actor_id("staff-1"));
         group.label = Some(group_id.to_string());
         group.group_strategy = GroupStrategy::Chat;
         self.groups.upsert(group).await.expect("store group");
@@ -191,7 +188,7 @@ impl Fixture {
             driver,
             vec![Participant::bot(driver, ParticipantRole::Driver)],
         );
-        group.originator = Some(driver.to_string());
+        group.originator = Some(Self::human_actor_id("staff-1"));
         group.label = Some(group_id.to_string());
         group.group_strategy = GroupStrategy::Chat;
         group.status = status;
@@ -209,7 +206,7 @@ impl Fixture {
                 Participant::bot(other, ParticipantRole::Consultant),
             ],
         );
-        group.originator = Some(driver.to_string());
+        group.originator = Some(Self::human_actor_id("staff-1"));
         group.label = Some(group_id.to_string());
         group.group_strategy = GroupStrategy::Chat;
         group.group_kind = GroupKind::Dm;
@@ -252,34 +249,63 @@ impl Fixture {
         outcome.session.id
     }
 
-    fn bot_principal(bot_uuid: &str) -> Principal {
-        Principal::bot(bot_uuid, "dev", BTreeSet::new())
+    fn bot_owner(bot_uuid: &str) -> &str {
+        match bot_uuid {
+            "bot-a" => "staff-1",
+            "bot-b" => "staff-2",
+            "bot-c" => "staff-3",
+            "bot-x" => "staff-x",
+            _ => "staff-owner",
+        }
     }
 
-    fn human_principal(subject_id: &str) -> Principal {
-        Principal::human(
-            AuthenticatedUser {
+    fn bot_principal(bot_uuid: &str) -> AuthenticatedCaller {
+        Self::human_principal(Self::bot_owner(bot_uuid))
+    }
+
+    fn human_principal(subject_id: &str) -> AuthenticatedCaller {
+        AuthenticatedCaller {
+            tenant: "dev".into(),
+            user: Some(AuthenticatedUserIdentity {
                 id: subject_id.to_string(),
                 username: subject_id.to_string(),
                 display_name: None,
                 full_name: None,
-            },
-            "dev",
-            BTreeSet::new(),
-        )
+            }),
+            bot: None,
+            app: None,
+            access_key: None,
+        }
     }
 
-    fn human_principal_with_display(subject_id: &str, display_name: &str) -> Principal {
-        Principal::human(
-            AuthenticatedUser {
+    fn human_principal_with_display(subject_id: &str, display_name: &str) -> AuthenticatedCaller {
+        AuthenticatedCaller {
+            tenant: "dev".into(),
+            user: Some(AuthenticatedUserIdentity {
                 id: subject_id.to_string(),
                 username: subject_id.to_string(),
                 display_name: Some(display_name.to_string()),
                 full_name: None,
-            },
-            "dev",
-            BTreeSet::new(),
-        )
+            }),
+            bot: None,
+            app: None,
+            access_key: None,
+        }
+    }
+
+    fn bot_only_caller(bot_uuid: &str) -> AuthenticatedCaller {
+        AuthenticatedCaller {
+            tenant: "dev".into(),
+            user: None,
+            bot: Some(bcs_service_api::application::v1::AuthenticatedBotIdentity {
+                bot_uuid: bot_uuid.into(),
+                owner_id: "staff-1".into(),
+                app_id: 1,
+                agent_code: "agent".into(),
+            }),
+            app: None,
+            access_key: None,
+        }
     }
 
     /// Actor ID legacy `ensure_human` records for the given staff_no. Used in
@@ -360,7 +386,7 @@ async fn create_group_invitation_manager_ok() {
     let invitation = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             group_id: "grp-1".to_string(),
             expires_in_seconds: Some(1800),
         })
@@ -390,7 +416,7 @@ async fn create_group_invitation_non_manager_forbidden() {
     let error = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-b"),
+            caller: Fixture::bot_principal("bot-b"),
             group_id: "grp-1".to_string(),
             expires_in_seconds: None,
         })
@@ -427,7 +453,7 @@ async fn create_group_invitation_dm_group_rejected() {
     let error = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             group_id: "dm-1".to_string(),
             expires_in_seconds: None,
         })
@@ -452,7 +478,7 @@ async fn create_session_invitation_manager_ok() {
     let invitation = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             session_id: session_id.clone(),
             expires_in_seconds: None,
         })
@@ -480,7 +506,7 @@ async fn create_group_invitation_inactive_group_rejected() {
     let error = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             group_id: "grp-1".to_string(),
             expires_in_seconds: None,
         })
@@ -508,7 +534,7 @@ async fn create_session_invitation_dm_parent_group_rejected() {
     let error = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             session_id: session_id.clone(),
             expires_in_seconds: None,
         })
@@ -537,7 +563,7 @@ async fn create_session_invitation_inactive_parent_group_rejected() {
     let error = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             session_id,
             expires_in_seconds: None,
         })
@@ -563,7 +589,7 @@ async fn accept_invitation_human_joins_group() {
     let invitation = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             group_id: "grp-1".to_string(),
             expires_in_seconds: None,
         })
@@ -573,7 +599,7 @@ async fn accept_invitation_human_joins_group() {
     let result = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token: invitation.token,
         })
         .await
@@ -612,7 +638,7 @@ async fn accept_invitation_human_display_name_provides_nick_name() {
     let invitation = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             group_id: "grp-1".to_string(),
             expires_in_seconds: None,
         })
@@ -622,7 +648,7 @@ async fn accept_invitation_human_display_name_provides_nick_name() {
     let result = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal_with_display("staff-1", "Alice"),
+            caller: Fixture::human_principal_with_display("staff-1", "Alice"),
             token: invitation.token,
         })
         .await
@@ -640,11 +666,9 @@ async fn accept_invitation_human_display_name_provides_nick_name() {
 }
 
 #[tokio::test]
-async fn accept_invitation_bot_principal_rejected() {
-    // Vcj6H: a Bot Principal may not accept invitations at all. The V1 facade
-    // rejects it up-front with `forbidden`, before any legacy `join_*` side
-    // effects. This naturally subsumes the removed `bot_uuid` field: there is
-    // no way for a Bot Principal to masquerade as another identity.
+async fn accept_invitation_caller_without_user_rejected() {
+    // Vcj6H: a valid Caller without User may not accept invitations. In
+    // particular, Bot owner_id is not a Human fallback.
     let fx = Fixture::new().await;
     fx.add_bot("bot-a").await;
     fx.add_bot("bot-b").await;
@@ -653,7 +677,7 @@ async fn accept_invitation_bot_principal_rejected() {
     let invitation = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             group_id: "grp-1".to_string(),
             expires_in_seconds: None,
         })
@@ -663,11 +687,11 @@ async fn accept_invitation_bot_principal_rejected() {
     let error = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::bot_principal("bot-b"),
+            caller: Fixture::bot_only_caller("bot-b"),
             token: invitation.token,
         })
         .await
-        .expect_err("bot principal rejected");
+        .expect_err("caller without User rejected");
 
     assert!(
         matches!(error, ApplicationError::Forbidden(_)),
@@ -705,7 +729,7 @@ async fn accept_invitation_expired_is_gone() {
     let error = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token: expired,
         })
         .await
@@ -734,7 +758,7 @@ async fn accept_invitation_legacy_token_without_target_type_rejected() {
     let error = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token: legacy,
         })
         .await
@@ -752,7 +776,7 @@ async fn accept_invitation_already_member_is_idempotent() {
     let invitation = fx
         .service
         .create_group_invitation(CreateGroupInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             group_id: "grp-1".to_string(),
             expires_in_seconds: None,
         })
@@ -761,7 +785,7 @@ async fn accept_invitation_already_member_is_idempotent() {
 
     fx.service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token: invitation.token.clone(),
         })
         .await
@@ -770,7 +794,7 @@ async fn accept_invitation_already_member_is_idempotent() {
     let result = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token: invitation.token,
         })
         .await
@@ -790,7 +814,7 @@ async fn accept_invitation_session_target_joins() {
     let invitation = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             session_id: session_id.clone(),
             expires_in_seconds: None,
         })
@@ -800,7 +824,7 @@ async fn accept_invitation_session_target_joins() {
     let result = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token: invitation.token,
         })
         .await
@@ -849,7 +873,7 @@ async fn accept_invitation_target_group_deleted_returns_invitation_not_found() {
     let error = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token,
         })
         .await
@@ -889,7 +913,7 @@ async fn accept_invitation_target_session_deleted_returns_invitation_not_found()
     let error = fx
         .service
         .accept_invitation(AcceptInvitation {
-            principal: Fixture::human_principal("staff-1"),
+            caller: Fixture::human_principal("staff-1"),
             token,
         })
         .await
@@ -928,7 +952,7 @@ async fn list_friendships_sorted_desc_with_pagination() {
     let page = fx
         .service
         .list_bot_friendships(ListBotFriendships {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             offset: 0,
             limit: 100,
@@ -944,7 +968,7 @@ async fn list_friendships_sorted_desc_with_pagination() {
     let page_two = fx
         .service
         .list_bot_friendships(ListBotFriendships {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             offset: 1,
             limit: 1,
@@ -965,7 +989,7 @@ async fn list_friendships_non_owner_forbidden() {
     let error = fx
         .service
         .list_bot_friendships(ListBotFriendships {
-            principal: Fixture::bot_principal("bot-x"),
+            caller: Fixture::bot_principal("bot-x"),
             bot_uuid: "bot-a".to_string(),
             offset: 0,
             limit: 10,
@@ -974,6 +998,25 @@ async fn list_friendships_non_owner_forbidden() {
         .expect_err("non-owner forbidden");
 
     assert!(matches!(error, ApplicationError::Forbidden(_)));
+}
+
+#[tokio::test]
+async fn list_friendships_does_not_use_authenticated_bot_owner_as_human() {
+    let fx = Fixture::new().await;
+    fx.add_bot("bot-a").await;
+
+    let error = fx
+        .service
+        .list_bot_friendships(ListBotFriendships {
+            caller: Fixture::bot_only_caller("bot-a"),
+            bot_uuid: "bot-a".to_string(),
+            offset: 0,
+            limit: 10,
+        })
+        .await
+        .expect_err("Bot identity must not supply Human ownership");
+
+    assert_eq!(error.code(), "forbidden");
 }
 
 #[tokio::test]
@@ -989,7 +1032,7 @@ async fn remove_friendship_is_idempotent() {
     let first = fx
         .service
         .delete_bot_friendship(DeleteBotFriendship {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             friend_bot_uuid: "bot-b".to_string(),
         })
@@ -1000,7 +1043,7 @@ async fn remove_friendship_is_idempotent() {
     let second = fx
         .service
         .delete_bot_friendship(DeleteBotFriendship {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             friend_bot_uuid: "bot-b".to_string(),
         })
@@ -1018,7 +1061,7 @@ async fn create_friend_request_bot_self() {
     let request = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-c".to_string(),
         })
@@ -1040,7 +1083,7 @@ async fn create_friend_request_cannot_add_self() {
     let error = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-a".to_string(),
         })
@@ -1058,7 +1101,7 @@ async fn create_friend_request_duplicate_is_conflict() {
 
     fx.service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-c".to_string(),
         })
@@ -1068,7 +1111,7 @@ async fn create_friend_request_duplicate_is_conflict() {
     let error = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-c".to_string(),
         })
@@ -1086,7 +1129,7 @@ async fn create_friend_request_unknown_target_is_not_found() {
     let error = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-ghost".to_string(),
         })
@@ -1105,7 +1148,7 @@ async fn list_friend_requests_direction_filter_and_sort() {
 
     fx.service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-b".to_string(),
         })
@@ -1114,7 +1157,7 @@ async fn list_friend_requests_direction_filter_and_sort() {
     tokio::time::sleep(Duration::from_millis(25)).await;
     fx.service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-c".to_string(),
         })
@@ -1125,7 +1168,7 @@ async fn list_friend_requests_direction_filter_and_sort() {
     let sent = fx
         .service
         .list_bot_friend_requests(ListBotFriendRequests {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             direction: FriendRequestDirection::Sent,
             status: None,
@@ -1142,7 +1185,7 @@ async fn list_friend_requests_direction_filter_and_sort() {
     let received = fx
         .service
         .list_bot_friend_requests(ListBotFriendRequests {
-            principal: Fixture::bot_principal("bot-b"),
+            caller: Fixture::bot_principal("bot-b"),
             bot_uuid: "bot-b".to_string(),
             direction: FriendRequestDirection::Received,
             status: None,
@@ -1158,7 +1201,7 @@ async fn list_friend_requests_direction_filter_and_sort() {
     let paged = fx
         .service
         .list_bot_friend_requests(ListBotFriendRequests {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             direction: FriendRequestDirection::Sent,
             status: None,
@@ -1186,7 +1229,7 @@ async fn list_bot_friend_requests_propagates_repo_failure_as_internal() {
 
     let error = service
         .list_bot_friend_requests(ListBotFriendRequests {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             direction: FriendRequestDirection::Sent,
             status: None,
@@ -1211,7 +1254,7 @@ async fn accept_friend_request_receiver_ok() {
     let created = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-b".to_string(),
         })
@@ -1221,7 +1264,7 @@ async fn accept_friend_request_receiver_ok() {
     let accepted = fx
         .service
         .accept_friend_request(AcceptFriendRequest {
-            principal: Fixture::bot_principal("bot-b"),
+            caller: Fixture::bot_principal("bot-b"),
             request_id: created.request_id.clone(),
         })
         .await
@@ -1241,7 +1284,7 @@ async fn accept_friend_request_non_receiver_forbidden() {
     let created = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-b".to_string(),
         })
@@ -1251,7 +1294,7 @@ async fn accept_friend_request_non_receiver_forbidden() {
     let error = fx
         .service
         .accept_friend_request(AcceptFriendRequest {
-            principal: Fixture::bot_principal("bot-c"),
+            caller: Fixture::bot_principal("bot-c"),
             request_id: created.request_id,
         })
         .await
@@ -1269,7 +1312,7 @@ async fn accept_friend_request_cannot_accept_rejected() {
     let created = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-b".to_string(),
         })
@@ -1278,7 +1321,7 @@ async fn accept_friend_request_cannot_accept_rejected() {
 
     fx.service
         .reject_friend_request(RejectFriendRequest {
-            principal: Fixture::bot_principal("bot-b"),
+            caller: Fixture::bot_principal("bot-b"),
             request_id: created.request_id.clone(),
         })
         .await
@@ -1287,7 +1330,7 @@ async fn accept_friend_request_cannot_accept_rejected() {
     let error = fx
         .service
         .accept_friend_request(AcceptFriendRequest {
-            principal: Fixture::bot_principal("bot-b"),
+            caller: Fixture::bot_principal("bot-b"),
             request_id: created.request_id,
         })
         .await
@@ -1305,7 +1348,7 @@ async fn reject_friend_request_receiver_ok_and_sender_forbidden() {
     let created = fx
         .service
         .create_bot_friend_request(CreateBotFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             to_bot_uuid: "bot-b".to_string(),
         })
@@ -1316,7 +1359,7 @@ async fn reject_friend_request_receiver_ok_and_sender_forbidden() {
     let sender_err = fx
         .service
         .reject_friend_request(RejectFriendRequest {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             request_id: created.request_id.clone(),
         })
         .await
@@ -1326,7 +1369,7 @@ async fn reject_friend_request_receiver_ok_and_sender_forbidden() {
     let rejected = fx
         .service
         .reject_friend_request(RejectFriendRequest {
-            principal: Fixture::bot_principal("bot-b"),
+            caller: Fixture::bot_principal("bot-b"),
             request_id: created.request_id,
         })
         .await
@@ -1346,7 +1389,7 @@ async fn friendship_page_shape_is_identity_projected() {
     let page: Page<Friendship> = fx
         .service
         .list_bot_friendships(ListBotFriendships {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             offset: 0,
             limit: 10,
@@ -1362,7 +1405,7 @@ async fn friendship_page_shape_is_identity_projected() {
     let del = fx
         .service
         .delete_bot_friendship(DeleteBotFriendship {
-            principal: Fixture::bot_principal("bot-a"),
+            caller: Fixture::bot_principal("bot-a"),
             bot_uuid: "bot-a".to_string(),
             friend_bot_uuid: "bot-b".to_string(),
         })

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -1,16 +1,13 @@
 //! Versioned Session application facade for the BCN V1 API.
 //!
 //! Implements both [`SessionService`] and [`SessionMessageService`]. The
-//! facade owns Principal-based resource authorization and V1 projections
+//! facade owns authenticated-Caller resource authorization and V1 projections
 //! while delegating the legacy session lifecycle to
 //! [`SessionManagementService`]. No HTTP type crosses this boundary.
 //!
-//! Authorization model (design §8.7):
-//! - Manage operations (create / update / complete / participant mutations)
-//!   require the caller to be a group manager (driver / originator /
-//!   ManagerWorker manager) or the session creator.
-//! - Read operations (get / list / list messages) additionally allow session
-//!   participants and group members.
+//! All current V1 operations are Human-facing. Detail reads, actor-relative
+//! lists, message history, and mutations intentionally use separate
+//! authorization rules defined by the V1 contract.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -30,7 +27,8 @@ use bcs_service_api::application::v1::{
         SessionParticipantInput, SessionService, SessionStatus as V1SessionStatus,
         SessionSummary, UpdateSession, UpdateSessionParticipant,
     },
-    ApplicationError, DeleteResult, HumanPrincipal, Page, Principal,
+    ApplicationError, AuthenticatedCaller, DeleteResult, Page, Principal,
+    require_authenticated_user, require_human,
 };
 use bcs_service_api::application::session::{
     CreateOrReactivateCommand, SessionManagementService, SessionUseCaseError,
@@ -118,41 +116,6 @@ impl SessionServiceImpl {
                 .is_some_and(|creator| creator == principal.actor_id())
     }
 
-    /// Read a group's sessions: group participant, group manager, or a
-    /// session-only participant (a Bot added to a session but not to
-    /// `group.participants`). Mirrors `bcs-app-group::can_read_group`
-    /// (lib.rs:180-199) so an invitation-accept that adds the Bot to the
-    /// session (not the group) still authorizes `list_sessions`.
-    async fn can_read_group(
-        &self,
-        principal: &Principal,
-        group: &DomainGroup,
-    ) -> Result<bool, ApplicationError> {
-        let principal_actor_id = principal.actor_id();
-        if Self::can_manage_group(principal, group)
-            || group
-                .participants
-                .iter()
-                .any(|participant| participant.bot_uuid == principal_actor_id)
-        {
-            return Ok(true);
-        }
-        let session_group_ids = self
-            .sessions
-            .list_group_ids_by_session_participant(&principal_actor_id)
-            .await
-            .map_err(|error| ApplicationError::internal(error.to_string()))?;
-        Ok(session_group_ids.iter().any(|id| id == &group.id))
-    }
-
-    /// Read a specific session: session participant, group manager, or the
-    /// session's creator.
-    fn can_read_session(principal: &Principal, session: &Session, group: &DomainGroup) -> bool {
-        let actor_id = principal.actor_id();
-        session.participants.iter().any(|p| p.bot_uuid == actor_id)
-            || Self::can_manage_session(principal, session, group)
-    }
-
     async fn load_group(&self, group_id: &str) -> Result<DomainGroup, ApplicationError> {
         self.groups
             .try_get(group_id)
@@ -175,20 +138,6 @@ impl SessionServiceImpl {
         if !Self::can_manage_group(principal, &group) {
             return Err(ApplicationError::forbidden(
                 "Only the Group originator, driver, or manager may manage Sessions",
-            ));
-        }
-        Ok(group)
-    }
-
-    async fn load_readable_group(
-        &self,
-        principal: &Principal,
-        group_id: &str,
-    ) -> Result<DomainGroup, ApplicationError> {
-        let group = self.load_group(group_id).await?;
-        if !self.can_read_group(principal, &group).await? {
-            return Err(ApplicationError::forbidden(
-                "Principal has no readable relation to this Group",
             ));
         }
         Ok(group)
@@ -220,12 +169,7 @@ impl SessionServiceImpl {
         Ok((session, group))
     }
 
-    /// Load a session and its parent group, authorizing read access.
-    async fn load_session_for_read(
-        &self,
-        principal: &Principal,
-        session_id: &str,
-    ) -> Result<Session, ApplicationError> {
+    async fn load_session(&self, session_id: &str) -> Result<Session, ApplicationError> {
         let session = self
             .sessions
             .get(session_id)
@@ -237,12 +181,6 @@ impl SessionServiceImpl {
                     format!("Session '{session_id}' was not found"),
                 )
             })?;
-        let group = self.load_group(&session.group_id).await?;
-        if !Self::can_read_session(principal, &session, &group) {
-            return Err(ApplicationError::forbidden(
-                "Principal has no readable relation to this Session",
-            ));
-        }
         Ok(session)
     }
 
@@ -260,6 +198,90 @@ impl SessionServiceImpl {
                     format!("Bot '{bot_uuid}' was not found"),
                 )
             })
+    }
+
+    async fn resolve_view_actor(
+        &self,
+        caller: &AuthenticatedCaller,
+        requested: Option<&str>,
+    ) -> Result<String, ApplicationError> {
+        let user = require_authenticated_user(caller)?;
+        let human_actor_id = format!("human_{}", user.id);
+        let Some(requested) = requested else {
+            return Ok(human_actor_id);
+        };
+        if requested == human_actor_id {
+            return Ok(human_actor_id);
+        }
+        if requested.starts_with("human_") {
+            return Err(ApplicationError::forbidden(
+                "The explicit Human View Actor must identify the authenticated User",
+            ));
+        }
+        let bot = self.load_bot(requested).await.map_err(|error| match error {
+            ApplicationError::NotFound { .. } => {
+                ApplicationError::forbidden("The explicit View Actor is not authorized")
+            }
+            other => other,
+        })?;
+        if bot.actor_kind == ActorKind::Bot
+            && bot.created_by.as_deref() == Some(user.id.as_str())
+        {
+            Ok(requested.to_string())
+        } else {
+            Err(ApplicationError::forbidden(
+                "The explicit View Actor is not authorized",
+            ))
+        }
+    }
+
+    async fn can_read_session_detail(
+        &self,
+        caller: &AuthenticatedCaller,
+        session: &Session,
+    ) -> Result<bool, ApplicationError> {
+        let user = require_authenticated_user(caller)?;
+        let human_actor_id = format!("human_{}", user.id);
+        if session
+            .participants
+            .iter()
+            .any(|participant| {
+                participant.actor_kind == ActorKind::Human
+                    && participant.bot_uuid == human_actor_id
+            })
+        {
+            return Ok(true);
+        }
+        let owned_bot_ids = self
+            .registry
+            .list_bots_by_creator(&user.id)
+            .await
+            .into_iter()
+            .filter(|bot| bot.actor_kind == ActorKind::Bot)
+            .map(|bot| bot.bot_uuid)
+            .collect::<HashSet<_>>();
+        Ok(session
+            .participants
+            .iter()
+            .any(|participant| {
+                participant.actor_kind == ActorKind::Bot
+                    && owned_bot_ids.contains(&participant.bot_uuid)
+            }))
+    }
+
+    async fn load_session_for_detail(
+        &self,
+        caller: &AuthenticatedCaller,
+        session_id: &str,
+    ) -> Result<Session, ApplicationError> {
+        let session = self.load_session(session_id).await?;
+        self.load_group(&session.group_id).await?;
+        if !self.can_read_session_detail(caller, &session).await? {
+            return Err(ApplicationError::forbidden(
+                "Neither the Human Actor nor an owned Bot is a Session Participant",
+            ));
+        }
+        Ok(session)
     }
 
     /// VSN7B: Mirror `bcs-app-group`'s `ensure_collaboration_eligible`. A
@@ -324,62 +346,6 @@ impl SessionServiceImpl {
         )))
     }
 
-    /// VYQHN: a Human principal may self-service mutate (update / remove) a
-    /// Session participant when the Human owns the target Bot — i.e.
-    /// `bot.created_by == human.subject.id` or a creator relation edge from
-    /// the Human actor to the Bot exists. Mirrors the Human branch of
-    /// [`ensure_collaboration_eligible`] and `bcs-app-group::authorize_bot_resource`
-    /// so a Human owner is authorized without group-level manager permissions
-    /// (design §8.7 line 557 explicitly allows Human owners to remove owned
-    /// Bots from sessions they can read).
-    async fn is_owned_bot(
-        &self,
-        human: &HumanPrincipal,
-        bot_uuid: &str,
-    ) -> Result<bool, ApplicationError> {
-        let bot = self.load_bot(bot_uuid).await?;
-        if bot.created_by.as_deref() == Some(human.subject.id.as_str()) {
-            return Ok(true);
-        }
-        let actor_id = format!("human_{}", human.subject.id);
-        let edge = self
-            .relation
-            .get_edge(&actor_id, bot_uuid, &self.config.relation_env)
-            .await
-            .map_err(map_service_error)?;
-        Ok(edge.is_some_and(|edge| edge.is_creator))
-    }
-
-    /// Load a session + parent group WITHOUT the read-authorization gate,
-    /// used only by the participant-mutation endpoints (VSN7L self-service
-    /// and VYQHN Human-owner self-service). The legacy read gate
-    /// ([`can_read_session`]) refuses a non-creator/non-manager Human owner
-    /// of a session participant Bot, which would short-circuit the
-    /// participant-mutation path with a 403 before the ownership check
-    /// ([`is_owned_bot`]) could authorize the Human owner. The unified
-    /// `is_self || is_human_owner || can_manage_session` gate performed by
-    /// the caller after this fetch subsumes the read gate for this path:
-    /// `is_self` implies the Bot is a session participant; `can_manage_session`
-    /// implies `can_read_session`; and `is_human_owner` is the VYQHN addition.
-    async fn load_session_and_group_for_participant_mutation(
-        &self,
-        session_id: &str,
-    ) -> Result<(Session, DomainGroup), ApplicationError> {
-        let session = self
-            .sessions
-            .get(session_id)
-            .await
-            .map_err(map_session_error)?
-            .ok_or_else(|| {
-                ApplicationError::not_found(
-                    "session_not_found",
-                    format!("Session '{session_id}' was not found"),
-                )
-            })?;
-        let group = self.load_group(&session.group_id).await?;
-        Ok((session, group))
-    }
-
     // ── projections ────────────────────────────────────────────────────
 
     async fn project_detail(&self, session: &Session) -> Result<SessionDetail, ApplicationError> {
@@ -428,8 +394,9 @@ impl SessionService for SessionServiceImpl {
         &self,
         command: CreateSession,
     ) -> Result<CreateSessionOutcome, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let group = self
-            .load_manageable_group(&command.principal, &command.group_id)
+            .load_manageable_group(&principal, &command.group_id)
             .await?;
 
         // The contract marks `driver_bot_uuid` as required and 404s on an
@@ -441,7 +408,7 @@ impl SessionService for SessionServiceImpl {
         // for the caller (visible + friend/creator relation) before the session
         // is materialized, mirroring the sibling Group V1 facade.
         self.ensure_collaboration_eligible(
-            &command.principal,
+            &principal,
             &command.driver_bot_uuid,
             "driver_bot_uuid",
         )
@@ -469,7 +436,7 @@ impl SessionService for SessionServiceImpl {
         }
         for input in &command.participants {
             self.ensure_collaboration_eligible(
-                &command.principal,
+                &principal,
                 &input.bot_uuid,
                 "participants",
             )
@@ -521,7 +488,7 @@ impl SessionService for SessionServiceImpl {
             )),
         }
 
-        let caller_actor_id = command.principal.actor_id();
+        let caller_actor_id = principal.actor_id();
         let params = NewSessionParams {
             session_kind: SessionKind::Chat,
             participants,
@@ -551,37 +518,17 @@ impl SessionService for SessionServiceImpl {
     }
 
     async fn list(&self, command: ListSessions) -> Result<Page<SessionSummary>, ApplicationError> {
+        let view_actor_id = self
+            .resolve_view_actor(&command.caller, command.view_bot_id.as_deref())
+            .await?;
         if command.limit == 0 || command.limit > 100 {
             return Err(ApplicationError::invalid(
                 "invalid_request",
                 "limit must be between 1 and 100",
             ));
         }
-        let group = self
-            .load_readable_group(&command.principal, &command.group_id)
-            .await?;
-        // Vcj5: scope the listing + count to the caller's own sessions when
-        // the caller's read authority derives solely from session membership
-        // (a Bot added to a session but NOT to `group.participants`).
-        // `can_read_group` already authorized the call above via either the
-        // direct path (group participant / group manager) OR the
-        // session-only fallback (`list_group_ids_by_session_participant`).
-        // When access is direct, the caller has group-level read authority
-        // and sees the full group session pool (`participant_id=None`). When
-        // access is session-only, scope both `list_by_group` and
-        // `count_by_group` to `Some(principal.actor_id())` so a session-only
-        // Bot only sees / counts the sessions it actually participates in.
-        let principal_actor_id = command.principal.actor_id();
-        let is_direct = Self::can_manage_group(&command.principal, &group)
-            || group
-                .participants
-                .iter()
-                .any(|p| p.bot_uuid == principal_actor_id);
-        let participant_id: Option<&str> = if is_direct {
-            None
-        } else {
-            Some(principal_actor_id.as_str())
-        };
+        self.load_group(&command.group_id).await?;
+        let participant_id = Some(view_actor_id.as_str());
         let status = command.status.map(map_status_to_domain);
         let mut sessions = self
             .sessions
@@ -618,11 +565,14 @@ impl SessionService for SessionServiceImpl {
     }
 
     async fn get(&self, query: GetSession) -> Result<SessionDetail, ApplicationError> {
-        let session = self.load_session_for_read(&query.principal, &query.session_id).await?;
+        let session = self
+            .load_session_for_detail(&query.caller, &query.session_id)
+            .await?;
         self.project_detail(&session).await
     }
 
     async fn update(&self, command: UpdateSession) -> Result<SessionDetail, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         // Only `title` is mutable in phase one; a request carrying no field is
         // rejected (mirrors the sibling Group V1 facade).
         if command.title.is_none() {
@@ -631,7 +581,7 @@ impl SessionService for SessionServiceImpl {
                 "at least one mutable field is required",
             ));
         }
-        self.load_session_for_manage(&command.principal, &command.session_id)
+        self.load_session_for_manage(&principal, &command.session_id)
             .await?;
         let session = self
             .sessions
@@ -642,6 +592,7 @@ impl SessionService for SessionServiceImpl {
     }
 
     async fn delete(&self, command: DeleteSession) -> Result<DeleteResult, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         // Idempotent: a missing session yields `deleted: false` rather than a
         // 404 so repeat deletes converge. Non-managers still get 403.
         let session = match self
@@ -654,7 +605,7 @@ impl SessionService for SessionServiceImpl {
             None => return Ok(DeleteResult { deleted: false }),
         };
         let group = self.load_group(&session.group_id).await?;
-        if !Self::can_manage_session(&command.principal, &session, &group) {
+        if !Self::can_manage_session(&principal, &session, &group) {
             return Err(ApplicationError::forbidden(
                 "Principal may not delete this Session",
             ));
@@ -671,8 +622,9 @@ impl SessionService for SessionServiceImpl {
         &self,
         command: CompleteSession,
     ) -> Result<SessionCompletionResult, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let (session, _) = self
-            .load_session_for_manage(&command.principal, &command.session_id)
+            .load_session_for_manage(&principal, &command.session_id)
             .await?;
         // VaGQN: ServiceInvocation sessions have their own callback/output
         // lifecycle and must not be completed via this V1 endpoint (legacy
@@ -726,12 +678,13 @@ impl SessionService for SessionServiceImpl {
         &self,
         command: AddSessionParticipant,
     ) -> Result<SessionParticipant, ApplicationError> {
+        let principal = require_human(&command.caller)?;
         let (session, group) = self
-            .load_session_for_manage(&command.principal, &command.session_id)
+            .load_session_for_manage(&principal, &command.session_id)
             .await?;
         // VSN7B: the added Bot must be collaboration-eligible for the caller
         // (visible + friend/creator relation), not merely registered.
-        self.ensure_collaboration_eligible(&command.principal, &command.bot_uuid, "bot_uuid")
+        self.ensure_collaboration_eligible(&principal, &command.bot_uuid, "bot_uuid")
             .await?;
         // VfhG3: explicit 409 if the target Bot is already a session participant.
         // The legacy memory repo silently skipped duplicates (idempotent); the V1
@@ -788,29 +741,9 @@ impl SessionService for SessionServiceImpl {
         &self,
         command: UpdateSessionParticipant,
     ) -> Result<SessionParticipant, ApplicationError> {
-        // VSN7L: the target Actor may update its own participant mode
-        // (self-service) in addition to the driver/originator/manager path,
-        // mirroring the sibling Group V1 facade's participant self-service.
-        // VYQHN: a Human principal who owns the target Bot (via created_by
-        // or a creator relation edge) is also authorized to self-service. The
-        // legacy read gate is bypassed here because it would 403 a
-        // non-creator/non-manager Human owner before the ownership check
-        // could authorize them; the unified check below (is_self ||
-        // is_human_owner || can_manage_session) subsumes the read gate for
-        // this path.
-        let (session, group) = self
-            .load_session_and_group_for_participant_mutation(&command.session_id)
+        let principal = require_human(&command.caller)?;
+        self.load_session_for_manage(&principal, &command.session_id)
             .await?;
-        let is_self = command.principal.actor_id() == command.bot_uuid;
-        let is_human_owner = match &command.principal {
-            Principal::Human(human) => self.is_owned_bot(human, &command.bot_uuid).await?,
-            Principal::Bot(_) => false,
-        };
-        if !is_self && !is_human_owner && !Self::can_manage_session(&command.principal, &session, &group) {
-            return Err(ApplicationError::forbidden(
-                "Principal may not manage this Session's participants",
-            ));
-        }
         let domain_mode = map_v1_mode_to_domain(command.mode);
         let mut updated = self
             .sessions
@@ -837,28 +770,10 @@ impl SessionService for SessionServiceImpl {
         &self,
         command: DeleteSessionParticipant,
     ) -> Result<DeleteResult, ApplicationError> {
-        // VSN7L: the target Actor may leave the session (self-service delete)
-        // in addition to the driver/originator/manager path, mirroring the
-        // sibling Group V1 facade's participant self-leave.
-        // VYQHN: a Human principal who owns the target Bot (via created_by
-        // or a creator relation edge) is also authorized to self-service. As
-        // in update_participant, the legacy read gate is bypassed so the
-        // ownership check is reachable for a non-creator/non-manager Human
-        // owner; the unified check below (is_self || is_human_owner ||
-        // can_manage_session) subsumes the read gate for this path.
-        let (session, group) = self
-            .load_session_and_group_for_participant_mutation(&command.session_id)
+        let principal = require_human(&command.caller)?;
+        let (session, _) = self
+            .load_session_for_manage(&principal, &command.session_id)
             .await?;
-        let is_self = command.principal.actor_id() == command.bot_uuid;
-        let is_human_owner = match &command.principal {
-            Principal::Human(human) => self.is_owned_bot(human, &command.bot_uuid).await?,
-            Principal::Bot(_) => false,
-        };
-        if !is_self && !is_human_owner && !Self::can_manage_session(&command.principal, &session, &group) {
-            return Err(ApplicationError::forbidden(
-                "Principal may not manage this Session's participants",
-            ));
-        }
         // Idempotent: if the target is not a current participant, return
         // `deleted: false` without invoking the legacy removal (which would
         // surface a `SessionInvalidParams` "not in session" error otherwise).
@@ -889,9 +804,19 @@ impl SessionMessageService for SessionServiceImpl {
                 "limit must be between 1 and 100",
             ));
         }
-        let session = self
-            .load_session_for_read(&query.principal, &query.session_id)
+        let view_actor_id = self
+            .resolve_view_actor(&query.caller, query.view_bot_id.as_deref())
             .await?;
+        let session = self.load_session(&query.session_id).await?;
+        if !session
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == view_actor_id)
+        {
+            return Err(ApplicationError::forbidden(
+                "The selected View Actor is not a Session Participant",
+            ));
+        }
         // VSN7A/VUlai/VHxMU — reuse the legacy `bcs-message` visibility helper
         // (single source of truth) so the V1 session list applies the EXACT
         // same scoping the group history path does: the full 3-state
@@ -899,44 +824,11 @@ impl SessionMessageService for SessionServiceImpl {
         // the spec §5.2 new-participant `visible_from_seq` cutoff. The V1 facade
         // no longer reimplements these predicates.
         let group = self.load_group(&session.group_id).await?;
-        // view_bot_id authz (design §8.7 visibility scoping): the optional
-        // `view_bot_id` query param is resolved to the `Option<&str>` cutoff
-        // identity passed into the legacy helper.
-        // - Bot Principal: omit → auto-derive self; explicit → must equal self.
-        // - Human Principal: omit → None (manager god-view, no cutoff);
-        //   `"human_<self>"` → own participant cutoff; any other Bot UUID →
-        //   ownership verified via `is_owned_bot` (`created_by` or creator
-        //   relation edge), else forbidden. Reuses the same Human→Bot ownership
-        //   path as `update_participant`/`delete_participant` (VYQHN).
-        let view_bot_id: Option<String> = match &query.principal {
-            Principal::Bot(bot) => match &query.view_bot_id {
-                None => Some(bot.bot_uuid.clone()),
-                Some(explicit) if explicit == &bot.bot_uuid => Some(bot.bot_uuid.clone()),
-                Some(_) => {
-                    return Err(ApplicationError::forbidden(
-                        "Bot Principal may only view as self",
-                    ));
-                }
-            },
-            Principal::Human(human) => match &query.view_bot_id {
-                None => None,
-                Some(vid) if vid == &format!("human_{}", human.subject.id) => Some(vid.clone()),
-                Some(vid) => {
-                    let owned = self.is_owned_bot(human, vid.as_str()).await?;
-                    if !owned {
-                        return Err(ApplicationError::forbidden(
-                            "Human Principal may only view as self or an owned Bot",
-                        ));
-                    }
-                    Some(vid.clone())
-                }
-            },
-        };
         let (owner_filter, visible_from_seq) =
             MessageService::compute_session_history_query(
                 &group,
                 &session,
-                view_bot_id.as_deref(),
+                Some(&view_actor_id),
                 NEW_PARTICIPANT_VISIBLE_LIMIT as u64,
             )
             .map_err(map_group_use_case_error)?;

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -5,7 +5,6 @@
 //! / MemorySessionRepo / MemoryMessageRepo), mirroring the sibling
 //! `bcs-app-group` test harness.
 
-use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,9 +15,10 @@ use bcs_group::{GroupCore, MemoryGroupRepo};
 use bcs_message_store::MemoryMessageRepo;
 use bcs_relation::RelationCore;
 use bcs_service_api::application::v1::{
-    AddSessionParticipant, AuthenticatedUser, BotParticipantMode, CompleteSession, CreateSession,
-    DeleteSession, DeleteSessionParticipant, GetSession, ListSessionMessages, ListSessions,
-    SessionInput, SessionMessageService, SessionParticipantInput, SessionService,
+    AddSessionParticipant, AuthenticatedBotIdentity, AuthenticatedCaller,
+    AuthenticatedUserIdentity, BotParticipantMode, CompleteSession, CreateSession, DeleteSession,
+    DeleteSessionParticipant, GetSession, ListSessionMessages, ListSessions, SessionInput,
+    SessionMessageService, SessionParticipantInput, SessionService,
     SessionStatus as V1SessionStatus, UpdateSession, UpdateSessionParticipant,
 };
 use bcs_service_api::port::repo::{MessageRepoPort, NewSessionParams, SessionRepoPort};
@@ -85,17 +85,24 @@ impl Fixture {
             )
             .await
             .expect("register bot");
+        self.bots
+            .save_created_by(bot_uuid, bot_uuid, true)
+            .await
+            .expect("assign test Bot owner");
     }
 
     async fn store_group(&self, group_id: &str, driver: &str, context: Option<&str>) {
-        self.store_group_with_originator(group_id, driver, driver, context)
-            .await;
+        self.store_group_with_originator(
+            group_id,
+            driver,
+            &format!("human_{driver}"),
+            context,
+        )
+        .await;
     }
 
     /// Like `store_group` but lets the caller name a distinct group
-    /// `originator` — used by the Human-view authz tests where the Human must
-    /// be a group manager (originator) to pass `can_read_session` before the
-    /// `view_bot_id` authz runs.
+    /// `originator` for direct Human management tests.
     async fn store_group_with_originator(
         &self,
         group_id: &str,
@@ -142,25 +149,38 @@ impl Fixture {
     }
 }
 
-fn bot_principal(bot_uuid: &str) -> bcs_service_api::application::v1::Principal {
-    bcs_service_api::application::v1::Principal::bot(
-        bot_uuid.to_string(),
-        "tenant-a".to_string(),
-        BTreeSet::new(),
-    )
+fn bot_principal(bot_uuid: &str) -> AuthenticatedCaller {
+    human_principal(bot_uuid)
 }
 
-fn human_principal(staff_no: &str) -> bcs_service_api::application::v1::Principal {
-    bcs_service_api::application::v1::Principal::human(
-        AuthenticatedUser {
+fn human_principal(staff_no: &str) -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
             id: staff_no.to_string(),
             username: staff_no.to_string(),
             display_name: None,
             full_name: None,
-        },
-        "tenant-a".to_string(),
-        BTreeSet::new(),
-    )
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn bot_only_caller(bot_uuid: &str) -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: None,
+        bot: Some(AuthenticatedBotIdentity {
+            bot_uuid: bot_uuid.into(),
+            owner_id: "alice".into(),
+            app_id: 1,
+            agent_code: "test".into(),
+        }),
+        app: None,
+        access_key: None,
+    }
 }
 
 fn participant_input(bot_uuid: &str, mode: Option<BotParticipantMode>) -> SessionParticipantInput {
@@ -172,7 +192,7 @@ fn participant_input(bot_uuid: &str, mode: Option<BotParticipantMode>) -> Sessio
 
 async fn create_session(
     fixture: &Fixture,
-    principal: bcs_service_api::application::v1::Principal,
+    caller: AuthenticatedCaller,
     group_id: &str,
     driver: &str,
     participants: Vec<SessionParticipantInput>,
@@ -182,7 +202,7 @@ async fn create_session(
     fixture
         .service
         .create(CreateSession {
-            principal,
+            caller,
             group_id: group_id.to_string(),
             driver_bot_uuid: driver.to_string(),
             title: title.map(str::to_string),
@@ -304,7 +324,7 @@ async fn create_as_non_manager_is_forbidden() {
     let error = fixture
         .service
         .create(CreateSession {
-            principal: bot_principal("outsider"),
+            caller: bot_principal("outsider"),
             group_id: "g1".into(),
             driver_bot_uuid: "driver".into(),
             title: None,
@@ -328,7 +348,7 @@ async fn create_with_unknown_driver_bot_is_not_found() {
     let error = fixture
         .service
         .create(CreateSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "g1".into(),
             driver_bot_uuid: "ghost".into(),
             title: None,
@@ -367,8 +387,9 @@ async fn list_sorts_desc_and_reports_total() {
     let page = SessionService::list(
         &fixture.service,
         ListSessions {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "g1".into(),
+            view_bot_id: Some("driver".into()),
             offset: 0,
             limit: 10,
             status: None,
@@ -389,7 +410,7 @@ async fn list_sorts_desc_and_reports_total() {
 }
 
 #[tokio::test]
-async fn list_non_member_is_forbidden() {
+async fn list_authorized_human_with_no_participating_sessions_is_empty() {
     let fixture = Fixture::new().await;
     fixture.add_bot("driver").await;
     fixture.store_group("g1", "driver", None).await;
@@ -397,15 +418,166 @@ async fn list_non_member_is_forbidden() {
     let error = SessionService::list(
         &fixture.service,
         ListSessions {
-            principal: bot_principal("outsider"),
+            caller: bot_principal("outsider"),
             group_id: "g1".into(),
+            view_bot_id: None,
             offset: 0,
             limit: 10,
             status: None,
         },
     )
     .await
-    .expect_err("non-member should be forbidden");
+    .expect("an authorized Human view with no matching sessions is empty");
+    assert_eq!(error.total, 0);
+    assert!(error.items.is_empty());
+}
+
+#[tokio::test]
+async fn session_list_uses_only_the_selected_authorized_view_actor() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "owned", "unowned"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture
+        .bots
+        .save_created_by("owned", "alice", true)
+        .await
+        .expect("assign Alice's Bot ownership");
+    fixture.store_group("g1", "driver", None).await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    for participant in ["human_alice", "owned", "unowned"] {
+        fixture
+            .session_repo
+            .create(
+                "g1",
+                NewSessionParams {
+                    participants: vec![if participant.starts_with("human_") {
+                        Participant::human(participant, ParticipantRole::Observer)
+                    } else {
+                        Participant::bot(participant, ParticipantRole::Consultant)
+                    }],
+                    group_version: Some(group.version),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("seed actor-scoped Session");
+    }
+
+    let list = |view_bot_id| ListSessions {
+        caller: human_principal("alice"),
+        group_id: "g1".into(),
+        view_bot_id,
+        offset: 0,
+        limit: 20,
+        status: None,
+    };
+    let default_human = SessionService::list(&fixture.service, list(None))
+        .await
+        .expect("omission selects the authenticated Human");
+    assert_eq!(default_human.total, 1);
+    let explicit_human = SessionService::list(
+        &fixture.service,
+        list(Some("human_alice".into())),
+    )
+    .await
+    .expect("the authenticated Human is a valid explicit view");
+    assert_eq!(explicit_human.total, 1);
+    let owned_bot = SessionService::list(&fixture.service, list(Some("owned".into())))
+        .await
+        .expect("an exact-created_by Bot is a valid explicit view");
+    assert_eq!(owned_bot.total, 1);
+
+    for invalid_view in ["human_bob", "unowned", "missing"] {
+        let error = SessionService::list(
+            &fixture.service,
+            list(Some(invalid_view.into())),
+        )
+        .await
+        .expect_err("an unauthorized explicit view never falls back to Human");
+        assert!(matches!(
+            error,
+            bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+        ));
+    }
+}
+
+#[tokio::test]
+async fn session_detail_accepts_human_or_exact_owned_bot_participation_only() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "owned", "unowned"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture
+        .bots
+        .save_created_by("owned", "alice", true)
+        .await
+        .expect("assign Alice's Bot ownership");
+    fixture.store_group("g1", "driver", None).await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    let mut ids = Vec::new();
+    for participant in ["human_alice", "owned", "unowned"] {
+        let session = fixture
+            .session_repo
+            .create(
+                "g1",
+                NewSessionParams {
+                    participants: vec![if participant.starts_with("human_") {
+                        Participant::human(participant, ParticipantRole::Observer)
+                    } else {
+                        Participant::bot(participant, ParticipantRole::Consultant)
+                    }],
+                    group_version: Some(group.version),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("seed Session");
+        ids.push(session.id);
+    }
+
+    for session_id in &ids[..2] {
+        fixture
+            .service
+            .get(GetSession {
+                caller: human_principal("alice"),
+                session_id: session_id.clone(),
+            })
+            .await
+            .expect("Human or exact owned Bot participation grants detail read");
+    }
+    let error = fixture
+        .service
+        .get(GetSession {
+            caller: human_principal("alice"),
+            session_id: ids[2].clone(),
+        })
+        .await
+        .expect_err("an unowned Bot participant grants no detail read");
+    assert!(matches!(
+        error,
+        bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+    ));
+}
+
+#[tokio::test]
+async fn session_v1_rejects_a_caller_without_user_identity() {
+    let fixture = Fixture::new().await;
+    fixture.add_bot("driver").await;
+    fixture.store_group("g1", "driver", None).await;
+    let error = SessionService::list(
+        &fixture.service,
+        ListSessions {
+            caller: bot_only_caller("driver"),
+            group_id: "g1".into(),
+            view_bot_id: Some("driver".into()),
+            offset: 0,
+            limit: 20,
+            status: None,
+        },
+    )
+    .await
+    .expect_err("current V1 operations require an authenticated User");
     assert!(matches!(
         error,
         bcs_service_api::application::v1::ApplicationError::Forbidden(_)
@@ -433,7 +605,7 @@ async fn get_returns_detail_and_not_found_for_missing() {
     let detail = fixture
         .service
         .get(GetSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: outcome.session.session_id.clone(),
         })
         .await
@@ -444,7 +616,7 @@ async fn get_returns_detail_and_not_found_for_missing() {
     let error = fixture
         .service
         .get(GetSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: "g1:deadbeef".into(),
         })
         .await
@@ -473,7 +645,7 @@ async fn update_changes_title() {
     let detail = fixture
         .service
         .update(UpdateSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: outcome.session.session_id.clone(),
             title: Some("new title".into()),
         })
@@ -503,7 +675,7 @@ async fn update_requires_a_field() {
     let error = fixture
         .service
         .update(UpdateSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: outcome.session.session_id,
             title: None,
         })
@@ -534,7 +706,7 @@ async fn delete_is_idempotent() {
     let first = fixture
         .service
         .delete(DeleteSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
         })
         .await
@@ -544,7 +716,7 @@ async fn delete_is_idempotent() {
     let second = fixture
         .service
         .delete(DeleteSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id,
         })
         .await
@@ -575,7 +747,7 @@ async fn complete_is_idempotent() {
     let first = fixture
         .service
         .complete(CompleteSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
         })
         .await
@@ -586,7 +758,7 @@ async fn complete_is_idempotent() {
     let second = fixture
         .service
         .complete(CompleteSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id,
         })
         .await
@@ -637,11 +809,11 @@ async fn list_messages_returns_descending_with_cursor() {
     let page = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             before: None,
             limit: 50,
-            view_bot_id: None,
+            view_bot_id: Some("driver".into()),
         },
     )
     .await
@@ -712,11 +884,11 @@ async fn list_messages_composite_cursor_no_skip_tied_created_at() {
     let page = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             before: None,
             limit: 2,
-            view_bot_id: None,
+            view_bot_id: Some("driver".into()),
         },
     )
     .await
@@ -732,11 +904,11 @@ async fn list_messages_composite_cursor_no_skip_tied_created_at() {
     let page = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             before: page.next_cursor,
             limit: 2,
-            view_bot_id: None,
+            view_bot_id: Some("driver".into()),
         },
     )
     .await
@@ -752,11 +924,11 @@ async fn list_messages_composite_cursor_no_skip_tied_created_at() {
     let page = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id,
             before: page.next_cursor,
             limit: 2,
-            view_bot_id: None,
+            view_bot_id: Some("driver".into()),
         },
     )
     .await
@@ -790,11 +962,11 @@ async fn list_messages_rejects_malformed_before_cursor() {
     let error = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: outcome.session.session_id.clone(),
             before: Some("not-a-cursor".to_string()),
             limit: 10,
-            view_bot_id: None,
+            view_bot_id: Some("driver".into()),
         },
     )
     .await
@@ -825,7 +997,7 @@ async fn participant_add_update_remove_lifecycle() {
     let added = fixture
         .service
         .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "newcomer".into(),
             mode: Some(BotParticipantMode::Auto),
@@ -840,7 +1012,7 @@ async fn participant_add_update_remove_lifecycle() {
     let error = fixture
         .service
         .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "newcomer".into(),
             mode: None,
@@ -853,7 +1025,7 @@ async fn participant_add_update_remove_lifecycle() {
     let updated = fixture
         .service
         .update_participant(UpdateSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "newcomer".into(),
             mode: BotParticipantMode::Muted,
@@ -866,7 +1038,7 @@ async fn participant_add_update_remove_lifecycle() {
     let removed = fixture
         .service
         .delete_participant(DeleteSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "newcomer".into(),
         })
@@ -878,7 +1050,7 @@ async fn participant_add_update_remove_lifecycle() {
     let again = fixture
         .service
         .delete_participant(DeleteSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id,
             bot_uuid: "newcomer".into(),
         })
@@ -888,10 +1060,7 @@ async fn participant_add_update_remove_lifecycle() {
 }
 
 #[tokio::test]
-async fn delete_participant_human_owner_succeeds_and_non_owner_forbidden() {
-    // VYQHN: a Human principal who owns the target Bot (via created_by) may
-    // self-service-remove it from a session they can neither manage nor read
-    // otherwise; a Human without ownership is still forbidden.
+async fn owned_bot_does_not_grant_session_participant_removal_permission() {
     let fixture = Fixture::new().await;
     for bot in ["driver", "bot-a"] {
         fixture.add_bot(bot).await;
@@ -915,38 +1084,26 @@ async fn delete_participant_human_owner_succeeds_and_non_owner_forbidden() {
     .await;
     let session_id = outcome.session.session_id.clone();
 
-    // Owner Human removes the owned Bot (not self, not manager, not creator
-    // of this session): authorized solely by is_human_owner.
-    let removed = fixture
+    let owner_error = fixture
         .service
         .delete_participant(DeleteSessionParticipant {
-            principal: human_principal("staff-1"),
+            caller: human_principal("staff-1"),
             session_id: session_id.clone(),
             bot_uuid: "bot-a".into(),
         })
         .await
-        .expect("owner human removes owned bot");
-    assert!(removed.deleted);
-
-    // Re-add bot-a (the driver is a manager and bot-a is public) so the
-    // non-owner scenario starts from the same participant state.
-    fixture
-        .service
-        .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
-            session_id: session_id.clone(),
-            bot_uuid: "bot-a".into(),
-            mode: Some(BotParticipantMode::Auto),
-        })
-        .await
-        .expect("re-add bot-a");
+        .expect_err("Bot ownership grants detail read only, not management");
+    assert!(matches!(
+        owner_error,
+        bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+    ));
 
     // Non-owner Human (staff-2) is forbidden — neither self, owner, nor
     // manager/creator.
     let error = fixture
         .service
         .delete_participant(DeleteSessionParticipant {
-            principal: human_principal("staff-2"),
+            caller: human_principal("staff-2"),
             session_id,
             bot_uuid: "bot-a".into(),
         })
@@ -959,9 +1116,7 @@ async fn delete_participant_human_owner_succeeds_and_non_owner_forbidden() {
 }
 
 #[tokio::test]
-async fn update_participant_human_owner_succeeds_and_non_owner_forbidden() {
-    // VYQHN symmetric: the same Human-owner authorization applies to the
-    // participant mode update path.
+async fn owned_bot_does_not_grant_session_participant_update_permission() {
     let fixture = Fixture::new().await;
     for bot in ["driver", "bot-a"] {
         fixture.add_bot(bot).await;
@@ -984,24 +1139,26 @@ async fn update_participant_human_owner_succeeds_and_non_owner_forbidden() {
     .await;
     let session_id = outcome.session.session_id.clone();
 
-    // Owner Human mutates the owned Bot's participant mode.
-    let updated = fixture
+    let owner_error = fixture
         .service
         .update_participant(UpdateSessionParticipant {
-            principal: human_principal("staff-1"),
+            caller: human_principal("staff-1"),
             session_id: session_id.clone(),
             bot_uuid: "bot-a".into(),
             mode: BotParticipantMode::Muted,
         })
         .await
-        .expect("owner human updates owned bot");
-    assert_eq!(updated.mode, ParticipantMode::Muted);
+        .expect_err("Bot ownership grants detail read only, not management");
+    assert!(matches!(
+        owner_error,
+        bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+    ));
 
     // Non-owner Human is forbidden.
     let error = fixture
         .service
         .update_participant(UpdateSessionParticipant {
-            principal: human_principal("staff-2"),
+            caller: human_principal("staff-2"),
             session_id,
             bot_uuid: "bot-a".into(),
             mode: BotParticipantMode::Auto,
@@ -1050,7 +1207,7 @@ async fn complete_service_invocation_session_rejected() {
     let error = fixture
         .service
         .complete(CompleteSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session.id,
         })
         .await
@@ -1095,7 +1252,7 @@ async fn session_only_participant_can_list_sessions() {
     fixture
         .service
         .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "newcomer".into(),
             mode: Some(BotParticipantMode::Auto),
@@ -1117,8 +1274,9 @@ async fn session_only_participant_can_list_sessions() {
     let page = SessionService::list(
         &fixture.service,
         ListSessions {
-            principal: bot_principal("newcomer"),
+            caller: bot_principal("newcomer"),
             group_id: "g1".into(),
+            view_bot_id: Some("newcomer".into()),
             offset: 0,
             limit: 10,
             status: None,
@@ -1163,7 +1321,7 @@ async fn session_only_participant_list_sessions_scoped() {
     fixture
         .service
         .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: s1_id.clone(),
             bot_uuid: "newcomer".into(),
             mode: Some(BotParticipantMode::Auto),
@@ -1208,8 +1366,9 @@ async fn session_only_participant_list_sessions_scoped() {
     let page = SessionService::list(
         &fixture.service,
         ListSessions {
-            principal: bot_principal("newcomer"),
+            caller: bot_principal("newcomer"),
             group_id: "g1".into(),
+            view_bot_id: Some("newcomer".into()),
             offset: 0,
             limit: 10,
             status: None,
@@ -1240,7 +1399,7 @@ async fn create_session_duplicate_participant_rejected() {
     let error = fixture
         .service
         .create(CreateSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "g1".into(),
             driver_bot_uuid: "driver".into(),
             title: None,
@@ -1265,8 +1424,9 @@ async fn create_session_duplicate_participant_rejected() {
     let page = SessionService::list(
         &fixture.service,
         ListSessions {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             group_id: "g1".into(),
+            view_bot_id: Some("driver".into()),
             offset: 0,
             limit: 10,
             status: None,
@@ -1277,16 +1437,11 @@ async fn create_session_duplicate_participant_rejected() {
     assert_eq!(page.total, 0, "no session should be persisted on rejection");
 }
 
-// ── view_bot_id authz (Principal-based visibility scoping) ──────────────
+// ── view_bot_id authz (Human-facing visibility scoping) ─────────────────
 //
-// The optional `view_bot_id` query param on `list_session_messages` is
-// resolved by the V1 facade into the `Option<&str>` cutoff identity passed
-// to the legacy `compute_session_history_query` helper. Authz rules:
-// - Bot Principal: omit → self; explicit → must equal self; else forbidden.
-// - Human Principal (must be a group manager/originator to read the session):
-//   omit → None (manager view); `"human_<self>"` → own view; any other Bot
-//   UUID → ownership verified via `is_owned_bot` (`created_by` or creator
-//   relation edge), else forbidden.
+// Omission selects the authenticated User's Human Actor. An explicit Human
+// must be that same Actor; an explicit Bot requires exact `created_by`
+// ownership. The selected Actor must be a Session Participant.
 //
 // These tests use a ManagerWorker group + owner-tagged messages so the
 // `MessageOwnerFilter` scoping (`IsNull` public vs `Eq(worker)`) is the
@@ -1312,6 +1467,7 @@ async fn setup_manager_worker_session(fixture: &Fixture) -> String {
                     Participant::bot("driver", ParticipantRole::Driver),
                     Participant::bot("worker-a", ParticipantRole::Worker),
                     Participant::bot("worker-b", ParticipantRole::Worker),
+                    Participant::human("human_staff-1", ParticipantRole::Observer),
                 ],
                 group_version: Some(group.version),
                 caller_id: Some("driver".to_string()),
@@ -1330,79 +1486,7 @@ async fn setup_manager_worker_session(fixture: &Fixture) -> String {
 }
 
 #[tokio::test]
-async fn bot_view_session_messages_defaults_to_self() {
-    let fixture = Fixture::new().await;
-    for bot in ["driver", "worker-a", "worker-b"] {
-        fixture.add_bot(bot).await;
-    }
-    fixture
-        .store_manager_worker_group_with_originator(
-            "g1",
-            "driver",
-            &["worker-a", "worker-b"],
-            "driver",
-            None,
-        )
-        .await;
-    let session_id = setup_manager_worker_session(&fixture).await;
-
-    let page = SessionMessageService::list(
-        &fixture.service,
-        ListSessionMessages {
-            principal: bot_principal("worker-a"),
-            session_id: session_id.clone(),
-            before: None,
-            limit: 100,
-            view_bot_id: None,
-        },
-    )
-    .await
-    .expect("list messages");
-
-    // Omitted view_bot_id auto-derives self ("worker-a"); as a Worker this
-    // resolves to owner_filter=Eq("worker-a") → only worker-a's message.
-    assert_eq!(page.messages.len(), 1);
-    assert!(!page.has_more);
-    assert_eq!(page.messages[0].session_seq, 2);
-}
-
-#[tokio::test]
-async fn bot_view_session_messages_explicitly_self() {
-    let fixture = Fixture::new().await;
-    for bot in ["driver", "worker-a", "worker-b"] {
-        fixture.add_bot(bot).await;
-    }
-    fixture
-        .store_manager_worker_group_with_originator(
-            "g1",
-            "driver",
-            &["worker-a", "worker-b"],
-            "driver",
-            None,
-        )
-        .await;
-    let session_id = setup_manager_worker_session(&fixture).await;
-
-    let page = SessionMessageService::list(
-        &fixture.service,
-        ListSessionMessages {
-            principal: bot_principal("worker-a"),
-            session_id: session_id.clone(),
-            before: None,
-            limit: 100,
-            view_bot_id: Some("worker-a".to_string()),
-        },
-    )
-    .await
-    .expect("list messages");
-
-    // Explicit self == omitted self: same Eq("worker-a") scoping.
-    assert_eq!(page.messages.len(), 1);
-    assert_eq!(page.messages[0].session_seq, 2);
-}
-
-#[tokio::test]
-async fn bot_view_session_messages_as_other_bot_forbidden() {
+async fn omitted_message_view_selects_human_and_requires_session_participation() {
     let fixture = Fixture::new().await;
     for bot in ["driver", "worker-a", "worker-b"] {
         fixture.add_bot(bot).await;
@@ -1421,15 +1505,15 @@ async fn bot_view_session_messages_as_other_bot_forbidden() {
     let error = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: bot_principal("worker-a"),
-            session_id,
+            caller: bot_principal("worker-a"),
+            session_id: session_id.clone(),
             before: None,
             limit: 100,
-            view_bot_id: Some("worker-b".to_string()),
+            view_bot_id: None,
         },
     )
     .await
-    .expect_err("bot impersonating another bot should be forbidden");
+    .expect_err("omission selects human_worker-a, which is not a participant");
     assert!(matches!(
         error,
         bcs_service_api::application::v1::ApplicationError::Forbidden(_)
@@ -1437,7 +1521,77 @@ async fn bot_view_session_messages_as_other_bot_forbidden() {
 }
 
 #[tokio::test]
-async fn human_view_session_messages_god_view_no_cutoff() {
+async fn human_caller_can_explicitly_select_an_owned_bot_message_view() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "worker-a", "worker-b"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture
+        .store_manager_worker_group_with_originator(
+            "g1",
+            "driver",
+            &["worker-a", "worker-b"],
+            "driver",
+            None,
+        )
+        .await;
+    let session_id = setup_manager_worker_session(&fixture).await;
+
+    let page = SessionMessageService::list(
+        &fixture.service,
+        ListSessionMessages {
+            caller: bot_principal("worker-a"),
+            session_id: session_id.clone(),
+            before: None,
+            limit: 100,
+            view_bot_id: Some("worker-a".to_string()),
+        },
+    )
+    .await
+    .expect("list messages");
+
+    // Explicit owned Bot resolves to Eq("worker-a") scoping.
+    assert_eq!(page.messages.len(), 1);
+    assert_eq!(page.messages[0].session_seq, 2);
+}
+
+#[tokio::test]
+async fn human_caller_cannot_select_an_unowned_bot_message_view() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "worker-a", "worker-b"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture
+        .store_manager_worker_group_with_originator(
+            "g1",
+            "driver",
+            &["worker-a", "worker-b"],
+            "driver",
+            None,
+        )
+        .await;
+    let session_id = setup_manager_worker_session(&fixture).await;
+
+    let error = SessionMessageService::list(
+        &fixture.service,
+        ListSessionMessages {
+            caller: bot_principal("worker-a"),
+            session_id,
+            before: None,
+            limit: 100,
+            view_bot_id: Some("worker-b".to_string()),
+        },
+    )
+    .await
+    .expect_err("an unowned Bot view should be forbidden");
+    assert!(matches!(
+        error,
+        bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+    ));
+}
+
+#[tokio::test]
+async fn omitted_human_message_view_equals_the_human_participant_view() {
     let fixture = Fixture::new().await;
     for bot in ["driver", "worker-a", "worker-b"] {
         fixture.add_bot(bot).await;
@@ -1456,7 +1610,7 @@ async fn human_view_session_messages_god_view_no_cutoff() {
     let page = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: human_principal("staff-1"),
+            caller: human_principal("staff-1"),
             session_id: session_id.clone(),
             before: None,
             limit: 100,
@@ -1466,9 +1620,8 @@ async fn human_view_session_messages_god_view_no_cutoff() {
     .await
     .expect("list messages");
 
-    // Omitted → None → manager god-view: ManagerWorker Public (IsNull) →
-    // only the public message (worker-private messages are hidden from the
-    // unscoped manager view, distinct from the worker-a bot view above).
+    // Omitted selects human_staff-1. Human ManagerWorker views are Public
+    // (IsNull), so only the public message is visible.
     assert_eq!(page.messages.len(), 1);
     assert_eq!(page.messages[0].session_seq, 1);
 }
@@ -1493,7 +1646,7 @@ async fn human_view_session_messages_as_self_human() {
     let page = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: human_principal("staff-1"),
+            caller: human_principal("staff-1"),
             session_id: session_id.clone(),
             before: None,
             limit: 100,
@@ -1535,7 +1688,7 @@ async fn human_view_session_messages_as_owned_bot() {
     let page = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: human_principal("staff-1"),
+            caller: human_principal("staff-1"),
             session_id: session_id.clone(),
             before: None,
             limit: 100,
@@ -1572,7 +1725,7 @@ async fn human_view_session_messages_as_unowned_bot_forbidden() {
     let error = SessionMessageService::list(
         &fixture.service,
         ListSessionMessages {
-            principal: human_principal("staff-1"),
+            caller: human_principal("staff-1"),
             session_id,
             before: None,
             limit: 100,
@@ -1633,7 +1786,7 @@ async fn get_preserves_human_participant_from_legacy_invitation_join() {
     let detail = fixture
         .service
         .get(GetSession {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session.id.clone(),
         })
         .await
@@ -1683,7 +1836,7 @@ async fn create_session_preserves_manager_worker_worker_role() {
             "g1",
             "driver",
             &["worker"],
-            "driver",
+            "human_driver",
             Some("the task"),
         )
         .await;
@@ -1783,7 +1936,7 @@ async fn add_participant_duplication_rejects_409() {
     fixture
         .service
         .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "newcomer".into(),
             mode: Some(BotParticipantMode::Auto),
@@ -1795,7 +1948,7 @@ async fn add_participant_duplication_rejects_409() {
     let error = fixture
         .service
         .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "newcomer".into(),
             mode: None,
@@ -1827,7 +1980,7 @@ async fn add_participant_derives_worker_role_for_manager_worker() {
             "g1",
             "driver",
             &["worker"],
-            "driver",
+            "human_driver",
             None,
         )
         .await;
@@ -1848,7 +2001,7 @@ async fn add_participant_derives_worker_role_for_manager_worker() {
     let added = fixture
         .service
         .add_participant(AddSessionParticipant {
-            principal: bot_principal("driver"),
+            caller: bot_principal("driver"),
             session_id: session_id.clone(),
             bot_uuid: "worker".into(),
             mode: Some(BotParticipantMode::Auto),

--- a/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
+++ b/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
@@ -7,6 +7,8 @@
 - Default `Noop*` implementations used to keep contract boundaries explicit in tests and local wiring.
 - Current-session state-machine permission/start contracts and the outbound
   result-publisher port used to return a completed one-shot result to chat.
+- V1 `AuthenticatedCaller` contract types that preserve User, Bot, App, and
+  AccessKey context without retaining transport metadata or credentials.
 - The state-machine run repository contract includes an atomic
   `create_run_if_session_idle` operation for one-shot session launch
   serialization; production stores must override its compatibility default
@@ -15,12 +17,12 @@
 ## Consumes
 
 - `bcs-protocol` types only where protocol reuse is intentional at the contract boundary.
-- Async trait, serialization, logging, and error helper crates.
+- Async trait, serialization, logging, error, and transport-neutral time types.
 
 ## Allowed dependencies
 
 - `bcs-protocol` wire contract crate, currently located at `service-api/bcs-protocol`
-- Contract-only support crates such as `async-trait`, `serde`, `tokio`, and `thiserror`
+- Contract-only support crates such as `async-trait`, `serde`, `time`, `tokio`, and `thiserror`
 
 ## Forbidden dependencies
 
@@ -37,7 +39,9 @@
 
 ## Runtime ownership
 
-The crate owns contract semantics and fail-closed default behavior. It does not own concrete runtime behavior.
+The crate owns contract semantics and fail-closed default behavior. Its V1
+authenticated identity types own no JWT, HTTP, Gateway signing, credential, or
+Actor-selection semantics, and the crate does not own concrete runtime behavior.
 
 ## Tests
 

--- a/src/bcs/crates/service-api/bcs-service-api/Cargo.toml
+++ b/src/bcs/crates/service-api/bcs-service-api/Cargo.toml
@@ -17,6 +17,7 @@ serde       = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }
 strum       = { workspace = true }
+time        = { workspace = true, features = ["parsing"] }
 tokio       = { workspace = true }
 bcs-domain   = { workspace = true }
 bcs-protocol = { workspace = true }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/authorization.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/authorization.rs
@@ -1,10 +1,43 @@
+use std::collections::BTreeSet;
+
 use async_trait::async_trait;
 
-use super::{ApplicationError, Principal};
+use super::{
+    ApplicationError, AuthenticatedCaller, AuthenticatedUser, AuthenticatedUserIdentity, Principal,
+};
+
+/// Require the User identity admitted by the current Human-facing V1 APIs.
+///
+/// Gateway authentication may establish several identities at once. These
+/// APIs deliberately select only `caller.user`; Bot/App/AccessKey identities
+/// never act as a fallback.
+pub fn require_authenticated_user(
+    caller: &AuthenticatedCaller,
+) -> Result<&AuthenticatedUserIdentity, ApplicationError> {
+    caller
+        .user
+        .as_ref()
+        .ok_or_else(|| ApplicationError::forbidden("This operation requires a Human caller"))
+}
+
+/// Project the authenticated User into BCS's existing Human Actor model.
+pub fn require_human(caller: &AuthenticatedCaller) -> Result<Principal, ApplicationError> {
+    let user = require_authenticated_user(caller)?;
+    Ok(Principal::human(
+        AuthenticatedUser {
+            id: user.id.clone(),
+            username: user.username.clone(),
+            display_name: user.display_name.clone(),
+            full_name: user.full_name.clone(),
+        },
+        caller.tenant.clone(),
+        BTreeSet::new(),
+    ))
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Action {
-    ListBotGroups,
+    ListGroups,
     CreateGroup,
     ReadGroup,
     UpdateGroup,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
@@ -1,0 +1,221 @@
+//! Versioned Bot control-plane application contract for BCN OpenAPI v1.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::{ApplicationError, Page, Principal};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotKind {
+    Bot,
+    Human,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotVisibility {
+    Public,
+    Protected,
+    Private,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotStatus {
+    Online,
+    Hidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotReachability {
+    Reachable,
+    Unreachable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BotCandidatePurpose {
+    #[default]
+    Discovery,
+    Collaboration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BotSkill {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BotDescriptor {
+    pub summary: String,
+    pub domains: Vec<String>,
+    pub skills: Vec<BotSkill>,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BotProvider {
+    pub provider_id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PhysicalBot {
+    pub bot_id: String,
+    pub kind: BotKind,
+    pub name: String,
+    pub visibility: BotVisibility,
+    pub status: BotStatus,
+    pub env: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+    pub descriptor: BotDescriptor,
+    pub reachability: BotReachability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<BotProvider>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_code: Option<String>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HumanBot {
+    pub bot_id: String,
+    pub kind: BotKind,
+    pub name: String,
+    pub visibility: BotVisibility,
+    pub status: BotStatus,
+    pub env: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Bot {
+    Physical(PhysicalBot),
+    Human(HumanBot),
+}
+
+impl Bot {
+    pub fn bot_id(&self) -> &str {
+        match self {
+            Self::Physical(bot) => &bot.bot_id,
+            Self::Human(bot) => &bot.bot_id,
+        }
+    }
+
+    pub fn kind(&self) -> BotKind {
+        match self {
+            Self::Physical(_) => BotKind::Bot,
+            Self::Human(_) => BotKind::Human,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BotCandidate {
+    pub bot: PhysicalBot,
+    pub is_friend: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BotList {
+    pub items: Vec<Bot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListBotCandidates {
+    pub principal: Principal,
+    pub bot_id: String,
+    pub purpose: BotCandidatePurpose,
+    pub name: Option<String>,
+    pub offset: u64,
+    pub limit: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryBots {
+    pub principal: Principal,
+    pub bot_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GetBot {
+    pub principal: Principal,
+    pub bot_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BotDescriptorPatch {
+    pub summary: Option<String>,
+    pub domains: Option<Vec<String>>,
+    pub skills: Option<Vec<BotSkill>>,
+    pub scopes: Option<Vec<String>>,
+}
+
+impl BotDescriptorPatch {
+    pub fn is_empty(&self) -> bool {
+        self.summary.is_none()
+            && self.domains.is_none()
+            && self.skills.is_none()
+            && self.scopes.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BotPatch {
+    pub name: Option<String>,
+    pub visibility: Option<BotVisibility>,
+    pub status: Option<BotStatus>,
+    pub descriptor: Option<BotDescriptorPatch>,
+}
+
+impl BotPatch {
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.visibility.is_none()
+            && self.status.is_none()
+            && self.descriptor.is_none()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateBot {
+    pub principal: Principal,
+    pub bot_id: String,
+    pub patch: BotPatch,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListMyBots {
+    pub principal: Principal,
+    pub kind: Option<BotKind>,
+    pub name: Option<String>,
+    pub status: Option<BotStatus>,
+    pub reachability: Option<BotReachability>,
+    pub offset: u64,
+    pub limit: u64,
+}
+
+#[async_trait]
+pub trait BotService: Send + Sync {
+    async fn list_candidates(
+        &self,
+        command: ListBotCandidates,
+    ) -> Result<Page<BotCandidate>, ApplicationError>;
+
+    async fn query(&self, command: QueryBots) -> Result<Vec<Bot>, ApplicationError>;
+
+    async fn get(&self, query: GetBot) -> Result<Bot, ApplicationError>;
+
+    async fn update(&self, command: UpdateBot) -> Result<Bot, ApplicationError>;
+
+    async fn list_mine(&self, command: ListMyBots) -> Result<Page<Bot>, ApplicationError>;
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use super::{ApplicationError, Page, Principal};
+use super::{ApplicationError, AuthenticatedCaller, Page};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -132,7 +132,7 @@ pub struct BotList {
 
 #[derive(Debug, Clone)]
 pub struct ListBotCandidates {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_id: String,
     pub purpose: BotCandidatePurpose,
     pub name: Option<String>,
@@ -142,13 +142,13 @@ pub struct ListBotCandidates {
 
 #[derive(Debug, Clone)]
 pub struct QueryBots {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct GetBot {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_id: String,
 }
 
@@ -188,14 +188,14 @@ impl BotPatch {
 
 #[derive(Debug, Clone)]
 pub struct UpdateBot {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_id: String,
     pub patch: BotPatch,
 }
 
 #[derive(Debug, Clone)]
 pub struct ListMyBots {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub kind: Option<BotKind>,
     pub name: Option<String>,
     pub status: Option<BotStatus>,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/friendship.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/friendship.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use super::group::{DeleteResult, Page};
-use super::{ApplicationError, Principal};
+use super::{ApplicationError, AuthenticatedCaller};
 
 /// Reuse the domain friend-request status vocabulary.
 ///
@@ -60,7 +60,7 @@ pub struct FriendRequest {
 /// List a bot's friendships, ordered by `created_at` descending.
 #[derive(Debug, Clone)]
 pub struct ListBotFriendships {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_uuid: String,
     pub offset: u64,
     pub limit: u64,
@@ -69,7 +69,7 @@ pub struct ListBotFriendships {
 /// Remove a friendship symmetrically and idempotently.
 #[derive(Debug, Clone)]
 pub struct DeleteBotFriendship {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_uuid: String,
     pub friend_bot_uuid: String,
 }
@@ -78,7 +78,7 @@ pub struct DeleteBotFriendship {
 /// used) to `to_bot_uuid` (the receiver).
 #[derive(Debug, Clone)]
 pub struct CreateBotFriendRequest {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_uuid: String,
     pub to_bot_uuid: String,
 }
@@ -86,7 +86,7 @@ pub struct CreateBotFriendRequest {
 /// List friend requests sent by or received by `bot_uuid`.
 #[derive(Debug, Clone)]
 pub struct ListBotFriendRequests {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub bot_uuid: String,
     pub direction: FriendRequestDirection,
     pub status: Option<FriendRequestStatus>,
@@ -97,14 +97,14 @@ pub struct ListBotFriendRequests {
 /// Accept a friend request as the receiver; idempotent after acceptance.
 #[derive(Debug, Clone)]
 pub struct AcceptFriendRequest {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub request_id: String,
 }
 
 /// Reject a friend request as the receiver; idempotent after rejection.
 #[derive(Debug, Clone)]
 pub struct RejectFriendRequest {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub request_id: String,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use super::{ApplicationError, Principal};
+use super::{ApplicationError, AuthenticatedCaller};
 
 pub use bcs_domain::{ActorKind, ParticipantMode, ParticipantRole};
 
@@ -232,9 +232,9 @@ impl<T> Page<T> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ListBotGroups {
-    pub principal: Principal,
-    pub bot_uuid: String,
+pub struct ListGroups {
+    pub caller: AuthenticatedCaller,
+    pub view_bot_id: Option<String>,
     pub offset: u64,
     pub limit: u64,
     pub q: Option<String>,
@@ -274,7 +274,7 @@ pub enum CreateGroupSpec {
 
 #[derive(Debug, Clone)]
 pub struct CreateGroup {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group: CreateGroupSpec,
 }
 
@@ -286,7 +286,7 @@ pub struct CreateGroupOutcome {
 
 #[derive(Debug, Clone)]
 pub struct GetGroup {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
 }
 
@@ -309,20 +309,20 @@ impl GroupPatch {
 
 #[derive(Debug, Clone)]
 pub struct UpdateGroup {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
     pub patch: GroupPatch,
 }
 
 #[derive(Debug, Clone)]
 pub struct DeleteGroup {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct AddGroupParticipant {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
     pub actor_id: String,
     pub role: ParticipantRole,
@@ -330,7 +330,7 @@ pub struct AddGroupParticipant {
 
 #[derive(Debug, Clone)]
 pub struct UpdateGroupParticipant {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
     pub actor_id: String,
     pub mode: ParticipantMode,
@@ -338,7 +338,7 @@ pub struct UpdateGroupParticipant {
 
 #[derive(Debug, Clone)]
 pub struct DeleteGroupParticipant {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
     pub actor_id: String,
 }
@@ -350,9 +350,9 @@ pub struct DeleteResult {
 
 #[async_trait]
 pub trait GroupService: Send + Sync {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        command: ListBotGroups,
+        command: ListGroups,
     ) -> Result<Page<GroupSummary>, ApplicationError>;
 
     async fn create(&self, command: CreateGroup) -> Result<GroupDetail, ApplicationError>;

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs
@@ -1,0 +1,40 @@
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedCaller {
+    pub tenant: String,
+    pub user: Option<AuthenticatedUserIdentity>,
+    pub bot: Option<AuthenticatedBotIdentity>,
+    pub app: Option<AuthenticatedAppIdentity>,
+    pub access_key: Option<AuthenticatedAccessKeyIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedUserIdentity {
+    pub id: String,
+    pub username: String,
+    pub display_name: Option<String>,
+    pub full_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedBotIdentity {
+    pub bot_uuid: String,
+    pub owner_id: String,
+    pub app_id: i64,
+    pub agent_code: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedAppIdentity {
+    pub app_id: i64,
+    pub app_name: String,
+    pub owners: String,
+    pub app_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedAccessKeyIdentity {
+    pub access_key: String,
+    pub expire_at: OffsetDateTime,
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/invitation.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/invitation.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use super::{ApplicationError, Principal};
+use super::{ApplicationError, AuthenticatedCaller};
 
 /// Kind of resource an invitation grants access to.
 ///
@@ -59,7 +59,7 @@ pub struct InvitationAcceptResult {
 /// `expires_in_seconds` overrides the server default lifetime when supplied.
 #[derive(Debug, Clone)]
 pub struct CreateGroupInvitation {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
     pub expires_in_seconds: Option<u64>,
 }
@@ -69,21 +69,20 @@ pub struct CreateGroupInvitation {
 /// `expires_in_seconds` overrides the server default lifetime when supplied.
 #[derive(Debug, Clone)]
 pub struct CreateSessionInvitation {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
     pub expires_in_seconds: Option<u64>,
 }
 
 /// Accept an invitation token and join its target.
 ///
-/// Only a Human Principal authenticated by the Gateway may accept; the V1
-/// facade rejects `Principal::Bot` outright. The joining Human actor is
-/// derived from the Principal's `staff_no` (subject id) and delegated to the
+/// Only a Caller with User identity authenticated by Gateway may accept. The
+/// joining Human actor is derived from the User subject id and delegated to the
 /// legacy `InviteService::join_*_by_invite`, mirroring the legacy Human-only
 /// join path that creates a Human Participant (Consultant role, Present mode).
 #[derive(Debug, Clone)]
 pub struct AcceptInvitation {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub token: String,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/message.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/message.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use super::{ApplicationError, Principal};
+use super::{ApplicationError, AuthenticatedCaller};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -34,7 +34,7 @@ pub struct SessionMessage {
 
 #[derive(Debug, Clone)]
 pub struct ListSessionMessages {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
     /// Opaque composite cursor for cursor-based pagination (VYQHI). Encoded
     /// by the V1 facade as `"created_at:session_seq"` (e.g. `"1234567890:42"`)
@@ -43,11 +43,10 @@ pub struct ListSessionMessages {
     /// previous response's `next_cursor`.
     pub before: Option<String>,
     pub limit: u64,
-    /// Optional viewer identity for message history visibility scoping. The
-    /// V1 facade applies Principal-based authz: a Bot Principal may omit
-    /// (auto-derives self) or pass self; a Human Principal may omit (manager
-    /// god-view, no cutoff), pass `"human_<staff_no>"` for self cutoff, or
-    /// pass an owned Bot's UUID (ownership verified via `is_owned_bot`).
+    /// Optional viewer identity for message history visibility scoping. Omit
+    /// for the authenticated User's `human_<id>` Participant view, explicitly
+    /// pass that same Human Actor ID, or pass an exact-`created_by` owned Bot.
+    /// The selected Actor must be a Session Participant.
     pub view_bot_id: Option<String>,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
@@ -5,6 +5,7 @@
 //! request-supplied caller identities into domain services.
 
 pub mod authorization;
+pub mod bot;
 pub mod error;
 pub mod friendship;
 pub mod group;
@@ -14,6 +15,7 @@ pub mod principal;
 pub mod session;
 
 pub use authorization::{Action, AuthorizationService, ResourceRef};
+pub use bot::*;
 pub use error::ApplicationError;
 pub use friendship::*;
 pub use group::*;

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
@@ -15,7 +15,9 @@ pub mod message;
 pub mod principal;
 pub mod session;
 
-pub use authorization::{Action, AuthorizationService, ResourceRef};
+pub use authorization::{
+    Action, AuthorizationService, ResourceRef, require_authenticated_user, require_human,
+};
 pub use bot::*;
 pub use error::ApplicationError;
 pub use friendship::*;

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
@@ -8,6 +8,7 @@ pub mod authorization;
 pub mod error;
 pub mod friendship;
 pub mod group;
+pub mod identity;
 pub mod invitation;
 pub mod message;
 pub mod principal;
@@ -17,6 +18,10 @@ pub use authorization::{Action, AuthorizationService, ResourceRef};
 pub use error::ApplicationError;
 pub use friendship::*;
 pub use group::*;
+pub use identity::{
+    AuthenticatedAccessKeyIdentity, AuthenticatedAppIdentity, AuthenticatedBotIdentity,
+    AuthenticatedCaller, AuthenticatedUserIdentity,
+};
 pub use invitation::*;
 pub use message::*;
 pub use principal::{AuthenticatedUser, BotPrincipal, HumanPrincipal, Principal};

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use super::group::{DeleteResult, Page};
-use super::{ApplicationError, Principal};
+use super::{ApplicationError, AuthenticatedCaller};
 
 pub use bcs_domain::{ActorKind, ParticipantMode, ParticipantRole};
 
@@ -103,7 +103,7 @@ pub struct CreateSessionOutcome {
 
 #[derive(Debug, Clone)]
 pub struct CreateSession {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
     pub driver_bot_uuid: String,
     pub title: Option<String>,
@@ -113,8 +113,9 @@ pub struct CreateSession {
 
 #[derive(Debug, Clone)]
 pub struct ListSessions {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub group_id: String,
+    pub view_bot_id: Option<String>,
     pub offset: u64,
     pub limit: u64,
     pub status: Option<SessionStatus>,
@@ -122,32 +123,32 @@ pub struct ListSessions {
 
 #[derive(Debug, Clone)]
 pub struct GetSession {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct UpdateSession {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
     pub title: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct DeleteSession {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct CompleteSession {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct AddSessionParticipant {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
     pub bot_uuid: String,
     pub mode: Option<BotParticipantMode>,
@@ -155,7 +156,7 @@ pub struct AddSessionParticipant {
 
 #[derive(Debug, Clone)]
 pub struct UpdateSessionParticipant {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
     pub bot_uuid: String,
     pub mode: BotParticipantMode,
@@ -163,7 +164,7 @@ pub struct UpdateSessionParticipant {
 
 #[derive(Debug, Clone)]
 pub struct DeleteSessionParticipant {
-    pub principal: Principal,
+    pub caller: AuthenticatedCaller,
     pub session_id: String,
     pub bot_uuid: String,
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -153,6 +153,9 @@ pub use application::{
 pub use port::{
     BotConnectionControlPort, BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort,
     BotDeliveryResult, BotMetricCount, BotMetricsSnapshotPort, BotRepoPort, BotRunContext,
+    BotCandidateReadQuery, BotCandidateReadRecord, BotCandidateVisibility,
+    BotControlPlaneDescriptor, BotControlPlaneDescriptorPatch, BotControlPlaneOwnedQuery,
+    BotControlPlanePatch, BotControlPlaneRecord, BotControlPlaneRepoPort,
     BotRunContextPort, BotTerminalEvent, BotTerminalObserverPort, BotTerminalState,
     NoopBotTerminalObserver, NoopChannelBindingCleanupPort, ChatRunCleanupPort,
     ChatRunEventPort, ChatRunMetricCount, DeliveryBlockContext,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
@@ -48,7 +48,10 @@ pub use metrics::{
 };
 pub use provider_stream_gray::ProviderStreamGrayList;
 pub use repo::{
-    BotRepoPort, ChannelBindingRepoPort, CollaborationDefinitionRecord, CollaborationEventRecord,
+    BotCandidateReadQuery, BotCandidateReadRecord, BotCandidateVisibility,
+    BotControlPlaneDescriptor, BotControlPlaneDescriptorPatch, BotControlPlaneOwnedQuery,
+    BotControlPlanePatch, BotControlPlaneRecord, BotControlPlaneRepoPort, BotRepoPort,
+    ChannelBindingRepoPort, CollaborationDefinitionRecord, CollaborationEventRecord,
     CollaborationEventRepoPort, CollaborationTemplateEntry, CollaborationTemplateRepoPort,
     CreateOrganizationRecord, ListOrganizationMembersPageQuery, ListOrganizationMembersQuery,
     ListOrganizationsQuery, OrganizationCandidateReadPage, OrganizationCandidateReadPort,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot_control_plane.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot_control_plane.rs
@@ -1,0 +1,122 @@
+//! Narrow persistence contract for V1 Bot control-plane reads and updates.
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use bcs_domain::{ActorKind, ActorStatus, Skill};
+
+use crate::ServiceResult;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotControlPlaneDescriptor {
+    pub summary: String,
+    pub domains: Vec<String>,
+    pub skills: Vec<Skill>,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotControlPlaneRecord {
+    pub bot_id: String,
+    pub kind: ActorKind,
+    pub name: String,
+    pub visibility: String,
+    pub status: ActorStatus,
+    pub env: String,
+    pub created_by: Option<String>,
+    pub descriptor: BotControlPlaneDescriptor,
+    pub agent_code: Option<String>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BotCandidateVisibility {
+    Discovery,
+    Collaboration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotCandidateReadQuery {
+    pub acting_bot_id: String,
+    pub env: String,
+    pub visibility: BotCandidateVisibility,
+    pub friend_ids: HashSet<String>,
+    pub name: Option<String>,
+    pub offset: u64,
+    pub limit: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotCandidateReadRecord {
+    pub bot: BotControlPlaneRecord,
+    pub is_friend: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotControlPlaneOwnedQuery {
+    pub created_by: String,
+    pub env: String,
+    pub kind: Option<ActorKind>,
+    pub name: Option<String>,
+    pub status: Option<ActorStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BotControlPlaneDescriptorPatch {
+    pub summary: Option<String>,
+    pub domains: Option<Vec<String>>,
+    pub skills: Option<Vec<Skill>>,
+    pub scopes: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BotControlPlanePatch {
+    pub name: Option<String>,
+    pub visibility: Option<String>,
+    pub status: Option<ActorStatus>,
+    pub descriptor: Option<BotControlPlaneDescriptorPatch>,
+}
+
+#[async_trait]
+pub trait BotControlPlaneRepoPort: Send + Sync {
+    async fn get_control_plane(
+        &self,
+        bot_id: &str,
+        env: &str,
+    ) -> ServiceResult<Option<BotControlPlaneRecord>>;
+
+    async fn get_control_plane_by_ids(
+        &self,
+        bot_ids: &[String],
+        env: &str,
+    ) -> ServiceResult<Vec<BotControlPlaneRecord>> {
+        let mut seen = HashSet::new();
+        let mut records = Vec::new();
+        for bot_id in bot_ids {
+            if seen.insert(bot_id.as_str()) {
+                if let Some(record) = self.get_control_plane(bot_id, env).await? {
+                    records.push(record);
+                }
+            }
+        }
+        Ok(records)
+    }
+
+    async fn list_control_plane_candidates(
+        &self,
+        query: BotCandidateReadQuery,
+    ) -> ServiceResult<(Vec<BotCandidateReadRecord>, u64)>;
+
+    async fn list_control_plane_by_creator(
+        &self,
+        query: BotControlPlaneOwnedQuery,
+    ) -> ServiceResult<Vec<BotControlPlaneRecord>>;
+
+    async fn patch_control_plane(
+        &self,
+        bot_id: &str,
+        env: &str,
+        patch: BotControlPlanePatch,
+    ) -> ServiceResult<Option<BotControlPlaneRecord>>;
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/mod.rs
@@ -1,4 +1,5 @@
 pub mod bot;
+pub mod bot_control_plane;
 pub mod channel;
 pub mod collaboration;
 pub mod collaboration_template;
@@ -13,6 +14,7 @@ pub mod session_file;
 pub mod user_identity;
 
 pub use bot::BotRepoPort;
+pub use bot_control_plane::*;
 pub use channel::{
     ChannelBindingRepoPort, ConversationSessionRepoPort, HumanInputEnqueueDisposition,
     HumanInputRequestRepoPort, ImParticipantRepoPort,

--- a/src/bcs/crates/service-api/bcs-service-api/tests/boundary_contracts.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/boundary_contracts.rs
@@ -217,6 +217,29 @@ fn crate_root_does_not_reexport_wire_dtos() {
 }
 
 #[test]
+fn authenticated_caller_contract_contains_no_transport_or_credential_fields() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source = match fs::read_to_string(manifest_dir.join("src/application/v1/identity.rs")) {
+        Ok(source) => source,
+        Err(_) => panic!("read authenticated identity contract"),
+    };
+
+    for forbidden in [
+        "jsonwebtoken",
+        "axum",
+        "HeaderMap",
+        "X-Avernet-Principal",
+        "access_key_token",
+        "bot_token",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "authenticated identity contract must not contain {forbidden}",
+        );
+    }
+}
+
+#[test]
 fn boundary_scan_ignores_comments_and_string_literals() {
     let offenses = source_offenses(
         r#"

--- a/src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs
@@ -6,8 +6,10 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 #[test]
 fn authenticated_caller_preserves_all_identity_kinds_without_selecting_an_actor() {
-    let expire_at =
-        OffsetDateTime::parse("2030-01-01T00:00:00Z", &Rfc3339).expect("valid contract timestamp");
+    let expire_at = match OffsetDateTime::parse("2030-01-01T00:00:00Z", &Rfc3339) {
+        Ok(value) => value,
+        Err(_) => panic!("valid contract timestamp"),
+    };
     let caller = AuthenticatedCaller {
         tenant: "tenant-a".into(),
         user: Some(AuthenticatedUserIdentity {

--- a/src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs
@@ -1,6 +1,6 @@
 use bcs_service_api::application::v1::{
     AuthenticatedAccessKeyIdentity, AuthenticatedAppIdentity, AuthenticatedBotIdentity,
-    AuthenticatedCaller, AuthenticatedUserIdentity,
+    AuthenticatedCaller, AuthenticatedUserIdentity, Principal, require_human,
 };
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
@@ -53,4 +53,50 @@ fn authenticated_caller_preserves_all_identity_kinds_without_selecting_an_actor(
             .map(|value| value.access_key.as_str()),
         Some("ak-test-1"),
     );
+}
+
+#[test]
+fn require_human_projects_only_the_authenticated_user() {
+    let caller = AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: Some("Alice".into()),
+            full_name: Some("Alice Example".into()),
+        }),
+        bot: Some(AuthenticatedBotIdentity {
+            bot_uuid: "bot-extra".into(),
+            owner_id: "someone-else".into(),
+            app_id: 7,
+            agent_code: "agent-extra".into(),
+        }),
+        app: None,
+        access_key: None,
+    };
+
+    let principal = require_human(&caller).expect("caller has User");
+    assert_eq!(principal.actor_id(), "human_staff-1");
+    assert_eq!(principal.tenant(), "tenant-a");
+    assert!(principal.scopes().is_empty());
+    assert!(matches!(principal, Principal::Human(_)));
+}
+
+#[test]
+fn require_human_rejects_a_valid_caller_without_user() {
+    let caller = AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: None,
+        bot: Some(AuthenticatedBotIdentity {
+            bot_uuid: "bot-only".into(),
+            owner_id: "staff-1".into(),
+            app_id: 7,
+            agent_code: "agent-only".into(),
+        }),
+        app: None,
+        access_key: None,
+    };
+
+    let error = require_human(&caller).expect_err("Bot-only caller is not Human");
+    assert_eq!(error.code(), "forbidden");
 }

--- a/src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs
@@ -1,0 +1,54 @@
+use bcs_service_api::application::v1::{
+    AuthenticatedAccessKeyIdentity, AuthenticatedAppIdentity, AuthenticatedBotIdentity,
+    AuthenticatedCaller, AuthenticatedUserIdentity,
+};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+#[test]
+fn authenticated_caller_preserves_all_identity_kinds_without_selecting_an_actor() {
+    let expire_at =
+        OffsetDateTime::parse("2030-01-01T00:00:00Z", &Rfc3339).expect("valid contract timestamp");
+    let caller = AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "user-1".into(),
+            username: "alice".into(),
+            display_name: Some("Alice".into()),
+            full_name: None,
+        }),
+        bot: Some(AuthenticatedBotIdentity {
+            bot_uuid: "bot-1".into(),
+            owner_id: "user-1".into(),
+            app_id: 7,
+            agent_code: "agent-1".into(),
+        }),
+        app: Some(AuthenticatedAppIdentity {
+            app_id: 7,
+            app_name: "Contract App".into(),
+            owners: "contract-owner".into(),
+            app_type: "THIRD_PARTY".into(),
+        }),
+        access_key: Some(AuthenticatedAccessKeyIdentity {
+            access_key: "ak-test-1".into(),
+            expire_at,
+        }),
+    };
+
+    assert_eq!(caller.tenant, "tenant-a");
+    assert_eq!(
+        caller.user.as_ref().map(|value| value.id.as_str()),
+        Some("user-1")
+    );
+    assert_eq!(
+        caller.bot.as_ref().map(|value| value.bot_uuid.as_str()),
+        Some("bot-1")
+    );
+    assert_eq!(caller.app.as_ref().map(|value| value.app_id), Some(7));
+    assert_eq!(
+        caller
+            .access_key
+            .as_ref()
+            .map(|value| value.access_key.as_str()),
+        Some("ak-test-1"),
+    );
+}

--- a/src/bcs/crates/service-api/bcs-service-api/tests/v1_group_application_contracts.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/v1_group_application_contracts.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 use bcs_service_api::application::v1::{
-    AddGroupParticipant, ApplicationError, AuthenticatedUser, BotFinalDelivery, DeleteGroup,
-    DeleteGroupParticipant, DeleteResult,
+    AddGroupParticipant, ApplicationError, AuthenticatedCaller, AuthenticatedUser,
+    AuthenticatedUserIdentity, BotFinalDelivery, DeleteGroup, DeleteGroupParticipant, DeleteResult,
     DirectMessageGroupSummary, GetGroup, GroupDeliveryPolicy, GroupDetail, GroupKindFilter,
-    GroupService, GroupStatus, GroupSummary, GroupVisibility, ListBotGroups, Membership,
+    GroupService, GroupStatus, GroupSummary, GroupVisibility, ListGroups, Membership,
     MembershipFilter, Page, Participant, ParticipantMode, ParticipantRole, Principal, UpdateGroup,
     UpdateGroupParticipant,
 };
@@ -14,9 +14,9 @@ struct NoopGroupService;
 
 #[async_trait]
 impl GroupService for NoopGroupService {
-    async fn list_bot_groups(
+    async fn list_groups(
         &self,
-        _command: ListBotGroups,
+        _command: ListGroups,
     ) -> Result<Page<GroupSummary>, ApplicationError> {
         Ok(Page::empty(0, 20))
     }
@@ -64,6 +64,21 @@ impl GroupService for NoopGroupService {
     }
 }
 
+fn human_caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
 #[test]
 fn principal_preserves_gateway_identity_without_bot_impersonation() {
     let bot = Principal::bot("bot-123", "tenant-a", BTreeSet::new());
@@ -91,10 +106,10 @@ fn principal_preserves_gateway_identity_without_bot_impersonation() {
 }
 
 #[test]
-fn list_command_carries_principal_and_all_approved_filters() {
-    let command = ListBotGroups {
-        principal: Principal::bot("bot-1", "tenant-a", BTreeSet::new()),
-        bot_uuid: "bot-1".into(),
+fn list_command_carries_caller_view_actor_and_all_approved_filters() {
+    let command = ListGroups {
+        caller: human_caller(),
+        view_bot_id: Some("bot-1".into()),
         offset: 10,
         limit: 25,
         q: Some("planning".into()),
@@ -103,7 +118,8 @@ fn list_command_carries_principal_and_all_approved_filters() {
         strategy: Some(bcs_service_api::application::v1::GroupStrategy::StateMachine),
     };
 
-    assert_eq!(command.principal.actor_id(), "bot-1");
+    assert_eq!(command.caller.user.expect("User").id, "staff-1");
+    assert_eq!(command.view_bot_id.as_deref(), Some("bot-1"));
     assert_eq!(command.membership, MembershipFilter::SessionOnly);
     assert_eq!(command.kind, GroupKindFilter::All);
 }
@@ -150,26 +166,26 @@ fn group_service_is_object_safe() {
 }
 
 #[test]
-fn participant_commands_carry_principal_and_no_raw_credentials() {
-    let principal = Principal::bot("bot-1", "tenant-a", BTreeSet::new());
+fn participant_commands_carry_caller_and_no_raw_credentials() {
+    let caller = human_caller();
     let add = AddGroupParticipant {
-        principal: principal.clone(),
+        caller: caller.clone(),
         group_id: "g1".into(),
         actor_id: "bot-2".into(),
         role: ParticipantRole::Consultant,
     };
     let update = UpdateGroupParticipant {
-        principal: principal.clone(),
+        caller: caller.clone(),
         group_id: "g1".into(),
         actor_id: "bot-2".into(),
         mode: ParticipantMode::Muted,
     };
     let remove = DeleteGroupParticipant {
-        principal,
+        caller,
         group_id: "g1".into(),
         actor_id: "bot-2".into(),
     };
-    for cmd in [&add.principal as &Principal, &update.principal, &remove.principal] {
+    for cmd in [&add.caller, &update.caller, &remove.caller] {
         let s = format!("{cmd:?}");
         assert!(!s.contains("Cookie") && !s.contains("Bearer") && !s.contains("sender"));
     }

--- a/src/bcs/crates/service-api/bcs-service-api/tests/v1_invitation_friendship_application_contracts.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/v1_invitation_friendship_application_contracts.rs
@@ -1,13 +1,27 @@
-use std::collections::BTreeSet;
-
 use async_trait::async_trait;
 use bcs_service_api::application::v1::{
-    AcceptFriendRequest, AcceptInvitation, ApplicationError, AuthenticatedUser, CreateBotFriendRequest,
-    CreateGroupInvitation, CreateSessionInvitation, DeleteResult, Friendship, FriendshipService,
-    FriendRequest, FriendRequestDirection, FriendRequestStatus, Invitation, InvitationAcceptResult,
-    InvitationService, InvitationState, InvitationTargetType, ListBotFriendRequests, ListBotFriendships,
-    Page, Principal, RejectFriendRequest, DeleteBotFriendship,
+    AcceptFriendRequest, AcceptInvitation, ApplicationError, AuthenticatedCaller,
+    AuthenticatedUserIdentity, CreateBotFriendRequest, CreateGroupInvitation,
+    CreateSessionInvitation, DeleteBotFriendship, DeleteResult, FriendRequest,
+    FriendRequestDirection, FriendRequestStatus, Friendship, FriendshipService, Invitation,
+    InvitationAcceptResult, InvitationService, InvitationState, InvitationTargetType,
+    ListBotFriendRequests, ListBotFriendships, Page, RejectFriendRequest,
 };
+
+fn human_caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
 
 struct NoopInvitationService;
 
@@ -95,26 +109,26 @@ fn friendship_service_is_object_safe() {
 }
 
 #[test]
-fn invitation_commands_carry_principal_and_no_raw_credentials() {
-    let principal = Principal::bot("bot-1", "tenant-a", BTreeSet::new());
+fn invitation_commands_carry_caller_and_no_raw_credentials() {
+    let caller = human_caller();
     let create_group = CreateGroupInvitation {
-        principal: principal.clone(),
+        caller: caller.clone(),
         group_id: "g1".into(),
         expires_in_seconds: Some(3600),
     };
     let create_session = CreateSessionInvitation {
-        principal: principal.clone(),
+        caller: caller.clone(),
         session_id: "s1".into(),
         expires_in_seconds: None,
     };
     let accept = AcceptInvitation {
-        principal: principal.clone(),
+        caller: caller.clone(),
         token: "tok-1".into(),
     };
     for cmd in [
-        &create_group.principal as &Principal,
-        &create_session.principal,
-        &accept.principal,
+        &create_group.caller,
+        &create_session.caller,
+        &accept.caller,
     ] {
         let s = format!("{cmd:?}");
         assert!(!s.contains("Cookie") && !s.contains("Bearer") && !s.contains("sender"));
@@ -126,26 +140,26 @@ fn invitation_commands_carry_principal_and_no_raw_credentials() {
 }
 
 #[test]
-fn friendship_commands_carry_principal_and_no_raw_credentials() {
-    let principal = Principal::bot("bot-1", "tenant-a", BTreeSet::new());
+fn friendship_commands_carry_caller_and_no_raw_credentials() {
+    let caller = human_caller();
     let list_bot_friendships = ListBotFriendships {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_uuid: "bot-1".into(),
         offset: 0,
         limit: 25,
     };
     let remove = DeleteBotFriendship {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_uuid: "bot-1".into(),
         friend_bot_uuid: "bot-2".into(),
     };
     let create_req = CreateBotFriendRequest {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_uuid: "bot-1".into(),
         to_bot_uuid: "bot-2".into(),
     };
     let list_reqs = ListBotFriendRequests {
-        principal: principal.clone(),
+        caller: caller.clone(),
         bot_uuid: "bot-1".into(),
         direction: FriendRequestDirection::Sent,
         status: Some(FriendRequestStatus::Pending),
@@ -153,20 +167,20 @@ fn friendship_commands_carry_principal_and_no_raw_credentials() {
         limit: 10,
     };
     let accept_req = AcceptFriendRequest {
-        principal: principal.clone(),
+        caller: caller.clone(),
         request_id: "req-1".into(),
     };
     let reject_req = RejectFriendRequest {
-        principal,
+        caller,
         request_id: "req-1".into(),
     };
     for cmd in [
-        &list_bot_friendships.principal as &Principal,
-        &remove.principal,
-        &create_req.principal,
-        &list_reqs.principal,
-        &accept_req.principal,
-        &reject_req.principal,
+        &list_bot_friendships.caller,
+        &remove.caller,
+        &create_req.caller,
+        &list_reqs.caller,
+        &accept_req.caller,
+        &reject_req.caller,
     ] {
         let s = format!("{cmd:?}");
         assert!(!s.contains("Cookie") && !s.contains("Bearer") && !s.contains("sender"));
@@ -313,21 +327,11 @@ fn friend_request_serializes_with_v1_field_names() {
 }
 
 #[test]
-fn human_principal_can_be_carried_in_invitation_command() {
-    let human = Principal::human(
-        AuthenticatedUser {
-            id: "staff-1".into(),
-            username: "alice".into(),
-            display_name: None,
-            full_name: None,
-        },
-        "tenant-a",
-        BTreeSet::new(),
-    );
+fn authenticated_caller_can_be_carried_in_invitation_command() {
     let command = AcceptInvitation {
-        principal: human,
+        caller: human_caller(),
         token: "tok-1".into(),
     };
-    assert_eq!(command.principal.actor_id(), "human_staff-1");
+    assert_eq!(command.caller.user.expect("User").id, "staff-1");
     assert_eq!(command.token, "tok-1");
 }

--- a/src/bcs/crates/service-api/bcs-service-api/tests/v1_session_application_contracts.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/v1_session_application_contracts.rs
@@ -1,14 +1,28 @@
-use std::collections::BTreeSet;
-
 use async_trait::async_trait;
 use bcs_service_api::application::v1::{
-    ActorKind, AddSessionParticipant, ApplicationError, AuthenticatedUser, BotParticipantMode,
-    CompleteSession, CreateSession, CreateSessionOutcome, DeleteResult, DeleteSession,
+    ActorKind, AddSessionParticipant, ApplicationError, AuthenticatedCaller,
+    AuthenticatedUserIdentity, BotParticipantMode, CompleteSession, CreateSession,
+    CreateSessionOutcome, DeleteResult, DeleteSession,
     DeleteSessionParticipant, GetSession, ListSessionMessages, ListSessions, MessageSenderKind,
-    Page, ParticipantMode, Principal, SessionCompletionResult, SessionDetail, SessionMessage,
+    Page, ParticipantMode, SessionCompletionResult, SessionDetail, SessionMessage,
     SessionMessageKind, SessionMessagePage, SessionMessageService, SessionParticipant,
     SessionParticipantInput, SessionService, SessionStatus, UpdateSession, UpdateSessionParticipant,
 };
+
+fn human_caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "staff-1".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
 
 struct NoopSessionService;
 
@@ -91,10 +105,10 @@ fn session_service_is_object_safe() {
 }
 
 #[test]
-fn session_commands_carry_principal_and_no_raw_credentials() {
-    let principal = Principal::bot("bot-1", "tenant-a", BTreeSet::new());
+fn session_commands_carry_caller_and_no_raw_credentials() {
+    let caller = human_caller();
     let create = CreateSession {
-        principal: principal.clone(),
+        caller: caller.clone(),
         group_id: "g1".into(),
         driver_bot_uuid: "bot-1".into(),
         title: Some("plan".into()),
@@ -105,56 +119,57 @@ fn session_commands_carry_principal_and_no_raw_credentials() {
         }],
     };
     let list = ListSessions {
-        principal: principal.clone(),
+        caller: caller.clone(),
         group_id: "g1".into(),
+        view_bot_id: Some("bot-1".into()),
         offset: 0,
         limit: 25,
         status: Some(SessionStatus::Running),
     };
     let get = GetSession {
-        principal: principal.clone(),
+        caller: caller.clone(),
         session_id: "s1".into(),
     };
     let update = UpdateSession {
-        principal: principal.clone(),
+        caller: caller.clone(),
         session_id: "s1".into(),
         title: Some("renamed".into()),
     };
     let delete = DeleteSession {
-        principal: principal.clone(),
+        caller: caller.clone(),
         session_id: "s1".into(),
     };
     let complete = CompleteSession {
-        principal: principal.clone(),
+        caller: caller.clone(),
         session_id: "s1".into(),
     };
     let add = AddSessionParticipant {
-        principal: principal.clone(),
+        caller: caller.clone(),
         session_id: "s1".into(),
         bot_uuid: "bot-3".into(),
         mode: Some(BotParticipantMode::Muted),
     };
     let update_p = UpdateSessionParticipant {
-        principal: principal.clone(),
+        caller: caller.clone(),
         session_id: "s1".into(),
         bot_uuid: "bot-3".into(),
         mode: BotParticipantMode::Auto,
     };
     let remove_p = DeleteSessionParticipant {
-        principal,
+        caller,
         session_id: "s1".into(),
         bot_uuid: "bot-3".into(),
     };
     for cmd in [
-        &create.principal as &Principal,
-        &list.principal,
-        &get.principal,
-        &update.principal,
-        &delete.principal,
-        &complete.principal,
-        &add.principal,
-        &update_p.principal,
-        &remove_p.principal,
+        &create.caller,
+        &list.caller,
+        &get.caller,
+        &update.caller,
+        &delete.caller,
+        &complete.caller,
+        &add.caller,
+        &update_p.caller,
+        &remove_p.caller,
     ] {
         let s = format!("{cmd:?}");
         assert!(!s.contains("Cookie") && !s.contains("Bearer") && !s.contains("sender"));
@@ -238,24 +253,14 @@ fn session_participant_serializes_bot_and_human_actors() {
 }
 
 #[test]
-fn human_principal_can_be_carried_in_session_command() {
-    let human = Principal::human(
-        AuthenticatedUser {
-            id: "staff-1".into(),
-            username: "alice".into(),
-            display_name: None,
-            full_name: None,
-        },
-        "tenant-a",
-        BTreeSet::new(),
-    );
+fn authenticated_caller_can_be_carried_in_session_command() {
     let command = ListSessionMessages {
-        principal: human,
+        caller: human_caller(),
         session_id: "s1".into(),
         before: None,
         limit: 10,
         view_bot_id: None,
     };
-    assert_eq!(command.principal.actor_id(), "human_staff-1");
+    assert_eq!(command.caller.user.expect("User").id, "staff-1");
     assert_eq!(command.session_id, "s1");
 }

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -28,8 +28,10 @@ use bcs_db_api::{
     DbPlugin, DbRow, DbSqlFlavor, DbStatement, DbValue as Value, db_get_column, db_get_column_opt,
 };
 use bcs_service_api::{
-    BindingChannels, BotCapabilities, BotDynamicStatus, BotMetricCount, BotMetricsSnapshotPort,
-    RegisteredBot, ServiceError, ServiceResult, Skill,
+    BindingChannels, BotCandidateReadQuery, BotCandidateReadRecord, BotCandidateVisibility,
+    BotCapabilities, BotControlPlaneDescriptor, BotControlPlaneOwnedQuery, BotControlPlanePatch,
+    BotControlPlaneRecord, BotControlPlaneRepoPort, BotDynamicStatus, BotMetricCount,
+    BotMetricsSnapshotPort, RegisteredBot, ServiceError, ServiceResult, Skill,
 };
 
 pub mod memory;
@@ -2548,6 +2550,372 @@ impl BotRepoPort for PersistentBotRepo {
         if let Some(tx) = pending.remove(request_id) {
             let _ = tx.send(response);
         }
+    }
+}
+
+fn control_plane_record_from_row(row: &DbRow) -> ServiceResult<BotControlPlaneRecord> {
+    let bot_id: String = db_get_column(row, "bot_uuid")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+    let name: String = db_get_column(row, "name")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+    let env: String = db_get_column(row, "env")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+    let visibility = db_get_column_opt::<String>(row, "visibility")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "protected".to_string());
+    let kind = match db_get_column_opt::<String>(row, "actor_kind")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .as_deref()
+    {
+        Some("human") => bcs_service_api::ActorKind::Human,
+        _ => bcs_service_api::ActorKind::Bot,
+    };
+    let status = match db_get_column_opt::<String>(row, "status")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .as_deref()
+    {
+        Some("hidden") => bcs_service_api::ActorStatus::Hidden,
+        _ => bcs_service_api::ActorStatus::Online,
+    };
+    let created_by = db_get_column_opt(row, "created_by")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+    let bot_info = db_get_column_opt::<String>(row, "bot_info")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .and_then(|value| serde_json::from_str::<BotInfo>(&value).ok())
+        .unwrap_or_default();
+    let agent_code = db_get_column_opt::<String>(row, "agent_code")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .or(bot_info.agent_code);
+    let created_at = db_get_column::<i64>(row, "gmt_create_ms")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .max(0) as u64;
+    let updated_at = db_get_column::<i64>(row, "gmt_modified_ms")
+        .map_err(|error| ServiceError::InternalError(error.to_string()))?
+        .max(0) as u64;
+
+    Ok(BotControlPlaneRecord {
+        bot_id,
+        kind,
+        name,
+        visibility,
+        status,
+        env,
+        created_by,
+        descriptor: BotControlPlaneDescriptor {
+            summary: bot_info.summary.unwrap_or_default(),
+            domains: bot_info.domains,
+            skills: bot_info.skills,
+            scopes: bot_info.scopes,
+        },
+        agent_code,
+        created_at,
+        updated_at,
+    })
+}
+
+#[async_trait]
+impl BotControlPlaneRepoPort for PersistentBotRepo {
+    async fn get_control_plane(
+        &self,
+        bot_id: &str,
+        env: &str,
+    ) -> ServiceResult<Option<BotControlPlaneRecord>> {
+        let sql = format!(
+            "SELECT bot_uuid, name, bot_info, visibility, status, actor_kind, env, \
+                    created_by, agent_code, ({}) * 1000 AS gmt_create_ms, \
+                    ({}) * 1000 AS gmt_modified_ms \
+             FROM bcs_bots \
+             WHERE bot_uuid = ? AND env = ? AND COALESCE(is_deleted, 0) = 0 \
+             LIMIT 1",
+            self.flavor.unix_ts("gmt_create"),
+            self.flavor.unix_ts("gmt_modified")
+        );
+        let rows = self
+            .db_query(&sql, vec![Value::from(bot_id), Value::from(env)])
+            .await
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+        rows.first().map(control_plane_record_from_row).transpose()
+    }
+
+    async fn list_control_plane_candidates(
+        &self,
+        query: BotCandidateReadQuery,
+    ) -> ServiceResult<(Vec<BotCandidateReadRecord>, u64)> {
+        let name = query
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let name_filter = name.unwrap_or_default().to_lowercase();
+        let mut friend_ids = query.friend_ids.iter().cloned().collect::<Vec<_>>();
+        friend_ids.sort_unstable();
+        let visibility_filter = match query.visibility {
+            BotCandidateVisibility::Discovery => "b.visibility IN ('public', 'protected')",
+            BotCandidateVisibility::Collaboration => {
+                "b.visibility = 'public' OR f.bot_uuid IS NOT NULL"
+            }
+        };
+        let friend_rows = if friend_ids.is_empty() {
+            "SELECT NULL AS bot_uuid WHERE 1 = 0".to_string()
+        } else {
+            friend_ids
+                .iter()
+                .enumerate()
+                .map(|(index, _)| {
+                    if index == 0 {
+                        "SELECT ? AS bot_uuid"
+                    } else {
+                        "SELECT ?"
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" UNION ALL ")
+        };
+        let common = format!("WITH friend_uuids AS ({friend_rows}) ");
+        let page_sql = format!(
+            "{common}\
+             SELECT b.bot_uuid, b.name, b.bot_info, b.visibility, b.status, \
+                    b.actor_kind, b.env, b.created_by, b.agent_code, \
+                    ({} ) * 1000 AS gmt_create_ms, \
+                    ({} ) * 1000 AS gmt_modified_ms, \
+                    CASE WHEN f.bot_uuid IS NULL THEN 0 ELSE 1 END AS is_friend \
+             FROM bcs_bots b \
+             LEFT JOIN friend_uuids f ON b.bot_uuid = f.bot_uuid \
+             WHERE b.env = ? AND COALESCE(b.is_deleted, 0) = 0 \
+               AND COALESCE(b.actor_kind, 'bot') = 'bot' \
+               AND b.bot_uuid != ? AND INSTR(LOWER(b.name), ?) > 0 \
+               AND ({visibility_filter}) \
+             ORDER BY b.gmt_create DESC, b.bot_uuid ASC \
+             LIMIT ? OFFSET ?",
+            self.flavor.unix_ts("b.gmt_create"),
+            self.flavor.unix_ts("b.gmt_modified"),
+        );
+        let mut base_params = friend_ids
+            .iter()
+            .map(|friend_id| Value::from(friend_id.as_str()))
+            .collect::<Vec<_>>();
+        base_params.extend([
+            Value::from(query.env.as_str()),
+            Value::from(query.acting_bot_id.as_str()),
+            Value::from(name_filter.as_str()),
+        ]);
+        let mut page_params = base_params.clone();
+        page_params.push(Value::from(query.limit as i64));
+        page_params.push(Value::from(query.offset as i64));
+        let rows = self
+            .db_query(&page_sql, page_params)
+            .await
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+        let mut records = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let is_friend = db_get_column::<i64>(row, "is_friend")
+                .map_err(|error| ServiceError::InternalError(error.to_string()))?
+                != 0;
+            records.push(BotCandidateReadRecord {
+                bot: control_plane_record_from_row(row)?,
+                is_friend,
+            });
+        }
+
+        let count_sql = format!(
+            "{common}\
+             SELECT COUNT(*) AS total \
+             FROM bcs_bots b \
+             LEFT JOIN friend_uuids f ON b.bot_uuid = f.bot_uuid \
+             WHERE b.env = ? AND COALESCE(b.is_deleted, 0) = 0 \
+               AND COALESCE(b.actor_kind, 'bot') = 'bot' \
+               AND b.bot_uuid != ? AND INSTR(LOWER(b.name), ?) > 0 \
+               AND ({visibility_filter})"
+        );
+        let count_rows = self
+            .db_query(&count_sql, base_params)
+            .await
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+        let total = count_rows
+            .first()
+            .map(|row| db_get_column::<i64>(row, "total"))
+            .transpose()
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?
+            .unwrap_or(0)
+            .max(0) as u64;
+        Ok((records, total))
+    }
+
+    async fn list_control_plane_by_creator(
+        &self,
+        query: BotControlPlaneOwnedQuery,
+    ) -> ServiceResult<Vec<BotControlPlaneRecord>> {
+        let mut sql = format!(
+            "SELECT bot_uuid, name, bot_info, visibility, status, actor_kind, env, \
+                    created_by, agent_code, ({}) * 1000 AS gmt_create_ms, \
+                    ({}) * 1000 AS gmt_modified_ms \
+             FROM bcs_bots \
+             WHERE created_by = ? AND env = ? AND COALESCE(is_deleted, 0) = 0",
+            self.flavor.unix_ts("gmt_create"),
+            self.flavor.unix_ts("gmt_modified")
+        );
+        let mut params = vec![
+            Value::from(query.created_by.as_str()),
+            Value::from(query.env.as_str()),
+        ];
+        if let Some(kind) = query.kind {
+            sql.push_str(" AND COALESCE(actor_kind, 'bot') = ?");
+            params.push(Value::from(match kind {
+                bcs_service_api::ActorKind::Bot => "bot",
+                bcs_service_api::ActorKind::Human => "human",
+            }));
+        }
+        if let Some(name) = query
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            sql.push_str(" AND INSTR(LOWER(name), ?) > 0");
+            params.push(Value::from(name.to_lowercase()));
+        }
+        if let Some(status) = query.status {
+            sql.push_str(" AND status = ?");
+            params.push(Value::from(match status {
+                bcs_service_api::ActorStatus::Online => "online",
+                bcs_service_api::ActorStatus::Hidden => "hidden",
+            }));
+        }
+        sql.push_str(" ORDER BY gmt_create DESC, bot_uuid ASC");
+        let rows = self
+            .db_query(&sql, params)
+            .await
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+        rows.iter().map(control_plane_record_from_row).collect()
+    }
+
+    async fn patch_control_plane(
+        &self,
+        bot_id: &str,
+        env: &str,
+        patch: BotControlPlanePatch,
+    ) -> ServiceResult<Option<BotControlPlaneRecord>> {
+        let existing = self.get_control_plane(bot_id, env).await?;
+        if existing.is_none() {
+            return Ok(None);
+        }
+
+        let mut assignments = Vec::new();
+        let mut params = Vec::new();
+        if let Some(name) = patch.name.as_deref() {
+            assignments.push("name = ?");
+            params.push(Value::from(name));
+        }
+        if let Some(visibility) = patch.visibility.as_deref() {
+            assignments.push("visibility = ?");
+            params.push(Value::from(visibility));
+        }
+        if let Some(status) = patch.status {
+            assignments.push("status = ?");
+            params.push(Value::from(match status {
+                bcs_service_api::ActorStatus::Online => "online",
+                bcs_service_api::ActorStatus::Hidden => "hidden",
+            }));
+        }
+        if let Some(descriptor) = patch.descriptor.as_ref() {
+            let rows = self
+                .db_query(
+                    "SELECT bot_info FROM bcs_bots WHERE bot_uuid = ? AND env = ? \
+                     AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
+                    vec![Value::from(bot_id), Value::from(env)],
+                )
+                .await
+                .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+            let raw = rows
+                .first()
+                .map(|row| db_get_column_opt::<String>(row, "bot_info"))
+                .transpose()
+                .map_err(|error| ServiceError::InternalError(error.to_string()))?
+                .flatten();
+            let mut value = raw
+                .as_deref()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+                .filter(serde_json::Value::is_object)
+                .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+            let object = value.as_object_mut().ok_or_else(|| {
+                ServiceError::InternalError("Bot descriptor is not a JSON object".to_string())
+            })?;
+            if let Some(summary) = descriptor.summary.as_ref() {
+                object.insert(
+                    "summary".to_string(),
+                    serde_json::Value::String(summary.clone()),
+                );
+            }
+            if let Some(domains) = descriptor.domains.as_ref() {
+                object.insert(
+                    "domains".to_string(),
+                    serde_json::to_value(domains)
+                        .map_err(|error| ServiceError::InternalError(error.to_string()))?,
+                );
+            }
+            if let Some(skills) = descriptor.skills.as_ref() {
+                object.insert(
+                    "skills".to_string(),
+                    serde_json::to_value(skills)
+                        .map_err(|error| ServiceError::InternalError(error.to_string()))?,
+                );
+            }
+            if let Some(scopes) = descriptor.scopes.as_ref() {
+                object.insert(
+                    "scopes".to_string(),
+                    serde_json::to_value(scopes)
+                        .map_err(|error| ServiceError::InternalError(error.to_string()))?,
+                );
+            }
+            assignments.push("bot_info = ?");
+            params.push(Value::from(value.to_string()));
+        }
+
+        assignments.push("gmt_modified = CURRENT_TIMESTAMP");
+        assignments.push("updated_at = CURRENT_TIMESTAMP");
+        params.push(Value::from(bot_id));
+        params.push(Value::from(env));
+        let sql = format!(
+            "UPDATE bcs_bots SET {} WHERE bot_uuid = ? AND env = ? \
+             AND COALESCE(is_deleted, 0) = 0",
+            assignments.join(", ")
+        );
+        let affected = self
+            .db_execute_affected(&sql, params)
+            .await
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+        if affected == 0 {
+            return Ok(None);
+        }
+
+        if let Some(bot) = self.bots.write().await.get_mut(bot_id) {
+            if let Some(name) = patch.name {
+                bot.capabilities.name = Some(name);
+            }
+            if let Some(visibility) = patch.visibility {
+                bot.capabilities.visibility = visibility;
+            }
+            if let Some(status) = patch.status {
+                bot.status = status;
+            }
+            if let Some(descriptor) = patch.descriptor {
+                if let Some(summary) = descriptor.summary {
+                    bot.capabilities.summary = Some(summary);
+                }
+                if let Some(domains) = descriptor.domains {
+                    bot.capabilities.domains = domains;
+                }
+                if let Some(skills) = descriptor.skills {
+                    bot.capabilities.skills = skills;
+                }
+                if let Some(scopes) = descriptor.scopes {
+                    bot.capabilities.scopes = scopes;
+                }
+            }
+        }
+
+        self.get_control_plane(bot_id, env).await
     }
 }
 

--- a/src/bcs/crates/services/bcs-bot-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/memory.rs
@@ -15,9 +15,18 @@ use tracing::{debug, info, warn};
 use bcs_config::resolve_env_str as resolve_env;
 use bcs_service_api::port::repo::BotRepoPort;
 use bcs_service_api::{
-    BindingChannels, BotCapabilities, BotDynamicStatus, BotMetricCount, BotMetricsSnapshotPort,
-    RegisteredBot, ServiceError, ServiceResult, Skill,
+    BindingChannels, BotCandidateReadQuery, BotCandidateReadRecord, BotCandidateVisibility,
+    BotCapabilities, BotControlPlaneDescriptor, BotControlPlaneOwnedQuery, BotControlPlanePatch,
+    BotControlPlaneRecord, BotControlPlaneRepoPort, BotDynamicStatus, BotMetricCount,
+    BotMetricsSnapshotPort, RegisteredBot, ServiceError, ServiceResult, Skill,
 };
+
+fn unix_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
 
 /// Check whether a `bot_uuid` has the form `{namespace}:{staff_no}` where
 /// `namespace` is one of the whitelisted legacy patterns:
@@ -67,6 +76,8 @@ pub struct BotConnection {
 #[derive(Debug)]
 pub struct MemoryBotRepo {
     bots: RwLock<BTreeMap<String, RegisteredBotInner>>,
+    /// Audit timestamps for the local control-plane projection.
+    control_plane_audit: RwLock<HashMap<String, (u64, u64)>>,
     /// Token to bot_uuid mapping for authentication.
     /// Tokens persist across streaming disconnects for reconnection.
     token_to_bot: RwLock<HashMap<String, String>>,
@@ -235,6 +246,7 @@ impl MemoryBotRepo {
     pub fn with_base_dir(bots_base_dir: PathBuf) -> Self {
         Self {
             bots: RwLock::new(BTreeMap::new()),
+            control_plane_audit: RwLock::new(HashMap::new()),
             token_to_bot: RwLock::new(HashMap::new()),
             deleted_bot_ids: RwLock::new(HashSet::new()),
             binding_channel_index: RwLock::new(HashMap::new()),
@@ -356,6 +368,7 @@ impl Default for MemoryBotRepo {
     fn default() -> Self {
         Self {
             bots: RwLock::new(BTreeMap::new()),
+            control_plane_audit: RwLock::new(HashMap::new()),
             token_to_bot: RwLock::new(HashMap::new()),
             deleted_bot_ids: RwLock::new(HashSet::new()),
             binding_channel_index: RwLock::new(HashMap::new()),
@@ -482,6 +495,11 @@ impl BotRepoPort for MemoryBotRepo {
             info!(bot_id = %bot_id, "Bot registered");
         }
 
+        let now = unix_millis();
+        let mut audit = self.control_plane_audit.write().await;
+        let entry = audit.entry(bot_id).or_insert((now, now));
+        entry.1 = now;
+
         Ok(())
     }
 
@@ -598,6 +616,11 @@ impl BotRepoPort for MemoryBotRepo {
             token_to_bot.remove(&previous_token);
         }
         token_to_bot.insert(token.to_string(), bot_id.clone());
+
+        let now = unix_millis();
+        let mut audit = self.control_plane_audit.write().await;
+        let entry = audit.entry(bot_id.clone()).or_insert((now, now));
+        entry.1 = now;
 
         info!(bot_id = %bot_id, "Bot registered with owner and token");
         Ok(())
@@ -1023,6 +1046,12 @@ impl BotRepoPort for MemoryBotRepo {
                 protocol_version: 1,
             },
         );
+
+        let now = unix_millis();
+        self.control_plane_audit
+            .write()
+            .await
+            .insert(bot_uuid.clone(), (now, now));
 
         info!(
             bot_uuid = %bot_uuid,
@@ -1608,6 +1637,250 @@ impl BotRepoPort for MemoryBotRepo {
         if let Some(tx) = pending.remove(request_id) {
             let _ = tx.send(response);
         }
+    }
+}
+
+#[async_trait]
+impl BotControlPlaneRepoPort for MemoryBotRepo {
+    async fn get_control_plane(
+        &self,
+        bot_id: &str,
+        env: &str,
+    ) -> ServiceResult<Option<BotControlPlaneRecord>> {
+        if self.deleted_bot_ids.read().await.contains(bot_id) {
+            return Ok(None);
+        }
+        let audit = self
+            .control_plane_audit
+            .read()
+            .await
+            .get(bot_id)
+            .copied()
+            .unwrap_or((0, 0));
+        let bots = self.bots.read().await;
+        let Some(bot) = bots.get(bot_id) else {
+            return Ok(None);
+        };
+        let record_env = bot.env.clone().unwrap_or_else(resolve_env);
+        if record_env != env {
+            return Ok(None);
+        }
+        let Some(name) = bot
+            .capabilities
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        else {
+            return Ok(None);
+        };
+        Ok(Some(BotControlPlaneRecord {
+            bot_id: bot.bot_id.clone(),
+            kind: bot.actor_kind,
+            name: name.to_string(),
+            visibility: if bot.capabilities.visibility.is_empty() {
+                "protected".to_string()
+            } else {
+                bot.capabilities.visibility.clone()
+            },
+            status: bot.status,
+            env: record_env,
+            created_by: bot.created_by.clone(),
+            descriptor: BotControlPlaneDescriptor {
+                summary: bot.capabilities.summary.clone().unwrap_or_default(),
+                domains: bot.capabilities.domains.clone(),
+                skills: bot.capabilities.skills.clone(),
+                scopes: bot.capabilities.scopes.clone(),
+            },
+            agent_code: bot.capabilities.agent_code.clone(),
+            created_at: audit.0,
+            updated_at: audit.1,
+        }))
+    }
+
+    async fn list_control_plane_candidates(
+        &self,
+        query: BotCandidateReadQuery,
+    ) -> ServiceResult<(Vec<BotCandidateReadRecord>, u64)> {
+        let ids = self.bots.read().await.keys().cloned().collect::<Vec<_>>();
+        let name = query
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_lowercase);
+        let mut records = Vec::new();
+        for bot_id in ids {
+            let Some(bot) = self.get_control_plane(&bot_id, &query.env).await? else {
+                continue;
+            };
+            if bot.bot_id == query.acting_bot_id || bot.kind != bcs_service_api::ActorKind::Bot {
+                continue;
+            }
+            if name
+                .as_ref()
+                .is_some_and(|name| !bot.name.to_lowercase().contains(name))
+            {
+                continue;
+            }
+            let is_friend = query.friend_ids.contains(&bot.bot_id);
+            let visible = match query.visibility {
+                BotCandidateVisibility::Discovery => {
+                    matches!(bot.visibility.as_str(), "public" | "protected")
+                }
+                BotCandidateVisibility::Collaboration => bot.visibility == "public" || is_friend,
+            };
+            if visible {
+                records.push(BotCandidateReadRecord { bot, is_friend });
+            }
+        }
+        records.sort_by(|left, right| {
+            right
+                .bot
+                .created_at
+                .cmp(&left.bot.created_at)
+                .then_with(|| left.bot.bot_id.cmp(&right.bot.bot_id))
+        });
+        let total = records.len() as u64;
+        let page = records
+            .into_iter()
+            .skip(query.offset as usize)
+            .take(query.limit as usize)
+            .collect();
+        Ok((page, total))
+    }
+
+    async fn list_control_plane_by_creator(
+        &self,
+        query: BotControlPlaneOwnedQuery,
+    ) -> ServiceResult<Vec<BotControlPlaneRecord>> {
+        let ids = self.bots.read().await.keys().cloned().collect::<Vec<_>>();
+        let name = query
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_lowercase);
+        let mut records = Vec::new();
+        for bot_id in ids {
+            let Some(bot) = self.get_control_plane(&bot_id, &query.env).await? else {
+                continue;
+            };
+            if bot.created_by.as_deref() != Some(query.created_by.as_str())
+                || query.kind.is_some_and(|kind| bot.kind != kind)
+                || query.status.is_some_and(|status| bot.status != status)
+                || name
+                    .as_ref()
+                    .is_some_and(|name| !bot.name.to_lowercase().contains(name))
+            {
+                continue;
+            }
+            records.push(bot);
+        }
+        records.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| left.bot_id.cmp(&right.bot_id))
+        });
+        Ok(records)
+    }
+
+    async fn patch_control_plane(
+        &self,
+        bot_id: &str,
+        env: &str,
+        patch: BotControlPlanePatch,
+    ) -> ServiceResult<Option<BotControlPlaneRecord>> {
+        if self.deleted_bot_ids.read().await.contains(bot_id) {
+            return Ok(None);
+        }
+        let (mut capabilities, token, created_by, record_env) = {
+            let bots = self.bots.read().await;
+            let Some(bot) = bots.get(bot_id) else {
+                return Ok(None);
+            };
+            let record_env = bot.env.clone().unwrap_or_else(resolve_env);
+            if record_env != env {
+                return Ok(None);
+            }
+            (
+                bot.capabilities.clone(),
+                bot.session_token.clone(),
+                bot.created_by.clone(),
+                record_env,
+            )
+        };
+
+        if let Some(name) = patch.name.as_ref() {
+            capabilities.name = Some(name.clone());
+        }
+        if let Some(visibility) = patch.visibility.as_ref() {
+            capabilities.visibility = visibility.clone();
+        }
+        if let Some(descriptor) = patch.descriptor.as_ref() {
+            if let Some(summary) = descriptor.summary.as_ref() {
+                capabilities.summary = Some(summary.clone());
+            }
+            if let Some(domains) = descriptor.domains.as_ref() {
+                capabilities.domains = domains.clone();
+            }
+            if let Some(skills) = descriptor.skills.as_ref() {
+                capabilities.skills = skills.clone();
+            }
+            if let Some(scopes) = descriptor.scopes.as_ref() {
+                capabilities.scopes = scopes.clone();
+            }
+        }
+
+        let now = unix_millis();
+        let created_at = self
+            .control_plane_audit
+            .read()
+            .await
+            .get(bot_id)
+            .map(|audit| audit.0)
+            .unwrap_or(now);
+        let persisted = PersistedCapabilities {
+            bot_id: bot_id.to_string(),
+            name: capabilities.name.clone(),
+            summary: capabilities.summary.clone(),
+            domains: capabilities.domains.clone(),
+            skills: capabilities.skills.clone(),
+            scopes: capabilities.scopes.clone(),
+            binding_channels: capabilities.binding_channels.clone(),
+            token,
+            registered_at: created_at,
+            hidden: false,
+            created_by: created_by.clone(),
+            visibility: Some(capabilities.visibility.clone()),
+            agent_code: capabilities.agent_code.clone(),
+            agent_token: capabilities.agent_token.clone(),
+        };
+        let path = self.bot_info_path(bot_id);
+        let directory = path.parent().ok_or_else(|| {
+            ServiceError::InternalError(format!("Invalid path for bot: {bot_id}"))
+        })?;
+        fs::create_dir_all(directory).await?;
+        fs::write(&path, serde_json::to_string_pretty(&persisted)?).await?;
+
+        {
+            let mut bots = self.bots.write().await;
+            let Some(bot) = bots.get_mut(bot_id) else {
+                return Ok(None);
+            };
+            bot.capabilities = capabilities;
+            bot.created_by = created_by;
+            bot.env = Some(record_env);
+            if let Some(status) = patch.status {
+                bot.status = status;
+            }
+        }
+        self.control_plane_audit
+            .write()
+            .await
+            .insert(bot_id.to_string(), (created_at, now));
+        self.get_control_plane(bot_id, env).await
     }
 }
 

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
@@ -1,0 +1,553 @@
+#![allow(
+    clippy::expect_used,
+    reason = "test assertions intentionally fail fast"
+)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use bcs_bot_store::{MemoryBotRepo, PersistentBotRepo};
+use bcs_cache_local::InMemoryCachePlugin;
+use bcs_db_api::{DbPlugin, DbSqlFlavor, DbStatement, DbValue as Value};
+use bcs_db_local::LocalSqliteDbPlugin;
+use bcs_service_api::{
+    ActorKind, ActorStatus, BotCandidateReadQuery, BotCandidateVisibility, BotCapabilities,
+    BotControlPlaneDescriptorPatch, BotControlPlaneOwnedQuery, BotControlPlanePatch,
+    BotControlPlaneRepoPort, BotRepoPort,
+};
+
+#[tokio::test]
+async fn memory_control_plane_supports_both_kinds_candidates_and_patch_timestamps() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let repo = MemoryBotRepo::with_base_dir(temp.path().to_path_buf());
+    let env = bcs_config::resolve_env_str();
+    repo.register_with_owner_and_token(
+        "acting-memory".to_string(),
+        BotCapabilities {
+            name: Some("Acting Memory".to_string()),
+            visibility: "private".to_string(),
+            ..Default::default()
+        },
+        "staff-1",
+        "acting-token",
+    )
+    .await
+    .expect("register acting bot");
+    repo.register_with_owner_and_token(
+        "friend-memory".to_string(),
+        BotCapabilities {
+            name: Some("Friend Memory".to_string()),
+            summary: Some("friend".to_string()),
+            visibility: "private".to_string(),
+            ..Default::default()
+        },
+        "staff-2",
+        "friend-token",
+    )
+    .await
+    .expect("register friend bot");
+    repo.register_with_owner_and_token(
+        "default-visibility-memory".to_string(),
+        BotCapabilities {
+            name: Some("Default Visibility".to_string()),
+            ..Default::default()
+        },
+        "staff-2",
+        "default-visibility-token",
+    )
+    .await
+    .expect("register default visibility bot");
+    repo.ensure_human_actor("staff-1", "Memory Human")
+        .await
+        .expect("ensure human");
+
+    bcs_test_support::contract::repo::bot_control_plane_repo_port_contract_tests(
+        &repo,
+        &env,
+        "acting-memory",
+    )
+    .await;
+
+    let human = repo
+        .get_control_plane("human_staff-1", &env)
+        .await
+        .expect("get human")
+        .expect("human exists");
+    assert_eq!(human.kind, ActorKind::Human);
+    assert_eq!(
+        repo.get_control_plane("default-visibility-memory", &env)
+            .await
+            .expect("get default visibility bot")
+            .expect("default visibility bot exists")
+            .visibility,
+        "protected"
+    );
+
+    let (candidates, total) = repo
+        .list_control_plane_candidates(BotCandidateReadQuery {
+            acting_bot_id: "acting-memory".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Collaboration,
+            friend_ids: HashSet::from(["friend-memory".to_string()]),
+            name: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("memory candidates");
+    assert_eq!(total, 1);
+    assert_eq!(candidates[0].bot.bot_id, "friend-memory");
+    assert!(candidates[0].is_friend);
+
+    let before = repo
+        .get_control_plane("acting-memory", &env)
+        .await
+        .expect("get acting")
+        .expect("acting exists");
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    let after = repo
+        .patch_control_plane(
+            "acting-memory",
+            &env,
+            BotControlPlanePatch {
+                name: Some("Acting Renamed".to_string()),
+                descriptor: Some(BotControlPlaneDescriptorPatch {
+                    domains: Some(vec!["memory".to_string()]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("patch memory")
+        .expect("memory bot exists");
+    assert_eq!(after.name, "Acting Renamed");
+    assert_eq!(after.descriptor.domains, vec!["memory"]);
+    assert_eq!(after.created_at, before.created_at);
+    assert!(after.updated_at > before.updated_at);
+}
+
+#[tokio::test]
+async fn persistent_control_plane_reads_project_audit_fields_and_preserve_batch_order() {
+    let (repo, db) = fixture().await;
+    seed_bot(
+        db.as_ref(),
+        "bot-a",
+        "Alpha",
+        "bot",
+        "public",
+        "online",
+        Some("staff-1"),
+        "2026-01-02 03:04:05",
+    )
+    .await;
+
+    bcs_test_support::contract::repo::bot_control_plane_repo_port_contract_tests(
+        &repo, "dev", "bot-a",
+    )
+    .await;
+    seed_bot(
+        db.as_ref(),
+        "human-1",
+        "Human",
+        "human",
+        "protected",
+        "hidden",
+        Some("staff-1"),
+        "2026-01-01 03:04:05",
+    )
+    .await;
+
+    let bot = repo
+        .get_control_plane("bot-a", "dev")
+        .await
+        .expect("get bot")
+        .expect("bot exists");
+    assert_eq!(bot.kind, ActorKind::Bot);
+    assert_eq!(bot.status, ActorStatus::Online);
+    assert_eq!(bot.descriptor.summary, "summary-bot-a");
+    assert_eq!(bot.agent_code.as_deref(), Some("agent-bot-a"));
+    assert!(bot.created_at > 0);
+    assert_eq!(bot.created_at, bot.updated_at);
+
+    let rows = repo
+        .get_control_plane_by_ids(
+            &[
+                "human-1".to_string(),
+                "missing".to_string(),
+                "bot-a".to_string(),
+                "human-1".to_string(),
+            ],
+            "dev",
+        )
+        .await
+        .expect("batch query");
+    assert_eq!(
+        rows.iter()
+            .map(|row| row.bot_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["human-1", "bot-a"]
+    );
+}
+
+#[tokio::test]
+async fn persistent_control_plane_candidates_apply_purpose_and_stable_ordering() {
+    let (repo, db) = fixture().await;
+    for (id, name, kind, visibility, created) in [
+        ("acting", "Acting", "bot", "private", "2026-01-05 00:00:00"),
+        (
+            "public-a",
+            "Public A",
+            "bot",
+            "public",
+            "2026-01-04 00:00:00",
+        ),
+        (
+            "public-b",
+            "Public B",
+            "bot",
+            "public",
+            "2026-01-04 00:00:00",
+        ),
+        (
+            "protected",
+            "Protected",
+            "bot",
+            "protected",
+            "2026-01-03 00:00:00",
+        ),
+        (
+            "private-friend",
+            "Private Friend",
+            "bot",
+            "private",
+            "2026-01-02 00:00:00",
+        ),
+        (
+            "human-row",
+            "Human Row",
+            "human",
+            "public",
+            "2026-01-06 00:00:00",
+        ),
+    ] {
+        seed_bot(
+            db.as_ref(),
+            id,
+            name,
+            kind,
+            visibility,
+            "online",
+            Some("staff-1"),
+            created,
+        )
+        .await;
+    }
+    db.execute(DbStatement::with_params(
+        "INSERT INTO bcs_friendships (left_bot, right_bot, env) VALUES (?, ?, ?)",
+        vec![
+            Value::from("acting"),
+            Value::from("private-friend"),
+            Value::from("dev"),
+        ],
+    ))
+    .await
+    .expect("insert friendship");
+
+    let (discovery, total) = repo
+        .list_control_plane_candidates(BotCandidateReadQuery {
+            acting_bot_id: "acting".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::from(["private-friend".to_string()]),
+            name: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("discovery candidates");
+    assert_eq!(total, 3);
+    assert_eq!(
+        discovery
+            .iter()
+            .map(|row| row.bot.bot_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["public-a", "public-b", "protected"]
+    );
+    assert!(discovery.iter().all(|row| !row.is_friend));
+
+    let (without_friends, total) = repo
+        .list_control_plane_candidates(BotCandidateReadQuery {
+            acting_bot_id: "acting".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Collaboration,
+            friend_ids: HashSet::new(),
+            name: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("collaboration candidates without supplied friends");
+    assert_eq!(total, 2);
+    assert_eq!(
+        without_friends
+            .iter()
+            .map(|row| row.bot.bot_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["public-a", "public-b"]
+    );
+
+    let (collaboration, total) = repo
+        .list_control_plane_candidates(BotCandidateReadQuery {
+            acting_bot_id: "acting".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Collaboration,
+            friend_ids: HashSet::from(["private-friend".to_string()]),
+            name: Some("  ".to_string()),
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("collaboration candidates");
+    assert_eq!(total, 3);
+    assert_eq!(
+        collaboration
+            .iter()
+            .map(|row| (row.bot.bot_id.as_str(), row.is_friend))
+            .collect::<Vec<_>>(),
+        vec![
+            ("public-a", false),
+            ("public-b", false),
+            ("private-friend", true),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn persistent_control_plane_name_filters_treat_sql_wildcards_as_literals() {
+    let (repo, db) = fixture().await;
+    for (id, name, owner) in [
+        ("acting", "Acting", "staff-1"),
+        ("literal-percent", "100% Real", "staff-1"),
+        ("wildcard-match", "100x Real", "staff-1"),
+    ] {
+        seed_bot(
+            db.as_ref(),
+            id,
+            name,
+            "bot",
+            "public",
+            "online",
+            Some(owner),
+            "2026-01-01 00:00:00",
+        )
+        .await;
+    }
+
+    let (candidates, total) = repo
+        .list_control_plane_candidates(BotCandidateReadQuery {
+            acting_bot_id: "acting".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: Some("%".to_string()),
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("literal candidate filter");
+    assert_eq!(total, 1);
+    assert_eq!(candidates[0].bot.bot_id, "literal-percent");
+
+    let owned = repo
+        .list_control_plane_by_creator(BotControlPlaneOwnedQuery {
+            created_by: "staff-1".to_string(),
+            env: "dev".to_string(),
+            kind: None,
+            name: Some("%".to_string()),
+            status: None,
+        })
+        .await
+        .expect("literal owned filter");
+    assert_eq!(owned.len(), 1);
+    assert_eq!(owned[0].bot_id, "literal-percent");
+}
+
+#[tokio::test]
+async fn persistent_control_plane_owned_filters_and_patch_replace_descriptor_arrays() {
+    let (repo, db) = fixture().await;
+    seed_bot(
+        db.as_ref(),
+        "owned",
+        "Owned Planner",
+        "bot",
+        "public",
+        "online",
+        Some("staff-1"),
+        "2026-01-01 00:00:00",
+    )
+    .await;
+    seed_bot(
+        db.as_ref(),
+        "other",
+        "Other Planner",
+        "bot",
+        "public",
+        "online",
+        Some("staff-2"),
+        "2026-01-02 00:00:00",
+    )
+    .await;
+
+    let owned = repo
+        .list_control_plane_by_creator(BotControlPlaneOwnedQuery {
+            created_by: "staff-1".to_string(),
+            env: "dev".to_string(),
+            kind: Some(ActorKind::Bot),
+            name: Some(" planner ".to_string()),
+            status: Some(ActorStatus::Online),
+        })
+        .await
+        .expect("owned rows");
+    assert_eq!(owned.len(), 1);
+    let before = &owned[0];
+
+    tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+    let updated = repo
+        .patch_control_plane(
+            "owned",
+            "dev",
+            BotControlPlanePatch {
+                name: Some("Renamed".to_string()),
+                visibility: Some("protected".to_string()),
+                status: Some(ActorStatus::Hidden),
+                descriptor: Some(BotControlPlaneDescriptorPatch {
+                    summary: Some("new summary".to_string()),
+                    domains: Some(vec![]),
+                    skills: None,
+                    scopes: Some(vec!["new-scope".to_string()]),
+                }),
+            },
+        )
+        .await
+        .expect("patch row")
+        .expect("patched row");
+    assert_eq!(updated.name, "Renamed");
+    assert_eq!(updated.visibility, "protected");
+    assert_eq!(updated.status, ActorStatus::Hidden);
+    assert_eq!(updated.descriptor.summary, "new summary");
+    assert!(updated.descriptor.domains.is_empty());
+    assert_eq!(updated.descriptor.skills, before.descriptor.skills);
+    assert_eq!(updated.descriptor.scopes, vec!["new-scope"]);
+    assert_eq!(updated.agent_code, before.agent_code);
+    assert_eq!(updated.created_at, before.created_at);
+    assert!(updated.updated_at > before.updated_at);
+
+    let credential = db
+        .query(DbStatement::with_params(
+            "SELECT session_token FROM bcs_bots WHERE bot_uuid = ? AND env = ?",
+            vec![Value::from("owned"), Value::from("dev")],
+        ))
+        .await
+        .expect("read credential");
+    assert_eq!(
+        credential[0].get("session_token").and_then(Value::as_str),
+        Some("token-owned")
+    );
+}
+
+async fn fixture() -> (PersistentBotRepo, Arc<dyn DbPlugin>) {
+    let db = sqlite_db().await;
+    let repo = PersistentBotRepo::with_plugins_flavor_and_cache_key_prefix(
+        Arc::new(InMemoryCachePlugin::new()),
+        db.clone(),
+        DbSqlFlavor::Sqlite,
+        "test:",
+    );
+    (repo, db)
+}
+
+async fn sqlite_db() -> Arc<dyn DbPlugin> {
+    let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    db.execute(DbStatement::new(
+        "CREATE TABLE bcs_bots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            bot_uuid TEXT NOT NULL,
+            name TEXT NOT NULL,
+            bot_info TEXT,
+            session_token TEXT,
+            registered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            env TEXT,
+            visibility TEXT NOT NULL DEFAULT 'public',
+            created_by TEXT,
+            actor_kind TEXT NOT NULL DEFAULT 'bot',
+            status TEXT NOT NULL DEFAULT 'online',
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            agent_code TEXT,
+            UNIQUE (bot_uuid, env)
+        )",
+    ))
+    .await
+    .expect("create bots table");
+    db.execute(DbStatement::new(
+        "CREATE TABLE bcs_friendships (
+            left_bot TEXT NOT NULL,
+            right_bot TEXT NOT NULL,
+            env TEXT NOT NULL,
+            gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (left_bot, right_bot, env)
+        )",
+    ))
+    .await
+    .expect("create friendships table");
+    db
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn seed_bot(
+    db: &dyn DbPlugin,
+    bot_id: &str,
+    name: &str,
+    kind: &str,
+    visibility: &str,
+    status: &str,
+    created_by: Option<&str>,
+    timestamp: &str,
+) {
+    let bot_info = serde_json::json!({
+        "summary": format!("summary-{bot_id}"),
+        "domains": ["planning"],
+        "skills": [{"name": "plan", "description": "Make a plan"}],
+        "scopes": ["workspace"]
+    })
+    .to_string();
+    db.execute(DbStatement::with_params(
+        "INSERT INTO bcs_bots
+         (gmt_create, gmt_modified, bot_uuid, name, bot_info, session_token,
+          registered_at, updated_at, env, visibility, created_by, actor_kind,
+          status, is_deleted, agent_code)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)",
+        vec![
+            Value::from(timestamp),
+            Value::from(timestamp),
+            Value::from(bot_id),
+            Value::from(name),
+            Value::from(bot_info),
+            Value::from(format!("token-{bot_id}")),
+            Value::from(timestamp),
+            Value::from(timestamp),
+            Value::from("dev"),
+            Value::from(visibility),
+            created_by.map(Value::from).unwrap_or(Value::Null),
+            Value::from(kind),
+            Value::from(status),
+            Value::from(format!("agent-{bot_id}")),
+        ],
+    ))
+    .await
+    .expect("seed bot row");
+}

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
@@ -1,5 +1,7 @@
 //! Application service contract harnesses.
 
+use std::collections::BTreeSet;
+
 use bcs_service_api::{
     A2aChatRunService, A2aChatService, ActorDirectoryService, BotDiscoveryService,
     BotManagementService, BotOnboardingService, BotQueryService, BotRuntimeConnectionService,
@@ -9,6 +11,18 @@ use bcs_service_api::{
     OrganizationMemberAuth, ServiceError, SystemMessageService, WorkbenchSessionService,
     WorkerProfileService,
 };
+use bcs_service_api::application::v1::{BotService, Principal, QueryBots};
+
+pub async fn bot_service_contract_tests<T: BotService + ?Sized>(svc: &T) {
+    let error = svc
+        .query(QueryBots {
+            principal: Principal::bot("contract-bot", "contract", BTreeSet::new()),
+            bot_ids: Vec::new(),
+        })
+        .await
+        .expect_err("Bot control-plane service rejects Bot Principals");
+    assert_eq!(error.code(), "forbidden");
+}
 
 pub async fn a2a_chat_service_contract_tests<T: A2aChatService + ?Sized>(_svc: &T) {}
 

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/application/mod.rs
@@ -1,7 +1,5 @@
 //! Application service contract harnesses.
 
-use std::collections::BTreeSet;
-
 use bcs_service_api::{
     A2aChatRunService, A2aChatService, ActorDirectoryService, BotDiscoveryService,
     BotManagementService, BotOnboardingService, BotQueryService, BotRuntimeConnectionService,
@@ -11,16 +9,29 @@ use bcs_service_api::{
     OrganizationMemberAuth, ServiceError, SystemMessageService, WorkbenchSessionService,
     WorkerProfileService,
 };
-use bcs_service_api::application::v1::{BotService, Principal, QueryBots};
+use bcs_service_api::application::v1::{
+    AuthenticatedBotIdentity, AuthenticatedCaller, BotService, QueryBots,
+};
 
 pub async fn bot_service_contract_tests<T: BotService + ?Sized>(svc: &T) {
     let error = svc
         .query(QueryBots {
-            principal: Principal::bot("contract-bot", "contract", BTreeSet::new()),
+            caller: AuthenticatedCaller {
+                tenant: "contract".into(),
+                user: None,
+                bot: Some(AuthenticatedBotIdentity {
+                    bot_uuid: "contract-bot".into(),
+                    owner_id: "owner".into(),
+                    app_id: 1,
+                    agent_code: "contract-agent".into(),
+                }),
+                app: None,
+                access_key: None,
+            },
             bot_ids: Vec::new(),
         })
         .await
-        .expect_err("Bot control-plane service rejects Bot Principals");
+        .expect_err("Bot control-plane service rejects callers without User");
     assert_eq!(error.code(), "forbidden");
 }
 

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
@@ -7,12 +7,12 @@ use bcs_domain::{
     MessageOwnerFilter, MessageQuery, NewMessage, SenderType,
 };
 use bcs_service_api::{
-    BindingChannel, BotCapabilities, BotRepoPort, DefaultDelivery, FriendRepoPort, FriendRequest,
-    FriendRequestDirection, FriendRequestRepoPort, FriendRequestStatus, Group, GroupChatProposal,
-    GroupKind, GroupMutableFieldsPatch, GroupRepoPort, GroupStatus, NewSessionParams, Participant,
-    ParticipantMode, ParticipantRole, ProposalCoreService, RelationEdge, RelationRepoPort,
-    RoutingMode, RoutingPolicy, ServiceSpec, Session, SessionKind, SessionRepoPort, SessionStatus,
-    Skill,
+    BindingChannel, BotCapabilities, BotControlPlaneRepoPort, BotRepoPort, DefaultDelivery,
+    FriendRepoPort, FriendRequest, FriendRequestDirection, FriendRequestRepoPort,
+    FriendRequestStatus, Group, GroupChatProposal, GroupKind, GroupMutableFieldsPatch,
+    GroupRepoPort, GroupStatus, NewSessionParams, Participant, ParticipantMode, ParticipantRole,
+    ProposalCoreService, RelationEdge, RelationRepoPort, RoutingMode, RoutingPolicy, ServiceSpec,
+    Session, SessionKind, SessionRepoPort, SessionStatus, Skill,
 };
 use bcs_service_api::ServiceError;
 use bcs_service_api::port::repo::{
@@ -245,6 +245,41 @@ pub async fn bot_repo_contract_tests<T: BotRepoPort + ?Sized>(repo: &T) {
 
 pub async fn bot_repo_port_contract_tests<T: BotRepoPort + ?Sized>(repo: &T) {
     bot_repo_contract_tests(repo).await;
+}
+
+pub async fn bot_control_plane_repo_port_contract_tests<T: BotControlPlaneRepoPort + ?Sized>(
+    repo: &T,
+    env: &str,
+    known_bot_id: &str,
+) {
+    assert!(
+        repo.get_control_plane("control-plane-contract-missing", env)
+            .await
+            .expect("read missing control-plane Bot")
+            .is_none()
+    );
+
+    let record = repo
+        .get_control_plane(known_bot_id, env)
+        .await
+        .expect("read known control-plane Bot")
+        .expect("known control-plane Bot exists");
+    assert_eq!(record.bot_id, known_bot_id);
+    assert_eq!(record.env, env);
+
+    let batch = repo
+        .get_control_plane_by_ids(
+            &[
+                known_bot_id.to_string(),
+                "control-plane-contract-missing".to_string(),
+                known_bot_id.to_string(),
+            ],
+            env,
+        )
+        .await
+        .expect("batch read control-plane Bots");
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch[0].bot_id, known_bot_id);
 }
 
 pub async fn group_repo_contract_tests<T: GroupRepoPort + ?Sized>(repo: &T) {

--- a/src/bcs/docs/superpowers/plans/2026-08-02-bcs-gateway-principal-verifier.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-02-bcs-gateway-principal-verifier.md
@@ -1,0 +1,1321 @@
+# BCS Gateway Principal Verifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and contract-test a production-quality HS256 Gateway Principal token verifier that returns a complete, secret-free `AuthenticatedCaller`, without mounting BCS V1 or selecting a business Actor.
+
+**Architecture:** Add transport-neutral authenticated identity types to `bcs-service-api::application::v1`, then implement the Gateway wire projection and JWT verifier under `bcs-api-http::v1::gateway_principal`. A shared JSON fixture pins Gateway's provider serialization and BCS's consumer projection; the existing single-Principal route seam and production bootstrap stay unchanged.
+
+**Tech Stack:** Rust 1.91, `jsonwebtoken` 11.0.0 with the pure-Rust `rust_crypto` backend, `time` 0.3, Serde, PyJWT, Pydantic 2, Cargo tests, and Pytest.
+
+## Global Constraints
+
+- Work only in `/private/tmp/avernet_yg-bcs-gateway-principal-contract` on branch `codex/bcs-gateway-principal-contract`; do not modify `dev` directly.
+- Pin JWT verification to `HS256`; never select an algorithm from untrusted token data.
+- Require `typ=JWT`, `kid=bare`, `iss=gateway`, `aud=bcs`, `iat`, `exp`, and a non-empty `principals` array.
+- Apply exactly 5 seconds of clock-skew tolerance; the tolerance is not configurable.
+- User, Bot, App, and AccessKey may coexist; do not select an Actor in this work.
+- Never retain, log, serialize, or expose the raw JWT, HMAC key, `bot.token`, or `access_key_token`.
+- Do not add scopes, bootstrap/config wiring, middleware integration, route changes, Application command migrations, or a V1 production mount.
+- `bcs-service-api` remains transport-agnostic; `bcs-api-http` must not depend on `bcs-jwt`, bootstrap, legacy `bcs-http`, or concrete Application implementations.
+- Follow TDD for every behavior change: add the focused failing test, observe the expected failure, add the minimum implementation, rerun the focused test, then commit.
+
+**Design reference:** `src/bcs/docs/superpowers/specs/2026-08-02-bcs-gateway-principal-verifier-design.md`
+
+**Library reference:** `jsonwebtoken` 11.0.0 supports HS256 and reusable `DecodingKey`; its official metadata declares Rust 1.88, below this workspace's Rust 1.91 floor. Configure it with `default-features = false, features = ["rust_crypto"]` so BCS does not pull PEM support or AWS-LC.
+
+---
+
+## File Structure
+
+- Create `src/bcs/api-contracts/v1/gateway-principal/contract.md` — canonical Gateway-to-BCS V1 authentication wire contract.
+- Create `src/bcs/api-contracts/v1/gateway-principal/principal-set.json` — shared all-four-Principal fixture with synthetic credential markers.
+- Create `src/gateway/tests/contracts/test_bcs_gateway_principal_contract.py` — Gateway provider-side fixture and signer conformance test.
+- Create `src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs` — transport-neutral safe authenticated caller types.
+- Create `src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs` — internal identity contract tests.
+- Modify `src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs` — publish the identity module and types.
+- Modify `src/bcs/crates/service-api/bcs-service-api/Cargo.toml` — add the workspace `time` dependency.
+- Modify `src/bcs/Cargo.toml` — declare `jsonwebtoken` 11.0.0 as a workspace dependency.
+- Modify `src/bcs/Cargo.lock` — lock the approved JWT implementation and pure-Rust crypto dependencies.
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/Cargo.toml` — consume `jsonwebtoken` and `time` with RFC 3339 parsing.
+- Create `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/mod.rs` — public verifier exports and test module declaration.
+- Create `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs` — private Gateway claims and discriminated-union DTOs.
+- Create `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs` — trust construction, JWT verification, validation, and safe projection.
+- Create `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs` — deterministic success, forgery, shape, tenant, and secret-erasure tests.
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs` — expose the versioned Gateway Principal module without changing the router.
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs` — prevent concrete auth-service dependency and accidental production mount.
+- Modify `src/bcs/crates/service-api/bcs-service-api/tests/boundary_contracts.rs` — prohibit transport/JWT/credential fields in the internal caller contract.
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md` — document the preparatory verifier and non-mount boundary.
+- Modify `src/bcs/crates/service-api/bcs-service-api/CONTEXT.md` — document ownership of safe authenticated identity types.
+
+---
+
+### Task 1: Pin the shared Gateway provider contract
+
+**Files:**
+- Create: `src/gateway/tests/contracts/test_bcs_gateway_principal_contract.py`
+- Create: `src/bcs/api-contracts/v1/gateway-principal/principal-set.json`
+- Create: `src/bcs/api-contracts/v1/gateway-principal/contract.md`
+
+**Interfaces:**
+- Consumes: Gateway `Principal` union and `BarePrincipalSigner` exactly as production uses them.
+- Produces: a stable fixture with keys `issuer`, `audience`, `key_id`, and `principals`, consumed by Task 3's Rust verifier tests.
+
+- [ ] **Step 1: Write the failing Gateway provider contract test**
+
+Create `src/gateway/tests/contracts/test_bcs_gateway_principal_contract.py`:
+
+```python
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import jwt
+from pydantic import TypeAdapter
+
+from gateway.community.plugins.principal_signer.bare import (
+    BarePrincipalSigner,
+    PrincipalSignerConfig,
+)
+from gateway.community.spi.authn import Principal
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FIXTURE_PATH = (
+    _REPO_ROOT
+    / "src/bcs/api-contracts/v1/gateway-principal/principal-set.json"
+)
+_TEST_ONLY_KEY = "TEST-ONLY-bcs-principal-contract-key-32-bytes"
+
+
+async def test_gateway_serialization_matches_bcs_principal_contract() -> None:
+    raw = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    principals = TypeAdapter(list[Principal]).validate_python(raw["principals"])
+    serialized = [principal.model_dump(mode="json") for principal in principals]
+    assert serialized == raw["principals"]
+
+    now = int(time.time())
+    signer = BarePrincipalSigner(
+        PrincipalSignerConfig(
+            signing_key=_TEST_ONLY_KEY,
+            kid=raw["key_id"],
+            issuer=raw["issuer"],
+            ttl_seconds=60,
+        ),
+        clock=lambda: now,
+    )
+    token = await signer.sign(
+        {principal.type: principal for principal in principals},
+        audience=raw["audience"],
+    )
+
+    header = jwt.get_unverified_header(token)
+    assert header == {"alg": "HS256", "kid": "bare", "typ": "JWT"}
+    claims = jwt.decode(
+        token,
+        _TEST_ONLY_KEY,
+        algorithms=["HS256"],
+        audience="bcs",
+        issuer="gateway",
+    )
+    assert claims["iat"] == now
+    assert claims["exp"] == now + 60
+    assert claims["principals"] == raw["principals"]
+```
+
+- [ ] **Step 2: Run the provider test and observe the missing-contract failure**
+
+Run:
+
+```bash
+cd src/gateway
+uv run pytest tests/contracts/test_bcs_gateway_principal_contract.py -q
+```
+
+Expected: FAIL with `FileNotFoundError` for `principal-set.json`. This proves the provider test is reading the shared contract rather than a local copy.
+
+- [ ] **Step 3: Add the exact shared fixture**
+
+Create `src/bcs/api-contracts/v1/gateway-principal/principal-set.json`:
+
+```json
+{
+  "issuer": "gateway",
+  "audience": "bcs",
+  "key_id": "bare",
+  "principals": [
+    {
+      "type": "user",
+      "tenant": "tenant-a",
+      "subject": {
+        "id": "user-1",
+        "username": "alice",
+        "display_name": "Alice",
+        "full_name": null,
+        "tenant_id": "tenant-a"
+      }
+    },
+    {
+      "type": "bot",
+      "tenant": "tenant-a",
+      "bot": {
+        "bot_uuid": "bot-1",
+        "owner_id": "user-1",
+        "token": "TEST_ONLY_BOT_TOKEN_MARKER",
+        "app_id": 7,
+        "agent_code": "agent-1",
+        "tenant": "tenant-a"
+      }
+    },
+    {
+      "type": "app",
+      "tenant": "tenant-a",
+      "app": {
+        "app_id": 7,
+        "app_name": "Contract App",
+        "owners": "contract-owner",
+        "tenant": "tenant-a",
+        "app_type": "THIRD_PARTY"
+      }
+    },
+    {
+      "type": "access_key",
+      "tenant": "tenant-a",
+      "access_key": {
+        "access_key": "ak-test-1",
+        "access_key_token": "TEST_ONLY_ACCESS_KEY_TOKEN_MARKER",
+        "expire_at": "2030-01-01T00:00:00Z"
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Document the fixture's acceptance rules**
+
+Create `src/bcs/api-contracts/v1/gateway-principal/contract.md` with these normative sections and values:
+
+```markdown
+# Gateway Principal Contract for BCS V1
+
+`X-Avernet-Principal` carries one raw compact JWT. The verifier requires
+`alg=HS256`, `typ=JWT`, `kid=bare`, `iss=gateway`, `aud=bcs`, integer `iat` and
+`exp`, and a non-empty `principals` array. It allows one each of `user`, `bot`,
+`app`, and `access_key`; all must agree on one non-blank tenant.
+
+Known Principal types may add fields compatibly. Unknown Principal types,
+duplicate types, removed required fields, mixed tenants, invalid time claims,
+and invalid signatures fail the whole request. BCS never projects `bot.token`
+or `access_key_token` into its internal caller.
+
+This contract is preparatory: BCS V1 is not production-mounted by this change.
+```
+
+- [ ] **Step 5: Run the Gateway provider contract test**
+
+Run:
+
+```bash
+cd src/gateway
+uv run pytest tests/contracts/test_bcs_gateway_principal_contract.py -q
+uv run ruff check tests/contracts/test_bcs_gateway_principal_contract.py
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 6: Commit the provider contract**
+
+```bash
+git add src/gateway/tests/contracts/test_bcs_gateway_principal_contract.py \
+        src/bcs/api-contracts/v1/gateway-principal/contract.md \
+        src/bcs/api-contracts/v1/gateway-principal/principal-set.json
+git commit -m "test(gateway): pin BCS principal token contract"
+```
+
+---
+
+### Task 2: Add the transport-neutral authenticated caller contract
+
+**Files:**
+- Create: `src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs`
+- Create: `src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/Cargo.toml`
+
+**Interfaces:**
+- Consumes: no transport or Gateway wire types.
+- Produces: `AuthenticatedCaller` and four safe identity structs used as Task 3's verifier output.
+
+- [ ] **Step 1: Write the failing caller-contract test**
+
+Create `src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs`:
+
+```rust
+use bcs_service_api::application::v1::{
+    AuthenticatedAccessKeyIdentity, AuthenticatedAppIdentity,
+    AuthenticatedBotIdentity, AuthenticatedCaller, AuthenticatedUserIdentity,
+};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+#[test]
+fn authenticated_caller_preserves_all_identity_kinds_without_selecting_an_actor() {
+    let expire_at = OffsetDateTime::parse("2030-01-01T00:00:00Z", &Rfc3339)
+        .expect("valid contract timestamp");
+    let caller = AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "user-1".into(),
+            username: "alice".into(),
+            display_name: Some("Alice".into()),
+            full_name: None,
+        }),
+        bot: Some(AuthenticatedBotIdentity {
+            bot_uuid: "bot-1".into(),
+            owner_id: "user-1".into(),
+            app_id: 7,
+            agent_code: "agent-1".into(),
+        }),
+        app: Some(AuthenticatedAppIdentity {
+            app_id: 7,
+            app_name: "Contract App".into(),
+            owners: "contract-owner".into(),
+            app_type: "THIRD_PARTY".into(),
+        }),
+        access_key: Some(AuthenticatedAccessKeyIdentity {
+            access_key: "ak-test-1".into(),
+            expire_at,
+        }),
+    };
+
+    assert_eq!(caller.tenant, "tenant-a");
+    assert_eq!(caller.user.as_ref().map(|value| value.id.as_str()), Some("user-1"));
+    assert_eq!(caller.bot.as_ref().map(|value| value.bot_uuid.as_str()), Some("bot-1"));
+    assert_eq!(caller.app.as_ref().map(|value| value.app_id), Some(7));
+    assert_eq!(
+        caller.access_key.as_ref().map(|value| value.access_key.as_str()),
+        Some("ak-test-1"),
+    );
+}
+```
+
+- [ ] **Step 2: Run the focused test and observe missing types**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml \
+  --package bcs-service-api \
+  --test v1_authenticated_caller_contract
+```
+
+Expected: FAIL because the five authenticated identity types are not exported.
+
+- [ ] **Step 3: Add the safe identity types**
+
+Create `src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs` with `Debug, Clone, PartialEq, Eq` structs matching these exact fields:
+
+```rust
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedCaller {
+    pub tenant: String,
+    pub user: Option<AuthenticatedUserIdentity>,
+    pub bot: Option<AuthenticatedBotIdentity>,
+    pub app: Option<AuthenticatedAppIdentity>,
+    pub access_key: Option<AuthenticatedAccessKeyIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedUserIdentity {
+    pub id: String,
+    pub username: String,
+    pub display_name: Option<String>,
+    pub full_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedBotIdentity {
+    pub bot_uuid: String,
+    pub owner_id: String,
+    pub app_id: i64,
+    pub agent_code: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedAppIdentity {
+    pub app_id: i64,
+    pub app_name: String,
+    pub owners: String,
+    pub app_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedAccessKeyIdentity {
+    pub access_key: String,
+    pub expire_at: OffsetDateTime,
+}
+```
+
+Add `time = { workspace = true, features = ["parsing"] }` to `bcs-service-api` dependencies. In `application/v1/mod.rs`, add `pub mod identity;` and re-export all five types explicitly.
+
+- [ ] **Step 4: Run the caller-contract and boundary tests**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml \
+  --package bcs-service-api \
+  --test v1_authenticated_caller_contract \
+  --test boundary_contracts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the internal contract**
+
+```bash
+git add src/bcs/crates/service-api/bcs-service-api/Cargo.toml \
+        src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs \
+        src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs \
+        src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs
+git commit -m "feat(bcs): add authenticated caller contract"
+```
+
+---
+
+### Task 3: Decode a valid Gateway Principal token into the safe caller
+
+**Files:**
+- Modify: `src/bcs/Cargo.toml`
+- Modify: `src/bcs/Cargo.lock`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/Cargo.toml`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs`
+- Create: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/mod.rs`
+- Create: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs`
+- Create: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs`
+- Create: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs`
+
+**Interfaces:**
+- Consumes: Task 1's fixture and Task 2's five authenticated identity types.
+- Produces: `GatewayPrincipalTrust::new`, `GatewayPrincipalTokenVerifier::new`, and `GatewayPrincipalTokenVerifier::verify`, re-exported from `bcs_api_http::v1::gateway_principal`.
+
+- [ ] **Step 1: Add a failing all-identities verifier test module**
+
+Create `gateway_principal/mod.rs` with private `wire`, `verifier`, and test modules, and re-export the verifier API. Add `pub mod gateway_principal;` to `v1/mod.rs`. In `gateway_principal/tests.rs`, load the shared fixture and assert the expected projection:
+
+```rust
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{GatewayPrincipalTokenVerifier, GatewayPrincipalTrust};
+
+const NOW: u64 = 1_785_657_600;
+const TEST_KEY: &[u8] = b"TEST-ONLY-bcs-principal-contract-key-32-bytes";
+
+#[derive(Deserialize)]
+struct ContractFixture {
+    issuer: String,
+    audience: String,
+    key_id: String,
+    principals: Value,
+}
+
+fn fixture() -> ContractFixture {
+    serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../../api-contracts/v1/gateway-principal/principal-set.json"
+    )))
+    .expect("valid shared Principal fixture")
+}
+
+fn mint(fixture: &ContractFixture, principals: Value) -> String {
+    let mut header = Header::new(Algorithm::HS256);
+    header.typ = Some("JWT".into());
+    header.kid = Some(fixture.key_id.clone());
+    encode(
+        &header,
+        &json!({
+            "iss": fixture.issuer,
+            "aud": fixture.audience,
+            "iat": NOW,
+            "exp": NOW + 60,
+            "principals": principals,
+        }),
+        &EncodingKey::from_secret(TEST_KEY),
+    )
+    .expect("test token signs")
+}
+
+fn verifier_from(fixture: &ContractFixture) -> GatewayPrincipalTokenVerifier {
+    let trust = GatewayPrincipalTrust::new(
+        fixture.issuer.clone(),
+        fixture.audience.clone(),
+        fixture.key_id.clone(),
+    )
+    .expect("valid trust");
+    GatewayPrincipalTokenVerifier::new(TEST_KEY, trust).expect("valid verifier")
+}
+
+#[test]
+fn verifies_the_shared_all_identity_fixture_without_projecting_secrets() {
+    let fixture = fixture();
+    let trust = GatewayPrincipalTrust::new(
+        fixture.issuer.clone(),
+        fixture.audience.clone(),
+        fixture.key_id.clone(),
+    )
+    .expect("valid trust");
+    let verifier = GatewayPrincipalTokenVerifier::new(TEST_KEY, trust)
+        .expect("valid verifier");
+    let token = mint(&fixture, fixture.principals.clone());
+
+    let caller = verifier.verify_at(&token, NOW).expect("verified caller");
+
+    assert_eq!(caller.tenant, "tenant-a");
+    assert_eq!(caller.user.as_ref().map(|value| value.id.as_str()), Some("user-1"));
+    assert_eq!(caller.bot.as_ref().map(|value| value.bot_uuid.as_str()), Some("bot-1"));
+    assert_eq!(caller.app.as_ref().map(|value| value.app_id), Some(7));
+    assert_eq!(
+        caller.access_key.as_ref().map(|value| value.access_key.as_str()),
+        Some("ak-test-1"),
+    );
+    let debug = format!("{caller:?}");
+    assert!(!debug.contains("TEST_ONLY_BOT_TOKEN_MARKER"));
+    assert!(!debug.contains("TEST_ONLY_ACCESS_KEY_TOKEN_MARKER"));
+}
+```
+
+Add this selector and the focused combination/order tests:
+
+```rust
+fn select_principals(principals: &Value, kinds: &[&str]) -> Value {
+    Value::Array(
+        principals
+            .as_array()
+            .expect("fixture principals array")
+            .iter()
+            .filter(|principal| {
+                principal["type"]
+                    .as_str()
+                    .is_some_and(|kind| kinds.contains(&kind))
+            })
+            .cloned()
+            .collect(),
+    )
+}
+
+#[test]
+fn accepts_user_only_bot_only_and_user_plus_bot() {
+    let fixture = fixture();
+    for (kinds, expect_user, expect_bot) in [
+        (&["user"][..], true, false),
+        (&["bot"][..], false, true),
+        (&["user", "bot"][..], true, true),
+    ] {
+        let caller = verifier_from(&fixture)
+            .verify_at(&mint(&fixture, select_principals(&fixture.principals, kinds)), NOW)
+            .expect("valid identity combination");
+        assert_eq!(caller.user.is_some(), expect_user);
+        assert_eq!(caller.bot.is_some(), expect_bot);
+    }
+}
+
+#[test]
+fn principal_order_does_not_change_the_normalized_caller() {
+    let fixture = fixture();
+    let forward = verifier_from(&fixture)
+        .verify_at(&mint(&fixture, fixture.principals.clone()), NOW)
+        .expect("forward order");
+    let mut reversed = fixture
+        .principals
+        .as_array()
+        .expect("fixture principals array")
+        .clone();
+    reversed.reverse();
+    let reverse = verifier_from(&fixture)
+        .verify_at(&mint(&fixture, Value::Array(reversed)), NOW)
+        .expect("reverse order");
+    assert_eq!(forward, reverse);
+}
+```
+
+- [ ] **Step 2: Run the focused crate test and observe missing verifier APIs**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml \
+  --package bcs-api-http \
+  gateway_principal
+```
+
+Expected: FAIL because `jsonwebtoken`, `GatewayPrincipalTrust`, and `GatewayPrincipalTokenVerifier` do not exist.
+
+- [ ] **Step 3: Add the approved JWT dependencies**
+
+In workspace dependencies:
+
+```toml
+jsonwebtoken = { version = "11.0.0", default-features = false, features = ["rust_crypto"] }
+```
+
+In `bcs-api-http` dependencies:
+
+```toml
+jsonwebtoken = { workspace = true }
+time = { workspace = true, features = ["parsing"] }
+```
+
+Run `cargo check --manifest-path src/bcs/Cargo.toml --package bcs-api-http` once to resolve and update `src/bcs/Cargo.lock`. Confirm the lockfile selects `jsonwebtoken 11.0.0`.
+
+- [ ] **Step 4: Add the private Gateway wire DTOs**
+
+In `wire.rs`, define these claims and the Serde-tagged union:
+
+```rust
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(super) struct GatewayClaims {
+    pub iss: String,
+    pub aud: String,
+    pub iat: u64,
+    pub exp: u64,
+    pub principals: Vec<GatewayPrincipal>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum GatewayPrincipal {
+    User { tenant: String, subject: GatewayUser },
+    Bot { tenant: String, bot: GatewayBot },
+    App { tenant: String, app: GatewayApp },
+    AccessKey { tenant: String, access_key: GatewayAccessKey },
+}
+```
+
+Define the nested DTOs with these exact fields:
+
+```rust
+#[derive(Deserialize)]
+pub(super) struct GatewayUser {
+    pub id: String,
+    pub username: String,
+    pub display_name: Option<String>,
+    pub full_name: Option<String>,
+    pub tenant_id: Option<String>,
+}
+#[derive(Deserialize)]
+pub(super) struct GatewayBot {
+    pub bot_uuid: String,
+    pub owner_id: String,
+    pub app_id: i64,
+    pub agent_code: String,
+    pub tenant: String,
+}
+#[derive(Deserialize)]
+pub(super) struct GatewayApp {
+    pub app_id: i64,
+    pub app_name: String,
+    pub owners: String,
+    pub tenant: String,
+    pub app_type: String,
+}
+#[derive(Deserialize)]
+pub(super) struct GatewayAccessKey {
+    pub access_key: String,
+    pub expire_at: String,
+}
+```
+
+Derive only `Deserialize` and test-support traits needed by the module. Do not declare Bot `token` or `access_key_token`; default Serde behavior deliberately ignores those known wire extras.
+
+- [ ] **Step 5: Implement trust construction and the happy-path verifier**
+
+In `verifier.rs`, define these exact public interfaces:
+
+```rust
+pub struct GatewayPrincipalTrust {
+    issuer: String,
+    audience: String,
+    key_id: String,
+}
+
+impl GatewayPrincipalTrust {
+    pub fn new(
+        issuer: impl Into<String>,
+        audience: impl Into<String>,
+        key_id: impl Into<String>,
+    ) -> Result<Self, GatewayPrincipalVerifierBuildError>;
+}
+
+pub struct GatewayPrincipalTokenVerifier {
+    decoding_key: jsonwebtoken::DecodingKey,
+    trust: GatewayPrincipalTrust,
+}
+
+impl GatewayPrincipalTokenVerifier {
+    pub fn new(
+        signing_key: &[u8],
+        trust: GatewayPrincipalTrust,
+    ) -> Result<Self, GatewayPrincipalVerifierBuildError>;
+
+    pub fn verify(
+        &self,
+        token: &str,
+    ) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError>;
+
+    pub(super) fn verify_at(
+        &self,
+        token: &str,
+        now: u64,
+    ) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError>;
+}
+```
+
+Introduce the complete closed error vocabulary with the public API so every
+subsequent validation step preserves the same signatures:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum GatewayPrincipalVerifierBuildError {
+    #[error("Gateway Principal signing key is empty")]
+    EmptySigningKey,
+    #[error("Gateway Principal trust configuration is invalid")]
+    InvalidTrustConfiguration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum GatewayPrincipalVerificationError {
+    #[error("Gateway Principal token is empty")]
+    EmptyToken,
+    #[error("Gateway Principal token header is invalid")]
+    InvalidHeader,
+    #[error("Gateway Principal token algorithm is unsupported")]
+    UnsupportedAlgorithm,
+    #[error("Gateway Principal token type is invalid")]
+    InvalidTokenType,
+    #[error("Gateway Principal token key id is invalid")]
+    InvalidKeyId,
+    #[error("Gateway Principal token signature is invalid")]
+    InvalidSignature,
+    #[error("Gateway Principal token claims are invalid")]
+    InvalidClaims,
+    #[error("Gateway Principal set is invalid")]
+    InvalidPrincipalSet,
+}
+```
+
+Use `decode_header`, require HS256/JWT/the expected key ID, then call `decode::<GatewayClaims>` with `Validation::new(Algorithm::HS256)`. Set issuer and audience; require `exp`, `iss`, and `aud`; set `validate_exp = false` so `verify_at` owns deterministic time checks. `iat` and `principals` remain required through non-optional Serde fields. Convert the four wire variants into the Task 2 identity structs and parse AccessKey expiry with `OffsetDateTime::parse(..., &Rfc3339)`.
+
+Implement `verify` by obtaining the current non-negative Unix timestamp from
+`OffsetDateTime::now_utc()` and delegating to `verify_at`. In
+`gateway_principal/mod.rs`, re-export all four public types explicitly:
+
+```rust
+pub use verifier::{
+    GatewayPrincipalTokenVerifier, GatewayPrincipalTrust,
+    GatewayPrincipalVerificationError, GatewayPrincipalVerifierBuildError,
+};
+```
+
+For this task, implement the successful projection and `iat < exp`; Task 4 adds all fail-closed semantic validation. Never derive `Debug` for the verifier or decoding key holder.
+
+- [ ] **Step 6: Run the happy-path tests**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml \
+  --package bcs-api-http \
+  gateway_principal
+```
+
+Expected: User-only, Bot-only, User+Bot, all-four identities, order independence, and secret-erasure tests PASS.
+
+- [ ] **Step 7: Commit the working consumer projection**
+
+```bash
+git add src/bcs/Cargo.toml src/bcs/Cargo.lock \
+        src/bcs/crates/adapters/http/bcs-api-http/Cargo.toml \
+        src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs \
+        src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal
+git commit -m "feat(bcs): parse gateway principal tokens"
+```
+
+---
+
+### Task 4: Enforce fail-closed JWT and Principal-set validation
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs`
+
+**Interfaces:**
+- Consumes: Task 3's verifier interface; no public signature changes.
+- Produces: deterministic build/request error enums and the complete validation contract from the design.
+
+- [ ] **Step 1: Add failing trust, header, signature, and time tests**
+
+Extend the test helpers so tests can mint with an arbitrary `Header`, signing key, and JSON claims. Add these exact assertions:
+
+```rust
+use bcs_service_api::application::v1::AuthenticatedCaller;
+
+use super::{
+    GatewayPrincipalTokenVerifier, GatewayPrincipalTrust,
+    GatewayPrincipalVerificationError, GatewayPrincipalVerifierBuildError,
+};
+
+fn header(typ: &str, kid: &str) -> Header {
+    let mut header = Header::new(Algorithm::HS256);
+    header.typ = Some(typ.into());
+    header.kid = Some(kid.into());
+    header
+}
+
+fn valid_claims() -> Value {
+    let fixture = fixture();
+    json!({
+        "iss": fixture.issuer,
+        "aud": fixture.audience,
+        "iat": NOW,
+        "exp": NOW + 60,
+        "principals": fixture.principals,
+    })
+}
+
+fn mint_with(header: Header, claims: Value, signing_key: &[u8]) -> String {
+    encode(&header, &claims, &EncodingKey::from_secret(signing_key))
+        .expect("test token signs")
+}
+
+fn verifier() -> GatewayPrincipalTokenVerifier {
+    let fixture = fixture();
+    verifier_from(&fixture)
+}
+
+fn token_with_times(iat: u64, exp: u64) -> String {
+    let mut claims = valid_claims();
+    claims["iat"] = json!(iat);
+    claims["exp"] = json!(exp);
+    mint_with(header("JWT", "bare"), claims, TEST_KEY)
+}
+```
+
+Keep the existing imports of `Algorithm`, `EncodingKey`, `Header`, `encode`,
+`Value`, and `json`; replace the narrower `super` import from Task 3 with the
+one above.
+
+```rust
+#[test]
+fn rejects_wrong_algorithm_before_claims_are_trusted() {
+    let mut header = Header::new(Algorithm::HS512);
+    header.typ = Some("JWT".into());
+    header.kid = Some("bare".into());
+    let token = mint_with(header, valid_claims(), TEST_KEY);
+    assert_eq!(
+        verifier().verify_at(&token, NOW),
+        Err(GatewayPrincipalVerificationError::UnsupportedAlgorithm),
+    );
+}
+
+#[test]
+fn rejects_wrong_token_type_and_key_id() {
+    let wrong_type = mint_with(header("NOT-JWT", "bare"), valid_claims(), TEST_KEY);
+    let wrong_kid = mint_with(header("JWT", "rotated"), valid_claims(), TEST_KEY);
+    assert_eq!(
+        verifier().verify_at(&wrong_type, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidTokenType),
+    );
+    assert_eq!(
+        verifier().verify_at(&wrong_kid, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidKeyId),
+    );
+}
+
+#[test]
+fn rejects_wrong_signature_issuer_and_audience() {
+    let wrong_key = mint_with(header("JWT", "bare"), valid_claims(), b"different-test-key");
+    assert_eq!(
+        verifier().verify_at(&wrong_key, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidSignature),
+    );
+    for (claim, value) in [("iss", "other-gateway"), ("aud", "backend")] {
+        let mut claims = valid_claims();
+        claims[claim] = json!(value);
+        let token = mint_with(header("JWT", "bare"), claims, TEST_KEY);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+        );
+    }
+}
+
+#[test]
+fn enforces_exact_five_second_clock_skew() {
+    let accepted_future = token_with_times(NOW + 5, NOW + 65);
+    let rejected_future = token_with_times(NOW + 6, NOW + 66);
+    let accepted_expired = token_with_times(NOW - 65, NOW - 4);
+    let rejected_expired = token_with_times(NOW - 66, NOW - 5);
+    assert!(verifier().verify_at(&accepted_future, NOW).is_ok());
+    assert_eq!(
+        verifier().verify_at(&rejected_future, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidClaims),
+    );
+    assert!(verifier().verify_at(&accepted_expired, NOW).is_ok());
+    assert_eq!(
+        verifier().verify_at(&rejected_expired, NOW),
+        Err(GatewayPrincipalVerificationError::InvalidClaims),
+    );
+}
+```
+
+Add the remaining trust/shape tests explicitly:
+
+```rust
+#[test]
+fn rejects_empty_trust_material() {
+    let valid = GatewayPrincipalTrust::new("gateway", "bcs", "bare")
+        .expect("valid trust");
+    assert_eq!(
+        GatewayPrincipalTokenVerifier::new(b"", valid).err(),
+        Some(GatewayPrincipalVerifierBuildError::EmptySigningKey),
+    );
+    for values in [("", "bcs", "bare"), ("gateway", "", "bare"), ("gateway", "bcs", "")] {
+        assert!(matches!(
+            GatewayPrincipalTrust::new(values.0, values.1, values.2),
+            Err(GatewayPrincipalVerifierBuildError::InvalidTrustConfiguration),
+        ));
+    }
+}
+
+#[test]
+fn rejects_empty_malformed_and_unsigned_tokens() {
+    let verifier = verifier();
+    assert_eq!(
+        verifier.verify_at("", NOW),
+        Err(GatewayPrincipalVerificationError::EmptyToken),
+    );
+    for token in [
+        "not-a-jwt",
+        "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.",
+    ] {
+        assert_eq!(
+            verifier.verify_at(token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidHeader),
+        );
+    }
+}
+
+#[test]
+fn rejects_missing_required_claims() {
+    for claim in ["iss", "aud", "iat", "exp", "principals"] {
+        let mut claims = valid_claims();
+        claims.as_object_mut().expect("claims object").remove(claim);
+        let token = mint_with(header("JWT", "bare"), claims, TEST_KEY);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+            "missing {claim}",
+        );
+    }
+}
+
+#[test]
+fn rejects_invalid_claim_shapes() {
+    for (claim, value) in [
+        ("iat", json!("1785657600")),
+        ("exp", json!(null)),
+        ("principals", json!({})),
+    ] {
+        let mut claims = valid_claims();
+        claims[claim] = value;
+        let token = mint_with(header("JWT", "bare"), claims, TEST_KEY);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+            "invalid shape for {claim}",
+        );
+    }
+}
+
+#[test]
+fn rejects_non_positive_token_lifetime() {
+    for (iat, exp) in [(NOW, NOW), (NOW + 1, NOW)] {
+        let token = token_with_times(iat, exp);
+        assert_eq!(
+            verifier().verify_at(&token, NOW),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Add failing Principal-set validation tests**
+
+Using `valid_claims()` and JSON mutation, add this helper and the semantic
+rejection tests. Fixture ordering is intentionally part of the fixture only,
+not production behavior: User=0, Bot=1, App=2, AccessKey=3.
+
+```rust
+fn verify_principals(principals: Value) -> Result<AuthenticatedCaller, GatewayPrincipalVerificationError> {
+    let mut claims = valid_claims();
+    claims["principals"] = principals;
+    let token = mint_with(header("JWT", "bare"), claims, TEST_KEY);
+    verifier().verify_at(&token, NOW)
+}
+
+#[test]
+fn rejects_empty_unknown_and_duplicate_principal_types() {
+    assert_eq!(
+        verify_principals(json!([])),
+        Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+    );
+
+    let mut unknown = fixture().principals;
+    unknown[0]["type"] = json!("future_identity");
+    assert_eq!(
+        verify_principals(unknown),
+        Err(GatewayPrincipalVerificationError::InvalidClaims),
+    );
+
+    let mut duplicate = fixture().principals;
+    let repeated_user = duplicate[0].clone();
+    duplicate.as_array_mut().expect("principals array").push(repeated_user);
+    assert_eq!(
+        verify_principals(duplicate),
+        Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+    );
+}
+
+#[test]
+fn rejects_missing_required_known_principal_fields() {
+    for (index, field) in [
+        (0, "subject"),
+        (1, "bot"),
+        (2, "app"),
+        (3, "access_key"),
+    ] {
+        let mut principals = fixture().principals;
+        principals[index]
+            .as_object_mut()
+            .expect("principal object")
+            .remove(field);
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidClaims),
+            "missing {field}",
+        );
+    }
+}
+
+#[test]
+fn rejects_mixed_and_contradictory_tenants() {
+    for pointer in [
+        "/1/tenant",
+        "/1/bot/tenant",
+        "/2/app/tenant",
+        "/0/subject/tenant_id",
+    ] {
+        let mut principals = fixture().principals;
+        *principals.pointer_mut(pointer).expect("fixture pointer") = json!("tenant-b");
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+            "tenant mutation at {pointer}",
+        );
+    }
+
+    for value in ["", "   "] {
+        let mut principals = fixture().principals;
+        principals[0]["subject"]["tenant_id"] = json!(value);
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+        );
+    }
+}
+
+#[test]
+fn rejects_blank_stable_identities_and_invalid_access_key_time() {
+    for pointer in [
+        "/0/tenant",
+        "/0/subject/id",
+        "/0/subject/username",
+        "/1/bot/bot_uuid",
+        "/1/bot/owner_id",
+        "/1/bot/agent_code",
+        "/3/access_key/access_key",
+    ] {
+        let mut principals = fixture().principals;
+        *principals.pointer_mut(pointer).expect("fixture pointer") = json!("   ");
+        assert_eq!(
+            verify_principals(principals),
+            Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+            "blank identity at {pointer}",
+        );
+    }
+
+    let mut principals = fixture().principals;
+    principals[3]["access_key"]["expire_at"] = json!("not-rfc3339");
+    assert_eq!(
+        verify_principals(principals),
+        Err(GatewayPrincipalVerificationError::InvalidPrincipalSet),
+    );
+}
+
+#[test]
+fn ignores_future_fields_within_known_principal_types() {
+    let mut principals = fixture().principals;
+    principals[0]["future_principal_field"] = json!(true);
+    principals[0]["subject"]["future_user_field"] = json!(1);
+    principals[1]["bot"]["future_bot_field"] = json!(2);
+    principals[2]["app"]["future_app_field"] = json!(3);
+    principals[3]["access_key"]["future_access_key_field"] = json!(4);
+    assert!(verify_principals(principals).is_ok());
+}
+```
+
+- [ ] **Step 3: Run the new tests and verify they fail for missing validation**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml \
+  --package bcs-api-http \
+  gateway_principal
+```
+
+Expected: the new forgery/time/duplicate/tenant/blank-identity tests FAIL against Task 3's permissive successful projection.
+
+- [ ] **Step 4: Complete the closed build and request error mapping**
+
+Retain the exact error enums introduced in Task 3 without adding raw library
+messages or secret-bearing fields:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum GatewayPrincipalVerifierBuildError {
+    #[error("Gateway Principal signing key is empty")]
+    EmptySigningKey,
+    #[error("Gateway Principal trust configuration is invalid")]
+    InvalidTrustConfiguration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum GatewayPrincipalVerificationError {
+    #[error("Gateway Principal token is empty")]
+    EmptyToken,
+    #[error("Gateway Principal token header is invalid")]
+    InvalidHeader,
+    #[error("Gateway Principal token algorithm is unsupported")]
+    UnsupportedAlgorithm,
+    #[error("Gateway Principal token type is invalid")]
+    InvalidTokenType,
+    #[error("Gateway Principal token key id is invalid")]
+    InvalidKeyId,
+    #[error("Gateway Principal token signature is invalid")]
+    InvalidSignature,
+    #[error("Gateway Principal token claims are invalid")]
+    InvalidClaims,
+    #[error("Gateway Principal set is invalid")]
+    InvalidPrincipalSet,
+}
+```
+
+Map `jsonwebtoken::errors::ErrorKind::InvalidSignature` only to `InvalidSignature`; map every other decode/validation error to `InvalidClaims`. Do not attach the source error.
+
+- [ ] **Step 5: Implement header, time, and Principal-set validation**
+
+Add focused helpers in `verifier.rs`:
+
+```rust
+const CLOCK_SKEW_SECONDS: u64 = 5;
+
+fn validate_times(iat: u64, exp: u64, now: u64) -> Result<(), GatewayPrincipalVerificationError> {
+    let latest_allowed_iat = now.saturating_add(CLOCK_SKEW_SECONDS);
+    let expiration_with_skew = exp.saturating_add(CLOCK_SKEW_SECONDS);
+    if iat >= exp || iat > latest_allowed_iat || now >= expiration_with_skew {
+        return Err(GatewayPrincipalVerificationError::InvalidClaims);
+    }
+    Ok(())
+}
+
+fn is_non_blank(value: &str) -> bool {
+    !value.trim().is_empty()
+}
+```
+
+Normalize Principals into four initially-empty `Option` slots. Reject before assignment when a slot is already occupied. Set the normalized tenant from the first Principal, require every later outer tenant to equal it, and validate each nested tenant before constructing the safe identity. Require the stable identifiers listed in Step 2 to pass `is_non_blank`. Parse AccessKey expiry with RFC 3339; preserve the original identity strings rather than trimming or rewriting them.
+
+Keep unknown-field compatibility by leaving `deny_unknown_fields` off the wire structs. Keep unknown-type rejection through the Serde-tagged enum.
+
+- [ ] **Step 6: Prove errors do not expose credentials**
+
+Add this exact regression test; it signs the shared fixture after making the
+outer tenant invalid, so both synthetic credential markers are present in the
+verified payload but absent from the closed error:
+
+```rust
+#[test]
+fn verification_errors_do_not_expose_tokens_or_keys() {
+    let mut principals = fixture().principals;
+    principals[0]["tenant"] = json!("   ");
+    let mut claims = valid_claims();
+    claims["principals"] = principals;
+    let token = mint_with(header("JWT", "bare"), claims, TEST_KEY);
+
+    let error = verifier()
+        .verify_at(&token, NOW)
+        .expect_err("blank tenant must fail");
+    let message = error.to_string();
+    for forbidden in [
+        "TEST_ONLY_BOT_TOKEN_MARKER",
+        "TEST_ONLY_ACCESS_KEY_TOKEN_MARKER",
+        token.as_str(),
+        std::str::from_utf8(TEST_KEY).expect("ASCII test key"),
+    ] {
+        assert!(!message.contains(forbidden));
+    }
+}
+```
+
+- [ ] **Step 7: Run the complete verifier suite**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml \
+  --package bcs-api-http \
+  gateway_principal
+```
+
+Expected: all success, forgery, time, Principal-shape, tenant, compatibility, and secret-erasure tests PASS.
+
+- [ ] **Step 8: Commit fail-closed validation**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs \
+        src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+git commit -m "feat(bcs): enforce gateway principal trust validation"
+```
+
+---
+
+### Task 5: Enforce boundaries, document staging, and run final verification
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/tests/boundary_contracts.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/CONTEXT.md`
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: executable architecture guards and an explicitly production-unreachable completed slice.
+
+- [ ] **Step 1: Extend the HTTP adapter boundary guards**
+
+In `bcs-api-http/tests/boundary_contract.rs`, add `"bcs-jwt"` to the forbidden manifest dependencies. Add a staging guard that resolves
+`../../../bootstrap/bcs/Cargo.toml` from `CARGO_MANIFEST_DIR` and asserts that no dependency line begins with `bcs-api-http`; use a line-prefix check rather than a broad substring so comments cannot fail it.
+
+- [ ] **Step 2: Extend the Application identity boundary guard**
+
+In `bcs-service-api/tests/boundary_contracts.rs`, read `src/application/v1/identity.rs` and assert that it contains none of these production transport/credential tokens:
+
+```rust
+for forbidden in [
+    "jsonwebtoken",
+    "axum",
+    "HeaderMap",
+    "X-Avernet-Principal",
+    "access_key_token",
+    "bot_token",
+] {
+    assert!(
+        !source.contains(forbidden),
+        "authenticated identity contract must not contain {forbidden}",
+    );
+}
+```
+
+Run both boundary test binaries; they should PASS immediately and then guard future integration work.
+
+- [ ] **Step 3: Update crate context documents**
+
+Update `bcs-api-http/CONTEXT.md` to state that V1 owns the Gateway wire projection and injectable verifier implementation, while HTTP header extraction, production trust selection, and router mounting remain deferred. Update `bcs-service-api/CONTEXT.md` to state that Application V1 owns secret-free `AuthenticatedCaller` contract types but no JWT or HTTP semantics.
+
+- [ ] **Step 4: Format and run focused Rust verification**
+
+Run:
+
+```bash
+cargo fmt --manifest-path src/bcs/Cargo.toml --all
+cargo fmt --manifest-path src/bcs/Cargo.toml --all -- --check
+cargo test --manifest-path src/bcs/Cargo.toml \
+  --package bcs-service-api \
+  --package bcs-api-http
+cargo check --manifest-path src/bcs/Cargo.toml \
+  --package bcs-service-api \
+  --package bcs-api-http \
+  --all-targets
+cargo clippy --manifest-path src/bcs/Cargo.toml \
+  --package bcs-service-api \
+  --package bcs-api-http \
+  --all-targets -- -D warnings
+```
+
+Expected: every command exits 0; existing 27-route tests remain green.
+
+- [ ] **Step 5: Run Gateway provider verification**
+
+Run:
+
+```bash
+cd src/gateway
+uv run pytest tests/contracts/test_bcs_gateway_principal_contract.py -q
+uv run ruff check tests/contracts/test_bcs_gateway_principal_contract.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 6: Verify staging and secret hygiene**
+
+Run from the repository root:
+
+```bash
+git diff --check
+git status --short
+rg -n 'bcs-api-http' src/bcs/crates/bootstrap/bcs/Cargo.toml
+rg -n 'TEST_ONLY_(BOT|ACCESS_KEY)_TOKEN_MARKER' \
+  src/bcs/api-contracts/v1/gateway-principal \
+  src/bcs/crates/adapters/http/bcs-api-http
+```
+
+Expected: no whitespace errors; bootstrap search has no dependency match; marker values appear only in the contract fixture and assertions, never in production Rust sources.
+
+- [ ] **Step 7: Commit boundary and documentation updates**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md \
+        src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs \
+        src/bcs/crates/service-api/bcs-service-api/CONTEXT.md \
+        src/bcs/crates/service-api/bcs-service-api/tests/boundary_contracts.rs
+git commit -m "test(bcs): enforce gateway principal boundaries"
+```
+
+- [ ] **Step 8: Confirm the implementation branch is clean and scoped**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate dev..HEAD
+git diff --stat dev...HEAD
+```
+
+Expected: clean worktree; only the approved design/plan, shared contract, Gateway provider test, BCS identity/verifier code, focused dependency changes, tests, and context docs differ from `dev`.

--- a/src/bcs/docs/superpowers/plans/2026-08-02-bcs-gateway-principal-verifier.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-02-bcs-gateway-principal-verifier.md
@@ -1254,7 +1254,7 @@ Update `bcs-api-http/CONTEXT.md` to state that V1 owns the Gateway wire projecti
 Run:
 
 ```bash
-rustfmt --edition 2024 \
+rustfmt --edition 2024 --config skip_children=true \
   src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs \
   src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs \
   src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs \
@@ -1265,7 +1265,7 @@ rustfmt --edition 2024 \
   src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs \
   src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs \
   src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs
-rustfmt --edition 2024 --check \
+rustfmt --edition 2024 --config skip_children=true --check \
   src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs \
   src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs \
   src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs \

--- a/src/bcs/docs/superpowers/plans/2026-08-02-bcs-gateway-principal-verifier.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-02-bcs-gateway-principal-verifier.md
@@ -1249,13 +1249,33 @@ Run both boundary test binaries; they should PASS immediately and then guard fut
 
 Update `bcs-api-http/CONTEXT.md` to state that V1 owns the Gateway wire projection and injectable verifier implementation, while HTTP header extraction, production trust selection, and router mounting remain deferred. Update `bcs-service-api/CONTEXT.md` to state that Application V1 owns secret-free `AuthenticatedCaller` contract types but no JWT or HTTP semantics.
 
-- [ ] **Step 4: Format and run focused Rust verification**
+- [ ] **Step 4: Format only touched Rust files and run focused verification**
 
 Run:
 
 ```bash
-cargo fmt --manifest-path src/bcs/Cargo.toml --all
-cargo fmt --manifest-path src/bcs/Cargo.toml --all -- --check
+rustfmt --edition 2024 \
+  src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs \
+  src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs \
+  src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs \
+  src/bcs/crates/service-api/bcs-service-api/tests/boundary_contracts.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/mod.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs
+rustfmt --edition 2024 --check \
+  src/bcs/crates/service-api/bcs-service-api/src/application/v1/identity.rs \
+  src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs \
+  src/bcs/crates/service-api/bcs-service-api/tests/v1_authenticated_caller_contract.rs \
+  src/bcs/crates/service-api/bcs-service-api/tests/boundary_contracts.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/mod.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/tests/boundary_contract.rs
 cargo test --manifest-path src/bcs/Cargo.toml \
   --package bcs-service-api \
   --package bcs-api-http
@@ -1269,7 +1289,9 @@ cargo clippy --manifest-path src/bcs/Cargo.toml \
   --all-targets -- -D warnings
 ```
 
-Expected: every command exits 0; existing 27-route tests remain green.
+Expected: every command exits 0; only touched Rust files are formatted and the
+existing 27-route tests remain green. Do not run `cargo fmt` or any workspace
+formatter, per `src/bcs/AGENTS.md` and `src/bcs/CLAUDE.md`.
 
 - [ ] **Step 5: Run Gateway provider verification**
 

--- a/src/bcs/docs/superpowers/plans/2026-08-02-bcs-v1-view-actor-contract.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-02-bcs-v1-view-actor-contract.md
@@ -1,0 +1,154 @@
+# BCS V1 Human Caller Integration Implementation Plan
+
+> **Execution:** Use `superpowers:executing-plans` in this worktree and apply
+> `superpowers:test-driven-development` within each behavior-changing task.
+
+**Goal:** Carry the complete Gateway-authenticated caller through all 32 BCS
+V1 operations, admit only callers with User identity, and implement the
+approved Human, View Actor, owned-Bot, and detail-read authorization rules.
+
+**Architecture:** The HTTP verifier authenticates the signed
+`X-Avernet-Principal` JWT and stores `AuthenticatedCaller`. Delivery DTOs pass
+that caller unchanged. Application use cases project only `caller.user` to the
+existing Human `Principal` for domain authorization. Core and persistence stay
+transport-neutral. Exact `bot.created_by == caller.user.id` is the only V1 Bot
+ownership rule.
+
+**Tech stack:** Rust, Axum, async-trait, existing BCS Application/Core ports,
+OpenAPI 3.1 YAML, pytest/PyYAML Contract tests, Cargo tests.
+
+## Binding behavior
+
+- All 32 operations declare `x-avernet-security: {user: required}`.
+- A valid caller without User is rejected by Application with Forbidden.
+- User plus Bot/App/AccessKey behaves exactly like the same User alone.
+- The three optional `view_bot_id` reads are Group list, Session list, and
+  Session history. Omission means `human_<user.id>`; an explicit Human must be
+  that same Actor; an explicit Bot must have exact `created_by` ownership.
+- Group/Session detail has no `view_bot_id`. Read succeeds when the resource
+  participants contain either the current Human Actor or a Bot created by the
+  current User. This does not grant mutation or message-view authority.
+- Creator relation edges may remain collaboration-eligibility evidence where
+  already defined, but never count as ownership.
+- Legacy HTTP and CLI behavior is unchanged.
+
+---
+
+### Task 1: Finalize and validate the Contract
+
+**Files:**
+- Modify `src/bcs/api-contracts/v1/openapi.yaml`
+- Modify `src/bcs/api-contracts/v1/shared.yaml`
+- Modify `src/bcs/api-contracts/v1/openapi/{bots,friendships,groups,invitations,sessions}.yaml`
+- Modify `src/bcs/tests/openapi/test_contract.py`
+- Modify `src/bcs/tests/openapi/test_bot_v1_contract.py`
+- Modify `src/bcs/tests/openapi/test_group_v1_contract.py`
+- Create `src/bcs/tests/openapi/test_session_v1_contract.py`
+- Modify `src/bcs/docs/superpowers/specs/2026-08-02-bcs-v1-human-caller-integration-design.md`
+
+- [x] Add failing tests for the Gateway security marker and detail-read rules.
+- [x] Use `user: required` on all 32 operations.
+- [x] Expose the shared `view_bot_id` only on the three actor-relative reads.
+- [x] Document Human/owned-Bot participant access for Group and Session detail.
+- [x] Run all OpenAPI tests, validation, and deterministic bundling.
+
+### Task 2: Change the Service API caller boundary
+
+**Files:**
+- Modify `src/bcs/crates/service-api/bcs-service-api/src/application/v1/authorization.rs`
+- Modify `src/bcs/crates/service-api/bcs-service-api/src/application/v1/{bot,friendship,group,invitation,message,session}.rs`
+- Add or modify focused tests under `src/bcs/crates/service-api/bcs-service-api/tests/`
+
+- [ ] Write tests for `require_human`: User-only and multi-identity callers
+  project identically; callers without User return Forbidden.
+- [ ] Add the transport-neutral Human projection and raw User-ID helpers.
+- [ ] Replace every command/query `principal: Principal` with
+  `caller: AuthenticatedCaller`.
+- [ ] Rename `ListBotGroups`/`list_bot_groups` to `ListGroups`/`list_groups`,
+  remove the required path Bot, and add optional `view_bot_id` to both list
+  contracts.
+- [ ] Update message-history documentation to the Human-default participant
+  semantics.
+- [ ] Run the Service API crate tests and formatting check.
+
+### Task 3: Change the HTTP verification and propagation boundary
+
+**Files:**
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/principal.rs`
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/{mod,verifier}.rs`
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/{bot,friendship,group,invitation,session}.rs`
+- Modify `src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/{bot,friendship,group,invitation,session}.rs`
+- Modify route tests under `src/bcs/crates/adapters/http/bcs-api-http/tests/`
+
+- [ ] Write failing verifier tests for missing, duplicate, non-UTF-8, blank,
+  and invalid signed `X-Avernet-Principal`, plus successful full-caller output.
+- [ ] Make `PrincipalVerifier` return `AuthenticatedCaller` and insert it into
+  Axum extensions.
+- [ ] Add the production header adapter that extracts exactly one compact JWT
+  and delegates cryptographic verification.
+- [ ] Change all route extractors and DTO command builders to pass full caller.
+- [ ] Move Group list routing to `GET /openapi/v1/groups` and add the two list
+  `view_bot_id` query fields without adding them to detail routes.
+- [ ] Run the HTTP adapter route and Gateway-principal tests.
+
+### Task 4: Enforce Human admission and exact Bot ownership
+
+**Files:**
+- Modify `src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs`
+- Modify `src/bcs/crates/application/v1/bcs-app-friendship/src/lib.rs`
+- Modify `src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs`
+- Modify their focused test suites.
+
+- [ ] Add failing tests for non-User callers and User-plus-extra-identity callers.
+- [ ] Project Human explicitly in every public use case.
+- [ ] Make Bot and Friendship ownership checks use only exact `created_by`.
+- [ ] Ensure invitation acceptance joins as `human_<user.id>` and never falls
+  back to a Bot identity.
+- [ ] Run all three Application crate test suites.
+
+### Task 5: Implement Group View Actor and detail-read rules
+
+**Files:**
+- Modify `src/bcs/crates/application/v1/bcs-app-group/src/lib.rs`
+- Modify `src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs`
+
+- [ ] Write failing tests for omitted/explicit-Human/owned-Bot list views,
+  invalid/unowned views, pre-pagination filtering, and empty pages.
+- [ ] Resolve an effective list Actor with exact Bot ownership and no fallback.
+- [ ] Write failing detail tests for direct Human participant, owned-Bot
+  participant, unrelated participants, and creator-relation-only non-ownership.
+- [ ] Implement implicit detail access from Human plus exact-created Bots.
+- [ ] Keep Group mutation authorization on the Human Actor only.
+- [ ] Run the Group Application suite.
+
+### Task 6: Implement Session list, detail, and history rules
+
+**Files:**
+- Modify `src/bcs/crates/application/v1/bcs-app-session/src/lib.rs`
+- Modify `src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs`
+
+- [ ] Write failing list tests for the three View Actor branches, ownership
+  rejection, participant-only filtering, total-before-pagination, and empty pages.
+- [ ] Implement list scoping by the effective participant Actor.
+- [ ] Write failing detail tests matching the Human-or-owned-Bot participant rule.
+- [ ] Implement implicit detail access without exposing a message perspective.
+- [ ] Write failing history tests proving omission equals Human self view,
+  manager/creator has no fallback view, and owned Bot must be a participant.
+- [ ] Remove creator-edge ownership from session self-service operations and
+  implement the approved history visibility/cutoff behavior.
+- [ ] Keep all Session mutation authorization on the Human Actor only.
+- [ ] Run the Session Application suite.
+
+### Task 7: Integration regression and architecture verification
+
+**Files:**
+- Modify only tests or implementation files directly required by failures.
+
+- [ ] Run `cargo fmt --check` for the touched BCS packages/files.
+- [ ] Run focused tests for Service API, five V1 Application crates, and
+  `bcs-api-http`.
+- [ ] Run `cargo test --workspace` if practical; otherwise record the exact
+  remaining gate and reason.
+- [ ] Re-run OpenAPI tests, validation, bundling, and `git diff --check`.
+- [ ] Run the applicable architecture/BCS boundary checks from the repository
+  instructions and inspect the final diff for Legacy API or CLI changes.

--- a/src/bcs/docs/superpowers/plans/2026-08-02-bot-control-plane-v1-contract.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-02-bot-control-plane-v1-contract.md
@@ -1,0 +1,115 @@
+# Bot Control-plane OpenAPI V1 Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the approved Bot domain model and five Human control-plane operations to the modular BCN OpenAPI V1 contract, without implementing Rust handlers.
+
+**Architecture:** Keep `api-contracts/v1/openapi.yaml` as the public entrypoint. Define reusable Bot response models in `domain-models.yaml`, resource-specific requests and path items in a new `openapi/bots.yaml`, and the `bot_id` path parameter in `shared.yaml`. Contract tests lock down the operation inventory, Human-principal boundary, model variants, mutable fields, filters, ordering, and legacy-compatible query semantics.
+
+**Tech Stack:** OpenAPI 3.1 YAML, JSON Schema composition, Python 3, PyYAML, pytest.
+
+**Approved scope:**
+
+- `GET /openapi/v1/bots/{bot_id}/candidates`
+- `POST /openapi/v1/bots/query`
+- `GET /openapi/v1/bots/{bot_id}`
+- `PATCH /openapi/v1/bots/{bot_id}`
+- `GET /openapi/v1/bots/mine`
+
+The batch deliberately excludes generic `GET /bots`, `/actors/**`, `GET /bots/discover`, and a separate descriptor patch endpoint.
+
+---
+
+### Task 1: Lock the approved operation and security surface
+
+**Files:**
+
+- Modify: `src/bcs/tests/openapi/test_contract.py`
+- Create: `src/bcs/tests/openapi/test_bot_v1_contract.py`
+
+- [x] Add the five Bot operations to the exact public operation inventory.
+- [x] Assert every Bot management operation declares `x-avernet-security.principal: human`.
+- [x] Assert candidates use path `bot_id`, not `acting_bot_id` query input.
+- [x] Assert `kind` accepts only `bot|human` and omission means all kinds.
+- [x] Run the OpenAPI tests and confirm they fail before the contract is added.
+
+Run:
+
+```bash
+cd src/bcs
+python -m pytest tests/openapi -q
+```
+
+Expected: FAIL because the five Bot paths and schemas are not yet present.
+
+---
+
+### Task 2: Define the Bot domain model
+
+**Files:**
+
+- Modify: `src/bcs/api-contracts/v1/domain-models.yaml`
+
+- [x] Define common enums for `kind`, `visibility`, raw `status`, and computed `reachability`.
+- [x] Define `BotDescriptor`, descriptor skills, and optional provider identity without a provider slug.
+- [x] Define a discriminated `Bot` union:
+  - Physical Bot requires `descriptor` and `reachability`; `provider` and `agent_code` are optional.
+  - Human Bot has only common fields and cannot carry physical-Bot fields.
+- [x] Keep `env` required, `created_by` optional, and expose `created_at`/`updated_at` as Unix milliseconds.
+- [x] Define `BotCandidate`, Bot pages, query result, and success envelopes.
+
+---
+
+### Task 3: Define the five Bot resource contracts
+
+**Files:**
+
+- Create: `src/bcs/api-contracts/v1/openapi/bots.yaml`
+- Modify: `src/bcs/api-contracts/v1/shared.yaml`
+- Modify: `src/bcs/api-contracts/v1/openapi.yaml`
+
+- [x] Add reusable `BotIdPath` named `bot_id` without changing legacy `BotUuidPath`.
+- [x] Define candidates behavior:
+  - acting `bot_id` must be a physical Bot managed by the current Human;
+  - `purpose=discovery|collaboration`, default `discovery`;
+  - optional trimmed case-insensitive `name`, `offset=0`, `limit=20`, maximum 100;
+  - same environment, non-deleted physical Bots only, excluding self;
+  - discovery is `public|protected`; collaboration is `public|friend`;
+  - no `status` or `reachability` filtering;
+  - order by `created_at DESC, bot_id ASC`.
+- [x] Define batch query behavior:
+  - request `{bot_ids: [...]}`, maximum 100, duplicates allowed;
+  - preserve first-occurrence input order and de-duplicate;
+  - return both kinds regardless of ownership or visibility;
+  - silently omit missing, deleted, and unonboarded rows; allow an empty request.
+- [x] Define exact-ID read for both kinds with no acting Bot parameter or visibility filter.
+- [x] Define owner-only patch with at least one of `name`, `visibility`, `status`, or partial `descriptor`; descriptor arrays replace the complete array and descriptor is valid only for physical Bots.
+- [x] Define `mine` filters for optional `kind`, `name`, `status`, `reachability`, offset, and limit; omission of kind means both kinds and reachability only matches physical Bots.
+- [x] Reference all paths and public schemas from the root OpenAPI document.
+
+---
+
+### Task 4: Document and verify the modular contract
+
+**Files:**
+
+- Modify: `src/bcs/api-contracts/README.md`
+
+- [x] Document the Bot control-plane batch and validation commands.
+- [x] Run the custom contract validator.
+- [x] Run all OpenAPI tests.
+- [x] Bundle twice and confirm deterministic output plus resolvable discriminator mappings.
+- [x] Review the diff for accidental legacy Actor/API changes and credential fields.
+
+Run:
+
+```bash
+cd src/bcs
+python scripts/validate_openapi_contract.py --root api-contracts/v1
+python -m pytest tests/openapi -q
+python scripts/bundle_openapi_contract.py \
+  --root api-contracts/v1 \
+  --output-dir /tmp/bcn-bot-v1-contract
+```
+
+Expected: validator reports 32 operations; all OpenAPI tests pass; bundling succeeds without unresolved references.

--- a/src/bcs/docs/superpowers/plans/2026-08-02-bot-control-plane-v1-implementation.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-02-bot-control-plane-v1-implementation.md
@@ -1,0 +1,123 @@
+# Bot Control-plane OpenAPI V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` and `superpowers:test-driven-development`.
+
+**Goal:** Implement the five approved Bot control-plane V1 operations as a
+testable BCN vertical slice while preserving all Legacy routes.
+
+**Architecture:** Add a versioned `BotService` contract, a narrow non-sensitive
+control-plane store port, a new `bcs-app-bot` use-case crate, and thin
+`bcs-api-http` routes. Keep production mounting out of this slice because the
+trusted Gateway Principal transport is still a rollout prerequisite.
+
+**Tech Stack:** Rust 1.91, Axum 0.8, Tokio, Serde, async-trait, existing DB and
+cache plugin APIs, Python/PyYAML OpenAPI tests.
+
+---
+
+### Task 1: Define the versioned Bot application contract
+
+**Files:**
+
+- Create: `crates/service-api/bcs-service-api/src/application/v1/bot.rs`
+- Modify: `crates/service-api/bcs-service-api/src/application/v1/mod.rs`
+- Create: `crates/application/v1/bcs-app-bot/Cargo.toml`
+- Create: `crates/application/v1/bcs-app-bot/src/lib.rs`
+- Create: `crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs`
+- Modify: `Cargo.toml`
+
+- [ ] Add a compile-time test using the five commands and `BotService` methods.
+- [ ] Run `cargo test -p bcs-app-bot --test v1_bot_service` and confirm RED
+  because the V1 Bot contract is absent.
+- [ ] Define the serializable V1 Bot models, page/result types, commands,
+  patches, filters, and `BotService` trait.
+- [ ] Keep HTTP/Axum types out of the contract and application crate.
+- [ ] Re-run the focused test until the contract compiles; behavioral tests may
+  remain red until Task 3.
+
+### Task 2: Add the narrow control-plane persistence boundary
+
+**Files:**
+
+- Create: `crates/service-api/bcs-service-api/src/port/repo/bot_control_plane.rs`
+- Modify: `crates/service-api/bcs-service-api/src/port/repo/mod.rs`
+- Modify: `crates/service-api/bcs-service-api/src/port/mod.rs`
+- Modify: `crates/service-api/bcs-service-api/src/lib.rs`
+- Modify: `crates/services/bcs-bot-store/src/lib.rs`
+- Modify: `crates/services/bcs-bot-store/src/memory.rs`
+- Create: `crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs`
+
+- [ ] Add conformance tests for exact/batch reads, both kinds, Unix-ms audit
+  timestamps, first-occurrence ordering, candidate visibility/friendship/order,
+  owned static filters, patch replacement semantics, and no credential fields.
+- [ ] Run the new conformance test and confirm RED because the port and store
+  implementations are absent.
+- [ ] Implement the port records/queries and `PersistentBotRepo` mapping using
+  dialect-aware `gmt_create/gmt_modified` projections.
+- [ ] Implement the equivalent `MemoryBotRepo` behavior without changing
+  Legacy query semantics.
+- [ ] Apply name/visibility/status/descriptor patches in one store operation,
+  refresh `updated_at`, and keep hot in-memory state synchronized.
+- [ ] Run the conformance test until GREEN.
+
+### Task 3: Implement Bot application behavior
+
+**Files:**
+
+- Modify: `crates/application/v1/bcs-app-bot/src/lib.rs`
+- Modify: `crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs`
+
+- [ ] Add failing tests for Human-only access, acting-Bot ownership/kind,
+  candidates purposes, query ordering/omission, exact read, owner-only patch,
+  Human descriptor rejection, mine filters, reachability, provider projection,
+  timestamps, and error propagation.
+- [ ] Implement `BotServiceImpl` over `BotControlPlaneRepoPort`,
+  `BotRegistryCoreService`, `FriendCoreService`, `ProviderBotBindingRepoPort`,
+  and `ProviderRepoPort`.
+- [ ] Batch reachability and provider enrichment; never expose provider config,
+  credentials, tokens, webhook URLs, or binding refs.
+- [ ] Run `cargo test -p bcs-app-bot` until GREEN.
+
+### Task 4: Add the five thin HTTP routes
+
+**Files:**
+
+- Create: `crates/adapters/http/bcs-api-http/src/v1/openapi/dto/bot.rs`
+- Create: `crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs`
+- Modify: `crates/adapters/http/bcs-api-http/src/v1/openapi/dto/mod.rs`
+- Modify: `crates/adapters/http/bcs-api-http/src/v1/openapi/routes/mod.rs`
+- Modify: `crates/adapters/http/bcs-api-http/src/v1/openapi/mod.rs`
+- Modify: `crates/adapters/http/bcs-api-http/src/v1/common/state.rs`
+- Create: `crates/adapters/http/bcs-api-http/tests/bot_routes.rs`
+- Modify: existing `bcs-api-http` route test `ApiState::new` call sites
+
+- [ ] Add route tests for all five paths and confirm RED before registering Bot
+  routes/state.
+- [ ] Add strict DTOs with defaults and limits matching the OpenAPI contract.
+- [ ] Forward only verified Principal plus decoded commands to `BotService`.
+- [ ] Return the common envelope and existing `ApplicationError` mapping.
+- [ ] Update test state constructors with a no-op/fake Bot service.
+- [ ] Run `cargo test -p bcs-api-http` until GREEN.
+
+### Task 5: Boundary and regression verification
+
+**Files:**
+
+- Modify if needed: `crates/adapters/http/bcs-api-http/tests/boundary_contract.rs`
+- Modify if needed: `tests/openapi/test_bot_v1_contract.py`
+
+- [ ] Format only the Rust files changed by this implementation.
+- [ ] Run `cargo test -p bcs-app-bot -p bcs-bot-store -p bcs-api-http`.
+- [ ] Run `python -m pytest tests/openapi -q` and the custom OpenAPI validator.
+- [ ] Inspect `git diff -- src/bcs` and confirm no Legacy HTTP behavior or
+  non-BCS files changed.
+- [ ] Run `git diff --check` and summarize any unrun broader gates explicitly.
+
+### Task 6: Review checkpoint
+
+- [ ] Self-review authorization, missing/deleted behavior, timestamp units,
+  query ordering, descriptor replacement, and credential exclusion against the
+  approved OpenAPI annotations.
+- [ ] Use `superpowers:verification-before-completion` before reporting success.
+- [ ] Do not commit or push unless the user explicitly requests it.

--- a/src/bcs/docs/superpowers/specs/2026-08-02-bcs-gateway-principal-verifier-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-02-bcs-gateway-principal-verifier-design.md
@@ -1,0 +1,383 @@
+# BCS Gateway Principal Verifier Design
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorm)
+- **Scope:** Gateway authentication and Principal parsing for the BCS V1 HTTP boundary
+
+## Context
+
+Gateway authenticates the upstream caller, resolves every identity present on
+the request, and forwards the resulting Principal set in a short-lived JWT in
+`X-Avernet-Principal`. The community Gateway signer currently uses HS256 with a
+shared secret and emits `kid`, `iss`, `aud`, `iat`, `exp`, and `principals`.
+
+BCS V1 currently has 27 implemented HTTP operations, but the production
+bootstrap does not mount `bcs-api-http`. Its route tests inject a test-only
+`PrincipalVerifier`, and every V1 Application command currently carries one
+closed `Principal::{Human, Bot}`. That single-actor type cannot represent the
+Gateway identity set: a valid request can contain User, Bot, App, and AccessKey
+at the same time.
+
+This design prepares the trusted Gateway authentication boundary without
+inventing an Actor-selection rule. It deliberately keeps V1 production
+unreachable until a later design decides how each use case selects a Human or
+Bot Actor from a verified caller.
+
+## Goals
+
+1. Verify the current Gateway HS256 Principal token without changing Gateway
+   behavior or relying on mTLS.
+2. Parse all four Gateway Principal kinds and preserve their coexistence.
+3. Convert the wire payload into a transport-neutral, secret-free
+   `AuthenticatedCaller` owned by the V1 Application contract.
+4. Fail closed on malformed, forged, expired, mis-scoped, or internally
+   contradictory identity sets.
+5. Establish shared Gateway-provider and BCS-consumer contract fixtures and
+   tests.
+6. Keep the verifier isolated inside the versioned HTTP adapter so it can be
+   integrated later without leaking JWT concepts into Application services.
+
+## Non-goals
+
+- Do not modify the current 27 V1 Application commands.
+- Do not replace or rename the current single `Principal::{Human, Bot}`.
+- Do not define the Actor-selection policy for User+Bot callers.
+- Do not change route handlers, the current test `PrincipalVerifier`, or HTTP
+  middleware.
+- Do not add bootstrap/config wiring, resolve a production secret, or mount the
+  V1 router.
+- Do not change Gateway signing behavior.
+- Do not reuse the Bot token or AccessKey token forwarded inside the JWT.
+- Do not add scopes that Gateway does not provide.
+
+## Chosen approach
+
+Use the Rust `jsonwebtoken` crate inside
+`bcs-api-http::v1::gateway_principal`. The library handles compact-JWT parsing
+and signature verification; BCS pins HS256 and performs its own BCS-specific
+header, time, Principal-set, and tenant validation.
+
+The alternatives are rejected as follows:
+
+- A manual implementation using `base64`, `hmac`, and `sha2` would duplicate
+  security-sensitive JWT machinery.
+- Extending `bcs-jwt` would couple the V1 HTTP adapter to a concrete service and
+  mix the unrelated BCS session-token claims (`sub/src/iat/exp`) with the
+  Gateway Principal protocol.
+
+## Module and dependency boundaries
+
+```text
+bcs-service-api
+  `-- application/v1/identity.rs
+        transport-neutral authenticated identity contract
+
+bcs-api-http
+  `-- src/v1/gateway_principal/
+        |-- mod.rs
+        |-- wire.rs
+        `-- verifier.rs
+              Gateway JWT wire parsing and verification
+```
+
+Compile-time dependencies remain:
+
+```text
+bcs-api-http --> bcs-service-api
+```
+
+`bcs-service-api` must not depend on Axum, HTTP, JWT, `jsonwebtoken`, bootstrap,
+or concrete services. `bcs-api-http` must not depend on bootstrap, legacy
+`bcs-http`, `bcs-jwt`, or concrete V1 Application implementations.
+
+No `bcs-config-api` or bootstrap change belongs to this batch. The verifier
+constructor receives already-resolved trust material; a later integration
+batch will define how bootstrap resolves and injects it.
+
+## Internal authenticated identity contract
+
+`bcs-service-api::application::v1::identity` defines the following conceptual
+types:
+
+```rust
+pub struct AuthenticatedCaller {
+    pub tenant: String,
+    pub user: Option<AuthenticatedUserIdentity>,
+    pub bot: Option<AuthenticatedBotIdentity>,
+    pub app: Option<AuthenticatedAppIdentity>,
+    pub access_key: Option<AuthenticatedAccessKeyIdentity>,
+}
+
+pub struct AuthenticatedUserIdentity {
+    pub id: String,
+    pub username: String,
+    pub display_name: Option<String>,
+    pub full_name: Option<String>,
+}
+
+pub struct AuthenticatedBotIdentity {
+    pub bot_uuid: String,
+    pub owner_id: String,
+    pub app_id: i64,
+    pub agent_code: String,
+}
+
+pub struct AuthenticatedAppIdentity {
+    pub app_id: i64,
+    pub app_name: String,
+    pub owners: String,
+    pub app_type: String,
+}
+
+pub struct AuthenticatedAccessKeyIdentity {
+    pub access_key: String,
+    pub expire_at: time::OffsetDateTime,
+}
+```
+
+The caller stores one normalized tenant after verification. Nested tenant
+copies are not retained because accepting contradictory tenants is forbidden.
+The four optional identities may coexist, but at least one must be present.
+
+These types contain no raw JWT, Gateway signing metadata, Bot token,
+AccessKey token, HTTP type, or scopes. App and AccessKey are authenticated
+calling context; neither becomes a BCS business Actor in this design.
+
+## External Gateway token contract
+
+The future HTTP integration consumes exactly one non-empty raw compact JWT from
+`X-Avernet-Principal`; it does not use a `Bearer` prefix. Header extraction and
+401 mapping are explicitly deferred from this batch, but the token contract is
+fixed here so the verifier can be implemented and tested independently.
+
+The JOSE header must contain:
+
+```json
+{
+  "alg": "HS256",
+  "typ": "JWT",
+  "kid": "bare"
+}
+```
+
+The claims payload must contain:
+
+```json
+{
+  "iss": "gateway",
+  "aud": "bcs",
+  "iat": 1785657600,
+  "exp": 1785657660,
+  "principals": [
+    {
+      "type": "user",
+      "tenant": "tenant-a",
+      "subject": {
+        "id": "user-1",
+        "username": "alice"
+      }
+    }
+  ]
+}
+```
+
+Initial trust values are therefore:
+
+- algorithm: `HS256`, pinned in code;
+- token type: `JWT`;
+- key ID: `bare`;
+- issuer: `gateway`;
+- audience: `bcs`;
+- clock-skew allowance: 5 seconds.
+
+The verifier receives the expected issuer, audience, and key ID as explicit
+runtime trust inputs so later key rotation and deployment wiring do not require
+the verifier to read environment variables. The accepted algorithm and clock
+skew are not configurable. Construction rejects an empty signing key, issuer,
+audience, or key ID before any token can be verified.
+
+## Gateway wire projection
+
+`wire.rs` privately models the Gateway discriminated union:
+
+- `user`: outer `tenant` plus `subject`;
+- `bot`: outer `tenant` plus nested `bot`;
+- `app`: outer `tenant` plus nested `app`;
+- `access_key`: outer `tenant` plus nested `access_key`.
+
+Unknown fields within a known Principal are ignored so Gateway can add fields
+compatibly. An unknown Principal discriminator is rejected. Required known
+fields cannot be renamed or removed without failing closed.
+
+The private Bot and AccessKey projections intentionally omit `bot.token` and
+`access_key.access_key_token`. Serde ignores these wire fields without storing
+them in a Rust object. BCS also does not require them to be present, allowing
+Gateway to stop forwarding those secrets in a later compatible change.
+
+## Verification pipeline
+
+`GatewayPrincipalTokenVerifier` receives a token string and resolved trust
+material. It does not receive `HeaderMap`, read environment variables, access a
+secret store, select an Actor, or return an HTTP response.
+
+Validation runs in this order:
+
+1. Reject an empty token. Empty trust material has already failed verifier
+   construction.
+2. Decode the JOSE header.
+3. Require `alg=HS256`, `typ=JWT`, and the expected `kid`.
+4. Verify the signature with a `jsonwebtoken::DecodingKey` created from the
+   shared HMAC secret.
+5. Require `iss`, `aud`, `iat`, `exp`, and `principals`.
+6. Require the configured issuer and the exact string audience `bcs`.
+7. Require integer NumericDate values and `iat < exp`.
+8. Reject `iat > now + 5 seconds`.
+9. Reject when `now >= exp + 5 seconds`.
+10. Validate and normalize the complete Principal set.
+11. Return `AuthenticatedCaller` only after every check succeeds.
+
+The public production entrypoint obtains current Unix time from the system
+clock. Verification delegates to an internal `verify_at(token, now)` path so
+unit tests can exercise time boundaries deterministically. The verifier keeps
+`jsonwebtoken` signature verification and algorithm pinning enabled, but turns
+off that library's wall-clock expiration check and applies the time rules above
+inside `verify_at`; otherwise fixed-time contract tests would still depend on
+the machine clock.
+
+## Principal-set validation
+
+- `principals` must contain at least one entry.
+- Each of User, Bot, App, and AccessKey may occur at most once.
+- Principal ordering has no semantic meaning.
+- Every outer tenant must be non-blank and identical.
+- `bot.bot.tenant` and `app.app.tenant` must equal the outer tenant.
+- `user.subject.tenant_id` may be null; when present it must be non-blank and
+  equal the outer tenant.
+- Stable identity fields used by BCS must be non-blank after trimming. These
+  include User ID and username, Bot UUID, Bot owner ID, Bot agent code, and
+  AccessKey ID.
+- AccessKey `expire_at` must parse as RFC 3339 into `OffsetDateTime`.
+- BCS does not independently re-authenticate the underlying AccessKey from
+  `expire_at`; Gateway authenticates that credential, while the Principal JWT
+  `exp` controls this request's authentication lifetime.
+
+BCS accepts User-only, Bot-only, User+Bot, and all other valid combinations. It
+does not impose Backend's user-required admission rule.
+
+## Errors and secret handling
+
+The verifier returns a closed error classification such as:
+
+```rust
+pub enum GatewayPrincipalVerifierBuildError {
+    EmptySigningKey,
+    InvalidTrustConfiguration,
+}
+
+pub enum GatewayPrincipalVerificationError {
+    EmptyToken,
+    InvalidHeader,
+    UnsupportedAlgorithm,
+    InvalidTokenType,
+    InvalidKeyId,
+    InvalidSignature,
+    InvalidClaims,
+    InvalidPrincipalSet,
+}
+```
+
+Construction errors are separate from request-token errors so later bootstrap
+can fail startup on invalid trust configuration. The error contract is
+diagnostic, not a wrapper around raw
+`jsonwebtoken`/Serde errors. It must never include the JWT, signing key, raw
+payload, Bot token, or AccessKey token. HTTP 401 mapping is deferred until the
+middleware integration batch.
+
+The verifier and its decoding key must not derive or implement a `Debug`
+representation that exposes key material.
+
+## Contract fixtures
+
+Add the canonical BCS V1 Gateway Principal contract under:
+
+```text
+src/bcs/api-contracts/v1/gateway-principal/
+  |-- contract.md
+  `-- principal-set.json
+```
+
+The fixture contains one example of all four Principal kinds coexisting.
+Clearly labeled synthetic marker values occupy the Bot-token and
+AccessKey-token fields solely to prove that BCS discards them. The fixture
+contains no real credential, signing key, or reusable long-lived JWT.
+
+Gateway provider tests load the fixture and prove that current Gateway model
+serialization and signer claims match it. BCS consumer tests load the same
+fixture, sign it with an explicitly test-only HMAC key at test time, verify it,
+and assert the normalized `AuthenticatedCaller`. This pins the cross-language
+payload contract without committing a bearer token.
+
+## Test strategy
+
+### Successful verification
+
+- User-only caller.
+- Bot-only caller.
+- User+Bot caller.
+- User+Bot+App+AccessKey caller from the shared fixture.
+- Principal order does not affect the normalized result.
+- Unknown fields on known types are ignored.
+- Forwarded secret fields are absent from the returned identity and any
+  serialization/debug output.
+- Time skew within 5 seconds is accepted.
+
+### Rejection cases
+
+- Empty or malformed compact token.
+- Missing required claim.
+- Unsigned token or algorithm other than HS256.
+- Wrong `typ`, `kid`, issuer, audience, or signing key.
+- Expired token, future-issued token beyond skew, or `iat >= exp`.
+- Missing, non-array, or empty Principal set.
+- Unknown or duplicate Principal kind.
+- Blank stable identity.
+- Mixed outer tenants or nested/outer tenant contradiction.
+- Invalid AccessKey timestamp.
+
+### Boundary and regression tests
+
+- `bcs-service-api::application::v1` remains transport-agnostic.
+- `bcs-api-http` continues to depend only on Application service contracts and
+  HTTP/serialization/security utility crates.
+- Existing V1 route tests and the test-only single-Principal verifier continue
+  to pass unchanged.
+- Production bootstrap still has no `bcs-api-http` mount after this batch.
+
+Focused verification commands are:
+
+```text
+cargo test --package bcs-service-api
+cargo test --package bcs-api-http
+cargo check --package bcs-service-api --all-targets
+cargo check --package bcs-api-http --all-targets
+Gateway Principal provider contract pytest
+BCS boundary/architecture tests
+```
+
+## Staging and follow-up
+
+This batch ends with a verified, tested authentication component that is not
+on the live request path. That is intentional rather than an incomplete
+security fallback.
+
+A separate design must next define:
+
+1. how each V1 use case selects an `ActorPrincipal` when User and Bot coexist;
+2. how all 27 commands carry the complete `AuthenticatedCaller` without losing
+   App and AccessKey context;
+3. bootstrap trust configuration and one-time secret resolution;
+4. middleware extraction, uniform 401 mapping, and V1 router mounting;
+5. end-to-end Gateway-to-BCS coverage.
+
+No production mount may occur before those decisions and migrations are
+complete.

--- a/src/bcs/docs/superpowers/specs/2026-08-02-bcs-v1-human-caller-integration-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-02-bcs-v1-human-caller-integration-design.md
@@ -40,7 +40,13 @@ implicit Human/Bot priority rule now.
    `bot.owner_id`, App owner metadata, or AccessKey metadata.
 7. A `bot_uuid` in a path or request body identifies a managed resource. It
    does not turn the Human caller into that Bot Actor.
-8. Bot-facing APIs, `act_as`, Human-first/Bot-first policies, and duplicated
+8. The three read operations that expose an Actor-relative collaboration view
+   use one explicit View Actor rule: omit `view_bot_id` for the authenticated
+   User's Human Actor, pass that same Human Actor ID explicitly, or pass the
+   UUID of a Bot whose `created_by` equals the authenticated User ID.
+9. Selecting a View Actor scopes returned data. It does not change the caller,
+   impersonate the selected Bot, or grant Group/Session management authority.
+10. Bot-facing APIs, `act_as`, Human-first/Bot-first policies, and duplicated
    Human/Bot HTTP surfaces are out of scope.
 
 ## Goals
@@ -61,7 +67,8 @@ implicit Human/Bot priority rule now.
 
 - Do not add a Bot-facing V1 operation.
 - Do not add `act_as`, Actor-selection headers, or request fields.
-- Do not let a Human impersonate an owned Bot.
+- Do not let a Human impersonate an owned Bot. Selecting an owned Bot as a
+  read-only View Actor is data scoping, not caller substitution.
 - Do not infer Human identity from `AuthenticatedBotIdentity.owner_id`.
 - Do not make App or AccessKey a BCS business Actor.
 - Do not add scopes that Gateway does not provide.
@@ -185,14 +192,17 @@ requirements. App and AccessKey are not evaluated in this batch.
 
 ## Operation semantics
 
-All 32 OpenAPI operations declare `x-avernet-security.principal: human`.
+All 32 OpenAPI operations declare the Gateway-recognized extension
+`x-avernet-security.user: required`. This is the transport contract requiring
+a usable User identity; BCS still receives and retains the complete
+`AuthenticatedCaller`.
 
 | Operation group | Count | Human semantics |
 | --- | ---: | --- |
 | Bot control plane | 5 | Human queries or mutates Bot registry/control-plane records; ownership uses raw User ID against `created_by`. |
-| Bot-scoped Group/Friendship | 7 | Human manages the path or request Bot through `created_by` or creator relations. The Bot remains a target resource, not the caller Actor. |
-| Group | 7 | Human is an independent Group Actor using `human_<subject.id>` for participant, originator, driver, and manager comparisons. |
-| Session | 10 | Human is an independent Session Actor; read/manage/message visibility follows the existing Human Principal rules. |
+| Bot-scoped Friendship | 6 | Human manages the path, request, or resolved receiver Bot only when its `created_by` equals the authenticated User ID. The Bot remains a target resource, not the caller Actor. |
+| Group | 8 | Human is an independent Group Actor using `human_<subject.id>` for participant, originator, driver, and manager comparisons. Group listing may use the authenticated Human or an owned Bot as its View Actor. |
+| Session | 10 | Human is an independent Session Actor. Session listing and message history use the authenticated Human by default and accept an explicitly authorized View Actor. |
 | Invitation | 3 | Human must be authorized to create invitations and is the joining Actor when accepting one. |
 
 ### Bot control-plane operations
@@ -209,20 +219,19 @@ Their Application service continues to compare `caller.user.id` with the
 stored `created_by` value where ownership is required. The other authenticated
 identity kinds neither grant nor deny access.
 
-### Bot-scoped resource operations
+### Bot-scoped Friendship operations
 
 Paths such as:
 
 ```text
 /openapi/v1/bots/collaboration/{bot_uuid}/friendships
-/openapi/v1/bots/collaboration/{bot_uuid}/groups
 ```
 
 remain Human APIs for this batch. The Application service checks that the
-Human manages the named Bot through its `created_by` value or the existing
-creator relation edge. It must not compare `caller.bot.bot_uuid` with the path,
-select the Bot identity, or fall back to Bot after a Human authorization
-failure.
+named Bot's `created_by` equals `caller.user.id`. Creator relation edges, a
+legacy Bot UUID suffix, missing-`created_by` auto-claim, and
+`caller.bot.bot_uuid` do not grant ownership. Application must not select the
+Bot identity or fall back to Bot after a Human authorization failure.
 
 For friend-request acceptance and rejection, Application first loads the
 request, resolves the receiver Bot, then applies the same Human-to-managed-Bot
@@ -236,14 +245,84 @@ its own right. Existing comparisons against Group participants, originator,
 driver, ManagerWorker manager, Session participants, and Session creator use
 `human_<subject.id>`.
 
-Human ownership of a Bot does not imply permission to act as that Bot inside a
-Group or Session. If a Bot is the driver or manager but the Human is not an
-independently authorized Human Actor, the request remains forbidden.
+Human ownership of a Bot does not imply permission to act as that Bot or to
+manage the Bot's Group or Session. If a Bot is the driver or manager but the
+Human is not an independently authorized Human Actor, management requests
+remain forbidden. The read-only View Actor selection below is the only
+exception and scopes data rather than changing the business caller.
 
-Session message visibility continues to use the Human branch of the existing
-policy. An explicit `view_bot_id` may be accepted only when the existing
-Human-to-owned-Bot check permits that view; the Caller having a Bot identity
-does not bypass the ownership check.
+### Unified View Actor contract
+
+These Human HTTP operations use the same optional `view_bot_id` query
+parameter:
+
+```text
+GET /openapi/v1/groups
+GET /openapi/v1/groups/{group_id}/sessions
+GET /openapi/v1/sessions/{session_id}/messages
+```
+
+The first path replaces the Bot-scoped
+`GET /openapi/v1/bots/collaboration/{bot_uuid}/groups` list operation. The
+operation count remains 32 and its operation ID becomes `list_groups`.
+
+Application resolves one effective View Actor before querying data:
+
+| Request value | Effective View Actor | Required authorization |
+| --- | --- | --- |
+| `view_bot_id` omitted | `human_<caller.user.id>` | A usable authenticated User is already required. |
+| `view_bot_id=human_<staff_no>` | The supplied Human Actor | It must equal `human_<caller.user.id>`. |
+| `view_bot_id=<bot_uuid>` | The supplied Bot | The Bot must exist and `bot.created_by == caller.user.id`. |
+
+The parameter name remains `view_bot_id` for compatibility even though it may
+contain the caller's Human Actor ID. A different Human Actor, an unknown Bot,
+a Bot without `created_by`, or a Bot created by another User is rejected with
+the same generic `403 forbidden`. The check never uses a creator relation edge
+and never auto-claims a legacy Bot. Extra Bot/App/AccessKey identities in the
+authenticated Caller do not change the result.
+
+The selected Actor affects only these read operations:
+
+- `list_groups` applies the existing `membership=all|direct|session_only`,
+  search, kind, and strategy filters to the selected Actor's Group relations.
+  Omitting `view_bot_id` therefore lists the authenticated Human Actor's
+  Groups, not Groups belonging to all Bots that the Human created.
+- `list_sessions` returns only Sessions under `group_id` where the selected
+  Actor is a Session Participant. Group membership, ownership, creator, or
+  manager status does not broaden the result set.
+- `list_session_messages` requires the selected Actor to be a Participant of
+  the requested Session and applies that Participant's history cutoff and
+  message-owner visibility rules.
+
+Explicit and default View Actor branches are mutually exclusive. A failed
+explicit View Actor check never falls back to the Human Actor's direct
+permissions. For both list operations, an authorized View Actor with no
+matching relation returns `200` with an empty page. Both `items` and `total`
+must be filtered by the selected Actor before `offset`/`limit` pagination.
+
+For message history, omitting `view_bot_id` is exactly equivalent to passing
+the authenticated Human Actor ID. The Human must be a Session Participant;
+being Group/Session creator, driver, or manager does not create an implicit
+manager view. Likewise, an explicitly selected owned Bot must be a Session
+Participant. A selected Actor that is not a Session Participant is rejected
+with the same generic `403 forbidden`.
+
+View Actor selection does not apply to `get_group`, `get_session`, or any
+Group/Session mutation. In particular, neither detail operation accepts a
+`view_bot_id` query parameter.
+
+Detail reads instead use an implicit read relation derived from the
+authenticated User. `get_group` is readable when the Group participants
+contain either the User's `human_<caller.user.id>` Actor or at least one Bot
+whose `created_by` equals `caller.user.id`. `get_session` applies the same rule
+to Session participants. This owned-Bot intersection grants only the detail
+read: the caller remains Human, no Bot message perspective is selected, and
+no Group or Session management authority is granted. Bot ownership is still
+determined only by exact `created_by`; creator relation edges, UUID suffixes,
+and auto-claim do not count.
+
+All Group and Session mutations continue to evaluate the authenticated Human
+Actor and their operation-specific direct management relations.
 
 ## Error semantics
 
@@ -256,7 +335,10 @@ authorization:
 | JWT valid but `AuthenticatedCaller.user` absent | `403 forbidden` |
 | User present with additional Bot/App/AccessKey identities | Continue as Human |
 | Human does not own or manage a target Bot | `403 forbidden` |
-| Human lacks required Group/Session relation or role | `403 forbidden` |
+| Explicit View Actor is another Human, unknown, unowned, or not a required Session Participant | `403 forbidden` |
+| Authorized View Actor has no matching Group or Session relation in a list operation | `200` with an empty page |
+| Neither the Human Actor nor any Bot created by that Human is a participant for a Group/Session detail read | `403 forbidden` |
+| Human lacks a required Group/Session mutation relation or role | `403 forbidden` |
 | Resource is absent or deliberately hidden by an existing use case | Existing `404` behavior |
 | Request shape or state is invalid | Existing `400`/`409` behavior |
 
@@ -267,34 +349,52 @@ contents.
 
 ## OpenAPI contract changes
 
-The original 27 operations currently use the broader marker:
+Gateway derives route requirements from this extension:
 
 ```yaml
 x-avernet-security:
-  principal: required
+  user: required
 ```
 
-They change to:
+Contract tests must assert that every one of the 32 operations uses exactly
+`{user: required}`. The older `{principal: required}` and locally invented
+`{principal: human}` shapes are not recognized by Gateway and must not appear.
+Invalid Gateway authentication remains `401`; a valid Caller that reaches
+Application without User remains `403` as a defense-in-depth rule.
 
-```yaml
-x-avernet-security:
-  principal: human
+The Group list operation also moves from:
+
+```text
+GET /openapi/v1/bots/collaboration/{bot_uuid}/groups
 ```
 
-The five Bot control-plane operations already use `human` and establish the
-desired response split: invalid Gateway authentication is `401`; a valid
-non-Human Caller is `403`.
+to:
 
-Contract tests must assert that every one of the 32 operations uses `human` and
-that no operation silently reintroduces `required`, `bot`, or an implicit
-multi-Actor contract.
+```text
+GET /openapi/v1/groups?view_bot_id=<optional-view-actor>
+```
+
+The existing `POST /openapi/v1/groups` operation remains on the same path. The
+Group list retains `offset`, `limit`, `q`, `membership`, `kind`, and `strategy`.
+The Session list adds the same optional `view_bot_id` parameter; Session
+message history changes the default from an implicit manager view to the
+authenticated Human Actor's Participant view. All three parameter descriptions
+must document that an explicit Human value may only identify the caller and an
+explicit Bot value requires `created_by` ownership.
+
+`GET /openapi/v1/groups/{group_id}` and
+`GET /openapi/v1/sessions/{session_id}` deliberately do not add
+`view_bot_id`. Their `403` contract documents the implicit participant
+intersection across the caller's Human Actor and Bots created by that User.
 
 ## Compatibility and risk
 
-This is a deliberate narrowing of the unmounted V1 contract. The current
-branch's test verifier can inject Bot Principals into the original 27 routes,
-but production bootstrap does not mount `bcs-api-http`; therefore the change
-does not remove a deployed Bot API.
+This is a deliberate narrowing and path revision of the unmounted V1 contract.
+The current branch's test verifier can inject Bot Principals into the original
+27 routes and the current Group list path embeds a Bot UUID, but production
+bootstrap does not mount `bcs-api-http`; therefore the change does not remove a
+deployed Bot API. Generated V1 clients must update from `list_bot_groups` to
+`list_groups` before this V1 surface is mounted.
 
 Legacy HTTP routes, bot-token authentication, WebSocket behavior, and
 `bcs-cli` remain unchanged. Bot callers continue to use those Legacy surfaces
@@ -329,11 +429,22 @@ Focused contract and regression tests must pin all three boundaries.
 ### Operation-family tests
 
 - All five Bot control-plane operations require Human.
-- All seven Bot-scoped operations authorize only through Human ownership or
-  creator relations.
+- All six Bot-scoped Friendship operations authorize only when the target or
+  resolved Bot's `created_by` equals the authenticated User ID.
 - Group operations use the Human Actor ID for participant and manager rules.
 - Session operations use the Human Actor ID for read, manage, completion,
   participant, and message-visibility rules.
+- Group and Session detail reads succeed when either the Human Actor or an
+  exact-`created_by` owned Bot is a participant, but that implicit relation
+  grants neither management access nor a message perspective.
+- Omitting `view_bot_id` on all three View Actor operations selects the
+  authenticated Human Actor and never expands to owned Bots.
+- Passing the caller's Human Actor is equivalent to omission; passing an owned
+  Bot scopes to that Bot; every other explicit value is Forbidden without
+  fallback.
+- Group and Session list `items` and `total` are both scoped before pagination.
+- Session history requires the selected Human or Bot to be a Session
+  Participant, including when the Human is a creator or manager.
 - Invitation creation uses Human Group/Session authorization and invitation
   acceptance joins as Human.
 - A User+Bot Caller never changes outcome merely because the extra Bot
@@ -342,7 +453,13 @@ Focused contract and regression tests must pin all three boundaries.
 ### Contract and regression tests
 
 - OpenAPI validation counts 32 operations and requires
-  `x-avernet-security.principal: human` on every operation.
+  `x-avernet-security.user: required` on every operation.
+- The operation inventory contains `GET /openapi/v1/groups` with
+  `operationId: list_groups` and excludes the old Bot-scoped Group list path.
+- Group list, Session list, and Session message history expose the documented
+  optional `view_bot_id` parameter.
+- Group and Session detail expose no `view_bot_id` parameter and document the
+  Human-or-created-Bot participant read rule.
 - HTTP route tests distinguish invalid authentication (`401`) from valid
   non-Human callers (`403`).
 - Existing Human behavior and error mappings remain covered.

--- a/src/bcs/docs/superpowers/specs/2026-08-02-bcs-v1-human-caller-integration-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-02-bcs-v1-human-caller-integration-design.md
@@ -1,0 +1,363 @@
+# BCS V1 Human Caller Integration Design
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorm)
+- **Scope:** Principal propagation and Human Actor selection for all 32 implemented BCS V1 HTTP operations
+
+## Context
+
+BCS V1 now contains 32 implemented HTTP operations: the original 27 Group,
+Session, Invitation, and Friendship operations plus five Bot control-plane
+operations. The V1 HTTP adapter still injects one preselected
+`Principal::{Human, Bot}` into request extensions and every Application command
+still carries that single Principal.
+
+The Gateway Principal verifier added in the preceding batch has a different
+and intentionally broader output. It verifies the signed
+`X-Avernet-Principal` JWT and returns a complete, secret-free
+`AuthenticatedCaller` that may contain User, Bot, App, and AccessKey identities
+at the same time.
+
+The current public product surface does not need Bot callers. All 32 operations
+in this batch are Human APIs. A later feature may introduce Bot-facing HTTP
+operations with similar business capabilities, but that feature will make its
+own HTTP contract and Application-reuse decisions rather than adding an
+implicit Human/Bot priority rule now.
+
+## Decision summary
+
+1. All 32 current V1 operations require a usable User identity and execute as
+   a Human Actor.
+2. Gateway verification returns the complete `AuthenticatedCaller`; it never
+   selects a business Actor.
+3. HTTP middleware stores the complete caller in request extensions, and
+   routes pass it unchanged into Application commands.
+4. Each Application use case explicitly selects the Human identity before
+   applying resource authorization.
+5. A Caller that contains User plus Bot, App, or AccessKey is valid. The User
+   is selected; the other identities do not alter authorization.
+6. A valid Caller without User is forbidden. There is no fallback to Bot,
+   `bot.owner_id`, App owner metadata, or AccessKey metadata.
+7. A `bot_uuid` in a path or request body identifies a managed resource. It
+   does not turn the Human caller into that Bot Actor.
+8. Bot-facing APIs, `act_as`, Human-first/Bot-first policies, and duplicated
+   Human/Bot HTTP surfaces are out of scope.
+
+## Goals
+
+- Connect the verified Gateway Caller contract to every implemented V1 use
+  case without losing App or AccessKey calling context.
+- Make the Human-only admission rule explicit in the OpenAPI contract and in
+  Application code.
+- Preserve the existing BCS Human Actor convention and resource-level
+  authorization behavior.
+- Distinguish authentication failures from authenticated callers that are not
+  admitted to a Human API.
+- Keep JWT, headers, and Gateway protocol details out of Application and Core.
+- Avoid speculative abstractions for Bot-facing operations that do not yet
+  exist.
+
+## Non-goals
+
+- Do not add a Bot-facing V1 operation.
+- Do not add `act_as`, Actor-selection headers, or request fields.
+- Do not let a Human impersonate an owned Bot.
+- Do not infer Human identity from `AuthenticatedBotIdentity.owner_id`.
+- Do not make App or AccessKey a BCS business Actor.
+- Do not add scopes that Gateway does not provide.
+- Do not change Legacy HTTP authentication or Legacy CLI behavior.
+- Do not mount the V1 router in production or add bootstrap trust wiring in
+  this batch.
+- Do not migrate Human Actor IDs, `created_by`, relationships, or stored
+  Group/Session data.
+
+## Architecture and data flow
+
+```text
+Gateway-authenticated request
+        |
+        | X-Avernet-Principal: <compact signed JWT>
+        v
+bcs-api-http Gateway verifier
+        | verify signature, iss, aud, kid, time, tenants, identity shapes
+        v
+AuthenticatedCaller { tenant, user?, bot?, app?, access_key? }
+        |
+        | request extension and Application command
+        v
+V1 Application use case
+        | require User; project Human Principal; apply resource authorization
+        v
+existing Application/Core ports and persistence
+```
+
+The trust and policy boundaries remain separate:
+
+- Gateway answers which identities were authenticated.
+- The HTTP verifier proves that the Caller description came from the trusted
+  Gateway and is valid for BCS.
+- The current HTTP contract declares that the operation is a Human API.
+- Application selects Human and decides whether that Human may perform the
+  requested action on the target BCS resource.
+- Core and repositories remain unaware of JWT and HTTP concepts.
+
+## HTTP verifier and middleware contract
+
+The injectable HTTP `PrincipalVerifier` changes from returning a single
+`Principal` to returning the full Caller:
+
+```rust
+#[async_trait]
+pub trait PrincipalVerifier: Send + Sync {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError>;
+}
+```
+
+Its production implementation extracts exactly one non-empty raw compact JWT
+from `X-Avernet-Principal` and delegates cryptographic and wire validation to
+the existing `GatewayPrincipalTokenVerifier`. The middleware inserts
+`AuthenticatedCaller` and `RequestId` into request extensions. It does not
+require User, inspect path parameters, select an Actor, or perform ownership
+checks.
+
+Header absence, malformed header values, invalid JWTs, invalid signatures,
+expired tokens, wrong audience or issuer, and invalid Principal sets all fail
+at this boundary with the same unauthenticated response.
+
+## Application command contract
+
+Every current V1 command or query that carries:
+
+```rust
+pub principal: Principal
+```
+
+changes to carry:
+
+```rust
+pub caller: AuthenticatedCaller
+```
+
+Routes do not discard identities by constructing a Human Principal. This
+preserves the authenticated calling context and prevents transport policy from
+leaking into commands as a pre-authorized Actor.
+
+Application owns one transport-neutral Human projection helper. Each public
+use-case method calls it explicitly before resource authorization:
+
+```rust
+fn require_human(caller: &AuthenticatedCaller) -> Result<Principal, ApplicationError> {
+    let user = caller.user.as_ref().ok_or_else(|| {
+        ApplicationError::forbidden("This operation requires a Human caller")
+    })?;
+
+    Ok(Principal::human(
+        AuthenticatedUser {
+            id: user.id.clone(),
+            username: user.username.clone(),
+            display_name: user.display_name.clone(),
+            full_name: user.full_name.clone(),
+        },
+        caller.tenant.clone(),
+        BTreeSet::new(),
+    ))
+}
+```
+
+The exact helper name and ownership may follow local style, but these
+invariants are binding:
+
+- It consumes `AuthenticatedCaller`, not headers or JWT claims.
+- It selects only `caller.user`.
+- It uses the already-normalized `caller.tenant`.
+- It does not infer or synthesize scopes; Gateway currently supplies none.
+- It does not consult `caller.bot.owner_id`.
+- It returns Forbidden when User is absent.
+- Its result preserves the existing Human Actor mapping:
+  `subject.id = staff-1` becomes `actor_id = human_staff-1` only through the
+  existing Application `Principal::actor_id()` convention.
+
+The full Caller remains available on the command for future audit or policy
+requirements. App and AccessKey are not evaluated in this batch.
+
+## Operation semantics
+
+All 32 OpenAPI operations declare `x-avernet-security.principal: human`.
+
+| Operation group | Count | Human semantics |
+| --- | ---: | --- |
+| Bot control plane | 5 | Human queries or mutates Bot registry/control-plane records; ownership uses raw User ID against `created_by`. |
+| Bot-scoped Group/Friendship | 7 | Human manages the path or request Bot through `created_by` or creator relations. The Bot remains a target resource, not the caller Actor. |
+| Group | 7 | Human is an independent Group Actor using `human_<subject.id>` for participant, originator, driver, and manager comparisons. |
+| Session | 10 | Human is an independent Session Actor; read/manage/message visibility follows the existing Human Principal rules. |
+| Invitation | 3 | Human must be authorized to create invitations and is the joining Actor when accepting one. |
+
+### Bot control-plane operations
+
+The five newly merged operations already require Human semantically:
+
+- `list_my_bots`
+- `query_bots`
+- `get_bot`
+- `update_bot`
+- `list_bot_candidates`
+
+Their Application service continues to compare `caller.user.id` with the
+stored `created_by` value where ownership is required. The other authenticated
+identity kinds neither grant nor deny access.
+
+### Bot-scoped resource operations
+
+Paths such as:
+
+```text
+/openapi/v1/bots/collaboration/{bot_uuid}/friendships
+/openapi/v1/bots/collaboration/{bot_uuid}/groups
+```
+
+remain Human APIs for this batch. The Application service checks that the
+Human manages the named Bot through its `created_by` value or the existing
+creator relation edge. It must not compare `caller.bot.bot_uuid` with the path,
+select the Bot identity, or fall back to Bot after a Human authorization
+failure.
+
+For friend-request acceptance and rejection, Application first loads the
+request, resolves the receiver Bot, then applies the same Human-to-managed-Bot
+authorization. For friendship deletion, the current rule allowing management
+of either endpoint remains, but both checks use the selected Human Principal.
+
+### Group and Session operations
+
+For generic Group and Session resources, the Human is the business Actor in
+its own right. Existing comparisons against Group participants, originator,
+driver, ManagerWorker manager, Session participants, and Session creator use
+`human_<subject.id>`.
+
+Human ownership of a Bot does not imply permission to act as that Bot inside a
+Group or Session. If a Bot is the driver or manager but the Human is not an
+independently authorized Human Actor, the request remains forbidden.
+
+Session message visibility continues to use the Human branch of the existing
+policy. An explicit `view_bot_id` may be accepted only when the existing
+Human-to-owned-Bot check permits that view; the Caller having a Bot identity
+does not bypass the ownership check.
+
+## Error semantics
+
+The response boundary distinguishes authentication from admission and
+authorization:
+
+| Condition | Result |
+| --- | --- |
+| `X-Avernet-Principal` missing, malformed, forged, expired, or scoped to another audience | `401 unauthenticated` |
+| JWT valid but `AuthenticatedCaller.user` absent | `403 forbidden` |
+| User present with additional Bot/App/AccessKey identities | Continue as Human |
+| Human does not own or manage a target Bot | `403 forbidden` |
+| Human lacks required Group/Session relation or role | `403 forbidden` |
+| Resource is absent or deliberately hidden by an existing use case | Existing `404` behavior |
+| Request shape or state is invalid | Existing `400`/`409` behavior |
+
+No error response reveals whether a signature, claim, or Principal-set detail
+caused authentication failure. Application-level Forbidden responses may use
+the existing stable error envelope but must not expose credentials or JWT
+contents.
+
+## OpenAPI contract changes
+
+The original 27 operations currently use the broader marker:
+
+```yaml
+x-avernet-security:
+  principal: required
+```
+
+They change to:
+
+```yaml
+x-avernet-security:
+  principal: human
+```
+
+The five Bot control-plane operations already use `human` and establish the
+desired response split: invalid Gateway authentication is `401`; a valid
+non-Human Caller is `403`.
+
+Contract tests must assert that every one of the 32 operations uses `human` and
+that no operation silently reintroduces `required`, `bot`, or an implicit
+multi-Actor contract.
+
+## Compatibility and risk
+
+This is a deliberate narrowing of the unmounted V1 contract. The current
+branch's test verifier can inject Bot Principals into the original 27 routes,
+but production bootstrap does not mount `bcs-api-http`; therefore the change
+does not remove a deployed Bot API.
+
+Legacy HTTP routes, bot-token authentication, WebSocket behavior, and
+`bcs-cli` remain unchanged. Bot callers continue to use those Legacy surfaces
+until a separately designed V1 Bot API exists.
+
+No persistence schema or data migration is required. The stable Human
+compatibility rules remain:
+
+- Gateway User ID maps to raw `created_by` for ownership checks.
+- BCS maps the same User ID to `human_<id>` for Actor relationships.
+- Tenant remains authenticated context and is not added to existing storage
+  keys in this batch.
+
+The principal implementation risks are accidental privilege fallback,
+discarding the full Caller too early, and treating a path Bot as the caller.
+Focused contract and regression tests must pin all three boundaries.
+
+## Test strategy
+
+### Identity and boundary tests
+
+- `PrincipalVerifier` returns `AuthenticatedCaller` and cannot return a
+  preselected `Principal`.
+- Middleware inserts the full Caller and the Route passes it unchanged into
+  the command.
+- Application and Core remain free of HTTP, JWT, and Gateway wire types.
+- User-only and User+Bot+App+AccessKey Callers both select the same Human Actor.
+- Bot-only, App-only, and AccessKey-only Callers reach Application only after
+  successful authentication and are rejected with Forbidden.
+- No code derives Human from `AuthenticatedBotIdentity.owner_id`.
+
+### Operation-family tests
+
+- All five Bot control-plane operations require Human.
+- All seven Bot-scoped operations authorize only through Human ownership or
+  creator relations.
+- Group operations use the Human Actor ID for participant and manager rules.
+- Session operations use the Human Actor ID for read, manage, completion,
+  participant, and message-visibility rules.
+- Invitation creation uses Human Group/Session authorization and invitation
+  acceptance joins as Human.
+- A User+Bot Caller never changes outcome merely because the extra Bot
+  identity matches a target or resource participant.
+
+### Contract and regression tests
+
+- OpenAPI validation counts 32 operations and requires
+  `x-avernet-security.principal: human` on every operation.
+- HTTP route tests distinguish invalid authentication (`401`) from valid
+  non-Human callers (`403`).
+- Existing Human behavior and error mappings remain covered.
+- Legacy route and CLI tests remain unchanged and passing.
+- Workspace boundary and architecture tests continue to pass.
+
+## Deferred Bot-facing design
+
+When a concrete Bot-facing use case is requested, it will define:
+
+- distinct Bot HTTP paths or operations;
+- Gateway route-security requirements;
+- how the Application selects and validates `caller.bot`;
+- whether and how Human and Bot entrypoints share Application orchestration;
+- Bot-specific authorization, audit attribution, and error behavior.
+
+That future design must not change the meaning of these Human endpoints or add
+automatic Human/Bot fallback to them.

--- a/src/bcs/docs/superpowers/specs/2026-08-02-bot-control-plane-v1-implementation-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-02-bot-control-plane-v1-implementation-design.md
@@ -1,0 +1,121 @@
+# Bot Control-plane OpenAPI V1 Implementation Design
+
+- **Date:** 2026-08-02
+- **Status:** Approved contract, implementation-ready
+- **Scope:** `src/bcs` only
+- **Contract:** `api-contracts/v1/openapi/bots.yaml`
+
+## Goal
+
+Implement the five approved Human control-plane Bot operations without changing
+Legacy Actor/Bot routes or making the new V1 adapter production-reachable before
+the trusted Principal transport is available.
+
+## Vertical Slice
+
+The implementation follows the existing BCN V1 layering:
+
+```text
+bcs-api-http Bot routes
+        -> application::v1::BotService
+        -> bcs-app-bot use-case facade
+        -> BotControlPlaneRepoPort + existing BotRegistry/Friend/Provider ports
+        -> bcs-bot-store implementations
+```
+
+HTTP owns only request decoding, response envelopes, and error translation.
+`bcs-app-bot` owns Human-only authorization, ownership checks, kind rules,
+filter semantics, ordering, reachability/provider enrichment, and V1 projection.
+The store owns SQL/file/in-memory mapping, including `gmt_create` and
+`gmt_modified` conversion.
+
+## Service API
+
+Add `application::v1::bot` with:
+
+- the V1 Bot union and descriptor/provider/reachability value types;
+- commands for candidates, batch query, exact read, patch, and mine;
+- `BotService`, whose methods accept a normalized `Principal` as part of each
+  command and return `ApplicationError`.
+
+Every method rejects `Principal::Bot`. Human ownership uses raw
+`HumanPrincipal.subject.id`, which is the same identity stored in `created_by`.
+
+## Control-plane Store Port
+
+Add a narrow `BotControlPlaneRepoPort` instead of adding timestamps and
+provider-facing fields to Legacy `RegisteredBot`. Its record contains only the
+non-sensitive persisted fields needed by V1:
+
+- identity, kind, name, visibility, raw status, env, optional created_by;
+- descriptor fields and optional read-only agent_code;
+- created_at/updated_at in Unix milliseconds.
+
+The port supports exact read, ordered batch hydration, candidate paging,
+owner-list static filtering, and one partial mutable-field patch. It never
+returns session tokens, agent tokens, provider credentials, endpoints, or
+binding-channel internals.
+
+`PersistentBotRepo` maps `gmt_create/gmt_modified` with dialect-aware Unix-time
+SQL. `MemoryBotRepo` keeps equivalent timestamps in process/file-backed state
+for local and test behavior.
+
+## Use-case Rules
+
+### Candidates
+
+The acting path Bot must exist, be physical, and have
+`created_by == current subject.id`. The query uses the acting Bot's persisted
+environment, excludes self/Humans/deleted rows, and applies the approved
+purpose visibility rules. Friendship is read from the existing Friend core.
+Ordering and pagination happen after all filters.
+
+### Query and Exact Read
+
+Both kinds are projected without ownership or visibility filtering. Batch
+query de-duplicates by first occurrence, preserves request order, and omits
+missing rows. A maximum of 100 IDs is enforced at both HTTP and application
+boundaries.
+
+### Patch
+
+The target must have `created_by == current subject.id`; missing `created_by`
+is forbidden. Name, visibility, raw status, and descriptor are mutable.
+Descriptor updates are physical-Bot-only and replace any supplied arrays in
+full. The store applies the patch in one write and refreshes `updated_at`.
+
+### Mine
+
+Select by `created_by == current subject.id`, then apply optional kind, trimmed
+case-insensitive name, raw status, and computed reachability filters. Omitted
+kind means both kinds. Reachability removes Humans before pagination.
+
+## Projection
+
+Physical Bots receive normalized descriptor fields, effective reachability,
+optional provider `{provider_id, name}`, and optional agent_code. Reachability
+uses the existing batch runtime-active/downlink logic combined with raw
+`status=online`; it introduces no database column. Human records omit all four
+physical-only projections.
+
+Provider metadata is obtained by batching existing binding and provider ports.
+Bindings or providers that cannot be resolved produce no provider projection;
+store failures remain internal errors.
+
+## Rollout Boundary
+
+This slice adds executable services and HTTP route tests through an injected
+`PrincipalVerifier`, matching the existing V1 implementation strategy. It does
+not mount the V1 router in production or invent a Principal signing format.
+Those remain part of the separately approved rollout slice.
+
+## Verification
+
+- store conformance tests for timestamps, ordering, filtering, patch semantics,
+  and credential exclusion;
+- application tests for the authorization and behavior matrix;
+- HTTP route tests for all five methods, DTO validation, envelopes, and error
+  mapping;
+- boundary tests proving HTTP production sources depend only on the V1
+  application Service API;
+- targeted Cargo tests and the OpenAPI contract test suite.

--- a/src/bcs/tests/openapi/test_bot_v1_contract.py
+++ b/src/bcs/tests/openapi/test_bot_v1_contract.py
@@ -1,0 +1,226 @@
+"""Bot control-plane OpenAPI V1 contract decisions."""
+
+import sys
+from pathlib import Path
+
+BCS_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_ROOT = BCS_ROOT / "api-contracts" / "v1"
+sys.path.insert(0, str(BCS_ROOT))
+
+from scripts.validate_openapi_contract import load_contract  # noqa: E402
+
+
+BOT_OPERATIONS = {
+    ("get", "/openapi/v1/bots/{bot_id}/candidates"),
+    ("post", "/openapi/v1/bots/query"),
+    ("get", "/openapi/v1/bots/{bot_id}"),
+    ("patch", "/openapi/v1/bots/{bot_id}"),
+    ("get", "/openapi/v1/bots/mine"),
+}
+
+
+def _contract():
+    return load_contract(CONTRACT_ROOT)
+
+
+def _operation(method: str, path: str):
+    return _contract()["paths"][path][method]
+
+
+def _parameters(operation):
+    return {parameter["name"]: parameter for parameter in operation.get("parameters", [])}
+
+
+def _success_data(operation, status: str = "200"):
+    return operation["responses"][status]["content"]["application/json"]["schema"][
+        "properties"
+    ]["data"]
+
+
+def test_bot_management_operations_are_human_control_plane_only() -> None:
+    contract = _contract()
+
+    for method, path in BOT_OPERATIONS:
+        operation = contract["paths"][path][method]
+        assert operation["x-avernet-security"] == {"principal": "human"}
+
+
+def test_bot_domain_model_is_a_strict_bot_human_union() -> None:
+    bot = _contract()["components"]["schemas"]["Bot"]
+    variants = {
+        variant["properties"]["kind"]["const"]: variant for variant in bot["oneOf"]
+    }
+
+    assert bot["discriminator"]["propertyName"] == "kind"
+    assert set(bot["discriminator"]["mapping"]) == {"bot", "human"}
+    assert set(variants) == {"bot", "human"}
+
+    common_required = {
+        "bot_id",
+        "kind",
+        "name",
+        "visibility",
+        "status",
+        "env",
+        "created_at",
+        "updated_at",
+    }
+    physical = variants["bot"]
+    human = variants["human"]
+
+    assert physical["additionalProperties"] is False
+    assert human["additionalProperties"] is False
+    assert set(physical["required"]) == common_required | {"descriptor", "reachability"}
+    assert set(human["required"]) == common_required
+    assert "created_by" in physical["properties"]
+    assert "created_by" in human["properties"]
+    assert "created_by" not in physical["required"]
+    assert "created_by" not in human["required"]
+
+    physical_only = {"descriptor", "reachability", "provider", "agent_code"}
+    assert physical_only.issubset(physical["properties"])
+    assert physical_only.isdisjoint(human["properties"])
+    assert set(physical["properties"]["provider"]["required"]) == {
+        "provider_id",
+        "name",
+    }
+    assert "slug" not in physical["properties"]["provider"]["properties"]
+
+    descriptor = physical["properties"]["descriptor"]
+    assert set(descriptor["required"]) == {"summary", "domains", "skills", "scopes"}
+    assert set(descriptor["properties"]) == {"summary", "domains", "skills", "scopes"}
+    assert set(descriptor["properties"]["skills"]["items"]["required"]) == {"name"}
+
+    assert set(physical["properties"]["visibility"]["enum"]) == {
+        "public",
+        "protected",
+        "private",
+    }
+    assert set(physical["properties"]["status"]["enum"]) == {"online", "hidden"}
+    assert set(physical["properties"]["reachability"]["enum"]) == {
+        "reachable",
+        "unreachable",
+    }
+    assert "gmt_create" in physical["properties"]["created_at"]["description"]
+    assert "gmt_modified" in physical["properties"]["updated_at"]["description"]
+
+    serialized = repr(bot)
+    for secret in ("session_token", "agent_token", "access_token", "cookie"):
+        assert secret not in serialized
+
+
+def test_candidates_contract_matches_legacy_list_semantics() -> None:
+    operation = _operation("get", "/openapi/v1/bots/{bot_id}/candidates")
+    parameters = _parameters(operation)
+
+    assert set(parameters) == {"bot_id", "purpose", "name", "offset", "limit"}
+    assert parameters["bot_id"]["in"] == "path"
+    assert parameters["bot_id"]["required"] is True
+    assert parameters["purpose"]["schema"] == {
+        "type": "string",
+        "enum": ["discovery", "collaboration"],
+        "default": "discovery",
+    }
+    assert parameters["offset"]["schema"]["default"] == 0
+    assert parameters["limit"]["schema"]["default"] == 20
+    assert parameters["limit"]["schema"]["maximum"] == 100
+    assert "acting_bot_id" not in parameters
+
+    assert operation["x-avernet-behavior"] == {
+        "acting_bot": "managed_physical_bot",
+        "result_kind": "bot",
+        "environment": "same_as_acting_bot",
+        "exclude_self": True,
+        "purpose_visibility": {
+            "discovery": ["public", "protected"],
+            "collaboration": ["public", "friend"],
+        },
+        "status_filter": "none",
+        "reachability_filter": "none",
+        "ordering": ["created_at_desc", "bot_id_asc"],
+    }
+
+    candidate = _success_data(operation)["properties"]["items"]["items"]
+    assert set(candidate["required"]) == {"bot", "is_friend"}
+    assert candidate["properties"]["bot"]["properties"]["kind"]["const"] == "bot"
+
+
+def test_batch_query_is_sparse_ordered_and_not_visibility_filtered() -> None:
+    operation = _operation("post", "/openapi/v1/bots/query")
+    request = operation["requestBody"]["content"]["application/json"]["schema"]
+    bot_ids = request["properties"]["bot_ids"]
+
+    assert request["additionalProperties"] is False
+    assert request["required"] == ["bot_ids"]
+    assert bot_ids["maxItems"] == 100
+    assert bot_ids.get("minItems", 0) == 0
+    assert bot_ids.get("uniqueItems", False) is False
+    assert operation["x-avernet-behavior"] == {
+        "result_kinds": ["bot", "human"],
+        "authorization_filter": "none",
+        "visibility_filter": "none",
+        "deduplicate": "first_occurrence",
+        "ordering": "request_order",
+        "missing": "omit",
+        "deleted": "omit",
+        "unonboarded": "omit",
+    }
+
+    data = _success_data(operation)
+    assert data["required"] == ["items"]
+    assert data["properties"]["items"]["items"]["discriminator"]["propertyName"] == "kind"
+    assert "404" not in operation["responses"]
+
+
+def test_exact_get_has_no_acting_identity_or_visibility_filter() -> None:
+    operation = _operation("get", "/openapi/v1/bots/{bot_id}")
+
+    assert set(_parameters(operation)) == {"bot_id"}
+    assert operation["x-avernet-behavior"] == {
+        "result_kinds": ["bot", "human"],
+        "visibility_filter": "none",
+    }
+    assert _success_data(operation)["discriminator"]["propertyName"] == "kind"
+    assert operation["responses"]["404"]["x-error-codes"] == ["bot_not_found"]
+
+
+def test_bot_patch_exposes_only_the_approved_mutable_fields() -> None:
+    operation = _operation("patch", "/openapi/v1/bots/{bot_id}")
+    request = operation["requestBody"]["content"]["application/json"]["schema"]
+
+    assert set(_parameters(operation)) == {"bot_id"}
+    assert request["minProperties"] == 1
+    assert request["additionalProperties"] is False
+    assert set(request["properties"]) == {"name", "visibility", "status", "descriptor"}
+    descriptor = request["properties"]["descriptor"]
+    assert descriptor["minProperties"] == 1
+    assert descriptor["additionalProperties"] is False
+    assert set(descriptor["properties"]) == {"summary", "domains", "skills", "scopes"}
+    assert operation["x-avernet-behavior"] == {
+        "authorization": "created_by_matches_current_staff_no",
+        "missing_created_by": "forbidden",
+        "descriptor_kind": "bot_only",
+        "descriptor_arrays": "replace",
+    }
+    assert _success_data(operation)["discriminator"]["propertyName"] == "kind"
+
+
+def test_mine_filters_both_kinds_without_an_all_enum_value() -> None:
+    operation = _operation("get", "/openapi/v1/bots/mine")
+    parameters = _parameters(operation)
+
+    assert set(parameters) == {"kind", "name", "status", "reachability", "offset", "limit"}
+    assert parameters["kind"]["schema"]["enum"] == ["bot", "human"]
+    assert "default" not in parameters["kind"]["schema"]
+    assert parameters["limit"]["schema"]["maximum"] == 100
+    assert operation["x-avernet-behavior"] == {
+        "owner_field": "created_by",
+        "owner_value": "current_staff_no",
+        "omitted_kind": "all",
+        "reachability_applies_to": "bot",
+        "ordering": ["created_at_desc", "bot_id_asc"],
+    }
+
+    data = _success_data(operation)
+    assert data["properties"]["items"]["items"]["discriminator"]["propertyName"] == "kind"
+

--- a/src/bcs/tests/openapi/test_bot_v1_contract.py
+++ b/src/bcs/tests/openapi/test_bot_v1_contract.py
@@ -42,7 +42,7 @@ def test_bot_management_operations_are_human_control_plane_only() -> None:
 
     for method, path in BOT_OPERATIONS:
         operation = contract["paths"][path][method]
-        assert operation["x-avernet-security"] == {"principal": "human"}
+        assert operation["x-avernet-security"] == {"user": "required"}
 
 
 def test_bot_domain_model_is_a_strict_bot_human_union() -> None:
@@ -223,4 +223,3 @@ def test_mine_filters_both_kinds_without_an_all_enum_value() -> None:
 
     data = _success_data(operation)
     assert data["properties"]["items"]["items"]["discriminator"]["propertyName"] == "kind"
-

--- a/src/bcs/tests/openapi/test_contract.py
+++ b/src/bcs/tests/openapi/test_contract.py
@@ -1,9 +1,9 @@
-"""Phase-one BCN OpenAPI contract inventory.
+"""Approved BCN OpenAPI V1 contract inventory.
 
-The contract must expose exactly the 27 approved operations across Group,
-GroupParticipant, Session, SessionParticipant, Invitation, and
-Friendship/FriendRequest, and must not expose message-send, Internal API, or
-routing-only path aliases.
+The contract must expose exactly the approved operations across Bot, Group,
+GroupParticipant, Session, SessionParticipant, Invitation, and Friendship /
+FriendRequest, and must not expose message-send, Internal API, or routing-only
+path aliases.
 """
 
 import sys
@@ -18,6 +18,11 @@ from scripts.validate_openapi_contract import load_contract  # noqa: E402
 HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
 
 EXPECTED_OPERATIONS = {
+    ("get", "/openapi/v1/bots/{bot_id}/candidates"),
+    ("post", "/openapi/v1/bots/query"),
+    ("get", "/openapi/v1/bots/{bot_id}"),
+    ("patch", "/openapi/v1/bots/{bot_id}"),
+    ("get", "/openapi/v1/bots/mine"),
     ("get", "/openapi/v1/bots/collaboration/{bot_uuid}/groups"),
     ("post", "/openapi/v1/groups"),
     ("get", "/openapi/v1/groups/{group_id}"),
@@ -58,14 +63,17 @@ def _actual_operations():
     }
 
 
-def test_contract_contains_exactly_the_27_phase_one_operations() -> None:
+def test_contract_contains_exactly_the_32_approved_operations() -> None:
     assert _actual_operations() == EXPECTED_OPERATIONS
 
 
-def test_phase_one_excludes_send_message_internal_and_routing_aliases() -> None:
+def test_contract_excludes_unapproved_runtime_and_routing_surfaces() -> None:
     actual = _actual_operations()
 
     assert ("post", "/openapi/v1/sessions/{session_id}/messages") not in actual
+    assert ("get", "/openapi/v1/bots") not in actual
+    assert ("get", "/openapi/v1/bots/discover") not in actual
+    assert ("patch", "/openapi/v1/bots/{bot_id}/descriptor") not in actual
     assert not any(path.startswith("/openapi/v1/bcn/") for _, path in actual)
     assert not any(path.startswith("/openapi/v1/actors/") for _, path in actual)
     assert not any(path.startswith("/openapi/v1/internal/") for _, path in actual)

--- a/src/bcs/tests/openapi/test_contract.py
+++ b/src/bcs/tests/openapi/test_contract.py
@@ -23,7 +23,7 @@ EXPECTED_OPERATIONS = {
     ("get", "/openapi/v1/bots/{bot_id}"),
     ("patch", "/openapi/v1/bots/{bot_id}"),
     ("get", "/openapi/v1/bots/mine"),
-    ("get", "/openapi/v1/bots/collaboration/{bot_uuid}/groups"),
+    ("get", "/openapi/v1/groups"),
     ("post", "/openapi/v1/groups"),
     ("get", "/openapi/v1/groups/{group_id}"),
     ("patch", "/openapi/v1/groups/{group_id}"),
@@ -67,6 +67,18 @@ def test_contract_contains_exactly_the_32_approved_operations() -> None:
     assert _actual_operations() == EXPECTED_OPERATIONS
 
 
+def test_all_current_operations_require_a_human_caller() -> None:
+    contract = load_contract(CONTRACT_ROOT)
+
+    for path, path_item in contract["paths"].items():
+        for method, operation in path_item.items():
+            if method.lower() not in HTTP_METHODS:
+                continue
+            assert operation["x-avernet-security"] == {"user": "required"}, (
+                f"{method.upper()} {path} must require a Gateway User identity"
+            )
+
+
 def test_contract_excludes_unapproved_runtime_and_routing_surfaces() -> None:
     actual = _actual_operations()
 
@@ -74,6 +86,10 @@ def test_contract_excludes_unapproved_runtime_and_routing_surfaces() -> None:
     assert ("get", "/openapi/v1/bots") not in actual
     assert ("get", "/openapi/v1/bots/discover") not in actual
     assert ("patch", "/openapi/v1/bots/{bot_id}/descriptor") not in actual
+    assert (
+        "get",
+        "/openapi/v1/bots/collaboration/{bot_uuid}/groups",
+    ) not in actual
     assert not any(path.startswith("/openapi/v1/bcn/") for _, path in actual)
     assert not any(path.startswith("/openapi/v1/actors/") for _, path in actual)
     assert not any(path.startswith("/openapi/v1/internal/") for _, path in actual)

--- a/src/bcs/tests/openapi/test_group_v1_contract.py
+++ b/src/bcs/tests/openapi/test_group_v1_contract.py
@@ -31,9 +31,8 @@ def test_group_contract_keeps_the_approved_compatibility_surface() -> None:
     assert "sender_routes" not in serialized
     assert "routing_policy" not in serialized
 
-    list_operation = contract["paths"][
-        "/openapi/v1/bots/collaboration/{bot_uuid}/groups"
-    ]["get"]
+    list_operation = contract["paths"]["/openapi/v1/groups"]["get"]
+    assert list_operation["operationId"] == "list_groups"
     query_names = {
         parameter["name"]
         for parameter in list_operation["parameters"]
@@ -46,7 +45,15 @@ def test_group_contract_keeps_the_approved_compatibility_surface() -> None:
         "membership",
         "kind",
         "strategy",
+        "view_bot_id",
     }
+    view_actor = next(
+        parameter
+        for parameter in list_operation["parameters"]
+        if parameter["name"] == "view_bot_id"
+    )
+    assert view_actor["schema"] == {"type": "string", "minLength": 1}
+    assert view_actor.get("required", False) is False
 
     assert (
         contract["paths"]["/openapi/v1/groups"]["post"]["responses"]["201"]["content"][
@@ -118,6 +125,23 @@ def test_group_contract_keeps_the_approved_compatibility_surface() -> None:
     )
 
 
+def test_group_detail_uses_implicit_human_or_owned_bot_participant_access() -> None:
+    contract = load_contract(CONTRACT_ROOT)
+    operation = contract["paths"]["/openapi/v1/groups/{group_id}"]["get"]
+
+    assert "view_bot_id" not in {
+        parameter["name"]
+        for parameter in operation["parameters"]
+        if parameter["in"] == "query"
+    }
+    forbidden = operation["responses"]["403"]
+    assert forbidden["x-error-codes"] == ["forbidden"]
+    description = forbidden["description"]
+    assert "Human Actor" in description
+    assert "created by that Human" in description
+    assert "Group Participant" in description
+
+
 def test_contract_bundles_to_a_deterministic_document(
     tmp_path: Path,
 ) -> None:
@@ -127,7 +151,7 @@ def test_contract_bundles_to_a_deterministic_document(
 
     assert first == second
     assert "$ref:" not in first
-    assert "operationId: list_bot_groups" in first
+    assert "operationId: list_groups" in first
 
 
 def test_bundled_discriminator_mappings_resolve_inside_the_document(

--- a/src/bcs/tests/openapi/test_session_v1_contract.py
+++ b/src/bcs/tests/openapi/test_session_v1_contract.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+
+BCS_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_ROOT = BCS_ROOT / "api-contracts" / "v1"
+sys.path.insert(0, str(BCS_ROOT))
+
+from scripts.validate_openapi_contract import load_contract  # noqa: E402
+
+
+def _query_parameters(operation: dict) -> dict[str, dict]:
+    return {
+        parameter["name"]: parameter
+        for parameter in operation["parameters"]
+        if parameter["in"] == "query"
+    }
+
+
+def test_session_list_and_history_use_the_shared_view_actor_contract() -> None:
+    contract = load_contract(CONTRACT_ROOT)
+    list_sessions = contract["paths"]["/openapi/v1/groups/{group_id}/sessions"][
+        "get"
+    ]
+    list_messages = contract["paths"][
+        "/openapi/v1/sessions/{session_id}/messages"
+    ]["get"]
+
+    list_queries = _query_parameters(list_sessions)
+    message_queries = _query_parameters(list_messages)
+
+    assert set(list_queries) == {"offset", "limit", "status", "view_bot_id"}
+    assert set(message_queries) == {"before", "limit", "view_bot_id"}
+    assert list_queries["view_bot_id"] == message_queries["view_bot_id"]
+    assert list_queries["view_bot_id"]["schema"] == {
+        "type": "string",
+        "minLength": 1,
+    }
+    assert list_queries["view_bot_id"].get("required", False) is False
+
+
+def test_view_actor_failures_are_forbidden_without_a_bot_not_found_response() -> None:
+    contract = load_contract(CONTRACT_ROOT)
+    operations = [
+        contract["paths"]["/openapi/v1/groups"]["get"],
+        contract["paths"]["/openapi/v1/groups/{group_id}/sessions"]["get"],
+        contract["paths"]["/openapi/v1/sessions/{session_id}/messages"]["get"],
+    ]
+
+    for operation in operations:
+        assert operation["responses"]["403"]["x-error-codes"] == ["forbidden"]
+        assert "bot_not_found" not in {
+            error_code
+            for response in operation["responses"].values()
+            for error_code in response.get("x-error-codes", [])
+        }
+
+
+def test_session_detail_uses_implicit_human_or_owned_bot_participant_access() -> None:
+    contract = load_contract(CONTRACT_ROOT)
+    operation = contract["paths"]["/openapi/v1/sessions/{session_id}"]["get"]
+
+    assert "view_bot_id" not in {
+        parameter["name"]
+        for parameter in operation["parameters"]
+        if parameter["in"] == "query"
+    }
+    forbidden = operation["responses"]["403"]
+    assert forbidden["x-error-codes"] == ["forbidden"]
+    description = forbidden["description"]
+    assert "Human Actor" in description
+    assert "created by that Human" in description
+    assert "Session Participant" in description

--- a/src/gateway/tests/contracts/test_bcs_gateway_principal_contract.py
+++ b/src/gateway/tests/contracts/test_bcs_gateway_principal_contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import jwt
+from pydantic import TypeAdapter
+
+from gateway.community.plugins.principal_signer.bare import (
+    BarePrincipalSigner,
+    PrincipalSignerConfig,
+)
+from gateway.community.spi.authn import Principal
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FIXTURE_PATH = (
+    _REPO_ROOT
+    / "src/bcs/api-contracts/v1/gateway-principal/principal-set.json"
+)
+_TEST_ONLY_KEY = "TEST-ONLY-bcs-principal-contract-key-32-bytes"
+
+
+async def test_gateway_serialization_matches_bcs_principal_contract() -> None:
+    raw = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    principals = TypeAdapter(list[Principal]).validate_python(raw["principals"])
+    serialized = [principal.model_dump(mode="json") for principal in principals]
+    assert serialized == raw["principals"]
+
+    now = int(time.time())
+    signer = BarePrincipalSigner(
+        PrincipalSignerConfig(
+            signing_key=_TEST_ONLY_KEY,
+            kid=raw["key_id"],
+            issuer=raw["issuer"],
+            ttl_seconds=60,
+        ),
+        clock=lambda: now,
+    )
+    token = await signer.sign(
+        {principal.type: principal for principal in principals},
+        audience=raw["audience"],
+    )
+
+    header = jwt.get_unverified_header(token)
+    assert header == {"alg": "HS256", "kid": "bare", "typ": "JWT"}
+    claims = jwt.decode(
+        token,
+        _TEST_ONLY_KEY,
+        algorithms=["HS256"],
+        audience="bcs",
+        issuer="gateway",
+    )
+    assert claims["iat"] == now
+    assert claims["exp"] == now + 60
+    assert claims["principals"] == raw["principals"]


### PR DESCRIPTION
## Problem

BCS V1 had separate gateway-principal and Bot API contract work, but the caller model was not yet applied consistently across the Human-facing API surface. The HTTP layer needed to authenticate Gateway-issued principal tokens without collapsing identities, and each Application use case needed explicit Human admission and resource-specific authorization rules.

Without this integration, V1 endpoints could interpret Human and Bot identities inconsistently, especially for `view_bot_id`, Group/Session reads, Bot ownership, and mutation permissions.

## Solution

- Finalize the OpenAPI contract for all 32 current V1 operations and mark them as requiring an authenticated User identity.
- Validate the signed JWT carried by `X-Avernet-Principal`, reject ambiguous or malformed headers, and preserve the complete `AuthenticatedCaller` through the HTTP and Service API boundaries.
- Require Application use cases to select `caller.user` explicitly; additional Bot identities do not grant authority or change the selected Human actor.
- Define Bot ownership strictly as `bot.created_by == caller.user.id`.
- Support `view_bot_id` only for:
  - `GET /openapi/v1/groups`
  - `GET /openapi/v1/groups/{group_id}/sessions`
  - `GET /openapi/v1/sessions/{session_id}/messages`
- Default an omitted view to `human_<user.id>`; require an explicit Human view to match the caller and an explicit Bot view to reference a Bot created by the caller.
- Scope Group and Session listings to the selected participant view before pagination.
- Authorize Group/Session detail reads when the caller's Human actor is a participant or a Bot created by the caller is a participant.
- Keep mutations Human-direct: ownership of a participant Bot does not implicitly grant Group or Session management permissions.
- Include the Bot control-plane V1 contracts and implementation merged into this branch.
- Add contract, adapter, Application, and regression tests for the complete behavior.

## Validation

Validation completed before publication:

- `cargo test --workspace`
- `cargo check --workspace`
- Focused tests for `bcs-service-api`, `bcs-api-http`, `bcs-app-bot`, `bcs-app-invitation`, `bcs-app-group`, and `bcs-app-session`
- OpenAPI contract tests: 18 passed
- OpenAPI validation: 32 operations validated
- OpenAPI bundle generation
- `git diff --check`

No additional verification was run during the push, as requested.

## Compatibility and risk

- Legacy and CLI routes are unchanged.
- The V1 HTTP adapter remains intentionally unmounted from the production bootstrap, so this PR prepares the contract and implementation without activating a new production route surface.
- Explicit unknown, mismatched, or unowned `view_bot_id` values now fail closed with HTTP 403 and never fall back to the Human view.
- No database migration or new runtime configuration is introduced.

## Spec

- `src/bcs/docs/superpowers/specs/2026-08-02-bcs-v1-human-caller-integration-design.md`
- `src/bcs/docs/superpowers/plans/2026-08-02-bcs-v1-view-actor-contract.md`
