### PR TITLE
fix: preserve Pool layout for empty skill mappings

### DIFF
--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -133,6 +133,38 @@ def test_external_only_mapping_uses_active_marker_as_layout_authority(
     )
 
 
+def test_empty_mapping_uses_active_marker_as_layout_authority(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+
+    assert not mapping_sources_use_pool(
+        engine="hermes",
+        sources=[],
+        home=home,
+    )
+
+    active_marker = home / ".hermes" / "workspace" / "skills-pool" / ".pool-active"
+    active_marker.parent.mkdir(parents=True)
+    active_marker.write_text(
+        json.dumps(
+            {
+                "engine": "hermes",
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                "preparation_id": PREPARATION_ID,
+                "migration_generation": "generation-1",
+                "activation_state": "active",
+            }
+        )
+    )
+
+    assert mapping_sources_use_pool(
+        engine="hermes",
+        sources=[],
+        home=home,
+    )
+
+
 def _prepared_home(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
     home = tmp_path / "home" / "admin"
     workspace = home / ".openclaw" / "workspace"

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -178,7 +178,7 @@ def mapping_sources_use_pool(
         raise ValueError("mapping sources mix Legacy and Pool managed roots")
     if has_pool:
         return True
-    if has_legacy or not sources:
+    if has_legacy:
         return False
     return _active_marker_selects_pool(layout=layout, engine=engine)
 


### PR DESCRIPTION
## Summary

- treat an empty mapping set as Pool when the persisted `.pool-active` marker is valid
- preserve Legacy behavior when no active Pool marker exists
- prevent restart-time empty reconciliation from selecting Legacy layout

## Tests

- shared Pool/OpenClaw/AICoding/Hermes focused suite: 81 passed
- ruff: passed