### PR TITLE
feat(bcs): namespace collaboration API paths

### DIFF
--- a/src/bcs/api-contracts/README.md
+++ b/src/bcs/api-contracts/README.md
@@ -10,17 +10,22 @@ FriendRequest resources.
 
 The Human control-plane Bot batch contains exactly five operations:
 
-- `GET /openapi/v1/bots/{bot_id}/candidates`
-- `POST /openapi/v1/bots/query`
-- `GET /openapi/v1/bots/{bot_id}`
-- `PATCH /openapi/v1/bots/{bot_id}`
-- `GET /openapi/v1/bots/mine`
+- `GET /openapi/v1/bots/collaboration/{bot_id}/candidates`
+- `POST /openapi/v1/bots/collaboration/query`
+- `GET /openapi/v1/bots/collaboration/{bot_id}`
+- `PATCH /openapi/v1/bots/collaboration/{bot_id}`
+- `GET /openapi/v1/bots/collaboration/mine`
 
 These operations deliberately do not add generic `GET /bots`, legacy
 `/actors/**` aliases, runtime discovery, or a separate descriptor patch route.
 All five require a Human Principal. The Bot domain object is discriminated by
 `kind=bot|human`; omission of a `kind` query filter means both kinds rather
 than a synthetic `all` enum value.
+
+Global collaboration Session resources use the distinct
+`/openapi/v1/group-sessions/{session_id}/**` prefix so they do not collide with
+the Gateway's general `/openapi/v1/sessions/**` surface. Creating and listing a
+Group's Sessions remains nested at `/openapi/v1/groups/{group_id}/sessions`.
 
 Validate the contract:
 

--- a/src/bcs/api-contracts/v1/openapi.yaml
+++ b/src/bcs/api-contracts/v1/openapi.yaml
@@ -4,13 +4,13 @@ info:
   version: 1.0.0
   description: Versioned public contract for Bot Collaboration Network resources.
 paths:
-  /openapi/v1/bots/mine:
+  /openapi/v1/bots/collaboration/mine:
     $ref: ./openapi/bots.yaml#/MyBotsPath
-  /openapi/v1/bots/query:
+  /openapi/v1/bots/collaboration/query:
     $ref: ./openapi/bots.yaml#/QueryBotsPath
-  /openapi/v1/bots/{bot_id}:
+  /openapi/v1/bots/collaboration/{bot_id}:
     $ref: ./openapi/bots.yaml#/BotPath
-  /openapi/v1/bots/{bot_id}/candidates:
+  /openapi/v1/bots/collaboration/{bot_id}/candidates:
     $ref: ./openapi/bots.yaml#/BotCandidatesPath
   /openapi/v1/bots/collaboration/{bot_uuid}/friendships:
     $ref: ./openapi/friendships.yaml#/ListFriendshipsPath
@@ -34,17 +34,17 @@ paths:
     $ref: ./openapi/sessions.yaml#/GroupSessionsPath
   /openapi/v1/groups/{group_id}/invitations:
     $ref: ./openapi/invitations.yaml#/CreateGroupInvitationPath
-  /openapi/v1/sessions/{session_id}:
+  /openapi/v1/group-sessions/{session_id}:
     $ref: ./openapi/sessions.yaml#/SessionPath
-  /openapi/v1/sessions/{session_id}/completion:
+  /openapi/v1/group-sessions/{session_id}/completion:
     $ref: ./openapi/sessions.yaml#/SessionCompletionPath
-  /openapi/v1/sessions/{session_id}/messages:
+  /openapi/v1/group-sessions/{session_id}/messages:
     $ref: ./openapi/sessions.yaml#/SessionMessagesPath
-  /openapi/v1/sessions/{session_id}/participants:
+  /openapi/v1/group-sessions/{session_id}/participants:
     $ref: ./openapi/sessions.yaml#/AddSessionParticipantPath
-  /openapi/v1/sessions/{session_id}/participants/{bot_uuid}:
+  /openapi/v1/group-sessions/{session_id}/participants/{bot_uuid}:
     $ref: ./openapi/sessions.yaml#/SessionParticipantPath
-  /openapi/v1/sessions/{session_id}/invitations:
+  /openapi/v1/group-sessions/{session_id}/invitations:
     $ref: ./openapi/invitations.yaml#/CreateSessionInvitationPath
   /openapi/v1/invitations/{token}/accept:
     $ref: ./openapi/invitations.yaml#/AcceptInvitationPath

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs
@@ -20,10 +20,16 @@ use crate::v1::openapi::dto::bot::{
 
 pub fn router() -> Router<ApiState> {
     Router::new()
-        .route("/openapi/v1/bots/{bot_id}/candidates", get(list_candidates))
-        .route("/openapi/v1/bots/query", post(query_bots))
-        .route("/openapi/v1/bots/mine", get(list_mine))
-        .route("/openapi/v1/bots/{bot_id}", get(get_bot).patch(update_bot))
+        .route(
+            "/openapi/v1/bots/collaboration/{bot_id}/candidates",
+            get(list_candidates),
+        )
+        .route("/openapi/v1/bots/collaboration/query", post(query_bots))
+        .route("/openapi/v1/bots/collaboration/mine", get(list_mine))
+        .route(
+            "/openapi/v1/bots/collaboration/{bot_id}",
+            get(get_bot).patch(update_bot),
+        )
 }
 
 fn service(state: &ApiState, request_id: &RequestId) -> Result<Arc<dyn BotService>, ErrorResponse> {

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/invitation.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/invitation.rs
@@ -18,7 +18,7 @@ pub fn router() -> Router<ApiState> {
             post(create_group_invitation),
         )
         .route(
-            "/openapi/v1/sessions/{session_id}/invitations",
+            "/openapi/v1/group-sessions/{session_id}/invitations",
             post(create_session_invitation),
         )
         .route(

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/session.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/session.rs
@@ -25,25 +25,25 @@ pub fn router() -> Router<ApiState> {
             get(list_sessions).post(create_session),
         )
         .route(
-            "/openapi/v1/sessions/{session_id}",
+            "/openapi/v1/group-sessions/{session_id}",
             get(get_session)
                 .patch(update_session)
                 .delete(delete_session),
         )
         .route(
-            "/openapi/v1/sessions/{session_id}/completion",
+            "/openapi/v1/group-sessions/{session_id}/completion",
             post(complete_session),
         )
         .route(
-            "/openapi/v1/sessions/{session_id}/messages",
+            "/openapi/v1/group-sessions/{session_id}/messages",
             get(list_session_messages),
         )
         .route(
-            "/openapi/v1/sessions/{session_id}/participants",
+            "/openapi/v1/group-sessions/{session_id}/participants",
             post(add_session_participant),
         )
         .route(
-            "/openapi/v1/sessions/{session_id}/participants/{bot_uuid}",
+            "/openapi/v1/group-sessions/{session_id}/participants/{bot_uuid}",
             patch(update_session_participant).delete(remove_session_participant),
         )
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
@@ -282,7 +282,7 @@ async fn all_five_bot_routes_forward_verified_human_and_contract_inputs() {
         .clone()
         .oneshot(request(
             "GET",
-            "/openapi/v1/bots/acting/candidates?purpose=collaboration&name=planner&offset=5&limit=10",
+            "/openapi/v1/bots/collaboration/acting/candidates?purpose=collaboration&name=planner&offset=5&limit=10",
             Value::Null,
         ))
         .await
@@ -297,7 +297,7 @@ async fn all_five_bot_routes_forward_verified_human_and_contract_inputs() {
         .clone()
         .oneshot(request(
             "POST",
-            "/openapi/v1/bots/query",
+            "/openapi/v1/bots/collaboration/query",
             json!({"bot_ids": ["bot-2", "bot-1", "bot-2"]}),
         ))
         .await
@@ -306,7 +306,11 @@ async fn all_five_bot_routes_forward_verified_human_and_contract_inputs() {
 
     let got = app
         .clone()
-        .oneshot(request("GET", "/openapi/v1/bots/bot-1", Value::Null))
+        .oneshot(request(
+            "GET",
+            "/openapi/v1/bots/collaboration/bot-1",
+            Value::Null,
+        ))
         .await
         .expect("get response");
     assert_eq!(got.status(), StatusCode::OK);
@@ -315,7 +319,7 @@ async fn all_five_bot_routes_forward_verified_human_and_contract_inputs() {
         .clone()
         .oneshot(request(
             "PATCH",
-            "/openapi/v1/bots/bot-1",
+            "/openapi/v1/bots/collaboration/bot-1",
             json!({
                 "name": "Renamed",
                 "visibility": "protected",
@@ -330,7 +334,7 @@ async fn all_five_bot_routes_forward_verified_human_and_contract_inputs() {
     let mine = app
         .oneshot(request(
             "GET",
-            "/openapi/v1/bots/mine?kind=human&name=vin&status=online&reachability=unreachable&offset=2&limit=3",
+            "/openapi/v1/bots/collaboration/mine?kind=human&name=vin&status=online&reachability=unreachable&offset=2&limit=3",
             Value::Null,
         ))
         .await
@@ -387,7 +391,7 @@ async fn bot_routes_reject_unknown_request_fields_and_missing_principal() {
         .clone()
         .oneshot(request(
             "PATCH",
-            "/openapi/v1/bots/bot-1",
+            "/openapi/v1/bots/collaboration/bot-1",
             json!({"name": "Bot", "created_by": "forged"}),
         ))
         .await
@@ -401,13 +405,31 @@ async fn bot_routes_reject_unknown_request_fields_and_missing_principal() {
     let missing = app
         .oneshot(
             Request::builder()
-                .uri("/openapi/v1/bots/bot-1")
+                .uri("/openapi/v1/bots/collaboration/bot-1")
                 .body(Body::empty())
                 .expect("request"),
         )
         .await
         .expect("missing principal response");
     assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn legacy_bot_control_plane_paths_are_not_mounted() {
+    let service = Arc::new(FakeBotService::default());
+    let app = test_router(service.clone());
+
+    for uri in ["/openapi/v1/bots/bot-1", "/openapi/v1/bots/mine"] {
+        let response = app
+            .clone()
+            .oneshot(request("GET", uri, Value::Null))
+            .await
+            .expect("legacy path response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{uri}");
+    }
+
+    assert!(service.get.lock().expect("get lock").is_none());
+    assert!(service.mine.lock().expect("mine lock").is_none());
 }
 
 fn physical_bot() -> PhysicalBot {

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/invitation_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/invitation_routes.rs
@@ -446,7 +446,7 @@ async fn create_session_invitation_returns_created_and_forwards_principal() {
     let response = app
         .oneshot(authenticated_request(
             "POST",
-            "/openapi/v1/sessions/session-1/invitations",
+            "/openapi/v1/group-sessions/session-1/invitations",
             json!({}),
         ))
         .await
@@ -464,6 +464,29 @@ async fn create_session_invitation_returns_created_and_forwards_principal() {
         assert_eq!(caller_user_id(&created.caller), "staff-1");
         assert_eq!(created.session_id, "session-1");
     }
+}
+
+#[tokio::test]
+async fn legacy_session_invitation_path_is_not_mounted() {
+    let service = Arc::new(FakeInvitationService::default());
+    let app = test_router(service.clone());
+
+    let response = app
+        .oneshot(authenticated_request(
+            "POST",
+            "/openapi/v1/sessions/session-1/invitations",
+            json!({}),
+        ))
+        .await
+        .expect("legacy session invitation response");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert!(
+        service
+            .created_session
+            .lock()
+            .expect("create session lock")
+            .is_none()
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
@@ -557,7 +557,7 @@ async fn get_session_returns_detail() {
     let response = app
         .oneshot(authenticated_request(
             "GET",
-            "/openapi/v1/sessions/session-1",
+            "/openapi/v1/group-sessions/session-1",
             Value::Null,
         ))
         .await
@@ -583,7 +583,7 @@ async fn update_session_returns_updated_detail() {
     let response = app
         .oneshot(authenticated_request(
             "PATCH",
-            "/openapi/v1/sessions/session-1",
+            "/openapi/v1/group-sessions/session-1",
             json!({"title": "Renamed"}),
         ))
         .await
@@ -610,7 +610,7 @@ async fn delete_session_returns_deleted() {
     let response = app
         .oneshot(authenticated_request(
             "DELETE",
-            "/openapi/v1/sessions/session-1",
+            "/openapi/v1/group-sessions/session-1",
             Value::Null,
         ))
         .await
@@ -636,7 +636,7 @@ async fn complete_session_returns_completion_result() {
     let response = app
         .oneshot(authenticated_request(
             "POST",
-            "/openapi/v1/sessions/session-1/completion",
+            "/openapi/v1/group-sessions/session-1/completion",
             Value::Null,
         ))
         .await
@@ -664,7 +664,7 @@ async fn list_session_messages_returns_cursor_page() {
     let response = app
         .oneshot(authenticated_request(
             "GET",
-            "/openapi/v1/sessions/session-1/messages?limit=50",
+            "/openapi/v1/group-sessions/session-1/messages?limit=50",
             Value::Null,
         ))
         .await
@@ -696,7 +696,7 @@ async fn list_session_messages_passes_opaque_before_cursor_through() {
     let response = app
         .oneshot(authenticated_request(
             "GET",
-            "/openapi/v1/sessions/session-1/messages?before=1234567890:42&limit=10",
+            "/openapi/v1/group-sessions/session-1/messages?before=1234567890:42&limit=10",
             Value::Null,
         ))
         .await
@@ -723,7 +723,7 @@ async fn list_session_messages_passes_view_bot_id_through() {
     let response = app
         .oneshot(authenticated_request(
             "GET",
-            "/openapi/v1/sessions/session-1/messages?limit=50&view_bot_id=bot-xyz",
+            "/openapi/v1/group-sessions/session-1/messages?limit=50&view_bot_id=bot-xyz",
             Value::Null,
         ))
         .await
@@ -764,7 +764,7 @@ async fn list_session_messages_surfaces_next_cursor_when_has_more() {
     let response = app
         .oneshot(authenticated_request(
             "GET",
-            "/openapi/v1/sessions/session-1/messages?limit=1",
+            "/openapi/v1/group-sessions/session-1/messages?limit=1",
             Value::Null,
         ))
         .await
@@ -784,7 +784,7 @@ async fn add_session_participant_returns_participant() {
     let response = app
         .oneshot(authenticated_request(
             "POST",
-            "/openapi/v1/sessions/session-1/participants",
+            "/openapi/v1/group-sessions/session-1/participants",
             json!({"bot_uuid": "bot-2", "mode": "muted"}),
         ))
         .await
@@ -813,7 +813,7 @@ async fn update_session_participant_returns_updated_mode() {
     let response = app
         .oneshot(authenticated_request(
             "PATCH",
-            "/openapi/v1/sessions/session-1/participants/bot-2",
+            "/openapi/v1/group-sessions/session-1/participants/bot-2",
             json!({"mode": "muted"}),
         ))
         .await
@@ -841,7 +841,7 @@ async fn remove_session_participant_returns_deleted() {
     let response = app
         .oneshot(authenticated_request(
             "DELETE",
-            "/openapi/v1/sessions/session-1/participants/bot-2",
+            "/openapi/v1/group-sessions/session-1/participants/bot-2",
             Value::Null,
         ))
         .await
@@ -886,7 +886,7 @@ async fn unknown_fields_rejected_with_invalid_request() {
     let patch_response = app
         .oneshot(authenticated_request(
             "PATCH",
-            "/openapi/v1/sessions/session-1",
+            "/openapi/v1/group-sessions/session-1",
             json!({"title": "Renamed", "extra": 1}),
         ))
         .await
@@ -905,7 +905,7 @@ async fn missing_principal_returns_unauthenticated() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/openapi/v1/sessions/session-1")
+                .uri("/openapi/v1/group-sessions/session-1")
                 .body(Body::empty())
                 .expect("request"),
         )
@@ -917,6 +917,28 @@ async fn missing_principal_returns_unauthenticated() {
 }
 
 #[tokio::test]
+async fn legacy_global_session_paths_are_not_mounted() {
+    let session = Arc::new(FakeSessionService::default());
+    let message = Arc::new(FakeSessionMessageService::default());
+    let app = test_session_router(session.clone(), message.clone());
+
+    for uri in [
+        "/openapi/v1/sessions/session-1",
+        "/openapi/v1/sessions/session-1/messages",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(authenticated_request("GET", uri, Value::Null))
+            .await
+            .expect("legacy path response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{uri}");
+    }
+
+    assert!(session.got.lock().expect("get lock").is_none());
+    assert!(message.listed.lock().expect("list messages lock").is_none());
+}
+
+#[tokio::test]
 async fn update_session_participant_requires_mode() {
     let session = Arc::new(FakeSessionService::default());
     let message = Arc::new(FakeSessionMessageService::default());
@@ -925,7 +947,7 @@ async fn update_session_participant_requires_mode() {
     let response = app
         .oneshot(authenticated_request(
             "PATCH",
-            "/openapi/v1/sessions/session-1/participants/bot-2",
+            "/openapi/v1/group-sessions/session-1/participants/bot-2",
             json!({}),
         ))
         .await

--- a/src/bcs/docs/plans/2026-08-03-bcn-collaboration-paths-design.md
+++ b/src/bcs/docs/plans/2026-08-03-bcn-collaboration-paths-design.md
@@ -1,0 +1,88 @@
+# BCN Collaboration Path Alignment Design
+
+**Date:** 2026-08-03  
+**Status:** Approved
+
+## Problem
+
+BCN currently publishes Bot control-plane operations directly under
+`/openapi/v1/bots/**` and global Session operations under
+`/openapi/v1/sessions/**`. Those paths collide with the Gateway's existing
+Backend-owned Bot surface and BaaS-owned Session surface. Directly aggregating
+the BCN contract into the Gateway OpenAPI document would overwrite existing
+paths and make runtime ownership ambiguous.
+
+The public API should retain one top-level Bot vocabulary. Collaboration is a
+Bot capability, not a second kind of Bot or a separate top-level bounded
+context.
+
+## Public Path Contract
+
+BCN owns two unambiguous public prefixes:
+
+```text
+/openapi/v1/bots/collaboration/**
+/openapi/v1/group-sessions/**
+```
+
+The Bot control-plane operations move as follows:
+
+| Existing path | New path |
+| --- | --- |
+| `GET /openapi/v1/bots/mine` | `GET /openapi/v1/bots/collaboration/mine` |
+| `POST /openapi/v1/bots/query` | `POST /openapi/v1/bots/collaboration/query` |
+| `GET /openapi/v1/bots/{bot_id}` | `GET /openapi/v1/bots/collaboration/{bot_id}` |
+| `PATCH /openapi/v1/bots/{bot_id}` | `PATCH /openapi/v1/bots/collaboration/{bot_id}` |
+| `GET /openapi/v1/bots/{bot_id}/candidates` | `GET /openapi/v1/bots/collaboration/{bot_id}/candidates` |
+
+Existing friendship and friend-request operations already live under
+`/openapi/v1/bots/collaboration/{bot_uuid}/**` and remain unchanged.
+
+The global Session resource moves as follows:
+
+| Existing prefix | New prefix |
+| --- | --- |
+| `/openapi/v1/sessions/{session_id}` | `/openapi/v1/group-sessions/{session_id}` |
+
+This includes Session detail, completion, messages, participants, and
+Session invitation operations. The nested collection
+`/openapi/v1/groups/{group_id}/sessions` remains unchanged because its parent
+Group already establishes BCN ownership.
+
+## Contract and Runtime Synchronization
+
+`src/bcs/api-contracts/v1/openapi.yaml` remains the public contract authority.
+Its path keys change in the same commit as the Axum route literals under
+`bcs-api-http`. The operation set, request and response schemas, authorization
+requirements, and application-service calls do not change.
+
+No compatibility aliases are mounted at the old paths. The V1 adapter is not
+production-mounted yet, so keeping duplicate legacy public paths would add
+ambiguity without preserving an active client contract. Tests explicitly prove
+that representative old Bot and Session paths no longer resolve.
+
+## Error Handling
+
+Path migration does not introduce new error semantics. Requests to new paths
+retain the existing V1 envelope and status mappings. Requests to old paths are
+absent from the versioned router and therefore return the router's normal
+not-found or method-not-allowed response.
+
+## Validation
+
+- OpenAPI validation continues to report exactly 32 approved operations.
+- Bot contract tests require every Bot control-plane operation under
+  `/openapi/v1/bots/collaboration/**`.
+- Session contract tests require global Session operations under
+  `/openapi/v1/group-sessions/**` while preserving the nested Group collection.
+- Axum route tests call the new paths and prove representative old paths are
+  absent.
+- The deterministic bundled OpenAPI document contains no direct BCN-owned
+  `/openapi/v1/bots/{bot_id}` or `/openapi/v1/sessions/{session_id}` paths.
+
+## Out of Scope
+
+- Gateway longest-prefix routing and schema aggregation changes.
+- Production mounting of `bcs-api-http`.
+- Changes to application services, persistence, authorization, DTOs, or
+  Gateway Principal verification.

--- a/src/bcs/docs/plans/2026-08-03-bcn-collaboration-paths-design.md
+++ b/src/bcs/docs/plans/2026-08-03-bcn-collaboration-paths-design.md
@@ -1,6 +1,6 @@
 # BCN Collaboration Path Alignment Design
 
-**Date:** 2026-08-03  
+**Date:** 2026-08-03
 **Status:** Approved
 
 ## Problem

--- a/src/bcs/docs/superpowers/plans/2026-08-03-bcn-collaboration-paths.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-03-bcn-collaboration-paths.md
@@ -1,0 +1,294 @@
+# BCN Collaboration Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move BCN Bot control-plane and global Session operations onto Gateway-safe public prefixes without changing operation behavior.
+
+**Architecture:** The versioned OpenAPI contract remains authoritative. Contract tests move first, then the YAML path keys, followed by Axum route tests and route literals. Bot collaboration uses the fixed prefix `/openapi/v1/bots/collaboration`; global Session resources use `/openapi/v1/group-sessions`; nested `/openapi/v1/groups/{group_id}/sessions` remains unchanged.
+
+**Tech Stack:** OpenAPI 3.1 YAML, Python/pytest contract tests, Rust/Axum, Cargo.
+
+## Global Constraints
+
+- Change only BCS contracts, BCS HTTP delivery routes, related tests, and current contract documentation.
+- Do not mount `bcs-api-http` in the production bootstrap.
+- Do not change DTOs, application services, authorization, persistence, or Gateway Principal verification.
+- Do not retain compatibility aliases at the old V1 paths.
+- Do not run `cargo fmt`, `cargo fmt --all`, or another global BCS formatter.
+- Keep the approved operation count at exactly 32.
+
+---
+
+### Task 1: Move the authoritative OpenAPI paths
+
+**Files:**
+- Modify: `src/bcs/tests/openapi/test_contract.py`
+- Modify: `src/bcs/tests/openapi/test_bot_v1_contract.py`
+- Modify: `src/bcs/tests/openapi/test_session_v1_contract.py`
+- Modify: `src/bcs/api-contracts/v1/openapi.yaml`
+- Modify: `src/bcs/api-contracts/README.md`
+
+**Interfaces:**
+- Consumes: `scripts.validate_openapi_contract.load_contract(Path) -> dict`
+- Produces: a 32-operation contract whose Bot control-plane paths are under `/openapi/v1/bots/collaboration/**` and global Session paths are under `/openapi/v1/group-sessions/**`.
+
+- [ ] **Step 1: Change the exact-operation tests to the approved paths**
+
+Replace the five Bot entries with:
+
+```python
+BOT_OPERATIONS = {
+    ("get", "/openapi/v1/bots/collaboration/{bot_id}/candidates"),
+    ("post", "/openapi/v1/bots/collaboration/query"),
+    ("get", "/openapi/v1/bots/collaboration/{bot_id}"),
+    ("patch", "/openapi/v1/bots/collaboration/{bot_id}"),
+    ("get", "/openapi/v1/bots/collaboration/mine"),
+}
+```
+
+Replace every global `/openapi/v1/sessions/{session_id}` expectation with `/openapi/v1/group-sessions/{session_id}`. Preserve both operations on `/openapi/v1/groups/{group_id}/sessions`.
+
+Add explicit exclusion assertions for the old base paths:
+
+```python
+assert not any(path.startswith("/openapi/v1/sessions/") for _, path in actual)
+assert ("get", "/openapi/v1/bots/{bot_id}") not in actual
+assert ("get", "/openapi/v1/bots/mine") not in actual
+```
+
+- [ ] **Step 2: Run the contract tests and verify RED**
+
+Run:
+
+```bash
+uv run --with pytest --with pyyaml pytest \
+  src/bcs/tests/openapi/test_contract.py \
+  src/bcs/tests/openapi/test_bot_v1_contract.py \
+  src/bcs/tests/openapi/test_session_v1_contract.py -q
+```
+
+Expected: FAIL because `openapi.yaml` still publishes the old Bot and Session path keys.
+
+- [ ] **Step 3: Move the OpenAPI path keys and current README inventory**
+
+In `api-contracts/v1/openapi.yaml`, apply these prefix mappings without changing `$ref` targets:
+
+```text
+/openapi/v1/bots/mine                         -> /openapi/v1/bots/collaboration/mine
+/openapi/v1/bots/query                        -> /openapi/v1/bots/collaboration/query
+/openapi/v1/bots/{bot_id}                     -> /openapi/v1/bots/collaboration/{bot_id}
+/openapi/v1/bots/{bot_id}/candidates          -> /openapi/v1/bots/collaboration/{bot_id}/candidates
+/openapi/v1/sessions/{session_id}             -> /openapi/v1/group-sessions/{session_id}
+/openapi/v1/sessions/{session_id}/**          -> /openapi/v1/group-sessions/{session_id}/**
+```
+
+Update `api-contracts/README.md` so its five-operation Bot inventory uses the collaboration prefix and states that global Session resources use `group-sessions`.
+
+- [ ] **Step 4: Run the OpenAPI suite and verify GREEN**
+
+Run:
+
+```bash
+uv run --with pytest --with pyyaml pytest src/bcs/tests/openapi -q
+```
+
+Expected: 18 passed, including exactly 32 operations.
+
+- [ ] **Step 5: Commit the contract migration**
+
+```bash
+git add src/bcs/api-contracts src/bcs/tests/openapi
+git commit -m "feat(bcs): namespace BCN bot and session contracts"
+```
+
+---
+
+### Task 2: Move Bot control-plane HTTP routes
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs`
+
+**Interfaces:**
+- Consumes: existing `ApiState`, `BotService`, DTOs, and principal middleware.
+- Produces: the same five handlers mounted exclusively below `/openapi/v1/bots/collaboration/**`.
+
+- [ ] **Step 1: Point Bot route tests at the approved prefix and reject old paths**
+
+Update all five successful request URIs. Add a test that sends authenticated requests to `/openapi/v1/bots/bot-1` and `/openapi/v1/bots/mine` and asserts `StatusCode::NOT_FOUND` without recording a `FakeBotService` call.
+
+Representative new requests:
+
+```rust
+request(
+    "GET",
+    "/openapi/v1/bots/collaboration/acting/candidates?purpose=collaboration&name=planner&offset=5&limit=10",
+    Value::Null,
+)
+
+request(
+    "POST",
+    "/openapi/v1/bots/collaboration/query",
+    json!({"bot_ids": ["bot-2", "bot-1", "bot-2"]}),
+)
+```
+
+- [ ] **Step 2: Run Bot route tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml --package bcs-api-http --test bot_routes
+```
+
+Expected: FAIL because the router still mounts the five handlers at the old paths.
+
+- [ ] **Step 3: Move the Axum Bot route literals**
+
+Change `routes/bot.rs::router()` to mount:
+
+```rust
+Router::new()
+    .route(
+        "/openapi/v1/bots/collaboration/{bot_id}/candidates",
+        get(list_candidates),
+    )
+    .route("/openapi/v1/bots/collaboration/query", post(query_bots))
+    .route("/openapi/v1/bots/collaboration/mine", get(list_mine))
+    .route(
+        "/openapi/v1/bots/collaboration/{bot_id}",
+        get(get_bot).patch(update_bot),
+    )
+```
+
+Do not change handler bodies or service commands.
+
+- [ ] **Step 4: Run Bot route tests and verify GREEN**
+
+Run the Task 2 test command again. Expected: 2 or more tests passed, 0 failed.
+
+- [ ] **Step 5: Commit the Bot router migration**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/bot.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
+git commit -m "feat(bcs): move bot control plane under collaboration"
+```
+
+---
+
+### Task 3: Move global Session and Session invitation HTTP routes
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/tests/invitation_routes.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/session.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/invitation.rs`
+
+**Interfaces:**
+- Consumes: existing `SessionService`, `SessionMessageService`, `InvitationService`, DTOs, and principal middleware.
+- Produces: global Session handlers exclusively under `/openapi/v1/group-sessions/{session_id}/**`; nested Group Session collection handlers remain unchanged.
+
+- [ ] **Step 1: Point Session tests at `group-sessions` and reject old paths**
+
+Replace every test request beginning `/openapi/v1/sessions/session-1` with `/openapi/v1/group-sessions/session-1`, including invitation tests. Do not change `/openapi/v1/groups/group-1/sessions`.
+
+Add a route-isolation test that asserts authenticated requests to these old paths return `StatusCode::NOT_FOUND`:
+
+```text
+GET  /openapi/v1/sessions/session-1
+GET  /openapi/v1/sessions/session-1/messages
+POST /openapi/v1/sessions/session-1/invitations
+```
+
+- [ ] **Step 2: Run Session and invitation route tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src/bcs/Cargo.toml --package bcs-api-http \
+  --test session_routes --test invitation_routes
+```
+
+Expected: FAIL because the production route literals still use `/openapi/v1/sessions`.
+
+- [ ] **Step 3: Move the Axum Session route literals**
+
+In `routes/session.rs`, keep `/openapi/v1/groups/{group_id}/sessions` unchanged and change the other five route patterns to the `group-sessions` prefix:
+
+```text
+/openapi/v1/group-sessions/{session_id}
+/openapi/v1/group-sessions/{session_id}/completion
+/openapi/v1/group-sessions/{session_id}/messages
+/openapi/v1/group-sessions/{session_id}/participants
+/openapi/v1/group-sessions/{session_id}/participants/{bot_uuid}
+```
+
+In `routes/invitation.rs`, change only the Session invitation pattern to:
+
+```text
+/openapi/v1/group-sessions/{session_id}/invitations
+```
+
+- [ ] **Step 4: Run Session and invitation route tests and verify GREEN**
+
+Run the Task 3 test command again. Expected: all Session and invitation route tests pass.
+
+- [ ] **Step 5: Commit the Session router migration**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/session.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/invitation.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs \
+  src/bcs/crates/adapters/http/bcs-api-http/tests/invitation_routes.rs
+git commit -m "feat(bcs): rename collaboration sessions to group sessions"
+```
+
+---
+
+### Task 4: Verify contract/runtime parity and stale-path absence
+
+**Files:**
+- Modify only if a verification failure identifies a stale current contract reference.
+
+**Interfaces:**
+- Consumes: completed OpenAPI contract and `bcs-api-http` router.
+- Produces: evidence that the contract and implementation expose the same migrated path families.
+
+- [ ] **Step 1: Validate and bundle the OpenAPI contract**
+
+```bash
+uv run --with pyyaml python src/bcs/scripts/validate_openapi_contract.py \
+  --root src/bcs/api-contracts/v1
+uv run --with pyyaml python src/bcs/scripts/bundle_openapi_contract.py \
+  --root src/bcs/api-contracts/v1 \
+  --output-dir /tmp/bcn-collaboration-paths-openapi
+```
+
+Expected: validation succeeds and `bcn-openapi-v1.yaml` is generated.
+
+- [ ] **Step 2: Scan authoritative and executable surfaces for stale paths**
+
+```bash
+rg -n '/openapi/v1/bots/(mine|query|\{bot_id\})|/openapi/v1/sessions/\{session_id\}' \
+  src/bcs/api-contracts \
+  src/bcs/crates/adapters/http/bcs-api-http/src \
+  src/bcs/tests/openapi
+```
+
+Expected: no matches except explicit negative assertions that document old paths.
+
+- [ ] **Step 3: Run focused full suites**
+
+```bash
+uv run --with pytest --with pyyaml pytest src/bcs/tests/openapi -q
+cargo test --manifest-path src/bcs/Cargo.toml --package bcs-api-http
+cargo check --manifest-path src/bcs/Cargo.toml --package bcs-api-http --all-targets
+git diff --check
+```
+
+Expected: OpenAPI 18 passed; all `bcs-api-http` tests and checks pass; no whitespace errors.
+
+- [ ] **Step 4: Review the final diff**
+
+Confirm that no application, persistence, bootstrap, Gateway, or unrelated BCS files changed and that the operation count remains 32.

--- a/src/bcs/tests/openapi/test_bot_v1_contract.py
+++ b/src/bcs/tests/openapi/test_bot_v1_contract.py
@@ -11,11 +11,11 @@ from scripts.validate_openapi_contract import load_contract  # noqa: E402
 
 
 BOT_OPERATIONS = {
-    ("get", "/openapi/v1/bots/{bot_id}/candidates"),
-    ("post", "/openapi/v1/bots/query"),
-    ("get", "/openapi/v1/bots/{bot_id}"),
-    ("patch", "/openapi/v1/bots/{bot_id}"),
-    ("get", "/openapi/v1/bots/mine"),
+    ("get", "/openapi/v1/bots/collaboration/{bot_id}/candidates"),
+    ("post", "/openapi/v1/bots/collaboration/query"),
+    ("get", "/openapi/v1/bots/collaboration/{bot_id}"),
+    ("patch", "/openapi/v1/bots/collaboration/{bot_id}"),
+    ("get", "/openapi/v1/bots/collaboration/mine"),
 }
 
 
@@ -43,6 +43,13 @@ def test_bot_management_operations_are_human_control_plane_only() -> None:
     for method, path in BOT_OPERATIONS:
         operation = contract["paths"][path][method]
         assert operation["x-avernet-security"] == {"user": "required"}
+
+
+def test_bot_management_operations_share_the_collaboration_prefix() -> None:
+    assert all(
+        path.startswith("/openapi/v1/bots/collaboration/")
+        for _, path in BOT_OPERATIONS
+    )
 
 
 def test_bot_domain_model_is_a_strict_bot_human_union() -> None:
@@ -110,7 +117,9 @@ def test_bot_domain_model_is_a_strict_bot_human_union() -> None:
 
 
 def test_candidates_contract_matches_legacy_list_semantics() -> None:
-    operation = _operation("get", "/openapi/v1/bots/{bot_id}/candidates")
+    operation = _operation(
+        "get", "/openapi/v1/bots/collaboration/{bot_id}/candidates"
+    )
     parameters = _parameters(operation)
 
     assert set(parameters) == {"bot_id", "purpose", "name", "offset", "limit"}
@@ -146,7 +155,7 @@ def test_candidates_contract_matches_legacy_list_semantics() -> None:
 
 
 def test_batch_query_is_sparse_ordered_and_not_visibility_filtered() -> None:
-    operation = _operation("post", "/openapi/v1/bots/query")
+    operation = _operation("post", "/openapi/v1/bots/collaboration/query")
     request = operation["requestBody"]["content"]["application/json"]["schema"]
     bot_ids = request["properties"]["bot_ids"]
 
@@ -173,7 +182,7 @@ def test_batch_query_is_sparse_ordered_and_not_visibility_filtered() -> None:
 
 
 def test_exact_get_has_no_acting_identity_or_visibility_filter() -> None:
-    operation = _operation("get", "/openapi/v1/bots/{bot_id}")
+    operation = _operation("get", "/openapi/v1/bots/collaboration/{bot_id}")
 
     assert set(_parameters(operation)) == {"bot_id"}
     assert operation["x-avernet-behavior"] == {
@@ -185,7 +194,7 @@ def test_exact_get_has_no_acting_identity_or_visibility_filter() -> None:
 
 
 def test_bot_patch_exposes_only_the_approved_mutable_fields() -> None:
-    operation = _operation("patch", "/openapi/v1/bots/{bot_id}")
+    operation = _operation("patch", "/openapi/v1/bots/collaboration/{bot_id}")
     request = operation["requestBody"]["content"]["application/json"]["schema"]
 
     assert set(_parameters(operation)) == {"bot_id"}
@@ -206,7 +215,7 @@ def test_bot_patch_exposes_only_the_approved_mutable_fields() -> None:
 
 
 def test_mine_filters_both_kinds_without_an_all_enum_value() -> None:
-    operation = _operation("get", "/openapi/v1/bots/mine")
+    operation = _operation("get", "/openapi/v1/bots/collaboration/mine")
     parameters = _parameters(operation)
 
     assert set(parameters) == {"kind", "name", "status", "reachability", "offset", "limit"}

--- a/src/bcs/tests/openapi/test_contract.py
+++ b/src/bcs/tests/openapi/test_contract.py
@@ -18,11 +18,11 @@ from scripts.validate_openapi_contract import load_contract  # noqa: E402
 HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
 
 EXPECTED_OPERATIONS = {
-    ("get", "/openapi/v1/bots/{bot_id}/candidates"),
-    ("post", "/openapi/v1/bots/query"),
-    ("get", "/openapi/v1/bots/{bot_id}"),
-    ("patch", "/openapi/v1/bots/{bot_id}"),
-    ("get", "/openapi/v1/bots/mine"),
+    ("get", "/openapi/v1/bots/collaboration/{bot_id}/candidates"),
+    ("post", "/openapi/v1/bots/collaboration/query"),
+    ("get", "/openapi/v1/bots/collaboration/{bot_id}"),
+    ("patch", "/openapi/v1/bots/collaboration/{bot_id}"),
+    ("get", "/openapi/v1/bots/collaboration/mine"),
     ("get", "/openapi/v1/groups"),
     ("post", "/openapi/v1/groups"),
     ("get", "/openapi/v1/groups/{group_id}"),
@@ -33,16 +33,16 @@ EXPECTED_OPERATIONS = {
     ("delete", "/openapi/v1/groups/{group_id}/participants/{actor_id}"),
     ("post", "/openapi/v1/groups/{group_id}/sessions"),
     ("get", "/openapi/v1/groups/{group_id}/sessions"),
-    ("get", "/openapi/v1/sessions/{session_id}"),
-    ("patch", "/openapi/v1/sessions/{session_id}"),
-    ("delete", "/openapi/v1/sessions/{session_id}"),
-    ("post", "/openapi/v1/sessions/{session_id}/completion"),
-    ("get", "/openapi/v1/sessions/{session_id}/messages"),
-    ("post", "/openapi/v1/sessions/{session_id}/participants"),
-    ("patch", "/openapi/v1/sessions/{session_id}/participants/{bot_uuid}"),
-    ("delete", "/openapi/v1/sessions/{session_id}/participants/{bot_uuid}"),
+    ("get", "/openapi/v1/group-sessions/{session_id}"),
+    ("patch", "/openapi/v1/group-sessions/{session_id}"),
+    ("delete", "/openapi/v1/group-sessions/{session_id}"),
+    ("post", "/openapi/v1/group-sessions/{session_id}/completion"),
+    ("get", "/openapi/v1/group-sessions/{session_id}/messages"),
+    ("post", "/openapi/v1/group-sessions/{session_id}/participants"),
+    ("patch", "/openapi/v1/group-sessions/{session_id}/participants/{bot_uuid}"),
+    ("delete", "/openapi/v1/group-sessions/{session_id}/participants/{bot_uuid}"),
     ("post", "/openapi/v1/groups/{group_id}/invitations"),
-    ("post", "/openapi/v1/sessions/{session_id}/invitations"),
+    ("post", "/openapi/v1/group-sessions/{session_id}/invitations"),
     ("post", "/openapi/v1/invitations/{token}/accept"),
     ("get", "/openapi/v1/bots/collaboration/{bot_uuid}/friendships"),
     ("delete", "/openapi/v1/bots/collaboration/{bot_uuid}/friendships/{friend_bot_uuid}"),
@@ -82,10 +82,13 @@ def test_all_current_operations_require_a_human_caller() -> None:
 def test_contract_excludes_unapproved_runtime_and_routing_surfaces() -> None:
     actual = _actual_operations()
 
-    assert ("post", "/openapi/v1/sessions/{session_id}/messages") not in actual
+    assert ("post", "/openapi/v1/group-sessions/{session_id}/messages") not in actual
     assert ("get", "/openapi/v1/bots") not in actual
     assert ("get", "/openapi/v1/bots/discover") not in actual
     assert ("patch", "/openapi/v1/bots/{bot_id}/descriptor") not in actual
+    assert ("get", "/openapi/v1/bots/{bot_id}") not in actual
+    assert ("get", "/openapi/v1/bots/mine") not in actual
+    assert not any(path.startswith("/openapi/v1/sessions/") for _, path in actual)
     assert (
         "get",
         "/openapi/v1/bots/collaboration/{bot_uuid}/groups",

--- a/src/bcs/tests/openapi/test_session_v1_contract.py
+++ b/src/bcs/tests/openapi/test_session_v1_contract.py
@@ -22,7 +22,7 @@ def test_session_list_and_history_use_the_shared_view_actor_contract() -> None:
         "get"
     ]
     list_messages = contract["paths"][
-        "/openapi/v1/sessions/{session_id}/messages"
+        "/openapi/v1/group-sessions/{session_id}/messages"
     ]["get"]
 
     list_queries = _query_parameters(list_sessions)
@@ -43,7 +43,7 @@ def test_view_actor_failures_are_forbidden_without_a_bot_not_found_response() ->
     operations = [
         contract["paths"]["/openapi/v1/groups"]["get"],
         contract["paths"]["/openapi/v1/groups/{group_id}/sessions"]["get"],
-        contract["paths"]["/openapi/v1/sessions/{session_id}/messages"]["get"],
+        contract["paths"]["/openapi/v1/group-sessions/{session_id}/messages"]["get"],
     ]
 
     for operation in operations:
@@ -57,7 +57,7 @@ def test_view_actor_failures_are_forbidden_without_a_bot_not_found_response() ->
 
 def test_session_detail_uses_implicit_human_or_owned_bot_participant_access() -> None:
     contract = load_contract(CONTRACT_ROOT)
-    operation = contract["paths"]["/openapi/v1/sessions/{session_id}"]["get"]
+    operation = contract["paths"]["/openapi/v1/group-sessions/{session_id}"]["get"]
 
     assert "view_bot_id" not in {
         parameter["name"]


### PR DESCRIPTION
## Problem

BCN currently exposes its bot control-plane operations under the generic `/openapi/v1/bots/**` namespace and its collaboration session resources under `/openapi/v1/sessions/**`. Those paths overlap with the Gateway's existing Backend-owned bot and session surfaces, which prevents the BCN contract from being aggregated into the Gateway OpenAPI document without ambiguous ownership or route collisions.

## Solution

- Move the five BCN bot control-plane operations under `/openapi/v1/bots/collaboration/**`.
- Move global collaboration session resources, messages, participants, completion, and session invitations under `/openapi/v1/group-sessions/**`.
- Keep session creation and listing at `/openapi/v1/groups/{group_id}/sessions` because those operations remain scoped to a group.
- Update the authoritative OpenAPI contract, contract inventory, Axum route registration, and route/contract tests together.
- Add explicit regression coverage confirming that the former paths are no longer mounted and do not reach application services.
- Do not add compatibility aliases, keeping route ownership unambiguous for future Gateway aggregation.

## Validation

- `uv run --with pytest --with pyyaml pytest src/bcs/tests/openapi -q` — 19 passed.
- `uv run --with pyyaml python src/bcs/scripts/validate_openapi_contract.py --root src/bcs/api-contracts/v1` — 32 operations validated.
- `uv run --with pyyaml python src/bcs/scripts/bundle_openapi_contract.py --root src/bcs/api-contracts/v1 --output-dir /tmp/bcn-collaboration-paths-openapi` — bundle generated successfully.
- `cargo test --manifest-path src/bcs/Cargo.toml --package bcs-api-http` — all 77 tests passed.
- `cargo check --manifest-path src/bcs/Cargo.toml --package bcs-api-http --all-targets` — passed.
- `git diff --check upstream/dev...HEAD` — passed.

## Compatibility and risk

This is an intentional breaking path change for direct consumers of the BCN HTTP adapter. Callers must migrate to the new namespaces; the old routes return 404 and no compatibility aliases are provided.

Gateway OpenAPI aggregation, Gateway route mounting, and production end-to-end reachability are intentionally outside this PR. The production bootstrap remains unchanged and continues not to mount `bcs-api-http` directly.

## Spec

- `src/bcs/docs/plans/2026-08-03-bcn-collaboration-paths-design.md`
- `src/bcs/docs/superpowers/plans/2026-08-03-bcn-collaboration-paths.md`
