### PR TITLE
fix(baas): honor template runtime engine for personal bots

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_binding_resolver.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_binding_resolver.py
@@ -56,6 +56,36 @@ def _normalize_engine_type(
     return "openclaw"
 
 
+def _resolve_effective_engine_type(
+    active_engine: str | None,
+    template_type: str | None = None,
+    template_runtime_engine_type: str | None = None,
+) -> str:
+    """Resolve the effective engine from an explicit supported value or legacy rules.
+
+    A non-empty ``template_runtime_engine_type`` takes precedence only when it is
+    supported by BaaS. Empty or unsupported values fall back to the existing
+    ``active_engine`` and ``template_type`` normalization rules; unsupported
+    explicit values are logged to make configuration drift observable.
+    """
+    runtime_engine_type = (
+        template_runtime_engine_type.strip()
+        if isinstance(template_runtime_engine_type, str)
+        else ""
+    )
+    if runtime_engine_type in _SUPPORTED_ENGINES:
+        return runtime_engine_type
+    if runtime_engine_type:
+        logger.warning(
+            "engine_type.unsupported_template_runtime: "
+            "template_runtime_engine_type=%r not in whitelist %s, "
+            "fallback to legacy normalization",
+            runtime_engine_type,
+            sorted(_SUPPORTED_ENGINES),
+        )
+    return _normalize_engine_type(active_engine, template_type)
+
+
 class BotBindingResolver:
     """Binding 解析器 — 单次查询完整链路。
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_run_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from secbaas.community.api.bot_runtime import BotBindingInfo
 from secbaas.community.spi.bot_service import BotBindingData
 
-from ._bot_binding_resolver import _normalize_engine_type
+from ._bot_binding_resolver import _resolve_effective_engine_type
 
 if TYPE_CHECKING:
     from secbaas.community.api.bot_runtime import BotChatContext
@@ -134,9 +134,8 @@ def binding_data_to_info(data: BotBindingData) -> BotBindingInfo:
     - owner_id → entity_id
     - sandbox_id: device_id when device_provider == "arca", else None
     - device_props: always {} (BotBindingData has no device_props)
-    - engine_type: normalized via _normalize_engine_type(active_engine, template_type);
-      empty active_engine → "openclaw"; claude_code + {personalCoding,applicationCoding}
-      template → "aicoding"; unknown → "openclaw" (with WARN)
+    - engine_type: non-empty template_runtime_engine_type wins; when it is absent
+      or blank, legacy normalization uses active_engine + template_type unchanged
     - baas_session_id: always None (set at runtime by BaasBotService)
     - publish_id / publish_status: dropped (no counterpart in BotBindingInfo)
     """
@@ -149,7 +148,11 @@ def binding_data_to_info(data: BotBindingData) -> BotBindingInfo:
         binding_id=data.binding_id,
         device_props={},
         bot_type=data.bot_type,
-        engine_type=_normalize_engine_type(data.engine_type, data.template_type),
+        engine_type=_resolve_effective_engine_type(
+            data.engine_type,
+            data.template_type,
+            data.template_runtime_engine_type,
+        ),
         baas_session_id=None,
     )
 

--- a/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
@@ -291,10 +291,11 @@ class AiohttpBotServicePlugin(BotServicePlugin):
             )
             logger.info(
                 "[bot-service] get_binding raw: bot_id=%s engine_type=%r "
-                "template_type=%r device_provider=%r",
+                "template_type=%r template_runtime_engine_type=%r device_provider=%r",
                 inner.get("bot_id", bot_id),
                 inner.get("engine_type"),
                 inner.get("template_type"),
+                inner.get("template_runtime_engine_type"),
                 inner.get("device_provider"),
             )
             return BotBindingData(
@@ -308,6 +309,7 @@ class AiohttpBotServicePlugin(BotServicePlugin):
                 device_provider=inner.get("device_provider", ""),
                 device_id=inner.get("device_id", ""),
                 template_type=inner.get("template_type"),
+                template_runtime_engine_type=inner.get("template_runtime_engine_type"),
             )
 
         if last_error is not None and last_error.code != ErrorCode.PLATFORM_UNAVAILABLE:

--- a/src/baas/src/secbaas/community/spi/bot_service/_models.py
+++ b/src/baas/src/secbaas/community/spi/bot_service/_models.py
@@ -20,6 +20,7 @@ class BotBindingData:
     device_provider: str = ""
     device_id: str = ""
     template_type: str | None = None
+    template_runtime_engine_type: str | None = None
 
 
 @dataclass

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_utils.py
@@ -9,7 +9,7 @@ Covers:
 - parse_wait_result: 从 metadata 解析 ignore_content / ignore_result 标志
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -548,7 +548,12 @@ class TestBindingDataToInfoEngineNormalization:
     沙箱却传 engine=claude_code 报 500。
     """
 
-    def _data(self, engine_type: str, template_type: str | None) -> BotBindingData:
+    def _data(
+        self,
+        engine_type: str,
+        template_type: str | None,
+        template_runtime_engine_type: str | None = None,
+    ) -> BotBindingData:
         return BotBindingData(
             bot_id="bot-001",
             owner_id="entity-001",
@@ -558,6 +563,7 @@ class TestBindingDataToInfoEngineNormalization:
             device_provider="arca",
             device_id="ARCA-SANDBOX-abc@0",
             template_type=template_type,
+            template_runtime_engine_type=template_runtime_engine_type,
         )
 
     @pytest.mark.parametrize(
@@ -586,3 +592,59 @@ class TestBindingDataToInfoEngineNormalization:
     ):
         info = binding_data_to_info(self._data(engine_type, template_type))
         assert info.engine_type == expected
+
+    @pytest.mark.parametrize(
+        ("template_runtime_engine_type", "expected"),
+        [
+            (None, "aicoding"),
+            ("", "aicoding"),
+            ("   ", "aicoding"),
+            ("claude_code", "claude_code"),
+            (" aicoding ", "aicoding"),
+            ("future_engine", "aicoding"),
+        ],
+    )
+    def test_explicit_template_runtime_engine_type_or_legacy_fallback(
+        self, template_runtime_engine_type, expected
+    ):
+        data = self._data(
+            "claude_code",
+            "applicationCoding",
+            template_runtime_engine_type,
+        )
+
+        info = binding_data_to_info(data)
+
+        assert info.engine_type == expected
+
+    def test_explicit_runtime_engine_fixes_genercc_mismatch(self):
+        data = self._data(
+            "claude_code",
+            "generCC",
+            "aicoding",
+        )
+
+        info = binding_data_to_info(data)
+
+        assert info.engine_type == "aicoding"
+
+    def test_unsupported_explicit_runtime_engine_warns_and_falls_back(self):
+        data = self._data(
+            "claude_code",
+            "applicationCoding",
+            "future_engine",
+        )
+
+        with patch(
+            "secbaas.community.core.service.bot_run._bot_binding_resolver.logger"
+        ) as logger:
+            info = binding_data_to_info(data)
+
+        assert info.engine_type == "aicoding"
+        logger.warning.assert_called_once_with(
+            "engine_type.unsupported_template_runtime: "
+            "template_runtime_engine_type=%r not in whitelist %s, "
+            "fallback to legacy normalization",
+            "future_engine",
+            ["aicoding", "claude_code", "hermes", "openclaw", "teclaw"],
+        )

--- a/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
+++ b/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
@@ -178,6 +178,7 @@ class TestBotBindingData:
         assert data.binding_id == 0
         assert data.device_provider == ""
         assert data.device_id == ""
+        assert data.template_runtime_engine_type is None
 
 
 # ==================== Tests: AiohttpBotServicePlugin.report ===================
@@ -356,6 +357,7 @@ class TestAiohttpBotServicePluginGetBinding:
                 "owner_id": "20881234",
                 "bot_type": "service",
                 "engine_type": "openclaw",
+                "template_runtime_engine_type": "claude_code",
                 "publish_id": 9527,
                 "publish_status": "success",
                 "binding_id": 202,
@@ -384,6 +386,7 @@ class TestAiohttpBotServicePluginGetBinding:
         assert result.owner_id == "20881234"
         assert result.bot_type == "service"
         assert result.engine_type == "openclaw"
+        assert result.template_runtime_engine_type == "claude_code"
         assert result.publish_id == 9527
         assert result.publish_status == "success"
         assert result.binding_id == 202

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -23,6 +23,9 @@ from agentclaw.community.core.service_bot.services.publish_exceptions import (
     PublishStatusInvalidError,
 )
 from agentclaw.community.core.service_bot.services.publish_rollback_mixin import PublishRollbackMixin
+from agentclaw.community.core.service_bot.services.template_runtime_engine_type_resolver import (
+    TemplateRuntimeEngineTypeResolver,
+)
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
@@ -47,6 +50,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         bot_repo: BotRepository,
         publish_flow_service_provider: Callable[[], "PublishFlowService"],
         bot_service: "BotService",
+        template_runtime_engine_type_resolver: TemplateRuntimeEngineTypeResolver,
         device_binding_repo: DeviceBindingRepository,
         bcn_service: "BcnService",
         quality_task_service: "QualityTaskService",
@@ -58,6 +62,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         # Lazy provider — breaks the BotPublishService ↔ PublishFlowService cycle.
         self._publish_flow_service_provider = publish_flow_service_provider
         self._bot_service = bot_service
+        self._template_runtime_engine_type_resolver = template_runtime_engine_type_resolver
         self._device_binding_repo = device_binding_repo
         self._bcn_service = bcn_service
         self._quality_task_service = quality_task_service
@@ -436,10 +441,11 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 raise BotPublishServiceError(
                     f"Binding record missing sandbox_id in device_props: binding_id={binding_id}"
                 )
-        return {
+        bot_type = bot.get("bot_type", "personal")
+        result = {
             "bot_id": bot_id,
             "owner_id": owner_id,
-            "bot_type": bot.get("bot_type", "personal"),
+            "bot_type": bot_type,
             "engine_type": bot.get("active_engine", ""),
             "template_type": bot.get("template_type", ""),
             "publish_id": None,
@@ -448,6 +454,21 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             "device_provider": getattr(binding, "device_provider", ""),
             "device_id": device_id,
         }
+        if bot_type == "personal":
+            result["template_runtime_engine_type"] = (
+                self._get_template_runtime_engine_type(
+                    bot_type=bot_type, bot_id=bot_id
+                )
+            )
+        return result
+
+    def _get_template_runtime_engine_type(
+        self, *, bot_type: str, bot_id: str
+    ) -> str:
+        """Resolve the explicit template runtime engine for the bot type."""
+        return self._template_runtime_engine_type_resolver.resolve(
+            bot_type=bot_type, bot_id=bot_id
+        )
 
     def _get_service_publish_record_for_stage(
         self,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/template_runtime_engine_type_resolver.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/template_runtime_engine_type_resolver.py
@@ -1,0 +1,59 @@
+"""Resolve a bot template's explicit runtime engine by bot type."""
+
+from __future__ import annotations
+
+from typing import Mapping, Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.bot_management.services.template_service import (
+        TemplateService,
+    )
+
+
+class TemplateRuntimeEngineTypeResolver(Protocol):
+    """Resolve the template runtime engine for a bot type."""
+
+    def resolve(self, *, bot_type: str, bot_id: str) -> str:
+        """Return the explicit runtime engine, or an empty string if unsupported."""
+
+
+class PersonalTemplateRuntimeEngineTypeResolver:
+    """Read the explicit runtime engine from a personal bot's template."""
+
+    def __init__(self, template_service: TemplateService) -> None:
+        self._template_service = template_service
+
+    def resolve(self, *, bot_type: str, bot_id: str) -> str:
+        del bot_type
+        template_config = self._template_service.get_template_config(bot_id)
+        if not isinstance(template_config, dict):
+            return ""
+        runtime_engine_type = template_config.get("template_runtime_engine_type")
+        if not isinstance(runtime_engine_type, str):
+            return ""
+        return runtime_engine_type.strip()
+
+
+class EmptyTemplateRuntimeEngineTypeResolver:
+    """Return no template runtime engine for unsupported bot types."""
+
+    def resolve(self, *, bot_type: str, bot_id: str) -> str:
+        del bot_type, bot_id
+        return ""
+
+
+class BotTypeTemplateRuntimeEngineTypeResolver:
+    """Dispatch template runtime engine resolution by bot type."""
+
+    def __init__(
+        self,
+        *,
+        resolvers: Mapping[str, TemplateRuntimeEngineTypeResolver],
+        default_resolver: TemplateRuntimeEngineTypeResolver,
+    ) -> None:
+        self._resolvers = dict(resolvers)
+        self._default_resolver = default_resolver
+
+    def resolve(self, *, bot_type: str, bot_id: str) -> str:
+        resolver = self._resolvers.get(bot_type, self._default_resolver)
+        return resolver.resolve(bot_type=bot_type, bot_id=bot_id)

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -40,6 +40,7 @@ from agentclaw.community.api.quality_service import QualityTaskServiceProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.bcn_service import BcnService
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.channel.services.engine_overrides_reader import (
     ChannelEngineOverridesReader,
 )
@@ -71,6 +72,12 @@ from agentclaw.community.core.service_bot.repository.publish_operation_repositor
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
 from agentclaw.community.core.service_bot.services.bot_publish_service import BotPublishService
+from agentclaw.community.core.service_bot.services.template_runtime_engine_type_resolver import (
+    BotTypeTemplateRuntimeEngineTypeResolver,
+    EmptyTemplateRuntimeEngineTypeResolver,
+    PersonalTemplateRuntimeEngineTypeResolver,
+    TemplateRuntimeEngineTypeResolver,
+)
 from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
     ArcaSnapshotProducer,
 )
@@ -263,12 +270,27 @@ class ServiceBotModule(Module):
     @singleton
     @provider
     @inject
+    def template_runtime_engine_type_resolver(
+        self, template_service: TemplateService
+    ) -> TemplateRuntimeEngineTypeResolver:
+        """Select template runtime engine resolution by bot type."""
+        return BotTypeTemplateRuntimeEngineTypeResolver(
+            resolvers={
+                "personal": PersonalTemplateRuntimeEngineTypeResolver(template_service)
+            },
+            default_resolver=EmptyTemplateRuntimeEngineTypeResolver(),
+        )
+
+    @singleton
+    @provider
+    @inject
     def bot_publish_service(
         self,
         injector: Injector,
         bot_publish_repo: BotPublishRepositoryProtocol,
         bot_repo: BotRepository,
         bot_service: BotService,
+        template_runtime_engine_type_resolver: TemplateRuntimeEngineTypeResolver,
         device_binding_repo: DeviceBindingRepository,
         bcn_service: BcnService,
         quality_task_service: QualityTaskServiceProtocol,
@@ -287,6 +309,7 @@ class ServiceBotModule(Module):
             bot_publish_repo=bot_publish_repo,
             bot_repo=bot_repo,
             bot_service=bot_service,
+            template_runtime_engine_type_resolver=template_runtime_engine_type_resolver,
             device_binding_repo=device_binding_repo,
             bcn_service=bcn_service,
             quality_task_service=quality_task_service,

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -24,6 +24,11 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishOperationState,
     PublishStatus,
 )
+from agentclaw.community.core.service_bot.services.template_runtime_engine_type_resolver import (
+    BotTypeTemplateRuntimeEngineTypeResolver,
+    EmptyTemplateRuntimeEngineTypeResolver,
+    PersonalTemplateRuntimeEngineTypeResolver,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
 
 
@@ -33,6 +38,8 @@ def _make_service(
     bot_repo=None,
     publish_flow_service_provider=None,
     bot_service=None,
+    template_service=None,
+    template_runtime_engine_type_resolver=None,
     device_binding_repo=None,
     bcn_service=None,
     quality_task_service=None,
@@ -50,11 +57,22 @@ def _make_service(
         operation_repo.get_latest_by_kind.return_value = None
         operation_repo.max_attempt.return_value = 0
 
+    if template_runtime_engine_type_resolver is None:
+        template_runtime_engine_type_resolver = BotTypeTemplateRuntimeEngineTypeResolver(
+            resolvers={
+                "personal": PersonalTemplateRuntimeEngineTypeResolver(
+                    template_service or MagicMock()
+                )
+            },
+            default_resolver=EmptyTemplateRuntimeEngineTypeResolver(),
+        )
+
     return BotPublishService(
         bot_publish_repo=bot_publish_repo,
         bot_repo=bot_repo or MagicMock(),
         publish_flow_service_provider=publish_flow_service_provider or (lambda: MagicMock()),
         bot_service=bot_service or MagicMock(),
+        template_runtime_engine_type_resolver=template_runtime_engine_type_resolver,
         device_binding_repo=device_binding_repo or MagicMock(),
         bcn_service=bcn_service or MagicMock(),
         quality_task_service=quality_task_service or MagicMock(),
@@ -2143,9 +2161,14 @@ class TestGetBotStageBindingInfo:
             device_provider="arca",
             device_props={"sandbox_id": "BOT-UUID-PERSONAL"},
         )
+        template_service = Mock()
+        template_service.get_template_config.return_value = {
+            "template_runtime_engine_type": " claude_code "
+        }
         service = _make_service(
             bot_publish_repo=mock_repo,
             bot_repo=bot_repo,
+            template_service=template_service,
             device_binding_repo=device_binding_repo,
         )
 
@@ -2157,12 +2180,58 @@ class TestGetBotStageBindingInfo:
             "bot_type": "personal",
             "engine_type": "openclaw",
             "template_type": "standard",
+            "template_runtime_engine_type": "claude_code",
             "publish_id": None,
             "publish_status": None,
             "binding_id": 501,
             "device_provider": "arca",
             "device_id": "BOT-UUID-PERSONAL",
         }
+
+    @pytest.mark.parametrize(
+        ("template_config", "expected"),
+        [
+            ({}, ""),
+            ({"template_runtime_engine_type": None}, ""),
+            ({"template_runtime_engine_type": ""}, ""),
+            ({"template_runtime_engine_type": "   "}, ""),
+            ({"template_runtime_engine_type": 123}, ""),
+            ({"runtime": "aicoding"}, ""),
+            (None, ""),
+        ],
+    )
+    def test_personal_bot_empty_or_invalid_template_runtime_engine_type(
+        self, template_config, expected
+    ):
+        bot_repo = Mock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "bot_id": "bot_001",
+            "bot_type": "personal",
+            "binding_id": 502,
+            "active_engine": "claude_code",
+            "template_type": "normalCC",
+        }
+        device_binding_repo = Mock()
+        device_binding_repo.get_by_id.return_value = Mock(
+            device_id="IGNORED-FOR-PERSONAL",
+            device_provider="arca",
+            device_props={"sandbox_id": "BOT-UUID-PERSONAL"},
+        )
+        template_service = Mock()
+        template_service.get_template_config.return_value = template_config
+        service = _make_service(
+            bot_publish_repo=Mock(),
+            bot_repo=bot_repo,
+            template_service=template_service,
+            device_binding_repo=device_binding_repo,
+        )
+
+        result = service.get_bot_stage_binding_info(
+            "bot_001", "user_001", "online"
+        )
+
+        assert result["template_runtime_engine_type"] == expected
+        template_service.get_template_config.assert_called_once_with("bot_001")
 
     def test_service_bot_draft_uses_personal_binding_info(self):
         mock_repo = Mock()
@@ -2180,9 +2249,11 @@ class TestGetBotStageBindingInfo:
             device_provider="arca",
             device_props={"sandbox_id": "BOT-UUID-DRAFT"},
         )
+        template_service = Mock()
         service = _make_service(
             bot_publish_repo=mock_repo,
             bot_repo=bot_repo,
+            template_service=template_service,
             device_binding_repo=device_binding_repo,
         )
 
@@ -2200,6 +2271,7 @@ class TestGetBotStageBindingInfo:
             "device_provider": "arca",
             "device_id": "BOT-UUID-DRAFT",
         }
+        template_service.get_template_config.assert_not_called()
 
     def test_service_bot_verify_success(self):
         mock_repo = Mock()

--- a/src/backend/tests/community/core/service_bot/services/test_template_runtime_engine_type_resolver.py
+++ b/src/backend/tests/community/core/service_bot/services/test_template_runtime_engine_type_resolver.py
@@ -1,0 +1,55 @@
+"""Tests for bot-type-specific template runtime engine resolution."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services.template_runtime_engine_type_resolver import (
+    BotTypeTemplateRuntimeEngineTypeResolver,
+    EmptyTemplateRuntimeEngineTypeResolver,
+    PersonalTemplateRuntimeEngineTypeResolver,
+)
+
+
+@pytest.mark.parametrize(
+    ("template_config", "expected"),
+    [
+        ({"template_runtime_engine_type": " claude_code "}, "claude_code"),
+        ({}, ""),
+        ({"template_runtime_engine_type": None}, ""),
+        ({"template_runtime_engine_type": 123}, ""),
+        (None, ""),
+    ],
+)
+def test_personal_resolver_reads_explicit_template_runtime_engine_type(
+    template_config, expected
+):
+    template_service = Mock()
+    template_service.get_template_config.return_value = template_config
+    resolver = PersonalTemplateRuntimeEngineTypeResolver(template_service)
+
+    result = resolver.resolve(bot_type="personal", bot_id="bot-1")
+
+    assert result == expected
+    template_service.get_template_config.assert_called_once_with("bot-1")
+
+
+def test_empty_resolver_returns_empty_string():
+    resolver = EmptyTemplateRuntimeEngineTypeResolver()
+
+    assert resolver.resolve(bot_type="service", bot_id="bot-1") == ""
+
+
+def test_bot_type_resolver_uses_empty_resolver_for_non_personal_bot():
+    template_service = Mock()
+    resolver = BotTypeTemplateRuntimeEngineTypeResolver(
+        resolvers={
+            "personal": PersonalTemplateRuntimeEngineTypeResolver(template_service)
+        },
+        default_resolver=EmptyTemplateRuntimeEngineTypeResolver(),
+    )
+
+    result = resolver.resolve(bot_type="service", bot_id="bot-1")
+
+    assert result == ""
+    template_service.get_template_config.assert_not_called()

--- a/src/backend/tests/community/endpoints/test_service_bot_publish_binding.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_publish_binding.py
@@ -14,6 +14,7 @@ from tests.community.framework import (
 
 _OWNER = "u_bind"
 _BOT_ID = "bind_bot"
+_PERSONAL_BOT_ID = "bind_personal_bot"
 _BINDING_ID = 123
 
 _ENDPOINT = "/api/service-bot/publish/{bot_id}/binding"
@@ -76,6 +77,47 @@ def _seed_binding_happy(world) -> None:
     })
 
 
+def _seed_personal_binding_with_runtime_engine(world) -> None:
+    """Seed a personal bot whose template explicitly selects its runtime engine."""
+    from tests.community.factories.access import make_staff_user
+    from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+    from agentclaw.community.core.bot_management.repository.template_repository_protocol import (
+        TemplateRepository,
+    )
+    from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+
+    make_staff_user(world, user_id=_OWNER)
+    binding_id = world.get(DeviceBindingRepository).insert_binding(
+        entity_id=_OWNER,
+        entity_type="staff",
+        device_id="personal-baas-device",
+        device_provider="baas",
+        env="dev",
+        device_props={},
+        status="ACTIVE",
+        apply_reason="seed",
+        applied_by=_OWNER,
+    )
+    world.get(BotRepository).insert({
+        "bot_id": _PERSONAL_BOT_ID,
+        "bot_name": "Personal Binding Bot",
+        "owner_id": _OWNER,
+        "owner_name": _OWNER,
+        "bot_type": "personal",
+        "status": "ACTIVE",
+        "entity_id": _OWNER,
+        "entity_type": "staff",
+        "creator_id": _OWNER,
+        "active_engine": "claude_code",
+        "template_type": "applicationCoding",
+        "binding_id": binding_id,
+    })
+    world.get(TemplateRepository).insert({
+        "bot_id": _PERSONAL_BOT_ID,
+        "ext": {"template_runtime_engine_type": " claude_code "},
+    })
+
+
 def _seed_binding_error(world) -> None:
     """Seed without the target bot - triggers BotNotFoundError."""
     from tests.community.factories.access import make_staff_user
@@ -96,6 +138,27 @@ def _seed_binding_error(world) -> None:
 )
 def get_binding_happy():
     """Happy path: query binding info for online stage succeeds."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_ENDPOINT,
+    scenario="personal-explicit-runtime-engine",
+    input=CaseInput(
+        path_params={"bot_id": _PERSONAL_BOT_ID},
+        query_params={"owner_id": _OWNER, "stage": "online"},
+    ),
+    seed=_seed_personal_binding_with_runtime_engine,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {"template_runtime_engine_type": "claude_code"},
+        },
+    ),
+)
+def get_personal_binding_explicit_runtime_engine():
+    """Personal binding exposes the trimmed template runtime engine field."""
 
 
 @endpoint_test(


### PR DESCRIPTION
## Problem

Personal Bot 的 `active_engine` 和 `template_type` 不能可靠表达实际运行的 Engine Runtime。当前故障 Bot 的 `active_engine=claude_code`、`template_type=generCC`，但实际 Runtime 为 `aicoding`，导致 BaaS 选择错误 Adapter 并连接 `/api/claude_code/ws`。

## Solution

- Backend Personal Bot binding 响应从 `ac_templates.ext` 读取并返回 `template_runtime_engine_type`。
- 缺失、空白、非字符串配置统一返回空字符串，不使用 `template_config.runtime` 兜底。
- BaaS SPI 增加可选字段并透传到 Binding 映射。
- BaaS 仅优先使用白名单内的显式 Runtime Engine；空值或未支持值按 legacy normalization 回退，未支持值同时记录告警。
- Service Bot 查询路径保持现状，不读取 Personal Bot 模板配置。
- 增加 Backend、BaaS 单元测试以及当前 `generCC -> aicoding` 故障场景覆盖。

## Validation

- BaaS 定向单元测试：`149 passed`
- Backend 定向单元及 Endpoint 测试：`151 passed, 18 warnings`
- Backend 架构测试：`112 passed, 17 warnings`
- 本次 BaaS 相关文件 Ruff import/format 检查：通过
- Pre-push Backend/BaaS lint-only SAST：通过
- BaaS 架构测试：`69 passed, 1 failed`；唯一失败为本次未修改的既有文件 `src/secbaas/community/core/service/bot_manage/_bot_management_service.py` 未通过全仓 Ruff format 检查

## Compatibility and risk

- 新字段在 BaaS SPI 中为可选字段，旧 Backend 响应和历史 Bot 会继续走原有 normalization 逻辑。
- 非白名单显式值不会选择不存在的 Adapter，而是告警并兼容回退。
- 不修改数据库 Schema、Service Bot 生命周期解析、BCN 协议或 Engine Adapter WebSocket 路径。
- 回滚可直接撤销本提交，旧字段缺失时的行为与现有兼容路径一致。
