### PR TITLE
fix: resolve skill deletion from persisted bot context

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -91,6 +91,9 @@ from agentclaw.community.core.skill_center.services.repositories import (
     SkillRepository,
     SkillSetRepository,
 )
+from agentclaw.community.core.skill_center.services.skill_service import (
+    SkillDeleteConsistencyError,
+)
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.di import Injected
 from agentclaw.community.api.skill_member_service import SkillMemberServiceProtocol
@@ -2070,6 +2073,7 @@ async def delete_skill(
     bot_id: str | None = Query(None, description="Bot ID"),
     engine_type: str | None = Query(None, description="Engine type override; defaults to bot's active_engine"),
     ctx: RequestContext = Depends(get_request_context),
+    skill_repo: SkillRepository = Injected(SkillRepository),
     bot_repo: BotRepository = Injected(BotRepository),
     path_factory: WorkspacePathFactory = Injected(WorkspacePathFactory),
     skill_service_factory: SkillServiceFactoryProtocol = Injected(SkillServiceFactoryProtocol),
@@ -2084,35 +2088,30 @@ async def delete_skill(
     - 协作者（member 角色）返回 403
     - 管理员可直接删除（Service 层双重保障）
     """
-    # 优先使用传入的 user_id 参数，否则使用认证上下文的 user_id
+    # 删除的物理上下文必须以已持久化 Skill 所属 Bot 为准。历史客户端
+    # 不传 bot_id/entity_id，不能因此回退到 default/openclaw 并删错路径。
     current_user_id = user_id or ctx.user_id
-
-    if entity_id and bot_id:
-        effective_entity_id = entity_id
-        effective_entity_type = entity_type if entity_type else "staff"
-        effective_bot_id = bot_id
-    elif current_user_id:
-        effective_entity_id = current_user_id
-        effective_entity_type = "staff"
-        effective_bot_id = "default"
-    else:
+    if not current_user_id:
         raise HTTPException(status_code=401, detail="未认证用户无法删除技能")
 
-    owner_id_for_lookup = entity_id if entity_id else (current_user_id or "")
+    skill = skill_repo.get_by_id(skill_id)
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    effective_bot_id = str(skill.get("bolt_id") or "")
+    skill_owner_id = str(skill.get("user_id") or "")
+    if not effective_bot_id or not skill_owner_id:
+        raise HTTPException(status_code=409, detail="Skill is missing its Bot identity")
 
-    effective_engine = resolve_engine_for_bot(
-        bot_id=effective_bot_id,
-        owner_id=owner_id_for_lookup,
-        override=engine_type,
-        bot_repo=bot_repo,
+    bot = bot_repo.get_by_id_and_owner(effective_bot_id, skill_owner_id)
+    if not bot:
+        raise HTTPException(status_code=404, detail="Bot not found")
+
+    effective_entity_id = str(
+        bot.get("entity_id") or bot.get("owner_id") or skill_owner_id
     )
-    is_desktop = False
-    try:
-        bot = bot_repo.get_by_id_and_owner(effective_bot_id, owner_id_for_lookup)
-        if bot and bot.get("bot_type") == "desktop":
-            is_desktop = True
-    except Exception:
-        bot = None
+    effective_entity_type = str(bot.get("entity_type") or "staff")
+    effective_engine = str(bot.get("active_engine") or DEFAULT_ENGINE_TYPE)
+    is_desktop = bot.get("bot_type") == "desktop"
 
     # teclaw deletes the skill files from the (draft) container; resolve provider
     # so the device-fs path is the workspace-namespace form.
@@ -2132,8 +2131,6 @@ async def delete_skill(
         engine_type=effective_engine,
     )
     try:
-        if bot is None:
-            raise HTTPException(status_code=404, detail="Bot not found")
         edit_lease = edit_guard.acquire_for_edit(
             scope=BotSkillLayoutScope(
                 env=str(bot["env"]),
@@ -2149,6 +2146,8 @@ async def delete_skill(
             raise HTTPException(status_code=404, detail="Skill not found")
         return MessageResponse(success=True, message="Skill deleted successfully")
     except SkillsPoolEditPausedError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except SkillDeleteConsistencyError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
     except ValueError as e:
         error_msg = str(e)

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -93,6 +93,7 @@ from agentclaw.community.core.skill_center.services.repositories import (
 )
 from agentclaw.community.core.skill_center.services.skill_service import (
     SkillDeleteConsistencyError,
+    SkillReferencedBySkillSetError,
 )
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.di import Injected
@@ -2149,6 +2150,15 @@ async def delete_skill(
         raise HTTPException(status_code=409, detail=str(e)) from e
     except SkillDeleteConsistencyError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
+    except SkillReferencedBySkillSetError as e:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "SKILL_REFERENCED_BY_SKILL_SET",
+                "message": "请先从所有技能集中移除该技能，再删除技能",
+                "skill_set_ids": e.skill_set_ids,
+            },
+        ) from e
     except ValueError as e:
         error_msg = str(e)
         # 权限错误返回 403

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -82,6 +82,10 @@ from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.engine_resolver import resolve_engine_for_bot
 from agentclaw.community.core.skill_center.constants import LOCK_HELD_ERRORS
+from agentclaw.community.core.skill_center.errors import (
+    SkillDeleteConsistencyError,
+    SkillReferencedBySkillSetError,
+)
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditGuard,
     SkillsPoolEditPausedError,
@@ -90,10 +94,6 @@ from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 from agentclaw.community.core.skill_center.services.repositories import (
     SkillRepository,
     SkillSetRepository,
-)
-from agentclaw.community.core.skill_center.services.skill_service import (
-    SkillDeleteConsistencyError,
-    SkillReferencedBySkillSetError,
 )
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.di import Injected

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -2072,7 +2072,10 @@ async def delete_skill(
     entity_id: str | None = Query(None, description="Entity ID (pure ID, no prefix needed)"),
     entity_type: str | None = Query(None, description="Entity type (staff/proj/team, default: staff)"),
     bot_id: str | None = Query(None, description="Bot ID"),
-    engine_type: str | None = Query(None, description="Engine type override; defaults to bot's active_engine"),
+    engine_type: str | None = Query(
+        None,
+        description="Legacy compatibility hint; when provided it must match the Bot active_engine",
+    ),
     ctx: RequestContext = Depends(get_request_context),
     skill_repo: SkillRepository = Injected(SkillRepository),
     bot_repo: BotRepository = Injected(BotRepository),
@@ -2094,24 +2097,67 @@ async def delete_skill(
     current_user_id = user_id or ctx.user_id
     if not current_user_id:
         raise HTTPException(status_code=401, detail="未认证用户无法删除技能")
+    if not skill_id.isdigit():
+        raise HTTPException(status_code=400, detail="Invalid skill ID")
 
     skill = skill_repo.get_by_id(skill_id)
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
+    persisted_git_path = str(skill.get("git_path") or "")
+    is_shared_source = (
+        not skill.get("user_id")
+        and persisted_git_path.startswith(("git://", "center://"))
+    )
+    if is_shared_source:
+        service = skill_service_factory.create()
+        try:
+            success = await service.delete_skill(
+                skill_id,
+                user_id=current_user_id,
+            )
+            if not success:
+                raise HTTPException(status_code=404, detail="Skill not found")
+            return MessageResponse(
+                success=True,
+                message="Skill deleted successfully",
+            )
+        except SkillReferencedBySkillSetError as e:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error_code": "SKILL_REFERENCED_BY_SKILL_SET",
+                    "message": "请先从所有技能集中移除该技能，再删除技能",
+                    "skill_set_ids": e.skill_set_ids,
+                },
+            ) from e
+        except ValueError as e:
+            error_msg = str(e)
+            if "无权删除" in error_msg or "Permission denied" in error_msg:
+                raise HTTPException(status_code=403, detail=error_msg) from e
+            raise HTTPException(status_code=400, detail=error_msg) from e
+
     effective_bot_id = str(skill.get("bolt_id") or "")
-    skill_owner_id = str(skill.get("user_id") or "")
-    if not effective_bot_id or not skill_owner_id:
+    if not effective_bot_id:
         raise HTTPException(status_code=409, detail="Skill is missing its Bot identity")
 
-    bot = bot_repo.get_by_id_and_owner(effective_bot_id, skill_owner_id)
+    bot = bot_repo.get_unique_by_id(effective_bot_id)
     if not bot:
         raise HTTPException(status_code=404, detail="Bot not found")
 
     effective_entity_id = str(
-        bot.get("entity_id") or bot.get("owner_id") or skill_owner_id
+        bot.get("entity_id") or bot.get("owner_id") or ""
     )
     effective_entity_type = str(bot.get("entity_type") or "staff")
     effective_engine = str(bot.get("active_engine") or DEFAULT_ENGINE_TYPE)
+    if engine_type and engine_type != effective_engine:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "SKILL_ENGINE_CONTEXT_MISMATCH",
+                "message": "删除技能必须使用 Bot 当前的生效引擎",
+                "active_engine": effective_engine,
+            },
+        )
     is_desktop = bot.get("bot_type") == "desktop"
 
     # teclaw deletes the skill files from the (draft) container; resolve provider

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -2097,7 +2097,11 @@ async def delete_skill(
     """
     # 删除的物理上下文必须以已持久化 Skill 所属 Bot 为准。历史客户端
     # 不传 bot_id/entity_id，不能因此回退到 default/openclaw 并删错路径。
-    current_user_id = user_id or ctx.user_id
+    # ``user_id`` is a legacy compatibility hint supplied by the caller and
+    # must never override the authenticated actor.  In particular, shared
+    # market Skills have no owner row, so trusting the query parameter here
+    # would let any authenticated caller impersonate a configured Skill admin.
+    current_user_id = ctx.user_id
     if not current_user_id:
         raise HTTPException(status_code=401, detail="未认证用户无法删除技能")
     if not skill_id.isdigit():
@@ -2200,6 +2204,7 @@ async def delete_skill(
         local_dir=local_dir,
         local_skill_path_adapter=local_skill_adapter,
         entity_id=effective_entity_id,
+        bot_owner_id=str(bot.get("owner_id") or ""),
         bot_id=effective_bot_id,
         engine_type=effective_engine,
     )

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -79,7 +79,10 @@ from agentclaw.community.adapters.http.skill_center.schemas import (
     VersionListResponse,
 )
 from agentclaw.community.api.bot_service import BotServiceProtocol
-from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotLookupAmbiguousError,
+    BotRepository,
+)
 from agentclaw.community.core.bot_management.services.engine_resolver import resolve_engine_for_bot
 from agentclaw.community.core.skill_center.constants import LOCK_HELD_ERRORS
 from agentclaw.community.core.skill_center.errors import (
@@ -2139,8 +2142,31 @@ async def delete_skill(
     effective_bot_id = str(skill.get("bolt_id") or "")
     if not effective_bot_id:
         raise HTTPException(status_code=409, detail="Skill is missing its Bot identity")
+    if bot_id and bot_id != effective_bot_id:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "SKILL_BOT_CONTEXT_MISMATCH",
+                "message": "删除技能必须使用 Skill 持久化归属的 Bot",
+                "bot_id": effective_bot_id,
+            },
+        )
 
-    bot = bot_repo.get_unique_by_id(effective_bot_id)
+    try:
+        bot = (
+            bot_repo.get_by_id_and_entity(effective_bot_id, entity_id)
+            if entity_id
+            else bot_repo.get_unique_by_id(effective_bot_id)
+        )
+    except BotLookupAmbiguousError as e:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "SKILL_BOT_CONTEXT_AMBIGUOUS",
+                "message": "历史 Bot ID 不唯一，请提供 entity_id 精确定位",
+                "bot_id": effective_bot_id,
+            },
+        ) from e
     if not bot:
         raise HTTPException(status_code=404, detail="Bot not found")
 

--- a/src/backend/src/agentclaw/community/core/devices/services/local_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/local_device_filesystem.py
@@ -326,19 +326,15 @@ class LocalDeviceFileSystem(DeviceFileSystem):
         return body.get("data", {}).get("files", [])
 
     async def _baas_exists(self, path: str) -> bool:
-        """exists 是 bool 契约——异常吞掉返 False，避免炸 caller。
+        """Probe a BaaS path without confusing absence with unavailability.
 
-        策略与 prod BaasDeviceFileSystem.exists 一致：先 read_file（命中文件），
-        miss 再 list_dir（命中目录）。两者都 raise → 视为不存在/不可达。
+        ``_baas_read_file`` / ``_baas_list_dir`` map an explicit 404 to
+        ``None`` and propagate transport/server failures.  Keeping that
+        distinction is required by Pool deletion's fail-closed contract:
+        an unreachable runtime must never be treated as an absent source.
         """
-        try:
-            content = await self._baas_read_file(path)
-            if content is not None:
-                return True
-            files = await self._baas_list_dir(path)
-            return files is not None
-        except Exception as e:
-            logger.warning(
-                "[LocalDeviceFileSystem.baas.exists] swallowed: %s: %s", path, e
-            )
-            return False
+        content = await self._baas_read_file(path)
+        if content is not None:
+            return True
+        files = await self._baas_list_dir(path)
+        return files is not None

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -1,0 +1,13 @@
+"""Domain errors raised by Skill Center operations."""
+
+
+class SkillDeleteConsistencyError(RuntimeError):
+    """A Skill delete could not safely converge filesystem and database state."""
+
+
+class SkillReferencedBySkillSetError(RuntimeError):
+    """A Skill cannot be deleted while any SkillSet still references it."""
+
+    def __init__(self, skill_set_ids: list[str]) -> None:
+        super().__init__("skill is still referenced by a skill set")
+        self.skill_set_ids = skill_set_ids

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -153,6 +153,7 @@ class SkillServiceFactory:
             local_skill_path_adapter=local_skill_path_adapter,
             local_skill_locator_adapter=local_skill_locator_adapter,
             runtime_uses_pool_paths=uses_pool_paths,
+            device_owner_id=entity_id,
         )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -119,13 +119,18 @@ class SkillServiceFactory:
             Callable[[str], str]
         ] = None,
         entity_id: str | None = None,
+        bot_owner_id: str | None = None,
         bot_id: str | None = None,
         engine_type: str | None = None,
     ) -> SkillService:
         uses_pool_paths = False
         if entity_id is not None and bot_id is not None:
+            # Paths are scoped by the Bot entity, while Bot lookup and device
+            # binding are owned by ac_bots.owner_id.  They differ for project
+            # and team Bots and therefore must not be conflated.
+            lookup_owner_id = bot_owner_id or entity_id
             pool_paths = self.resolve_pool_paths(
-                str(entity_id),
+                str(lookup_owner_id),
                 str(bot_id),
                 engine_type or "",
             )
@@ -153,7 +158,7 @@ class SkillServiceFactory:
             local_skill_path_adapter=local_skill_path_adapter,
             local_skill_locator_adapter=local_skill_locator_adapter,
             runtime_uses_pool_paths=uses_pool_paths,
-            device_owner_id=entity_id,
+            device_owner_id=bot_owner_id or entity_id,
         )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
@@ -54,7 +54,11 @@ class SkillRepository(Protocol):
     def delete(self, skill_id: str) -> bool:
         ...
 
-    def list_skill_set_references(self, skill_id: str) -> list[dict]:
+    def list_skill_set_references(
+        self,
+        skill_id: str,
+        skill_uuid: str | None = None,
+    ) -> list[dict]:
         """Return every current-environment SkillSet association for a Skill."""
         ...
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
@@ -54,6 +54,10 @@ class SkillRepository(Protocol):
     def delete(self, skill_id: str) -> bool:
         ...
 
+    def list_skill_set_references(self, skill_id: str) -> list[dict]:
+        """Return every current-environment SkillSet association for a Skill."""
+        ...
+
     def check_skill_blocked_by_bot(self, name: str, env: str | None = None) -> list[str]:
         """Return bot ids whose active skill-sets reference this skill
         (deletion blockers); empty list if none."""

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
     from agentclaw.community.core.skill_center.services.git_sync import GitSyncService
 
 from agentclaw.community.core.access.admin_scopes import skill_admin
+from agentclaw.community.core.skill_center.errors import (
+    SkillDeleteConsistencyError,
+    SkillReferencedBySkillSetError,
+)
 from agentclaw.community.core.skill_center.services.repositories import (
     SkillCategoryRepository,
     SkillRepository,
@@ -49,18 +53,6 @@ SKILLS_LOCAL_DIR = SKILLS_DIR / "skills-local"
 # ``config_compose.teclaw_paths.LOCAL_SKILLS_DIRNAME``; kept as a local literal so
 # core.skill_center doesn't import config_compose (which depends on skill_center).
 _LOCAL_SKILLS_DIRNAME = "skills-local"
-
-
-class SkillDeleteConsistencyError(RuntimeError):
-    """A Skill delete could not safely converge filesystem and database state."""
-
-
-class SkillReferencedBySkillSetError(RuntimeError):
-    """A Skill cannot be deleted while any SkillSet still references it."""
-
-    def __init__(self, skill_set_ids: list[str]) -> None:
-        super().__init__("skill is still referenced by a skill set")
-        self.skill_set_ids = skill_set_ids
 
 
 def _get_default_global_repo_dir() -> Path:
@@ -2318,11 +2310,20 @@ class SkillService:
         logger.info(f"[SkillService] Deleting skill: id={skill_id}, name={skill_name}, git_path={git_path}")
         logger.info(f"[SkillService] local_dir: {self.local_dir}, active_dir: {self.active_dir}")
 
-        device_fs = (
-            None
-            if is_shared_source
-            else self._device_fs_factory(bolt_id, skill_user_id)
-        )
+        device_fs = None
+        if not is_shared_source:
+            try:
+                device_fs = self._device_fs_factory(bolt_id, skill_user_id)
+            except Exception as e:
+                if self.runtime_uses_pool_paths:
+                    raise SkillDeleteConsistencyError(
+                        "failed to resolve device filesystem before delete"
+                    ) from e
+                logger.warning(
+                    "[SkillService] Legacy runtime has no available device "
+                    "filesystem; keeping historical metadata-only delete",
+                    exc_info=True,
+                )
 
         # 1. 先收敛 active entry。已激活 Skill 的 entry 删除失败时必须 fail closed，
         # 否则继续删除 source/DB 会把它变成 dangling link。未激活时 entry
@@ -2355,7 +2356,7 @@ class SkillService:
 
         # 2. 删除物理文件（仅 local:// 技能）— 通过 DeviceFileSystem
         logger.info(f"[SkillService] Checking git_path: {git_path}, starts_with_local={git_path.startswith('local://')}")
-        if git_path.startswith('local://'):
+        if git_path.startswith('local://') and device_fs is not None:
             # teclaw: skills-local/<name> → workspace/skills-local/<name>;
             # 非 teclaw: identity（主机路径原样）。
             local_path_str = self._local_skill_path_adapter(git_path[8:])  # 去掉 local:// 前缀
@@ -2397,7 +2398,7 @@ class SkillService:
                     )
                 else:
                     logger.info(f"[SkillService] Deleted skill files: {local_path_str}")
-        else:
+        elif not git_path.startswith('local://'):
             logger.info("[SkillService] Not a local skill, skipping physical delete")
 
         # 3. 删除数据库记录

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -82,6 +82,7 @@ class SkillService:
         local_skill_path_adapter: "Callable[[str], str] | None" = None,
         local_skill_locator_adapter: "Callable[[str], str] | None" = None,
         runtime_uses_pool_paths: bool = False,
+        device_owner_id: str | None = None,
     ):
         """
         Args:
@@ -113,6 +114,7 @@ class SkillService:
         # Device filesystem factory — supplied per-request by
         # SkillServiceFactory.create() (uses DeviceFilesystemDispatcher.for_bot).
         self._device_fs_factory = device_fs_factory
+        self._device_owner_id = device_owner_id
 
         # Adapter applied to a local-skill path right before it is handed to the
         # device filesystem. Identity for arca/baas/local (they pass a host path
@@ -2288,9 +2290,16 @@ class SkillService:
             logger.warning(f"[SkillService] Permission denied: user={user_id} attempted to delete skill={skill_id} owned by={skill_owner}")
             raise ValueError("无权删除此技能：您不是该技能的创建者，且没有管理员权限")
 
+        git_path = skill.get('git_path') or ''
+        published_center_uuid = (
+            skill.get("skill_uuid")
+            if git_path.startswith("center://")
+            and str(skill.get("status") or "").upper() == "PUBLISHED"
+            else None
+        )
         references = self._skill_repo.list_skill_set_references(
             skill_id,
-            skill_uuid=skill.get("skill_uuid"),
+            skill_uuid=published_center_uuid,
         )
         if references:
             raise SkillReferencedBySkillSetError(
@@ -2299,9 +2308,9 @@ class SkillService:
 
         # 获取技能名称和路径
         skill_name = skill.get('name')
-        git_path = skill.get('git_path') or ''
         bolt_id = skill.get('bolt_id')
         skill_user_id = skill.get('user_id') or user_id
+        device_owner_id = self._device_owner_id or skill_user_id
         is_shared_source = (
             not skill.get('user_id')
             and git_path.startswith(("git://", "center://"))
@@ -2313,7 +2322,7 @@ class SkillService:
         device_fs = None
         if not is_shared_source:
             try:
-                device_fs = self._device_fs_factory(bolt_id, skill_user_id)
+                device_fs = self._device_fs_factory(bolt_id, device_owner_id)
             except Exception as e:
                 if self.runtime_uses_pool_paths:
                     raise SkillDeleteConsistencyError(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -51,6 +51,10 @@ SKILLS_LOCAL_DIR = SKILLS_DIR / "skills-local"
 _LOCAL_SKILLS_DIRNAME = "skills-local"
 
 
+class SkillDeleteConsistencyError(RuntimeError):
+    """A Skill delete could not safely converge filesystem and database state."""
+
+
 def _get_default_global_repo_dir() -> Path:
     """Get global skills repo dir — lazy import from config if available."""
     try:
@@ -2293,34 +2297,83 @@ class SkillService:
         logger.info(f"[SkillService] Deleting skill: id={skill_id}, name={skill_name}, git_path={git_path}")
         logger.info(f"[SkillService] local_dir: {self.local_dir}, active_dir: {self.active_dir}")
 
-        # 1. 删除激活的软链接（如果存在）—— Phase 4 引入 helper
-        try:
-            link_name = self.get_link_name(skill_name) if skill_name else None
-            logger.info(f"[SkillService] link_name: {link_name}")
-            if link_name:
-                active_link = self.active_dir / link_name
-                device_fs = self._device_fs_factory(bolt_id, skill_user_id)
-                await self._delete_active_entry(device_fs, active_link)
-        except Exception as e:
-            logger.warning(f"[SkillService] Failed to delete active link: {e}", exc_info=True)
+        device_fs = self._device_fs_factory(bolt_id, skill_user_id)
+
+        # 1. 先收敛 active entry。已激活 Skill 的 entry 删除失败时必须 fail closed，
+        # 否则继续删除 source/DB 会把它变成 dangling link。未激活时 entry
+        # 本来就不存在，仍保持幂等成功。
+        link_name = self.get_link_name(skill_name) if skill_name else None
+        logger.info(f"[SkillService] link_name: {link_name}")
+        if link_name:
+            active_link = self.active_dir / link_name
+            try:
+                active_entry_exists = await device_fs.exists(str(active_link))
+            except Exception as e:
+                if self.runtime_uses_pool_paths:
+                    raise SkillDeleteConsistencyError(
+                        f"failed to inspect active skill entry before delete: {active_link}"
+                    ) from e
+                logger.warning(
+                    "[SkillService] Legacy runtime could not inspect active entry: %s",
+                    active_link,
+                    exc_info=True,
+                )
+                active_entry_exists = True
+            if active_entry_exists:
+                active_deleted = await self._delete_active_entry(
+                    device_fs, active_link
+                )
+                if not active_deleted and self.runtime_uses_pool_paths:
+                    raise SkillDeleteConsistencyError(
+                        f"failed to delete active skill entry: {active_link}"
+                    )
 
         # 2. 删除物理文件（仅 local:// 技能）— 通过 DeviceFileSystem
-        try:
-            logger.info(f"[SkillService] Checking git_path: {git_path}, starts_with_local={git_path.startswith('local://')}")
-            if git_path.startswith('local://'):
-                # teclaw: skills-local/<name> → workspace/skills-local/<name>;
-                # 非 teclaw: identity（主机路径原样）。
-                local_path_str = self._local_skill_path_adapter(git_path[8:])  # 去掉 local:// 前缀
-                device_fs = self._device_fs_factory(bolt_id, skill_user_id)
-                success = await device_fs.delete_tree(local_path_str)
-                if success:
-                    logger.info(f"[SkillService] Deleted skill files: {local_path_str}")
+        logger.info(f"[SkillService] Checking git_path: {git_path}, starts_with_local={git_path.startswith('local://')}")
+        if git_path.startswith('local://'):
+            # teclaw: skills-local/<name> → workspace/skills-local/<name>;
+            # 非 teclaw: identity（主机路径原样）。
+            local_path_str = self._local_skill_path_adapter(git_path[8:])  # 去掉 local:// 前缀
+            try:
+                local_source_exists = await device_fs.exists(local_path_str)
+            except Exception as e:
+                if self.runtime_uses_pool_paths:
+                    raise SkillDeleteConsistencyError(
+                        f"failed to inspect local skill source before delete: {local_path_str}"
+                    ) from e
+                logger.warning(
+                    "[SkillService] Legacy runtime could not inspect local source: %s",
+                    local_path_str,
+                    exc_info=True,
+                )
+                local_source_exists = True
+            if local_source_exists:
+                try:
+                    success = await device_fs.delete_tree(local_path_str)
+                except Exception as e:
+                    if self.runtime_uses_pool_paths:
+                        raise SkillDeleteConsistencyError(
+                            f"failed to delete local skill source: {local_path_str}"
+                        ) from e
+                    logger.warning(
+                        "[SkillService] Legacy runtime failed to delete local source: %s",
+                        local_path_str,
+                        exc_info=True,
+                    )
+                    success = False
+                if not success:
+                    if self.runtime_uses_pool_paths:
+                        raise SkillDeleteConsistencyError(
+                            f"failed to delete local skill source: {local_path_str}"
+                        )
+                    logger.warning(
+                        "[SkillService] Legacy runtime did not delete local source: %s",
+                        local_path_str,
+                    )
                 else:
-                    logger.warning(f"[SkillService] Failed to delete skill files: {local_path_str}")
-            else:
-                logger.info("[SkillService] Not a local skill, skipping physical delete")
-        except Exception as e:
-            logger.warning(f"[SkillService] Failed to delete local skill: {e}", exc_info=True)
+                    logger.info(f"[SkillService] Deleted skill files: {local_path_str}")
+        else:
+            logger.info("[SkillService] Not a local skill, skipping physical delete")
 
         # 3. 删除数据库记录
         return self._skill_repo.delete(skill_id)

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -55,6 +55,14 @@ class SkillDeleteConsistencyError(RuntimeError):
     """A Skill delete could not safely converge filesystem and database state."""
 
 
+class SkillReferencedBySkillSetError(RuntimeError):
+    """A Skill cannot be deleted while any SkillSet still references it."""
+
+    def __init__(self, skill_set_ids: list[str]) -> None:
+        super().__init__("skill is still referenced by a skill set")
+        self.skill_set_ids = skill_set_ids
+
+
 def _get_default_global_repo_dir() -> Path:
     """Get global skills repo dir — lazy import from config if available."""
     try:
@@ -2287,6 +2295,12 @@ class SkillService:
             skill_owner = skill.get('user_id')
             logger.warning(f"[SkillService] Permission denied: user={user_id} attempted to delete skill={skill_id} owned by={skill_owner}")
             raise ValueError("无权删除此技能：您不是该技能的创建者，且没有管理员权限")
+
+        references = self._skill_repo.list_skill_set_references(skill_id)
+        if references:
+            raise SkillReferencedBySkillSetError(
+                [str(ref["skill_set_id"]) for ref in references]
+            )
 
         # 获取技能名称和路径
         skill_name = skill.get('name')

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -2296,7 +2296,10 @@ class SkillService:
             logger.warning(f"[SkillService] Permission denied: user={user_id} attempted to delete skill={skill_id} owned by={skill_owner}")
             raise ValueError("无权删除此技能：您不是该技能的创建者，且没有管理员权限")
 
-        references = self._skill_repo.list_skill_set_references(skill_id)
+        references = self._skill_repo.list_skill_set_references(
+            skill_id,
+            skill_uuid=skill.get("skill_uuid"),
+        )
         if references:
             raise SkillReferencedBySkillSetError(
                 [str(ref["skill_set_id"]) for ref in references]
@@ -2304,21 +2307,29 @@ class SkillService:
 
         # 获取技能名称和路径
         skill_name = skill.get('name')
-        git_path = skill.get('git_path', '')
+        git_path = skill.get('git_path') or ''
         bolt_id = skill.get('bolt_id')
         skill_user_id = skill.get('user_id') or user_id
+        is_shared_source = (
+            not skill.get('user_id')
+            and git_path.startswith(("git://", "center://"))
+        )
 
         logger.info(f"[SkillService] Deleting skill: id={skill_id}, name={skill_name}, git_path={git_path}")
         logger.info(f"[SkillService] local_dir: {self.local_dir}, active_dir: {self.active_dir}")
 
-        device_fs = self._device_fs_factory(bolt_id, skill_user_id)
+        device_fs = (
+            None
+            if is_shared_source
+            else self._device_fs_factory(bolt_id, skill_user_id)
+        )
 
         # 1. 先收敛 active entry。已激活 Skill 的 entry 删除失败时必须 fail closed，
         # 否则继续删除 source/DB 会把它变成 dangling link。未激活时 entry
         # 本来就不存在，仍保持幂等成功。
         link_name = self.get_link_name(skill_name) if skill_name else None
         logger.info(f"[SkillService] link_name: {link_name}")
-        if link_name:
+        if link_name and device_fs is not None:
             active_link = self.active_dir / link_name
             try:
                 active_entry_exists = await device_fs.exists(str(active_link))

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -715,6 +715,22 @@ class SkillRepository:
                 ).delete(synchronize_session=False)
             return count
 
+    def list_skill_set_references(self, skill_id: str) -> list[dict]:
+        """List all SkillSet associations, regardless of activation state."""
+        from agentclaw.community.core.models import SkillSetSkill
+
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(SkillSetSkill.skill_set_id)
+                .filter(
+                    SkillSetSkill.skill_id == int(skill_id),
+                    SkillSetSkill.env == get_current_env(),
+                )
+                .order_by(SkillSetSkill.id)
+                .all()
+            )
+            return [{"skill_set_id": str(row[0])} for row in rows]
+
     def get_active_skills_by_bot(
         self,
         bot_id: str,

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -715,18 +715,37 @@ class SkillRepository:
                 ).delete(synchronize_session=False)
             return count
 
-    def list_skill_set_references(self, skill_id: str) -> list[dict]:
-        """List all SkillSet associations, regardless of activation state."""
+    def list_skill_set_references(
+        self,
+        skill_id: str,
+        skill_uuid: str | None = None,
+    ) -> list[dict]:
+        """List live SkillSet associations, regardless of activation state."""
         from agentclaw.community.core.models import SkillSetSkill
 
+        identity_filter = SkillSetSkill.skill_id == int(skill_id)
+        if skill_uuid:
+            identity_filter = or_(
+                identity_filter,
+                SkillSetSkill.skill_uuid == skill_uuid,
+            )
         with self._db.orm_session() as db:
             rows = (
                 db.query(SkillSetSkill.skill_set_id)
-                .filter(
-                    SkillSetSkill.skill_id == int(skill_id),
-                    SkillSetSkill.env == get_current_env(),
+                .join(
+                    self.SkillSet,
+                    SkillSetSkill.skill_set_id == self.SkillSet.id,
                 )
-                .order_by(SkillSetSkill.id)
+                .filter(
+                    identity_filter,
+                    SkillSetSkill.env == get_current_env(),
+                    or_(
+                        self.SkillSet.env == get_current_env(),
+                        self.SkillSet.env.is_(None),
+                    ),
+                )
+                .distinct()
+                .order_by(SkillSetSkill.skill_set_id)
                 .all()
             )
             return [{"skill_set_id": str(row[0])} for row in rows]

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -106,6 +106,7 @@ async def test_delete_without_bot_query_uses_skill_bot_and_engine_paths():
     """DELETE derives the physical context from the persisted Skill, not default."""
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.list_skill_set_references.return_value = []
     skill_repo.delete.return_value = True
     device_fs = MagicMock()
     device_fs.exists = AsyncMock(return_value=True)
@@ -135,6 +136,7 @@ async def test_delete_fails_closed_when_existing_active_entry_cannot_be_removed(
     """An active-link deletion failure keeps Pool source and DB intact."""
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.list_skill_set_references.return_value = []
     skill_repo.delete.return_value = True
     device_fs = MagicMock()
     device_fs.exists = AsyncMock(return_value=True)
@@ -148,3 +150,30 @@ async def test_delete_fails_closed_when_existing_active_entry_cannot_be_removed(
     device_fs.delete_tree.assert_awaited_once_with(
         f"{ACTIVE_ROOT}/find-skills"
     )
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_skill_referenced_by_any_skill_set():
+    """Active and inactive SkillSet references both block metadata deletion."""
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.list_skill_set_references.return_value = [
+        {"skill_set_id": "1113652"},
+        {"skill_set_id": "1113653"},
+    ]
+    device_fs = MagicMock()
+    device_fs.exists = AsyncMock(return_value=True)
+    device_fs.delete_tree = AsyncMock(return_value=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_delete(device_fs=device_fs, skill_repo=skill_repo)
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {
+        "error_code": "SKILL_REFERENCED_BY_SKILL_SET",
+        "message": "请先从所有技能集中移除该技能，再删除技能",
+        "skill_set_ids": ["1113652", "1113653"],
+    }
+    skill_repo.delete.assert_not_called()
+    device_fs.exists.assert_not_awaited()
+    device_fs.delete_tree.assert_not_awaited()

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from agentclaw.community.adapters.http.dependencies import RequestContext
+from agentclaw.community.adapters.http.skill_center.skills import delete_skill
+from agentclaw.community.core.skill_center.services.skill_service import SkillService
+
+
+BOT_ID = "20260731_yh7d4xom"
+OWNER_ID = "168944"
+SKILL_ID = "1120413"
+ACTIVE_ROOT = Path("/home/admin/.hermes/skills")
+POOL_LOCAL = Path(
+    "/home/admin/.hermes/workspace/skills-pool/skills-local"
+)
+
+
+class _SkillServiceFactory:
+    def __init__(self, *, skill_repo, device_fs) -> None:
+        self._skill_repo = skill_repo
+        self._device_fs = device_fs
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SkillService(
+            skill_repo=self._skill_repo,
+            skill_repo_sync=MagicMock(),
+            category_repo=MagicMock(),
+            market_cache=MagicMock(),
+            active_dir=kwargs.get("active_dir", ACTIVE_ROOT),
+            repo_dir=kwargs.get("repo_dir", ACTIVE_ROOT / "skills-repo"),
+            local_dir=kwargs.get("local_dir", POOL_LOCAL),
+            device_fs_factory=lambda _bot_id, _owner_id: self._device_fs,
+            git_sync_service_factory=MagicMock(),
+            local_skill_path_adapter=kwargs.get("local_skill_path_adapter"),
+            runtime_uses_pool_paths=True,
+        )
+
+
+def _skill_record() -> dict:
+    return {
+        "id": SKILL_ID,
+        "name": "find-skills",
+        "git_path": f"local://{POOL_LOCAL}/find-skills",
+        "bolt_id": BOT_ID,
+        "user_id": OWNER_ID,
+    }
+
+
+def _bot_record() -> dict:
+    return {
+        "bot_id": BOT_ID,
+        "owner_id": OWNER_ID,
+        "entity_id": OWNER_ID,
+        "entity_type": "staff",
+        "active_engine": "hermes",
+        "bot_type": "personal",
+        "env": "pre",
+    }
+
+
+async def _call_delete(*, device_fs, skill_repo):
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_owner.return_value = _bot_record()
+
+    path_factory = MagicMock()
+    path_factory.get_bot_skills_dir.return_value = ACTIVE_ROOT
+    path_factory.get_bot_skills_local_dir.return_value = POOL_LOCAL
+    path_factory.get_bot_skills_repo_dir.return_value = (
+        Path("/home/admin/.hermes/workspace/skills-pool/skills-repo")
+    )
+
+    resolver = MagicMock()
+    resolver.resolve_for_bot.return_value.provider = "arca"
+    edit_guard = MagicMock()
+    edit_guard.acquire_for_edit.return_value = MagicMock()
+    factory = _SkillServiceFactory(skill_repo=skill_repo, device_fs=device_fs)
+
+    endpoint = getattr(delete_skill, "__wrapped__", delete_skill)
+    response = await endpoint(
+        skill_id=SKILL_ID,
+        user_id=OWNER_ID,
+        entity_id=None,
+        entity_type=None,
+        bot_id=None,
+        engine_type=None,
+        ctx=RequestContext(user_id=OWNER_ID, bot_id="default"),
+        bot_repo=bot_repo,
+        path_factory=path_factory,
+        skill_service_factory=factory,
+        resolver=resolver,
+        edit_guard=edit_guard,
+        skill_repo=skill_repo,
+    )
+    return response, path_factory, factory
+
+
+@pytest.mark.asyncio
+async def test_delete_without_bot_query_uses_skill_bot_and_engine_paths():
+    """DELETE derives the physical context from the persisted Skill, not default."""
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.delete.return_value = True
+    device_fs = MagicMock()
+    device_fs.exists = AsyncMock(return_value=True)
+    device_fs.delete_tree = AsyncMock(return_value=True)
+
+    response, path_factory, factory = await _call_delete(
+        device_fs=device_fs,
+        skill_repo=skill_repo,
+    )
+
+    assert response.success is True
+    path_factory.get_bot_skills_dir.assert_called_once_with(
+        OWNER_ID, BOT_ID, "hermes", "staff"
+    )
+    assert factory.calls[0]["bot_id"] == BOT_ID
+    assert factory.calls[0]["engine_type"] == "hermes"
+    assert device_fs.delete_tree.await_args_list[0].args[0] == (
+        f"{ACTIVE_ROOT}/find-skills"
+    )
+    assert device_fs.delete_tree.await_args_list[1].args[0] == (
+        f"{POOL_LOCAL}/find-skills"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_fails_closed_when_existing_active_entry_cannot_be_removed():
+    """An active-link deletion failure keeps Pool source and DB intact."""
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.delete.return_value = True
+    device_fs = MagicMock()
+    device_fs.exists = AsyncMock(return_value=True)
+    device_fs.delete_tree = AsyncMock(return_value=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_delete(device_fs=device_fs, skill_repo=skill_repo)
+
+    assert exc_info.value.status_code == 409
+    skill_repo.delete.assert_not_called()
+    device_fs.delete_tree.assert_awaited_once_with(
+        f"{ACTIVE_ROOT}/find-skills"
+    )

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -48,7 +48,9 @@ class _SkillServiceFactory:
             git_sync_service_factory=MagicMock(),
             local_skill_path_adapter=kwargs.get("local_skill_path_adapter"),
             runtime_uses_pool_paths=bool(kwargs.get("bot_id")),
-            device_owner_id=kwargs.get("entity_id"),
+            device_owner_id=(
+                kwargs.get("bot_owner_id") or kwargs.get("entity_id")
+            ),
         )
 
 
@@ -82,11 +84,13 @@ async def _call_delete(
     current_user_id=OWNER_ID,
     entity_id=None,
     bot_repo=None,
+    bot_record=None,
 ):
     bot_repo = bot_repo or MagicMock()
-    bot_repo.get_by_id_and_owner.return_value = _bot_record()
-    bot_repo.get_unique_by_id.return_value = _bot_record()
-    bot_repo.get_by_id_and_entity.return_value = _bot_record()
+    resolved_bot = bot_record or _bot_record()
+    bot_repo.get_by_id_and_owner.return_value = resolved_bot
+    bot_repo.get_unique_by_id.return_value = resolved_bot
+    bot_repo.get_by_id_and_entity.return_value = resolved_bot
 
     path_factory = MagicMock()
     path_factory.get_bot_skills_dir.return_value = ACTIVE_ROOT
@@ -109,7 +113,7 @@ async def _call_delete(
         entity_type=None,
         bot_id=None,
         engine_type=engine_type,
-        ctx=RequestContext(user_id=OWNER_ID, bot_id="default"),
+        ctx=RequestContext(user_id=current_user_id, bot_id="default"),
         bot_repo=bot_repo,
         path_factory=path_factory,
         skill_service_factory=factory,
@@ -221,6 +225,36 @@ async def test_delete_uses_bot_owner_when_skill_was_authored_by_collaborator():
     path_factory.get_bot_skills_dir.assert_called_once_with(
         OWNER_ID, BOT_ID, "hermes", "staff"
     )
+    assert factory.device_fs_calls == [(BOT_ID, OWNER_ID)]
+
+
+@pytest.mark.asyncio
+async def test_delete_project_bot_uses_entity_paths_and_owner_device_binding():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.list_skill_set_references.return_value = []
+    skill_repo.delete.return_value = True
+    bot_record = {
+        **_bot_record(),
+        "owner_id": OWNER_ID,
+        "entity_id": "project-42",
+        "entity_type": "proj",
+    }
+    device_fs = MagicMock()
+    device_fs.exists = AsyncMock(return_value=False)
+
+    response, path_factory, factory = await _call_delete(
+        device_fs=device_fs,
+        skill_repo=skill_repo,
+        bot_record=bot_record,
+    )
+
+    assert response.success is True
+    path_factory.get_bot_skills_dir.assert_called_once_with(
+        "project-42", BOT_ID, "hermes", "proj"
+    )
+    assert factory.calls[0]["entity_id"] == "project-42"
+    assert factory.calls[0]["bot_owner_id"] == OWNER_ID
     assert factory.device_fs_calls == [(BOT_ID, OWNER_ID)]
 
 
@@ -355,3 +389,43 @@ async def test_admin_can_delete_unreferenced_shared_market_skill():
     assert response.success is True
     skill_repo.delete.assert_called_once_with(SKILL_ID)
     device_fs.exists.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shared_delete_does_not_trust_query_user_id_for_admin_permission():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        "id": SKILL_ID,
+        "name": "market-skill",
+        "git_path": "git://business/market-skill",
+        "bolt_id": "default",
+        "user_id": None,
+    }
+    factory = _SkillServiceFactory(skill_repo=skill_repo, device_fs=MagicMock())
+    endpoint = getattr(delete_skill, "__wrapped__", delete_skill)
+
+    with (
+        patch(
+            "agentclaw.community.core.skill_center.services.skill_service.skill_admin",
+            return_value=[OWNER_ID],
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await endpoint(
+            skill_id=SKILL_ID,
+            user_id=OWNER_ID,
+            entity_id=None,
+            entity_type=None,
+            bot_id=None,
+            engine_type=None,
+            ctx=RequestContext(user_id="ordinary-user", bot_id="default"),
+            skill_repo=skill_repo,
+            bot_repo=MagicMock(),
+            path_factory=MagicMock(),
+            skill_service_factory=factory,
+            resolver=MagicMock(),
+            edit_guard=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+    skill_repo.delete.assert_not_called()

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -39,7 +39,7 @@ class _SkillServiceFactory:
             device_fs_factory=lambda _bot_id, _owner_id: self._device_fs,
             git_sync_service_factory=MagicMock(),
             local_skill_path_adapter=kwargs.get("local_skill_path_adapter"),
-            runtime_uses_pool_paths=True,
+            runtime_uses_pool_paths=bool(kwargs.get("bot_id")),
         )
 
 
@@ -65,9 +65,12 @@ def _bot_record() -> dict:
     }
 
 
-async def _call_delete(*, device_fs, skill_repo):
+async def _call_delete(
+    *, device_fs, skill_repo, engine_type=None, current_user_id=OWNER_ID
+):
     bot_repo = MagicMock()
     bot_repo.get_by_id_and_owner.return_value = _bot_record()
+    bot_repo.get_unique_by_id.return_value = _bot_record()
 
     path_factory = MagicMock()
     path_factory.get_bot_skills_dir.return_value = ACTIVE_ROOT
@@ -85,11 +88,11 @@ async def _call_delete(*, device_fs, skill_repo):
     endpoint = getattr(delete_skill, "__wrapped__", delete_skill)
     response = await endpoint(
         skill_id=SKILL_ID,
-        user_id=OWNER_ID,
+        user_id=current_user_id,
         entity_id=None,
         entity_type=None,
         bot_id=None,
-        engine_type=None,
+        engine_type=engine_type,
         ctx=RequestContext(user_id=OWNER_ID, bot_id="default"),
         bot_repo=bot_repo,
         path_factory=path_factory,
@@ -177,3 +180,115 @@ async def test_delete_rejects_skill_referenced_by_any_skill_set():
     skill_repo.delete.assert_not_called()
     device_fs.exists.assert_not_awaited()
     device_fs.delete_tree.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_uses_bot_owner_when_skill_was_authored_by_collaborator():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        **_skill_record(),
+        "user_id": "405935",
+    }
+    skill_repo.list_skill_set_references.return_value = []
+    skill_repo.delete.return_value = True
+    device_fs = MagicMock()
+    device_fs.exists = AsyncMock(return_value=True)
+    device_fs.delete_tree = AsyncMock(return_value=True)
+
+    response, path_factory, _ = await _call_delete(
+        device_fs=device_fs,
+        skill_repo=skill_repo,
+        current_user_id="405935",
+    )
+
+    assert response.success is True
+    path_factory.get_bot_skills_dir.assert_called_once_with(
+        OWNER_ID, BOT_ID, "hermes", "staff"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_malformed_skill_id_with_400():
+    endpoint = getattr(delete_skill, "__wrapped__", delete_skill)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await endpoint(
+            skill_id="not-a-number",
+            user_id=OWNER_ID,
+            entity_id=None,
+            entity_type=None,
+            bot_id=None,
+            engine_type=None,
+            ctx=RequestContext(user_id=OWNER_ID, bot_id="default"),
+            skill_repo=MagicMock(),
+            bot_repo=MagicMock(),
+            path_factory=MagicMock(),
+            skill_service_factory=MagicMock(),
+            resolver=MagicMock(),
+            edit_guard=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_engine_override_that_differs_from_bot():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    device_fs = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_delete(
+            device_fs=device_fs,
+            skill_repo=skill_repo,
+            engine_type="openclaw",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {
+        "error_code": "SKILL_ENGINE_CONTEXT_MISMATCH",
+        "message": "删除技能必须使用 Bot 当前的生效引擎",
+        "active_engine": "hermes",
+    }
+    skill_repo.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_admin_can_delete_unreferenced_shared_market_skill():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = {
+        "id": SKILL_ID,
+        "name": "market-skill",
+        "git_path": "git://business/market-skill",
+        "bolt_id": "default",
+        "user_id": None,
+    }
+    skill_repo.list_skill_set_references.return_value = []
+    skill_repo.delete.return_value = True
+    device_fs = MagicMock()
+    factory = _SkillServiceFactory(skill_repo=skill_repo, device_fs=device_fs)
+    endpoint = getattr(delete_skill, "__wrapped__", delete_skill)
+
+    with patch(
+        "agentclaw.community.core.skill_center.services.skill_service.skill_admin",
+        return_value=[OWNER_ID],
+    ):
+        response = await endpoint(
+            skill_id=SKILL_ID,
+            user_id=OWNER_ID,
+            entity_id=None,
+            entity_type=None,
+            bot_id=None,
+            engine_type=None,
+            ctx=RequestContext(user_id=OWNER_ID, bot_id="default"),
+            skill_repo=skill_repo,
+            bot_repo=MagicMock(),
+            path_factory=MagicMock(),
+            skill_service_factory=factory,
+            resolver=MagicMock(),
+            edit_guard=MagicMock(),
+        )
+
+    assert response.success is True
+    skill_repo.delete.assert_called_once_with(SKILL_ID)
+    device_fs.exists.assert_not_called()

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -8,6 +8,9 @@ from fastapi import HTTPException
 
 from agentclaw.community.adapters.http.dependencies import RequestContext
 from agentclaw.community.adapters.http.skill_center.skills import delete_skill
+from agentclaw.community.core.bot_management.repository.protocol import (
+    BotLookupAmbiguousError,
+)
 from agentclaw.community.core.skill_center.services.skill_service import SkillService
 
 
@@ -66,11 +69,18 @@ def _bot_record() -> dict:
 
 
 async def _call_delete(
-    *, device_fs, skill_repo, engine_type=None, current_user_id=OWNER_ID
+    *,
+    device_fs,
+    skill_repo,
+    engine_type=None,
+    current_user_id=OWNER_ID,
+    entity_id=None,
+    bot_repo=None,
 ):
-    bot_repo = MagicMock()
+    bot_repo = bot_repo or MagicMock()
     bot_repo.get_by_id_and_owner.return_value = _bot_record()
     bot_repo.get_unique_by_id.return_value = _bot_record()
+    bot_repo.get_by_id_and_entity.return_value = _bot_record()
 
     path_factory = MagicMock()
     path_factory.get_bot_skills_dir.return_value = ACTIVE_ROOT
@@ -89,7 +99,7 @@ async def _call_delete(
     response = await endpoint(
         skill_id=SKILL_ID,
         user_id=current_user_id,
-        entity_id=None,
+        entity_id=entity_id,
         entity_type=None,
         bot_id=None,
         engine_type=engine_type,
@@ -249,6 +259,52 @@ async def test_delete_rejects_engine_override_that_differs_from_bot():
         "error_code": "SKILL_ENGINE_CONTEXT_MISMATCH",
         "message": "删除技能必须使用 Bot 当前的生效引擎",
         "active_engine": "hermes",
+    }
+    skill_repo.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_uses_entity_to_disambiguate_legacy_bot_id():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.list_skill_set_references.return_value = []
+    skill_repo.delete.return_value = True
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_entity.return_value = _bot_record()
+    device_fs = MagicMock()
+    device_fs.exists = AsyncMock(return_value=False)
+
+    response, _, _ = await _call_delete(
+        device_fs=device_fs,
+        skill_repo=skill_repo,
+        entity_id=OWNER_ID,
+        bot_repo=bot_repo,
+    )
+
+    assert response.success is True
+    bot_repo.get_by_id_and_entity.assert_called_once_with(BOT_ID, OWNER_ID)
+    bot_repo.get_unique_by_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_ambiguous_legacy_bot_without_entity():
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    bot_repo = MagicMock()
+    bot_repo.get_unique_by_id.side_effect = BotLookupAmbiguousError
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_delete(
+            device_fs=MagicMock(),
+            skill_repo=skill_repo,
+            bot_repo=bot_repo,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {
+        "error_code": "SKILL_BOT_CONTEXT_AMBIGUOUS",
+        "message": "历史 Bot ID 不唯一，请提供 entity_id 精确定位",
+        "bot_id": BOT_ID,
     }
     skill_repo.delete.assert_not_called()
 

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -28,6 +28,11 @@ class _SkillServiceFactory:
         self._skill_repo = skill_repo
         self._device_fs = device_fs
         self.calls: list[dict] = []
+        self.device_fs_calls: list[tuple[str, str]] = []
+
+    def _device_fs_for_bot(self, bot_id: str, owner_id: str):
+        self.device_fs_calls.append((bot_id, owner_id))
+        return self._device_fs
 
     def create(self, **kwargs):
         self.calls.append(kwargs)
@@ -39,10 +44,11 @@ class _SkillServiceFactory:
             active_dir=kwargs.get("active_dir", ACTIVE_ROOT),
             repo_dir=kwargs.get("repo_dir", ACTIVE_ROOT / "skills-repo"),
             local_dir=kwargs.get("local_dir", POOL_LOCAL),
-            device_fs_factory=lambda _bot_id, _owner_id: self._device_fs,
+            device_fs_factory=self._device_fs_for_bot,
             git_sync_service_factory=MagicMock(),
             local_skill_path_adapter=kwargs.get("local_skill_path_adapter"),
             runtime_uses_pool_paths=bool(kwargs.get("bot_id")),
+            device_owner_id=kwargs.get("entity_id"),
         )
 
 
@@ -205,7 +211,7 @@ async def test_delete_uses_bot_owner_when_skill_was_authored_by_collaborator():
     device_fs.exists = AsyncMock(return_value=True)
     device_fs.delete_tree = AsyncMock(return_value=True)
 
-    response, path_factory, _ = await _call_delete(
+    response, path_factory, factory = await _call_delete(
         device_fs=device_fs,
         skill_repo=skill_repo,
         current_user_id="405935",
@@ -215,6 +221,7 @@ async def test_delete_uses_bot_owner_when_skill_was_authored_by_collaborator():
     path_factory.get_bot_skills_dir.assert_called_once_with(
         OWNER_ID, BOT_ID, "hermes", "staff"
     )
+    assert factory.device_fs_calls == [(BOT_ID, OWNER_ID)]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -30,6 +30,26 @@ def _make_service(device_fs, *, runtime_uses_pool_paths=False):
 
 class TestDeleteSkillStep1:
     @pytest.mark.asyncio
+    async def test_delete_tolerates_nullable_git_path(self):
+        """Historical metadata with a NULL locator must not crash deletion."""
+        device_fs = MagicMock()
+        device_fs.exists = AsyncMock(return_value=False)
+        device_fs.delete_tree = AsyncMock(return_value=True)
+        svc, _ = _make_service(device_fs)
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": None,
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            assert await svc.delete_skill("sk-1", user_id="u-1") is True
+
+    @pytest.mark.asyncio
     async def test_delete_skill_calls_device_fs_delete_tree_for_active_link(self):
         """delete_skill step 1 must call device_fs.delete_tree on active_link, not shutil.rmtree."""
         device_fs = MagicMock()

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-def _make_service(device_fs):
+def _make_service(device_fs, *, runtime_uses_pool_paths=False):
     """Build SkillService with a mocked device_fs_factory and stubbed deps."""
     from agentclaw.community.core.skill_center.services.skill_service import SkillService
 
@@ -22,6 +22,7 @@ def _make_service(device_fs):
         local_dir=Path("/oss-view/.../skills-local"),
         device_fs_factory=factory,
         git_sync_service_factory=MagicMock(),
+        runtime_uses_pool_paths=runtime_uses_pool_paths,
     )
     return svc, factory
 
@@ -31,6 +32,7 @@ class TestDeleteSkillStep1:
     async def test_delete_skill_calls_device_fs_delete_tree_for_active_link(self):
         """delete_skill step 1 must call device_fs.delete_tree on active_link, not shutil.rmtree."""
         device_fs = MagicMock()
+        device_fs.exists = AsyncMock(return_value=True)
         device_fs.delete_tree = AsyncMock(return_value=True)
         svc, factory = _make_service(device_fs)
 
@@ -63,11 +65,16 @@ class TestDeleteSkillStep1:
         mock_rmtree.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_delete_skill_swallows_active_link_delete_failure(self):
-        """If device_fs.delete_tree returns False for active link, delete_skill still proceeds."""
+    async def test_delete_skill_fails_closed_on_active_link_delete_failure(self):
+        """An active-link failure must preserve both local source and DB metadata."""
+        from agentclaw.community.core.skill_center.services.skill_service import (
+            SkillDeleteConsistencyError,
+        )
+
         device_fs = MagicMock()
-        device_fs.delete_tree = AsyncMock(side_effect=[False, True])
-        svc, _ = _make_service(device_fs)
+        device_fs.exists = AsyncMock(return_value=True)
+        device_fs.delete_tree = AsyncMock(return_value=False)
+        svc, _ = _make_service(device_fs, runtime_uses_pool_paths=True)
 
         skill = {
             "id": "sk-1",
@@ -85,9 +92,148 @@ class TestDeleteSkillStep1:
         ), patch("pathlib.Path.exists", return_value=True), patch(
             "pathlib.Path.is_symlink", return_value=True
         ):
-            ok = await svc.delete_skill("sk-1", user_id="u-1")
+            with pytest.raises(SkillDeleteConsistencyError):
+                await svc.delete_skill("sk-1", user_id="u-1")
 
-        assert ok is True
+        svc._skill_repo.delete.assert_not_called()
+        device_fs.delete_tree.assert_awaited_once_with(
+            "/oss-view/.../skills/x"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_unactivated_skill_treats_missing_active_entry_as_idempotent(self):
+        """An absent active entry must not block deleting an unactivated local Skill."""
+        device_fs = MagicMock()
+        device_fs.exists = AsyncMock(side_effect=[False, True])
+        device_fs.delete_tree = AsyncMock(return_value=True)
+        svc, _ = _make_service(device_fs, runtime_uses_pool_paths=True)
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": "local:///oss-view/.../skills-local/x",
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            assert await svc.delete_skill("sk-1", user_id="u-1") is True
+
+        device_fs.delete_tree.assert_awaited_once_with(
+            "/oss-view/.../skills-local/x"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_fails_closed_when_local_source_delete_fails(self):
+        """A source deletion failure must preserve DB metadata for recovery."""
+        from agentclaw.community.core.skill_center.services.skill_service import (
+            SkillDeleteConsistencyError,
+        )
+
+        device_fs = MagicMock()
+        device_fs.exists = AsyncMock(side_effect=[False, True])
+        device_fs.delete_tree = AsyncMock(return_value=False)
+        svc, _ = _make_service(device_fs, runtime_uses_pool_paths=True)
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": "local:///oss-view/.../skills-local/x",
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            with pytest.raises(SkillDeleteConsistencyError):
+                await svc.delete_skill("sk-1", user_id="u-1")
+
+        svc._skill_repo.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("exists_effect", "delete_effect"),
+        [
+            (RuntimeError("inspect failed"), True),
+            (True, RuntimeError("delete failed")),
+        ],
+    )
+    async def test_pool_delete_fails_closed_on_local_source_io_exception(
+        self,
+        exists_effect,
+        delete_effect,
+    ):
+        """Pool source inspection/deletion exceptions preserve DB metadata."""
+        from agentclaw.community.core.skill_center.services.skill_service import (
+            SkillDeleteConsistencyError,
+        )
+
+        device_fs = MagicMock()
+        device_fs.exists = AsyncMock(side_effect=[False, exists_effect])
+        device_fs.delete_tree = AsyncMock(side_effect=delete_effect)
+        svc, _ = _make_service(device_fs, runtime_uses_pool_paths=True)
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": "local:///oss-view/.../skills-local/x",
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            with pytest.raises(SkillDeleteConsistencyError):
+                await svc.delete_skill("sk-1", user_id="u-1")
+
+        svc._skill_repo.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pool_delete_fails_closed_when_active_inspection_fails(self):
+        from agentclaw.community.core.skill_center.services.skill_service import (
+            SkillDeleteConsistencyError,
+        )
+
+        device_fs = MagicMock()
+        device_fs.exists = AsyncMock(side_effect=RuntimeError("inspect failed"))
+        device_fs.delete_tree = AsyncMock(return_value=True)
+        svc, _ = _make_service(device_fs, runtime_uses_pool_paths=True)
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": "local:///oss-view/.../skills-local/x",
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            with pytest.raises(SkillDeleteConsistencyError):
+                await svc.delete_skill("sk-1", user_id="u-1")
+
+        svc._skill_repo.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_delete_keeps_historical_best_effort_behavior(self):
+        """Legacy runtimes remain best effort when their device is unavailable."""
+        device_fs = MagicMock()
+        device_fs.exists = AsyncMock(side_effect=RuntimeError("offline"))
+        device_fs.delete_tree = AsyncMock(return_value=False)
+        svc, _ = _make_service(device_fs, runtime_uses_pool_paths=False)
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": "local:///oss-view/.../skills-local/x",
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            assert await svc.delete_skill("sk-1", user_id="u-1") is True
 
 
 class TestDeleteActiveEntryHelper:

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -30,6 +30,48 @@ def _make_service(device_fs, *, runtime_uses_pool_paths=False):
 
 class TestDeleteSkillStep1:
     @pytest.mark.asyncio
+    async def test_legacy_delete_keeps_metadata_only_fallback_without_device(self):
+        """Legacy deletion preserves its historical behavior without a binding."""
+        svc, _ = _make_service(MagicMock())
+        svc._device_fs_factory = MagicMock(side_effect=RuntimeError("not bound"))
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": "local:///oss-view/.../skills-local/x",
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            assert await svc.delete_skill("sk-1", user_id="u-1") is True
+
+    @pytest.mark.asyncio
+    async def test_pool_delete_fails_closed_without_device(self):
+        from agentclaw.community.core.skill_center.errors import (
+            SkillDeleteConsistencyError,
+        )
+
+        svc, _ = _make_service(MagicMock(), runtime_uses_pool_paths=True)
+        svc._device_fs_factory = MagicMock(side_effect=RuntimeError("not bound"))
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": "local:///oss-view/.../skills-local/x",
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ):
+            with pytest.raises(SkillDeleteConsistencyError):
+                await svc.delete_skill("sk-1", user_id="u-1")
+
+        svc._skill_repo.delete.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_delete_tolerates_nullable_git_path(self):
         """Historical metadata with a NULL locator must not crash deletion."""
         device_fs = MagicMock()

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -30,6 +30,44 @@ def _make_service(device_fs, *, runtime_uses_pool_paths=False):
 
 class TestDeleteSkillStep1:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("git_path", "status", "expected_uuid"),
+        [
+            ("center://uuid", "PUBLISHED", "uuid"),
+            ("", "DEVELOPING", None),
+            ("center://uuid", "OFFLINE", None),
+        ],
+    )
+    async def test_delete_checks_uuid_only_for_published_center_version(
+        self,
+        git_path,
+        status,
+        expected_uuid,
+    ):
+        device_fs = MagicMock()
+        device_fs.exists = AsyncMock(return_value=False)
+        svc, _ = _make_service(device_fs)
+        skill = {
+            "id": "sk-1",
+            "name": "x",
+            "git_path": git_path,
+            "skill_uuid": "uuid",
+            "status": status,
+            "bolt_id": "bolt-1",
+            "user_id": "u-1",
+        }
+
+        with patch.object(svc, "get_skill", return_value=skill), patch.object(
+            svc, "_can_delete_skill", return_value=True
+        ), patch.object(svc._skill_repo, "delete", return_value=True):
+            assert await svc.delete_skill("sk-1", user_id="u-1") is True
+
+        svc._skill_repo.list_skill_set_references.assert_called_once_with(
+            "sk-1",
+            skill_uuid=expected_uuid,
+        )
+
+    @pytest.mark.asyncio
     async def test_legacy_delete_keeps_metadata_only_fallback_without_device(self):
         """Legacy deletion preserves its historical behavior without a binding."""
         svc, _ = _make_service(MagicMock())

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -24,6 +24,7 @@ def _make_service(device_fs, *, runtime_uses_pool_paths=False):
         git_sync_service_factory=MagicMock(),
         runtime_uses_pool_paths=runtime_uses_pool_paths,
     )
+    svc._skill_repo.list_skill_set_references.return_value = []
     return svc, factory
 
 

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -133,6 +133,7 @@ async def test_teclaw_get_skill_readme_reads_adapted_path():
 @pytest.mark.asyncio
 async def test_teclaw_delete_skill_removes_adapted_path():
     fake_fs = MagicMock()
+    fake_fs.exists = AsyncMock(return_value=True)
     fake_fs.delete_tree = AsyncMock(return_value=True)
     fake_fs.delete_file = AsyncMock(return_value=True)
     fake_fs.read_file = AsyncMock(return_value=None)

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -100,6 +100,7 @@ async def test_non_teclaw_upload_passes_host_path_through_unchanged():
 def _readonly_service(adapter, fake_fs, skill_row) -> SkillService:
     repo = MagicMock()
     repo.get_by_id.return_value = skill_row
+    repo.list_skill_set_references.return_value = []
     svc = SkillService(
         skill_repo=repo,
         skill_repo_sync=MagicMock(get_local_skills_root=MagicMock(return_value=None)),

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -97,6 +97,32 @@ def test_pool_active_factory_scopes_direct_skill_crud_to_canonical_pool(
     ) == f"{engine_root}/skills-pool/skills-local/handmade"
 
 
+def test_skill_factory_uses_bot_owner_for_pool_and_device_resolution(
+    test_injector,
+):
+    factory = test_injector.get(SkillServiceFactory)
+    pool_resolution_calls = []
+
+    def resolve_pool_paths(owner_id, bot_id, engine_type):
+        pool_resolution_calls.append((owner_id, bot_id, engine_type))
+        return (
+            "/home/admin/.hermes/skills",
+            "/home/admin/.hermes/workspace/skills-pool/skills-local",
+            "/home/admin/.hermes/workspace/skills-pool/skills-repo",
+        )
+
+    factory._pool_layout_paths = resolve_pool_paths
+    service = factory.create(
+        entity_id="project-42",
+        bot_owner_id="owner-7",
+        bot_id="bot-1",
+        engine_type="hermes",
+    )
+
+    assert pool_resolution_calls == [("owner-7", "bot-1", "hermes")]
+    assert service._device_owner_id == "owner-7"
+
+
 def test_real_skill_set_service_factory_create_default_branch(test_injector):
     """No user_id/entity_id → the SKILLS_DIR-defaults (else) branch."""
     factory = test_injector.get(SkillSetServiceFactory)

--- a/src/backend/tests/community/plugins/local/test_local_device_filesystem_baas.py
+++ b/src/backend/tests/community/plugins/local/test_local_device_filesystem_baas.py
@@ -449,24 +449,22 @@ async def test_exists_baas_nonexistent_returns_false(fs_baas):
 
 
 @pytest.mark.asyncio
-async def test_exists_baas_swallows_baas_exception_returns_false(fs_baas, mock_baas):
-    """BaaS 异常 → exists 吞掉返 False（保 bool 契约，与 spec §4.2 一致）。
-
-    其他方法 raise 透传是因为 caller 需要错误信号；exists 是 yes/no 问题，
-    异常等价 "无法确认存在" = False，避免炸 caller。
-    """
+async def test_exists_baas_propagates_baas_exception(fs_baas, mock_baas):
+    """BaaS 不可达不是路径不存在，必须向 caller 暴露失败。"""
     mock_baas.get_http_info.side_effect = BaasServiceError("baas down")
-    assert await fs_baas.exists("/tmp/x") is False
+    with pytest.raises(BaasServiceError, match="baas down"):
+        await fs_baas.exists("/tmp/x")
 
 
 @pytest.mark.asyncio
-async def test_exists_baas_swallows_5xx_returns_false(fs_baas):
-    """容器 5xx 同 BaaS 异常 → False。"""
+async def test_exists_baas_propagates_5xx(fs_baas):
+    """容器 5xx 不是路径不存在，必须向 caller 暴露失败。"""
     response = _mock_httpx_response(status_code=500, json_body={"error": "boom"})
     client = _patch_async_client(response)
 
     with patch("httpx.AsyncClient", return_value=client):
-        assert await fs_baas.exists("/tmp/x") is False
+        with pytest.raises(httpx.HTTPStatusError):
+            await fs_baas.exists("/tmp/x")
 
 
 # ── D3: 每业务调用 1 次 get_http_info ─────────────────────────────────

--- a/src/backend/tests/community/plugins/test_skill_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_skill_repository_unified.py
@@ -211,6 +211,25 @@ def test_delete_by_bot_id(skills):
     assert skills.list_skills(bolt_id="bot-x") == []
 
 
+def test_list_skill_set_references_includes_active_and_inactive_sets(
+    skills, sets
+):
+    skill = skills.create({"name": "referenced", "bolt_id": "bot-x"})
+    active_set = sets.create(
+        {"name": "active", "bolt_id": "bot-x", "is_active": True}
+    )
+    inactive_set = sets.create(
+        {"name": "inactive", "bolt_id": "bot-x", "is_active": False}
+    )
+    sets.add_skill_to_set(active_set["id"], skill["id"])
+    sets.add_skill_to_set(inactive_set["id"], skill["id"])
+
+    assert skills.list_skill_set_references(skill["id"]) == [
+        {"skill_set_id": active_set["id"]},
+        {"skill_set_id": inactive_set["id"]},
+    ]
+
+
 def test_skills_pool_asset_views_are_exactly_bot_scoped(skills, sets):
     local = skills.create(
         {

--- a/src/backend/tests/community/plugins/test_skill_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_skill_repository_unified.py
@@ -230,6 +230,40 @@ def test_list_skill_set_references_includes_active_and_inactive_sets(
     ]
 
 
+def test_list_skill_set_references_ignores_orphans_and_matches_center_uuid(
+    skills, sets, db
+):
+    center = skills.create(
+        {
+            "name": "center",
+            "git_path": "center://center",
+            "skill_uuid": "center-uuid",
+        }
+    )
+    live_set = sets.create({"name": "live", "is_active": False})
+    deleted_set = sets.create({"name": "deleted", "is_active": False})
+    with db.orm_session() as session:
+        session.add(
+            SkillSetSkill(
+                skill_set_id=int(live_set["id"]),
+                skill_id=0,
+                skill_uuid="center-uuid",
+            )
+        )
+        session.add(
+            SkillSetSkill(
+                skill_set_id=int(deleted_set["id"]),
+                skill_id=int(center["id"]),
+            )
+        )
+    assert sets.delete(deleted_set["id"]) is True
+
+    assert skills.list_skill_set_references(
+        center["id"],
+        skill_uuid="center-uuid",
+    ) == [{"skill_set_id": live_set["id"]}]
+
+
 def test_skills_pool_asset_views_are_exactly_bot_scoped(skills, sets):
     local = skills.create(
         {

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -40,6 +40,7 @@ class TestSkillServiceAsyncRouting:
             mock_repo.get_bot_local_by_name.return_value = None
             mock_repo.create.side_effect = lambda data: {"id": "1", **data}
             mock_repo.get_by_name_global.return_value = None
+        mock_repo.list_skill_set_references.return_value = []
 
         service = SkillService(
             skill_repo=mock_repo,
@@ -399,6 +400,7 @@ class TestSkillServiceAsyncRouting:
             "bolt_id": "bot1", "user_id": "user1"
         }
         mock_repo.delete.return_value = True
+        mock_repo.list_skill_set_references.return_value = []
 
         service = SkillService(
             skill_repo=mock_repo,


### PR DESCRIPTION
## Summary

- resolve DELETE /api/skills/{skill_id} from the persisted Skill owner Bot instead of falling back to default/openclaw when query context is absent
- reject deletion with HTTP 409 and `SKILL_REFERENCED_BY_SKILL_SET` whenever any active or inactive SkillSet still references the Skill
- use the Bot active_engine and canonical layout paths for active-link and local-source cleanup
- fail closed for Pool-owned I/O when active/source cleanup cannot converge, while preserving Legacy best-effort behavior

## Root cause

The delete endpoint accepted requests without bot_id/entity_id and built a default OpenClaw SkillService. It attempted to remove the wrong active path, swallowed the failure, then deleted the real Pool source and DB row. On Hermes this left a dangling active link and made runtime probe INVALID. It also allowed a Skill that was still referenced by ac_skill_set_skill to be deleted, leaving stale membership metadata.

## Product contract

A Skill must first be removed from every SkillSet before its own metadata can be deleted. The delete endpoint does not cascade or implicitly deactivate SkillSets.

## Compatibility

- referenced Skills are rejected before filesystem or metadata mutation, regardless of SkillSet activation state
- Pool-active file engines preserve source and DB metadata on cleanup failure
- unactivated or already-absent entries remain idempotent
- Legacy runtimes keep their historical best-effort filesystem behavior
- Teclaw path adaptation remains covered

## Validation

- ruff check on changed Python files
- 619 Skill Center/API/service/repository tests passed
- focused delete/context suite passed