### PR TITLE
feat(bcs): add session-scoped websocket token foundation

### DIFF
--- a/docs/plans/2026-08-03-bcn-group-session-websocket-token-design.md
+++ b/docs/plans/2026-08-03-bcn-group-session-websocket-token-design.md
@@ -1,0 +1,530 @@
+# BCN Group Session WebSocket Token Design
+
+- Date: 2026-08-03
+- Status: Approved
+- Scope: BCN Workbench session WebSocket authentication and session scoping
+
+## Problem
+
+The existing Workbench WebSocket endpoint, `/ws`, authenticates a Human during
+the HTTP Upgrade and then lets the client select a group and optional session in
+the `connect` frame. The frontend currently connects directly to BCS. This does
+not provide a portable, session-scoped credential that a browser can use when
+the WebSocket is exposed through the application Gateway.
+
+The new public connection flow needs to:
+
+1. let an authenticated Human obtain a short-lived credential for one group
+   session;
+2. carry that credential in a browser-compatible WebSocket URL;
+3. bind the authenticated user, group, and session before Upgrade;
+4. re-check current authorization when the Workbench `connect` frame is
+   processed; and
+5. preserve full feature parity with the existing `/ws` Workbench protocol.
+
+## Goals
+
+1. Add `POST /group-sessions/{sid}/token` for issuing a five-minute JWT.
+2. Add `GET /group-sessions/{sid}/ws?token={token}` for session-scoped
+   Workbench WebSocket connections.
+3. Bind one JWT to exactly one tenant, Human, group, and group session.
+4. Keep JWT verification stateless. A valid JWT may open multiple connections
+   to its one session during its five-minute lifetime.
+5. Re-run current session authorization when the `connect` frame arrives.
+6. Reuse the existing Workbench connection handler, dispatcher, connection
+   registry, frontend delivery, frame protocol, and event stream.
+7. Keep `/ws` and `/ws/bot` behavior unchanged.
+8. Keep HTTP, WebSocket, application, token, and composition responsibilities
+   within the existing architecture boundaries.
+
+## Non-goals
+
+- Do not create a user-wide token that can connect to every session the user
+  may access.
+- Do not create a group-wide token that can select among multiple sessions.
+- Do not make the JWT single-use or persist a `jti` consumption record.
+- Do not close an established WebSocket merely because its opening JWT later
+  expires.
+- Do not replace or remove the existing `/ws` endpoint in this change.
+- Do not change the bot runtime `/ws/bot` protocol.
+- Do not implement a second, reduced Workbench protocol for the new endpoint.
+
+## Chosen Approach
+
+Use a single-session bearer JWT. The token carries immutable connection scope,
+while current resource authorization remains server-side and is checked again
+when the Workbench `connect` frame is processed.
+
+This separates two decisions:
+
+- **Upgrade authentication:** Is this a genuine, unexpired BCN token for the
+  session named in the URL?
+- **Connect authorization:** Does this Human still have permission to access
+  this group session now?
+
+The token is not a cache of an authorization decision. It is a signed binding
+of identity and requested scope.
+
+### Rejected alternatives
+
+#### User-wide token
+
+A token that can connect to all sessions accessible to one Human has a larger
+leak blast radius, permits session probing, and turns the new credential into a
+second login token. It also makes the `{sid}` URL component and the `gid`/`sid`
+claims non-authoritative.
+
+#### Upgrade-only validation
+
+Verifying the JWT and then trusting arbitrary `connect` frame parameters lets a
+client escape the scope in the token. It also fails to detect permissions that
+were revoked after issuance.
+
+#### Server-side replacement of frame scope
+
+Silently ignoring `connect.group_id` and `connect.session_id` and replacing them
+with claims would be safe but confusing: the server would act on values other
+than those visible in the frame. Exact matching is explicit and preserves the
+existing Workbench protocol.
+
+#### Single-use JWT
+
+Strict single-use requires a persistent or distributed `jti` store and atomic
+consumption at Upgrade. The accepted requirement is a stateless five-minute
+opening credential, so that state and operational dependency are unnecessary.
+
+## External Contract
+
+### Issue a connection token
+
+```http
+POST /group-sessions/{sid}/token
+```
+
+The request must carry an authenticated Gateway Human Principal. The caller
+cannot provide `uid`, `gid`, token lifetime, or any JWT claim.
+
+BCN performs these steps:
+
+1. Require a Human identity in the authenticated caller.
+2. Load the session named by `sid`.
+3. Derive the authoritative `gid` from that session.
+4. Check that the Human currently has permission to read/connect to it.
+5. Sign a token whose expiration is exactly 300 seconds after issuance.
+
+Success response:
+
+```json
+{
+  "data": {
+    "token": "<compact-jwt>",
+    "expires_at": "2026-08-03T12:05:00Z"
+  }
+}
+```
+
+The response includes:
+
+```http
+Cache-Control: no-store
+Pragma: no-cache
+```
+
+The response does not repeat `uid` or `gid`. They are server-owned values and
+must not become caller inputs on the next request.
+
+### Open the session WebSocket
+
+```http
+GET /group-sessions/{sid}/ws?token=<compact-jwt>
+```
+
+The browser opens this URL as given. The JWT is the authentication credential
+for this WebSocket handshake. A Gateway login cookie is not required on this
+route.
+
+After Upgrade, the endpoint exposes the same Workbench protocol and feature set
+as `/ws`. Its only differences are its authentication source and immutable
+session scope.
+
+## JWT Contract
+
+The token uses HS256 with a dedicated BCN group-session WebSocket signing key.
+It must not reuse the OAuth login JWT claims or signing key.
+
+Example payload:
+
+```json
+{
+  "iss": "bcn",
+  "aud": "bcn-group-session-ws",
+  "purpose": "group_session_ws",
+  "sub": "user-123",
+  "tenant": "tenant-a",
+  "uid": "user-123",
+  "gid": "group-456",
+  "sid": "session-789",
+  "iat": 1785744000,
+  "exp": 1785744300
+}
+```
+
+Claim rules:
+
+- `iss` must be `bcn`.
+- `aud` must be `bcn-group-session-ws`.
+- `purpose` must be `group_session_ws`, preventing token-type confusion.
+- `sub` and `uid` must both equal the authenticated Human's stable user ID.
+- `tenant`, `uid`, `gid`, and `sid` must be non-blank and length-bounded.
+- `gid` is derived from the stored session, never from the caller.
+- `sid` comes from the token-issuance path.
+- `iat` is the server issuance time.
+- `exp` equals `iat + 300` seconds.
+- Tokens with an unsupported algorithm, invalid signature, future issuance
+  time, invalid lifetime, or expired `exp` are rejected.
+- The verifier rejects excessively large compact tokens before decoding.
+
+Expiration limits opening or reopening a connection. Once a socket has passed
+Upgrade and `connect`, expiration alone does not terminate it. Reconnection
+after expiration requires a newly issued token.
+
+One token may establish multiple concurrent WebSockets during its lifetime,
+but every WebSocket is restricted to the token's one `sid` and independently
+performs connect-time authorization.
+
+## Connection Binding
+
+Successful JWT verification produces a transport-neutral immutable binding:
+
+```rust
+pub struct SessionConnectionBinding {
+    pub tenant: String,
+    pub group_id: String,
+    pub session_id: String,
+    pub user_id: String,
+}
+```
+
+The Workbench connection handler receives one of two authentication contexts:
+
+```rust
+pub enum WorkbenchConnectionAuth {
+    UserBound {
+        actor_id: Option<String>,
+    },
+    SessionBound {
+        tenant: String,
+        actor_id: String,
+        group_id: String,
+        session_id: String,
+    },
+}
+```
+
+The existing `/ws` route supplies `UserBound`. The new route supplies
+`SessionBound`, with `actor_id = "human_{uid}"`.
+
+Both routes enter the same `handle_client_connection`, dispatcher, connection
+registry, frontend delivery path, run-channel integration, and disconnect
+cleanup.
+
+## Connection State Machine
+
+```text
+HTTP Upgrade
+    | JWT is valid and path sid matches claims sid
+    v
+AwaitingConnect(binding)
+    | connect scope matches and current authorization succeeds
+    v
+Connected(binding, subscription)
+    | close, protocol failure, idle timeout, or authorization failure
+    v
+Closed
+```
+
+### Upgrade phase
+
+Before accepting the socket, BCN verifies:
+
+1. the token is present and non-empty;
+2. its header, signature, issuer, audience, purpose, times, and claim shape;
+3. `claims.sid == path.sid`; and
+4. the required binding fields are non-empty and valid.
+
+Upgrade performs no session database query. Current authorization is checked
+when the protocol establishes its subscription, avoiding an authorization
+decision at Upgrade that can become stale before `connect`.
+
+### AwaitingConnect phase
+
+Ping/pong remains available. Business frames other than `connect` are rejected
+with `connect_required`.
+
+For a session-bound connection:
+
+```text
+frame.group_id   must equal binding.group_id
+frame.session_id must equal binding.session_id
+```
+
+The handler then calls the existing `WorkbenchSessionService.connect` with:
+
+```text
+bound_actor_id = human_{binding.user_id}
+group_id       = binding.group_id
+session_id     = binding.session_id
+```
+
+That service reloads current group/session state and checks the existing
+Workbench access policy, including ownership or participation and participant
+mode. It also confirms that the session still belongs to the bound group.
+
+Only one `connect` may succeed on one socket. Repeated connects are rejected
+with `already_connected` so they cannot create duplicate subscriptions.
+
+### Connected phase
+
+Every scoped request remains constrained by the immutable binding:
+
+- `chat.send.group_id` and `chat.send.session_id` must match it;
+- `chat.abort.group_id` must match it and the run must belong to the bound
+  session;
+- frame fields such as `bot_id` and `bot_uuid` cannot replace the bound Human
+  identity; and
+- every future Workbench method must declare and test its scope behavior for a
+  `SessionBound` connection.
+
+The two endpoints remain functionally equivalent. New Workbench methods must
+flow through their shared dispatcher so `/ws` and the session-bound endpoint do
+not drift into separate feature sets.
+
+## Component Boundaries
+
+### `bcs-service-api`
+
+Add an inbound application contract such as
+`GroupSessionConnectionService`:
+
+```rust
+#[async_trait]
+pub trait GroupSessionConnectionService: Send + Sync {
+    async fn issue_token(
+        &self,
+        command: IssueGroupSessionConnectionToken,
+    ) -> Result<IssuedGroupSessionConnectionToken, ApplicationError>;
+
+    async fn verify_token(
+        &self,
+        command: VerifyGroupSessionConnectionToken,
+    ) -> Result<SessionConnectionBinding, ApplicationError>;
+}
+```
+
+Add a non-repository outbound port for signing and verifying the dedicated
+token claims. Delivery adapters depend only on the application contract and do
+not call a JWT implementation directly.
+
+### `bcs-app-session`
+
+Implement the application use cases. Reuse the existing session lookup and
+read/connect authorization policy rather than duplicating membership rules in
+an adapter. The application service derives `gid`, maps the authenticated Human
+to `uid`, fixes the 300-second lifetime, and calls the token port.
+
+### `bcs-jwt`
+
+Implement the token port with dedicated group-session claims. OAuth login JWTs
+and group-session WebSocket JWTs remain separately typed and separately keyed.
+
+### `bcs-api-http`
+
+Own the `POST /group-sessions/{sid}/token` wire route, path extraction, response
+DTO, no-store headers, and HTTP error mapping. It calls only the application
+service.
+
+### `bcs-ws`
+
+Own `GET /group-sessions/{sid}/ws`, query extraction, pre-Upgrade error mapping,
+the `SessionBound` authentication context, and scope enforcement around the
+shared Workbench dispatcher. It calls only application services.
+
+### Bootstrap
+
+The composition root resolves the dedicated signing key, constructs the token
+implementation and application service, injects them into both delivery
+adapters, and mounts both routes. No adapter reads environment variables or
+constructs a concrete JWT service.
+
+Configuration is validated at startup. A missing or empty signing key fails
+closed; it must not select a default production credential or anonymous mode.
+
+## Gateway Behavior
+
+The Gateway continues to perform application-level WebSocket relay in Python.
+An outer Nginx or ingress may terminate TLS and pass Upgrade traffic, but it
+does not replace the Gateway authentication and routing plane.
+
+The two routes have intentionally different Gateway security requirements:
+
+```text
+POST /group-sessions/{sid}/token
+    authenticated Gateway Human required
+
+GET /group-sessions/{sid}/ws?token=...
+    anonymous at Gateway; authenticated by the BCN session JWT
+```
+
+The `group-sessions` upstream domain therefore serves both HTTP and WebSocket
+planes. Gateway configuration maps both requests to the same BCN upstream. The
+Gateway does not parse or validate the BCN JWT.
+
+All Gateway, ingress, application-server, and BCN access logs must redact the
+`token` query value. Existing `x-proxypass-token` redaction is not sufficient
+for this new credential name.
+
+Every L7 hop must pass WebSocket Upgrade and avoid a read timeout shorter than
+the Workbench heartbeat and connection policy.
+
+## Error Semantics
+
+### Token issuance
+
+- Missing or invalid Gateway Human Principal: HTTP 401.
+- Existing session access policy rejects the Human: the existing application
+  authorization error mapping is preserved.
+- Session does not exist: the existing session-read not-found behavior is
+  preserved.
+- Signing infrastructure failure: HTTP 500 without credential or claim data.
+
+### Upgrade
+
+| Failure | Result |
+| --- | --- |
+| Missing, malformed, forged, expired, or wrong-purpose token | HTTP 401; no Upgrade |
+| `path.sid != claims.sid` | HTTP 403; no Upgrade |
+| Token verification service unavailable | HTTP 503; no Upgrade |
+
+The browser-facing Gateway relay may expose only a generic handshake failure.
+BCN logs and low-cardinality metrics retain the internal reason classification
+without recording the token.
+
+### Workbench frames
+
+The shared protocol adds these closed error codes where needed:
+
+- `invalid_connection_token`
+- `token_scope_mismatch`
+- `connect_required`
+- `already_connected`
+- `session_access_revoked`
+
+A scope mismatch or failed connect-time authorization produces an error
+response and closes the session-bound socket. Retrying different scope on the
+same immutable connection cannot succeed.
+
+## Security and Observability
+
+- Never log the compact JWT, signature, query value, or complete claims.
+- Never put `uid`, `gid`, `sid`, or token values into metric labels.
+- Metric labels remain low-cardinality, for example:
+  `endpoint`, `phase`, `result`, and `reason`.
+- If correlation is necessary, use an existing request/connection ID. Do not
+  introduce a persisted raw-token identifier.
+- Do not accept caller-provided `uid`, `gid`, lifetime, issuer, audience, or
+  purpose.
+- Keep the JWT signing secret separate from Gateway Principal and OAuth login
+  secrets.
+- Validate compact-token and individual claim lengths before allocating or
+  using them as identifiers.
+- Preserve constant-time signature verification through the JWT implementation.
+
+## Compatibility
+
+- `/ws` keeps its current authentication and behavior.
+- `/ws/bot` is unchanged.
+- The new endpoint uses the same Workbench frames and events as `/ws`.
+- Existing frontend code can migrate one session at a time.
+- The current frontend already maintains providers by `groupId:sessionId`, so
+  one Token per session fits the existing connection model.
+- Both endpoints run in parallel until a separate, explicit deprecation design
+  is approved.
+
+## Test Strategy
+
+### JWT tests
+
+- Exact required claims and 300-second lifetime.
+- Wrong key, algorithm, issuer, audience, purpose, and signature.
+- Expired token, future `iat`, invalid lifetime, blank claims, oversized token,
+  and oversized claims.
+- Deterministic clock injection; no tests sleep for expiration.
+- Login JWTs cannot be accepted as group-session tokens and vice versa.
+
+### Application tests
+
+- Human-only issuance.
+- `uid` comes only from the authenticated caller.
+- `gid` comes only from the stored session.
+- Missing or unreadable session does not yield a token.
+- Participant and ownership access follows existing policy.
+- TTL, claims, and scope cannot be overridden by request data.
+
+### HTTP adapter tests
+
+- Principal middleware failures do not call the issuance service.
+- Success returns only `token` and `expires_at` in the standard envelope.
+- `Cache-Control: no-store` and `Pragma: no-cache` are present.
+- Error responses and logs contain no token or claims.
+
+### WebSocket boundary tests
+
+- Every pre-Upgrade rejection class.
+- Path/session mismatch.
+- Correct immutable binding.
+- `connect` scope mismatch, connect-before-business requirement, and duplicate
+  connect rejection.
+- Permission revoked, session deleted, group changed, or participant absent
+  between token issuance and `connect`.
+- Cross-session `chat.send` and `chat.abort` rejection.
+- Same-token multiple connections to the same session.
+- Token expiration does not close an established connection.
+
+### Workbench parity tests
+
+Run the existing `/ws` Workbench protocol cases through both entrypoints after
+authentication setup. Assert identical response/event behavior for:
+
+- connect and participant response;
+- chat send, mentions, attachments, thinking, and idempotency;
+- run streaming, final events, error events, and abort;
+- frontend broadcast and multi-observer delivery;
+- heartbeat, idle timeout, close, and cleanup.
+
+Only authentication and scope-mismatch cases intentionally differ.
+
+### Gateway and end-to-end tests
+
+- Human authentication is required on token issuance.
+- The WS route is anonymously relayed and BCN enforces its JWT.
+- HTTP and WebSocket planes resolve to the BCN upstream.
+- Query-token redaction covers Gateway and BCN access logs.
+- Text, binary, subprotocol, and close frames remain transparent.
+- Full flow: Gateway Human authentication, token issuance, Gateway WS relay,
+  BCN Upgrade verification, dynamic `connect` authorization, `chat.send`, and
+  session event delivery.
+- Existing `/ws` and `/ws/bot` regression suites stay green.
+
+## Rollout
+
+1. Add contracts, token implementation, configuration, and composition wiring.
+2. Add HTTP issuance and session-bound WS routes behind the existing BCN
+   deployment boundary.
+3. Add Gateway routing, route security, and credential redaction.
+4. Exercise the complete flow in singlebox and a deployed pre-production
+   environment.
+5. Migrate the frontend session Provider flow to request one token per active
+   session.
+6. Run both Workbench endpoints in parallel and monitor issuance, Upgrade,
+   connect, scope, and disconnect metrics.
+7. Treat removal of `/ws` as a separate compatibility decision.

--- a/docs/plans/2026-08-03-bcn-group-session-websocket-token-design.md
+++ b/docs/plans/2026-08-03-bcn-group-session-websocket-token-design.md
@@ -24,9 +24,10 @@ The new public connection flow needs to:
 
 ## Goals
 
-1. Add `POST /group-sessions/{sid}/token` for issuing a five-minute JWT.
-2. Add `GET /group-sessions/{sid}/ws?token={token}` for session-scoped
-   Workbench WebSocket connections.
+1. Add `POST /openapi/v1/collaboration/sessions/{sid}/token` in BCN for
+   issuing a five-minute JWT.
+2. Add `GET /openapi/v1/collaboration/group/ws?token={token}` in BCN for
+   session-scoped Workbench WebSocket connections.
 3. Bind one JWT to exactly one tenant, Human, group, and group session.
 4. Keep JWT verification stateless. A valid JWT may open multiple connections
    to its one session during its five-minute lifetime.
@@ -57,8 +58,8 @@ when the Workbench `connect` frame is processed.
 
 This separates two decisions:
 
-- **Upgrade authentication:** Is this a genuine, unexpired BCN token for the
-  session named in the URL?
+- **Upgrade authentication:** Is this a genuine, unexpired BCN token carrying
+  one complete session binding?
 - **Connect authorization:** Does this Human still have permission to access
   this group session now?
 
@@ -71,7 +72,7 @@ of identity and requested scope.
 
 A token that can connect to all sessions accessible to one Human has a larger
 leak blast radius, permits session probing, and turns the new credential into a
-second login token. It also makes the `{sid}` URL component and the `gid`/`sid`
+second login token. It also makes the token-issuance `{sid}` and the `gid`/`sid`
 claims non-authoritative.
 
 #### Upgrade-only validation
@@ -98,7 +99,7 @@ opening credential, so that state and operational dependency are unnecessary.
 ### Issue a connection token
 
 ```http
-POST /group-sessions/{sid}/token
+POST /openapi/v1/collaboration/sessions/{sid}/token
 ```
 
 The request must carry an authenticated Gateway Human Principal. The caller
@@ -136,7 +137,7 @@ must not become caller inputs on the next request.
 ### Open the session WebSocket
 
 ```http
-GET /group-sessions/{sid}/ws?token=<compact-jwt>
+GET /openapi/v1/collaboration/group/ws?token=<compact-jwt>
 ```
 
 The browser opens this URL as given. The JWT is the authentication credential
@@ -192,6 +193,27 @@ One token may establish multiple concurrent WebSockets during its lifetime,
 but every WebSocket is restricted to the token's one `sid` and independently
 performs connect-time authorization.
 
+## Signing Key Source
+
+The first release reuses the existing `SecretAccessPort` contract and its
+environment-backed `EnvSecretAccess` implementation. Bootstrap constructs the
+port with the fixed prefix `BCS_SECRET_` and requests the fixed secret name
+`bcn-group-session-ws-jwt`. The resulting environment variable is:
+
+```text
+BCS_SECRET_BCN_GROUP_SESSION_WS_JWT
+```
+
+Bootstrap reads the value once during startup and passes it directly to the
+dedicated group-session JWT implementation. Adapters, application services,
+and the JWT implementation do not read process environment variables.
+
+Missing or empty key material fails BCN startup. There is no fallback key and
+the value is not written to merged configuration logs. This key remains
+independent from both the OAuth session JWT key and the Gateway Principal key.
+Mist, KMS, and online key rotation are later implementations of the same
+`SecretAccessPort`, not part of the first release.
+
 ## Connection Binding
 
 Successful JWT verification produces a transport-neutral immutable binding:
@@ -232,7 +254,7 @@ cleanup.
 
 ```text
 HTTP Upgrade
-    | JWT is valid and path sid matches claims sid
+    | JWT is valid and yields one complete binding
     v
 AwaitingConnect(binding)
     | connect scope matches and current authorization succeeds
@@ -249,8 +271,10 @@ Before accepting the socket, BCN verifies:
 
 1. the token is present and non-empty;
 2. its header, signature, issuer, audience, purpose, times, and claim shape;
-3. `claims.sid == path.sid`; and
-4. the required binding fields are non-empty and valid.
+3. the required binding fields are non-empty and valid.
+
+The WebSocket route has no `sid` path or query parameter. The verified JWT is
+the sole Upgrade-time source of `tenant`, `uid`, `gid`, and `sid`.
 
 Upgrade performs no session database query. Current authorization is checked
 when the protocol establishes its subscription, avoiding an authorization
@@ -339,22 +363,24 @@ and group-session WebSocket JWTs remain separately typed and separately keyed.
 
 ### `bcs-api-http`
 
-Own the `POST /group-sessions/{sid}/token` wire route, path extraction, response
-DTO, no-store headers, and HTTP error mapping. It calls only the application
-service.
+Own `POST /openapi/v1/collaboration/sessions/{sid}/token`, path extraction,
+response DTO, no-store headers, and HTTP error mapping. It calls only the
+application service.
 
 ### `bcs-ws`
 
-Own `GET /group-sessions/{sid}/ws`, query extraction, pre-Upgrade error mapping,
-the `SessionBound` authentication context, and scope enforcement around the
-shared Workbench dispatcher. It calls only application services.
+Own `GET /openapi/v1/collaboration/group/ws`, query extraction, pre-Upgrade
+error mapping, the `SessionBound` authentication context, and scope
+enforcement around the shared Workbench dispatcher. It calls only application
+services.
 
 ### Bootstrap
 
-The composition root resolves the dedicated signing key, constructs the token
-implementation and application service, injects them into both delivery
-adapters, and mounts both routes. No adapter reads environment variables or
-constructs a concrete JWT service.
+The composition root creates `EnvSecretAccess` with the `BCS_SECRET_` prefix,
+resolves `bcn-group-session-ws-jwt`, constructs the token implementation and
+application service, injects them into both delivery adapters, and mounts both
+routes. No adapter reads environment variables or constructs a concrete JWT
+service.
 
 Configuration is validated at startup. A missing or empty signing key fails
 closed; it must not select a default production credential or anonymous mode.
@@ -368,16 +394,17 @@ does not replace the Gateway authentication and routing plane.
 The two routes have intentionally different Gateway security requirements:
 
 ```text
-POST /group-sessions/{sid}/token
+POST /openapi/v1/collaboration/sessions/{sid}/token
     authenticated Gateway Human required
 
-GET /group-sessions/{sid}/ws?token=...
+GET /openapi/v1/collaboration/group/ws?token=...
     anonymous at Gateway; authenticated by the BCN session JWT
 ```
 
-The `group-sessions` upstream domain therefore serves both HTTP and WebSocket
-planes. Gateway configuration maps both requests to the same BCN upstream. The
-Gateway does not parse or validate the BCN JWT.
+The `collaboration` upstream domain therefore serves both HTTP and WebSocket
+planes. Gateway configuration maps both requests to the same BCN upstream and
+forwards each path unchanged. The Gateway does not parse or validate the BCN
+JWT.
 
 All Gateway, ingress, application-server, and BCN access logs must redact the
 `token` query value. Existing `x-proxypass-token` redaction is not sufficient
@@ -402,7 +429,6 @@ the Workbench heartbeat and connection policy.
 | Failure | Result |
 | --- | --- |
 | Missing, malformed, forged, expired, or wrong-purpose token | HTTP 401; no Upgrade |
-| `path.sid != claims.sid` | HTTP 403; no Upgrade |
 | Token verification service unavailable | HTTP 503; no Upgrade |
 
 The browser-facing Gateway relay may expose only a generic handshake failure.
@@ -480,7 +506,8 @@ same immutable connection cannot succeed.
 ### WebSocket boundary tests
 
 - Every pre-Upgrade rejection class.
-- Path/session mismatch.
+- Binding is derived only from the verified token because the WS path has no
+  session selector.
 - Correct immutable binding.
 - `connect` scope mismatch, connect-before-business requirement, and duplicate
   connect rejection.

--- a/docs/plans/2026-08-03-bcn-group-session-websocket-token-implementation.md
+++ b/docs/plans/2026-08-03-bcn-group-session-websocket-token-implementation.md
@@ -1,0 +1,660 @@
+# BCN Group Session WebSocket Token Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Expose a five-minute, single-session JWT flow through Gateway so a browser can open `/group-sessions/{sid}/ws?token=...` with behavior equivalent to the existing Workbench `/ws` endpoint.
+
+**Architecture:** `bcs-service-api` defines transport-neutral issuance and verification contracts plus an outbound token port. `bcs-app-session` authorizes the Human and derives `gid` from `sid`; `bcs-jwt` signs and verifies the dedicated JWT. `bcs-api-http` exposes token issuance, while `bcs-ws` authenticates before Upgrade and feeds an immutable session-bound identity into the existing Workbench handler and dispatcher. Bootstrap composes the dependencies, and the Python Gateway transparently relays both HTTP and WebSocket traffic. The paths below are BCN paths; the shipped Gateway exposes them under its existing `/openapi/v1` base path.
+
+**Tech Stack:** Rust, Axum, Tokio, HMAC-SHA256 JWT, Python/FastAPI Gateway, pytest, Cargo workspace tests.
+
+---
+
+## Preconditions and invariants
+
+- Read `docs/arch/arch.rules.md`, `docs/arch/ci.enforce.md`, `docs/arch/context-boundary-format.md`, `docs/arch/protocol-contract-tests.md`, `src/bcs/AGENTS.md`, and `src/bcs/CLAUDE.md` before editing production code.
+- Keep the public logical suffixes `POST /group-sessions/{sid}/token` and `GET /group-sessions/{sid}/ws?token=...`. In the versioned BCS/Gateway adapters they are mounted as `/openapi/v1/group-sessions/{sid}/token` and `/openapi/v1/group-sessions/{sid}/ws`.
+- Never accept `uid`, `gid`, tenant, lifetime, or JWT purpose from the request body or query string.
+- The token lifetime is exactly 300 seconds. It scopes one tenant, one Human, one group, and one session. It is stateless and may open more than one socket to that same session before expiration.
+- Token expiration only gates a new Upgrade. It does not terminate an established WebSocket.
+- `/ws` and `/ws/bot` remain backward-compatible.
+- The new route uses the same Workbench handler, dispatcher, registry, frontend delivery, frame envelopes, ping behavior, idle timeout, chat/run behavior, and error delivery as `/ws`.
+- Redact the `token` query value everywhere. Do not use tokens, `uid`, `gid`, or `sid` as metric labels.
+
+### Task 1: Define the application and token-port contracts
+
+**Files:**
+
+- Create: `src/bcs/crates/service-api/bcs-service-api/src/application/v1/group_session_connection.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs`
+- Create: `src/bcs/crates/service-api/bcs-service-api/src/port/group_session_token.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs`
+- Create: `src/bcs/crates/service-api/bcs-service-api/tests/group_session_connection_contracts.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/CONTEXT.md`
+
+**Step 1: Write the failing contract test**
+
+Add compile-time and value tests that require these transport-neutral types:
+
+```rust
+use bcs_service_api::application::v1::{
+    GroupSessionConnectionBinding, GroupSessionConnectionError,
+    GroupSessionConnectionService, IssueGroupSessionConnectionToken,
+    IssuedGroupSessionConnectionToken, VerifyGroupSessionConnectionToken,
+};
+use bcs_service_api::port::{
+    GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
+};
+
+#[test]
+fn connection_binding_keeps_one_exact_session_scope() {
+    let binding = GroupSessionConnectionBinding {
+        tenant: "tenant-a".into(),
+        user_id: "user-a".into(),
+        group_id: "group-a".into(),
+        session_id: "session-a".into(),
+    };
+    assert_eq!(binding.session_id, "session-a");
+    assert_eq!(binding.group_id, "group-a");
+}
+```
+
+Also require a `GROUP_SESSION_WS_TOKEN_TTL_SECONDS: u64 = 300` constant and closed error variants that distinguish unauthenticated/invalid token, forbidden scope, unavailable verifier, and internal failure.
+
+**Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test --package bcs-service-api --test group_session_connection_contracts --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because the modules and types do not exist.
+
+**Step 3: Add the minimal contracts**
+
+Define:
+
+- `IssueGroupSessionConnectionToken { caller: AuthenticatedCaller, sid: String }`
+- `VerifyGroupSessionConnectionToken { token: String, path_sid: String }`
+- `IssuedGroupSessionConnectionToken { token: String, expires_at: OffsetDateTime }`
+- `GroupSessionConnectionBinding { tenant, user_id, group_id, session_id }`
+- async `GroupSessionConnectionService::{issue_token, verify_token}`
+- `GroupSessionTokenClaims { tenant, uid, gid, sid, purpose, iat, exp }`
+- async or synchronous `GroupSessionTokenPort::{issue, verify}`, with no HTTP/Axum types
+
+Keep validation and error projection at this boundary so adapters do not know JWT internals.
+
+**Step 4: Run the test to verify it passes**
+
+Run the command from Step 2, then:
+
+```bash
+cargo check --package bcs-service-api --all-targets --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/service-api/bcs-service-api
+git commit -m "feat(bcs): define group session connection contracts"
+```
+
+### Task 2: Implement the dedicated five-minute JWT
+
+**Files:**
+
+- Modify: `src/bcs/crates/services/bcs-jwt/Cargo.toml`
+- Create: `src/bcs/crates/services/bcs-jwt/src/group_session.rs`
+- Modify: `src/bcs/crates/services/bcs-jwt/src/lib.rs`
+- Create: `src/bcs/crates/services/bcs-jwt/tests/group_session_jwt.rs`
+- Create: `src/bcs/crates/services/bcs-jwt/CONTEXT.md`
+
+**Step 1: Write failing deterministic tests**
+
+Test with a fixed `now` and a dedicated test key. Cover:
+
+- emitted `exp == iat + 300`;
+- exact round-trip of tenant/uid/gid/sid and `purpose == "group_session_ws"`;
+- rejection at `now >= exp`;
+- rejection of future `iat`, non-300-second lifetime, blank/oversized claims, oversized compact token, invalid signature, wrong algorithm/type, and wrong purpose;
+- rejection when an existing OAuth/login JWT is passed to this verifier;
+- rejection of empty signing keys at construction.
+
+Expose `issue_at` and `verify_at` only as deterministic seams; production `GroupSessionTokenPort` methods obtain current Unix time internally.
+
+**Step 2: Run the tests to verify they fail**
+
+```bash
+cargo test --package bcs-jwt --test group_session_jwt --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because `GroupSessionJwtService` is missing.
+
+**Step 3: Implement the minimal signer/verifier**
+
+Add a separate claims struct and service; do not widen or reinterpret the current generic login `Claims`. Implement the `GroupSessionTokenPort` from Task 1. Require HS256 and JWT type, use constant-time HMAC verification, bound compact-token and claim lengths before expensive decoding, and return token-port errors without embedding the raw credential.
+
+The group-session key must be supplied to `GroupSessionJwtService::new`; never reuse or default to the OAuth key.
+
+**Step 4: Run focused and regression tests**
+
+```bash
+cargo test --package bcs-jwt --test group_session_jwt --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-jwt --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS, including existing login JWT tests.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/services/bcs-jwt
+git commit -m "feat(bcs): sign scoped group session websocket tokens"
+```
+
+### Task 3: Authorize token issuance and derive scope in `bcs-app-session`
+
+**Files:**
+
+- Modify: `src/bcs/crates/application/v1/bcs-app-session/Cargo.toml`
+- Create: `src/bcs/crates/application/v1/bcs-app-session/src/connection.rs`
+- Modify: `src/bcs/crates/application/v1/bcs-app-session/src/lib.rs`
+- Create: `src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs`
+- Create or modify: `src/bcs/crates/application/v1/bcs-app-session/CONTEXT.md`
+
+**Step 1: Write failing application tests**
+
+Build fakes for `SessionService` and `GroupSessionTokenPort`. Verify:
+
+- an authenticated Human with session read access receives a 300-second token;
+- `uid` comes from `AuthenticatedCaller.user.id`, tenant comes from the caller, `sid` comes from the command path, and `gid` comes from `SessionService::get`;
+- request-controlled values cannot override any claim;
+- Bot-only, App-only, access-key-only, or missing-Human callers are rejected;
+- missing session and forbidden session access do not call the signer;
+- token-port unavailable/internal errors remain distinguishable;
+- verification returns the binding only when `path_sid == claims.sid`, otherwise returns forbidden scope.
+
+**Step 2: Run the tests to verify they fail**
+
+```bash
+cargo test --package bcs-app-session --test group_session_connection --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because the connection application service is missing.
+
+**Step 3: Implement the service**
+
+Create `GroupSessionConnectionServiceImpl` with injected `Arc<dyn SessionService>` and `Arc<dyn GroupSessionTokenPort>`. Reuse `SessionService::get` so the existing V1 session-read authorization remains authoritative. Do not duplicate repository or group membership rules. Pass the fixed TTL constant to the port.
+
+On verification, validate the JWT through the port and enforce exact URL/session equality before returning the immutable binding. Do not perform the dynamic connection authorization here; that remains the Workbench `connect` operation.
+
+**Step 4: Run focused and package tests**
+
+```bash
+cargo test --package bcs-app-session --test group_session_connection --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-app-session --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/application/v1/bcs-app-session
+git commit -m "feat(bcs): issue authorized group session tokens"
+```
+
+### Task 4: Expose the token issuance HTTP endpoint
+
+**Files:**
+
+- Create: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/group_session_connection.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/src/lib.rs`
+- Create: `src/bcs/crates/adapters/http/bcs-api-http/tests/group_session_connection_routes.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md`
+
+**Step 1: Write failing HTTP contract tests**
+
+Build a focused route fixture with an injected fake `GroupSessionConnectionService` and `PrincipalVerifier`. Verify:
+
+- `POST /openapi/v1/group-sessions/session-a/token` returns the standard envelope containing only `data.token` and `data.expires_at`;
+- response headers include `Cache-Control: no-store` and `Pragma: no-cache`;
+- missing/invalid Gateway Principal is 401;
+- a valid signed Gateway Principal without a Human is rejected;
+- session not found, forbidden access, and signer unavailable map to the approved status/code without leaking claims or raw token;
+- query/body `uid`, `gid`, `sid`, or TTL fields are ignored or rejected rather than trusted.
+
+**Step 2: Run the test to verify it fails**
+
+```bash
+cargo test --package bcs-api-http --test group_session_connection_routes --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because the route is absent.
+
+**Step 3: Implement the handler and response DTO**
+
+Add a focused `group_session_connection_router` with a minimal state containing only `Arc<dyn GroupSessionConnectionService>` and `Arc<dyn PrincipalVerifier>`. Mount the POST route under the existing versioned group-session path and apply the trusted Principal middleware. Extract `AuthenticatedCaller` from that middleware, and pass only caller plus path `session_id` to the application service.
+
+Do not mount the whole preparatory V1 router in production as a side effect of this feature. Reuse the existing envelope, request-id, and error response helpers instead of duplicating the wire format.
+
+Do not add the token to structured logs or tracing fields.
+
+**Step 4: Run route and package tests**
+
+```bash
+cargo test --package bcs-api-http --test group_session_connection_routes --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-api-http --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-api-http
+git commit -m "feat(bcs): expose group session token endpoint"
+```
+
+### Task 5: Refactor Workbench authentication context without changing `/ws`
+
+**Files:**
+
+- Create: `src/bcs/crates/adapters/ws/bcs-ws/src/web/auth.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/src/web/mod.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs`
+
+**Step 1: Lock current `/ws` behavior with failing characterization tests**
+
+Introduce tests expecting a `WorkbenchConnectionAuth::UserBound { actor_id }` input while preserving all existing frame results. Cover connect, chat.send, chat.abort, subscription registration, ping/pong, unknown method, and cleanup.
+
+**Step 2: Run the tests to verify they fail**
+
+```bash
+cargo test --package bcs-ws --test web_frame_compat --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because the new auth context does not exist.
+
+**Step 3: Add the minimal auth-context refactor**
+
+Define:
+
+```rust
+pub enum WorkbenchConnectionAuth {
+    UserBound { actor_id: Option<String> },
+    SessionBound {
+        tenant: String,
+        actor_id: String,
+        group_id: String,
+        session_id: String,
+    },
+}
+```
+
+Change the shared handler and dispatcher to accept this enum instead of a loose optional actor string. For `UserBound`, retain the current `/ws` behavior byte-for-byte. Do not mount the new route yet.
+
+**Step 4: Run the entire WebSocket adapter suite**
+
+```bash
+cargo test --package bcs-ws --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS with no existing `/ws` or `/ws/bot` regression.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/adapters/ws/bcs-ws
+git commit -m "refactor(bcs): carry explicit workbench connection auth"
+```
+
+### Task 6: Enforce session scope across Workbench commands
+
+**Files:**
+
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs`
+- Modify: `src/bcs/crates/services/bcs-message-flow/src/group_flow.rs`
+- Modify: all `ChatAbortCommand` constructors reported by `rg -n "ChatAbortCommand" src/bcs/crates`
+- Modify: `src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs`
+
+**Step 1: Write failing scope tests**
+
+For `SessionBound`, verify:
+
+- before successful `connect`, business frames return `connect_required`;
+- `connect.group_id` and `connect.session_id` must exactly equal bound `gid`/`sid`, otherwise return `token_scope_mismatch` and close;
+- the dynamic `WorkbenchSessionService::connect` authorization still runs using the bound Human actor;
+- a second successful connect returns `already_connected`;
+- chat.send cannot name another group/session;
+- chat.abort cannot abort a run belonging to another session, including the form without a client-provided run/session selector;
+- revoked access at connect returns `session_access_revoked` and closes;
+- UserBound behavior remains unchanged.
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --package bcs-ws --test web_frame_compat session_bound --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-message-flow --test contract_message_flow abort --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because session scope is not enforced for all commands.
+
+**Step 3: Implement the state machine and abort scope**
+
+Use explicit `AwaitingConnect -> Connected -> Closed` state. Before connect, allow only ping/pong and connect. On connect, compare exact scope first, then call the existing dynamic authorization/service path. Keep the accepted binding immutable for the life of the connection.
+
+Extend `ChatAbortCommand` with `session_id: Option<String>` rather than creating a second abort path. Existing `/ws`, HTTP, provider, and test callers pass `None`; session-bound WS passes `Some(bound_sid)`. In message flow, constrain candidate runs by session when present. Propagate constructor changes mechanically without changing unrelated behavior.
+
+**Step 4: Run affected packages**
+
+```bash
+cargo test --package bcs-message-flow --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-ws --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-http --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-provider-http --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/service-api/bcs-service-api src/bcs/crates/services/bcs-message-flow src/bcs/crates/adapters/ws/bcs-ws src/bcs/crates/adapters/http/bcs-http src/bcs/crates/adapters/http/bcs-provider-http src/bcs/crates/services/bcs-channel src/bcs/crates/bootstrap/bcs/tests
+git commit -m "feat(bcs): confine workbench commands to one session"
+```
+
+### Task 7: Add the session-bound WebSocket Upgrade route
+
+**Files:**
+
+- Create: `src/bcs/crates/adapters/ws/bcs-ws/src/web/group_session.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/src/web/mod.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/Cargo.toml`
+- Create: `src/bcs/crates/adapters/ws/bcs-ws/tests/group_session_ws.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/CONTEXT.md`
+
+**Step 1: Write failing Upgrade tests**
+
+Build an adapter router with a fake `GroupSessionConnectionService` and shared Workbench state. Verify:
+
+- missing, malformed, forged, expired, or wrong-purpose token returns HTTP 401 before Upgrade;
+- valid token whose `sid` differs from the path returns HTTP 403;
+- unavailable verifier returns HTTP 503;
+- valid binding upgrades and enters the same `handle_client_connection` path used by `/ws`;
+- token values never appear in response bodies, close reasons, logs, or metrics;
+- an already-upgraded socket remains alive after the token's `exp`.
+
+**Step 2: Run the tests to verify they fail**
+
+```bash
+cargo test --package bcs-ws --test group_session_ws --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because the route builder is missing.
+
+**Step 3: Implement pre-Upgrade verification and shared handling**
+
+Add a handler for `GET /openapi/v1/group-sessions/{session_id}/ws?token=...`. Extract and validate the query credential before calling `on_upgrade`. Map only the approved status classes and use sanitized messages. Convert the application binding to `WorkbenchConnectionAuth::SessionBound`, with `actor_id = format!("human_{}", binding.user_id)`, then call the existing shared Workbench connection handler.
+
+Do not add a second dispatcher, registry, idle timer, or frontend delivery path.
+
+**Step 4: Run focused and regression tests**
+
+```bash
+cargo test --package bcs-ws --test group_session_ws --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-ws --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/adapters/ws/bcs-ws
+git commit -m "feat(bcs): add session-bound workbench websocket"
+```
+
+### Task 8: Add fail-closed configuration and bootstrap composition
+
+**Files:**
+
+- Modify: `src/bcs/crates/bootstrap/bcs/src/config.rs`
+- Modify: `src/bcs/crates/bootstrap/bcs/src/config_loader.rs`
+- Modify: `src/bcs/crates/bootstrap/bcs/src/server.rs`
+- Modify: `src/bcs/crates/bootstrap/bcs/Cargo.toml`
+- Modify: `src/bcs/configs/bcs-config-example.toml`
+- Modify: `src/bcs/configs/bcs-config-local.toml`
+- Modify: `src/bcs/crates/bootstrap/bcs/tests/integration_http_api.rs`
+- Modify: `src/bcs/crates/bootstrap/bcs/tests/e2e_workbench.rs`
+- Modify: `src/bcs/crates/bootstrap/bcs/CONTEXT.md`
+
+**Step 1: Write failing configuration and composition tests**
+
+Require two independent trust configurations:
+
+```toml
+[gateway_principal]
+signing_key = "..."
+issuer = "gateway"
+audience = "bcs"
+kid = "bare"
+
+[group_session_ws]
+jwt_secret = "..."
+token_ttl_seconds = 300
+```
+
+Test that missing/empty secrets, wrong audience/kid, or any TTL other than 300 fail startup. Assert the two secret values need not and should not be equal. Add router tests proving both versioned routes are mounted and existing `/ws` still resolves.
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --package bcs --test integration_http_api group_session --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs --test e2e_workbench group_session --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because config and wiring are absent.
+
+**Step 3: Compose the approved services**
+
+At bootstrap only:
+
+1. resolve the Gateway Principal verification key and build `GatewayPrincipalTokenVerifier` with issuer `gateway`, audience `bcs`, and configured `kid`;
+2. resolve the dedicated group-session WebSocket key and build `GroupSessionJwtService`;
+3. build `GroupSessionConnectionServiceImpl` using the V1 session service and token port;
+4. inject the connection service into the HTTP and WS adapters;
+5. mount the focused V1 token route and session WebSocket route without unintentionally exposing unrelated preparatory V1 routes;
+6. retain current `/ws` and `/ws/bot` mounting and auth behavior.
+
+Do not read environment variables in adapters or application services. Do not provide a production fallback secret. A test/local fixture may use an explicit clearly test-only value.
+
+**Step 4: Run bootstrap tests**
+
+```bash
+cargo test --package bcs --test integration_http_api --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs --test e2e_workbench --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs --test e2e_ws_messaging --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/bootstrap/bcs src/bcs/configs
+git commit -m "feat(bcs): wire group session websocket authentication"
+```
+
+### Task 9: Route both planes through the Python Gateway
+
+**Files:**
+
+- Modify: `src/gateway/configs/application.yaml`
+- Modify: `src/gateway/tests/test_domain_map.py`
+- Modify: `src/gateway/tests/test_route_security.py`
+- Modify: `src/gateway/tests/test_log_redaction.py`
+- Modify: `src/gateway/tests/integration/test_relay_ws_route.py`
+- Modify: `src/gateway/tests/integration/test_forward_signs_principal.py`
+
+**Step 1: Write failing Gateway tests**
+
+Require:
+
+- a `bcs_server_url` upstream variable and `bcs` server;
+- `group-sessions` domain with `protocols: [http, websocket]` and verbatim path forwarding;
+- `POST /openapi/v1/group-sessions/{sid}/token` to require a Gateway Human and forward a signed Principal with audience `bcs`;
+- `GET /openapi/v1/group-sessions/{sid}/ws` to have an explicit empty Gateway requirement so browser WebSocket Upgrade works without headers;
+- the more-specific WS rule to beat the general authenticated group-session rule;
+- `token=...` to be redacted in request/relay/error logs, including percent-encoded query cases;
+- no route or query rewriting beyond the configured upstream origin.
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd src/gateway
+uv run pytest tests/test_domain_map.py tests/test_route_security.py tests/test_log_redaction.py tests/integration/test_relay_ws_route.py tests/integration/test_forward_signs_principal.py -q
+```
+
+Expected: FAIL because the group-session domain and security exception are absent.
+
+**Step 3: Add the minimal Gateway configuration**
+
+Add:
+
+```yaml
+upstream_vars:
+  bcs_server_url: https://bcs.sample.com
+
+route_security:
+  "POST /openapi/v1/group-sessions/{sid}/token":
+    user: required
+  "GET /openapi/v1/group-sessions/{sid}/ws": {}
+
+upstreams:
+  domains:
+    group-sessions:
+      server: bcs
+      protocols: [http, websocket]
+  servers:
+    bcs:
+      base_url: "${bcs_server_url}"
+```
+
+Keep Nginx/L7 responsible only for TLS and passing Upgrade headers. The WebSocket relay remains in the Python Gateway application.
+
+The current redactor already treats query keys containing `token` as sensitive; add explicit regression coverage rather than a second redaction mechanism unless the test exposes a real gap.
+
+**Step 4: Run Gateway tests**
+
+Run the command from Step 2, then the full Gateway suite required by its module instructions.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/gateway/configs/application.yaml src/gateway/tests
+git commit -m "feat(gateway): relay group session websocket"
+```
+
+### Task 10: Add parity, security, and end-to-end contract coverage
+
+**Files:**
+
+- Create: `src/bcs/crates/bootstrap/bcs/tests/e2e_group_session_ws.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs`
+- Modify: `src/bcs/crates/bootstrap/bcs/tests/metrics_cardinality.rs`
+- Modify: `src/bcs/docs/BCS.md`
+- Create: `src/bcs/docs/protocols/group-session-workbench-websocket.md`
+- Modify: relevant `CONTEXT.md` files touched above
+
+**Step 1: Write the failing parity matrix**
+
+Run the same Workbench frame cases through `/ws` and the new session-bound route, then compare successful response/event envelopes for:
+
+- connect and registry subscription;
+- chat.send and streamed bot/frontend events;
+- chat.abort;
+- run lifecycle events;
+- ping/pong and idle timeout;
+- malformed/unknown frames;
+- disconnect cleanup and reconnect;
+- concurrent sockets using one still-valid token for the same session.
+
+Add negative cases for cross-session replay, permission revoked between issuance and connect, token expiration before reconnect, and an established connection surviving token expiration.
+
+Add metrics assertions proving token/uid/gid/sid are absent from labels and cardinality remains bounded.
+
+**Step 2: Run the tests to verify any missing behavior fails**
+
+```bash
+cargo test --package bcs --test e2e_group_session_ws --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-ws --test web_frame_compat --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL for any parity or security case not yet implemented.
+
+**Step 3: Fix only the exposed gaps and document the contract**
+
+Do not create new protocol behavior. Route all fixes through the existing Workbench implementation. Document:
+
+- issuance and connection sequence;
+- exact JWT claims and 300-second semantics;
+- single-session scope and multi-connection reuse;
+- Upgrade and connect-time authorization split;
+- protocol error codes and close behavior;
+- Gateway `/openapi/v1` prefix versus logical BCN suffix;
+- credential redaction and key separation;
+- compatibility guarantee for `/ws` and `/ws/bot`.
+
+**Step 4: Run the affected workspace gates**
+
+```bash
+cargo fmt --all --manifest-path src/bcs/Cargo.toml -- --check
+cargo test --package bcs-service-api --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-jwt --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-app-session --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-api-http --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-message-flow --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-ws --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs --test e2e_group_session_ws --manifest-path src/bcs/Cargo.toml
+cargo check --workspace --all-targets --manifest-path src/bcs/Cargo.toml
+cd src/gateway && uv run pytest -q
+```
+
+If time permits and the focused suites pass, run:
+
+```bash
+cargo test --workspace --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS. Record any suite that cannot run and the exact reason.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/bootstrap/bcs/tests src/bcs/crates/adapters/ws/bcs-ws/tests src/bcs/docs src/bcs/crates/bootstrap/bcs/CONTEXT.md src/bcs/crates/adapters/ws/bcs-ws/CONTEXT.md src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md src/bcs/crates/application/v1/bcs-app-session/CONTEXT.md src/bcs/crates/service-api/bcs-service-api/CONTEXT.md src/bcs/crates/services/bcs-jwt/CONTEXT.md
+git commit -m "test(bcs): verify group session websocket parity"
+```
+
+## Frontend adoption follow-up
+
+The BCN and Gateway contract is complete without changing the current frontend in the same patch. Migrate the frontend separately after deployment routing is available:
+
+1. request a fresh token for the active `sid`;
+2. open the returned session-scoped WebSocket URL;
+3. send the existing Workbench `connect` frame with the exact `gid` and `sid`;
+4. on reconnect after token expiry, request a new token;
+5. keep one provider/socket cache entry per `gid:sid`;
+6. retain a rollout fallback to `/ws` until parity telemetry is stable.
+
+This separate rollout avoids coupling the server security contract to frontend release timing while preserving the requirement that a successful new connection is functionally equivalent to `/ws`.

--- a/docs/plans/2026-08-03-bcn-group-session-websocket-token-implementation.md
+++ b/docs/plans/2026-08-03-bcn-group-session-websocket-token-implementation.md
@@ -2,9 +2,9 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Expose a five-minute, single-session JWT flow through Gateway so a browser can open `/group-sessions/{sid}/ws?token=...` with behavior equivalent to the existing Workbench `/ws` endpoint.
+**Goal:** Expose a five-minute, single-session JWT flow through the `/openapi/v1/collaboration` Gateway domain so a browser can open `/openapi/v1/collaboration/group/ws?token=...` with behavior equivalent to the existing Workbench `/ws` endpoint.
 
-**Architecture:** `bcs-service-api` defines transport-neutral issuance and verification contracts plus an outbound token port. `bcs-app-session` authorizes the Human and derives `gid` from `sid`; `bcs-jwt` signs and verifies the dedicated JWT. `bcs-api-http` exposes token issuance, while `bcs-ws` authenticates before Upgrade and feeds an immutable session-bound identity into the existing Workbench handler and dispatcher. Bootstrap composes the dependencies, and the Python Gateway transparently relays both HTTP and WebSocket traffic. The paths below are BCN paths; the shipped Gateway exposes them under its existing `/openapi/v1` base path.
+**Architecture:** `bcs-service-api` defines transport-neutral issuance and verification contracts plus an outbound token port. `bcs-app-session` authorizes the Human and derives `gid` from `sid`; `bcs-jwt` signs and verifies the dedicated JWT. Bootstrap obtains the signing key through the existing environment-backed `SecretAccessPort`. `bcs-api-http` exposes token issuance, while `bcs-ws` authenticates before Upgrade and feeds an immutable session-bound identity into the existing Workbench handler and dispatcher. The Python Gateway transparently relays both planes to identical BCN paths under `/openapi/v1/collaboration`.
 
 **Tech Stack:** Rust, Axum, Tokio, HMAC-SHA256 JWT, Python/FastAPI Gateway, pytest, Cargo workspace tests.
 
@@ -13,7 +13,7 @@
 ## Preconditions and invariants
 
 - Read `docs/arch/arch.rules.md`, `docs/arch/ci.enforce.md`, `docs/arch/context-boundary-format.md`, `docs/arch/protocol-contract-tests.md`, `src/bcs/AGENTS.md`, and `src/bcs/CLAUDE.md` before editing production code.
-- Keep the public logical suffixes `POST /group-sessions/{sid}/token` and `GET /group-sessions/{sid}/ws?token=...`. In the versioned BCS/Gateway adapters they are mounted as `/openapi/v1/group-sessions/{sid}/token` and `/openapi/v1/group-sessions/{sid}/ws`.
+- Expose `POST /openapi/v1/collaboration/sessions/{sid}/token` and `GET /openapi/v1/collaboration/group/ws?token=...` at both Gateway and BCN. Gateway forwards both paths unchanged.
 - Never accept `uid`, `gid`, tenant, lifetime, or JWT purpose from the request body or query string.
 - The token lifetime is exactly 300 seconds. It scopes one tenant, one Human, one group, and one session. It is stateless and may open more than one socket to that same session before expiration.
 - Token expiration only gates a new Upgrade. It does not terminate an established WebSocket.
@@ -76,7 +76,7 @@ Expected: FAIL because the modules and types do not exist.
 Define:
 
 - `IssueGroupSessionConnectionToken { caller: AuthenticatedCaller, sid: String }`
-- `VerifyGroupSessionConnectionToken { token: String, path_sid: String }`
+- `VerifyGroupSessionConnectionToken { token: String }`
 - `IssuedGroupSessionConnectionToken { token: String, expires_at: OffsetDateTime }`
 - `GroupSessionConnectionBinding { tenant, user_id, group_id, session_id }`
 - async `GroupSessionConnectionService::{issue_token, verify_token}`
@@ -175,7 +175,7 @@ Build fakes for `SessionService` and `GroupSessionTokenPort`. Verify:
 - Bot-only, App-only, access-key-only, or missing-Human callers are rejected;
 - missing session and forbidden session access do not call the signer;
 - token-port unavailable/internal errors remain distinguishable;
-- verification returns the binding only when `path_sid == claims.sid`, otherwise returns forbidden scope.
+- verification returns the complete binding from verified claims; the WS route has no path or query session selector.
 
 **Step 2: Run the tests to verify they fail**
 
@@ -189,7 +189,7 @@ Expected: FAIL because the connection application service is missing.
 
 Create `GroupSessionConnectionServiceImpl` with injected `Arc<dyn SessionService>` and `Arc<dyn GroupSessionTokenPort>`. Reuse `SessionService::get` so the existing V1 session-read authorization remains authoritative. Do not duplicate repository or group membership rules. Pass the fixed TTL constant to the port.
 
-On verification, validate the JWT through the port and enforce exact URL/session equality before returning the immutable binding. Do not perform the dynamic connection authorization here; that remains the Workbench `connect` operation.
+On verification, validate the JWT through the port and return its immutable binding. Do not perform the dynamic connection authorization here; that remains the Workbench `connect` operation.
 
 **Step 4: Run focused and package tests**
 
@@ -221,7 +221,7 @@ git commit -m "feat(bcs): issue authorized group session tokens"
 
 Build a focused route fixture with an injected fake `GroupSessionConnectionService` and `PrincipalVerifier`. Verify:
 
-- `POST /openapi/v1/group-sessions/session-a/token` returns the standard envelope containing only `data.token` and `data.expires_at`;
+- `POST /openapi/v1/collaboration/sessions/session-a/token` returns the standard envelope containing only `data.token` and `data.expires_at`;
 - response headers include `Cache-Control: no-store` and `Pragma: no-cache`;
 - missing/invalid Gateway Principal is 401;
 - a valid signed Gateway Principal without a Human is rejected;
@@ -238,7 +238,7 @@ Expected: FAIL because the route is absent.
 
 **Step 3: Implement the handler and response DTO**
 
-Add a focused `group_session_connection_router` with a minimal state containing only `Arc<dyn GroupSessionConnectionService>` and `Arc<dyn PrincipalVerifier>`. Mount the POST route under the existing versioned group-session path and apply the trusted Principal middleware. Extract `AuthenticatedCaller` from that middleware, and pass only caller plus path `session_id` to the application service.
+Add a focused `group_session_connection_router` with a minimal state containing only `Arc<dyn GroupSessionConnectionService>` and `Arc<dyn PrincipalVerifier>`. Mount `POST /openapi/v1/collaboration/sessions/{session_id}/token` and apply the trusted Principal middleware. Extract `AuthenticatedCaller` from that middleware, and pass only caller plus path `session_id` to the application service.
 
 Do not mount the whole preparatory V1 router in production as a side effect of this feature. Reuse the existing envelope, request-id, and error response helpers instead of duplicating the wire format.
 
@@ -387,8 +387,8 @@ git commit -m "feat(bcs): confine workbench commands to one session"
 Build an adapter router with a fake `GroupSessionConnectionService` and shared Workbench state. Verify:
 
 - missing, malformed, forged, expired, or wrong-purpose token returns HTTP 401 before Upgrade;
-- valid token whose `sid` differs from the path returns HTTP 403;
 - unavailable verifier returns HTTP 503;
+- the verified token is the only source of `tenant`, `uid`, `gid`, and `sid` because the route carries no session selector;
 - valid binding upgrades and enters the same `handle_client_connection` path used by `/ws`;
 - token values never appear in response bodies, close reasons, logs, or metrics;
 - an already-upgraded socket remains alive after the token's `exp`.
@@ -403,7 +403,7 @@ Expected: FAIL because the route builder is missing.
 
 **Step 3: Implement pre-Upgrade verification and shared handling**
 
-Add a handler for `GET /openapi/v1/group-sessions/{session_id}/ws?token=...`. Extract and validate the query credential before calling `on_upgrade`. Map only the approved status classes and use sanitized messages. Convert the application binding to `WorkbenchConnectionAuth::SessionBound`, with `actor_id = format!("human_{}", binding.user_id)`, then call the existing shared Workbench connection handler.
+Add a handler for `GET /openapi/v1/collaboration/group/ws?token=...`. Extract and validate the query credential before calling `on_upgrade`. Map only the approved status classes and use sanitized messages. Convert the application binding to `WorkbenchConnectionAuth::SessionBound`, with `actor_id = format!("human_{}", binding.user_id)`, then call the existing shared Workbench connection handler.
 
 Do not add a second dispatcher, registry, idle timer, or frontend delivery path.
 
@@ -423,63 +423,62 @@ git add src/bcs/crates/adapters/ws/bcs-ws
 git commit -m "feat(bcs): add session-bound workbench websocket"
 ```
 
-### Task 8: Add fail-closed configuration and bootstrap composition
+### Task 8: Resolve the signing key from the environment and compose Bootstrap
 
 **Files:**
 
-- Modify: `src/bcs/crates/bootstrap/bcs/src/config.rs`
-- Modify: `src/bcs/crates/bootstrap/bcs/src/config_loader.rs`
 - Modify: `src/bcs/crates/bootstrap/bcs/src/server.rs`
-- Modify: `src/bcs/crates/bootstrap/bcs/Cargo.toml`
-- Modify: `src/bcs/configs/bcs-config-example.toml`
-- Modify: `src/bcs/configs/bcs-config-local.toml`
+- Modify: `src/bcs/crates/plugins/bcs-secret-local/src/lib.rs`
 - Modify: `src/bcs/crates/bootstrap/bcs/tests/integration_http_api.rs`
 - Modify: `src/bcs/crates/bootstrap/bcs/tests/e2e_workbench.rs`
 - Modify: `src/bcs/crates/bootstrap/bcs/CONTEXT.md`
 
-**Step 1: Write failing configuration and composition tests**
+**Step 1: Write failing secret-resolution and composition tests**
 
-Require two independent trust configurations:
+Extend the existing `EnvSecretAccess` tests with the exact production mapping:
 
-```toml
-[gateway_principal]
-signing_key = "..."
-issuer = "gateway"
-audience = "bcs"
-kid = "bare"
-
-[group_session_ws]
-jwt_secret = "..."
-token_ttl_seconds = 300
+```rust
+#[tokio::test]
+async fn resolves_group_session_ws_key_from_fixed_environment_name() {
+    let env = HashMap::from([(
+        "BCS_SECRET_BCN_GROUP_SESSION_WS_JWT".to_string(),
+        "test-only-key".to_string(),
+    )]);
+    let access = EnvSecretAccess::from_map("BCS_SECRET_", env);
+    let result = access.get_secret("bcn-group-session-ws-jwt").await;
+    assert!(matches!(result, Ok(secret) if secret.value == "test-only-key"));
+}
 ```
 
-Test that missing/empty secrets, wrong audience/kid, or any TTL other than 300 fail startup. Assert the two secret values need not and should not be equal. Add router tests proving both versioned routes are mounted and existing `/ws` still resolves.
+Add Bootstrap tests proving that missing or empty `BCS_SECRET_BCN_GROUP_SESSION_WS_JWT` fails startup, a non-empty value constructs the group-session JWT service, both BCN routes are mounted, and existing `/ws` still resolves. Assert that the key is never included in formatted errors or configuration logs.
 
 **Step 2: Run tests to verify they fail**
 
 ```bash
+cargo test --package bcs-secret-local env_plugin --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs --test integration_http_api group_session --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs --test e2e_workbench group_session --manifest-path src/bcs/Cargo.toml
 ```
 
-Expected: FAIL because config and wiring are absent.
+Expected: FAIL because the exact environment mapping and Bootstrap wiring are absent.
 
 **Step 3: Compose the approved services**
 
 At bootstrap only:
 
 1. resolve the Gateway Principal verification key and build `GatewayPrincipalTokenVerifier` with issuer `gateway`, audience `bcs`, and configured `kid`;
-2. resolve the dedicated group-session WebSocket key and build `GroupSessionJwtService`;
+2. construct `EnvSecretAccess::new("BCS_SECRET_")`, request `bcn-group-session-ws-jwt`, reject missing or empty material, and build `GroupSessionJwtService`;
 3. build `GroupSessionConnectionServiceImpl` using the V1 session service and token port;
 4. inject the connection service into the HTTP and WS adapters;
 5. mount the focused V1 token route and session WebSocket route without unintentionally exposing unrelated preparatory V1 routes;
 6. retain current `/ws` and `/ws/bot` mounting and auth behavior.
 
-Do not read environment variables in adapters or application services. Do not provide a production fallback secret. A test/local fixture may use an explicit clearly test-only value.
+The 300-second TTL remains a code-level protocol constant, not an environment-controlled value. Do not read environment variables in adapters, application services, or `bcs-jwt`. Do not provide a fallback secret. A test fixture may inject `InMemorySecretAccess` or `EnvSecretAccess::from_map` with an explicit test-only value.
 
 **Step 4: Run bootstrap tests**
 
 ```bash
+cargo test --package bcs-secret-local --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs --test integration_http_api --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs --test e2e_workbench --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs --test e2e_ws_messaging --manifest-path src/bcs/Cargo.toml
@@ -490,7 +489,7 @@ Expected: PASS.
 **Step 5: Commit**
 
 ```bash
-git add src/bcs/crates/bootstrap/bcs src/bcs/configs
+git add src/bcs/crates/bootstrap/bcs src/bcs/crates/plugins/bcs-secret-local/src/lib.rs
 git commit -m "feat(bcs): wire group session websocket authentication"
 ```
 
@@ -510,12 +509,12 @@ git commit -m "feat(bcs): wire group session websocket authentication"
 Require:
 
 - a `bcs_server_url` upstream variable and `bcs` server;
-- `group-sessions` domain with `protocols: [http, websocket]` and verbatim path forwarding;
-- `POST /openapi/v1/group-sessions/{sid}/token` to require a Gateway Human and forward a signed Principal with audience `bcs`;
-- `GET /openapi/v1/group-sessions/{sid}/ws` to have an explicit empty Gateway requirement so browser WebSocket Upgrade works without headers;
-- the more-specific WS rule to beat the general authenticated group-session rule;
+- `collaboration` domain with `protocols: [http, websocket]`;
+- `POST /openapi/v1/collaboration/sessions/{sid}/token` to require a Gateway Human, forward a signed Principal with audience `bcs`, and arrive at the identical BCN path;
+- `GET /openapi/v1/collaboration/group/ws` to have an explicit empty Gateway requirement, work without browser-supplied headers, and arrive at the identical BCN path;
+- the more-specific WS rule to beat the general authenticated collaboration rule;
 - `token=...` to be redacted in request/relay/error logs, including percent-encoded query cases;
-- no route or query rewriting beyond the configured upstream origin.
+- no path or query rewriting beyond changing the upstream origin.
 
 **Step 2: Run tests to verify they fail**
 
@@ -524,7 +523,7 @@ cd src/gateway
 uv run pytest tests/test_domain_map.py tests/test_route_security.py tests/test_log_redaction.py tests/integration/test_relay_ws_route.py tests/integration/test_forward_signs_principal.py -q
 ```
 
-Expected: FAIL because the group-session domain and security exception are absent.
+Expected: FAIL because the collaboration domain and security exception are absent.
 
 **Step 3: Add the minimal Gateway configuration**
 
@@ -535,13 +534,15 @@ upstream_vars:
   bcs_server_url: https://bcs.sample.com
 
 route_security:
-  "POST /openapi/v1/group-sessions/{sid}/token":
+  "/openapi/v1/collaboration/**":
     user: required
-  "GET /openapi/v1/group-sessions/{sid}/ws": {}
+  "POST /openapi/v1/collaboration/sessions/{sid}/token":
+    user: required
+  "GET /openapi/v1/collaboration/group/ws": {}
 
 upstreams:
   domains:
-    group-sessions:
+    collaboration:
       server: bcs
       protocols: [http, websocket]
   servers:
@@ -621,6 +622,7 @@ Do not create new protocol behavior. Route all fixes through the existing Workbe
 ```bash
 cargo fmt --all --manifest-path src/bcs/Cargo.toml -- --check
 cargo test --package bcs-service-api --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-secret-local --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs-jwt --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs-app-session --manifest-path src/bcs/Cargo.toml
 cargo test --package bcs-api-http --manifest-path src/bcs/Cargo.toml

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1093,11 +1093,13 @@ name = "bcs-jwt"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "bcs-service-api",
  "hmac",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.19",
+ "time",
  "tokio",
 ]
 

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "bcs-session-store",
  "bcs-test-support",
  "serde_json",
+ "time",
  "tokio",
 ]
 

--- a/src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md
+++ b/src/bcs/crates/adapters/http/bcs-api-http/CONTEXT.md
@@ -5,6 +5,8 @@
 - Versioned `/openapi/v1/**` and `/internal/v1/**` HTTP delivery boundaries.
 - Request/response DTO translation and the common response envelope.
 - An injectable Gateway Principal verification boundary.
+- The focused authenticated
+  `POST /openapi/v1/collaboration/sessions/{sid}/token` delivery slice.
 - A preparatory V1 Gateway wire projection and HS256 token verifier that
   returns a complete, secret-free authenticated caller.
 
@@ -36,9 +38,10 @@
 ## Runtime ownership
 
 This crate owns HTTP parsing, versioned wire DTOs, Gateway token verification,
-request IDs, envelopes, and HTTP error mapping. Header extraction, production
-trust selection, router mounting, resource authorization, Actor selection, and
-business policy remain outside this preparatory verifier slice.
+request IDs, envelopes, no-store token responses, and HTTP error mapping.
+Header extraction, production trust selection, router mounting, resource
+authorization, Actor selection, and business policy remain outside this
+delivery boundary.
 
 ## Tests
 

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/lib.rs
@@ -3,4 +3,5 @@
 pub mod v1;
 
 pub use v1::common::{ApiState, PrincipalVerificationError, PrincipalVerifier};
+pub use v1::group_session_connection_router;
 pub use v1::router;

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/mod.rs
@@ -8,4 +8,4 @@ pub use envelope::{Envelope, ErrorData};
 pub use error::{ErrorResponse, application_error_response, invalid_request};
 pub use principal::{PrincipalVerificationError, PrincipalVerifier, verify_principal};
 pub use request_id::RequestId;
-pub use state::ApiState;
+pub use state::{ApiState, PrincipalVerificationState};

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/principal.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/principal.rs
@@ -5,7 +5,7 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use bcs_service_api::application::v1::AuthenticatedCaller;
 
-use super::{ApiState, ErrorResponse, RequestId};
+use super::{ErrorResponse, PrincipalVerificationState, RequestId};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PrincipalVerificationError {
@@ -27,13 +27,16 @@ pub trait PrincipalVerifier: Send + Sync {
     ) -> Result<AuthenticatedCaller, PrincipalVerificationError>;
 }
 
-pub async fn verify_principal(
-    State(state): State<ApiState>,
+pub async fn verify_principal<S>(
+    State(state): State<S>,
     mut request: Request,
     next: Next,
-) -> Response {
+) -> Response
+where
+    S: PrincipalVerificationState,
+{
     let request_id = RequestId::from_headers(request.headers());
-    match state.principal_verifier.verify(request.headers()).await {
+    match state.principal_verifier().verify(request.headers()).await {
         Ok(caller) => {
             request.extensions_mut().insert(caller);
             request.extensions_mut().insert(request_id);

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/state.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/state.rs
@@ -7,6 +7,10 @@ use bcs_service_api::application::v1::{
 
 use super::PrincipalVerifier;
 
+pub trait PrincipalVerificationState: Clone + Send + Sync + 'static {
+    fn principal_verifier(&self) -> &Arc<dyn PrincipalVerifier>;
+}
+
 #[derive(Clone)]
 pub struct ApiState {
     pub bot_service: Option<Arc<dyn BotService>>,
@@ -45,5 +49,11 @@ impl ApiState {
     pub fn with_bot_service(mut self, bot_service: Arc<dyn BotService>) -> Self {
         self.bot_service = Some(bot_service);
         self
+    }
+}
+
+impl PrincipalVerificationState for ApiState {
+    fn principal_verifier(&self) -> &Arc<dyn PrincipalVerifier> {
+        &self.principal_verifier
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/group_session_connection.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/group_session_connection.rs
@@ -1,0 +1,110 @@
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::StatusCode;
+use axum::middleware;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use bcs_service_api::application::v1::{
+    AuthenticatedCaller, GroupSessionConnectionError, GroupSessionConnectionService,
+    IssueGroupSessionConnectionToken,
+};
+use serde::Serialize;
+
+use super::common::{
+    Envelope, ErrorResponse, PrincipalVerificationState, PrincipalVerifier, RequestId,
+    application_error_response, verify_principal,
+};
+
+#[derive(Clone)]
+struct GroupSessionConnectionHttpState {
+    service: Arc<dyn GroupSessionConnectionService>,
+    principal_verifier: Arc<dyn PrincipalVerifier>,
+}
+
+impl PrincipalVerificationState for GroupSessionConnectionHttpState {
+    fn principal_verifier(&self) -> &Arc<dyn PrincipalVerifier> {
+        &self.principal_verifier
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct GroupSessionConnectionTokenResponse {
+    token: String,
+    expires_at: i64,
+}
+
+/// Build only the authenticated session-token issuance slice.
+pub fn group_session_connection_router(
+    service: Arc<dyn GroupSessionConnectionService>,
+    principal_verifier: Arc<dyn PrincipalVerifier>,
+) -> Router {
+    let state = GroupSessionConnectionHttpState {
+        service,
+        principal_verifier,
+    };
+    Router::new()
+        .route(
+            "/openapi/v1/collaboration/sessions/{session_id}/token",
+            post(issue_token),
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            verify_principal::<GroupSessionConnectionHttpState>,
+        ))
+        .with_state(state)
+}
+
+async fn issue_token(
+    State(state): State<GroupSessionConnectionHttpState>,
+    Extension(caller): Extension<AuthenticatedCaller>,
+    Extension(request_id): Extension<RequestId>,
+    Path(session_id): Path<String>,
+) -> Result<Response, ErrorResponse> {
+    let issued = state
+        .service
+        .issue_token(IssueGroupSessionConnectionToken { caller, session_id })
+        .await
+        .map_err(|error| connection_error_response(&request_id, error))?;
+    let data = GroupSessionConnectionTokenResponse {
+        token: issued.token,
+        expires_at: issued.expires_at.unix_timestamp(),
+    };
+
+    Ok((
+        StatusCode::OK,
+        [("cache-control", "no-store"), ("pragma", "no-cache")],
+        Json(Envelope::success(20_000, "OK", data, request_id.0)),
+    )
+        .into_response())
+}
+
+fn connection_error_response(
+    request_id: &RequestId,
+    error: GroupSessionConnectionError,
+) -> ErrorResponse {
+    match error {
+        GroupSessionConnectionError::Application(error) => {
+            application_error_response(request_id, error)
+        }
+        GroupSessionConnectionError::InvalidConnectionToken => application_error_response(
+            request_id,
+            bcs_service_api::application::v1::ApplicationError::internal(
+                "unexpected token verification error during issuance",
+            ),
+        ),
+        GroupSessionConnectionError::TokenServiceUnavailable => application_error_response(
+            request_id,
+            bcs_service_api::application::v1::ApplicationError::internal(
+                "group-session token service unavailable",
+            ),
+        ),
+        GroupSessionConnectionError::Internal(_) => application_error_response(
+            request_id,
+            bcs_service_api::application::v1::ApplicationError::internal(
+                "group-session connection token issuance failed",
+            ),
+        ),
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/mod.rs
@@ -1,5 +1,6 @@
 pub mod common;
 pub mod gateway_principal;
+pub mod group_session_connection;
 pub mod internal;
 pub mod openapi;
 
@@ -7,6 +8,8 @@ use axum::Router;
 use axum::middleware;
 
 use common::{ApiState, verify_principal};
+
+pub use group_session_connection::group_session_connection_router;
 
 /// Build the v1 router with an injected Principal verification boundary.
 ///
@@ -17,7 +20,7 @@ pub fn router(state: ApiState) -> Router {
         .merge(internal::router())
         .layer(middleware::from_fn_with_state(
             state.clone(),
-            verify_principal,
+            verify_principal::<ApiState>,
         ))
         .with_state(state)
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/group_session_connection_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/group_session_connection_routes.rs
@@ -1,0 +1,275 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::body::{Body, to_bytes};
+use axum::http::{HeaderMap, Request, StatusCode};
+use bcs_api_http::{
+    PrincipalVerificationError, PrincipalVerifier, group_session_connection_router,
+};
+use bcs_service_api::application::v1::{
+    ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity,
+    GroupSessionConnectionBinding, GroupSessionConnectionError, GroupSessionConnectionService,
+    IssueGroupSessionConnectionToken, IssuedGroupSessionConnectionToken,
+    VerifyGroupSessionConnectionToken,
+};
+use serde_json::{Value, json};
+use time::OffsetDateTime;
+use tower::ServiceExt;
+
+struct HeaderVerifier {
+    caller: AuthenticatedCaller,
+}
+
+#[async_trait]
+impl PrincipalVerifier for HeaderVerifier {
+    async fn verify(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedCaller, PrincipalVerificationError> {
+        match headers
+            .get("x-test-auth")
+            .and_then(|value| value.to_str().ok())
+        {
+            Some("yes") => Ok(self.caller.clone()),
+            Some("invalid") => Err(PrincipalVerificationError::Invalid("bad signature".into())),
+            _ => Err(PrincipalVerificationError::Missing),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ServiceMode {
+    Success,
+    NotFound,
+    Forbidden,
+    Unavailable,
+}
+
+struct FakeConnectionService {
+    mode: ServiceMode,
+    commands: Mutex<Vec<IssueGroupSessionConnectionToken>>,
+}
+
+impl FakeConnectionService {
+    fn new(mode: ServiceMode) -> Self {
+        Self {
+            mode,
+            commands: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn commands(&self) -> Vec<IssueGroupSessionConnectionToken> {
+        self.commands.lock().expect("command lock").clone()
+    }
+}
+
+#[async_trait]
+impl GroupSessionConnectionService for FakeConnectionService {
+    async fn issue_token(
+        &self,
+        command: IssueGroupSessionConnectionToken,
+    ) -> Result<IssuedGroupSessionConnectionToken, GroupSessionConnectionError> {
+        self.commands
+            .lock()
+            .expect("command lock")
+            .push(command.clone());
+        if command.caller.user.is_none() {
+            return Err(ApplicationError::forbidden("Human caller required").into());
+        }
+        match self.mode {
+            ServiceMode::Success => Ok(IssuedGroupSessionConnectionToken {
+                token: "secret.jwt.value".into(),
+                expires_at: OffsetDateTime::from_unix_timestamp(400)
+                    .expect("valid test timestamp"),
+            }),
+            ServiceMode::NotFound => Err(ApplicationError::not_found(
+                "session_not_found",
+                "Session was not found",
+            )
+            .into()),
+            ServiceMode::Forbidden => {
+                Err(ApplicationError::forbidden("Session access denied").into())
+            }
+            ServiceMode::Unavailable => {
+                Err(GroupSessionConnectionError::TokenServiceUnavailable)
+            }
+        }
+    }
+
+    async fn verify_token(
+        &self,
+        _command: VerifyGroupSessionConnectionToken,
+    ) -> Result<GroupSessionConnectionBinding, GroupSessionConnectionError> {
+        panic!("token route does not verify connection tokens")
+    }
+}
+
+fn human_caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "user-a".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn request(auth: Option<&str>, uri: &str, body: Value) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("x-request-id", "request-123");
+    if let Some(auth) = auth {
+        builder = builder.header("x-test-auth", auth);
+    }
+    builder
+        .body(Body::from(body.to_string()))
+        .expect("request")
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&bytes).expect("JSON response")
+}
+
+fn app(
+    service: Arc<FakeConnectionService>,
+    caller: AuthenticatedCaller,
+) -> axum::Router {
+    group_session_connection_router(service, Arc::new(HeaderVerifier { caller }))
+}
+
+#[tokio::test]
+async fn returns_only_token_expiry_and_no_store_headers() {
+    let service = Arc::new(FakeConnectionService::new(ServiceMode::Success));
+    let response = app(service.clone(), human_caller())
+        .oneshot(request(
+            Some("yes"),
+            "/openapi/v1/collaboration/sessions/session-a/token",
+            json!({}),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["cache-control"], "no-store");
+    assert_eq!(response.headers()["pragma"], "no-cache");
+    let body = response_json(response).await;
+    assert_eq!(body["code"], 20_000);
+    assert_eq!(body["data"]["token"], "secret.jwt.value");
+    assert_eq!(body["data"]["expires_at"], 400);
+    assert_eq!(body["data"].as_object().expect("data object").len(), 2);
+    assert_eq!(service.commands().len(), 1);
+}
+
+#[tokio::test]
+async fn rejects_missing_or_invalid_gateway_principal_before_service_call() {
+    for auth in [None, Some("invalid")] {
+        let service = Arc::new(FakeConnectionService::new(ServiceMode::Success));
+        let response = app(service.clone(), human_caller())
+            .oneshot(request(
+                auth,
+                "/openapi/v1/collaboration/sessions/session-a/token",
+                json!({}),
+            ))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(service.commands().is_empty());
+        let body = response_json(response).await;
+        assert_eq!(body["data"]["error_code"], "unauthenticated");
+    }
+}
+
+#[tokio::test]
+async fn valid_principal_without_human_is_forbidden() {
+    let service = Arc::new(FakeConnectionService::new(ServiceMode::Success));
+    let mut caller = human_caller();
+    caller.user = None;
+    let response = app(service, caller)
+        .oneshot(request(
+            Some("yes"),
+            "/openapi/v1/collaboration/sessions/session-a/token",
+            json!({}),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = response_json(response).await;
+    assert_eq!(body["data"]["error_code"], "forbidden");
+}
+
+#[tokio::test]
+async fn preserves_session_errors_and_sanitizes_signer_failure() {
+    let cases = [
+        (ServiceMode::NotFound, StatusCode::NOT_FOUND, "session_not_found"),
+        (ServiceMode::Forbidden, StatusCode::FORBIDDEN, "forbidden"),
+        (
+            ServiceMode::Unavailable,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+        ),
+    ];
+
+    for (mode, status, error_code) in cases {
+        let response = app(
+            Arc::new(FakeConnectionService::new(mode)),
+            human_caller(),
+        )
+        .oneshot(request(
+            Some("yes"),
+            "/openapi/v1/collaboration/sessions/session-a/token",
+            json!({}),
+        ))
+        .await
+        .expect("response");
+
+        assert_eq!(response.status(), status);
+        let body = response_json(response).await;
+        assert_eq!(body["data"]["error_code"], error_code);
+        assert!(!body.to_string().contains("secret.jwt.value"));
+    }
+}
+
+#[tokio::test]
+async fn ignores_request_controlled_claims_and_uses_only_path_and_principal() {
+    let service = Arc::new(FakeConnectionService::new(ServiceMode::Success));
+    let response = app(service.clone(), human_caller())
+        .oneshot(request(
+            Some("yes"),
+            "/openapi/v1/collaboration/sessions/path-session/token?sid=query-session&gid=evil&uid=evil&ttl=99999",
+            json!({
+                "sid": "body-session",
+                "gid": "evil",
+                "uid": "evil",
+                "ttl": 99999
+            }),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let commands = service.commands();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].session_id, "path-session");
+    assert_eq!(commands[0].caller.tenant, "tenant-a");
+    assert_eq!(
+        commands[0]
+            .caller
+            .user
+            .as_ref()
+            .expect("Human caller")
+            .id,
+        "user-a"
+    );
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/group_session_connection_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/group_session_connection_routes.rs
@@ -102,6 +102,16 @@ impl GroupSessionConnectionService for FakeConnectionService {
     ) -> Result<GroupSessionConnectionBinding, GroupSessionConnectionError> {
         panic!("token route does not verify connection tokens")
     }
+
+    async fn authorize_connect(
+        &self,
+        _command: bcs_service_api::application::v1::AuthorizeGroupSessionConnection,
+    ) -> Result<
+        bcs_service_api::application::v1::AuthorizedGroupSessionConnection,
+        GroupSessionConnectionError,
+    > {
+        panic!("token route does not authorize WebSocket connects")
+    }
 }
 
 fn human_caller() -> AuthenticatedCaller {

--- a/src/bcs/crates/adapters/ws/bcs-ws/CONTEXT.md
+++ b/src/bcs/crates/adapters/ws/bcs-ws/CONTEXT.md
@@ -5,6 +5,9 @@
 - WebSocket delivery adapter for BCS.
 - Bot runtime entry under `src/bot/`.
 - Workbench/Web entry under `src/web/`.
+- Session-bound Workbench connect delivery that delegates current Session
+  authorization to the V1 group-session connection service; legacy
+  user-bound `/ws` connect remains on the Workbench session service.
 - Shared connection-state helpers under `src/shared/`.
 - Implementations of `BotDeliveryPort` and `FrontendDeliveryPort`.
 

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/auth.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/auth.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkbenchConnectionAuth {
+    UserBound {
+        actor_id: Option<String>,
+    },
+    SessionBound {
+        tenant: String,
+        actor_id: String,
+        group_id: String,
+        session_id: String,
+    },
+}
+
+impl WorkbenchConnectionAuth {
+    pub fn actor_id(&self) -> Option<&str> {
+        match self {
+            Self::UserBound { actor_id } => actor_id.as_deref(),
+            Self::SessionBound { actor_id, .. } => Some(actor_id),
+        }
+    }
+}

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -1,11 +1,16 @@
 use std::sync::Arc;
 
 use bcs_protocol::{BcsFrame, ErrorShape, RequestFrame, ResponseFrame};
+use bcs_service_api::application::v1::{
+    AuthorizeGroupSessionConnection, GroupSessionConnectionBinding,
+    GroupSessionConnectionService, ParticipantRole,
+};
 use bcs_service_api::{
     CallerContext, ChatAbortCommand, CollaborationRuntimeError, CollaborationRuntimeService,
     HandleSessionHumanInputCommand, HandleSessionHumanInputOutcome, HumanActor,
     HumanResponseSource, MessageFlowService, ServiceError, WebSendCommand,
-    WorkbenchChatAuthorizationCommand, WorkbenchConnectCommand, WorkbenchSessionService,
+    ParticipantKind, WorkbenchChatAuthorizationCommand, WorkbenchConnectCommand,
+    WorkbenchConnectOutcome, WorkbenchParticipantView, WorkbenchSessionService,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -44,6 +49,7 @@ pub struct WebDispatchState {
     pub message_flow: Arc<dyn MessageFlowService>,
     pub collaboration_runtime: Arc<dyn CollaborationRuntimeService>,
     pub workbench_sessions: Arc<dyn WorkbenchSessionService>,
+    pub group_session_connections: Option<Arc<dyn GroupSessionConnectionService>>,
     pub frontend_connections: Arc<WorkbenchConnectionRegistry>,
     pub run_channels: Arc<RunChannelManager>,
 }
@@ -54,6 +60,13 @@ impl std::fmt::Debug for WebDispatchState {
             .field("message_flow", &"<MessageFlowService>")
             .field("collaboration_runtime", &"<CollaborationRuntimeService>")
             .field("workbench_sessions", &"<WorkbenchSessionService>")
+            .field(
+                "group_session_connections",
+                &self
+                    .group_session_connections
+                    .as_ref()
+                    .map(|_| "<GroupSessionConnectionService>"),
+            )
             .field("frontend_connections", &"<WorkbenchConnectionRegistry>")
             .field("run_channels", &"<RunChannelManager>")
             .finish()
@@ -237,38 +250,80 @@ async fn handle_connect(
         "Processing connect request"
     );
 
-    let outcome = match state
-        .workbench_sessions
-        .connect(WorkbenchConnectCommand {
-            bound_actor_id: bound_actor_id.map(str::to_string),
-            group_id: group_id.clone(),
-            session_id: session_id.clone(),
-        })
-        .await
-    {
-        Ok(outcome) => outcome,
-        Err(err) => {
-            warn!(
-                group_id = %group_id,
-                session_id = ?session_id,
-                bound_actor_id = ?bound_actor_id,
-                error = ?err,
-                "connect rejected by Workbench WS authorization"
-            );
-            if matches!(auth, WorkbenchConnectionAuth::SessionBound { .. }) {
-                send_error(
-                    tx,
-                    &req.id,
-                    "session_access_revoked",
-                    "Session access is no longer authorized",
-                )
-                .await?;
-                connection_state.phase = WebConnectionPhase::Closed;
-            } else {
+    let outcome = match auth {
+        WorkbenchConnectionAuth::UserBound { .. } => match state
+            .workbench_sessions
+            .connect(WorkbenchConnectCommand {
+                bound_actor_id: bound_actor_id.map(str::to_string),
+                group_id: group_id.clone(),
+                session_id: session_id.clone(),
+            })
+            .await
+        {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                warn!(
+                    group_id = %group_id,
+                    session_id = ?session_id,
+                    bound_actor_id = ?bound_actor_id,
+                    error = ?err,
+                    "connect rejected by Workbench WS authorization"
+                );
                 let message = err.message();
                 send_error(tx, &req.id, err.code(), &message).await?;
+                return Ok(());
             }
-            return Ok(());
+        },
+        WorkbenchConnectionAuth::SessionBound {
+            tenant,
+            actor_id,
+            group_id,
+            session_id,
+        } => {
+            let user_id = actor_id
+                .strip_prefix("human_")
+                .filter(|user_id| !user_id.is_empty());
+            let service = state.group_session_connections.as_ref();
+            let authorized = match (service, user_id) {
+                (Some(service), Some(user_id)) => service
+                    .authorize_connect(AuthorizeGroupSessionConnection {
+                        binding: GroupSessionConnectionBinding {
+                            tenant: tenant.clone(),
+                            user_id: user_id.to_string(),
+                            group_id: group_id.clone(),
+                            session_id: session_id.clone(),
+                        },
+                    })
+                    .await,
+                _ => {
+                    warn!("session-bound connect is missing a valid V1 authorization context");
+                    send_session_access_revoked(tx, &req.id, connection_state).await?;
+                    return Ok(());
+                }
+            };
+            match authorized {
+                Ok(authorized) => WorkbenchConnectOutcome {
+                    group_id: group_id.clone(),
+                    participants: authorized
+                        .participants
+                        .into_iter()
+                        .map(|participant| WorkbenchParticipantView {
+                            bot_uuid: participant.actor_id,
+                            role: participant_role_to_wire(participant.role).to_string(),
+                            kind: ParticipantKind::Bot,
+                            mode: Some(participant.mode),
+                        })
+                        .collect(),
+                },
+                Err(err) => {
+                    warn!(
+                        error = ?err,
+                        "connect rejected by V1 group-session authorization"
+                    );
+                    send_session_access_revoked(tx, &req.id, connection_state).await?;
+                    return Ok(());
+                }
+            }
         }
     };
 
@@ -301,6 +356,32 @@ async fn handle_connect(
 
     send_ok(tx, &req.id, serde_json::to_value(response)?).await?;
     Ok(())
+}
+
+async fn send_session_access_revoked(
+    tx: &mpsc::Sender<String>,
+    request_id: &str,
+    connection_state: &mut WebClientConnectionState,
+) -> Result<()> {
+    send_error(
+        tx,
+        request_id,
+        "session_access_revoked",
+        "Session access is no longer authorized",
+    )
+    .await?;
+    connection_state.phase = WebConnectionPhase::Closed;
+    Ok(())
+}
+
+fn participant_role_to_wire(role: ParticipantRole) -> &'static str {
+    match role {
+        ParticipantRole::Driver => "driver",
+        ParticipantRole::Consultant => "consultant",
+        ParticipantRole::Manager => "manager",
+        ParticipantRole::Worker => "worker",
+        ParticipantRole::Observer => "observer",
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use crate::shared::RunChannelManager;
-use crate::web::WorkbenchConnectionRegistry;
+use crate::web::{WorkbenchConnectionAuth, WorkbenchConnectionRegistry};
 
 const STATE_MACHINE_EVENT_BOT_UUID: &str = "bcs_state_machine";
 
@@ -70,7 +70,7 @@ pub async fn dispatch_client_frame(
     text: &str,
     tx: &mpsc::Sender<String>,
     connection_state: &mut WebClientConnectionState,
-    bound_actor_id: Option<&str>,
+    auth: &WorkbenchConnectionAuth,
 ) -> Result<WebDispatchOutcome> {
     let frame: BcsFrame = serde_json::from_str(text)
         .map_err(|e| WebWsDispatchError::InvalidFrameFormat(e.to_string()))?;
@@ -80,7 +80,7 @@ pub async fn dispatch_client_frame(
             let is_connect = req.method == "connect";
             let subscribed_before = connection_state.subscribed_sessions.len();
             if let Err(error) =
-                handle_client_request(state, &req, tx, connection_state, bound_actor_id).await
+                handle_client_request(state, &req, tx, connection_state, auth).await
             {
                 if is_connect {
                     return Err(WebWsDispatchError::ClientConnectError(Box::new(error)));
@@ -109,20 +109,20 @@ async fn handle_client_request(
     req: &RequestFrame,
     tx: &mpsc::Sender<String>,
     connection_state: &mut WebClientConnectionState,
-    bound_actor_id: Option<&str>,
+    auth: &WorkbenchConnectionAuth,
 ) -> Result<()> {
     debug!(id = %req.id, method = %req.method, "Handling client RequestFrame");
     info!(method = %req.method, "Client request received");
 
     match req.method.as_str() {
         "connect" => {
-            handle_connect(state, req, tx, connection_state, bound_actor_id).await?;
+            handle_connect(state, req, tx, connection_state, auth).await?;
         }
         "chat.send" => {
-            handle_chat_send(state, req, tx, connection_state, bound_actor_id).await?;
+            handle_chat_send(state, req, tx, connection_state, auth).await?;
         }
         "chat.abort" => {
-            handle_chat_abort(state, req, tx).await?;
+            handle_chat_abort(state, req, tx, auth).await?;
         }
         _ => {
             send_error(
@@ -156,8 +156,9 @@ async fn handle_connect(
     req: &RequestFrame,
     tx: &mpsc::Sender<String>,
     connection_state: &mut WebClientConnectionState,
-    bound_actor_id: Option<&str>,
+    auth: &WorkbenchConnectionAuth,
 ) -> Result<()> {
+    let bound_actor_id = auth.actor_id();
     let params: ConnectParams = serde_json::from_value(req.params.clone().unwrap_or(Value::Null))
         .map_err(|e| {
         WebWsDispatchError::InvalidFrameFormat(format!("Invalid connect params: {}", e))
@@ -256,8 +257,9 @@ async fn handle_chat_send(
     req: &RequestFrame,
     tx: &mpsc::Sender<String>,
     connection_state: &mut WebClientConnectionState,
-    bound_actor_id: Option<&str>,
+    auth: &WorkbenchConnectionAuth,
 ) -> Result<()> {
+    let bound_actor_id = auth.actor_id();
     let params: ChatSendParams = serde_json::from_value(req.params.clone().unwrap_or(Value::Null))
         .map_err(|e| {
             WebWsDispatchError::InvalidFrameFormat(format!("Invalid chat.send params: {}", e))
@@ -472,6 +474,7 @@ async fn handle_chat_abort(
     state: &Arc<WebDispatchState>,
     req: &RequestFrame,
     tx: &mpsc::Sender<String>,
+    _auth: &WorkbenchConnectionAuth,
 ) -> Result<()> {
     let params: ClientChatAbortParams =
         serde_json::from_value(req.params.clone().unwrap_or(Value::Null)).map_err(|e| {

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -37,6 +37,7 @@ pub enum WebWsDispatchError {
 pub enum WebDispatchOutcome {
     Dispatched,
     ClientConnect { subscribed: bool },
+    Close,
 }
 
 pub struct WebDispatchState {
@@ -59,10 +60,19 @@ impl std::fmt::Debug for WebDispatchState {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WebConnectionPhase {
+    #[default]
+    AwaitingConnect,
+    Connected,
+    Closed,
+}
+
 #[derive(Debug, Default)]
 pub struct WebClientConnectionState {
     pub active_run_ids: Vec<String>,
     pub subscribed_sessions: Vec<(String, u64)>,
+    pub phase: WebConnectionPhase,
 }
 
 pub async fn dispatch_client_frame(
@@ -87,9 +97,17 @@ pub async fn dispatch_client_frame(
                 }
                 return Err(error);
             }
+            if connection_state.phase == WebConnectionPhase::Closed {
+                return Ok(WebDispatchOutcome::Close);
+            }
             if is_connect {
+                let subscribed =
+                    connection_state.subscribed_sessions.len() > subscribed_before;
+                if matches!(auth, WorkbenchConnectionAuth::SessionBound { .. }) && !subscribed {
+                    return Ok(WebDispatchOutcome::Dispatched);
+                }
                 return Ok(WebDispatchOutcome::ClientConnect {
-                    subscribed: connection_state.subscribed_sessions.len() > subscribed_before,
+                    subscribed,
                 });
             }
         }
@@ -114,6 +132,20 @@ async fn handle_client_request(
     debug!(id = %req.id, method = %req.method, "Handling client RequestFrame");
     info!(method = %req.method, "Client request received");
 
+    if matches!(auth, WorkbenchConnectionAuth::SessionBound { .. })
+        && connection_state.phase == WebConnectionPhase::AwaitingConnect
+        && req.method != "connect"
+    {
+        send_error(
+            tx,
+            &req.id,
+            "connect_required",
+            "A successful connect request is required before this method",
+        )
+        .await?;
+        return Ok(());
+    }
+
     match req.method.as_str() {
         "connect" => {
             handle_connect(state, req, tx, connection_state, auth).await?;
@@ -122,7 +154,7 @@ async fn handle_client_request(
             handle_chat_send(state, req, tx, connection_state, auth).await?;
         }
         "chat.abort" => {
-            handle_chat_abort(state, req, tx, auth).await?;
+            handle_chat_abort(state, req, tx, connection_state, auth).await?;
         }
         _ => {
             send_error(
@@ -164,9 +196,43 @@ async fn handle_connect(
         WebWsDispatchError::InvalidFrameFormat(format!("Invalid connect params: {}", e))
     })?;
 
+    let (group_id, session_id) = match auth {
+        WorkbenchConnectionAuth::UserBound { .. } => {
+            (params.group_id.clone(), params.session_id.clone())
+        }
+        WorkbenchConnectionAuth::SessionBound {
+            group_id,
+            session_id,
+            ..
+        } => {
+            if connection_state.phase == WebConnectionPhase::Connected {
+                send_error(
+                    tx,
+                    &req.id,
+                    "already_connected",
+                    "This WebSocket is already connected",
+                )
+                .await?;
+                return Ok(());
+            }
+            if params.group_id != *group_id || params.session_id.as_deref() != Some(session_id) {
+                send_error(
+                    tx,
+                    &req.id,
+                    "token_scope_mismatch",
+                    "Connect scope does not match the connection token",
+                )
+                .await?;
+                connection_state.phase = WebConnectionPhase::Closed;
+                return Ok(());
+            }
+            (group_id.clone(), Some(session_id.clone()))
+        }
+    };
+
     debug!(
-        group_id = %params.group_id,
-        session_id = ?params.session_id,
+        group_id = %group_id,
+        session_id = ?session_id,
         bound_actor_id = ?bound_actor_id,
         "Processing connect request"
     );
@@ -175,30 +241,38 @@ async fn handle_connect(
         .workbench_sessions
         .connect(WorkbenchConnectCommand {
             bound_actor_id: bound_actor_id.map(str::to_string),
-            group_id: params.group_id.clone(),
-            session_id: params.session_id.clone(),
+            group_id: group_id.clone(),
+            session_id: session_id.clone(),
         })
         .await
     {
         Ok(outcome) => outcome,
         Err(err) => {
             warn!(
-                group_id = %params.group_id,
-                session_id = ?params.session_id,
+                group_id = %group_id,
+                session_id = ?session_id,
                 bound_actor_id = ?bound_actor_id,
                 error = ?err,
                 "connect rejected by Workbench WS authorization"
             );
-            let message = err.message();
-            send_error(tx, &req.id, err.code(), &message).await?;
+            if matches!(auth, WorkbenchConnectionAuth::SessionBound { .. }) {
+                send_error(
+                    tx,
+                    &req.id,
+                    "session_access_revoked",
+                    "Session access is no longer authorized",
+                )
+                .await?;
+                connection_state.phase = WebConnectionPhase::Closed;
+            } else {
+                let message = err.message();
+                send_error(tx, &req.id, err.code(), &message).await?;
+            }
             return Ok(());
         }
     };
 
-    let subscription_key = params
-        .session_id
-        .clone()
-        .unwrap_or_else(|| params.group_id.clone());
+    let subscription_key = session_id.clone().unwrap_or_else(|| group_id.clone());
     let conn_id = state
         .frontend_connections
         .subscribe(
@@ -210,6 +284,9 @@ async fn handle_connect(
     connection_state
         .subscribed_sessions
         .push((subscription_key, conn_id));
+    if matches!(auth, WorkbenchConnectionAuth::SessionBound { .. }) {
+        connection_state.phase = WebConnectionPhase::Connected;
+    }
 
     let participants: Vec<Value> = outcome
         .participants
@@ -265,15 +342,38 @@ async fn handle_chat_send(
             WebWsDispatchError::InvalidFrameFormat(format!("Invalid chat.send params: {}", e))
         })?;
 
-    let from_id = params
+    let mut from_id = params
         .bot_id
         .clone()
         .or_else(|| params.bot_uuid.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    let session_id = resolve_bcs_session_id(&params);
+    let mut session_id = resolve_bcs_session_id(&params);
+    let mut group_id = params.group_id.clone();
+    if let WorkbenchConnectionAuth::SessionBound {
+        actor_id,
+        group_id: bound_group_id,
+        session_id: bound_session_id,
+        ..
+    } = auth
+    {
+        if group_id != *bound_group_id || session_id.as_deref() != Some(bound_session_id) {
+            send_error(
+                tx,
+                &req.id,
+                "token_scope_mismatch",
+                "Request scope does not match the connection token",
+            )
+            .await?;
+            connection_state.phase = WebConnectionPhase::Closed;
+            return Ok(());
+        }
+        group_id = bound_group_id.clone();
+        session_id = Some(bound_session_id.clone());
+        from_id = actor_id.clone();
+    }
 
     info!(
-        group_id = %params.group_id,
+        group_id = %group_id,
         session_id = ?session_id,
         bot_id = ?params.bot_id,
         bot_uuid = ?params.bot_uuid,
@@ -285,7 +385,7 @@ async fn handle_chat_send(
         .workbench_sessions
         .authorize_chat_send(WorkbenchChatAuthorizationCommand {
             bound_actor_id: bound_actor_id.map(str::to_string),
-            group_id: params.group_id.clone(),
+            group_id: group_id.clone(),
             from_actor_id: from_id.clone(),
             session_id: session_id.clone(),
         })
@@ -293,7 +393,7 @@ async fn handle_chat_send(
     {
         warn!(
             from = %from_id,
-            group_id = %params.group_id,
+            group_id = %group_id,
             bound_actor_id = ?bound_actor_id,
             error = ?err,
             "chat.send rejected by Workbench WS authorization"
@@ -309,7 +409,7 @@ async fn handle_chat_send(
     match state
         .collaboration_runtime
         .handle_session_human_input(HandleSessionHumanInputCommand {
-            group_id: params.group_id.clone(),
+            group_id: group_id.clone(),
             session_id: session_id.clone(),
             caller_actor_id: bound_actor_id.unwrap_or_default().to_string(),
             content: params.message.clone(),
@@ -327,7 +427,7 @@ async fn handle_chat_send(
             send_ok(tx, &req.id, serde_json::to_value(response)?).await?;
             send_empty_human_input_final(
                 tx,
-                &params.group_id,
+                &group_id,
                 session_id.as_deref(),
                 &run_id,
             )
@@ -336,7 +436,7 @@ async fn handle_chat_send(
         }
         Err(error) => {
             warn!(
-                group_id = %params.group_id,
+                group_id = %group_id,
                 session_id = ?session_id,
                 error = %error,
                 "chat.send rejected by state-machine HumanInput routing"
@@ -346,7 +446,7 @@ async fn handle_chat_send(
             send_error(tx, &req.id, error_code, &error_message).await?;
             send_human_input_error_event(
                 tx,
-                &params.group_id,
+                &group_id,
                 session_id.as_deref(),
                 error_code,
                 &error_message,
@@ -356,7 +456,7 @@ async fn handle_chat_send(
         }
     }
 
-    let sender_subscription_key = session_id.as_deref().unwrap_or(&params.group_id);
+    let sender_subscription_key = session_id.as_deref().unwrap_or(&group_id);
     let sender_conn_id = connection_state
         .subscribed_sessions
         .iter()
@@ -365,7 +465,7 @@ async fn handle_chat_send(
             connection_state
                 .subscribed_sessions
                 .iter()
-                .find(|(key, _)| key == &params.group_id)
+                .find(|(key, _)| key == &group_id)
         })
         .map(|(_, id)| *id);
 
@@ -376,7 +476,7 @@ async fn handle_chat_send(
         .message_flow
         .handle_web_send(WebSendCommand {
             caller,
-            group_id: params.group_id.clone(),
+            group_id: group_id.clone(),
             session_id: session_id.clone(),
             from_actor_id: from_id,
             from_name: params.bot_name.clone(),
@@ -404,7 +504,7 @@ async fn handle_chat_send(
     connection_state
         .active_run_ids
         .extend(outcome.active_run_ids.iter().cloned());
-    let run_session_key = session_id.unwrap_or_else(|| params.group_id.clone());
+    let run_session_key = session_id.unwrap_or_else(|| group_id.clone());
     for run_id in &outcome.active_run_ids {
         state
             .run_channels
@@ -474,15 +574,44 @@ async fn handle_chat_abort(
     state: &Arc<WebDispatchState>,
     req: &RequestFrame,
     tx: &mpsc::Sender<String>,
-    _auth: &WorkbenchConnectionAuth,
+    connection_state: &mut WebClientConnectionState,
+    auth: &WorkbenchConnectionAuth,
 ) -> Result<()> {
     let params: ClientChatAbortParams =
         serde_json::from_value(req.params.clone().unwrap_or(Value::Null)).map_err(|e| {
             WebWsDispatchError::InvalidFrameFormat(format!("Invalid chat.abort params: {}", e))
         })?;
 
-    let group_id = params.group_id;
+    let mut group_id = params.group_id;
     let run_id = params.run_id;
+    let (caller, session_id) = match auth {
+        WorkbenchConnectionAuth::UserBound { .. } => {
+            (caller_context_from_bound_actor(None, "unknown"), None)
+        }
+        WorkbenchConnectionAuth::SessionBound {
+            actor_id,
+            group_id: bound_group_id,
+            session_id,
+            ..
+        } => {
+            if group_id != *bound_group_id {
+                send_error(
+                    tx,
+                    &req.id,
+                    "token_scope_mismatch",
+                    "Request scope does not match the connection token",
+                )
+                .await?;
+                connection_state.phase = WebConnectionPhase::Closed;
+                return Ok(());
+            }
+            group_id = bound_group_id.clone();
+            (
+                caller_context_from_bound_actor(Some(actor_id), actor_id),
+                Some(session_id.clone()),
+            )
+        }
+    };
 
     info!(
         group_id = %group_id,
@@ -493,8 +622,9 @@ async fn handle_chat_abort(
     let outcome = state
         .message_flow
         .handle_chat_abort(ChatAbortCommand {
-            caller: caller_context_from_bound_actor(None, "unknown"),
+            caller,
             group_id: group_id.clone(),
+            session_id,
             run_id,
         })
         .await?;

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::web::{
     dispatch_client_frame, WebClientConnectionState, WebDispatchOutcome, WebDispatchState,
-    WebWsDispatchError,
+    WebWsDispatchError, WorkbenchConnectionAuth,
 };
 
 static CLIENT_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -29,7 +29,7 @@ struct PingFrame {
 pub async fn handle_client_connection(
     socket: WebSocket,
     state: Arc<WebDispatchState>,
-    bound_actor_id: Option<String>,
+    auth: WorkbenchConnectionAuth,
     metrics_hook: Arc<dyn WsLifecycleInstrumentationHook>,
 ) {
     let (mut ws_tx, mut ws_rx) = socket.split();
@@ -59,7 +59,7 @@ pub async fn handle_client_connection(
 
     info!(
         client_id = client_id,
-        bound_actor_id = ?bound_actor_id,
+        bound_actor_id = ?auth.actor_id(),
         "New frontend WebSocket connection established"
     );
 
@@ -81,7 +81,7 @@ pub async fn handle_client_connection(
                             &text,
                             &client_tx,
                             &mut connection_state,
-                            bound_actor_id.as_deref(),
+                            &auth,
                         ).await {
                             Ok(outcome) => {
                                 debug!(client_id = client_id, "Frame dispatched successfully");

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/handler.rs
@@ -39,6 +39,7 @@ pub async fn handle_client_connection(
     let client_id = CLIENT_COUNTER.fetch_add(1, Ordering::Relaxed);
     let send_error_seen = Arc::new(AtomicBool::new(false));
     let mut close_reason = WsCloseReason::Unknown;
+    let mut flush_server_close = false;
     metrics_hook
         .accepted(WsPeer::Frontend, crate::web::FRONTEND_WS_ENDPOINT)
         .await;
@@ -85,23 +86,31 @@ pub async fn handle_client_connection(
                         ).await {
                             Ok(outcome) => {
                                 debug!(client_id = client_id, "Frame dispatched successfully");
-                                if let WebDispatchOutcome::ClientConnect { subscribed } = outcome {
-                                    if subscribed {
-                                        metrics_hook
-                                            .registered(
-                                                WsPeer::Frontend,
-                                                crate::web::FRONTEND_WS_ENDPOINT,
-                                            )
-                                            .await;
-                                    } else {
-                                        metrics_hook
-                                            .error(
-                                                WsPeer::Frontend,
-                                                crate::web::FRONTEND_WS_ENDPOINT,
-                                                WsErrorKind::RegisterRejected,
-                                            )
-                                            .await;
+                                match outcome {
+                                    WebDispatchOutcome::ClientConnect { subscribed } => {
+                                        if subscribed {
+                                            metrics_hook
+                                                .registered(
+                                                    WsPeer::Frontend,
+                                                    crate::web::FRONTEND_WS_ENDPOINT,
+                                                )
+                                                .await;
+                                        } else {
+                                            metrics_hook
+                                                .error(
+                                                    WsPeer::Frontend,
+                                                    crate::web::FRONTEND_WS_ENDPOINT,
+                                                    WsErrorKind::RegisterRejected,
+                                                )
+                                                .await;
+                                        }
                                     }
+                                    WebDispatchOutcome::Close => {
+                                        close_reason = WsCloseReason::ProtocolError;
+                                        flush_server_close = true;
+                                        break;
+                                    }
+                                    WebDispatchOutcome::Dispatched => {}
                                 }
                             }
                             Err(e) => {
@@ -224,7 +233,12 @@ pub async fn handle_client_connection(
         "Frontend client disconnected"
     );
 
-    write_handle.abort();
+    if flush_server_close {
+        drop(client_tx);
+        let _ = tokio::time::timeout(Duration::from_secs(1), write_handle).await;
+    } else {
+        write_handle.abort();
+    }
     metrics_hook
         .closed(
             WsPeer::Frontend,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/mod.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod connection_registry;
 pub mod dispatcher;
 pub mod frontend_delivery;
@@ -5,6 +6,7 @@ pub mod handler;
 
 pub const FRONTEND_WS_ENDPOINT: &str = "/ws";
 
+pub use auth::WorkbenchConnectionAuth;
 pub use connection_registry::WorkbenchConnectionRegistry;
 pub use dispatcher::{
     WebClientConnectionState, WebDispatchOutcome, WebDispatchState, WebWsDispatchError,

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/mod.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/mod.rs
@@ -9,8 +9,8 @@ pub const FRONTEND_WS_ENDPOINT: &str = "/ws";
 pub use auth::WorkbenchConnectionAuth;
 pub use connection_registry::WorkbenchConnectionRegistry;
 pub use dispatcher::{
-    WebClientConnectionState, WebDispatchOutcome, WebDispatchState, WebWsDispatchError,
-    dispatch_client_frame,
+    WebClientConnectionState, WebConnectionPhase, WebDispatchOutcome, WebDispatchState,
+    WebWsDispatchError, dispatch_client_frame,
 };
 pub use frontend_delivery::WorkbenchFrontendDelivery;
 pub use handler::handle_client_connection;

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
@@ -179,6 +179,7 @@ struct RecordingMessageFlow {
 struct RecordingWorkbenchSessions {
     connects: Mutex<Vec<WorkbenchConnectCommand>>,
     authorizations: Mutex<Vec<WorkbenchChatAuthorizationCommand>>,
+    connect_error: Mutex<Option<WorkbenchUseCaseError>>,
 }
 
 #[async_trait]
@@ -188,6 +189,9 @@ impl WorkbenchSessionService for RecordingWorkbenchSessions {
         command: WorkbenchConnectCommand,
     ) -> Result<WorkbenchConnectOutcome, WorkbenchUseCaseError> {
         self.connects.lock().await.push(command.clone());
+        if let Some(error) = self.connect_error.lock().await.take() {
+            return Err(error);
+        }
         Ok(WorkbenchConnectOutcome {
             group_id: command.group_id,
             participants: vec![WorkbenchParticipantView {
@@ -742,4 +746,302 @@ async fn user_bound_unknown_method_preserves_protocol_error_response() {
         response.error.as_ref().map(|error| error.code.as_str()),
         Some("unknown_method")
     );
+}
+
+fn session_bound_auth() -> WorkbenchConnectionAuth {
+    WorkbenchConnectionAuth::SessionBound {
+        tenant: "tenant-a".to_string(),
+        actor_id: "human_100001".to_string(),
+        group_id: "group-web-1".to_string(),
+        session_id: "session-bound-1".to_string(),
+    }
+}
+
+async fn connect_session_bound(
+    state: &TestState,
+    tx: &mpsc::Sender<String>,
+    rx: &mut mpsc::Receiver<String>,
+    connection_state: &mut WebClientConnectionState,
+) -> WebDispatchOutcome {
+    let connect = BcsFrame::Request(RequestFrame::new(
+        "connect-bound",
+        "connect",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "session-bound-1"
+        })),
+    ));
+    let outcome = dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&connect).unwrap(),
+        tx,
+        connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+    assert!(recv_response(rx).await.ok);
+    outcome
+}
+
+#[tokio::test]
+async fn session_bound_requires_connect_before_business_frames() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    let send = BcsFrame::Request(RequestFrame::new(
+        "send-before-connect",
+        "chat.send",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "session-bound-1",
+            "message": "hello"
+        })),
+    ));
+
+    let outcome = dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&send).unwrap(),
+        &tx,
+        &mut connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome, WebDispatchOutcome::Dispatched);
+    let response = recv_response(&mut rx).await;
+    assert_eq!(
+        response.error.as_ref().map(|error| error.code.as_str()),
+        Some("connect_required")
+    );
+    assert!(state.message_flow.web_sends.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn session_bound_scope_mismatch_closes_without_dynamic_authorization() {
+    for params in [
+        serde_json::json!({
+            "group_id": "other-group",
+            "session_id": "session-bound-1"
+        }),
+        serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "other-session"
+        }),
+    ] {
+        let state = new_state();
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut connection_state = WebClientConnectionState::default();
+        let connect = BcsFrame::Request(RequestFrame::new(
+            "connect-mismatch",
+            "connect",
+            Some(params),
+        ));
+
+        let outcome = dispatch_client_frame(
+            &state.dispatch_state,
+            &serde_json::to_string(&connect).unwrap(),
+            &tx,
+            &mut connection_state,
+            &session_bound_auth(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, WebDispatchOutcome::Close);
+        let response = recv_response(&mut rx).await;
+        assert_eq!(
+            response.error.as_ref().map(|error| error.code.as_str()),
+            Some("token_scope_mismatch")
+        );
+        assert!(state.workbench_sessions.connects.lock().await.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn session_bound_connect_authorizes_once_with_immutable_binding() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+
+    assert_eq!(
+        connect_session_bound(&state, &tx, &mut rx, &mut connection_state).await,
+        WebDispatchOutcome::ClientConnect { subscribed: true }
+    );
+    let connects = state.workbench_sessions.connects.lock().await;
+    assert_eq!(connects.len(), 1);
+    assert_eq!(connects[0].bound_actor_id.as_deref(), Some("human_100001"));
+    assert_eq!(connects[0].group_id, "group-web-1");
+    assert_eq!(connects[0].session_id.as_deref(), Some("session-bound-1"));
+    drop(connects);
+
+    let second = BcsFrame::Request(RequestFrame::new(
+        "connect-again",
+        "connect",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "session-bound-1"
+        })),
+    ));
+    let outcome = dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&second).unwrap(),
+        &tx,
+        &mut connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome, WebDispatchOutcome::Dispatched);
+    let response = recv_response(&mut rx).await;
+    assert_eq!(
+        response.error.as_ref().map(|error| error.code.as_str()),
+        Some("already_connected")
+    );
+    assert_eq!(state.workbench_sessions.connects.lock().await.len(), 1);
+}
+
+#[tokio::test]
+async fn session_bound_chat_send_cannot_escape_bound_scope() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    connect_session_bound(&state, &tx, &mut rx, &mut connection_state).await;
+    let send = BcsFrame::Request(RequestFrame::new(
+        "send-mismatch",
+        "chat.send",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "other-session",
+            "bot_uuid": "other-actor",
+            "message": "escape"
+        })),
+    ));
+
+    let outcome = dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&send).unwrap(),
+        &tx,
+        &mut connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome, WebDispatchOutcome::Close);
+    let response = recv_response(&mut rx).await;
+    assert_eq!(
+        response.error.as_ref().map(|error| error.code.as_str()),
+        Some("token_scope_mismatch")
+    );
+    assert!(state.workbench_sessions.authorizations.lock().await.is_empty());
+    assert!(state.message_flow.web_sends.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn session_bound_chat_send_uses_bound_human_identity() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    connect_session_bound(&state, &tx, &mut rx, &mut connection_state).await;
+    let send = BcsFrame::Request(RequestFrame::new(
+        "send-bound",
+        "chat.send",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "session-bound-1",
+            "bot_uuid": "payload-controlled-actor",
+            "message": "hello"
+        })),
+    ));
+
+    dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&send).unwrap(),
+        &tx,
+        &mut connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+    assert!(recv_response(&mut rx).await.ok);
+
+    let authorizations = state.workbench_sessions.authorizations.lock().await;
+    assert_eq!(authorizations.len(), 1);
+    assert_eq!(authorizations[0].from_actor_id, "human_100001");
+    drop(authorizations);
+    let sends = state.message_flow.web_sends.lock().await;
+    assert_eq!(sends.len(), 1);
+    assert_eq!(sends[0].from_actor_id, "human_100001");
+    assert_eq!(sends[0].session_id.as_deref(), Some("session-bound-1"));
+}
+
+#[tokio::test]
+async fn session_bound_chat_abort_passes_only_the_bound_session() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    connect_session_bound(&state, &tx, &mut rx, &mut connection_state).await;
+    let abort = BcsFrame::Request(RequestFrame::new(
+        "abort-bound",
+        "chat.abort",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "run_id": "run-bound"
+        })),
+    ));
+
+    dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&abort).unwrap(),
+        &tx,
+        &mut connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+    assert!(recv_response(&mut rx).await.ok);
+
+    let aborts = state.message_flow.aborts.lock().await;
+    assert_eq!(aborts.len(), 1);
+    assert_eq!(aborts[0].group_id, "group-web-1");
+    assert_eq!(aborts[0].run_id.as_deref(), Some("run-bound"));
+    assert_eq!(aborts[0].session_id.as_deref(), Some("session-bound-1"));
+}
+
+#[tokio::test]
+async fn session_bound_revoked_access_closes_with_stable_error() {
+    let state = new_state();
+    *state.workbench_sessions.connect_error.lock().await =
+        Some(WorkbenchUseCaseError::ForbiddenGroupAccess);
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    let connect = BcsFrame::Request(RequestFrame::new(
+        "connect-revoked",
+        "connect",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "session-bound-1"
+        })),
+    ));
+
+    let outcome = dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&connect).unwrap(),
+        &tx,
+        &mut connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome, WebDispatchOutcome::Close);
+    let response = recv_response(&mut rx).await;
+    assert_eq!(
+        response.error.as_ref().map(|error| error.code.as_str()),
+        Some("session_access_revoked")
+    );
+    assert_eq!(state.workbench_sessions.connects.lock().await.len(), 1);
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
@@ -19,6 +19,13 @@ use bcs_service_api::{
     WorkbenchConnectCommand, WorkbenchConnectOutcome, WorkbenchParticipantView,
     WorkbenchSessionService, WorkbenchUseCaseError,
 };
+use bcs_service_api::application::v1::{
+    ActorKind, ApplicationError, AuthorizeGroupSessionConnection,
+    AuthorizedGroupSessionConnection, GroupSessionConnectionBinding,
+    GroupSessionConnectionError, GroupSessionConnectionService,
+    IssueGroupSessionConnectionToken, IssuedGroupSessionConnectionToken, ParticipantRole,
+    SessionParticipant, VerifyGroupSessionConnectionToken,
+};
 use bcs_test_support::NoopCollaborationRuntimeService;
 use bcs_ws::shared::RunChannelManager;
 use bcs_ws::web::{
@@ -182,6 +189,49 @@ struct RecordingWorkbenchSessions {
     connect_error: Mutex<Option<WorkbenchUseCaseError>>,
 }
 
+#[derive(Default)]
+struct RecordingGroupSessionConnections {
+    authorizations: Mutex<Vec<AuthorizeGroupSessionConnection>>,
+    reject_connect: Mutex<bool>,
+}
+
+#[async_trait]
+impl GroupSessionConnectionService for RecordingGroupSessionConnections {
+    async fn issue_token(
+        &self,
+        _command: IssueGroupSessionConnectionToken,
+    ) -> Result<IssuedGroupSessionConnectionToken, GroupSessionConnectionError> {
+        unreachable!("token issuance is not used by WebSocket frame tests")
+    }
+
+    async fn verify_token(
+        &self,
+        _command: VerifyGroupSessionConnectionToken,
+    ) -> Result<GroupSessionConnectionBinding, GroupSessionConnectionError> {
+        unreachable!("token verification is not used by WebSocket frame tests")
+    }
+
+    async fn authorize_connect(
+        &self,
+        command: AuthorizeGroupSessionConnection,
+    ) -> Result<AuthorizedGroupSessionConnection, GroupSessionConnectionError> {
+        self.authorizations.lock().await.push(command);
+        if *self.reject_connect.lock().await {
+            return Err(ApplicationError::forbidden("session access revoked").into());
+        }
+        Ok(AuthorizedGroupSessionConnection {
+            participants: vec![SessionParticipant {
+                actor_id: "human_100001".to_string(),
+                actor_kind: ActorKind::Human,
+                name: Some("Test Human".to_string()),
+                role: ParticipantRole::Observer,
+                mode: ParticipantMode::Present,
+                joined_at: None,
+            }],
+        })
+    }
+}
+
 #[async_trait]
 impl WorkbenchSessionService for RecordingWorkbenchSessions {
     async fn connect(
@@ -277,6 +327,7 @@ impl MessageFlowService for RecordingMessageFlow {
 
 struct TestState {
     workbench_sessions: Arc<RecordingWorkbenchSessions>,
+    group_session_connections: Arc<RecordingGroupSessionConnections>,
     message_flow: Arc<RecordingMessageFlow>,
     dispatch_state: Arc<WebDispatchState>,
 }
@@ -289,18 +340,21 @@ fn new_state_with_collaboration_runtime(
     collaboration_runtime: Arc<dyn CollaborationRuntimeService>,
 ) -> TestState {
     let workbench_sessions = Arc::new(RecordingWorkbenchSessions::default());
+    let group_session_connections = Arc::new(RecordingGroupSessionConnections::default());
     let message_flow = Arc::new(RecordingMessageFlow::default());
     let frontend_connections = Arc::new(WorkbenchConnectionRegistry::new());
     let dispatch_state = Arc::new(WebDispatchState {
         message_flow: message_flow.clone(),
         collaboration_runtime,
         workbench_sessions: workbench_sessions.clone(),
+        group_session_connections: Some(group_session_connections.clone()),
         frontend_connections,
         run_channels: Arc::new(RunChannelManager::new()),
     });
 
     TestState {
         workbench_sessions,
+        group_session_connections,
         message_flow,
         dispatch_state,
     }
@@ -355,6 +409,12 @@ async fn web_connect_frame_subscribes_frontend_registry() {
     assert_eq!(connects[0].group_id, "group-web-1");
     assert_eq!(connects[0].session_id, None);
     assert_eq!(connects[0].bound_actor_id.as_deref(), Some("human_100001"));
+    assert!(state
+        .group_session_connections
+        .authorizations
+        .lock()
+        .await
+        .is_empty());
 }
 
 #[tokio::test]
@@ -860,6 +920,45 @@ async fn session_bound_scope_mismatch_closes_without_dynamic_authorization() {
 }
 
 #[tokio::test]
+async fn session_bound_connect_projects_v1_participants_into_workbench_shape() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    let connect = BcsFrame::Request(RequestFrame::new(
+        "connect-projection",
+        "connect",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "session_id": "session-bound-1"
+        })),
+    ));
+
+    dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&connect).unwrap(),
+        &tx,
+        &mut connection_state,
+        &session_bound_auth(),
+    )
+    .await
+    .unwrap();
+
+    let response = recv_response(&mut rx).await;
+    assert!(response.ok);
+    let payload = response.payload.expect("connect payload");
+    assert_eq!(payload["group_id"], "group-web-1");
+    assert_eq!(
+        payload["participants"],
+        serde_json::json!([{
+            "bot_uuid": "human_100001",
+            "role": "observer",
+            "type": "bot",
+            "mode": "present"
+        }])
+    );
+}
+
+#[tokio::test]
 async fn session_bound_connect_authorizes_once_with_immutable_binding() {
     let state = new_state();
     let (tx, mut rx) = mpsc::channel(8);
@@ -869,12 +968,19 @@ async fn session_bound_connect_authorizes_once_with_immutable_binding() {
         connect_session_bound(&state, &tx, &mut rx, &mut connection_state).await,
         WebDispatchOutcome::ClientConnect { subscribed: true }
     );
-    let connects = state.workbench_sessions.connects.lock().await;
-    assert_eq!(connects.len(), 1);
-    assert_eq!(connects[0].bound_actor_id.as_deref(), Some("human_100001"));
-    assert_eq!(connects[0].group_id, "group-web-1");
-    assert_eq!(connects[0].session_id.as_deref(), Some("session-bound-1"));
-    drop(connects);
+    assert!(state.workbench_sessions.connects.lock().await.is_empty());
+    let authorizations = state.group_session_connections.authorizations.lock().await;
+    assert_eq!(authorizations.len(), 1);
+    assert_eq!(
+        authorizations[0].binding,
+        GroupSessionConnectionBinding {
+            tenant: "tenant-a".to_string(),
+            user_id: "100001".to_string(),
+            group_id: "group-web-1".to_string(),
+            session_id: "session-bound-1".to_string(),
+        }
+    );
+    drop(authorizations);
 
     let second = BcsFrame::Request(RequestFrame::new(
         "connect-again",
@@ -900,7 +1006,16 @@ async fn session_bound_connect_authorizes_once_with_immutable_binding() {
         response.error.as_ref().map(|error| error.code.as_str()),
         Some("already_connected")
     );
-    assert_eq!(state.workbench_sessions.connects.lock().await.len(), 1);
+    assert!(state.workbench_sessions.connects.lock().await.is_empty());
+    assert_eq!(
+        state
+            .group_session_connections
+            .authorizations
+            .lock()
+            .await
+            .len(),
+        1
+    );
 }
 
 #[tokio::test]
@@ -1014,8 +1129,7 @@ async fn session_bound_chat_abort_passes_only_the_bound_session() {
 #[tokio::test]
 async fn session_bound_revoked_access_closes_with_stable_error() {
     let state = new_state();
-    *state.workbench_sessions.connect_error.lock().await =
-        Some(WorkbenchUseCaseError::ForbiddenGroupAccess);
+    *state.group_session_connections.reject_connect.lock().await = true;
     let (tx, mut rx) = mpsc::channel(8);
     let mut connection_state = WebClientConnectionState::default();
     let connect = BcsFrame::Request(RequestFrame::new(
@@ -1043,5 +1157,14 @@ async fn session_bound_revoked_access_closes_with_stable_error() {
         response.error.as_ref().map(|error| error.code.as_str()),
         Some("session_access_revoked")
     );
-    assert_eq!(state.workbench_sessions.connects.lock().await.len(), 1);
+    assert!(state.workbench_sessions.connects.lock().await.is_empty());
+    assert_eq!(
+        state
+            .group_session_connections
+            .authorizations
+            .lock()
+            .await
+            .len(),
+        1
+    );
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
@@ -22,8 +22,8 @@ use bcs_service_api::{
 use bcs_test_support::NoopCollaborationRuntimeService;
 use bcs_ws::shared::RunChannelManager;
 use bcs_ws::web::{
-    WebClientConnectionState, WebDispatchOutcome, WebDispatchState, WorkbenchConnectionRegistry,
-    dispatch_client_frame,
+    WebClientConnectionState, WebDispatchOutcome, WebDispatchState, WorkbenchConnectionAuth,
+    WorkbenchConnectionRegistry, dispatch_client_frame,
 };
 use tokio::sync::{Mutex, mpsc};
 
@@ -172,6 +172,7 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
 #[derive(Default)]
 struct RecordingMessageFlow {
     web_sends: Mutex<Vec<WebSendCommand>>,
+    aborts: Mutex<Vec<ChatAbortCommand>>,
 }
 
 #[derive(Default)]
@@ -236,7 +237,8 @@ impl MessageFlowService for RecordingMessageFlow {
         unreachable!("group callback is not used by web ws compat tests")
     }
 
-    async fn handle_chat_abort(&self, _cmd: ChatAbortCommand) -> ServiceResult<ChatAbortOutcome> {
+    async fn handle_chat_abort(&self, cmd: ChatAbortCommand) -> ServiceResult<ChatAbortOutcome> {
+        self.aborts.lock().await.push(cmd);
         Ok(ChatAbortOutcome {
             aborted: true,
             aborted_run_ids: vec![],
@@ -325,7 +327,9 @@ async fn web_connect_frame_subscribes_frontend_registry() {
         &serde_json::to_string(&connect).unwrap(),
         &tx,
         &mut connection_state,
-        Some("human_100001"),
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
     )
     .await
     .unwrap();
@@ -369,7 +373,9 @@ async fn web_connect_with_session_id_subscribes_session_registry_key() {
         &serde_json::to_string(&connect).unwrap(),
         &tx,
         &mut connection_state,
-        Some("human_100001"),
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
     )
     .await
     .unwrap();
@@ -431,7 +437,9 @@ async fn web_chat_send_frame_is_forwarded_to_message_flow_and_tracks_run() {
         &serde_json::to_string(&send).unwrap(),
         &tx,
         &mut connection_state,
-        Some("human_100001"),
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
     )
     .await
     .unwrap();
@@ -502,7 +510,9 @@ async fn web_chat_send_is_consumed_by_the_single_pending_human_input_and_emits_e
         &serde_json::to_string(&send).unwrap(),
         &tx,
         &mut connection_state,
-        Some("human_100001"),
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
     )
     .await
     .unwrap();
@@ -568,7 +578,9 @@ async fn web_chat_send_is_rejected_when_state_machine_has_no_pending_human_input
         &serde_json::to_string(&send).unwrap(),
         &tx,
         &mut connection_state,
-        Some("human_100001"),
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
     )
     .await
     .unwrap();
@@ -629,7 +641,9 @@ async fn web_chat_send_uses_session_subscription_key_for_sender_conn_id() {
         &serde_json::to_string(&connect).unwrap(),
         &tx,
         &mut connection_state,
-        Some("human_100001"),
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
     )
     .await
     .unwrap();
@@ -655,7 +669,9 @@ async fn web_chat_send_uses_session_subscription_key_for_sender_conn_id() {
         &serde_json::to_string(&send).unwrap(),
         &tx,
         &mut connection_state,
-        Some("human_100001"),
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
     )
     .await
     .unwrap();
@@ -667,4 +683,63 @@ async fn web_chat_send_uses_session_subscription_key_for_sender_conn_id() {
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].session_id.as_deref(), Some("group-web-1:abcdef12"));
     assert_eq!(calls[0].sender_conn_id, Some(sender_conn_id));
+}
+
+#[tokio::test]
+async fn user_bound_chat_abort_preserves_existing_response() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    let abort = BcsFrame::Request(RequestFrame::new(
+        "abort-1",
+        "chat.abort",
+        Some(serde_json::json!({
+            "group_id": "group-web-1",
+            "run_id": "run-web-1"
+        })),
+    ));
+
+    dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&abort).unwrap(),
+        &tx,
+        &mut connection_state,
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+
+    let response = recv_response(&mut rx).await;
+    assert!(response.ok);
+    assert_eq!(response.payload.as_ref().expect("payload")["aborted"], true);
+    assert_eq!(state.message_flow.aborts.lock().await.len(), 1);
+}
+
+#[tokio::test]
+async fn user_bound_unknown_method_preserves_protocol_error_response() {
+    let state = new_state();
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut connection_state = WebClientConnectionState::default();
+    let request = BcsFrame::Request(RequestFrame::new("unknown-1", "future.method", None));
+
+    dispatch_client_frame(
+        &state.dispatch_state,
+        &serde_json::to_string(&request).unwrap(),
+        &tx,
+        &mut connection_state,
+        &WorkbenchConnectionAuth::UserBound {
+            actor_id: Some("human_100001".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+
+    let response = recv_response(&mut rx).await;
+    assert!(!response.ok);
+    assert_eq!(
+        response.error.as_ref().map(|error| error.code.as_str()),
+        Some("unknown_method")
+    );
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/ws_boundary_contract.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/ws_boundary_contract.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::Path;
 
 const WS_SOURCES: &[&str] = &[
+    "src/web/auth.rs",
     "src/bot/connection_registry.rs",
     "src/bot/dispatcher.rs",
     "src/bot/handler.rs",

--- a/src/bcs/crates/application/v1/bcs-app-session/CONTEXT.md
+++ b/src/bcs/crates/application/v1/bcs-app-session/CONTEXT.md
@@ -4,8 +4,9 @@
 
 - `SessionServiceImpl`, the transport-agnostic BCN V1 Session facade.
 - `GroupSessionConnectionServiceImpl`, which authorizes session access before
-  issuing a session-scoped Workbench WebSocket token and verifies that token
-  into an immutable connection binding.
+  issuing a session-scoped Workbench WebSocket token, verifies that token into
+  an immutable connection binding, and revalidates the exact bound Session at
+  connect time through the V1 Session facade.
 
 ## Consumes
 

--- a/src/bcs/crates/application/v1/bcs-app-session/CONTEXT.md
+++ b/src/bcs/crates/application/v1/bcs-app-session/CONTEXT.md
@@ -1,0 +1,43 @@
+# bcs-app-session Context
+
+## Provides
+
+- `SessionServiceImpl`, the transport-agnostic BCN V1 Session facade.
+- `GroupSessionConnectionServiceImpl`, which authorizes session access before
+  issuing a session-scoped Workbench WebSocket token and verifies that token
+  into an immutable connection binding.
+
+## Consumes
+
+- `bcs-service-api` application, Core, repository-port, and connection-token
+  port contracts.
+- Pure utility crates for asynchronous traits and JSON values.
+
+## Allowed dependencies
+
+- `service-api/*`
+- Utility crates such as `async-trait` and `serde_json`
+
+## Forbidden dependencies
+
+- `bootstrap/bcs`
+- `adapters/*`
+- Concrete `plugins/*` in production code
+- Direct environment or transport access
+
+## Configuration
+
+- The composition root injects Session and connection-token service
+  implementations.
+- This crate must not select implementations or inspect environment variables.
+
+## Runtime ownership
+
+This crate owns V1 Session authorization and orchestration. Delivery adapters
+may translate HTTP and WebSocket requests into these contracts but must not
+reimplement session authorization or token policy.
+
+## Tests
+
+- `cargo test --package bcs-app-session --manifest-path src/bcs/Cargo.toml`
+- `cargo check --package bcs-app-session --all-targets --manifest-path src/bcs/Cargo.toml`

--- a/src/bcs/crates/application/v1/bcs-app-session/Cargo.toml
+++ b/src/bcs/crates/application/v1/bcs-app-session/Cargo.toml
@@ -31,3 +31,4 @@ bcs-session = { workspace = true }
 bcs-session-store = { workspace = true }
 bcs-test-support = { workspace = true }
 tokio = { workspace = true }
+time = { workspace = true }

--- a/src/bcs/crates/application/v1/bcs-app-session/src/connection.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/connection.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bcs_service_api::application::v1::{
+    GetSession, GroupSessionConnectionBinding, GroupSessionConnectionError,
+    GroupSessionConnectionService, IssueGroupSessionConnectionToken,
+    IssuedGroupSessionConnectionToken, SessionService, VerifyGroupSessionConnectionToken,
+    GROUP_SESSION_WS_TOKEN_TTL_SECONDS, require_authenticated_user,
+};
+use bcs_service_api::port::{
+    GroupSessionTokenError, GroupSessionTokenPort, GroupSessionTokenScope,
+};
+
+/// Transport-agnostic use cases for issuing and verifying session-scoped
+/// Workbench WebSocket connection tokens.
+pub struct GroupSessionConnectionServiceImpl {
+    sessions: Arc<dyn SessionService>,
+    tokens: Arc<dyn GroupSessionTokenPort>,
+}
+
+impl GroupSessionConnectionServiceImpl {
+    pub fn new(
+        sessions: Arc<dyn SessionService>,
+        tokens: Arc<dyn GroupSessionTokenPort>,
+    ) -> Self {
+        Self { sessions, tokens }
+    }
+}
+
+#[async_trait]
+impl GroupSessionConnectionService for GroupSessionConnectionServiceImpl {
+    async fn issue_token(
+        &self,
+        command: IssueGroupSessionConnectionToken,
+    ) -> Result<IssuedGroupSessionConnectionToken, GroupSessionConnectionError> {
+        let user_id = require_authenticated_user(&command.caller)?.id.clone();
+        let tenant = command.caller.tenant.clone();
+        let session_id = command.session_id.clone();
+        let session = self
+            .sessions
+            .get(GetSession {
+                caller: command.caller,
+                session_id: session_id.clone(),
+            })
+            .await?;
+
+        let issued = self
+            .tokens
+            .issue(
+                GroupSessionTokenScope {
+                    tenant,
+                    user_id,
+                    group_id: session.group_id,
+                    session_id,
+                },
+                GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
+            )
+            .map_err(map_issue_error)?;
+
+        Ok(IssuedGroupSessionConnectionToken {
+            token: issued.token,
+            expires_at: issued.expires_at,
+        })
+    }
+
+    async fn verify_token(
+        &self,
+        command: VerifyGroupSessionConnectionToken,
+    ) -> Result<GroupSessionConnectionBinding, GroupSessionConnectionError> {
+        let claims = self
+            .tokens
+            .verify(&command.token)
+            .map_err(map_verify_error)?;
+
+        Ok(GroupSessionConnectionBinding {
+            tenant: claims.scope.tenant,
+            user_id: claims.scope.user_id,
+            group_id: claims.scope.group_id,
+            session_id: claims.scope.session_id,
+        })
+    }
+}
+
+fn map_issue_error(error: GroupSessionTokenError) -> GroupSessionConnectionError {
+    match error {
+        GroupSessionTokenError::Unavailable(_) => {
+            GroupSessionConnectionError::TokenServiceUnavailable
+        }
+        GroupSessionTokenError::Invalid
+        | GroupSessionTokenError::Expired
+        | GroupSessionTokenError::Internal(_) => GroupSessionConnectionError::Internal(
+            "group-session connection token issuance failed".into(),
+        ),
+    }
+}
+
+fn map_verify_error(error: GroupSessionTokenError) -> GroupSessionConnectionError {
+    match error {
+        GroupSessionTokenError::Invalid | GroupSessionTokenError::Expired => {
+            GroupSessionConnectionError::InvalidConnectionToken
+        }
+        GroupSessionTokenError::Unavailable(_) => {
+            GroupSessionConnectionError::TokenServiceUnavailable
+        }
+        GroupSessionTokenError::Internal(_) => GroupSessionConnectionError::Internal(
+            "group-session connection token verification failed".into(),
+        ),
+    }
+}

--- a/src/bcs/crates/application/v1/bcs-app-session/src/connection.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/connection.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_service_api::application::v1::{
-    GetSession, GroupSessionConnectionBinding, GroupSessionConnectionError,
-    GroupSessionConnectionService, IssueGroupSessionConnectionToken,
-    IssuedGroupSessionConnectionToken, SessionService, VerifyGroupSessionConnectionToken,
-    GROUP_SESSION_WS_TOKEN_TTL_SECONDS, require_authenticated_user,
+    ActorKind, ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity,
+    AuthorizeGroupSessionConnection, AuthorizedGroupSessionConnection, GetSession,
+    GroupSessionConnectionBinding, GroupSessionConnectionError, GroupSessionConnectionService,
+    IssueGroupSessionConnectionToken, IssuedGroupSessionConnectionToken, ParticipantMode,
+    SessionService, VerifyGroupSessionConnectionToken, GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
+    require_authenticated_user,
 };
 use bcs_service_api::port::{
     GroupSessionTokenError, GroupSessionTokenPort, GroupSessionTokenScope,
@@ -77,6 +79,53 @@ impl GroupSessionConnectionService for GroupSessionConnectionServiceImpl {
             user_id: claims.scope.user_id,
             group_id: claims.scope.group_id,
             session_id: claims.scope.session_id,
+        })
+    }
+
+    async fn authorize_connect(
+        &self,
+        command: AuthorizeGroupSessionConnection,
+    ) -> Result<AuthorizedGroupSessionConnection, GroupSessionConnectionError> {
+        let binding = command.binding;
+        let user_id = binding.user_id;
+        let caller = AuthenticatedCaller {
+            tenant: binding.tenant,
+            user: Some(AuthenticatedUserIdentity {
+                id: user_id.clone(),
+                username: user_id.clone(),
+                display_name: None,
+                full_name: None,
+            }),
+            bot: None,
+            app: None,
+            access_key: None,
+        };
+        let session = self
+            .sessions
+            .get(GetSession {
+                caller,
+                session_id: binding.session_id,
+            })
+            .await?;
+        if session.group_id != binding.group_id {
+            return Err(ApplicationError::forbidden(
+                "Session no longer belongs to the token-bound Group",
+            )
+            .into());
+        }
+        let actor_id = format!("human_{user_id}");
+        if session.participants.iter().any(|participant| {
+            participant.actor_kind == ActorKind::Human
+                && participant.actor_id == actor_id
+                && participant.mode == ParticipantMode::Absent
+        }) {
+            return Err(ApplicationError::forbidden(
+                "Human participant is absent from the token-bound Session",
+            )
+            .into());
+        }
+        Ok(AuthorizedGroupSessionConnection {
+            participants: session.participants,
         })
     }
 }

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -9,6 +9,10 @@
 //! lists, message history, and mutations intentionally use separate
 //! authorization rules defined by the V1 contract.
 
+mod connection;
+
+pub use connection::GroupSessionConnectionServiceImpl;
+
 use std::collections::HashSet;
 use std::sync::Arc;
 

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs
@@ -1,0 +1,417 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use bcs_app_session::GroupSessionConnectionServiceImpl;
+use bcs_service_api::application::v1::{
+    ActorKind, AddSessionParticipant, ApplicationError, AuthenticatedAccessKeyIdentity,
+    AuthenticatedAppIdentity, AuthenticatedBotIdentity, AuthenticatedCaller,
+    AuthenticatedUserIdentity, CompleteSession, CreateSession, CreateSessionOutcome, DeleteResult,
+    DeleteSession, DeleteSessionParticipant, GetSession, GroupSessionConnectionError,
+    GroupSessionConnectionService, IssueGroupSessionConnectionToken,
+    IssuedGroupSessionConnectionToken, ListSessions, Page, ParticipantMode, ParticipantRole,
+    SessionCompletionResult, SessionDetail, SessionParticipant, SessionService, SessionStatus,
+    SessionSummary, UpdateSession, UpdateSessionParticipant, VerifyGroupSessionConnectionToken,
+    GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
+};
+use bcs_service_api::port::{
+    GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
+    GroupSessionTokenScope, IssuedGroupSessionToken,
+};
+use time::OffsetDateTime;
+
+#[derive(Clone, Copy)]
+enum SessionMode {
+    Success,
+    Forbidden,
+    NotFound,
+}
+
+struct FakeSessionService {
+    mode: SessionMode,
+    get_calls: Mutex<Vec<String>>,
+}
+
+impl FakeSessionService {
+    fn new(mode: SessionMode) -> Self {
+        Self {
+            mode,
+            get_calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn get_call_count(&self) -> usize {
+        match self.get_calls.lock() {
+            Ok(calls) => calls.len(),
+            Err(_) => panic!("test mutex must not be poisoned"),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionService for FakeSessionService {
+    async fn create(
+        &self,
+        _command: CreateSession,
+    ) -> Result<CreateSessionOutcome, ApplicationError> {
+        panic!("create is not used by connection-token tests")
+    }
+
+    async fn list(&self, _command: ListSessions) -> Result<Page<SessionSummary>, ApplicationError> {
+        panic!("list is not used by connection-token tests")
+    }
+
+    async fn get(&self, query: GetSession) -> Result<SessionDetail, ApplicationError> {
+        match self.get_calls.lock() {
+            Ok(mut calls) => calls.push(query.session_id.clone()),
+            Err(_) => panic!("test mutex must not be poisoned"),
+        }
+        match self.mode {
+            SessionMode::Success => Ok(session_detail(&query.session_id, "server-owned-group")),
+            SessionMode::Forbidden => Err(ApplicationError::forbidden("session access denied")),
+            SessionMode::NotFound => Err(ApplicationError::not_found(
+                "session_not_found",
+                "session not found",
+            )),
+        }
+    }
+
+    async fn update(&self, _command: UpdateSession) -> Result<SessionDetail, ApplicationError> {
+        panic!("update is not used by connection-token tests")
+    }
+
+    async fn delete(&self, _command: DeleteSession) -> Result<DeleteResult, ApplicationError> {
+        panic!("delete is not used by connection-token tests")
+    }
+
+    async fn complete(
+        &self,
+        _command: CompleteSession,
+    ) -> Result<SessionCompletionResult, ApplicationError> {
+        panic!("complete is not used by connection-token tests")
+    }
+
+    async fn add_participant(
+        &self,
+        _command: AddSessionParticipant,
+    ) -> Result<SessionParticipant, ApplicationError> {
+        panic!("add_participant is not used by connection-token tests")
+    }
+
+    async fn update_participant(
+        &self,
+        _command: UpdateSessionParticipant,
+    ) -> Result<SessionParticipant, ApplicationError> {
+        panic!("update_participant is not used by connection-token tests")
+    }
+
+    async fn delete_participant(
+        &self,
+        _command: DeleteSessionParticipant,
+    ) -> Result<DeleteResult, ApplicationError> {
+        panic!("delete_participant is not used by connection-token tests")
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TokenMode {
+    Success,
+    Invalid,
+    Unavailable,
+    Internal,
+}
+
+struct FakeTokenPort {
+    mode: TokenMode,
+    issue_calls: Mutex<Vec<(GroupSessionTokenScope, u64)>>,
+}
+
+impl FakeTokenPort {
+    fn new(mode: TokenMode) -> Self {
+        Self {
+            mode,
+            issue_calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn issued_scopes(&self) -> Vec<(GroupSessionTokenScope, u64)> {
+        match self.issue_calls.lock() {
+            Ok(calls) => calls.clone(),
+            Err(_) => panic!("test mutex must not be poisoned"),
+        }
+    }
+}
+
+impl GroupSessionTokenPort for FakeTokenPort {
+    fn issue(
+        &self,
+        scope: GroupSessionTokenScope,
+        ttl_seconds: u64,
+    ) -> Result<IssuedGroupSessionToken, GroupSessionTokenError> {
+        match self.issue_calls.lock() {
+            Ok(mut calls) => calls.push((scope, ttl_seconds)),
+            Err(_) => panic!("test mutex must not be poisoned"),
+        }
+        match self.mode {
+            TokenMode::Success => Ok(IssuedGroupSessionToken {
+                token: "session-token".into(),
+                expires_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+            TokenMode::Invalid => Err(GroupSessionTokenError::Invalid),
+            TokenMode::Unavailable => Err(GroupSessionTokenError::Unavailable("offline".into())),
+            TokenMode::Internal => Err(GroupSessionTokenError::Internal("sign failed".into())),
+        }
+    }
+
+    fn verify(&self, _token: &str) -> Result<GroupSessionTokenClaims, GroupSessionTokenError> {
+        match self.mode {
+            TokenMode::Success => Ok(GroupSessionTokenClaims {
+                scope: GroupSessionTokenScope {
+                    tenant: "tenant-a".into(),
+                    user_id: "user-a".into(),
+                    group_id: "group-a".into(),
+                    session_id: "session-a".into(),
+                },
+                issued_at: 100,
+                expires_at: 400,
+            }),
+            TokenMode::Invalid => Err(GroupSessionTokenError::Invalid),
+            TokenMode::Unavailable => Err(GroupSessionTokenError::Unavailable("offline".into())),
+            TokenMode::Internal => Err(GroupSessionTokenError::Internal("verify failed".into())),
+        }
+    }
+}
+
+fn human_caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: "tenant-a".into(),
+        user: Some(AuthenticatedUserIdentity {
+            id: "user-a".into(),
+            username: "alice".into(),
+            display_name: None,
+            full_name: None,
+        }),
+        bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+fn session_detail(session_id: &str, group_id: &str) -> SessionDetail {
+    SessionDetail {
+        session_id: session_id.into(),
+        version: 1,
+        group_id: group_id.into(),
+        status: SessionStatus::Running,
+        title: None,
+        input: None,
+        participants: vec![SessionParticipant {
+            actor_id: "human_user-a".into(),
+            actor_kind: ActorKind::Human,
+            name: None,
+            role: ParticipantRole::Consultant,
+            mode: ParticipantMode::Present,
+            joined_at: None,
+        }],
+        created_at: 1,
+        updated_at: 1,
+    }
+}
+
+#[tokio::test]
+async fn issues_scope_only_from_human_and_authorized_session() {
+    let sessions = Arc::new(FakeSessionService::new(SessionMode::Success));
+    let tokens = Arc::new(FakeTokenPort::new(TokenMode::Success));
+    let service = GroupSessionConnectionServiceImpl::new(sessions.clone(), tokens.clone());
+
+    let result = service
+        .issue_token(IssueGroupSessionConnectionToken {
+            caller: human_caller(),
+            session_id: "session-from-path".into(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Ok(IssuedGroupSessionConnectionToken { ref token, .. }) if token == "session-token"
+    ));
+    assert_eq!(sessions.get_call_count(), 1);
+    assert_eq!(
+        tokens.issued_scopes(),
+        vec![(
+            GroupSessionTokenScope {
+                tenant: "tenant-a".into(),
+                user_id: "user-a".into(),
+                group_id: "server-owned-group".into(),
+                session_id: "session-from-path".into(),
+            },
+            GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
+        )]
+    );
+}
+
+#[tokio::test]
+async fn rejects_every_non_human_caller_before_reading_session_or_signing() {
+    let sessions = Arc::new(FakeSessionService::new(SessionMode::Success));
+    let tokens = Arc::new(FakeTokenPort::new(TokenMode::Success));
+    let service = GroupSessionConnectionServiceImpl::new(sessions.clone(), tokens.clone());
+    let callers = [
+        AuthenticatedCaller {
+            tenant: "tenant-a".into(),
+            user: None,
+            bot: Some(AuthenticatedBotIdentity {
+                bot_uuid: "bot-a".into(),
+                owner_id: "owner-a".into(),
+                app_id: 1,
+                agent_code: "agent-a".into(),
+            }),
+            app: None,
+            access_key: None,
+        },
+        AuthenticatedCaller {
+            tenant: "tenant-a".into(),
+            user: None,
+            bot: None,
+            app: Some(AuthenticatedAppIdentity {
+                app_id: 1,
+                app_name: "app-a".into(),
+                owners: "owner-a".into(),
+                app_type: "service".into(),
+            }),
+            access_key: None,
+        },
+        AuthenticatedCaller {
+            tenant: "tenant-a".into(),
+            user: None,
+            bot: None,
+            app: None,
+            access_key: Some(AuthenticatedAccessKeyIdentity {
+                access_key: "test-access-key".into(),
+                expire_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+        },
+        AuthenticatedCaller {
+            tenant: "tenant-a".into(),
+            user: None,
+            bot: None,
+            app: None,
+            access_key: None,
+        },
+    ];
+
+    for caller in callers {
+        let result = service
+            .issue_token(IssueGroupSessionConnectionToken {
+                caller,
+                session_id: "session-a".into(),
+            })
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(GroupSessionConnectionError::Application(ApplicationError::Forbidden(_)))
+        ));
+    }
+    assert_eq!(sessions.get_call_count(), 0);
+    assert!(tokens.issued_scopes().is_empty());
+}
+
+#[tokio::test]
+async fn does_not_sign_when_session_access_is_forbidden() {
+    let sessions = Arc::new(FakeSessionService::new(SessionMode::Forbidden));
+    let tokens = Arc::new(FakeTokenPort::new(TokenMode::Success));
+    let service = GroupSessionConnectionServiceImpl::new(sessions, tokens.clone());
+
+    let result = service
+        .issue_token(IssueGroupSessionConnectionToken {
+            caller: human_caller(),
+            session_id: "session-a".into(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GroupSessionConnectionError::Application(ApplicationError::Forbidden(_)))
+    ));
+    assert!(tokens.issued_scopes().is_empty());
+}
+
+#[tokio::test]
+async fn does_not_sign_when_session_is_missing() {
+    let sessions = Arc::new(FakeSessionService::new(SessionMode::NotFound));
+    let tokens = Arc::new(FakeTokenPort::new(TokenMode::Success));
+    let service = GroupSessionConnectionServiceImpl::new(sessions, tokens.clone());
+
+    let result = service
+        .issue_token(IssueGroupSessionConnectionToken {
+            caller: human_caller(),
+            session_id: "missing-session".into(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GroupSessionConnectionError::Application(ApplicationError::NotFound { .. }))
+    ));
+    assert!(tokens.issued_scopes().is_empty());
+}
+
+#[tokio::test]
+async fn maps_token_failures_to_closed_application_errors() {
+    let sessions = Arc::new(FakeSessionService::new(SessionMode::Success));
+    let unavailable = GroupSessionConnectionServiceImpl::new(
+        sessions.clone(),
+        Arc::new(FakeTokenPort::new(TokenMode::Unavailable)),
+    );
+    let internal = GroupSessionConnectionServiceImpl::new(
+        sessions,
+        Arc::new(FakeTokenPort::new(TokenMode::Internal)),
+    );
+
+    let command = || IssueGroupSessionConnectionToken {
+        caller: human_caller(),
+        session_id: "session-a".into(),
+    };
+    assert!(matches!(
+        unavailable.issue_token(command()).await,
+        Err(GroupSessionConnectionError::TokenServiceUnavailable)
+    ));
+    assert!(matches!(
+        internal.issue_token(command()).await,
+        Err(GroupSessionConnectionError::Internal(_))
+    ));
+}
+
+#[tokio::test]
+async fn verifies_binding_and_maps_invalid_connection_tokens() {
+    let sessions = Arc::new(FakeSessionService::new(SessionMode::Success));
+    let valid = GroupSessionConnectionServiceImpl::new(
+        sessions.clone(),
+        Arc::new(FakeTokenPort::new(TokenMode::Success)),
+    );
+    let invalid = GroupSessionConnectionServiceImpl::new(
+        sessions,
+        Arc::new(FakeTokenPort::new(TokenMode::Invalid)),
+    );
+
+    let binding = valid
+        .verify_token(VerifyGroupSessionConnectionToken {
+            token: "valid".into(),
+        })
+        .await;
+    assert!(matches!(
+        binding,
+        Ok(value)
+            if value.tenant == "tenant-a"
+                && value.user_id == "user-a"
+                && value.group_id == "group-a"
+                && value.session_id == "session-a"
+    ));
+    assert!(matches!(
+        invalid
+            .verify_token(VerifyGroupSessionConnectionToken {
+                token: "invalid".into(),
+            })
+            .await,
+        Err(GroupSessionConnectionError::InvalidConnectionToken)
+    ));
+}

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs
@@ -5,13 +5,13 @@ use bcs_app_session::GroupSessionConnectionServiceImpl;
 use bcs_service_api::application::v1::{
     ActorKind, AddSessionParticipant, ApplicationError, AuthenticatedAccessKeyIdentity,
     AuthenticatedAppIdentity, AuthenticatedBotIdentity, AuthenticatedCaller,
-    AuthenticatedUserIdentity, CompleteSession, CreateSession, CreateSessionOutcome, DeleteResult,
-    DeleteSession, DeleteSessionParticipant, GetSession, GroupSessionConnectionError,
-    GroupSessionConnectionService, IssueGroupSessionConnectionToken,
-    IssuedGroupSessionConnectionToken, ListSessions, Page, ParticipantMode, ParticipantRole,
-    SessionCompletionResult, SessionDetail, SessionParticipant, SessionService, SessionStatus,
-    SessionSummary, UpdateSession, UpdateSessionParticipant, VerifyGroupSessionConnectionToken,
-    GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
+    AuthenticatedUserIdentity, AuthorizeGroupSessionConnection, CompleteSession, CreateSession,
+    CreateSessionOutcome, DeleteResult, DeleteSession, DeleteSessionParticipant, GetSession,
+    GroupSessionConnectionBinding, GroupSessionConnectionError, GroupSessionConnectionService,
+    IssueGroupSessionConnectionToken, IssuedGroupSessionConnectionToken, ListSessions, Page,
+    ParticipantMode, ParticipantRole, SessionCompletionResult, SessionDetail, SessionParticipant,
+    SessionService, SessionStatus, SessionSummary, UpdateSession, UpdateSessionParticipant,
+    VerifyGroupSessionConnectionToken, GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
 };
 use bcs_service_api::port::{
     GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
@@ -24,11 +24,14 @@ enum SessionMode {
     Success,
     Forbidden,
     NotFound,
+    OtherGroup,
+    HumanAbsent,
+    OwnedBotOnly,
 }
 
 struct FakeSessionService {
     mode: SessionMode,
-    get_calls: Mutex<Vec<String>>,
+    get_calls: Mutex<Vec<GetSession>>,
 }
 
 impl FakeSessionService {
@@ -42,6 +45,13 @@ impl FakeSessionService {
     fn get_call_count(&self) -> usize {
         match self.get_calls.lock() {
             Ok(calls) => calls.len(),
+            Err(_) => panic!("test mutex must not be poisoned"),
+        }
+    }
+
+    fn get_calls(&self) -> Vec<GetSession> {
+        match self.get_calls.lock() {
+            Ok(calls) => calls.clone(),
             Err(_) => panic!("test mutex must not be poisoned"),
         }
     }
@@ -62,7 +72,7 @@ impl SessionService for FakeSessionService {
 
     async fn get(&self, query: GetSession) -> Result<SessionDetail, ApplicationError> {
         match self.get_calls.lock() {
-            Ok(mut calls) => calls.push(query.session_id.clone()),
+            Ok(mut calls) => calls.push(query.clone()),
             Err(_) => panic!("test mutex must not be poisoned"),
         }
         match self.mode {
@@ -72,6 +82,24 @@ impl SessionService for FakeSessionService {
                 "session_not_found",
                 "session not found",
             )),
+            SessionMode::OtherGroup => Ok(session_detail(&query.session_id, "moved-group")),
+            SessionMode::HumanAbsent => {
+                let mut session = session_detail(&query.session_id, "server-owned-group");
+                session.participants[0].mode = ParticipantMode::Absent;
+                Ok(session)
+            }
+            SessionMode::OwnedBotOnly => {
+                let mut session = session_detail(&query.session_id, "server-owned-group");
+                session.participants[0] = SessionParticipant {
+                    actor_id: "owned-bot".into(),
+                    actor_kind: ActorKind::Bot,
+                    name: None,
+                    role: ParticipantRole::Driver,
+                    mode: ParticipantMode::Auto,
+                    joined_at: None,
+                };
+                Ok(session)
+            }
         }
     }
 
@@ -109,6 +137,15 @@ impl SessionService for FakeSessionService {
         _command: DeleteSessionParticipant,
     ) -> Result<DeleteResult, ApplicationError> {
         panic!("delete_participant is not used by connection-token tests")
+    }
+}
+
+fn session_binding() -> GroupSessionConnectionBinding {
+    GroupSessionConnectionBinding {
+        tenant: "tenant-a".into(),
+        user_id: "user-a".into(),
+        group_id: "server-owned-group".into(),
+        session_id: "session-a".into(),
     }
 }
 
@@ -215,6 +252,128 @@ fn session_detail(session_id: &str, group_id: &str) -> SessionDetail {
         created_at: 1,
         updated_at: 1,
     }
+}
+
+#[tokio::test]
+async fn authorize_connect_reloads_the_exact_bound_session() {
+    let sessions = Arc::new(FakeSessionService::new(SessionMode::Success));
+    let service = GroupSessionConnectionServiceImpl::new(
+        sessions.clone(),
+        Arc::new(FakeTokenPort::new(TokenMode::Success)),
+    );
+
+    let authorized = service
+        .authorize_connect(AuthorizeGroupSessionConnection {
+            binding: session_binding(),
+        })
+        .await
+        .expect("current V1 session access should authorize connect");
+
+    assert_eq!(authorized.participants.len(), 1);
+    assert_eq!(authorized.participants[0].actor_id, "human_user-a");
+    let calls = sessions.get_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].session_id, "session-a");
+    assert_eq!(calls[0].caller.tenant, "tenant-a");
+    assert_eq!(
+        calls[0].caller.user.as_ref().map(|user| user.id.as_str()),
+        Some("user-a")
+    );
+}
+
+#[tokio::test]
+async fn authorize_connect_rejects_a_deleted_session() {
+    let service = GroupSessionConnectionServiceImpl::new(
+        Arc::new(FakeSessionService::new(SessionMode::NotFound)),
+        Arc::new(FakeTokenPort::new(TokenMode::Success)),
+    );
+
+    let result = service
+        .authorize_connect(AuthorizeGroupSessionConnection {
+            binding: session_binding(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GroupSessionConnectionError::Application(ApplicationError::NotFound { .. }))
+    ));
+}
+
+#[tokio::test]
+async fn authorize_connect_rejects_revoked_v1_session_access() {
+    let service = GroupSessionConnectionServiceImpl::new(
+        Arc::new(FakeSessionService::new(SessionMode::Forbidden)),
+        Arc::new(FakeTokenPort::new(TokenMode::Success)),
+    );
+
+    let result = service
+        .authorize_connect(AuthorizeGroupSessionConnection {
+            binding: session_binding(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GroupSessionConnectionError::Application(ApplicationError::Forbidden(_)))
+    ));
+}
+
+#[tokio::test]
+async fn authorize_connect_rejects_a_session_moved_to_another_group() {
+    let service = GroupSessionConnectionServiceImpl::new(
+        Arc::new(FakeSessionService::new(SessionMode::OtherGroup)),
+        Arc::new(FakeTokenPort::new(TokenMode::Success)),
+    );
+
+    let result = service
+        .authorize_connect(AuthorizeGroupSessionConnection {
+            binding: session_binding(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GroupSessionConnectionError::Application(ApplicationError::Forbidden(_)))
+    ));
+}
+
+#[tokio::test]
+async fn authorize_connect_rejects_an_absent_bound_human() {
+    let service = GroupSessionConnectionServiceImpl::new(
+        Arc::new(FakeSessionService::new(SessionMode::HumanAbsent)),
+        Arc::new(FakeTokenPort::new(TokenMode::Success)),
+    );
+
+    let result = service
+        .authorize_connect(AuthorizeGroupSessionConnection {
+            binding: session_binding(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GroupSessionConnectionError::Application(ApplicationError::Forbidden(_)))
+    ));
+}
+
+#[tokio::test]
+async fn authorize_connect_accepts_v1_access_through_an_owned_bot() {
+    let service = GroupSessionConnectionServiceImpl::new(
+        Arc::new(FakeSessionService::new(SessionMode::OwnedBotOnly)),
+        Arc::new(FakeTokenPort::new(TokenMode::Success)),
+    );
+
+    let authorized = service
+        .authorize_connect(AuthorizeGroupSessionConnection {
+            binding: session_binding(),
+        })
+        .await
+        .expect("the V1 Session service already authorized the owned Bot");
+
+    assert_eq!(authorized.participants.len(), 1);
+    assert_eq!(authorized.participants[0].actor_id, "owned-bot");
+    assert_eq!(authorized.participants[0].actor_kind, ActorKind::Bot);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -4500,7 +4500,14 @@ async fn ws_upgrade_handler(
     ws.on_upgrade(move |socket| {
         let ws_state = web_ws_dispatch_state(&state);
         let metrics_hook = ws_lifecycle_hook(&state);
-        bcs_ws::web::handle_client_connection(socket, ws_state, bound_actor_id, metrics_hook)
+        bcs_ws::web::handle_client_connection(
+            socket,
+            ws_state,
+            bcs_ws::web::WorkbenchConnectionAuth::UserBound {
+                actor_id: bound_actor_id,
+            },
+            metrics_hook,
+        )
     })
 }
 

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -3796,6 +3796,7 @@ fn web_ws_dispatch_state(state: &Arc<BcsServerState>) -> Arc<bcs_ws::web::WebDis
         message_flow: state.services.message_flow.clone(),
         collaboration_runtime: state.services.collaboration_runtime.clone(),
         workbench_sessions: state.services.workbench_sessions.clone(),
+        group_session_connections: None,
         frontend_connections: state.frontend_connections.clone(),
         run_channels: state.frontend_run_channels.clone(),
     })

--- a/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
@@ -619,6 +619,7 @@ fn chat_abort_cmd() -> ChatAbortCommand {
     ChatAbortCommand {
         caller: CallerContext::Public,
         group_id: "group-wrapper".to_string(),
+        session_id: None,
         run_id: Some("run-wrapper".to_string()),
     }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
+++ b/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
@@ -9,8 +9,8 @@
   result-publisher port used to return a completed one-shot result to chat.
 - V1 `AuthenticatedCaller` contract types that preserve User, Bot, App, and
   AccessKey context without retaining transport metadata or credentials.
-- Session-scoped Workbench connection-token use cases and the outbound token
-  signing/verification port.
+- Session-scoped Workbench connection-token use cases, exact-session connect
+  reauthorization contracts, and the outbound token signing/verification port.
 - The state-machine run repository contract includes an atomic
   `create_run_if_session_idle` operation for one-shot session launch
   serialization; production stores must override its compatibility default

--- a/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
+++ b/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
@@ -9,6 +9,8 @@
   result-publisher port used to return a completed one-shot result to chat.
 - V1 `AuthenticatedCaller` contract types that preserve User, Bot, App, and
   AccessKey context without retaining transport metadata or credentials.
+- Session-scoped Workbench connection-token use cases and the outbound token
+  signing/verification port.
 - The state-machine run repository contract includes an atomic
   `create_run_if_session_idle` operation for one-shot session launch
   serialization; production stores must override its compatibility default

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
@@ -147,6 +147,7 @@ pub struct GroupCallbackOutcome {
 pub struct ChatAbortCommand {
     pub caller: CallerContext,
     pub group_id: String,
+    pub session_id: Option<String>,
     pub run_id: Option<String>,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group_session_connection.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group_session_connection.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use time::OffsetDateTime;
 
-use super::{ApplicationError, AuthenticatedCaller};
+use super::{ApplicationError, AuthenticatedCaller, SessionParticipant};
 
 pub const GROUP_SESSION_WS_TOKEN_TTL_SECONDS: u64 = 300;
 
@@ -32,6 +32,16 @@ pub struct GroupSessionConnectionBinding {
     pub session_id: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizeGroupSessionConnection {
+    pub binding: GroupSessionConnectionBinding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizedGroupSessionConnection {
+    pub participants: Vec<SessionParticipant>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum GroupSessionConnectionError {
     #[error(transparent)]
@@ -55,4 +65,9 @@ pub trait GroupSessionConnectionService: Send + Sync {
         &self,
         command: VerifyGroupSessionConnectionToken,
     ) -> Result<GroupSessionConnectionBinding, GroupSessionConnectionError>;
+
+    async fn authorize_connect(
+        &self,
+        command: AuthorizeGroupSessionConnection,
+    ) -> Result<AuthorizedGroupSessionConnection, GroupSessionConnectionError>;
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group_session_connection.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group_session_connection.rs
@@ -1,0 +1,58 @@
+//! Session-scoped Workbench connection-token use cases.
+
+use async_trait::async_trait;
+use time::OffsetDateTime;
+
+use super::{ApplicationError, AuthenticatedCaller};
+
+pub const GROUP_SESSION_WS_TOKEN_TTL_SECONDS: u64 = 300;
+
+#[derive(Debug, Clone)]
+pub struct IssueGroupSessionConnectionToken {
+    pub caller: AuthenticatedCaller,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyGroupSessionConnectionToken {
+    pub token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssuedGroupSessionConnectionToken {
+    pub token: String,
+    pub expires_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupSessionConnectionBinding {
+    pub tenant: String,
+    pub user_id: String,
+    pub group_id: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GroupSessionConnectionError {
+    #[error(transparent)]
+    Application(#[from] ApplicationError),
+    #[error("invalid group-session connection token")]
+    InvalidConnectionToken,
+    #[error("group-session token service unavailable")]
+    TokenServiceUnavailable,
+    #[error("group-session connection failed: {0}")]
+    Internal(String),
+}
+
+#[async_trait]
+pub trait GroupSessionConnectionService: Send + Sync {
+    async fn issue_token(
+        &self,
+        command: IssueGroupSessionConnectionToken,
+    ) -> Result<IssuedGroupSessionConnectionToken, GroupSessionConnectionError>;
+
+    async fn verify_token(
+        &self,
+        command: VerifyGroupSessionConnectionToken,
+    ) -> Result<GroupSessionConnectionBinding, GroupSessionConnectionError>;
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
@@ -9,6 +9,7 @@ pub mod bot;
 pub mod error;
 pub mod friendship;
 pub mod group;
+pub mod group_session_connection;
 pub mod identity;
 pub mod invitation;
 pub mod message;
@@ -22,6 +23,7 @@ pub use bot::*;
 pub use error::ApplicationError;
 pub use friendship::*;
 pub use group::*;
+pub use group_session_connection::*;
 pub use identity::{
     AuthenticatedAccessKeyIdentity, AuthenticatedAppIdentity, AuthenticatedBotIdentity,
     AuthenticatedCaller, AuthenticatedUserIdentity,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/group_session_token.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/group_session_token.rs
@@ -1,0 +1,46 @@
+//! Outbound port for the session-scoped Workbench connection token.
+
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupSessionTokenScope {
+    pub tenant: String,
+    pub user_id: String,
+    pub group_id: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupSessionTokenClaims {
+    pub scope: GroupSessionTokenScope,
+    pub issued_at: u64,
+    pub expires_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssuedGroupSessionToken {
+    pub token: String,
+    pub expires_at: OffsetDateTime,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GroupSessionTokenError {
+    #[error("invalid group-session connection token")]
+    Invalid,
+    #[error("group-session connection token expired")]
+    Expired,
+    #[error("group-session token service unavailable: {0}")]
+    Unavailable(String),
+    #[error("group-session token service failed: {0}")]
+    Internal(String),
+}
+
+pub trait GroupSessionTokenPort: Send + Sync + 'static {
+    fn issue(
+        &self,
+        scope: GroupSessionTokenScope,
+        ttl_seconds: u64,
+    ) -> Result<IssuedGroupSessionToken, GroupSessionTokenError>;
+
+    fn verify(&self, token: &str) -> Result<GroupSessionTokenClaims, GroupSessionTokenError>;
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/group_session_token.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/group_session_token.rs
@@ -2,6 +2,8 @@
 
 use time::OffsetDateTime;
 
+pub const GROUP_SESSION_TOKEN_MAX_COMPACT_LEN: usize = 4096;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupSessionTokenScope {
     pub tenant: String,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
@@ -5,6 +5,7 @@ pub mod channel_binding_cleanup;
 pub mod channel_delivery;
 pub mod delivery;
 pub mod group_context;
+pub mod group_session_token;
 pub mod judge;
 pub mod leader_election;
 pub mod metrics;
@@ -33,6 +34,10 @@ pub use delivery::{
     FrontendDeliveryTarget, ProviderTransportPreference, RunFallbackDelivery,
 };
 pub use group_context::{GroupDispatchContextPort, GroupHistoryBotRequestPort};
+pub use group_session_token::{
+    GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
+    GroupSessionTokenScope, IssuedGroupSessionToken,
+};
 pub use judge::{
     JudgeArtifact, JudgeCheckedCriterion, JudgeDecision, JudgeEvaluatorPort, JudgeRequest,
 };

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
@@ -36,7 +36,7 @@ pub use delivery::{
 pub use group_context::{GroupDispatchContextPort, GroupHistoryBotRequestPort};
 pub use group_session_token::{
     GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
-    GroupSessionTokenScope, IssuedGroupSessionToken,
+    GroupSessionTokenScope, IssuedGroupSessionToken, GROUP_SESSION_TOKEN_MAX_COMPACT_LEN,
 };
 pub use judge::{
     JudgeArtifact, JudgeCheckedCriterion, JudgeDecision, JudgeEvaluatorPort, JudgeRequest,

--- a/src/bcs/crates/service-api/bcs-service-api/tests/group_session_connection_contracts.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/group_session_connection_contracts.rs
@@ -1,8 +1,8 @@
 use bcs_service_api::application::v1::{
-    GroupSessionConnectionBinding, GroupSessionConnectionError,
-    GroupSessionConnectionService, IssueGroupSessionConnectionToken,
-    IssuedGroupSessionConnectionToken, VerifyGroupSessionConnectionToken,
-    GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
+    AuthorizeGroupSessionConnection, AuthorizedGroupSessionConnection,
+    GroupSessionConnectionBinding, GroupSessionConnectionError, GroupSessionConnectionService,
+    IssueGroupSessionConnectionToken, IssuedGroupSessionConnectionToken,
+    VerifyGroupSessionConnectionToken, GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
 };
 use bcs_service_api::port::{
     GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
@@ -35,6 +35,8 @@ fn connection_contracts_remain_transport_neutral_and_object_safe() {
     let _ = size_of::<IssueGroupSessionConnectionToken>();
     let _ = size_of::<VerifyGroupSessionConnectionToken>();
     let _ = size_of::<IssuedGroupSessionConnectionToken>();
+    let _ = size_of::<AuthorizeGroupSessionConnection>();
+    let _ = size_of::<AuthorizedGroupSessionConnection>();
     let _ = size_of::<GroupSessionConnectionError>();
     let _ = size_of::<GroupSessionTokenScope>();
     let _ = size_of::<GroupSessionTokenClaims>();

--- a/src/bcs/crates/service-api/bcs-service-api/tests/group_session_connection_contracts.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/group_session_connection_contracts.rs
@@ -1,0 +1,44 @@
+use bcs_service_api::application::v1::{
+    GroupSessionConnectionBinding, GroupSessionConnectionError,
+    GroupSessionConnectionService, IssueGroupSessionConnectionToken,
+    IssuedGroupSessionConnectionToken, VerifyGroupSessionConnectionToken,
+    GROUP_SESSION_WS_TOKEN_TTL_SECONDS,
+};
+use bcs_service_api::port::{
+    GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
+    GroupSessionTokenScope, IssuedGroupSessionToken,
+};
+
+#[test]
+fn connection_binding_keeps_one_exact_session_scope() {
+    let binding = GroupSessionConnectionBinding {
+        tenant: "tenant-a".into(),
+        user_id: "user-a".into(),
+        group_id: "group-a".into(),
+        session_id: "session-a".into(),
+    };
+
+    assert_eq!(binding.tenant, "tenant-a");
+    assert_eq!(binding.user_id, "user-a");
+    assert_eq!(binding.group_id, "group-a");
+    assert_eq!(binding.session_id, "session-a");
+    assert_eq!(GROUP_SESSION_WS_TOKEN_TTL_SECONDS, 300);
+}
+
+#[test]
+fn connection_contracts_remain_transport_neutral_and_object_safe() {
+    fn accepts_connection_service(_: &dyn GroupSessionConnectionService) {}
+    fn accepts_token_port(_: &dyn GroupSessionTokenPort) {}
+
+    let _ = accepts_connection_service;
+    let _ = accepts_token_port;
+    let _ = size_of::<IssueGroupSessionConnectionToken>();
+    let _ = size_of::<VerifyGroupSessionConnectionToken>();
+    let _ = size_of::<IssuedGroupSessionConnectionToken>();
+    let _ = size_of::<GroupSessionConnectionError>();
+    let _ = size_of::<GroupSessionTokenScope>();
+    let _ = size_of::<GroupSessionTokenClaims>();
+    let _ = size_of::<IssuedGroupSessionToken>();
+    let _ = size_of::<GroupSessionTokenError>();
+}
+use std::mem::size_of;

--- a/src/bcs/crates/services/bcs-jwt/CONTEXT.md
+++ b/src/bcs/crates/services/bcs-jwt/CONTEXT.md
@@ -1,0 +1,30 @@
+# bcs-jwt Context
+
+## Provides
+
+- HS256 signing and verification for existing OAuth/session JWTs.
+- A separately typed and keyed group-session Workbench connection JWT
+  implementation of `GroupSessionTokenPort`.
+
+## Consumes
+
+- `bcs-service-api` group-session token port types.
+- Injected signing key material from Bootstrap.
+
+## Allowed dependencies
+
+- Contract and cryptographic support crates.
+
+## Forbidden dependencies
+
+- Delivery adapters and HTTP/WebSocket framework types.
+- Bootstrap configuration or direct environment access.
+
+## Runtime ownership
+
+This crate owns compact JWT encoding, signature verification, claim-shape and
+time validation. It does not authorize access to a stored session.
+
+## Tests
+
+- `cargo test --package bcs-jwt --manifest-path src/bcs/Cargo.toml`

--- a/src/bcs/crates/services/bcs-jwt/Cargo.toml
+++ b/src/bcs/crates/services/bcs-jwt/Cargo.toml
@@ -11,9 +11,11 @@ version = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
+bcs-service-api = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/src/bcs/crates/services/bcs-jwt/src/group_session.rs
+++ b/src/bcs/crates/services/bcs-jwt/src/group_session.rs
@@ -1,0 +1,208 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bcs_service_api::application::v1::GROUP_SESSION_WS_TOKEN_TTL_SECONDS;
+use bcs_service_api::port::{
+    GroupSessionTokenClaims, GroupSessionTokenError, GroupSessionTokenPort,
+    GroupSessionTokenScope, IssuedGroupSessionToken, GROUP_SESSION_TOKEN_MAX_COMPACT_LEN,
+};
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use time::OffsetDateTime;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const ISSUER: &str = "bcn";
+const AUDIENCE: &str = "bcn-group-session-ws";
+const PURPOSE: &str = "group_session_ws";
+const MAX_CLAIM_LEN: usize = 256;
+
+#[derive(Debug, thiserror::Error)]
+pub enum GroupSessionJwtBuildError {
+    #[error("group-session JWT signing key is empty")]
+    EmptySigningKey,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JwtHeader {
+    alg: String,
+    typ: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GroupSessionWireClaims {
+    iss: String,
+    aud: String,
+    purpose: String,
+    sub: String,
+    tenant: String,
+    uid: String,
+    gid: String,
+    sid: String,
+    iat: u64,
+    exp: u64,
+}
+
+pub struct GroupSessionJwtService {
+    secret: Vec<u8>,
+}
+
+impl GroupSessionJwtService {
+    pub fn new(secret: &str) -> Result<Self, GroupSessionJwtBuildError> {
+        if secret.trim().is_empty() {
+            return Err(GroupSessionJwtBuildError::EmptySigningKey);
+        }
+        Ok(Self {
+            secret: secret.as_bytes().to_vec(),
+        })
+    }
+
+    pub fn issue_at(
+        &self,
+        scope: GroupSessionTokenScope,
+        ttl_seconds: u64,
+        now: u64,
+    ) -> Result<IssuedGroupSessionToken, GroupSessionTokenError> {
+        if ttl_seconds != GROUP_SESSION_WS_TOKEN_TTL_SECONDS || !valid_scope(&scope) {
+            return Err(GroupSessionTokenError::Invalid);
+        }
+        let exp = now
+            .checked_add(ttl_seconds)
+            .ok_or(GroupSessionTokenError::Invalid)?;
+        let claims = GroupSessionWireClaims {
+            iss: ISSUER.into(),
+            aud: AUDIENCE.into(),
+            purpose: PURPOSE.into(),
+            sub: scope.user_id.clone(),
+            tenant: scope.tenant,
+            uid: scope.user_id,
+            gid: scope.group_id,
+            sid: scope.session_id,
+            iat: now,
+            exp,
+        };
+        let header = JwtHeader {
+            alg: "HS256".into(),
+            typ: "JWT".into(),
+        };
+        let header_json = serde_json::to_vec(&header)
+            .map_err(|_| GroupSessionTokenError::Internal("header encoding failed".into()))?;
+        let claims_json = serde_json::to_vec(&claims)
+            .map_err(|_| GroupSessionTokenError::Internal("claims encoding failed".into()))?;
+        let header_b64 = URL_SAFE_NO_PAD.encode(header_json);
+        let claims_b64 = URL_SAFE_NO_PAD.encode(claims_json);
+        let signing_input = format!("{header_b64}.{claims_b64}");
+        let signature = self.sign(signing_input.as_bytes())?;
+        let token = format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature));
+        if token.len() > GROUP_SESSION_TOKEN_MAX_COMPACT_LEN {
+            return Err(GroupSessionTokenError::Invalid);
+        }
+        let exp_i64 = i64::try_from(exp).map_err(|_| GroupSessionTokenError::Invalid)?;
+        let expires_at = OffsetDateTime::from_unix_timestamp(exp_i64)
+            .map_err(|_| GroupSessionTokenError::Invalid)?;
+        Ok(IssuedGroupSessionToken { token, expires_at })
+    }
+
+    pub fn verify_at(
+        &self,
+        token: &str,
+        now: u64,
+    ) -> Result<GroupSessionTokenClaims, GroupSessionTokenError> {
+        if token.is_empty() || token.len() > GROUP_SESSION_TOKEN_MAX_COMPACT_LEN {
+            return Err(GroupSessionTokenError::Invalid);
+        }
+        let mut parts = token.split('.');
+        let header_b64 = parts.next().ok_or(GroupSessionTokenError::Invalid)?;
+        let claims_b64 = parts.next().ok_or(GroupSessionTokenError::Invalid)?;
+        let signature_b64 = parts.next().ok_or(GroupSessionTokenError::Invalid)?;
+        if parts.next().is_some()
+            || header_b64.is_empty()
+            || claims_b64.is_empty()
+            || signature_b64.is_empty()
+        {
+            return Err(GroupSessionTokenError::Invalid);
+        }
+
+        let header_bytes = URL_SAFE_NO_PAD
+            .decode(header_b64)
+            .map_err(|_| GroupSessionTokenError::Invalid)?;
+        let header: JwtHeader = serde_json::from_slice(&header_bytes)
+            .map_err(|_| GroupSessionTokenError::Invalid)?;
+        if header.alg != "HS256" || header.typ != "JWT" {
+            return Err(GroupSessionTokenError::Invalid);
+        }
+
+        let signature = URL_SAFE_NO_PAD
+            .decode(signature_b64)
+            .map_err(|_| GroupSessionTokenError::Invalid)?;
+        let signing_input = format!("{header_b64}.{claims_b64}");
+        let mut mac = HmacSha256::new_from_slice(&self.secret)
+            .map_err(|_| GroupSessionTokenError::Internal("HMAC initialization failed".into()))?;
+        mac.update(signing_input.as_bytes());
+        mac.verify_slice(&signature)
+            .map_err(|_| GroupSessionTokenError::Invalid)?;
+
+        let claims_bytes = URL_SAFE_NO_PAD
+            .decode(claims_b64)
+            .map_err(|_| GroupSessionTokenError::Invalid)?;
+        let claims: GroupSessionWireClaims = serde_json::from_slice(&claims_bytes)
+            .map_err(|_| GroupSessionTokenError::Invalid)?;
+        if claims.iss != ISSUER
+            || claims.aud != AUDIENCE
+            || claims.purpose != PURPOSE
+            || claims.sub != claims.uid
+        {
+            return Err(GroupSessionTokenError::Invalid);
+        }
+        let scope = GroupSessionTokenScope {
+            tenant: claims.tenant,
+            user_id: claims.uid,
+            group_id: claims.gid,
+            session_id: claims.sid,
+        };
+        if !valid_scope(&scope)
+            || claims.iat >= claims.exp
+            || claims.exp - claims.iat != GROUP_SESSION_WS_TOKEN_TTL_SECONDS
+            || claims.iat > now
+        {
+            return Err(GroupSessionTokenError::Invalid);
+        }
+        if claims.exp <= now {
+            return Err(GroupSessionTokenError::Expired);
+        }
+        Ok(GroupSessionTokenClaims {
+            scope,
+            issued_at: claims.iat,
+            expires_at: claims.exp,
+        })
+    }
+
+    fn sign(&self, input: &[u8]) -> Result<Vec<u8>, GroupSessionTokenError> {
+        let mut mac = HmacSha256::new_from_slice(&self.secret)
+            .map_err(|_| GroupSessionTokenError::Internal("HMAC initialization failed".into()))?;
+        mac.update(input);
+        Ok(mac.finalize().into_bytes().to_vec())
+    }
+}
+
+impl GroupSessionTokenPort for GroupSessionJwtService {
+    fn issue(
+        &self,
+        scope: GroupSessionTokenScope,
+        ttl_seconds: u64,
+    ) -> Result<IssuedGroupSessionToken, GroupSessionTokenError> {
+        self.issue_at(scope, ttl_seconds, crate::now_secs())
+    }
+
+    fn verify(&self, token: &str) -> Result<GroupSessionTokenClaims, GroupSessionTokenError> {
+        self.verify_at(token, crate::now_secs())
+    }
+}
+
+fn valid_scope(scope: &GroupSessionTokenScope) -> bool {
+    [&scope.tenant, &scope.user_id, &scope.group_id, &scope.session_id]
+        .into_iter()
+        .all(|value| !value.trim().is_empty() && value.chars().count() <= MAX_CLAIM_LEN)
+}

--- a/src/bcs/crates/services/bcs-jwt/src/lib.rs
+++ b/src/bcs/crates/services/bcs-jwt/src/lib.rs
@@ -4,6 +4,10 @@ use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+mod group_session;
+
+pub use group_session::{GroupSessionJwtBuildError, GroupSessionJwtService};
+
 type HmacSha256 = Hmac<Sha256>;
 
 /// JWT claims payload.

--- a/src/bcs/crates/services/bcs-jwt/tests/group_session_jwt.rs
+++ b/src/bcs/crates/services/bcs-jwt/tests/group_session_jwt.rs
@@ -1,0 +1,155 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bcs_jwt::{Claims, GroupSessionJwtService, JwtService};
+use bcs_service_api::port::{
+    GroupSessionTokenError, GroupSessionTokenScope, GROUP_SESSION_TOKEN_MAX_COMPACT_LEN,
+};
+
+const NOW: u64 = 1_800_000_000;
+const TTL_SECONDS: u64 = 300;
+const TEST_KEY: &str = "test-only-group-session-jwt-key-at-least-32-bytes";
+
+fn service() -> GroupSessionJwtService {
+    match GroupSessionJwtService::new(TEST_KEY) {
+        Ok(value) => value,
+        Err(_) => panic!("test key must build the group-session JWT service"),
+    }
+}
+
+fn scope() -> GroupSessionTokenScope {
+    GroupSessionTokenScope {
+        tenant: "tenant-a".into(),
+        user_id: "user-a".into(),
+        group_id: "group-a".into(),
+        session_id: "session-a".into(),
+    }
+}
+
+#[test]
+fn issues_exact_five_minute_session_scoped_claims() {
+    let issued = match service().issue_at(scope(), TTL_SECONDS, NOW) {
+        Ok(value) => value,
+        Err(_) => panic!("valid scope must issue"),
+    };
+    let claims = match service().verify_at(&issued.token, NOW + 1) {
+        Ok(value) => value,
+        Err(_) => panic!("fresh token must verify"),
+    };
+
+    assert_eq!(claims.scope, scope());
+    assert_eq!(claims.issued_at, NOW);
+    assert_eq!(claims.expires_at, NOW + TTL_SECONDS);
+    assert_eq!(issued.expires_at.unix_timestamp(), (NOW + TTL_SECONDS) as i64);
+
+    let payload = issued.token.split('.').nth(1).unwrap_or_default();
+    let decoded = match URL_SAFE_NO_PAD.decode(payload) {
+        Ok(value) => value,
+        Err(_) => panic!("issued payload must be base64url"),
+    };
+    let wire: serde_json::Value = match serde_json::from_slice(&decoded) {
+        Ok(value) => value,
+        Err(_) => panic!("issued payload must be JSON"),
+    };
+    assert_eq!(wire["iss"], "bcn");
+    assert_eq!(wire["aud"], "bcn-group-session-ws");
+    assert_eq!(wire["purpose"], "group_session_ws");
+    assert_eq!(wire["sub"], "user-a");
+    assert_eq!(wire["uid"], "user-a");
+    assert_eq!(wire["gid"], "group-a");
+    assert_eq!(wire["sid"], "session-a");
+}
+
+#[test]
+fn rejects_expired_and_future_issued_tokens() {
+    let issued = match service().issue_at(scope(), TTL_SECONDS, NOW) {
+        Ok(value) => value,
+        Err(_) => panic!("valid scope must issue"),
+    };
+
+    assert!(matches!(
+        service().verify_at(&issued.token, NOW + TTL_SECONDS),
+        Err(GroupSessionTokenError::Expired)
+    ));
+    assert!(matches!(
+        service().verify_at(&issued.token, NOW - 1),
+        Err(GroupSessionTokenError::Invalid)
+    ));
+}
+
+#[test]
+fn rejects_invalid_lifetime_blank_scope_and_oversized_inputs() {
+    assert!(matches!(
+        service().issue_at(scope(), TTL_SECONDS - 1, NOW),
+        Err(GroupSessionTokenError::Invalid)
+    ));
+
+    let mut blank = scope();
+    blank.session_id = "   ".into();
+    assert!(matches!(
+        service().issue_at(blank, TTL_SECONDS, NOW),
+        Err(GroupSessionTokenError::Invalid)
+    ));
+
+    let mut oversized = scope();
+    oversized.group_id = "g".repeat(257);
+    assert!(matches!(
+        service().issue_at(oversized, TTL_SECONDS, NOW),
+        Err(GroupSessionTokenError::Invalid)
+    ));
+
+    let compact = "x".repeat(GROUP_SESSION_TOKEN_MAX_COMPACT_LEN + 1);
+    assert!(matches!(
+        service().verify_at(&compact, NOW),
+        Err(GroupSessionTokenError::Invalid)
+    ));
+}
+
+#[test]
+fn rejects_wrong_key_and_login_jwt_token_confusion() {
+    let issued = match service().issue_at(scope(), TTL_SECONDS, NOW) {
+        Ok(value) => value,
+        Err(_) => panic!("valid scope must issue"),
+    };
+    let other = match GroupSessionJwtService::new(
+        "different-test-only-group-session-key-at-least-32-bytes",
+    ) {
+        Ok(value) => value,
+        Err(_) => panic!("second test key must build"),
+    };
+    assert!(matches!(
+        other.verify_at(&issued.token, NOW + 1),
+        Err(GroupSessionTokenError::Invalid)
+    ));
+
+    let login = JwtService::new(TEST_KEY);
+    let login_token = match login.sign(&Claims {
+        sub: "user-a".into(),
+        src: "oauth".into(),
+        iat: NOW,
+        exp: NOW + TTL_SECONDS,
+    }) {
+        Ok(value) => value,
+        Err(_) => panic!("login JWT fixture must sign"),
+    };
+    assert!(matches!(
+        service().verify_at(&login_token, NOW + 1),
+        Err(GroupSessionTokenError::Invalid)
+    ));
+}
+
+#[test]
+fn rejects_empty_signing_key() {
+    assert!(GroupSessionJwtService::new("").is_err());
+    assert!(GroupSessionJwtService::new("   ").is_err());
+}
+
+#[test]
+fn one_token_can_be_verified_more_than_once_during_its_lifetime() {
+    let issued = match service().issue_at(scope(), TTL_SECONDS, NOW) {
+        Ok(value) => value,
+        Err(_) => panic!("valid scope must issue"),
+    };
+
+    assert!(service().verify_at(&issued.token, NOW + 1).is_ok());
+    assert!(service().verify_at(&issued.token, NOW + 2).is_ok());
+}

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -1572,6 +1572,19 @@ pub async fn handle_chat_abort(
     flow: &BcsMessageFlow,
     cmd: ChatAbortCommand,
 ) -> ServiceResult<ChatAbortOutcome> {
+    if !abort_run_matches_session_scope(flow, &cmd).await {
+        warn!(
+            group_id = %cmd.group_id,
+            "chat.abort run does not belong to the bound session"
+        );
+        return Ok(ChatAbortOutcome {
+            aborted: false,
+            aborted_run_ids: Vec::new(),
+            bot_deliveries: Vec::new(),
+            frontend_deliveries: Vec::new(),
+        });
+    }
+
     let Some(group) = flow.group.get(&cmd.group_id).await else {
         warn!(
             group_id = %cmd.group_id,
@@ -1585,7 +1598,10 @@ pub async fn handle_chat_abort(
         });
     };
 
-    let session_key = build_session_key(&cmd.group_id);
+    let session_key = cmd
+        .session_id
+        .clone()
+        .unwrap_or_else(|| build_session_key(&cmd.group_id));
     let participant_ids: Vec<String> = group
         .bot_participant_ids()
         .into_iter()
@@ -1645,7 +1661,13 @@ pub async fn handle_chat_abort(
     }
 
     let aborted_run_ids = cmd.run_id.into_iter().collect::<Vec<_>>();
-    let frontend_deliveries = publish_chat_abort_event(flow, &cmd.group_id, &aborted_run_ids).await;
+    let frontend_deliveries = publish_chat_abort_event(
+        flow,
+        &cmd.group_id,
+        cmd.session_id.as_deref(),
+        &aborted_run_ids,
+    )
+    .await;
 
     Ok(ChatAbortOutcome {
         aborted: !aborted_run_ids.is_empty() || !has_participants,
@@ -1653,6 +1675,22 @@ pub async fn handle_chat_abort(
         bot_deliveries,
         frontend_deliveries,
     })
+}
+
+async fn abort_run_matches_session_scope(flow: &BcsMessageFlow, cmd: &ChatAbortCommand) -> bool {
+    let Some(session_id) = cmd.session_id.as_deref() else {
+        return true;
+    };
+    let Some(run_id) = cmd.run_id.as_deref() else {
+        return true;
+    };
+    let Some(run_context) = flow.bot_run_context.as_ref() else {
+        return false;
+    };
+    let Some(context) = run_context.get_context(run_id).await else {
+        return false;
+    };
+    context.group_id == cmd.group_id && context.bcs_session_id.as_deref() == Some(session_id)
 }
 
 fn resolve_group_chat_sender(cmd: &GroupChatCommand) -> ServiceResult<String> {
@@ -2418,15 +2456,22 @@ async fn publish_group_callback_event(
 async fn publish_chat_abort_event(
     flow: &BcsMessageFlow,
     group_id: &str,
+    session_id: Option<&str>,
     aborted_run_ids: &[String],
 ) -> Vec<FrontendDeliveryResult> {
     let event_json = build_chat_abort_event(group_id, aborted_run_ids);
+    let target = match session_id {
+        Some(session_id) => FrontendDeliveryTarget::Session {
+            session_id: session_id.to_string(),
+        },
+        None => FrontendDeliveryTarget::Group {
+            group_id: group_id.to_string(),
+        },
+    };
     let delivery = flow
         .frontend_delivery
         .publish(FrontendDeliveryCommand {
-            target: FrontendDeliveryTarget::Group {
-                group_id: group_id.to_string(),
-            },
+            target,
             event_json,
             delivery_kind: FrontendDeliveryKind::WorkbenchEvent,
             run_fallback: None,

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -3043,6 +3043,7 @@ async fn chat_abort_delivers_abort_frame_to_bot_participants() {
                 staff_no: "1".to_string(),
             }),
             group_id: "group-1".to_string(),
+            session_id: None,
             run_id: Some("run-1".to_string()),
         })
         .await
@@ -3086,6 +3087,7 @@ async fn chat_abort_publishes_frontend_event_through_port() {
                 staff_no: "1".to_string(),
             }),
             group_id: "group-1".to_string(),
+            session_id: None,
             run_id: Some("run-1".to_string()),
         })
         .await
@@ -3096,6 +3098,128 @@ async fn chat_abort_publishes_frontend_event_through_port() {
     assert_eq!(events.len(), 1);
     assert!(events[0].contains(r#""event":"chat.abort""#));
     assert!(events[0].contains(r#""run_id":"run-1""#));
+}
+
+#[tokio::test]
+async fn chat_abort_with_session_rejects_a_run_from_another_session() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let run_context = Arc::new(MemoryBotRunContextStore::new());
+    run_context
+        .put_context(bcs_service_api::BotRunContext {
+            run_id: "run-other-session".to_string(),
+            bot_id: "bot-driver".to_string(),
+            group_id: "group-1".to_string(),
+            bcs_session_id: Some("session-other".to_string()),
+            deadline_ms: u64::MAX,
+            terminal: false,
+        })
+        .await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_bot_run_context(run_context);
+
+    let outcome = flow
+        .handle_chat_abort(ChatAbortCommand {
+            caller: CallerContext::Human(HumanActor {
+                actor_id: "human_1".to_string(),
+                staff_no: "1".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            session_id: Some("session-bound".to_string()),
+            run_id: Some("run-other-session".to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert!(!outcome.aborted);
+    assert!(outcome.aborted_run_ids.is_empty());
+    assert!(support.bot_delivery.frames().await.is_empty());
+    assert!(support.frontend_delivery.events().await.is_empty());
+}
+
+#[tokio::test]
+async fn chat_abort_with_session_accepts_a_run_from_the_same_session() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let run_context = Arc::new(MemoryBotRunContextStore::new());
+    run_context
+        .put_context(bcs_service_api::BotRunContext {
+            run_id: "run-bound".to_string(),
+            bot_id: "bot-driver".to_string(),
+            group_id: "group-1".to_string(),
+            bcs_session_id: Some("session-bound".to_string()),
+            deadline_ms: u64::MAX,
+            terminal: false,
+        })
+        .await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_bot_run_context(run_context);
+
+    let outcome = flow
+        .handle_chat_abort(ChatAbortCommand {
+            caller: CallerContext::Human(HumanActor {
+                actor_id: "human_1".to_string(),
+                staff_no: "1".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            session_id: Some("session-bound".to_string()),
+            run_id: Some("run-bound".to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert!(outcome.aborted);
+    assert_eq!(outcome.aborted_run_ids, vec!["run-bound".to_string()]);
+    assert!(!support.bot_delivery.frames().await.is_empty());
+}
+
+#[tokio::test]
+async fn chat_abort_without_run_id_uses_only_the_bound_session_key() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_chat_abort(ChatAbortCommand {
+        caller: CallerContext::Human(HumanActor {
+            actor_id: "human_1".to_string(),
+            staff_no: "1".to_string(),
+        }),
+        group_id: "group-1".to_string(),
+        session_id: Some("session-bound".to_string()),
+        run_id: None,
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        support
+            .bot_delivery
+            .frames()
+            .await
+            .into_iter()
+            .all(|frame| matches!(
+                frame,
+                BcsFrame::Request(req)
+                    if req.params.as_ref().and_then(|params| params["session_key"].as_str())
+                        == Some("session-bound")
+                    && req.params.as_ref().and_then(|params| params.get("run_id")).is_none()
+            ))
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/docs/plans/2026-08-03-bcn-group-session-websocket-token-design.md
+++ b/src/bcs/docs/plans/2026-08-03-bcn-group-session-websocket-token-design.md
@@ -292,17 +292,26 @@ frame.group_id   must equal binding.group_id
 frame.session_id must equal binding.session_id
 ```
 
-The handler then calls the existing `WorkbenchSessionService.connect` with:
+The handler then calls the V1 `GroupSessionConnectionService.authorize_connect`
+use case with the immutable binding:
 
 ```text
-bound_actor_id = human_{binding.user_id}
-group_id       = binding.group_id
-session_id     = binding.session_id
+tenant     = binding.tenant
+user_id    = binding.user_id
+group_id   = binding.group_id
+session_id = binding.session_id
 ```
 
-That service reloads current group/session state and checks the existing
-Workbench access policy, including ownership or participation and participant
-mode. It also confirms that the session still belongs to the bound group.
+That V1 application service reconstructs a trusted Human caller from the signed
+binding and reuses `SessionService::get` to reload the exact session and apply
+the same V1 read/connect authorization used during token issuance. It also
+confirms that the session still belongs to the bound group and rejects an
+explicit Human participant whose current mode is `Absent`.
+
+The legacy `WorkbenchSessionService.connect` remains the exclusive path for
+`UserBound` `/ws` connections. The session-bound V1 route does not add flags or
+branches to that legacy contract, so its authorization and participant response
+remain unchanged.
 
 Only one `connect` may succeed on one socket. Repeated connects are rejected
 with `already_connected` so they cannot create duplicate subscriptions.
@@ -336,14 +345,24 @@ pub trait GroupSessionConnectionService: Send + Sync {
     async fn issue_token(
         &self,
         command: IssueGroupSessionConnectionToken,
-    ) -> Result<IssuedGroupSessionConnectionToken, ApplicationError>;
+    ) -> Result<IssuedGroupSessionConnectionToken, GroupSessionConnectionError>;
 
     async fn verify_token(
         &self,
         command: VerifyGroupSessionConnectionToken,
-    ) -> Result<SessionConnectionBinding, ApplicationError>;
+    ) -> Result<GroupSessionConnectionBinding, GroupSessionConnectionError>;
+
+    async fn authorize_connect(
+        &self,
+        command: AuthorizeGroupSessionConnection,
+    ) -> Result<AuthorizedGroupSessionConnection, GroupSessionConnectionError>;
 }
 ```
+
+`authorize_connect` accepts only the immutable binding produced by token
+verification and returns the currently authorized V1 Session participants.
+The WebSocket adapter uses this operation only for `SessionBound`; legacy
+`UserBound` connections continue to use `WorkbenchSessionService.connect`.
 
 Add a non-repository outbound port for signing and verifying the dedicated
 token claims. Delivery adapters depend only on the application contract and do
@@ -354,7 +373,8 @@ not call a JWT implementation directly.
 Implement the application use cases. Reuse the existing session lookup and
 read/connect authorization policy rather than duplicating membership rules in
 an adapter. The application service derives `gid`, maps the authenticated Human
-to `uid`, fixes the 300-second lifetime, and calls the token port.
+to `uid`, fixes the 300-second lifetime, calls the token port, and reloads the
+exact bound Session during `authorize_connect`.
 
 ### `bcs-jwt`
 

--- a/src/bcs/docs/plans/2026-08-03-bcn-group-session-websocket-token-implementation.md
+++ b/src/bcs/docs/plans/2026-08-03-bcn-group-session-websocket-token-implementation.md
@@ -189,7 +189,10 @@ Expected: FAIL because the connection application service is missing.
 
 Create `GroupSessionConnectionServiceImpl` with injected `Arc<dyn SessionService>` and `Arc<dyn GroupSessionTokenPort>`. Reuse `SessionService::get` so the existing V1 session-read authorization remains authoritative. Do not duplicate repository or group membership rules. Pass the fixed TTL constant to the port.
 
-On verification, validate the JWT through the port and return its immutable binding. Do not perform the dynamic connection authorization here; that remains the Workbench `connect` operation.
+On verification, validate the JWT through the port and return its immutable
+binding. This initial token task does not yet add dynamic connect authorization;
+Task 6A adds the dedicated V1 `authorize_connect` operation and invokes it from
+the session-bound Workbench `connect` path.
 
 **Step 4: Run focused and package tests**
 
@@ -332,7 +335,7 @@ For `SessionBound`, verify:
 
 - before successful `connect`, business frames return `connect_required`;
 - `connect.group_id` and `connect.session_id` must exactly equal bound `gid`/`sid`, otherwise return `token_scope_mismatch` and close;
-- the dynamic `WorkbenchSessionService::connect` authorization still runs using the bound Human actor;
+- the dynamic V1 group-session authorization still runs using the immutable binding;
 - a second successful connect returns `already_connected`;
 - chat.send cannot name another group/session;
 - chat.abort cannot abort a run belonging to another session, including the form without a client-provided run/session selector;
@@ -350,7 +353,7 @@ Expected: FAIL because session scope is not enforced for all commands.
 
 **Step 3: Implement the state machine and abort scope**
 
-Use explicit `AwaitingConnect -> Connected -> Closed` state. Before connect, allow only ping/pong and connect. On connect, compare exact scope first, then call the existing dynamic authorization/service path. Keep the accepted binding immutable for the life of the connection.
+Use explicit `AwaitingConnect -> Connected -> Closed` state. Before connect, allow only ping/pong and connect. On connect, compare exact scope first, then call the dynamic V1 authorization path. Keep the accepted binding immutable for the life of the connection.
 
 Extend `ChatAbortCommand` with `session_id: Option<String>` rather than creating a second abort path. Existing `/ws`, HTTP, provider, and test callers pass `None`; session-bound WS passes `Some(bound_sid)`. In message flow, constrain candidate runs by session when present. Propagate constructor changes mechanically without changing unrelated behavior.
 
@@ -370,6 +373,128 @@ Expected: PASS.
 ```bash
 git add src/bcs/crates/service-api/bcs-service-api src/bcs/crates/services/bcs-message-flow src/bcs/crates/adapters/ws/bcs-ws src/bcs/crates/adapters/http/bcs-http src/bcs/crates/adapters/http/bcs-provider-http src/bcs/crates/services/bcs-channel src/bcs/crates/bootstrap/bcs/tests
 git commit -m "feat(bcs): confine workbench commands to one session"
+```
+
+### Task 6A: Revalidate the exact session through V1 without changing legacy `/ws`
+
+**Files:**
+
+- Modify: `src/bcs/crates/service-api/bcs-service-api/src/application/v1/group_session_connection.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/tests/group_session_connection_contracts.rs`
+- Modify: `src/bcs/crates/application/v1/bcs-app-session/src/connection.rs`
+- Modify: `src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs`
+- Modify: `src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs`
+- Verify unchanged: `src/bcs/crates/services/bcs-group/src/application/management.rs`
+- Verify unchanged behavior: `src/bcs/crates/services/bcs-group/tests/management.rs`
+
+**Step 1: Write failing V1 application tests**
+
+Extend `GroupSessionConnectionService` with an `authorize_connect` operation
+whose input is the already-verified `GroupSessionConnectionBinding`. Its output
+contains the exact V1 `SessionParticipant` list used by the Workbench connect
+response.
+
+Add tests proving that connect authorization:
+
+- reloads the session instead of trusting the token's issuance-time decision;
+- rejects a deleted session;
+- rejects a session whose current `group_id` differs from the binding;
+- rejects a caller who no longer has V1 session read access;
+- rejects a matching Human participant whose mode is `Absent`;
+- accepts a current Human participant or a Human who still owns a Bot in the
+  exact session.
+
+**Step 2: Run the focused V1 test and verify RED**
+
+```bash
+cargo test --package bcs-app-session --test group_session_connection authorize_connect --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because the V1 connect authorization operation does not exist.
+
+**Step 3: Implement minimal V1 revalidation**
+
+In `GroupSessionConnectionServiceImpl::authorize_connect`:
+
+1. reconstruct `AuthenticatedCaller` only from the signed binding's `tenant`
+   and `user_id`;
+2. call `SessionService::get` for the bound `session_id` so the existing V1
+   session-read policy remains the single authority;
+3. require the loaded session's `group_id` to equal the bound `group_id`;
+4. reject a matching Human participant whose mode is `Absent`; and
+5. return the loaded V1 session participants.
+
+Do not call or modify `GroupManagement::connect` and do not add a V1 flag to
+`WorkbenchConnectCommand`.
+
+**Step 4: Run the V1 application test and verify GREEN**
+
+```bash
+cargo test --package bcs-app-session --test group_session_connection authorize_connect --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS.
+
+**Step 5: Write failing WebSocket routing tests**
+
+Add a recording V1 connection service to `WebDispatchState`. Verify that:
+
+- `SessionBound` connect calls `authorize_connect` with the exact immutable
+  tenant/user/group/session binding and does not call the legacy
+  `WorkbenchSessionService::connect`;
+- a V1 authorization error produces `session_access_revoked` and closes;
+- `UserBound` connect still calls only `WorkbenchSessionService::connect` and
+  never calls the V1 service; and
+- the session-bound success response projects the authorized V1 participant
+  list into the existing Workbench connect frame shape.
+
+**Step 6: Run the focused WebSocket tests and verify RED**
+
+```bash
+cargo test --package bcs-ws --test web_frame_compat session_bound --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-ws --test web_frame_compat user_bound_connect --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: FAIL because the dispatcher still routes session-bound connect
+through the legacy service.
+
+**Step 7: Route only session-bound connect through V1**
+
+Add the V1 application service dependency to `WebDispatchState`. In
+`handle_connect`, dispatch by authentication context:
+
+- `UserBound` keeps the existing legacy `WorkbenchSessionService::connect`
+  path byte-for-byte;
+- `SessionBound` calls only `GroupSessionConnectionService::authorize_connect`,
+  maps application failures to `session_access_revoked`, and projects the V1
+  participants into the existing Workbench response.
+
+Until the new V1 Upgrade route is composed, the optional V1 dependency is
+absent in the legacy bootstrap state and must fail closed if a `SessionBound`
+context is ever constructed without it. Task 8 makes this dependency required
+when mounting the V1 route.
+
+**Step 8: Run focused and compatibility tests**
+
+```bash
+cargo test --package bcs-service-api --test group_session_connection_contracts --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-app-session --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-ws --manifest-path src/bcs/Cargo.toml
+cargo test --package bcs-group --test management workbench --manifest-path src/bcs/Cargo.toml
+```
+
+Expected: PASS. `src/bcs/crates/services/bcs-group/src/application/management.rs`
+has no diff, and all legacy Workbench management tests remain green.
+
+**Step 9: Commit**
+
+```bash
+git add src/bcs/docs/plans \
+  src/bcs/crates/service-api/bcs-service-api \
+  src/bcs/crates/application/v1/bcs-app-session \
+  src/bcs/crates/adapters/ws/bcs-ws
+git commit -m "fix(bcs): revalidate v1 websocket session access"
 ```
 
 ### Task 7: Add the session-bound WebSocket Upgrade route


### PR DESCRIPTION
## Problem

BCN needs a safe way to expose Workbench-compatible WebSocket messaging to an authenticated collaboration session. The existing `/ws` endpoint is user-bound and accepts group/session selectors from client frames, so it cannot be reused directly for an externally issued session credential without an immutable server-side scope.

The new flow also needs a short-lived credential that can carry the tenant, user, group, and session binding across the application-level WebSocket proxy without trusting browser-provided identity fields.

## Solution

- Define application contracts for issuing and verifying a group-session WebSocket credential.
- Add a signed JWT implementation with a fixed five-minute lifetime and claims for tenant, user, group, session, issuer, audience, and purpose.
- Add an authenticated token endpoint adapter at `POST /openapi/v1/collaboration/sessions/{sid}/token` that resolves the caller's authorized group-session binding before issuing a token.
- Replace the loose Workbench actor argument with explicit `UserBound` and `SessionBound` connection authentication contexts while preserving the existing `/ws` behavior.
- Add an `AwaitingConnect -> Connected -> Closed` state machine for session-bound connections.
- Require `connect`, `chat.send`, and `chat.abort` to remain inside the JWT-bound group and session, and rerun dynamic session authorization during `connect`.
- Extend abort routing with an optional session scope so a session-bound connection cannot abort work from another session.
- Document the agreed API shape, trust boundaries, error behavior, and implementation plan.

## Validation

The following checks were completed successfully before publication:

- `cargo test --package bcs-api-http --manifest-path src/bcs/Cargo.toml`
- `cargo test --package bcs-message-flow --manifest-path src/bcs/Cargo.toml`
- `cargo test --package bcs-ws --manifest-path src/bcs/Cargo.toml`
- `cargo test --package bcs-http --manifest-path src/bcs/Cargo.toml`
- `cargo test --package bcs-provider-http --manifest-path src/bcs/Cargo.toml`
- `cargo test --package bcs --test metrics_wrappers --manifest-path src/bcs/Cargo.toml`

No additional verification was run during the requested `--no-verify` push.

## Compatibility and risk

- Existing `/ws` and `/ws/bot` behavior remains unchanged through the `UserBound` compatibility path.
- Existing HTTP and provider abort callers use `session_id: None`; only session-bound WebSocket calls apply the new abort scope.
- Scope mismatches and revoked access fail closed before business commands are dispatched.
- This PR is the authentication and command-confinement foundation. The public WebSocket Upgrade route, environment-backed secret composition, Gateway application proxy, and end-to-end wiring remain follow-up work described in the implementation plan.

## Spec

- `docs/plans/2026-08-03-bcn-group-session-websocket-token-design.md`
- `docs/plans/2026-08-03-bcn-group-session-websocket-token-implementation.md`
