### PR TITLE
fix(bcs): require session history caller authorization

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -1815,6 +1815,9 @@ pub async fn get_session_messages(
 
     let limit = query.limit.unwrap_or(u64::MAX);
     if group.group_strategy == bcs_service_api::GroupStrategy::StateMachine {
+        if let Err(response) = authorize_state_machine_session_history(&state, &sess, &caller).await {
+            return response;
+        }
         return match state
             .services
             .collaboration_runtime
@@ -1853,6 +1856,47 @@ pub async fn get_session_messages(
             let (status, body) = session_history_error_to_response(&e);
             (status, Json(body)).into_response()
         }
+    }
+}
+
+async fn authorize_state_machine_session_history(
+    state: &HttpAppState,
+    session: &bcs_service_api::Session,
+    caller: &bcs_service_api::CallerContext,
+) -> Result<(), Response> {
+    let authorized = match caller {
+        bcs_service_api::CallerContext::Human(human) => {
+            human_has_session_access(state, session, &human.actor_id, &human.staff_no).await
+        }
+        bcs_service_api::CallerContext::Bot(bot) => session
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == bot.bot_uuid),
+        bcs_service_api::CallerContext::Public => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": "unauthorized",
+                    "message": "valid Human identity or Bot token is required for session history"
+                })),
+            )
+                .into_response());
+        }
+        bcs_service_api::CallerContext::Integration(_)
+        | bcs_service_api::CallerContext::Admin(_) => true,
+    };
+
+    if authorized {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "forbidden",
+                "message": "caller is not a session participant and owns no Bot in this session"
+            })),
+        )
+            .into_response())
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -1807,14 +1807,10 @@ pub async fn get_session_messages(
         }
     };
 
-    // 3. Resolve caller context (only when view_bot_id is provided, matching old behavior)
-    let caller = if query.view_bot_id.is_some() {
-        match resolve_session_caller(&state, &group, &headers, &uri).await {
-            Ok(c) => c,
-            Err(response) => return response,
-        }
-    } else {
-        bcs_service_api::CallerContext::Public
+    // 3. Resolve caller context before any session history read.
+    let caller = match resolve_session_caller(&state, &group, &headers, &uri).await {
+        Ok(c) => c,
+        Err(response) => return response,
     };
 
     let limit = query.limit.unwrap_or(u64::MAX);
@@ -1866,27 +1862,34 @@ async fn resolve_session_caller(
     headers: &HeaderMap,
     uri: &Uri,
 ) -> Result<bcs_service_api::CallerContext, Response> {
-    // Try to extract a human caller from headers
-    if let Some(identity) = state.user_identity.extract(headers, uri).await {
-        if let Some(staff_no) = &identity.staff_no {
-            return Ok(bcs_service_api::CallerContext::Human(
-                bcs_service_api::HumanActor {
-                    actor_id: format!("human_{}", staff_no),
-                    staff_no: staff_no.clone(),
-                },
-            ));
-        }
-    }
-
-    // Try to extract a bot caller from token
+    // Try to extract a bot caller from token first so bearer Bot tokens are not
+    // accidentally treated as an ambient Human identity in local/static auth setups.
     if let Some(bot_id) = state.bot_uuid_from_headers(headers).await {
         return Ok(bcs_service_api::CallerContext::Bot(
             bcs_service_api::BotActor { bot_uuid: bot_id },
         ));
     }
 
-    // Default: public caller — allow through but with no ownership verification
-    Ok(bcs_service_api::CallerContext::Public)
+    // Try to extract a human caller from headers.
+    if let Some(identity) = state.user_identity.extract(headers, uri).await {
+        if let Some(staff_no) = identity.staff_no.filter(|staff_no| !staff_no.is_empty()) {
+            return Ok(bcs_service_api::CallerContext::Human(
+                bcs_service_api::HumanActor {
+                    actor_id: format!("human_{}", staff_no),
+                    staff_no,
+                },
+            ));
+        }
+    }
+
+    Err((
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({
+            "error": "unauthorized",
+            "message": "valid Human identity or Bot token is required for this session history request"
+        })),
+    )
+        .into_response())
 }
 
 fn session_history_error_to_response(

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -1225,7 +1225,10 @@ async fn state_machine_session_messages_use_runtime_history() {
     let session = test_session(
         "sm-group:abcdef12",
         "sm-group",
-        vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+        vec![
+            Participant::bot("driver-bot", ParticipantRole::Driver),
+            Participant::human("human_123", ParticipantRole::Observer),
+        ],
     );
     let group_message_history = Arc::new(RecordingGroupMessageHistory::default());
     let collaboration_runtime = Arc::new(RecordingStateMachineHistoryRuntime {
@@ -1285,6 +1288,144 @@ async fn state_machine_session_messages_use_runtime_history() {
     );
     let calls = collaboration_runtime.calls.lock().await;
     assert_eq!(calls.as_slice(), &[("sm-group:abcdef12".to_string(), 20, None)]);
+}
+
+#[tokio::test]
+async fn state_machine_session_messages_non_session_human_returns_forbidden() {
+    let mut group = Group::new(
+        "sm-group-human-forbidden",
+        "driver-bot",
+        vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+    );
+    group.group_strategy = GroupStrategy::StateMachine;
+    group.status = GroupStatus::Active;
+    let group_store = Arc::new(GroupStore::new());
+    group_store.upsert(group).await.unwrap();
+
+    let session = test_session(
+        "sm-group-human-forbidden:abcdef12",
+        "sm-group-human-forbidden",
+        vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+    );
+    let collaboration_runtime = Arc::new(RecordingStateMachineHistoryRuntime {
+        calls: Mutex::new(Vec::new()),
+        result: SessionHistoryResult {
+            session_id: session.id.clone(),
+            messages: vec![],
+            limit: 20,
+            before: None,
+            next_before: None,
+        },
+    });
+    let mut services = Services::noop();
+    services.group = group_store;
+    services.session_management = Arc::new(StaticSessionManagement::new(session));
+    services.collaboration_runtime = collaboration_runtime.clone();
+    let app = build_router(
+        HttpAppState::new(services).with_user_identity(Arc::new(ChainUserIdentityPort::new(
+            static_auth_chain("456", "Intruder"),
+        ))),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/sm-group-human-forbidden:abcdef12/messages?limit=20")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(collaboration_runtime.calls.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn state_machine_session_messages_group_only_bot_returns_forbidden() {
+    let temp_dir = TempDir::new().unwrap();
+    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
+    registry
+        .register(
+            "driver-bot".to_string(),
+            BotCapabilities {
+                name: Some("Driver".to_string()),
+                visibility: "public".to_string(),
+                ..BotCapabilities::default()
+            },
+        )
+        .await
+        .unwrap();
+    registry
+        .register(
+            "intruder-bot".to_string(),
+            BotCapabilities {
+                name: Some("Intruder".to_string()),
+                visibility: "public".to_string(),
+                ..BotCapabilities::default()
+            },
+        )
+        .await
+        .unwrap();
+    registry
+        .store_token_mapping(
+            "intruder-token".to_string(),
+            "intruder-bot".to_string(),
+        )
+        .await;
+
+    let mut group = Group::new(
+        "sm-group-bot-forbidden",
+        "driver-bot",
+        vec![
+            Participant::bot("driver-bot", ParticipantRole::Driver),
+            Participant::bot("intruder-bot", ParticipantRole::Observer),
+        ],
+    );
+    group.group_strategy = GroupStrategy::StateMachine;
+    group.status = GroupStatus::Active;
+    let group_store = Arc::new(GroupStore::new());
+    group_store.upsert(group).await.unwrap();
+
+    let session = test_session(
+        "sm-group-bot-forbidden:abcdef12",
+        "sm-group-bot-forbidden",
+        vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+    );
+    let collaboration_runtime = Arc::new(RecordingStateMachineHistoryRuntime {
+        calls: Mutex::new(Vec::new()),
+        result: SessionHistoryResult {
+            session_id: session.id.clone(),
+            messages: vec![],
+            limit: 20,
+            before: None,
+            next_before: None,
+        },
+    });
+    let mut services = Services::noop();
+    services.registry = registry;
+    services.group = group_store;
+    services.session_management = Arc::new(StaticSessionManagement::new(session));
+    services.collaboration_runtime = collaboration_runtime.clone();
+    let app = build_router(
+        HttpAppState::new(services).with_user_identity(Arc::new(NoUserIdentity)),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/sm-group-bot-forbidden:abcdef12/messages?limit=20")
+                .header("authorization", "Bearer intruder-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(collaboration_runtime.calls.lock().await.is_empty());
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -588,6 +588,22 @@ impl GroupMessageHistoryService for RecordingGroupMessageHistory {
         &self,
         cmd: SessionHistoryCommand,
     ) -> Result<SessionHistoryResult, GroupUseCaseError> {
+        let session_member = match &cmd.caller {
+            CallerContext::Human(human) => cmd
+                .session_participants
+                .iter()
+                .any(|participant| participant.bot_uuid == human.actor_id),
+            CallerContext::Bot(bot) => cmd
+                .session_participants
+                .iter()
+                .any(|participant| participant.bot_uuid == bot.bot_uuid),
+            _ => false,
+        };
+        if !session_member {
+            return Err(GroupUseCaseError::Forbidden(
+                "caller is not a session participant".to_string(),
+            ));
+        }
         self.session_calls.lock().await.push(cmd.clone());
         Ok(SessionHistoryResult {
             session_id: cmd.session_id,
@@ -852,6 +868,97 @@ async fn group_chat_missing_group_preserves_legacy_404_before_auth() {
     let json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["error"], "Group not found: missing-group");
     assert_eq!(json["status"], 404);
+}
+
+#[tokio::test]
+async fn session_messages_without_identity_returns_unauthorized() {
+    let (app, _group_store, _routing, _bot_delivery, _frontend_delivery, _bot_request, _message_flow, group_message_history) =
+        build_group_app_with_identity(Arc::new(NoUserIdentity)).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/group-1:abcdef12/messages")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(group_message_history.session_calls.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn session_messages_authenticated_human_uses_history_service_without_view_bot() {
+    let (app, _group_store, _routing, _bot_delivery, _frontend_delivery, _bot_request, _message_flow, group_message_history) =
+        build_group_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/group-1:abcdef12/messages")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let session_calls = group_message_history.session_calls.lock().await;
+    assert_eq!(session_calls.len(), 1);
+    assert_eq!(session_calls[0].view_bot_id, None);
+    assert!(matches!(
+        &session_calls[0].caller,
+        CallerContext::Human(human)
+            if human.actor_id == "human_123" && human.staff_no == "123"
+    ));
+}
+
+#[tokio::test]
+async fn session_messages_non_session_human_returns_forbidden() {
+    let (app, _group_store, _routing, _bot_delivery, _frontend_delivery, _bot_request, _message_flow, group_message_history) =
+        build_group_app_with_identity(Arc::new(ChainUserIdentityPort::new(static_auth_chain(
+            "456", "Intruder",
+        ))))
+        .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/group-1:abcdef12/messages")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(group_message_history.session_calls.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn session_messages_non_participant_bot_token_returns_forbidden() {
+    let (app, _group_store, _routing, _bot_delivery, _frontend_delivery, _bot_request, _message_flow, group_message_history) =
+        build_group_app_with_identity(Arc::new(NoUserIdentity)).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/group-1:abcdef12/messages")
+                .header("authorization", "Bearer intruder-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(group_message_history.session_calls.lock().await.is_empty());
 }
 
 #[tokio::test]
@@ -1147,7 +1254,11 @@ async fn state_machine_session_messages_use_runtime_history() {
     services.session_management = Arc::new(StaticSessionManagement::new(session));
     services.group_message_history = group_message_history.clone();
     services.collaboration_runtime = collaboration_runtime.clone();
-    let app = build_router(HttpAppState::new(services));
+    let app = build_router(
+        HttpAppState::new(services).with_user_identity(Arc::new(ChainUserIdentityPort::new(
+            static_auth_chain("123", "Owner"),
+        ))),
+    );
 
     let response = app
         .oneshot(
@@ -1174,6 +1285,56 @@ async fn state_machine_session_messages_use_runtime_history() {
     );
     let calls = collaboration_runtime.calls.lock().await;
     assert_eq!(calls.as_slice(), &[("sm-group:abcdef12".to_string(), 20, None)]);
+}
+
+#[tokio::test]
+async fn state_machine_session_messages_without_identity_returns_unauthorized() {
+    let mut group = Group::new(
+        "sm-group-no-auth",
+        "driver-bot",
+        vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+    );
+    group.group_strategy = GroupStrategy::StateMachine;
+    group.status = GroupStatus::Active;
+    let group_store = Arc::new(GroupStore::new());
+    group_store.upsert(group).await.unwrap();
+
+    let session = test_session(
+        "sm-group-no-auth:abcdef12",
+        "sm-group-no-auth",
+        vec![Participant::bot("driver-bot", ParticipantRole::Driver)],
+    );
+    let collaboration_runtime = Arc::new(RecordingStateMachineHistoryRuntime {
+        calls: Mutex::new(Vec::new()),
+        result: SessionHistoryResult {
+            session_id: session.id.clone(),
+            messages: vec![],
+            limit: 20,
+            before: None,
+            next_before: None,
+        },
+    });
+    let mut services = Services::noop();
+    services.group = group_store;
+    services.session_management = Arc::new(StaticSessionManagement::new(session));
+    services.collaboration_runtime = collaboration_runtime.clone();
+    let app = build_router(
+        HttpAppState::new(services).with_user_identity(Arc::new(NoUserIdentity)),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/sm-group-no-auth:abcdef12/messages?limit=20")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(collaboration_runtime.calls.lock().await.is_empty());
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-message-flow/src/group_history.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_history.rs
@@ -194,10 +194,12 @@ impl GroupMessageHistoryService for BcsGroupMessageHistory {
                 }
                 None
             }
-            CallerContext::Public | CallerContext::Integration(_) | CallerContext::Admin(_) => {
-                // Public/integration/admin callers: allow access without ownership verification
-                None
+            CallerContext::Public => {
+                return Err(GroupUseCaseError::Unauthorized(
+                    "valid Human identity or Bot token is required for session history".to_string(),
+                ));
             }
+            CallerContext::Integration(_) | CallerContext::Admin(_) => None,
         };
 
         backfill_bot_names(self.registry.as_ref(), &mut group).await;
@@ -340,7 +342,10 @@ impl BcsGroupMessageHistory {
             }
         }
 
-        self.verify_human_group_access(group, caller).await
+        Err(GroupUseCaseError::Forbidden(format!(
+            "current Human '{}' is not a session participant and owns no Bot in session '{}'",
+            caller.actor_id, group.id
+        )))
     }
 
     async fn verify_view_actor_ownership(

--- a/src/bcs/crates/services/bcs-message-flow/src/group_history.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_history.rs
@@ -181,15 +181,14 @@ impl GroupMessageHistoryService for BcsGroupMessageHistory {
                 Some(human.actor_id.as_str())
             }
             CallerContext::Bot(bot_actor) => {
-                if !group.participants.iter().any(|p| p.bot_uuid == bot_actor.bot_uuid)
-                    && !cmd
-                        .session_participants
-                        .iter()
-                        .any(|p| p.bot_uuid == bot_actor.bot_uuid)
+                if !cmd
+                    .session_participants
+                    .iter()
+                    .any(|p| p.bot_uuid == bot_actor.bot_uuid)
                 {
                     return Err(GroupUseCaseError::Forbidden(format!(
-                        "bot '{}' is not a participant in group '{}'",
-                        bot_actor.bot_uuid, cmd.group_id
+                        "bot '{}' is not a participant in session '{}'",
+                        bot_actor.bot_uuid, cmd.session_id
                     )));
                 }
                 None

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -684,6 +684,41 @@ async fn session_history_denies_group_owner_when_not_in_session_and_owns_no_sess
 }
 
 #[tokio::test]
+async fn session_history_denies_group_participant_bot_not_in_session() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(
+        HashMap::new(),
+        HashMap::new(),
+    ));
+    let history = BcsGroupMessageHistory::new(
+        support.group.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        bot_request,
+    );
+
+    let err = history
+        .get_session_history(SessionHistoryCommand {
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: "bot-observer".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            session_id: "group-1:abcdef12".to_string(),
+            session_participants: vec![Participant::bot("bot-driver", ParticipantRole::Driver)],
+            view_bot_id: None,
+            limit: 500,
+            before: None,
+        })
+        .await
+        .expect_err("group participant bot must be rejected when absent from the session");
+
+    assert!(
+        matches!(err, bcs_service_api::GroupUseCaseError::Forbidden(_)),
+        "expected Forbidden, got {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn session_history_denies_non_participant_bot() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -609,6 +609,116 @@ async fn session_history_denies_human_with_no_session_or_group_stake() {
 }
 
 #[tokio::test]
+async fn session_history_rejects_public_caller() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(
+        HashMap::new(),
+        HashMap::new(),
+    ));
+    let history = BcsGroupMessageHistory::new(
+        support.group.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        bot_request,
+    );
+
+    let err = history
+        .get_session_history(SessionHistoryCommand {
+            caller: CallerContext::Public,
+            group_id: "group-1".to_string(),
+            session_id: "group-1:abcdef12".to_string(),
+            session_participants: vec![Participant::bot("bot-driver", ParticipantRole::Driver)],
+            view_bot_id: None,
+            limit: 500,
+            before: None,
+        })
+        .await
+        .expect_err("public session history reads must be rejected");
+
+    assert!(
+        matches!(err, bcs_service_api::GroupUseCaseError::Unauthorized(_)),
+        "expected Unauthorized, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn session_history_denies_group_owner_when_not_in_session_and_owns_no_session_bot() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    support
+        .registry
+        .save_created_by("bot-observer", "1", true)
+        .await
+        .unwrap();
+
+    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(
+        HashMap::new(),
+        HashMap::new(),
+    ));
+    let history = BcsGroupMessageHistory::new(
+        support.group.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        bot_request,
+    );
+
+    let err = history
+        .get_session_history(SessionHistoryCommand {
+            caller: CallerContext::Human(HumanActor {
+                actor_id: "human_1".to_string(),
+                staff_no: "1".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            session_id: "group-1:abcdef12".to_string(),
+            session_participants: vec![Participant::bot("bot-driver", ParticipantRole::Driver)],
+            view_bot_id: None,
+            limit: 500,
+            before: None,
+        })
+        .await
+        .expect_err("group ownership alone must not grant session history access");
+
+    assert!(
+        matches!(err, bcs_service_api::GroupUseCaseError::Forbidden(_)),
+        "expected Forbidden, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn session_history_denies_non_participant_bot() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(
+        HashMap::new(),
+        HashMap::new(),
+    ));
+    let history = BcsGroupMessageHistory::new(
+        support.group.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        bot_request,
+    );
+
+    let err = history
+        .get_session_history(SessionHistoryCommand {
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: "intruder-bot".to_string(),
+            }),
+            group_id: "group-1".to_string(),
+            session_id: "group-1:abcdef12".to_string(),
+            session_participants: vec![Participant::bot("bot-driver", ParticipantRole::Driver)],
+            view_bot_id: None,
+            limit: 500,
+            before: None,
+        })
+        .await
+        .expect_err("non-participant bot must be rejected");
+
+    assert!(
+        matches!(err, bcs_service_api::GroupUseCaseError::Forbidden(_)),
+        "expected Forbidden, got {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn session_history_resolves_from_prefix_using_session_participants() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let mut group = support.group.get("group-1").await.unwrap();
@@ -752,7 +862,9 @@ async fn session_history_v3_falls_back_to_session_key_when_explicit_session_requ
 
     let result = history
         .get_session_history(SessionHistoryCommand {
-            caller: CallerContext::Public,
+            caller: CallerContext::Bot(BotActor {
+                bot_uuid: "bot-driver".to_string(),
+            }),
             group_id: "group-1".to_string(),
             session_id: "group-1:abcdef12".to_string(),
             session_participants: vec![Participant::bot("bot-driver", ParticipantRole::Driver)],


### PR DESCRIPTION
## Problem
The legacy `GET /sessions/{sid}/messages` endpoint could read session history without resolving a caller when `view_bot_id` was absent. That allowed public callers to reach session history reads, including StateMachine session history.

## Solution
- Resolve a Human identity or Bot token before any legacy session history read.
- Return `401 Unauthorized` when no valid caller identity is present.
- Reject public callers defensively in the session history service.
- Restrict Human session-history access to direct session participants or Humans who own a Bot participating in that session.
- Preserve the existing `view_bot_id` success path while keeping owner validation in the history service.

## Validation
- Not run per request: "commit & push no verify".
- Note: the repository pre-push hook still executed automatically in lint-only mode during `git push` and reported success.

## Compatibility and risk
- Behavior change: unauthenticated legacy session history reads now return `401` instead of succeeding as public reads.
- Non-member Humans and non-participant Bot tokens now receive `403` for session history reads.
- Existing authenticated owner `view_bot_id` reads remain supported.

## Related issues
- DIMA: 2026072800117814363
