### PR TITLE
fix: restore bot ownership for uploaded skills

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/dependencies.py
+++ b/src/backend/src/agentclaw/community/adapters/http/dependencies.py
@@ -4,8 +4,8 @@ API-layer dependencies for request context extraction.
 Migrated from: services/openclawserver/server/dependencies.py
 This is the canonical new-arch location for RequestContext.
 """
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Optional
 from fastapi import Request, Query, HTTPException
 
 from agentclaw.community.di import Injected
@@ -21,6 +21,9 @@ class RequestContext:
     user_id: str
     bot_id: str = "default"
     nick_name: str | None = None  # 花名
+    # 仅承载同一 HTTP 请求内、由服务端拦截器写入的可信授权结论；不可由客户端
+    # 请求参数构造或覆盖。
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 async def get_request_context(

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -2222,7 +2222,14 @@ async def delete_skill(
             )
         )
         try:
-            success = await service.delete_skill(skill_id, user_id=current_user_id)
+            # 路由已先通过 CollaboratorPermissionInterceptor；仍把持久化
+            # Bot owner 显式传给 Service 做 scope 双重校验，不能把协作者当成
+            # Skill metadata owner。
+            success = await service.delete_skill(
+                skill_id,
+                user_id=current_user_id,
+                authorized_bot_owner_id=str(bot.get("owner_id") or ""),
+            )
         finally:
             edit_guard.release(edit_lease)
         if not success:

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -11,7 +11,7 @@ import time
 import zipfile
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from starlette.concurrency import run_in_threadpool
 
 from agentclaw.community.adapters.http.dependencies import (
@@ -1957,33 +1957,110 @@ async def update_skill_risk_tags(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+async def _extract_skill_mutation_permission(
+    skill_id: str,
+    ctx: InterceptorContext,
+) -> PermissionParams:
+    """Resolve the persisted Bot identity used for local Skill mutations."""
+    if not skill_id or ctx.injector is None:
+        return PermissionParams()
+    try:
+        service = ctx.injector.get(SkillServiceFactoryProtocol).create()
+        skill = service.get_skill(skill_id)
+    except Exception:
+        return PermissionParams()
+    if not skill:
+        return PermissionParams()
+    return PermissionParams(
+        bot_id=skill.get("bolt_id"),
+        owner_id=skill.get("user_id"),
+    )
+
+
+class _FailClosedSkillMutationPermissionInterceptor(
+    CollaboratorPermissionInterceptor,
+):
+    """Never turn a collaborator permission lookup failure into mutation access."""
+
+    def __init__(self, *args, authorization_state_key: str, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._authorization_state_key = authorization_state_key
+
+    async def before(
+        self,
+        ctx: InterceptorContext,
+    ) -> InterceptorContext | None:
+        actor_id = ctx.user.staffId if ctx.user else None
+        # Preserve the pre-existing global Skill admin capability; it is not a
+        # Bot-collaborator grant and therefore must not depend on that service.
+        if actor_id and actor_id in skill_admin():
+            ctx.metadata["permission_level"] = "SKILL_ADMIN"
+            return ctx
+
+        result = await super().before(ctx)
+        if result is None:
+            return None
+        actor_id = ctx.metadata.get("_log_user_id")
+        owner_id = ctx.metadata.get("_log_owner_id")
+        if actor_id != owner_id:
+            if not ctx.metadata.get("permission_level"):
+                ctx.response = InterceptedResponse(
+                    success=False,
+                    message="协作者权限服务暂不可用",
+                    error_code=503,
+                )
+                return None
+            if ctx.request is not None:
+                setattr(ctx.request.state, self._authorization_state_key, True)
+            for value in ctx.route_kwargs.values():
+                if isinstance(value, RequestContext):
+                    value.metadata[self._authorization_state_key] = True
+        return result
+
+
 @router.post("/{skill_id}/mcp-dependencies", response_model=SkillDetailResponse)
+@with_interceptors(_FailClosedSkillMutationPermissionInterceptor(
+    params_extractor=_extract_skill_mutation_permission,
+    extractor_params={"skill_id": "$skill_id"},
+    persist_audit_log=True,
+    authorization_state_key="skill_mcp_collaborator_authorized",
+))
 async def update_skill_mcp_dependencies(
     skill_id: str,
     request: UpdateMCPDependenciesRequest,
     user: AuthenticatedUser = Depends(get_current_user),
+    http_request: Request = None,
     skill_service_factory: SkillServiceFactoryProtocol = Injected(SkillServiceFactoryProtocol),
 ) -> SkillDetailResponse:
     """Update skill MCP dependencies by ID.
 
     权限控制：只有技能的创建者或管理员可以修改 MCP 依赖。
     """
-    # 管理员名单校验：非管理员只能修改自己创建的技能
-    if user.staffId not in skill_admin():
-        service = skill_service_factory.create()
+    service = skill_service_factory.create()
+    try:
         existing = service.get_skill(skill_id, user_id=user.staffId)
         if not existing:
             raise HTTPException(status_code=404, detail="Skill not found")
         skill_owner = str(existing.get("user_id", ""))
-        if skill_owner and skill_owner != user.staffId:
-            logger.warning(
-                f"[update_skill_mcp_dependencies] 权限拒绝: user={user.staffId} "
-                f"尝试修改非自己创建的 skill_id={skill_id} (owner={skill_owner}) 的MCP依赖"
+        is_local_skill = str(existing.get("git_path") or "").startswith("local://")
+        collaborator_authorized = bool(
+            http_request
+            and getattr(
+                http_request.state,
+                "skill_mcp_collaborator_authorized",
+                False,
             )
-            raise HTTPException(status_code=403, detail="无权修改此技能的MCP依赖，仅技能创建者或管理员可操作")
-
-    service = skill_service_factory.create()
-    try:
+        )
+        if (
+            user.staffId not in skill_admin()
+            and skill_owner
+            and skill_owner != user.staffId
+            and not (is_local_skill and collaborator_authorized)
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="无权修改此技能的MCP依赖，仅技能创建者、已授权协作者或管理员可操作",
+            )
         # 使用认证用户ID替代请求体中的user_id，防止越权
         if request.user_id and request.user_id != user.staffId:
             logger.warning(f"[update_skill_mcp_dependencies] 权限拒绝: user={user.staffId} 尝试以 user_id={request.user_id} 修改 skill_id={skill_id} 的MCP依赖，已使用认证用户ID")
@@ -2069,10 +2146,11 @@ async def extract_from_skill_id(skill_id: str, ctx) -> PermissionParams:
 
 
 @router.delete("/{skill_id}", response_model=MessageResponse)
-@with_interceptors(CollaboratorPermissionInterceptor(
+@with_interceptors(_FailClosedSkillMutationPermissionInterceptor(
     params_extractor=extract_from_skill_id,
     extractor_params={"skill_id": "$skill_id"},  # 表达式：从路由参数取值
     persist_audit_log=True,  # 记录操作审计日志
+    authorization_state_key="skill_delete_collaborator_authorized",
 ))
 async def delete_skill(
     skill_id: str,
@@ -2229,6 +2307,9 @@ async def delete_skill(
                 skill_id,
                 user_id=current_user_id,
                 authorized_bot_owner_id=str(bot.get("owner_id") or ""),
+                collaborator_authorization_verified=bool(
+                    ctx.metadata.get("skill_delete_collaborator_authorized")
+                ),
             )
         finally:
             edit_guard.release(edit_lease)

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -374,6 +374,12 @@ async def upload_skill(
     bot = bot_repo.get_by_id_and_owner(effective_bot_id, owner_id_for_lookup)
     if not bot:
         return UploadSkillResponse(success=False, message="Bot not found.")
+    bot_owner_id = str(bot.get("owner_id") or "")
+    if not bot_owner_id:
+        return UploadSkillResponse(
+            success=False,
+            message="Bot ownership metadata is incomplete.",
+        )
 
     # 状态闸门:桌面 bot 的 DB 状态(ac_bots.status)有延迟 —— BaaS 上 VM 已
     # ACTIVE 但 ac_bots 还停旧值会误拒上传。桌面 bot 先用 BaaS 实时状态覆盖;
@@ -459,11 +465,10 @@ async def upload_skill(
 
         logger.info(f"[skills.upload_skill] Calling service.upload_skill with {len(uploaded_files)} files")
 
-        # ``user_id`` identifies the Bot owner for collaborator authorization and
-        # device access. Skill metadata belongs to the authenticated uploader;
-        # using the owner for both made collaborator-uploaded local Skills appear
-        # to have been authored by the Bot owner.
-        effective_user_id = user_id or ctx.user_id
+        # ``ctx.user_id`` is the authenticated actor used by the collaborator
+        # interceptor and audit trail.  Local Skill metadata follows the
+        # historical product contract and belongs to the Bot owner, resolved
+        # from the persisted Bot rather than a caller-controlled parameter.
 
         # Call the service method (async)
         edit_lease = edit_guard.acquire_for_edit(
@@ -476,8 +481,7 @@ async def upload_skill(
         try:
             skill = await service.upload_skill(
                 uploaded_files,
-                user_id=effective_user_id,
-                author_id=ctx.user_id,
+                user_id=bot_owner_id,
                 bolt_id=effective_bot_id,
             )
         finally:
@@ -1241,7 +1245,8 @@ async def get_skill_readme(
     # A Skill may be read while the caller is operating another Bot.  Its DB
     # ``bolt_id`` is the authoritative target; derive owner, entity type and
     # engine from that Bot instead of trusting the caller's route parameters.
-    # ``skill.user_id`` is only the Skill author and can be a collaborator.
+    # ``skill.user_id`` is metadata ownership, but historical rows may contain
+    # a collaborator ID; device ownership must still come from the Bot row.
     read_bot_id = (skill or {}).get("bolt_id") or effective_bot_id
     target_bot = None
     # ``default`` is shared by many owners.  Resolve an explicitly supplied
@@ -2287,8 +2292,8 @@ def _resolve_parameter_bot(
     not the authenticated actor (who may be an ADMIN collaborator).
 
     The requested Bot ID is used only as a lookup key; ownership always comes
-    from the Bot row. ``Skill.user_id`` records the author and may therefore be
-    a collaborator, so it must never participate in device-owner resolution.
+    from the Bot row. Historical ``Skill.user_id`` values may contain a
+    collaborator, so they must never participate in device-owner resolution.
     Bot-private Skills are scoped by ``bolt_id``; shared Git market Skills have
     no Bot binding and remain usable across Bots.
     """

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/base.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/interceptor/base.py
@@ -60,6 +60,7 @@ class InterceptorContext:
     metadata: dict = field(default_factory=dict)
     result: Any | None = None
     injector: Injector | None = None
+    request: Request | None = None
 
 
 @runtime_checkable
@@ -201,6 +202,7 @@ def with_interceptors(
                 user=user,
                 route_kwargs=kwargs,
                 injector=injector,
+                request=request,
             )
 
             # 预加载服务：从 ctx.injector 获取

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1869,7 +1869,11 @@ class SkillService:
             name=skill_name,
             user_id=user_id,
         )
-        if existing_skill is None:
+        # Teclaw 的逻辑 locator 是 ``local://skills-local/<name>``，不携带
+        # owner/workspace 身份，不能据此修复历史 collaborator 行；否则共享
+        # ``default`` Bot 的不同 owner 会发生跨 owner 命中。只有 owner-qualified
+        # 的绝对 locator 才允许这条历史兼容分支。
+        if existing_skill is None and Path(expected_skill_dir).is_absolute():
             historical_skill = self._skill_repo.get_by_git_path(expected_skill_path)
             if (
                 historical_skill is not None
@@ -2238,6 +2242,7 @@ class SkillService:
         skill: dict,
         user_id: str | None = None,
         authorized_bot_owner_id: str | None = None,
+        collaborator_authorization_verified: bool = False,
     ) -> bool:
         """检查用户是否有权限删除技能
 
@@ -2266,6 +2271,7 @@ class SkillService:
         if (
             skill_user_id
             and authorized_bot_owner_id
+            and collaborator_authorization_verified
             and str(skill_user_id) == str(authorized_bot_owner_id)
             and str(self._device_owner_id or "") == str(authorized_bot_owner_id)
         ):
@@ -2307,6 +2313,7 @@ class SkillService:
         skill_id: str,
         user_id: str | None = None,
         authorized_bot_owner_id: str | None = None,
+        collaborator_authorization_verified: bool = False,
     ) -> bool:
         """删除技能 - 同时删除数据库记录和物理文件
 
@@ -2315,6 +2322,8 @@ class SkillService:
             user_id: 当前操作用户ID（用于权限验证）
             authorized_bot_owner_id: 已完成协作者授权时，由 adapter 注入的
                 Bot owner；不接受任何外部请求透传
+            collaborator_authorization_verified: adapter 从 fail-closed
+                协作者拦截器取得的可信授权结论
 
         Returns:
             bool: 删除是否成功
@@ -2332,6 +2341,7 @@ class SkillService:
             skill,
             user_id,
             authorized_bot_owner_id=authorized_bot_owner_id,
+            collaborator_authorization_verified=collaborator_authorization_verified,
         ):
             skill_owner = skill.get('user_id')
             logger.warning(f"[SkillService] Permission denied: user={user_id} attempted to delete skill={skill_id} owned by={skill_owner}")

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1854,15 +1854,30 @@ class SkillService:
         # POOL_ACTIVE 后 DB locator 已经是 Pool canonical 绝对路径。重传同名
         # 本地技能时必须继续使用该 locator；否则会写到 Legacy bridge 后又以
         # Legacy locator 新建一条重复记录。
+        #
+        # 正常查询必须始终带 Bot owner。尤其 ``default`` 是多个 owner 可共用的
+        # Bot ID，不能为修复历史 collaborator metadata 而做无 owner 的 name
+        # 查询，否则会命中另一位 owner 的同名本地 Skill。历史修复仅允许精确
+        # 命中本次 Bot layout 推导出的 locator；该路径包含 owner/entity + bot，
+        # 因而不会跨 Bot 取数。
+        expected_skill_dir = self._local_skill_locator_adapter(
+            str(self.local_dir / skill_name)
+        )
+        expected_skill_path = f"local://{expected_skill_dir}"
         existing_skill = self._skill_repo.get_bot_local_by_name(
             bot_id=bolt_id or "default",
             name=skill_name,
-            # Bot-private local Skills are identified by Bot + name.  Do not
-            # filter by the historical metadata owner here: an earlier release
-            # wrote collaborator IDs and re-upload must repair that row rather
-            # than create a duplicate.
-            user_id=None,
+            user_id=user_id,
         )
+        if existing_skill is None:
+            historical_skill = self._skill_repo.get_by_git_path(expected_skill_path)
+            if (
+                historical_skill is not None
+                and str(historical_skill.get("bolt_id") or "default")
+                == (bolt_id or "default")
+                and historical_skill.get("name") == skill_name
+            ):
+                existing_skill = historical_skill
         existing_locator = (
             str(existing_skill["git_path"])[len("local://") :]
             if existing_skill is not None
@@ -2218,12 +2233,19 @@ class SkillService:
         update_data['gmt_modified'] = datetime.utcnow()
         return self._skill_repo.update(skill_id, update_data)
 
-    def _can_delete_skill(self, skill: dict, user_id: str | None = None) -> bool:
+    def _can_delete_skill(
+        self,
+        skill: dict,
+        user_id: str | None = None,
+        authorized_bot_owner_id: str | None = None,
+    ) -> bool:
         """检查用户是否有权限删除技能
 
         只有以下用户可以删除技能：
         1. 技能的创建者（user_id 匹配）
         2. 指定的管理员用户
+        3. 已在 HTTP adapter 经协作者拦截器授权、且当前 Service 也绑定到
+           该 Skill 所属 Bot owner 的协作者
         """
         if not user_id:
             return False
@@ -2235,6 +2257,18 @@ class SkillService:
         # 技能的创建者可以删除自己的技能
         skill_user_id = skill.get('user_id')
         if skill_user_id and str(skill_user_id) == str(user_id):
+            return True
+
+        # ``authorized_bot_owner_id`` 不是客户端参数，只能由已经完成
+        # CollaboratorPermissionInterceptor 校验的 adapter 注入。二次校验
+        # 它与 Skill metadata 和本 Service 的设备 owner 一致，避免调用方仅凭
+        # 伪造 owner 值跨 Bot 删除。
+        if (
+            skill_user_id
+            and authorized_bot_owner_id
+            and str(skill_user_id) == str(authorized_bot_owner_id)
+            and str(self._device_owner_id or "") == str(authorized_bot_owner_id)
+        ):
             return True
 
         return False
@@ -2268,12 +2302,19 @@ class SkillService:
             return False
 
     # ----- Delete -----
-    async def delete_skill(self, skill_id: str, user_id: str | None = None) -> bool:
+    async def delete_skill(
+        self,
+        skill_id: str,
+        user_id: str | None = None,
+        authorized_bot_owner_id: str | None = None,
+    ) -> bool:
         """删除技能 - 同时删除数据库记录和物理文件
 
         Args:
             skill_id: 技能ID
             user_id: 当前操作用户ID（用于权限验证）
+            authorized_bot_owner_id: 已完成协作者授权时，由 adapter 注入的
+                Bot owner；不接受任何外部请求透传
 
         Returns:
             bool: 删除是否成功
@@ -2287,7 +2328,11 @@ class SkillService:
             return False
 
         # 权限检查：只有技能所有者或管理员可以删除
-        if not self._can_delete_skill(skill, user_id):
+        if not self._can_delete_skill(
+            skill,
+            user_id,
+            authorized_bot_owner_id=authorized_bot_owner_id,
+        ):
             skill_owner = skill.get('user_id')
             logger.warning(f"[SkillService] Permission denied: user={user_id} attempted to delete skill={skill_id} owned by={skill_owner}")
             raise ValueError("无权删除此技能：您不是该技能的创建者，且没有管理员权限")

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1342,12 +1342,13 @@ class SkillService:
                 git_path = skill.get('git_path', '')
                 db_bolt_id = skill.get('bolt_id')
                 bolt_id = db_bolt_id or bolt_id
-                skill_author_id = skill.get('user_id') or user_id
-                device_user_id = device_owner_id or skill_author_id
+                skill_metadata_owner_id = skill.get('user_id') or user_id
+                device_user_id = device_owner_id or skill_metadata_owner_id
                 logger.info(
                     f"[get_skill_readme] DB found, git_path={git_path}, "
                     f"db_bolt_id={db_bolt_id}, effective_bolt_id={bolt_id}, "
-                    f"skill_author_id={skill_author_id}, device_user_id={device_user_id}"
+                    f"skill_metadata_owner_id={skill_metadata_owner_id}, "
+                    f"device_user_id={device_user_id}"
                 )
 
                 if git_path.startswith('local://'):
@@ -1803,7 +1804,6 @@ class SkillService:
         self,
         uploaded_files: list[dict[str, Any]],
         user_id: str | None = None,
-        author_id: str | None = None,
         bolt_id: str | None = None
     ):
         """
@@ -1814,8 +1814,7 @@ class SkillService:
                 - filename: 文件名
                 - content: 文件内容（bytes）
                 - relative_path: 相对路径（文件夹上传时使用）
-            user_id: Bot owner ID，用于设备文件系统路由
-            author_id: 实际上传者 ID，用于 Skill 元数据；未提供时兼容为 user_id
+            user_id: Bot owner ID，用于设备文件系统路由和 Skill 元数据
             bolt_id: Bot ID，为空时默认使用 'default'
 
         Returns:
@@ -1824,10 +1823,9 @@ class SkillService:
         Raises:
             ValueError: 如果验证失败
         """
-        author_id = author_id or user_id
         logger.info(
             f"[SkillService.upload_skill] Start: file_count={len(uploaded_files)}, "
-            f"user_id={user_id}, author_id={author_id}, bolt_id={bolt_id}"
+            f"user_id={user_id}, bolt_id={bolt_id}"
         )
 
         if not uploaded_files:
@@ -1859,7 +1857,11 @@ class SkillService:
         existing_skill = self._skill_repo.get_bot_local_by_name(
             bot_id=bolt_id or "default",
             name=skill_name,
-            user_id=author_id,
+            # Bot-private local Skills are identified by Bot + name.  Do not
+            # filter by the historical metadata owner here: an earlier release
+            # wrote collaborator IDs and re-upload must repair that row rather
+            # than create a duplicate.
+            user_id=None,
         )
         existing_locator = (
             str(existing_skill["git_path"])[len("local://") :]
@@ -1910,8 +1912,8 @@ class SkillService:
                     'git_path': skill_path,
                     'gmt_modified': datetime.utcnow()
                 }
-                if author_id:
-                    update_data['user_id'] = author_id
+                if user_id:
+                    update_data['user_id'] = user_id
                 updated = self._skill_repo.update(existing_skill['id'], update_data)
                 logger.info(
                     f"[SkillService.upload_skill] Updated existing skill: {skill_name} "
@@ -1927,7 +1929,7 @@ class SkillService:
                     category=skill_info.get("category", "general"),
                     tags=skill_info.get("tags", []),
                     is_public=False,  # 本地技能默认不公开
-                    user_id=author_id,
+                    user_id=user_id,
                     bolt_id=bolt_id
                 )
                 logger.info(f"[SkillService.upload_skill] Created new skill: {skill_name} (id: {skill.get('id')})")

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1853,35 +1853,14 @@ class SkillService:
         device_fs = self._device_fs_factory(bolt_id, user_id)
         # POOL_ACTIVE 后 DB locator 已经是 Pool canonical 绝对路径。重传同名
         # 本地技能时必须继续使用该 locator；否则会写到 Legacy bridge 后又以
-        # Legacy locator 新建一条重复记录。
-        #
-        # 正常查询必须始终带 Bot owner。尤其 ``default`` 是多个 owner 可共用的
-        # Bot ID，不能为修复历史 collaborator metadata 而做无 owner 的 name
-        # 查询，否则会命中另一位 owner 的同名本地 Skill。历史修复仅允许精确
-        # 命中本次 Bot layout 推导出的 locator；该路径包含 owner/entity + bot，
-        # 因而不会跨 Bot 取数。
-        expected_skill_dir = self._local_skill_locator_adapter(
-            str(self.local_dir / skill_name)
-        )
-        expected_skill_path = f"local://{expected_skill_dir}"
+        # Legacy locator 新建一条重复记录。查询必须始终带 Bot owner：历史
+        # collaborator metadata 由离线 DB 订正处理，在线请求不从不完整 locator
+        # 猜测记录归属，避免 ``default`` / desktop / teclaw 场景跨 owner 命中。
         existing_skill = self._skill_repo.get_bot_local_by_name(
             bot_id=bolt_id or "default",
             name=skill_name,
             user_id=user_id,
         )
-        # Teclaw 的逻辑 locator 是 ``local://skills-local/<name>``，不携带
-        # owner/workspace 身份，不能据此修复历史 collaborator 行；否则共享
-        # ``default`` Bot 的不同 owner 会发生跨 owner 命中。只有 owner-qualified
-        # 的绝对 locator 才允许这条历史兼容分支。
-        if existing_skill is None and Path(expected_skill_dir).is_absolute():
-            historical_skill = self._skill_repo.get_by_git_path(expected_skill_path)
-            if (
-                historical_skill is not None
-                and str(historical_skill.get("bolt_id") or "default")
-                == (bolt_id or "default")
-                and historical_skill.get("name") == skill_name
-            ):
-                existing_skill = historical_skill
         existing_locator = (
             str(existing_skill["git_path"])[len("local://") :]
             if existing_skill is not None

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -229,6 +229,27 @@ async def test_delete_uses_bot_owner_when_skill_was_authored_by_collaborator():
 
 
 @pytest.mark.asyncio
+async def test_authorized_collaborator_can_delete_owner_owned_skill():
+    """The route passes the persisted Bot owner as trusted collaborator scope."""
+    skill_repo = MagicMock()
+    skill_repo.get_by_id.return_value = _skill_record()
+    skill_repo.list_skill_set_references.return_value = []
+    skill_repo.delete.return_value = True
+    device_fs = MagicMock()
+    device_fs.exists = AsyncMock(return_value=True)
+    device_fs.delete_tree = AsyncMock(return_value=True)
+
+    response, _, factory = await _call_delete(
+        device_fs=device_fs,
+        skill_repo=skill_repo,
+        current_user_id="authorized-collaborator",
+    )
+
+    assert response.success is True
+    assert factory.device_fs_calls == [(BOT_ID, OWNER_ID)]
+
+
+@pytest.mark.asyncio
 async def test_delete_project_bot_uses_entity_paths_and_owner_device_binding():
     skill_repo = MagicMock()
     skill_repo.get_by_id.return_value = _skill_record()

--- a/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
+++ b/src/backend/tests/community/api/skill_center/test_delete_skill_context.py
@@ -85,6 +85,7 @@ async def _call_delete(
     entity_id=None,
     bot_repo=None,
     bot_record=None,
+    verified_collaborator=False,
 ):
     bot_repo = bot_repo or MagicMock()
     resolved_bot = bot_record or _bot_record()
@@ -113,7 +114,15 @@ async def _call_delete(
         entity_type=None,
         bot_id=None,
         engine_type=engine_type,
-        ctx=RequestContext(user_id=current_user_id, bot_id="default"),
+        ctx=RequestContext(
+            user_id=current_user_id,
+            bot_id="default",
+            metadata=(
+                {"skill_delete_collaborator_authorized": True}
+                if verified_collaborator
+                else {}
+            ),
+        ),
         bot_repo=bot_repo,
         path_factory=path_factory,
         skill_service_factory=factory,
@@ -243,6 +252,7 @@ async def test_authorized_collaborator_can_delete_owner_owned_skill():
         device_fs=device_fs,
         skill_repo=skill_repo,
         current_user_id="authorized-collaborator",
+        verified_collaborator=True,
     )
 
     assert response.success is True

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -16,6 +16,7 @@ it in run_in_threadpool.
 """
 import json
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -138,8 +139,15 @@ def _skill_service_di_app(
 
 
 @contextmanager
-def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
-                         bot_service=None, device_id=None):
+def _upload_skill_di_app(
+    mock_ctx,
+    bot_status="ACTIVE",
+    bot_type="personal",
+    bot_service=None,
+    device_id=None,
+    bot_owner_id=None,
+):
+    bot_owner_id = bot_owner_id or mock_ctx.user_id
     mock_skill_service = MagicMock()
     mock_skill_service.upload_skill = AsyncMock(
         return_value={
@@ -156,7 +164,7 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
             "output_schema": "",
             "is_public": False,
             "is_builtin": False,
-            "user_id": mock_ctx.user_id,
+            "user_id": bot_owner_id,
             "bot_id": mock_ctx.bot_id,
             "bolt_id": mock_ctx.bot_id,
             "gmt_created": "",
@@ -175,8 +183,8 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
 
     bot_record = {
         "bot_id": mock_ctx.bot_id,
-        "owner_id": mock_ctx.user_id,
-        "entity_id": f"staff_{mock_ctx.user_id}",
+        "owner_id": bot_owner_id,
+        "entity_id": f"staff_{bot_owner_id}",
         "env": "local",
         "active_engine": "openclaw",
         "bot_type": bot_type,
@@ -202,6 +210,17 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
 
     mock_edit_guard = MagicMock()
     mock_edit_guard.acquire_for_edit.return_value = object()
+    mock_lock_service = MagicMock()
+    mock_lock_service.get_lock_info.return_value = SimpleNamespace(
+        has_collaborators=True,
+        lock=SimpleNamespace(holder_user_id=mock_ctx.user_id),
+        holder_name="collaborator",
+    )
+    mock_collaborator_service = MagicMock()
+    mock_collaborator_service.check_collaborator_permission.return_value = {
+        "has_permission": True,
+        "level": "ADMIN",
+    }
 
     app = FastAPI()
     app.include_router(skills_router)
@@ -211,6 +230,12 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
         def configure(self, binder):
             from agentclaw.community.api.bot_service import BotServiceProtocol
             from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+            from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
+                CollaboratorLockService,
+            )
+            from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+                CollaboratorService,
+            )
             from agentclaw.community.core.devices.services.device_context_resolver import (
                 DeviceContextResolver,
             )
@@ -228,6 +253,8 @@ def _upload_skill_di_app(mock_ctx, bot_status="ACTIVE", bot_type="personal",
             binder.bind(DeviceContextResolver, to=mock_resolver)
             binder.bind(BotServiceProtocol, to=bot_service)
             binder.bind(SkillsPoolEditGuard, to=mock_edit_guard)
+            binder.bind(CollaboratorLockService, to=mock_lock_service)
+            binder.bind(CollaboratorService, to=mock_collaborator_service)
 
     injector = Injector([_TestModule()])
     attach_injector(app, injector)
@@ -302,20 +329,33 @@ class TestUploadSkillValidation:
             assert body["success"] is True
             assert mock_svc.upload_skill.await_count == 1
 
-    def test_upload_passes_authenticated_user_as_author(self, mock_ctx):
-        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _, _):
+    def test_upload_persists_bot_owner_for_collaborator_upload(self):
+        collaborator_ctx = RequestContext(
+            user_id="collaborator-9",
+            bot_id="service-bot-1",
+        )
+        with _upload_skill_di_app(
+            collaborator_ctx,
+            bot_status="ACTIVE",
+            bot_type="service",
+            bot_owner_id="bot-owner-1",
+        ) as (client, mock_svc, _, _):
             response = client.post(
-                "/api/skills/upload",
+                (
+                    "/api/skills/upload?user_id=bot-owner-1"
+                    "&bot_id=service-bot-1"
+                ),
                 files=[
                     ("files", ("SKILL.md", b"---\nname: a\ndescription: a\n---", "text/markdown"))
                 ],
                 data={"file_paths": json.dumps(["SKILL.md"])},
             )
 
-            assert response.json()["success"] is True
+            assert response.json()["success"] is True, response.json()
             mock_svc.upload_skill.assert_awaited_once()
-            assert mock_svc.upload_skill.await_args.kwargs["user_id"] == mock_ctx.user_id
-            assert mock_svc.upload_skill.await_args.kwargs["author_id"] == mock_ctx.user_id
+            kwargs = mock_svc.upload_skill.await_args.kwargs
+            assert kwargs["user_id"] == "bot-owner-1"
+            assert "author_id" not in kwargs
 
     def test_upload_passes_bot_scope_to_layout_aware_factory(self, mock_ctx):
         with _upload_skill_di_app(

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -299,6 +299,26 @@ class TestUploadSkillValidation:
             assert body["message"] == "Bot not found."
             mock_svc.upload_skill.assert_not_called()
 
+    def test_upload_rejects_bot_without_owner_metadata(self, mock_ctx):
+        """Local Skill 的归属无法确定时，不能将上传归到请求方。"""
+        with _upload_skill_di_app(
+            mock_ctx, bot_status="ACTIVE"
+        ) as (client, mock_svc, mock_bot_repo, _):
+            mock_bot_repo.get_by_id_and_owner.return_value["owner_id"] = ""
+
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    ("files", ("SKILL.md", b"---\nname: a\ndescription: a\n---", "text/markdown"))
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            body = response.json()
+            assert body["success"] is False
+            assert body["message"] == "Bot ownership metadata is incomplete."
+            mock_svc.upload_skill.assert_not_called()
+
     def test_upload_rejects_file_paths_length_mismatch(self, mock_ctx):
         with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _, _):
             response = client.post(

--- a/src/backend/tests/community/api/skill_center/test_vuln_fix_mcp_deps.py
+++ b/src/backend/tests/community/api/skill_center/test_vuln_fix_mcp_deps.py
@@ -3,16 +3,31 @@
 Verifies that update_skill_mcp_dependencies requires authentication
 and uses authenticated user ID instead of request body user_id.
 """
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
 from agentclaw.community.adapters.http.auth.dependencies import get_current_user
 from agentclaw.community.core.auth.models import AuthenticatedIdentity
+from agentclaw.community.adapters.http.dependencies import RequestContext
+from agentclaw.community.adapters.http.skill_center.schemas import (
+    UpdateMCPDependenciesRequest,
+)
+from agentclaw.community.adapters.http.skill_center.skills import (
+    _FailClosedSkillMutationPermissionInterceptor,
+    _extract_skill_mutation_permission,
+    update_skill_mcp_dependencies,
+)
+from agentclaw.community.core.bot_collaborator.interceptor import (
+    CollaboratorPermissionInterceptor,
+    InterceptorContext,
+    PermissionParams,
+)
 from agentclaw.community.core.skill_center.factories import SkillServiceFactory
 
 
@@ -139,3 +154,125 @@ class TestUpdateSkillMcpDependenciesAuth:
             json={"user_id": "100011", "mcp_dependencies": []},
         )
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_owner_without_interceptor_grant_is_rejected(self, user_a):
+        """本地 Skill 的协作者必须由前置拦截器显式授权。"""
+        service = MagicMock()
+        service.get_skill.return_value = {
+            "id": 42,
+            "user_id": "bot-owner",
+            "git_path": "local:///workspace/skills-local/test-skill",
+        }
+        endpoint = getattr(
+            update_skill_mcp_dependencies,
+            "__wrapped__",
+            update_skill_mcp_dependencies,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await endpoint(
+                skill_id="42",
+                request=UpdateMCPDependenciesRequest(mcp_dependencies=[]),
+                user=user_a,
+                http_request=SimpleNamespace(state=SimpleNamespace()),
+                skill_service_factory=MagicMock(create=MagicMock(return_value=service)),
+            )
+
+        assert exc_info.value.status_code == 403
+        service.update_skill.assert_not_called()
+
+
+class TestFailClosedSkillMutationPermissionInterceptor:
+    """覆盖协作者权限异常时的 fail-closed 行为。"""
+
+    @pytest.mark.asyncio
+    async def test_extractor_returns_empty_when_skill_id_or_injector_missing(self):
+        assert await _extract_skill_mutation_permission(
+            "", InterceptorContext()
+        ) == PermissionParams()
+        assert await _extract_skill_mutation_permission(
+            "42", InterceptorContext(injector=None)
+        ) == PermissionParams()
+
+    @pytest.mark.asyncio
+    async def test_extractor_returns_empty_when_skill_lookup_raises(self):
+        injector = MagicMock()
+        injector.get.side_effect = RuntimeError("lookup unavailable")
+
+        result = await _extract_skill_mutation_permission(
+            "42", InterceptorContext(injector=injector)
+        )
+
+        assert result.bot_id is None
+        assert result.owner_id is None
+
+    @pytest.mark.asyncio
+    async def test_global_skill_admin_bypasses_collaborator_lookup(self):
+        interceptor = _FailClosedSkillMutationPermissionInterceptor(
+            authorization_state_key="skill_mutation_authorized"
+        )
+        ctx = InterceptorContext(
+            user=AuthenticatedIdentity(id="1", operatorName="admin", staffId="admin"),
+        )
+
+        with patch(
+            "agentclaw.community.adapters.http.skill_center.skills.skill_admin",
+            return_value={"admin"},
+        ):
+            assert await interceptor.before(ctx) is ctx
+
+        assert ctx.metadata["permission_level"] == "SKILL_ADMIN"
+
+    @pytest.mark.asyncio
+    async def test_collaborator_permission_service_failure_is_fail_closed(self):
+        interceptor = _FailClosedSkillMutationPermissionInterceptor(
+            authorization_state_key="skill_mutation_authorized"
+        )
+        ctx = InterceptorContext(
+            user=AuthenticatedIdentity(id="1", operatorName="collab", staffId="collab"),
+            metadata={"_log_user_id": "collab", "_log_owner_id": "owner"},
+        )
+
+        with patch(
+            "agentclaw.community.adapters.http.skill_center.skills.skill_admin",
+            return_value=set(),
+        ), patch.object(
+            CollaboratorPermissionInterceptor,
+            "before",
+            new=AsyncMock(return_value=ctx),
+        ):
+            assert await interceptor.before(ctx) is None
+
+        assert ctx.response.error_code == 503
+
+    @pytest.mark.asyncio
+    async def test_verified_collaborator_grant_reaches_request_context(self):
+        interceptor = _FailClosedSkillMutationPermissionInterceptor(
+            authorization_state_key="skill_mutation_authorized"
+        )
+        request = SimpleNamespace(state=SimpleNamespace())
+        request_context = RequestContext(user_id="collab")
+        ctx = InterceptorContext(
+            user=AuthenticatedIdentity(id="1", operatorName="collab", staffId="collab"),
+            request=request,
+            route_kwargs={"ctx": request_context},
+            metadata={
+                "_log_user_id": "collab",
+                "_log_owner_id": "owner",
+                "permission_level": "ADMIN",
+            },
+        )
+
+        with patch(
+            "agentclaw.community.adapters.http.skill_center.skills.skill_admin",
+            return_value=set(),
+        ), patch.object(
+            CollaboratorPermissionInterceptor,
+            "before",
+            new=AsyncMock(return_value=ctx),
+        ):
+            assert await interceptor.before(ctx) is ctx
+
+        assert request.state.skill_mutation_authorized is True
+        assert request_context.metadata["skill_mutation_authorized"] is True

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_delete.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-def _make_service(device_fs, *, runtime_uses_pool_paths=False):
+def _make_service(
+    device_fs,
+    *,
+    runtime_uses_pool_paths=False,
+    device_owner_id: str | None = None,
+):
     """Build SkillService with a mocked device_fs_factory and stubbed deps."""
     from agentclaw.community.core.skill_center.services.skill_service import SkillService
 
@@ -23,9 +28,27 @@ def _make_service(device_fs, *, runtime_uses_pool_paths=False):
         device_fs_factory=factory,
         git_sync_service_factory=MagicMock(),
         runtime_uses_pool_paths=runtime_uses_pool_paths,
+        device_owner_id=device_owner_id,
     )
     svc._skill_repo.list_skill_set_references.return_value = []
     return svc, factory
+
+
+def test_collaborator_delete_requires_explicit_verified_authorization():
+    svc, _ = _make_service(MagicMock(), device_owner_id="owner-1")
+    skill = {"user_id": "owner-1"}
+
+    assert not svc._can_delete_skill(
+        skill,
+        user_id="collaborator-1",
+        authorized_bot_owner_id="owner-1",
+    )
+    assert svc._can_delete_skill(
+        skill,
+        user_id="collaborator-1",
+        authorized_bot_owner_id="owner-1",
+        collaborator_authorization_verified=True,
+    )
 
 
 class TestDeleteSkillStep1:

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -26,7 +26,6 @@ def _service(local_dir: Path, adapter, fake_fs) -> SkillService:
     repo = MagicMock()
     repo.list_skills.return_value = []  # get_skill_by_path -> None -> create path
     repo.get_bot_local_by_name.return_value = None
-    repo.get_by_git_path.return_value = None
     svc = SkillService(
         skill_repo=repo,
         skill_repo_sync=MagicMock(get_local_skills_root=MagicMock(return_value=None)),
@@ -80,48 +79,6 @@ async def test_upload_uses_bot_owner_for_skill_metadata():
 
 
 @pytest.mark.asyncio
-async def test_reupload_normalizes_historical_collaborator_owner_for_qualified_locator():
-    fake_fs = MagicMock()
-    fake_fs.delete_tree = AsyncMock(return_value=True)
-    fake_fs.write_file = AsyncMock()
-    local_dir = Path("/aidesktop/aidesktop_pre/bolt_data/staff_1/b1/openclaw/workspace/skills/skills-local")
-    svc = _service(local_dir, None, fake_fs)
-    historical = {
-        "id": "17",
-        "name": "sync-and-pr",
-        "bolt_id": "b1",
-        "user_id": "collaborator",
-        "git_path": f"local://{local_dir}/sync-and-pr",
-    }
-    svc._skill_repo.get_by_git_path.return_value = historical
-    svc._skill_repo.update.return_value = {**historical, "user_id": "bot-owner"}
-
-    uploaded = [
-        {
-            "filename": "SKILL.md",
-            "relative_path": "SKILL.md",
-            "content": SKILL_MD,
-        }
-    ]
-    result = await svc.upload_skill(
-        uploaded,
-        user_id="bot-owner",
-        bolt_id="b1",
-    )
-
-    svc._skill_repo.get_bot_local_by_name.assert_called_once_with(
-        bot_id="b1",
-        name="sync-and-pr",
-        user_id="bot-owner",
-    )
-    svc._skill_repo.get_by_git_path.assert_called_once_with(
-        f"local://{local_dir}/sync-and-pr"
-    )
-    assert svc._skill_repo.update.call_args.args[0] == "17"
-    assert svc._skill_repo.update.call_args.args[1]["user_id"] == "bot-owner"
-    assert result["user_id"] == "bot-owner"
-
-
 @pytest.mark.asyncio
 async def test_default_bot_upload_never_uses_unscoped_owner_lookup():
     """Shared ``default`` Bot IDs must not select another owner's same-name row."""
@@ -141,34 +98,7 @@ async def test_default_bot_upload_never_uses_unscoped_owner_lookup():
         name="sync-and-pr",
         user_id="bot-owner",
     )
-    svc._skill_repo.get_by_git_path.assert_not_called()
     svc._skill_repo.update.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_teclaw_upload_does_not_repair_foreign_historical_row():
-    """Teclaw's relative locator carries no owner scope and is never a repair key."""
-    fake_fs = MagicMock()
-    fake_fs.delete_tree = AsyncMock(return_value=True)
-    fake_fs.write_file = AsyncMock()
-    svc = _service(Path("skills-local"), to_local_skill_engine_path, fake_fs)
-    svc._skill_repo.get_by_git_path.return_value = {
-        "id": "foreign-skill",
-        "bolt_id": "default",
-        "name": "sync-and-pr",
-        "user_id": "another-owner",
-        "git_path": "local://skills-local/sync-and-pr",
-    }
-
-    await svc.upload_skill(
-        [{"filename": "SKILL.md", "relative_path": "SKILL.md", "content": SKILL_MD}],
-        user_id="bot-owner",
-        bolt_id="default",
-    )
-
-    svc._skill_repo.get_by_git_path.assert_not_called()
-    svc._skill_repo.update.assert_not_called()
-    assert svc.create_skill.call_args.kwargs["user_id"] == "bot-owner"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -62,7 +62,7 @@ async def test_teclaw_upload_adapts_path_and_stores_logical_git_path():
 
 
 @pytest.mark.asyncio
-async def test_upload_uses_author_id_for_skill_metadata():
+async def test_upload_uses_bot_owner_for_skill_metadata():
     fake_fs = MagicMock()
     fake_fs.delete_tree = AsyncMock(return_value=True)
     fake_fs.write_file = AsyncMock()
@@ -72,11 +72,48 @@ async def test_upload_uses_author_id_for_skill_metadata():
     await svc.upload_skill(
         uploaded,
         user_id="bot-owner",
-        author_id="collaborator",
         bolt_id="b1",
     )
 
-    assert svc.create_skill.call_args.kwargs["user_id"] == "collaborator"
+    assert svc.create_skill.call_args.kwargs["user_id"] == "bot-owner"
+
+
+@pytest.mark.asyncio
+async def test_reupload_normalizes_historical_collaborator_owner():
+    fake_fs = MagicMock()
+    fake_fs.delete_tree = AsyncMock(return_value=True)
+    fake_fs.write_file = AsyncMock()
+    svc = _service(Path("skills-local"), to_local_skill_engine_path, fake_fs)
+    historical = {
+        "id": "17",
+        "name": "sync-and-pr",
+        "user_id": "collaborator",
+        "git_path": "local://skills-local/sync-and-pr",
+    }
+    svc._skill_repo.get_bot_local_by_name.return_value = historical
+    svc._skill_repo.update.return_value = {**historical, "user_id": "bot-owner"}
+
+    uploaded = [
+        {
+            "filename": "SKILL.md",
+            "relative_path": "SKILL.md",
+            "content": SKILL_MD,
+        }
+    ]
+    result = await svc.upload_skill(
+        uploaded,
+        user_id="bot-owner",
+        bolt_id="b1",
+    )
+
+    svc._skill_repo.get_bot_local_by_name.assert_called_once_with(
+        bot_id="b1",
+        name="sync-and-pr",
+        user_id=None,
+    )
+    assert svc._skill_repo.update.call_args.args[0] == "17"
+    assert svc._skill_repo.update.call_args.args[1]["user_id"] == "bot-owner"
+    assert result["user_id"] == "bot-owner"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -26,6 +26,7 @@ def _service(local_dir: Path, adapter, fake_fs) -> SkillService:
     repo = MagicMock()
     repo.list_skills.return_value = []  # get_skill_by_path -> None -> create path
     repo.get_bot_local_by_name.return_value = None
+    repo.get_by_git_path.return_value = None
     svc = SkillService(
         skill_repo=repo,
         skill_repo_sync=MagicMock(get_local_skills_root=MagicMock(return_value=None)),
@@ -87,10 +88,11 @@ async def test_reupload_normalizes_historical_collaborator_owner():
     historical = {
         "id": "17",
         "name": "sync-and-pr",
+        "bolt_id": "b1",
         "user_id": "collaborator",
         "git_path": "local://skills-local/sync-and-pr",
     }
-    svc._skill_repo.get_bot_local_by_name.return_value = historical
+    svc._skill_repo.get_by_git_path.return_value = historical
     svc._skill_repo.update.return_value = {**historical, "user_id": "bot-owner"}
 
     uploaded = [
@@ -109,11 +111,38 @@ async def test_reupload_normalizes_historical_collaborator_owner():
     svc._skill_repo.get_bot_local_by_name.assert_called_once_with(
         bot_id="b1",
         name="sync-and-pr",
-        user_id=None,
+        user_id="bot-owner",
+    )
+    svc._skill_repo.get_by_git_path.assert_called_once_with(
+        "local://skills-local/sync-and-pr"
     )
     assert svc._skill_repo.update.call_args.args[0] == "17"
     assert svc._skill_repo.update.call_args.args[1]["user_id"] == "bot-owner"
     assert result["user_id"] == "bot-owner"
+
+
+@pytest.mark.asyncio
+async def test_default_bot_upload_never_uses_unscoped_owner_lookup():
+    """Shared ``default`` Bot IDs must not select another owner's same-name row."""
+    fake_fs = MagicMock()
+    fake_fs.delete_tree = AsyncMock(return_value=True)
+    fake_fs.write_file = AsyncMock()
+    svc = _service(Path("skills-local"), to_local_skill_engine_path, fake_fs)
+
+    await svc.upload_skill(
+        [{"filename": "SKILL.md", "relative_path": "SKILL.md", "content": SKILL_MD}],
+        user_id="bot-owner",
+        bolt_id="default",
+    )
+
+    svc._skill_repo.get_bot_local_by_name.assert_called_once_with(
+        bot_id="default",
+        name="sync-and-pr",
+        user_id="bot-owner",
+    )
+    svc._skill_repo.get_by_git_path.assert_called_once_with(
+        "local://skills-local/sync-and-pr"
+    )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_upload_teclaw.py
@@ -80,17 +80,18 @@ async def test_upload_uses_bot_owner_for_skill_metadata():
 
 
 @pytest.mark.asyncio
-async def test_reupload_normalizes_historical_collaborator_owner():
+async def test_reupload_normalizes_historical_collaborator_owner_for_qualified_locator():
     fake_fs = MagicMock()
     fake_fs.delete_tree = AsyncMock(return_value=True)
     fake_fs.write_file = AsyncMock()
-    svc = _service(Path("skills-local"), to_local_skill_engine_path, fake_fs)
+    local_dir = Path("/aidesktop/aidesktop_pre/bolt_data/staff_1/b1/openclaw/workspace/skills/skills-local")
+    svc = _service(local_dir, None, fake_fs)
     historical = {
         "id": "17",
         "name": "sync-and-pr",
         "bolt_id": "b1",
         "user_id": "collaborator",
-        "git_path": "local://skills-local/sync-and-pr",
+        "git_path": f"local://{local_dir}/sync-and-pr",
     }
     svc._skill_repo.get_by_git_path.return_value = historical
     svc._skill_repo.update.return_value = {**historical, "user_id": "bot-owner"}
@@ -114,7 +115,7 @@ async def test_reupload_normalizes_historical_collaborator_owner():
         user_id="bot-owner",
     )
     svc._skill_repo.get_by_git_path.assert_called_once_with(
-        "local://skills-local/sync-and-pr"
+        f"local://{local_dir}/sync-and-pr"
     )
     assert svc._skill_repo.update.call_args.args[0] == "17"
     assert svc._skill_repo.update.call_args.args[1]["user_id"] == "bot-owner"
@@ -140,9 +141,34 @@ async def test_default_bot_upload_never_uses_unscoped_owner_lookup():
         name="sync-and-pr",
         user_id="bot-owner",
     )
-    svc._skill_repo.get_by_git_path.assert_called_once_with(
-        "local://skills-local/sync-and-pr"
+    svc._skill_repo.get_by_git_path.assert_not_called()
+    svc._skill_repo.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_teclaw_upload_does_not_repair_foreign_historical_row():
+    """Teclaw's relative locator carries no owner scope and is never a repair key."""
+    fake_fs = MagicMock()
+    fake_fs.delete_tree = AsyncMock(return_value=True)
+    fake_fs.write_file = AsyncMock()
+    svc = _service(Path("skills-local"), to_local_skill_engine_path, fake_fs)
+    svc._skill_repo.get_by_git_path.return_value = {
+        "id": "foreign-skill",
+        "bolt_id": "default",
+        "name": "sync-and-pr",
+        "user_id": "another-owner",
+        "git_path": "local://skills-local/sync-and-pr",
+    }
+
+    await svc.upload_skill(
+        [{"filename": "SKILL.md", "relative_path": "SKILL.md", "content": SKILL_MD}],
+        user_id="bot-owner",
+        bolt_id="default",
     )
+
+    svc._skill_repo.get_by_git_path.assert_not_called()
+    svc._skill_repo.update.assert_not_called()
+    assert svc.create_skill.call_args.kwargs["user_id"] == "bot-owner"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -255,7 +255,7 @@ class TestSkillServiceAsyncRouting:
         repo.get_bot_local_by_name.assert_called_once_with(
             bot_id="bot1",
             name="shared-name",
-            user_id="user1",
+            user_id=None,
         )
         repo.update.assert_not_called()
         repo.create.assert_called_once()

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -255,7 +255,7 @@ class TestSkillServiceAsyncRouting:
         repo.get_bot_local_by_name.assert_called_once_with(
             bot_id="bot1",
             name="shared-name",
-            user_id=None,
+            user_id="user1",
         )
         repo.update.assert_not_called()
         repo.create.assert_called_once()


### PR DESCRIPTION
## Summary

- keep the authenticated collaborator as the authorization and audit actor only
- persist the Service Bot owner from the Bot record as `ac_skill.user_id` for collaborator uploads
- identify Bot-private local Skills by Bot + name during re-upload and normalize historical collaborator-owned rows instead of creating duplicates
- preserve existing device ownership, Pool path, parameter, and collaborator permission behavior

## Test Plan

- `uv run ruff check` on all changed files
- Skill Center API/domain/contract/architecture suite: 736 passed