### PR TITLE
feat(backend): include caller instances in Passport token refresh

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -11,6 +11,7 @@ import shutil
 import string
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional, Dict, Any, List, Tuple, TYPE_CHECKING
@@ -66,9 +67,7 @@ from agentclaw.community.core.workspace.path_factory import (
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.utils.avernet_tenant import (
-    DEFAULT_AVERNET_TENANT,
     bind_current_avernet_tenant,
-    get_current_avernet_tenant,
 )
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.core.devices.errors import (
@@ -83,6 +82,7 @@ from agentclaw.community.core.devices.repository.protocol import (
     DeviceBindingRepository,
     OssToNasRecordRepository,
 )
+from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.devices.services.device_service import DeviceService
 from agentclaw.community.plugin_api.drm import DRMReaderPlugin
 from agentclaw.community.plugin_api.passport import PassportError
@@ -98,6 +98,11 @@ logger = get_logger()
 # and is reaped on the next restart attempt so a bot is never permanently
 # blocked from restarting.
 RESTART_LOCK_TTL_SECONDS = 120
+
+# Passport refresh is callback-driven and retryable. Keep caller-instance
+# fan-out bounded while still attempting every instance before reporting an
+# aggregate failure.
+_CALLER_REFRESH_MAX_WORKERS = 5
 
 
 def _compose_operator_context(user_id: str, nick_name: str) -> OperatorContext:
@@ -4624,7 +4629,10 @@ class BotService:
 
         new_token = token
         token_prefix = new_token[:20]
-        logger.info(f"[bot_service.refresh_passport_token] Got new token for bot_id={bot_id}, user_id={user_id}, bot_type={bot_type}, token_prefix={token_prefix}...")
+        logger.info(
+            f"[bot_service.refresh_passport_token] Got new token for "
+            f"bot_id={bot_id}, user_id={user_id}, bot_type={bot_type}, has_token=yes"
+        )
 
         # 提取 agent_code
         from agentclaw.community.core.bot_management.utils import resolve_agent_code
@@ -4744,8 +4752,10 @@ class BotService:
     ) -> list[dict]:
         """Service Bot Passport Token 热更新入口。
 
-        同时更新草稿态和已发布态的 binding（如果存在）。
+        同时更新草稿态、已发布态和 ACTIVE caller 实例 binding（如果存在）。
         草稿态复用 `_hot_update_by_device_binding`，已发布态调用 `_hot_update_by_publish_binding`。
+        caller 实例使用同一份 owner Passport token；caller 自己的
+        ``x-caller-token`` 属于独立链路，不在这里处理。
 
         Args:
             bot_id: Bot ID
@@ -4754,10 +4764,12 @@ class BotService:
             bot: bot 字典（用于获取草稿态 binding_id）
 
         Returns:
-            成功更新的 binding 列表，每项为 {"binding_id": int, "type": "draft"|"online"|"verify"}
+            成功更新的 binding 列表，每项为
+            {"binding_id": int, "type": "draft"|"online"|"verify"|"caller"}
 
         Raises:
-            BotServiceError: 草稿态和发布态均无可用的设备 binding 时抛出
+            BotServiceError: 任一目标失败，或所有目标均不存在时抛出。所有
+                已发现目标都会先 best-effort 尝试完毕，再聚合失败。
         """
         updated_bindings: list[dict] = []
         errors: list[str] = []
@@ -4781,7 +4793,7 @@ class BotService:
                     "device_count": len(devices),
                     "devices": devices,
                 })
-            except BotServiceError as e:
+            except Exception as e:
                 logger.warning(
                     f"[_hot_update_service_bot_passport_token] Draft binding update failed: "
                     f"bot_id={bot_id}, user_id={user_id}, binding_id={draft_binding_id}, error={e}"
@@ -4804,10 +4816,18 @@ class BotService:
         has_publish_record = False
 
         for status, binding_key in _PUBLISHED_STATUS_BINDINGS:
-            publish_record = publish_repo.get_by_publish_bot_id(
-                publish_bot_id=bot_id, owner_id=user_id, env=env,
-                publish_status=status,
-            )
+            try:
+                publish_record = publish_repo.get_by_publish_bot_id(
+                    publish_bot_id=bot_id, owner_id=user_id, env=env,
+                    publish_status=status,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[_hot_update_service_bot_passport_token] {binding_key} publish query failed: "
+                    f"bot_id={bot_id}, user_id={user_id}, status={status}, error={e}"
+                )
+                errors.append(f"{binding_key}: 发布记录查询失败: {e}")
+                continue
             if not publish_record:
                 continue
             has_publish_record = True
@@ -4838,7 +4858,7 @@ class BotService:
                     "device_count": len(devices),
                     "devices": devices,
                 })
-            except BotServiceError as e:
+            except Exception as e:
                 logger.warning(
                     f"[_hot_update_service_bot_passport_token] {binding_key} binding update failed: "
                     f"bot_id={bot_id}, user_id={user_id}, binding_id={binding_id}, error={e}"
@@ -4848,6 +4868,70 @@ class BotService:
         if not has_publish_record:
             logger.info(
                 f"[_hot_update_service_bot_passport_token] No publish record: "
+                f"bot_id={bot_id}, user_id={user_id}, env={env}"
+            )
+
+        # ========== 步骤 3: 并发更新 ACTIVE caller 实例 ==========
+        try:
+            caller_bindings = self._device_binding_repo.list_active_caller_instance_bindings(
+                bot_id=bot_id,
+                owner_id=user_id,
+                env=env,
+            )
+        except Exception as e:
+            logger.warning(
+                f"[_hot_update_service_bot_passport_token] Caller binding query failed: "
+                f"bot_id={bot_id}, user_id={user_id}, env={env}, error={e}"
+            )
+            errors.append(f"caller: binding 查询失败: {e}")
+            caller_bindings = []
+
+        if caller_bindings:
+            logger.info(
+                f"[_hot_update_service_bot_passport_token] Updating caller bindings: "
+                f"bot_id={bot_id}, user_id={user_id}, caller_count={len(caller_bindings)}, "
+                f"max_workers={_CALLER_REFRESH_MAX_WORKERS}"
+            )
+            update_caller = bind_current_avernet_tenant(
+                self._hot_update_by_caller_binding
+            )
+            try:
+                with ThreadPoolExecutor(
+                    max_workers=_CALLER_REFRESH_MAX_WORKERS
+                ) as executor:
+                    future_to_binding = {
+                        executor.submit(
+                            update_caller,
+                            bot_id=bot_id,
+                            user_id=user_id,
+                            token=token,
+                            binding=binding,
+                            agent_code=agent_code,
+                        ): binding
+                        for binding in caller_bindings
+                    }
+                    for future in as_completed(future_to_binding):
+                        binding = future_to_binding[future]
+                        try:
+                            updated_bindings.append(future.result())
+                        except Exception as e:
+                            logger.warning(
+                                f"[_hot_update_service_bot_passport_token] Caller binding update failed: "
+                                f"bot_id={bot_id}, user_id={user_id}, binding_id={binding.id}, "
+                                f"device_id={binding.device_id}, error={e}"
+                            )
+                            errors.append(
+                                f"caller(binding_id={binding.id}): {e}"
+                            )
+            except Exception as e:
+                logger.warning(
+                    f"[_hot_update_service_bot_passport_token] Caller fan-out failed: "
+                    f"bot_id={bot_id}, user_id={user_id}, error={e}"
+                )
+                errors.append(f"caller: 并发更新失败: {e}")
+        else:
+            logger.info(
+                f"[_hot_update_service_bot_passport_token] No active caller binding: "
                 f"bot_id={bot_id}, user_id={user_id}, env={env}"
             )
 
@@ -4863,6 +4947,48 @@ class BotService:
             f"bot_id={bot_id}, user_id={user_id}, updated_bindings={updated_bindings}"
         )
         return updated_bindings
+
+    def _hot_update_by_caller_binding(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        token: str,
+        binding: DeviceBindingRecord,
+        agent_code: str = "",
+    ) -> dict:
+        """用 owner Passport token 更新一个 caller BaaS Bot 的 ACTIVE 设备。"""
+        service = self._device_service_provider()
+        device = AllocatedDevice(
+            device_id=binding.device_id,
+            device_provider=binding.device_provider,
+            device_props={
+                **(binding.device_props or {}),
+                "bolt_id": bot_id,
+                "entity_id": user_id,
+            },
+        )
+        update_result = service.update_device_headers(
+            device=device,
+            agent_pass_token=token,
+            agent_code=agent_code,
+            active_only=True,
+        )
+        devices = update_result if isinstance(update_result, list) else []
+        if not devices:
+            raise BotServiceError("caller 实例没有 ACTIVE 物理设备")
+
+        logger.info(
+            f"[_hot_update_by_caller_binding] Hot-update succeeded: "
+            f"bot_id={bot_id}, user_id={user_id}, binding_id={binding.id}, "
+            f"device_id={binding.device_id}, updated_devices={len(devices)}"
+        )
+        return {
+            "binding_id": binding.id,
+            "type": "caller",
+            "device_count": len(devices),
+            "devices": devices,
+        }
 
     def _hot_update_by_publish_binding(
         self, bot_id: str, user_id: str, token: str, binding_id: int, agent_code: str = ""

--- a/src/backend/src/agentclaw/community/core/devices/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/devices/repository/protocol.py
@@ -143,6 +143,21 @@ class DeviceBindingRepository(Protocol):
         """
         ...
 
+    def list_active_caller_instance_bindings(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+    ) -> list[DeviceBindingRecord]:
+        """列出服务 Bot 在指定环境中的 ACTIVE caller 实例 binding。
+
+        caller 实例由 ``apply_reason=caller_instance:{bot_id}`` 标识，且
+        binding 的 ``entity_id`` 始终是服务 Bot owner；``applied_by`` 才是
+        caller。这里只返回 BaaS staff binding，并按 ``device_id`` 去重。
+        """
+        ...
+
     def count_non_released_bindings(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
@@ -1,0 +1,187 @@
+"""BaaS physical-device outbound-header updates."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agentclaw.community.core.devices.errors import DeviceServiceError
+from agentclaw.community.core.devices.models import AllocatedDevice
+from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
+    TECLAW_DEVICE_PROVIDER,
+)
+from agentclaw.community.log import get_logger
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.service_bot.services.baas_service import BaasService
+
+
+logger = get_logger()
+
+
+class BaasDeviceHeaderUpdateError(DeviceServiceError):
+    """Internal failure surfaced by the BaaS header-update module."""
+
+
+class BaasDeviceHeaderUpdater:
+    """Build and install outbound rules for one BaaS logical Bot."""
+
+    def __init__(self, baas_service: BaasService) -> None:
+        self._baas_service = baas_service
+
+    def update(
+        self,
+        *,
+        device: AllocatedDevice,
+        agent_pass_token: str = "",
+        agent_code: str = "",
+        active_only: bool = False,
+    ) -> list[dict]:
+        """Update one physical device or every eligible device under a Bot.
+
+        ``device_props.device_uuid`` selects single-device mode. Otherwise the
+        updater lists physical devices by the BaaS ``bot_uuid``. When
+        ``active_only`` is true, only devices whose BaaS status is exactly
+        ``ACTIVE`` are eligible.
+        """
+        bolt_id = device.device_props.get("bolt_id", "")
+        owner_id = device.device_props.get("entity_id", "")
+        device_uuid = device.device_props.get("device_uuid", "")
+
+        logger.info(
+            f"[BaasDeviceHeaderUpdater.update] Start: "
+            f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
+            f"has_device_uuid={'yes' if device_uuid else 'no'}, active_only={active_only}"
+        )
+
+        try:
+            if device.device_provider == TECLAW_DEVICE_PROVIDER:
+                outbound_rule = self._baas_service._build_teclaw_outbound_operation_rule(
+                    agent_pass_token=agent_pass_token,
+                )
+            else:
+                outbound_rule = self._baas_service._build_outbound_operation_rule(
+                    bot_id=bolt_id,
+                    owner_id=owner_id,
+                    agent_pass_token=agent_pass_token,
+                    agent_code=agent_code,
+                )
+        except Exception as e:
+            logger.error(
+                f"[BaasDeviceHeaderUpdater.update] Build rule failed: "
+                f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, error={e}"
+            )
+            raise BaasDeviceHeaderUpdateError(f"构建 outbound rule 失败: {e}") from e
+
+        if outbound_rule is None:
+            return []
+
+        try:
+            if device_uuid:
+                updated_devices = self._update_single_device(
+                    device=device,
+                    device_uuid=device_uuid,
+                    outbound_rule=outbound_rule,
+                    active_only=active_only,
+                )
+            else:
+                updated_devices = self._update_bot_devices(
+                    device=device,
+                    outbound_rule=outbound_rule,
+                    active_only=active_only,
+                )
+            logger.info(
+                f"[BaasDeviceHeaderUpdater.update] Done: "
+                f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
+                f"updated_count={len(updated_devices)}"
+            )
+            return updated_devices
+        except Exception as e:
+            logger.error(
+                f"[BaasDeviceHeaderUpdater.update] BaaS API error: "
+                f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, error={e}"
+            )
+            raise BaasDeviceHeaderUpdateError(f"BaaS 设备 header 更新失败: {e}") from e
+
+    def _update_single_device(
+        self,
+        *,
+        device: AllocatedDevice,
+        device_uuid: str,
+        outbound_rule: object,
+        active_only: bool,
+    ) -> list[dict]:
+        device_info = self._baas_service.get_device_by_uuid(device_uuid)
+        if active_only and not self._is_active(device_info):
+            logger.info(
+                f"[BaasDeviceHeaderUpdater.update] Skip non-active device: "
+                f"device_id={device.device_id}, device_uuid={device_uuid}, "
+                f"status={device_info.get('status', '')}"
+            )
+            return []
+
+        paas_device_id = device_info.get("provider_device_id")
+        if not paas_device_id:
+            raise BaasDeviceHeaderUpdateError(
+                f"BaaS 设备缺少 provider_device_id: device_uuid={device_uuid}"
+            )
+        self._baas_service.update_device_outbound_rule(
+            paas_device_id,
+            outbound_rule,
+        )
+        logger.info(
+            f"[BaasDeviceHeaderUpdater.update] Single device updated: "
+            f"device_id={device.device_id}, device_uuid={device_uuid}, "
+            f"paas_device_id={paas_device_id}"
+        )
+        return [{
+            "baas_device_uuid": device_uuid,
+            "paas_device_id": paas_device_id,
+        }]
+
+    def _update_bot_devices(
+        self,
+        *,
+        device: AllocatedDevice,
+        outbound_rule: object,
+        active_only: bool,
+    ) -> list[dict]:
+        bot_uuid = device.device_props.get("bot_uuid") or device.device_id
+        devices = self._baas_service.list_devices_by_bot_uuid(bot_uuid)
+        if active_only:
+            devices = [dev for dev in devices if self._is_active(dev)]
+        if not devices:
+            logger.warning(
+                f"[BaasDeviceHeaderUpdater.update] No devices found: "
+                f"device_id={device.device_id}, bot_uuid={bot_uuid}, "
+                f"active_only={active_only}"
+            )
+            return []
+
+        updated_devices: list[dict] = []
+        for physical_device in devices:
+            paas_device_id = physical_device.get("provider_device_id")
+            device_uuid = physical_device.get("device_uuid", "")
+            if not paas_device_id:
+                logger.warning(
+                    f"[BaasDeviceHeaderUpdater.update] Skip device without provider_device_id: "
+                    f"device_id={device.device_id}, device_uuid={device_uuid}"
+                )
+                continue
+            self._baas_service.update_device_outbound_rule(
+                paas_device_id,
+                outbound_rule,
+            )
+            updated_devices.append({
+                "device_uuid": device_uuid,
+                "paas_device_id": paas_device_id,
+            })
+            logger.info(
+                f"[BaasDeviceHeaderUpdater.update] Device updated: "
+                f"device_id={device.device_id}, device_uuid={device_uuid}, "
+                f"paas_device_id={paas_device_id}"
+            )
+        return updated_devices
+
+    @staticmethod
+    def _is_active(device: dict) -> bool:
+        return str(device.get("status", "")).upper() == "ACTIVE"

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
@@ -24,6 +24,10 @@ from agentclaw.community.core.devices.services.baas_device_lifecycle_executor im
     BaasDeviceLifecycleError,
     BaasDeviceLifecycleExecutor,
 )
+from agentclaw.community.core.devices.services.baas_device_header_updater import (
+    BaasDeviceHeaderUpdateError,
+    BaasDeviceHeaderUpdater,
+)
 from agentclaw.community.core.devices.services.baas_container_init import (
     BaasContainerInitializer,
     _deserialize_symbol,
@@ -38,9 +42,6 @@ from agentclaw.community.core.devices.services.device_service import (
     BAAS_DEVICE_PROVIDER,
     DEFAULT_ENGINE_TYPE,
     DeviceService,
-)
-from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
-    TECLAW_DEVICE_PROVIDER,
 )
 from agentclaw.community.log import get_logger
 
@@ -115,6 +116,7 @@ class BaasDeviceService(DeviceService):
             task_queue_service=task_queue_service,
         )
         self._baas_service = baas_service
+        self._header_updater = BaasDeviceHeaderUpdater(baas_service)
         self._lifecycle_executor = lifecycle_executor or BaasDeviceLifecycleExecutor(
             baas_service
         )
@@ -852,149 +854,15 @@ class BaasDeviceService(DeviceService):
         device: AllocatedDevice,
         agent_pass_token: str = "",
         agent_code: str = "",
+        active_only: bool = False,
     ) -> list[dict]:
-        """热更新 BaaS 设备出站 header 规则。
-
-        通过 BaaS 层 PUT /paas/devices/{paas_device_id}/outbound-rule 接口更新，
-        不再直接调用 Arca SDK。
-
-        说明：BaaS 侧一个逻辑 Bot 可能对应多台 Arca 物理设备实例，ocb 侧 bot 粒度与 BaaS 侧不同。
-        因此支持两种更新粒度：
-        1. 单设备实例：按 device_uuid 精确更新一台设备（device_uuid 是 BaaS
-           侧的概念，如 DEVICE-xxx，用于查询设备信息）。
-           例如：bootstrap_device_auth 回调时，刚启动的这台设备需要拿到 agent_code 和
-           passport token，此时只更新它自身，不影响该 Bot 下的其他设备。
-        2. Bot 维度批量：按 BaaS 侧 bot_uuid 查出该 Bot 下全部设备，全部更新。
-           例如：定时刷新 passport token（refresh token）时，需要把该 Bot 下的所有
-           设备批量更新为新 token。
-
-        Args:
-            device: 已分配设备信息
-            agent_pass_token: Agent Passport token
-            agent_code: Agent Passport agent_code
-
-        Returns:
-            成功更新的设备列表，每项包含 device_uuid 和 paas_device_id
-
-        Raises:
-            BaasDeviceServiceError: 更新失败
-        """
-        # 从 device 中提取关键字段
-        bolt_id = device.device_props.get("bolt_id", "")
-        owner_id = device.device_props.get("entity_id", "")
-        device_uuid = device.device_props.get("device_uuid", "")
-
-        logger.info(
-            f"[BaasDeviceService.update_device_headers] Start: "
-            f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-            f"has_device_uuid={'yes' if device_uuid else 'no'}"
-        )
-
-        # Teclaw 由 BaaS 托管，只构造身份认证（identity-auth）出站规则；
-        # 其他 BaaS 设备保持完整的 outbound-rule 规则包。规则内容由注入的
-        # OutboundRuleProvider 决定（corp 才有网关域名/secret，community 为空）。
+        """热更新 BaaS 设备出站 header 规则。"""
         try:
-            if device.device_provider == TECLAW_DEVICE_PROVIDER:
-                outbound_rule = self._baas_service._build_teclaw_outbound_operation_rule(
-                    agent_pass_token=agent_pass_token,
-                )
-            else:
-                outbound_rule = self._baas_service._build_outbound_operation_rule(
-                    bot_id=bolt_id,
-                    owner_id=owner_id,
-                    agent_pass_token=agent_pass_token,
-                    agent_code=agent_code,
-                )
-        except Exception as e:
-            logger.error(
-                f"[BaasDeviceService.update_device_headers] Build rule failed: "
-                f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, error={e}"
+            return self._header_updater.update(
+                device=device,
+                agent_pass_token=agent_pass_token,
+                agent_code=agent_code,
+                active_only=active_only,
             )
-            raise BaasDeviceServiceError(f"构建 outbound rule 失败: {e}") from e
-
-        if outbound_rule is None:
-            return []
-
-        updated_devices: list[dict] = []
-
-        try:
-            if device_uuid:
-                # ========== 单设备场景：按 device_uuid 精确更新 ==========
-                logger.info(
-                    f"[BaasDeviceService.update_device_headers] Single device mode: "
-                    f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-                    f"device_uuid={device_uuid}"
-                )
-                # 通过 device_uuid 查询 BaaS 设备信息，获取 PaaS 层设备 ID
-                device_info = self._baas_service.get_device_by_uuid(device_uuid)
-                paas_device_id = device_info.get("provider_device_id")
-                if not paas_device_id:
-                    raise BaasDeviceServiceError(
-                        f"BaaS 设备缺少 provider_device_id: device_uuid={device_uuid}"
-                    )
-                # 调用 BaaS 接口更新该设备的出站 header 规则
-                self._baas_service.update_device_outbound_rule(paas_device_id, outbound_rule)
-                updated_devices.append({
-                    "baas_device_uuid": device_uuid,
-                    "paas_device_id": paas_device_id,
-                })
-                logger.info(
-                    f"[BaasDeviceService.update_device_headers] Single device updated: "
-                    f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-                    f"device_uuid={device_uuid}, paas_device_id={paas_device_id}"
-                )
-            else:
-                # ========== 批量场景：按 bot_uuid 全量更新 ==========
-                # 优先用 device_props.bot_uuid(个人 bot via BaaS 写入);否则
-                # 兼容老的"device_id 就是 bot_uuid"约定(桌面 bot 在用)。
-                bot_uuid = device.device_props.get("bot_uuid") or device.device_id
-                logger.info(
-                    f"[BaasDeviceService.update_device_headers] Batch mode: "
-                    f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-                    f"bot_uuid={bot_uuid}"
-                )
-                # 查询该 Bot 下的全部 BaaS 设备
-                devices = self._baas_service.list_devices_by_bot_uuid(bot_uuid)
-                if not devices:
-                    logger.warning(
-                        f"[BaasDeviceService.update_device_headers] No devices found: "
-                        f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-                        f"bot_uuid={bot_uuid}"
-                    )
-                    return updated_devices
-
-                # 遍历设备列表，逐台更新出站规则
-                for dev in devices:
-                    paas_device_id = dev.get("provider_device_id")
-                    dev_uuid = dev.get("device_uuid", "")
-                    if not paas_device_id:
-                        logger.warning(
-                            f"[BaasDeviceService.update_device_headers] Skip device: "
-                            f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-                            f"device_uuid={dev_uuid}"
-                        )
-                        continue
-                    self._baas_service.update_device_outbound_rule(paas_device_id, outbound_rule)
-                    updated_devices.append({
-                        "device_uuid": dev_uuid,
-                        "paas_device_id": paas_device_id,
-                    })
-                    logger.info(
-                        f"[BaasDeviceService.update_device_headers] Device updated: "
-                        f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-                        f"device_uuid={dev_uuid}, paas_device_id={paas_device_id}"
-                    )
-
-            logger.info(
-                f"[BaasDeviceService.update_device_headers] Done: "
-                f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, "
-                f"updated_count={len(updated_devices)}"
-            )
-            return updated_devices
-
-        except Exception as e:
-            logger.error(
-                f"[BaasDeviceService.update_device_headers] BaaS API error: "
-                f"device_id={device.device_id}, bolt_id={bolt_id}, owner_id={owner_id}, error={e}"
-            )
-            raise BaasDeviceServiceError(f"BaaS 设备 header 更新失败: {e}") from e
+        except BaasDeviceHeaderUpdateError as e:
+            raise BaasDeviceServiceError(str(e)) from e

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -337,10 +337,13 @@ class DeviceService:
         device: AllocatedDevice,
         agent_pass_token: str = "",
         agent_code: str = "",
+        active_only: bool = False,
     ) -> bool:
         """Update outbound header rules on a running device (hot-update hook)。
 
         Subclasses override this to provider-specific implementations.
+        ``active_only`` limits a provider's batch target set to ACTIVE physical
+        devices; providers without physical-device fan-out may ignore it.
         Default: no-op.
         """
         return False

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
@@ -689,6 +689,7 @@ class DeviceServiceRouter(DeviceService):
         device: Any,
         agent_pass_token: str = "",
         agent_code: str = "",
+        active_only: bool = False,
     ) -> bool | list[dict]:
         """热更新设备出站 header 规则 - 根据 device_provider 路由.
 
@@ -696,6 +697,7 @@ class DeviceServiceRouter(DeviceService):
             device: 已分配设备信息（AllocatedDevice）
             agent_pass_token: Agent Passport token
             agent_code: Agent Passport agent_code
+            active_only: 是否只更新 ACTIVE 物理设备
 
         Returns:
             bool | list[dict]: 更新是否成功，或 BaaS 模式下返回更新的设备列表
@@ -705,18 +707,19 @@ class DeviceServiceRouter(DeviceService):
         """
         provider = getattr(device, "device_provider", "")
         device_id = getattr(device, "device_id", "")
-        token_prefix = agent_pass_token[:6] if agent_pass_token else "(empty)"
 
         if provider in self._providers:
             logger.info(
                 f"[update_device_headers] Routing: device_id={device_id}, "
                 f"provider={provider}, agent_code={agent_code or '(empty)'}, "
-                f"token_prefix={token_prefix}..."
+                f"has_token={'yes' if agent_pass_token else 'no'}, "
+                f"active_only={active_only}"
             )
             return self._providers[provider].update_device_headers(
                 device=device,
                 agent_pass_token=agent_pass_token,
                 agent_code=agent_code,
+                active_only=active_only,
             )
         logger.warning(
             f"[update_device_headers] Unknown provider: device_id={device_id}, "
@@ -726,6 +729,7 @@ class DeviceServiceRouter(DeviceService):
             device=device,
             agent_pass_token=agent_pass_token,
             agent_code=agent_code,
+            active_only=active_only,
         )
 
     def bootstrap_device_auth(

--- a/src/backend/src/agentclaw/community/plugins/device_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/device_repository.py
@@ -343,6 +343,41 @@ class DeviceRepository(_DeviceBindingRepositoryProtocol):
             ]
             return total, items
 
+    def list_active_caller_instance_bindings(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        env: str,
+    ) -> list[DeviceBindingRecord]:
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(EntityDeviceBinding)
+                .filter(
+                    EntityDeviceBinding.env == env,
+                    EntityDeviceBinding.entity_id == owner_id,
+                    EntityDeviceBinding.entity_type == "staff",
+                    EntityDeviceBinding.status == _DeviceBindingStatus.ACTIVE,
+                    EntityDeviceBinding.device_provider == "baas",
+                    EntityDeviceBinding.apply_reason
+                    == f"caller_instance:{bot_id}",
+                )
+                .order_by(EntityDeviceBinding.id.desc())
+                .all()
+            )
+
+            # ``device_id`` is unique in prod, but keep this defensive de-dupe
+            # for legacy/local data and retain the latest binding deterministically.
+            seen_device_ids: set[str] = set()
+            bindings: list[DeviceBindingRecord] = []
+            for row in rows:
+                record = _to_record(row)
+                if record is None or record.device_id in seen_device_ids:
+                    continue
+                seen_device_ids.add(record.device_id)
+                bindings.append(record)
+            return bindings
+
     def count_non_released_bindings(
         self,
         *,

--- a/src/backend/tests/community/adapters/http/bot_management/test_refresh_token_callback.py
+++ b/src/backend/tests/community/adapters/http/bot_management/test_refresh_token_callback.py
@@ -1,13 +1,17 @@
 """refresh-token 回调按 (bot_id, owner_workno) 跨租户解析,不被 tenant guard 挡。"""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
     BotService,
+    BotServiceError,
+)
+from agentclaw.community.adapters.http.bot_management.router import (
+    refresh_bot_passport_token,
 )
 
 
@@ -42,3 +46,48 @@ def test_callback_missing_bot_raises_not_found():
         svc.hot_update_passport_token_to_device(
             bot_id="missing", user_id="user001", token="tok"
         )
+
+
+@pytest.mark.asyncio
+async def test_http_callback_success_contract_is_unchanged():
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "bot_id": "service-bot-1",
+            "owner_workno": "owner-1",
+            "token": "fake-owner-passport-token",
+        }
+    )
+    svc = MagicMock()
+    svc.hot_update_passport_token_to_device.return_value = {
+        "token_prefix": "fake-owner-passport-",
+        "bindings": [{"binding_id": 30, "type": "caller"}],
+    }
+
+    response = await refresh_bot_passport_token(request=request, bot_service=svc)
+
+    assert response.success is True
+    assert response.error_code == 200
+    assert response.message == "Passport Token 刷新成功"
+
+
+@pytest.mark.asyncio
+async def test_http_callback_partial_failure_keeps_retryable_500_contract():
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "bot_id": "service-bot-1",
+            "owner_workno": "owner-1",
+            "token": "fake-owner-passport-token",
+        }
+    )
+    svc = MagicMock()
+    svc.hot_update_passport_token_to_device.side_effect = BotServiceError(
+        "部分设备热更新失败: caller(binding_id=30): unavailable"
+    )
+
+    response = await refresh_bot_passport_token(request=request, bot_service=svc)
+
+    assert response.success is False
+    assert response.error_code == 500
+    assert response.data is None

--- a/src/backend/tests/community/core/devices/services/test_baas_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_device_service.py
@@ -266,6 +266,46 @@ class TestUpdateDeviceHeaders:
         baas.list_devices_by_bot_uuid.assert_called_once_with("BOT-fallback")
         baas.update_device_outbound_rule.assert_not_called()
 
+    def test_batch_mode_active_only_updates_only_active_devices(self):
+        baas = MagicMock()
+        rule = MagicMock()
+        baas._build_outbound_operation_rule.return_value = rule
+        baas.list_devices_by_bot_uuid.return_value = [
+            {"device_uuid": "D-active", "provider_device_id": "P-active", "status": "ACTIVE"},
+            {"device_uuid": "D-failed", "provider_device_id": "P-failed", "status": "FAILED"},
+            {"device_uuid": "D-released", "provider_device_id": "P-released", "status": "RELEASED"},
+        ]
+        svc = _make_service(baas_service=baas)
+        device = AllocatedDevice(
+            device_id="BOT-caller",
+            device_provider=BAAS_DEVICE_PROVIDER,
+            device_props={"bolt_id": "bot-1", "entity_id": "owner-1"},
+        )
+
+        result = svc.update_device_headers(device=device, active_only=True)
+
+        assert result == [
+            {"device_uuid": "D-active", "paas_device_id": "P-active"},
+        ]
+        baas.update_device_outbound_rule.assert_called_once_with("P-active", rule)
+
+    def test_batch_mode_active_only_returns_empty_when_no_active_devices(self):
+        baas = MagicMock()
+        baas._build_outbound_operation_rule.return_value = MagicMock()
+        baas.list_devices_by_bot_uuid.return_value = [
+            {"device_uuid": "D-failed", "provider_device_id": "P-failed", "status": "FAILED"},
+            {"device_uuid": "D-released", "provider_device_id": "P-released", "status": "RELEASED"},
+        ]
+        svc = _make_service(baas_service=baas)
+        device = AllocatedDevice(
+            device_id="BOT-caller",
+            device_provider=BAAS_DEVICE_PROVIDER,
+            device_props={"bolt_id": "bot-1", "entity_id": "owner-1"},
+        )
+
+        assert svc.update_device_headers(device=device, active_only=True) == []
+        baas.update_device_outbound_rule.assert_not_called()
+
 
 class TestGetDeviceConnection:
     def _ws_info(self):

--- a/src/backend/tests/community/core/devices/services/test_device_service_router.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service_router.py
@@ -10,6 +10,7 @@ import pytest
 
 from agentclaw.community.core.devices.errors import DeviceServiceError
 from agentclaw.community.core.devices.models import (
+    AllocatedDevice,
     DeviceBindingInfo,
     DeviceBindingStatus,
     DeviceConnectionInfo,
@@ -309,6 +310,31 @@ class TestGetProviderForDeviceId:
 
         provider = router._get_provider_for_device_id("nonexistent")
         assert provider is router._default_service
+
+
+class TestUpdateDeviceHeadersRouting:
+    def test_forwards_active_only_to_provider(self):
+        router, _, _, _ = _make_router(is_local=False)
+        provider = router._providers[BAAS_DEVICE_PROVIDER]
+        device = AllocatedDevice(
+            device_id="BOT-caller",
+            device_provider=BAAS_DEVICE_PROVIDER,
+            device_props={},
+        )
+
+        router.update_device_headers(
+            device=device,
+            agent_pass_token="fake-passport-token",
+            agent_code="agent-code",
+            active_only=True,
+        )
+
+        provider.update_device_headers.assert_called_once_with(
+            device=device,
+            agent_pass_token="fake-passport-token",
+            agent_code="agent-code",
+            active_only=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/community/plugins/test_device_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_device_repository_unified.py
@@ -1,7 +1,7 @@
 """Unified DeviceBindingRepository — behavior + contract.
 
 The last DB-repo twin in the unification program (S5). Covers all
-18 Protocol methods + the 3 adopt-prod behavior changes:
+19 Protocol methods + the 3 adopt-prod behavior changes:
 - ``gmt_modified`` advances DB-side after each UPDATE (proves the
   ``func.now()`` reaches the column on SQLite).
 - ``get_active_engine_by_device_id`` falls back to
@@ -243,6 +243,78 @@ def test_list_bindings_filters_and_pagination(repo):
     t_dev, _ = repo.list_bindings(env="dev")
     t_prod, _ = repo.list_bindings(env="prod")
     assert t_dev == 5 and t_prod == 1
+
+
+def test_list_active_caller_instance_bindings_filters_scope_and_deduplicates(repo):
+    matching_old = repo.insert_binding(
+        **_binding(
+            entity_id="owner-1",
+            device_id="BOT-caller-1",
+            device_provider="baas",
+            env="prod",
+            status="ACTIVE",
+            apply_reason="caller_instance:service-bot-1",
+            applied_by="caller-1",
+        )
+    )
+    matching_latest = repo.insert_binding(
+        **_binding(
+            entity_id="owner-1",
+            device_id="BOT-caller-1",
+            device_provider="baas",
+            env="prod",
+            status="ACTIVE",
+            apply_reason="caller_instance:service-bot-1",
+            applied_by="caller-1",
+        )
+    )
+    second_match = repo.insert_binding(
+        **_binding(
+            entity_id="owner-1",
+            device_id="BOT-caller-2",
+            device_provider="baas",
+            env="prod",
+            status="ACTIVE",
+            apply_reason="caller_instance:service-bot-1",
+            applied_by="caller-2",
+        )
+    )
+
+    excluded = [
+        dict(entity_id="other-owner"),
+        dict(env="dev"),
+        dict(status="PENDING"),
+        dict(device_provider="arca"),
+        dict(entity_type="team"),
+        dict(apply_reason="caller_instance:other-service-bot"),
+        dict(apply_reason="caller_instance:service-bot-1-extra"),
+    ]
+    for index, override in enumerate(excluded):
+        values = dict(
+            entity_id="owner-1",
+            entity_type="staff",
+            device_id=f"BOT-excluded-{index}",
+            device_provider="baas",
+            env="prod",
+            status="ACTIVE",
+            apply_reason="caller_instance:service-bot-1",
+            applied_by=f"excluded-{index}",
+        )
+        values.update(override)
+        repo.insert_binding(**_binding(**values))
+
+    bindings = repo.list_active_caller_instance_bindings(
+        bot_id="service-bot-1",
+        owner_id="owner-1",
+        env="prod",
+    )
+
+    assert [binding.id for binding in bindings] == [second_match, matching_latest]
+    assert {binding.device_id for binding in bindings} == {
+        "BOT-caller-1",
+        "BOT-caller-2",
+    }
+    assert matching_old not in {binding.id for binding in bindings}
 
 
 def test_count_non_released_bindings(repo):

--- a/src/backend/tests/community/services/test_bot_passport.py
+++ b/src/backend/tests/community/services/test_bot_passport.py
@@ -5,8 +5,17 @@ Tests for:
 - bot_service.create_bot with bot_id parameter (idempotency)
 - bot_service.update_bot_ext method
 """
+from concurrent.futures import ThreadPoolExecutor as RealThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
+
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotServiceError,
+)
+from agentclaw.community.core.devices.errors import DeviceServiceError
+from agentclaw.community.core.service_bot.repository.models import PublishStatus
 
 
 class TestBotServicePassportIntegration:
@@ -52,6 +61,241 @@ class TestBotServicePassportIntegration:
         )
         return service
 
+
+def _caller_binding(
+    binding_id: int,
+    device_id: str,
+    applied_by: str,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=binding_id,
+        entity_id="owner-1",
+        entity_type="staff",
+        device_id=device_id,
+        device_provider="baas",
+        env="prod",
+        device_props={},
+        status="ACTIVE",
+        apply_reason="caller_instance:service-bot-1",
+        applied_by=applied_by,
+    )
+
+
+class TestServiceBotPassportRefresh(TestBotServicePassportIntegration):
+    @staticmethod
+    def _set_publish_records(bot_service, *, online_id: int | None, verify_id: int | None):
+        records = {
+            PublishStatus.SUCCESS.value: (
+                SimpleNamespace(id=101, ext={"binding": {"online": online_id}})
+                if online_id is not None
+                else None
+            ),
+            PublishStatus.VALIDATING.value: (
+                SimpleNamespace(id=102, ext={"binding": {"verify": verify_id}})
+                if verify_id is not None
+                else None
+            ),
+        }
+        bot_service._bot_publish_repo.get_by_publish_bot_id.side_effect = (
+            lambda **kwargs: records[kwargs["publish_status"]]
+        )
+
+    def test_updates_standard_and_caller_targets_with_owner_token_at_fixed_concurrency(
+        self,
+        bot_service,
+    ):
+        self._set_publish_records(bot_service, online_id=21, verify_id=22)
+        bot_service._hot_update_by_device_binding = MagicMock(
+            return_value={"binding_id": 20, "devices": [{"device_uuid": "draft"}]}
+        )
+        bot_service._hot_update_by_publish_binding = MagicMock(
+            side_effect=[
+                {"binding_id": 21, "devices": [{"device_uuid": "online"}]},
+                {"binding_id": 22, "devices": [{"device_uuid": "verify"}]},
+            ]
+        )
+        caller_bindings = [
+            _caller_binding(30 + index, f"BOT-caller-{index}", f"caller-{index}")
+            for index in range(6)
+        ]
+        bot_service._device_binding_repo.list_active_caller_instance_bindings.return_value = (
+            caller_bindings
+        )
+        device_service = MagicMock()
+        device_service.update_device_headers.side_effect = lambda **kwargs: [
+            {"device_uuid": f"DEVICE-{kwargs['device'].device_id}"}
+        ]
+        bot_service._device_service_provider = lambda: device_service
+
+        worker_counts: list[int] = []
+
+        def executor_factory(*, max_workers: int):
+            worker_counts.append(max_workers)
+            return RealThreadPoolExecutor(max_workers=max_workers)
+
+        with (
+            patch(
+                "agentclaw.community.core.bot_management.services.bot_service.get_current_env",
+                return_value="prod",
+            ),
+            patch(
+                "agentclaw.community.core.bot_management.services.bot_service.ThreadPoolExecutor",
+                side_effect=executor_factory,
+            ),
+        ):
+            result = bot_service._hot_update_service_bot_passport_token(
+                bot_id="service-bot-1",
+                user_id="owner-1",
+                token="fake-owner-passport-token",
+                bot={"binding_id": 20},
+                agent_code="owner-agent-code",
+            )
+
+        assert worker_counts == [5]
+        assert {item["type"] for item in result} == {
+            "draft",
+            "online",
+            "verify",
+            "caller",
+        }
+        assert sum(item["type"] == "caller" for item in result) == 6
+        bot_service._device_binding_repo.list_active_caller_instance_bindings.assert_called_once_with(
+            bot_id="service-bot-1",
+            owner_id="owner-1",
+            env="prod",
+        )
+        assert len(device_service.update_device_headers.call_args_list) == 6
+        for call in device_service.update_device_headers.call_args_list:
+            assert call.kwargs["agent_pass_token"] == "fake-owner-passport-token"
+            assert call.kwargs["agent_code"] == "owner-agent-code"
+            assert call.kwargs["active_only"] is True
+
+    def test_device_service_error_does_not_stop_later_stages_or_callers(self, bot_service):
+        self._set_publish_records(bot_service, online_id=21, verify_id=22)
+        bot_service._hot_update_by_device_binding = MagicMock(
+            side_effect=DeviceServiceError("draft unavailable")
+        )
+        bot_service._hot_update_by_publish_binding = MagicMock(
+            side_effect=[
+                {"binding_id": 21, "devices": [{"device_uuid": "online"}]},
+                {"binding_id": 22, "devices": [{"device_uuid": "verify"}]},
+            ]
+        )
+        bot_service._device_binding_repo.list_active_caller_instance_bindings.return_value = [
+            _caller_binding(30, "BOT-caller-1", "caller-1")
+        ]
+        device_service = MagicMock()
+        device_service.update_device_headers.return_value = [
+            {"device_uuid": "DEVICE-caller-1"}
+        ]
+        bot_service._device_service_provider = lambda: device_service
+
+        with (
+            patch(
+                "agentclaw.community.core.bot_management.services.bot_service.get_current_env",
+                return_value="prod",
+            ),
+            pytest.raises(BotServiceError, match="draft unavailable"),
+        ):
+            bot_service._hot_update_service_bot_passport_token(
+                bot_id="service-bot-1",
+                user_id="owner-1",
+                token="fake-owner-passport-token",
+                bot={"binding_id": 20},
+            )
+
+        assert bot_service._hot_update_by_publish_binding.call_count == 2
+        device_service.update_device_headers.assert_called_once()
+
+    def test_caller_failure_does_not_stop_other_callers_but_fails_overall(self, bot_service):
+        self._set_publish_records(bot_service, online_id=None, verify_id=None)
+        bot_service._device_binding_repo.list_active_caller_instance_bindings.return_value = [
+            _caller_binding(30, "BOT-caller-a", "caller-a"),
+            _caller_binding(31, "BOT-caller-b", "caller-b"),
+            _caller_binding(32, "BOT-caller-c", "caller-c"),
+        ]
+        attempted: list[str] = []
+
+        def update_caller(**kwargs):
+            device_id = kwargs["device"].device_id
+            attempted.append(device_id)
+            if device_id == "BOT-caller-a":
+                raise DeviceServiceError("caller a unavailable")
+            return [{"device_uuid": f"DEVICE-{device_id}"}]
+
+        device_service = MagicMock()
+        device_service.update_device_headers.side_effect = update_caller
+        bot_service._device_service_provider = lambda: device_service
+
+        with (
+            patch(
+                "agentclaw.community.core.bot_management.services.bot_service.get_current_env",
+                return_value="prod",
+            ),
+            pytest.raises(BotServiceError, match="caller a unavailable"),
+        ):
+            bot_service._hot_update_service_bot_passport_token(
+                bot_id="service-bot-1",
+                user_id="owner-1",
+                token="fake-owner-passport-token",
+                bot={},
+            )
+
+        assert set(attempted) == {
+            "BOT-caller-a",
+            "BOT-caller-b",
+            "BOT-caller-c",
+        }
+
+    def test_caller_binding_with_zero_active_devices_fails_overall(self, bot_service):
+        self._set_publish_records(bot_service, online_id=None, verify_id=None)
+        bot_service._device_binding_repo.list_active_caller_instance_bindings.return_value = [
+            _caller_binding(30, "BOT-caller-1", "caller-1")
+        ]
+        device_service = MagicMock()
+        device_service.update_device_headers.return_value = []
+        bot_service._device_service_provider = lambda: device_service
+
+        with (
+            patch(
+                "agentclaw.community.core.bot_management.services.bot_service.get_current_env",
+                return_value="prod",
+            ),
+            pytest.raises(BotServiceError, match="没有 ACTIVE 物理设备"),
+        ):
+            bot_service._hot_update_service_bot_passport_token(
+                bot_id="service-bot-1",
+                user_id="owner-1",
+                token="fake-owner-passport-token",
+                bot={},
+            )
+
+    def test_no_callers_preserves_existing_standard_target_result(self, bot_service):
+        self._set_publish_records(bot_service, online_id=None, verify_id=None)
+        bot_service._device_binding_repo.list_active_caller_instance_bindings.return_value = []
+        bot_service._hot_update_by_device_binding = MagicMock(
+            return_value={"binding_id": 20, "devices": [{"device_uuid": "draft"}]}
+        )
+
+        with patch(
+            "agentclaw.community.core.bot_management.services.bot_service.get_current_env",
+            return_value="prod",
+        ):
+            result = bot_service._hot_update_service_bot_passport_token(
+                bot_id="service-bot-1",
+                user_id="owner-1",
+                token="fake-owner-passport-token",
+                bot={"binding_id": 20},
+            )
+
+        assert result == [
+            {
+                "binding_id": 20,
+                "type": "draft",
+                "device_count": 1,
+                "devices": [{"device_uuid": "draft"}],
+            }
+        ]
 
 class TestCreateBotWithBotId(TestBotServicePassportIntegration):
     """Tests for create_bot with bot_id parameter."""


### PR DESCRIPTION
## Problem

Service Bot Passport refresh currently updates Draft, Online, and Verify bindings, but caller mode can create multiple additional BaaS caller-instance bindings. Those caller containers still require the service Bot owner's normal Passport token, yet the refresh path does not discover or update them.

The existing best-effort stage loop also catches only `BotServiceError`; provider failures such as `BaasDeviceServiceError` derive from `DeviceServiceError` and can stop later stages before they are attempted.

## Solution

- Add an environment/owner/Bot-scoped repository query for ACTIVE BaaS bindings identified by `apply_reason=caller_instance:{bot_id}`, with defensive `device_id` de-duplication.
- Fan out the same owner Passport token to every caller binding with a fixed five-worker pool and preserved tenant context.
- Limit caller updates to ACTIVE BaaS physical devices; an ACTIVE binding with zero ACTIVE physical devices is a failure.
- Attempt Draft, Online, Verify, and all callers before aggregating any errors into the existing `BotServiceError` response path.
- Keep caller-specific `x-caller-token` handling entirely out of this flow.
- Extract BaaS outbound-header updating behind a small internal module to keep the device lifecycle module below the architecture size cap.
- Stop writing Passport token prefixes to refresh/routing logs; logs now record only whether a token was present.

## Validation

Candidate rebased onto `origin/dev@f16416c9`.

- `DEPLOY_PROFILE=test uv run pytest tests/community -q`: 10,284 passed after rebase.
- `DEPLOY_PROFILE=test uv run pytest tests/community/architecture -q`: 112 passed.
- Targeted repository, BaaS device, router, BotService, and HTTP callback suites: 197 passed before the full run.
- Ruff check on all changed Python files: passed after rebase.
- `scripts/ci/python_sast_local.sh src/backend 1 --base origin/dev --head HEAD`: passed.
- `scripts/ci/pre_push.sh --base origin/dev --head HEAD` (lint-only gate): passed.
- Live pre-environment callback validation is intentionally pending: it requires an enabled caller-mode Bot and a manually supplied sensitive token. Validation should inspect only non-sensitive target/count/success logs.

## Compatibility and risk

- No HTTP request or response schema changes.
- No database DDL or migration.
- Personal Bot behavior and non-caller Service Bot behavior remain unchanged.
- Partial failure remains `success=false`, `error_code=500`, so the existing callback retry behavior is preserved.
- The update PUT remains idempotent; retries may re-update already successful targets.
