### PR TITLE
fix(engine): reconcile trusted AICoding repo bridge links

### DIFF
--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -613,6 +613,107 @@ def test_aicoding_active_probe_rejects_skill_link_through_retired_corpus(
     )
 
 
+def test_aicoding_active_rewrites_trusted_stable_repo_bridge_mapping(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, repo_bridge, _, pool_repo = _prepared_home(
+        tmp_path
+    )
+    active_repo_skill = local_bridge.parent / "shared"
+    mappings = [
+        SkillMapping(
+            source=str(pool_repo / "business" / "shared"),
+            target=str(active_repo_skill),
+        )
+    ]
+    relay_owned_source = home / ".agents" / "skills" / "relay-owned"
+    relay_owned_source.mkdir(parents=True)
+    (relay_owned_source / "SKILL.md").write_text("relay")
+    relay_owned_link = local_bridge.parent / "relay-owned"
+    relay_owned_link.symlink_to(relay_owned_source, target_is_directory=True)
+    activated = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    assert active_repo_skill.is_symlink()
+
+    active_repo_skill.unlink()
+    active_repo_skill.symlink_to(
+        repo_bridge / "business" / "shared",
+        target_is_directory=True,
+    )
+    before_retry = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert before_retry.status is RuntimeLayoutInspectionStatus.INVALID
+    assert before_retry.evidence["reason"] == "active_managed_entry_invalid"
+
+    retry = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert active_repo_skill.readlink() == pool_repo / "business" / "shared"
+    assert relay_owned_link.readlink() == relay_owned_source
+    ready = inspect_aicoding_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert ready.status is RuntimeLayoutInspectionStatus.READY
+
+
+def test_aicoding_active_refuses_untrusted_stable_repo_bridge_mapping(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, repo_bridge, _, pool_repo = _prepared_home(
+        tmp_path
+    )
+    active_repo_skill = local_bridge.parent / "shared"
+    mappings = [
+        SkillMapping(
+            source=str(pool_repo / "business" / "shared"),
+            target=str(active_repo_skill),
+        )
+    ]
+    activated = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    active_repo_skill.unlink()
+    active_repo_skill.symlink_to(
+        repo_bridge / "business" / "missing",
+        target_is_directory=True,
+    )
+
+    retry = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert retry.status is PoolActivationStatus.INVALID
+    assert retry.evidence["reason"] == "runtime_layout_not_ready"
+
+
 def test_aicoding_rollback_rebuilds_legacy_from_current_pool(
     tmp_path: Path,
 ) -> None:

--- a/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/aicoding/tests/test_pool_layout.py
@@ -18,6 +18,8 @@ from engine.community.plugins.aicoding.layout_pool import (
 )
 from engine.community.plugins.skills_pool.layout_activation import (
     ActiveRepoRetirementError,
+    _Layout,
+    _trusted_active_repo_bridge_rewrite_retry,
     mapping_sources_use_pool,
 )
 
@@ -616,11 +618,15 @@ def test_aicoding_active_probe_rejects_skill_link_through_retired_corpus(
 def test_aicoding_active_rewrites_trusted_stable_repo_bridge_mapping(
     tmp_path: Path,
 ) -> None:
-    home, _, local_bridge, repo_bridge, _, pool_repo = _prepared_home(
+    home, _, local_bridge, repo_bridge, pool_local, pool_repo = _prepared_home(
         tmp_path
     )
     active_repo_skill = local_bridge.parent / "shared"
     mappings = [
+        SkillMapping(
+            source=str(pool_local / "handmade"),
+            target=str(local_bridge.parent / "handmade"),
+        ),
         SkillMapping(
             source=str(pool_repo / "business" / "shared"),
             target=str(active_repo_skill),
@@ -631,6 +637,8 @@ def test_aicoding_active_rewrites_trusted_stable_repo_bridge_mapping(
     (relay_owned_source / "SKILL.md").write_text("relay")
     relay_owned_link = local_bridge.parent / "relay-owned"
     relay_owned_link.symlink_to(relay_owned_source, target_is_directory=True)
+    relay_owned_directory = local_bridge.parent / "relay-owned-directory"
+    relay_owned_directory.mkdir()
     activated = activate_aicoding_pool(
         migration_generation="generation-1",
         preparation_id=PREPARATION_ID,
@@ -666,6 +674,7 @@ def test_aicoding_active_rewrites_trusted_stable_repo_bridge_mapping(
     assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
     assert active_repo_skill.readlink() == pool_repo / "business" / "shared"
     assert relay_owned_link.readlink() == relay_owned_source
+    assert relay_owned_directory.is_dir()
     ready = inspect_aicoding_runtime_layout(
         home=home,
         repo_is_mounted=lambda path: path == pool_repo,
@@ -712,6 +721,72 @@ def test_aicoding_active_refuses_untrusted_stable_repo_bridge_mapping(
 
     assert retry.status is PoolActivationStatus.INVALID
     assert retry.evidence["reason"] == "runtime_layout_not_ready"
+
+
+def test_aicoding_active_rewrites_stable_bridge_when_pool_repo_is_downloaded(
+    tmp_path: Path,
+) -> None:
+    home, _, local_bridge, repo_bridge, _, pool_repo = _prepared_home(tmp_path)
+    downloaded_repo = home / ".aicoding" / ".downloads" / "skills-repo"
+    downloaded_repo.parent.mkdir(parents=True)
+    pool_repo.rename(downloaded_repo)
+    pool_repo.symlink_to(downloaded_repo, target_is_directory=True)
+    active_repo_skill = local_bridge.parent / "shared"
+    mappings = [
+        SkillMapping(
+            source=str(pool_repo / "business" / "shared"),
+            target=str(active_repo_skill),
+        )
+    ]
+    activated = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+    assert activated.committed
+    active_repo_skill.unlink()
+    active_repo_skill.symlink_to(
+        repo_bridge / "business" / "shared",
+        target_is_directory=True,
+    )
+
+    retry = activate_aicoding_pool(
+        migration_generation="generation-1",
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=mappings,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert retry.status is PoolActivationStatus.ALREADY_COMMITTED
+    assert active_repo_skill.readlink() == pool_repo / "business" / "shared"
+
+
+def test_aicoding_active_bridge_rewrite_refuses_dangling_or_retired_sources(
+    tmp_path: Path,
+) -> None:
+    home, legacy_local, local_bridge, _, pool_local, pool_repo = _prepared_home(
+        tmp_path
+    )
+    layout = _Layout.for_engine("aicoding", home)
+    active_root = local_bridge.parent
+    dangling = active_root / "dangling"
+    dangling.symlink_to(pool_repo / "missing", target_is_directory=True)
+    assert not _trusted_active_repo_bridge_rewrite_retry(layout=layout)
+
+    dangling.unlink()
+    retired = active_root / "retired"
+    retired.symlink_to(legacy_local / "handmade", target_is_directory=True)
+    assert not _trusted_active_repo_bridge_rewrite_retry(layout=layout)
+
+    retired.unlink()
+    escaped = active_root / "escaped"
+    escaped.symlink_to(pool_local / "handmade", target_is_directory=True)
+    assert not _trusted_active_repo_bridge_rewrite_retry(layout=layout)
 
 
 def test_aicoding_rollback_rebuilds_legacy_from_current_pool(

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -732,6 +732,57 @@ def _active_entry_inventory(
     return managed, tuple(external), tuple(occupied)
 
 
+def _trusted_active_repo_bridge_rewrite_retry(*, layout: _Layout) -> bool:
+    """判定已激活 AICoding Bot 能否将旧 repo bridge 映射重发为 Pool 直链。
+
+    早期 Pool-active 运行时会把已激活的 repo Skill 指向稳定的
+    ``repo_bridge``。该 bridge 最终解析到 Pool repo，因而当时可用；新版
+    probe 则要求 active root 中的受管入口词法上直接指向 Pool。这里仅为
+    已提交布局的前滚收敛放行这一种旧格式，不能把 Legacy、dangling 或
+    未知路径当作可信映射。
+    """
+
+    active_root = Path(os.path.abspath(layout.active_root))
+    pool_local = Path(os.path.abspath(layout.pool_local))
+    pool_repo = Path(os.path.abspath(layout.pool_repo))
+    repo_bridge = Path(os.path.abspath(layout.repo_bridge))
+    retired_roots = (
+        Path(os.path.abspath(layout.legacy_local)),
+        Path(os.path.abspath(layout.legacy_repo)),
+        Path(os.path.abspath(layout.local_bridge)),
+    )
+    saw_bridge_mapping = False
+
+    try:
+        for entry in active_root.iterdir():
+            if not entry.is_symlink():
+                # Relay/AIX own real directories; they are not Pool mappings.
+                continue
+            target = _lexical_target(entry)
+            if target.is_relative_to(pool_local) or target.is_relative_to(pool_repo):
+                try:
+                    if not entry.is_dir():
+                        return False
+                except OSError:
+                    return False
+                continue
+            if target.is_relative_to(repo_bridge):
+                try:
+                    resolved = target.resolve(strict=True)
+                except OSError:
+                    return False
+                if not resolved.is_relative_to(pool_repo) or not resolved.is_dir():
+                    return False
+                saw_bridge_mapping = True
+                continue
+            if any(target.is_relative_to(root) for root in retired_roots):
+                return False
+            # External symlinks predate Pool and must remain outside its scope.
+    except OSError:
+        return False
+    return saw_bridge_mapping
+
+
 def _mapping_plan(
     *,
     layout: _Layout,
@@ -1263,7 +1314,20 @@ def _activate_pool(
         and inspection.preparation_id == preparation_id
         and inspection.evidence.get("reason") == "active_repo_corpus_present"
     )
-    if not layout_ready and not trusted_finalizing_retirement_retry:
+    trusted_active_repo_bridge_rewrite_retry = (
+        engine == "aicoding"
+        and active_marker is not None
+        and active_marker.get("activation_state") == "active"
+        and inspection.status is RuntimeLayoutInspectionStatus.INVALID
+        and inspection.preparation_id == preparation_id
+        and inspection.evidence.get("reason") == "active_managed_entry_invalid"
+        and _trusted_active_repo_bridge_rewrite_retry(layout=layout)
+    )
+    if not (
+        layout_ready
+        or trusted_finalizing_retirement_retry
+        or trusted_active_repo_bridge_rewrite_retry
+    ):
         return _invalid(
             "runtime_layout_not_ready",
             probe_status=inspection.status.value,

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -754,6 +754,7 @@ def _trusted_active_repo_bridge_rewrite_retry(*, layout: _Layout) -> bool:
     saw_bridge_mapping = False
 
     try:
+        resolved_pool_repo = pool_repo.resolve(strict=True)
         for entry in active_root.iterdir():
             if not entry.is_symlink():
                 # Relay/AIX own real directories; they are not Pool mappings.
@@ -771,7 +772,10 @@ def _trusted_active_repo_bridge_rewrite_retry(*, layout: _Layout) -> bool:
                     resolved = target.resolve(strict=True)
                 except OSError:
                     return False
-                if not resolved.is_relative_to(pool_repo) or not resolved.is_dir():
+                if (
+                    not resolved.is_relative_to(resolved_pool_repo)
+                    or not resolved.is_dir()
+                ):
                     return False
                 saw_bridge_mapping = True
                 continue


### PR DESCRIPTION
## Summary

Reconcile already Pool-active AICoding layouts whose historical repo Skill links traverse the trusted stable repo bridge. The reconciler rewrites only those links to direct canonical Pool targets, then retains the strict probe contract.

## Safety

- Only applies to active, identity-matching AICoding Pool layouts with `active_managed_entry_invalid`.
- Requires every legacy-form managed link to resolve beneath the canonical Pool repo.
- Keeps external Relay/AIX links untouched; dangling, Legacy, and unknown targets remain fail-closed.

## Tests

- `uvx ruff check ...`
- `uv run --with pytest --with pytest-asyncio pytest src/engine/community/plugins/aicoding/tests/test_pool_layout.py src/engine/community/plugins/claude_code/tests/test_pool_layout.py src/engine/community/plugins/hermes/tests/test_pool_layout.py -q` (28 passed)