### PR TITLE
fix(baas): honor active runtime engine type

### DIFF
--- a/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
@@ -28,6 +28,10 @@ from secbaas.community.spi.bot_service import (
 
 logger = get_logger("plugin-bot-service")
 
+_SUPPORTED_RUNTIME_ENGINE_TYPES = frozenset(
+    {"openclaw", "teclaw", "aicoding", "hermes", "claude_code"}
+)
+
 
 class AiohttpBotServicePlugin(BotServicePlugin):
     """Aiohttp-based BotService plugin — production HTTP implementation.
@@ -289,19 +293,51 @@ class AiohttpBotServicePlugin(BotServicePlugin):
                 _stage_ms,
                 (time.monotonic() - _binding_t0) * 1000,
             )
+            resolved_bot_id = inner.get("bot_id", bot_id)
+            bot_type = inner.get("bot_type", "")
+            original_engine_type = inner.get("engine_type", "openclaw")
+            runtime_engine_type = inner.get("active_runtime_engine_type")
+            normalized_runtime_engine_type = (
+                runtime_engine_type.strip()
+                if isinstance(runtime_engine_type, str)
+                else ""
+            )
+            if normalized_runtime_engine_type in _SUPPORTED_RUNTIME_ENGINE_TYPES:
+                engine_type = normalized_runtime_engine_type
+            else:
+                engine_type = original_engine_type
+                runtime_field_present = "active_runtime_engine_type" in inner
+                unsupported_nonempty_value = bool(normalized_runtime_engine_type)
+                if runtime_field_present and (
+                    bot_type == "personal" or unsupported_nonempty_value
+                ):
+                    logger.warning(
+                        "[bot-service] invalid active runtime engine; fallback to "
+                        "original engine: bot_id=%s bot_type=%r engine_type=%r "
+                        "active_runtime_engine_type=%r fallback=%r",
+                        resolved_bot_id,
+                        bot_type,
+                        original_engine_type,
+                        runtime_engine_type,
+                        engine_type,
+                    )
+
             logger.info(
                 "[bot-service] get_binding raw: bot_id=%s engine_type=%r "
+                "active_runtime_engine_type=%r consumed_engine_type=%r "
                 "template_type=%r device_provider=%r",
-                inner.get("bot_id", bot_id),
-                inner.get("engine_type"),
+                resolved_bot_id,
+                original_engine_type,
+                runtime_engine_type,
+                engine_type,
                 inner.get("template_type"),
                 inner.get("device_provider"),
             )
             return BotBindingData(
-                bot_id=inner.get("bot_id", bot_id),
+                bot_id=resolved_bot_id,
                 owner_id=inner.get("owner_id", owner_id),
-                bot_type=inner.get("bot_type", ""),
-                engine_type=inner.get("engine_type", "openclaw"),
+                bot_type=bot_type,
+                engine_type=engine_type,
                 publish_id=inner.get("publish_id"),
                 publish_status=inner.get("publish_status"),
                 binding_id=inner.get("binding_id", 0),

--- a/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
+++ b/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
@@ -887,3 +887,95 @@ class TestStubBotServicePluginGetBinding:
         result = await plugin.get_binding("bot_001", "owner_001", "online")
 
         assert result is None
+
+
+class TestAiohttpBotServicePluginRuntimeEngineSelection:
+    """Runtime engine is selected only at the Backend HTTP consumption boundary."""
+
+    @staticmethod
+    def _binding_inner(**overrides):
+        inner = {
+            "bot_id": "bot_personal_001",
+            "owner_id": "20881234",
+            "bot_type": "personal",
+            "engine_type": "claude_code",
+            "template_type": "generCC",
+            "binding_id": 101,
+            "device_provider": "arca",
+            "device_id": "ARCA-SANDBOX-001",
+        }
+        inner.update(overrides)
+        return inner
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "runtime_engine_type",
+        ["openclaw", "teclaw", "aicoding", "hermes", "claude_code"],
+    )
+    async def test_supported_runtime_engine_overrides_original_engine(
+        self, runtime_engine_type
+    ):
+        plugin = AiohttpBotServicePlugin(base_url="https://agentclaw.example.com")
+        plugin._get_binding_raw = AsyncMock(
+            return_value=self._binding_inner(
+                active_runtime_engine_type=f"  {runtime_engine_type}  "
+            )
+        )
+
+        result = await plugin.get_binding(
+            "bot_personal_001", "20881234", "online"
+        )
+
+        assert result.engine_type == runtime_engine_type
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("runtime_engine_type", "bot_type", "warning_expected"),
+        [
+            (None, "personal", True),
+            ("", "personal", True),
+            ("   ", "personal", True),
+            (123, "personal", True),
+            ("unsupported", "personal", True),
+            ("unsupported", "service", True),
+            ("", "service", False),
+        ],
+    )
+    async def test_invalid_runtime_engine_falls_back_to_original_engine(
+        self, runtime_engine_type, bot_type, warning_expected
+    ):
+        plugin = AiohttpBotServicePlugin(base_url="https://agentclaw.example.com")
+        plugin._get_binding_raw = AsyncMock(
+            return_value=self._binding_inner(
+                bot_type=bot_type,
+                active_runtime_engine_type=runtime_engine_type,
+            )
+        )
+
+        with patch(
+            "secbaas.community.plugins.bot_service.real._plugin.logger"
+        ) as mock_logger:
+            result = await plugin.get_binding(
+                "bot_personal_001", "20881234", "online"
+            )
+
+        assert result.engine_type == "claude_code"
+        if warning_expected:
+            mock_logger.warning.assert_called_once()
+        else:
+            mock_logger.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_runtime_engine_field_keeps_old_backend_behavior(self):
+        plugin = AiohttpBotServicePlugin(base_url="https://agentclaw.example.com")
+        plugin._get_binding_raw = AsyncMock(return_value=self._binding_inner())
+
+        with patch(
+            "secbaas.community.plugins.bot_service.real._plugin.logger"
+        ) as mock_logger:
+            result = await plugin.get_binding(
+                "bot_personal_001", "20881234", "online"
+            )
+
+        assert result.engine_type == "claude_code"
+        mock_logger.warning.assert_not_called()

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_process.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_process.py
@@ -1,0 +1,57 @@
+"""Bot-type-specific data enrichment for service-bot binding responses."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from agentclaw.community.core.bot_management.services.template_service import (
+    TemplateService,
+)
+
+
+class BotProcess(Protocol):
+    """Provide bot-type-specific fields for binding responses."""
+
+    def get_active_runtime_engine_type(self, bot_id: str) -> str:
+        """Return the explicit runtime engine type, or an empty string."""
+        ...
+
+
+class PersonalBotProcess:
+    """Read the explicit runtime engine type from a personal bot template."""
+
+    def __init__(self, template_service: TemplateService) -> None:
+        self._template_service = template_service
+
+    def get_active_runtime_engine_type(self, bot_id: str) -> str:
+        template_config = self._template_service.get_template_config(bot_id)
+        if not isinstance(template_config, dict):
+            return ""
+
+        runtime_engine_type = template_config.get("active_runtime_engine_type")
+        if not isinstance(runtime_engine_type, str):
+            return ""
+        return runtime_engine_type.strip()
+
+
+class EmptyBotProcess:
+    """Default process for bot types without runtime-engine enrichment."""
+
+    def get_active_runtime_engine_type(self, bot_id: str) -> str:
+        return ""
+
+
+class BotProcessRegistry:
+    """Select the process implementation for a bot type."""
+
+    def __init__(
+        self,
+        personal_bot_process: BotProcess,
+        default_bot_process: BotProcess,
+    ) -> None:
+        self._personal_bot_process = personal_bot_process
+        self._default_bot_process = default_bot_process
+
+    def get(self, bot_type: str) -> BotProcess:
+        if bot_type == "personal":
+            return self._personal_bot_process
+        return self._default_bot_process

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.bot_management.repository.protocol import BotRepos
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
+from agentclaw.community.core.service_bot.services.bot_process import BotProcessRegistry
 from agentclaw.community.core.service_bot.services.publish_draft_restore_mixin import PublishDraftRestoreMixin
 from agentclaw.community.core.service_bot.services.publish_exceptions import (
     BotAlreadyServiceTypeError,
@@ -52,6 +53,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         quality_task_service: "QualityTaskService",
         publish_operation_repo: PublishOperationRepository,
         task_queue_service: TaskQueueService,
+        bot_process_registry: BotProcessRegistry,
     ):
         self._repo = bot_publish_repo
         self._bot_repo = bot_repo
@@ -63,6 +65,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         self._quality_task_service = quality_task_service
         self._publish_operation_repo = publish_operation_repo
         self._task_queue_service = task_queue_service
+        self._bot_process_registry = bot_process_registry
         self._env = get_current_env()
 
     def create_device_binding(
@@ -396,6 +399,8 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             raise BotNotFoundError(f"Bot not found: bot_id={bot_id}, owner_id={owner_id}")
 
         bot_type = bot.get("bot_type", "personal")
+        bot_process = self._bot_process_registry.get(bot_type)
+        active_runtime_engine_type = bot_process.get_active_runtime_engine_type(bot_id)
         if bot_type == "service" and stage != PublishStage.DRAFT.value:
             return self._get_service_bot_stage_binding_info(
                 bot=bot,
@@ -403,8 +408,14 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 owner_id=owner_id,
                 stage=stage,
                 task_uuid=biz_id,
+                active_runtime_engine_type=active_runtime_engine_type,
             )
-        return self._get_personal_bot_binding_info(bot=bot, bot_id=bot_id, owner_id=owner_id)
+        return self._get_personal_bot_binding_info(
+            bot=bot,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            active_runtime_engine_type=active_runtime_engine_type,
+        )
 
     def _get_personal_bot_binding_info(
         self,
@@ -412,6 +423,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         bot: Dict[str, Any],
         bot_id: str,
         owner_id: str,
+        active_runtime_engine_type: str,
     ) -> Dict[str, Any]:
         binding_id = bot.get("binding_id")
         if not binding_id:
@@ -442,6 +454,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             "bot_type": bot.get("bot_type", "personal"),
             "engine_type": bot.get("active_engine", ""),
             "template_type": bot.get("template_type", ""),
+            "active_runtime_engine_type": active_runtime_engine_type,
             "publish_id": None,
             "publish_status": None,
             "binding_id": binding_id,
@@ -486,6 +499,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         owner_id: str,
         stage: str,
         task_uuid: Optional[str] = None,
+        active_runtime_engine_type: str = "",
     ) -> Dict[str, Any]:
         if stage == PublishStage.EVAL.value:
             task_record = self._quality_task_service.get_task_by_uuid(task_uuid)
@@ -505,6 +519,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 "bot_type": "service",
                 "engine_type": bot.get("active_engine", ""),
                 "template_type": bot.get("template_type", ""),
+                "active_runtime_engine_type": active_runtime_engine_type,
                 "publish_id": None,
                 "publish_status": None,
                 "binding_id": None,
@@ -537,6 +552,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             "bot_type": "service",
             "engine_type": bot.get("active_engine", ""),
             "template_type": bot.get("template_type", ""),
+            "active_runtime_engine_type": active_runtime_engine_type,
             "publish_id": publish_record.id,
             "publish_status": publish_record.status,
             "binding_id": binding_id,

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -40,6 +40,7 @@ from agentclaw.community.api.quality_service import QualityTaskServiceProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.bcn_service import BcnService
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.channel.services.engine_overrides_reader import (
     ChannelEngineOverridesReader,
 )
@@ -70,6 +71,11 @@ from agentclaw.community.core.service_bot.repository.publish_operation_repositor
 )
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
+from agentclaw.community.core.service_bot.services.bot_process import (
+    BotProcessRegistry,
+    EmptyBotProcess,
+    PersonalBotProcess,
+)
 from agentclaw.community.core.service_bot.services.bot_publish_service import BotPublishService
 from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
     ArcaSnapshotProducer,
@@ -263,6 +269,18 @@ class ServiceBotModule(Module):
     @singleton
     @provider
     @inject
+    def bot_process_registry(
+        self, template_service: TemplateService
+    ) -> BotProcessRegistry:
+        """Construct bot-type-specific binding response processors."""
+        return BotProcessRegistry(
+            personal_bot_process=PersonalBotProcess(template_service),
+            default_bot_process=EmptyBotProcess(),
+        )
+
+    @singleton
+    @provider
+    @inject
     def bot_publish_service(
         self,
         injector: Injector,
@@ -274,6 +292,7 @@ class ServiceBotModule(Module):
         quality_task_service: QualityTaskServiceProtocol,
         publish_operation_repo: PublishOperationRepository,
         task_queue_service: TaskQueueService,
+        bot_process_registry: BotProcessRegistry,
     ) -> BotPublishService:
         """Construct ``BotPublishService``.
 
@@ -292,6 +311,7 @@ class ServiceBotModule(Module):
             quality_task_service=quality_task_service,
             publish_operation_repo=publish_operation_repo,
             task_queue_service=task_queue_service,
+            bot_process_registry=bot_process_registry,
             publish_flow_service_provider=lambda: injector.get(PublishFlowService),
         )
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_process.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_process.py
@@ -1,0 +1,50 @@
+"""Tests for bot-type-specific binding response processors."""
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services.bot_process import (
+    BotProcessRegistry,
+    EmptyBotProcess,
+    PersonalBotProcess,
+)
+
+
+@pytest.mark.parametrize(
+    ("template_config", "expected"),
+    [
+        ({"active_runtime_engine_type": "aicoding"}, "aicoding"),
+        ({"active_runtime_engine_type": "  claude_code  "}, "claude_code"),
+        ({"active_runtime_engine_type": ""}, ""),
+        ({"active_runtime_engine_type": "   "}, ""),
+        ({"active_runtime_engine_type": None}, ""),
+        ({"active_runtime_engine_type": 1}, ""),
+        ({"runtime": "codefuse-antcc"}, ""),
+        (None, ""),
+        ("not-a-dict", ""),
+    ],
+)
+def test_personal_bot_process_reads_only_explicit_runtime_engine(
+    template_config, expected
+):
+    template_service = Mock()
+    template_service.get_template_config.return_value = template_config
+    process = PersonalBotProcess(template_service)
+
+    assert process.get_active_runtime_engine_type("bot_001") == expected
+    template_service.get_template_config.assert_called_once_with("bot_001")
+
+
+def test_empty_bot_process_returns_empty_runtime_engine():
+    assert EmptyBotProcess().get_active_runtime_engine_type("bot_001") == ""
+
+
+def test_registry_selects_personal_process_and_defaults_other_types():
+    personal = Mock()
+    default = Mock()
+    registry = BotProcessRegistry(personal, default)
+
+    assert registry.get("personal") is personal
+    assert registry.get("service") is default
+    assert registry.get("desktop") is default
+    assert registry.get("") is default

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -38,6 +38,7 @@ def _make_service(
     quality_task_service=None,
     publish_operation_repo=None,
     task_queue_service=None,
+    bot_process_registry=None,
 ) -> BotPublishService:
     """Build a ``BotPublishService`` with MagicMock fallbacks for unused deps.
 
@@ -50,6 +51,10 @@ def _make_service(
         operation_repo.get_latest_by_kind.return_value = None
         operation_repo.max_attempt.return_value = 0
 
+    process_registry = bot_process_registry or MagicMock()
+    if bot_process_registry is None:
+        process_registry.get.return_value.get_active_runtime_engine_type.return_value = ""
+
     return BotPublishService(
         bot_publish_repo=bot_publish_repo,
         bot_repo=bot_repo or MagicMock(),
@@ -60,6 +65,7 @@ def _make_service(
         quality_task_service=quality_task_service or MagicMock(),
         publish_operation_repo=operation_repo,
         task_queue_service=task_queue_service or MagicMock(),
+        bot_process_registry=process_registry,
     )
 
 
@@ -2143,20 +2149,30 @@ class TestGetBotStageBindingInfo:
             device_provider="arca",
             device_props={"sandbox_id": "BOT-UUID-PERSONAL"},
         )
+        bot_process_registry = Mock()
+        bot_process_registry.get.return_value.get_active_runtime_engine_type.return_value = (
+            "aicoding"
+        )
         service = _make_service(
             bot_publish_repo=mock_repo,
             bot_repo=bot_repo,
             device_binding_repo=device_binding_repo,
+            bot_process_registry=bot_process_registry,
         )
 
         result = service.get_bot_stage_binding_info("bot_001", "user_001", "online")
 
+        bot_process_registry.get.assert_called_once_with("personal")
+        bot_process_registry.get.return_value.get_active_runtime_engine_type.assert_called_once_with(
+            "bot_001"
+        )
         assert result == {
             "bot_id": "bot_001",
             "owner_id": "user_001",
             "bot_type": "personal",
             "engine_type": "openclaw",
             "template_type": "standard",
+            "active_runtime_engine_type": "aicoding",
             "publish_id": None,
             "publish_status": None,
             "binding_id": 501,
@@ -2194,6 +2210,7 @@ class TestGetBotStageBindingInfo:
             "bot_type": "service",
             "engine_type": "teclaw",
             "template_type": "advanced",
+            "active_runtime_engine_type": "",
             "publish_id": None,
             "publish_status": None,
             "binding_id": 503,
@@ -2234,6 +2251,7 @@ class TestGetBotStageBindingInfo:
             "bot_type": "service",
             "engine_type": "teclaw",
             "template_type": "custom",
+            "active_runtime_engine_type": "",
             "publish_id": 12,
             "publish_status": PublishStatus.VALIDATING,
             "binding_id": 601,
@@ -2268,6 +2286,7 @@ class TestGetBotStageBindingInfo:
             "bot_type": "service",
             "engine_type": "teclaw",
             "template_type": "eval-type",
+            "active_runtime_engine_type": "",
             "publish_id": None,
             "publish_status": None,
             "binding_id": None,
@@ -2347,6 +2366,7 @@ class TestGetBotStageBindingInfo:
             "bot_type": "service",
             "engine_type": "teclaw",
             "template_type": "online-template",
+            "active_runtime_engine_type": "",
             "publish_id": 13,
             "publish_status": PublishStatus.SUCCESS,
             "binding_id": 602,
@@ -2612,6 +2632,7 @@ class TestGetBotStageBindingInfo:
             "bot_type": "weird",
             "engine_type": "openclaw",
             "template_type": "weird-template",
+            "active_runtime_engine_type": "",
             "publish_id": None,
             "publish_status": None,
             "binding_id": 902,
@@ -2646,6 +2667,7 @@ class TestGetBotStageBindingInfo:
             "bot_type": "weird",
             "engine_type": "openclaw",
             "template_type": "non-service-template",
+            "active_runtime_engine_type": "",
             "publish_id": None,
             "publish_status": None,
             "binding_id": 901,

--- a/src/backend/tests/community/endpoints/test_service_bot_publish_binding.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_publish_binding.py
@@ -92,7 +92,13 @@ def _seed_binding_error(world) -> None:
         query_params={"owner_id": _OWNER, "stage": "online"},
     ),
     seed=_seed_binding_happy,
-    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {"active_runtime_engine_type": ""},
+        },
+    ),
 )
 def get_binding_happy():
     """Happy path: query binding info for online stage succeeds."""


### PR DESCRIPTION
## Problem

BaaS previously consumed Backend binding responses using the original `engine_type` only. For Personal Bots whose actual runtime engine is explicitly configured in `ac_templates.ext.active_runtime_engine_type`, this could select the wrong Engine Adapter. Invalid or empty runtime-engine data must not alter existing behavior.

## Solution

- Add `active_runtime_engine_type` to Backend binding responses.
- Read the Personal Bot value from template configuration through a bot-type-specific processor.
- At the BaaS HTTP consumption boundary, override the existing `engine_type` only when the runtime value is a non-empty supported type.
- Fall back to the original Backend `engine_type` for missing, empty, non-string, or unsupported values.
- Keep `BotBindingData`, `_normalize_engine_type()`, Runner, Executor, Queue Worker, and Adapter selection logic unchanged.

## Validation

- BaaS BotService Plugin: 49 passed
- Backend service tests: 127 passed
- Backend endpoint/router tests: 28 passed
- BaaS binding resolver/run-utils tests: 105 passed
- Backend architecture tests: 13 passed
- BaaS Runner/Executor tests: 100 passed
- Targeted Flake8 checks passed for all changed Backend and BaaS files
- `git diff --check` passed

## Compatibility and risk

Older Backend responses without `active_runtime_engine_type` continue using the original `engine_type`. Invalid explicit values also fall back to the original value, preserving the existing normalization and execution path.