### PR TITLE
feat(baas): raise ChatRequestError on ok=False in chat_send/chat_inject

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/__init__.py
@@ -28,7 +28,7 @@ from ._bot_run_utils import (
     resolve_user_id,
 )
 from ._bot_service_selector import BotServiceSelector
-from ._bot_websocket_client import BotWebSocketClient
+from ._bot_websocket_client import BotWebSocketClient, ChatRequestError
 from ._claw_service import BotServiceConfig, ClawBotService
 from ._engine_adapter_registry import BotEngineAdapterRegistry
 from ._executor import BotRunRequestExecutor, ResultGuardExecutor, SerializingExecutor
@@ -54,6 +54,7 @@ __all__ = [
     "BotBindingNotFoundError",
     "BotServiceConfig",
     "BotWebSocketClient",
+    "ChatRequestError",
     "ClawBotService",
     "ConcurrentSessionError",
     "NotConnectedError",

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -25,7 +25,7 @@ from secbaas.community.api.sse import StreamChunk
 from secbaas.community.logger import get_logger
 from secbaas.community.tracer import get_tracer_plugin
 
-from ._bot_websocket_client import BotWebSocketClient
+from ._bot_websocket_client import BotWebSocketClient, ChatRequestError
 from ._session_key_matcher import SessionKeyMatcher
 from ._session_state import _SessionState
 
@@ -361,14 +361,24 @@ class AsyncChatClient:
                     timeout,
                 )
                 assert self._client is not None
-                send_result = await self._client.chat_send(
-                    session_key=session_key,
-                    message=message,
-                    auth_token=auth_token,
-                    app_id=app_id,
-                    timeout_ms=int(timeout * 1000) if timeout else None,
-                    chat_metadata=chat_metadata,
-                )
+                try:
+                    send_result = await self._client.chat_send(
+                        session_key=session_key,
+                        message=message,
+                        auth_token=auth_token,
+                        app_id=app_id,
+                        timeout_ms=int(timeout * 1000) if timeout else None,
+                        chat_metadata=chat_metadata,
+                    )
+                except ChatRequestError as e:
+                    logger.error(
+                        "[send] chat.send failed: session_key=%s, error_code=%s, error_message=%s",
+                        session_key,
+                        e.error_code,
+                        e.error_message,
+                    )
+                    state.chat_complete.set()
+                    raise
 
                 logger.info(
                     "[send] Sent successfully: session_key=%s, result=%s",
@@ -470,14 +480,28 @@ class AsyncChatClient:
                     timeout,
                 )
                 assert self._client is not None
-                await self._client.chat_send(
-                    session_key=session_key,
-                    message=message,
-                    auth_token=auth_token,
-                    app_id=app_id,
-                    timeout_ms=int(timeout * 1000) if timeout else None,
-                    chat_metadata=chat_metadata,
-                )
+                try:
+                    await self._client.chat_send(
+                        session_key=session_key,
+                        message=message,
+                        auth_token=auth_token,
+                        app_id=app_id,
+                        timeout_ms=int(timeout * 1000) if timeout else None,
+                        chat_metadata=chat_metadata,
+                    )
+                except ChatRequestError as e:
+                    logger.error(
+                        "[send_stream] chat.send failed: session_key=%s, error_code=%s, error_message=%s",
+                        session_key,
+                        e.error_code,
+                        e.error_message,
+                    )
+                    state.chat_complete.set()
+                    yield StreamChunk(
+                        type="error",
+                        content=f"chat.send failed: {e.error_code} - {e.error_message}",
+                    )
+                    return
 
                 # 消费 stream_queue，逐 chunk 产出
                 async for chunk in self._drain_stream_queue(queue, timeout):

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
@@ -29,6 +29,31 @@ logger = get_logger("core-bot-run")
 EventHandler = Callable[..., Any]
 
 
+class ChatRequestError(Exception):
+    """chat.send / chat.inject 响应 ok=False 时抛出。
+
+    当服务器返回的响应中 ok 字段为 False 时（例如会话验证失败、服务不可用），
+    BotWebSocketClient.chat_send / chat_inject 会抛出此异常，避免静默失败。
+
+    Attributes:
+        error_code: 服务器返回的错误码（如 "UNAVAILABLE"），可能为 None
+        error_message: 服务器返回的错误信息，可能为 None
+        retryable: 服务器指示是否可重试，可能为 None
+    """
+
+    def __init__(
+        self,
+        message: str,
+        error_code: str | None = None,
+        error_message: str | None = None,
+        retryable: bool | None = None,
+    ):
+        super().__init__(message)
+        self.error_code = error_code
+        self.error_message = error_message
+        self.retryable = retryable
+
+
 class BotWebSocketClient:
     """Bot WebSocket 客户端（纯异步版本）
 
@@ -208,11 +233,22 @@ class BotWebSocketClient:
             params.update(chat_metadata)
         params["x-iam-token"] = auth_token or "OPEN_API:NOT_PROVIDED"
 
-        return await self._send_request(
+        result = await self._send_request(
             "chat.send",
             params,
             timeout=min(timeout_ms / 1000, 120) if timeout_ms else 120,
         )
+
+        if not result.get("ok"):
+            error = result.get("error", {})
+            raise ChatRequestError(
+                message=f"chat.send failed: {error.get('code')} - {error.get('message')}",
+                error_code=error.get("code"),
+                error_message=error.get("message"),
+                retryable=error.get("retryable"),
+            )
+
+        return result
 
     async def chat_inject(
         self,
@@ -233,11 +269,22 @@ class BotWebSocketClient:
             params.update(chat_metadata)
         params["x-iam-token"] = auth_token or "OPEN_API:NOT_PROVIDED"
 
-        return await self._send_request(
+        result = await self._send_request(
             "chat.inject",
             params,
             timeout=min(timeout_ms / 1000, 120) if timeout_ms else 120,
         )
+
+        if not result.get("ok"):
+            error = result.get("error", {})
+            raise ChatRequestError(
+                message=f"chat.inject failed: {error.get('code')} - {error.get('message')}",
+                error_code=error.get("code"),
+                error_message=error.get("message"),
+                retryable=error.get("retryable"),
+            )
+
+        return result
 
     async def chat_abort(
         self,

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -1423,3 +1423,237 @@ class TestInjectMessageSemaphore:
             client.inject_message("m3", session_key="s3"),
         )
         assert call_count == 3
+
+
+# ==================== ChatRequestError propagation tests ====================
+
+
+class TestChatRequestErrorPropagation:
+    """Tests for ChatRequestError handling in AsyncChatClient."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_propagates_chat_request_error(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """send_message propagates ChatRequestError from chat_send and sets chat_complete."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatRequestError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
+            message="chat.send failed: UNAVAILABLE - Session validation failed",
+            error_code="UNAVAILABLE",
+            error_message="Session validation failed",
+            retryable=True,
+        )
+
+        with pytest.raises(ChatRequestError, match="chat.send failed"):
+            await client.send_message("Hi", session_key="sk-err")
+
+    @pytest.mark.asyncio
+    async def test_send_message_sets_chat_complete_on_chat_request_error(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """send_message sets chat_complete on ChatRequestError to unblock waiters."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatRequestError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
+            message="chat.send failed: UNAVAILABLE - Session validation failed",
+            error_code="UNAVAILABLE",
+            error_message="Session validation failed",
+        )
+
+        # Capture session state before the error to verify chat_complete is set
+        captured_state = None
+
+        original_chat_send = mock_bot_ws_instance.chat_send.side_effect
+
+        async def chat_send_with_state_capture(*args, **kwargs):
+            state = client._sessions.get(kwargs.get("session_key"))
+            nonlocal captured_state
+            captured_state = state
+            raise original_chat_send
+
+        mock_bot_ws_instance.chat_send.side_effect = chat_send_with_state_capture
+
+        with pytest.raises(ChatRequestError, match="chat.send failed"):
+            await client.send_message("Hi", session_key="sk-err")
+
+        # chat_complete should have been set to unblock any waiters
+        assert captured_state is not None
+        assert captured_state.chat_complete.is_set()
+
+    @pytest.mark.asyncio
+    async def test_send_message_cleans_up_session_on_chat_request_error(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """send_message cleans up session state after ChatRequestError."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatRequestError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
+            message="chat.send failed: UNAVAILABLE - Session validation failed",
+            error_code="UNAVAILABLE",
+            error_message="Session validation failed",
+        )
+
+        with pytest.raises(ChatRequestError, match="chat.send failed"):
+            await client.send_message("Hi", session_key="sk-err")
+
+        # Session should be cleaned up in the finally block
+        assert "sk-err" not in client._sessions
+        assert "sk-err" not in client._active_sessions
+
+
+# ==================== ChatRequestError in send_message_stream tests ====================
+
+
+class TestChatRequestErrorStream:
+    """Tests for ChatRequestError handling in send_message_stream."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_emits_error_on_chat_request_error(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """send_message_stream emits error StreamChunk when ChatRequestError is raised."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatRequestError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
+            message="chat.send failed: UNAVAILABLE - Session validation failed",
+            error_code="UNAVAILABLE",
+            error_message="Session validation failed",
+        )
+
+        chunks = []
+        async for chunk in client.send_message_stream("Hi", session_key="sk-err"):
+            chunks.append(chunk)
+
+        # Should emit exactly one error chunk
+        assert len(chunks) == 1
+        assert chunks[0].type == "error"
+        assert "UNAVAILABLE" in chunks[0].content
+        assert "Session validation failed" in chunks[0].content
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_sets_chat_complete_on_chat_request_error(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """send_message_stream sets chat_complete when ChatRequestError is raised."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+            _SessionState,
+        )
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatRequestError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        # Pre-register a session state so we can inspect it after the error
+        sk = "sk-err"
+        state = _SessionState()
+        client._sessions[sk] = state
+
+        mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
+            message="chat.send failed: UNAVAILABLE - Session validation failed",
+            error_code="UNAVAILABLE",
+            error_message="Session validation failed",
+        )
+
+        chunks = []
+        async for chunk in client.send_message_stream("Hi", session_key=sk):
+            chunks.append(chunk)
+
+        # The session gets cleaned up in the finally block, but chat_complete
+        # was set before the iterator returned
+        assert len(chunks) == 1
+        assert chunks[0].type == "error"
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_cleans_up_on_chat_request_error(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """send_message_stream cleans up session state after ChatRequestError."""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatRequestError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
+            message="chat.send failed: UNAVAILABLE - Session validation failed",
+            error_code="UNAVAILABLE",
+            error_message="Session validation failed",
+        )
+
+        chunks = []
+        async for chunk in client.send_message_stream("Hi", session_key="sk-err"):
+            chunks.append(chunk)
+
+        # Session should be cleaned up
+        assert "sk-err" not in client._sessions
+        assert "sk-err" not in client._active_sessions

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py
@@ -20,6 +20,7 @@ import pytest
 
 from secbaas.community.core.service.bot_run._bot_websocket_client import (
     BotWebSocketClient,
+    ChatRequestError,
 )
 
 # ==================== Fixtures ====================
@@ -744,6 +745,139 @@ class TestConvenienceMethods:
         sent = sent_frames[0]
         assert sent["method"] == "sessions.reset"
         assert sent["params"] == {"sessionKey": "sk-reset"}
+
+
+# ==================== Tests: ChatRequestError ====================
+
+
+class TestChatRequestError:
+    """Tests for ChatRequestError ok=False handling in chat_send/chat_inject."""
+
+    async def _setup_mock_ws_ok_false(self, client, error_payload):
+        """Helper: set up a mock ws that responds with ok=False."""
+        mock_ws = AsyncMock()
+        client._ws = mock_ws
+        client._connected = True
+
+        async def mock_send(data):
+            sent = json.loads(data)
+            req_id = sent["id"]
+            entry = client._pending_requests.get(req_id)
+            if entry:
+                if not entry.done():
+                    entry.set_result(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": False,
+                            "error": error_payload,
+                        }
+                    )
+
+        mock_ws.send = mock_send
+
+    # [单测用例]测试场景：chat_send ok=False 抛出 ChatRequestError
+    async def test_chat_send_ok_false_raises_error(self, client):
+        """chat_send raises ChatRequestError when response ok=False."""
+        error_payload = {
+            "code": "UNAVAILABLE",
+            "message": "Session validation failed",
+            "retryable": True,
+        }
+        await self._setup_mock_ws_ok_false(client, error_payload)
+
+        with pytest.raises(ChatRequestError, match="chat.send failed"):
+            await client.chat_send(session_key="sk-err", message="hello")
+
+    # [单测用例]测试场景：chat_send ChatRequestError 包含 error 详情
+    async def test_chat_send_error_details(self, client):
+        """ChatRequestError from chat_send includes error_code, error_message, retryable."""
+        error_payload = {
+            "code": "UNAVAILABLE",
+            "message": "Session validation failed",
+            "retryable": True,
+        }
+        await self._setup_mock_ws_ok_false(client, error_payload)
+
+        with pytest.raises(ChatRequestError) as exc_info:
+            await client.chat_send(session_key="sk-err", message="hello")
+
+        err = exc_info.value
+        assert err.error_code == "UNAVAILABLE"
+        assert err.error_message == "Session validation failed"
+        assert err.retryable is True
+
+    # [单测用例]测试场景：chat_send ok=False 缺少 error 字段时安全处理
+    async def test_chat_send_ok_false_missing_error_fields(self, client):
+        """ChatRequestError handles missing error fields gracefully."""
+        await self._setup_mock_ws_ok_false(client, {})
+
+        with pytest.raises(ChatRequestError) as exc_info:
+            await client.chat_send(session_key="sk-err", message="hello")
+
+        err = exc_info.value
+        assert err.error_code is None
+        assert err.error_message is None
+        assert err.retryable is None
+
+    # [单测用例]测试场景：chat_inject ok=False 抛出 ChatRequestError
+    async def test_chat_inject_ok_false_raises_error(self, client):
+        """chat_inject raises ChatRequestError when response ok=False."""
+        error_payload = {
+            "code": "FORBIDDEN",
+            "message": "Permission denied",
+            "retryable": False,
+        }
+        await self._setup_mock_ws_ok_false(client, error_payload)
+
+        with pytest.raises(ChatRequestError, match="chat.inject failed"):
+            await client.chat_inject(session_key="sk-err", message="inject")
+
+    # [单测用例]测试场景：chat_inject ChatRequestError 包含 error 详情
+    async def test_chat_inject_error_details(self, client):
+        """ChatRequestError from chat_inject includes error_code, error_message, retryable."""
+        error_payload = {
+            "code": "FORBIDDEN",
+            "message": "Permission denied",
+            "retryable": False,
+        }
+        await self._setup_mock_ws_ok_false(client, error_payload)
+
+        with pytest.raises(ChatRequestError) as exc_info:
+            await client.chat_inject(session_key="sk-err", message="inject")
+
+        err = exc_info.value
+        assert err.error_code == "FORBIDDEN"
+        assert err.error_message == "Permission denied"
+        assert err.retryable is False
+
+    # [单测用例]测试场景：chat_send ok=True 正常返回
+    async def test_chat_send_ok_true_returns_result(self, client):
+        """chat_send returns result when ok=True."""
+        mock_ws = AsyncMock()
+        client._ws = mock_ws
+        client._connected = True
+
+        async def mock_send(data):
+            sent = json.loads(data)
+            req_id = sent["id"]
+            entry = client._pending_requests.get(req_id)
+            if entry:
+                if not entry.done():
+                    entry.set_result(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": True,
+                            "payload": {"accepted": True},
+                        }
+                    )
+
+        mock_ws.send = mock_send
+
+        result = await client.chat_send(session_key="sk-ok", message="hello")
+        assert result["ok"] is True
+        assert result["payload"]["accepted"] is True
 
 
 # ==================== Tests: on_event ====================


### PR DESCRIPTION
## Summary

Add `ChatRequestError` exception and raise it when the server responds with `ok=False` in `chat_send` and `chat_inject`. In `AsyncChatClient`, catch this exception and emit an error chunk in the streaming iterator so consumers get a structured failure signal instead of a silently empty stream.

## Motivation

Previously, `chat_send` and `chat_inject` returned the raw result dict when `ok=False`, giving callers no indication that the chat request had failed. Callers that relied on the streaming iterator would simply receive no chunks, making failures invisible and hard to diagnose.

## Changes

| File | Change |
|------|--------|
| `__init__.py` | Export `ChatRequestError` |
| `_bot_websocket_client.py` | Raise `ChatRequestError` in `chat_send` and `chat_inject` when `ok=False` |
| `_async_chat_client.py` | Catch `ChatRequestError` in `chat_send` streaming and emit an error chunk; `chat_inject` lets the exception propagate |
| `test_bot_websocket_client.py` | Unit tests for `ChatRequestError` on `ok=False` |
| `test_async_chat_client.py` | Unit tests for error chunk emission on `ChatRequestError` |

## Testing

- 115 unit tests passed, 0 failed
- Linting (ruff check) passed
- Format check (ruff format --check) passed

## Privacy Scan

No privacy issues introduced. Pre-existing: none.

## Code Review Notes

- 0 blocking issues. One P2 noted: `chat_abort` and `session_reset` do not yet check `ok=False` -- this is deferred to a follow-up change for consistency.
- Two P3 notes (non-issues): `inject_message` correctly lets `ChatRequestError` propagate; `connect()` raises `RuntimeError` at a different protocol layer which is acceptable.

## Breaking Change

Callers that previously ignored the return value of `chat_send`/`chat_inject` on failure will now receive a `ChatRequestError` exception. Top-level handlers with `try/except` will catch this naturally.