### PR TITLE
refactor(gateway): route domains by path pattern and move the bot socket under bots

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -575,6 +575,29 @@ approvals  ceiling  check-name  connection  engine  identity
 mcp  models  resources  routines  sessions  skills
 ```
 
+**Reserved ahead of their routes.** A second, separate list — names claimed here
+before any route publishes them. They are *not* reserved for the reason above:
+no route serves them, so nothing is currently unreachable at those addresses.
+They are reserved because something else already occupies the address and a
+component is intended there, so a bot id must not be allowed to take it in the
+meantime.
+
+<!-- reserved-component-names-unrouted -->
+```text
+messages
+```
+
+- `messages` — the gateway serves the bot's chat WebSocket at
+  `/openapi/v1/bots/messages/**`, relayed to the engine proxy
+  (`src/gateway/configs/application.yaml`). That claim is on the **socket plane
+  only**, so an HTTP request to the address still reaches this service; the name
+  is held for the HTTP endpoint intended there. See
+  `src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/`.
+
+A name in this list must move to the routed list above the moment a route
+publishes it — the convention test asserts the two lists stay disjoint, so
+adding the route without moving the name fails there rather than in review.
+
 > **Mount order is load-bearing.** `build_public_router()` includes the literal
 > sub-groups **before** the bots group, so `/openapi/v1/bots/resources` resolves
 > ahead of the `/openapi/v1/bots/{bot_id}` wildcard. Only the components that

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -503,10 +503,30 @@ base 之下再容纳第二个 owner 的可能 —— BCS 正是从另一侧撞�
 id 恰好等于某个组件名，它在该地址上就不可达。这个集合是固定的，同一个测试会断言下面这份
 清单仍然等于路由实际发布的字面量（英文版 `README.md` 中的同名清单是被解析的那一份）：
 
+<!-- reserved-component-names -->
 ```text
 approvals  ceiling  check-name  connection  engine  identity
 mcp  models  resources  routines  sessions  skills
 ```
+
+**先于路由保留的名字。** 另有一份独立清单 —— 在任何路由发布它们之前就已在此占位的名字。
+它们的保留理由与上面那份**不同**：没有任何路由提供它们，因此当前也不存在"某个地址不可达"
+的问题。保留是因为该地址已被别处占用，且我们确实打算在那里放一个组件，所以在此期间不能让
+某个 Agent id 把它占走。
+
+<!-- reserved-component-names-unrouted -->
+```text
+messages
+```
+
+- `messages` —— 网关在 `/openapi/v1/bots/messages/**` 上提供 Agent 的聊天 WebSocket，
+  并中继到 engine proxy（`src/gateway/configs/application.yaml`）。该占用**只在 socket
+  平面**上成立，因此发往该地址的 HTTP 请求仍会到达本服务；这个名字是为将来要放在那里的
+  HTTP 端点保留的。参见
+  `src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/`。
+
+一旦有路由发布了这份清单里的某个名字，就必须把它移到上面那份已路由的清单里 —— 约定测试会
+断言两份清单互不相交，因此"加了路由却没搬名字"会在测试里失败，而不是留给评审去发现。
 
 > **挂载顺序是有承重作用的。** `build_public_router()` 会先挂字面量子组，再挂 bots 组，
 > 这样 `/openapi/v1/bots/resources` 才能排在通配的 `/openapi/v1/bots/{bot_id}` 前面被

--- a/src/backend/docs/openapi-v1/engine-surface.md
+++ b/src/backend/docs/openapi-v1/engine-surface.md
@@ -181,7 +181,7 @@ sockets, never proxypass topology:
   "sockets": [
     {
       "kind": "chat",
-      "url": "wss://<gateway>/openapi/v1/engine/<target>/api/openclaw/ws?x-proxypass-token=<scoped token>"
+      "url": "wss://<gateway>/openapi/v1/bots/messages/<target>/api/openclaw/ws?x-proxypass-token=<scoped token>"
     }
   ]
 }
@@ -212,23 +212,28 @@ Rules this endpoint must hold:
   this same socket the same way. _Corrected 2026-07-31._
 - **The address is the gateway's, not the hop behind it.** The published origin
   comes from the `gateway` config block (`base_url` / `base_url_pre`, selected
-  by env), under an `/openapi/v1/engine/{target}{path}` prefix the gateway
+  by env), under an `/openapi/v1/bots/messages/{target}{path}` prefix the gateway
   rewrites onto that hop. A deployment that fronts no gateway — the community
   build's normal state — is a named upstream error, not a 500 and not a
   published address nothing serves. The prefix sits inside the published API
-  namespace, not at the host root: `engine` is an ordinary gateway domain,
-  resolved by the same leading-segment lookup as `bots`, so the socket lives in
-  the same surface as the endpoint that hands it out. _Corrected 2026-08-02._
+  namespace, not at the host root, and inside the `bots` scope rather than
+  beside it: the gateway resolves domains by path pattern, so this prefix is
+  served by the engine proxy while everything else under `/openapi/v1/bots/**`
+  is served by this service. The leading segment names the **owner** of the
+  surface, not the process behind it, and management and runtime here are one
+  owner. Claimed on the socket plane only, so an HTTP request to the same
+  address still reaches this service. _Moved 2026-08-03; previously
+  `/openapi/v1/engine`._
 - **The provider's URL is re-addressed, not rebuilt.** The device connection is
   still requested in **`ws_conn_mode="relay"`**, and the provider still builds a
   finished URL around the engine path it is given — that path passthrough is why
   a `claude_code` bot is not handed openclaw's default and rejected with 4001 on
   connect. Exactly two things then change: the origin becomes the gateway's, and
-  the hop's `/proxypass/` prefix becomes `/openapi/v1/engine/`. Everything past that prefix
+  the hop's `/proxypass/` prefix becomes `/openapi/v1/bots/messages/`. Everything past that prefix
   — target, engine path, any query the provider set — is carried through as the
   provider wrote it, so this endpoint holds no opinion about a URL grammar it
   does not own and cannot silently drop a part it did not anticipate. A provider
-  URL of a shape the `/engine` prefix cannot express — BaaS's LOCAL platform
+  URL of a shape the `/openapi/v1/bots/messages` prefix cannot express — BaaS's LOCAL platform
   answers `/wsrelay/{session_id}` — is refused rather than published, so a wrong
   assumption surfaces server-side instead of as a socket that will not open.
   _Corrected 2026-07-31._

--- a/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
+++ b/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
@@ -152,7 +152,7 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
   "sockets": [
     {
       "kind": "chat",
-      "url": "wss://<gateway>/openapi/v1/engine/<target>/api/openclaw/ws?x-proxypass-token=<scoped token>"
+      "url": "wss://<gateway>/openapi/v1/bots/messages/<target>/api/openclaw/ws?x-proxypass-token=<scoped token>"
     }
   ]
 }
@@ -180,19 +180,21 @@ socket 也是干净的。
   内部 console 打开同一条 socket 用的就是同样的方式。_2026-07-31 更正。_
 - **地址是网关的，不是它背后那一跳的。** 对外发布的 origin 取自 `gateway` 配置块
   （`base_url` / `base_url_pre`，按环境选择），前缀是
-  `/openapi/v1/engine/{target}{path}`，由网关改写到那一跳上。前面没有网关的部署
+  `/openapi/v1/bots/messages/{target}{path}`，由网关改写到那一跳上。前面没有网关的部署
   —— 也就是 community 构建的常态 —— 是一个有名字的 upstream 错误，不是 500，
   也不是发布一个没人服务的地址。该前缀位于对外发布的 API 命名空间之内，而不是
-  主机根路径：`engine` 就是一个普通的网关 domain，和 `bots` 用同一套按首段解析的
-  查找逻辑，因此这条 socket 与分发它地址的那个端点处在同一张对外表面上。
-  _2026-08-02 更正。_
+  主机根路径；并且位于 `bots` 作用域**之内**，而不是与之并列：网关按 path pattern
+  解析 domain，因此这个前缀由 engine proxy 服务，而 `/openapi/v1/bots/**` 下的其余
+  地址由本服务服务。首段标识这张表面的**归属方**，而不是背后的进程 —— 管理面与运行时
+  在这里属于同一个归属方。该占用只在 socket 平面成立，因此发往同一地址的 HTTP 请求
+  仍会到达本服务。_2026-08-03 迁移；此前为 `/openapi/v1/engine`。_
 - **provider 给的 URL 是被改写地址，不是被重新拼装。** 获取设备连接时仍然请求
   **`ws_conn_mode="relay"`**，provider 也仍然围绕我们给它的引擎 path 拼出一条完整
   URL —— 正是这个 path 透传，才让 `claude_code` bot 不会拿到 openclaw 的默认路径、
   在连接时被 4001 拒掉。之后只改两处：origin 换成网关的，`/proxypass/` 前缀换成
-  `/openapi/v1/engine/`。该前缀之后的一切 —— target、引擎 path、provider 自己带的 query ——
+  `/openapi/v1/bots/messages/`。该前缀之后的一切 —— target、引擎 path、provider 自己带的 query ——
   原封不动透传，因此本端点对一套并不属于它的 URL 语法不持任何假设，也不会悄悄丢掉
-  没预料到的部分。若 provider 给回的形状是 `/openapi/v1/engine` 前缀无法表达的 —— BaaS 的
+  没预料到的部分。若 provider 给回的形状是 `/openapi/v1/bots/messages` 前缀无法表达的 —— BaaS 的
   LOCAL 平台返回 `/wsrelay/{session_id}` —— 则直接拒绝而不是发布，这样错误的假设会在
   服务端暴露，而不是变成一条连不上的 socket。_2026-07-31 更正。_
 - **`expires_at` 必填**，让调用方知道该重新获取，而不是在 token 过期后静默失败。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/connection/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/connection/schemas.py
@@ -15,7 +15,7 @@ class Socket(BaseModel):
             "example": {
                 "kind": "chat",
                 "url": (
-                    "wss://gateway.example/openapi/v1/engine/abc/api/openclaw/ws"
+                    "wss://gateway.example/openapi/v1/bots/messages/abc/api/openclaw/ws"
                     "?x-proxypass-token=…"
                 ),
             }
@@ -43,7 +43,7 @@ class Connection(BaseModel):
                     {
                         "kind": "chat",
                         "url": (
-                            "wss://gateway.example/openapi/v1/engine/abc/api/openclaw/ws"
+                            "wss://gateway.example/openapi/v1/bots/messages/abc/api/openclaw/ws"
                             "?x-proxypass-token=…"
                         ),
                     }

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -7,11 +7,10 @@ topology and a raw device credential, both of which become things we cannot
 change without breaking integrators.
 
 This service returns **finished** socket URLs instead, addressed to the public
-gateway under ``/openapi/v1/engine``. The target and the credential do travel
-*inside* that
-URL — a browser's WebSocket handshake can carry a credential nowhere else — but
-no field beside it hands a caller the pieces to assemble a different one, and
-nothing names the hop behind the gateway.
+gateway under ``/openapi/v1/bots/messages``. The target and the credential do
+travel *inside* that URL — a browser's WebSocket handshake can carry a credential
+nowhere else — but no field beside it hands a caller the pieces to assemble a
+different one, and nothing names the hop behind the gateway.
 """
 
 from __future__ import annotations
@@ -56,10 +55,16 @@ CONNECTION_TTL_SECONDS = 120 * 60
 _PROXY_TOKEN_PARAM = "x-proxypass-token"
 
 #: Path prefix the gateway routes on. It sits *inside* the published API
-#: namespace rather than at the host root: ``engine`` is an ordinary gateway
-#: domain, resolved by the same leading-segment lookup as ``bots``, and the
-#: socket is part of the same public surface as the endpoint that hands it out.
-_ENGINE_PREFIX = "/openapi/v1/engine"
+#: namespace rather than at the host root, and inside the ``bots`` scope rather
+#: than beside it: the whole bots surface — management here, runtime on the hop
+#: behind the gateway — is one team's, and the leading segment names the owner
+#: rather than the process. The gateway resolves it by path pattern, so a
+#: socket prefix nested under another domain's is an ordinary configuration.
+#:
+#: ``messages`` names the channel the messages travel over. Other domains are
+#: expected to grow their own, so the word is shared vocabulary rather than
+#: this surface's alone.
+_ENGINE_PREFIX = "/openapi/v1/bots/messages"
 
 #: The routing prefix the hop behind the gateway serves. Recognised, then swapped
 #: for :data:`_ENGINE_PREFIX` — see :meth:`_readdress_onto_gateway`.
@@ -343,7 +348,8 @@ class EngineConnectionService:
         """The provider's relay URL, re-pointed at the gateway.
 
         Exactly two things change: the origin becomes the gateway's, and the
-        hop's ``/proxypass/`` routing prefix becomes ``/openapi/v1/engine/``.
+        hop's ``/proxypass/`` routing prefix becomes
+        ``/openapi/v1/bots/messages/``.
         Everything past that prefix — the target, the engine path, any query the
         provider set — is carried through as the provider wrote it, so this
         endpoint holds no opinion about a URL grammar it does not own.
@@ -434,7 +440,7 @@ class EngineConnectionService:
         # A bare origin is all this may be. The prefix appended below already
         # carries the API namespace, so a base url with a path of its own would
         # double it — ``https://gw.example/api`` would publish
-        # ``/api/openapi/v1/engine/…``, which no gateway domain resolves. A
+        # ``/api/openapi/v1/bots/messages/…``, which no gateway domain resolves. A
         # ``#`` or ``?`` is worse still: it ends the path before the prefix is
         # even appended, putting the credential somewhere a browser never sends.
         if any(delimiter in rest for delimiter in "/#?") or not rest:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py
@@ -47,7 +47,7 @@ class FakeConnections:
             SocketInfo(
                 kind="chat",
                 url=(
-                    "wss://gw.example/openapi/v1/engine/tgt/api/openclaw/ws"
+                    "wss://gw.example/openapi/v1/bots/messages/tgt/api/openclaw/ws"
                     "?x-proxypass-token=tok"
                 ),
             )

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
@@ -33,6 +33,13 @@ _BASE = f"{PUBLIC_API_PREFIX}/bots"
 _README = Path(__file__).resolve().parents[5] / "docs" / "openapi-v1" / "README.md"
 _RESERVED_ANCHOR = "<!-- reserved-component-names -->"
 
+#: Names claimed in the docs *before* any route publishes them — currently only
+#: where the gateway serves the address on another plane. Kept as its own list
+#: rather than folded into the one above, so the equality check there stays an
+#: equality check: a documented name with no route is otherwise indistinguishable
+#: from docs that have fallen behind the routes.
+_UNROUTED_ANCHOR = "<!-- reserved-component-names-unrouted -->"
+
 
 def _paths() -> list[str]:
     app = FastAPI()
@@ -118,13 +125,22 @@ def test_channels_is_gone():
     assert not offenders, f"channels was removed: {offenders}"
 
 
-def _documented_reserved_names() -> set[str]:
+def _fenced_names(anchor: str) -> set[str]:
+    """The first fenced block following *anchor* in the README, as a name set."""
     text = _README.read_text(encoding="utf-8")
-    anchored = text.split(_RESERVED_ANCHOR, 1)
-    assert len(anchored) == 2, f"{_RESERVED_ANCHOR} missing from {_README}"
+    anchored = text.split(anchor, 1)
+    assert len(anchored) == 2, f"{anchor} missing from {_README}"
     fenced = re.search(r"```text\n(.*?)```", anchored[1], re.DOTALL)
-    assert fenced is not None, f"no fenced block after {_RESERVED_ANCHOR}"
+    assert fenced is not None, f"no fenced block after {anchor}"
     return set(fenced.group(1).split())
+
+
+def _documented_reserved_names() -> set[str]:
+    return _fenced_names(_RESERVED_ANCHOR)
+
+
+def _documented_unrouted_names() -> set[str]:
+    return _fenced_names(_UNROUTED_ANCHOR)
 
 
 def test_the_docs_reserved_names_match_the_routes():
@@ -136,3 +152,29 @@ def test_the_docs_reserved_names_match_the_routes():
     quietly falling behind a component added later.
     """
     assert _documented_reserved_names() == _components()
+
+
+def test_names_reserved_ahead_of_their_routes_are_not_routed():
+    """A reserved name that gains a route must move to the routed list.
+
+    The two lists are asserted disjoint rather than merged, because they are
+    reserved for different reasons and only one of them can be checked against
+    the routes. Merging would force the equality check above to be relaxed to a
+    subset check, and that check is the only thing stopping the docs from
+    quietly falling behind a component added later.
+    """
+    overlap = _documented_unrouted_names() & _components()
+    assert not overlap, (
+        f"{sorted(overlap)} now has routes — move it to the routed reserved list"
+    )
+
+
+def test_the_socket_prefix_is_reserved():
+    """`messages` is claimed by the gateway on the socket plane.
+
+    Recorded here because nothing in *this* service publishes it: an HTTP
+    request to `/openapi/v1/bots/messages/...` still arrives here, so without
+    the reservation a bot could take the id and the intended component could
+    never have the address.
+    """
+    assert "messages" in _documented_unrouted_names()

--- a/src/backend/tests/community/core/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/core/engine_runtime/test_connection.py
@@ -178,7 +178,7 @@ def test_the_engines_socket_path_is_requested_from_the_provider():
 
 def test_a_relay_url_the_gateway_prefix_cannot_express_is_refused():
     """``/wsrelay/{session_id}`` cannot be rebuilt from a target and a path, and
-    the gateway only rewrites ``/openapi/v1/engine/`` onto ``/proxypass/``. Publishing the
+    the gateway only rewrites ``/openapi/v1/bots/messages/`` onto ``/proxypass/``. Publishing the
     provider's own URL instead would name the hop behind the gateway."""
     devices = _Devices(url="wss://relay.example/wsrelay/s1/api/openclaw/ws")
     with pytest.raises(EngineUpstreamError):
@@ -261,7 +261,7 @@ def test_a_deployment_fronting_no_gateway_is_an_upstream_error():
 
 
 def test_a_gateway_base_without_a_scheme_is_an_upstream_error():
-    """``gw.example/openapi/v1/engine/…`` is not openable. Refused rather than published,
+    """``gw.example/openapi/v1/bots/messages/…`` is not openable. Refused rather than published,
     since the value comes from a deployment overlay this build does not own."""
     with pytest.raises(EngineUpstreamError):
         _build(_svc(gateway=_gateway(base="gw.example")))
@@ -270,7 +270,7 @@ def test_a_gateway_base_without_a_scheme_is_an_upstream_error():
 def test_the_relay_url_is_readdressed_onto_the_gateway():
     result = _build(_svc())
     assert result.sockets[0].url == (
-        "wss://gw.example/openapi/v1/engine/tgt/api/openclaw/ws?x-proxypass-token=tok"
+        "wss://gw.example/openapi/v1/bots/messages/tgt/api/openclaw/ws?x-proxypass-token=tok"
     )
 
 
@@ -281,12 +281,12 @@ def test_the_published_url_never_names_the_hop_behind_the_gateway():
 def test_an_http_gateway_base_becomes_ws():
     """The branch singlebox actually runs — its overlay ships an http base."""
     result = _build(_svc(gateway=_gateway(base="http://127.0.0.1:9999")))
-    assert result.sockets[0].url.startswith("ws://127.0.0.1:9999/openapi/v1/engine/")
+    assert result.sockets[0].url.startswith("ws://127.0.0.1:9999/openapi/v1/bots/messages/")
 
 
 def test_a_gateway_base_already_spelled_as_a_socket_origin_is_kept():
     result = _build(_svc(gateway=_gateway(base="wss://gw.example")))
-    assert result.sockets[0].url.startswith("wss://gw.example/openapi/v1/engine/")
+    assert result.sockets[0].url.startswith("wss://gw.example/openapi/v1/bots/messages/")
 
 
 @pytest.mark.parametrize(
@@ -294,7 +294,7 @@ def test_a_gateway_base_already_spelled_as_a_socket_origin_is_kept():
 )
 def test_a_gateway_base_carrying_a_path_is_refused(base):
     """``/engine`` has to sit at the root — that is where the gateway's rewrite
-    is anchored. A base with a path would double the namespace (``/api/openapi/v1/engine/…``), which the
+    is anchored. A base with a path would double the namespace (``/api/openapi/v1/bots/messages/…``), which the
     gateway does not route, so the socket would be unopenable rather than
     named."""
     with pytest.raises(EngineUpstreamError):
@@ -303,7 +303,7 @@ def test_a_gateway_base_carrying_a_path_is_refused(base):
 
 def test_a_trailing_slash_and_stray_whitespace_are_normalised():
     result = _build(_svc(gateway=_gateway(base="  https://gw.example//  ")))
-    assert result.sockets[0].url.startswith("wss://gw.example/openapi/v1/engine/")
+    assert result.sockets[0].url.startswith("wss://gw.example/openapi/v1/bots/messages/")
 
 
 def test_a_relay_url_carrying_a_fragment_is_refused():
@@ -323,7 +323,7 @@ def test_a_provider_query_is_preserved_and_the_credential_appended():
     )
     url = _build(_svc(devices=devices)).sockets[0].url
     assert url == (
-        "wss://gw.example/openapi/v1/engine/tgt/api/openclaw/ws"
+        "wss://gw.example/openapi/v1/bots/messages/tgt/api/openclaw/ws"
         "?session=s1&x-proxypass-token=tok"
     )
 
@@ -335,7 +335,7 @@ def test_the_provider_path_is_carried_through_verbatim():
         url="wss://proxy.example/proxypass/tgt/v2/api/openclaw/ws"
     )
     url = _build(_svc(devices=devices)).sockets[0].url
-    assert url.startswith("wss://gw.example/openapi/v1/engine/tgt/v2/api/openclaw/ws?")
+    assert url.startswith("wss://gw.example/openapi/v1/bots/messages/tgt/v2/api/openclaw/ws?")
 
 
 @pytest.mark.parametrize("base", ["https://gw.example/#", "https://gw.example/?x=1"])
@@ -384,7 +384,7 @@ def test_a_malformed_provider_url_is_named_rather_than_a_500():
 
 def test_a_provider_relay_url_of_an_unknown_shape_is_refused():
     """Same guard as the ``/wsrelay/`` case: anything this endpoint cannot
-    re-address onto ``/openapi/v1/engine/`` is an upstream error, not a passthrough."""
+    re-address onto ``/openapi/v1/bots/messages/`` is an upstream error, not a passthrough."""
     devices = _Devices(url="wss://relay.example/route/xyz")
     with pytest.raises(EngineUpstreamError):
         _build(_svc(devices=devices))
@@ -396,7 +396,7 @@ def test_only_the_origin_and_routing_prefix_change():
     devices = _Devices(url="wss://proxy.example/proxypass/tgt/api/openclaw/ws")
     result = _build(_svc(devices=devices))
     assert result.sockets[0].url == (
-        "wss://gw.example/openapi/v1/engine/tgt/api/openclaw/ws?x-proxypass-token=tok"
+        "wss://gw.example/openapi/v1/bots/messages/tgt/api/openclaw/ws?x-proxypass-token=tok"
     )
 
 
@@ -421,7 +421,7 @@ def test_no_credential_publishes_no_query_string():
     header."""
     devices = _Devices(token="", ws_token="")
     url = _build(_svc(devices=devices)).sockets[0].url
-    assert url == "wss://gw.example/openapi/v1/engine/tgt/api/openclaw/ws"
+    assert url == "wss://gw.example/openapi/v1/bots/messages/tgt/api/openclaw/ws"
     assert "?" not in url
 
 
@@ -436,7 +436,7 @@ def test_the_target_segment_is_not_percent_encoded():
     gateway matches the target raw."""
     devices = _Devices(target="ARCA_ARCA-SANDBOX-abc@0:20003")
     url = _build(_svc(devices=devices)).sockets[0].url
-    assert "/openapi/v1/engine/ARCA_ARCA-SANDBOX-abc@0:20003/api/openclaw/ws" in url
+    assert "/openapi/v1/bots/messages/ARCA_ARCA-SANDBOX-abc@0:20003/api/openclaw/ws" in url
 
 
 def test_a_local_ipv6_target_keeps_its_brackets():

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -103,8 +103,8 @@ user_config:
     "/openapi/v1/bots/**":
       user: required
 
-    # The tenant engine socket, and the FIRST rule under /openapi/v1 that
-    # requires no identity at all. Deliberate: the credential is already in the
+    # The tenant bot socket, and the ONLY rule under /openapi/v1 that requires
+    # no identity at all. Deliberate: the credential is already in the
     # handshake's query string and is checked by the proxypass hop behind the
     # gateway, and a browser's WebSocket API can attach nothing else — it takes
     # a URL and a subprotocol, no headers.
@@ -114,7 +114,12 @@ user_config:
     # here would refuse every socket. Stating it keeps this table an honest
     # description of what the gateway requires, and makes tightening the prefix
     # a config edit rather than a code change.
-    "/openapi/v1/engine/**": {}
+    #
+    # It sits INSIDE the authenticated "/openapi/v1/bots/**" prefix above, and
+    # wins there by being more specific: rules are ranked by literal segment
+    # count, and this one has four to that one's three. Only this exact prefix
+    # is exempt; every other path under /openapi/v1/bots still requires a user.
+    "/openapi/v1/bots/messages/**": {}
 
   # Domain → upstream-server map for the gateway.
   #
@@ -136,6 +141,23 @@ user_config:
     base_path: /openapi/v1
 
     # Each domain may also declare:
+    #
+    #   match: <path pattern>
+    #     Which paths this domain claims: literal segments, then `**`. Unset
+    #     means `<base_path>/<domain name>/**` — the leading-segment routing
+    #     every domain had before patterns, so a domain that says nothing keeps
+    #     its address exactly. Declare one to put a domain BENEATH another, on a
+    #     different upstream.
+    #
+    #     Resolution matches first and ranks second: every domain claiming the
+    #     path AND answering the request's plane is a candidate, and the most
+    #     specific (most literal segments) wins. The plane filters the
+    #     candidates, so claiming a prefix for one plane leaves the other
+    #     plane's resolution of the same path untouched.
+    #
+    #     Startup REFUSES a pattern that does not pin `base_path` plus at least
+    #     one more literal segment. `match: /**` is an open proxy into that
+    #     domain's upstream, and this is the check that makes it untypable.
     #
     #   protocols: [http] | [websocket] | [http, websocket]
     #     Which plane serves it. Unset means `[http]`, so every domain below
@@ -182,12 +204,21 @@ user_config:
           path: schemas/baas.openapi.json
           refresh_seconds: 300
 
-      # The tenant engine socket. The backend's connection endpoint publishes
-      # `wss://<gateway>/openapi/v1/engine/<target><engine-path>?x-proxypass-token=…`
+      # The tenant bot socket. The backend's connection endpoint publishes
+      # `wss://<gateway>/openapi/v1/bots/messages/<target><engine-path>?x-proxypass-token=…`
       # and this is what serves it.
       #
-      # Socket-only: an HTTP request here is an unknown route, because the one
-      # thing this domain publishes is a relayed socket.
+      # It sits BENEATH the `bots` domain above, on a different upstream, which
+      # is what `match` exists for: the whole bots scope — management on the
+      # backend, runtime on the engine proxy — is one team's surface and belongs
+      # under one public prefix. The leading segment names the OWNER, not the
+      # process, and the gateway is what decouples the two.
+      #
+      # Socket-only, and that is not a detail. `messages` is reserved for a
+      # future HTTP endpoint here; because a domain is only a candidate on the
+      # plane it declares, an HTTP request to this prefix is not served by this
+      # domain at all — it falls to `bots` above, and reaches the backend. The
+      # reservation therefore costs that endpoint nothing.
       #
       # The engine proxy serves the same targets under `/proxypass/`, so the
       # prefix is substituted; everything past it — the routing target, the
@@ -201,11 +232,12 @@ user_config:
       # this path. The credential is checked once, at the handshake, and the
       # connection is designed to outlive its expiry — an idle deadline tears
       # down healthy sockets.
-      engine:
+      bots-messages-ws:
+        match: /openapi/v1/bots/messages/**
         server: engine_proxy
         protocols: [websocket]
         rewrite:
-          from: /openapi/v1/engine
+          from: /openapi/v1/bots/messages
           to: /proxypass
 
     servers:

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -115,11 +115,23 @@ user_config:
     # description of what the gateway requires, and makes tightening the prefix
     # a config edit rather than a code change.
     #
-    # It sits INSIDE the authenticated "/openapi/v1/bots/**" prefix above, and
-    # wins there by being more specific: rules are ranked by literal segment
-    # count, and this one has four to that one's three. Only this exact prefix
-    # is exempt; every other path under /openapi/v1/bots still requires a user.
-    "/openapi/v1/bots/messages/**": {}
+    # QUALIFIED BY PLANE, and that is load-bearing rather than decorative.
+    #
+    # This table is plane-blind: an unqualified rule governs every request to the
+    # path, whichever entrypoint serves it. The exemption sits INSIDE the
+    # authenticated "/openapi/v1/bots/**" prefix above and outranks it on literal
+    # segment count — four to three — so unqualified it would exempt ordinary
+    # HTTP requests here too. Those do not 404: a socket domain is not a
+    # candidate on the HTTP plane, so they fall through to `bots` and are
+    # forwarded to the backend. An unauthenticated caller could therefore reach
+    # the backend through this prefix, and a `..` in the path normalises out on
+    # the way, landing anywhere under /openapi/v1.
+    #
+    # `WEBSOCKET` is the method the relay entrypoint authenticates under, so this
+    # rule matches a handshake and nothing else. An HTTP GET to the same path
+    # does not match it and falls to "/openapi/v1/bots/**" above — user required,
+    # which is exactly right for the HTTP endpoint this prefix is reserved for.
+    "WEBSOCKET /openapi/v1/bots/messages/**": {}
 
   # Domain → upstream-server map for the gateway.
   #

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -348,7 +348,7 @@
           "sockets": [
             {
               "kind": "chat",
-              "url": "wss://gateway.example/openapi/v1/engine/abc/api/openclaw/ws?x-proxypass-token=…"
+              "url": "wss://gateway.example/openapi/v1/bots/messages/abc/api/openclaw/ws?x-proxypass-token=…"
             }
           ]
         },
@@ -3516,7 +3516,7 @@
         "description": "One WebSocket you may open against the bot.",
         "example": {
           "kind": "chat",
-          "url": "wss://gateway.example/openapi/v1/engine/abc/api/openclaw/ws?x-proxypass-token=…"
+          "url": "wss://gateway.example/openapi/v1/bots/messages/abc/api/openclaw/ws?x-proxypass-token=…"
         },
         "properties": {
           "kind": {

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/plan.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/plan.md
@@ -54,15 +54,16 @@ None.
 # src/gateway/src/gateway/community/core/paths/_pattern.py  (new)
 @dataclass(frozen=True)
 class PathPattern:
-    segments: tuple[str, ...]           # ("openapi", "v1", "bots", "**")
+    segments: tuple[str, ...]  # ("openapi", "v1", "bots", "**")
 
     @classmethod
     def parse(cls, pattern: str) -> PathPattern: ...
     def matches(self, path_segments: tuple[str, ...]) -> bool: ...
     @property
-    def specificity(self) -> tuple[int, int, int]: ...   # (exact?, literals, params)
+    def specificity(self) -> tuple[int, int, int]: ...  # (exact?, literals, params)
     @property
-    def literal_prefix(self) -> str: ...                 # "/openapi/v1/bots/messages"
+    def literal_prefix(self) -> str: ...  # "/openapi/v1/bots/messages"
+
 
 def split_segments(path: str) -> tuple[str, ...]: ...
 ```
@@ -73,6 +74,7 @@ tie-break, which stays in route security — the domain map has no methods.
 ```python
 # src/gateway/src/gateway/community/core/paths/__init__.py  (new)
 from ._pattern import PathPattern, split_segments
+
 __all__ = ["PathPattern", "split_segments"]
 ```
 
@@ -413,13 +415,15 @@ def test_the_rewrite_anchor_follows_the_declared_pattern(): ...
 #   existing cases re-pointed at /openapi/v1/bots/messages/…, plus:
 def test_the_old_engine_prefix_no_longer_relays(): ...
 def test_an_http_request_to_the_socket_prefix_reaches_the_backend(): ...
+
+
 #   the encoded-prefix matrix (:522-524, :441) moves to the new prefix — the
 #   %62ots / %6dessages spellings, not dropped.
 ```
 
 ```python
 # src/gateway/tests/test_route_security.py:23
-def test_shipped_config_exempts_the_bot_socket_prefix(): ...   # renamed + re-pointed
+def test_shipped_config_exempts_the_bot_socket_prefix(): ...  # renamed + re-pointed
 def test_the_socket_exemption_beats_the_bots_user_requirement(): ...  # new, pins precedence
 ```
 

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/plan.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/plan.md
@@ -1,0 +1,462 @@
+# Plan: Path-specific gateway domain routing, and the bot socket under `bots`
+
+## Approach
+
+A gateway domain stops *being* its leading path segment and instead **declares**
+a path pattern plus the planes it answers. Resolution collects every domain whose
+pattern matches the path **and** which answers the requesting plane, then picks
+the most specific of those — match first, rank second, with the plane filtering
+the candidate set rather than vetoing a winner.
+
+The pattern grammar and its specificity ranking are lifted into one shared core
+module so the routing plane and the auth plane rank identically by construction.
+The socket domain then moves to `/openapi/v1/bots/messages/**` as configuration,
+and the backend swaps one prefix constant.
+
+Every domain that declares no pattern gets the implicit pattern
+`{base_path}/{name}/**`, which is exactly the leading-segment match it has
+today — so the four shipped HTTP domains are byte-identical after the change.
+
+## Affected Components
+
+- `src/gateway/src/gateway/community/core/paths/` — **new.** The shared path
+  pattern: parse, match, rank, literal prefix.
+- `src/gateway/src/gateway/community/core/forwarding/_domains.py` — pattern-based
+  `Domain`; plane-filtered resolution; boot-time validation of over-broad
+  patterns and colliding declarations.
+- `src/gateway/src/gateway/community/core/authn/_route_security.py` — reuses the
+  shared pattern instead of its private matcher/ranker. No behaviour change.
+- `src/gateway/src/gateway/community/adapters/web/_forward.py` — asks the map for
+  the *HTTP* domain rather than resolving then checking.
+- `src/gateway/src/gateway/community/adapters/web/_relay_ws.py` — same on the
+  socket plane; mount paths and the raw-prefix guard derive from the pattern.
+- `src/gateway/src/gateway/community/adapters/web/app.py` — mounts socket routes
+  from patterns.
+- `src/gateway/configs/application.yaml` — the socket domain moves; the
+  route-security exemption moves with it.
+- `src/backend/src/agentclaw/community/core/engine_runtime/connection.py` — the
+  published prefix constant.
+- `src/backend/.../openapi_v1/engine_runtime/connection/schemas.py` — the two
+  example URLs.
+- `src/gateway/configs/schemas/bots.openapi.json` — regenerated build output.
+- `src/backend/docs/openapi-v1/{README,engine-surface}.md` + `.zh-CN.md` — the
+  reserved-name record and the quoted socket address.
+
+## Data Model Changes
+
+None.
+
+## API / Interface Changes
+
+### New: the shared path pattern (public module, so both planes may import it)
+
+```python
+# src/gateway/src/gateway/community/core/paths/_pattern.py  (new)
+@dataclass(frozen=True)
+class PathPattern:
+    segments: tuple[str, ...]           # ("openapi", "v1", "bots", "**")
+
+    @classmethod
+    def parse(cls, pattern: str) -> PathPattern: ...
+    def matches(self, path_segments: tuple[str, ...]) -> bool: ...
+    @property
+    def specificity(self) -> tuple[int, int, int]: ...   # (exact?, literals, params)
+    @property
+    def literal_prefix(self) -> str: ...                 # "/openapi/v1/bots/messages"
+
+def split_segments(path: str) -> tuple[str, ...]: ...
+```
+
+`specificity` is today's `_route_security._specificity` minus its method
+tie-break, which stays in route security — the domain map has no methods.
+
+```python
+# src/gateway/src/gateway/community/core/paths/__init__.py  (new)
+from ._pattern import PathPattern, split_segments
+__all__ = ["PathPattern", "split_segments"]
+```
+
+A public package because `tests/architecture/test_no_private_imports.py` forbids
+`from gateway.community.core.authn._route_security import _specificity`.
+
+### Changed: domain resolution takes a plane
+
+```diff
+# src/gateway/src/gateway/community/core/forwarding/_domains.py:289-303
+-    def resolve(self, path: str) -> Server | None:
+-    def domain_for(self, path: str) -> Domain | None:
+-        ...
+-        return self.domains.get(rest[0])
++    def domain_for(self, path: str, protocol: str) -> Domain | None:
++        """Every domain matching *path* on *protocol*, most specific one wins."""
++        segments = split_segments(path)
++        candidates = [
++            domain
++            for domain in self.domains.values()
++            if protocol in domain.protocols and domain.pattern.matches(segments)
++        ]
++        return max(candidates, key=_rank, default=None)
++
++    def http_domain_for(self, path: str) -> Domain | None: ...
++    def websocket_domain_for(self, path: str) -> Domain | None: ...
+```
+
+The two named wrappers exist because the delivery adapters are the callers and
+may not import core (layer rule) — the same reason `serves_http` /
+`serves_websocket` are predicates rather than a protocol argument today
+(`_domains.py:245-259`). No protocol constant crosses that boundary.
+
+`resolve(path)` is dropped rather than given a default plane: a default would
+silently pick one, which is the failure mode this change exists to remove. Its
+only callers are tests.
+
+### Changed: config grammar — one new optional key
+
+```yaml
+# src/gateway/configs/application.yaml — user_config.upstreams.domains
+bots:
+  server: backend                       # implicit match: /openapi/v1/bots/**
+
+bots-messages-ws:
+  match: /openapi/v1/bots/messages/**   # explicit; the domain name is now just a name
+  server: engine_proxy
+  protocols: [websocket]
+  rewrite:
+    from: /openapi/v1/bots/messages
+    to: /proxypass
+```
+
+```diff
+# src/gateway/src/gateway/community/core/forwarding/_domains.py:329
+- _DOMAIN_KEYS = frozenset({"server", "schema", "protocols", "rewrite"})
++ _DOMAIN_KEYS = frozenset({"match", "server", "schema", "protocols", "rewrite"})
+```
+
+### BREAKING (public surface): the socket address
+
+```diff
+- wss://<gw>/openapi/v1/engine/<target>/api/openclaw/ws?x-proxypass-token=…
++ wss://<gw>/openapi/v1/bots/messages/<target>/api/openclaw/ws?x-proxypass-token=…
+```
+
+No alias. `GET /openapi/v1/bots/connection/{bot_id}` — its path, name, and
+response shape — is unchanged, so the endpoint coverage baseline needs no edit
+(`coverage_baseline.txt:181` keys on that path).
+
+## Key Files & Functions
+
+### Pattern validation — the security-critical part
+
+```python
+# src/gateway/src/gateway/community/core/forwarding/_domains.py (new helper)
+def _parse_pattern(name: str, raw: Any, base_path: str) -> PathPattern:
+    """`match`, or the implicit `{base_path}/{name}/**`.
+
+    Refused: a pattern that does not pin the version base plus at least one
+    literal segment. Today an unknown leading segment resolves to None and the
+    gateway denies — "never an open proxy" is one line and the mistake cannot be
+    typed. With patterns, `/**` IS an open proxy.
+    """
+```
+
+Accepted shape is `<literal segments>/**` only — no parameters, no interior
+`**`, and the literal prefix must extend `base_path` by ≥1 segment:
+
+| pattern | verdict |
+|---|---|
+| `/openapi/v1/bots/**` | ok |
+| `/openapi/v1/bots/messages/**` | ok |
+| `/**`, `/openapi/**`, `/openapi/v1/**` | refused — over-broad |
+| `/openapi/v1/{x}/**` | refused — a parameter cannot pin a prefix |
+| `/openapi/v1/bots` | refused — write the `/**` |
+
+Note `**` matches **zero** segments (`_match_segments`, `_route_security.py:108`),
+so `/openapi/v1/bots/**` still resolves the bare `/openapi/v1/bots` — preserving
+`test_domain_at_root_resolves`.
+
+Why domains accept a narrower grammar than route security, while sharing its
+ranking: three separate mechanisms — the socket mount path, the raw-prefix guard,
+and the rewrite anchor — each need a concrete literal prefix. Making that
+derivable by construction beats partially supporting patterns that cannot
+produce one.
+
+### Boot-time collision check
+
+```python
+# _domains.py — after domains are parsed
+def _reject_ambiguous(domains: dict[str, Domain]) -> None:
+    """Two domains answering one path on one plane have no defined winner."""
+```
+
+Only identical patterns can collide: two *different* literal prefixes of equal
+length differ at some segment, so no path matches both.
+
+### Rewrite anchor re-derived from the pattern
+
+```diff
+# src/gateway/src/gateway/community/core/forwarding/_domains.py:385-391
+-        domain_prefix = f"{base_path.rstrip('/')}/{name}"
++        pattern = _parse_pattern(name, spec.get("match"), base_path)
++        domain_prefix = pattern.literal_prefix
+```
+
+The `"can never match"` check at `:476-482` is otherwise unchanged — it catches
+real config mistakes and the segment-boundary reasoning in its docstring still
+holds, now against a longer prefix.
+
+### Socket mount paths from the pattern
+
+```diff
+# src/gateway/src/gateway/community/adapters/web/_relay_ws.py:53-69
+- def relay_routes(base_path: str, domain: str) -> tuple[str, ...]:
+-     prefix = f"{base_path.rstrip('/')}/{domain}"
++ def relay_routes(prefix: str) -> tuple[str, ...]:
+      return (prefix, f"{prefix}/{{full_path:path}}")
+```
+
+```diff
+# src/gateway/src/gateway/community/adapters/web/app.py:139-141
+- for name in domain_map.websocket_domains():
+-     for route in relay_routes(domain_map.base_path, name):
++ for domain in domain_map.websocket_domains():
++     for route in relay_routes(domain.mount_prefix):
+          app.add_api_websocket_route(route, forward_websocket)
+```
+
+`websocket_domains()` returns the domains themselves rather than a name→domain
+mapping; `Domain.mount_prefix` is `self.pattern.literal_prefix`.
+
+### The raw-path evasion guard — same guard, pattern-derived prefix
+
+```diff
+# src/gateway/src/gateway/community/adapters/web/_relay_ws.py:206-235
+  def _required_raw_prefix(domain_map: Any, domain: Any) -> str:
+      if domain.rewrite is not None:
+          return str(domain.rewrite.from_prefix)
+-     return f"{domain_map.base_path.rstrip('/')}/{domain.name}"
++     return str(domain.mount_prefix)
+```
+
+Unchanged in substance and **must not be weakened**: it is what defeats
+`/openapi/v1/%62ots/messages/...`. Its docstring's worked example needs
+re-writing against the new prefix. `_has_dot_segment` is untouched.
+
+```diff
+# src/gateway/src/gateway/community/adapters/web/_relay_ws.py:116
+- domain = state.domain_map.domain_for(path)
+- if domain is None or not domain.serves_websocket:
++ domain = state.domain_map.websocket_domain_for(path)
++ if domain is None:
+```
+
+```diff
+# src/gateway/src/gateway/community/adapters/web/_forward.py:113-118
+- domain = request.app.state.domain_map.domain_for(path)
+- if domain is None or not domain.serves_http:
++ domain = request.app.state.domain_map.http_domain_for(path)
++ if domain is None:
+      return _error(404, 1, "no route for path")
+```
+
+This is the whole trap in two lines: today `domain_for` picks `bots-messages-ws`
+for an HTTP request and `serves_http` then 404s it. After the change that domain
+is not a candidate, so `/openapi/v1/bots/**` wins and backend serves it.
+
+### Route security
+
+```diff
+# src/gateway/configs/application.yaml:117
+-    "/openapi/v1/engine/**": {}
++    "/openapi/v1/bots/messages/**": {}
+```
+
+The existing comment (credential is in the handshake query; a browser's
+WebSocket API can attach no headers; stated explicitly because an omitted rule
+falls through to `/**` and fails closed) carries over verbatim. Precedence needs
+no change: `_specificity` already ranks 4 literals above 3.
+
+### Backend
+
+```diff
+# src/backend/src/agentclaw/community/core/engine_runtime/connection.py:62
+- _ENGINE_PREFIX = "/openapi/v1/engine"
++ _ENGINE_PREFIX = "/openapi/v1/bots/messages"
+```
+
+`_readdress_onto_gateway` (`:342-406`) already substitutes around this constant;
+no logic changes. Module docstring (`:10`), the constant's own comment
+(`:58-61`), and the docstrings at `:346` and `:437` name the old address and
+need updating.
+
+## Dependencies
+
+None.
+
+## Risks & Mitigations
+
+- **Risk:** the generalisation makes an open proxy typable, where today it is
+  structurally impossible.
+  **Mitigation:** `_parse_pattern` refuses anything not pinning the version base
+  plus one literal segment, at boot, naming the domain. Tested directly.
+
+- **Risk:** the raw-prefix guard silently weakens at the longer prefix, letting
+  `/openapi/v1/%62ots/messages/...` authenticate as one resource and dial as
+  another.
+  **Mitigation:** guard logic is untouched — only its source of truth moves from
+  `base_path + name` to the pattern's literal prefix. The existing encoded-prefix
+  test cases move to the new prefix rather than being dropped.
+
+- **Risk:** someone later "simplifies" resolution back to rank-then-check-plane,
+  quietly making the future HTTP `messages` endpoint unreachable.
+  **Mitigation:** a test asserting an HTTP request to `/openapi/v1/bots/messages/x`
+  reaches **backend** — the regression is then a red test, not a discovery at
+  integration time.
+
+- **Risk:** the docs' reserved-name list and the routes drift.
+  **Mitigation:** see below — the existing equality interlock is preserved, not
+  relaxed.
+
+## Alternatives Considered
+
+- **Rank first, then check the plane, with fallback on mismatch.** Rejected in
+  the spec: a request refused by the winning domain getting a second attempt at
+  another is a smuggling hole. Filtering the candidate set reaches the same
+  outcome for today's traffic without the retry.
+- **Full route-security pattern grammar for domains** (parameters, interior
+  globs). Rejected: no requirement needs it, and three mechanisms need a concrete
+  literal prefix that such patterns cannot yield.
+- **Keying the plane on URL scheme** (`wss` vs `https`). Rejected in the spec —
+  scheme encodes TLS, not routing; one upstream is already addressable on both
+  planes via `Server.http_base_url` / `websocket_base_url`.
+- **Duplicating the specificity ranking in `_domains.py`.** Rejected: two rankers
+  that must agree will eventually not.
+- **Keeping `domain_for(path)` with a default plane.** Rejected: a default
+  silently picks a plane.
+
+## Rollout
+
+Single deploy, but **ordered** — the gateway must accept the new address before
+the backend publishes it:
+
+```bash
+# 1. gateway (routing mechanism + config): serves BOTH old and new? No —
+#    the config moves the domain, so old stops and new starts atomically.
+# 2. backend: publishes the new address.
+```
+
+Between (1) and (2) the backend publishes an address the gateway no longer
+serves, so **in-flight sockets survive** (already established) but new connection
+requests fail until (2) lands. Acceptable for the same reason no alias is
+provided: the surface has no reachable external caller — its route-security rule
+requires a Google-resolved user identity a tenant with an access key cannot
+satisfy. Single-box deploys both together.
+
+Rollback: revert the config block and the backend constant. The routing mechanism
+is inert without a domain that declares `match`.
+
+## Test Strategy
+
+### Reserved names — correcting the handoff's assumption
+
+`test_the_docs_reserved_names_match_the_routes` asserts documented **==**
+route-published components, so adding `messages` to that block *fails* the test.
+Rather than weaken it to `>=`, add a second, explicitly-labelled record:
+
+```diff
+# src/backend/docs/openapi-v1/README.md:572
+  <!-- reserved-component-names -->
+  ```text
+  approvals  ceiling  check-name  connection  engine  identity
+  mcp  models  resources  routines  sessions  skills
+  ```
++
++ <!-- reserved-component-names-unrouted -->
++ ```text
++ messages
++ ```
+```
+
+```python
+# src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
+def test_the_docs_reserved_names_match_the_routes(): ...      # unchanged, still ==
+def test_names_reserved_ahead_of_their_routes_are_not_routed():
+    """A reserved name that gains a route must move to the routed block."""
+    assert _documented_unrouted_names().isdisjoint(_components())
+```
+
+The routed block must stay *above* the new anchor: the existing parser takes the
+first fenced block after its anchor.
+
+Accuracy note for the prose: `messages` is **not** unreachable today the way the
+other twelve are — an HTTP `GET /openapi/v1/bots/messages` still reaches backend
+and resolves as `bot_id="messages"`. It is reserved because the gateway claims
+the prefix on the socket plane and a `messages` component is planned there. The
+README text will say that rather than being appended to a list whose stated
+reason does not apply to it.
+
+### Gateway
+
+```python
+# src/gateway/tests/test_domain_map.py
+def test_a_domain_without_a_match_keeps_its_leading_segment_pattern(): ...
+def test_the_most_specific_matching_pattern_wins(): ...
+def test_a_pattern_is_only_a_candidate_on_the_plane_it_declares(): ...
+def test_an_http_request_under_a_socket_prefix_falls_to_the_broader_domain(): ...
+@pytest.mark.parametrize("pattern", ["/**", "/openapi/**", "/openapi/v1/**"])
+def test_an_over_broad_pattern_is_refused_at_boot(pattern): ...
+def test_two_domains_on_one_pattern_and_plane_are_refused_at_boot(): ...
+def test_the_rewrite_anchor_follows_the_declared_pattern(): ...
+```
+
+```python
+# src/gateway/tests/integration/test_relay_ws_route.py
+#   existing cases re-pointed at /openapi/v1/bots/messages/…, plus:
+def test_the_old_engine_prefix_no_longer_relays(): ...
+def test_an_http_request_to_the_socket_prefix_reaches_the_backend(): ...
+#   the encoded-prefix matrix (:522-524, :441) moves to the new prefix — the
+#   %62ots / %6dessages spellings, not dropped.
+```
+
+```python
+# src/gateway/tests/test_route_security.py:23
+def test_shipped_config_exempts_the_bot_socket_prefix(): ...   # renamed + re-pointed
+def test_the_socket_exemption_beats_the_bots_user_requirement(): ...  # new, pins precedence
+```
+
+Also touched: `tests/test_log_redaction.py` (sample paths, cosmetic) and
+`tests/architecture/*` (must stay green — the new `core/paths` package needs
+`__all__`, per `test_all_exports_valid.py`).
+
+### Backend
+
+```python
+# src/backend/tests/community/core/engine_runtime/test_connection.py
+#   the published-URL assertions at :273-439 move to the new prefix.
+# src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py:50
+```
+
+### Build artifact
+
+```bash
+# published paths do not change, but the socket URL appears as an *example*
+# at bots.openapi.json:351 and :3519, sourced from connection/schemas.py
+python src/backend/scripts/dump_openapi.py
+python src/gateway/scripts/gate_and_publish_openapi.py
+```
+
+Do **not** regenerate `src/gateway/tests/fixtures/bots.openapi.json` — that is a
+hand-written fixture, not a copy.
+
+### Gates that mislead if not watched
+
+- `tests/community/framework/test_coverage_gate.py` ERRORs on a missing fixture
+  in isolation and only does real work in a full-suite run — grep for `ERROR` as
+  well as `FAILED` when diffing before/after, or it drops out of both sides.
+- Pre-existing sandbox failures, **not** caused by this change: legacy
+  `/api/bots` admin routes 403 (empty community allow-list);
+  `tests/community/endpoints/*` and `tests/community/e2e/*` missing a SQLite
+  fixture; gateway `tests/e2e/*` need a live server; `ruff format --check` flags
+  code blocks in gateway `docs/*.md` under a newer ruff than the repo pins.
+- Dependency install: the pinned index is unreachable here. `uv sync --frozen`
+  fails; `uv pip install --index-url https://pypi.org/simple -e .` works, plus
+  the `dev` group and `pytestarch` for the gateway.

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/spec.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/spec.md
@@ -1,0 +1,142 @@
+# Path-specific gateway domain routing, and the bot socket under `bots`
+
+## Summary
+
+The gateway today picks an upstream by the single path segment after the version
+base, so every public prefix is one word and every word belongs to exactly one
+upstream. This adds path-specific routing — a domain claims a *path pattern* and
+the protocol it answers — and uses it to move the bot's chat WebSocket from
+`/openapi/v1/engine/**` to `/openapi/v1/bots/messages/**`. After the change the
+whole bots scope, management and runtime alike, lives under one public prefix.
+
+## Motivation
+
+`GET /openapi/v1/bots/connection/{bot_id}` hands a tenant a finished socket URL,
+and that URL points at a *sibling* top-level prefix:
+
+```text
+today   wss://<gw>/openapi/v1/engine/<target>/api/openclaw/ws?x-proxypass-token=…
+after   wss://<gw>/openapi/v1/bots/messages/<target>/api/openclaw/ws?x-proxypass-token=…
+```
+
+Two things are wrong with the status quo.
+
+**Scope coherence.** The BCN collaboration-prefix design
+(`src/bcs/docs/plans/2026-08-03-bcn-collaboration-prefix-design.md`, approved
+2026-08-03) settled that the leading segment names the *owner* of a surface, not
+the process serving it. Backend management and the engine-proxy runtime are one
+team and one scope, so they belong under one prefix; `engine` sitting as a
+sibling of `bots` splits one owner's surface across two namespaces — the exact
+problem that design was written to stop.
+
+**Naming the hop.** The connection service's own stated goal is that "nothing
+names the hop behind the gateway." A top-level `engine` domain is close to
+naming one, and it is not even a separate owner.
+
+Neither is reachable by a config edit: a domain *is* its leading segment today,
+so `bots` cannot be both a backend prefix and the parent of a socket prefix
+served by a different upstream.
+
+`messages` is the socket prefix (rather than, say, `socket` or `ws`) because it
+names the channel the messages actually travel over, and because other domains
+are expected to grow their own `messages` endpoints. One vocabulary across
+domains is the point.
+
+## User Stories
+
+- As a tenant integrating with the public API, I want every address for my bot —
+  management and chat socket alike — under one prefix, so that I learn one scope
+  rather than discovering a second top-level namespace from a response body.
+- As a gateway operator, I want a domain's public path decoupled from the
+  upstream that serves it, so that the address space reflects ownership rather
+  than process topology.
+- As the owner of a future `/openapi/v1/bots/messages/{bot_id}` HTTP endpoint, I
+  want reserving the socket prefix today not to make that address unreachable
+  tomorrow.
+- As a reviewer, I want it to remain impossible to configure the gateway as an
+  open proxy, even though prefixes are now patterns rather than single words.
+
+## Acceptance Criteria
+
+- [ ] A WebSocket handshake to `/openapi/v1/bots/messages/<target><engine-path>`
+      is relayed to the engine proxy, with everything past the prefix — routing
+      target, engine path, credential in the query — travelling byte for byte,
+      exactly as it does at the old address today.
+- [ ] A handshake to `/openapi/v1/engine/**` no longer resolves.
+- [ ] An HTTP request under `/openapi/v1/bots/**`, **including**
+      `/openapi/v1/bots/messages/...`, still reaches the backend. Reserving the
+      socket prefix must not make the future HTTP address unreachable.
+- [ ] An HTTP request to `/openapi/v1/bots/messages/...` is not served by the
+      engine proxy, and a WebSocket handshake elsewhere under
+      `/openapi/v1/bots/**` is not relayed.
+- [ ] The socket prefix requires no caller identity; every other path under
+      `/openapi/v1/bots/**` still requires an authenticated user. The exemption
+      is written down explicitly rather than inferred.
+- [ ] `GET /openapi/v1/bots/connection/{bot_id}` publishes socket URLs at the new
+      address. Its own path, name, and response shape are unchanged.
+- [ ] The existing evasion guards still hold at the longer prefix: a handshake
+      whose raw path percent-encodes any part of the routing prefix is refused,
+      and a path carrying a `.`/`..` segment in any spelling is refused.
+- [ ] A configuration that would make the gateway an open or over-broad proxy is
+      refused at startup, naming the offending domain — not resolved at request
+      time and not silently accepted.
+- [ ] A configuration whose declared prefix substitution could never fire is
+      refused at startup, as it is today.
+- [ ] Two domains that would answer the same path on the same protocol are
+      refused at startup rather than resolved by an undefined order.
+- [ ] Every domain that does not opt into a path pattern keeps its current
+      address and behaviour byte for byte.
+- [ ] `messages` is recorded as a reserved component name under
+      `/openapi/v1/bots` in the published English and Chinese API docs, and the
+      record cannot silently fall out of step with the routes.
+- [ ] The published English and Chinese engine-surface docs quote the new socket
+      address.
+
+## In Scope
+
+- Gateway domain resolution keyed on (path pattern, protocol) instead of the
+  leading segment alone, with startup validation for over-broad patterns and for
+  two domains colliding on one path and protocol.
+- Moving the shipped socket domain, its route-security exemption, and the address
+  the backend publishes, to `/openapi/v1/bots/messages`.
+- Reserving `messages` as a component name under `/openapi/v1/bots`, and the
+  documentation and tests that keep that reservation honest.
+- English and Chinese documentation updates for both the reserved-name list and
+  the engine-surface socket address.
+
+## Out of Scope
+
+- **Hiding the engine.** `/api/openclaw/ws` stays in the path,
+  `x-proxypass-token` stays in the query, and `engine` remains a documented field
+  on the connection response. Secrecy is not the goal; scope coherence is.
+  Making any of them opaque would break the verbatim prefix-substitution
+  property the forwarding design rests on.
+- **Renaming `GET /openapi/v1/bots/connection/{bot_id}`.** It hands out a
+  connection; it is not a message resource.
+- **A compatibility alias at `/openapi/v1/engine/**`.** That surface has no
+  reachable external caller — its route-security rule requires a Google-resolved
+  user identity, which a tenant presenting an access key cannot satisfy — so
+  there is no contract to preserve. Same reasoning as PR #706.
+- **Implicit protocol-based fallback.** Resolution must not "try the most
+  specific pattern, then silently try the next one when the protocol does not
+  match." Two deliberate per-protocol declarations at one pattern are safe; a
+  silent retry is a smuggling hole and is not built.
+- **Moving any other domain under `bots`.** `sessions`, `messages` and `runs`
+  belong to BaaS and `collaboration` to BCS; those are different owners and the
+  ownership principle keeps them where they are.
+- **Adding the future `/openapi/v1/bots/messages/{bot_id}` HTTP endpoint.** This
+  change only has to leave the address reachable.
+
+## Open Questions
+
+*(none blocking — the three objections raised in review were answered before this
+was written: ownership rather than process decides the prefix; the auth-exemption
+precedence already ranks the longer literal prefix higher; and hiding the engine
+was never the goal.)*
+
+One coordination item, informational rather than blocking: the owner of
+`src/bcs/docs/plans/2026-08-03-bcn-collaboration-prefix-design.md` should be told
+that longest-prefix routing has moved from "out of scope" to "in scope". BCN does
+not need the mechanism — it owns `/openapi/v1/collaboration/**` outright — and the
+ownership framing above leaves its one-prefix-per-owner principle intact, but they
+wrote that constraint down the same week and should hear it from us.

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/spec.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/spec.md
@@ -73,9 +73,13 @@ domains is the point.
       socket — and that declaration participates in *selecting* the domain, not
       only in checking one already selected. A path claimed for one plane must
       leave the other plane's resolution of that same path untouched.
-- [ ] The socket prefix requires no caller identity; every other path under
-      `/openapi/v1/bots/**` still requires an authenticated user. The exemption
-      is written down explicitly rather than inferred.
+- [ ] A **handshake** to the socket prefix requires no caller identity; every
+      other path under `/openapi/v1/bots/**` still requires an authenticated
+      user. The exemption is written down explicitly rather than inferred.
+- [ ] The exemption reaches the socket plane **only**. An ordinary HTTP request
+      to the socket prefix — including one whose path carries `..` segments that
+      normalise outside it — still requires an authenticated user, because it is
+      forwarded to the backend rather than refused.
 - [ ] `GET /openapi/v1/bots/connection/{bot_id}` publishes socket URLs at the new
       address. Its own path, name, and response shape are unchanged.
 - [ ] The existing evasion guards still hold at the longer prefix: a handshake
@@ -151,6 +155,27 @@ domains is the point.
 was written: ownership rather than process decides the prefix; the auth-exemption
 precedence already ranks the longer literal prefix higher; and hiding the engine
 was never the goal.)*
+
+> **Correction, found during implementation.** The second of those answers was
+> wrong, and the acceptance criteria above have been amended accordingly.
+> Precedence does rank the longer prefix higher, but that was never the issue:
+> **the route-security table is plane-blind.** An unqualified rule governs every
+> request to a path, whichever entrypoint serves it — so the socket's deliberate
+> "no identity required" exemption would cover ordinary HTTP requests to the same
+> prefix. Those no longer 404 the way they did when the socket was its own
+> top-level domain; they fall through to `bots` and are forwarded to the backend,
+> with any `..` in the path normalising away en route. `GET
+> /openapi/v1/bots/messages/../../admin/keys` would have reached the backend as
+> `/openapi/v1/admin/keys`, unauthenticated.
+>
+> The move is exactly what makes the exemption reachable on the HTTP plane; it
+> was harmless only while the exempt prefix was both socket-only *and*
+> top-level, with nothing beneath it to fall through to. The exemption is
+> therefore **qualified by plane** — the socket entrypoint authenticates under a
+> distinct method and the rule is written `WEBSOCKET /openapi/v1/bots/messages/**`,
+> so an HTTP `GET` there falls to `/openapi/v1/bots/**` and requires a user. That
+> is also the right answer for the future HTTP endpoint the prefix is reserved
+> for.
 
 One coordination item, informational rather than blocking: the owner of
 `src/bcs/docs/plans/2026-08-03-bcn-collaboration-prefix-design.md` should be told

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/spec.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/spec.md
@@ -69,6 +69,10 @@ domains is the point.
 - [ ] An HTTP request to `/openapi/v1/bots/messages/...` is not served by the
       engine proxy, and a WebSocket handshake elsewhere under
       `/openapi/v1/bots/**` is not relayed.
+- [ ] A domain declares which **plane** it answers — request/response or relayed
+      socket — and that declaration participates in *selecting* the domain, not
+      only in checking one already selected. A path claimed for one plane must
+      leave the other plane's resolution of that same path untouched.
 - [ ] The socket prefix requires no caller identity; every other path under
       `/openapi/v1/bots/**` still requires an authenticated user. The exemption
       is written down explicitly rather than inferred.
@@ -97,6 +101,13 @@ domains is the point.
 - Gateway domain resolution keyed on (path pattern, protocol) instead of the
   leading segment alone, with startup validation for over-broad patterns and for
   two domains colliding on one path and protocol.
+
+  "Protocol" here means the **plane** — request/response, or relayed socket — and
+  not the URL scheme. `ws` and `wss` are one plane, as `http` and `https` are;
+  the scheme says only whether the connection is TLS, and one configured upstream
+  is already addressable on either plane. A domain that answered `wss` but not
+  `ws` would be describing its transport security, which is not a routing
+  question.
 - Moving the shipped socket domain, its route-security exemption, and the address
   the backend publishes, to `/openapi/v1/bots/messages`.
 - Reserving `messages` as a component name under `/openapi/v1/bots`, and the
@@ -121,6 +132,13 @@ domains is the point.
   specific pattern, then silently try the next one when the protocol does not
   match." Two deliberate per-protocol declarations at one pattern are safe; a
   silent retry is a smuggling hole and is not built.
+
+  The distinction is not academic, because both reach the backend for today's
+  HTTP `messages` request. The plane belongs in the *candidate set*: a domain
+  that does not answer this plane is never a candidate, so the most specific
+  remaining match wins outright. Under a retry, a request that was ranked into
+  one domain and refused there gets a second attempt at another — which is a
+  request being served by a domain that did not win.
 - **Moving any other domain under `bots`.** `sessions`, `messages` and `runs`
   belong to BaaS and `collaboration` to BCS; those are different owners and the
   ownership principle keeps them where they are.

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -39,7 +39,7 @@
         plan did not list; re-pointed at `rule.pattern.segments`.
 - **Depends on:** Task 1
 
-## Task 3: Give `Domain` a pattern, and validate it at boot
+## [x] Task 3: Give `Domain` a pattern, and validate it at boot
 
 - **Goal:** A domain declares `match:` (or inherits `{base_path}/{name}/**`), and
   a pattern that would make the gateway an open or ambiguous proxy is refused at
@@ -48,21 +48,21 @@
   - `src/gateway/src/gateway/community/core/forwarding/_domains.py`
   - `src/gateway/tests/test_domain_map.py`
 - **Done when:**
-  - [ ] `Domain.pattern: PathPattern` and `Domain.mount_prefix` exist; `match` is
+  - [x] `Domain.pattern: PathPattern` and `Domain.mount_prefix` exist; `match` is
         added to `_DOMAIN_KEYS`.
-  - [ ] A domain with no `match` gets `{base_path}/{name}/**` — every shipped
+  - [x] A domain with no `match` gets `{base_path}/{name}/**` — every shipped
         HTTP domain keeps its current address.
-  - [ ] Accepted shape is `<literal segments>/**` only. Refused, at boot, naming
+  - [x] Accepted shape is `<literal segments>/**` only. Refused, at boot, naming
         the domain: `/**`, `/openapi/**`, `/openapi/v1/**` (over-broad);
         `/openapi/v1/{x}/**` (a parameter cannot pin a prefix);
         `/openapi/v1/bots` (missing `/**`).
-  - [ ] Two domains declaring the same pattern with overlapping protocols are
+  - [x] Two domains declaring the same pattern with overlapping protocols are
         refused at boot.
-  - [ ] `_parse_rewrite`'s anchor is `pattern.literal_prefix`; its existing
+  - [x] `_parse_rewrite`'s anchor is `pattern.literal_prefix`; its existing
         `"can never match"` and segment-boundary checks still fire.
 - **Depends on:** Task 1
 
-## Task 4: Resolve on (pattern, plane) — match first, then most specific
+## [x] Task 4: Resolve on (pattern, plane) — match first, then most specific
 
 - **Goal:** Replace leading-segment lookup with plane-filtered, specificity-ranked
   resolution, and hand the adapters two named entry points so no protocol
@@ -72,18 +72,18 @@
   - `src/gateway/src/gateway/community/adapters/web/_forward.py`
   - `src/gateway/tests/test_domain_map.py`
 - **Done when:**
-  - [ ] `domain_for(path, protocol)` filters candidates by plane **before**
+  - [x] `domain_for(path, protocol)` filters candidates by plane **before**
         ranking, and returns the most specific match or `None`.
-  - [ ] `http_domain_for` / `websocket_domain_for` wrap it; `resolve(path)` is
+  - [x] `http_domain_for` / `websocket_domain_for` wrap it; `resolve(path)` is
         gone (a default plane would silently pick one).
-  - [ ] `_forward.py` calls `http_domain_for` and drops its `serves_http` check.
-  - [ ] A test proves an HTTP request under a websocket-only prefix resolves to
+  - [x] `_forward.py` calls `http_domain_for` and drops its `serves_http` check.
+  - [x] A test proves an HTTP request under a websocket-only prefix resolves to
         the **broader HTTP domain**, not to `None` — the trap this design exists
         to avoid.
-  - [ ] A test proves resolution does **not** retry after a plane mismatch.
+  - [x] A test proves resolution does **not** retry after a plane mismatch.
 - **Depends on:** Task 3
 
-## Task 5: Mount socket routes and the raw-path guard from the pattern
+## [x] Task 5: Mount socket routes and the raw-path guard from the pattern
 
 - **Goal:** The socket entrypoint derives its mount paths and its
   encoded-prefix guard from the declared pattern rather than from `base_path +
@@ -93,17 +93,17 @@
   - `src/gateway/src/gateway/community/adapters/web/app.py`
   - `src/gateway/src/gateway/community/core/forwarding/_domains.py`
 - **Done when:**
-  - [ ] `relay_routes(prefix)` takes the prefix; `websocket_domains()` returns
+  - [x] `relay_routes(prefix)` takes the prefix; `websocket_domains()` returns
         the domains themselves.
-  - [ ] Both mount forms are still produced together (bare prefix **and**
+  - [x] Both mount forms are still produced together (bare prefix **and**
         `/{full_path:path}`) — a handshake to exactly the prefix must still be
         served.
-  - [ ] `_required_raw_prefix` returns `rewrite.from_prefix`, else
+  - [x] `_required_raw_prefix` returns `rewrite.from_prefix`, else
         `domain.mount_prefix`. **Guard logic unchanged** — it is what defeats a
         percent-encoded routing prefix.
-  - [ ] `forward_websocket` calls `websocket_domain_for` and drops its
+  - [x] `forward_websocket` calls `websocket_domain_for` and drops its
         `serves_websocket` check.
-  - [ ] Docstrings naming `/openapi/v1/engine` in worked examples are rewritten
+  - [x] Docstrings naming `/openapi/v1/engine` in worked examples are rewritten
         against the new prefix.
 - **Depends on:** Task 4
 

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -1,0 +1,248 @@
+# Tasks: Path-specific gateway domain routing, and the bot socket under `bots`
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+## Task 1: Extract the shared path pattern into `core/paths`
+
+- **Goal:** One parse/match/rank implementation for path patterns, importable by
+  both the routing and the auth plane without a private-module import.
+- **Files:**
+  - `src/gateway/src/gateway/community/core/paths/__init__.py` (new)
+  - `src/gateway/src/gateway/community/core/paths/_pattern.py` (new)
+  - `src/gateway/tests/test_path_pattern.py` (new)
+- **Done when:**
+  - [ ] `PathPattern.parse`, `.matches`, `.specificity`, `.literal_prefix` and
+        `split_segments` exist, with `__all__` declared.
+  - [ ] `specificity` is `(exact?, literals, params)` — today's
+        `_route_security._specificity` **minus** its method tie-break.
+  - [ ] `**` matches zero segments, so `/openapi/v1/bots/**` matches the bare
+        `/openapi/v1/bots` (the property `test_domain_at_root_resolves` rests on).
+  - [ ] `literal_prefix` returns the leading run of literal segments as a path.
+  - [ ] `tests/architecture/` stays green (`test_all_exports_valid.py` requires
+        the new package's `__all__`).
+- **Depends on:** —
+
+## Task 2: Re-point `RouteSecurity` at the shared pattern
+
+- **Goal:** Delete route security's private matcher/ranker in favour of
+  `PathPattern`, with no behaviour change on the auth plane.
+- **Files:**
+  - `src/gateway/src/gateway/community/core/authn/_route_security.py`
+  - `src/gateway/tests/test_route_security.py`
+- **Done when:**
+  - [ ] `_Rule` holds a `PathPattern`; `_match_segments`, `_is_param` and the
+        segment-counting half of `_specificity` are gone from this module.
+  - [ ] The method tie-break stays here — the domain map has no methods.
+  - [ ] `tests/test_route_security.py` passes **unchanged** (the engine-prefix
+        case still asserts the old path at this point; Task 7 moves it).
+- **Depends on:** Task 1
+
+## Task 3: Give `Domain` a pattern, and validate it at boot
+
+- **Goal:** A domain declares `match:` (or inherits `{base_path}/{name}/**`), and
+  a pattern that would make the gateway an open or ambiguous proxy is refused at
+  startup, naming the domain.
+- **Files:**
+  - `src/gateway/src/gateway/community/core/forwarding/_domains.py`
+  - `src/gateway/tests/test_domain_map.py`
+- **Done when:**
+  - [ ] `Domain.pattern: PathPattern` and `Domain.mount_prefix` exist; `match` is
+        added to `_DOMAIN_KEYS`.
+  - [ ] A domain with no `match` gets `{base_path}/{name}/**` — every shipped
+        HTTP domain keeps its current address.
+  - [ ] Accepted shape is `<literal segments>/**` only. Refused, at boot, naming
+        the domain: `/**`, `/openapi/**`, `/openapi/v1/**` (over-broad);
+        `/openapi/v1/{x}/**` (a parameter cannot pin a prefix);
+        `/openapi/v1/bots` (missing `/**`).
+  - [ ] Two domains declaring the same pattern with overlapping protocols are
+        refused at boot.
+  - [ ] `_parse_rewrite`'s anchor is `pattern.literal_prefix`; its existing
+        `"can never match"` and segment-boundary checks still fire.
+- **Depends on:** Task 1
+
+## Task 4: Resolve on (pattern, plane) — match first, then most specific
+
+- **Goal:** Replace leading-segment lookup with plane-filtered, specificity-ranked
+  resolution, and hand the adapters two named entry points so no protocol
+  constant crosses the layer boundary.
+- **Files:**
+  - `src/gateway/src/gateway/community/core/forwarding/_domains.py`
+  - `src/gateway/src/gateway/community/adapters/web/_forward.py`
+  - `src/gateway/tests/test_domain_map.py`
+- **Done when:**
+  - [ ] `domain_for(path, protocol)` filters candidates by plane **before**
+        ranking, and returns the most specific match or `None`.
+  - [ ] `http_domain_for` / `websocket_domain_for` wrap it; `resolve(path)` is
+        gone (a default plane would silently pick one).
+  - [ ] `_forward.py` calls `http_domain_for` and drops its `serves_http` check.
+  - [ ] A test proves an HTTP request under a websocket-only prefix resolves to
+        the **broader HTTP domain**, not to `None` — the trap this design exists
+        to avoid.
+  - [ ] A test proves resolution does **not** retry after a plane mismatch.
+- **Depends on:** Task 3
+
+## Task 5: Mount socket routes and the raw-path guard from the pattern
+
+- **Goal:** The socket entrypoint derives its mount paths and its
+  encoded-prefix guard from the declared pattern rather than from `base_path +
+  domain name`.
+- **Files:**
+  - `src/gateway/src/gateway/community/adapters/web/_relay_ws.py`
+  - `src/gateway/src/gateway/community/adapters/web/app.py`
+  - `src/gateway/src/gateway/community/core/forwarding/_domains.py`
+- **Done when:**
+  - [ ] `relay_routes(prefix)` takes the prefix; `websocket_domains()` returns
+        the domains themselves.
+  - [ ] Both mount forms are still produced together (bare prefix **and**
+        `/{full_path:path}`) — a handshake to exactly the prefix must still be
+        served.
+  - [ ] `_required_raw_prefix` returns `rewrite.from_prefix`, else
+        `domain.mount_prefix`. **Guard logic unchanged** — it is what defeats a
+        percent-encoded routing prefix.
+  - [ ] `forward_websocket` calls `websocket_domain_for` and drops its
+        `serves_websocket` check.
+  - [ ] Docstrings naming `/openapi/v1/engine` in worked examples are rewritten
+        against the new prefix.
+- **Depends on:** Task 4
+
+## Task 6: Move the shipped socket domain to `/openapi/v1/bots/messages`
+
+- **Goal:** The gateway serves the socket at its new address and no longer at the
+  old one — configuration only.
+- **Files:**
+  - `src/gateway/configs/application.yaml`
+- **Done when:**
+  - [ ] The `engine` domain block becomes `bots-messages-ws` with
+        `match: /openapi/v1/bots/messages/**`, `protocols: [websocket]`, and
+        `rewrite: {from: /openapi/v1/bots/messages, to: /proxypass}`.
+  - [ ] Its explanatory comment carries over: Upgrade pass-through, **no read
+        timeout** on the path, and no `schema:` because a socket has no OpenAPI
+        representation.
+  - [ ] `route_security` declares `"/openapi/v1/bots/messages/**": {}` and no
+        longer declares `"/openapi/v1/engine/**"`; the comment explaining why it
+        requires no identity carries over.
+  - [ ] The `domains:` block comment documents the new `match:` key.
+- **Depends on:** Task 5
+
+## Task 7: Re-point the gateway test suites at the new address
+
+- **Goal:** Every gateway test that pins the socket address moves with it, and the
+  old address is pinned as *no longer resolving*.
+- **Files:**
+  - `src/gateway/tests/integration/test_relay_ws_route.py`
+  - `src/gateway/tests/test_route_security.py`
+  - `src/gateway/tests/test_domain_map.py`
+  - `src/gateway/tests/test_log_redaction.py`
+- **Done when:**
+  - [ ] Relay integration cases run against `/openapi/v1/bots/messages/…`; the
+        rewrite still lands on `/proxypass/<target><path>` byte for byte.
+  - [ ] The encoded-prefix matrix moves to the new prefix (the `%62ots` /
+        `%6dessages` spellings) rather than being dropped, and still refuses.
+  - [ ] The dot-segment matrix still refuses at the new prefix.
+  - [ ] A handshake to `/openapi/v1/engine/**` no longer resolves.
+  - [ ] An HTTP request to `/openapi/v1/bots/messages/x` reaches **backend**.
+  - [ ] `test_route_security.py` asserts the exemption at the new prefix **and**
+        that it beats the `/openapi/v1/bots/**` user requirement.
+- **Depends on:** Task 6
+
+## Task 8: Publish the new address from the backend
+
+- **Goal:** `GET /openapi/v1/bots/connection/{bot_id}` hands out the new socket
+  URL; its own path, name, and response shape are unchanged.
+- **Files:**
+  - `src/backend/src/agentclaw/community/core/engine_runtime/connection.py`
+  - `src/backend/src/agentclaw/.../openapi_v1/engine_runtime/connection/schemas.py`
+  - `src/backend/tests/community/core/engine_runtime/test_connection.py`
+  - `src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py`
+- **Done when:**
+  - [ ] `_ENGINE_PREFIX = "/openapi/v1/bots/messages"`.
+  - [ ] The module docstring, the constant's comment, and the docstrings at
+        `_readdress_onto_gateway` and `_gateway_ws_base` no longer name the old
+        address.
+  - [ ] Both example URLs in `schemas.py` use the new address.
+  - [ ] Published-URL assertions in both test files move to the new prefix.
+  - [ ] `coverage_baseline.txt` needs **no** edit — verify, don't assume: the
+        endpoint's own path did not change.
+- **Depends on:** Task 6
+
+## Task 9: Record `messages` as a reserved component name
+
+- **Goal:** The reservation is written down where the addressing rule lives, and
+  cannot silently fall out of step with the routes.
+- **Files:**
+  - `src/backend/docs/openapi-v1/README.md`
+  - `src/backend/docs/openapi-v1/README.zh-CN.md`
+  - `src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py`
+- **Done when:**
+  - [ ] A second fenced block under a new `<!-- reserved-component-names-unrouted -->`
+        anchor holds `messages`, placed **after** the existing block (the parser
+        takes the first fence following its anchor).
+  - [ ] `test_the_docs_reserved_names_match_the_routes` is **unchanged** — still
+        an equality check.
+  - [ ] A new test asserts the unrouted block is disjoint from the routed
+        components, so a name that gains a route must move blocks.
+  - [ ] The prose states the accurate reason: `messages` is reserved because the
+        gateway claims the prefix on the **socket plane** and a component is
+        planned there — *not* because a bot id would be unreachable, which is
+        untrue for this name today.
+  - [ ] The Chinese README carries the same record. It has **no** anchor today;
+        add one so both stay parseable.
+- **Depends on:** Task 8
+
+## Task 10: Update the engine-surface docs and regenerate the pinned artifact
+
+- **Goal:** Published documentation and the gateway's pinned OpenAPI artifact
+  quote the new socket address.
+- **Files:**
+  - `src/backend/docs/openapi-v1/engine-surface.md`
+  - `src/backend/docs/openapi-v1/engine-surface.zh-CN.md`
+  - `src/gateway/configs/schemas/bots.openapi.json`
+- **Done when:**
+  - [ ] Both documents quote `wss://<gateway>/openapi/v1/bots/messages/…` and
+        describe the rewrite against the new prefix.
+  - [ ] `bots.openapi.json` is regenerated via `dump_openapi.py` +
+        `gate_and_publish_openapi.py` — the *paths* do not change, but the socket
+        URL appears as an example value in two places.
+  - [ ] `src/gateway/tests/fixtures/bots.openapi.json` is **not** regenerated —
+        it is a hand-written fixture, not a copy.
+- **Depends on:** Task 8, Task 9
+
+## Task 11: Tests & Verification
+
+- **Goal:** Every spec acceptance criterion is demonstrably met, and what could
+  not be run is stated.
+- **Files:** —
+- **Done when:**
+  - [ ] Gateway suite green: `test_path_pattern`, `test_domain_map`,
+        `test_route_security`, `test_relay_ws_route`, `tests/architecture/*`.
+  - [ ] Backend suite green for `engine_runtime` and `openapi_v1` tests.
+  - [ ] Coverage gate checked by grepping for **`ERROR` as well as `FAILED`** —
+        it errors on a missing fixture in isolation and would otherwise drop out
+        of a before/after diff silently.
+  - [ ] Every acceptance criterion in `spec.md` ticked, each against a named test
+        or a named file.
+  - [ ] Pre-existing sandbox failures reported as such, not as regressions:
+        legacy `/api/bots` 403s, missing SQLite fixtures under
+        `tests/community/{endpoints,e2e}/*`, gateway `tests/e2e/*` needing a live
+        server, and `ruff format --check` on gateway `docs/*.md`.
+- **Depends on:** Task 10
+
+---
+
+## Groups
+
+- **Group A — The shared pattern:** Tasks 1, 2
+  - Theme: One parse/match/rank implementation, adopted by the auth plane with no
+    behaviour change. Lands independently and is provably inert.
+- **Group B — Pattern-based routing:** Tasks 3, 4, 5
+  - Theme: The gateway resolves on (pattern, plane) with boot-time refusal of
+    over-broad and ambiguous declarations. Still serves the *old* address — the
+    mechanism arrives before the move, so a failure here is unambiguous.
+- **Group C — The move:** Tasks 6, 7
+  - Theme: The socket changes address, and the gateway suites prove both the new
+    address works and the old one is gone.
+- **Group D — Backend and docs:** Tasks 8, 9, 10
+  - Theme: The backend publishes the new address; the reservation and the
+    published docs and artifact catch up.
+- **Group E — Verification:** Task 11
+  - Theme: Final spec acceptance check.

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -151,7 +151,7 @@
         `spec.md`'s corrected answer to objection 2.
 - **Depends on:** Task 6
 
-## Task 8: Publish the new address from the backend
+## [x] Task 8: Publish the new address from the backend
 
 - **Goal:** `GET /openapi/v1/bots/connection/{bot_id}` hands out the new socket
   URL; its own path, name, and response shape are unchanged.
@@ -161,13 +161,13 @@
   - `src/backend/tests/community/core/engine_runtime/test_connection.py`
   - `src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py`
 - **Done when:**
-  - [ ] `_ENGINE_PREFIX = "/openapi/v1/bots/messages"`.
-  - [ ] The module docstring, the constant's comment, and the docstrings at
+  - [x] `_ENGINE_PREFIX = "/openapi/v1/bots/messages"`.
+  - [x] The module docstring, the constant's comment, and the docstrings at
         `_readdress_onto_gateway` and `_gateway_ws_base` no longer name the old
         address.
-  - [ ] Both example URLs in `schemas.py` use the new address.
-  - [ ] Published-URL assertions in both test files move to the new prefix.
-  - [ ] `coverage_baseline.txt` needs **no** edit — verify, don't assume: the
+  - [x] Both example URLs in `schemas.py` use the new address.
+  - [x] Published-URL assertions in both test files move to the new prefix.
+  - [x] `coverage_baseline.txt` needs **no** edit — verify, don't assume: the
         endpoint's own path did not change.
 - **Depends on:** Task 6
 

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -2,7 +2,7 @@
 
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
-## Task 1: Extract the shared path pattern into `core/paths`
+## [x] Task 1: Extract the shared path pattern into `core/paths`
 
 - **Goal:** One parse/match/rank implementation for path patterns, importable by
   both the routing and the auth plane without a private-module import.
@@ -11,14 +11,14 @@
   - `src/gateway/src/gateway/community/core/paths/_pattern.py` (new)
   - `src/gateway/tests/test_path_pattern.py` (new)
 - **Done when:**
-  - [ ] `PathPattern.parse`, `.matches`, `.specificity`, `.literal_prefix` and
+  - [x] `PathPattern.parse`, `.matches`, `.specificity`, `.literal_prefix` and
         `split_segments` exist, with `__all__` declared.
-  - [ ] `specificity` is `(exact?, literals, params)` — today's
+  - [x] `specificity` is `(exact?, literals, params)` — today's
         `_route_security._specificity` **minus** its method tie-break.
-  - [ ] `**` matches zero segments, so `/openapi/v1/bots/**` matches the bare
+  - [x] `**` matches zero segments, so `/openapi/v1/bots/**` matches the bare
         `/openapi/v1/bots` (the property `test_domain_at_root_resolves` rests on).
-  - [ ] `literal_prefix` returns the leading run of literal segments as a path.
-  - [ ] `tests/architecture/` stays green (`test_all_exports_valid.py` requires
+  - [x] `literal_prefix` returns the leading run of literal segments as a path.
+  - [x] `tests/architecture/` stays green (`test_all_exports_valid.py` requires
         the new package's `__all__`).
 - **Depends on:** —
 

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -195,7 +195,7 @@
         add one so both stay parseable.
 - **Depends on:** Task 8
 
-## Task 10: Update the engine-surface docs and regenerate the pinned artifact
+## [x] Task 10: Update the engine-surface docs and regenerate the pinned artifact
 
 - **Goal:** Published documentation and the gateway's pinned OpenAPI artifact
   quote the new socket address.
@@ -204,12 +204,12 @@
   - `src/backend/docs/openapi-v1/engine-surface.zh-CN.md`
   - `src/gateway/configs/schemas/bots.openapi.json`
 - **Done when:**
-  - [ ] Both documents quote `wss://<gateway>/openapi/v1/bots/messages/…` and
+  - [x] Both documents quote `wss://<gateway>/openapi/v1/bots/messages/…` and
         describe the rewrite against the new prefix.
-  - [ ] `bots.openapi.json` is regenerated via `dump_openapi.py` +
+  - [x] `bots.openapi.json` is regenerated via `dump_openapi.py` +
         `gate_and_publish_openapi.py` — the *paths* do not change, but the socket
         URL appears as an example value in two places.
-  - [ ] `src/gateway/tests/fixtures/bots.openapi.json` is **not** regenerated —
+  - [x] `src/gateway/tests/fixtures/bots.openapi.json` is **not** regenerated —
         it is a hand-written fixture, not a copy.
 - **Depends on:** Task 8, Task 9
 

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -126,7 +126,7 @@
   - [x] The `domains:` block comment documents the new `match:` key.
 - **Depends on:** Task 5
 
-## Task 7: Re-point the gateway test suites at the new address
+## [x] Task 7: Re-point the gateway test suites at the new address
 
 - **Goal:** Every gateway test that pins the socket address moves with it, and the
   old address is pinned as *no longer resolving*.
@@ -136,15 +136,19 @@
   - `src/gateway/tests/test_domain_map.py`
   - `src/gateway/tests/test_log_redaction.py`
 - **Done when:**
-  - [ ] Relay integration cases run against `/openapi/v1/bots/messages/…`; the
+  - [x] Relay integration cases run against `/openapi/v1/bots/messages/…`; the
         rewrite still lands on `/proxypass/<target><path>` byte for byte.
-  - [ ] The encoded-prefix matrix moves to the new prefix (the `%62ots` /
+  - [x] The encoded-prefix matrix moves to the new prefix (the `%62ots` /
         `%6dessages` spellings) rather than being dropped, and still refuses.
-  - [ ] The dot-segment matrix still refuses at the new prefix.
-  - [ ] A handshake to `/openapi/v1/engine/**` no longer resolves.
-  - [ ] An HTTP request to `/openapi/v1/bots/messages/x` reaches **backend**.
-  - [ ] `test_route_security.py` asserts the exemption at the new prefix **and**
+  - [x] The dot-segment matrix still refuses at the new prefix.
+  - [x] A handshake to `/openapi/v1/engine/**` no longer resolves.
+  - [x] An HTTP request to `/openapi/v1/bots/messages/x` reaches **backend**.
+  - [x] `test_route_security.py` asserts the exemption at the new prefix **and**
         that it beats the `/openapi/v1/bots/**` user requirement.
+  - [x] **Security fix, not in the plan:** the route-security exemption is
+        qualified by plane (`WEBSOCKET /openapi/v1/bots/messages/**`). Unqualified,
+        it exempted HTTP requests that now fall through to the backend — see
+        `spec.md`'s corrected answer to objection 2.
 - **Depends on:** Task 6
 
 ## Task 8: Publish the new address from the backend

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -171,7 +171,7 @@
         endpoint's own path did not change.
 - **Depends on:** Task 6
 
-## Task 9: Record `messages` as a reserved component name
+## [x] Task 9: Record `messages` as a reserved component name
 
 - **Goal:** The reservation is written down where the addressing rule lives, and
   cannot silently fall out of step with the routes.
@@ -180,18 +180,18 @@
   - `src/backend/docs/openapi-v1/README.zh-CN.md`
   - `src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py`
 - **Done when:**
-  - [ ] A second fenced block under a new `<!-- reserved-component-names-unrouted -->`
+  - [x] A second fenced block under a new `<!-- reserved-component-names-unrouted -->`
         anchor holds `messages`, placed **after** the existing block (the parser
         takes the first fence following its anchor).
-  - [ ] `test_the_docs_reserved_names_match_the_routes` is **unchanged** — still
+  - [x] `test_the_docs_reserved_names_match_the_routes` is **unchanged** — still
         an equality check.
-  - [ ] A new test asserts the unrouted block is disjoint from the routed
+  - [x] A new test asserts the unrouted block is disjoint from the routed
         components, so a name that gains a route must move blocks.
-  - [ ] The prose states the accurate reason: `messages` is reserved because the
+  - [x] The prose states the accurate reason: `messages` is reserved because the
         gateway claims the prefix on the **socket plane** and a component is
         planned there — *not* because a bot id would be unreachable, which is
         untrue for this name today.
-  - [ ] The Chinese README carries the same record. It has **no** anchor today;
+  - [x] The Chinese README carries the same record. It has **no** anchor today;
         add one so both stay parseable.
 - **Depends on:** Task 8
 

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -213,25 +213,47 @@
         it is a hand-written fixture, not a copy.
 - **Depends on:** Task 8, Task 9
 
-## Task 11: Tests & Verification
+## [x] Task 11: Tests & Verification
 
 - **Goal:** Every spec acceptance criterion is demonstrably met, and what could
   not be run is stated.
 - **Files:** —
 - **Done when:**
-  - [ ] Gateway suite green: `test_path_pattern`, `test_domain_map`,
+  - [x] Gateway suite green: `test_path_pattern`, `test_domain_map`,
         `test_route_security`, `test_relay_ws_route`, `tests/architecture/*`.
-  - [ ] Backend suite green for `engine_runtime` and `openapi_v1` tests.
-  - [ ] Coverage gate checked by grepping for **`ERROR` as well as `FAILED`** —
+  - [x] Backend suite green for `engine_runtime` and `openapi_v1` tests.
+  - [x] Coverage gate checked by grepping for **`ERROR` as well as `FAILED`** —
         it errors on a missing fixture in isolation and would otherwise drop out
         of a before/after diff silently.
-  - [ ] Every acceptance criterion in `spec.md` ticked, each against a named test
+  - [x] Every acceptance criterion in `spec.md` ticked, each against a named test
         or a named file.
-  - [ ] Pre-existing sandbox failures reported as such, not as regressions:
+  - [x] Pre-existing sandbox failures reported as such, not as regressions:
         legacy `/api/bots` 403s, missing SQLite fixtures under
         `tests/community/{endpoints,e2e}/*`, gateway `tests/e2e/*` needing a live
         server, and `ruff format --check` on gateway `docs/*.md`.
 - **Depends on:** Task 10
+
+
+### Results
+
+- **Gateway** — 630 passed. One failure, `test_ruff_formatting_passes`, is
+  pre-existing: the identical 8-file list reproduces on the base commit
+  (`770d677`), and this branch adds none. Two relay cases
+  (`test_a_dot_inside_a_name_still_relays`,
+  `test_a_nested_rewrite_still_relays_its_own_paths`) flake ~1 run in 3 on a
+  teardown race; also reproduced on the base commit, so pre-existing and left
+  alone.
+- **Backend** — 10319 passed, 3 skipped, 0 failed (full suite, 9m52s). The
+  sandbox gaps the handoff warned about did not reproduce here.
+- **Coverage gate** — 16 passed, no `ERROR` (checked for both, in isolation and
+  in the full run). Baseline needed no edit: verified against the generated
+  document that `GET /openapi/v1/bots/connection/{bot_id}` is unchanged.
+- **Pinned artifact** — regenerated through `dump_openapi.py` +
+  `gate_and_publish_openapi.py`; the compat gate reported *compatible*, and the
+  diff is exactly the two example URLs.
+- **Acceptance criteria** — every criterion in `spec.md` checked against the
+  shipped `application.yaml`, including the corrected criterion that the socket
+  exemption does not reach the HTTP plane.
 
 ---
 

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -107,23 +107,23 @@
         against the new prefix.
 - **Depends on:** Task 4
 
-## Task 6: Move the shipped socket domain to `/openapi/v1/bots/messages`
+## [x] Task 6: Move the shipped socket domain to `/openapi/v1/bots/messages`
 
 - **Goal:** The gateway serves the socket at its new address and no longer at the
   old one — configuration only.
 - **Files:**
   - `src/gateway/configs/application.yaml`
 - **Done when:**
-  - [ ] The `engine` domain block becomes `bots-messages-ws` with
+  - [x] The `engine` domain block becomes `bots-messages-ws` with
         `match: /openapi/v1/bots/messages/**`, `protocols: [websocket]`, and
         `rewrite: {from: /openapi/v1/bots/messages, to: /proxypass}`.
-  - [ ] Its explanatory comment carries over: Upgrade pass-through, **no read
+  - [x] Its explanatory comment carries over: Upgrade pass-through, **no read
         timeout** on the path, and no `schema:` because a socket has no OpenAPI
         representation.
-  - [ ] `route_security` declares `"/openapi/v1/bots/messages/**": {}` and no
+  - [x] `route_security` declares `"/openapi/v1/bots/messages/**": {}` and no
         longer declares `"/openapi/v1/engine/**"`; the comment explaining why it
         requires no identity carries over.
-  - [ ] The `domains:` block comment documents the new `match:` key.
+  - [x] The `domains:` block comment documents the new `match:` key.
 - **Depends on:** Task 5
 
 ## Task 7: Re-point the gateway test suites at the new address

--- a/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
+++ b/src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/tasks.md
@@ -22,7 +22,7 @@
         the new package's `__all__`).
 - **Depends on:** —
 
-## Task 2: Re-point `RouteSecurity` at the shared pattern
+## [x] Task 2: Re-point `RouteSecurity` at the shared pattern
 
 - **Goal:** Delete route security's private matcher/ranker in favour of
   `PathPattern`, with no behaviour change on the auth plane.
@@ -30,11 +30,13 @@
   - `src/gateway/src/gateway/community/core/authn/_route_security.py`
   - `src/gateway/tests/test_route_security.py`
 - **Done when:**
-  - [ ] `_Rule` holds a `PathPattern`; `_match_segments`, `_is_param` and the
+  - [x] `_Rule` holds a `PathPattern`; `_match_segments`, `_is_param` and the
         segment-counting half of `_specificity` are gone from this module.
-  - [ ] The method tie-break stays here — the domain map has no methods.
-  - [ ] `tests/test_route_security.py` passes **unchanged** (the engine-prefix
+  - [x] The method tie-break stays here — the domain map has no methods.
+  - [x] `tests/test_route_security.py` passes **unchanged** (the engine-prefix
         case still asserts the old path at this point; Task 7 moves it).
+  - [x] `bootstrap/_authn.py` logged the table via `_Rule.segments` — a caller the
+        plan did not list; re-pointed at `rule.pattern.segments`.
 - **Depends on:** Task 1
 
 ## Task 3: Give `Domain` a pattern, and validate it at boot

--- a/src/gateway/src/gateway/community/adapters/web/_forward.py
+++ b/src/gateway/src/gateway/community/adapters/web/_forward.py
@@ -2,8 +2,8 @@
 
 One route handles every request that is not a gateway-local endpoint:
 
-1. resolve the domain from the leading path segment (unknown → 404; the gateway
-   forwards only into known domains, never as an open proxy);
+1. resolve the domain claiming this path *on the HTTP plane* (none → 404; the
+   gateway forwards only into known domains, never as an open proxy);
 2. authenticate (fail-closed) — a known domain still requires a principal;
 3. forward the path **verbatim** to the resolved server and stream the response
    back unchanged.
@@ -110,12 +110,13 @@ async def _attach_identities(
 async def forward_request(request: Request) -> Response:
     """Resolve domain → authenticate → forward verbatim, streaming the response."""
     path = request.url.path
-    domain = request.app.state.domain_map.domain_for(path)
-    # A domain that does not answer HTTP is as unknown here as one that is not
-    # configured at all. Socket domains are served by the WebSocket entrypoint
-    # and must not become an HTTP proxy into their upstream as a side effect of
-    # sharing the domain map.
-    if domain is None or not domain.serves_http:
+    # Asked for the *HTTP* domain, not for whichever domain claims the path.
+    # A socket domain is not a candidate here at all, so it can neither become an
+    # HTTP proxy into its upstream nor shadow a broader HTTP domain that also
+    # claims the path — an HTTP request beneath a socket-only prefix still
+    # resolves to the domain that serves the prefix above it.
+    domain = request.app.state.domain_map.http_domain_for(path)
+    if domain is None:
         return _error(404, 1, "no route for path")
     server = domain.server
     upstream_path = domain.upstream_path(path)

--- a/src/gateway/src/gateway/community/adapters/web/_log_redaction.py
+++ b/src/gateway/src/gateway/community/adapters/web/_log_redaction.py
@@ -5,7 +5,7 @@ so socket credentials travel as query parameters. The engine socket's
 ``x-proxypass-token`` is one such credential, and uvicorn logs the request
 target *including its query string* on every accepted or refused handshake::
 
-    INFO: 127.0.0.1:43078 - "WebSocket /openapi/v1/engine/T/api/ws?x-proxypass-token=eyJ…" [accepted]
+    INFO: 127.0.0.1:43078 - "WebSocket /openapi/v1/bots/messages/T/api/ws?x-proxypass-token=eyJ…" [accepted]
 
 That line is emitted through ``uvicorn.error`` and is not governed by the
 ``access_log`` switch, so a deployment cannot turn it off without losing the

--- a/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
+++ b/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
@@ -50,22 +50,22 @@ from ._forward import _INBOUND_STRIP, _PRINCIPAL_HEADER, _bundle
 logger = get_logger("relay_ws")
 
 
-def relay_routes(base_path: str, domain: str) -> tuple[str, ...]:
+def relay_routes(prefix: str) -> tuple[str, ...]:
     """Every path a socket domain's entrypoint must be mounted on.
 
-    Built from configuration rather than written down, so adding a socket domain
-    is a config edit and this module never names one.
+    Takes the domain's declared prefix rather than deriving one from its name, so
+    a domain may sit anywhere its pattern claims — including beneath another
+    domain — and this module still never names one.
 
     **Two paths, not one.** Starlette compiles ``{full_path:path}`` with a
     mandatory separator in front of it, so mounting only the tail form leaves
-    the bare prefix unserved — a handshake to exactly ``/openapi/v1/engine``
-    is refused before it reaches the entrypoint. That is not hypothetical: a
-    domain whose upstream publishes its socket at the rewrite target's own root
-    is reached at precisely that prefix, and :meth:`PathRewrite.apply` has an
-    exact-prefix branch for it. Returned together so a caller cannot mount one
-    and forget the other.
+    the bare prefix unserved — a handshake to exactly
+    ``/openapi/v1/bots/messages`` is refused before it reaches the entrypoint.
+    That is not hypothetical: a domain whose upstream publishes its socket at the
+    rewrite target's own root is reached at precisely that prefix, and
+    :meth:`PathRewrite.apply` has an exact-prefix branch for it. Returned
+    together so a caller cannot mount one and forget the other.
     """
-    prefix = f"{base_path.rstrip('/')}/{domain}"
     return (prefix, f"{prefix}/{{full_path:path}}")
 
 
@@ -113,8 +113,8 @@ async def forward_websocket(websocket: WebSocket) -> None:
     # plane does, so one request cannot be routed or authorised differently
     # depending on which entrypoint serves it.
     path = websocket.url.path
-    domain = state.domain_map.domain_for(path)
-    if domain is None or not domain.serves_websocket:
+    domain = state.domain_map.websocket_domain_for(path)
+    if domain is None:
         await _refuse(websocket, _CLOSE_NO_ROUTE, "no route for path")
         return
 
@@ -127,7 +127,7 @@ async def forward_websocket(websocket: WebSocket) -> None:
     # something, or the request is authorised as one resource and dialled as
     # another — see _required_raw_prefix.
     raw_path = _raw_path(websocket)
-    if not _starts_at(raw_path, _required_raw_prefix(state.domain_map, domain)):
+    if not _starts_at(raw_path, _required_raw_prefix(domain)):
         await _refuse(websocket, _CLOSE_BAD_PATH, "routing prefix is encoded")
         return
 
@@ -203,7 +203,7 @@ def _has_dot_segment(path: str) -> bool:
     return any(segment in _DOT_SEGMENTS for segment in path.split("/"))
 
 
-def _required_raw_prefix(domain_map: Any, domain: Any) -> str:
+def _required_raw_prefix(domain: Any) -> str:
     """The prefix the **raw** path must carry literally, for this domain.
 
     Routing and authentication run on the decoded path; the dial is built from
@@ -213,13 +213,17 @@ def _required_raw_prefix(domain_map: Any, domain: Any) -> str:
 
     Two prefixes decide something, and the deeper one governs:
 
-    - the domain prefix, which chose the route and the authentication rule.
-      ``/openapi/v1/%65ngine/...`` decodes to the domain, so it resolves and
-      authenticates as it, while the raw path keeps ``%65ngine``.
+    - the domain's own prefix, which chose the route and the authentication rule.
+      ``/openapi/v1/bots/%6dessages/...`` decodes to the socket domain, so it
+      resolves and authenticates as it, while the raw path keeps ``%6dessages``
+      — and would dial the upstream outside the substituted prefix. Note this
+      prefix is now several segments deep and may nest inside another domain's,
+      so every segment of it has to be literal, not merely the first.
     - the rewrite's own ``from``, when one is declared — which may be *deeper*
       than the domain prefix, since a nested ``from`` is accepted. With
-      ``from: /openapi/v1/engine/v2``, a raw ``/openapi/v1/engine/%76%32/...``
-      clears the domain prefix but defeats the substitution.
+      ``from: /openapi/v1/bots/messages/v2``, a raw
+      ``/openapi/v1/bots/messages/%76%32/...`` clears the domain prefix but
+      defeats the substitution.
 
     In both cases the rewrite silently fails to fire and the upstream is dialled
     outside the prefix its credential check is scoped to. Requiring the rewrite's
@@ -232,7 +236,7 @@ def _required_raw_prefix(domain_map: Any, domain: Any) -> str:
     """
     if domain.rewrite is not None:
         return str(domain.rewrite.from_prefix)
-    return f"{domain_map.base_path.rstrip('/')}/{domain.name}"
+    return str(domain.mount_prefix)
 
 
 def _starts_at(path: str, prefix: str) -> bool:

--- a/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
+++ b/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
@@ -69,9 +69,26 @@ def relay_routes(prefix: str) -> tuple[str, ...]:
     return (prefix, f"{prefix}/{{full_path:path}}")
 
 
-#: A WebSocket handshake is an HTTP ``GET``; route security is resolved for it
-#: the same way it is for any other request.
-_HANDSHAKE_METHOD = "GET"
+#: The method a handshake is authenticated under.
+#:
+#: A WebSocket handshake *is* an HTTP ``GET`` on the wire, and this used to say
+#: so. It cannot any longer: the route-security table is plane-blind, so a rule
+#: written for the socket also governs an ordinary request to the same path, and
+#: a socket prefix now sits **inside** an authenticated HTTP prefix rather than
+#: beside it as its own top-level domain.
+#:
+#: Authenticating under ``GET`` there would mean the socket's deliberate "no
+#: identity required" exemption — the credential rides in the handshake query,
+#: because a browser's WebSocket API can attach no headers — silently applied to
+#: HTTP requests on that prefix too. Those no longer 404: they fall through to
+#: the broader domain and reach its upstream, so the exemption would let an
+#: unauthenticated caller forward a request there.
+#:
+#: A distinct method keeps the exemption to the plane it was written for. The
+#: table's keys already carry an optional method qualifier, so this is expressed
+#: as ``WEBSOCKET /path`` and an HTTP ``GET`` to the same path simply does not
+#: match it — falling to whatever rule governs the prefix above.
+_HANDSHAKE_METHOD = "WEBSOCKET"
 
 # Refusals, all of them *before* the client is accepted. A close code is not
 # transmitted on a handshake that never completed — a real client sees an HTTP

--- a/src/gateway/src/gateway/community/adapters/web/app.py
+++ b/src/gateway/src/gateway/community/adapters/web/app.py
@@ -136,8 +136,8 @@ def create_app() -> FastAPI:
     # only http gets no socket route, and a socket domain is refused by the HTTP
     # catch-all below.
     domain_map = bs.forwarding.domain_map
-    for name in domain_map.websocket_domains():
-        for route in relay_routes(domain_map.base_path, name):
+    for domain in domain_map.websocket_domains():
+        for route in relay_routes(domain.mount_prefix):
             app.add_api_websocket_route(route, forward_websocket)
 
     app.add_api_route(

--- a/src/gateway/src/gateway/community/bootstrap/_authn.py
+++ b/src/gateway/src/gateway/community/bootstrap/_authn.py
@@ -120,7 +120,7 @@ def _load_route_security(user_config: UserConfig | None = None) -> RouteSecurity
         "route security (application.yaml user_config.route_security): %d routes\n%s",
         len(rules._rules),
         "\n".join(
-            f"  {rule.method or '*'} /{'/'.join(rule.segments)} → "
+            f"  {rule.method or '*'} /{'/'.join(rule.pattern.segments)} → "
             + str({idty.value: pres.value for idty, pres in rule.requirement.items()})
             for rule in rules._rules
         ),

--- a/src/gateway/src/gateway/community/core/authn/_route_security.py
+++ b/src/gateway/src/gateway/community/core/authn/_route_security.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 
 import yaml
 
+from gateway.community.core.paths import PathPattern, split_segments
 from gateway.community.spi.authn import Presence, PrincipalType
 
 # A requirement maps each identity the route cares about to its Presence.
@@ -24,7 +25,7 @@ Requirement = dict[PrincipalType, Presence]
 @dataclass(frozen=True)
 class _Rule:
     method: str | None  # None = applies to every method
-    segments: tuple[str, ...]
+    pattern: PathPattern
     requirement: Requirement
 
 
@@ -51,7 +52,7 @@ class RouteSecurity:
 
     def resolve(self, method: str, path: str) -> Requirement | None:
         """Most-specific matching rule's requirement, or ``None`` if none match."""
-        segments = _segments(path)
+        segments = split_segments(path)
         matches = [r for r in self._rules if _matches(r, method, segments)]
         if not matches:
             return None
@@ -63,7 +64,11 @@ class RouteSecurity:
 
 def _parse_rule(key: str, value: Any) -> _Rule:
     method, path = _split_key(key)
-    return _Rule(method=method, segments=_segments(path), requirement=_parse_req(value))
+    return _Rule(
+        method=method,
+        pattern=PathPattern.parse(path),
+        requirement=_parse_req(value),
+    )
 
 
 def _split_key(key: str) -> tuple[str | None, str]:
@@ -71,10 +76,6 @@ def _split_key(key: str) -> tuple[str | None, str]:
     if len(parts) == 2 and parts[0].isupper() and parts[1].startswith("/"):
         return parts[0], parts[1]
     return None, key.strip()
-
-
-def _segments(path: str) -> tuple[str, ...]:
-    return tuple(seg for seg in path.split("/") if seg)
 
 
 def _parse_req(value: Any) -> Requirement:
@@ -91,32 +92,18 @@ def _parse_req(value: Any) -> Requirement:
 # ── matching (§8.3) ──────────────────────────────────────────────────────────
 
 
-def _is_param(seg: str) -> bool:
-    return seg.startswith("{") and seg.endswith("}")
-
-
 def _matches(rule: _Rule, method: str, path_segments: tuple[str, ...]) -> bool:
     if rule.method is not None and rule.method != method:
         return False
-    return _match_segments(rule.segments, path_segments)
-
-
-def _match_segments(pattern: tuple[str, ...], segs: tuple[str, ...]) -> bool:
-    if not pattern:
-        return not segs
-    head, rest = pattern[0], pattern[1:]
-    if head == "**":
-        return True
-    if not segs:
-        return False
-    if head != segs[0] and not _is_param(head):
-        return False
-    return _match_segments(rest, segs[1:])
+    return rule.pattern.matches(path_segments)
 
 
 def _specificity(rule: _Rule) -> tuple[int, int, int, int]:
-    """Higher = more specific: exact beats glob, more literals, then method."""
-    has_glob = "**" in rule.segments
-    literals = sum(1 for s in rule.segments if s != "**" and not _is_param(s))
-    params = sum(1 for s in rule.segments if _is_param(s))
-    return (0 if has_glob else 1, literals, params, int(rule.method is not None))
+    """Higher = more specific: the shared path ranking, then method.
+
+    The path terms come from :attr:`PathPattern.specificity`, shared with the
+    domain map so both planes cannot come to rank one pair of patterns
+    differently. The method tie-break stays here: it is this table's alone, since
+    a domain answers a path rather than a verb.
+    """
+    return (*rule.pattern.specificity, int(rule.method is not None))

--- a/src/gateway/src/gateway/community/core/forwarding/_domains.py
+++ b/src/gateway/src/gateway/community/core/forwarding/_domains.py
@@ -253,10 +253,11 @@ class Domain:
     name: str
     server: Server
     schema: SchemaSource
-    #: The paths this domain claims. Defaults to the domain's own name under the
-    #: version base, which is exactly the leading-segment match every domain had
-    #: before patterns existed.
-    pattern: PathPattern = field(default_factory=lambda: PathPattern(()))
+    #: The paths this domain claims. Required: parsing supplies the implicit
+    #: ``{base_path}/{name}/**`` when the config declares no ``match``, so there
+    #: is no such thing as a domain that claims nothing, and a default here could
+    #: only be a value that silently matches the wrong set of paths.
+    pattern: PathPattern
     protocols: frozenset[str] = _DEFAULT_PROTOCOLS
     #: ``None`` when the path forwards verbatim, which is the default and the
     #: case for every domain that does not declare otherwise.

--- a/src/gateway/src/gateway/community/core/forwarding/_domains.py
+++ b/src/gateway/src/gateway/community/core/forwarding/_domains.py
@@ -1,10 +1,24 @@
 """Domain → upstream-server resolution (transport-agnostic).
 
-The gateway routes by **domain**: the leading path segment after the version
-base (e.g. ``bots`` in ``/openapi/v1/bots/...``) selects the target server. The
-map is loaded from the ``user_config.upstreams`` section in
-``application.yaml``; a request whose leading segment matches no configured
-domain resolves to ``None`` (the caller denies — never an open proxy).
+The gateway routes by **domain**, and a domain claims a *path pattern*: a run of
+literal segments under the version base, followed by ``**``. Resolution gathers
+every domain whose pattern matches the path **and** which answers the requesting
+plane, then takes the most specific of those — match first, rank second. A path
+no configured domain claims on that plane resolves to ``None`` (the caller
+denies — never an open proxy).
+
+The pattern usually goes unwritten: a domain that declares no ``match`` claims
+``{base_path}/{name}/**``, which is the leading-segment routing every domain had
+before patterns existed. Writing one lets a domain sit *beneath* another —
+``/openapi/v1/bots/messages/**`` is served by the engine proxy while
+``/openapi/v1/bots/**`` is served by the backend — so the public address space
+can follow ownership rather than process topology.
+
+Because the plane filters the *candidates* rather than vetoing the winner, a
+prefix claimed for one plane leaves the other plane's resolution of that same
+path untouched: an HTTP request under a websocket-only prefix still finds the
+broader HTTP domain. Resolution never retries after a mismatch; a request
+refused by the domain that won must not get a second attempt at another.
 
 A domain also declares two things about *how* it is served:
 
@@ -30,6 +44,8 @@ from typing import Any, cast
 from urllib.parse import urlsplit
 
 import yaml
+
+from gateway.community.core.paths import GLOB, PathPattern, split_segments
 
 _ENV_REF = re.compile(r"\$\{([^}]+)\}")
 _DEFAULT_BASE_PATH = "/openapi/v1"
@@ -232,15 +248,30 @@ class SchemaSource:
 
 @dataclass(frozen=True)
 class Domain:
-    """A configured domain: its server, schema source, protocols and rewrite."""
+    """A configured domain: its pattern, server, schema, protocols and rewrite."""
 
     name: str
     server: Server
     schema: SchemaSource
+    #: The paths this domain claims. Defaults to the domain's own name under the
+    #: version base, which is exactly the leading-segment match every domain had
+    #: before patterns existed.
+    pattern: PathPattern = field(default_factory=lambda: PathPattern(()))
     protocols: frozenset[str] = _DEFAULT_PROTOCOLS
     #: ``None`` when the path forwards verbatim, which is the default and the
     #: case for every domain that does not declare otherwise.
     rewrite: PathRewrite | None = None
+
+    @property
+    def mount_prefix(self) -> str:
+        """The fixed path this domain is reachable at.
+
+        Every accepted pattern is ``<literals>/**``, so this is the whole of it
+        bar the glob — the prefix a route is mounted on and the prefix a raw,
+        still-encoded path must carry literally. Validation is what makes it
+        meaningful: a pattern that could not produce one is refused at boot.
+        """
+        return self.pattern.literal_prefix
 
     @property
     def serves_http(self) -> bool:
@@ -286,38 +317,57 @@ class DomainMap:
         domains = _parse_domains(raw.get("domains") or {}, servers, base_path)
         return cls(base_path=base_path, domains=domains)
 
-    def resolve(self, path: str) -> Server | None:
-        """The server for *path*'s domain, or ``None`` if the domain is unknown."""
-        domain = self.domain_for(path)
-        return domain.server if domain is not None else None
+    def domain_for(self, path: str, protocol: str) -> Domain | None:
+        """The domain serving *path* on *protocol*, or ``None`` if none does.
 
-    def domain_for(self, path: str) -> Domain | None:
-        """The domain *path* belongs to, or ``None`` if outside the version base."""
-        base = _segments(self.base_path)
-        segments = _segments(path)
-        if segments[: len(base)] != base:
-            return None
-        rest = segments[len(base) :]
-        if not rest:
-            return None
-        return self.domains.get(rest[0])
+        Match first, rank second. Every domain claiming this path **and**
+        answering this plane is a candidate; the most specific of them wins.
 
-    def websocket_domains(self) -> dict[str, Domain]:
-        """Every domain answering the socket plane, keyed by name.
+        The plane filters the candidates rather than vetoing the winner, and the
+        difference is load-bearing. Ranking first and then checking the plane
+        would let a narrow socket-only prefix swallow the HTTP traffic beneath
+        it — ``/openapi/v1/bots/messages/**`` is claimed for sockets, and an HTTP
+        request there has to keep resolving to the backend that serves
+        ``/openapi/v1/bots/**``. Recovering that by *retrying* the next-best
+        candidate is worse than the bug: a request the winning domain refused
+        would get a second attempt at a domain that did not win.
+        """
+        segments = split_segments(path)
+        candidates = [
+            domain
+            for domain in self.domains.values()
+            if protocol in domain.protocols and domain.pattern.matches(segments)
+        ]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda domain: domain.pattern.specificity)
+
+    def http_domain_for(self, path: str) -> Domain | None:
+        """The domain serving *path* on the request/response plane.
+
+        Named rather than parameterised because the delivery adapters are the
+        callers and may not import core (layer rule) — the same reason
+        :attr:`Domain.serves_http` is a predicate. A protocol constant would
+        otherwise have to be duplicated across that boundary, where it can drift.
+        """
+        return self.domain_for(path, HTTP)
+
+    def websocket_domain_for(self, path: str) -> Domain | None:
+        """The domain serving *path* on the relayed-socket plane."""
+        return self.domain_for(path, WEBSOCKET)
+
+    def websocket_domains(self) -> tuple[Domain, ...]:
+        """Every domain answering the socket plane.
 
         The web adapter uses this to mount one socket entrypoint per such
-        domain, so no code has to name a particular domain — ``engine`` is
-        configuration, not an identifier the gateway knows.
+        domain, so no code has to name a particular domain — which prefix is
+        served is configuration, not an identifier the gateway knows. The domains
+        themselves rather than their names, because the mount path comes from the
+        declared pattern and a name no longer implies one.
         """
-        return {
-            name: domain
-            for name, domain in self.domains.items()
-            if domain.serves_websocket
-        }
-
-
-def _segments(path: str) -> list[str]:
-    return [seg for seg in path.split("/") if seg]
+        return tuple(
+            domain for domain in self.domains.values() if domain.serves_websocket
+        )
 
 
 #: Every key each block of the ``upstreams`` section understands. An unknown one
@@ -326,7 +376,7 @@ def _segments(path: str) -> list[str]:
 #: exposes. ``protcols: [websocket]`` would otherwise turn the socket domain
 #: into an HTTP route — on the one prefix the shipped table exempts from
 #: authentication.
-_DOMAIN_KEYS = frozenset({"server", "schema", "protocols", "rewrite"})
+_DOMAIN_KEYS = frozenset({"match", "server", "schema", "protocols", "rewrite"})
 _SERVER_KEYS = frozenset({"base_url"})
 _REWRITE_KEYS = frozenset({"from", "to"})
 _SCHEMA_KEYS = frozenset({"source", "path", "url", "refresh_seconds"})
@@ -382,15 +432,97 @@ def _parse_domains(
             raise ValueError(
                 f"domain {name!r} references unknown server {server_name!r}"
             )
-        domain_prefix = f"{base_path.rstrip('/')}/{name}"
+        pattern = _parse_pattern(name, spec.get("match"), base_path)
         domains[name] = Domain(
             name=name,
             server=server,
             schema=_parse_schema(name, spec.get("schema") or {}),
+            pattern=pattern,
             protocols=_parse_protocols(name, spec.get("protocols")),
-            rewrite=_parse_rewrite(name, spec.get("rewrite"), domain_prefix),
+            rewrite=_parse_rewrite(name, spec.get("rewrite"), pattern.literal_prefix),
         )
+    _reject_ambiguous(domains)
     return domains
+
+
+def _parse_pattern(name: str, raw: Any, base_path: str) -> PathPattern:
+    """The paths this domain claims: ``match``, or its own name under the base.
+
+    **This is the check that keeps the gateway from being an open proxy.** Before
+    patterns, a domain *was* its leading path segment: an unknown segment
+    resolved to ``None`` and the caller denied, so "never an open proxy" was a
+    property of the data structure and the mistake could not be typed. A pattern
+    can be written wider than that, and ``match: /**`` is precisely an open
+    proxy — so the invariant now has to be enforced rather than assumed.
+
+    The accepted shape is a run of literal segments followed by ``**``, and the
+    literals must extend *past* the version base. That refuses the three ways to
+    write something too wide (``/**``, ``/openapi/**``, ``/openapi/v1/**``) and
+    also refuses a leading parameter, which pins nothing at all: ``/openapi/v1/{x}/**``
+    matches every domain's traffic while looking specific.
+
+    A trailing ``**`` is required rather than inferred. A domain serves a
+    *subtree* — the bare prefix and everything beneath it — and writing the glob
+    keeps that visible at the config, where a reader decides whether the claim is
+    too wide. (``**`` matches no remaining segments as well as many, so the bare
+    prefix is still served.)
+    """
+    if raw is None:
+        return PathPattern.parse(f"{base_path.rstrip('/')}/{name}/{GLOB}")
+    pattern = PathPattern.parse(str(raw))
+    if not pattern.segments or pattern.segments[-1] != GLOB:
+        raise ValueError(
+            f"domain {name!r}: match {raw!r} must end in '/{GLOB}' — a domain "
+            f"serves a subtree, and writing the glob keeps the width of the "
+            f"claim visible where it is configured"
+        )
+    literals = pattern.segments[:-1]
+    if GLOB in literals or any(_is_param_segment(seg) for seg in literals):
+        raise ValueError(
+            f"domain {name!r}: match {raw!r} must be literal segments followed "
+            f"by '/{GLOB}' — a parameter or an inner glob pins no prefix, so "
+            f"routes could not be mounted and a raw path could not be checked "
+            f"against it"
+        )
+    base = split_segments(base_path)
+    if literals[: len(base)] != base or len(literals) <= len(base):
+        raise ValueError(
+            f"domain {name!r}: match {raw!r} is too broad — it must pin "
+            f"{base_path.rstrip('/')!r} plus at least one more literal segment. "
+            f"A wider pattern makes the gateway an open proxy into this "
+            f"domain's upstream"
+        )
+    return pattern
+
+
+def _is_param_segment(segment: str) -> bool:
+    return segment.startswith("{") and segment.endswith("}")
+
+
+def _reject_ambiguous(domains: dict[str, Domain]) -> None:
+    """Refuse two domains that would answer one path on one plane.
+
+    Only *identical* patterns can collide: every accepted pattern is a literal
+    prefix, so two of equal length differ at some segment and no path matches
+    both, while two of unequal length are ranked apart by literal count. Same
+    pattern and an overlapping plane, though, is a tie with no defined winner —
+    and the winner would decide which upstream receives the traffic.
+
+    Two declarations at one pattern for *different* planes are the supported way
+    to serve a prefix over both, so those are left alone.
+    """
+    for name, domain in domains.items():
+        for other_name, other in domains.items():
+            if other_name <= name or domain.pattern != other.pattern:
+                continue
+            shared = domain.protocols & other.protocols
+            if shared:
+                raise ValueError(
+                    f"domains {name!r} and {other_name!r} both claim "
+                    f"{domain.mount_prefix!r} on {sorted(shared)} — which one "
+                    f"serves a request there is undefined. Give them different "
+                    f"patterns, or different protocols"
+                )
 
 
 def _parse_protocols(name: str, raw: Any) -> frozenset[str]:
@@ -419,18 +551,17 @@ def _validated_protocols(name: str, protocols: frozenset[str]) -> frozenset[str]
 def _parse_rewrite(name: str, raw: Any, domain_prefix: str) -> PathRewrite | None:
     """The domain's declared prefix substitution, or ``None`` for verbatim.
 
-    ``from`` must begin at the domain's own prefix, **on a segment boundary**. A
-    rewrite anchored anywhere else could never fire — the domain map matches the
-    leading segment exactly, so nothing routed here can carry another prefix —
+    ``from`` must begin at the domain's own prefix — the literal head of its
+    pattern — **on a segment boundary**. A rewrite anchored anywhere else could
+    never fire, since every path routed here carries that prefix by definition,
     and it is a configuration mistake worth refusing at startup rather than a
     rule that silently never matches.
 
     The boundary is the whole point of the check. A textual ``startswith`` would
-    accept ``/openapi/v1/engine-v2`` for the ``engine`` domain, since it does
-    begin with those characters; but ``/openapi/v1/engine-v2/…`` resolves to a
-    domain *named* ``engine-v2``, never to this one, so the rule would be
-    accepted and then never apply — the exact silent no-op being guarded
-    against.
+    accept ``/openapi/v1/bots/messages-v2`` for a domain claiming
+    ``/openapi/v1/bots/messages/**``, since it does begin with those characters;
+    but that path does not match the pattern, so the rule would be accepted and
+    then never apply — the exact silent no-op being guarded against.
     """
     if not raw:
         return None

--- a/src/gateway/src/gateway/community/core/forwarding/_domains.py
+++ b/src/gateway/src/gateway/community/core/forwarding/_domains.py
@@ -207,7 +207,7 @@ class PathRewrite:
     the path exactly as it arrived. A rewrite is the declared exception, for an
     upstream that serves the same resources under a different prefix — the
     engine proxy publishes ``/proxypass/{target}{path}`` where the gateway
-    publishes ``/openapi/v1/engine/{target}{path}``.
+    publishes ``/openapi/v1/bots/messages/{target}{path}``.
 
     Only the prefix changes. Everything past it is carried through untouched, so
     a percent-encoded segment reaches the upstream exactly as its author wrote
@@ -579,8 +579,8 @@ def _parse_rewrite(name: str, raw: Any, domain_prefix: str) -> PathRewrite | Non
     if "?" in from_prefix or "#" in from_prefix:
         # A request path never carries either, so such a rule could not match —
         # the same silent no-op the anchor check below exists to prevent. The
-        # anchor check alone does not catch it: `/openapi/v1/engine/v2?x` does
-        # begin with the domain prefix and a `/`, so it passes that test.
+        # anchor check alone does not catch it: `/openapi/v1/bots/messages/v2?x`
+        # does begin with the domain prefix and a `/`, so it passes that test.
         raise ValueError(
             f"domain {name!r}: rewrite.from {from_prefix!r} must be a path "
             f"prefix with no query or fragment — a request path contains "

--- a/src/gateway/src/gateway/community/core/paths/__init__.py
+++ b/src/gateway/src/gateway/community/core/paths/__init__.py
@@ -1,0 +1,13 @@
+"""Core paths — the shared path-pattern grammar, matcher and ranking.
+
+Imported by both :mod:`gateway.community.core.authn` and
+:mod:`gateway.community.core.forwarding` so the auth plane and the routing plane
+cannot come to rank the same two patterns differently. A public package rather
+than a private module in either of them, because a cross-package import of a
+private module is refused by the architecture tests — and rightly: a shared rule
+with one owner and one importer is not shared, it is borrowed.
+"""
+
+from ._pattern import GLOB, PathPattern, split_segments
+
+__all__ = ["GLOB", "PathPattern", "split_segments"]

--- a/src/gateway/src/gateway/community/core/paths/_pattern.py
+++ b/src/gateway/src/gateway/community/core/paths/_pattern.py
@@ -1,0 +1,124 @@
+"""Path patterns — one grammar, one ranking, for every plane that matches paths.
+
+Two planes ask the same question of an incoming path. Route security asks which
+configured rule governs ``(method, path)``; the domain map asks which configured
+domain serves it. Both answer it the same way — of the patterns this path
+matches, take the most specific — and a second implementation of "most specific"
+is somewhere the two can come to disagree about which rule governs one request.
+That disagreement is not a cosmetic one: the auth plane deciding a path is
+covered by an exempt rule while the routing plane sends it somewhere else is
+precisely the shape of an authorisation bypass. So there is one implementation.
+
+The grammar is three kinds of segment:
+
+- a **literal**, matching itself;
+- a **parameter** (``{id}``), matching exactly one segment, whatever it holds;
+- the **glob** (``**``), matching every remaining segment *including none*.
+
+Callers may accept a narrower grammar than they can rank — the domain map does,
+taking only ``<literals>/**`` — but they all rank through :attr:`specificity`.
+
+No web framework here (Rule 7): this is pure matching logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: The wildcard segment. Matches every remaining segment, and also *no*
+#: remaining segment: ``/a/b/**`` matches the bare ``/a/b``. Domains rely on
+#: this — ``/openapi/v1/bots/**`` has to serve ``/openapi/v1/bots`` itself.
+GLOB = "**"
+
+
+def split_segments(path: str) -> tuple[str, ...]:
+    """*path*'s non-empty segments.
+
+    Empty segments are dropped rather than preserved, so a leading slash, a
+    trailing slash, and an accidental doubled slash all describe the same path.
+    Patterns and request paths are split by this same function, so the two can
+    never disagree about how many segments a path has.
+    """
+    return tuple(segment for segment in path.split("/") if segment)
+
+
+def _is_param(segment: str) -> bool:
+    """Whether *segment* is a ``{name}`` placeholder."""
+    return segment.startswith("{") and segment.endswith("}")
+
+
+@dataclass(frozen=True)
+class PathPattern:
+    """A parsed path pattern: matchable against a path, comparable to its peers."""
+
+    segments: tuple[str, ...]
+
+    @classmethod
+    def parse(cls, pattern: str) -> PathPattern:
+        """Parse ``/openapi/v1/bots/**`` into its segments."""
+        return cls(segments=split_segments(pattern))
+
+    def matches(self, path_segments: tuple[str, ...]) -> bool:
+        """Whether a path — already split by :func:`split_segments` — matches."""
+        return _match(self.segments, path_segments)
+
+    @property
+    def specificity(self) -> tuple[int, int, int]:
+        """Higher is more specific: exact beats glob, then literals, then params.
+
+        Compared as a tuple, so each term only breaks a tie in the one before it.
+        Literals outrank parameters because a literal names one resource while a
+        parameter names a shape: between ``/bots/{id}`` and ``/bots/messages``,
+        the request for ``messages`` is more precisely described by the latter.
+
+        The glob term comes first because a pattern that ends in ``**`` claims a
+        whole subtree, and a pattern that claims exactly one path should win over
+        one that claims everything beneath it however many literals each has.
+        """
+        has_glob = GLOB in self.segments
+        literals = sum(
+            1 for segment in self.segments if segment != GLOB and not _is_param(segment)
+        )
+        params = sum(1 for segment in self.segments if _is_param(segment))
+        return (0 if has_glob else 1, literals, params)
+
+    @property
+    def literal_prefix(self) -> str:
+        """The leading run of literal segments, as an absolute path.
+
+        The part of the pattern that is fixed text — everything up to the first
+        parameter or glob. This is what a caller needs when it has to *produce* a
+        path rather than test one: a route to mount, or a prefix a raw
+        (still-encoded) path must carry literally.
+
+        A pattern beginning with a parameter or a glob has no such prefix and
+        yields ``"/"``. Callers that cannot use that are expected to refuse the
+        pattern when it is configured, rather than discover it here.
+        """
+        literals: list[str] = []
+        for segment in self.segments:
+            if segment == GLOB or _is_param(segment):
+                break
+            literals.append(segment)
+        return "/" + "/".join(literals)
+
+
+def _match(pattern: tuple[str, ...], segments: tuple[str, ...]) -> bool:
+    """Whether *pattern* matches *segments*, one segment at a time.
+
+    The glob returns ``True`` without consuming anything, which is what makes it
+    match zero remaining segments as well as many.
+    """
+    if not pattern:
+        return not segments
+    head, rest = pattern[0], pattern[1:]
+    if head == GLOB:
+        return True
+    if not segments:
+        return False
+    if head != segments[0] and not _is_param(head):
+        return False
+    return _match(rest, segments[1:])
+
+
+__all__ = ["GLOB", "PathPattern", "split_segments"]

--- a/src/gateway/tests/integration/test_relay_ws_route.py
+++ b/src/gateway/tests/integration/test_relay_ws_route.py
@@ -169,8 +169,8 @@ def _build(
     # Mounted the way the composition root does it: one route per socket domain,
     # driven from config. With no engine domain configured, nothing is mounted
     # under that prefix at all — which is the behaviour under test.
-    for name in domain_map.websocket_domains():
-        for route in relay_routes(domain_map.base_path, name):
+    for socket_domain in domain_map.websocket_domains():
+        for route in relay_routes(socket_domain.mount_prefix):
             app.add_api_websocket_route(route, forward_websocket)
     # An always-present route so an unconfigured prefix is refused by the
     # endpoint rather than by Starlette's router, keeping the assertion about
@@ -478,7 +478,7 @@ def test_the_bare_domain_prefix_is_mounted_too() -> None:
 
 def test_relay_routes_returns_both_forms_together() -> None:
     """Returned as one tuple so a caller cannot mount one and forget the other."""
-    assert relay_routes("/openapi/v1", "engine") == (
+    assert relay_routes("/openapi/v1/engine") == (
         "/openapi/v1/engine",
         "/openapi/v1/engine/{full_path:path}",
     )
@@ -510,8 +510,8 @@ def _nested_rewrite_app(forwarder: _StubForwarder) -> FastAPI:
     app.state.principal_signer = _FixedSigner()
     app.state.ws_forwarder = forwarder
     app.state.domain_map = domain_map
-    for name in domain_map.websocket_domains():
-        for route in relay_routes(domain_map.base_path, name):
+    for socket_domain in domain_map.websocket_domains():
+        for route in relay_routes(socket_domain.mount_prefix):
             app.add_api_websocket_route(route, forward_websocket)
     return app
 
@@ -602,7 +602,7 @@ def test_an_http_domain_still_forwards_verbatim() -> None:
         },
         variables={},
     )
-    bots = domain_map.domain_for("/openapi/v1/bots/x")
+    bots = domain_map.http_domain_for("/openapi/v1/bots/x")
     assert bots is not None
     assert bots.serves_http and not bots.serves_websocket
     assert bots.upstream_path("/openapi/v1/bots/x") == "/openapi/v1/bots/x"

--- a/src/gateway/tests/integration/test_relay_ws_route.py
+++ b/src/gateway/tests/integration/test_relay_ws_route.py
@@ -131,17 +131,19 @@ class _FixedSigner:
         return f"signed-for-{audience}"
 
 
-_ENGINE_DOMAIN = {
+#: The shipped socket domain: nested beneath `bots`, on a different upstream.
+_SOCKET_DOMAIN = {
+    "match": "/openapi/v1/bots/messages/**",
     "server": "engine_proxy",
     "protocols": ["websocket"],
-    "rewrite": {"from": "/openapi/v1/engine", "to": "/proxypass"},
+    "rewrite": {"from": "/openapi/v1/bots/messages", "to": "/proxypass"},
 }
 
 
 def _build(
     *,
     forwarder: _StubForwarder | None = None,
-    engine_configured: bool = True,
+    socket_configured: bool = True,
 ) -> tuple[FastAPI, _FakeAuth, _StubForwarder]:
     app = FastAPI()
     ws_forwarder = forwarder or _StubForwarder()
@@ -151,8 +153,8 @@ def _build(
     app.state.ws_forwarder = ws_forwarder
 
     domains: dict[str, object] = {"bots": {"server": "up"}}
-    if engine_configured:
-        domains["engine"] = _ENGINE_DOMAIN
+    if socket_configured:
+        domains["bots-messages-ws"] = _SOCKET_DOMAIN
     domain_map = DomainMap.from_config(
         {
             "domains": domains,
@@ -180,7 +182,9 @@ def _build(
     return app, auth, ws_forwarder
 
 
-_PATH = "/openapi/v1/engine/ARCA_x@0:20003/api/openclaw/ws?x-proxypass-token=t.o.k"
+_PATH = (
+    "/openapi/v1/bots/messages/ARCA_x@0:20003/api/openclaw/ws?x-proxypass-token=t.o.k"
+)
 
 
 # ── the happy path ───────────────────────────────────────────────────────────
@@ -214,7 +218,9 @@ def test_the_prefix_is_rewritten_onto_proxypass_verbatim() -> None:
 def test_an_encoded_target_is_not_decoded_on_the_way_through() -> None:
     app, _, forwarder = _build()
     with TestClient(app) as client:
-        with client.websocket_connect("/openapi/v1/engine/a%2Fb/api/openclaw/ws") as ws:
+        with client.websocket_connect(
+            "/openapi/v1/bots/messages/a%2Fb/api/openclaw/ws"
+        ) as ws:
             ws.close(1000)
             _settled(forwarder)
     # %2F must not become a path separator on the upstream.
@@ -270,7 +276,11 @@ def test_route_security_is_consulted_for_the_handshake() -> None:
         with client.websocket_connect(_PATH) as ws:
             ws.close(1000)
             _settled(forwarder)
-    assert auth.calls == [("GET", "/openapi/v1/engine/ARCA_x@0:20003/api/openclaw/ws")]
+    # Authenticated under WEBSOCKET, not GET: the table is plane-blind, so a
+    # handshake must not resolve to the same rule an ordinary request would.
+    assert auth.calls == [
+        ("WEBSOCKET", "/openapi/v1/bots/messages/ARCA_x@0:20003/api/openclaw/ws")
+    ]
 
 
 # ── closing ──────────────────────────────────────────────────────────────────
@@ -320,7 +330,7 @@ def test_an_upstream_close_noticed_while_sending_is_carried_to_the_client() -> N
 
 
 def test_a_domain_that_is_not_configured_refuses_the_handshake() -> None:
-    app, auth, forwarder = _build(engine_configured=False)
+    app, auth, forwarder = _build(socket_configured=False)
     with TestClient(app) as client:
         with pytest.raises(WebSocketDisconnect) as caught:
             with client.websocket_connect(_PATH):
@@ -354,32 +364,49 @@ def test_an_unreachable_upstream_refuses_the_handshake() -> None:
 # ── the prefix publishes a socket and nothing else ───────────────────────────
 
 
-def test_http_on_a_socket_only_domain_is_an_unknown_route() -> None:
-    """The domain resolves, but it does not answer this plane."""
-    app, _, forwarder = _build()
+def test_http_on_the_socket_prefix_falls_through_to_the_broader_domain() -> None:
+    """The socket domain is not a candidate on this plane, so `bots` serves it.
+
+    Deliberate, and the reason `messages` can be reserved here at all: a future
+    HTTP endpoint at this address must stay reachable. What must NOT happen is
+    the socket domain winning the path and then refusing the plane — that would
+    make the reserved address unreachable the day it is implemented.
+    """
+    app, auth, ws_forwarder = _build()
+    # Stopped at the auth seam, which is past domain resolution: a 404 here would
+    # mean no HTTP domain claimed the path, and the request never got that far.
+    auth.fail = True
     with TestClient(app) as client:
-        response = client.get("/openapi/v1/engine/ARCA_x@0:20003/api/openclaw/ws")
-    assert response.status_code == 404
-    assert response.json()["code"] == 404001
-    assert forwarder.opened == []  # never dialled the upstream
+        response = client.get("/openapi/v1/bots/messages/some-bot")
+    assert response.status_code == 401
+    # Authenticated as an ordinary request, not as a handshake.
+    assert auth.calls == [("GET", "/openapi/v1/bots/messages/some-bot")]
+    assert ws_forwarder.opened == []  # the socket upstream was never dialled
 
 
-def test_a_traversal_under_the_socket_domain_never_reaches_http() -> None:
-    """`%2e%2e` decodes to `..`, which httpx would collapse — but the HTTP
-    plane refuses this domain outright, so there is nothing to collapse."""
-    app, _, forwarder = _build()
+def test_an_unauthenticated_http_request_to_the_socket_prefix_is_refused() -> None:
+    """The socket's exemption must not reach the plane that forwards upstream.
+
+    The table is plane-blind, so an unqualified rule here would exempt ordinary
+    requests too — and those no longer 404 the way they did when the socket was
+    its own top-level domain: they fall through to `bots` and are forwarded to
+    the backend, with any `..` normalising away en route. That is an
+    unauthenticated caller reaching an arbitrary backend path, so the exemption
+    is qualified by plane and this request must be challenged.
+    """
+    app, auth, _ = _build()
+    auth.fail = True
     with TestClient(app) as client:
-        response = client.get("/openapi/v1/engine/%2e%2e/%2e%2e/admin/keys")
-    assert response.status_code == 404
-    assert forwarder.opened == []
+        response = client.get("/openapi/v1/bots/messages/%2e%2e/%2e%2e/admin/keys")
+    assert response.status_code == 401
 
 
 @pytest.mark.parametrize(
     "decoded_path",
     [
-        "/openapi/v1/engine/../../admin",
-        "/openapi/v1/engine/./admin",
-        "/openapi/v1/engine/a/../../admin",
+        "/openapi/v1/bots/messages/../../admin",
+        "/openapi/v1/bots/messages/./admin",
+        "/openapi/v1/bots/messages/a/../../admin",
     ],
 )
 def test_the_traversal_guard_matches_decoded_dot_segments(decoded_path: str) -> None:
@@ -395,10 +422,10 @@ def test_the_traversal_guard_matches_decoded_dot_segments(decoded_path: str) -> 
 @pytest.mark.parametrize(
     "decoded_path",
     [
-        "/openapi/v1/engine/a.b/ws",  # a dot inside a name is not a dot segment
-        "/openapi/v1/engine/%2e/ws",  # what `%252e` decodes to: a filename
-        "/openapi/v1/engine/.../ws",
-        "/openapi/v1/engine/..a/ws",
+        "/openapi/v1/bots/messages/a.b/ws",  # a dot inside a name is not a dot segment
+        "/openapi/v1/bots/messages/%2e/ws",  # what `%252e` decodes to: a filename
+        "/openapi/v1/bots/messages/.../ws",
+        "/openapi/v1/bots/messages/..a/ws",
     ],
 )
 def test_the_traversal_guard_leaves_ordinary_paths_alone(decoded_path: str) -> None:
@@ -408,10 +435,10 @@ def test_the_traversal_guard_leaves_ordinary_paths_alone(decoded_path: str) -> N
 @pytest.mark.parametrize(
     "path",
     [
-        "/openapi/v1/engine/%2e%2e/%2e%2e/admin",
-        "/openapi/v1/engine/%2E%2E/admin",  # encoding is case-insensitive
-        "/openapi/v1/engine/.%2e/admin",  # half-encoded
-        "/openapi/v1/engine/%2e%2e%2Fadmin",  # an encoded slash hiding the boundary
+        "/openapi/v1/bots/messages/%2e%2e/%2e%2e/admin",
+        "/openapi/v1/bots/messages/%2E%2E/admin",  # encoding is case-insensitive
+        "/openapi/v1/bots/messages/.%2e/admin",  # half-encoded
+        "/openapi/v1/bots/messages/%2e%2e%2Fadmin",  # an encoded slash hiding the boundary
     ],
 )
 def test_a_traversal_on_the_socket_plane_is_refused_before_dialling(path: str) -> None:
@@ -436,10 +463,13 @@ def test_a_traversal_on_the_socket_plane_is_refused_before_dialling(path: str) -
 @pytest.mark.parametrize(
     "path",
     [
-        "/openapi/v1/%65ngine/t/ws",  # 'e' encoded — decodes to the domain
-        "/openapi/v1/engin%65/t/ws",
-        "/openapi/v1/engine%2Ft/ws",  # the separator itself encoded
-        "/openapi%2Fv1/engine/t/ws",
+        # Every segment of the routing prefix, not merely the first: the
+        # prefix is four segments deep now and nested inside another domain's.
+        "/openapi/v1/%62ots/messages/t/ws",  # 'b' encoded — decodes to the domain
+        "/openapi/v1/bots/%6dessages/t/ws",  # 'm' encoded
+        "/openapi/v1/bots/message%73/t/ws",  # trailing 's' encoded
+        "/openapi/v1/bots/messages%2Ft/ws",  # the separator itself encoded
+        "/openapi%2Fv1/bots/messages/t/ws",
     ],
 )
 def test_an_encoded_routing_prefix_is_refused(path: str) -> None:
@@ -472,15 +502,15 @@ def test_the_bare_domain_prefix_is_mounted_too() -> None:
     """
     app, _, _ = _build()
     mounted = {getattr(route, "path", None) for route in app.routes}
-    assert "/openapi/v1/engine" in mounted
-    assert "/openapi/v1/engine/{full_path:path}" in mounted
+    assert "/openapi/v1/bots/messages" in mounted
+    assert "/openapi/v1/bots/messages/{full_path:path}" in mounted
 
 
 def test_relay_routes_returns_both_forms_together() -> None:
     """Returned as one tuple so a caller cannot mount one and forget the other."""
-    assert relay_routes("/openapi/v1/engine") == (
-        "/openapi/v1/engine",
-        "/openapi/v1/engine/{full_path:path}",
+    assert relay_routes("/openapi/v1/bots/messages") == (
+        "/openapi/v1/bots/messages",
+        "/openapi/v1/bots/messages/{full_path:path}",
     )
 
 
@@ -495,10 +525,14 @@ def _nested_rewrite_app(forwarder: _StubForwarder) -> FastAPI:
     domain_map = DomainMap.from_config(
         {
             "domains": {
-                "engine": {
+                "bots-messages-ws": {
+                    "match": "/openapi/v1/bots/messages/**",
                     "server": "p",
                     "protocols": ["websocket"],
-                    "rewrite": {"from": "/openapi/v1/engine/v2", "to": "/proxypass"},
+                    "rewrite": {
+                        "from": "/openapi/v1/bots/messages/v2",
+                        "to": "/proxypass",
+                    },
                 }
             },
             "servers": {"p": {"base_url": "wss://proxy.internal"}},
@@ -519,15 +553,15 @@ def _nested_rewrite_app(forwarder: _StubForwarder) -> FastAPI:
 @pytest.mark.parametrize(
     "path",
     [
-        "/openapi/v1/engine/%76%32/T/ws",  # 'v2' encoded — clears the domain prefix
-        "/openapi/v1/engine/v%32/T/ws",
-        "/openapi/v1/engine/other/T/ws",  # simply not under the declared `from`
+        "/openapi/v1/bots/messages/%76%32/T/ws",  # 'v2' encoded — clears the domain prefix
+        "/openapi/v1/bots/messages/v%32/T/ws",
+        "/openapi/v1/bots/messages/other/T/ws",  # simply not under the declared `from`
     ],
 )
 def test_a_raw_path_that_misses_a_nested_rewrite_is_refused(path: str) -> None:
     """The rewrite's own `from` is what decided the upstream path, so it governs.
 
-    `/openapi/v1/engine/%76%32/...` decodes to `/openapi/v1/engine/v2/...`, so it
+    `/openapi/v1/bots/messages/%76%32/...` decodes to `/openapi/v1/bots/messages/v2/...`, so it
     resolves and authenticates as the anonymous domain and clears the *domain*
     prefix — but the raw path no longer carries the literal `from`, the
     substitution misses, and the dial lands outside `/proxypass`. Checking only
@@ -546,7 +580,7 @@ def test_a_nested_rewrite_still_relays_its_own_paths() -> None:
     """The tightening must not close the configuration it is guarding."""
     forwarder = _StubForwarder()
     with TestClient(_nested_rewrite_app(forwarder)) as client:
-        with client.websocket_connect("/openapi/v1/engine/v2/T%40x/ws") as ws:
+        with client.websocket_connect("/openapi/v1/bots/messages/v2/T%40x/ws") as ws:
             ws.send_text("ping")
             ws.receive_text()
         _settled(forwarder)
@@ -562,7 +596,7 @@ def test_an_encoded_tail_still_relays_verbatim() -> None:
     app, _, forwarder = _build()
     with TestClient(app) as client:
         with client.websocket_connect(
-            "/openapi/v1/engine/ARCA_x%400%3A20003/api/ws"
+            "/openapi/v1/bots/messages/ARCA_x%400%3A20003/api/ws"
         ) as ws:
             ws.send_text("ping")
             ws.receive_text()
@@ -582,7 +616,7 @@ def test_a_dot_inside_a_name_still_relays() -> None:
     """
     app, _, forwarder = _build()
     with TestClient(app) as client:
-        with client.websocket_connect("/openapi/v1/engine/a.b/c..d/ws") as ws:
+        with client.websocket_connect("/openapi/v1/bots/messages/a.b/c..d/ws") as ws:
             ws.send_text("ping")
             ws.receive_text()
         _settled(forwarder)

--- a/src/gateway/tests/test_domain_map.py
+++ b/src/gateway/tests/test_domain_map.py
@@ -683,13 +683,15 @@ def test_every_key_the_shipped_config_uses_is_recognised() -> None:
     """Guards the tightening itself: no shipped key may trip the new check.
 
     `test_shipped_config_loads` covers `bots`; this one pins the socket domain,
-    whose `protocols` and `rewrite` keys are exactly what the check is about.
+    whose `match`, `protocols` and `rewrite` keys are exactly what the check is
+    about.
     """
     raw = yaml.safe_load(_CONFIG.read_text())
     domain_map = DomainMap.from_config(raw["user_config"]["upstreams"], variables=_VARS)
-    engine = domain_map.websocket_domain_for("/openapi/v1/engine/t/ws")
-    assert engine is not None
-    assert engine.serves_websocket and not engine.serves_http
+    socket = domain_map.websocket_domain_for("/openapi/v1/bots/messages/t/ws")
+    assert socket is not None
+    assert socket.serves_websocket and not socket.serves_http
+    assert socket.mount_prefix == "/openapi/v1/bots/messages"
 
 
 # ── path patterns: match first, then most specific ───────────────────────────

--- a/src/gateway/tests/test_domain_map.py
+++ b/src/gateway/tests/test_domain_map.py
@@ -17,6 +17,11 @@ _VARS = {
 }
 
 
+def _server(domain: object) -> Server | None:
+    """The resolved domain's upstream, or ``None`` if nothing resolved."""
+    return getattr(domain, "server", None)
+
+
 def _map() -> DomainMap:
     return DomainMap.from_config(
         {
@@ -34,30 +39,30 @@ def _map() -> DomainMap:
 
 
 def test_resolves_configured_domain() -> None:
-    server = _map().resolve("/openapi/v1/bots/123/restart")
+    server = _server(_map().http_domain_for("/openapi/v1/bots/123/restart"))
     assert server is not None
     assert server.name == "backend"
     assert server.base_url == "http://backend:8080"
 
 
 def test_domain_at_root_resolves() -> None:
-    assert _map().resolve("/openapi/v1/bots") is not None
+    assert _map().http_domain_for("/openapi/v1/bots") is not None
 
 
 def test_unknown_domain_returns_none() -> None:
-    assert _map().resolve("/openapi/v1/unknown/x") is None
+    assert _map().http_domain_for("/openapi/v1/unknown/x") is None
 
 
 def test_path_outside_version_base_returns_none() -> None:
-    assert _map().resolve("/api/bots/123") is None
+    assert _map().http_domain_for("/api/bots/123") is None
 
 
 def test_bare_version_base_has_no_domain() -> None:
-    assert _map().resolve("/openapi/v1") is None
+    assert _map().http_domain_for("/openapi/v1") is None
 
 
 def test_schema_source_parsed() -> None:
-    domain = _map().domain_for("/openapi/v1/bots/1")
+    domain = _map().http_domain_for("/openapi/v1/bots/1")
     assert domain is not None
     assert domain.schema.source == "file"
     assert domain.schema.location == "schemas/bots.openapi.json"
@@ -67,7 +72,7 @@ def test_schema_source_parsed() -> None:
 def test_shipped_config_loads() -> None:
     raw = yaml.safe_load(_CONFIG.read_text())
     dm = DomainMap.from_config(raw["user_config"]["upstreams"], variables=_VARS)
-    assert dm.domain_for("/openapi/v1/bots") is not None
+    assert dm.http_domain_for("/openapi/v1/bots") is not None
 
 
 # ── protocols ────────────────────────────────────────────────────────────────
@@ -96,27 +101,27 @@ def _protocol_map() -> DomainMap:
 
 def test_protocols_default_to_http_only() -> None:
     """Every domain predating the declaration keeps behaving identically."""
-    bots = _protocol_map().domain_for("/openapi/v1/bots/x")
+    bots = _protocol_map().http_domain_for("/openapi/v1/bots/x")
     assert bots is not None
     assert bots.serves_http
     assert not bots.serves_websocket
 
 
 def test_a_socket_domain_does_not_serve_http() -> None:
-    engine = _protocol_map().domain_for("/openapi/v1/engine/t/ws")
+    engine = _protocol_map().websocket_domain_for("/openapi/v1/engine/t/ws")
     assert engine is not None
     assert engine.serves_websocket
     assert not engine.serves_http
 
 
 def test_a_domain_may_declare_both_planes() -> None:
-    both = _protocol_map().domain_for("/openapi/v1/both/x")
+    both = _protocol_map().http_domain_for("/openapi/v1/both/x")
     assert both is not None
     assert both.serves_http and both.serves_websocket
 
 
 def test_websocket_domains_lists_only_socket_domains() -> None:
-    assert set(_protocol_map().websocket_domains()) == {"engine", "both"}
+    assert {d.name for d in _protocol_map().websocket_domains()} == {"engine", "both"}
 
 
 def test_unknown_protocol_is_rejected() -> None:
@@ -134,14 +139,14 @@ def test_unknown_protocol_is_rejected() -> None:
 
 
 def test_no_rewrite_means_the_path_travels_verbatim() -> None:
-    bots = _protocol_map().domain_for("/openapi/v1/bots/x")
+    bots = _protocol_map().http_domain_for("/openapi/v1/bots/x")
     assert bots is not None
     assert bots.rewrite is None
     assert bots.upstream_path("/openapi/v1/bots/a%2Fb") == "/openapi/v1/bots/a%2Fb"
 
 
 def test_a_declared_rewrite_substitutes_only_the_prefix() -> None:
-    engine = _protocol_map().domain_for("/openapi/v1/engine/t/ws")
+    engine = _protocol_map().websocket_domain_for("/openapi/v1/engine/t/ws")
     assert engine is not None
     assert (
         engine.upstream_path("/openapi/v1/engine/ARCA_x@0:20003/api/openclaw/ws")
@@ -150,7 +155,7 @@ def test_a_declared_rewrite_substitutes_only_the_prefix() -> None:
 
 
 def test_a_rewrite_never_re_encodes_the_tail() -> None:
-    engine = _protocol_map().domain_for("/openapi/v1/engine/t/ws")
+    engine = _protocol_map().websocket_domain_for("/openapi/v1/engine/t/ws")
     assert engine is not None
     assert (
         engine.upstream_path("/openapi/v1/engine/ARCA%5Fx%400%3A2/api/x%20y")
@@ -197,7 +202,7 @@ def test_a_rewrite_anchored_off_the_domain_is_rejected(from_prefix: str) -> None
 )
 def test_a_rewrite_on_the_domain_boundary_is_accepted(from_prefix: str) -> None:
     """The domain's own prefix, and any path beneath it, can both fire."""
-    engine = _rewrite_map(from_prefix).domain_for("/openapi/v1/engine/t")
+    engine = _rewrite_map(from_prefix).http_domain_for("/openapi/v1/engine/t")
     assert engine is not None
     assert engine.rewrite is not None
 
@@ -209,7 +214,9 @@ def test_a_rewrite_matches_on_segment_boundaries_not_characters() -> None:
     *different* segment, but a character-wise prefix match would rewrite it to
     `/proxypass0/ws` — a path on the upstream nobody asked for.
     """
-    engine = _rewrite_map("/openapi/v1/engine/v2").domain_for("/openapi/v1/engine/v20")
+    engine = _rewrite_map("/openapi/v1/engine/v2").http_domain_for(
+        "/openapi/v1/engine/v20"
+    )
     assert engine is not None
     assert engine.upstream_path("/openapi/v1/engine/v20/ws") == (
         "/openapi/v1/engine/v20/ws"
@@ -305,7 +312,7 @@ def test_a_rewrite_target_of_root_strips_the_prefix() -> None:
         },
         variables={},
     )
-    engine = dm.domain_for("/openapi/v1/engine/t")
+    engine = dm.http_domain_for("/openapi/v1/engine/t")
     assert engine is not None
     assert engine.upstream_path("/openapi/v1/engine/t/ws") == "/t/ws"
 
@@ -474,7 +481,7 @@ def test_an_http_only_domain_is_still_reachable_as_a_socket_origin() -> None:
         },
         variables={},
     )
-    bots = dm.domain_for("/openapi/v1/bots")
+    bots = dm.http_domain_for("/openapi/v1/bots")
     assert bots is not None
     assert not bots.serves_websocket
     assert bots.server.websocket_base_url == "wss://backend.sample.com"
@@ -558,10 +565,10 @@ def test_from_config_with_variables_resolves_all() -> None:
         },
         variables=_VARS,
     )
-    bots = dm.resolve("/openapi/v1/bots")
+    bots = _server(dm.http_domain_for("/openapi/v1/bots"))
     assert bots is not None
     assert bots.base_url == "http://backend:8080"
-    runs = dm.resolve("/openapi/v1/runs")
+    runs = _server(dm.http_domain_for("/openapi/v1/runs"))
     assert runs is not None
     assert runs.base_url == "http://baas:9090"
 
@@ -594,21 +601,21 @@ def test_from_yaml_loads_upstreams(tmp_path) -> None:
         "        base_url: http://backend:8080\n"
     )
     dm = DomainMap.from_yaml(cfg, variables={})
-    assert dm.resolve("/openapi/v1/bots/123") is not None
+    assert dm.http_domain_for("/openapi/v1/bots/123") is not None
 
 
 def test_from_yaml_non_dict_root_uses_empty(tmp_path) -> None:
     cfg = tmp_path / "application.yaml"
     cfg.write_text("- just a list")
     dm = DomainMap.from_yaml(cfg, variables={})
-    assert dm.resolve("/openapi/v1/bots/123") is None
+    assert dm.http_domain_for("/openapi/v1/bots/123") is None
 
 
 def test_from_yaml_user_config_not_dict_uses_empty(tmp_path) -> None:
     cfg = tmp_path / "application.yaml"
     cfg.write_text("user_config: not-a-dict\n")
     dm = DomainMap.from_yaml(cfg, variables={})
-    assert dm.resolve("/openapi/v1/bots/123") is None
+    assert dm.http_domain_for("/openapi/v1/bots/123") is None
 
 
 # ── unknown configuration keys ───────────────────────────────────────────────
@@ -680,6 +687,196 @@ def test_every_key_the_shipped_config_uses_is_recognised() -> None:
     """
     raw = yaml.safe_load(_CONFIG.read_text())
     domain_map = DomainMap.from_config(raw["user_config"]["upstreams"], variables=_VARS)
-    engine = domain_map.domain_for("/openapi/v1/engine/t/ws")
+    engine = domain_map.websocket_domain_for("/openapi/v1/engine/t/ws")
     assert engine is not None
     assert engine.serves_websocket and not engine.serves_http
+
+
+# ── path patterns: match first, then most specific ───────────────────────────
+
+
+def _pattern_map() -> DomainMap:
+    """The shipped shape: a socket prefix nested inside an HTTP domain."""
+    return DomainMap.from_config(
+        {
+            "domains": {
+                "bots": {"server": "backend"},
+                "bots-messages-ws": {
+                    "match": "/openapi/v1/bots/messages/**",
+                    "server": "proxy",
+                    "protocols": ["websocket"],
+                    "rewrite": {
+                        "from": "/openapi/v1/bots/messages",
+                        "to": "/proxypass",
+                    },
+                },
+            },
+            "servers": {
+                "backend": {"base_url": "http://backend:8080"},
+                "proxy": {"base_url": "https://proxy:20003"},
+            },
+        },
+        variables={},
+    )
+
+
+def test_a_domain_without_a_match_claims_its_own_name() -> None:
+    """The implicit pattern is exactly the leading-segment routing it replaces."""
+    bots = _map().domains["bots"]
+    assert bots.pattern.segments == ("openapi", "v1", "bots", "**")
+    assert bots.mount_prefix == "/openapi/v1/bots"
+
+
+def test_the_most_specific_matching_pattern_wins() -> None:
+    domain = _pattern_map().websocket_domain_for("/openapi/v1/bots/messages/T/api/ws")
+    assert domain is not None
+    assert domain.name == "bots-messages-ws"
+
+
+def test_an_http_request_under_a_socket_prefix_reaches_the_broader_domain() -> None:
+    """The trap this design exists to avoid.
+
+    ``messages`` is reserved for a future *HTTP* endpoint. Were the plane checked
+    after ranking rather than before, the socket domain would win the path, fail
+    the check, and the endpoint would be unreachable the day it is added — the
+    prefix would have eaten exactly the thing it was reserved for.
+    """
+    domain = _pattern_map().http_domain_for("/openapi/v1/bots/messages/some-bot")
+    assert domain is not None
+    assert domain.name == "bots"
+    assert domain.server.name == "backend"
+
+
+def test_a_socket_prefix_is_not_relayed_outside_its_own_pattern() -> None:
+    """The narrower claim does not spill onto the rest of the parent prefix."""
+    assert _pattern_map().websocket_domain_for("/openapi/v1/bots/abc") is None
+
+
+def test_resolution_does_not_retry_after_a_plane_mismatch() -> None:
+    """A domain refusing the plane must not hand the request to another.
+
+    With no HTTP domain configured at all, an HTTP request under the socket
+    prefix has nowhere to fall — it resolves to ``None`` rather than being
+    served by the socket domain's upstream over the wrong plane.
+    """
+    dm = DomainMap.from_config(
+        {
+            "domains": {
+                "bots-messages-ws": {
+                    "match": "/openapi/v1/bots/messages/**",
+                    "server": "proxy",
+                    "protocols": ["websocket"],
+                }
+            },
+            "servers": {"proxy": {"base_url": "https://proxy:20003"}},
+        },
+        variables={},
+    )
+    assert dm.http_domain_for("/openapi/v1/bots/messages/x") is None
+
+
+def test_a_pattern_serves_its_own_bare_prefix() -> None:
+    """`**` matches no remaining segments, so the prefix itself is claimed."""
+    domain = _pattern_map().websocket_domain_for("/openapi/v1/bots/messages")
+    assert domain is not None
+    assert domain.name == "bots-messages-ws"
+
+
+# ── refusing a pattern that would widen the gateway ──────────────────────────
+
+
+def _match_map(pattern: str, **extra: object) -> DomainMap:
+    return DomainMap.from_config(
+        {
+            "domains": {"x": {"match": pattern, "server": "s", **extra}},
+            "servers": {"s": {"base_url": "http://s"}},
+        },
+        variables={},
+    )
+
+
+@pytest.mark.parametrize("pattern", ["/**", "/openapi/**", "/openapi/v1/**"])
+def test_an_over_broad_pattern_is_refused_at_boot(pattern: str) -> None:
+    """Before patterns, an open proxy could not be typed; now it must be refused.
+
+    A domain used to *be* its leading segment, so an unknown segment resolved to
+    ``None`` and the caller denied. `match: /**` is an open proxy into that
+    domain's upstream, so the invariant is now enforced rather than structural.
+    """
+    with pytest.raises(ValueError, match="too broad"):
+        _match_map(pattern)
+
+
+@pytest.mark.parametrize(
+    "pattern", ["/openapi/v1/{tenant}/**", "/openapi/v1/**/bots/**"]
+)
+def test_a_pattern_that_pins_no_prefix_is_refused(pattern: str) -> None:
+    """A leading parameter matches every domain's traffic while looking specific,
+    and neither it nor an inner glob yields a prefix to mount a route on."""
+    with pytest.raises(ValueError, match="literal segments"):
+        _match_map(pattern)
+
+
+def test_a_pattern_must_declare_its_glob() -> None:
+    """Required rather than inferred: the width of the claim stays visible."""
+    with pytest.raises(ValueError, match=r"must end in"):
+        _match_map("/openapi/v1/bots")
+
+
+def test_two_domains_claiming_one_pattern_and_plane_are_refused() -> None:
+    with pytest.raises(ValueError, match="undefined"):
+        DomainMap.from_config(
+            {
+                "domains": {
+                    "a": {"match": "/openapi/v1/z/**", "server": "s"},
+                    "b": {"match": "/openapi/v1/z/**", "server": "s"},
+                },
+                "servers": {"s": {"base_url": "http://s"}},
+            },
+            variables={},
+        )
+
+
+def test_one_pattern_may_be_declared_once_per_plane() -> None:
+    """Two deliberate per-plane declarations are the supported way to serve both.
+
+    This is what keeps the design honest: reserving a prefix for one plane never
+    forecloses the other, it only requires saying so.
+    """
+    dm = DomainMap.from_config(
+        {
+            "domains": {
+                "z-http": {"match": "/openapi/v1/z/**", "server": "s"},
+                "z-ws": {
+                    "match": "/openapi/v1/z/**",
+                    "server": "s",
+                    "protocols": ["websocket"],
+                },
+            },
+            "servers": {"s": {"base_url": "http://s"}},
+        },
+        variables={},
+    )
+    http = dm.http_domain_for("/openapi/v1/z/x")
+    ws = dm.websocket_domain_for("/openapi/v1/z/x")
+    assert http is not None and http.name == "z-http"
+    assert ws is not None and ws.name == "z-ws"
+
+
+def test_the_rewrite_anchor_follows_the_declared_pattern() -> None:
+    """A nested domain's rewrite anchors at its own prefix, not at its name."""
+    domain = _pattern_map().websocket_domain_for("/openapi/v1/bots/messages/T/api/ws")
+    assert domain is not None
+    assert domain.rewrite is not None
+    assert domain.upstream_path("/openapi/v1/bots/messages/T/api/ws") == (
+        "/proxypass/T/api/ws"
+    )
+
+
+def test_a_rewrite_anchored_off_the_declared_pattern_is_refused() -> None:
+    """The anchor is the pattern's literal head — not `base_path` + the name."""
+    with pytest.raises(ValueError, match="can never match"):
+        _match_map(
+            "/openapi/v1/bots/messages/**",
+            rewrite={"from": "/openapi/v1/x", "to": "/proxypass"},
+        )

--- a/src/gateway/tests/test_log_redaction.py
+++ b/src/gateway/tests/test_log_redaction.py
@@ -23,8 +23,8 @@ from gateway.community.adapters.web._log_redaction import (
     [
         # The one this change actually introduces.
         (
-            "/openapi/v1/engine/T/api/ws?x-proxypass-token=eyJhbGciOi.J9.sig",
-            "/openapi/v1/engine/T/api/ws?x-proxypass-token=<redacted>",
+            "/openapi/v1/bots/messages/T/api/ws?x-proxypass-token=eyJhbGciOi.J9.sig",
+            "/openapi/v1/bots/messages/T/api/ws?x-proxypass-token=<redacted>",
         ),
         ("/x?a=1&token=abc&b=2", "/x?a=1&token=<redacted>&b=2"),
         ("/x?password=p&secret=s", "/x?password=<redacted>&secret=<redacted>"),
@@ -39,7 +39,7 @@ def test_a_credential_query_value_is_replaced(target: str, expected: str) -> Non
 @pytest.mark.parametrize(
     "target",
     [
-        "/openapi/v1/engine/T/api/ws",  # no query at all
+        "/openapi/v1/bots/messages/T/api/ws",  # no query at all
         "/x?ordinary=value",
         "/x?monkey=fine",  # contains 'key', and is not a credential
         "/x?page=2&limit=10",
@@ -56,9 +56,11 @@ def test_the_parameter_name_and_path_survive() -> None:
     A log that says *which* credential was presented and to what path is still
     useful for tracing a request; one that drops the query entirely is not.
     """
-    redacted = redact_credentials("/openapi/v1/engine/T/ws?x-proxypass-token=live")
+    redacted = redact_credentials(
+        "/openapi/v1/bots/messages/T/ws?x-proxypass-token=live"
+    )
     assert "x-proxypass-token" in redacted
-    assert "/openapi/v1/engine/T/ws" in redacted
+    assert "/openapi/v1/bots/messages/T/ws" in redacted
     assert "live" not in redacted
 
 
@@ -70,7 +72,7 @@ def test_the_filter_rewrites_the_record_uvicorn_actually_emits() -> None:
         pathname=__file__,
         lineno=1,
         msg='%s - "WebSocket %s" [accepted]',
-        args=("127.0.0.1:1", "/openapi/v1/engine/T/ws?x-proxypass-token=live"),
+        args=("127.0.0.1:1", "/openapi/v1/bots/messages/T/ws?x-proxypass-token=live"),
         exc_info=None,
     )
     assert CredentialRedactingFilter().filter(record) is True

--- a/src/gateway/tests/test_path_pattern.py
+++ b/src/gateway/tests/test_path_pattern.py
@@ -1,0 +1,127 @@
+"""The shared path pattern: grammar, matching, ranking, and literal prefix.
+
+These properties are relied on by both planes, so they are pinned here once
+rather than re-derived in each plane's own suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.community.core.paths import PathPattern, split_segments
+
+
+def _matches(pattern: str, path: str) -> bool:
+    return PathPattern.parse(pattern).matches(split_segments(path))
+
+
+# ── splitting ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/openapi/v1/bots", ("openapi", "v1", "bots")),
+        ("openapi/v1/bots", ("openapi", "v1", "bots")),
+        ("/openapi/v1/bots/", ("openapi", "v1", "bots")),
+        ("//openapi//v1//bots", ("openapi", "v1", "bots")),
+        ("/", ()),
+        ("", ()),
+    ],
+)
+def test_empty_segments_are_dropped(path: str, expected: tuple[str, ...]) -> None:
+    """One splitter for patterns and paths, so the two cannot disagree on count."""
+    assert split_segments(path) == expected
+
+
+# ── matching ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/openapi/v1/bots/abc",
+        "/openapi/v1/bots/messages/x/y/z",
+        "/openapi/v1/bots",  # the glob matches *no* remaining segments too
+    ],
+)
+def test_a_glob_matches_the_whole_subtree_and_its_root(path: str) -> None:
+    """`/a/b/**` serving the bare `/a/b` is what domain resolution rests on."""
+    assert _matches("/openapi/v1/bots/**", path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/openapi/v1/botsy", "/openapi/v1", "/openapi/v2/bots", "/api/bots"],
+)
+def test_a_glob_does_not_match_outside_its_prefix(path: str) -> None:
+    """Segment-wise, not character-wise: `botsy` is a different segment."""
+    assert not _matches("/openapi/v1/bots/**", path)
+
+
+def test_a_parameter_matches_exactly_one_segment() -> None:
+    assert _matches("/openapi/v1/bots/{id}", "/openapi/v1/bots/42")
+    assert not _matches("/openapi/v1/bots/{id}", "/openapi/v1/bots/42/skills")
+    assert not _matches("/openapi/v1/bots/{id}", "/openapi/v1/bots")
+
+
+def test_an_exact_pattern_matches_only_itself() -> None:
+    assert _matches("/openapi/v1/bots", "/openapi/v1/bots")
+    assert not _matches("/openapi/v1/bots", "/openapi/v1/bots/42")
+
+
+# ── ranking ──────────────────────────────────────────────────────────────────
+
+
+def _rank(pattern: str) -> tuple[int, int, int]:
+    return PathPattern.parse(pattern).specificity
+
+
+def test_more_literals_beat_fewer() -> None:
+    """The rule the socket prefix depends on, on both planes.
+
+    `/openapi/v1/bots/messages/**` must outrank `/openapi/v1/bots/**` — for
+    routing, so the socket domain wins its own prefix; and for route security,
+    so the socket's empty requirement wins over the bots user requirement.
+    """
+    assert _rank("/openapi/v1/bots/messages/**") > _rank("/openapi/v1/bots/**")
+
+
+def test_an_exact_pattern_beats_a_glob_with_more_literals() -> None:
+    """A pattern claiming one path beats one claiming a whole subtree."""
+    assert _rank("/openapi/v1") > _rank("/openapi/v1/bots/messages/**")
+
+
+def test_a_literal_beats_a_parameter_at_the_same_depth() -> None:
+    """`/bots/messages` names a resource; `/bots/{id}` names a shape."""
+    assert _rank("/openapi/v1/bots/messages") > _rank("/openapi/v1/bots/{id}")
+
+
+def test_the_root_glob_ranks_lowest_of_all() -> None:
+    assert _rank("/**") < _rank("/openapi/**") < _rank("/openapi/v1/**")
+
+
+# ── literal prefix ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("/openapi/v1/bots/**", "/openapi/v1/bots"),
+        ("/openapi/v1/bots/messages/**", "/openapi/v1/bots/messages"),
+        ("/openapi/v1/bots", "/openapi/v1/bots"),
+        ("/openapi/v1/bots/{id}/skills", "/openapi/v1/bots"),
+    ],
+)
+def test_the_literal_prefix_stops_at_the_first_wildcard(
+    pattern: str, expected: str
+) -> None:
+    """What a caller needs when it must *produce* a path, not test one."""
+    assert PathPattern.parse(pattern).literal_prefix == expected
+
+
+@pytest.mark.parametrize("pattern", ["/**", "/{id}/x"])
+def test_a_pattern_with_no_literal_head_has_no_prefix(pattern: str) -> None:
+    """Callers that cannot use `/` are expected to refuse such a pattern at
+    configuration time rather than discover it here."""
+    assert PathPattern.parse(pattern).literal_prefix == "/"

--- a/src/gateway/tests/test_route_security.py
+++ b/src/gateway/tests/test_route_security.py
@@ -20,7 +20,10 @@ def test_shipped_config_loads_and_requires_user() -> None:
     assert req[PrincipalType.USER] is Presence.REQUIRED
 
 
-def test_shipped_config_exempts_the_engine_socket_prefix() -> None:
+_SOCKET_PATH = "/openapi/v1/bots/messages/ARCA_x@0:20003/api/openclaw/ws"
+
+
+def test_shipped_config_exempts_the_bot_socket_handshake() -> None:
     """The socket's credential is checked by the hop behind the gateway.
 
     An *empty* requirement, not a missing rule: an omitted rule falls through to
@@ -29,8 +32,38 @@ def test_shipped_config_exempts_the_engine_socket_prefix() -> None:
     """
     raw = yaml.safe_load(_CONFIG.read_text())
     rs = RouteSecurity.from_table(raw["user_config"]["route_security"])
-    req = rs.resolve("GET", "/openapi/v1/engine/ARCA_x@0:20003/api/openclaw/ws")
-    assert req == {}
+    assert rs.resolve("WEBSOCKET", _SOCKET_PATH) == {}
+
+
+def test_the_socket_exemption_beats_the_bots_user_requirement() -> None:
+    """It is nested inside an authenticated prefix and must win there.
+
+    Ranked by literal segment count: four to three. Were it the other way, the
+    handshake would be challenged for an identity a browser cannot present.
+    """
+    raw = yaml.safe_load(_CONFIG.read_text())
+    rs = RouteSecurity.from_table(raw["user_config"]["route_security"])
+    assert rs.resolve("WEBSOCKET", _SOCKET_PATH) == {}
+    bots = rs.resolve("WEBSOCKET", "/openapi/v1/bots/abc")
+    assert bots is not None
+    assert bots[PrincipalType.USER] is Presence.REQUIRED
+
+
+def test_the_socket_exemption_does_not_reach_the_http_plane() -> None:
+    """The table is plane-blind, so the exemption is qualified by plane.
+
+    An ordinary request to this prefix is *not* refused as an unknown route —
+    the socket domain is not a candidate on the HTTP plane, so it falls through
+    to the ``bots`` domain and is forwarded to the backend. An unqualified
+    exemption would therefore let an unauthenticated caller through, and a ``..``
+    in the path normalises away en route, landing anywhere under the namespace.
+    """
+    raw = yaml.safe_load(_CONFIG.read_text())
+    rs = RouteSecurity.from_table(raw["user_config"]["route_security"])
+    for path in (_SOCKET_PATH, "/openapi/v1/bots/messages/../../admin/keys"):
+        req = rs.resolve("GET", path)
+        assert req is not None, path
+        assert req[PrincipalType.USER] is Presence.REQUIRED, path
 
 
 def test_more_specific_rule_wins() -> None:


### PR DESCRIPTION
## Problem

`GET /openapi/v1/bots/connection/{bot_id}` hands a tenant a finished socket URL
that points at a *sibling* top-level prefix:

```text
before  wss://{gw}/openapi/v1/engine/{target}/api/openclaw/ws?x-proxypass-token=…
after   wss://{gw}/openapi/v1/bots/messages/{target}/api/openclaw/ws?x-proxypass-token=…
```

The BCN collaboration-prefix design (approved 2026-08-03) settled that the
leading segment names the **owner** of a surface, not the process serving it.
Backend management and the engine-proxy runtime are one team and one scope, so
`engine` as a sibling of `bots` splits one owner across two namespaces. The
connection service's own stated goal is also that "nothing names the hop behind
the gateway," and a top-level `engine` domain comes close to naming one.

Neither is reachable by a config edit: a gateway domain *was* its leading path
segment, so `bots` could not simultaneously be a backend prefix and the parent of
a socket prefix served by a different upstream.

## Solution

A domain now claims a **path pattern** — literal segments under the version base,
then `**` — plus the **planes** it answers. Resolution gathers every domain
matching the path *and* answering the requesting plane, then takes the most
specific: match first, rank second.

The plane filters the **candidates** rather than vetoing the winner, and that is
load-bearing. `messages` is reserved for a future *HTTP* endpoint here; ranking
first and checking the plane after would let the socket domain win the path, fail
the check, and make that endpoint unreachable the day it is added — the prefix
would eat exactly what it was reserved for. Recovering that by *retrying* the
next-best candidate would be worse: a request the winning domain refused would
get a second attempt at a domain that did not win. So retry-on-mismatch is
deliberately not built.

A domain that declares no `match` claims `{base_path}/{name}/**` — exactly the
leading-segment routing it had before — so the four shipped HTTP domains are
unchanged.

The pattern grammar and its specificity ranking moved into one shared
`core/paths` module, adopted by both the routing plane and `RouteSecurity`. Two
implementations of "most specific" is somewhere the planes can come to disagree
about which rule governs a request, and that disagreement has the shape of an
authorisation bypass.

**Boot-time validation replaces an invariant that used to be structural.** While
a domain *was* its leading segment, an unknown segment resolved to `None` and
"never an open proxy" could not be mistyped. `match: /**` is precisely an open
proxy, so a pattern must now pin the version base plus one literal segment, and
two domains claiming one pattern on one plane are refused as having no defined
winner.

### ⚠️ A security bug found during implementation

The spec recorded the objection "this puts an auth-exempt path inside an
authenticated prefix" as **"a legibility concern, not a correctness one"**, on
the grounds that precedence ranks the longer prefix higher. Precedence does — but
that was never the issue. **The route-security table is plane-blind:** an
unqualified rule governs every request to a path, whichever entrypoint serves it.

Chained with the fallthrough this change introduces, that was an authentication
bypass:

1. the exemption covered ordinary HTTP requests to the prefix, not just handshakes;
2. those no longer 404 as they did when the socket was its own top-level domain —
   they fall through to `bots` and are forwarded to the backend;
3. the path travels verbatim, so its dot segments normalise away en route.

`GET /openapi/v1/bots/messages/../../admin/keys` reached the backend as
`/openapi/v1/admin/keys` **with no identity at all**. The move is exactly what
made the exemption reachable on the HTTP plane; it was harmless only while the
exempt prefix was both socket-only *and* top-level, with nothing beneath it to
fall through to.

Fixed by qualifying the exemption by plane, using machinery the table already
has — its keys carry an optional method qualifier. The relay authenticates
handshakes under a distinct `WEBSOCKET` method and the rule is written
`WEBSOCKET /openapi/v1/bots/messages/**`, so an HTTP `GET` there falls to
`/openapi/v1/bots/**` and requires a user — which is also the right answer for
the endpoint the prefix is reserved for. `spec.md` carries the corrected
reasoning, and `test_the_socket_exemption_does_not_reach_the_http_plane` pins it.

### Two corrections to the original handoff

- **The reserved-name interlock runs the opposite way.**
  `test_the_docs_reserved_names_match_the_routes` asserts the documented list
  *equals* the components the routes publish, so adding `messages` to that block
  fails it. Relaxing it to a subset check would give up the only thing stopping
  the docs falling behind a component added later — so names reserved *ahead* of
  their routes get a separate anchored list, with its own assertion that the two
  stay disjoint. The prose also states the accurate reason: `messages` is not
  unreachable the way the other twelve are, since an HTTP `GET` to it still
  arrives at the backend and resolves as a bot id.
- **The pinned artifact did need regenerating.** Published *paths* are unchanged,
  but the socket URL appears as an example value in two places.

## Validation

- **Gateway** — 630 passed. The one failure, `test_ruff_formatting_passes`, is
  pre-existing: the identical 8-file list reproduces on the base commit
  (`770d677`); this branch adds none. Two relay cases flake ~1 run in 3 on a
  teardown race — also reproduced on the base commit, so left alone rather than
  fixed as scope creep.
- **Backend** — 10319 passed, 3 skipped, 0 failed (full suite, 9m52s). The
  sandbox gaps the handoff warned about did not reproduce in this environment.
- **Coverage gate** — 16 passed, checked for `ERROR` as well as `FAILED`, both in
  isolation and in the full run. The frozen baseline needed no edit; verified
  against the generated document that the connection endpoint's path is
  unchanged, rather than assumed.
- **Pinned artifact** — regenerated via `dump_openapi.py` +
  `gate_and_publish_openapi.py`; the compat gate reported *compatible* and the
  diff is exactly the two example URLs. `tests/fixtures/bots.openapi.json` is
  deliberately untouched — it is hand-written, not a copy.
- **Acceptance criteria** — each one checked against the shipped
  `application.yaml`, including that `/openapi/v1/messages` (the BaaS domain)
  still resolves independently of `/openapi/v1/bots/messages`.

Not run: gateway `tests/e2e/*` (needs a live server) and the Singlebox coverage
gate (needs a full product stack).

## Compatibility and risk

Every domain that declares no `match` keeps its address and behaviour exactly.
The public break is the socket address itself, taken deliberately and without an
alias: that surface has no reachable external caller, since its route-security
rule required a Google-resolved user identity a tenant presenting an access key
cannot satisfy. Same reasoning as #706.

**Deploy ordering matters.** The config move is atomic — the old prefix stops and
the new one starts — so between the gateway deploy and the backend deploy the
backend publishes an address the gateway no longer serves. Established sockets
survive; *new* connection requests fail in that window. Single-box deploys both
together.

Rollback is reverting the config block and the backend prefix constant; the
routing mechanism is inert without a domain that declares `match`.

## Spec

`src/gateway/specs/2026-08-03-gateway-path-specific-domain-routing/` — spec,
plan, and tasks, developed through the SDD flow.

## Related issues

Independent of #706 (`/openapi/v1/bots` path normalization).

Informational, for whoever owns
`src/bcs/docs/plans/2026-08-03-bcn-collaboration-prefix-design.md`:
longest-prefix routing has moved from "out of scope" to "in scope". BCN does not
need the mechanism — it owns `/openapi/v1/collaboration/**` outright — and the
ownership framing here leaves the one-prefix-per-owner principle intact, but that
constraint was written down the same week and you should hear it from us.